### PR TITLE
fix(reingest): remove case_title doc_meta fallback in text-split branch (#2521)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -6826,6 +6826,302 @@ class TestReparseDocumentMultimodal:
 
 
 # ---------------------------------------------------------------------------
+# Text-split branch tests — sibling of TestReparseDocumentMultimodal (#2521)
+# ---------------------------------------------------------------------------
+
+
+class TestReparseDocumentTextSplit:
+    """Regression tests for the text-split branch of ``_full_reparse_document``.
+
+    Mirrors ``TestReparseDocumentMultimodal``'s ``case_title`` tests to
+    guard against the same #2502-style fixed point in the split path used
+    by Fresno, Contra Costa, and any future text-split counties (#2521).
+    """
+
+    _SCRAPER_ID = "test-split-title-2521"
+
+    def _make_doc_meta(
+        self,
+        *,
+        case_title: str | None = None,
+        case_number: str | None = "CVPS2306157",
+    ) -> dict:
+        return {
+            "document_id": str(_DOC_ID_1),
+            "state": "CA",
+            "county": "Fresno",
+            "court_name": "Fresno Superior Court",
+            "source_url": "https://court.example.com/ruling.pdf",
+            "captured_at": _CAPTURED_AT_1,
+            "content_hash": "abc123",
+            "format": "pdf",
+            "case_number": case_number,
+            "case_title": case_title,
+            "case_type": None,
+            "hearing_date": _HEARING_DATE,
+            "court_id": str(_COURT_ID),
+            "scraper_id": self._SCRAPER_ID,
+            "s3_key": "docs/test.pdf",
+            "s3_bucket": "test-bucket",
+        }
+
+    def _register_split(self, rulings: list[Any]) -> MagicMock:
+        """Register a regex-split mock under ``_SCRAPER_ID`` and return it.
+
+        Callers are responsible for popping the registry entry in a
+        ``finally`` block.  Using a distinct scraper_id keeps these tests
+        isolated from real-scraper registry state.
+        """
+        mock_split = MagicMock(return_value=rulings)
+        reingest._SPLIT_REGISTRY[self._SCRAPER_ID] = mock_split
+        # Ensure no LLM split is registered so we exercise the regex path.
+        reingest._LLM_SPLIT_REGISTRY.pop(self._SCRAPER_ID, None)
+        # Ensure no scraper registry entry — avoids parse_document() call.
+        reingest._SCRAPER_REGISTRY.pop(self._SCRAPER_ID, None)
+        return mock_split
+
+    def test_case_title_null_when_split_returns_none_no_db_fallback(self) -> None:
+        """When the text split returns no case_title for a ruling, the
+        reingest dict must have case_title=None — NOT the stale DB title
+        from doc_meta (#2521, sibling of #2502).
+
+        Previously, the code used ``ruling.case_title or
+        doc_meta.get("case_title")`` which pulled the existing DB title
+        (carried via the LEFT JOIN in FETCH_DOCUMENTS_QUERY) into the
+        result when the split produced nothing.  Combined with
+        ``upsert_case(force_update=True)``, that created a self-sustaining
+        fixed point for wrong titles.  The fix removes the fallback so
+        None flows through to upsert_case, where the COALESCE semantic at
+        db.py:316 preserves the existing (non-null) title.
+        """
+        from courts.ca.fresno_tentatives import SplitRuling
+
+        doc_meta = self._make_doc_meta(case_title="Stale DB Title")
+        rulings = [
+            SplitRuling(
+                ruling_index=1,
+                case_number="CVPS2306157",
+                ruling_text="First ruling text.",
+                case_title=None,  # split did not extract a title
+                motion_type=None,
+                outcome=None,
+                hearing_date=None,
+            ),
+            SplitRuling(
+                ruling_index=2,
+                case_number="CVPS2306202",
+                ruling_text="Second ruling text.",
+                case_title=None,
+                motion_type=None,
+                outcome=None,
+                hearing_date=None,
+            ),
+        ]
+        self._register_split(rulings)
+
+        try:
+            with (
+                patch.object(reingest, "_apply_regex_fallbacks"),
+                patch.object(reingest, "_extract_text_from_content", return_value="pdf text"),
+            ):
+                results = reingest._full_reparse_document(
+                    b"%PDF-1.4 fake pdf",
+                    self._SCRAPER_ID,
+                    doc_meta,
+                )
+        finally:
+            reingest._SPLIT_REGISTRY.pop(self._SCRAPER_ID, None)
+
+        assert len(results) == 2
+        # Both must be None — not "Stale DB Title" (no fallback to doc_meta)
+        assert results[0]["case_title"] is None
+        assert results[1]["case_title"] is None
+        # extraction_methods must NOT mark case_title as "split" when the
+        # field is None (guards against misleading provenance).
+        assert "case_title" not in results[0]["extraction_methods"]
+        assert "case_title" not in results[1]["extraction_methods"]
+
+    def test_case_title_from_split_wins_over_db_title(self) -> None:
+        """When the text split returns a case_title, it wins over any
+        existing doc_meta title (#2521, sibling of #2502).
+        """
+        from courts.ca.fresno_tentatives import SplitRuling
+
+        doc_meta = self._make_doc_meta(case_title="Old DB Title")
+        rulings = [
+            SplitRuling(
+                ruling_index=1,
+                case_number="CVPS2306157",
+                ruling_text="First ruling text.",
+                case_title="Fresh Split Title",
+                motion_type=None,
+                outcome=None,
+                hearing_date=None,
+            ),
+            SplitRuling(
+                ruling_index=2,
+                case_number="CVPS2306202",
+                ruling_text="Second ruling text.",
+                case_title="Another Fresh Title",
+                motion_type=None,
+                outcome=None,
+                hearing_date=None,
+            ),
+        ]
+        self._register_split(rulings)
+
+        try:
+            with (
+                patch.object(reingest, "_apply_regex_fallbacks"),
+                patch.object(reingest, "_extract_text_from_content", return_value="pdf text"),
+            ):
+                results = reingest._full_reparse_document(
+                    b"%PDF-1.4 fake pdf",
+                    self._SCRAPER_ID,
+                    doc_meta,
+                )
+        finally:
+            reingest._SPLIT_REGISTRY.pop(self._SCRAPER_ID, None)
+
+        assert len(results) == 2
+        assert results[0]["case_title"] == "Fresh Split Title"
+        assert results[1]["case_title"] == "Another Fresh Title"
+
+    def test_multi_ruling_no_title_swap_when_some_rulings_miss_title(self) -> None:
+        """Multi-ruling text-split PDFs: rulings whose split extraction
+        returned no title must keep case_title=None — they must NOT pick
+        up doc_meta's title and must NOT pick up a sibling ruling's title
+        (#2521, sibling of #2502).
+
+        This mirrors the canonical #2490 Palacios-v.-Vallejo repro in the
+        multimodal branch: a multi-case PDF where one or more splits come
+        back without a title, and any fallback causes them to converge on
+        the same wrong title across reingest cycles.
+        """
+        from courts.ca.fresno_tentatives import SplitRuling
+
+        doc_meta = self._make_doc_meta(case_title="Palacios v. Vallejo")
+        rulings = [
+            SplitRuling(
+                ruling_index=1,
+                case_number="CVPS2306001",
+                ruling_text="First ruling text.",
+                case_title="Gu v. Smith",  # split extracted this one
+                motion_type=None,
+                outcome=None,
+                hearing_date=None,
+            ),
+            SplitRuling(
+                ruling_index=2,
+                case_number="CVPS2306002",
+                ruling_text="Second ruling text.",
+                case_title=None,  # split did NOT extract
+                motion_type=None,
+                outcome=None,
+                hearing_date=None,
+            ),
+            SplitRuling(
+                ruling_index=3,
+                case_number="CVPS2306003",
+                ruling_text="Third ruling text.",
+                case_title="Clarke v. Jones",
+                motion_type=None,
+                outcome=None,
+                hearing_date=None,
+            ),
+            SplitRuling(
+                ruling_index=4,
+                case_number="CVPS2306004",
+                ruling_text="Fourth ruling text.",
+                case_title=None,  # split did NOT extract
+                motion_type=None,
+                outcome=None,
+                hearing_date=None,
+            ),
+        ]
+        self._register_split(rulings)
+
+        try:
+            with (
+                patch.object(reingest, "_apply_regex_fallbacks"),
+                patch.object(reingest, "_extract_text_from_content", return_value="pdf text"),
+            ):
+                results = reingest._full_reparse_document(
+                    b"%PDF-1.4 fake pdf",
+                    self._SCRAPER_ID,
+                    doc_meta,
+                )
+        finally:
+            reingest._SPLIT_REGISTRY.pop(self._SCRAPER_ID, None)
+
+        assert len(results) == 4
+        # Rulings with split titles keep them.
+        assert results[0]["case_title"] == "Gu v. Smith"
+        assert results[2]["case_title"] == "Clarke v. Jones"
+        # Rulings without split titles must be None — NOT doc_meta's
+        # stale "Palacios v. Vallejo", NOT a sibling ruling's title.
+        assert results[1]["case_title"] is None
+        assert results[3]["case_title"] is None
+
+    def test_case_number_preserves_doc_meta_fallback_identity_anchor(self) -> None:
+        """``case_number`` keeps its ``doc_meta`` fallback even when the
+        split returns no case_number — it is an *identity anchor* keyed
+        on ``(court_id, case_number)`` in ``cases``, not descriptive
+        metadata subject to the #2502 fixed-point risk (#2521).
+
+        If the split produces no case_number, falling back to doc_meta's
+        value keeps the ruling attached to its existing case row.
+        Replacing a real number with ``UNKNOWN-<uuid>`` would orphan it.
+        """
+        from courts.ca.fresno_tentatives import SplitRuling
+
+        doc_meta = self._make_doc_meta(
+            case_title=None,
+            case_number="CVPS-REAL-123",  # existing identity anchor
+        )
+        rulings = [
+            SplitRuling(
+                ruling_index=1,
+                case_number=None,  # split produced nothing
+                ruling_text="First ruling text.",
+                case_title=None,
+                motion_type=None,
+                outcome=None,
+                hearing_date=None,
+            ),
+            SplitRuling(
+                ruling_index=2,
+                case_number=None,
+                ruling_text="Second ruling text.",
+                case_title=None,
+                motion_type=None,
+                outcome=None,
+                hearing_date=None,
+            ),
+        ]
+        self._register_split(rulings)
+
+        try:
+            with (
+                patch.object(reingest, "_apply_regex_fallbacks"),
+                patch.object(reingest, "_extract_text_from_content", return_value="pdf text"),
+            ):
+                results = reingest._full_reparse_document(
+                    b"%PDF-1.4 fake pdf",
+                    self._SCRAPER_ID,
+                    doc_meta,
+                )
+        finally:
+            reingest._SPLIT_REGISTRY.pop(self._SCRAPER_ID, None)
+
+        assert len(results) == 2
+        # Both rulings must inherit the doc_meta case_number (identity
+        # anchor preserved) — NOT be None.
+        assert results[0]["case_number"] == "CVPS-REAL-123"
+        assert results[1]["case_number"] == "CVPS-REAL-123"
+
+
+# ---------------------------------------------------------------------------
 # LLM enrichment tests (#2406)
 # ---------------------------------------------------------------------------
 

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -33,6 +33,26 @@ the live worker path — known divergences have been resolved.
     cases.case_title)`` semantic at ``db.py:316`` preserves the existing
     non-null title instead of erasing it.
 
