### PR TITLE
feat(ci): add lint check for raw json.loads on LLM response text (#2550)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -833,6 +833,17 @@ jobs:
         run: scripts/check-hardcoded-colors.sh
 
   # ---------------------------------------------------------------
+  # LLM JSON loads guard: flag raw json.loads on LLM response text
+  # — should use parse_llm_json (or strict=False) instead (#2550).
+  # ---------------------------------------------------------------
+  llm-json-loads-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check for raw json.loads on LLM response text
+        run: scripts/check-llm-json-loads.sh
+
+  # ---------------------------------------------------------------
   # Schema drift guard: schema.sql must match applied migrations
   # ---------------------------------------------------------------
   schema-drift-check:
@@ -1151,7 +1162,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/packages/nlp-pipeline/src/classification/classifier.py
+++ b/packages/nlp-pipeline/src/classification/classifier.py
@@ -131,7 +131,11 @@ class RulingClassifier:
         )
 
         raw_text = response.content[0].text.strip()
-        parsed = json.loads(raw_text)
+        # ``strict=False`` tolerates unescaped control characters inside
+        # JSON string values — LLMs occasionally emit ESC/tab/vertical-tab
+        # inside string values, which vanilla ``json.loads`` rejects per
+        # RFC 8259 §7.  See #2518 for the full rationale.
+        parsed = json.loads(raw_text, strict=False)
 
         outcome = parsed["outcome"]
         motion_type = parsed["motion_type"]

--- a/packages/nlp-pipeline/src/entity_extraction/extractor.py
+++ b/packages/nlp-pipeline/src/entity_extraction/extractor.py
@@ -119,7 +119,11 @@ class EntityExtractor:
         )
 
         raw_text = response.content[0].text.strip()
