### PR TITLE
fix(ci): replace ECS services-stable wait with task-def-specific polling loop (#2519)

### DIFF
--- a/.github/actions/ecs-deploy/action.yml
+++ b/.github/actions/ecs-deploy/action.yml
@@ -141,12 +141,20 @@ runs:
           --query 'service.serviceName' \
           --output text
 
-        echo "Waiting for service to stabilize..."
-        aws ecs wait services-stable \
-          --cluster "$ECS_CLUSTER" \
-          --services "$ECS_SERVICE"
-
-        echo "Service updated successfully."
+        # Wait for OUR task definition's deployment to reach a terminal state.
+        #
+        # This replaces `aws ecs wait services-stable`, which:
+        #   - polls every 15s for 40 attempts (10 min) with no way to customize;
+        #   - emits no progress output, making it hard to distinguish a real
+        #     timeout from a workflow cancellation (e.g. concurrency.cancel-in-
+        #     progress firing on a rapid follow-up merge, see #1867); and
+        #   - waits on "service stable" rather than on our specific deployment,
+        #     which can report steady state on an old deployment before the new
+        #     one begins rolling.
+        #
+        # See issue #2519 for the full motivation. The logic lives in a separate
+        # script so it can be shellchecked and unit-tested with a mock AWS CLI.
+        "${GITHUB_ACTION_PATH}/wait-for-rollout.sh"
 
     - name: Update EventBridge Scheduler target
       if: inputs.deploy-mode == 'scheduler'

--- a/.github/actions/ecs-deploy/wait-for-rollout.sh
+++ b/.github/actions/ecs-deploy/wait-for-rollout.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# wait-for-rollout.sh — Poll an ECS service deployment until the specified task
+# definition's rollout reaches a terminal state (COMPLETED or FAILED), or until
+# the configured timeout elapses.
+#
+# Called from .github/actions/ecs-deploy/action.yml's "Update ECS service" step.
+# Extracted into a standalone script so it can be shellchecked and unit-tested
+# with a mock aws CLI. See issue #2519.
+#
+# Required environment variables:
+#   ECS_CLUSTER        — ECS cluster name
+#   ECS_SERVICE        — ECS service name
+#   NEW_TASK_DEF_ARN   — Task definition ARN we are waiting to roll out
+#
+# Optional environment variables:
+#   ROLLOUT_TIMEOUT_SECS   — overall timeout in seconds (default: 900)
+#   ROLLOUT_POLL_INTERVAL  — polling interval in seconds (default: 10)
+#   AWS_CLI                — binary name for aws CLI (default: aws; used for
+#                            mocking in tests)
+#
+# Exit codes:
+#   0 — Target deployment reached rolloutState=COMPLETED with runningCount==
+#       desiredCount (and desiredCount > 0).
+#   1 — rolloutState=FAILED, or the timeout elapsed, or the aws CLI failed.
+
+set -euo pipefail
+
+: "${ECS_CLUSTER:?ECS_CLUSTER is required}"
+: "${ECS_SERVICE:?ECS_SERVICE is required}"
+: "${NEW_TASK_DEF_ARN:?NEW_TASK_DEF_ARN is required}"
+
+ROLLOUT_TIMEOUT_SECS="${ROLLOUT_TIMEOUT_SECS:-900}"
+ROLLOUT_POLL_INTERVAL="${ROLLOUT_POLL_INTERVAL:-10}"
+AWS_CLI="${AWS_CLI:-aws}"
+
+echo "Waiting for task definition $NEW_TASK_DEF_ARN to roll out on ${ECS_CLUSTER}/${ECS_SERVICE} (timeout: ${ROLLOUT_TIMEOUT_SECS}s, poll every ${ROLLOUT_POLL_INTERVAL}s)..."
+
+START_TS=$(date +%s)
+DEADLINE=$((START_TS + ROLLOUT_TIMEOUT_SECS))
+LAST_STATE=""
+LAST_COUNTS=""
+
+while true; do
+  NOW_TS=$(date +%s)
+  ELAPSED=$((NOW_TS - START_TS))
+
+  if ! SERVICE_JSON=$("$AWS_CLI" ecs describe-services \
+        --cluster "$ECS_CLUSTER" \
+        --services "$ECS_SERVICE" \
+        --output json); then
+    echo "ERROR: aws ecs describe-services failed after ${ELAPSED}s."
+    exit 1
+  fi
+
+  DEPLOYMENT=$(echo "$SERVICE_JSON" | jq --arg arn "$NEW_TASK_DEF_ARN" \
+    '.services[0].deployments[] | select(.taskDefinition == $arn)')
+
+  if [ -z "$DEPLOYMENT" ]; then
+    # Our deployment has not yet been registered in the deployments list.
+    # Give ECS a moment — retry.
+    echo "[${ELAPSED}s] Deployment for new task def not yet visible, retrying..."
+  else
+    ROLLOUT_STATE=$(echo "$DEPLOYMENT" | jq -r '.rolloutState // "UNKNOWN"')
+    ROLLOUT_REASON=$(echo "$DEPLOYMENT" | jq -r '.rolloutStateReason // ""')
+    RUNNING_COUNT=$(echo "$DEPLOYMENT" | jq -r '.runningCount')
+    DESIRED_COUNT=$(echo "$DEPLOYMENT" | jq -r '.desiredCount')
+    PENDING_COUNT=$(echo "$DEPLOYMENT" | jq -r '.pendingCount')
+    STATE_SIG="${ROLLOUT_STATE}|running=${RUNNING_COUNT}|desired=${DESIRED_COUNT}|pending=${PENDING_COUNT}"
+    if [ "$STATE_SIG" != "$LAST_COUNTS" ]; then
+      echo "[${ELAPSED}s] rolloutState=${ROLLOUT_STATE} running=${RUNNING_COUNT} desired=${DESIRED_COUNT} pending=${PENDING_COUNT} ${ROLLOUT_REASON:+(${ROLLOUT_REASON})}"
+      LAST_COUNTS="$STATE_SIG"
+    fi
+
+    case "$ROLLOUT_STATE" in
+      COMPLETED)
+        if [ "$RUNNING_COUNT" = "$DESIRED_COUNT" ] && [ "$RUNNING_COUNT" != "0" ]; then
+          echo "Service updated successfully after ${ELAPSED}s."
+          exit 0
+        fi
+        ;;
+      FAILED)
+        echo "ERROR: ECS reported rolloutState=FAILED for $NEW_TASK_DEF_ARN after ${ELAPSED}s."
+        echo "Reason: $ROLLOUT_REASON"
+        echo "Full deployment JSON:"
+        echo "$DEPLOYMENT" | jq '.'
+        exit 1
+        ;;
+      IN_PROGRESS|UNKNOWN)
+        : # keep polling
+        ;;
+    esac
+    LAST_STATE="$ROLLOUT_STATE"
+  fi
+
+  if [ "$NOW_TS" -ge "$DEADLINE" ]; then
+    echo "ERROR: Timed out after ${ROLLOUT_TIMEOUT_SECS}s waiting for $NEW_TASK_DEF_ARN to stabilize."
+    echo "Last observed state: ${LAST_STATE:-<none>} (${LAST_COUNTS:-<no counts>})"
+    echo "Full service JSON snapshot:"
+    echo "$SERVICE_JSON" | jq '.services[0] | {serviceName, desiredCount, runningCount, pendingCount, deployments, events: (.events[:5])}'
+    exit 1
+  fi
+
+  sleep "$ROLLOUT_POLL_INTERVAL"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,11 @@ jobs:
               - 'infra/**'
             scripts:
               - 'scripts/**'