+-   The text-split branch of ``_full_reparse_document`` (the regex- or
+    LLM-split path used by counties like Fresno and Contra Costa) also
+    no longer falls back to ``doc_meta.get("case_title")`` when the
+    split produces no title (#2521).  Same fixed-point pattern, same
+    fix — let ``None`` flow through and rely on the ``db.py:316``
+    COALESCE safeguard.  Note: the scaffold path at
+    ``_reparse_document`` line ~797 *does* still initialise
+    ``case_title`` from ``doc_meta`` as the starting point, because a
+    per-scraper ``parse_document()`` overwrite immediately replaces it
+    with the parser's output; that pattern is intentional and distinct
+    from the split-branch bug.
+
+-   ``case_number`` is treated differently from ``case_title`` in the
+    split branch: it keeps its ``doc_meta`` fallback because it is an
+    identity anchor (``cases`` is keyed on ``(court_id,
+    case_number)``), not descriptive metadata.  Replacing a real number
+    with ``UNKNOWN-<uuid>`` would orphan the ruling from its existing
+    case row.  The LLM always wins when it produces a case_number, so
+    the fixed-point risk that affected ``case_title`` does not apply.
+
 For cleanup of corrupted ``derived.*`` state, prefer ``rebuild_db.py
 --county <name>`` over reingest — rebuild walks S3 directly and does not
 touch existing ``cases.*`` rows when the split set changes across runs.
@@ -1291,8 +1311,33 @@ def _full_reparse_document(
 
         extracted: dict = {
             "ruling_text": ruling_text_cleaned,
+            # ``case_number`` keeps its ``doc_meta`` fallback because it is
+            # an *identity anchor*, not descriptive metadata: the ``cases``
+            # row is keyed on ``(court_id, case_number)`` (``db.py:325``).
+            # If the split returns no case_number we want to continue
+            # writing this ruling back to the *same* case row — replacing
+            # a real number with ``UNKNOWN-<uuid>`` would orphan the
+            # ruling from the existing case.  The same doc_meta ->
+            # UNKNOWN layering repeats in the DB-write path at lines
+            # 2373-2377 as a final safety net.  (Unlike case_title, the
+            # #2502 fixed-point risk does not apply here: the LLM always
+            # wins when it produces a case_number, and a stable identity
+            # anchor is the desired behaviour.)
             "case_number": ruling.case_number or doc_meta.get("case_number"),
-            "case_title": ruling.case_title or doc_meta.get("case_title"),
+            # #2521 (sibling of #2502): Do NOT fall back to
+            # ``doc_meta.get("case_title")`` here — ``doc_meta`` carries
+            # the *existing* DB ``case_title`` (via the LEFT JOIN in
+            # ``FETCH_DOCUMENTS_QUERY``).  Falling back would create a
+            # self-sustaining fixed point for wrong titles: once a bad
+            # title is stored for a case, every reingest where the split
+            # returns no title re-writes that same wrong title back
+            # (because reingest uses ``upsert_case(force_update=True)``).
+            # Letting ``None`` flow through is SAFE: ``upsert_case``'s
+            # ``force_update=True`` branch at ``db.py:316`` uses
+            # ``COALESCE(EXCLUDED.case_title, cases.case_title)``, so an
+            # incoming ``NULL`` preserves the existing non-null title
+            # instead of erasing it.
+            "case_title": ruling.case_title,
             "case_type": doc_meta.get("case_type"),
             "judge_name": doc_judge_name,
             "outcome": normalize_outcome(ruling.outcome),


### PR DESCRIPTION
## Summary

Removes the `doc_meta.get("case_title")` fallback from the text-split
branch of `scripts/reingest_from_s3.py::_full_reparse_document` — same
self-sustaining fixed-point pattern as #2502 (multimodal branch), same
fix.  `case_number` keeps its doc_meta fallback with an explanatory
comment: it is an identity anchor, not descriptive metadata, so the
#2502 fixed-point risk does not apply.  Adds a
`TestReparseDocumentTextSplit` regression class mirroring the three
multimodal-branch title-fallback tests plus a case_number-identity test.

Closes #2521

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — changes affect `scripts/reingest_from_s3.py` (an ECS one-off
      reingest script) and its regression tests.  The script is invoked
      manually via `scripts/ecs-run-task.sh` when an operator wants to
      re-process existing records after an extraction fix; it is not on
      the live ingestion critical path.  Regression coverage is the
      verification here — the new `TestReparseDocumentTextSplit` tests
      were shown to fail without the fix (2 of 4 tests fail with
      `assert 'Palacios v. Vallejo' is None`) and pass with it.
- [x] Verification evidence posted on issue (see A.8)
