### PR TITLE
chore(audit): self-adjusting scripts/*.py threshold via permanent-count (#2547)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -194,13 +194,25 @@ Monitor the `scripts/` directory for one-off script accumulation. After #2095 ar
 
 #### Checks
 
-1. **Script count threshold.** Count `scripts/*.py` files (top-level only, not `scripts/archive/` or `scripts/eval/`):
+1. **Script count threshold — self-adjusting based on `# permanent: true` markers.** The threshold is computed from the marker counts, not a fixed literal, so adding a new permanent utility automatically raises the ceiling while adding a new one-off consumes a slot of headroom. Get the current marker counts:
 
 ```
-Glob pattern: scripts/*.py
+scripts/check-script-headers.py --count
 ```
 
-If the count exceeds **42**, flag a finding. The permanent utility baseline has grown from ~29 (when the threshold was initially set at 35) to ~37 as new permanent checkers and tooling were added (e.g., `check-ci-job-skipped.py` from #2527, `check-script-headers.py` from #2533, plus the `phase_timer.py`, `ralph_review_log.py`, `log_ralph_review.py`, and `log_ralph_summary.py` utilities that support the task workflow). 42 gives ~5 slots of headroom above the current permanent baseline to absorb legitimately-blocked one-off scripts (e.g., `cleanup_sc_aborted_reingest_2416.py` and `cleanup_sc_failed_reingest.py`, waiting on #2454 / #2419; `patch-telegram-link-preview.py`, waiting on the upstream plugin to land `disable_web_page_preview`) without triggering a false-positive audit finding. When `#2454` and similar blockers clear, the count will drift back toward 37 and headroom is restored. Revisit this number whenever permanent utilities cross 38 — the threshold should track the real permanent baseline plus a few slots for transient one-offs. See #2537 for the rationale.
+This emits JSON with four keys: `total` (candidate scripts, excluding exempt/archive), `permanent` (scripts carrying `# permanent: true`), `one_off` (scripts carrying `# one-off: true`), and `unmarked` (no marker). The enforcement check (§1.9 check 2 below) guarantees `unmarked == 0` on the repo baseline, so in normal operation `total == permanent + one_off`.
+
+Compute the threshold as:
+
+```
+threshold = permanent + HEADROOM   # HEADROOM = 5
+```
+
+`HEADROOM = 5` absorbs legitimately-blocked one-off scripts (e.g., cleanup scripts waiting on upstream issues, patch scripts awaiting a library fix) without triggering a false-positive audit finding. When blockers clear and the one-offs archive, the count drifts back toward `permanent` and headroom is restored.
+
+**Flag a finding when `total > threshold`.** Include the current `permanent`, `one_off`, `total`, and computed threshold in the issue body, plus the list of unarchived `# one-off: true` scripts (these are the archival candidates — permanent utilities are intentionally at baseline).
+
+The formula is self-adjusting: a new permanent utility landing bumps `permanent`, which bumps `threshold`, so the next audit does not raise a false-positive ratchet issue (see #2547 for the rationale). Conversely, a new one-off script consumes a headroom slot — if too many one-offs accumulate without being archived, the check correctly flags them.
 
 2. **Missing `# one-off: true` or `# permanent: true` headers.** Use the machine-verifiable check — do not eyeball line numbers:
 
@@ -208,13 +220,15 @@ If the count exceeds **42**, flag a finding. The permanent utility baseline has 
 scripts/check-script-headers.sh   # exit 0 = all good, exit 1 = missing markers
 ```
 
-The script scans top-level `scripts/*.py` whose filename contains `backfill`, `cleanup`, `fix`, `dedup`, `merge`, `migrate`, or `remediat` and requires EITHER `# one-off: true` OR `# permanent: true` anywhere in the first 50 lines (the script's header comment block — the marker sits adjacent to the `# venv:` header, typically just before or after the module docstring). The 50-line window replaces the old "first 10 lines" rule-of-thumb that routinely flagged correctly-marked scripts whose docstrings pushed the marker to line 15, 20, or 32 (see #2533 for the historical context).
+The script scans **every** top-level `scripts/*.py` (excluding the check script itself and the `archive`/`eval`/`tests`/`spotcheck` subdirectories) and requires EITHER `# one-off: true` OR `# permanent: true` anywhere in the first 50 lines (the script's header comment block — the marker sits adjacent to the `# venv:` header, typically just before or after the module docstring). The 50-line window replaces the old "first 10 lines" rule-of-thumb that routinely flagged correctly-marked scripts whose docstrings pushed the marker to line 15, 20, or 32 (see #2533 for the historical context).
+
+Historical note: the original (#2533) convention only required a marker on scripts whose filename matched a set of name fragments (`backfill`, `cleanup`, `fix`, `dedup`, `merge`, `migrate`, `remediat`). #2547 extended the requirement to ALL top-level scripts so check 1 above can use `permanent_count + HEADROOM` as a self-adjusting threshold — a new permanent utility raises the threshold automatically, while a new one-off consumes a slot of headroom. The narrow (#2533) behaviour is still available via `scripts/check-script-headers.py --narrow` for callers that want the historical scan.
 
 A script should carry exactly one marker:
    - `# one-off: true` — finite-lifetime script (tied to a specific bug fix or migration). Candidate for archival once its work is done.
    - `# permanent: true` — re-runnable utility (parameterizable, idempotent, intended to be invoked repeatedly). Exempt from one-off nagging and staleness checks.
 
-Scripts previously confirmed as permanent in issue comments should carry the canonical `# permanent: true` marker so the check is machine-readable and does not re-flag them each audit cycle (see #2530). The audit treats either marker as sufficient — only unmarked scripts matching the name pattern are flagged.
+Scripts previously confirmed as permanent in issue comments should carry the canonical `# permanent: true` marker so the check is machine-readable and does not re-flag them each audit cycle (see #2530). The audit treats either marker as sufficient — only unmarked scripts are flagged.
 
 The same check runs in CI as the `script-headers-check` job and in `.githooks/pre-push`, so the repo baseline should always be green; audit findings here should be rare and typically represent newly-added unmarked scripts.
 
@@ -223,8 +237,8 @@ The same check runs in CI as the `script-headers-check` job and in `.githooks/pr
 #### Filing issues
 
 For script count threshold violations, file a `priority/p2` `type/chore` issue with:
-- Current count and the threshold (42).
-- List of scripts that appear to be one-off (by name pattern or `# one-off: true` header).
+- Current `total`, `permanent`, `one_off` counts and the computed threshold (`permanent + 5`).
+- List of scripts carrying `# one-off: true` — these are the archival candidates. Permanent utilities are at baseline by design; they should NOT be listed as candidates.
 - Suggested action: archive completed one-off scripts to `scripts/archive/`.
 
 For missing headers, file a single `priority/p3` `type/dx` issue listing the scripts that should be reviewed. Include the verbatim output of `scripts/check-script-headers.sh` in the body so the fix is mechanical. Each listed script should get either `# one-off: true` (if finite-lifetime) or `# permanent: true` (if re-runnable utility).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,7 +278,7 @@ For detailed infrastructure reference (Vercel, Terraform state, ECS, secrets), s
 
 See **`docs/agent/code-standards.md`** for the full reference (Python/TypeScript/Terraform style, one-off script conventions, pre-PR commands, coverage gates). Highlights every agent must internalize:
 
-- **Python:** 3.12+, `.venv` per package, ruff + pytest. Scripts in `scripts/` need a `# venv:` header; one-off scripts also need `# one-off: true`. ECS oneshot scripts cannot import from other `scripts/*.py` files.
+- **Python:** 3.12+, `.venv` per package, ruff + pytest. Scripts in `scripts/` need a `# venv:` header, plus exactly one of `# one-off: true` or `# permanent: true` (see `docs/agent/code-standards.md` §Python scripts). ECS oneshot scripts cannot import from other `scripts/*.py` files.
 - **TypeScript:** strict mode, Node 20+. In `packages/web/`, use `@/` path aliases; any new GraphQL type without `id` needs a `keyFields` entry in `apollo-client.ts`.
 - **General:** all code has tests. Never hardcode secrets. When removing/renaming exports, grep every import site across `src/` and `tests/` before committing.
 - **Perf:** watch for sequential I/O, `LIMIT/OFFSET` pagination, unbatched DB writes, missing connection reuse.

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 Run scripts via `scripts/run-py.sh scripts/<name>.py` — it reads the header and activates the correct venv automatically.
 
-**One-off and permanent markers.** Top-level scripts whose filename contains `backfill`, `cleanup`, `fix`, `dedup`, `merge`, `migrate`, or `remediat` must carry exactly one of the following markers, as a standalone top-level comment anywhere in the **first 50 lines** of the file (the header comment block — the marker sits adjacent to the `# venv:` header, typically just before or after the module docstring):
+**One-off and permanent markers.** **Every** top-level script must carry exactly one of the following markers, as a standalone top-level comment anywhere in the **first 50 lines** of the file (the header comment block — the marker sits adjacent to the `# venv:` header, typically just before or after the module docstring):
 
 - `# one-off: true` — finite-lifetime script (backfills, cleanups, fixups) tied to a specific bug fix or migration. Candidate for archival to `scripts/archive/` once its work is done.
 - `# permanent: true` — re-runnable utility (parameterizable, idempotent, intended to be invoked repeatedly). Exempt from one-off staleness checks.
@@ -40,7 +40,9 @@ from __future__ import annotations
 
 The 50-line window is enforced by `scripts/check-script-headers.py` (CI job `script-headers-check`, and `.githooks/pre-push`). The window accommodates long module docstrings — e.g. `scripts/backfill_llm_enrichment.py` has a 29-line docstring and carries `# permanent: true` on line 32, which the old "first 10 lines" rule-of-thumb incorrectly flagged (see #2533). If a marker would otherwise land past line 50, shorten the docstring rather than expanding the window.
 
-Eval scripts (`scripts/eval/`) and archived scripts (`scripts/archive/`) are excluded from this convention.
+Historical note: the original (#2533) convention only required a marker on scripts whose filename matched `backfill`, `cleanup`, `fix`, `dedup`, `merge`, `migrate`, or `remediat`. #2547 extended the requirement to ALL top-level scripts so the `/audit` skill (§1.9) can use `permanent_count + 5` as a self-adjusting `scripts/*.py` count threshold — a new permanent utility raises the ceiling automatically; a new one-off consumes a slot of headroom. Run `scripts/check-script-headers.py --count` to see the current marker breakdown. The historical narrow scan is still available via `scripts/check-script-headers.py --narrow` for callers that want the #2533 behaviour.
+
+The `archive/`, `eval/`, `tests/`, and `spotcheck/` subdirectories under `scripts/` are excluded from the scan.
 
 **ECS oneshot constraint:** Scripts run via `ecs-run-task.sh` are uploaded as single files — they **cannot import other `.py` files from `scripts/`**. Only stdlib and installed packages are available. If you need shared code, either inline it, use a lazy import inside a function (for optional features), or move the shared code into an installed package. CI enforces this via `scripts/check-oneshot-imports.sh`. Scripts that are never run as ECS oneshots can be added to the `LOCAL_ONLY` list in that script.
 

--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -170,9 +170,16 @@ Best practices:
 | Initial population of a county that has S3 data but no DB records | `rebuild_db.py --county <name> --skip-reset` | Discovers documents directly from S3 keys — does not require pre-existing DB records |
 | Full database rebuild from scratch | `rebuild_db.py` (no `--skip-reset`) | Truncates derived tables and re-processes everything from S3 |
 
-### One-off script convention
+### One-off / permanent script convention
 
-Scripts in `scripts/` that are one-off (backfills, cleanups, fixups — intended to run once or a few times and then be archived) must include a `# one-off: true` header comment in the first 50 lines. This makes them programmatically identifiable by the `/audit` skill, which monitors `scripts/*.py` count and flags when it exceeds 42 (the threshold tracks the permanent utility baseline plus a few slots for transient one-offs; see `.claude/skills/audit/SKILL.md` §1.9 and #2537). One-off scripts that have been run and verified should be moved to `scripts/archive/` to keep the directory manageable.
+Every top-level `scripts/*.py` file (excluding the `archive/`, `eval/`, `tests/`, and `spotcheck/` subdirectories) must carry exactly one of these headers in the first 50 lines:
+
+- `# one-off: true` — finite-lifetime script (backfill, cleanup, migration, fixup). Candidate for archival to `scripts/archive/` once its work is done.
+- `# permanent: true` — re-runnable utility (parameterizable, idempotent, intended to be invoked repeatedly). Exempt from one-off nagging and staleness checks.
+
+The marker makes scripts programmatically classifiable. The `/audit` skill (§1.9) computes a self-adjusting threshold of `permanent_count + 5` from `scripts/check-script-headers.py --count` output — a new permanent utility landing raises the ceiling automatically, while a new one-off consumes a slot of headroom. When the total exceeds that threshold, the audit files a chore issue listing the unarchived one-off scripts as archival candidates. See #2533 (original convention) and #2547 (extension to all scripts + self-adjusting threshold) for background.
+
+One-off scripts that have been run and verified should be moved to `scripts/archive/` to keep the directory manageable.
 
 ```python
 #!/usr/bin/env python3
@@ -180,6 +187,15 @@ Scripts in `scripts/` that are one-off (backfills, cleanups, fixups — intended
 # venv: scraper-framework
 # one-off: true
 ```
+
+```python
+#!/usr/bin/env python3
+"""Query the dev DB and print row counts per table."""
+# venv: scraper-framework
+# permanent: true
+```
+
+The CI `script-headers-check` job and `.githooks/pre-push` both run `scripts/check-script-headers.sh`, which fails closed on any unmarked top-level script. Check marker counts locally with `scripts/check-script-headers.py --count`.
 
 ## Secrets Retrieval
 

--- a/scripts/_unblock_dependents.py
+++ b/scripts/_unblock_dependents.py
@@ -4,6 +4,8 @@
 Not meant to be run directly. Called by unblock-dependents.sh with environment
 variables: REPO, CLOSED_ISSUE, DRY_RUN, BLOCKED_ISSUES, WORK_TMPDIR.
 """
+
+# permanent: true
 from __future__ import annotations
 
 import json

--- a/scripts/agent_status.py
+++ b/scripts/agent_status.py
@@ -9,6 +9,7 @@ signal and presents it compactly.
 Usage:
     python3 scripts/agent_status.py <agent-id-or-path> [--last N] [--full]
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/api-error-check.py
+++ b/scripts/api-error-check.py
@@ -24,6 +24,7 @@ Options:
 
 Exit code: 0 if all healthy, 1 if alerts found.
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/audit_ci_health.py
+++ b/scripts/audit_ci_health.py
@@ -31,6 +31,7 @@ Exit codes:
     1 — at least one threshold violation or trend regression detected
     2 — error (network, auth, malformed data)
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/audit_field_completeness.py
+++ b/scripts/audit_field_completeness.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # venv: scraper-framework
+# permanent: true
 """Audit field completeness across all counties.
 
 Queries the database and produces a per-county report showing what

--- a/scripts/check-ci-job-skipped.py
+++ b/scripts/check-ci-job-skipped.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # venv: none
+# permanent: true
 """
 check-ci-job-skipped.py — Detect CI jobs whose body was modified in a diff
 but would be SKIPPED on that diff's CI run because the paths-filter gate

--- a/scripts/check-duplicate-functions.py
+++ b/scripts/check-duplicate-functions.py
@@ -18,6 +18,7 @@ Exit codes:
 
 Ref: https://github.com/judgemind/judgemind/issues/1300
 """
+# permanent: true
 from __future__ import annotations
 
 import ast

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -39,6 +39,7 @@ Exit codes:
 
 Ref: https://github.com/judgemind/judgemind/issues/2425
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/check-scraper-registry.py
+++ b/scripts/check-scraper-registry.py
@@ -16,6 +16,7 @@ Exit codes:
 
 See https://github.com/judgemind/judgemind/issues/2132 for context.
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/check-script-headers.py
+++ b/scripts/check-script-headers.py
@@ -1,43 +1,59 @@
 #!/usr/bin/env python3
+# venv: none
 """Enforce the ``# one-off: true`` / ``# permanent: true`` header convention.
 
-Top-level scripts under ``scripts/`` whose filename matches a known one-off
-name pattern (``backfill``, ``cleanup``, ``fix``, ``dedup``, ``merge``,
-``migrate``, ``remediat``) must carry exactly one of:
+Every top-level script under ``scripts/`` (excluding the check script itself
+and the ``archive``/``eval``/``tests``/``spotcheck`` subdirectories) must
+carry exactly one of:
 
 * ``# one-off: true`` — finite-lifetime script (backfill, migration,
   cleanup). Candidate for archival once its work is done.
 * ``# permanent: true`` — re-runnable utility (parameterizable, idempotent,
   intended to be invoked repeatedly). Exempt from one-off staleness checks.
 
+Historical note: the original (#2533) convention only required a marker on
+scripts whose filename matched a set of name fragments (``backfill``,
+``cleanup``, ``fix``, ``dedup``, ``merge``, ``migrate``, ``remediat``).
+#2547 extended the requirement to ALL top-level scripts so the
+``/audit`` skill could use ``count(# permanent: true) + HEADROOM`` as a
+self-adjusting threshold for script-directory accumulation — a new
+permanent utility raises the threshold automatically; a new one-off
+consumes a slot of headroom, correctly flagging when too many one-offs
+accumulate.
+
 The marker must appear anywhere in the first 50 lines of the file (the
 ``# venv:`` / ``# one-off:`` / ``# permanent:`` headers sit immediately
 before or after the module docstring, so a docstring up to ~40 lines still
-leaves room for the marker). The 50-line window replaces the historical
-"first 10 lines" rule-of-thumb, which never matched reality — existing
-scripts like ``backfill_llm_enrichment.py`` carry the marker at line 32
-after a long docstring. See issue #2533.
+leaves room for the marker). See #2533 for the original 50-line window
+rationale.
 
 Usage:
     scripts/check-script-headers.py            # scan scripts/ (default)
     scripts/check-script-headers.py PATH ...   # scan specific paths
+    scripts/check-script-headers.py --count    # emit JSON marker counts (for audit)
+    scripts/check-script-headers.py --narrow   # historical #2533 check (name-pattern only)
 
 Exit codes:
-    0 — All matched scripts carry a marker.
-    1 — One or more matched scripts are missing a marker.
+    0 — All scripts carry a marker (or, with --count, counts emitted OK).
+    1 — One or more scripts are missing a marker.
 
-Ref: https://github.com/judgemind/judgemind/issues/2533
+Ref:
+    - https://github.com/judgemind/judgemind/issues/2533 (original convention)
+    - https://github.com/judgemind/judgemind/issues/2547 (extend to all scripts)
 """
 
 from __future__ import annotations
 
+import argparse
+import json
 import re
 import sys
 from pathlib import Path
 
-# Name fragments that signal a one-off script. A file whose basename (minus
-# ``.py``) contains any of these substrings is expected to carry either
-# ``# one-off: true`` or ``# permanent: true``.
+# Name fragments that historically signalled a one-off script. These are
+# retained for backwards compatibility (``matches_one_off_pattern`` /
+# ``find_unmarked_scripts``) but are no longer used by the default check —
+# every top-level script now requires a marker regardless of its name.
 ONE_OFF_NAME_PATTERNS: tuple[str, ...] = (
     "backfill",
     "cleanup",
@@ -59,11 +75,12 @@ HEADER_WINDOW_LINES: int = 50
 # does NOT match the marker embedded in prose (e.g. inside a docstring)
 # — it must be a real top-level comment.
 _MARKER_RE = re.compile(r"^#\s*(?:one-off|permanent):\s*true\s*$")
+_PERMANENT_RE = re.compile(r"^#\s*permanent:\s*true\s*$")
+_ONE_OFF_RE = re.compile(r"^#\s*one-off:\s*true\s*$")
 
-# File basenames that should never be scanned even if they match the
-# one-off name pattern by coincidence. The check script itself is listed
-# here for documentation — its name does not actually match a pattern,
-# but an explicit exemption keeps the intent clear.
+# File basenames that should never be scanned even if they would otherwise
+# be included. The check script itself is listed here — it IS the marker
+# convention, so it has no need to declare itself.
 _ALWAYS_EXEMPT_BASENAMES: frozenset[str] = frozenset(
     {
         "check-script-headers.py",
@@ -84,15 +101,27 @@ _EXCLUDED_SUBDIRS: frozenset[str] = frozenset(
 
 
 def matches_one_off_pattern(filename: str) -> bool:
-    """Return True if ``filename`` matches one of the one-off name fragments.
+    """Return True if ``filename`` matches one of the historical one-off name fragments.
 
-    Matches substring-style: ``backfill_llm_enrichment.py`` matches because
-    ``backfill`` is in its name. ``check-test-except-pass.py`` does NOT match
-    any fragment, so it is exempt from the marker requirement.
+    Retained for backwards compatibility with the #2533 convention. The
+    default check no longer uses this function — every top-level script
+    now requires a marker regardless of its name (#2547). The ``--narrow``
+    CLI flag still invokes the historical behaviour for callers that
+    want the original scan.
     """
 
     name = filename.lower()
     return any(frag in name for frag in ONE_OFF_NAME_PATTERNS)
+
+
+def _read_header_lines(path: Path, window: int = HEADER_WINDOW_LINES) -> list[str]:
+    """Return up to ``window`` leading lines of ``path`` (safe on unreadable files)."""
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    return text.splitlines()[:window]
 
 
 def has_marker(path: Path, window: int = HEADER_WINDOW_LINES) -> bool:
@@ -102,14 +131,26 @@ def has_marker(path: Path, window: int = HEADER_WINDOW_LINES) -> bool:
     ``# one-off: true`` or ``# permanent: true`` (whitespace tolerated).
     """
 
-    try:
-        text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return False
-
-    lines = text.splitlines()[:window]
-    for line in lines:
+    for line in _read_header_lines(path, window):
         if _MARKER_RE.match(line):
+            return True
+    return False
+
+
+def has_permanent_marker(path: Path, window: int = HEADER_WINDOW_LINES) -> bool:
+    """Return True if the file carries a ``# permanent: true`` marker."""
+
+    for line in _read_header_lines(path, window):
+        if _PERMANENT_RE.match(line):
+            return True
+    return False
+
+
+def has_one_off_marker(path: Path, window: int = HEADER_WINDOW_LINES) -> bool:
+    """Return True if the file carries a ``# one-off: true`` marker."""
+
+    for line in _read_header_lines(path, window):
+        if _ONE_OFF_RE.match(line):
             return True
     return False
 
@@ -153,7 +194,12 @@ def iter_candidate_files(roots: list[Path]) -> list[Path]:
 
 
 def find_unmarked_scripts(roots: list[Path]) -> list[Path]:
-    """Return candidate scripts that match the one-off name pattern but lack a marker."""
+    """Return candidate scripts that match the one-off name pattern but lack a marker.
+
+    Historical (#2533) narrow behaviour: only flags scripts whose filename
+    matches a one-off name fragment. Retained for backwards compatibility
+    with callers that want the narrow scan (CLI ``--narrow``).
+    """
 
     unmarked: list[Path] = []
     for path in iter_candidate_files(roots):
@@ -165,24 +211,69 @@ def find_unmarked_scripts(roots: list[Path]) -> list[Path]:
     return unmarked
 
 
-def main(argv: list[str]) -> int:
-    # Default to scanning the top-level scripts/ directory if no args.
-    if argv:
-        roots = [Path(p) for p in argv]
-    else:
-        # Resolve relative to this script's location so invocation from
-        # any cwd works (e.g. pre-push hook, CI, manual run).
-        scripts_dir = Path(__file__).resolve().parent
-        roots = [scripts_dir]
+def find_unmarked_all_scripts(roots: list[Path]) -> list[Path]:
+    """Return every candidate script that lacks a marker.
 
-    unmarked = find_unmarked_scripts(roots)
+    New (#2547) default behaviour: every top-level script must carry
+    either ``# one-off: true`` or ``# permanent: true``. A marker-less
+    script would otherwise raise the audit's computed threshold (``total
+    > permanent_count + HEADROOM``) without contributing to the legitimate
+    baseline, eventually triggering false-positive ratchet findings.
+    """
 
-    if not unmarked:
-        return 0
+    unmarked: list[Path] = []
+    for path in iter_candidate_files(roots):
+        if has_marker(path):
+            continue
+        unmarked.append(path)
+    return unmarked
 
+
+def count_markers(roots: list[Path]) -> dict[str, int]:
+    """Return marker counts across candidate scripts.
+
+    Keys:
+        total       — total candidate scripts (excluding exempt/archive).
+        permanent   — scripts carrying ``# permanent: true``.
+        one_off     — scripts carrying ``# one-off: true``.
+        unmarked    — scripts with no marker at all.
+
+    The sum of ``permanent + one_off + unmarked`` equals ``total``. Used
+    by ``/audit`` §1.9 to compute the self-adjusting threshold
+    ``permanent + HEADROOM``.
+    """
+
+    total = 0
+    permanent = 0
+    one_off = 0
+    unmarked = 0
+    for path in iter_candidate_files(roots):
+        total += 1
+        if has_permanent_marker(path):
+            permanent += 1
+        elif has_one_off_marker(path):
+            one_off += 1
+        else:
+            unmarked += 1
+    return {
+        "total": total,
+        "permanent": permanent,
+        "one_off": one_off,
+        "unmarked": unmarked,
+    }
+
+
+def _default_roots() -> list[Path]:
+    """Resolve to the top-level ``scripts/`` directory the check script lives in."""
+
+    scripts_dir = Path(__file__).resolve().parent
+    return [scripts_dir]
+
+
+def _print_unmarked_error(unmarked: list[Path]) -> None:
     print(
-        "ERROR: scripts matching the one-off name pattern lack a "
-        "`# one-off: true` or `# permanent: true` marker:",
+        "ERROR: top-level scripts lack a `# one-off: true` or "
+        "`# permanent: true` marker:",
         file=sys.stderr,
     )
     print("", file=sys.stderr)
@@ -207,6 +298,59 @@ def main(argv: list[str]) -> int:
         "See docs/agent/code-standards.md §Python scripts for the convention.",
         file=sys.stderr,
     )
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description=("Enforce one-off/permanent marker convention on scripts/*.py."),
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        help=(
+            "Paths to scan (files or directories). Defaults to the "
+            "top-level scripts/ directory."
+        ),
+    )
+    parser.add_argument(
+        "--count",
+        action="store_true",
+        help=(
+            "Emit JSON marker counts (total/permanent/one_off/unmarked) "
+            "instead of running the enforcement check. Used by /audit §1.9 "
+            "to compute the self-adjusting threshold."
+        ),
+    )
+    parser.add_argument(
+        "--narrow",
+        action="store_true",
+        help=(
+            "Use the historical (#2533) narrow check: only flag scripts "
+            "whose filename matches the one-off name pattern. The default "
+            "(#2547) is to flag every top-level script without a marker."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    if args.paths:
+        roots = [Path(p) for p in args.paths]
+    else:
+        roots = _default_roots()
+
+    if args.count:
+        counts = count_markers(roots)
+        print(json.dumps(counts, indent=2, sort_keys=True))
+        return 0
+
+    if args.narrow:
+        unmarked = find_unmarked_scripts(roots)
+    else:
+        unmarked = find_unmarked_all_scripts(roots)
+
+    if not unmarked:
+        return 0
+
+    _print_unmarked_error(unmarked)
     return 1
 
 

--- a/scripts/check-sql-columns.py
+++ b/scripts/check-sql-columns.py
@@ -18,6 +18,7 @@ Exit codes:
     0 -- No invalid column references found.
     1 -- One or more invalid column references detected.
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/check-sql-conflicts.py
+++ b/scripts/check-sql-conflicts.py
@@ -18,6 +18,7 @@ Exit codes:
     0 -- No invalid ON CONFLICT targets found.
     1 -- One or more invalid ON CONFLICT targets detected.
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/check-test-except-pass.py
+++ b/scripts/check-test-except-pass.py
@@ -32,6 +32,7 @@ Exit codes:
 
 Ref: https://github.com/judgemind/judgemind/issues/2459
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/data-quality-check.py
+++ b/scripts/data-quality-check.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # venv: scraper-framework
+# permanent: true
 """Data quality monitoring — collection health and field completeness checks.
 
 Queries the database and flags counties with unhealthy ruling ingest

--- a/scripts/dev_db_query_runner.py
+++ b/scripts/dev_db_query_runner.py
@@ -26,6 +26,7 @@ Exit codes:
     0   Success
     1   Usage error or connection failure
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/dispatcher-request.py
+++ b/scripts/dispatcher-request.py
@@ -18,6 +18,7 @@ dispatcher is reading from the same file concurrently.
 The default inbox file is ``tmp/dispatcher_inbox.json`` relative to the
 repo root.  Override with ``--inbox-file``.
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/dispatcher-send.py
+++ b/scripts/dispatcher-send.py
@@ -14,6 +14,7 @@ The script is stdlib-only and does not require any venv.  It uses file
 locking (``fcntl.flock``) to safely append entries even when the subagent's
 hook is reading from the same file concurrently.
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/dq_trend_storage.py
+++ b/scripts/dq_trend_storage.py
@@ -12,6 +12,7 @@ and field completeness percentages).
 This module is designed to be imported by ``data-quality-check.py`` and
 tested independently with mocked S3 clients.
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/ecs-smoke-test.py
+++ b/scripts/ecs-smoke-test.py
@@ -16,6 +16,7 @@ or state changes.
 Exit code 0 means the environment is healthy.
 Exit code 1 means one or more checks failed.
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/fetch_rosters.py
+++ b/scripts/fetch_rosters.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # venv: scraper-framework
+# permanent: true
 """Fetch all court directory snapshots and archive to S3 + DB.
 
 Runs every CourtDirectory subclass, archives raw HTML to S3, and stores

--- a/scripts/format-dq-summary.py
+++ b/scripts/format-dq-summary.py
@@ -22,6 +22,7 @@ Options:
 
 Exit code: 0 on success, 1 if no alert data could be extracted.
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/gemini_review.py
+++ b/scripts/gemini_review.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # venv: scraper-framework
+# permanent: true
 """Gemini 2.5 Pro cross-model reviewer for the /ralph loop.
 
 Reads task context and a git diff, sends them to Gemini for review,

--- a/scripts/log_ralph_review.py
+++ b/scripts/log_ralph_review.py
@@ -16,6 +16,7 @@ The script reads:
 It appends a record to:
   {worktree}/tmp/ralph/review-log.jsonl
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/log_ralph_summary.py
+++ b/scripts/log_ralph_summary.py
@@ -15,6 +15,7 @@ The script reads:
 It appends a summary record to:
   {worktree}/tmp/ralph/review-log.jsonl
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/phase_timer.py
+++ b/scripts/phase_timer.py
@@ -21,6 +21,7 @@ Usage from agent skill files:
     # Generate timing.json and append to task-timings.jsonl:
     python3 scripts/phase_timer.py summarize <worktree> <repo_root> <issue_number>
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/ralph_review_log.py
+++ b/scripts/ralph_review_log.py
@@ -6,6 +6,7 @@ verdicts, feedback, agreement patterns, and token usage can be analyzed.
 This module is intentionally dependency-free (stdlib only) to avoid requiring
 a venv for the scripts/ directory.
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # venv: scraper-framework
+# permanent: true
 """Rebuild the entire database from S3 archived content.
 #
 # Lists S3 objects (or local cache), derives courts from key prefixes,

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # venv: scraper-framework
+# permanent: true
 """Re-ingest existing documents from S3 through the pipeline.
 
 **This script operates on existing database records only.** It queries the

--- a/scripts/remove_test_functions.py
+++ b/scripts/remove_test_functions.py
@@ -20,6 +20,7 @@ Exit codes:
 
 Ref: https://github.com/judgemind/judgemind/issues/2320
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/s3_cache.py
+++ b/scripts/s3_cache.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Local S3 cache — bulk sync and CLI utilities."""
 # venv: scraper-framework
+# permanent: true
 #
 # Content-addressed keys mean a local file is always correct if it exists.
 # Cache dir: /tmp/judgemind-archive/ (mirrors S3 key structure)

--- a/scripts/screenshot.py
+++ b/scripts/screenshot.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # venv: scraper-framework
+# permanent: true
 """Take a screenshot of a page on dev.judgemind.org.
 
 Usage:

--- a/scripts/site-quality-check.py
+++ b/scripts/site-quality-check.py
@@ -15,6 +15,7 @@ Environment variables:
   BASELINES_FILE - Path to baselines JSON (default: site-quality-baselines.json)
   GITHUB_OUTPUT  - GitHub Actions output file (optional, for CI integration)
 """
+# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/spot_check.py
+++ b/scripts/spot_check.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # venv: scraper-framework
+# permanent: true
 """Spot-check case detail pages for data quality issues.
 
 Takes screenshots of multiple case detail pages from the rulings feed

--- a/scripts/tests/test_check_script_headers.py
+++ b/scripts/tests/test_check_script_headers.py
@@ -1,9 +1,10 @@
 # venv: none
-"""Unit tests for check-script-headers.py (#2533)."""
+"""Unit tests for check-script-headers.py (#2533, #2547)."""
 
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
 import sys
 import textwrap
@@ -21,8 +22,12 @@ spec.loader.exec_module(check_script_headers)
 
 matches_one_off_pattern = check_script_headers.matches_one_off_pattern
 has_marker = check_script_headers.has_marker
+has_permanent_marker = check_script_headers.has_permanent_marker
+has_one_off_marker = check_script_headers.has_one_off_marker
 iter_candidate_files = check_script_headers.iter_candidate_files
 find_unmarked_scripts = check_script_headers.find_unmarked_scripts
+find_unmarked_all_scripts = check_script_headers.find_unmarked_all_scripts
+count_markers = check_script_headers.count_markers
 ONE_OFF_NAME_PATTERNS = check_script_headers.ONE_OFF_NAME_PATTERNS
 
 
@@ -206,6 +211,31 @@ class TestHasMarker:
 
 
 # ---------------------------------------------------------------------------
+# has_permanent_marker / has_one_off_marker (#2547)
+# ---------------------------------------------------------------------------
+
+
+class TestMarkerKindPredicates:
+    def test_permanent_only_matches_permanent(self, tmp_path: Path) -> None:
+        path = tmp_path / "utility.py"
+        path.write_text('"""Perma."""\n# permanent: true\n')
+        assert has_permanent_marker(path)
+        assert not has_one_off_marker(path)
+
+    def test_one_off_only_matches_one_off(self, tmp_path: Path) -> None:
+        path = tmp_path / "backfill_x.py"
+        path.write_text('"""Transient."""\n# one-off: true\n')
+        assert has_one_off_marker(path)
+        assert not has_permanent_marker(path)
+
+    def test_no_marker(self, tmp_path: Path) -> None:
+        path = tmp_path / "plain.py"
+        path.write_text('"""Nothing."""\n')
+        assert not has_permanent_marker(path)
+        assert not has_one_off_marker(path)
+
+
+# ---------------------------------------------------------------------------
 # iter_candidate_files
 # ---------------------------------------------------------------------------
 
@@ -264,7 +294,7 @@ class TestIterCandidateFiles:
 
 
 # ---------------------------------------------------------------------------
-# find_unmarked_scripts
+# find_unmarked_scripts (historical narrow behaviour, #2533)
 # ---------------------------------------------------------------------------
 
 
@@ -281,6 +311,7 @@ class TestFindUnmarkedScripts:
         assert find_unmarked_scripts([tmp_path]) == []
 
     def test_non_matching_name_not_flagged(self, tmp_path: Path) -> None:
+        # Narrow mode: only name-pattern scripts are flagged.
         (tmp_path / "utility.py").write_text('"""Not a one-off name."""\n')
         assert find_unmarked_scripts([tmp_path]) == []
 
@@ -307,18 +338,152 @@ class TestFindUnmarkedScripts:
 
 
 # ---------------------------------------------------------------------------
+# find_unmarked_all_scripts (new default behaviour, #2547)
+# ---------------------------------------------------------------------------
+
+
+class TestFindUnmarkedAllScripts:
+    def test_unmarked_name_pattern_flagged(self, tmp_path: Path) -> None:
+        (tmp_path / "backfill_missing.py").write_text('"""Missing marker."""\n')
+        result = find_unmarked_all_scripts([tmp_path])
+        assert [p.name for p in result] == ["backfill_missing.py"]
+
+    def test_unmarked_non_pattern_also_flagged(self, tmp_path: Path) -> None:
+        # New behaviour: scripts NOT matching the name pattern are ALSO
+        # required to carry a marker. This is the central change in #2547.
+        (tmp_path / "utility.py").write_text('"""Not a one-off name."""\n')
+        result = find_unmarked_all_scripts([tmp_path])
+        assert [p.name for p in result] == ["utility.py"]
+
+    def test_permanent_marked_script_is_ok(self, tmp_path: Path) -> None:
+        (tmp_path / "utility.py").write_text(
+            '"""Permanent utility."""\n# permanent: true\n'
+        )
+        assert find_unmarked_all_scripts([tmp_path]) == []
+
+    def test_one_off_marked_script_is_ok(self, tmp_path: Path) -> None:
+        (tmp_path / "utility.py").write_text('"""Finite."""\n# one-off: true\n')
+        assert find_unmarked_all_scripts([tmp_path]) == []
+
+    def test_archive_subdir_still_excluded(self, tmp_path: Path) -> None:
+        archive = tmp_path / "archive"
+        archive.mkdir()
+        (archive / "utility_old.py").write_text('"""No marker."""\n')
+        assert find_unmarked_all_scripts([tmp_path]) == []
+
+    def test_check_script_itself_exempt(self, tmp_path: Path) -> None:
+        # The check script itself is in _ALWAYS_EXEMPT_BASENAMES — it
+        # has no need to declare itself since it IS the convention.
+        (tmp_path / "check-script-headers.py").write_text('"""Check."""\n')
+        assert find_unmarked_all_scripts([tmp_path]) == []
+
+
+# ---------------------------------------------------------------------------
+# count_markers (#2547)
+# ---------------------------------------------------------------------------
+
+
+class TestCountMarkers:
+    def test_counts_empty_dir(self, tmp_path: Path) -> None:
+        assert count_markers([tmp_path]) == {
+            "total": 0,
+            "permanent": 0,
+            "one_off": 0,
+            "unmarked": 0,
+        }
+
+    def test_counts_mixed(self, tmp_path: Path) -> None:
+        (tmp_path / "p1.py").write_text('"""p."""\n# permanent: true\n')
+        (tmp_path / "p2.py").write_text('"""p."""\n# permanent: true\n')
+        (tmp_path / "o1.py").write_text('"""o."""\n# one-off: true\n')
+        (tmp_path / "u1.py").write_text('"""u."""\n')
+        result = count_markers([tmp_path])
+        assert result == {
+            "total": 4,
+            "permanent": 2,
+            "one_off": 1,
+            "unmarked": 1,
+        }
+
+    def test_counts_exclude_archive(self, tmp_path: Path) -> None:
+        (tmp_path / "p.py").write_text('"""p."""\n# permanent: true\n')
+        archive = tmp_path / "archive"
+        archive.mkdir()
+        (archive / "archived.py").write_text('"""old."""\n')
+        result = count_markers([tmp_path])
+        # Only the top-level p.py counts — archive/ is excluded.
+        assert result == {
+            "total": 1,
+            "permanent": 1,
+            "one_off": 0,
+            "unmarked": 0,
+        }
+
+    def test_sum_equals_total(self, tmp_path: Path) -> None:
+        # Property: permanent + one_off + unmarked == total.
+        (tmp_path / "a.py").write_text('"""a."""\n# permanent: true\n')
+        (tmp_path / "b.py").write_text('"""b."""\n# one-off: true\n')
+        (tmp_path / "c.py").write_text('"""c."""\n')
+        (tmp_path / "d.py").write_text('"""d."""\n# permanent: true\n')
+        result = count_markers([tmp_path])
+        assert (
+            result["permanent"] + result["one_off"] + result["unmarked"]
+            == result["total"]
+        )
+
+    def test_counts_exempt_check_script(self, tmp_path: Path) -> None:
+        # The check script itself is exempt — it must not appear in counts.
+        (tmp_path / "check-script-headers.py").write_text('"""Check script."""\n')
+        (tmp_path / "utility.py").write_text('"""u."""\n# permanent: true\n')
+        result = count_markers([tmp_path])
+        assert result == {
+            "total": 1,
+            "permanent": 1,
+            "one_off": 0,
+            "unmarked": 0,
+        }
+
+    def test_real_scripts_dir_marker_counts(self) -> None:
+        # The repo's real scripts/ directory: confirm the counts are
+        # populated as expected. The specific numbers drift, but the
+        # invariant must hold: unmarked == 0 (every script is marked)
+        # and total matches len(glob("*.py")) - 1 (exempt check script).
+        scripts_dir = SCRIPT_PATH.parent
+        counts = count_markers([scripts_dir])
+        all_top_py = [
+            p for p in scripts_dir.glob("*.py") if p.name != "check-script-headers.py"
+        ]
+        assert counts["total"] == len(all_top_py)
+        assert counts["unmarked"] == 0, (
+            "Unmarked scripts found — baseline broken. Run "
+            "scripts/check-script-headers.py to list."
+        )
+        assert (
+            counts["permanent"] + counts["one_off"] + counts["unmarked"]
+            == counts["total"]
+        )
+
+
+# ---------------------------------------------------------------------------
 # End-to-end: real scripts/ directory should pass.
 # ---------------------------------------------------------------------------
 
 
 class TestAgainstRealScriptsDir:
-    def test_real_scripts_dir_passes(self) -> None:
-        # The repo's own scripts/ must pass this check at all times;
-        # otherwise the baseline is broken and a human should add the
-        # missing markers.
+    def test_real_scripts_dir_passes_narrow(self) -> None:
+        # Historical narrow check: name-pattern scripts must carry a marker.
         scripts_dir = SCRIPT_PATH.parent
         unmarked = find_unmarked_scripts([scripts_dir])
         assert unmarked == [], "Unmarked one-off scripts detected:\n" + "\n".join(
+            f"  {p}" for p in unmarked
+        )
+
+    def test_real_scripts_dir_passes_all(self) -> None:
+        # New (#2547) default check: every top-level script must carry a
+        # marker. Baseline must be green at all times.
+        scripts_dir = SCRIPT_PATH.parent
+        unmarked = find_unmarked_all_scripts([scripts_dir])
+        assert unmarked == [], "Unmarked top-level scripts detected:\n" + "\n".join(
             f"  {p}" for p in unmarked
         )
 
@@ -330,7 +495,7 @@ class TestAgainstRealScriptsDir:
 
 class TestCli:
     def test_cli_exits_zero_on_clean_dir(self, tmp_path: Path) -> None:
-        (tmp_path / "utility.py").write_text('"""Fine."""\n')
+        (tmp_path / "utility.py").write_text('"""Fine."""\n# permanent: true\n')
         result = subprocess.run(
             [sys.executable, str(SCRIPT_PATH), str(tmp_path)],
             capture_output=True,
@@ -339,7 +504,7 @@ class TestCli:
         )
         assert result.returncode == 0, result.stderr
 
-    def test_cli_exits_one_on_violation(self, tmp_path: Path) -> None:
+    def test_cli_exits_one_on_violation_name_pattern(self, tmp_path: Path) -> None:
         (tmp_path / "backfill_missing.py").write_text('"""No marker."""\n')
         result = subprocess.run(
             [sys.executable, str(SCRIPT_PATH), str(tmp_path)],
@@ -349,6 +514,31 @@ class TestCli:
         )
         assert result.returncode == 1
         assert "backfill_missing.py" in result.stderr
+
+    def test_cli_exits_one_on_violation_non_pattern(self, tmp_path: Path) -> None:
+        # #2547: scripts NOT matching the one-off name pattern are ALSO
+        # required to carry a marker under the default (broad) check.
+        (tmp_path / "utility.py").write_text('"""No marker."""\n')
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), str(tmp_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 1
+        assert "utility.py" in result.stderr
+
+    def test_cli_narrow_mode_skips_non_pattern(self, tmp_path: Path) -> None:
+        # --narrow falls back to the historical (#2533) behaviour: only
+        # name-pattern scripts are flagged; plain utility.py is ignored.
+        (tmp_path / "utility.py").write_text('"""No marker."""\n')
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--narrow", str(tmp_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
 
     def test_cli_default_scans_repo_scripts(self) -> None:
         # No args -> scans the scripts/ directory where the check lives.
@@ -360,3 +550,39 @@ class TestCli:
         )
         # The real scripts/ directory should pass.
         assert result.returncode == 0, result.stderr
+
+    def test_cli_count_mode_emits_json(self, tmp_path: Path) -> None:
+        (tmp_path / "p.py").write_text('"""p."""\n# permanent: true\n')
+        (tmp_path / "o.py").write_text('"""o."""\n# one-off: true\n')
+        (tmp_path / "u.py").write_text('"""u."""\n')
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--count", str(tmp_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        counts = json.loads(result.stdout)
+        assert counts == {
+            "total": 3,
+            "permanent": 1,
+            "one_off": 1,
+            "unmarked": 1,
+        }
+
+    def test_cli_count_mode_no_paths_scans_repo(self) -> None:
+        # --count with no paths scans the real scripts/ directory.
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "--count"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        counts = json.loads(result.stdout)
+        assert counts["unmarked"] == 0
+        assert counts["total"] > 0
+        assert (
+            counts["permanent"] + counts["one_off"] + counts["unmarked"]
+            == counts["total"]
+        )

--- a/scripts/update-coverage-baselines.py
+++ b/scripts/update-coverage-baselines.py
@@ -35,6 +35,7 @@ Example:
         --coverage-file coverage-artifacts/coverage-scraper-framework/coverage.xml \
         --coverage-file coverage-artifacts/coverage-scraper-ingestion/coverage.xml
 """
+# permanent: true
 
 import argparse
 import json

--- a/scripts/validate-dq-baselines.py
+++ b/scripts/validate-dq-baselines.py
@@ -20,6 +20,7 @@ Usage:
 
 Exit code: 0 if valid, 1 if validation errors found.
 """
+# permanent: true
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Replaces the fixed 42-script threshold in `/audit` §1.9 with a computed `permanent_count + 5` formula. A new permanent utility landing automatically raises the ceiling; a new one-off consumes a slot of headroom — so the check self-adjusts and no longer needs periodic ratchet PRs.

Extends the `# permanent: true` / `# one-off: true` marker requirement from the #2533 narrow name-pattern set to every top-level `scripts/*.py`, so the formula is meaningful (only marked scripts contribute to the `permanent` count). Adds `--count` and `--narrow` flags to `scripts/check-script-headers.py`, annotates 34 previously-unmarked permanent utilities with `# permanent: true`, and updates `/audit` SKILL.md, `CLAUDE.md`, `docs/agent/code-standards.md`, and `docs/agent/infrastructure-reference.md`.

Current state: `total=39, permanent=36, one_off=3, unmarked=0`. Threshold = 36 + 5 = 41 ≥ 39 → no false-positive audit finding.

Closes #2547

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass (59 tests in `scripts/tests/test_check_script_headers.py`)
- [ ] `scripts/check-script-headers.sh` exits 0 on the repo baseline
- [ ] Markdown links check passes
- [ ] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (docs + CI tooling + marker annotations only)
