### PR TITLE
fix(reingest): remove case_title doc_meta fallback in multimodal path (#2502)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -6704,6 +6704,126 @@ class TestReparseDocumentMultimodal:
         assert results[0]["parties"][0] == {"name": "Smith", "role": "plaintiff"}
         assert results[0]["parties"][1] == {"name": "Jones", "role": "defendant"}
 
+    def test_case_title_null_when_llm_returns_none_no_db_fallback(self) -> None:
+        """When the multimodal LLM returns no case_title, the reingest dict
+        must have case_title=None — NOT the stale DB title from doc_meta (#2502).
+
+        Previously, the code used ``cr.case_title or doc_meta.get("case_title")``
+        which pulled the existing DB title (carried via the LEFT JOIN in
+        FETCH_DOCUMENTS_QUERY) into the result when the LLM produced nothing.
+        Combined with ``upsert_case(force_update=True)``, that created a
+        self-sustaining fixed point for wrong titles.  The fix removes the
+        fallback so None flows through to upsert_case, where the COALESCE
+        semantic at db.py:316 preserves the existing (non-null) title.
+        """
+        from framework.llm_schema import ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        doc_meta["case_title"] = "Stale DB Title"  # existing DB title
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01234567",
+                extracted_case_title=None,  # LLM did not extract a title
+                ruling_text="The motion is GRANTED.",
+            ),
+        ]
+
+        with patch.object(reingest, "_apply_regex_fallbacks"):
+            results = reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+            )
+
+        assert len(results) == 1
+        # Must be None — not "Stale DB Title" (no fallback to doc_meta)
+        assert results[0]["case_title"] is None
+
+    def test_case_title_from_llm_wins_over_db_title(self) -> None:
+        """When the multimodal LLM returns a case_title, it wins over any
+        existing doc_meta title (#2502).
+        """
+        from framework.llm_schema import ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        doc_meta["case_title"] = "Old DB Title"
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01234567",
+                extracted_case_title="Fresh LLM Title",
+                ruling_text="The motion is GRANTED.",
+            ),
+        ]
+
+        with patch.object(reingest, "_apply_regex_fallbacks"):
+            results = reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+            )
+
+        assert len(results) == 1
+        assert results[0]["case_title"] == "Fresh LLM Title"
+
+    def test_multi_ruling_no_title_swap_when_some_rulings_miss_title(self) -> None:
+        """Multi-ruling PDFs: rulings whose LLM extraction returned no title
+        must keep case_title=None — they must NOT pick up doc_meta's title and
+        must NOT pick up a sibling ruling's title (#2502).
+
+        This is the canonical repro for the #2490 Palacios-v.-Vallejo bug:
+        a multi-case PDF where one or more splits come back without a title,
+        and any fallback causes them to converge on the same wrong title
+        across reingest cycles.
+        """
+        from framework.llm_schema import ExtractedRuling
+
+        doc_meta = self._make_doc_meta()
+        doc_meta["case_title"] = "Palacios v. Vallejo"  # stale per-doc title
+        mock_extractor = MagicMock()
+        mock_extractor.extract_from_pdf.return_value = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00000001",
+                extracted_case_title="Gu v. Smith",  # LLM extracted this one
+                ruling_text="First ruling text.",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00000002",
+                extracted_case_title=None,  # LLM did NOT extract
+                ruling_text="Second ruling text.",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00000003",
+                extracted_case_title="Clarke v. Jones",
+                ruling_text="Third ruling text.",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00000004",
+                extracted_case_title=None,  # LLM did NOT extract
+                ruling_text="Fourth ruling text.",
+            ),
+        ]
+
+        with patch.object(reingest, "_apply_regex_fallbacks"):
+            results = reingest._reparse_document_multimodal(
+                b"%PDF-1.4 fake pdf",
+                "ca-oc-tentatives-civil",
+                doc_meta,
+                mock_extractor,
+            )
+
+        assert len(results) == 4
+        # Rulings with LLM titles keep them
+        assert results[0]["case_title"] == "Gu v. Smith"
+        assert results[2]["case_title"] == "Clarke v. Jones"
+        # Rulings without LLM titles must be None — NOT doc_meta's stale
+        # "Palacios v. Vallejo", NOT a sibling ruling's title.
+        assert results[1]["case_title"] is None
+        assert results[3]["case_title"] is None
+
 
 # ---------------------------------------------------------------------------
 # LLM enrichment tests (#2406)

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -10,14 +10,8 @@ script will process 0 documents.  For initial population from S3, use
 ``rebuild_db.py --county <name>`` instead — it discovers documents directly
 from S3 keys and does not require pre-existing database records.
 
