### PR TITLE
fix(ci): defer test_pre_push.sh from scripts-tests auto-discovery (#2536)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,8 +553,23 @@ jobs:
       # (test_check_oneshot_imports.sh, test_ecs_logs.sh, test_preflight.sh)
       # were silently never running in CI because they'd never been added
       # to the list.
+      #
+      # SKIP_PATTERNS: tests that are expensive AND already covered by a
+      # dedicated CI job with its own narrow path filter. Keeping them
+      # here would mean running them twice whenever scripts/** changes.
+      #
+      #   test_pre_push.sh (~32s)  — dedicated job: githooks-pre-push-test
+      #                              triggered by the `githooks` path
+      #                              filter (.githooks/**, the test file
+      #                              itself, and ci.yml). See #2536 for
+      #                              the duration regression this skip
+      #                              addresses (+34s, +112%).
       - name: Run all scripts/tests shell tests
         shell: bash
+        env:
+          # Whitespace-separated list of test paths to defer to their own
+          # dedicated CI jobs. See the comment above this step for why.
+          SKIP_TESTS: "scripts/tests/test_pre_push.sh"
         run: |
           set -uo pipefail
           shopt -s nullglob
@@ -563,10 +578,27 @@ jobs:
             echo "No shell test files found under scripts/tests/ — nothing to run."
             exit 0
           fi
+          # Returns 0 if $1 is listed in $SKIP_TESTS (whitespace-separated).
+          is_skipped() {
+            local target="$1"
+            local entry
+            for entry in $SKIP_TESTS; do
+              if [ "$entry" = "$target" ]; then
+                return 0
+              fi
+            done
+            return 1
+          }
           failed=0
           ran=0
           skipped=0
+          deferred=0
           for t in "${tests[@]}"; do
+            if is_skipped "$t"; then
+              echo "::notice::Deferring $t — covered by a dedicated CI job"
+              deferred=$((deferred + 1))
+              continue
+            fi
             if [ ! -x "$t" ]; then
               echo "::warning::Skipping $t — not executable (chmod +x required)"
               skipped=$((skipped + 1))
@@ -580,7 +612,7 @@ jobs:
             ran=$((ran + 1))
             echo "::endgroup::"
           done
-          echo "Ran $ran shell test(s). Skipped: $skipped. Failed: $failed."
+          echo "Ran $ran shell test(s). Skipped (not executable): $skipped. Deferred to dedicated jobs: $deferred. Failed: $failed."
           if [ "$failed" -gt 0 ]; then
             echo "::error::$failed shell test(s) failed."
             exit 1

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -2,6 +2,30 @@
 
 Tests for standalone scripts in `scripts/`.
 
+## CI Execution
+
+The `scripts-tests` CI job auto-discovers and runs every executable
+`scripts/tests/*.sh` under a single loop (see `.github/workflows/ci.yml`,
+job `scripts-tests`, step `Run all scripts/tests shell tests`). Adding a
+new shell test is just `touch + chmod +x` — no ci.yml edit required.
+
+### Deferred tests (dedicated CI jobs)
+
+A small set of tests are intentionally **skipped** by the scripts-tests
+auto-discovery loop because they already run in a dedicated CI job with a
+narrower path filter. Running them in both places is wasted CI minutes.
+
+The skip list is maintained via the `SKIP_TESTS` env var on the
+`Run all scripts/tests shell tests` step. Current entries:
+
+| Test | Dedicated job | Trigger | Rationale |
+|---|---|---|---|
+| `test_pre_push.sh` | `githooks-pre-push-test` | `.githooks/**`, `scripts/tests/test_pre_push.sh`, `.github/workflows/ci.yml` | ~32s. Originally added to scripts-tests via #2505 auto-discovery; caused a +112% duration regression (#2536). |
+
+When adding a new "deferred" entry, make sure the dedicated job's path
+filter covers every file that the test exercises — otherwise relevant
+changes will no longer run the test in any job.
+
 ## CI Environment
 
 The `scripts-tests` CI job runs in a **minimal environment** with only these


### PR DESCRIPTION
## Summary

The `scripts-tests` CI job regressed from ~30s mean to ~65s (+112%) because PR #2525's auto-discovery loop picked up `test_pre_push.sh` — a 32s integration suite that already runs in its own dedicated `githooks-pre-push-test` job. This PR adds a `SKIP_TESTS` env var that defers `test_pre_push.sh` out of the auto-discovery loop, eliminating the duplicate run without reducing coverage.

Closes #2536

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (this PR only touches ci.yml and a README; no unit tests changed)
- [x] CI green
- [x] `scripts-tests` job itself runs in this PR's CI (ci.yml change triggers it) and completes in ~10-20s instead of ~65s
  - Observed on this PR's CI run (24555508706): `scripts-tests` job total **38s** (down from 65s); the `Run all scripts/tests shell tests` step itself dropped from ~45s to **11s**.

### Post-deploy verification
- [x] Post-merge `main` CI run confirmed `scripts-tests` at 38s (run 24555606674). The rolling-10-run `audit_ci_health.py` check will flip green automatically as more runs accumulate; single-run timing already under the 40s threshold.
- [x] Verification evidence posted on issue ([comment](https://github.com/judgemind/judgemind/issues/2536#issuecomment-4266511063))
