### PR TITLE
chore(audit): recognize '# permanent: true' marker in scripts hygiene check (#2530)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -202,9 +202,13 @@ Glob pattern: scripts/*.py
 
 If the count exceeds **35**, flag a finding. The current baseline is ~29 permanent utility scripts — 35 gives headroom for a few new utilities while catching accumulation of unarchived one-off scripts.
 
-2. **Missing `# one-off: true` headers.** Scan all `scripts/*.py` files for scripts that look like one-off data operations (names containing `backfill`, `cleanup`, `fix`, `dedup`, `merge`, `migrate`, `remediat`) but lack a `# one-off: true` header in the first 10 lines. These should either be marked as one-off or confirmed as permanent utilities.
+2. **Missing `# one-off: true` or `# permanent: true` headers.** Scan all `scripts/*.py` files for scripts that look like one-off data operations (names containing `backfill`, `cleanup`, `fix`, `dedup`, `merge`, `migrate`, `remediat`) but lack EITHER a `# one-off: true` header OR a `# permanent: true` header in the first 10 lines. A script should carry exactly one of these markers:
+   - `# one-off: true` — finite-lifetime script (tied to a specific bug fix or migration). Candidate for archival once its work is done.
+   - `# permanent: true` — re-runnable utility (parameterizable, idempotent, intended to be invoked repeatedly). Exempt from one-off nagging and staleness checks.
 
-3. **Stale one-off scripts.** For scripts that DO have `# one-off: true`, check their git log to see when they were last modified. If a one-off script has not been modified in more than 30 days, flag it as a candidate for archiving to `scripts/archive/`.
+   Scripts previously confirmed as permanent in issue comments should carry the canonical `# permanent: true` marker so the check is machine-readable and does not re-flag them each audit cycle (see #2530). The audit treats either marker as sufficient — only unmarked scripts matching the name pattern are flagged.
+
+3. **Stale one-off scripts.** For scripts that DO have `# one-off: true`, check their git log to see when they were last modified. If a one-off script has not been modified in more than 30 days, flag it as a candidate for archiving to `scripts/archive/`. Scripts with `# permanent: true` are exempt from this staleness check.
 
 #### Filing issues
 
@@ -213,7 +217,7 @@ For script count threshold violations, file a `priority/p2` `type/chore` issue w
 - List of scripts that appear to be one-off (by name pattern or `# one-off: true` header).
 - Suggested action: archive completed one-off scripts to `scripts/archive/`.
 
-For missing headers, file a single `priority/p3` `type/dx` issue listing the scripts that should be reviewed for the `# one-off: true` header.
+For missing headers, file a single `priority/p3` `type/dx` issue listing the scripts that should be reviewed. Each listed script should get either `# one-off: true` (if finite-lifetime) or `# permanent: true` (if re-runnable utility).
 
 ---
 

--- a/scripts/audit_oc_ruling_integrity.py
+++ b/scripts/audit_oc_ruling_integrity.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # venv: scraper-framework
+# permanent: true
 """Audit OC ruling data integrity — detect misrouted and boilerplate rulings.
 
 Queries the database for Orange County rulings and checks for two classes of

--- a/scripts/backfill_llm_enrichment.py
+++ b/scripts/backfill_llm_enrichment.py
@@ -29,6 +29,7 @@ Options:
 """
 
 # venv: scraper-framework
+# permanent: true
 # permanent utility -- ongoing LLM enrichment backfill tool
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Extends the `/audit` skill's scripts-hygiene check (SKILL.md §1.9, check 2) to accept `# permanent: true` as an alternative to `# one-off: true`, and adds the canonical marker to the two scripts confirmed permanent in #2498. This stops the audit from re-flagging known-permanent utilities every cycle.

Closes #2530

## Changes

- `.claude/skills/audit/SKILL.md` §1.9 — documents both markers, exempts `# permanent: true` from staleness check, updates filing guidance.
- `scripts/backfill_llm_enrichment.py` — added `# permanent: true` (kept pre-existing prose `# permanent utility -- ...` comment for context).
- `scripts/audit_oc_ruling_integrity.py` — added `# permanent: true` (confirmed permanent in #2498).

## Pattern sweep

The audit's §1.9 check 2 pattern is `backfill|cleanup|fix|dedup|merge|migrate|remediat`. Sweep results:

| Script | Marker |
|---|---|
| `scripts/backfill_llm_enrichment.py` | `# permanent: true` (this PR) |
| `scripts/cleanup_sc_aborted_reingest_2416.py` | `# one-off: true` (already marked) |
| `scripts/cleanup_sc_failed_reingest.py` | `# one-off: true` (already marked) |

Unmarked list is empty.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green
- [x] Markdown-links check passes (already verified locally via pre-push hook)

### Post-deploy verification
- [x] N/A — no deployed component (docs + comment-header edits only)
- [x] Verification evidence posted on issue
