### PR TITLE
feat(ci): detect modified ci.yml jobs that would be skipped on their own PR (#2527)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -405,6 +405,32 @@ if [ -n "$changed_workflows" ]; then
 fi
 
 # -------------------------------------------------------------------
+# CI job-skipped check — run whenever .github/workflows/ci.yml changes
+# -------------------------------------------------------------------
+# Catches the #2505 / #2410 footgun: a PR modifies a job body in ci.yml
+# whose if-gate paths-filter doesn't match anything in the diff, so the
+# job would be SKIPPED on that PR's CI run and the modification is never
+# actually exercised. Mirrors the CI `ci-job-skipped-check` job so the
+# failure is caught before the push even reaches CI (#2527).
+changed_ci_yml=$(echo "$changed_files" | grep -E '^\.github/workflows/ci\.yml$' || true)
+if [ -n "$changed_ci_yml" ]; then
+    echo "pre-push: checking for modified-but-skipped CI jobs..." >&2
+    if [ -x scripts/check-ci-job-skipped.sh ]; then
+        if ! scripts/check-ci-job-skipped.sh 2>&1; then
+            echo "" >&2
+            echo "  FAILED: scripts/check-ci-job-skipped.sh" >&2
+            echo "  A job body in ci.yml was modified but its paths-filter" >&2
+            echo "  gate doesn't match anything in the diff — the job will" >&2
+            echo "  be SKIPPED on this PR's CI run and the change won't be" >&2
+            echo "  exercised. See issue #2527 for background." >&2
+            failures=$((failures + 1))
+        fi
+    else
+        echo "  WARNING: scripts/check-ci-job-skipped.sh not found or not executable — skipping" >&2
+    fi
+fi
+
+# -------------------------------------------------------------------
 # Markdown link check — run whenever any .md file is in the push
 # -------------------------------------------------------------------
 # Mirrors the CI `markdown-links-check` job so broken internal pointers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -959,6 +959,21 @@ jobs:
         run: scripts/check-removed-exports.sh
 
   # ---------------------------------------------------------------
+  # CI job-skipped guard: detect jobs whose body is modified on a PR
+  # but would be SKIPPED on that PR's CI run because their paths-filter
+  # if-gate doesn't match anything in the diff (#2410, #2505, #2527).
+  # ---------------------------------------------------------------
+  ci-job-skipped-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Detect modified CI jobs that would be skipped on their own PR
+        run: python3 scripts/check-ci-job-skipped.py --base "origin/${{ github.event.pull_request.base.ref }}"
+
+  # ---------------------------------------------------------------
   # Preflight hook test suite: runs when .claude/hooks/ changes (#2408)
   # ---------------------------------------------------------------
   preflight-hook-test:
@@ -1088,7 +1103,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,6 +284,7 @@ See **`docs/agent/code-standards.md`** for the full reference (Python/TypeScript
 - **Perf:** watch for sequential I/O, `LIMIT/OFFSET` pagination, unbatched DB writes, missing connection reuse.
 - **Pre-PR (MANDATORY, `.githooks/pre-push` enforces):** from each touched package, run `ruff check`, `ruff format --check`, and `pytest` (Python) or `lint`/`typecheck`/`test` + `build` for `packages/web/` (TS). Diff coverage ≥ 90% on changed lines; package floor ratchet in `coverage-baselines.json`. Subagents run the same checks; never push on red.
 - **Docs / Markdown:** when any `.md` file changes, run `scripts/check-markdown-links.sh` to verify internal markdown pointers (both Markdown-link and backtick-ref styles) resolve. CI runs this in the `markdown-links-check` job; `.githooks/pre-push` runs it on any `.md` file being pushed so failures are caught before CI.
+- **CI workflow edits:** when `.github/workflows/ci.yml` changes, `scripts/check-ci-job-skipped.sh` runs automatically to detect the #2410 / #2505 footgun — modifying a job whose paths-filter gate doesn't match anything in the diff, so the job is SKIPPED on that PR's own CI run and your edits are never exercised. CI runs the same check in the `ci-job-skipped-check` job; pre-push runs it whenever ci.yml is in the push. If it fails, either add `.github/workflows/ci.yml` to the offending filter or modify a file that already matches the filter.
 
 ### Subagent Responsibilities
 

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -138,6 +138,16 @@ scripts/check-markdown-links.sh
 
 This validates internal markdown pointers — both Markdown-style links and backtick references to repo-relative paths — resolve to files that exist. The same check runs in CI as the `markdown-links-check` job; the pre-push hook runs it on any `.md` in the push so failures are caught before the 2-3 minute CI round trip. If a backtick token that looks like a repo path is illustrative (not a real file), remove the backticks or rephrase so the checker does not flag it.
 
+### CI workflow edits
+
+When `.github/workflows/ci.yml` changes, run:
+
+```
+scripts/check-ci-job-skipped.sh
+```
+
+This detects the #2410 / #2505 footgun: a PR modifies a job body whose `if: needs.detect-changes.outputs.X == 'true'` gate's paths-filter does not match anything in the diff, so the job will be SKIPPED on that PR's own CI run and the modification is never actually exercised. The same check runs in CI as the `ci-job-skipped-check` job; the pre-push hook runs it whenever `ci.yml` is in the push. If it fails, either add `.github/workflows/ci.yml` to the offending filter (so the job always runs when ci.yml itself changes) or modify a file that already matches the filter.
+
 ### Subagent responsibilities
 
 Subagents MUST install dependencies, run ALL lint/format/test commands for every package touched, fix failures before committing, and only push after all local checks pass.

--- a/scripts/check-ci-job-skipped.py
+++ b/scripts/check-ci-job-skipped.py
@@ -1,0 +1,631 @@
+#!/usr/bin/env python3
+# venv: none
+"""
+check-ci-job-skipped.py — Detect CI jobs whose body was modified in a diff
+but would be SKIPPED on that diff's CI run because the paths-filter gate
+doesn't match any changed file.
+
+Motivation (#2527): When a PR modifies a job in `.github/workflows/ci.yml`
+that has an `if: needs.detect-changes.outputs.X == 'true'` gate on a paths
+filter, the job may be SKIPPED on that PR's CI run — so the changes to the
+job definition are never actually exercised. The author sees green CI and
+merges with confidence, but the modification is only tested on some later
+PR that happens to touch a file the filter matches.
+
+This has recurred at least twice:
+
+- #2410: added a new test job gated on `hooks` filter; the filter did not
+  include `.github/workflows/ci.yml` itself, so edits to the job body
+  were not exercised on the PR that introduced them.
+- #2505: replaced 21 explicit `run:` steps in `scripts-tests` with a
+  single auto-discovery loop. The `scripts` filter did not include
+  `.github/workflows/ci.yml`, so the first commit never exercised
+  the new loop; the fix was a follow-up commit to add ci.yml to
+  the filter.
+
+This check detects that class of silent failure BEFORE the push:
+
+1. Parse `.github/workflows/ci.yml` to extract:
+   - The dorny/paths-filter filter block (filter-name → globs).
+   - Each job's body line range and its `if:` gate (if any).
+
+2. `git diff` against the merge base with origin/main to get:
+   - The set of changed files.
+   - The line ranges changed inside ci.yml itself.
+
+3. For each gated job whose body has modified lines:
+   - Look up the filter's glob list.
+   - If NO changed file matches any glob in that list, FAIL with
+     an actionable message.
+
+Usage:
+    scripts/check-ci-job-skipped.py                  # Diff against origin/main
+    scripts/check-ci-job-skipped.py --base main      # Diff against a specific base
+    scripts/check-ci-job-skipped.py --ci-yml PATH    # Override ci.yml location
+    scripts/check-ci-job-skipped.py --diff-file FILE # Read unified diff from a file
+                                                     # (for testing without git)
+    scripts/check-ci-job-skipped.py --help
+
+Exit codes:
+    0 — No modified-but-would-be-skipped jobs detected.
+    1 — One or more modified jobs would be skipped on their own PR.
+    2 — Script error (cannot parse ci.yml, cannot run git, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+# -----------------------------------------------------------------------------
+# Glob matching
+# -----------------------------------------------------------------------------
+# dorny/paths-filter uses picomatch glob syntax. We only need to support the
+# subset actually used in ci.yml:
+#
+#   - `packages/foo/**`          - recursive descendants
+#   - `scripts/*.py`             - files directly in scripts/
+#   - `.github/workflows/ci.yml` - exact path
+#   - `infra/**`                 - recursive
+#
+# We compile each glob to a regex. Rules:
+#   - `**` matches any sequence (including slashes, including empty).
+#   - `*`  matches any characters except `/`.
+#   - `?`  matches a single character except `/`.
+#   - Other chars are literal (escaped where needed for regex).
+
+
+def glob_to_regex(glob: str) -> re.Pattern[str]:
+    """Convert a picomatch-ish glob to a compiled regex anchored to full path."""
+    # Strip surrounding quotes if present
+    glob = glob.strip().strip("'\"")
+
+    out: list[str] = []
+    i = 0
+    n = len(glob)
+    while i < n:
+        c = glob[i]
+        if c == "*":
+            # Look for `**` (optionally followed by `/`)
+            if i + 1 < n and glob[i + 1] == "*":
+                # `**/` matches any sequence of dirs including none
+                if i + 2 < n and glob[i + 2] == "/":
+                    out.append("(?:.*/)?")
+                    i += 3
+                    continue
+                # `/**` at end or elsewhere: match anything (including empty).
+                out.append(".*")
+                i += 2
+                continue
+            # Single `*`: match anything except slash.
+            out.append("[^/]*")
+            i += 1
+        elif c == "?":
+            out.append("[^/]")
+            i += 1
+        elif c in r".+^$()[]{}|\\":
+            out.append(re.escape(c))
+            i += 1
+        else:
+            out.append(re.escape(c))
+            i += 1
+
+    pattern = "^" + "".join(out) + "$"
+    return re.compile(pattern)
+
+
+def path_matches_any(path: str, compiled_globs: list[re.Pattern[str]]) -> bool:
+    """Return True if path matches at least one compiled glob."""
+    for pat in compiled_globs:
+        if pat.match(path):
+            return True
+    return False
+
+
+# -----------------------------------------------------------------------------
+# ci.yml parsing
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class Job:
+    """A top-level job in the `jobs:` block of ci.yml."""
+
+    name: str
+    start_line: int  # 1-indexed, line of the `<name>:` header
+    end_line: int  # 1-indexed, last line of the job body
+    if_gate_filter: str | None  # e.g. "scripts" if gated on detect-changes.outputs.scripts
+
+
+@dataclass
+class CIYaml:
+    filters: dict[str, list[str]]  # filter-name -> list of glob strings
+    jobs: list[Job]
+
+
+# detect-changes `if` gate pattern:
+#   if: needs.detect-changes.outputs.scripts == 'true'
+#   if: needs.detect-changes.outputs.scraper == 'true' || needs.detect-changes.outputs.nlp == 'true'
+IF_OUTPUT_RE = re.compile(r"needs\.detect-changes\.outputs\.([A-Za-z0-9_\-]+)")
+
+
+def parse_ci_yaml(ci_yml_path: Path) -> CIYaml:
+    """Parse ci.yml into a CIYaml structure.
+
+    This is a minimal line-oriented parser tailored to the ci.yml structure
+    we actually have — NOT a general YAML parser. It assumes:
+      - 2-space indentation
+      - top-level `jobs:` block with each job at indent level 2
+      - `detect-changes` job contains a `filters: |` folded scalar
+    """
+    lines = ci_yml_path.read_text().splitlines()
+
+    # ------- Step 1: find `jobs:` block -------
+    jobs_start = None
+    for i, line in enumerate(lines):
+        if re.match(r"^jobs:\s*$", line):
+            jobs_start = i + 1  # First line of jobs block
+            break
+    if jobs_start is None:
+        raise ValueError("Could not find 'jobs:' block in ci.yml")
+
+    # ------- Step 2: find each job at indent level 2 -------
+    # A job header line matches: `  <name>:` with exactly 2 spaces.
+    job_header_re = re.compile(r"^  ([A-Za-z0-9_\-]+):\s*$")
+    job_headers: list[tuple[str, int]] = []  # (name, 0-indexed line)
+    for i in range(jobs_start, len(lines)):
+        line = lines[i]
+        if not line.strip():
+            continue
+        # If the line is at indent level 0 (non-empty, non-indent, non-comment),
+        # we've left the jobs block.
+        if line and not line.startswith(" ") and not line.startswith("#"):
+            break
+        m = job_header_re.match(line)
+        if m:
+            job_headers.append((m.group(1), i))
+
+    # ------- Step 3: for each job, find end line and `if:` gate -------
+    jobs: list[Job] = []
+    for idx, (name, start_i) in enumerate(job_headers):
+        # End is the line before the next job header (or EOF/end-of-jobs).
+        if idx + 1 < len(job_headers):
+            end_i = job_headers[idx + 1][1] - 1
+        else:
+            end_i = len(lines) - 1
+            for j in range(start_i + 1, len(lines)):
+                ln = lines[j]
+                if ln and not ln.startswith(" ") and not ln.startswith("#"):
+                    end_i = j - 1
+                    break
+
+        # Find `if:` gate inside this job body at indent 4 (direct child).
+        # Collect ALL outputs.X names in the expression so multi-filter
+        # gates (`A == 'true' || B == 'true'`) are handled.
+        if_filter: str | None = None
+        for j in range(start_i + 1, end_i + 1):
+            ln = lines[j]
+            m = re.match(r"^    if:\s*(.+)$", ln)
+            if m:
+                expr = m.group(1)
+                matches = IF_OUTPUT_RE.findall(expr)
+                if matches:
+                    # Join multi-filter names with `|` as a compact key.
+                    # Downstream logic checks ALL referenced filters (OR).
+                    if_filter = "|".join(matches)
+                break  # first `if:` wins; jobs only have one
+
+        jobs.append(
+            Job(
+                name=name,
+                start_line=start_i + 1,  # 1-indexed
+                end_line=end_i + 1,  # 1-indexed
+                if_gate_filter=if_filter,
+            )
+        )
+
+    # ------- Step 4: extract filters from detect-changes job -------
+    filters = _extract_filters(lines, jobs)
+
+    return CIYaml(filters=filters, jobs=jobs)
+
+
+def _extract_filters(lines: list[str], jobs: list[Job]) -> dict[str, list[str]]:
+    """Extract the paths-filter `filters: |` block from detect-changes."""
+    dc_job = next((j for j in jobs if j.name == "detect-changes"), None)
+    if dc_job is None:
+        return {}
+
+    # Find `filters: |` within the detect-changes body.
+    filters_start: int | None = None
+    filters_indent: int | None = None
+    for i in range(dc_job.start_line - 1, dc_job.end_line):
+        m = re.match(r"^(\s+)filters:\s*\|\s*$", lines[i])
+        if m:
+            filters_start = i + 1
+            filters_indent = len(m.group(1))
+            break
+    if filters_start is None or filters_indent is None:
+        return {}
+
+    # Determine the filter-name indent (first non-blank, non-comment line).
+    filter_name_indent: int | None = None
+    for i in range(filters_start, len(lines)):
+        ln = lines[i]
+        if not ln.strip():
+            continue
+        if ln.lstrip().startswith("#"):
+            continue
+        leading = len(ln) - len(ln.lstrip(" "))
+        if leading <= filters_indent:
+            break  # left the filters: | block
+        filter_name_indent = leading
+        break
+
+    if filter_name_indent is None:
+        return {}
+
+    filter_name_re = re.compile(
+        rf"^ {{{filter_name_indent}}}([A-Za-z0-9_\-]+):\s*$"
+    )
+    # Glob entries are lines more deeply indented than the filter name,
+    # starting with `- '...'`.
+    glob_entry_re = re.compile(
+        rf"^ {{{filter_name_indent + 2},}}-\s*(.+?)\s*$"
+    )
+
+    filters: dict[str, list[str]] = {}
+    current_filter: str | None = None
+
+    for i in range(filters_start, len(lines)):
+        ln = lines[i]
+        if not ln.strip():
+            continue
+        # Comment lines inside the block — skip.
+        if ln.lstrip().startswith("#"):
+            continue
+        leading = len(ln) - len(ln.lstrip(" "))
+        if leading <= filters_indent:
+            break  # out of filters: | block
+
+        m_name = filter_name_re.match(ln)
+        if m_name:
+            current_filter = m_name.group(1)
+            filters[current_filter] = []
+            continue
+
+        m_glob = glob_entry_re.match(ln)
+        if m_glob and current_filter is not None:
+            glob = m_glob.group(1).strip()
+            # Strip trailing `# comment` if any
+            if "#" in glob:
+                # Only strip if `#` is outside quotes (simple heuristic)
+                quote_char = None
+                for ci_idx, ch in enumerate(glob):
+                    if ch in ("'", '"'):
+                        if quote_char is None:
+                            quote_char = ch
+                        elif quote_char == ch:
+                            quote_char = None
+                    elif ch == "#" and quote_char is None:
+                        glob = glob[:ci_idx].rstrip()
+                        break
+            # Strip surrounding quotes
+            if (glob.startswith("'") and glob.endswith("'")) or (
+                glob.startswith('"') and glob.endswith('"')
+            ):
+                glob = glob[1:-1]
+            if glob:
+                filters[current_filter].append(glob)
+            continue
+
+    return filters
+
+
+# -----------------------------------------------------------------------------
+# Git diff parsing
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class DiffResult:
+    changed_files: list[str]
+    # For ci.yml specifically: the set of line numbers touched on the NEW side.
+    ci_yml_changed_lines: set[int]
+
+
+HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def parse_unified_diff(diff_text: str, ci_yml_rel_path: str) -> DiffResult:
+    """Parse a unified diff and extract changed files + ci.yml modified lines.
+
+    We consider a line modified on the NEW side if it is a `+` line. We
+    also mark nearby new-side lines when a hunk contains `-` (deletion)
+    lines, so that pure-deletion edits inside a job body are still
+    detected as a modification to that job.
+    """
+    changed_files: list[str] = []
+    ci_lines: set[int] = set()
+
+    lines = diff_text.splitlines()
+    i = 0
+    current_file: str | None = None
+    while i < len(lines):
+        line = lines[i]
+        # File header: `diff --git a/path b/path`
+        if line.startswith("diff --git "):
+            parts = line.split(" ")
+            new_path_token = parts[-1]
+            if new_path_token.startswith("b/"):
+                current_file = new_path_token[2:]
+                if current_file not in changed_files:
+                    changed_files.append(current_file)
+            else:
+                current_file = None
+            i += 1
+            continue
+
+        # Handle `+++ b/<path>` as a fallback file header
+        m_plus = re.match(r"^\+\+\+ b/(.+)$", line)
+        if m_plus:
+            current_file = m_plus.group(1)
+            if current_file and current_file not in changed_files:
+                changed_files.append(current_file)
+            i += 1
+            continue
+
+        if line.startswith("--- ") or line.startswith("+++ "):
+            i += 1
+            continue
+
+        m_hunk = HUNK_HEADER_RE.match(line)
+        if m_hunk and current_file == ci_yml_rel_path:
+            new_start = int(m_hunk.group(1))
+            hunk_has_deletion = False
+            j = i + 1
+            hunk_new_line_numbers: list[int] = []
+            running_new_line = new_start
+            while j < len(lines):
+                hl = lines[j]
+                if hl.startswith("@@ ") or hl.startswith("diff --git "):
+                    break
+                if hl.startswith("+"):
+                    ci_lines.add(running_new_line)
+                    hunk_new_line_numbers.append(running_new_line)
+                    running_new_line += 1
+                elif hl.startswith("-"):
+                    hunk_has_deletion = True
+                elif hl.startswith(" "):
+                    hunk_new_line_numbers.append(running_new_line)
+                    running_new_line += 1
+                elif hl.startswith("\\"):
+                    # `\ No newline at end of file`
+                    pass
+                else:
+                    break
+                j += 1
+
+            if hunk_has_deletion and hunk_new_line_numbers:
+                # Mark the new-side range of the hunk as changed so that
+                # pure deletions inside a job body are still detected.
+                for ln in hunk_new_line_numbers:
+                    ci_lines.add(ln)
+                # Also mark new_start for pure-deletion hunks with no +/context.
+                ci_lines.add(new_start)
+
+            i = j
+            continue
+
+        i += 1
+
+    return DiffResult(changed_files=changed_files, ci_yml_changed_lines=ci_lines)
+
+
+def get_diff_from_git(base_ref: str, repo_root: Path) -> str:
+    """Run `git diff` against the merge-base of `base_ref`."""
+    mb = subprocess.run(
+        ["git", "-C", str(repo_root), "merge-base", "HEAD", base_ref],
+        capture_output=True,
+        text=True,
+    )
+    if mb.returncode == 0 and mb.stdout.strip():
+        base = mb.stdout.strip()
+    else:
+        base = base_ref
+
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "diff", f"{base}...HEAD", "--unified=3"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git diff failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+# -----------------------------------------------------------------------------
+# Main check logic
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class SkippedJobProblem:
+    job_name: str
+    filter_name: str  # may be "a|b" for multi-filter gates
+    filter_globs: list[str]
+
+
+def find_skipped_modified_jobs(
+    ci: CIYaml,
+    changed_files: list[str],
+    ci_yml_changed_lines: set[int],
+) -> list[SkippedJobProblem]:
+    """Return the list of jobs whose body was modified but would be skipped.
+
+    A job is "modified" if any line in its body (inclusive of start_line and
+    end_line) is in ci_yml_changed_lines.
+
+    A job would be "skipped on its own PR" if it has an if-gate on a
+    detect-changes filter AND no changed file in the diff matches any glob
+    in any of the referenced filters' glob lists.
+    """
+    problems: list[SkippedJobProblem] = []
+    for job in ci.jobs:
+        if job.if_gate_filter is None:
+            continue
+        if job.name == "detect-changes":
+            continue
+
+        body_modified = any(
+            job.start_line <= ln <= job.end_line for ln in ci_yml_changed_lines
+        )
+        if not body_modified:
+            continue
+
+        filter_names = job.if_gate_filter.split("|")
+        all_globs: list[str] = []
+        for fname in filter_names:
+            globs = ci.filters.get(fname, [])
+            all_globs.extend(globs)
+
+        # Unknown filter (not in detect-changes) — skip silently.
+        if not all_globs:
+            continue
+
+        compiled = [glob_to_regex(g) for g in all_globs]
+
+        any_match = any(path_matches_any(f, compiled) for f in changed_files)
+        if any_match:
+            continue
+
+        problems.append(
+            SkippedJobProblem(
+                job_name=job.name,
+                filter_name=job.if_gate_filter,
+                filter_globs=all_globs,
+            )
+        )
+    return problems
+
+
+def format_problem(p: SkippedJobProblem) -> str:
+    globs_joined = ", ".join(p.filter_globs)
+    if "|" in p.filter_name:
+        filter_label = f"filters `{p.filter_name.replace('|', '`, `')}`"
+    else:
+        filter_label = f"filter `{p.filter_name}`"
+    return (
+        f"Job `{p.job_name}` is gated on {filter_label}.\n"
+        f"  Your diff modifies `{p.job_name}` in .github/workflows/ci.yml, but\n"
+        f"  NO file in the diff matches any glob in that filter's path list.\n"
+        f"  As a result, `{p.job_name}` will be SKIPPED on this PR's CI run,\n"
+        f"  and your changes to that job body will not actually be exercised.\n"
+        f"\n"
+        f"  Filter globs: {globs_joined}\n"
+        f"\n"
+        f"  Fix: add `.github/workflows/ci.yml` to the filter's path list in\n"
+        f"  `.github/workflows/ci.yml` (under `detect-changes` → `filters:`),\n"
+        f"  or modify a file that already matches one of those globs."
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Detect CI jobs whose body was modified but would be skipped on the PR."
+    )
+    ap.add_argument(
+        "--base",
+        default="origin/main",
+        help="Base ref to diff against (default: origin/main).",
+    )
+    ap.add_argument(
+        "--ci-yml",
+        default=".github/workflows/ci.yml",
+        help="Path to ci.yml, relative to repo root.",
+    )
+    ap.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repo root (default: auto-detect from git).",
+    )
+    ap.add_argument(
+        "--diff-file",
+        default=None,
+        help="Read unified diff from a file instead of invoking git (for tests).",
+    )
+    args = ap.parse_args()
+
+    if args.repo_root:
+        repo_root = Path(args.repo_root).resolve()
+    else:
+        try:
+            r = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            repo_root = Path(r.stdout.strip())
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            print(f"ERROR: cannot determine repo root: {exc}", file=sys.stderr)
+            return 2
+
+    ci_yml_path = repo_root / args.ci_yml
+    if not ci_yml_path.is_file():
+        print(f"ERROR: ci.yml not found at {ci_yml_path}", file=sys.stderr)
+        return 2
+
+    try:
+        ci = parse_ci_yaml(ci_yml_path)
+    except Exception as exc:
+        print(f"ERROR: failed to parse ci.yml: {exc}", file=sys.stderr)
+        return 2
+
+    if args.diff_file:
+        diff_path = Path(args.diff_file)
+        if not diff_path.is_file():
+            print(f"ERROR: diff file not found: {diff_path}", file=sys.stderr)
+            return 2
+        diff_text = diff_path.read_text()
+    else:
+        try:
+            diff_text = get_diff_from_git(args.base, repo_root)
+        except RuntimeError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+    diff = parse_unified_diff(diff_text, args.ci_yml)
+
+    problems = find_skipped_modified_jobs(
+        ci, diff.changed_files, diff.ci_yml_changed_lines
+    )
+
+    if not problems:
+        return 0
+
+    print(
+        "check-ci-job-skipped: one or more modified jobs would be SKIPPED",
+        file=sys.stderr,
+    )
+    print("on this PR's CI run:", file=sys.stderr)
+    print("", file=sys.stderr)
+    for p in problems:
+        print(format_problem(p), file=sys.stderr)
+        print("", file=sys.stderr)
+    print(
+        "See https://github.com/judgemind/judgemind/issues/2527 for background.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-ci-job-skipped.py
+++ b/scripts/check-ci-job-skipped.py
@@ -193,7 +193,7 @@ def parse_ci_yaml(ci_yml_path: Path) -> CIYaml:
     # ------- Step 3: for each job, find end line and `if:` gate -------
     jobs: list[Job] = []
     for idx, (name, start_i) in enumerate(job_headers):
-        # End is the line before the next job header (or EOF/end-of-jobs).
+        # Tentative end: line before the next job header (or EOF/end-of-jobs).
         if idx + 1 < len(job_headers):
             end_i = job_headers[idx + 1][1] - 1
         else:
@@ -203,6 +203,23 @@ def parse_ci_yaml(ci_yml_path: Path) -> CIYaml:
                 if ln and not ln.startswith(" ") and not ln.startswith("#"):
                     end_i = j - 1
                     break
+
+        # Walk backward to strip trailing blank lines AND top-level comments
+        # (lines that start with `  #` at indent 2 — those are leading
+        # doc comments for the NEXT job, not part of the current job body).
+        while end_i > start_i:
+            ln = lines[end_i]
+            stripped = ln.strip()
+            if not stripped:
+                end_i -= 1
+                continue
+            # Only strip comments at indent 2 — those are between-job banners.
+            # Comments at deeper indent (e.g. inline `# comment` on a step)
+            # are genuine body content and stay.
+            if re.match(r"^ {0,3}#", ln) and ln.startswith("  #"):
+                end_i -= 1
+                continue
+            break
 
         # Find `if:` gate inside this job body at indent 4 (direct child).
         # Collect ALL outputs.X names in the expression so multi-filter
@@ -345,10 +362,15 @@ HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
 def parse_unified_diff(diff_text: str, ci_yml_rel_path: str) -> DiffResult:
     """Parse a unified diff and extract changed files + ci.yml modified lines.
 
-    We consider a line modified on the NEW side if it is a `+` line. We
-    also mark nearby new-side lines when a hunk contains `-` (deletion)
-    lines, so that pure-deletion edits inside a job body are still
-    detected as a modification to that job.
+    We consider a new-side line truly "modified" only when there is a `+`
+    line in the diff at that position. Context lines (` `) and deletion
+    lines (`-`) never mark a new-side line as changed — deletions do not
+    exist on the new side, and context lines are unchanged by definition.
+
+    Edge case: a *pure-deletion* hunk (no `+` lines at all) still means
+    content was removed; we represent that by marking `new_start` as
+    changed so a job body that was purely deleted from is still detected
+    as modified.
     """
     changed_files: list[str] = []
     ci_lines: set[int] = set()
@@ -387,22 +409,25 @@ def parse_unified_diff(diff_text: str, ci_yml_rel_path: str) -> DiffResult:
         m_hunk = HUNK_HEADER_RE.match(line)
         if m_hunk and current_file == ci_yml_rel_path:
             new_start = int(m_hunk.group(1))
-            hunk_has_deletion = False
+            has_plus = False
+            has_minus = False
             j = i + 1
-            hunk_new_line_numbers: list[int] = []
             running_new_line = new_start
             while j < len(lines):
                 hl = lines[j]
                 if hl.startswith("@@ ") or hl.startswith("diff --git "):
                     break
                 if hl.startswith("+"):
+                    # True addition to new side — mark as changed.
                     ci_lines.add(running_new_line)
-                    hunk_new_line_numbers.append(running_new_line)
+                    has_plus = True
                     running_new_line += 1
                 elif hl.startswith("-"):
-                    hunk_has_deletion = True
+                    # Deletion — old-side only; no new-side line to mark.
+                    has_minus = True
                 elif hl.startswith(" "):
-                    hunk_new_line_numbers.append(running_new_line)
+                    # Context — unchanged. Advance new-side counter but do
+                    # NOT mark as changed.
                     running_new_line += 1
                 elif hl.startswith("\\"):
                     # `\ No newline at end of file`
@@ -411,12 +436,10 @@ def parse_unified_diff(diff_text: str, ci_yml_rel_path: str) -> DiffResult:
                     break
                 j += 1
 
-            if hunk_has_deletion and hunk_new_line_numbers:
-                # Mark the new-side range of the hunk as changed so that
-                # pure deletions inside a job body are still detected.
-                for ln in hunk_new_line_numbers:
-                    ci_lines.add(ln)
-                # Also mark new_start for pure-deletion hunks with no +/context.
+            # Pure-deletion hunk (only `-` lines, no `+`) — mark new_start
+            # as a synthetic change marker so body-level pure deletes are
+            # still detected as modifications to the surrounding job.
+            if has_minus and not has_plus:
                 ci_lines.add(new_start)
 
             i = j

--- a/scripts/check-ci-job-skipped.sh
+++ b/scripts/check-ci-job-skipped.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# check-ci-job-skipped.sh — Thin wrapper for check-ci-job-skipped.py
+#
+# Runs the Python checker against the current diff vs origin/main. Used
+# by the CI `ci-job-skipped-check` job and by the `.githooks/pre-push`
+# hook so the footgun is caught before a push even reaches CI.
+#
+# Passes all args through to the Python script — see that file for flags
+# and exit codes (#2527).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/check-ci-job-skipped.py" "$@"

--- a/scripts/tests/test_check_ci_job_skipped.py
+++ b/scripts/tests/test_check_ci_job_skipped.py
@@ -265,7 +265,9 @@ class TestParseUnifiedDiff:
         assert 13 in r.ci_yml_changed_lines
 
     def test_pure_deletion_is_detected(self) -> None:
-        """Deletion-only hunks should still flag the surrounding new-side range."""
+        """Deletion-only hunks flag exactly `new_start` — a synthetic marker
+        so body-level pure deletes are detected without claiming unchanged
+        context lines are "modified"."""
         diff = textwrap.dedent(
             """\
             diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
@@ -279,9 +281,30 @@ class TestParseUnifiedDiff:
             """
         )
         r = parse_unified_diff(diff, ".github/workflows/ci.yml")
-        # Context lines at new-side 20 and 21 should be flagged
+        # new_start (line 20) is flagged as a synthetic marker. Context
+        # lines (21) are NOT flagged — they're unchanged on the new side.
         assert 20 in r.ci_yml_changed_lines
-        assert 21 in r.ci_yml_changed_lines
+        assert 21 not in r.ci_yml_changed_lines
+
+    def test_context_lines_never_marked_as_changed(self) -> None:
+        """A pure-addition hunk with context should only flag `+` lines."""
+        diff = textwrap.dedent(
+            """\
+            diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+            --- a/.github/workflows/ci.yml
+            +++ b/.github/workflows/ci.yml
+            @@ -100,3 +100,5 @@
+             ctx-a
+             ctx-b
+            +new-1
+            +new-2
+             ctx-c
+            """
+        )
+        r = parse_unified_diff(diff, ".github/workflows/ci.yml")
+        # Only the two `+` lines (new-side 102 and 103) are marked.
+        # Context lines 100, 101, 104 are NOT marked.
+        assert r.ci_yml_changed_lines == {102, 103}
 
     def test_non_ci_yml_changes_dont_record_ci_lines(self) -> None:
         diff = textwrap.dedent(

--- a/scripts/tests/test_check_ci_job_skipped.py
+++ b/scripts/tests/test_check_ci_job_skipped.py
@@ -1,0 +1,473 @@
+# venv: none
+"""Unit tests for check-ci-job-skipped.py (#2527).
+
+Covers:
+  - Glob-to-regex conversion for dorny/paths-filter syntax.
+  - ci.yml parsing (filters block + job bodies + if-gate extraction).
+  - Diff parsing (which ci.yml lines changed; which files changed).
+  - End-to-end find_skipped_modified_jobs() with realistic fixtures.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Load the script as a module (it has a hyphen in its name)
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check-ci-job-skipped.py"
+spec = importlib.util.spec_from_file_location("check_ci_job_skipped", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+check_ci_job_skipped = importlib.util.module_from_spec(spec)
+sys.modules["check_ci_job_skipped"] = check_ci_job_skipped
+spec.loader.exec_module(check_ci_job_skipped)
+
+glob_to_regex = check_ci_job_skipped.glob_to_regex
+path_matches_any = check_ci_job_skipped.path_matches_any
+parse_ci_yaml = check_ci_job_skipped.parse_ci_yaml
+parse_unified_diff = check_ci_job_skipped.parse_unified_diff
+find_skipped_modified_jobs = check_ci_job_skipped.find_skipped_modified_jobs
+
+
+# ---------------------------------------------------------------------------
+# glob_to_regex
+# ---------------------------------------------------------------------------
+
+
+class TestGlobToRegex:
+    def test_recursive_doublestar(self) -> None:
+        pat = glob_to_regex("packages/scraper-framework/**")
+        assert pat.match("packages/scraper-framework/src/foo.py")
+        assert pat.match("packages/scraper-framework/tests/x/y/z.py")
+        assert pat.match("packages/scraper-framework/")  # bare prefix with slash
+        assert not pat.match("packages/nlp-pipeline/src/foo.py")
+        assert not pat.match("scripts/foo.py")
+
+    def test_single_star_in_dir(self) -> None:
+        pat = glob_to_regex("scripts/*.py")
+        assert pat.match("scripts/foo.py")
+        assert pat.match("scripts/check_something.py")
+        assert not pat.match("scripts/sub/foo.py")
+        assert not pat.match("scripts/foo.sh")
+
+    def test_exact_path(self) -> None:
+        pat = glob_to_regex(".github/workflows/ci.yml")
+        assert pat.match(".github/workflows/ci.yml")
+        assert not pat.match(".github/workflows/deploy.yml")
+        assert not pat.match("other/.github/workflows/ci.yml")
+
+    def test_quoted_glob_is_stripped(self) -> None:
+        pat = glob_to_regex("'packages/foo/**'")
+        assert pat.match("packages/foo/bar.py")
+
+    def test_leading_double_star_slash(self) -> None:
+        pat = glob_to_regex("**/ci.yml")
+        assert pat.match("ci.yml")
+        assert pat.match(".github/workflows/ci.yml")
+
+    def test_path_matches_any_accepts_first(self) -> None:
+        globs = [
+            glob_to_regex("packages/scraper-framework/**"),
+            glob_to_regex(".github/workflows/ci.yml"),
+        ]
+        assert path_matches_any(".github/workflows/ci.yml", globs)
+        assert path_matches_any("packages/scraper-framework/src/a.py", globs)
+        assert not path_matches_any("docs/other.md", globs)
+
+
+# ---------------------------------------------------------------------------
+# ci.yml parsing fixtures
+# ---------------------------------------------------------------------------
+
+
+MINIMAL_CI_YML = textwrap.dedent(
+    """\
+    name: CI
+
+    on:
+      push:
+
+    jobs:
+      detect-changes:
+        runs-on: ubuntu-latest
+        outputs:
+          scripts: ${{ steps.changes.outputs.scripts }}
+          hooks: ${{ steps.changes.outputs.hooks }}
+          scraper: ${{ steps.changes.outputs.scraper }}
+        steps:
+          - uses: actions/checkout@v6
+          - uses: dorny/paths-filter@v4
+            id: changes
+            with:
+              filters: |
+                scripts:
+                  - 'scripts/**'
+                  - '.github/workflows/ci.yml'
+                hooks:
+                  - '.claude/hooks/**'
+                  - '.github/workflows/ci.yml'
+                scraper:
+                  - 'packages/scraper-framework/**'
+
+      scripts-tests:
+        needs: detect-changes
+        if: needs.detect-changes.outputs.scripts == 'true'
+        runs-on: ubuntu-latest
+        steps:
+          - name: Test
+            run: echo hi
+
+      preflight-hook-test:
+        needs: detect-changes
+        if: needs.detect-changes.outputs.hooks == 'true'
+        runs-on: ubuntu-latest
+        steps:
+          - name: Test
+            run: echo hi
+
+      scraper-tests:
+        needs: detect-changes
+        if: needs.detect-changes.outputs.scraper == 'true'
+        runs-on: ubuntu-latest
+        steps:
+          - run: echo hi
+
+      always-runs:
+        runs-on: ubuntu-latest
+        steps:
+          - run: echo hi
+
+      multi-filter:
+        needs: detect-changes
+        if: needs.detect-changes.outputs.scripts == 'true' || needs.detect-changes.outputs.scraper == 'true'
+        runs-on: ubuntu-latest
+        steps:
+          - run: echo hi
+    """
+)
+
+
+@pytest.fixture
+def minimal_ci_path(tmp_path: Path) -> Path:
+    p = tmp_path / "ci.yml"
+    p.write_text(MINIMAL_CI_YML)
+    return p
+
+
+class TestParseCIYaml:
+    def test_filters_extracted(self, minimal_ci_path: Path) -> None:
+        ci = parse_ci_yaml(minimal_ci_path)
+        assert ci.filters["scripts"] == ["scripts/**", ".github/workflows/ci.yml"]
+        assert ci.filters["hooks"] == [".claude/hooks/**", ".github/workflows/ci.yml"]
+        assert ci.filters["scraper"] == ["packages/scraper-framework/**"]
+
+    def test_jobs_found(self, minimal_ci_path: Path) -> None:
+        ci = parse_ci_yaml(minimal_ci_path)
+        names = [j.name for j in ci.jobs]
+        assert names == [
+            "detect-changes",
+            "scripts-tests",
+            "preflight-hook-test",
+            "scraper-tests",
+            "always-runs",
+            "multi-filter",
+        ]
+
+    def test_if_gate_filter(self, minimal_ci_path: Path) -> None:
+        ci = parse_ci_yaml(minimal_ci_path)
+        by_name = {j.name: j for j in ci.jobs}
+        assert by_name["scripts-tests"].if_gate_filter == "scripts"
+        assert by_name["preflight-hook-test"].if_gate_filter == "hooks"
+        assert by_name["scraper-tests"].if_gate_filter == "scraper"
+        # always-runs has no `if:`
+        assert by_name["always-runs"].if_gate_filter is None
+        # multi-filter references both scripts and scraper
+        assert by_name["multi-filter"].if_gate_filter == "scripts|scraper"
+
+    def test_line_ranges_are_sane(self, minimal_ci_path: Path) -> None:
+        ci = parse_ci_yaml(minimal_ci_path)
+        by_name = {j.name: j for j in ci.jobs}
+        # Job bodies are non-empty
+        for name, job in by_name.items():
+            assert job.start_line < job.end_line, f"{name}: {job}"
+
+        # scripts-tests must START strictly after detect-changes ends
+        assert by_name["scripts-tests"].start_line > by_name["detect-changes"].start_line
+
+    def test_parses_real_ci_yml(self) -> None:
+        """Parse the real repo ci.yml and ensure filters + jobs come out sane."""
+        repo_ci = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "ci.yml"
+        if not repo_ci.is_file():
+            pytest.skip("real ci.yml not present")
+        ci = parse_ci_yaml(repo_ci)
+        # Sanity: expected filters present
+        assert "scripts" in ci.filters
+        assert "hooks" in ci.filters
+        assert "scraper" in ci.filters
+        # Both scripts and hooks filters include ci.yml itself post-#2505 / #2410
+        assert ".github/workflows/ci.yml" in ci.filters["scripts"]
+        assert ".github/workflows/ci.yml" in ci.filters["hooks"]
+        # Expected gated jobs present
+        names = {j.name for j in ci.jobs}
+        assert "scripts-tests" in names
+        assert "preflight-hook-test" in names
+        # scripts-tests is gated on 'scripts'
+        by_name = {j.name: j for j in ci.jobs}
+        assert by_name["scripts-tests"].if_gate_filter == "scripts"
+
+
+# ---------------------------------------------------------------------------
+# Diff parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseUnifiedDiff:
+    def test_basic_changed_files(self) -> None:
+        diff = textwrap.dedent(
+            """\
+            diff --git a/scripts/foo.sh b/scripts/foo.sh
+            index abc..def 100755
+            --- a/scripts/foo.sh
+            +++ b/scripts/foo.sh
+            @@ -1,3 +1,3 @@
+             hello
+            -old
+            +new
+             world
+            """
+        )
+        r = parse_unified_diff(diff, ".github/workflows/ci.yml")
+        assert r.changed_files == ["scripts/foo.sh"]
+        assert r.ci_yml_changed_lines == set()
+
+    def test_ci_yml_changed_lines(self) -> None:
+        diff = textwrap.dedent(
+            """\
+            diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+            index abc..def 100644
+            --- a/.github/workflows/ci.yml
+            +++ b/.github/workflows/ci.yml
+            @@ -10,3 +10,4 @@
+             context-a
+             context-b
+            -deleted-line
+            +replacement-line
+            +brand-new-line
+            """
+        )
+        r = parse_unified_diff(diff, ".github/workflows/ci.yml")
+        assert r.changed_files == [".github/workflows/ci.yml"]
+        # + lines are at new-side lines 12 and 13 (after 2 context lines starting at 10)
+        assert 12 in r.ci_yml_changed_lines
+        assert 13 in r.ci_yml_changed_lines
+
+    def test_pure_deletion_is_detected(self) -> None:
+        """Deletion-only hunks should still flag the surrounding new-side range."""
+        diff = textwrap.dedent(
+            """\
+            diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+            --- a/.github/workflows/ci.yml
+            +++ b/.github/workflows/ci.yml
+            @@ -20,4 +20,2 @@
+             ctx-a
+            -gone-1
+            -gone-2
+             ctx-b
+            """
+        )
+        r = parse_unified_diff(diff, ".github/workflows/ci.yml")
+        # Context lines at new-side 20 and 21 should be flagged
+        assert 20 in r.ci_yml_changed_lines
+        assert 21 in r.ci_yml_changed_lines
+
+    def test_non_ci_yml_changes_dont_record_ci_lines(self) -> None:
+        diff = textwrap.dedent(
+            """\
+            diff --git a/docs/foo.md b/docs/foo.md
+            --- a/docs/foo.md
+            +++ b/docs/foo.md
+            @@ -1,1 +1,1 @@
+            -old
+            +new
+            """
+        )
+        r = parse_unified_diff(diff, ".github/workflows/ci.yml")
+        assert r.changed_files == ["docs/foo.md"]
+        assert r.ci_yml_changed_lines == set()
+
+
+# ---------------------------------------------------------------------------
+# find_skipped_modified_jobs (end-to-end)
+# ---------------------------------------------------------------------------
+
+
+class TestFindSkippedModifiedJobs:
+    def _get_job_range(self, ci, name: str) -> tuple[int, int]:
+        job = next(j for j in ci.jobs if j.name == name)
+        return (job.start_line, job.end_line)
+
+    def test_repro_2505_first_commit(self, minimal_ci_path: Path) -> None:
+        """Reproduce #2505: modifying scripts-tests body without touching any
+        scripts/**-matching file AND without ci.yml being in the filter."""
+        ci = parse_ci_yaml(minimal_ci_path)
+        # Remove ci.yml from 'scripts' filter to simulate pre-fix state.
+        ci.filters["scripts"] = ["scripts/**"]
+
+        start, end = self._get_job_range(ci, "scripts-tests")
+        # Simulate a change at some line inside scripts-tests body
+        ci_lines = {start + 3}
+        # Changed files: only ci.yml itself
+        changed_files = [".github/workflows/ci.yml"]
+
+        problems = find_skipped_modified_jobs(ci, changed_files, ci_lines)
+        assert len(problems) == 1
+        assert problems[0].job_name == "scripts-tests"
+        assert problems[0].filter_name == "scripts"
+
+    def test_2505_fix_passes(self, minimal_ci_path: Path) -> None:
+        """With ci.yml in the 'scripts' filter (current state), changing
+        scripts-tests + ci.yml should NOT flag."""
+        ci = parse_ci_yaml(minimal_ci_path)
+        # ci.yml IS in filter (as configured in the fixture).
+        assert ".github/workflows/ci.yml" in ci.filters["scripts"]
+
+        start, _end = self._get_job_range(ci, "scripts-tests")
+        ci_lines = {start + 3}
+        changed_files = [".github/workflows/ci.yml"]
+
+        problems = find_skipped_modified_jobs(ci, changed_files, ci_lines)
+        assert problems == []
+
+    def test_unchanged_ci_yml_no_problems(self, minimal_ci_path: Path) -> None:
+        ci = parse_ci_yaml(minimal_ci_path)
+        changed_files = ["scripts/new-tool.sh"]
+        problems = find_skipped_modified_jobs(ci, changed_files, set())
+        assert problems == []
+
+    def test_always_runs_job_not_flagged(self, minimal_ci_path: Path) -> None:
+        """A modified job with no `if:` gate is never a problem."""
+        ci = parse_ci_yaml(minimal_ci_path)
+        start, _end = self._get_job_range(ci, "always-runs")
+        problems = find_skipped_modified_jobs(
+            ci, [".github/workflows/ci.yml"], {start + 1}
+        )
+        assert problems == []
+
+    def test_multi_filter_gate_any_match_is_ok(self, minimal_ci_path: Path) -> None:
+        """Job gated on A || B passes if either filter matches."""
+        ci = parse_ci_yaml(minimal_ci_path)
+        start, _end = self._get_job_range(ci, "multi-filter")
+        # ci.yml changed. 'scripts' filter includes ci.yml so the job WILL run.
+        problems = find_skipped_modified_jobs(
+            ci, [".github/workflows/ci.yml"], {start + 1}
+        )
+        assert problems == []
+
+    def test_multi_filter_gate_no_match_flags(self, minimal_ci_path: Path) -> None:
+        """Job gated on A || B fails if neither filter matches."""
+        ci = parse_ci_yaml(minimal_ci_path)
+        # Remove ci.yml from the 'scripts' filter so 'multi-filter' (scripts ||
+        # scraper) can't run when only ci.yml changes.
+        ci.filters["scripts"] = ["scripts/**"]
+        start, _end = self._get_job_range(ci, "multi-filter")
+        problems = find_skipped_modified_jobs(
+            ci, [".github/workflows/ci.yml"], {start + 1}
+        )
+        assert len(problems) == 1
+        assert problems[0].job_name == "multi-filter"
+        assert problems[0].filter_name == "scripts|scraper"
+
+    def test_multiple_problem_jobs(self, minimal_ci_path: Path) -> None:
+        ci = parse_ci_yaml(minimal_ci_path)
+        # Pre-fix state: ci.yml not in either filter
+        ci.filters["scripts"] = ["scripts/**"]
+        ci.filters["hooks"] = [".claude/hooks/**"]
+
+        s_start, _ = self._get_job_range(ci, "scripts-tests")
+        h_start, _ = self._get_job_range(ci, "preflight-hook-test")
+        ci_lines = {s_start + 1, h_start + 1}
+        problems = find_skipped_modified_jobs(
+            ci, [".github/workflows/ci.yml"], ci_lines
+        )
+        problem_names = sorted(p.job_name for p in problems)
+        assert problem_names == ["preflight-hook-test", "scripts-tests"]
+
+    def test_changed_matching_file_prevents_flag(self, minimal_ci_path: Path) -> None:
+        """Even without ci.yml in filter, a changed file matching the filter
+        means the job will actually run."""
+        ci = parse_ci_yaml(minimal_ci_path)
+        ci.filters["scripts"] = ["scripts/**"]  # no ci.yml
+
+        start, _end = self._get_job_range(ci, "scripts-tests")
+        # Change scripts-tests body AND change a file matching scripts/**
+        ci_lines = {start + 2}
+        changed_files = [".github/workflows/ci.yml", "scripts/new-tool.sh"]
+        problems = find_skipped_modified_jobs(ci, changed_files, ci_lines)
+        assert problems == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #2527 acceptance-criteria simulation
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptanceCriteria:
+    """These tests encode the issue's acceptance criteria verification."""
+
+    def test_toy_pr_that_would_skip_scripts_tests_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """AC1: a PR that modifies scripts-tests without touching scripts/**
+        AND without .github/workflows/ci.yml in the filter is flagged."""
+        ci_path = tmp_path / "ci.yml"
+        # Construct a minimal ci.yml where 'scripts' filter does NOT include ci.yml
+        ci_path.write_text(
+            textwrap.dedent(
+                """\
+                name: CI
+                on:
+                  push:
+                jobs:
+                  detect-changes:
+                    runs-on: ubuntu-latest
+                    steps:
+                      - uses: dorny/paths-filter@v4
+                        id: changes
+                        with:
+                          filters: |
+                            scripts:
+                              - 'scripts/**'
+                  scripts-tests:
+                    needs: detect-changes
+                    if: needs.detect-changes.outputs.scripts == 'true'
+                    runs-on: ubuntu-latest
+                    steps:
+                      - name: Auto-discover tests
+                        run: echo new-implementation
+                """
+            )
+        )
+        ci = parse_ci_yaml(ci_path)
+        start, _end = self._get_job_range(ci, "scripts-tests")
+        problems = find_skipped_modified_jobs(
+            ci, [".github/workflows/ci.yml"], {start + 1}
+        )
+        assert len(problems) == 1
+        assert problems[0].job_name == "scripts-tests"
+
+    def test_2505_post_fix_passes(self, minimal_ci_path: Path) -> None:
+        """AC2: after the filter includes ci.yml, the same diff passes."""
+        ci = parse_ci_yaml(minimal_ci_path)
+        # ci.yml IS in 'scripts' filter per fixture (mirrors post-fix state).
+        start, _end = self._get_job_range(ci, "scripts-tests")
+        problems = find_skipped_modified_jobs(
+            ci, [".github/workflows/ci.yml"], {start + 1}
+        )
+        assert problems == []
+
+    def _get_job_range(self, ci, name: str) -> tuple[int, int]:
+        job = next(j for j in ci.jobs if j.name == name)
+        return (job.start_line, job.end_line)

--- a/scripts/tests/test_check_ci_job_skipped.sh
+++ b/scripts/tests/test_check_ci_job_skipped.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# test_check_ci_job_skipped.sh — Integration test for check-ci-job-skipped.py (#2527)
+#
+# Runs the check against synthetic ci.yml fixtures and synthetic unified
+# diffs to verify end-to-end behavior without requiring a git repo state.
+#
+# Usage:
+#   scripts/tests/test_check_ci_job_skipped.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-ci-job-skipped.py"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+# The checker locates ci.yml via --ci-yml RELATIVE to --repo-root, so we
+# create a fake repo layout with .github/workflows/ci.yml inside TMPDIR_TEST.
+mkdir -p "$TMPDIR_TEST/.github/workflows"
+
+write_ci_yml() {
+    local include_ci_yml_in_scripts_filter="$1"
+    # IMPORTANT: match the indent of the `- 'scripts/**'` line below
+    # (14 spaces before the hyphen) so the generated YAML is well-formed.
+    local ci_yml_line="              - '.github/workflows/ci.yml'"
+    if [[ "$include_ci_yml_in_scripts_filter" != "yes" ]]; then
+        ci_yml_line=""
+    fi
+    cat > "$TMPDIR_TEST/.github/workflows/ci.yml" <<EOF
+name: CI
+on:
+  push:
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: |
+            scripts:
+              - 'scripts/**'
+$ci_yml_line
+            hooks:
+              - '.claude/hooks/**'
+
+  scripts-tests:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.scripts == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run tests
+        run: echo new-implementation-here
+EOF
+}
+
+# Line 26 is inside scripts-tests body in the fixture with ci.yml in filter;
+# line 25 without. We'll compute the exact line of 'Run tests' dynamically
+# in the diff fixture by anchoring to hunk header.
+
+# Helper: write a unified diff that modifies a line inside scripts-tests.
+# Writes: diff against an imaginary prior version where `echo new-...`
+# was `echo old-implementation`.
+write_diff_ci_yml_change_only() {
+    # We don't know the exact line, but that's fine — we just craft a diff
+    # that says "change line N in ci.yml". We use line 25 which is inside
+    # the scripts-tests body in the non-ci.yml-in-filter fixture, and 26
+    # in the ci.yml-in-filter fixture. Use a range that contains both.
+    cat > "$TMPDIR_TEST/diff.patch" <<'EOF'
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index abc..def 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -20,4 +20,4 @@ jobs:
+     runs-on: ubuntu-latest
+     steps:
+       - name: Run tests
+-        run: echo old-implementation
++        run: echo new-implementation-here
+EOF
+}
+
+write_diff_with_matching_script_file() {
+    # Diff changes BOTH ci.yml AND a scripts/ file. The script-file change
+    # causes the 'scripts' filter to match even if ci.yml isn't in the
+    # filter, so the check should pass.
+    cat > "$TMPDIR_TEST/diff.patch" <<'EOF'
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index abc..def 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -20,4 +20,4 @@ jobs:
+     runs-on: ubuntu-latest
+     steps:
+       - name: Run tests
+-        run: echo old-implementation
++        run: echo new-implementation-here
+diff --git a/scripts/new-tool.sh b/scripts/new-tool.sh
+new file mode 100644
+--- /dev/null
++++ b/scripts/new-tool.sh
+@@ -0,0 +1,1 @@
++#!/bin/bash
+EOF
+}
+
+write_diff_no_ci_yml_change() {
+    cat > "$TMPDIR_TEST/diff.patch" <<'EOF'
+diff --git a/scripts/unrelated.sh b/scripts/unrelated.sh
+index abc..def 100644
+--- a/scripts/unrelated.sh
++++ b/scripts/unrelated.sh
+@@ -1,1 +1,1 @@
+-old
++new
+EOF
+}
+
+run_check() {
+    python3 "$CHECK_SCRIPT" \
+        --repo-root "$TMPDIR_TEST" \
+        --diff-file "$TMPDIR_TEST/diff.patch"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    local out
+    local rc
+    out=$(run_check 2>&1)
+    rc=$?
+    if [[ "$rc" -ne 1 ]]; then
+        echo "FAIL: $desc (expected exit 1, got $rc)"
+        echo "  output: $out"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    local out
+    local rc
+    out=$(run_check 2>&1)
+    rc=$?
+    if [[ "$rc" -ne 0 ]]; then
+        echo "FAIL: $desc (expected exit 0, got $rc)"
+        echo "  output: $out"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+# ─── Test 1: scripts-tests modified, ci.yml NOT in filter, no scripts/ change ──
+# This is the #2505 pre-fix scenario: expected to FAIL.
+write_ci_yml "no"
+write_diff_ci_yml_change_only
+assert_fails "Modifying scripts-tests with ci.yml not in filter is flagged"
+
+# ─── Test 2: scripts-tests modified, ci.yml IS in filter ────────────────
+# This is the #2505 post-fix scenario: expected to PASS.
+write_ci_yml "yes"
+write_diff_ci_yml_change_only
+assert_passes "Modifying scripts-tests with ci.yml in filter passes"
+
+# ─── Test 3: scripts-tests modified, ci.yml NOT in filter, but a scripts/ file changed ──
+# The 'scripts' filter will still match because scripts/new-tool.sh matches.
+write_ci_yml "no"
+write_diff_with_matching_script_file
+assert_passes "Modifying scripts-tests with a matching scripts/ file change passes"
+
+# ─── Test 4: No ci.yml change at all ────────────────────────────────────
+write_ci_yml "no"
+write_diff_no_ci_yml_change
+assert_passes "Unrelated diff with no ci.yml change passes"
+
+# ─── Test 5: Help flag works ─────────────────────────────────────────────
+TESTS=$((TESTS + 1))
+if python3 "$CHECK_SCRIPT" --help 2>&1 | grep -q "Detect CI jobs"; then
+    echo "PASS: --help describes the script"
+else
+    echo "FAIL: --help output does not include expected description"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Summary ───────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a stdlib-only checker (`scripts/check-ci-job-skipped.py`) that detects the #2410 / #2505 footgun: a PR modifies a job body in `.github/workflows/ci.yml` whose `if: needs.detect-changes.outputs.X == 'true'` gate's paths-filter does not match anything in the diff, so the job is SKIPPED on that PR's own CI run and the modification is never actually exercised. The check runs locally via `.githooks/pre-push` when `ci.yml` is in the push, as a new `ci-job-skipped-check` CI job on every PR (added to `ci-passed` needs), and manually via `scripts/check-ci-job-skipped.sh`.

Closes #2527

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Unit tests pass (26 tests in `scripts/tests/test_check_ci_job_skipped.py`)
- [x] Integration tests pass (5 tests in `scripts/tests/test_check_ci_job_skipped.sh`)
- [x] CI green
- [x] New `ci-job-skipped-check` CI job runs on this PR

### Post-deploy verification
- [x] N/A — no deployed component (CI/tooling only). See verification evidence comment on #2527.
