### PR TITLE
feat(ci): explicit helper-file filter in scripts-tests auto-runner (#2559)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,7 +556,13 @@ jobs:
       # were silently never running in CI because they'd never been added
       # to the list.
       #
-      # SKIP_PATTERNS: tests that are expensive AND already covered by a
+      # Runner logic lives in scripts/run-scripts-tests.sh so it is
+      # unit-testable (see scripts/tests/test_scripts_tests_runner.sh,
+      # #2559). Files whose basename starts with '_' are treated as
+      # shared helpers and are never executed as tests — see the runner
+      # for the full filter rules.
+      #
+      # SKIP_TESTS: tests that are expensive AND already covered by a
       # dedicated CI job with its own narrow path filter. Keeping them
       # here would mean running them twice whenever scripts/** changes.
       #
@@ -572,53 +578,7 @@ jobs:
           # Whitespace-separated list of test paths to defer to their own
           # dedicated CI jobs. See the comment above this step for why.
           SKIP_TESTS: "scripts/tests/test_pre_push.sh"
-        run: |
-          set -uo pipefail
-          shopt -s nullglob
-          tests=(scripts/tests/*.sh)
-          if [ ${#tests[@]} -eq 0 ]; then
-            echo "No shell test files found under scripts/tests/ — nothing to run."
-            exit 0
-          fi
-          # Returns 0 if $1 is listed in $SKIP_TESTS (whitespace-separated).
-          is_skipped() {
-            local target="$1"
-            local entry
-            for entry in $SKIP_TESTS; do
-              if [ "$entry" = "$target" ]; then
-                return 0
-              fi
-            done
-            return 1
-          }
-          failed=0
-          ran=0
-          skipped=0
-          deferred=0
-          for t in "${tests[@]}"; do
-            if is_skipped "$t"; then
-              echo "::notice::Deferring $t — covered by a dedicated CI job"
-              deferred=$((deferred + 1))
-              continue
-            fi
-            if [ ! -x "$t" ]; then
-              echo "::warning::Skipping $t — not executable (chmod +x required)"
-              skipped=$((skipped + 1))
-              continue
-            fi
-            echo "::group::$t"
-            if ! "$t"; then
-              echo "::error::$t failed"
-              failed=$((failed + 1))
-            fi
-            ran=$((ran + 1))
-            echo "::endgroup::"
-          done
-          echo "Ran $ran shell test(s). Skipped (not executable): $skipped. Deferred to dedicated jobs: $deferred. Failed: $failed."
-          if [ "$failed" -gt 0 ]; then
-            echo "::error::$failed shell test(s) failed."
-            exit 1
-          fi
+        run: scripts/run-scripts-tests.sh
 
   # ---------------------------------------------------------------
   # Coverage gates: diff coverage (new lines) + overall floor ratchet

--- a/scripts/run-scripts-tests.sh
+++ b/scripts/run-scripts-tests.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# run-scripts-tests.sh — auto-discover and run scripts/tests/*.sh shell tests.
+#
+# This is the runner logic for the `scripts-tests` CI job's "Run all
+# scripts/tests shell tests" step. Extracting it into a standalone script
+# makes the filter logic unit-testable (see
+# scripts/tests/test_scripts_tests_runner.sh).
+#
+# Discovery rules:
+#   1. Glob scripts/tests/*.sh (configurable via TESTS_DIR env var).
+#   2. Skip files whose basename starts with an underscore ('_*.sh') —
+#      these are shared helpers meant to be sourced, not executed as
+#      tests.
+#   3. Skip (defer) files listed in SKIP_TESTS (whitespace-separated
+#      repo-relative paths) — these run in a dedicated CI job.
+#   4. Warn on (and skip) files that are not executable.
+#   5. Run the remainder. Exit 1 if any failed, 0 otherwise.
+#
+# Environment variables:
+#   SKIP_TESTS   — whitespace-separated list of repo-relative test paths
+#                  to defer (e.g. "scripts/tests/test_pre_push.sh").
+#   TESTS_DIR    — tests directory (default: "scripts/tests"). Testing
+#                  hook: the unit test sets this to a temp directory.
+#
+# Exit codes:
+#   0 — all discovered tests passed (or none were discovered).
+#   1 — one or more tests failed.
+
+set -uo pipefail
+shopt -s nullglob
+
+: "${SKIP_TESTS:=}"
+: "${TESTS_DIR:=scripts/tests}"
+
+tests=("$TESTS_DIR"/*.sh)
+if [ ${#tests[@]} -eq 0 ]; then
+    echo "No shell test files found under $TESTS_DIR/ — nothing to run."
+    exit 0
+fi
+
+# Returns 0 if $1 is listed in $SKIP_TESTS (whitespace-separated).
+is_skipped() {
+    local target="$1"
+    local entry
+    for entry in $SKIP_TESTS; do
+        if [ "$entry" = "$target" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Returns 0 if the basename of $1 starts with an underscore, indicating
+# a shared helper file that should be sourced, not executed as a test.
+is_helper() {
+    local base
+    base="$(basename "$1")"
+    case "$base" in
+        _*) return 0 ;;
+        *)  return 1 ;;
+    esac
+}
+
+failed=0
+ran=0
+skipped=0
+deferred=0
+helpers=0
+
+for t in "${tests[@]}"; do
+    if is_helper "$t"; then
+        # Shared helpers (e.g. scripts/tests/_guard_self_match_helpers.sh)
+        # are sourced by peer tests, not executed standalone. Silently skip.
+        helpers=$((helpers + 1))
+        continue
+    fi
+    if is_skipped "$t"; then
+        echo "::notice::Deferring $t — covered by a dedicated CI job"
+        deferred=$((deferred + 1))
+        continue
+    fi
+    if [ ! -x "$t" ]; then
+        echo "::warning::Skipping $t — not executable (chmod +x required)"
+        skipped=$((skipped + 1))
+        continue
+    fi
+    echo "::group::$t"
+    if ! "$t"; then
+        echo "::error::$t failed"
+        failed=$((failed + 1))
+    fi
+    ran=$((ran + 1))
+    echo "::endgroup::"
+done
+
+echo "Ran $ran shell test(s). Helpers skipped (underscore prefix): $helpers. Skipped (not executable): $skipped. Deferred to dedicated jobs: $deferred. Failed: $failed."
+
+if [ "$failed" -gt 0 ]; then
+    echo "::error::$failed shell test(s) failed."
+    exit 1
+fi
+exit 0

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -5,9 +5,19 @@ Tests for standalone scripts in `scripts/`.
 ## CI Execution
 
 The `scripts-tests` CI job auto-discovers and runs every executable
-`scripts/tests/*.sh` under a single loop (see `.github/workflows/ci.yml`,
+`scripts/tests/*.sh` under a single loop. The runner logic lives in
+`scripts/run-scripts-tests.sh` (called from `.github/workflows/ci.yml`,
 job `scripts-tests`, step `Run all scripts/tests shell tests`). Adding a
 new shell test is just `touch + chmod +x` — no ci.yml edit required.
+
+### Shared helpers (underscore-prefixed files)
+
+Files whose basename starts with `_` (e.g.
+`_guard_self_match_helpers.sh`) are treated as **shared helpers** that
+peer tests `source` — they are never executed as tests by the runner.
+Use this naming convention for any sourced library file under
+`scripts/tests/`. See `scripts/run-scripts-tests.sh` and the unit test
+`test_scripts_tests_runner.sh` for the enforced behavior (#2559).
 
 ### Deferred tests (dedicated CI jobs)
 

--- a/scripts/tests/test_scripts_tests_runner.sh
+++ b/scripts/tests/test_scripts_tests_runner.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# test_scripts_tests_runner.sh — Tests for scripts/run-scripts-tests.sh.
+#
+# Exercises the auto-discovery + filter logic of the scripts-tests CI
+# runner against a synthetic tests directory. Confirms:
+#   1. Executable non-helper tests are run.
+#   2. Underscore-prefixed helper files are skipped (not executed).
+#   3. Non-executable files are warned about and skipped.
+#   4. SKIP_TESTS entries are deferred, not run.
+#   5. Empty directories exit 0.
+#   6. A failing test causes the runner to exit 1.
+#   7. The real scripts/tests/_guard_self_match_helpers.sh is not
+#      executed by the runner on this repo (regression guard for #2559).
+#
+# Usage:
+#   scripts/tests/test_scripts_tests_runner.sh
+#
+# Exit codes:
+#   0 — all tests passed.
+#   1 — one or more tests failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUNNER="$SCRIPT_DIR/run-scripts-tests.sh"
+
+if [[ ! -x "$RUNNER" ]]; then
+    echo "FATAL: runner $RUNNER is missing or not executable"
+    exit 1
+fi
+
+FAILURES=0
+TESTS=0
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+}
+
+# Writes an executable shell test that records its own path when run.
+# Args: <filename> <marker_name>
+make_passing_test() {
+    local path="$TMPDIR_TEST/$1"
+    local marker="$2"
+    cat >"$path" <<EOF
+#!/usr/bin/env bash
+touch "$TMPDIR_TEST/RAN_$marker"
+exit 0
+EOF
+    chmod +x "$path"
+}
+
+# Writes an executable shell test that fails (exits 1) and records it ran.
+make_failing_test() {
+    local path="$TMPDIR_TEST/$1"
+    local marker="$2"
+    cat >"$path" <<EOF
+#!/usr/bin/env bash
+touch "$TMPDIR_TEST/RAN_$marker"
+exit 1
+EOF
+    chmod +x "$path"
+}
+
+# Writes a helper file that explodes if executed (to catch accidental
+# invocation). Note: not chmod +x by default — callers may override.
+make_helper() {
+    local path="$TMPDIR_TEST/$1"
+    cat >"$path" <<EOF
+#!/usr/bin/env bash
+# Shared helper — sourced, not executed. If the runner ever calls this
+# as a test, mark that we ran so the test can fail loudly.
+touch "$TMPDIR_TEST/HELPER_EXECUTED_$1"
+exit 0
+EOF
+}
+
+run_runner() {
+    local skip_tests="${1:-}"
+    # shellcheck disable=SC2097,SC2098
+    TESTS_DIR="$TMPDIR_TEST" SKIP_TESTS="$skip_tests" "$RUNNER"
+}
+
+assert_eq() {
+    local desc="$1"
+    local expected="$2"
+    local actual="$3"
+    TESTS=$((TESTS + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected='$expected' actual='$actual')"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_file_exists() {
+    local desc="$1"
+    local path="$2"
+    TESTS=$((TESTS + 1))
+    if [[ -e "$path" ]]; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (missing: $path)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_file_absent() {
+    local desc="$1"
+    local path="$2"
+    TESTS=$((TESTS + 1))
+    if [[ ! -e "$path" ]]; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (exists but should not: $path)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# ─── Test 1: Executable non-helper tests run ────────────────────────────
+reset_tmpdir
+make_passing_test "test_alpha.sh" alpha
+make_passing_test "test_beta.sh" beta
+set +e
+out="$(run_runner 2>&1)"
+rc=$?
+set -e
+assert_eq "runner exits 0 when all tests pass" 0 "$rc"
+assert_file_exists "test_alpha.sh was executed" "$TMPDIR_TEST/RAN_alpha"
+assert_file_exists "test_beta.sh was executed" "$TMPDIR_TEST/RAN_beta"
+
+# ─── Test 2: Underscore-prefixed helpers are skipped ────────────────────
+reset_tmpdir
+make_passing_test "test_real.sh" real
+make_helper "_guard_helpers.sh"
+chmod +x "$TMPDIR_TEST/_guard_helpers.sh"  # even if executable, must NOT run
+set +e
+out="$(run_runner 2>&1)"
+rc=$?
+set -e
+assert_eq "runner exits 0 when helpers are present and all real tests pass" 0 "$rc"
+assert_file_exists "real test was executed" "$TMPDIR_TEST/RAN_real"
+assert_file_absent "executable _-prefixed helper was NOT executed" "$TMPDIR_TEST/HELPER_EXECUTED__guard_helpers.sh"
+
+# ─── Test 3: Non-executable files trigger warning, skipped ──────────────
+reset_tmpdir
+make_passing_test "test_alpha.sh" alpha
+path_nonexec="$TMPDIR_TEST/test_broken.sh"
+cat >"$path_nonexec" <<'EOF'
+#!/usr/bin/env bash
+exit 1  # should never run — not executable
+EOF
+# deliberately NOT chmod +x
+set +e
+out="$(run_runner 2>&1)"
+rc=$?
+set -e
+assert_eq "runner exits 0 when non-executable files are warned+skipped" 0 "$rc"
+assert_file_exists "executable test ran" "$TMPDIR_TEST/RAN_alpha"
+case "$out" in
+    *"Skipping $path_nonexec — not executable"*)
+        TESTS=$((TESTS + 1))
+        echo "PASS: non-executable skip warning present in output" ;;
+    *)
+        TESTS=$((TESTS + 1))
+        FAILURES=$((FAILURES + 1))
+        echo "FAIL: missing 'not executable' warning in runner output"
+        echo "---OUTPUT---"
+        echo "$out"
+        echo "---END---" ;;
+esac
+
+# ─── Test 4: SKIP_TESTS entries are deferred ────────────────────────────
+reset_tmpdir
+make_passing_test "test_alpha.sh" alpha
+make_failing_test "test_deferred.sh" deferred  # would fail if run!
+set +e
+out="$(run_runner "$TMPDIR_TEST/test_deferred.sh" 2>&1)"
+rc=$?
+set -e
+assert_eq "runner exits 0 when failing test is deferred via SKIP_TESTS" 0 "$rc"
+assert_file_exists "alpha ran" "$TMPDIR_TEST/RAN_alpha"
+assert_file_absent "deferred test did NOT run" "$TMPDIR_TEST/RAN_deferred"
+
+# ─── Test 5: Empty directory exits 0 ────────────────────────────────────
+reset_tmpdir
+set +e
+out="$(run_runner 2>&1)"
+rc=$?
+set -e
+assert_eq "runner exits 0 on empty tests directory" 0 "$rc"
+
+# ─── Test 6: A failing test causes exit 1 ───────────────────────────────
+reset_tmpdir
+make_passing_test "test_alpha.sh" alpha
+make_failing_test "test_bad.sh" bad
+set +e
+out="$(run_runner 2>&1)"
+rc=$?
+set -e
+assert_eq "runner exits 1 when a test fails" 1 "$rc"
+assert_file_exists "passing test still ran" "$TMPDIR_TEST/RAN_alpha"
+assert_file_exists "failing test ran (and failed)" "$TMPDIR_TEST/RAN_bad"
+
+# ─── Test 7: Regression guard — real scripts/tests/_guard_self_match_helpers.sh
+#            is not executed by the live runner (the production scenario).
+#            This is the specific scenario acceptance criterion 3 of #2559.
+# We can't actually run the live runner from scripts/tests/ here (it would
+# invoke every real test — a giant loop). Instead, assert that the real
+# helper file is present, is NOT chmod'd +x, AND does match the glob but
+# the is_helper filter would exclude it. We prove the last by calling the
+# runner over a synthetic dir containing a copy of the real helper.
+reset_tmpdir
+real_helper="$REPO_ROOT/scripts/tests/_guard_self_match_helpers.sh"
+if [[ -f "$real_helper" ]]; then
+    cp "$real_helper" "$TMPDIR_TEST/_guard_self_match_helpers.sh"
+    chmod +x "$TMPDIR_TEST/_guard_self_match_helpers.sh"  # worst-case permissions
+    make_passing_test "test_sentinel.sh" sentinel
+    set +e
+    out="$(run_runner 2>&1)"
+    rc=$?
+    set -e
+    assert_eq "runner exits 0 with real _guard_self_match_helpers.sh copy present" 0 "$rc"
+    assert_file_exists "sentinel test ran alongside the helper" "$TMPDIR_TEST/RAN_sentinel"
+    # The real helper would error out if invoked (unset $CHECK_SCRIPT).
+    # If it had been invoked, rc would be non-zero and "sentinel" would
+    # still have run, but the summary line would show "Failed: 1". Check:
+    case "$out" in
+        *"Failed: 0"*)
+            TESTS=$((TESTS + 1))
+            echo "PASS: real _guard_self_match_helpers.sh copy was NOT executed" ;;
+        *)
+            TESTS=$((TESTS + 1))
+            FAILURES=$((FAILURES + 1))
+            echo "FAIL: runner appears to have executed _guard_self_match_helpers.sh"
+            echo "---OUTPUT---"
+            echo "$out"
+            echo "---END---" ;;
+    esac
+else
+    TESTS=$((TESTS + 1))
+    echo "PASS: (skipped) real _guard_self_match_helpers.sh not present in repo — regression guard N/A"
+fi
+
+# ─── Summary ────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Extracts the `scripts-tests` CI runner into `scripts/run-scripts-tests.sh` and adds an explicit filter that skips any `scripts/tests/_*.sh` file (shared helpers sourced by peer tests). Previously the underscore-prefix helpers were safe only because they weren't `chmod +x`'d — the coupling was implicit. Making the exclusion part of the runner contract means a future `chmod +x` cannot accidentally promote a helper into an executed "test."

Closes #2559.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (new `test_scripts_tests_runner.sh`: 19/19)
- [x] CI green
- [x] `ci-job-skipped-check` passes (ci.yml edit correctly triggers `scripts-tests`)

### Post-deploy verification
- [x] N/A — no deployed component (CI config / tooling scripts only)
