### PR TITLE
dx(ci): auto-discover scripts/tests/*.sh in the scripts-tests job (#2505)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,48 +540,45 @@ jobs:
         run: pytest scripts/tests/ -v --tb=short
       - name: Check AWS CLI boolean flag usage
         run: scripts/check-aws-bool-flags.sh
-      - name: Test AWS CLI boolean flag checker
-        run: scripts/tests/test_check_aws_bool_flags.sh
-      - name: Test deprecated model checker
-        run: scripts/tests/test_check_deprecated_models.sh
-      - name: Test hardcoded model checker
-        run: scripts/tests/test_check_hardcoded_models.sh
-      - name: Test schema drift checker
-        run: scripts/tests/test_check_schema_drift.sh
-      - name: Test duplicate function checker
-        run: scripts/tests/test_check_duplicate_functions.sh
-      - name: Test test-except-pass checker
-        run: scripts/tests/test_check_test_except_pass.sh
-      - name: Test markdown link checker
-        run: scripts/tests/test_check_markdown_links.sh
-      - name: Test migration files checker
-        run: scripts/tests/test_check_migration_files.sh
-      - name: Test gemini-review.sh smoke tests
-        run: scripts/tests/test_gemini_review.sh
-      - name: Test adopt-pr.sh
-        run: scripts/tests/test_adopt_pr.sh
-      - name: Test oneshot repo-path checker
-        run: scripts/tests/test_check_oneshot_repo_paths.sh
-      - name: Test run-scraper.sh
-        run: scripts/tests/test_run_scraper.sh
-      - name: Test ecs-task-logs.sh
-        run: scripts/tests/test_ecs_task_logs.sh
-      - name: Test write-claude-file.sh
-        run: scripts/tests/test_write_claude_file.sh
-      - name: Test cleanup_worktree.sh
-        run: scripts/tests/test_cleanup_worktree.sh
-      - name: Test sweep_stale_worktrees.sh
-        run: scripts/tests/test_sweep_stale_worktrees.sh
-      - name: Test run-py.sh
-        run: scripts/tests/test_run_py.sh
-      - name: Test removed exports checker
-        run: scripts/tests/test_check_removed_exports.sh
-      - name: Test GraphQL query checker
-        run: scripts/tests/test_check_graphql_queries.sh
-      - name: Test install-package-venv.sh
-        run: scripts/tests/test_install_package_venv.sh
-      - name: Test wait-for-rollout.sh
-        run: scripts/tests/test_wait_for_rollout.sh
+      # Auto-discover and run every executable shell test under
+      # scripts/tests/*.sh. Replaces the old per-script listing (#2505) so
+      # that adding a new shell test is just `touch + chmod +x` — no
+      # matching ci.yml edit required. Previously, three tests
+      # (test_check_oneshot_imports.sh, test_ecs_logs.sh, test_preflight.sh)
+      # were silently never running in CI because they'd never been added
+      # to the list.
+      - name: Run all scripts/tests shell tests
+        shell: bash
+        run: |
+          set -uo pipefail
+          shopt -s nullglob
+          tests=(scripts/tests/*.sh)
+          if [ ${#tests[@]} -eq 0 ]; then
+            echo "No shell test files found under scripts/tests/ — nothing to run."
+            exit 0
+          fi
+          failed=0
+          ran=0
+          skipped=0
+          for t in "${tests[@]}"; do
+            if [ ! -x "$t" ]; then
+              echo "::warning::Skipping $t — not executable (chmod +x required)"
+              skipped=$((skipped + 1))
+              continue
+            fi
+            echo "::group::$t"
+            if ! "$t"; then
+              echo "::error::$t failed"
+              failed=$((failed + 1))
+            fi
+            ran=$((ran + 1))
+            echo "::endgroup::"
+          done
+          echo "Ran $ran shell test(s). Skipped: $skipped. Failed: $failed."
+          if [ "$failed" -gt 0 ]; then
+            echo "::error::$failed shell test(s) failed."
+            exit 1
+          fi
 
   # ---------------------------------------------------------------
   # Coverage gates: diff coverage (new lines) + overall floor ratchet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,11 @@ jobs:
               # test_wait_for_rollout.sh fires on PRs that touch only the
               # composite action.
               - '.github/actions/ecs-deploy/**'
+              # Also trigger when the scripts-tests job itself changes, so
+              # regressions in the auto-discovery loop are caught on the
+              # PR that introduces them (#2505). Mirrors the 'hooks' filter
+              # below which does the same for preflight-hook-test.
+              - '.github/workflows/ci.yml'
             ecs-oneshot:
               - 'scripts/*.py'
               - 'scripts/ecs-run-task.sh'


### PR DESCRIPTION
## Summary

Replaces 21 hand-listed `run:` steps in the `scripts-tests` CI job with a single loop that auto-discovers and runs every executable `scripts/tests/*.sh`. Adding a new shell test is now just `touch + chmod +x` — no matching ci.yml edit required. Follows the existing `preflight-hook-test` loop pattern.

**Bonus fix:** discovered three tests (`test_check_oneshot_imports.sh`, `test_ecs_logs.sh`, `test_preflight.sh`) that were never listed in `ci.yml` and had been silently skipped in CI since they were added. All three pass locally and now run under the auto-discovery loop — exactly the kind of silent test-miss this PR prevents.

Also adds `.github/workflows/ci.yml` to the `scripts` paths filter so that regressions to the scripts-tests job definition itself are caught on the PR that introduces them (mirrors what the `hooks` filter already does for `preflight-hook-test`).

Closes #2505

## Test plan

### Automated checks
- [x] Lint passes (actionlint clean on new code; only pre-existing SC2086 warnings in unrelated sections)
- [x] Format check passes
- [x] Tests pass (scripts-tests: 25 shell tests ran, 0 skipped, 0 failed in 53s)
- [x] CI green (ci-passed SUCCESS)
- [x] All three previously-skipped tests (`test_check_oneshot_imports.sh`, `test_ecs_logs.sh`, `test_preflight.sh`) appear as log groups in the `scripts-tests` CI output

### Post-deploy verification
- [x] N/A — no deployed component (CI-only change)
- [x] Verification evidence posted on issue (see #2505)
