### PR TITLE
feat(scripts): port ecs-redeploy.sh off aws ecs wait services-stable (#2523)

### DIFF
--- a/.github/actions/ecs-deploy/action.yml
+++ b/.github/actions/ecs-deploy/action.yml
@@ -154,7 +154,10 @@ runs:
         #
         # See issue #2519 for the full motivation. The logic lives in a separate
         # script so it can be shellchecked and unit-tested with a mock AWS CLI.
-        "${GITHUB_ACTION_PATH}/wait-for-rollout.sh"
+        # Single source of truth at scripts/wait-for-rollout.sh (see #2523) —
+        # also invoked directly by scripts/ecs-redeploy.sh for operator-run
+        # manual redeploys.
+        "${GITHUB_WORKSPACE}/scripts/wait-for-rollout.sh"
 
     - name: Update EventBridge Scheduler target
       if: inputs.deploy-mode == 'scheduler'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,11 @@ jobs:
               - 'infra/**'
             scripts:
               - 'scripts/**'
-              # wait-for-rollout.sh is consumed by the ecs-deploy composite
-              # action. Running scripts-tests on ecs-deploy changes ensures
+              # scripts/wait-for-rollout.sh is shared by the ecs-deploy
+              # composite action AND scripts/ecs-redeploy.sh (see #2523).
+              # Running scripts-tests on ecs-deploy changes ensures
               # test_wait_for_rollout.sh fires on PRs that touch only the
-              # composite action.
+              # composite action (which still calls the shared script).
               - '.github/actions/ecs-deploy/**'
               # Also trigger when the scripts-tests job itself changes, so
               # regressions in the auto-discovery loop are caught on the

--- a/scripts/ecs-redeploy.sh
+++ b/scripts/ecs-redeploy.sh
@@ -8,14 +8,22 @@
 #   service   ECS service name (required)
 #   cluster   ECS cluster name (default: judgemind-dev)
 #
+# Optional environment variables:
+#   ROLLOUT_TIMEOUT_SECS   — overall timeout in seconds (default: 900)
+#   ROLLOUT_POLL_INTERVAL  — polling interval in seconds (default: 10)
+#
 # The script:
-#   1. Runs `aws ecs update-service --force-new-deployment`
-#   2. Waits for steady state via `aws ecs wait services-stable`
-#   3. Prints the new task ID and image digest on success
-#   4. Exits non-zero on failure (e.g. crash-loop, timeout)
+#   1. Runs `aws ecs update-service --force-new-deployment`, capturing the
+#      new deployment's ID.
+#   2. Waits for THAT specific deployment to reach rolloutState=COMPLETED
+#      with running==desired by calling scripts/wait-for-rollout.sh (same
+#      polling logic the CI composite action uses — see #2523).
+#   3. Prints the new task ID and image digest on success.
+#   4. Exits non-zero on failure (crash-loop, rollout FAILED, timeout).
 
 set -euo pipefail
 
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REGION="us-west-2"
 
 SERVICE="${1:-}"
@@ -30,32 +38,49 @@ fi
 
 echo "Forcing new deployment: cluster=$CLUSTER service=$SERVICE" >&2
 
-# Step 1 — Force a new deployment
-aws ecs update-service \
+# Step 1 — Force a new deployment and capture the new deployment ID.
+#
+# `--force-new-deployment` does not change the task-def ARN; it creates a
+# new deployment record with a fresh ID that re-pulls the image and rolls
+# replacement tasks. deployments[0] is the PRIMARY (new) deployment that
+# update-service just created.
+NEW_DEPLOYMENT_ID=$(aws ecs update-service \
     --cluster "$CLUSTER" \
     --service "$SERVICE" \
     --force-new-deployment \
     --region "$REGION" \
     --no-cli-pager \
     --output text \
-    --query 'service.deployments[0].id' \
-    | while read -r deployment_id; do
-        echo "Deployment started: $deployment_id" >&2
-    done
+    --query 'service.deployments[0].id')
 
-# Step 2 — Wait for steady state (max 40 polls x 15s = 10 minutes)
-echo "Waiting for service to reach steady state..." >&2
-
-if ! aws ecs wait services-stable \
-    --cluster "$CLUSTER" \
-    --services "$SERVICE" \
-    --region "$REGION"; then
-    echo "ERROR: Service did not reach steady state within the timeout." >&2
-    echo "Check the ECS console for crash-loop or deployment issues." >&2
+if [[ -z "$NEW_DEPLOYMENT_ID" || "$NEW_DEPLOYMENT_ID" == "None" ]]; then
+    echo "ERROR: Could not determine new deployment ID from update-service response." >&2
     exit 1
 fi
 
-echo "Service reached steady state." >&2
+echo "Deployment started: $NEW_DEPLOYMENT_ID" >&2
+
+# Step 2 — Wait for OUR deployment to reach COMPLETED.
+#
+# Replaces `aws ecs wait services-stable` (hard-coded 10-min cap, no
+# progress output, waits on service-level steady state rather than on
+# our specific deployment). See issue #2523 for the full motivation.
+#
+# Progress lines `[<N>s] rolloutState=…` are emitted while waiting.
+# On timeout or rolloutState=FAILED, the helper dumps a diagnostic
+# service JSON snapshot and exits non-zero.
+export AWS_DEFAULT_REGION="$REGION"
+export ECS_CLUSTER="$CLUSTER"
+export ECS_SERVICE="$SERVICE"
+export NEW_DEPLOYMENT_ID
+# ROLLOUT_TIMEOUT_SECS / ROLLOUT_POLL_INTERVAL flow through if set by caller;
+# otherwise wait-for-rollout.sh applies its defaults (900s / 10s).
+
+if ! "$REPO_ROOT/scripts/wait-for-rollout.sh"; then
+    echo "ERROR: Deployment did not complete successfully." >&2
+    echo "Check the ECS console for crash-loop or deployment issues." >&2
+    exit 1
+fi
 
 # Step 3 — Print the running task ID and image digest
 TASK_ARNS=$(aws ecs list-tasks \

--- a/scripts/tests/test_wait_for_rollout.sh
+++ b/scripts/tests/test_wait_for_rollout.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
-# test_wait_for_rollout.sh — Unit tests for .github/actions/ecs-deploy/wait-for-rollout.sh
+# test_wait_for_rollout.sh — Unit tests for scripts/wait-for-rollout.sh
 #
 # Exercises the ECS rollout polling loop against a mock aws CLI that emits a
 # sequence of pre-canned describe-services responses. Verifies the success,
-# failure, and timeout paths.
+# failure, and timeout paths — both for task-def-ARN selection (used by the
+# CI composite action, see #2519) and for deployment-id selection (used by
+# scripts/ecs-redeploy.sh for operator manual redeploys, see #2523).
 #
 # Usage:
 #   scripts/tests/test_wait_for_rollout.sh
@@ -15,7 +17,7 @@
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-SCRIPT_UNDER_TEST="$REPO_ROOT/.github/actions/ecs-deploy/wait-for-rollout.sh"
+SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/wait-for-rollout.sh"
 
 if [[ ! -x "$SCRIPT_UNDER_TEST" ]]; then
     echo "FATAL: $SCRIPT_UNDER_TEST is not executable." >&2
@@ -129,7 +131,7 @@ MOCK
 }
 
 # Write a describe-services response with the given deployment state.
-# Usage: write_response <file> <rollout_state> <running> <desired> <pending> [task_def_arn]
+# Usage: write_response <file> <rollout_state> <running> <desired> <pending> [task_def_arn] [deployment_id]
 write_response() {
     local file="$1"
     local rollout_state="$2"
@@ -137,6 +139,7 @@ write_response() {
     local desired="$4"
     local pending="$5"
     local task_def_arn="${6:-arn:test:new}"
+    local deployment_id="${7:-ecs-svc/new}"
 
     cat > "$file" << JSON
 {
@@ -148,13 +151,59 @@ write_response() {
       "pendingCount": $pending,
       "deployments": [
         {
-          "id": "ecs-svc/new",
+          "id": "$deployment_id",
           "taskDefinition": "$task_def_arn",
           "rolloutState": "$rollout_state",
           "rolloutStateReason": "test reason",
           "runningCount": $running,
           "desiredCount": $desired,
           "pendingCount": $pending
+        }
+      ],
+      "events": []
+    }
+  ]
+}
+JSON
+}
+
+# Write a response representing a --force-new-deployment redeploy: two
+# deployments sharing the same task-def ARN but with distinct deployment
+# IDs (the old primary being replaced + the new primary we're tracking).
+# Usage: write_response_redeploy <file> <rollout_state> <running> <desired> <pending>
+write_response_redeploy() {
+    local file="$1"
+    local rollout_state="$2"
+    local running="$3"
+    local desired="$4"
+    local pending="$5"
+
+    cat > "$file" << JSON
+{
+  "services": [
+    {
+      "serviceName": "test-svc",
+      "desiredCount": $desired,
+      "runningCount": $running,
+      "pendingCount": $pending,
+      "deployments": [
+        {
+          "id": "ecs-svc/new-redeploy",
+          "taskDefinition": "arn:test:shared",
+          "rolloutState": "$rollout_state",
+          "rolloutStateReason": "redeploy test reason",
+          "runningCount": $running,
+          "desiredCount": $desired,
+          "pendingCount": $pending
+        },
+        {
+          "id": "ecs-svc/old-primary",
+          "taskDefinition": "arn:test:shared",
+          "rolloutState": "COMPLETED",
+          "rolloutStateReason": "old",
+          "runningCount": 1,
+          "desiredCount": 1,
+          "pendingCount": 0
         }
       ],
       "events": []
@@ -193,7 +242,7 @@ write_response_missing_deployment() {
 JSON
 }
 
-# Run the script under test with mocks wired up.
+# Run the script under test with mocks wired up (task-def-ARN selector).
 run_script() {
     local tmpdir="$1"
     shift
@@ -207,6 +256,26 @@ run_script() {
     ECS_CLUSTER="test-cluster" \
     ECS_SERVICE="test-svc" \
     NEW_TASK_DEF_ARN="arn:test:new" \
+    ROLLOUT_POLL_INTERVAL="${ROLLOUT_POLL_INTERVAL:-0}" \
+    ROLLOUT_TIMEOUT_SECS="${ROLLOUT_TIMEOUT_SECS:-5}" \
+        "$SCRIPT_UNDER_TEST" "$@"
+}
+
+# Run the script under test with mocks wired up (deployment-id selector).
+run_script_by_deployment_id() {
+    local tmpdir="$1"
+    local deployment_id="${2:-ecs-svc/new-redeploy}"
+    shift 2 || shift $#
+    local mock_aws
+    mock_aws=$(setup_mock_aws "$tmpdir")
+
+    AWS_CLI="$mock_aws" \
+    RESPONSES_DIR="$tmpdir/responses" \
+    CALL_LOG="$tmpdir/calls.log" \
+    CALL_COUNTER_FILE="$tmpdir/counter" \
+    ECS_CLUSTER="test-cluster" \
+    ECS_SERVICE="test-svc" \
+    NEW_DEPLOYMENT_ID="$deployment_id" \
     ROLLOUT_POLL_INTERVAL="${ROLLOUT_POLL_INTERVAL:-0}" \
     ROLLOUT_TIMEOUT_SECS="${ROLLOUT_TIMEOUT_SECS:-5}" \
         "$SCRIPT_UNDER_TEST" "$@"
@@ -413,6 +482,165 @@ test_missing_required_env() {
     fi
 }
 
+# Test 9: Neither NEW_TASK_DEF_ARN nor NEW_DEPLOYMENT_ID set exits 1 with
+# a clear error. Guards the env-var contract for the dual selector.
+test_missing_selector_env() {
+    local output exit_code
+    exit_code=0
+    output=$(env -i PATH="$PATH" \
+        ECS_CLUSTER="c" ECS_SERVICE="s" \
+        bash "$SCRIPT_UNDER_TEST" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 1 ]]; then
+        pass "missing both selectors exits 1"
+    else
+        fail "missing both selectors exits 1" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "one of NEW_TASK_DEF_ARN or NEW_DEPLOYMENT_ID"; then
+        pass "missing both selectors emits clear error"
+    else
+        fail "missing both selectors emits clear error" "output=$output"
+    fi
+}
+
+# Test 10: Setting both NEW_TASK_DEF_ARN and NEW_DEPLOYMENT_ID exits 1.
+# The caller must pick exactly one selector to avoid ambiguity.
+test_both_selectors_set() {
+    local output exit_code
+    exit_code=0
+    output=$(env -i PATH="$PATH" \
+        ECS_CLUSTER="c" ECS_SERVICE="s" \
+        NEW_TASK_DEF_ARN="arn:x" NEW_DEPLOYMENT_ID="ecs-svc/y" \
+        bash "$SCRIPT_UNDER_TEST" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 1 ]]; then
+        pass "both selectors set exits 1"
+    else
+        fail "both selectors set exits 1" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "set only one of"; then
+        pass "both selectors set emits clear error"
+    else
+        fail "both selectors set emits clear error" "output=$output"
+    fi
+}
+
+# Test 11: Deployment-id selector succeeds on immediate COMPLETED.
+# Mirrors the operator `--force-new-deployment` path where task-def ARN
+# is ambiguous but deployment ID is unique.
+test_deployment_id_immediate_completed() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    mkdir -p "$tmpdir/responses"
+    write_response_redeploy "$tmpdir/responses/01.json" "COMPLETED" 1 1 0
+
+    local output exit_code
+    output=$(run_script_by_deployment_id "$tmpdir" "ecs-svc/new-redeploy" 2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        pass "deployment-id immediate COMPLETED exits 0"
+    else
+        fail "deployment-id immediate COMPLETED exits 0" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "Waiting for deployment ecs-svc/new-redeploy"; then
+        pass "deployment-id selector names the deployment in log output"
+    else
+        fail "deployment-id selector names the deployment in log output" "output=$output"
+    fi
+}
+
+# Test 12: Deployment-id selector picks OUR deployment even when another
+# deployment shares the same task-def ARN. This is the motivating case
+# for the deployment-id selector — force-new-deployment redeploys leave
+# multiple deployments with the same task-def ARN briefly.
+test_deployment_id_disambiguates_shared_taskdef() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    mkdir -p "$tmpdir/responses"
+    # Both deployments share arn:test:shared. Our new one is IN_PROGRESS,
+    # the old one is already COMPLETED. Selecting by task-def ARN would
+    # match BOTH ambiguously (jq would emit two objects). Selecting by
+    # deployment ID picks the IN_PROGRESS one — we should NOT exit 0.
+    # Second response: our new deployment completes.
+    write_response_redeploy "$tmpdir/responses/01.json" "IN_PROGRESS" 0 1 1
+    write_response_redeploy "$tmpdir/responses/02.json" "COMPLETED" 1 1 0
+
+    local output exit_code
+    output=$(run_script_by_deployment_id "$tmpdir" "ecs-svc/new-redeploy" 2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        pass "deployment-id disambiguates across shared-taskdef deployments"
+    else
+        fail "deployment-id disambiguates across shared-taskdef deployments" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "rolloutState=IN_PROGRESS"; then
+        pass "deployment-id selector reported IN_PROGRESS before COMPLETED"
+    else
+        fail "deployment-id selector reported IN_PROGRESS before COMPLETED" "output=$output"
+    fi
+}
+
+# Test 13: Deployment-id selector reports FAILED and exits 1.
+test_deployment_id_failed_rollout() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    mkdir -p "$tmpdir/responses"
+    write_response_redeploy "$tmpdir/responses/01.json" "FAILED" 0 1 0
+
+    local output exit_code
+    exit_code=0
+    output=$(run_script_by_deployment_id "$tmpdir" "ecs-svc/new-redeploy" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 1 ]]; then
+        pass "deployment-id FAILED rollout exits 1"
+    else
+        fail "deployment-id FAILED rollout exits 1" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "rolloutState=FAILED for deployment ecs-svc/new-redeploy"; then
+        pass "deployment-id FAILED emits clear error naming the deployment"
+    else
+        fail "deployment-id FAILED emits clear error naming the deployment" "output=$output"
+    fi
+}
+
+# Test 14: Deployment-id selector times out when rollout never completes.
+test_deployment_id_timeout() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    mkdir -p "$tmpdir/responses"
+    write_response_redeploy "$tmpdir/responses/01.json" "IN_PROGRESS" 0 1 1
+
+    local output exit_code
+    exit_code=0
+    output=$(ROLLOUT_TIMEOUT_SECS=1 ROLLOUT_POLL_INTERVAL=0 \
+        run_script_by_deployment_id "$tmpdir" "ecs-svc/new-redeploy" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 1 ]]; then
+        pass "deployment-id timeout exits 1"
+    else
+        fail "deployment-id timeout exits 1" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "Timed out after"; then
+        pass "deployment-id timeout emits clear error"
+    else
+        fail "deployment-id timeout emits clear error" "output=$output"
+    fi
+
+    if echo "$output" | grep -q "Full service JSON snapshot"; then
+        pass "deployment-id timeout includes diagnostic JSON snapshot"
+    else
+        fail "deployment-id timeout includes diagnostic JSON snapshot" "output=$output"
+    fi
+}
+
 # ── Run all tests ──────────────────────────────────────────────────────────
 
 test_immediate_completed
@@ -423,6 +651,12 @@ test_timeout
 test_completed_but_running_not_yet_matching
 test_aws_cli_failure
 test_missing_required_env
+test_missing_selector_env
+test_both_selectors_set
+test_deployment_id_immediate_completed
+test_deployment_id_disambiguates_shared_taskdef
+test_deployment_id_failed_rollout
+test_deployment_id_timeout
 
 echo ""
 echo "────────────────────────────────────────────"

--- a/scripts/wait-for-rollout.sh
+++ b/scripts/wait-for-rollout.sh
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
-# wait-for-rollout.sh — Poll an ECS service deployment until the specified task
-# definition's rollout reaches a terminal state (COMPLETED or FAILED), or until
-# the configured timeout elapses.
+# wait-for-rollout.sh — Poll an ECS service deployment until a specific
+# deployment reaches a terminal state (COMPLETED or FAILED) with
+# runningCount == desiredCount, or until the configured timeout elapses.
 #
-# Called from .github/actions/ecs-deploy/action.yml's "Update ECS service" step.
-# Extracted into a standalone script so it can be shellchecked and unit-tested
-# with a mock aws CLI. See issue #2519.
+# Shared between two callers:
+#   1. .github/actions/ecs-deploy/action.yml — waits for a newly registered
+#      task-definition ARN to roll out (CI deploy path, see #2519).
+#   2. scripts/ecs-redeploy.sh — waits for a newly triggered
+#      --force-new-deployment deployment to roll out (operator manual
+#      redeploy path, see #2523). Same task-def ARN as before, but a new
+#      deployment ID.
+#
+# Identifying the deployment:
+#   - CI path knows the new task-def ARN up front.
+#   - Operator redeploy path does not change the task-def ARN; only a new
+#     deployment ID is created. So we support selecting the deployment by
+#     either ARN or deployment ID — exactly one must be provided.
 #
 # Required environment variables:
-#   ECS_CLUSTER        — ECS cluster name
-#   ECS_SERVICE        — ECS service name
-#   NEW_TASK_DEF_ARN   — Task definition ARN we are waiting to roll out
+#   ECS_CLUSTER          — ECS cluster name
+#   ECS_SERVICE          — ECS service name
+#
+# One of:
+#   NEW_TASK_DEF_ARN     — Task definition ARN to select the deployment by
+#   NEW_DEPLOYMENT_ID    — Deployment ID to select the deployment by
 #
 # Optional environment variables:
 #   ROLLOUT_TIMEOUT_SECS   — overall timeout in seconds (default: 900)
@@ -21,19 +34,41 @@
 # Exit codes:
 #   0 — Target deployment reached rolloutState=COMPLETED with runningCount==
 #       desiredCount (and desiredCount > 0).
-#   1 — rolloutState=FAILED, or the timeout elapsed, or the aws CLI failed.
+#   1 — rolloutState=FAILED, or the timeout elapsed, or the aws CLI failed,
+#       or the env-var contract was violated.
 
 set -euo pipefail
 
 : "${ECS_CLUSTER:?ECS_CLUSTER is required}"
 : "${ECS_SERVICE:?ECS_SERVICE is required}"
-: "${NEW_TASK_DEF_ARN:?NEW_TASK_DEF_ARN is required}"
+
+NEW_TASK_DEF_ARN="${NEW_TASK_DEF_ARN:-}"
+NEW_DEPLOYMENT_ID="${NEW_DEPLOYMENT_ID:-}"
+
+if [ -z "$NEW_TASK_DEF_ARN" ] && [ -z "$NEW_DEPLOYMENT_ID" ]; then
+  echo "ERROR: one of NEW_TASK_DEF_ARN or NEW_DEPLOYMENT_ID is required." >&2
+  exit 1
+fi
+if [ -n "$NEW_TASK_DEF_ARN" ] && [ -n "$NEW_DEPLOYMENT_ID" ]; then
+  echo "ERROR: set only one of NEW_TASK_DEF_ARN or NEW_DEPLOYMENT_ID, not both." >&2
+  exit 1
+fi
 
 ROLLOUT_TIMEOUT_SECS="${ROLLOUT_TIMEOUT_SECS:-900}"
 ROLLOUT_POLL_INTERVAL="${ROLLOUT_POLL_INTERVAL:-10}"
 AWS_CLI="${AWS_CLI:-aws}"
 
-echo "Waiting for task definition $NEW_TASK_DEF_ARN to roll out on ${ECS_CLUSTER}/${ECS_SERVICE} (timeout: ${ROLLOUT_TIMEOUT_SECS}s, poll every ${ROLLOUT_POLL_INTERVAL}s)..."
+if [ -n "$NEW_TASK_DEF_ARN" ]; then
+  SELECTOR_DESC="task definition $NEW_TASK_DEF_ARN"
+  JQ_SELECT_FILTER='.services[0].deployments[] | select(.taskDefinition == $sel)'
+  JQ_SELECT_ARG="$NEW_TASK_DEF_ARN"
+else
+  SELECTOR_DESC="deployment $NEW_DEPLOYMENT_ID"
+  JQ_SELECT_FILTER='.services[0].deployments[] | select(.id == $sel)'
+  JQ_SELECT_ARG="$NEW_DEPLOYMENT_ID"
+fi
+
+echo "Waiting for $SELECTOR_DESC to roll out on ${ECS_CLUSTER}/${ECS_SERVICE} (timeout: ${ROLLOUT_TIMEOUT_SECS}s, poll every ${ROLLOUT_POLL_INTERVAL}s)..."
 
 START_TS=$(date +%s)
 DEADLINE=$((START_TS + ROLLOUT_TIMEOUT_SECS))
@@ -52,13 +87,13 @@ while true; do
     exit 1
   fi
 
-  DEPLOYMENT=$(echo "$SERVICE_JSON" | jq --arg arn "$NEW_TASK_DEF_ARN" \
-    '.services[0].deployments[] | select(.taskDefinition == $arn)')
+  DEPLOYMENT=$(echo "$SERVICE_JSON" | jq --arg sel "$JQ_SELECT_ARG" \
+    "$JQ_SELECT_FILTER")
 
   if [ -z "$DEPLOYMENT" ]; then
     # Our deployment has not yet been registered in the deployments list.
     # Give ECS a moment — retry.
-    echo "[${ELAPSED}s] Deployment for new task def not yet visible, retrying..."
+    echo "[${ELAPSED}s] Deployment for $SELECTOR_DESC not yet visible, retrying..."
   else
     ROLLOUT_STATE=$(echo "$DEPLOYMENT" | jq -r '.rolloutState // "UNKNOWN"')
     ROLLOUT_REASON=$(echo "$DEPLOYMENT" | jq -r '.rolloutStateReason // ""')
@@ -79,7 +114,7 @@ while true; do
         fi
         ;;
       FAILED)
