### PR TITLE
chore(audit): raise scripts/*.py threshold from 35 to 42 (#2537)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -200,7 +200,7 @@ Monitor the `scripts/` directory for one-off script accumulation. After #2095 ar
 Glob pattern: scripts/*.py
 ```
 
-If the count exceeds **35**, flag a finding. The current baseline is ~29 permanent utility scripts — 35 gives headroom for a few new utilities while catching accumulation of unarchived one-off scripts.
+If the count exceeds **42**, flag a finding. The permanent utility baseline has grown from ~29 (when the threshold was initially set at 35) to ~37 as new permanent checkers and tooling were added (e.g., `check-ci-job-skipped.py` from #2527, `check-script-headers.py` from #2533, plus the `phase_timer.py`, `ralph_review_log.py`, `log_ralph_review.py`, and `log_ralph_summary.py` utilities that support the task workflow). 42 gives ~5 slots of headroom above the current permanent baseline to absorb legitimately-blocked one-off scripts (e.g., `cleanup_sc_aborted_reingest_2416.py` and `cleanup_sc_failed_reingest.py`, waiting on #2454 / #2419; `patch-telegram-link-preview.py`, waiting on the upstream plugin to land `disable_web_page_preview`) without triggering a false-positive audit finding. When `#2454` and similar blockers clear, the count will drift back toward 37 and headroom is restored. Revisit this number whenever permanent utilities cross 38 — the threshold should track the real permanent baseline plus a few slots for transient one-offs. See #2537 for the rationale.
 
 2. **Missing `# one-off: true` or `# permanent: true` headers.** Use the machine-verifiable check — do not eyeball line numbers:
 
@@ -223,7 +223,7 @@ The same check runs in CI as the `script-headers-check` job and in `.githooks/pr
 #### Filing issues
 
 For script count threshold violations, file a `priority/p2` `type/chore` issue with:
-- Current count and the threshold (35).
+- Current count and the threshold (42).
 - List of scripts that appear to be one-off (by name pattern or `# one-off: true` header).
 - Suggested action: archive completed one-off scripts to `scripts/archive/`.
 

--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -128,7 +128,7 @@ Smaller counties (a few hundred documents or fewer) run fine at the 1024/4096 de
 
 ### One-off script convention
 
-Scripts in `scripts/` that are one-off (backfills, cleanups, fixups — intended to run once or a few times and then be archived) must include a `# one-off: true` header comment in the first 10 lines. This makes them programmatically identifiable by the `/audit` skill, which monitors `scripts/*.py` count and flags when it exceeds 35. One-off scripts that have been run and verified should be moved to `scripts/archive/` to keep the directory manageable.
+Scripts in `scripts/` that are one-off (backfills, cleanups, fixups — intended to run once or a few times and then be archived) must include a `# one-off: true` header comment in the first 50 lines. This makes them programmatically identifiable by the `/audit` skill, which monitors `scripts/*.py` count and flags when it exceeds 42 (the threshold tracks the permanent utility baseline plus a few slots for transient one-offs; see `.claude/skills/audit/SKILL.md` §1.9 and #2537). One-off scripts that have been run and verified should be moved to `scripts/archive/` to keep the directory manageable.
 
 ```python
 #!/usr/bin/env python3


### PR DESCRIPTION
## Summary

Raise the `/audit` skill's `scripts/*.py` count threshold from **35** to **42** to reflect the expanded permanent utility baseline. The 35 threshold was calibrated against a ~29 permanent baseline; since then several permanent checkers and task-workflow utilities have landed (`check-ci-job-skipped.py` from #2527, `check-script-headers.py` from #2533, plus `phase_timer.py` and three ralph review log utilities), raising the legitimate permanent baseline to ~37. 42 gives the same ~5 slots of headroom the original threshold had, letting blocked one-off scripts sit without triggering a false-positive audit finding until their blockers clear.

Also corrected a stale "first 10 lines" marker-window reference in `docs/agent/infrastructure-reference.md` — the actual check uses a 50-line window per #2533.

Closes #2537

## Context — why archive-only isn't an option

Three `# one-off: true` scripts account for the 40-file total, and all three have non-discretionary external blockers:

- `cleanup_sc_aborted_reingest_2416.py` and `cleanup_sc_failed_reingest.py` — tracked by #2454, blocked on #2419 (Santa Clara restore, still `status/blocked`).
- `patch-telegram-link-preview.py` — needs the upstream Telegram plugin to add `disable_web_page_preview`; the upstream PR tracking issue #2117 was closed without filing. Plugin version 0.0.6 (the currently cached version) still lacks the feature.

When these blockers clear, the count drifts back to ~37 and the full ~5 slots of headroom is restored. The full acceptance-criteria mapping is in the issue process summary: https://github.com/judgemind/judgemind/issues/2537#issuecomment-4266729354

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green
- [x] `scripts/check-markdown-links.sh` clean (verified locally in pre-push hook)
- [x] `scripts/check-script-headers.sh` still exits 0 (verified locally — no changes to scripts)

### Post-deploy verification
- [x] N/A — no deployed component (changes are limited to `.claude/skills/audit/SKILL.md` and `docs/agent/infrastructure-reference.md`; no runtime, no services, no workflows affected).
