### PR TITLE
fix(scraping): apply post-processing filters on LLM cache-hit paths (#2513)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -902,6 +902,91 @@ def _drop_calendar_listing_rulings(
 
 
 # ---------------------------------------------------------------------------
+# Post-processing: cache-hit filter re-application (#2513)
+# ---------------------------------------------------------------------------
+#
+# The LLM cache stores post-filter rulings keyed by content hash.  Returning
+# cached rulings directly means any filter changes made AFTER the cache entry
+# was written are not applied — leaving stale rows in the database.  See
+# #2489 for the Orange County calendar-listing filter widening that motivated
+# this fix.
+#
+# Both helpers re-apply the subset of post-processing filters that operate
+# purely on the final ``ExtractedRuling[]`` list.  They are idempotent: if
+# the cached rulings already passed the current filters, re-applying them is
+# a no-op.  If the filters have been updated since the cache entry was
+# written, the new logic takes effect on cache read — avoiding an expensive
+# cache-busting reingest.
+#
+# ``_resolve_cross_references`` and ``_propagate_document_fields`` are NOT
+# re-applied here because they need the pre-join row state (entry numbers
+# and metadata that are discarded once we have ``ExtractedRuling`` objects).
+
+
+def _apply_pdf_cache_hit_filters(
+    rulings: list[ExtractedRuling],
+    *,
+    content_key: str,
+) -> list[ExtractedRuling]:
+    """Re-apply post-processing filters on the PDF cache-hit path (#2513).
+
+    Mirrors the subset of filters in :func:`_join_page_rows` that operate
+    purely on the final ``ExtractedRuling[]`` list.  Order matches
+    ``_join_page_rows`` so the cache-hit output is equivalent to what a
+    fresh extraction would produce (for rulings that do not rely on
+    cross-reference resolution, which requires pre-join row state).
+
+    Logs ``llm_extractor.cache_hit_filters_dropped`` at info level if the
+    filters dropped rows — useful for observing the effect of filter
+    widening in production without re-running LLM calls.
+    """
+    original_count = len(rulings)
+    rulings = _drop_calendar_listing_rulings(rulings)
+    rulings = _deduplicate_ruling_texts(rulings)
+    rulings = _filter_citation_artifacts(rulings)
+    if len(rulings) != original_count:
+        logger.info(
+            "llm_extractor.cache_hit_filters_dropped",
+            content_key=content_key[:12],
+            path="pdf",
+            original_count=original_count,
+            kept_count=len(rulings),
+        )
+    return rulings
+
+
+def _apply_text_cache_hit_filters(
+    rulings: list[ExtractedRuling],
+    *,
+    content_key: str,
+) -> list[ExtractedRuling]:
+    """Re-apply post-processing filters on the text cache-hit path (#2513).
+
+    Applies ``_filter_citation_artifacts`` (matching the fresh text path in
+    :meth:`LlmExtractor.extract`) plus ``_deduplicate_ruling_texts`` so
+    the cache-hit path catches filter updates made after the cache entry
+    was written.  Calendar-listing filtering is not applied here because
+    the text path is used primarily for HTML-originated content where
+    those patterns do not appear.
+
+    Logs ``llm_extractor.cache_hit_filters_dropped`` at info level if the
+    filters dropped rows.
+    """
+    original_count = len(rulings)
+    rulings = _filter_citation_artifacts(rulings)
+    rulings = _deduplicate_ruling_texts(rulings)
+    if len(rulings) != original_count:
+        logger.info(
+            "llm_extractor.cache_hit_filters_dropped",
+            content_key=content_key[:12],
+            path="text",
+            original_count=original_count,
+            kept_count=len(rulings),
+        )
+    return rulings
+
+
+# ---------------------------------------------------------------------------
 # Post-processing: cross-reference resolution (#2317)
 # ---------------------------------------------------------------------------
 
@@ -1206,7 +1291,8 @@ class LlmExtractor:
             cached = self._cache.get(effective_prompt, content_key)
             if cached is not None:
                 logger.debug("llm_cache.hit", content_key=content_key[:12])
-                return [ExtractedRuling(**r) for r in cached]
+                rulings = [ExtractedRuling(**r) for r in cached]
+                return _apply_text_cache_hit_filters(rulings, content_key=content_key)
 
         chunks = self._split_into_chunks(text)
         usage = TokenUsage()
@@ -1310,7 +1396,8 @@ class LlmExtractor:
             cached = self._cache.get(PDF_PER_PAGE_PROMPT, content_key)
             if cached is not None:
                 logger.debug("llm_cache.hit_pdf", content_key=content_key[:12])
-                return [ExtractedRuling(**r) for r in cached]
+                rulings = [ExtractedRuling(**r) for r in cached]
+                return _apply_pdf_cache_hit_filters(rulings, content_key=content_key)
 
         page_images = _render_pdf_pages(pdf_bytes, max_pages)
         if not page_images:

--- a/packages/scraper-framework/tests/test_llm_cache_hit_filters.py
+++ b/packages/scraper-framework/tests/test_llm_cache_hit_filters.py
@@ -1,0 +1,505 @@
+"""Tests for post-processing filter re-application on LLM cache-hit paths (#2513).
+
+When the LLM result cache returns a hit, ``LlmExtractor.extract`` and
+``LlmExtractor.extract_from_pdf`` must re-apply the post-processing filters
+that operate on the final ``ExtractedRuling[]`` list.  Otherwise, filter
+updates made AFTER the cache entry was written do not take effect —
+leaving stale rows in downstream tables until an expensive full reingest
+is run with ``--bust-llm-cache``.
+
+The filters are idempotent, so re-applying them at cache-read time has no
+effect when the cached rulings already pass the filters.  When the filters
+have been widened (as in #2489), the new logic fires on read and the
+stale rulings are dropped before they reach the caller.
+
+These tests use a ``MagicMock`` cache to simulate pre-computed entries
+written under older, narrower filter logic.  No real network / LLM calls
+happen.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from framework.llm_extractor import (
+    PDF_PER_PAGE_PROMPT,
+    LlmExtractor,
+    _apply_pdf_cache_hit_filters,
+    _apply_text_cache_hit_filters,
+)
+from framework.llm_schema import EXTRACTION_SYSTEM_PROMPT, ExtractedRuling
+
+
+def _build_extractor_with_cache(cache: object) -> LlmExtractor:
+    """Build a bare LlmExtractor with the provided cache attached.
+
+    Mirrors the pattern used in ``test_citation_filter.py`` — constructs
+    the instance via ``__new__`` and fills in the required attributes so
+    no API key, client, or provider connection is needed.
+    """
+    extractor = LlmExtractor.__new__(LlmExtractor)
+    extractor._provider = "anthropic"
+    extractor._model = "stub"
+    extractor._client = None
+    extractor._max_retries = 0
+    extractor._base_delay = 0.0
+    extractor._max_delay = 0.0
+    extractor._max_output_tokens = 4096
+    extractor._max_chars_per_chunk = 80_000
+    extractor._cache = cache
+    extractor._bust_cache = False
+    return extractor
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the two filter-application helpers
+# ---------------------------------------------------------------------------
+
+
+class TestApplyPdfCacheHitFilters:
+    """Unit tests for ``_apply_pdf_cache_hit_filters`` (#2513)."""
+
+    def test_drops_off_calendar_listing(self) -> None:
+        """A cached OFF-CALENDAR listing is dropped on cache-hit."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01",
+                extracted_case_title="Smith v. Jones",
+                ruling_text="The motion is GRANTED in full. Plaintiff's request is approved.",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-02",
+                extracted_case_title="Doe v. Roe",
+                ruling_text="OFF-CALENDAR",
+            ),
+        ]
+        filtered = _apply_pdf_cache_hit_filters(rulings, content_key="abc123def456")
+        case_numbers = [r.extracted_case_number for r in filtered]
+        assert case_numbers == ["30-2024-01"]
+
+    def test_drops_bare_disposition_parenthetical(self) -> None:
+        """A ``(Moot)`` listing (widened by #2489) is dropped on cache-hit."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01",
+                extracted_case_title="Real Ruling",
+                ruling_text="The demurrer is SUSTAINED without leave to amend.",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-02",
+                extracted_case_title="Bare Disposition",
+                ruling_text="(Moot)",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-03",
+                extracted_case_title="OC Abbrev",
+                ruling_text="O/C",
+            ),
+        ]
+        filtered = _apply_pdf_cache_hit_filters(rulings, content_key="abc123def456")
+        case_numbers = [r.extracted_case_number for r in filtered]
+        assert case_numbers == ["30-2024-01"]
+
+    def test_preserves_valid_rulings(self) -> None:
+        """Non-listing rulings are preserved through cache-hit filters."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01",
+                extracted_case_title="Foo v. Bar",
+                ruling_text=(
+                    "The court finds that the moving party has met its burden. "
+                    "The motion is GRANTED. The opposing party shall comply "
+                    "with the ruling within 30 days."
+                ),
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-02",
+                extracted_case_title="Baz v. Qux",
+                ruling_text=(
+                    "Defendant's demurrer is OVERRULED. Plaintiff's complaint "
+                    "sufficiently states a cause of action for breach of contract."
+                ),
+            ),
+        ]
+        filtered = _apply_pdf_cache_hit_filters(rulings, content_key="abc123def456")
+        assert len(filtered) == 2
+        assert [r.extracted_case_number for r in filtered] == ["30-2024-01", "30-2024-02"]
+
+    def test_deduplicates_identical_ruling_texts(self) -> None:
+        """Duplicate ruling_text values are nulled out on cache-hit."""
+        # Must exceed _DEDUP_MIN_LENGTH (200 chars) to trigger dedup.
+        long_text = (
+            "The court finds the motion to be well-taken on all grounds "
+            "presented. After careful review of the briefs and supporting "
+            "evidence, the motion is GRANTED in its entirety. The opposing "
+            "party shall comply within thirty (30) days of notice of this order."
+        )
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01",
+                ruling_text=long_text,
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-02",
+                ruling_text=long_text,  # duplicate
+            ),
+        ]
+        filtered = _apply_pdf_cache_hit_filters(rulings, content_key="abc123def456")
+        # Dedup nulls out the text but keeps the row (metadata is preserved).
+        assert len(filtered) == 2
+        assert filtered[0].ruling_text == long_text
+        assert filtered[1].ruling_text is None
+
+    def test_idempotent_on_already_filtered_rulings(self) -> None:
+        """Applying filters twice is a no-op when rulings already pass."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01",
+                extracted_case_title="First Case",
+                ruling_text="Motion GRANTED. The parties shall proceed as ordered.",
+            ),
+        ]
+        once = _apply_pdf_cache_hit_filters(rulings, content_key="abc123def456")
+        twice = _apply_pdf_cache_hit_filters(once, content_key="abc123def456")
+        assert len(once) == len(twice) == 1
+        assert once[0].extracted_case_number == twice[0].extracted_case_number
+
+    def test_empty_input_returns_empty(self) -> None:
+        """Empty input yields empty output."""
+        assert _apply_pdf_cache_hit_filters([], content_key="abc123def456") == []
+
+
+class TestApplyTextCacheHitFilters:
+    """Unit tests for ``_apply_text_cache_hit_filters`` (#2513)."""
+
+    def test_drops_citation_artifacts(self) -> None:
+        """Inline citations (title + short text) are filtered out on cache-hit."""
+        real = ExtractedRuling(
+            extracted_case_number="CIVSB2223971",
+            extracted_case_title="Armistead v. Ford",
+            ruling_text=("Before the Court is Plaintiffs' Motion for Attorneys' Fees. " * 60),
+        )
+        citation = ExtractedRuling(
+            extracted_case_number=None,
+            extracted_case_title="Zargarian v. BMW C.D. Cal. Mar. 3, 2020",
+            ruling_text="B" * 200,  # shorter than _CITATION_MIN_RULING_LENGTH
+        )
+        filtered = _apply_text_cache_hit_filters([real, citation], content_key="abc123def456")
+        assert len(filtered) == 1
+        assert filtered[0].extracted_case_number == "CIVSB2223971"
+
+    def test_deduplicates_identical_ruling_texts(self) -> None:
+        """Duplicate ruling_text values are nulled out on cache-hit."""
+        # Must exceed _DEDUP_MIN_LENGTH (200 chars) to trigger dedup.
+        long_text = (
+            "The court finds the motion to be well-taken on all grounds "
+            "presented. After careful review of the briefs and supporting "
+            "evidence, the motion is GRANTED in its entirety. The opposing "
+            "party shall comply within thirty (30) days of notice of this order."
+        )
+        rulings = [
+            ExtractedRuling(extracted_case_number="A", ruling_text=long_text),
+            ExtractedRuling(extracted_case_number="B", ruling_text=long_text),
+        ]
+        filtered = _apply_text_cache_hit_filters(rulings, content_key="abc123def456")
+        assert filtered[0].ruling_text == long_text
+        assert filtered[1].ruling_text is None
+
+    def test_preserves_valid_rulings(self) -> None:
+        """Non-citation, non-duplicate rulings pass through unchanged."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="CIVSB1",
+                extracted_case_title="Real Case A",
+                ruling_text=("The motion is DENIED. Plaintiff has not shown good cause."),
+            ),
+            ExtractedRuling(
+                extracted_case_number="CIVSB2",
+                extracted_case_title="Real Case B",
+                ruling_text=(
+                    "Demurrer is SUSTAINED with leave to amend. Plaintiff shall "
+                    "file an amended complaint within 20 days."
+                ),
+            ),
+        ]
+        filtered = _apply_text_cache_hit_filters(rulings, content_key="abc123def456")
+        assert len(filtered) == 2
+
+    def test_empty_input_returns_empty(self) -> None:
+        """Empty input yields empty output."""
+        assert _apply_text_cache_hit_filters([], content_key="abc123def456") == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: cache-hit path on extract_from_pdf re-applies filters
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFromPdfCacheHitReappliesFilters:
+    """Integration: ``extract_from_pdf`` applies the filters on cache-hit (#2513)."""
+
+    def test_cache_hit_drops_calendar_listing_rulings(self) -> None:
+        """Simulates a cached entry written BEFORE #2489's filter widening.
+
+        The cached payload contains a real ruling + a ``(Moot)`` bare-disposition
+        listing.  On cache-hit, the post-processing filter now catches the listing
+        and drops it — exactly the behavior that avoids the 22-45h reingest
+        described in #2513.
+        """
+        # Pre-computed cache payload as it would be serialized to S3.
+        cached_payload: list[dict[str, Any]] = [
+            {
+                "extracted_case_number": "30-2024-01",
+                "extracted_case_title": "Real Motion",
+                "ruling_text": (
+                    "The motion is GRANTED. Moving party shall prepare "
+                    "the order consistent with the tentative ruling."
+                ),
+            },
+            {
+                "extracted_case_number": "30-2024-02",
+                "extracted_case_title": "Stale Listing",
+                "ruling_text": "(Moot)",
+            },
+            {
+                "extracted_case_number": "30-2024-03",
+                "extracted_case_title": "Stale OFF-CALENDAR",
+                "ruling_text": "OFF-CALENDAR",
+            },
+        ]
+        cache = MagicMock()
+        cache.get.return_value = cached_payload
+
+        extractor = _build_extractor_with_cache(cache)
+
+        # Any non-empty bytes payload drives the content_key computation.
+        rulings = extractor.extract_from_pdf(b"pdf-bytes-content")
+
+        cache.get.assert_called_once()
+        # The cached payload key must be the per-page PDF prompt.
+        prompt_arg = cache.get.call_args.args[0]
+        assert prompt_arg == PDF_PER_PAGE_PROMPT
+
+        case_numbers = [r.extracted_case_number for r in rulings]
+        assert case_numbers == ["30-2024-01"]
+
+    def test_cache_hit_respects_bust_cache_flag(self) -> None:
+        """``bust_cache=True`` skips the cache read entirely, avoiding filter re-apply.
+
+        The cache.get method must NOT be called, since the caller explicitly
+        asked for fresh extraction.  The call still fails (no API key) — we
+        only verify the bust behavior via ``cache.get.assert_not_called``.
+        """
+        cache = MagicMock()
+        cache.get.return_value = [
+            {
+                "extracted_case_number": "30-2024-01",
+                "ruling_text": "Anything.",
+            }
+        ]
+        extractor = _build_extractor_with_cache(cache)
+
+        # bust_cache=True short-circuits the cache-read branch.  The call
+        # proceeds into _render_pdf_pages which will fail on invalid bytes —
+        # but the important invariant is that cache.get was never called.
+        try:
+            extractor.extract_from_pdf(b"pdf-bytes-content", bust_cache=True)
+        except Exception:  # noqa: BLE001
+            # _render_pdf_pages / _extract_single_page may raise without a
+            # real client.  That's fine — we only care about cache.get.
+            pass
+        cache.get.assert_not_called()
+
+    def test_cache_hit_with_no_listings_returns_cached_rulings(self) -> None:
+        """If the cached rulings all already pass the filters, output matches input."""
+        cached_payload: list[dict[str, Any]] = [
+            {
+                "extracted_case_number": "30-2024-01",
+                "ruling_text": (
+                    "The court finds that the moving party has established good "
+                    "cause. The motion is GRANTED. Defendant shall produce the "
+                    "requested documents within 30 days."
+                ),
+            },
+            {
+                "extracted_case_number": "30-2024-02",
+                "ruling_text": (
+                    "Demurrer is OVERRULED as to the first cause of action and "
+                    "SUSTAINED with leave to amend as to the second. Plaintiff "
+                    "shall file an amended complaint within 20 days."
+                ),
+            },
+        ]
+        cache = MagicMock()
+        cache.get.return_value = cached_payload
+        extractor = _build_extractor_with_cache(cache)
+
+        rulings = extractor.extract_from_pdf(b"pdf-bytes")
+        assert [r.extracted_case_number for r in rulings] == ["30-2024-01", "30-2024-02"]
+
+
+# ---------------------------------------------------------------------------
+# Integration: cache-hit path on extract (text) re-applies filters
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTextCacheHitReappliesFilters:
+    """Integration: ``extract`` applies the filters on cache-hit (#2513)."""
+
+    def test_cache_hit_drops_citation_artifacts(self) -> None:
+        """Cached entries that include citation-artifact titles are filtered on read.
+
+        The fresh-path ``extract`` applies ``_filter_citation_artifacts`` before
+        caching, but if the cache was populated with older ``ExtractedRuling``
+        objects (or before the citation filter existed), the stale artifacts
+        must be removed on read.
+        """
+        cached_payload: list[dict[str, Any]] = [
+            {
+                "extracted_case_number": "CIVSB2223971",
+                "extracted_case_title": "Armistead v. Ford",
+                "ruling_text": (
+                    "Before the Court is Plaintiffs' Motion for Attorneys' Fees. " * 60
+                ),
+            },
+            {
+                "extracted_case_number": None,
+                "extracted_case_title": "Zargarian v. BMW C.D. Cal. Mar. 3, 2020",
+                "ruling_text": "B" * 200,
+            },
+            {
+                "extracted_case_number": None,
+                "extracted_case_title": "Williams v. KMA BC722351",
+                "ruling_text": "A" * 155,
+            },
+        ]
+        cache = MagicMock()
+        cache.get.return_value = cached_payload
+
+        extractor = _build_extractor_with_cache(cache)
+
+        rulings = extractor.extract("fake calendar text")
+
+        cache.get.assert_called_once()
+        prompt_arg = cache.get.call_args.args[0]
+        assert prompt_arg == EXTRACTION_SYSTEM_PROMPT
+
+        assert [r.extracted_case_number for r in rulings] == ["CIVSB2223971"]
+
+    def test_cache_hit_deduplicates_duplicate_texts(self) -> None:
+        """Cached duplicate ruling_text values are nulled on cache-hit."""
+        # Must exceed _DEDUP_MIN_LENGTH (200 chars) to trigger dedup.
+        long_text = (
+            "The court finds the motion to be well-taken on all grounds "
+            "presented. After review of the briefs and supporting evidence, "
+            "the motion is GRANTED in its entirety. The parties shall comply "
+            "within thirty (30) days of notice of this order."
+        )
+        cached_payload: list[dict[str, Any]] = [
+            {
+                "extracted_case_number": "CIVSB1",
+                "ruling_text": long_text,
+            },
+            {
+                "extracted_case_number": "CIVSB2",
+                "ruling_text": long_text,
+            },
+        ]
+        cache = MagicMock()
+        cache.get.return_value = cached_payload
+        extractor = _build_extractor_with_cache(cache)
+
+        rulings = extractor.extract("fake calendar text")
+
+        assert len(rulings) == 2
+        assert rulings[0].ruling_text == long_text
+        assert rulings[1].ruling_text is None
+
+    def test_cache_hit_respects_bust_cache_flag(self) -> None:
+        """``bust_cache=True`` skips the cache read entirely on the text path."""
+        cache = MagicMock()
+        cache.get.return_value = [
+            {
+                "extracted_case_number": "CIVSB1",
+                "ruling_text": "Any text.",
+            }
+        ]
+        extractor = _build_extractor_with_cache(cache)
+
+        try:
+            extractor.extract("fake calendar text", bust_cache=True)
+        except Exception:  # noqa: BLE001
+            # Without a real LLM, the fresh path fails — the invariant we care
+            # about is that cache.get was not called.
+            pass
+        cache.get.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Regression: exactly the scenario described in #2513
+# ---------------------------------------------------------------------------
+
+
+class TestCacheHitFilterReapplicationRegression:
+    """Regression test for the exact scenario in #2513.
+
+    Simulates the #2489 -> #2513 flow:
+
+    1. Cache a set of rulings that include a pattern NOT yet in the filter
+       (simulated by injecting a payload with ``(Moot)`` listings).
+    2. The cache returns the rulings with the stale listings on cache-hit.
+    3. The cache-hit path now applies the widened filter.
+    4. Verify the listings are dropped before returning to the caller.
+    """
+
+    def test_cache_populated_with_stale_listings_is_filtered_on_read(self) -> None:
+        """Stale ``(Moot)`` cache entries are dropped on read instead of requiring reingest."""
+        # A cache entry as it might have been written BEFORE #2489's widening.
+        # Under the old filter, none of these listings would have been dropped.
+        stale_payload: list[dict[str, Any]] = [
+            {
+                "extracted_case_number": "30-2024-A",
+                "ruling_text": (
+                    "The demurrer is SUSTAINED with leave to amend. Plaintiff "
+                    "shall file an amended complaint within 20 days."
+                ),
+            },
+            {
+                "extracted_case_number": "30-2024-B",
+                "ruling_text": "(Moot)",
+            },
+            {
+                "extracted_case_number": "30-2024-C",
+                "ruling_text": "(Continued)",
+            },
+            {
+                "extracted_case_number": "30-2024-D",
+                "ruling_text": "(Withdrawn)",
+            },
+            {
+                "extracted_case_number": "30-2024-E",
+                "ruling_text": "OFF-CALENDAR",
+            },
+            {
+                "extracted_case_number": "30-2024-F",
+                "ruling_text": "O/C",
+            },
+            {
+                "extracted_case_number": "30-2024-G",
+                "ruling_text": "NO TENTATIVE",
+            },
+            {
+                "extracted_case_number": "30-2024-H",
+                "ruling_text": "Tentative pending",
+            },
+        ]
+        cache = MagicMock()
+        cache.get.return_value = stale_payload
+        extractor = _build_extractor_with_cache(cache)
+
+        rulings = extractor.extract_from_pdf(b"pdf-bytes")
+
+        # Only the real ruling survives — seven stale listings dropped.
+        assert len(rulings) == 1
+        assert rulings[0].extracted_case_number == "30-2024-A"


### PR DESCRIPTION
## Summary

The LLM result cache in `LlmExtractor` stored post-filter rulings keyed by content hash. On cache hit, cached rulings were returned directly without re-running post-processing filters, so filter updates made after an entry was cached did not take effect — requiring a 22-45h reingest with `--bust-llm-cache` to pick up new logic.

This PR adds two idempotent helpers (`_apply_pdf_cache_hit_filters`, `_apply_text_cache_hit_filters`) and invokes them on the cache-hit branches of `extract` (text path) and `extract_from_pdf` (PDF path). The PDF helper applies `_drop_calendar_listing_rulings`, `_deduplicate_ruling_texts`, and `_filter_citation_artifacts` (mirroring the filters in `_join_page_rows`); the text helper applies `_filter_citation_artifacts` and `_deduplicate_ruling_texts`. Both emit `cache_hit_filters_dropped` info logs when they actually drop rows, so filter-widening effects are observable in production.

`_resolve_cross_references` and `_propagate_document_fields` are intentionally not re-applied — they need pre-join row state that is discarded once `ExtractedRuling` objects exist.

Closes #2513

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (17 new unit + integration tests in `test_llm_cache_hit_filters.py`)
- [x] Diff coverage >= 90% (100% on changed lines)
- [x] CI green

### Post-deploy verification
- [ ] Run `rebuild_db.py --county Orange --reset` on dev, confirm `SELECT COUNT(*) FROM rulings r JOIN documents d ON r.document_id = d.id JOIN courts c ON c.id = d.court_id WHERE c.county = 'Orange' AND LENGTH(r.ruling_text) < 100` returns < 50 rows
- [ ] Verification evidence posted on #2513 (see A.8)
