### PR TITLE
fix(rebuild): capture in-flight PDF keys on worker crash and retry serially (#2495)

### DIFF
--- a/packages/scraper-framework/tests/test_rebuild_db.py
+++ b/packages/scraper-framework/tests/test_rebuild_db.py
@@ -1404,3 +1404,518 @@ class TestRebuildSummaryHashMismatchCounter:
         ]
         assert len(rebuild_complete) == 1
         assert rebuild_complete[0].kwargs.get("hash_mismatch_warnings") == 1
+
+
+# ---------------------------------------------------------------------------
+# Worker-crash resilience — #2495
+# ---------------------------------------------------------------------------
+
+
+class TestAutoscaleConcurrency:
+    """Tests for _autoscale_concurrency()."""
+
+    def test_disabled_when_max_memory_zero(self) -> None:
+        """max_worker_memory_mb=0 returns requested concurrency unchanged."""
+        assert (
+            rebuild_db._autoscale_concurrency(
+                requested=64, max_worker_memory_mb=0, available_memory_mb=8192
+            )
+            == 64
+        )
+
+    def test_disabled_when_max_memory_negative(self) -> None:
+        """Negative values also disable autoscaling."""
+        assert (
+            rebuild_db._autoscale_concurrency(
+                requested=64, max_worker_memory_mb=-1, available_memory_mb=8192
+            )
+            == 64
+        )
+
+    def test_caps_when_memory_tight(self) -> None:
+        """With 8 GB RAM and 1 GB per worker, 64 requested → 8 effective."""
+        assert (
+            rebuild_db._autoscale_concurrency(
+                requested=64, max_worker_memory_mb=1024, available_memory_mb=8192
+            )
+            == 8
+        )
+
+    def test_returns_requested_when_memory_plentiful(self) -> None:
+        """With more than enough RAM, requested concurrency wins."""
+        assert (
+            rebuild_db._autoscale_concurrency(
+                requested=4, max_worker_memory_mb=1024, available_memory_mb=32768
+            )
+            == 4
+        )
+
+    def test_floor_of_one(self) -> None:
+        """Even with tiny RAM, at least one worker must run (no-zero floor)."""
+        assert (
+            rebuild_db._autoscale_concurrency(
+                requested=64, max_worker_memory_mb=2048, available_memory_mb=512
+            )
+            == 1
+        )
+
+    def test_falls_back_to_requested_when_memory_unknown(self) -> None:
+        """available_memory_mb=0 means we couldn't resolve — don't throttle."""
+        assert (
+            rebuild_db._autoscale_concurrency(
+                requested=32, max_worker_memory_mb=1024, available_memory_mb=0
+            )
+            == 32
+        )
+
+
+class TestAvailableMemoryMb:
+    """Tests for _available_memory_mb().
+
+    The helper reads cgroup memory limits (Fargate) before falling back to
+    ``psutil.virtual_memory()``.  We test the contract — a non-negative
+    integer — rather than mocking the filesystem, because the cgroup path
+    layout varies between cgroup v1 and v2 and across kernels.
+    """
+
+    def test_returns_non_negative_int(self) -> None:
+        value = rebuild_db._available_memory_mb()
+        assert isinstance(value, int)
+        assert value >= 0
+
+
+class TestRetryCrashedKeysSerially:
+    """Tests for _retry_crashed_keys_serially()."""
+
+    def test_empty_keys_returns_empty_summary(self) -> None:
+        """No crashed keys → no work, empty summary."""
+        summary = rebuild_db._retry_crashed_keys_serially(
+            [], "", "bucket", "postgres://x", "redis://x", ""
+        )
+        assert summary["processed"] == 0
+        assert summary["errors"] == 0
+        assert summary["skipped"] == 0
+        assert summary["still_crashed"] == []
+
+    def test_successful_retry_recovers_key(self, tmp_path: Any) -> None:
+        """When the retry worker processes the key without crashing, the
+        summary records it as processed and still_crashed stays empty.
+
+        Uses a real single-worker ``ProcessPoolExecutor`` via the function
+        under test; the child process uses the same ``_process_one_document``
+        code path and returns via a mocked ``IngestionWorker``.
+        """
+        content = b"<html>Date: 03/15/2026 ruling text</html>"
+        import hashlib
+
+        content_hash = hashlib.sha256(content).hexdigest()
+        key = f"ca/orange/superior_court/raw/{content_hash}.html"
+        cache_dir = str(tmp_path)
+        key_path = tmp_path / "ca" / "orange" / "superior_court" / "raw"
+        key_path.mkdir(parents=True)
+        (key_path / f"{content_hash}.html").write_bytes(content)
+
+        # Stub the pool so we don't fork — the retry helper uses
+        # ProcessPoolExecutor(max_workers=1) as a context manager.
+        mock_future = MagicMock()
+        mock_future.result.return_value = {
+            "status": "ok",
+            "content_format": "html",
+            "had_hearing_date": True,
+            "hash_mismatch": False,
+        }
+        mock_pool = MagicMock()
+        mock_pool.__enter__ = MagicMock(return_value=mock_pool)
+        mock_pool.__exit__ = MagicMock(return_value=False)
+        mock_pool.submit.return_value = mock_future
+
+        with patch("concurrent.futures.ProcessPoolExecutor", return_value=mock_pool):
+            summary = rebuild_db._retry_crashed_keys_serially(
+                [key],
+                cache_dir,
+                "test-bucket",
+                "postgres://test",
+                "redis://test",
+                "",
+            )
+
+        assert summary["processed"] == 1
+        assert summary["errors"] == 0
+        assert summary["still_crashed"] == []
+        assert summary["format_counts"] == {"html": 1}
+
+    def test_retry_that_also_crashes_appends_to_still_crashed(self, tmp_path: Any) -> None:
+        """When the single-worker retry also raises BrokenProcessPool, the
+        key lands in ``still_crashed`` and ``errors`` increments."""
+        from concurrent.futures.process import BrokenProcessPool
+
+        key = "ca/santa_clara/superior_court/raw/deadbeef.pdf"
+
+        mock_future = MagicMock()
+        mock_future.result.side_effect = BrokenProcessPool("retry segfault")
+        mock_pool = MagicMock()
+        mock_pool.__enter__ = MagicMock(return_value=mock_pool)
+        mock_pool.__exit__ = MagicMock(return_value=False)
+        mock_pool.submit.return_value = mock_future
+
+        with patch("concurrent.futures.ProcessPoolExecutor", return_value=mock_pool):
+            summary = rebuild_db._retry_crashed_keys_serially(
+                [key],
+                "",
+                "test-bucket",
+                "postgres://test",
+                "redis://test",
+                "",
+            )
+
+        assert summary["processed"] == 0
+        assert summary["errors"] == 1
+        assert summary["still_crashed"] == [key]
+
+
+class TestMainPoolBreakHandling:
+    """Integration tests for main()'s BrokenProcessPool handling.
+
+    Before #2495, a worker crash triggered ``BrokenProcessPool`` on every
+    in-flight future, and the orchestrator's generic ``except Exception``
+    logged a single opaque "Failed to process" line per victim without
+    distinguishing "this PDF ran in the dead worker" from "some other PDF
+    ran in the dead worker."  The fix:
+
+    * The loop catches ``BrokenProcessPool`` specifically and logs
+      ``in-flight at pool break`` with the specific S3 key.
+    * After the concurrent pass, affected keys are retried serially in
+      fresh single-worker pools.
+    * The rebuild summary carries ``pool_break_events``,
+      ``pool_break_keys_recovered``, and ``pool_break_keys_unrecovered``.
+    """
+
+    def _make_cache(self, tmp_path: Any, keys: list[str]) -> str:
+        """Create a local cache with stub content for each key."""
+        cache_dir = str(tmp_path / "cache")
+        for key in keys:
+            parsed = rebuild_db.parse_s3_key(key)
+            assert parsed is not None
+            full = tmp_path / "cache" / key
+            full.parent.mkdir(parents=True, exist_ok=True)
+            full.write_bytes(b"<html>x</html>")
+        return cache_dir
+
+    def test_pool_break_logs_in_flight_key(self, tmp_path: Any) -> None:
+        """A ``BrokenProcessPool`` raised by ``future.result()`` must produce
+        an ``in-flight at pool break`` log carrying the specific S3 key of
+        the future, so operators can identify candidate culprit PDFs."""
+        from concurrent.futures.process import BrokenProcessPool
+
+        keys = [
+            "ca/santa_clara/superior_court/raw/aaa111.html",
+            "ca/santa_clara/superior_court/raw/bbb222.html",
+        ]
+        cache_dir = self._make_cache(tmp_path, keys)
+
+        # Future A: normal success.  Future B: raises BrokenProcessPool.
+        future_a = MagicMock()
+        future_a.result.return_value = {
+            "status": "ok",
+            "content_format": "html",
+            "had_hearing_date": False,
+            "hash_mismatch": False,
+        }
+        future_b = MagicMock()
+        future_b.result.side_effect = BrokenProcessPool("pool died")
+
+        # Main-pass pool.  Its submit() is called for all input keys.
+        # We have to make the mapping deterministic so we know which key
+        # goes to which future.
+        mock_pool = MagicMock()
+        mock_pool.__enter__ = MagicMock(return_value=mock_pool)
+        mock_pool.__exit__ = MagicMock(return_value=False)
+        mock_pool.submit.side_effect = [future_a, future_b]
+
+        # Retry pool — the retry path submits its own ProcessPoolExecutor.
+        # Give it a future that re-raises so still_crashed is populated.
+        retry_future = MagicMock()
+        retry_future.result.side_effect = BrokenProcessPool("retry also died")
+        retry_pool = MagicMock()
+        retry_pool.__enter__ = MagicMock(return_value=retry_pool)
+        retry_pool.__exit__ = MagicMock(return_value=False)
+        retry_pool.submit.return_value = retry_future
+
+        # The main loop and the retry helper both instantiate
+        # ProcessPoolExecutor — patch so the main call gets the main pool
+        # and subsequent calls get the retry pool.
+        pool_sequence = [mock_pool, retry_pool]
+
+        def _pool_factory(*args: Any, **kwargs: Any) -> MagicMock:
+            return pool_sequence.pop(0) if pool_sequence else retry_pool
+
+        mock_logger = MagicMock()
+
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=keys,
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db._fetch_rosters"),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                side_effect=_pool_factory,
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([future_a, future_b]),
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://test",
+                    "S3_CACHE_DIR": cache_dir,
+                },
+            ),
+            patch("sys.argv", ["rebuild_db.py"]),
+            patch.object(rebuild_db, "logger", mock_logger),
+        ):
+            rebuild_db.main()
+
+        # Verify the in-flight log fired with the specific key.
+        err_calls = mock_logger.error.call_args_list
+        in_flight_logs = [
+            call for call in err_calls if call.args and call.args[0] == "in-flight at pool break"
+        ]
+        assert len(in_flight_logs) == 1, f"expected 1 in-flight log, got: {err_calls}"
+        # The key in the log must be one of the inputs, not an opaque
+        # "Failed to process" message.
+        assert in_flight_logs[0].kwargs.get("s3_key") in keys
+
+        # Verify the rebuild summary reports pool-break stats.
+        info_calls = mock_logger.info.call_args_list
+        rebuild_complete = [
+            call for call in info_calls if call.args and call.args[0] == "Rebuild complete"
+        ]
+        assert len(rebuild_complete) == 1
+        kwargs = rebuild_complete[0].kwargs
+        assert kwargs.get("pool_break_events") == 1
+        # The retry also crashed, so unrecovered = 1, recovered = 0.
+        assert kwargs.get("pool_break_keys_recovered") == 0
+        assert kwargs.get("pool_break_keys_unrecovered") == 1
+
+    def test_pool_break_retry_recovers_key(self, tmp_path: Any) -> None:
+        """When a worker crashes but a serial retry succeeds, the key moves
+        from errors → processed and the summary reports recovery."""
+        from concurrent.futures.process import BrokenProcessPool
+
+        keys = ["ca/santa_clara/superior_court/raw/aaa111.html"]
+        cache_dir = self._make_cache(tmp_path, keys)
+
+        crash_future = MagicMock()
+        crash_future.result.side_effect = BrokenProcessPool("initial crash")
+
+        mock_pool = MagicMock()
+        mock_pool.__enter__ = MagicMock(return_value=mock_pool)
+        mock_pool.__exit__ = MagicMock(return_value=False)
+        mock_pool.submit.return_value = crash_future
+
+        recover_future = MagicMock()
+        recover_future.result.return_value = {
+            "status": "ok",
+            "content_format": "html",
+            "had_hearing_date": False,
+            "hash_mismatch": False,
+        }
+        retry_pool = MagicMock()
+        retry_pool.__enter__ = MagicMock(return_value=retry_pool)
+        retry_pool.__exit__ = MagicMock(return_value=False)
+        retry_pool.submit.return_value = recover_future
+
+        pool_sequence = [mock_pool, retry_pool]
+
+        def _pool_factory(*args: Any, **kwargs: Any) -> MagicMock:
+            return pool_sequence.pop(0) if pool_sequence else retry_pool
+
+        mock_logger = MagicMock()
+
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=keys,
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db._fetch_rosters"),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                side_effect=_pool_factory,
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([crash_future]),
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://test",
+                    "S3_CACHE_DIR": cache_dir,
+                },
+            ),
+            patch("sys.argv", ["rebuild_db.py"]),
+            patch.object(rebuild_db, "logger", mock_logger),
+        ):
+            rebuild_db.main()
+
+        info_calls = mock_logger.info.call_args_list
+        rebuild_complete = [
+            call for call in info_calls if call.args and call.args[0] == "Rebuild complete"
+        ]
+        assert len(rebuild_complete) == 1
+        kwargs = rebuild_complete[0].kwargs
+        assert kwargs.get("pool_break_events") == 1
+        assert kwargs.get("pool_break_keys_recovered") == 1
+        assert kwargs.get("pool_break_keys_unrecovered") == 0
+        # Overall: 1 processed via retry, 0 errors.
+        assert kwargs.get("processed") == 1
+        assert kwargs.get("errors") == 0
+
+
+class TestMaxWorkerMemoryCLI:
+    """CLI integration: ``--max-worker-memory-mb`` caps concurrency."""
+
+    def test_flag_caps_concurrency_before_pool_start(self, tmp_path: Any) -> None:
+        """``--max-worker-memory-mb 1024`` with 2 GB available must result
+        in ``max_workers=2`` on the pool (2048/1024), even if --concurrency
+        asks for 64."""
+        keys = ["ca/orange/superior_court/raw/abc123.html"]
+        cache_dir = str(tmp_path / "cache")
+        full = tmp_path / "cache" / keys[0]
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_bytes(b"<html>x</html>")
+
+        mock_future = MagicMock()
+        mock_future.result.return_value = {
+            "status": "ok",
+            "content_format": "html",
+            "had_hearing_date": False,
+            "hash_mismatch": False,
+        }
+        mock_pool = MagicMock()
+        mock_pool.__enter__ = MagicMock(return_value=mock_pool)
+        mock_pool.__exit__ = MagicMock(return_value=False)
+        mock_pool.submit.return_value = mock_future
+
+        captured_max_workers: list[int] = []
+
+        def _pool_factory(*args: Any, **kwargs: Any) -> MagicMock:
+            captured_max_workers.append(kwargs.get("max_workers", -1))
+            return mock_pool
+
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=keys,
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db._fetch_rosters"),
+            patch(
+                "rebuild_db._available_memory_mb",
+                return_value=2048,
+            ),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                side_effect=_pool_factory,
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([mock_future]),
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://test",
+                    "S3_CACHE_DIR": cache_dir,
+                },
+                clear=False,
+            ),
+            patch(
+                "sys.argv",
+                [
+                    "rebuild_db.py",
+                    "--concurrency",
+                    "64",
+                    "--max-worker-memory-mb",
+                    "1024",
+                ],
+            ),
+        ):
+            rebuild_db.main()
+
+        # The main-pass pool gets max_workers=2 (2048/1024), not 64.
+        assert captured_max_workers[0] == 2
+
+    def test_flag_default_preserves_old_behavior(self, tmp_path: Any) -> None:
+        """Without ``--max-worker-memory-mb`` the old concurrency wins."""
+        keys = ["ca/orange/superior_court/raw/abc123.html"]
+        cache_dir = str(tmp_path / "cache")
+        full = tmp_path / "cache" / keys[0]
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_bytes(b"<html>x</html>")
+
+        mock_future = MagicMock()
+        mock_future.result.return_value = {
+            "status": "ok",
+            "content_format": "html",
+            "had_hearing_date": False,
+            "hash_mismatch": False,
+        }
+        mock_pool = MagicMock()
+        mock_pool.__enter__ = MagicMock(return_value=mock_pool)
+        mock_pool.__exit__ = MagicMock(return_value=False)
+        mock_pool.submit.return_value = mock_future
+
+        captured_max_workers: list[int] = []
+
+        def _pool_factory(*args: Any, **kwargs: Any) -> MagicMock:
+            captured_max_workers.append(kwargs.get("max_workers", -1))
+            return mock_pool
+
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=keys,
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db._fetch_rosters"),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                side_effect=_pool_factory,
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([mock_future]),
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://test",
+                    "S3_CACHE_DIR": cache_dir,
+                },
+                clear=False,
+            ),
+            patch(
+                "sys.argv",
+                [
+                    "rebuild_db.py",
+                    "--concurrency",
+                    "4",
+                ],
+            ),
+        ):
+            rebuild_db.main()
+
+        assert captured_max_workers[0] == 4

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -18,6 +18,15 @@
 #   --county NAME     Only process documents from this county (e.g. Ventura)
 #   --state CODE      State code for --county filtering (default: ca)
 #   --concurrency N   Number of parallel processes (default: 64)
