### PR TITLE
feat(ci): add guard against reintroducing aws ecs wait services-stable (#2532)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,6 +546,8 @@ jobs:
         run: pytest scripts/tests/ -v --tb=short
       - name: Check AWS CLI boolean flag usage
         run: scripts/check-aws-bool-flags.sh
+      - name: Check for forbidden 'aws ecs wait services-stable' usage
+        run: scripts/check-no-ecs-wait-services-stable.sh
       # Auto-discover and run every executable shell test under
       # scripts/tests/*.sh. Replaces the old per-script listing (#2505) so
       # that adding a new shell test is just `touch + chmod +x` — no

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,7 +546,7 @@ jobs:
         run: pytest scripts/tests/ -v --tb=short
       - name: Check AWS CLI boolean flag usage
         run: scripts/check-aws-bool-flags.sh
-      - name: Check for forbidden 'aws ecs wait services-stable' usage
+      - name: Check for forbidden ECS services-stable waiter usage
         run: scripts/check-no-ecs-wait-services-stable.sh
       # Auto-discover and run every executable shell test under
       # scripts/tests/*.sh. Replaces the old per-script listing (#2505) so

--- a/scripts/check-no-ecs-wait-services-stable.sh
+++ b/scripts/check-no-ecs-wait-services-stable.sh
@@ -48,6 +48,10 @@ EXCLUDE_DIRS=(
     "__pycache__"
     ".claude"
     ".vite"
+    # Local developer scratch dir for agent workflows (not tracked; see
+    # CLAUDE.md §ALWAYS — Before Acting).  CI checkout has no tmp/, so
+    # excluding it only affects local runs and keeps behavior consistent.
+    "tmp"
 )
 
 # ─── Files that legitimately mention the pattern as context ──────────────

--- a/scripts/check-no-ecs-wait-services-stable.sh
+++ b/scripts/check-no-ecs-wait-services-stable.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# check-no-ecs-wait-services-stable.sh — Forbid `aws ecs wait services-stable`.
+#
+# The CI composite action (`.github/actions/ecs-deploy/action.yml`) and
+# `scripts/ecs-redeploy.sh` both used to call `aws ecs wait services-stable`
+# to wait for an ECS rollout to finish.  That waiter has three real drawbacks
+# (see issues #2519 and #2523):
+#
+#   1. Hard-coded 10-minute ceiling (40 polls * 15s, no way to customize).
+#   2. No progress output — a real timeout is indistinguishable from a
+#      workflow cancellation (e.g. concurrency.cancel-in-progress).
+#   3. Waits for service-level steady state, not the specific deployment
+#      we just triggered.  Unrelated rollbacks or parallel deploys can make
+#      the waiter return early with a stale "success".
+#
+# Both callers have been ported off onto `scripts/wait-for-rollout.sh`, a
+# deployment-scoped waiter with configurable timeout and streaming progress.
+# This check exists to keep `aws ecs wait services-stable` from coming back.
+#
+# Usage:
+#   scripts/check-no-ecs-wait-services-stable.sh          # exits 0 if clean
+#   scripts/check-no-ecs-wait-services-stable.sh [dir]    # scan a specific directory
+#
+# Exit codes:
+#   0 — No violations found.
+#   1 — One or more tracked files call `aws ecs wait services-stable`.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-$REPO_ROOT}"
+
+# ─── Pattern ─────────────────────────────────────────────────────────────
+# Match `aws ecs wait services-stable` with any internal whitespace run.
+# The regex is anchored so `aws-ecs-wait-services-stable` (hypothetical
+# variable or filename) does not match.
+PATTERN='aws[[:space:]]+ecs[[:space:]]+wait[[:space:]]+services-stable'
+
+# ─── Directories to exclude from the scan ────────────────────────────────
+# Standard ignored directories (vendored dependencies, VCS metadata, build
+# output) plus local developer state (`.claude`, `.venv`).  These never
+# contain source-of-truth code we care about.
+EXCLUDE_DIRS=(
+    ".git"
+    ".venv"
+    "node_modules"
+    ".next"
+    "__pycache__"
+    ".claude"
+    ".vite"
+)
+
+# ─── Files that legitimately mention the pattern as context ──────────────
+# The check script and its test both have to spell the pattern literally.
+# Past incident post-mortems and forward-looking documentation may also
+# reference it as context.
+#
+# Note: comment lines (lines whose first non-whitespace character is `#`)
+# are filtered out below, so callers that replaced the pattern may keep
+# explanatory comments like `# Replaces aws ecs wait services-stable ...`
+# without tripping this check.
+EXCLUDE_FILES=(
+    "scripts/check-no-ecs-wait-services-stable.sh"
+    "scripts/tests/test_check_no_ecs_wait_services_stable.sh"
+)
+
+# ─── Build grep arguments ───────────────────────────────────────────────
+
+exclude_args=()
+for dir in "${EXCLUDE_DIRS[@]}"; do
+    exclude_args+=("--exclude-dir=$dir")
+done
+
+# ─── Scan the codebase ──────────────────────────────────────────────────
+
+violations=0
+
+matches=$(grep -rnE "$PATTERN" "$SCAN_DIR" "${exclude_args[@]}" 2>/dev/null || true)
+
+if [[ -n "$matches" ]]; then
+    while IFS= read -r line; do
+        # grep -rn output: <path>:<lineno>:<content>
+        file_path="${line%%:*}"
+        rest="${line#*:}"
+        content="${rest#*:}"
+
+        # Skip matches in the explicitly-excluded files.
+        skip=false
+        for excl in "${EXCLUDE_FILES[@]}"; do
+            # Match either a full path ending in the excluded relative path
+            # or an exact match (handles both absolute SCAN_DIR output and
+            # test-harness invocation with a bare filename).
+            if [[ "$file_path" == *"$excl" ]]; then
+                skip=true
+                break
+            fi
+        done
+        if "$skip"; then
+            continue
+        fi
+
+        # Skip docs/investigations/* — post-mortems may reference the
+        # pattern as historical context.
+        if [[ "$file_path" == *"docs/investigations/"* ]]; then
+            continue
+        fi
+
+        # Skip comment lines (first non-whitespace character is `#`).
+        # This covers shell comments, YAML comments, Python comments, and
+        # Dockerfile comments — all formats in use in this repo where the
+        # pattern is allowed to appear as context.
+        if [[ "$content" =~ ^[[:space:]]*# ]]; then
+            continue
+        fi
+
+        if [[ $violations -eq 0 ]]; then
+            echo "ERROR: Found forbidden 'aws ecs wait services-stable' usage."
+            echo ""
+            echo "  The following lines call the AWS CLI waiter that was"
+            echo "  retired in favor of scripts/wait-for-rollout.sh"
+            echo "  (see issues #2519 and #2523):"
+            echo ""
+        fi
+
+        echo "    $line"
+        violations=$((violations + 1))
+    done <<< "$matches"
+fi
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "  Found $violations occurrence(s) of 'aws ecs wait services-stable'."
+    echo ""
+    echo "  Fix: use scripts/wait-for-rollout.sh instead.  It waits on the"
+    echo "  specific deployment we just triggered (not service-level steady"
+    echo "  state), streams progress output, and accepts a configurable"
+    echo "  timeout via --timeout-seconds."
+    echo ""
+    echo "  Example:"
+    echo "    scripts/wait-for-rollout.sh \\"
+    echo "      --cluster judgemind-dev \\"
+    echo "      --service my-service \\"
+    echo "      --task-def-arn \"\$TASK_DEF_ARN\" \\"
+    echo "      --timeout-seconds 1200"
+    echo ""
+    echo "  If the pattern must appear as explanatory context, put it in a"
+    echo "  comment (lines starting with '#') or under docs/investigations/."
+    exit 1
+fi
+
+echo "All clean — no 'aws ecs wait services-stable' usage detected."
+exit 0

--- a/scripts/tests/test_check_no_ecs_wait_services_stable.sh
+++ b/scripts/tests/test_check_no_ecs_wait_services_stable.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# test_check_no_ecs_wait_services_stable.sh — Tests for check-no-ecs-wait-services-stable.sh
+#
+# Creates temporary files to verify that the checker correctly detects
+# forbidden `aws ecs wait services-stable` usage while allowing comments,
+# docs/investigations/ post-mortems, and the check script itself to
+# reference the pattern as context.
+#
+# Usage:
+#   scripts/tests/test_check_no_ecs_wait_services_stable.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-no-ecs-wait-services-stable.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: Bare shell call should fail ─────────────────────────────────
+create_test_file "bad1.sh" 'aws ecs wait services-stable --cluster foo --services bar'
+assert_fails "Bare shell call to aws ecs wait services-stable is detected"
+reset_tmpdir
+
+# ─── Test 2: YAML usage (composite action) should fail ───────────────────
+create_test_file "action.yml" 'runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        aws ecs wait services-stable --cluster "$CLUSTER" --services "$SVC"'
+assert_fails "YAML composite action call is detected"
+reset_tmpdir
+
+# ─── Test 3: Extra whitespace between words should still match ───────────
+create_test_file "bad_spaces.sh" 'aws    ecs   wait    services-stable --cluster foo'
+assert_fails "Extra whitespace between words is detected"
+reset_tmpdir
+
+# ─── Test 4: Tab whitespace between words should still match ─────────────
+printf 'aws\tecs\twait\tservices-stable --cluster foo\n' > "$TMPDIR_TEST/bad_tabs.sh"
+assert_fails "Tab-separated words are detected"
+reset_tmpdir
+
+# ─── Test 5: Shell comment lines should pass ─────────────────────────────
+create_test_file "redeploy.sh" '#!/usr/bin/env bash
+# Replaces `aws ecs wait services-stable` with a deployment-scoped waiter.
+# See issue #2523 for the full motivation.
+scripts/wait-for-rollout.sh --cluster foo --service bar'
+assert_passes "Shell comments referencing the pattern as context are allowed"
+reset_tmpdir
+
+# ─── Test 6: YAML comment lines should pass ──────────────────────────────
+create_test_file "action.yml" 'runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        # This replaces `aws ecs wait services-stable` with wait-for-rollout.
+        scripts/wait-for-rollout.sh --cluster foo'
+assert_passes "YAML comments referencing the pattern as context are allowed"
+reset_tmpdir
+
+# ─── Test 7: docs/investigations/*.md should pass ───────────────────────
+create_test_file "docs/investigations/ecs-waiter-retirement-2025-11.md" '# ECS waiter retirement
+
+Previously the composite action called `aws ecs wait services-stable` which
+had a hard-coded 10-minute timeout.  This doc records the migration to
+`scripts/wait-for-rollout.sh`.
+'
+assert_passes "docs/investigations/*.md post-mortems are allowed to reference the pattern"
+reset_tmpdir
+
+# ─── Test 8: Non-comment Python call (subprocess) should fail ────────────
+create_test_file "bad_py.py" 'import subprocess
+subprocess.run(["aws", "ecs", "wait", "services-stable", "--cluster", "foo"])'
+assert_passes "Python subprocess list form (no literal whitespace between words) does not match"
+reset_tmpdir
+# Note: the regex intentionally only matches the shell-form
+# `aws ecs wait services-stable` (whitespace-separated tokens in a single
+# string).  Catching argv-list forms would require parsing every language,
+# which is out of scope — the goal is to block the shell patterns callers
+# actually used.
+
+# ─── Test 9: Empty directory should pass ─────────────────────────────────
+assert_passes "Empty directory passes"
+
+# ─── Test 10: Non-matching shell content should pass ────────────────────
+create_test_file "good.sh" 'scripts/wait-for-rollout.sh --cluster foo --service bar'
+assert_passes "Shell script that uses the replacement passes"
+reset_tmpdir
+
+# ─── Test 11: Pattern inside a different AWS command should not match ───
+create_test_file "other.sh" 'aws ecs list-services --cluster foo
+aws ecs wait tasks-stopped --cluster foo --tasks t1'
+assert_passes "Other 'aws ecs wait' waiters (e.g. tasks-stopped) do not match"
+reset_tmpdir
+
+# ─── Test 12: .git directory should be excluded ──────────────────────────
+mkdir -p "$TMPDIR_TEST/.git/objects"
+printf 'aws ecs wait services-stable\n' > "$TMPDIR_TEST/.git/objects/badfile"
+assert_passes ".git directory contents are excluded"
+reset_tmpdir
+
+# ─── Test 13: node_modules should be excluded ────────────────────────────
+mkdir -p "$TMPDIR_TEST/node_modules/some-pkg"
+printf 'aws ecs wait services-stable\n' > "$TMPDIR_TEST/node_modules/some-pkg/index.js"
+assert_passes "node_modules directory is excluded"
+reset_tmpdir
+
+# ─── Test 14: Indented comment with the pattern should pass ──────────────
+create_test_file "indented.sh" '    # Legacy: aws ecs wait services-stable was used here.
+    scripts/wait-for-rollout.sh --cluster foo'
+assert_passes "Indented comment lines are allowed"
+reset_tmpdir
+
+# ─── Test 15: Mixed file — comment OK, code line fails ───────────────────
+create_test_file "mixed.sh" '#!/usr/bin/env bash
+# Previously: aws ecs wait services-stable --cluster foo
+aws ecs wait services-stable --cluster foo --services bar'
+assert_fails "Mixed file: code line is caught even when a comment mentions it"
+reset_tmpdir
+
+# ─── Test 16: Multiple violations in one file are detected ──────────────
+create_test_file "multi.sh" 'aws ecs wait services-stable --cluster a --services b
+aws ecs wait services-stable --cluster c --services d'
+assert_fails "Multiple code-level violations are detected"
+reset_tmpdir
+
+# ─── Test 17: Similar-but-not-matching identifier should pass ───────────
+# `aws-ecs-wait-services-stable` as a filename or variable is not the AWS
+# CLI invocation and should not trigger the check.
+create_test_file "lookalike.sh" 'SCRIPT=aws-ecs-wait-services-stable.sh
+echo "$SCRIPT"'
+assert_passes "Hyphenated lookalike identifier does not trigger the check"
+reset_tmpdir
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/check-no-ecs-wait-services-stable.sh` — a repo-hygiene check modeled on `check-aws-bool-flags.sh` / `check-deprecated-models.sh` — plus a shell-level test and a new step in the `scripts-tests` CI job. The check fails if any tracked file calls `aws ecs wait services-stable`, which was ported off to `scripts/wait-for-rollout.sh` in #2519 and #2523 (hard-coded 10-min ceiling, no progress output, service-level rather than deployment-level steady state). Shell/YAML comment lines, `docs/investigations/*` post-mortems, the check's own files, and standard ignored directories are excluded so existing callers can keep explanatory "# Replaces aws ecs wait services-stable …" comments.

Closes #2532

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_check_no_ecs_wait_services_stable.sh`: 17/17 locally)
- [x] CI green
- [x] `scripts-tests` job runs the new check step

### Post-deploy verification
- [x] N/A — no deployed component (CI-only hygiene check)
- [x] Verification evidence posted on issue (see task workflow §A.8)
