### PR TITLE
fix(agent): add post-compaction recovery to /task skill (#2545)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -10,6 +10,8 @@ Pick up one issue from the Judgemind backlog and complete it autonomously. Do no
 
 **IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation anywhere in a `/task` agent. All work runs synchronously in the foreground. The `/task` agent is already a background subagent from the dispatcher's perspective — further backgrounding causes completion notifications to surface in the wrong context (the dispatcher), leading to confusion and lost results.
 
+**IMPORTANT — Post-compaction recovery.** If your context was just autocompacted (your summary references "previous conversation"), you are NOT done with the task. Autocompaction preserves *what was done* but not the procedural imperative *what still needs to happen next* (see #2545). Before emitting any final report or `end_turn`, run the status-file-driven recovery check described in §A.0 (implementation tasks) or §B.0 (investigation tasks). The status file at `{repo_root}/tmp/agent-status/<agent-id>.txt` is your authoritative "where am I" anchor — re-read this SKILL.md from the section named by your current `phase` and continue. Only `phase=done`, `phase=verified`, or `phase=blocked` means stop.
+
 ---
 
 ## Step 0 — Verify worktree exists
@@ -28,7 +30,7 @@ mkdir -p {worktree}/tmp
 
 ### Status file setup
 
-After confirming the worktree, set up the agent status file so the dispatcher can monitor progress. Derive an identifier from the worktree path (e.g. `agent-ab4722a2` from `.claude/worktrees/agent-ab4722a2`, or `worker-2` from `worktrees/worker-2`).
+After confirming the worktree, set up the agent status file so the dispatcher can monitor progress **and so you can recover from autocompact**. Derive an identifier from the worktree path (e.g. `agent-ab4722a2` from `.claude/worktrees/agent-ab4722a2`, or `worker-2` from `worktrees/worker-2`).
 
 The status file lives at `{repo_root}/tmp/agent-status/{agent-id}.txt` (in the **repo root's** `tmp/`, not the worktree's `tmp/`). Create the directory if needed:
 
@@ -43,11 +45,15 @@ issue: #<N>
 phase: <phase>
 updated: <ISO-8601 timestamp>
 summary: <one-line description of current activity>
+autocompact_count: <integer, optional — increment on each post-compaction recovery>
+final_phase: <phase, optional — written only when the task ends>
 ```
 
 Phases (in typical order): `claiming`, `setup`, `ralph-worker (iteration N)`, `ralph-reviewer (iteration N)`, `pushing`, `ci-watch`, `ci-fix`, `merging`, `deploying`, `verifying`, `retrospective`, `done`, `blocked`.
 
-**Write a status update at every major step transition** — use the Write tool to overwrite the status file. The first update should be written immediately after worktree setup with phase `claiming`.
+**Terminal phases** (the task is actually finished): `done`, `verified`, `blocked`. Any other phase means work remains — you MUST continue.
+
+**Write a status update at every major step transition** — use the Write tool to overwrite the status file. The first update should be written immediately after worktree setup with phase `claiming`. The status file is your post-compaction recovery anchor — see §A.0 and §B.0 below.
 
 ### Phase timing instrumentation
 
@@ -190,6 +196,28 @@ Follow the full PR Workflow defined in CLAUDE.md. **All commits must be on the w
 
 **IMPORTANT — Completion contract:** This task is NOT done after implementation or after ralph says SHIP. The task requires completing ALL substeps A.1 through A.9. After ralph returns, you MUST continue with A.2b (process summary), A.3 (commit/push), A.4 (merge conflicts), A.5 (CI), A.6 (PR update), A.7 (merge), A.8 (deploy verification), and A.9 (retrospective). Stopping after ralph is a bug — see issue #721.
 
+#### A.0 — Post-compaction recovery (READ FIRST after any context reset)
+
+**When this applies:** Your context just went through autocompaction (the conversation summary references "previous conversation"), or you are otherwise starting a turn without a clear memory of which A.x phase you are in. Autocompaction preserves implementation details but elides procedural imperatives, so the summary alone cannot tell you whether the task is complete — the **status file** is authoritative (see #2545).
+
+**What to do — mechanical procedure:**
+
+1. **Run the recovery check:**
+   ```
+   {worktree}/scripts/check-task-recovery.sh {worktree}
+   ```
+   - **Exit 0 (`DONE`):** the status file shows a terminal phase (`done`, `verified`, `blocked`). The task is actually complete. You may emit your final report and end the turn.
+   - **Exit 1 (`RESUME`):** work remains. The script prints the next required step (e.g. `A.2b — post process summary on issue`). Continue from that step — do NOT emit `end_turn`, do NOT produce a final report.
+   - **Exit 2 (`UNKNOWN`):** the status file is missing or malformed. Assume work remains. Re-read this SKILL.md from the top and reconstruct phase from git state (uncommitted changes? PR open? CI green?) before proceeding.
+
+2. **Increment `autocompact_count`** in the status file so the dispatcher can track the pattern. If the file currently has no `autocompact_count` field, add one initialized to `1`. Otherwise increment the existing value.
+
+3. **Re-read this SKILL.md** from the step named in the `RESUME` output — e.g. if the script says "next step: A.2b", read A.2b and onward before taking any further action.
+
+4. **Do NOT emit `end_turn`** until `check-task-recovery.sh` returns exit 0 (`DONE`). This is the same completion contract as the normal flow, but made explicit because the compacted summary may have dropped it.
+
+**Why this section exists:** Two confirmed incidents (#2500, #2502) showed /task agents emitting `end_turn` after autocompact with `phase=ralph-worker (1)` in the status file — i.e. still mid-implementation, with uncommitted changes, no PR, and no merge. The agents read their own "iteration 1 COMPLETE" artifact as a done-signal and stopped. The recovery script is the mechanical self-check that prevents this failure mode.
+
 #### A.1 — Set up dependencies
 Write status: `phase: setup`, `summary: Installing dependencies for <packages>`.
 Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} setup`
@@ -223,8 +251,9 @@ Skip this for Terraform-only or docs-only tasks.
 1. Run `git -C {worktree} status` to confirm there are uncommitted changes (there should be — ralph implements but does not commit).
 2. Run `git -C {worktree} log --oneline -1` to see the latest commit — it should NOT contain the current issue number (the implementation hasn't been committed yet).
 3. Check whether a PR already exists for this branch: `gh pr list --repo judgemind/judgemind --head <branch-name> --json number --limit 1`. It should return an empty list (no PR yet).
+4. Run the authoritative recovery check: `{worktree}/scripts/check-task-recovery.sh {worktree}`. It must return exit 1 (`RESUME`). If it returns 0 (`DONE`), that means the status file shows a terminal phase you did not intend — update the status file to reflect the actual phase and re-run the check.
 
-If any of these checks show that work remains (uncommitted changes exist, no PR yet), you MUST continue to A.2b. Do not exit. Do not return. Do not consider the task done. Exiting at this point is a critical workflow failure (#721).
+If any of these checks show that work remains (uncommitted changes exist, no PR yet), you MUST continue to A.2b. Do not exit. Do not return. Do not consider the task done. Exiting at this point is a critical workflow failure (#721, #2545).
 
 #### A.2b — Post process summary on issue (MANDATORY)
 
@@ -492,6 +521,26 @@ Continue to Step 5.
 
 Write findings to `docs/investigations/<slug>-<YYYY-MM>.md` and/or into the issue body.
 
+#### B.0 — Post-compaction recovery (READ FIRST after any context reset)
+
+**When this applies:** Same as §A.0 — your context just went through autocompaction, or you are otherwise starting a turn without a clear memory of which B.x phase you are in.
+
+**What to do:**
+
+1. **Run the recovery check:**
+   ```
+   {worktree}/scripts/check-task-recovery.sh {worktree}
+   ```
+   - **Exit 0 (`DONE`):** the status file shows `done`, `verified`, or `blocked`. Stop.
+   - **Exit 1 (`RESUME`):** work remains. Continue from the step after the phase in the status file. Investigation-task phases commonly end at `done` only after B.3 (unblock dependents) runs; a phase like `implementing` or `retrospective` still means there is more to do.
+   - **Exit 2 (`UNKNOWN`):** re-read this SKILL.md and determine phase from git / GitHub state.
+
+2. **Increment `autocompact_count`** in the status file.
+
+3. **Re-read this SKILL.md** from the step named in the `RESUME` output (B.1, B.1.5, B.2, B.3, or Step 5).
+
+4. **Do NOT emit `end_turn`** until the recovery check returns exit 0.
+
 #### B.1 — File follow-up issues for every actionable finding
 
 Do not just list recommendations — **create GitHub issues** for each concrete next step so the work is tracked and can be picked up by agents. For each follow-up:
@@ -584,13 +633,19 @@ If the task was trivial and there are genuinely no improvements to make, that's 
 
 ### 5d — Generate timing summary
 
-Write status: `phase: done`, `summary: Task complete.`
+Write status: `phase: done`, `summary: Task complete.`, and add a `final_phase: done` line so the dispatcher's post-mortem tooling can distinguish a properly-ended agent from one that emitted `end_turn` mid-workflow (see #2545).
 
 **Generate the timing summary before the agent exits:**
 ```
 python3 {worktree}/scripts/phase_timer.py summarize {worktree} {repo_root} <issue_number>
 ```
 This writes `{worktree}/tmp/timing.json` with the full phase breakdown and appends a one-line summary to `{repo_root}/tmp/task-timings.jsonl`. The dispatcher can aggregate these across tasks to identify systemic bottlenecks.
+
+**Final recovery self-check** (sanity gate before exit):
+```
+{worktree}/scripts/check-task-recovery.sh {worktree}
+```
+This must return exit 0 (`DONE`). If it returns 1 (`RESUME`), the status file was not updated to `done` — fix the status file and re-run. This guards against the #2545 failure mode where an agent writes a retrospective-looking final message while the status file still shows a non-terminal phase.
 
 Worktree cleanup is handled automatically by Claude Code when the agent exits.
 
@@ -604,4 +659,5 @@ Worktree cleanup is handled automatically by Claude Code when the agent exits.
 - **Multi-line Python always goes in a `.py` file**, never `-c '...'`.
 - **No `run_in_background`.** All commands — CI watches, test suites, deploy watches, and reviewer invocations — must run in the foreground. Subagents are already background tasks from the parent's perspective. Further backgrounding causes `<task-notification>` messages to surface in the wrong context, leading to confusion and lost results.
 - **Use `timeout: 1200000`** on Bash commands that may exceed 2 minutes: `pytest`, `gh run watch`, `pip install`, `npm install`, `npm run build`, `terraform apply`, `ruff check` on large codebases, and any data-processing script.
+- **After any context reset, run §A.0 / §B.0 recovery** — `{worktree}/scripts/check-task-recovery.sh {worktree}` is the authoritative "am I done?" check.
 - See CLAUDE.md §Unattended Operation Patterns for the full list.

--- a/scripts/check-task-recovery.sh
+++ b/scripts/check-task-recovery.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# check-task-recovery.sh — Tell a /task agent whether to resume after autocompact.
+#
+# Autocompaction produces a conversation summary that preserves *what was done*
+# but not the procedural imperative *what still needs to happen next*. After
+# compaction, a /task agent may read its own "iteration 1 COMPLETE" artifact
+# as a done-signal and emit end_turn prematurely — leaving the PR uncommitted,
+# unpushed, and unmerged (see #2545).
+#
+# This script is the post-compaction recovery anchor. It reads the agent's
+# status file (tmp/agent-status/<agent-id>.txt) and prints a structured
+# verdict the agent can act on:
+#
+#   DONE     — final phase reached; nothing more to do
+#   RESUME   — work incomplete; continue from the step after <phase>
+#   UNKNOWN  — could not read status file; assume RESUME and re-read SKILL.md
+#
+# Usage:
+#   scripts/check-task-recovery.sh <worktree>
+#
+# Exit codes:
+#   0 — DONE (task complete; safe to exit)
+#   1 — RESUME (work remains; keep going)
+#   2 — UNKNOWN (status file missing or malformed; assume RESUME)
+
+set -uo pipefail
+
+WORKTREE="${1:?Usage: check-task-recovery.sh <worktree>}"
+
+# Derive the repo root and agent id from the worktree path.
+# Worktree path looks like: /path/to/repo/.claude/worktrees/agent-<id>
+if [[ "$WORKTREE" != *"/.claude/worktrees/"* ]]; then
+    echo "UNKNOWN: worktree path does not contain .claude/worktrees/" >&2
+    exit 2
+fi
+
+REPO_ROOT="${WORKTREE%%/.claude/worktrees/*}"
+AGENT_ID=$(basename "$WORKTREE")
+STATUS_FILE="$REPO_ROOT/tmp/agent-status/$AGENT_ID.txt"
+
+if [ ! -f "$STATUS_FILE" ]; then
+    cat >&2 <<EOF
+UNKNOWN: status file not found at $STATUS_FILE
+Re-read .claude/skills/task/SKILL.md from the start and determine the next step.
+EOF
+    exit 2
+fi
+
+PHASE=$(grep -E '^phase:' "$STATUS_FILE" | head -n 1 | sed -E 's/^phase:[[:space:]]*//')
+ISSUE=$(grep -E '^issue:' "$STATUS_FILE" | head -n 1 | sed -E 's/^issue:[[:space:]]*//')
+
+if [ -z "$PHASE" ]; then
+    echo "UNKNOWN: phase field empty in $STATUS_FILE" >&2
+    exit 2
+fi
+
+# Final terminal phases — task is done.
+case "$PHASE" in
+    done|completed|verified|blocked)
+        echo "DONE: issue=$ISSUE phase=$PHASE — task complete, safe to exit."
+        exit 0
+        ;;
+esac
+
+# All other phases indicate ongoing work. Print the next step per the A.x
+# workflow contract in .claude/skills/task/SKILL.md.
+case "$PHASE" in
+    claiming|setup)
+        NEXT="A.2 — implement and review (ralph loop) or direct implementation for non-testable tasks"
+        ;;
+    ralph-worker*|ralph-reviewer*|implementing)
+        NEXT="A.2b — post process summary on issue (MANDATORY before commit)"
+        ;;
+    pushing)
+        NEXT="A.4 — verify no merge conflicts, then A.5 — monitor CI"
+        ;;
+    ci-watch*)
+        NEXT="A.5 — continue watching CI; if failed, A.7 — fix CI failures"
+        ;;
+    ci-fix)
+        NEXT="A.3 — re-push, then A.5 — monitor CI again"
+        ;;
+    merging)
+        NEXT="A.8 — verify deployment and post evidence (MANDATORY)"
+        ;;
+    deploying)
+        NEXT="A.8 Step 2 — functional verification against dev environment"
+        ;;
+    verifying)
+        NEXT="A.8 Step 3 — post verification evidence comment (MANDATORY gate), then A.9 — retrospective"
+        ;;
+    retrospective)
+        NEXT="Step 5c — file retro issues, then 5d — generate timing summary"
+        ;;
+    *)
+        NEXT="Re-read .claude/skills/task/SKILL.md and determine which step corresponds to phase='$PHASE'"
+        ;;
+esac
+
+cat <<EOF
+RESUME: issue=$ISSUE phase=$PHASE
+The task is NOT done. Next required step: $NEXT
+Do NOT emit end_turn until the status file shows phase=done or phase=verified.
+Re-read .claude/skills/task/SKILL.md sections A.3 onward (or B.2 onward for investigation tasks) before proceeding.
+EOF
+exit 1