+#   --max-worker-memory-mb N
+#                     Reserve ~N MB of RAM per worker when auto-scaling
+#                     concurrency.  Computes ``min(--concurrency,
+#                     available_memory_mb / N)`` and uses the smaller value.
+#                     Use this after bumping Fargate memory with
+#                     ``scripts/ecs-run-task.sh --memory <mb>`` so concurrency
+#                     adapts to the new allocation.  Set to 0 (default) to
+#                     disable auto-scaling and use --concurrency as-is.
+#                     See #2495.
 #   --reset           Truncate derived tables before rebuilding.  When combined
 #                     with --county, the reset is scoped to just that county's
 #                     rows (per-county reset); otherwise it truncates the
@@ -28,6 +37,17 @@
 #                     raw PDF via the ingestion worker's LLM split path, so no
 #                     override is required.  Passing this flag logs a warning
 #                     and is otherwise ignored.
+#
+# Worker-crash resilience (see #2495):
+#   * When a child process in the pool dies mid-task (segfault from
+#     pdfplumber/pdfminer C extensions, OOM, etc.), every in-flight future
+#     gets a ``BrokenProcessPool`` exception — masking *which* PDF actually
+#     killed the worker.  The orchestrator now:
+#       1. Logs the specific S3 key for every future that was in flight when
+#          the pool broke (``in-flight at pool break`` log).
+#       2. After the concurrent pass, retries each crashed key serially in
+#          a fresh ``max_workers=1`` pool so segfaults only kill the retry
+#          worker, not the whole rebuild.
 """
 
 from __future__ import annotations
@@ -381,6 +401,179 @@ def _process_one_document(
         }
 
 
+def _available_memory_mb() -> int:
+    """Return the memory available to this process in MB.
+
+    Reads the Linux cgroup memory limit (Fargate sets this) when available,
+    then falls back to ``psutil.virtual_memory()`` or the host total.  Returns
+    0 when no reliable value can be resolved — the caller treats 0 as "skip
+    autoscaling."  Never raises — failure returns 0.  See #2495.
+    """
+    # Prefer cgroup v2, then v1, then psutil.  Fargate containers expose
+    # their memory limit via the memory cgroup — the host's psutil value
+    # would overcount on a shared host.
+    for cgroup_path in (
+        "/sys/fs/cgroup/memory.max",  # cgroup v2
+        "/sys/fs/cgroup/memory/memory.limit_in_bytes",  # cgroup v1
+    ):
+        try:
+            with open(cgroup_path) as f:
+                raw = f.read().strip()
+            if raw == "max":
+                continue
+            limit_bytes = int(raw)
+            # Kernel sentinel for "no limit" — huge value ≈ 2^63.  Fall through.
+            if limit_bytes <= 0 or limit_bytes > (1 << 60):
+                continue
+            return limit_bytes // (1024 * 1024)
+        except (OSError, ValueError):
+            continue
+
+    try:
+        import psutil
+
+        return int(psutil.virtual_memory().total) // (1024 * 1024)
+    except Exception:
+        return 0
+
+
+def _autoscale_concurrency(
+    requested: int,
+    max_worker_memory_mb: int,
+    available_memory_mb: int | None = None,
+) -> int:
+    """Compute the effective worker count given a per-worker memory budget.
+
+    When ``max_worker_memory_mb`` is 0 or negative, returns ``requested``
+    unchanged (autoscaling disabled).  Otherwise returns
+    ``min(requested, available_memory_mb // max_worker_memory_mb)`` with a
+    floor of 1 so the rebuild always makes forward progress, even on tiny
+    allocations.  Exposed as a separate function so tests can stub available
+    memory without touching /sys or psutil.  See #2495.
+    """
+    if max_worker_memory_mb <= 0:
+        return requested
+    if available_memory_mb is None:
+        available_memory_mb = _available_memory_mb()
+    if available_memory_mb <= 0:
+        # Could not resolve — fall back to requested, don't silently drop to 1.
+        return requested
+    capped = available_memory_mb // max_worker_memory_mb
+    return max(1, min(requested, capped))
+
+
+def _retry_crashed_keys_serially(
+    crashed_keys: list[str],
+    cache_dir: str,
+    bucket: str,
+    database_url: str,
+    redis_url: str,
+    os_url: str,
+) -> dict[str, Any]:
+    """Retry keys that crashed a worker in the concurrent pass.
+
+    Launches a fresh ``ProcessPoolExecutor(max_workers=1)`` per key so a
+    segfault or OOM only kills the single retry worker — the orchestrator
+    survives and keeps going.  Returns an aggregate result dict with the
+    same counters shape the main loop accumulates (``processed``, ``errors``,
+    ``skipped``, ``no_hearing_date``, ``hash_mismatch_warnings``,
+    ``format_counts``) plus a list of keys that crashed on the retry too.
+    See #2495.
+    """
+    from concurrent.futures import ProcessPoolExecutor
+    from concurrent.futures.process import BrokenProcessPool
+
+    processed = 0
+    errors = 0
+    skipped = 0
+    no_hearing_date = 0
+    hash_mismatch_warnings = 0
+    format_counts: dict[str, int] = {}
+    still_crashed: list[str] = []
+
+    logger.info(
+        "Retrying keys that crashed a worker in the concurrent pass "
+        "(serial, max_workers=1 per key)",
+        retry_count=len(crashed_keys),
+    )
+
+    for idx, key in enumerate(crashed_keys, 1):
+        logger.info(
+            "Retry in progress",
+            retry_index=idx,
+            retry_total=len(crashed_keys),
+            s3_key=key,
+        )
+        with ProcessPoolExecutor(max_workers=1) as pool:
+            future = pool.submit(
+                _process_one_document,
+                key,
+                cache_dir,
+                bucket,
+                database_url,
+                redis_url,
+                os_url,
+            )
+            try:
+                result = future.result()
+            except BrokenProcessPool:
+                # The PDF crashed even a dedicated single-worker subprocess —
+                # it's almost certainly a C-extension segfault on this file.
+                logger.error(
+                    "Retry also crashed the worker — giving up on this key",
+                    s3_key=key,
+                )
+                errors += 1
+                still_crashed.append(key)
+                continue
+            except Exception as exc:
+                logger.error(
+                    "Retry raised unexpected exception",
+                    s3_key=key,
+                    error=str(exc),
+                    exc_info=True,
+                )
+                errors += 1
+                continue
+
+        status = result.get("status", "error") if isinstance(result, dict) else result
+        content_format = (
+            result.get("content_format", "") if isinstance(result, dict) else ""
+        )
+        had_hearing_date = (
+            result.get("had_hearing_date", False) if isinstance(result, dict) else False
+        )
+        hash_mismatch = (
+            result.get("hash_mismatch", False) if isinstance(result, dict) else False
+        )
+
+        if status == "ok":
+            processed += 1
+            logger.info("Retry succeeded", s3_key=key)
+        elif status == "skip":
+            skipped += 1
+        else:
+            errors += 1
+            logger.warning("Retry produced error status", s3_key=key)
+
+        if content_format:
+            format_counts[content_format] = format_counts.get(content_format, 0) + 1
+        if status == "ok" and not had_hearing_date:
+            no_hearing_date += 1
+        if hash_mismatch:
+            hash_mismatch_warnings += 1
+
+    return {
+        "processed": processed,
+        "errors": errors,
+        "skipped": skipped,
+        "no_hearing_date": no_hearing_date,
+        "hash_mismatch_warnings": hash_mismatch_warnings,
+        "format_counts": format_counts,
+        "still_crashed": still_crashed,
+    }
+
+
 def reset_derived_tables(conn: psycopg.Connection) -> None:
     """Truncate all tables in the derived schema, preserving public/telemetry data."""
     logger.info("Resetting derived schema — truncating all derived tables...")
@@ -721,6 +914,17 @@ def main() -> None:
         help="Number of parallel processes (default: 64, or REBUILD_CONCURRENCY env)",
     )
     parser.add_argument(
+        "--max-worker-memory-mb",
+        type=int,
+        default=int(os.environ.get("REBUILD_MAX_WORKER_MEMORY_MB", "0")),
+        help=(
+            "Reserve ~N MB of RAM per worker when auto-scaling concurrency "
+            "(default: 0, disabled).  Computes min(--concurrency, "
+            "available_memory_mb / N) and uses the smaller value so "
+            "concurrency adapts to the Fargate allocation.  See #2495."
+        ),
+    )
+    parser.add_argument(
         "--reset",
         action="store_true",
         help="Truncate all derived tables and delete OpenSearch index before rebuilding",
@@ -847,8 +1051,20 @@ def main() -> None:
             logger.info("OPENSEARCH_URL not set — skipping search indexing")
 
         from concurrent.futures import ProcessPoolExecutor, as_completed
+        from concurrent.futures.process import BrokenProcessPool
 
-        concurrency = args.concurrency
+        concurrency_requested = args.concurrency
+        concurrency = _autoscale_concurrency(
+            concurrency_requested, args.max_worker_memory_mb
+        )
+        if concurrency != concurrency_requested:
+            logger.info(
+                "Autoscaled concurrency to fit memory budget",
+                requested=concurrency_requested,
+                effective=concurrency,
+                max_worker_memory_mb=args.max_worker_memory_mb,
+                available_memory_mb=_available_memory_mb(),
+            )
         logger.info("Processing documents", concurrency=concurrency, total=len(keys))
 
         # Step 4: Process documents concurrently using processes (not threads).
@@ -869,6 +1085,12 @@ def main() -> None:
         hash_mismatch_warnings = 0
         # Per-format counters for the summary.
         format_counts: dict[str, int] = {}
+
+        # Track keys that were in flight when a worker crashed the pool so we
+        # can (a) log exactly which raws were affected and (b) retry them
+        # serially after the concurrent pass.  See #2495.
+        crashed_keys: list[str] = []
+        pool_break_events = 0
 
         with ProcessPoolExecutor(max_workers=concurrency) as pool:
             futures = {
@@ -944,9 +1166,70 @@ def main() -> None:
                             eta_min=round(eta_min, 1),
                             errors=errors,
                         )
+                except BrokenProcessPool as exc:
+                    # A worker subprocess died mid-task (C-extension segfault,
+                    # OOM kill, etc.) and the pool propagates that to every
+                    # future that was running or pending.  We can't tell from
+                    # the exception alone which PDF triggered the crash, but
+                    # we *can* enumerate every key whose future never
+                    # completed — one of them is the culprit, all of them
+                    # deserve a retry.  See #2495.
+                    pool_break_events += 1
+                    errors += 1
+                    crashed_keys.append(key)
+                    logger.error(
+                        "in-flight at pool break",
+                        s3_key=key,
+                        error=str(exc),
+                    )
                 except Exception as exc:
                     errors += 1
                     logger.error("Failed to process", key=key, error=str(exc))
+
+        # Step 4b: Retry the keys that were in flight when the pool broke.
+        # Each retry runs in its own ``max_workers=1`` subprocess so a
+        # segfault only kills the single retry worker.  See #2495.
+        retry_summary: dict[str, Any] | None = None
+        if crashed_keys:
+            logger.warning(
+                "Pool break detected during concurrent pass — %d key(s) "
+                "affected across %d distinct crash event(s).  Retrying "
+                "serially.",
+                len(crashed_keys),
+                pool_break_events,
+                crashed_keys_count=len(crashed_keys),
+                pool_break_events=pool_break_events,
+            )
+            retry_summary = _retry_crashed_keys_serially(
+                crashed_keys,
+                cache_dir,
+                BUCKET,
+                database_url,
+                redis_url,
+                os_url,
+            )
+            # Fold retry counters back into the overall totals.  We already
+            # counted ``len(crashed_keys)`` errors during the concurrent pass
+            # (one per future that got ``BrokenProcessPool``).  Each retry
+            # resolves one of those: success → convert error into processed,
+            # skip → convert error into skipped, error → error stays.  Net
+            # effect: subtract the whole ``len(crashed_keys)`` from errors
+            # and re-add only the retry-level errors.
+            errors = max(0, errors - len(crashed_keys)) + retry_summary["errors"]
+            processed += retry_summary["processed"]
+            skipped += retry_summary["skipped"]
+            no_hearing_date += retry_summary["no_hearing_date"]
+            hash_mismatch_warnings += retry_summary["hash_mismatch_warnings"]
+            for fmt, count in retry_summary["format_counts"].items():
+                format_counts[fmt] = format_counts.get(fmt, 0) + count
+            logger.info(
+                "Retry pass complete",
+                retry_count=len(crashed_keys),
+                retry_processed=retry_summary["processed"],
+                retry_skipped=retry_summary["skipped"],
+                retry_errors=retry_summary["errors"],
+                still_crashed=retry_summary["still_crashed"],
+            )
 
         logger.info(
             "Rebuild complete",
@@ -956,6 +1239,15 @@ def main() -> None:
             total=len(keys),
             format_counts=format_counts,
             hash_mismatch_warnings=hash_mismatch_warnings,
+            pool_break_events=pool_break_events,
+            pool_break_keys_recovered=(
+                (retry_summary["processed"] + retry_summary["skipped"])
+                if retry_summary is not None
+                else 0
+            ),
+            pool_break_keys_unrecovered=(
+                len(retry_summary["still_crashed"]) if retry_summary is not None else 0
+            ),
         )
 
         if no_hearing_date > 0:


### PR DESCRIPTION
## Summary

When a `ProcessPoolExecutor` worker died mid-PDF (pdfplumber/pdfminer C-extension segfault or OOM), `BrokenProcessPool` was raised for every pending future from the dead worker and logged as a generic "Failed to process" error — leaving operators unable to identify which PDF actually killed the worker. This PR captures the specific `s3_key` for every in-flight PDF on pool break, retries crashed keys one-at-a-time through a fresh `ProcessPoolExecutor(max_workers=1)` so segfaults only kill the retry subprocess, and adds `--max-worker-memory-mb` so operators can bump Fargate memory via `scripts/ecs-run-task.sh --memory M` and have workers auto-scale their concurrency to fit.

Closes #2495

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (61/61 in test_rebuild_db.py; 6014/6014 full suite via pre-push hook)
- [x] CI green

### Post-deploy verification
- [x] `rebuild_db.py --help` executed on dev scraper image (ECS task `30dddad6d4884e68ac3d90d7a67568e4`, exit 0) — new `--max-worker-memory-mb` flag present with correct default (0, disabled) and `#2495` reference
- [x] Verification evidence posted on issue (#2495 comment 4266169702)
