### PR TITLE
refactor(ingestion): centralize hearing_date fallback plausibility (#2456)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -9313,6 +9313,109 @@ class TestApplyPostExtractionGuards:
         assert extracted["extraction_methods"] == {"hearing_date": "llm"}
 
 
+class TestFinalizeHearingDate:
+    """Unit tests for finalize_hearing_date helper (#2456).
+
+    The helper owns the entire "pick the final hearing_date" decision
+    end-to-end: it runs the #2370 plausibility guard on each candidate in
+    the fallback chain (extracted, then doc_meta) and returns the first
+    plausible value, or None if no candidate is plausible. This replaces
+    the ``extracted["hearing_date"] or doc_meta["hearing_date"]`` + post
+    check pattern that #2432 showed was easy to bypass.
+    """
+
+    _CAPTURE = datetime(2026, 4, 1, 12, 0)
+
+    def test_both_implausible_returns_none(self) -> None:
+        """When both candidates are implausible, returns None."""
+        result = reingest.finalize_hearing_date(
+            extracted_hearing=date(2099, 1, 1),  # far future
+            doc_meta_hearing=date(2020, 1, 1),  # far past
+            capture_timestamp=self._CAPTURE,
+        )
+        assert result is None
+
+    def test_extracted_implausible_doc_meta_plausible_returns_doc_meta(
+        self,
+    ) -> None:
+        """When extracted is implausible but doc_meta is plausible, returns doc_meta."""
+        plausible = date(2026, 4, 5)
+        result = reingest.finalize_hearing_date(
+            extracted_hearing=date(2099, 1, 1),
+            doc_meta_hearing=plausible,
+            capture_timestamp=self._CAPTURE,
+        )
+        assert result == plausible
+
+    def test_both_none_returns_none(self) -> None:
+        """When both candidates are None, returns None."""
+        result = reingest.finalize_hearing_date(
+            extracted_hearing=None,
+            doc_meta_hearing=None,
+            capture_timestamp=self._CAPTURE,
+        )
+        assert result is None
+
+    def test_extracted_plausible_returns_extracted(self) -> None:
+        """When extracted is plausible, returns extracted (no fallback consulted)."""
+        plausible = date(2026, 4, 5)
+        # Provide a plausible doc_meta too — we should still see extracted win.
+        other_plausible = date(2026, 4, 10)
+        result = reingest.finalize_hearing_date(
+            extracted_hearing=plausible,
+            doc_meta_hearing=other_plausible,
+            capture_timestamp=self._CAPTURE,
+        )
+        assert result == plausible
+
+    def test_capture_timestamp_none_is_permissive(self) -> None:
+        """With capture_timestamp=None, plausibility cannot be checked; the
+        first non-None candidate wins."""
+        # extracted non-None, doc_meta non-None: extracted wins.
+        result = reingest.finalize_hearing_date(
+            extracted_hearing=date(2099, 1, 1),
+            doc_meta_hearing=date(2026, 4, 5),
+            capture_timestamp=None,
+        )
+        assert result == date(2099, 1, 1)
+
+        # extracted None, doc_meta non-None: doc_meta wins.
+        result = reingest.finalize_hearing_date(
+            extracted_hearing=None,
+            doc_meta_hearing=date(2099, 1, 1),
+            capture_timestamp=None,
+        )
+        assert result == date(2099, 1, 1)
+
+        # Both None: None.
+        result = reingest.finalize_hearing_date(
+            extracted_hearing=None,
+            doc_meta_hearing=None,
+            capture_timestamp=None,
+        )
+        assert result is None
+
+    def test_extracted_none_doc_meta_plausible_returns_doc_meta(self) -> None:
+        """When extracted is None, doc_meta is consulted."""
+        plausible = date(2026, 4, 5)
+        result = reingest.finalize_hearing_date(
+            extracted_hearing=None,
+            doc_meta_hearing=plausible,
+            capture_timestamp=self._CAPTURE,
+        )
+        assert result == plausible
+
+    def test_extracted_plausible_doc_meta_none(self) -> None:
+        """When doc_meta is None, extracted plausible value wins."""
+        plausible = date(2026, 4, 5)
+        result = reingest.finalize_hearing_date(
+            extracted_hearing=plausible,
+            doc_meta_hearing=None,
+            capture_timestamp=self._CAPTURE,
+        )
+        assert result == plausible
+
+
 class TestReingestAppliesGuardsAndForceUpdate:
     """End-to-end: reingest DB-write loop applies guards + force_update (#2405)."""
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -634,6 +634,61 @@ def apply_post_extraction_guards(
             methods.pop("hearing_date", None)
 
 
+def finalize_hearing_date(
+    *,
+    extracted_hearing: date | None,
+    doc_meta_hearing: date | None,
+    capture_timestamp: datetime | None,
+) -> date | None:
+    """Return the final hearing_date to write, or None if no plausible value.
+
+    Owns the entire "pick the final hearing_date" decision end-to-end for
+    the reingest DB-write path.  Runs the #2370 plausibility guard on each
+    candidate in the fallback chain — the first plausible value wins,
+    implausible values are skipped.
+
+    This centralizes the logic that three successive point patches chased
+    around the codebase:
+
+    -   #2370 — original plausibility guard on ``extracted["hearing_date"]``.
+    -   #2405 / PR #2422 — reingest bypassed the guard; added
+        ``apply_post_extraction_guards`` to fix.
+    -   #2432 — ``effective = extracted or doc_meta`` bypassed the guard
+        again when ``doc_meta`` held the same bad value.
+
+    Making the fallback chain go through a single plausibility-checking
+    helper makes it structurally impossible for a fallback branch to
+    introduce an implausible hearing_date.  New fallback sources (e.g.
+    ruling row column, regex re-extraction) are added inside this helper
+    and automatically inherit the guard.
+
+    Parameters
+    ----------
+    extracted_hearing : date | None
+        Preferred candidate — the hearing_date produced by the extraction
+        pipeline (LLM / regex / scraper metadata).
+    doc_meta_hearing : date | None
+        Fallback candidate — the hearing_date surfaced from
+        ``documents.hearing_date`` via ``doc_meta``.
+    capture_timestamp : datetime | None
+        The document capture timestamp passed through to
+        ``is_plausible_hearing_date``.  When ``None``, plausibility cannot
+        be checked and the first non-None candidate wins (permissive —
+        don't drop data we can't verify).
+
+    Returns
+    -------
+    date | None
+        The chosen hearing_date, or ``None`` if no candidate is plausible.
+    """
+    for candidate in (extracted_hearing, doc_meta_hearing):
+        if candidate is None:
+            continue
+        if is_plausible_hearing_date(candidate, capture_timestamp):
+            return candidate
+    return None
+
+
 def _apply_regex_fallbacks(extracted: dict, text: str, scraper_id: str = "") -> None:
     """Apply the regex fallback chain to fill any fields still missing.
 
@@ -2321,29 +2376,15 @@ def reingest_batch(
                         force_update=True,
                     )
 
-                    effective_hearing = (
-                        extracted["hearing_date"] or doc_meta["hearing_date"]
+                    # #2456: single chokepoint owns the fallback chain +
+                    # plausibility check so no fallback branch can bypass
+                    # the #2370 guard.  See ``finalize_hearing_date`` for
+                    # the full rationale (#2370 / #2405 / #2432).
+                    effective_hearing = finalize_hearing_date(
+                        extracted_hearing=extracted["hearing_date"],
+                        doc_meta_hearing=doc_meta["hearing_date"],
+                        capture_timestamp=doc_meta.get("captured_at"),
                     )
-                    # #2432: the guard above cleared extracted["hearing_date"]
-                    # if it was implausible, but the fallback to
-                    # doc_meta["hearing_date"] bypasses that check — in
-                    # rebuilds where both columns were populated from the
-                    # same bad LLM output, the implausible value still wins
-                    # and reingest writes it back via force_update.  Re-run
-                    # the plausibility check on the effective fallback
-                    # result so a bad doc_meta value is also rejected.
-                    if effective_hearing is not None and not is_plausible_hearing_date(
-                        effective_hearing,
-                        doc_meta.get("captured_at"),
-                    ):
-                        logger.info(
-                            "post-extraction guard: rejected implausible "
-                            "doc_meta hearing_date fallback",
-                            hearing_date=effective_hearing,
-                            capture_timestamp=doc_meta.get("captured_at"),
-                            document_id=doc_id_str,
-                        )
-                        effective_hearing = None
 
                     # For split documents, generate a synthetic content hash
                     # by incorporating the ruling index.  All split children


### PR DESCRIPTION
## Summary

Centralize the hearing_date fallback + plausibility check in a single helper (`finalize_hearing_date`) so new fallback sources can be added without bypassing the #2370 guard. Replaces the 23-line fallback + re-check block in `reingest_batch` with a 9-line call.

Closes #2456

## Test plan

### Automated checks
- [x] Lint passes (ruff check)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (pytest tests/test_reingest_from_s3.py — 336/336 incl. #2405 / #2432 regression tests; full suite 6000/6000 via pre-push hook)
- [x] CI green

### Post-deploy verification
- [x] Deploy workflow `Deploy Scraper` built+pushed image `judgemind/scraper:8001f49` and registered `judgemind-ingestion-worker-dev:462`; the `aws ecs wait services-stable` step hit the GitHub Actions job timeout, but ECS completed the rollout — I re-waited from the worktree and the service stabilized on revision 462 (1 running task, 0 pending). Ingestion worker logs confirm normal startup. Since `scripts/reingest_from_s3.py` is a one-off ECS script (not a scheduled service), end-to-end verification relies on the existing 336/336-passing test suite covering the new helper and the #2405/#2432 regression tests. Evidence posted on #2456.
