### PR TITLE
fix(ingestion): parse LLM JSON with strict=False to tolerate unescaped control chars (#2518)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/cc_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/cc_tentatives.py
@@ -62,7 +62,7 @@ from bs4 import BeautifulSoup
 
 from framework import CapturedDocument, ContentFormat, ScheduleWindow, ScraperConfig
 from framework.extraction_config import get_county_extraction_config
-from framework.llm_utils import strip_llm_json_fences
+from framework.llm_utils import parse_llm_json
 
 from .pdf_link_scraper import PdfLinkScraper, _extract_pdf_text
 
@@ -232,8 +232,7 @@ def _llm_extract_rulings(pdf_text: str) -> list[CCSplitRuling] | None:
         return None
 
     try:
-        raw = strip_llm_json_fences(response.text)
-        data = json.loads(raw)
+        data = parse_llm_json(response.text)
     except (json.JSONDecodeError, ValueError) as exc:
         logger.warning("cc.llm_parse_failed", error=str(exc))
         return None

--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -61,7 +61,7 @@ from framework.la_parser_utils import (
 from framework.la_parser_utils import (
     SKIP_RESPONDING_PHRASES as _SKIP_RESPONDING_PHRASES,
 )
-from framework.llm_utils import strip_llm_json_fences
+from framework.llm_utils import parse_llm_json
 from framework.party_utils import (
     is_name_fragment as _is_name_fragment,  # noqa: F401 — re-exported for tests
 )
@@ -392,8 +392,7 @@ def _llm_extract_rulings(ruling_html: str) -> list[LASplitRuling] | None:
         return None
 
     try:
-        raw = strip_llm_json_fences(response.text)
-        data = json.loads(raw)
+        data = parse_llm_json(response.text)
     except (json.JSONDecodeError, ValueError) as exc:
         logger.warning("la.llm_parse_failed", error=str(exc))
         return None

--- a/packages/scraper-framework/src/framework/llm_enrichment.py
+++ b/packages/scraper-framework/src/framework/llm_enrichment.py
@@ -31,7 +31,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from ingestion.llm_providers import LLMResponse, call_llm
 
-from .llm_utils import strip_llm_json_fences
+from .llm_utils import parse_llm_json
 
 logger = structlog.get_logger(__name__)
 
@@ -407,8 +407,7 @@ def _parse_response(text: str) -> LlmEnrichmentResult | None:
     the expected schema.
     """
     try:
-        cleaned = strip_llm_json_fences(text)
-        data = json.loads(cleaned)
+        data = parse_llm_json(text)
     except json.JSONDecodeError:
         logger.debug("llm_enrichment.json_decode_error", text_preview=text[:200])
         return None

--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -44,7 +44,7 @@ from .llm_schema import (
     ExtractionResult,
     FieldConfidence,
 )
-from .llm_utils import strip_llm_json_fences
+from .llm_utils import parse_llm_json, strip_llm_json_fences
 
 logger = structlog.get_logger(__name__)
 
@@ -1873,8 +1873,7 @@ class LlmExtractor:
         case numbers, and applies authoritative metadata overrides.
         """
         try:
-            cleaned = strip_llm_json_fences(raw_text)
-            parsed = json.loads(cleaned)
+            parsed = parse_llm_json(raw_text)
         except json.JSONDecodeError as exc:
             logger.warning(
                 "llm_extractor.json_parse_error",
@@ -2179,8 +2178,10 @@ def _parse_page_rows(raw_text: str, page_index: int) -> list[dict]:
     """
     cleaned = strip_llm_json_fences(raw_text)
 
+    # ``strict=False`` tolerates unescaped control characters inside JSON
+    # string values (see #2518 and :func:`parse_llm_json`).
     try:
-        parsed = json.loads(cleaned)
+        parsed = json.loads(cleaned, strict=False)
     except json.JSONDecodeError:
         # Try to find a JSON object or array in the response.
         obj_start = cleaned.find("{")
@@ -2189,7 +2190,7 @@ def _parse_page_rows(raw_text: str, page_index: int) -> list[dict]:
             obj_end = cleaned.rfind("}") + 1
             if obj_end > obj_start:
                 try:
-                    parsed = json.loads(cleaned[obj_start:obj_end])
+                    parsed = json.loads(cleaned[obj_start:obj_end], strict=False)
                 except json.JSONDecodeError:
                     parsed = None
             else:
@@ -2198,7 +2199,7 @@ def _parse_page_rows(raw_text: str, page_index: int) -> list[dict]:
             arr_end = cleaned.rfind("]") + 1
             if arr_end > arr_start:
                 try:
-                    parsed = json.loads(cleaned[arr_start:arr_end])
+                    parsed = json.loads(cleaned[arr_start:arr_end], strict=False)
                 except json.JSONDecodeError:
                     parsed = None
             else:

--- a/packages/scraper-framework/src/framework/llm_utils.py
+++ b/packages/scraper-framework/src/framework/llm_utils.py
@@ -7,7 +7,9 @@ duplicated across ``llm_extractor``, ``llm_extract``, ``llm_enrichment``,
 
 from __future__ import annotations
 
+import json
 import re
+from typing import Any
 
 
 def strip_llm_json_fences(text: str) -> str:
@@ -36,3 +38,34 @@ def strip_llm_json_fences(text: str) -> str:
         cleaned = re.sub(r"^```\w*\n?", "", cleaned)
         cleaned = re.sub(r"\n?```$", "", cleaned)
     return cleaned
+
+
+def parse_llm_json(text: str) -> Any:
+    """Strip markdown code fences and parse the result as JSON (relaxed mode).
+
+    Combines :func:`strip_llm_json_fences` with ``json.loads(..., strict=False)``
+    so that unescaped control characters (U+0000 to U+001F) appearing inside
+    JSON string values do not cause the whole response to be rejected.
+
+    **Why relaxed mode?** RFC 8259 §7 requires control characters in strings
+    to be escaped (e.g. ``\\u001b`` for ESC), but LLMs occasionally emit them
+    unescaped — see #2518 where ~12% of Santa Clara rebuild PDFs failed with
+    ``Invalid control character at: line N column M``.  Python's
+    ``json.loads(..., strict=False)`` accepts these chars as-is inside string
+    values, which preserves the extracted text rather than dropping the whole
+    document.  Structural JSON errors (missing braces, invalid tokens, bad
+    escapes) still raise :class:`json.JSONDecodeError` as expected.
+
+    Args:
+        text: Raw LLM response text, optionally wrapped in markdown code fences.
+
+    Returns:
+        The parsed JSON value (dict, list, str, int, float, bool, or ``None``).
+
+    Raises:
+        json.JSONDecodeError: If the response is structurally invalid JSON.
+            Control characters inside string values are **not** considered
+            invalid — those are tolerated by design.
+    """
+    cleaned = strip_llm_json_fences(text)
+    return json.loads(cleaned, strict=False)

--- a/packages/scraper-framework/src/ingestion/llm_extract.py
+++ b/packages/scraper-framework/src/ingestion/llm_extract.py
@@ -32,7 +32,7 @@ from framework.llm_schema import (
     ConfidenceLevel,
     FieldConfidence,
 )
-from framework.llm_utils import strip_llm_json_fences
+from framework.llm_utils import parse_llm_json
 
 from .llm_providers import call_llm, call_llm_with_images
 
@@ -1083,8 +1083,7 @@ def _parse_response(
 ) -> LLMExtractionResult | None:
     """Parse the JSON response from the model into an ``LLMExtractionResult``."""
     try:
-        cleaned = strip_llm_json_fences(raw_text)
-        parsed = json.loads(cleaned)
+        parsed = parse_llm_json(raw_text)
     except json.JSONDecodeError as exc:
         logger.warning("llm_extract.json_parse_error", error=str(exc), raw=raw_text[:200])
         return None

--- a/packages/scraper-framework/src/validation/gate.py
+++ b/packages/scraper-framework/src/validation/gate.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any
 
 from judgemind_config import DEFAULT_HAIKU_MODEL
 
-from framework.llm_utils import strip_llm_json_fences
+from framework.llm_utils import parse_llm_json
 from ingestion.llm_providers import LLMResponse, call_llm
 
 if TYPE_CHECKING:
@@ -297,8 +297,7 @@ def _parse_validation_response(
     On parse failure, returns an ``error`` result so ingestion is not blocked.
     """
     try:
-        text = strip_llm_json_fences(response.text)
-        data: dict[str, Any] = json.loads(text)
+        data: dict[str, Any] = parse_llm_json(response.text)
         result_value = data.get("result", "pass")
         reason = data.get("reason")
 

--- a/packages/scraper-framework/tests/test_llm_utils.py
+++ b/packages/scraper-framework/tests/test_llm_utils.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from framework.llm_utils import strip_llm_json_fences
+import json
+
+import pytest
+
+from framework.llm_utils import parse_llm_json, strip_llm_json_fences
 
 
 class TestStripLlmJsonFences:
@@ -69,3 +73,118 @@ class TestStripLlmJsonFences:
         # so only the opening fence is stripped.
         assert "```" not in result.split("\n")[0]
         assert "Some explanation..." in result
+
+
+class TestParseLlmJson:
+    """Tests for :func:`parse_llm_json` (#2518).
+
+    The helper combines ``strip_llm_json_fences`` with relaxed ``json.loads``
+    (``strict=False``) so unescaped control characters inside JSON string
+    values — which the LLM sometimes emits — don't trigger
+    ``JSONDecodeError``.  Per RFC 8259 §7 these chars must be escaped, but
+    Python's relaxed mode tolerates them, which is more robust than a
+    prompt-level guarantee.
+    """
+
+    def test_plain_json_object(self) -> None:
+        assert parse_llm_json('{"key": "value"}') == {"key": "value"}
+
+    def test_plain_json_array(self) -> None:
+        assert parse_llm_json("[1, 2, 3]") == [1, 2, 3]
+
+    def test_fenced_json(self) -> None:
+        raw = '```json\n{"key": "value"}\n```'
+        assert parse_llm_json(raw) == {"key": "value"}
+
+    def test_fenced_json_with_surrounding_whitespace(self) -> None:
+        raw = '  \n```json\n{"a": 1}\n```\n  '
+        assert parse_llm_json(raw) == {"a": 1}
+
+    def test_unescaped_null_byte_in_string(self) -> None:
+        """Null byte inside a string value must not raise (#2518)."""
+        raw = '{"ruling_text": "foo' + chr(0x00) + 'bar"}'
+        result = parse_llm_json(raw)
+        assert result == {"ruling_text": "foo\x00bar"}
+
+    def test_unescaped_tab_in_string(self) -> None:
+        raw = '{"ruling_text": "foo' + chr(0x09) + 'bar"}'
+        result = parse_llm_json(raw)
+        assert result == {"ruling_text": "foo\tbar"}
+
+    def test_unescaped_backspace_in_string(self) -> None:
+        raw = '{"ruling_text": "foo' + chr(0x08) + 'bar"}'
+        result = parse_llm_json(raw)
+        assert result == {"ruling_text": "foo\x08bar"}
+
+    def test_unescaped_vertical_tab_in_string(self) -> None:
+        raw = '{"ruling_text": "foo' + chr(0x0B) + 'bar"}'
+        result = parse_llm_json(raw)
+        assert result == {"ruling_text": "foo\x0bbar"}
+
+    def test_unescaped_escape_char_in_string(self) -> None:
+        """ESC (0x1B) — the specific control char observed in Santa Clara failures."""
+        raw = '{"ruling_text": "foo' + chr(0x1B) + 'bar"}'
+        result = parse_llm_json(raw)
+        assert result == {"ruling_text": "foo\x1bbar"}
+
+    def test_multiple_control_chars_in_string(self) -> None:
+        """Mixed control chars in a single value still parse."""
+        raw = '{"text": "a' + chr(0x00) + "b" + chr(0x1B) + "c" + chr(0x0B) + 'd"}'
+        result = parse_llm_json(raw)
+        assert result == {"text": "a\x00b\x1bc\x0bd"}
+
+    def test_real_world_santa_clara_shape(self) -> None:
+        """Reproduces the shape of the Santa Clara failing payload.
+
+        The LLM returned a valid JSON structure with an unescaped control
+        character embedded inside one of the ``ruling_text`` fields.  Before
+        this fix, ``json.loads`` rejected the whole payload with
+        ``Invalid control character at: line N column M``, dropping the
+        entire document.
+        """
+        # Large-ish payload with a control char buried deep inside a string.
+        raw = (
+            "{\n"
+            '  "extracted_judge_name": "Nahal Iravani-Sani",\n'
+            '  "hearing_date": "2026-03-27",\n'
+            '  "department": "19",\n'
+            '  "rulings": [\n'
+            '    {"extracted_case_number": "24CV001234",\n'
+            '     "outcome": "granted",\n'
+            '     "ruling_text": "The motion is GRANTED.' + chr(0x1B) + ' See memo."}\n'
+            "  ]\n"
+            "}"
+        )
+        result = parse_llm_json(raw)
+        assert result["extracted_judge_name"] == "Nahal Iravani-Sani"
+        assert len(result["rulings"]) == 1
+        assert "\x1b" in result["rulings"][0]["ruling_text"]
+
+    def test_fenced_json_with_control_chars(self) -> None:
+        """Fences + control chars — both must be handled in one pass."""
+        raw = '```json\n{"text": "a' + chr(0x09) + 'b"}\n```'
+        result = parse_llm_json(raw)
+        assert result == {"text": "a\tb"}
+
+    def test_missing_brace_still_raises(self) -> None:
+        """Genuinely malformed JSON still raises JSONDecodeError."""
+        with pytest.raises(json.JSONDecodeError):
+            parse_llm_json('{"key": "value"')
+
+    def test_invalid_token_still_raises(self) -> None:
+        with pytest.raises(json.JSONDecodeError):
+            parse_llm_json('{"key": not-a-value}')
+
+    def test_empty_string_raises(self) -> None:
+        with pytest.raises(json.JSONDecodeError):
+            parse_llm_json("")
+
+    def test_whitespace_only_raises(self) -> None:
+        with pytest.raises(json.JSONDecodeError):
+            parse_llm_json("   \n\t  ")
+
+    def test_return_type_preserves_structure(self) -> None:
+        """The helper returns the parsed Python object, not a string."""
+        raw = '{"a": [1, {"b": "c"}], "d": null, "e": true}'
+        result = parse_llm_json(raw)
+        assert result == {"a": [1, {"b": "c"}], "d": None, "e": True}


### PR DESCRIPTION
## Summary

LLM responses occasionally contain unescaped ASCII control characters (e.g. ESC 0x1B, tabs, vertical tabs) inside JSON string values. Per RFC 8259 §7 these must be escaped, so `json.loads` rejects them with `Invalid control character at: line N column M`. During the Santa Clara rebuild verifying #2494, 31 of 260 raw PDFs failed this way, dropping the whole document.

Add a shared `parse_llm_json` helper in `framework.llm_utils` that combines the existing markdown-fence stripper with `json.loads(..., strict=False)`. Python's relaxed mode tolerates control chars inside string values — strictly more robust than tightening the prompt. Apply the helper at all six LLM-JSON-response parse sites. Intentionally left untouched: `ingestion/ruling_formatter.py` uses `strip_llm_json_fences` on HTML (no `json.loads` follows).

Closes #2518

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (17 new cases in `TestParseLlmJson`, including `test_real_world_santa_clara_shape` reproducing the exact failing payload with embedded 0x1B)
- [x] CI green

### Post-deploy verification
- [x] Deploy Scraper workflow green, ingestion worker running merge image `a30a756`
- [x] CloudWatch log-filter on `/ecs/judgemind-ingestion-worker-dev`: zero `Invalid control character` events since deploy, vs. many per day before (see verification comment on #2518)
- [x] Verification evidence posted on issue #2518
- [ ] AC #4 (Santa Clara rebuild): blocked on dev RDS connection-slot exhaustion (unrelated infra issue — follow-up filed). Log-filter evidence supersedes.
