### PR TITLE
chore(audit): add machine-verifiable script-header marker check (#2533)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -202,13 +202,23 @@ Glob pattern: scripts/*.py
 
 If the count exceeds **35**, flag a finding. The current baseline is ~29 permanent utility scripts — 35 gives headroom for a few new utilities while catching accumulation of unarchived one-off scripts.
 
-2. **Missing `# one-off: true` or `# permanent: true` headers.** Scan all `scripts/*.py` files for scripts that look like one-off data operations (names containing `backfill`, `cleanup`, `fix`, `dedup`, `merge`, `migrate`, `remediat`) but lack EITHER a `# one-off: true` header OR a `# permanent: true` header in the first 10 lines. A script should carry exactly one of these markers:
+2. **Missing `# one-off: true` or `# permanent: true` headers.** Use the machine-verifiable check — do not eyeball line numbers:
+
+```
+scripts/check-script-headers.sh   # exit 0 = all good, exit 1 = missing markers
+```
+
+The script scans top-level `scripts/*.py` whose filename contains `backfill`, `cleanup`, `fix`, `dedup`, `merge`, `migrate`, or `remediat` and requires EITHER `# one-off: true` OR `# permanent: true` anywhere in the first 50 lines (the script's header comment block — the marker sits adjacent to the `# venv:` header, typically just before or after the module docstring). The 50-line window replaces the old "first 10 lines" rule-of-thumb that routinely flagged correctly-marked scripts whose docstrings pushed the marker to line 15, 20, or 32 (see #2533 for the historical context).
+
+A script should carry exactly one marker:
    - `# one-off: true` — finite-lifetime script (tied to a specific bug fix or migration). Candidate for archival once its work is done.
    - `# permanent: true` — re-runnable utility (parameterizable, idempotent, intended to be invoked repeatedly). Exempt from one-off nagging and staleness checks.
 
-   Scripts previously confirmed as permanent in issue comments should carry the canonical `# permanent: true` marker so the check is machine-readable and does not re-flag them each audit cycle (see #2530). The audit treats either marker as sufficient — only unmarked scripts matching the name pattern are flagged.
+Scripts previously confirmed as permanent in issue comments should carry the canonical `# permanent: true` marker so the check is machine-readable and does not re-flag them each audit cycle (see #2530). The audit treats either marker as sufficient — only unmarked scripts matching the name pattern are flagged.
 
-3. **Stale one-off scripts.** For scripts that DO have `# one-off: true`, check their git log to see when they were last modified. If a one-off script has not been modified in more than 30 days, flag it as a candidate for archiving to `scripts/archive/`. Scripts with `# permanent: true` are exempt from this staleness check.
+The same check runs in CI as the `script-headers-check` job and in `.githooks/pre-push`, so the repo baseline should always be green; audit findings here should be rare and typically represent newly-added unmarked scripts.
+
+3. **Stale one-off scripts.** For scripts that DO have `# one-off: true`, check their git log to see when they were last modified. If a one-off script has not been modified in more than 30 days, flag it as a candidate for archiving to `scripts/archive/`. Scripts with `# permanent: true` are exempt from this staleness check. When reading the marker, use the same 50-line window as check 2 — a simple `grep -n "^# one-off: true" scripts/*.py` suffices.
 
 #### Filing issues
 
@@ -217,7 +227,7 @@ For script count threshold violations, file a `priority/p2` `type/chore` issue w
 - List of scripts that appear to be one-off (by name pattern or `# one-off: true` header).
 - Suggested action: archive completed one-off scripts to `scripts/archive/`.
 
-For missing headers, file a single `priority/p3` `type/dx` issue listing the scripts that should be reviewed. Each listed script should get either `# one-off: true` (if finite-lifetime) or `# permanent: true` (if re-runnable utility).
+For missing headers, file a single `priority/p3` `type/dx` issue listing the scripts that should be reviewed. Include the verbatim output of `scripts/check-script-headers.sh` in the body so the fix is mechanical. Each listed script should get either `# one-off: true` (if finite-lifetime) or `# permanent: true` (if re-runnable utility).
 
 ---
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -453,6 +453,32 @@ if [ -n "$changed_markdown" ]; then
 fi
 
 # -------------------------------------------------------------------
+# Script header marker check — run whenever scripts/*.py changes
+# -------------------------------------------------------------------
+# Mirrors the CI `script-headers-check` job so one-off/permanent marker
+# violations are caught locally before the CI round trip. See #2533 —
+# top-level scripts whose filename matches the one-off pattern
+# (backfill, cleanup, fix, dedup, merge, migrate, remediat) must carry
+# `# one-off: true` or `# permanent: true` in the first 50 lines.
+changed_scripts_py=$(echo "$changed_files" | grep -E '^scripts/[^/]+\.py$' || true)
+if [ -n "$changed_scripts_py" ]; then
+    echo "pre-push: checking one-off/permanent markers on scripts/*.py..." >&2
+    if [ -x scripts/check-script-headers.sh ]; then
+        if ! scripts/check-script-headers.sh 2>&1; then
+            echo "" >&2
+            echo "  FAILED: scripts/check-script-headers.sh" >&2
+            echo "  A top-level one-off-pattern script is missing its marker." >&2
+            echo "  Add '# one-off: true' or '# permanent: true' within the" >&2
+            echo "  first 50 lines of the file. See docs/agent/code-standards.md" >&2
+            echo "  §Python scripts and issue #2533." >&2
+            failures=$((failures + 1))
+        fi
+    else
+        echo "  WARNING: scripts/check-script-headers.sh not found or not executable — skipping" >&2
+    fi
+fi
+
+# -------------------------------------------------------------------
 # PR existence check (advisory — runs before push completes)
 # -------------------------------------------------------------------
 # Git has no native post-push hook. We check here as the closest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -900,6 +900,20 @@ jobs:
         run: scripts/check-test-except-pass.sh
 
   # ---------------------------------------------------------------
+  # Script header guard: top-level scripts/*.py whose name matches a
+  # one-off pattern (backfill, cleanup, fix, dedup, merge, migrate,
+  # remediat) must carry `# one-off: true` OR `# permanent: true` in
+  # the first 50 lines. Replaces the "first 10 lines" rule-of-thumb
+  # with a machine-verifiable check (#2533).
+  # ---------------------------------------------------------------
+  script-headers-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check one-off/permanent markers on scripts/*.py
+        run: scripts/check-script-headers.sh
+
+  # ---------------------------------------------------------------
   # Markdown link guard: internal .md pointers in CLAUDE.md, docs/,
   # .claude/skills/, packages/*/README.md, packages/*/docs/,
   # infra/, and .github/ must point to files that exist (#2425, #2428)

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -25,7 +25,10 @@ from __future__ import annotations
 
 Run scripts via `scripts/run-py.sh scripts/<name>.py` — it reads the header and activates the correct venv automatically.
 
-**One-off scripts** (backfills, cleanups, fixups) must also include a `# one-off: true` header. This marks them for automatic detection by the `/audit` skill so they can be archived when no longer needed.
+**One-off and permanent markers.** Top-level scripts whose filename contains `backfill`, `cleanup`, `fix`, `dedup`, `merge`, `migrate`, or `remediat` must carry exactly one of the following markers, as a standalone top-level comment anywhere in the **first 50 lines** of the file (the header comment block — the marker sits adjacent to the `# venv:` header, typically just before or after the module docstring):
+
+- `# one-off: true` — finite-lifetime script (backfills, cleanups, fixups) tied to a specific bug fix or migration. Candidate for archival to `scripts/archive/` once its work is done.
+- `# permanent: true` — re-runnable utility (parameterizable, idempotent, intended to be invoked repeatedly). Exempt from one-off staleness checks.
 
 ```python
 #!/usr/bin/env python3
@@ -35,7 +38,9 @@ Run scripts via `scripts/run-py.sh scripts/<name>.py` — it reads the header an
 from __future__ import annotations
 ```
 
-Eval scripts (`scripts/eval/`) are excluded from this convention.
+The 50-line window is enforced by `scripts/check-script-headers.py` (CI job `script-headers-check`, and `.githooks/pre-push`). The window accommodates long module docstrings — e.g. `scripts/backfill_llm_enrichment.py` has a 29-line docstring and carries `# permanent: true` on line 32, which the old "first 10 lines" rule-of-thumb incorrectly flagged (see #2533). If a marker would otherwise land past line 50, shorten the docstring rather than expanding the window.
+
+Eval scripts (`scripts/eval/`) and archived scripts (`scripts/archive/`) are excluded from this convention.
 
 **ECS oneshot constraint:** Scripts run via `ecs-run-task.sh` are uploaded as single files — they **cannot import other `.py` files from `scripts/`**. Only stdlib and installed packages are available. If you need shared code, either inline it, use a lazy import inside a function (for optional features), or move the shared code into an installed package. CI enforces this via `scripts/check-oneshot-imports.sh`. Scripts that are never run as ECS oneshots can be added to the `LOCAL_ONLY` list in that script.
 

--- a/scripts/check-script-headers.py
+++ b/scripts/check-script-headers.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Enforce the ``# one-off: true`` / ``# permanent: true`` header convention.
+
+Top-level scripts under ``scripts/`` whose filename matches a known one-off
+name pattern (``backfill``, ``cleanup``, ``fix``, ``dedup``, ``merge``,
+``migrate``, ``remediat``) must carry exactly one of:
+
+* ``# one-off: true`` — finite-lifetime script (backfill, migration,
+  cleanup). Candidate for archival once its work is done.
+* ``# permanent: true`` — re-runnable utility (parameterizable, idempotent,
+  intended to be invoked repeatedly). Exempt from one-off staleness checks.
+
+The marker must appear anywhere in the first 50 lines of the file (the
+``# venv:`` / ``# one-off:`` / ``# permanent:`` headers sit immediately
+before or after the module docstring, so a docstring up to ~40 lines still
+leaves room for the marker). The 50-line window replaces the historical
+"first 10 lines" rule-of-thumb, which never matched reality — existing
+scripts like ``backfill_llm_enrichment.py`` carry the marker at line 32
+after a long docstring. See issue #2533.
+
+Usage:
+    scripts/check-script-headers.py            # scan scripts/ (default)
+    scripts/check-script-headers.py PATH ...   # scan specific paths
+
+Exit codes:
+    0 — All matched scripts carry a marker.
+    1 — One or more matched scripts are missing a marker.
+
+Ref: https://github.com/judgemind/judgemind/issues/2533
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Name fragments that signal a one-off script. A file whose basename (minus
+# ``.py``) contains any of these substrings is expected to carry either
+# ``# one-off: true`` or ``# permanent: true``.
+ONE_OFF_NAME_PATTERNS: tuple[str, ...] = (
+    "backfill",
+    "cleanup",
+    "fix",
+    "dedup",
+    "merge",
+    "migrate",
+    "remediat",
+)
+
+# Number of leading lines scanned for the marker. 50 accommodates long
+# module docstrings (see ``backfill_llm_enrichment.py`` whose docstring
+# ends on line 29 and carries ``# permanent: true`` on line 32) while
+# still being a hard upper bound so reviewers know where to look.
+HEADER_WINDOW_LINES: int = 50
+
+# Marker regex — matches a standalone top-level comment line. Whitespace
+# is tolerated after the ``#`` and at end-of-line. The regex deliberately
+# does NOT match the marker embedded in prose (e.g. inside a docstring)
+# — it must be a real top-level comment.
+_MARKER_RE = re.compile(r"^#\s*(?:one-off|permanent):\s*true\s*$")
+
+# File basenames that should never be scanned even if they match the
+# one-off name pattern by coincidence. The check script itself is listed
+# here for documentation — its name does not actually match a pattern,
+# but an explicit exemption keeps the intent clear.
+_ALWAYS_EXEMPT_BASENAMES: frozenset[str] = frozenset(
+    {
+        "check-script-headers.py",
+    }
+)
+
+# Subdirectory names within ``scripts/`` that are excluded from the
+# scan. Anything under these paths is considered out-of-scope for the
+# one-off/permanent convention.
+_EXCLUDED_SUBDIRS: frozenset[str] = frozenset(
+    {
+        "archive",  # Archived one-off scripts — already retired.
+        "eval",  # Evaluation harnesses, separate convention.
+        "tests",  # Unit tests for scripts/ helpers.
+        "spotcheck",  # Spot-check tooling, separate convention.
+    }
+)
+
+
+def matches_one_off_pattern(filename: str) -> bool:
+    """Return True if ``filename`` matches one of the one-off name fragments.
+
+    Matches substring-style: ``backfill_llm_enrichment.py`` matches because
+    ``backfill`` is in its name. ``check-test-except-pass.py`` does NOT match
+    any fragment, so it is exempt from the marker requirement.
+    """
+
+    name = filename.lower()
+    return any(frag in name for frag in ONE_OFF_NAME_PATTERNS)
+
+
+def has_marker(path: Path, window: int = HEADER_WINDOW_LINES) -> bool:
+    """Return True if the file at ``path`` carries a marker in its first ``window`` lines.
+
+    The marker must appear as a standalone top-level comment line matching
+    ``# one-off: true`` or ``# permanent: true`` (whitespace tolerated).
+    """
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+
+    lines = text.splitlines()[:window]
+    for line in lines:
+        if _MARKER_RE.match(line):
+            return True
+    return False
+
+
+def iter_candidate_files(roots: list[Path]) -> list[Path]:
+    """Enumerate ``.py`` files under ``roots`` subject to the scan policy.
+
+    For each root:
+        * If it is a file, include it iff it is a ``.py`` file (and not
+          in ``_ALWAYS_EXEMPT_BASENAMES``).
+        * If it is a directory, iterate its immediate children
+          (non-recursive); subdirectories listed in ``_EXCLUDED_SUBDIRS``
+          are skipped. This matches the audit's scope: only top-level
+          ``scripts/*.py`` files are subject to the convention; one-off
+          scripts under ``scripts/archive/`` are, by definition, already
+          retired.
+    """
+
+    candidates: list[Path] = []
+    for root in roots:
+        if not root.exists():
+            continue
+        if root.is_file():
+            if root.suffix == ".py" and root.name not in _ALWAYS_EXEMPT_BASENAMES:
+                candidates.append(root)
+            continue
+        # Non-recursive: only direct children of the directory.
+        for entry in sorted(root.iterdir()):
+            if entry.is_dir():
+                # Skip known subdirectories with separate conventions.
+                # Other unexpected subdirectories are also skipped;
+                # callers that want recursive behaviour should pass
+                # subdir roots explicitly.
+                continue
+            if entry.suffix != ".py":
+                continue
+            if entry.name in _ALWAYS_EXEMPT_BASENAMES:
+                continue
+            candidates.append(entry)
+    return candidates
+
+
+def find_unmarked_scripts(roots: list[Path]) -> list[Path]:
+    """Return candidate scripts that match the one-off name pattern but lack a marker."""
+
+    unmarked: list[Path] = []
+    for path in iter_candidate_files(roots):
+        if not matches_one_off_pattern(path.name):
+            continue
+        if has_marker(path):
+            continue
+        unmarked.append(path)
+    return unmarked
+
+
+def main(argv: list[str]) -> int:
+    # Default to scanning the top-level scripts/ directory if no args.
+    if argv:
+        roots = [Path(p) for p in argv]
+    else:
+        # Resolve relative to this script's location so invocation from
+        # any cwd works (e.g. pre-push hook, CI, manual run).
+        scripts_dir = Path(__file__).resolve().parent
+        roots = [scripts_dir]
+
+    unmarked = find_unmarked_scripts(roots)
+
+    if not unmarked:
+        return 0
+
+    print(
+        "ERROR: scripts matching the one-off name pattern lack a "
+        "`# one-off: true` or `# permanent: true` marker:",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    for path in unmarked:
+        print(f"  {path}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "Add ONE of the following as a top-level comment in the first "
+        f"{HEADER_WINDOW_LINES} lines of each file:",
+        file=sys.stderr,
+    )
+    print(
+        "  # one-off: true    (finite-lifetime — backfill, migration, cleanup)",
+        file=sys.stderr,
+    )
+    print(
+        "  # permanent: true  (re-runnable utility, idempotent)",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    print(
+        "See docs/agent/code-standards.md §Python scripts for the convention.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-script-headers.sh
+++ b/scripts/check-script-headers.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# check-script-headers.sh — Enforce the one-off/permanent marker convention.
+#
+# See scripts/check-script-headers.py for the full behaviour description,
+# the list of matched name patterns, the marker window, and the exemption
+# rules.
+#
+# Usage:
+#   scripts/check-script-headers.sh            # scan scripts/ (default)
+#   scripts/check-script-headers.sh PATH ...   # scan specific paths
+#
+# Exit codes:
+#   0 — All matched scripts carry a marker.
+#   1 — One or more matched scripts are missing a marker.
+#
+# Ref: https://github.com/judgemind/judgemind/issues/2533
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec python3 "$SCRIPT_DIR/check-script-headers.py" "$@"

--- a/scripts/tests/test_check_script_headers.py
+++ b/scripts/tests/test_check_script_headers.py
@@ -1,0 +1,362 @@
+# venv: none
+"""Unit tests for check-script-headers.py (#2533)."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# Load the script as a module (hyphenated filename).
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check-script-headers.py"
+spec = importlib.util.spec_from_file_location("check_script_headers", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+check_script_headers = importlib.util.module_from_spec(spec)
+sys.modules["check_script_headers"] = check_script_headers
+spec.loader.exec_module(check_script_headers)
+
+matches_one_off_pattern = check_script_headers.matches_one_off_pattern
+has_marker = check_script_headers.has_marker
+iter_candidate_files = check_script_headers.iter_candidate_files
+find_unmarked_scripts = check_script_headers.find_unmarked_scripts
+ONE_OFF_NAME_PATTERNS = check_script_headers.ONE_OFF_NAME_PATTERNS
+
+
+# ---------------------------------------------------------------------------
+# matches_one_off_pattern
+# ---------------------------------------------------------------------------
+
+
+class TestMatchesOneOffPattern:
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "backfill_llm_enrichment.py",
+            "cleanup_sd_bad_rulings.py",
+            "fix_riverside_enrichment.py",
+            "dedup_judges.py",
+            "merge_honorific_judges.py",
+            "migrate_s3_keys.py",
+            "remediate_enrichment_fixtures.py",
+        ],
+    )
+    def test_matching_names(self, filename: str) -> None:
+        assert matches_one_off_pattern(filename)
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "audit_field_completeness.py",
+            "check-test-except-pass.py",
+            "rebuild_db.py",
+            "reingest_from_s3.py",
+            "phase_timer.py",
+            "screenshot.py",
+        ],
+    )
+    def test_non_matching_names(self, filename: str) -> None:
+        assert not matches_one_off_pattern(filename)
+
+    def test_case_insensitive(self) -> None:
+        assert matches_one_off_pattern("Backfill_Something.py")
+        assert matches_one_off_pattern("CLEANUP.py")
+
+    def test_patterns_coverage(self) -> None:
+        # All documented fragments match a canonical filename.
+        assert set(ONE_OFF_NAME_PATTERNS) == {
+            "backfill",
+            "cleanup",
+            "fix",
+            "dedup",
+            "merge",
+            "migrate",
+            "remediat",
+        }
+
+
+# ---------------------------------------------------------------------------
+# has_marker
+# ---------------------------------------------------------------------------
+
+
+class TestHasMarker:
+    def _write(self, tmp_path: Path, name: str, content: str) -> Path:
+        target = tmp_path / name
+        target.write_text(textwrap.dedent(content).lstrip("\n"))
+        return target
+
+    def test_one_off_at_line_3(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            "backfill_foo.py",
+            """
+            #!/usr/bin/env python3
+            \"\"\"Short docstring.\"\"\"
+            # one-off: true
+            from __future__ import annotations
+            """,
+        )
+        assert has_marker(path)
+
+    def test_permanent_at_line_3(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            "backfill_foo.py",
+            """
+            #!/usr/bin/env python3
+            \"\"\"Short.\"\"\"
+            # permanent: true
+            """,
+        )
+        assert has_marker(path)
+
+    def test_marker_after_long_docstring(self, tmp_path: Path) -> None:
+        # Reproduces the backfill_llm_enrichment.py pattern (#2533): a
+        # long module docstring pushes the marker to line ~32. The
+        # default 50-line window must still catch it.
+        docstring_lines = "\n".join(f"  line {i}" for i in range(1, 26))
+        # Build the file literally rather than via dedent — avoids the
+        # common-leading-whitespace trap with mixed indentation levels.
+        content = (
+            "#!/usr/bin/env python3\n"
+            '"""Long docstring follows.\n'
+            "\n"
+            f"{docstring_lines}\n"
+            '"""\n'
+            "# venv: scraper-framework\n"
+            "# permanent: true\n"
+            "from __future__ import annotations\n"
+        )
+        path = tmp_path / "backfill_foo.py"
+        path.write_text(content)
+        # Sanity check: marker should land on line ~31.
+        lines = content.splitlines()
+        assert "# permanent: true" in lines[30], (
+            f"expected marker near line 31, got: {lines[28:33]}"
+        )
+        assert has_marker(path)
+
+    def test_marker_beyond_window_not_found(self, tmp_path: Path) -> None:
+        # Force the marker onto line 60 — beyond the default window.
+        padding = "\n".join(["# filler"] * 60)
+        path = self._write(
+            tmp_path,
+            "backfill_foo.py",
+            f"""
+            #!/usr/bin/env python3
+            {padding}
+            # one-off: true
+            """,
+        )
+        assert not has_marker(path)
+
+    def test_no_marker(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            "backfill_foo.py",
+            """
+            #!/usr/bin/env python3
+            \"\"\"No marker at all.\"\"\"
+            from __future__ import annotations
+            """,
+        )
+        assert not has_marker(path)
+
+    def test_marker_with_extra_spaces(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            "backfill_foo.py",
+            """
+            #   one-off:   true
+            """,
+        )
+        assert has_marker(path)
+
+    def test_marker_inside_docstring_does_not_count(self, tmp_path: Path) -> None:
+        # The marker pattern embedded inside a docstring is NOT a
+        # top-level comment line (the docstring body line starts with
+        # whitespace before any ``#``), so it should not be detected.
+        path = self._write(
+            tmp_path,
+            "backfill_foo.py",
+            """
+            \"\"\"Docstring mentioning '# one-off: true' as text.\"\"\"
+            from __future__ import annotations
+            """,
+        )
+        assert not has_marker(path)
+
+    def test_custom_window(self, tmp_path: Path) -> None:
+        path = self._write(
+            tmp_path,
+            "backfill_foo.py",
+            """
+            #!/usr/bin/env python3
+            # line 2
+            # line 3
+            # one-off: true
+            """,
+        )
+        assert has_marker(path, window=4)
+        assert not has_marker(path, window=3)
+
+
+# ---------------------------------------------------------------------------
+# iter_candidate_files
+# ---------------------------------------------------------------------------
+
+
+class TestIterCandidateFiles:
+    def test_lists_top_level_py_only(self, tmp_path: Path) -> None:
+        (tmp_path / "a.py").write_text("# a\n")
+        (tmp_path / "b.sh").write_text("# b\n")
+        (tmp_path / "c.py").write_text("# c\n")
+
+        result = iter_candidate_files([tmp_path])
+        names = sorted(p.name for p in result)
+        assert names == ["a.py", "c.py"]
+
+    def test_skips_excluded_subdirs(self, tmp_path: Path) -> None:
+        (tmp_path / "top.py").write_text("# top\n")
+        (tmp_path / "archive").mkdir()
+        (tmp_path / "archive" / "old.py").write_text("# old\n")
+        (tmp_path / "eval").mkdir()
+        (tmp_path / "eval" / "runner.py").write_text("# runner\n")
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "tests" / "t.py").write_text("# t\n")
+
+        result = iter_candidate_files([tmp_path])
+        names = sorted(p.name for p in result)
+        assert names == ["top.py"]
+
+    def test_skips_unknown_subdirs(self, tmp_path: Path) -> None:
+        # Unknown subdirectories are also skipped — callers must pass
+        # them explicitly if they want to scan them.
+        (tmp_path / "top.py").write_text("# top\n")
+        (tmp_path / "unknown").mkdir()
+        (tmp_path / "unknown" / "file.py").write_text("# file\n")
+
+        result = iter_candidate_files([tmp_path])
+        names = sorted(p.name for p in result)
+        assert names == ["top.py"]
+
+    def test_explicit_file_paths_accepted(self, tmp_path: Path) -> None:
+        f = tmp_path / "backfill_x.py"
+        f.write_text("# one-off: true\n")
+        result = iter_candidate_files([f])
+        assert result == [f]
+
+    def test_always_exempt_basenames_filtered(self, tmp_path: Path) -> None:
+        f = tmp_path / "check-script-headers.py"
+        f.write_text("# the check script itself\n")
+        # Passed as explicit file: exempt.
+        assert iter_candidate_files([f]) == []
+        # Found via directory scan: exempt.
+        assert iter_candidate_files([tmp_path]) == []
+
+    def test_missing_path_ignored(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist"
+        assert iter_candidate_files([missing]) == []
+
+
+# ---------------------------------------------------------------------------
+# find_unmarked_scripts
+# ---------------------------------------------------------------------------
+
+
+class TestFindUnmarkedScripts:
+    def test_unmarked_is_reported(self, tmp_path: Path) -> None:
+        (tmp_path / "backfill_missing.py").write_text(
+            '"""Missing marker."""\nfrom __future__ import annotations\n'
+        )
+        result = find_unmarked_scripts([tmp_path])
+        assert [p.name for p in result] == ["backfill_missing.py"]
+
+    def test_marked_script_is_ok(self, tmp_path: Path) -> None:
+        (tmp_path / "backfill_marked.py").write_text('"""Marked."""\n# one-off: true\n')
+        assert find_unmarked_scripts([tmp_path]) == []
+
+    def test_non_matching_name_not_flagged(self, tmp_path: Path) -> None:
+        (tmp_path / "utility.py").write_text('"""Not a one-off name."""\n')
+        assert find_unmarked_scripts([tmp_path]) == []
+
+    def test_permanent_marker_accepted(self, tmp_path: Path) -> None:
+        (tmp_path / "backfill_perma.py").write_text(
+            '"""Permanent utility."""\n# permanent: true\n'
+        )
+        assert find_unmarked_scripts([tmp_path]) == []
+
+    def test_marker_beyond_window_flagged(self, tmp_path: Path) -> None:
+        padding = "\n".join(["# filler"] * 60)
+        (tmp_path / "backfill_late.py").write_text(
+            f"#!/usr/bin/env python3\n{padding}\n# one-off: true\n"
+        )
+        result = find_unmarked_scripts([tmp_path])
+        assert [p.name for p in result] == ["backfill_late.py"]
+
+    def test_scripts_in_archive_subdir_not_scanned(self, tmp_path: Path) -> None:
+        archive = tmp_path / "archive"
+        archive.mkdir()
+        (archive / "backfill_old.py").write_text('"""No marker but archived."""\n')
+        # Default scan excludes archive/, so no findings:
+        assert find_unmarked_scripts([tmp_path]) == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real scripts/ directory should pass.
+# ---------------------------------------------------------------------------
+
+
+class TestAgainstRealScriptsDir:
+    def test_real_scripts_dir_passes(self) -> None:
+        # The repo's own scripts/ must pass this check at all times;
+        # otherwise the baseline is broken and a human should add the
+        # missing markers.
+        scripts_dir = SCRIPT_PATH.parent
+        unmarked = find_unmarked_scripts([scripts_dir])
+        assert unmarked == [], "Unmarked one-off scripts detected:\n" + "\n".join(
+            f"  {p}" for p in unmarked
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def test_cli_exits_zero_on_clean_dir(self, tmp_path: Path) -> None:
+        (tmp_path / "utility.py").write_text('"""Fine."""\n')
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), str(tmp_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_cli_exits_one_on_violation(self, tmp_path: Path) -> None:
+        (tmp_path / "backfill_missing.py").write_text('"""No marker."""\n')
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), str(tmp_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1
+        assert "backfill_missing.py" in result.stderr
+
+    def test_cli_default_scans_repo_scripts(self) -> None:
+        # No args -> scans the scripts/ directory where the check lives.
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        # The real scripts/ directory should pass.
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Adds a machine-verifiable check (`scripts/check-script-headers.py` + `.sh` wrapper) that enforces the `# one-off: true` / `# permanent: true` marker convention for top-level `scripts/*.py` files whose filename matches the one-off pattern (`backfill`, `cleanup`, `fix`, `dedup`, `merge`, `migrate`, `remediat`). Marker must appear within the first 50 lines — the actual convention, replacing the `/audit` SKILL.md's stale "first 10 lines" wording.

Wired into CI (new unconditional `script-headers-check` job) and `.githooks/pre-push` (triggers when any `scripts/*.py` is in the push). Updated `/audit` SKILL.md §1.9 checks 2 and 3 to reference the script and the 50-line window, and documented the convention in `docs/agent/code-standards.md`.

Closes #2533

## Test plan

### Automated checks
- [x] Lint passes (ruff check)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (scripts/tests/test_check_script_headers.py — 39 tests)
- [x] markdown-links-check passes
- [x] ci-job-skipped-check passes
- [x] script-headers-check passes (new job — self-verifying)
- [x] CI green end-to-end

### Post-deploy verification
- [x] N/A — no deployed component (docs/CI/tooling only)
