### PR TITLE
feat(rebuild): preflight-guard --reset --county against split-child data loss (#2496)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,6 +361,8 @@ See `docs/agent/infrastructure-reference.md` §ECS Script Execution for full pat
 
 `reingest_from_s3.py` operates on **existing database records only**. If you run it for a county with no records in the `documents` table, it will process 0 documents silently.
 
+**Split-child caveat for `rebuild_db.py --reset --county <name>`.** On counties whose scrapers split multi-case PDFs into multiple `derived.documents` rows per raw S3 object (Santa Clara, Orange, Riverside, Fresno, and any other multi-case-PDF county), a `--reset --county` followed by rebuild will silently destroy the split-children: the reset deletes every row, but rebuild only recreates one row per raw PDF because of the `content_hash`/`key_hash` mismatch in the rebuild path (see #2494). A preflight guard in `rebuild_db.py` compares the S3 key count against the `derived.documents` row count and refuses to reset when the ratio indicates fanout (≥1.5x); operators who accept the loss can pass `--force-split-child-loss`. Prefer `reingest_from_s3.py --county <name>` for re-processing multi-case-PDF counties until #2494 lands and rebuild can re-derive split-children end-to-end.
+
 ### Local Development
 
 Docker Compose stack (Postgres, Redis, OpenSearch, MinIO), schema management, S3 cache, and `rebuild_db.sh` for full local rebuilds from S3 — see **`docs/agent/local-dev.md`** for commands, env vars, and rebuild options.

--- a/packages/scraper-framework/tests/test_rebuild_db.py
+++ b/packages/scraper-framework/tests/test_rebuild_db.py
@@ -977,6 +977,10 @@ class TestMainPerCountyResetDispatch:
             patch("rebuild_db.reset_derived_tables") as mock_global_reset,
             patch("rebuild_db.reset_derived_tables_for_county") as mock_per_county_reset,
             patch("rebuild_db.reset_opensearch_index") as mock_os_reset,
+            # Preflight is covered separately; neutralise it here so the
+            # --reset --county flow doesn't hit the DB lookups on the
+            # MagicMock connection.  See #2496.
+            patch("rebuild_db.preflight_split_child_guard"),
             patch("rebuild_db._fetch_rosters"),
             patch("rebuild_db._write_rebuild_marker"),
             patch(
@@ -1050,3 +1054,466 @@ class TestMainPerCountyResetDispatch:
         mock_per_county_reset.assert_not_called()
         # No marker writes either — that's reserved for --reset runs.
         mock_marker.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Split-child preflight guard tests (#2496)
+# ---------------------------------------------------------------------------
+
+
+def _build_preflight_mock_conn(
+    court_ids: list[str],
+    db_doc_count: int,
+) -> tuple[MagicMock, MagicMock]:
+    """Build a mock psycopg connection for the split-child preflight.
+
+    The preflight issues:
+      1. ``SELECT id FROM derived.courts WHERE ...`` (via _resolve_county_court_ids)
+      2. ``SELECT COUNT(*) FROM derived.documents WHERE court_id = ANY(...)``
+
+    Returns ``(mock_conn, mock_cur)``.
+    """
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    mock_cur.fetchall.return_value = [(cid,) for cid in court_ids]
+    mock_cur.fetchone.return_value = (db_doc_count,)
+    return mock_conn, mock_cur
+
+
+class TestSplitChildDataLossError:
+    """The guard raises a dedicated exception so callers can distinguish it."""
+
+    def test_exception_type_is_exported(self) -> None:
+        """``SplitChildDataLossError`` must exist and be a subclass of RuntimeError."""
+        assert hasattr(rebuild_db, "SplitChildDataLossError")
+        assert issubclass(rebuild_db.SplitChildDataLossError, RuntimeError)
+
+
+class TestPreflightSplitChildGuard:
+    """Tests for preflight_split_child_guard()."""
+
+    def test_passes_when_db_count_matches_s3(self) -> None:
+        """Equal counts → no fanout → preflight allows reset to proceed."""
+        court_ids = ["00000000-0000-0000-0000-000000000001"]
+        mock_conn, _ = _build_preflight_mock_conn(court_ids, db_doc_count=260)
+
+        # Should not raise.
+        rebuild_db.preflight_split_child_guard(
+            mock_conn,
+            state="ca",
+            county="Santa Clara",
+            s3_key_count=260,
+            force=False,
+        )
+
+    def test_passes_when_db_count_is_lower_than_s3(self) -> None:
+        """DB < S3 (common when some raw PDFs have no rows yet) → allowed."""
+        court_ids = ["00000000-0000-0000-0000-000000000001"]
+        mock_conn, _ = _build_preflight_mock_conn(court_ids, db_doc_count=100)
+
+        # Should not raise.
+        rebuild_db.preflight_split_child_guard(
+            mock_conn,
+            state="ca",
+            county="Santa Clara",
+            s3_key_count=260,
+            force=False,
+        )
+
+    def test_passes_within_fanout_tolerance(self) -> None:
+        """Small overhead (<=1.5x) is not treated as fanout — the ratio
+        threshold leaves headroom for normal drift (staging rows, dupes, etc.).
+        """
+        court_ids = ["00000000-0000-0000-0000-000000000001"]
+        # 260 keys → allow up to 390 rows.
+        mock_conn, _ = _build_preflight_mock_conn(court_ids, db_doc_count=380)
+
+        # Should not raise — under threshold.
+        rebuild_db.preflight_split_child_guard(
+            mock_conn,
+            state="ca",
+            county="Santa Clara",
+            s3_key_count=260,
+            force=False,
+        )
+
+    def test_raises_on_fanout_pattern(self) -> None:
+        """DB rows >> S3 keys → split-child fanout → refuse to proceed."""
+        court_ids = ["00000000-0000-0000-0000-000000000001"]
+        # Santa Clara pre-reset baseline: 5239 docs from 260 raw PDFs (~20x).
+        mock_conn, _ = _build_preflight_mock_conn(court_ids, db_doc_count=5239)
+
+        try:
+            rebuild_db.preflight_split_child_guard(
+                mock_conn,
+                state="ca",
+                county="Santa Clara",
+                s3_key_count=260,
+                force=False,
+            )
+        except rebuild_db.SplitChildDataLossError as exc:
+            # Error must name the numbers so operators see the hazard clearly.
+            msg = str(exc)
+            assert "5239" in msg
+            assert "260" in msg
+            # And must mention the override flag + the root-cause issue.
+            assert "--force-split-child-loss" in msg
+            assert "#2494" in msg
+        else:
+            raise AssertionError("expected SplitChildDataLossError")
+
+    def test_force_flag_overrides_guard(self) -> None:
+        """``force=True`` lets operators proceed at their own risk."""
+        court_ids = ["00000000-0000-0000-0000-000000000001"]
+        mock_conn, _ = _build_preflight_mock_conn(court_ids, db_doc_count=5239)
+
+        # Should not raise even with heavy fanout.
+        rebuild_db.preflight_split_child_guard(
+            mock_conn,
+            state="ca",
+            county="Santa Clara",
+            s3_key_count=260,
+            force=True,
+        )
+
+    def test_force_logs_warning(self) -> None:
+        """``force=True`` must still log a loud warning so the override shows
+        up in logs alongside the eventual data loss.
+        """
+        court_ids = ["00000000-0000-0000-0000-000000000001"]
+        mock_conn, _ = _build_preflight_mock_conn(court_ids, db_doc_count=5239)
+
+        mock_logger = MagicMock()
+        with patch.object(rebuild_db, "logger", mock_logger):
+            rebuild_db.preflight_split_child_guard(
+                mock_conn,
+                state="ca",
+                county="Santa Clara",
+                s3_key_count=260,
+                force=True,
+            )
+
+        # At least one warning log mentioning --force-split-child-loss.
+        warn_calls = mock_logger.warning.call_args_list
+        assert any(
+            "--force-split-child-loss" in str(call) or "force_split_child_loss" in str(call)
+            for call in warn_calls
+        ), f"expected force-override warning in {warn_calls!r}"
+
+    def test_raises_when_county_not_found(self) -> None:
+        """Mirrors reset_derived_tables_for_county: unknown county → ValueError."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_cur.fetchall.return_value = []  # No courts match
+
+        try:
+            rebuild_db.preflight_split_child_guard(
+                mock_conn,
+                state="ca",
+                county="Atlantis",
+                s3_key_count=10,
+                force=False,
+            )
+        except ValueError as exc:
+            assert "Atlantis" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+    def test_passes_when_zero_s3_keys_and_zero_db(self) -> None:
+        """Empty county (no S3 keys, no DB rows) must not trip the guard.
+
+        Edge case: initial population of a county where neither S3 nor the DB
+        has anything yet.
+        """
+        court_ids = ["00000000-0000-0000-0000-000000000001"]
+        mock_conn, _ = _build_preflight_mock_conn(court_ids, db_doc_count=0)
+
+        # Should not raise — ratio is undefined but there's no data loss risk.
+        rebuild_db.preflight_split_child_guard(
+            mock_conn,
+            state="ca",
+            county="Santa Clara",
+            s3_key_count=0,
+            force=False,
+        )
+
+    def test_raises_when_db_has_rows_but_s3_is_empty(self) -> None:
+        """DB rows exist but S3 has none → rebuild would nuke everything.
+
+        This is the worst case — the reset would delete every row and the
+        rebuild would recreate nothing.
+        """
+        court_ids = ["00000000-0000-0000-0000-000000000001"]
+        mock_conn, _ = _build_preflight_mock_conn(court_ids, db_doc_count=500)
+
+        try:
+            rebuild_db.preflight_split_child_guard(
+                mock_conn,
+                state="ca",
+                county="Santa Clara",
+                s3_key_count=0,
+                force=False,
+            )
+        except rebuild_db.SplitChildDataLossError as exc:
+            msg = str(exc)
+            assert "500" in msg
+            assert "--force-split-child-loss" in msg
+        else:
+            raise AssertionError("expected SplitChildDataLossError")
+
+    def test_logs_comparison_even_on_pass(self) -> None:
+        """The preflight always logs the comparison so operators have a
+        paper trail of what was about to be deleted, even on the happy path.
+        """
+        court_ids = ["00000000-0000-0000-0000-000000000001"]
+        mock_conn, _ = _build_preflight_mock_conn(court_ids, db_doc_count=260)
+
+        mock_logger = MagicMock()
+        with patch.object(rebuild_db, "logger", mock_logger):
+            rebuild_db.preflight_split_child_guard(
+                mock_conn,
+                state="ca",
+                county="Santa Clara",
+                s3_key_count=260,
+                force=False,
+            )
+
+        info_calls = mock_logger.info.call_args_list
+        # At least one info log summarising the counts.
+        assert any(
+            "s3_key_count" in str(call) and "db_doc_count" in str(call) for call in info_calls
+        ), f"expected count summary in info logs: {info_calls!r}"
+
+
+class TestMainPerCountyResetPreflight:
+    """Main() integration: preflight runs before reset on --reset --county."""
+
+    def _common_patches(
+        self,
+        tmp_path: Any,
+        argv: list[str],
+        db_doc_count: int = 0,
+    ) -> dict[str, Any]:
+        """Set up common patches used by preflight integration tests."""
+        cache_dir = str(tmp_path / "cache")
+        (tmp_path / "cache").mkdir()
+        key_dir = tmp_path / "cache" / "ca" / "santa_clara" / "superior_court" / "raw"
+        key_dir.mkdir(parents=True)
+        (key_dir / "abc123.html").write_bytes(b"<html>x</html>")
+
+        mock_pool = MagicMock()
+        mock_pool.__enter__ = MagicMock(return_value=mock_pool)
+        mock_pool.__exit__ = MagicMock(return_value=False)
+        mock_future = MagicMock()
+        mock_future.result.return_value = {
+            "status": "ok",
+            "content_format": "html",
+            "had_hearing_date": False,
+        }
+        mock_pool.submit.return_value = mock_future
+
+        return {
+            "cache_dir": cache_dir,
+            "argv": argv,
+            "mock_pool": mock_pool,
+            "mock_future": mock_future,
+            "db_doc_count": db_doc_count,
+        }
+
+    def test_preflight_blocks_reset_on_fanout(self, tmp_path: Any) -> None:
+        """Main exits non-zero when the preflight detects fanout without --force."""
+        ctx = self._common_patches(
+            tmp_path,
+            ["rebuild_db.py", "--reset", "--county", "Santa Clara"],
+        )
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=["ca/santa_clara/superior_court/raw/abc123.html"],
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db.reset_derived_tables") as mock_global_reset,
+            patch("rebuild_db.reset_derived_tables_for_county") as mock_per_county_reset,
+            patch("rebuild_db.preflight_split_child_guard") as mock_preflight,
+            patch("rebuild_db._fetch_rosters"),
+            patch("rebuild_db._write_rebuild_marker"),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                return_value=ctx["mock_pool"],
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([ctx["mock_future"]]),
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://test",
+                    "S3_CACHE_DIR": ctx["cache_dir"],
+                },
+                clear=False,
+            ),
+            patch("sys.argv", ctx["argv"]),
+        ):
+            mock_preflight.side_effect = rebuild_db.SplitChildDataLossError("fanout detected")
+            try:
+                rebuild_db.main()
+            except SystemExit as exc:
+                # sys.exit(non-zero) on guard failure.
+                assert exc.code != 0
+            else:
+                raise AssertionError("expected SystemExit on guard failure")
+
+        # Preflight ran; reset did NOT run.
+        mock_preflight.assert_called_once()
+        mock_per_county_reset.assert_not_called()
+        mock_global_reset.assert_not_called()
+
+    def test_preflight_runs_before_reset_on_per_county(self, tmp_path: Any) -> None:
+        """On the happy path, preflight runs and then reset proceeds."""
+        ctx = self._common_patches(
+            tmp_path,
+            ["rebuild_db.py", "--reset", "--county", "Santa Clara"],
+        )
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=["ca/santa_clara/superior_court/raw/abc123.html"],
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db.reset_derived_tables_for_county") as mock_per_county_reset,
+            patch("rebuild_db.preflight_split_child_guard") as mock_preflight,
+            patch("rebuild_db._fetch_rosters"),
+            patch("rebuild_db._write_rebuild_marker"),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                return_value=ctx["mock_pool"],
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([ctx["mock_future"]]),
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://test",
+                    "S3_CACHE_DIR": ctx["cache_dir"],
+                },
+                clear=False,
+            ),
+            patch("sys.argv", ctx["argv"]),
+        ):
+            rebuild_db.main()
+
+        # Preflight called exactly once with force=False.
+        mock_preflight.assert_called_once()
+        pf_kwargs = mock_preflight.call_args.kwargs
+        pf_args = mock_preflight.call_args.args
+        # Accept either calling style; force kwarg must be False.
+        force = pf_kwargs.get("force")
+        if force is None and len(pf_args) >= 5:
+            force = pf_args[4]
+        assert force is False
+        # Per-county reset runs after the preflight.
+        mock_per_county_reset.assert_called_once()
+
+    def test_preflight_skipped_on_global_reset(self, tmp_path: Any) -> None:
+        """``--reset`` without ``--county`` must not call the preflight.
+
+        The global truncate is a conscious nuclear option; the split-child
+        hazard is a per-county concern.
+        """
+        ctx = self._common_patches(tmp_path, ["rebuild_db.py", "--reset"])
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=["ca/santa_clara/superior_court/raw/abc123.html"],
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db.reset_derived_tables"),
+            patch("rebuild_db.preflight_split_child_guard") as mock_preflight,
+            patch("rebuild_db._fetch_rosters"),
+            patch("rebuild_db._write_rebuild_marker"),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                return_value=ctx["mock_pool"],
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([ctx["mock_future"]]),
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://test",
+                    "S3_CACHE_DIR": ctx["cache_dir"],
+                },
+                clear=False,
+            ),
+            patch("sys.argv", ctx["argv"]),
+        ):
+            rebuild_db.main()
+
+        mock_preflight.assert_not_called()
+
+    def test_force_flag_passes_through_to_preflight(self, tmp_path: Any) -> None:
+        """``--force-split-child-loss`` must propagate to the preflight call."""
+        ctx = self._common_patches(
+            tmp_path,
+            [
+                "rebuild_db.py",
+                "--reset",
+                "--county",
+                "Santa Clara",
+                "--force-split-child-loss",
+            ],
+        )
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=["ca/santa_clara/superior_court/raw/abc123.html"],
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db.reset_derived_tables_for_county"),
+            patch("rebuild_db.preflight_split_child_guard") as mock_preflight,
+            patch("rebuild_db._fetch_rosters"),
+            patch("rebuild_db._write_rebuild_marker"),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                return_value=ctx["mock_pool"],
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([ctx["mock_future"]]),
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://test",
+                    "S3_CACHE_DIR": ctx["cache_dir"],
+                },
+                clear=False,
+            ),
+            patch("sys.argv", ctx["argv"]),
+        ):
+            rebuild_db.main()
+
+        mock_preflight.assert_called_once()
+        pf_kwargs = mock_preflight.call_args.kwargs
+        pf_args = mock_preflight.call_args.args
+        force = pf_kwargs.get("force")
+        if force is None and len(pf_args) >= 5:
+            force = pf_args[4]
+        assert force is True

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -22,6 +22,11 @@
 #                     with --county, the reset is scoped to just that county's
 #                     rows (per-county reset); otherwise it truncates the
 #                     derived schema globally.
+#   --force-split-child-loss
+#                     Override the split-child preflight guard (see #2494,
+#                     #2496) and proceed with --reset --county even when the
+#                     rebuild cannot restore all deleted rows.  Expect data
+#                     loss on multi-case-PDF counties.
 """
 
 from __future__ import annotations
@@ -457,6 +462,20 @@ def reset_derived_tables_for_county(
     * Does **not** touch OpenSearch — the global index self-heals as new
       rulings are indexed.
 
+    .. note::
+        **Split-child hazard.** Counties whose scrapers split multi-case PDFs
+        into multiple ``derived.documents`` rows per raw S3 object (currently
+        Santa Clara, and any other county whose raws are multi-case PDFs —
+        Orange, Riverside, Fresno) fan out N:1 at ingest time.  On rebuild,
+        each raw PDF re-derives **only one** row, not N, because of the
+        ``content_hash`` / ``key_hash`` mismatch in the rebuild pipeline
+        (see #2494).  Running ``--reset --county`` on such a county will
+        therefore delete all the split-children and the rebuild cannot
+        restore them — the county ends up with only the raw-aligned subset.
+        Callers must clear ``preflight_split_child_guard`` (or pass
+        ``--force-split-child-loss`` on the CLI) before invoking this
+        function on a multi-case-PDF county.
+
     Raises:
         ValueError: if no courts match ``(state, county)``.  Silently
             matching zero rows would let a typo nuke nothing and rebuild
@@ -567,6 +586,149 @@ def reset_derived_tables_for_county(
         deleted=deleted,
     )
     return deleted
+
+
+# Fanout ratio at or above which the split-child guard fires.  Chosen to
+# leave headroom for normal drift (staging rows, accidental dupes, edits
+# that add a handful of rows per raw) while still catching the N:1 pattern
+# (Santa Clara pre-reset was ~20x).
+_SPLIT_CHILD_FANOUT_RATIO = 1.5
+
+
+class SplitChildDataLossError(RuntimeError):
+    """Raised when ``--reset --county`` would delete more rows than rebuild
+    can restore from S3 — the split-child data-loss hazard from #2494.
+
+    See ``preflight_split_child_guard`` for details and the override
+    mechanism (``--force-split-child-loss``).
+    """
+
+
+def preflight_split_child_guard(
+    conn: psycopg.Connection,
+    state: str,
+    county: str,
+    s3_key_count: int,
+    force: bool,
+) -> None:
+    """Refuse per-county reset when rebuild cannot restore what reset deletes.
+
+    Background (#2494, #2496): when the ingestion pipeline splits a single
+    multi-case raw PDF into N ``derived.documents`` rows (one per extracted
+    case), the rows share the raw's S3 key but carry different content
+    hashes.  The rebuild path hashes the raw bytes and tries to match against
+    the S3 key filename — that only reproduces **one** row per raw PDF, not
+    N.  So a ``--reset --county`` on a multi-case-PDF county (e.g. Santa
+    Clara, Orange, Riverside, Fresno) will delete all N split-children and
+    rebuild will only recreate the 1 raw-aligned row.  Result: silent data
+    loss equal to ``(N-1) * raw_count`` per county on every run.
+
+    The guard compares the DB's ``derived.documents`` count for the county
+    against the raw-object count in S3.  If the DB has meaningfully more
+    rows than S3 (ratio >= ``_SPLIT_CHILD_FANOUT_RATIO``), the fanout
+    pattern is present and the reset is refused unless ``force`` is True.
+
+    Edge cases:
+    * Both counts zero → no data to lose, allow.
+    * DB count lower than S3 count → no fanout, allow (this is the initial-
+      population path before the worker has caught up).
+    * S3 count zero but DB has rows → worst case, reset would nuke everything
+      with no rebuild capacity to restore; refuse unless forced.
+
+    Args:
+        conn: Open DB connection (used to resolve court ids and count rows).
+        state: Two-letter state code (case-insensitive).
+        county: County name (case-insensitive, unnormalised).
+        s3_key_count: Number of content-addressed raw objects under
+            ``{state}/{county}/`` in S3 (or the local cache) — caller is
+            responsible for counting these.
+        force: Caller opted into the data loss (``--force-split-child-loss``).
+
+    Raises:
+        ValueError: no courts match ``(state, county)`` (typo guard — mirrors
+            ``reset_derived_tables_for_county``).
+        SplitChildDataLossError: fanout detected and ``force`` is False.
+    """
+    court_ids = _resolve_county_court_ids(conn, state, county)
+    if not court_ids:
+        raise ValueError(
+            f"No courts found in derived.courts for state={state!r}, county={county!r}. "
+            "Refusing to run split-child preflight against a nonexistent county."
+        )
+
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM derived.documents WHERE court_id = ANY(%s::uuid[])",
+            (court_ids,),
+        )
+        db_doc_count = int(cur.fetchone()[0])
+
+    # Ratio is undefined if s3_key_count == 0 but db_doc_count > 0.  That's
+    # the worst case (reset would nuke everything, rebuild restores nothing)
+    # so treat it as an unconditional fanout violation.
+    if s3_key_count == 0 and db_doc_count == 0:
+        ratio: float = 0.0
+    elif s3_key_count == 0:
+        ratio = float("inf")
+    else:
+        ratio = db_doc_count / s3_key_count
+
+    logger.info(
+        "Split-child preflight",
+        state=state,
+        county=county,
+        s3_key_count=s3_key_count,
+        db_doc_count=db_doc_count,
+        fanout_ratio=round(ratio, 2) if ratio != float("inf") else "inf",
+        threshold=_SPLIT_CHILD_FANOUT_RATIO,
+        force_split_child_loss=force,
+    )
+
+    fanout_detected = ratio >= _SPLIT_CHILD_FANOUT_RATIO
+
+    if not fanout_detected:
+        logger.info(
+            "Split-child preflight passed — DB row count within fanout tolerance",
+            state=state,
+            county=county,
+            db_doc_count=db_doc_count,
+            s3_key_count=s3_key_count,
+        )
+        return
+
+    # Fanout detected.  Either refuse, or warn and proceed under --force.
+    msg = (
+        f"Split-child data-loss hazard detected for {state}/{county}: "
+        f"derived.documents has {db_doc_count} rows but S3 has only "
+        f"{s3_key_count} raw objects (fanout ratio "
+        f"{'inf' if ratio == float('inf') else f'{ratio:.2f}x'} "
+        f">= {_SPLIT_CHILD_FANOUT_RATIO}x threshold). "
+        "Running --reset --county will delete the split-children and the "
+        "rebuild cannot restore them (see #2494). Pass "
+        "--force-split-child-loss to proceed anyway."
+    )
+
+    if not force:
+        logger.error(
+            "Split-child preflight FAILED — refusing to reset",
+            state=state,
+            county=county,
+            db_doc_count=db_doc_count,
+            s3_key_count=s3_key_count,
+            fanout_ratio=round(ratio, 2) if ratio != float("inf") else "inf",
+        )
+        raise SplitChildDataLossError(msg)
+
+    logger.warning(
+        "Split-child preflight overridden by --force-split-child-loss — "
+        "proceeding with reset. Expected data loss: approximately "
+        "%d rows that rebuild cannot restore.",
+        max(0, db_doc_count - s3_key_count),
+        state=state,
+        county=county,
+        db_doc_count=db_doc_count,
+        s3_key_count=s3_key_count,
+    )
 
 
 def reset_opensearch_index(os_url: str) -> None:
@@ -706,6 +868,15 @@ def main() -> None:
         default="ca",
         help="State code for --county filtering (default: ca)",
     )
+    parser.add_argument(
+        "--force-split-child-loss",
+        action="store_true",
+        help=(
+            "Override the split-child preflight guard on --reset --county. "
+            "Proceed with reset even when the rebuild cannot restore all "
+            "deleted rows (see #2494, #2496).  Expect data loss."
+        ),
+    )
     args = parser.parse_args()
 
     database_url = os.environ.get("DATABASE_URL", "")
@@ -725,6 +896,37 @@ def main() -> None:
     if args.reset:
         if args.county:
             # Per-county reset: only delete rows belonging to this county.
+            # Before deleting, run the split-child preflight so we don't
+            # destroy rows that rebuild cannot restore (see #2494, #2496).
+            # We need an S3 key count for the preflight — this is the same
+            # list that step 1 builds later, but we need it up front here.
+            preflight_prefix = f"{sluggify(args.state)}/{sluggify(args.county)}/"
+            if cache_dir:
+                preflight_s3_key_count = len(
+                    list_local_keys(Path(cache_dir), prefix=preflight_prefix)
+                )
+            else:
+                preflight_s3_key_count = len(
+                    list_s3_keys(s3, BUCKET, prefix=preflight_prefix)
+                )
+
+            try:
+                preflight_split_child_guard(
+                    conn,
+                    state=args.state,
+                    county=args.county,
+                    s3_key_count=preflight_s3_key_count,
+                    force=args.force_split_child_loss,
+                )
+            except SplitChildDataLossError as exc:
+                logger.error(
+                    "Aborting per-county reset — pass --force-split-child-loss "
+                    "to override: %s",
+                    exc,
+                )
+                conn.close()
+                sys.exit(2)
+
             # Skip the OpenSearch index reset — the global index self-heals
             # as new rulings are indexed during the rebuild.  See #2465.
             reset_derived_tables_for_county(conn, args.state, args.county)


### PR DESCRIPTION
## Summary

Adds a preflight guard to `rebuild_db.py --reset --county <name>` that compares the S3 raw-object count against the `derived.documents` row count for the target county and refuses to reset when the fanout ratio indicates split-child data loss (≥1.5x). Overridable via a new `--force-split-child-loss` flag.

Without this guard, `--reset --county` on a multi-case-PDF county (Santa Clara, Orange, Riverside, Fresno) silently destroys split-children that the rebuild cannot restore — the SC pre-reset baseline (5239 rows from 260 raw PDFs, ~20x fanout) would collapse to just 260 raw-aligned rows on rebuild (see #2494). CLAUDE.md §"Reingest vs Rebuild" gets a matching caveat and recommends `reingest_from_s3.py --county` for multi-case-PDF counties until #2494 lands.

Closes #2496

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (58 passing, 15 new in `TestSplitChildDataLossError`, `TestPreflightSplitChildGuard`, `TestMainPerCountyResetPreflight`)
- [x] Markdown link check passes (`scripts/check-markdown-links.sh`)
- [x] Diff coverage ≥ 90% (pre-push hook enforced: 100% on the 3 diff-covered lines)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (tooling script + docs only). `rebuild_db.py` is an operator-invoked one-off; the guard takes effect the next time anyone runs `rebuild_db.py --reset --county`.
- [x] Verification evidence posted on issue (see step A.8)