+              # wait-for-rollout.sh is consumed by the ecs-deploy composite
+              # action. Running scripts-tests on ecs-deploy changes ensures
+              # test_wait_for_rollout.sh fires on PRs that touch only the
+              # composite action.
+              - '.github/actions/ecs-deploy/**'
             ecs-oneshot:
               - 'scripts/*.py'
               - 'scripts/ecs-run-task.sh'
@@ -575,6 +580,8 @@ jobs:
         run: scripts/tests/test_check_graphql_queries.sh
       - name: Test install-package-venv.sh
         run: scripts/tests/test_install_package_venv.sh
+      - name: Test wait-for-rollout.sh
+        run: scripts/tests/test_wait_for_rollout.sh
 
   # ---------------------------------------------------------------
   # Coverage gates: diff coverage (new lines) + overall floor ratchet

--- a/scripts/tests/test_wait_for_rollout.sh
+++ b/scripts/tests/test_wait_for_rollout.sh
@@ -1,0 +1,435 @@
+#!/usr/bin/env bash
+# test_wait_for_rollout.sh — Unit tests for .github/actions/ecs-deploy/wait-for-rollout.sh
+#
+# Exercises the ECS rollout polling loop against a mock aws CLI that emits a
+# sequence of pre-canned describe-services responses. Verifies the success,
+# failure, and timeout paths.
+#
+# Usage:
+#   scripts/tests/test_wait_for_rollout.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/.github/actions/ecs-deploy/wait-for-rollout.sh"
+
+if [[ ! -x "$SCRIPT_UNDER_TEST" ]]; then
+    echo "FATAL: $SCRIPT_UNDER_TEST is not executable." >&2
+    exit 1
+fi
+
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+# shellcheck disable=SC2329  # invoked via trap below
+cleanup() {
+    set +e
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    # Pre-create the responses dir so callers can drop canned JSON files into
+    # it before setup_mock_aws runs (setup_mock_aws also mkdirs it, but only
+    # when run_script is invoked).
+    mkdir -p "$dir/responses"
+    echo "$dir"
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Create a mock `aws` CLI that reads a sequence of JSON blobs from a directory
+# and emits each one on successive calls. Writes arg history to args.log.
+#
+# Usage: setup_mock_aws <tmpdir> — returns path to the mock script.
+#
+# The caller should drop JSON response files named 01.json, 02.json, ... into
+# <tmpdir>/responses/; each describe-services call emits the next one in order,
+# wrapping back to the last file once exhausted.
+setup_mock_aws() {
+    local tmpdir="$1"
+    local mock="$tmpdir/aws"
+
+    mkdir -p "$tmpdir/responses"
+
+    cat > "$mock" << 'MOCK'
+#!/usr/bin/env bash
+# Mock aws CLI — emits the next canned response from $RESPONSES_DIR/NN.json.
+set -euo pipefail
+
+RESPONSES_DIR="${RESPONSES_DIR:?RESPONSES_DIR required}"
+CALL_LOG="${CALL_LOG:-/dev/null}"
+CALL_COUNTER_FILE="${CALL_COUNTER_FILE:?CALL_COUNTER_FILE required}"
+
+echo "$*" >> "$CALL_LOG"
+
+# Only describe-services calls consume responses; update-service is a no-op here
+# (the script we're testing doesn't call it — only action.yml does).
+case "$*" in
+    "ecs describe-services"*)
+        :
+        ;;
+    *)
+        # Unknown mock call — just exit 0.
+        exit 0
+        ;;
+esac
+
+# Read and increment call counter
+if [[ -f "$CALL_COUNTER_FILE" ]]; then
+    COUNT=$(cat "$CALL_COUNTER_FILE")
+else
+    COUNT=0
+fi
+COUNT=$((COUNT + 1))
+echo "$COUNT" > "$CALL_COUNTER_FILE"
+
+# Pick response file; clamp to highest available.
+RESPONSE_FILE=$(printf '%s/%02d.json' "$RESPONSES_DIR" "$COUNT")
+if [[ ! -f "$RESPONSE_FILE" ]]; then
+    # Fall back to the highest-numbered file
+    RESPONSE_FILE=$(ls -1 "$RESPONSES_DIR"/*.json 2>/dev/null | sort | tail -n 1 || echo "")
+fi
+
+if [[ -z "$RESPONSE_FILE" || ! -f "$RESPONSE_FILE" ]]; then
+    echo "MOCK ERROR: no response file available" >&2
+    exit 1
+fi
+
+cat "$RESPONSE_FILE"
+MOCK
+    chmod +x "$mock"
+    echo "$mock"
+}
+
+# Write a describe-services response with the given deployment state.
+# Usage: write_response <file> <rollout_state> <running> <desired> <pending> [task_def_arn]
+write_response() {
+    local file="$1"
+    local rollout_state="$2"
+    local running="$3"
+    local desired="$4"
+    local pending="$5"
+    local task_def_arn="${6:-arn:test:new}"
+
+    cat > "$file" << JSON
+{
+  "services": [
+    {
+      "serviceName": "test-svc",
+      "desiredCount": $desired,
+      "runningCount": $running,
+      "pendingCount": $pending,
+      "deployments": [
+        {
+          "id": "ecs-svc/new",
+          "taskDefinition": "$task_def_arn",
+          "rolloutState": "$rollout_state",
+          "rolloutStateReason": "test reason",
+          "runningCount": $running,
+          "desiredCount": $desired,
+          "pendingCount": $pending
+        }
+      ],
+      "events": []
+    }
+  ]
+}
+JSON
+}
+
+# Write a describe-services response where our task def is NOT yet in the
+# deployments array (simulating the brief window after update-service).
+write_response_missing_deployment() {
+    local file="$1"
+    cat > "$file" << 'JSON'
+{
+  "services": [
+    {
+      "serviceName": "test-svc",
+      "desiredCount": 1,
+      "runningCount": 1,
+      "pendingCount": 0,
+      "deployments": [
+        {
+          "id": "ecs-svc/old",
+          "taskDefinition": "arn:test:old",
+          "rolloutState": "COMPLETED",
+          "runningCount": 1,
+          "desiredCount": 1,
+          "pendingCount": 0
+        }
+      ],
+      "events": []
+    }
+  ]
+}
+JSON
+}
+
+# Run the script under test with mocks wired up.
+run_script() {
+    local tmpdir="$1"
+    shift
+    local mock_aws
+    mock_aws=$(setup_mock_aws "$tmpdir")
+
+    AWS_CLI="$mock_aws" \
+    RESPONSES_DIR="$tmpdir/responses" \
+    CALL_LOG="$tmpdir/calls.log" \
+    CALL_COUNTER_FILE="$tmpdir/counter" \
+    ECS_CLUSTER="test-cluster" \
+    ECS_SERVICE="test-svc" \
+    NEW_TASK_DEF_ARN="arn:test:new" \
+    ROLLOUT_POLL_INTERVAL="${ROLLOUT_POLL_INTERVAL:-0}" \
+    ROLLOUT_TIMEOUT_SECS="${ROLLOUT_TIMEOUT_SECS:-5}" \
+        "$SCRIPT_UNDER_TEST" "$@"
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+# Test 1: Immediate COMPLETED with running==desired exits 0.
+test_immediate_completed() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    mkdir -p "$tmpdir/responses"
+    write_response "$tmpdir/responses/01.json" "COMPLETED" 1 1 0
+
+    local output exit_code
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        pass "immediate COMPLETED exits 0"
+    else
+        fail "immediate COMPLETED exits 0" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "Service updated successfully"; then
+        pass "immediate COMPLETED emits success message"
+    else
+        fail "immediate COMPLETED emits success message" "output=$output"
+    fi
+}
+
+# Test 2: IN_PROGRESS then COMPLETED exits 0.
+test_in_progress_then_completed() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    mkdir -p "$tmpdir/responses"
+    write_response "$tmpdir/responses/01.json" "IN_PROGRESS" 0 1 1
+    write_response "$tmpdir/responses/02.json" "IN_PROGRESS" 1 1 0
+    write_response "$tmpdir/responses/03.json" "COMPLETED" 1 1 0
+
+    local output exit_code
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        pass "IN_PROGRESS then COMPLETED exits 0"
+    else
+        fail "IN_PROGRESS then COMPLETED exits 0" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "rolloutState=IN_PROGRESS"; then
+        pass "progress output logged during IN_PROGRESS"
+    else
+        fail "progress output logged during IN_PROGRESS" "output=$output"
+    fi
+}
+
+# Test 3: Deployment missing then appearing as COMPLETED exits 0.
+test_deployment_missing_then_appears() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    mkdir -p "$tmpdir/responses"
+    write_response_missing_deployment "$tmpdir/responses/01.json"
+    write_response "$tmpdir/responses/02.json" "COMPLETED" 1 1 0
+
+    local output exit_code
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        pass "missing-then-present deployment exits 0"
+    else
+        fail "missing-then-present deployment exits 0" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "not yet visible"; then
+        pass "emits 'not yet visible' when deployment missing"
+    else
+        fail "emits 'not yet visible' when deployment missing" "output=$output"
+    fi
+}
+
+# Test 4: FAILED rolloutState exits 1 with clear error.
+test_failed_rollout() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    mkdir -p "$tmpdir/responses"
+    write_response "$tmpdir/responses/01.json" "FAILED" 0 1 0
+
+    local output exit_code
+    exit_code=0
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 1 ]]; then
+        pass "FAILED rollout exits 1"
+    else
+        fail "FAILED rollout exits 1" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "rolloutState=FAILED"; then
+        pass "FAILED rollout emits clear error"
+    else
+        fail "FAILED rollout emits clear error" "output=$output"
+    fi
+}
+
+# Test 5: Timeout exits 1 with diagnostic output.
+test_timeout() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    # Always returns IN_PROGRESS — will never reach COMPLETED.
+    write_response "$tmpdir/responses/01.json" "IN_PROGRESS" 0 1 1
+
+    local output exit_code
+    exit_code=0
+    # Tight timeout to keep the test fast.
+    output=$(ROLLOUT_TIMEOUT_SECS=1 ROLLOUT_POLL_INTERVAL=0 run_script "$tmpdir" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 1 ]]; then
+        pass "timeout exits 1"
+    else
+        fail "timeout exits 1" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "Timed out after"; then
+        pass "timeout emits clear error"
+    else
+        fail "timeout emits clear error" "output=$output"
+    fi
+
+    if echo "$output" | grep -q "Full service JSON snapshot"; then
+        pass "timeout includes diagnostic JSON snapshot"
+    else
+        fail "timeout includes diagnostic JSON snapshot" "output=$output"
+    fi
+}
+
+# Test 6: COMPLETED with running!=desired keeps polling until real completion.
+test_completed_but_running_not_yet_matching() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    # First call: rolloutState claims COMPLETED but runningCount is still 0 —
+    # we should NOT treat this as success. (Defensive: shouldn't happen in
+    # practice since ECS only sets COMPLETED after steady state, but we guard
+    # against the race.) Second call: true completion.
+    write_response "$tmpdir/responses/01.json" "COMPLETED" 0 1 0
+    write_response "$tmpdir/responses/02.json" "COMPLETED" 1 1 0
+
+    local output exit_code
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        pass "COMPLETED with running=0 waits for running=desired"
+    else
+        fail "COMPLETED with running=0 waits for running=desired" "exit=$exit_code output=$output"
+    fi
+}
+
+# Test 7: aws CLI failure exits 1 quickly.
+test_aws_cli_failure() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    # Create a mock that always exits 1
+    local mock="$tmpdir/aws"
+    cat > "$mock" << 'MOCK'
+#!/usr/bin/env bash
+echo "mock aws error" >&2
+exit 1
+MOCK
+    chmod +x "$mock"
+
+    local output exit_code
+    exit_code=0
+    output=$(AWS_CLI="$mock" \
+        ECS_CLUSTER="c" ECS_SERVICE="s" NEW_TASK_DEF_ARN="arn:x" \
+        ROLLOUT_TIMEOUT_SECS=5 ROLLOUT_POLL_INTERVAL=0 \
+        "$SCRIPT_UNDER_TEST" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 1 ]]; then
+        pass "aws CLI failure exits 1"
+    else
+        fail "aws CLI failure exits 1" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "describe-services failed"; then
+        pass "aws CLI failure emits clear error"
+    else
+        fail "aws CLI failure emits clear error" "output=$output"
+    fi
+}
+
+# Test 8: Missing required env vars exits non-zero.
+test_missing_required_env() {
+    local output exit_code
+    exit_code=0
+    output=$(env -i PATH="$PATH" bash "$SCRIPT_UNDER_TEST" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        pass "missing required env exits non-zero"
+    else
+        fail "missing required env exits non-zero" "exit=$exit_code output=$output"
+    fi
+}
+
+# ── Run all tests ──────────────────────────────────────────────────────────
+
+test_immediate_completed
+test_in_progress_then_completed
+test_deployment_missing_then_appears
+test_failed_rollout
+test_timeout
+test_completed_but_running_not_yet_matching
+test_aws_cli_failure
+test_missing_required_env
+
+echo ""
+echo "────────────────────────────────────────────"
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [[ $FAILURES -gt 0 ]]; then
+    echo "$FAILURES test(s) FAILED"
+    exit 1
+fi
+echo "All tests passed."
+exit 0


### PR DESCRIPTION
## Summary

Replaces `aws ecs wait services-stable` in the shared `ecs-deploy` composite action with a task-def-specific polling loop that emits progress output, waits for OUR new deployment (not overall service stable), has a configurable 15-min timeout, and dumps diagnostic JSON on timeout. Fixes the frequent false "deploy failed" signal on `Deploy Scraper` caused by concurrency-cancellation (#1867) looking identical to a real timeout.

Closes #2519

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] `scripts/tests/test_wait_for_rollout.sh` passes (15 tests)
- [x] CI green

### Post-deploy verification
- [x] Next merge to `main` that touches `packages/scraper-framework/**`, `.github/actions/ecs-deploy/**`, or `.github/workflows/deploy-scraper.yml` triggers `Deploy Scraper` and reports success on the `Deploy Ingestion Worker to Dev` job without manual re-verification. (Verified on run [24553191285](https://github.com/judgemind/judgemind/actions/runs/24553191285) — Deploy Ingestion Worker to Dev completed in 3m58s.)
- [x] The `Deploy to ECS` step log contains `[<N>s] rolloutState=…` progress lines (the new polling output), not just `Waiting for service to stabilize...`. (Confirmed — 5 transition lines from 0s→224s, rolloutState IN_PROGRESS→COMPLETED.)
- [x] Verification evidence posted on issue (see #2519 A.8).