-        parsed = json.loads(raw_text)
+        # ``strict=False`` tolerates unescaped control characters inside
+        # JSON string values — LLMs occasionally emit ESC/tab/vertical-tab
+        # inside string values, which vanilla ``json.loads`` rejects per
+        # RFC 8259 §7.  See #2518 for the full rationale.
+        parsed = json.loads(raw_text, strict=False)
 
         return ExtractedEntities(
             judge_name=parsed.get("judge_name"),

--- a/scripts/check-llm-json-loads.sh
+++ b/scripts/check-llm-json-loads.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# check-llm-json-loads.sh — Flag raw json.loads calls on LLM response text.
+#
+# After fixing #2518 (LLM JSON parse errors from unescaped control chars) we
+# centralized LLM JSON parsing on ``framework.llm_utils.parse_llm_json`` which
+# wraps ``json.loads(..., strict=False)``.  Future callers could easily
+# regress to a raw ``json.loads(response.text)`` call and re-introduce the
+# same class of ``Invalid control character`` failures.
+#
+# This check greps for two suspect patterns in Python source under
+# packages/*/src/:
+#
+#   1. ``json.loads(<expr>.text<word-boundary>)`` — the attribute access
+#      ``.text`` is the LLM response convention across google-genai
+#      (``response.text``) and anthropic (``response.content[0].text``).
+#   2. ``json.loads(raw_text)`` — the variable name our callers used
+#      pre-fix (see PR #2543 diff).
+#
+# When matched, the script emits a warning pointing at
+# ``framework.llm_utils.parse_llm_json``.  An explicit allowlist covers the
+# handful of sites that legitimately use ``json.loads`` on non-LLM response
+# text (e.g. httpx responses from a court data API, Redis stream events).
+#
+# Usage:
+#   scripts/check-llm-json-loads.sh          # exits 0 if clean, 1 if violations
+#   scripts/check-llm-json-loads.sh [dir]    # scan a specific directory
+#
+# Exit codes:
+#   0 — No suspect json.loads patterns found.
+#   1 — One or more files call json.loads on apparent LLM response text.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-$REPO_ROOT}"
+
+# ─── Suspect patterns ─────────────────────────────────────────────────
+# Pattern 1: json.loads(...text<word-boundary>)
+#   Catches json.loads(response.text), json.loads(response.text.strip()),
+#   json.loads(response.content[0].text), json.loads(foo.text[0]), etc.
+#   The leading ``\.`` ensures we match the ``.text`` attribute access
+#   rather than a standalone ``text`` identifier.
+#
+# Pattern 2: json.loads(<ws>raw_text<ws>)
+#   Catches the literal variable name used by the pre-#2518 callers.
+#   Allows leading/trailing whitespace for formatting tolerance.
+PATTERN='json\.loads\([^)]*\.text\b|json\.loads\(\s*raw_text\s*[,)]'
+
+# ─── Directories and files to exclude ─────────────────────────────────
+EXCLUDE_DIRS=(
+    ".git"
+    ".venv"
+    "node_modules"
+    ".next"
+    "__pycache__"
+    ".claude"
+    ".vite"
+    "tests"
+    "test"
+)
+
+# Allowlist — files where json.loads on .text or raw_text is legitimate
+# (non-LLM source).  Keep this list small and justified.  New entries
+# must be documented with why the call is safe.
+EXCLUDE_FILES=(
+    # This script itself (documents the forbidden patterns in comments).
+    "scripts/check-llm-json-loads.sh"
+    "scripts/tests/test_check_llm_json_loads.sh"
+    # Source of truth for parse_llm_json — the docstring mentions the
+    # forbidden pattern in its explanation.
+    "packages/scraper-framework/src/framework/llm_utils.py"
+    # SF civil fetches rulings via httpx GET from tr.dll — response.text
+    # is an HTTP API response, not an LLM response.  Unescaped control
+    # chars are not a risk here because the server emits RFC-compliant
+    # JSON.
+    "packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py"
+)
+
+# ─── Build grep arguments ─────────────────────────────────────────────
+exclude_args=()
+for dir in "${EXCLUDE_DIRS[@]}"; do
+    exclude_args+=("--exclude-dir=$dir")
+done
+
+# ─── Determine scan targets ───────────────────────────────────────────
+# When scanning the repo root, only look inside packages/*/src/.
+# When a custom directory is passed (e.g. from tests), scan everything in it.
+scan_targets=()
+if [[ "$SCAN_DIR" == "$REPO_ROOT" ]]; then
+    for pkg_src in "$REPO_ROOT"/packages/*/src/; do
+        [[ -d "$pkg_src" ]] && scan_targets+=("$pkg_src")
+    done
+    if [[ ${#scan_targets[@]} -eq 0 ]]; then
+        echo "All clean — no packages/*/src/ directories found, nothing to scan."
+        exit 0
+    fi
+else
+    scan_targets+=("$SCAN_DIR")
+fi
+
+# ─── Scan for violations ──────────────────────────────────────────────
+violations=0
+
+for target in "${scan_targets[@]}"; do
+    [[ -e "$target" ]] || continue
+
+    matches=$(grep -rnE "$PATTERN" "$target" --include='*.py' "${exclude_args[@]}" 2>/dev/null || true)
+
+    [[ -z "$matches" ]] && continue
+
+    while IFS= read -r line; do
+        # Check if this match is in an excluded file
+        skip=false
+        for excl in "${EXCLUDE_FILES[@]}"; do
+            if [[ "$line" == *"$excl"* ]]; then
+                skip=true
+                break
+            fi
+        done
+        "$skip" && continue
+
+        # Extract the content portion (after filename:lineno:)
+        content="${line#*:}"   # strip filename
+        content="${content#*:}"  # strip line number
+        trimmed="${content#"${content%%[![:space:]]*}"}"
+
+        # Skip comment lines
+        if [[ "$trimmed" == "#"* ]]; then
+            continue
+        fi
+
+        # Skip calls that already opt into relaxed parsing.  Both
+        # ``json.loads(..., strict=False)`` and ``parse_llm_json(...)``
+        # are safe against the #2518 control-char failure mode; the
+        # former is the inline fix pattern used where importing
+        # ``parse_llm_json`` would introduce a cross-package dependency
+        # (e.g. ``nlp-pipeline`` which does not depend on
+        # ``scraper-framework``).
+        if [[ "$content" == *"strict=False"* ]]; then
+            continue
+        fi
+
+        if [[ $violations -eq 0 ]]; then
+            echo "ERROR: Found raw json.loads call(s) on apparent LLM response text."
+            echo ""
+            echo "  LLM responses occasionally contain unescaped ASCII control"
+            echo "  characters inside JSON string values (see #2518).  Parsing"
+            echo "  them with a raw json.loads rejects the whole payload."
+            echo ""
+            echo "  Use parse_llm_json instead — it wraps json.loads with"
+            echo "  strict=False and strips markdown code fences:"
+            echo ""
+            echo "    from framework.llm_utils import parse_llm_json"
+            echo "    parsed = parse_llm_json(response.text)"
+            echo ""
+            echo "  Violations:"
+            echo ""
+        fi
+
+        echo "    $line"
+        violations=$((violations + 1))
+    done <<< "$matches"
+done
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "  Found $violations suspect json.loads call(s)."
+    echo ""
+    echo "  Fix: replace json.loads(<llm_response>.text) or"
+    echo "  json.loads(raw_text) with parse_llm_json(...) imported from"
+    echo "  framework.llm_utils."
+    echo ""
+    echo "  If the call is legitimately on non-LLM text (e.g. an HTTP API"
+    echo "  response from a court data server), add the file to the"
+    echo "  EXCLUDE_FILES allowlist in scripts/check-llm-json-loads.sh"
+    echo "  with a comment explaining why the call is safe."
+    echo ""
+    echo "  See: https://github.com/judgemind/judgemind/issues/2518"
+    exit 1
+fi
+
+echo "All clean — no raw json.loads calls on LLM response text found."
+exit 0

--- a/scripts/tests/test_check_llm_json_loads.sh
+++ b/scripts/tests/test_check_llm_json_loads.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# test_check_llm_json_loads.sh — Tests for check-llm-json-loads.sh
+#
+# Creates temporary files to verify that the checker correctly detects
+# raw json.loads calls on LLM response text while allowing legitimate
+# non-LLM json.loads calls.
+#
+# Usage:
+#   scripts/tests/test_check_llm_json_loads.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-llm-json-loads.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local path="$TMPDIR_TEST/$name"
+    mkdir -p "$(dirname "$path")"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: json.loads(response.text) should fail ────────────────────
+create_test_file "bad1.py" 'data = json.loads(response.text)' > /dev/null
+assert_fails "json.loads(response.text) is detected"
+reset_tmpdir
+
+# ─── Test 2: json.loads(raw_text) should fail ─────────────────────────
+create_test_file "bad2.py" 'parsed = json.loads(raw_text)' > /dev/null
+assert_fails "json.loads(raw_text) is detected"
+reset_tmpdir
+
+# ─── Test 3: json.loads(response.content[0].text) should fail ─────────
+create_test_file "bad3.py" 'parsed = json.loads(response.content[0].text)' > /dev/null
+assert_fails "json.loads(response.content[0].text) is detected"
+reset_tmpdir
+
+# ─── Test 4: json.loads(response.text.strip()) should fail ────────────
+create_test_file "bad4.py" 'parsed = json.loads(response.text.strip())' > /dev/null
+assert_fails "json.loads(response.text.strip()) is detected"
+reset_tmpdir
+
+# ─── Test 5: json.loads(raw_text, strict=False) should PASS ───────────
+# The fix pattern — opts into relaxed parsing explicitly.
+create_test_file "good1.py" 'parsed = json.loads(raw_text, strict=False)' > /dev/null
+assert_passes "json.loads(raw_text, strict=False) is allowed"
+reset_tmpdir
+
+# ─── Test 6: json.loads(response.text, strict=False) should PASS ──────
+create_test_file "good2.py" 'parsed = json.loads(response.text, strict=False)' > /dev/null
+assert_passes "json.loads(response.text, strict=False) is allowed"
+reset_tmpdir
+
+# ─── Test 7: parse_llm_json(response.text) should PASS ────────────────
+# The centralized helper — does not match json.loads at all.
+create_test_file "good3.py" 'parsed = parse_llm_json(response.text)' > /dev/null
+assert_passes "parse_llm_json(response.text) is allowed"
+reset_tmpdir
+
+# ─── Test 8: json.loads on a plain variable name should PASS ──────────
+# Variable names like ``cleaned``, ``config_str``, ``raw`` (not raw_text)
+# should not trigger.  Only ``.text`` attribute or the specific
+# ``raw_text`` variable is flagged.
+create_test_file "good4.py" 'config = json.loads(config_str)' > /dev/null
+assert_passes "json.loads(config_str) is allowed"
+reset_tmpdir
+
+# ─── Test 9: json.loads(bytes.decode()) should PASS ───────────────────
+# A bytes-decoded string is not the .text attribute pattern.
+create_test_file "good5.py" 'data = json.loads(blob.decode())' > /dev/null
+assert_passes "json.loads(blob.decode()) is allowed"
+reset_tmpdir
+
+# ─── Test 10: json.loads inside comment should PASS ───────────────────
+create_test_file "good6.py" '# Do not use: json.loads(response.text)' > /dev/null
+assert_passes "Comment referencing json.loads(response.text) is allowed"
+reset_tmpdir
+
+# ─── Test 11: Multiple suspect calls in one file should fail ──────────
+create_test_file "multi.py" 'def foo():
+    a = json.loads(response.text)
+    b = json.loads(raw_text)
+    return a, b' > /dev/null
+assert_fails "Multiple suspect json.loads calls in one file are detected"
+reset_tmpdir
+
+# ─── Test 12: Non-Python file with matching pattern should PASS ───────
+# The check scans *.py only.  JavaScript/TypeScript code is not its scope.
+create_test_file "script.js" 'const data = json.loads(response.text);' > /dev/null
+assert_passes "Non-Python file is not scanned"
+reset_tmpdir
+
+# ─── Test 13: .venv directory should be excluded ──────────────────────
+mkdir -p "$TMPDIR_TEST/.venv/lib"
+printf '%s\n' 'parsed = json.loads(response.text)' > "$TMPDIR_TEST/.venv/lib/foo.py"
+assert_passes ".venv directory is excluded"
+reset_tmpdir
+
+# ─── Test 14: tests directory should be excluded ──────────────────────
+mkdir -p "$TMPDIR_TEST/tests"
+printf '%s\n' 'parsed = json.loads(response.text)' > "$TMPDIR_TEST/tests/test_foo.py"
+assert_passes "tests directory is excluded"
+reset_tmpdir
+
+# ─── Test 15: Pre-fix state of #2518 would have been caught ───────────
+# Reproduces the exact variable-name pattern from the PR #2543 diff for
+# ``packages/scraper-framework/src/ingestion/llm_extract.py`` before the
+# fix: ``cleaned = strip_llm_json_fences(raw_text); parsed =
+# json.loads(cleaned)``.  Note that the *literal* pre-fix code used
+# ``json.loads(cleaned)`` — which this check does NOT flag by design,
+# because ``cleaned`` is a generic variable name used all over the
+# codebase for non-LLM JSON too.  The check instead targets the more
+# discriminating patterns (``.text`` attribute access and the specific
+# ``raw_text`` variable) that survive in the codebase today.
+#
+# This test reproduces the pattern that the nlp-pipeline files used at
+# the time of the fix — ``json.loads(raw_text)`` — to confirm detection.
+create_test_file "prefix2518_nlp.py" 'raw_text = response.content[0].text.strip()
+parsed = json.loads(raw_text)' > /dev/null
+assert_fails "Pre-fix #2518 pattern json.loads(raw_text) is detected"
+reset_tmpdir
+
+# ─── Test 16: Real-world Santa Clara LLM shape is caught ──────────────
+# The exact pattern in the pre-fix nlp-pipeline code.
+create_test_file "entity_extraction.py" '    raw_text = response.content[0].text.strip()
+    parsed = json.loads(raw_text)
+    return parsed.get("judge_name")' > /dev/null
+assert_fails "Real-world entity extraction pre-fix pattern is detected"
+reset_tmpdir
+
+# ─── Summary ──────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Adds `scripts/check-llm-json-loads.sh`, a lightweight grep-based lint that flags raw `json.loads(...)` calls on apparent LLM response text inside `packages/*/src/`, steering callers to `parse_llm_json` (or the inline `strict=False` fix) to prevent regressions of the #2518 control-character parsing bug fixed by PR #2543.
- Wires the check into CI as a new `llm-json-loads-check` job (pattern mirrors `hardcoded-colors-check`) and adds it to the `ci-passed` needs list.
- Fixes two `nlp-pipeline` callers (`entity_extraction/extractor.py`, `classification/classifier.py`) that still used raw `json.loads(raw_text)` — they pre-existed PR #2543's scope but match the same risk profile.

### Patterns the check flags

- `json.loads(<expr>.text<word-boundary>)` — `.text` is the LLM-response attribute across google-genai (`response.text`) and anthropic (`response.content[0].text`).
- `json.loads(raw_text)` — the literal variable name used by pre-fix callers.

Lines containing `strict=False` are skipped (safe opt-in). Comment lines and excluded dirs (`.venv`, `tests`, etc.) are ignored. Legitimate non-LLM sites (`llm_utils.py` source-of-truth, `sf_civil_tentatives.py` httpx HTTP-API response) are allowlisted with inline justification.

Closes #2550

## Test plan

### Automated checks

- [x] `scripts/tests/test_check_llm_json_loads.sh` — 16 cases pass locally (fail-cases, pass-cases including inline fix pattern, excluded dirs, non-Python files, two reproductions of the pre-fix #2518 pattern)
- [x] `scripts/check-llm-json-loads.sh` run against `packages/*/src/` — all clean
- [x] `nlp-pipeline` ruff check + format check — all passed
- [x] `nlp-pipeline` pytest — 59 passed, 100% coverage on `classifier.py` and `extractor.py`
- [x] CI `llm-json-loads-check` job runs green on this PR
- [x] CI `ci-passed` job runs green on this PR (includes the new check in needs list)

### Post-deploy verification

- [ ] N/A — CI/tooling only, no deployed component. Verification evidence comment on #2550 will note the skip reason.