-**Known non-idempotency (#2490):** This script is NOT a drop-in idempotent
-counterpart of the live worker path.  One divergence remains:
-
-1. The multimodal branch falls back to ``doc_meta.get("case_title")`` when
-   the LLM returns no title — this lets stale DB state propagate forward
-   instead of resetting to NULL, and combined with ``force_update=True``
-   on ``upsert_case`` creates a self-sustaining fixed point for wrong
-   titles (#2502).
+**Idempotency (#2490):** This script is a drop-in idempotent counterpart of
+the live worker path — known divergences have been resolved.
 
 **Resolved divergences:**
 
@@ -27,9 +21,21 @@ counterpart of the live worker path.  One divergence remains:
     the LLM-cache metadata footprint matches the worker path for the same
     raw PDF (#2501).
 
+-   The multimodal branch no longer falls back to
+    ``doc_meta.get("case_title")`` when the LLM returns no title (#2502).
+    Previously, this fallback pulled the existing DB title (carried via
+    the LEFT JOIN in ``FETCH_DOCUMENTS_QUERY``) into the result, and
+    combined with ``force_update=True`` on ``upsert_case`` created a
+    self-sustaining fixed point for wrong titles: once a bad title was
+    stored for a case, every reingest where the LLM returned no title
+    re-wrote that same wrong title back.  Now ``case_title`` is ``None``
+    when the LLM returns nothing, and the ``COALESCE(EXCLUDED.case_title,
+    cases.case_title)`` semantic at ``db.py:316`` preserves the existing
+    non-null title instead of erasing it.
+
 For cleanup of corrupted ``derived.*`` state, prefer ``rebuild_db.py
 --county <name>`` over reingest — rebuild walks S3 directly and does not
-participate in the remaining divergence above.
+touch existing ``cases.*`` rows when the split set changes across runs.
 
 For each document in the database, fetches the raw content from S3, re-runs
 the scraper's parse_document() to extract fields with the current (improved)
@@ -1636,7 +1642,19 @@ def _reparse_document_multimodal(
                 or doc_meta.get("case_number")
                 or f"UNKNOWN-{cr.document_id}"
             ),
-            "case_title": cr.case_title or doc_meta.get("case_title"),
+            # #2502: Do NOT fall back to ``doc_meta.get("case_title")`` here —
+            # ``doc_meta`` carries the *existing* DB ``case_title`` (via the
+            # LEFT JOIN in ``FETCH_DOCUMENTS_QUERY``).  Falling back would
+            # create a self-sustaining fixed point for wrong titles: once a
+            # bad title is stored for a case, every reingest where the LLM
+            # returns no title re-writes that same wrong title back (because
+            # the reingest path uses ``upsert_case(force_update=True)``).
+            # Letting ``None`` flow through is SAFE: ``upsert_case``'s
+            # ``force_update=True`` branch at ``db.py:316`` uses
+            # ``COALESCE(EXCLUDED.case_title, cases.case_title)``, so an
+            # incoming ``NULL`` preserves the existing non-null title
+            # instead of erasing it.
+            "case_title": cr.case_title,
             "case_type": cr.case_type,
             "judge_name": cr.judge_name or doc_judge_name,
             "outcome": cr.outcome,


### PR DESCRIPTION
## Summary

Removes the `or doc_meta.get("case_title")` fallback in `_reparse_document_multimodal` so a missing LLM title no longer pulls the existing DB title back through `doc_meta` (which is populated via the LEFT JOIN in `FETCH_DOCUMENTS_QUERY`). Combined with `upsert_case(force_update=True)`, that fallback created a self-sustaining fixed point for wrong titles — one of the three root causes chained together in the #2490 Palacios-v.-Vallejo regression. Letting `None` flow through is safe: `upsert_case`'s `force_update=True` path at `packages/scraper-framework/src/ingestion/db.py:316` uses `COALESCE(EXCLUDED.case_title, cases.case_title)` which preserves the existing non-null title against an incoming NULL.

Closes #2502

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (scraper-framework, full suite — 6000 passed locally; 3 new regression tests)
- [x] CI green

### Post-deploy verification
- [x] Fix present on `main` (commit `68d3306`) — `scripts/reingest_from_s3.py` is a one-off script delivered via `scripts/ecs-run-task.sh`, which copies from current git checkout at invocation. No service image contains it. Future reingest runs on dev will pick up the fixed code path.
- [x] Verification evidence posted on issue (https://github.com/judgemind/judgemind/issues/2502#issuecomment-4266152949)

Note: AC #5 from the issue (6 distinct `case_title` values for the 6 `UNKNOWN-<uuid>` cases backed by PDF hash `1dc5c7...`) is **not** verifiable from this PR alone — it requires the companion fixes for #TBD-A (row-fusion) and #TBD-B (cache-key fragmentation) to also land. This PR addresses one of the three root causes in the #2490 chain. The post-deploy verification above focuses on what this PR alone can demonstrate: `None` from the LLM no longer overwrites good DB state.