--- a/tests/test_check_task_recovery.py
+++ b/tests/test_check_task_recovery.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Tests for scripts/check-task-recovery.sh
+
+Run from the repo root:
+    python3 tests/test_check_task_recovery.py
+
+Each test builds a fake worktree + status file and checks the exit code and
+output of the recovery script. See #2545 for motivation.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.dirname(SCRIPT_DIR)
+SCRIPT = os.path.join(REPO_ROOT, "scripts", "check-task-recovery.sh")
+
+passed = 0
+failed = 0
+
+
+def _build_fake_worktree(base: str, agent_id: str) -> tuple[str, str]:
+    """Create a fake repo_root + worktree under `base` and return their paths."""
+    repo_root = os.path.join(base, "repo")
+    worktree = os.path.join(repo_root, ".claude", "worktrees", agent_id)
+    status_dir = os.path.join(repo_root, "tmp", "agent-status")
+    os.makedirs(worktree, exist_ok=True)
+    os.makedirs(status_dir, exist_ok=True)
+    return worktree, os.path.join(status_dir, f"{agent_id}.txt")
+
+
+def run_script(worktree: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", SCRIPT, worktree],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+
+def run_test(description: str, test_fn: object) -> None:
+    global passed, failed
+    try:
+        test_fn()
+        print(f"  PASS: {description}")
+        passed += 1
+    except AssertionError as e:
+        print(f"  FAIL: {description}")
+        print(f"        {e}")
+        failed += 1
+    except Exception as e:
+        print(f"  FAIL: {description} (exception: {e})")
+        failed += 1
+
+
+# --- Tests ---
+
+
+def test_missing_status_file_returns_unknown() -> None:
+    """Exit 2 when the status file is absent."""
+    with tempfile.TemporaryDirectory() as tmp:
+        worktree, _ = _build_fake_worktree(tmp, "agent-xxx")
+        # Don't create the status file.
+        result = run_script(worktree)
+        assert result.returncode == 2, (
+            f"expected exit 2 (UNKNOWN), got {result.returncode}: "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        assert "UNKNOWN" in result.stderr
+
+
+def test_done_phase_returns_done() -> None:
+    """Exit 0 when phase is `done`."""
+    with tempfile.TemporaryDirectory() as tmp:
+        worktree, status_path = _build_fake_worktree(tmp, "agent-done")
+        with open(status_path, "w") as f:
+            f.write("issue: #123\nphase: done\nupdated: x\nsummary: y\n")
+        result = run_script(worktree)
+        assert result.returncode == 0, (
+            f"expected exit 0 (DONE), got {result.returncode}: "
+            f"stdout={result.stdout!r}"
+        )
+        assert "DONE" in result.stdout
+
+
+def test_verified_phase_returns_done() -> None:
+    """Exit 0 when phase is `verified` (alias for done)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        worktree, status_path = _build_fake_worktree(tmp, "agent-verified")
+        with open(status_path, "w") as f:
+            f.write("issue: #456\nphase: verified\nupdated: x\nsummary: y\n")
+        result = run_script(worktree)
+        assert result.returncode == 0, f"expected exit 0, got {result.returncode}"
+        assert "DONE" in result.stdout
+
+
+def test_blocked_phase_returns_done() -> None:
+    """Exit 0 when phase is `blocked` — no further work expected."""
+    with tempfile.TemporaryDirectory() as tmp:
+        worktree, status_path = _build_fake_worktree(tmp, "agent-blocked")
+        with open(status_path, "w") as f:
+            f.write("issue: #789\nphase: blocked\nupdated: x\nsummary: y\n")
+        result = run_script(worktree)
+        assert result.returncode == 0
+
+
+def test_ralph_worker_phase_returns_resume() -> None:
+    """Exit 1 (RESUME) when phase is `ralph-worker (1)` — mid-implementation."""
+    with tempfile.TemporaryDirectory() as tmp:
+        worktree, status_path = _build_fake_worktree(tmp, "agent-ralph")
+        with open(status_path, "w") as f:
+            f.write("issue: #2500\nphase: ralph-worker (1)\nupdated: x\nsummary: y\n")
+        result = run_script(worktree)
+        assert result.returncode == 1, (
+            f"expected exit 1 (RESUME), got {result.returncode}: "
+            f"stdout={result.stdout!r}"
+        )
+        assert "RESUME" in result.stdout
+        assert "A.2b" in result.stdout  # Next step advice
+
+
+def test_pushing_phase_returns_resume() -> None:
+    """Exit 1 when phase is `pushing` — mid-PR creation."""
+    with tempfile.TemporaryDirectory() as tmp:
+        worktree, status_path = _build_fake_worktree(tmp, "agent-push")
+        with open(status_path, "w") as f:
+            f.write("issue: #2502\nphase: pushing\nupdated: x\nsummary: y\n")
+        result = run_script(worktree)
+        assert result.returncode == 1
+        assert "RESUME" in result.stdout
+        assert "A.4" in result.stdout or "A.5" in result.stdout
+
+
+def test_verifying_phase_returns_resume() -> None:
+    """Exit 1 when phase is `verifying` — evidence comment not yet posted."""
+    with tempfile.TemporaryDirectory() as tmp:
+        worktree, status_path = _build_fake_worktree(tmp, "agent-verify")
+        with open(status_path, "w") as f:
+            f.write("issue: #2500\nphase: verifying\nupdated: x\nsummary: y\n")
+        result = run_script(worktree)
+        assert result.returncode == 1
+        assert "RESUME" in result.stdout
+        assert "A.8" in result.stdout
+
+
+def test_ci_watch_phase_returns_resume() -> None:
+    """Exit 1 when phase is `ci-watch (2)` with attempt suffix."""
+    with tempfile.TemporaryDirectory() as tmp:
+        worktree, status_path = _build_fake_worktree(tmp, "agent-ci")
+        with open(status_path, "w") as f:
+            f.write("issue: #111\nphase: ci-watch (2)\nupdated: x\nsummary: y\n")
+        result = run_script(worktree)
+        assert result.returncode == 1
+        assert "RESUME" in result.stdout
+
+
+def test_unknown_phase_returns_resume_with_hint() -> None:
+    """Exit 1 with a re-read hint when the phase is unrecognized."""
+    with tempfile.TemporaryDirectory() as tmp:
+        worktree, status_path = _build_fake_worktree(tmp, "agent-unknown")
+        with open(status_path, "w") as f:
+            f.write("issue: #999\nphase: bogus-phase\nupdated: x\nsummary: y\n")
+        result = run_script(worktree)
+        assert result.returncode == 1
+        assert "RESUME" in result.stdout
+        assert "SKILL.md" in result.stdout
+
+
+def test_bad_worktree_path_returns_unknown() -> None:
+    """Exit 2 when worktree path doesn't contain .claude/worktrees/."""
+    with tempfile.TemporaryDirectory() as tmp:
+        result = run_script(tmp)
+        assert result.returncode == 2
+        assert "UNKNOWN" in result.stderr
+
+
+def test_empty_phase_field_returns_unknown() -> None:
+    """Exit 2 when the phase field is blank."""
+    with tempfile.TemporaryDirectory() as tmp:
+        worktree, status_path = _build_fake_worktree(tmp, "agent-empty")
+        with open(status_path, "w") as f:
+            f.write("issue: #777\nphase:\nupdated: x\nsummary: y\n")
+        result = run_script(worktree)
+        assert result.returncode == 2
+        assert "UNKNOWN" in result.stderr
+
+
+def main() -> int:
+    tests = [
+        ("missing status file -> UNKNOWN", test_missing_status_file_returns_unknown),
+        ("phase=done -> DONE", test_done_phase_returns_done),
+        ("phase=verified -> DONE", test_verified_phase_returns_done),
+        ("phase=blocked -> DONE", test_blocked_phase_returns_done),
+        ("phase=ralph-worker -> RESUME", test_ralph_worker_phase_returns_resume),
+        ("phase=pushing -> RESUME", test_pushing_phase_returns_resume),
+        ("phase=verifying -> RESUME", test_verifying_phase_returns_resume),
+        ("phase=ci-watch (N) -> RESUME", test_ci_watch_phase_returns_resume),
+        ("unknown phase -> RESUME with hint", test_unknown_phase_returns_resume_with_hint),
+        ("bad worktree path -> UNKNOWN", test_bad_worktree_path_returns_unknown),
+        ("empty phase field -> UNKNOWN", test_empty_phase_field_returns_unknown),
+    ]
+    for desc, fn in tests:
+        run_test(desc, fn)
+
+    print()
+    print(f"Results: {passed} passed, {failed} failed")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds post-compaction recovery to the `/task` skill so large-task agents no longer emit `end_turn` after ralph-worker iteration 1 when autocompact drops the procedural "what comes next" from their context. Option A from the issue (status-file-driven recovery) plus the telemetry acceptance criterion.

New `scripts/check-task-recovery.sh` reads the agent status file and prints `DONE` / `RESUME` / `UNKNOWN` with the next required `A.x` or `B.x` step. `SKILL.md` now references this script from §A.0 (new), §B.0 (new), the POST-RALPH self-recovery guard, and the Step 5d final self-check. Status file schema gains optional `autocompact_count` and `final_phase` telemetry fields.

Closes #2545

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (11-case regression test in `tests/test_check_task_recovery.py`)
- [x] CI green
- [x] Markdown link check passes

### Post-deploy verification
- [x] N/A — no deployed component (agent workflow docs + tooling script only)
- [x] Verification evidence posted on issue (see §A.8)