-        echo "ERROR: ECS reported rolloutState=FAILED for $NEW_TASK_DEF_ARN after ${ELAPSED}s."
+        echo "ERROR: ECS reported rolloutState=FAILED for $SELECTOR_DESC after ${ELAPSED}s."
         echo "Reason: $ROLLOUT_REASON"
         echo "Full deployment JSON:"
         echo "$DEPLOYMENT" | jq '.'
@@ -93,7 +128,7 @@ while true; do
   fi
 
   if [ "$NOW_TS" -ge "$DEADLINE" ]; then
-    echo "ERROR: Timed out after ${ROLLOUT_TIMEOUT_SECS}s waiting for $NEW_TASK_DEF_ARN to stabilize."
+    echo "ERROR: Timed out after ${ROLLOUT_TIMEOUT_SECS}s waiting for $SELECTOR_DESC to stabilize."
     echo "Last observed state: ${LAST_STATE:-<none>} (${LAST_COUNTS:-<no counts>})"
     echo "Full service JSON snapshot:"
     echo "$SERVICE_JSON" | jq '.services[0] | {serviceName, desiredCount, runningCount, pendingCount, deployments, events: (.events[:5])}'


### PR DESCRIPTION
## Summary

Ports `scripts/ecs-redeploy.sh` off `aws ecs wait services-stable` onto the same progress-emitting, task-def-scoped polling loop the CI composite action uses (#2519). Moves `wait-for-rollout.sh` from `.github/actions/ecs-deploy/` to `scripts/` as the single source of truth shared by both callers, and extends it with a `NEW_DEPLOYMENT_ID` selector so the operator `--force-new-deployment` path (which does NOT change the task-def ARN) can uniquely identify its new deployment.

Closes #2523

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] `scripts/tests/test_wait_for_rollout.sh` passes (28 tests — was 15, +13 covering deployment-id selector and env-var contract)
- [x] CI green

### Post-deploy verification
- [x] Next deploy to dev that uses the composite action (scraper / API / ingestion worker) still emits `[<N>s] rolloutState=…` progress lines and reports `Service updated successfully after <N>s`. (Verified on [Deploy Scraper run 24554313041](https://github.com/judgemind/judgemind/actions/runs/24554313041) — `Service updated successfully after 178s`.)
- [x] Manually invoke `scripts/ecs-redeploy.sh <service> judgemind-dev` against a dev service and confirm the new log lines. (Ran against `judgemind-ingestion-worker-dev` — 5 progress lines 0s→196s, deployment-id selector path, `Service updated successfully after 196s`.)
- [x] Verification evidence posted on issue #2523.
