### PR TITLE
fix(ingestion): supersede losing doc on content-hash collision (#2458)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -1458,9 +1458,21 @@ def insert_ruling(
        exists (from a prior scrape that produced different raw bytes but
        semantically identical text), the unique index
        ``uq_rulings_case_text_hash`` raises a UniqueViolation.  We catch it
-       inside a savepoint and fall back to an UPDATE of the existing row.
-       The hash is a SHA-256 of the lowercased, whitespace-collapsed ruling
-       text (see ``normalize_ruling_text_hash``).
+       inside a savepoint and **supersede the losing document** (#2458): the
+       ruling row already present for the winner keeps its text/fields, and
+       the losing document is marked ``status = 'superseded'`` so it is
+       excluded from future queries.  Any stale ruling row keyed on the
+       losing document_id is deleted first.  The hash is a SHA-256 of the
+       lowercased, whitespace-collapsed ruling text (see
+       ``normalize_ruling_text_hash``).
+
+       Historical note (pre-#2458): the fallback path used to run
+       ``UPDATE rulings ... WHERE case_id = ? AND ruling_text_hash = ?``,
+       which matched the *winner*'s row (already present) rather than the
+       loser's (never inserted).  That path silently mutated the winner
+       with the loser's fields and left the loser's document with stale
+       ``ruling_text`` from before reingest.  Superseding the loser is
+       both simpler and avoids writing the loser's fields onto the winner.
 
     Requires a UNIQUE constraint on ``rulings.document_id`` (migration 3) and
     a partial UNIQUE index on ``(case_id, ruling_text_hash)`` where
@@ -1663,95 +1675,47 @@ def insert_ruling(
             raise
 
         # Content-hash collision — a ruling with the same normalized text
-        # already exists for this case under a different document_id.
-        # Update the existing row instead.
+        # already exists for this case under a different document_id.  The
+        # current document is a duplicate at the content level; supersede it
+        # (#2458).
 
-    # Fallback: update the existing ruling that has the same content hash.
-    if text_hash is not None:
-        # Mirror the force_update semantics on the fallback UPDATE so reingest
-        # can correct bad judge_id / hearing_date / outcome / motion_type /
-        # department on rulings that matched by content hash rather than by
-        # document_id.  Text/summary fields always keep incoming-wins COALESCE.
-        #
-        # Identity-anchor semantics (#2475):
-        # - ``case_id`` is fixed by the WHERE clause (``WHERE case_id = %s::uuid
-        #   AND ruling_text_hash = %s``), so it cannot be silently re-routed
-        #   here — the match already requires it to stay the same.
-        # - ``judge_id`` is an assignment.  Default (live) mode uses
-        #   preserve-first ``COALESCE(judge_id, %s::uuid)``: an established
-        #   judge is never silently replaced by an incoming non-NULL value,
-        #   while a currently-NULL judge can still be filled in.  Under
-        #   ``force_update`` we overwrite unconditionally so reingest can
-        #   correct a bad judge link.
-        #
-        # Correctable facts (hearing_date, outcome, motion_type, department)
-        # keep incoming-wins COALESCE in the default path (a later extraction
-        # can legitimately improve them) and unconditional overwrite under
-        # force_update.
-        if force_update:
-            judge_id_clause = "judge_id = %s::uuid"
-            hearing_date_clause = "hearing_date = %s::date"
-            outcome_clause = "outcome = %s::ruling_outcome"
-            motion_type_clause = "motion_type = %s"
-            department_clause = "department = %s"
-        else:
-            # Identity anchor: preserve first.
-            judge_id_clause = "judge_id = COALESCE(judge_id, %s::uuid)"
-            # Correctable facts: incoming wins when non-NULL.
-            hearing_date_clause = "hearing_date = COALESCE(%s::date, hearing_date)"
-            outcome_clause = "outcome = COALESCE(%s::ruling_outcome, outcome)"
-            motion_type_clause = "motion_type = COALESCE(%s, motion_type)"
-            department_clause = "department = COALESCE(%s, department)"
-
-        update_sql = f"""
-            UPDATE rulings SET
-                {judge_id_clause},
-                {hearing_date_clause},
-                {outcome_clause},
-                {motion_type_clause},
-                ruling_text = COALESCE(%s, ruling_text),
-                ruling_text_html = COALESCE(%s, ruling_text_html),
-                {department_clause},
-                summary = COALESCE(%s, summary),
-                summary_model = COALESCE(%s, summary_model),
-                summary_generated_at = COALESCE(%s, summary_generated_at),
-                updated_at = NOW()
-            WHERE case_id = %s::uuid AND ruling_text_hash = %s
-        """
-
-        with conn.cursor() as cur:
-            cur.execute(
-                update_sql,
-                (
-                    judge_id,
-                    hearing_date,
-                    outcome,
-                    motion_type,
-                    ruling_text,
-                    ruling_text_html,
-                    department,
-                    summary,
-                    summary_model,
-                    summary_generated_at,
-                    case_id,
-                    text_hash,
-                ),
-            )
-            if cur.rowcount == 0:
-                logger.warning(
-                    "insert_ruling: fallback UPDATE matched 0 rows — "
-                    "conflicting row may have been deleted concurrently "
-                    "(document_id=%s, case_id=%s, text_hash=%s)",
-                    document_id,
-                    case_id,
-                    text_hash,
-                )
-        logger.info(
-            "insert_ruling: content-hash dedup — updated existing ruling "
-            "instead of inserting duplicate (document_id=%s, case_id=%s)",
-            document_id,
-            case_id,
+    # Fallback: supersede the losing document.
+    #
+    # A content-hash collision means another document (the winner) already
+    # owns a ruling row keyed on (case_id, ruling_text_hash).  Rather than
+    # mutating the winner's row with this document's fields — the old
+    # behavior that caused the bug in #2458 where the *loser's* row was
+    # left with stale ruling_text — we mark this document as superseded
+    # so it drops out of ``active`` queries.  The winner's ruling row is
+    # left untouched: it already has the correct text (same text by
+    # definition, since the hashes match) and was populated by whichever
+    # document was processed first.
+    #
+    # Any stale ruling row still keyed on ``document_id`` (e.g. from an
+    # earlier run that inserted before the other document existed) is
+    # deleted first so the superseded document leaves no orphaned ruling
+    # behind.
+    #
+    # Matches the existing ``_supersede_document`` pattern in
+    # ``scripts/reingest_from_s3.py`` used for split-child dedup.
+    with conn.cursor() as cur:
+        cur.execute(
+            "DELETE FROM rulings WHERE document_id = %s::uuid",
+            (document_id,),
         )
+        deleted = cur.rowcount
+        cur.execute(
+            "UPDATE documents SET status = 'superseded' WHERE id = %s::uuid",
+            (document_id,),
+        )
+    logger.info(
+        "insert_ruling: content-hash dedup — superseded losing document "
+        "%s (case_id=%s, ruling_text_hash=%s, deleted %d stale ruling row(s))",
+        document_id,
+        case_id,
+        text_hash,
+        deleted,
+    )
 
 
 def insert_document_and_ruling(

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -5504,7 +5504,7 @@ def _make_content_hash_fallback_conn() -> tuple[MagicMock, MagicMock]:
     """Return a (conn, cursor) mock that raises UniqueViolation on the INSERT.
 
     The raised UniqueViolation mimics the ``uq_rulings_case_text_hash``
-    constraint violation that triggers the fallback UPDATE path.
+    constraint violation that triggers the supersede-the-loser path (#2458).
     """
     conn = MagicMock(spec=psycopg.Connection)
     cur = MagicMock()
@@ -5516,7 +5516,7 @@ def _make_content_hash_fallback_conn() -> tuple[MagicMock, MagicMock]:
 
     def execute_side_effect(sql: str, *args: object, **kwargs: object) -> None:
         call_index[0] += 1
-        # SAVEPOINT -> INSERT -> ROLLBACK -> UPDATE
+        # SAVEPOINT -> INSERT -> ROLLBACK -> DELETE FROM rulings -> UPDATE documents
         if call_index[0] == 2 and "INSERT INTO rulings" in sql:
             exc = psycopg.errors.UniqueViolation("duplicate key")
             raise exc
@@ -5527,27 +5527,33 @@ def _make_content_hash_fallback_conn() -> tuple[MagicMock, MagicMock]:
     return conn, cur
 
 
-def _fallback_update_sql(cur: MagicMock) -> str:
+def _supersede_stmts(cur: MagicMock) -> list[tuple[str, tuple[object, ...]]]:
+    """Return (sql, params) tuples for the supersede-path calls.
+
+    The supersede path runs exactly two statements after ROLLBACK TO
+    SAVEPOINT: a ``DELETE FROM rulings WHERE document_id = %s::uuid`` and
+    an ``UPDATE documents SET status = 'superseded' WHERE id = %s::uuid``.
+    """
+    stmts: list[tuple[str, tuple[object, ...]]] = []
     for call in cur.execute.call_args_list:
         sql = call.args[0] if call.args else ""
-        if "UPDATE rulings SET" in sql:
-            return sql
-    raise AssertionError("No UPDATE rulings SET call was made on this cursor")
+        params = call.args[1] if len(call.args) > 1 else ()
+        if "DELETE FROM rulings WHERE document_id" in sql:
+            stmts.append((sql, params))
+        elif "UPDATE documents SET status = 'superseded'" in sql:
+            stmts.append((sql, params))
+    return stmts
 
 
-def test_insert_ruling_content_hash_fallback_default_uses_coalesce() -> None:
-    """Default fallback UPDATE path uses COALESCE for structured fields.
-
-    Per #2475, ``judge_id`` is an identity anchor: preserve-first in the default
-    path so a re-matching LLM extraction cannot silently overwrite an existing
-    non-NULL judge. Other fields (hearing_date, outcome, motion_type,
-    department) are correctable facts — incoming-wins when non-NULL.
-    """
+def test_insert_ruling_content_hash_collision_supersedes_loser_default() -> None:
+    """On ``uq_rulings_case_text_hash`` violation, the losing document is
+    superseded — no content-hash UPDATE runs on the winner (#2458)."""
     conn, cur = _make_content_hash_fallback_conn()
 
+    losing_doc_id = "11111111-1111-1111-1111-111111111111"
     insert_ruling(
         conn,
-        document_id="11111111-1111-1111-1111-111111111111",
+        document_id=losing_doc_id,
         case_id="22222222-2222-2222-2222-222222222222",
         court_id="33333333-3333-3333-3333-333333333333",
         hearing_date=date(2026, 4, 1),
@@ -5558,23 +5564,30 @@ def test_insert_ruling_content_hash_fallback_default_uses_coalesce() -> None:
         motion_type="Motion to Compel",
     )
 
-    update_sql = _fallback_update_sql(cur)
-    # Identity anchor: preserve-first COALESCE.
-    assert "judge_id = COALESCE(judge_id, %s::uuid)" in update_sql
-    # Correctable facts: incoming-wins COALESCE.
-    assert "hearing_date = COALESCE(%s::date, hearing_date)" in update_sql
-    assert "outcome = COALESCE(%s::ruling_outcome, outcome)" in update_sql
-    assert "motion_type = COALESCE(%s, motion_type)" in update_sql
-    assert "department = COALESCE(%s, department)" in update_sql
+    supersede_stmts = _supersede_stmts(cur)
+    # Exactly one DELETE + one UPDATE, both scoped to the losing document_id.
+    assert len(supersede_stmts) == 2
+    delete_sql, delete_params = supersede_stmts[0]
+    update_sql, update_params = supersede_stmts[1]
+    assert "DELETE FROM rulings WHERE document_id" in delete_sql
+    assert delete_params == (losing_doc_id,)
+    assert "UPDATE documents SET status = 'superseded'" in update_sql
+    assert update_params == (losing_doc_id,)
+    # The old buggy fallback UPDATE that targeted (case_id, ruling_text_hash)
+    # must not run — it silently mutated the winner's row (#2458).
+    all_sql = [call.args[0] if call.args else "" for call in cur.execute.call_args_list]
+    assert not any("UPDATE rulings SET" in s and "ruling_text_hash" in s for s in all_sql)
 
 
-def test_insert_ruling_content_hash_fallback_force_update_overrides() -> None:
-    """force_update=True fallback UPDATE uses direct %s assignment (no COALESCE)."""
+def test_insert_ruling_content_hash_collision_supersedes_loser_force_update() -> None:
+    """``force_update=True`` (reingest path) also supersedes the loser —
+    the supersede decision does not depend on ``force_update`` (#2458)."""
     conn, cur = _make_content_hash_fallback_conn()
 
+    losing_doc_id = "11111111-1111-1111-1111-111111111111"
     insert_ruling(
         conn,
-        document_id="11111111-1111-1111-1111-111111111111",
+        document_id=losing_doc_id,
         case_id="22222222-2222-2222-2222-222222222222",
         court_id="33333333-3333-3333-3333-333333333333",
         hearing_date=None,
@@ -5586,20 +5599,13 @@ def test_insert_ruling_content_hash_fallback_force_update_overrides() -> None:
         force_update=True,
     )
 
-    update_sql = _fallback_update_sql(cur)
-    # Structured fields: direct %s assignment (no COALESCE wrapper).
-    assert "judge_id = %s::uuid" in update_sql
-    assert "COALESCE(%s::uuid, judge_id)" not in update_sql
-    assert "hearing_date = %s::date" in update_sql
-    assert "COALESCE(%s::date, hearing_date)" not in update_sql
-    assert "outcome = %s::ruling_outcome" in update_sql
-    assert "COALESCE(%s::ruling_outcome, outcome)" not in update_sql
-    # motion_type/department are bare %s (the raw %s without cast) —
-    # use surrounding context to avoid matching the COALESCE variant.
-    assert "motion_type = %s,\n" in update_sql
-    assert "department = %s,\n" in update_sql
-    assert "COALESCE(%s, motion_type)" not in update_sql
-    assert "COALESCE(%s, department)" not in update_sql
-    # Text/summary fields always keep COALESCE.
-    assert "ruling_text = COALESCE(%s, ruling_text)" in update_sql
-    assert "summary = COALESCE(%s, summary)" in update_sql
+    supersede_stmts = _supersede_stmts(cur)
+    assert len(supersede_stmts) == 2
+    _, delete_params = supersede_stmts[0]
+    _, update_params = supersede_stmts[1]
+    assert delete_params == (losing_doc_id,)
+    assert update_params == (losing_doc_id,)
+    # No UPDATE rulings SET of any form should run — the supersede path
+    # must not touch the winner's ruling row.
+    all_sql = [call.args[0] if call.args else "" for call in cur.execute.call_args_list]
+    assert not any("UPDATE rulings SET" in s for s in all_sql)

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -1603,8 +1603,10 @@ class TestInsertRulingContentDedup:
         # text_hash (last arg) should be None
         assert args[-1] is None
 
-    def test_unique_violation_triggers_update_fallback(self) -> None:
-        """When UniqueViolation fires (content-hash conflict), fall back to UPDATE.
+    def test_unique_violation_triggers_supersede(self) -> None:
+        """When UniqueViolation fires on ``uq_rulings_case_text_hash``,
+        supersede the losing document instead of falling back to a
+        content-hash UPDATE (#2458).
 
         In tests without a real PG connection, diag.constraint_name is None.
         The code treats None as the expected constraint (see db.py comment).
@@ -1631,16 +1633,24 @@ class TestInsertRulingContentDedup:
             department="Dept. 1",
         )
 
-        # Verify: SAVEPOINT, INSERT (which raises), ROLLBACK TO SAVEPOINT, UPDATE
         execute_calls = cur.execute.call_args_list
         sql_stmts = [call[0][0] for call in execute_calls]
+        # Savepoint-rollback path still runs.
         assert any("SAVEPOINT" in s for s in sql_stmts)
         assert any("INSERT INTO rulings" in s for s in sql_stmts)
         assert any("ROLLBACK TO SAVEPOINT" in s for s in sql_stmts)
-        assert any("UPDATE rulings SET" in s for s in sql_stmts)
+        # New behavior: supersede the losing document.  No content-hash UPDATE.
+        assert any("DELETE FROM rulings WHERE document_id" in s for s in sql_stmts)
+        assert any("UPDATE documents SET status = 'superseded'" in s for s in sql_stmts)
+        # The old buggy fallback UPDATE targeting (case_id, ruling_text_hash)
+        # must NOT run — that was the #2458 bug.
+        assert not any("UPDATE rulings SET" in s and "ruling_text_hash" in s for s in sql_stmts), (
+            "Old fallback UPDATE-by-content-hash must not run — it silently "
+            "mutated the winner's row with the loser's fields (#2458)."
+        )
 
-    def test_unique_violation_update_uses_coalesce(self) -> None:
-        """Fallback UPDATE uses COALESCE to preserve existing non-NULL fields."""
+    def test_unique_violation_supersede_uses_losing_document_id(self) -> None:
+        """The DELETE and UPDATE target the current (losing) document_id."""
         import psycopg.errors
 
         conn = _mock_conn()
@@ -1655,7 +1665,52 @@ class TestInsertRulingContentDedup:
 
         insert_ruling(
             conn,
-            document_id="new-doc-1",
+            document_id="losing-doc",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+        )
+
+        execute_calls = cur.execute.call_args_list
+        delete_calls = [c for c in execute_calls if "DELETE FROM rulings" in c[0][0]]
+        assert len(delete_calls) == 1
+        assert delete_calls[0][0][1] == ("losing-doc",), (
+            "DELETE must target the losing document_id, not the winner's."
+        )
+
+        doc_update_calls = [
+            c for c in execute_calls if "UPDATE documents SET status = 'superseded'" in c[0][0]
+        ]
+        assert len(doc_update_calls) == 1
+        assert doc_update_calls[0][0][1] == ("losing-doc",), (
+            "UPDATE documents must target the losing document_id."
+        )
+
+    def test_unique_violation_supersede_in_force_update_mode(self) -> None:
+        """``force_update=True`` (reingest path) still supersedes the loser.
+
+        Supersede semantics do not depend on ``force_update`` — if the
+        (case_id, ruling_text_hash) constraint fires, the incoming document's
+        text is by definition identical to the winner's, so the loser must
+        drop out regardless of whether we are in live-ingestion or reingest.
+        """
+        import psycopg.errors
+
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        exc = psycopg.errors.UniqueViolation("duplicate key value violates unique constraint")
+
+        def side_effect_execute(sql: str, params: tuple | None = None) -> None:
+            if "INSERT INTO rulings" in sql:
+                raise exc
+
+        cur.execute = MagicMock(side_effect=side_effect_execute)
+
+        insert_ruling(
+            conn,
+            document_id="losing-doc",
             case_id="case-1",
             court_id="court-1",
             hearing_date=date(2026, 3, 5),
@@ -1663,13 +1718,14 @@ class TestInsertRulingContentDedup:
             department="Dept. 1",
             judge_id="judge-1",
             outcome="granted",
+            force_update=True,
         )
 
-        # Find the UPDATE call and verify COALESCE is used
-        update_calls = [c for c in cur.execute.call_args_list if "UPDATE rulings SET" in c[0][0]]
-        assert len(update_calls) == 1
-        sql = update_calls[0][0][0]
-        assert "COALESCE" in sql
+        sql_stmts = [call[0][0] for call in cur.execute.call_args_list]
+        assert any("DELETE FROM rulings WHERE document_id" in s for s in sql_stmts)
+        assert any("UPDATE documents SET status = 'superseded'" in s for s in sql_stmts)
+        # Under no mode should the old fallback UPDATE run.
+        assert not any("UPDATE rulings SET" in s and "ruling_text_hash" in s for s in sql_stmts)
 
     def test_unknown_constraint_violation_is_reraised(self) -> None:
         """UniqueViolation from an unrelated constraint should be re-raised.
@@ -1706,34 +1762,6 @@ class TestInsertRulingContentDedup:
                 ruling_text="Motion GRANTED",
                 department="Dept. 1",
             )
-
-    def test_fallback_update_logs_warning_on_zero_rowcount(self) -> None:
-        """When fallback UPDATE matches 0 rows, a warning should be logged."""
-        import psycopg.errors
-
-        conn = _mock_conn()
-        cur = conn.cursor.return_value.__enter__.return_value
-        exc = psycopg.errors.UniqueViolation("duplicate key value violates unique constraint")
-
-        # Track which SQL statement we're on to set rowcount on UPDATE
-        def side_effect_execute(sql: str, params: tuple | None = None) -> None:
-            if "INSERT INTO rulings" in sql:
-                raise exc
-            if "UPDATE rulings SET" in sql:
-                cur.rowcount = 0
-
-        cur.execute = MagicMock(side_effect=side_effect_execute)
-
-        # Should not raise — just log a warning
-        insert_ruling(
-            conn,
-            document_id="new-doc-1",
-            case_id="case-1",
-            court_id="court-1",
-            hearing_date=date(2026, 3, 5),
-            ruling_text="Motion GRANTED",
-            department="Dept. 1",
-        )
 
     def test_on_conflict_document_id_preserves_ruling_text_hash(self) -> None:
         """ON CONFLICT (document_id) DO UPDATE should preserve ruling_text_hash via COALESCE."""
@@ -3050,18 +3078,27 @@ class TestInsertRulingForceUpdateIdentityAnchors:
         assert "COALESCE(rulings.judge_id" not in sql
 
 
-class TestInsertRulingContentHashFallbackPreservesJudgeId:
-    """Regression tests for #2475 — the content-hash fallback UPDATE path
-    must also preserve an established ``judge_id`` in default mode.
+class TestInsertRulingContentHashSupersede:
+    """Regression tests for #2458 — the content-hash fallback must supersede
+    the losing document rather than running a stale-UPDATE-by-hash.
 
-    ``case_id`` is fixed by the WHERE clause (``WHERE case_id = %s::uuid AND
-    ruling_text_hash = %s``) so it cannot be silently re-routed there.  But
-    ``judge_id`` is an assignment and was previously written as
-    ``judge_id = COALESCE(%s::uuid, judge_id)`` — incoming wins.  Flipped to
-    preserve-first: ``judge_id = COALESCE(judge_id, %s::uuid)``.
+    Before #2458, a ``uq_rulings_case_text_hash`` UniqueViolation triggered
+    ``UPDATE rulings SET ... WHERE case_id = %s AND ruling_text_hash = %s``.
+    That WHERE clause matched the *winner*'s row (already present under a
+    different document_id), so the winner's fields were silently overwritten
+    with the loser's fields and the loser's document was left with stale
+    ``ruling_text`` from before reingest — the exact bug reported in #2458.
+
+    The fix supersedes the losing document (marks ``status = 'superseded'``
+    and deletes any stale ruling keyed on its document_id).  The winner's
+    ruling row is untouched: its text is identical by definition (the hashes
+    matched), and its fields were populated by whichever document was
+    processed first.
     """
 
-    def test_fallback_update_default_preserves_judge_id(self) -> None:
+    def test_supersede_sequence_deletes_then_marks_status(self) -> None:
+        """DELETE FROM rulings runs before UPDATE documents so the losing
+        document leaves no orphan ruling row behind."""
         import psycopg.errors
 
         conn = _mock_conn()
@@ -3076,30 +3113,36 @@ class TestInsertRulingContentHashFallbackPreservesJudgeId:
 
         insert_ruling(
             conn,
-            document_id="new-doc-1",
+            document_id="losing-doc",
             case_id="case-1",
             court_id="court-1",
             hearing_date=date(2026, 3, 5),
             ruling_text="Motion GRANTED",
             department="Dept. 1",
-            judge_id="judge-different",
         )
 
-        update_calls = [c for c in cur.execute.call_args_list if "UPDATE rulings SET" in c[0][0]]
-        assert len(update_calls) == 1
-        sql = update_calls[0][0][0]
-        assert "judge_id = COALESCE(judge_id, %s::uuid)" in sql, (
-            f"Expected preserve-first COALESCE for judge_id in fallback UPDATE, got SQL:\n{sql}"
+        execute_calls = cur.execute.call_args_list
+        # Locate the DELETE and the UPDATE documents call indices.
+        delete_idx = next(
+            i
+            for i, c in enumerate(execute_calls)
+            if "DELETE FROM rulings WHERE document_id" in c[0][0]
         )
-        # The old buggy order (incoming wins) must not appear.
-        assert "judge_id = COALESCE(%s::uuid, judge_id)" not in sql, (
-            f"Legacy incoming-wins COALESCE order found for judge_id in the "
-            f"content-hash fallback UPDATE. SQL:\n{sql}"
+        update_idx = next(
+            i
+            for i, c in enumerate(execute_calls)
+            if "UPDATE documents SET status = 'superseded'" in c[0][0]
+        )
+        assert delete_idx < update_idx, (
+            "DELETE FROM rulings must run before UPDATE documents so the "
+            "superseded document leaves no orphaned ruling row."
         )
 
-    def test_fallback_update_force_update_overwrites_judge_id(self) -> None:
-        """``force_update=True`` in the fallback UPDATE path still overwrites
-        judge_id unconditionally — this is the reingest / correction path.
+    def test_supersede_targets_losing_not_winning_document_id(self) -> None:
+        """The supersede DELETE/UPDATE must target the losing document_id
+        (the one currently being inserted), NOT the winner's row.  This is
+        the core #2458 regression — the old fallback UPDATE used the
+        winner's WHERE clause and mutated the wrong row.
         """
         import psycopg.errors
 
@@ -3115,22 +3158,66 @@ class TestInsertRulingContentHashFallbackPreservesJudgeId:
 
         insert_ruling(
             conn,
-            document_id="new-doc-1",
+            document_id="losing-doc-id",
             case_id="case-1",
             court_id="court-1",
             hearing_date=date(2026, 3, 5),
             ruling_text="Motion GRANTED",
             department="Dept. 1",
-            judge_id="judge-corrected",
-            force_update=True,
         )
 
-        update_calls = [c for c in cur.execute.call_args_list if "UPDATE rulings SET" in c[0][0]]
-        assert len(update_calls) == 1
-        sql = update_calls[0][0][0]
-        assert "judge_id = %s::uuid" in sql
-        # In force_update mode the default preserve-first clause must not appear.
-        assert "judge_id = COALESCE(judge_id, %s::uuid)" not in sql
+        execute_calls = cur.execute.call_args_list
+        delete_calls = [c for c in execute_calls if "DELETE FROM rulings" in c[0][0]]
+        assert delete_calls
+        assert delete_calls[0][0][1] == ("losing-doc-id",)
+
+        doc_update_calls = [
+            c for c in execute_calls if "UPDATE documents SET status = 'superseded'" in c[0][0]
+        ]
+        assert doc_update_calls
+        assert doc_update_calls[0][0][1] == ("losing-doc-id",)
+
+    def test_supersede_does_not_run_legacy_fallback_update(self) -> None:
+        """The legacy ``UPDATE rulings SET ... WHERE case_id = ? AND
+        ruling_text_hash = ?`` fallback must not run — that path was the
+        #2458 bug."""
+        import psycopg.errors
+
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        exc = psycopg.errors.UniqueViolation("duplicate key value violates unique constraint")
+
+        def side_effect_execute(sql: str, params: tuple | None = None) -> None:
+            if "INSERT INTO rulings" in sql:
+                raise exc
+
+        cur.execute = MagicMock(side_effect=side_effect_execute)
+
+        insert_ruling(
+            conn,
+            document_id="losing-doc",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+            judge_id="judge-different",
+            outcome="denied",
+        )
+
+        sql_stmts = [call[0][0] for call in cur.execute.call_args_list]
+        assert not any("UPDATE rulings SET" in s and "ruling_text_hash" in s for s in sql_stmts), (
+            "Content-hash-based UPDATE rulings must not run on supersede — "
+            "it was the #2458 bug that mutated the winner's row with the "
+            "loser's fields."
+        )
+        # And the loser's (judge_id / outcome / department / etc.) fields
+        # must not appear in any UPDATE rulings statement, because the
+        # winner's row must not be touched.
+        update_rulings_calls = [
+            c for c in cur.execute.call_args_list if "UPDATE rulings SET" in c[0][0]
+        ]
+        assert update_rulings_calls == [], "No UPDATE rulings SET must run in the supersede path."
 
 
 class TestInsertRulingReRouteScenario:


### PR DESCRIPTION
## Summary

Fixes a bug in `insert_ruling` where the content-hash dedup fallback UPDATE matched the winning row instead of the losing document, leaving losers with stale `ruling_text`. Now on a `uq_rulings_case_text_hash` unique-constraint violation we supersede the losing document (delete any stale ruling rows + set `status = 'superseded'`) using the losing `document_id`.

Closes #2458

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Query dev DB for stale-HTML rulings — 13 pre-fix residual rows identified (10 rebuild-ca-statewide, 3 federal-courtlistener-opinions). Go-forward behavior verified: new code path deployed and running.
- [x] Ingestion worker deployed and running on new image (logs confirm worker started successfully).
- [x] Verification evidence posted on issue.
