### PR TITLE
refactor(ingestion): extract LLM enrichment result application into shared helper (#2286)

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -103,6 +103,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Extraction-methods tag recorded for every field populated by the LLM
+# enrichment stage (``_llm_enrich_fields`` → ``_apply_enrichment_result``).
+_ENRICHMENT_METHOD_TAG = "llm_enrichment"
+
 # ---------------------------------------------------------------------------
 # Markdown ↔ HTML/plain text for multimodal PDF extraction
 # ---------------------------------------------------------------------------
@@ -888,6 +892,88 @@ class IngestionWorker:
 
         return result if has_data else None
 
+    @staticmethod
+    def _apply_enrichment_result(
+        enrichment_result: Any,
+        *,
+        outcome: str | None,
+        motion_type: str | None,
+        case_title: str | None,
+        parties_data: list[dict[str, str]],
+    ) -> tuple[
+        str | None,
+        str | None,
+        str | None,
+        list[dict[str, str]],
+        dict[str, str],
+    ]:
+        """Merge an LLM enrichment result into the current field values.
+
+        Applies ``enrichment_result`` fields (``outcome``, ``motion_type``,
+        ``case_title``, ``parties``) to the current values, preserving the
+        precedence rule that existing values are never overwritten — the
+        enrichment only fills fields that are currently missing.  Also
+        converts :class:`EnrichmentParties` (plaintiffs/defendants lists)
+        to the ``list[dict]`` format used by the rest of the pipeline.
+
+        Parameters
+        ----------
+        enrichment_result :
+            An :class:`LlmEnrichmentResult` (or ``None``).  The parameter is
+            typed loosely so callers do not need to import the class at the
+            top of the module (avoids a circular-import concern mirroring
+            the lazy import in :meth:`_llm_enrich_fields`).  When ``None``,
+            all current values are returned unchanged and the methods dict
+            is empty.
+        outcome, motion_type, case_title, parties_data :
+            Current values to merge into.
+
+        Returns
+        -------
+        tuple
+            ``(outcome, motion_type, case_title, parties_data,
+            extraction_methods_entries)``.  ``extraction_methods_entries``
+            contains one entry per field the helper actually populated,
+            each mapping the field name to the enrichment method tag.
+            Fields that were left unchanged (either already set or absent
+            from the enrichment result) are NOT present.
+
+        Notes
+        -----
+        A parallel implementation exists in ``scripts/reingest_from_s3.py``
+        that operates on a dict instead of individual variables.  Any
+        schema change (new field, renamed field) must be applied in both
+        places.
+        """
+        methods: dict[str, str] = {}
+        method_tag = _ENRICHMENT_METHOD_TAG
+
+        if enrichment_result is None:
+            return outcome, motion_type, case_title, parties_data, methods
+
+        if outcome is None and enrichment_result.outcome is not None:
+            outcome = enrichment_result.outcome
+            methods["outcome"] = method_tag
+        if motion_type is None and enrichment_result.motion_type is not None:
+            motion_type = enrichment_result.motion_type
+            methods["motion_type"] = method_tag
+        if not case_title and enrichment_result.case_title is not None:
+            case_title = enrichment_result.case_title
+            methods["case_title"] = method_tag
+        if not parties_data and (
+            enrichment_result.parties.plaintiffs or enrichment_result.parties.defendants
+        ):
+            # Convert from EnrichmentParties to the parties_data
+            # list[dict] format used by the rest of the pipeline.
+            parties_data = []
+            for name in enrichment_result.parties.plaintiffs:
+                parties_data.append({"name": name, "role": "plaintiff"})
+            for name in enrichment_result.parties.defendants:
+                parties_data.append({"name": name, "role": "defendant"})
+            methods["parties"] = method_tag
+
+        return outcome, motion_type, case_title, parties_data, methods
+
     def _file_validation_issue(
         self,
         *,
@@ -1368,27 +1454,20 @@ class IngestionWorker:
         )
         if enrichment_fields_missing:
             enrichment_result = self._llm_enrich_fields(ruling_text, document_id)
-            if enrichment_result is not None:
-                if outcome is None and enrichment_result.outcome is not None:
-                    outcome = enrichment_result.outcome
-                    extraction_methods["outcome"] = "llm_enrichment"
-                if motion_type is None and enrichment_result.motion_type is not None:
-                    motion_type = enrichment_result.motion_type
-                    extraction_methods["motion_type"] = "llm_enrichment"
-                if not case_title and enrichment_result.case_title is not None:
-                    case_title = enrichment_result.case_title
-                    extraction_methods["case_title"] = "llm_enrichment"
-                if not parties_data and (
-                    enrichment_result.parties.plaintiffs or enrichment_result.parties.defendants
-                ):
-                    # Convert from EnrichmentParties to the parties_data
-                    # list[dict] format used by the rest of the pipeline.
-                    parties_data = []
-                    for name in enrichment_result.parties.plaintiffs:
-                        parties_data.append({"name": name, "role": "plaintiff"})
-                    for name in enrichment_result.parties.defendants:
-                        parties_data.append({"name": name, "role": "defendant"})
-                    extraction_methods["parties"] = "llm_enrichment"
+            (
+                outcome,
+                motion_type,
+                case_title,
+                parties_data,
+                enrichment_methods,
+            ) = self._apply_enrichment_result(
+                enrichment_result,
+                outcome=outcome,
+                motion_type=motion_type,
+                case_title=case_title,
+                parties_data=parties_data,
+            )
+            extraction_methods.update(enrichment_methods)
 
         # ------------------------------------------------------------------
         # Remaining regex fallbacks — hearing_date, judge_name, case_number,

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -4831,6 +4831,283 @@ def test_enrichment_enabled_by_default() -> None:
 
 
 # ---------------------------------------------------------------------------
+# IngestionWorker._apply_enrichment_result — shared helper for merging an
+# LlmEnrichmentResult into the current field values (#2286).
+# ---------------------------------------------------------------------------
+
+
+def test_apply_enrichment_result_returns_inputs_when_result_is_none() -> None:
+    """None enrichment_result returns inputs unchanged and empty methods dict."""
+    outcome, motion_type, case_title, parties_data, methods = (
+        IngestionWorker._apply_enrichment_result(
+            None,
+            outcome=None,
+            motion_type=None,
+            case_title=None,
+            parties_data=[],
+        )
+    )
+    assert outcome is None
+    assert motion_type is None
+    assert case_title is None
+    assert parties_data == []
+    assert methods == {}
+
+
+def test_apply_enrichment_result_returns_inputs_when_result_is_none_with_values() -> None:
+    """None enrichment_result preserves any existing values."""
+    outcome, motion_type, case_title, parties_data, methods = (
+        IngestionWorker._apply_enrichment_result(
+            None,
+            outcome="granted",
+            motion_type="msj",
+            case_title="Existing v. Case",
+            parties_data=[{"name": "Alpha", "role": "plaintiff"}],
+        )
+    )
+    assert outcome == "granted"
+    assert motion_type == "msj"
+    assert case_title == "Existing v. Case"
+    assert parties_data == [{"name": "Alpha", "role": "plaintiff"}]
+    assert methods == {}
+
+
+def test_apply_enrichment_result_fills_all_missing_fields() -> None:
+    """All four fields are populated when currently missing and result has them."""
+    from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+
+    result = LlmEnrichmentResult(
+        case_title="Alpha v. Beta",
+        motion_type="msj",
+        outcome="granted",
+        parties=EnrichmentParties(plaintiffs=["Alpha"], defendants=["Beta"]),
+    )
+
+    outcome, motion_type, case_title, parties_data, methods = (
+        IngestionWorker._apply_enrichment_result(
+            result,
+            outcome=None,
+            motion_type=None,
+            case_title=None,
+            parties_data=[],
+        )
+    )
+
+    assert outcome == "granted"
+    assert motion_type == "msj"
+    assert case_title == "Alpha v. Beta"
+    assert parties_data == [
+        {"name": "Alpha", "role": "plaintiff"},
+        {"name": "Beta", "role": "defendant"},
+    ]
+    assert methods == {
+        "outcome": "llm_enrichment",
+        "motion_type": "llm_enrichment",
+        "case_title": "llm_enrichment",
+        "parties": "llm_enrichment",
+    }
+
+
+def test_apply_enrichment_result_does_not_overwrite_existing_fields() -> None:
+    """Existing values are preserved — helper only fills missing fields."""
+    from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+
+    result = LlmEnrichmentResult(
+        case_title="New Title",
+        motion_type="mtd",
+        outcome="denied",
+        parties=EnrichmentParties(plaintiffs=["NewP"], defendants=["NewD"]),
+    )
+
+    existing_parties = [{"name": "ExistingP", "role": "plaintiff"}]
+    outcome, motion_type, case_title, parties_data, methods = (
+        IngestionWorker._apply_enrichment_result(
+            result,
+            outcome="granted",
+            motion_type="msj",
+            case_title="Existing Title",
+            parties_data=existing_parties,
+        )
+    )
+
+    assert outcome == "granted"
+    assert motion_type == "msj"
+    assert case_title == "Existing Title"
+    assert parties_data == existing_parties
+    assert methods == {}
+
+
+def test_apply_enrichment_result_partial_fill() -> None:
+    """Only missing fields are filled; already-set fields are untouched."""
+    from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+
+    result = LlmEnrichmentResult(
+        case_title="From LLM",
+        motion_type="msj",
+        outcome="granted",
+        parties=EnrichmentParties(plaintiffs=["Alpha"], defendants=["Beta"]),
+    )
+
+    # outcome + parties already set; motion_type + case_title missing.
+    existing_parties = [{"name": "Existing", "role": "plaintiff"}]
+    outcome, motion_type, case_title, parties_data, methods = (
+        IngestionWorker._apply_enrichment_result(
+            result,
+            outcome="denied",
+            motion_type=None,
+            case_title=None,
+            parties_data=existing_parties,
+        )
+    )
+
+    assert outcome == "denied"  # preserved
+    assert motion_type == "msj"  # filled
+    assert case_title == "From LLM"  # filled
+    assert parties_data == existing_parties  # preserved
+    assert methods == {
+        "motion_type": "llm_enrichment",
+        "case_title": "llm_enrichment",
+    }
+
+
+def test_apply_enrichment_result_parties_conversion_multiple() -> None:
+    """EnrichmentParties with multiple plaintiffs/defendants converts correctly."""
+    from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+
+    result = LlmEnrichmentResult(
+        parties=EnrichmentParties(
+            plaintiffs=["A1", "A2"],
+            defendants=["B1", "B2", "B3"],
+        ),
+    )
+
+    outcome, motion_type, case_title, parties_data, methods = (
+        IngestionWorker._apply_enrichment_result(
+            result,
+            outcome=None,
+            motion_type=None,
+            case_title=None,
+            parties_data=[],
+        )
+    )
+
+    assert parties_data == [
+        {"name": "A1", "role": "plaintiff"},
+        {"name": "A2", "role": "plaintiff"},
+        {"name": "B1", "role": "defendant"},
+        {"name": "B2", "role": "defendant"},
+        {"name": "B3", "role": "defendant"},
+    ]
+    assert methods == {"parties": "llm_enrichment"}
+
+
+def test_apply_enrichment_result_no_parties_when_both_lists_empty() -> None:
+    """Parties field is NOT filled when both plaintiffs and defendants are empty."""
+    from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+
+    result = LlmEnrichmentResult(
+        case_title="Alpha v. Beta",
+        parties=EnrichmentParties(plaintiffs=[], defendants=[]),
+    )
+
+    outcome, motion_type, case_title, parties_data, methods = (
+        IngestionWorker._apply_enrichment_result(
+            result,
+            outcome=None,
+            motion_type=None,
+            case_title=None,
+            parties_data=[],
+        )
+    )
+
+    assert case_title == "Alpha v. Beta"
+    assert parties_data == []
+    assert "parties" not in methods
+    assert methods == {"case_title": "llm_enrichment"}
+
+
+def test_apply_enrichment_result_parties_plaintiffs_only() -> None:
+    """Parties populated when plaintiffs list is non-empty but defendants is empty."""
+    from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+
+    result = LlmEnrichmentResult(
+        parties=EnrichmentParties(plaintiffs=["OnlyP"], defendants=[]),
+    )
+
+    _, _, _, parties_data, methods = IngestionWorker._apply_enrichment_result(
+        result,
+        outcome=None,
+        motion_type=None,
+        case_title=None,
+        parties_data=[],
+    )
+
+    assert parties_data == [{"name": "OnlyP", "role": "plaintiff"}]
+    assert methods == {"parties": "llm_enrichment"}
+
+
+def test_apply_enrichment_result_parties_defendants_only() -> None:
+    """Parties populated when defendants list is non-empty but plaintiffs is empty."""
+    from framework.llm_enrichment import EnrichmentParties, LlmEnrichmentResult
+
+    result = LlmEnrichmentResult(
+        parties=EnrichmentParties(plaintiffs=[], defendants=["OnlyD"]),
+    )
+
+    _, _, _, parties_data, methods = IngestionWorker._apply_enrichment_result(
+        result,
+        outcome=None,
+        motion_type=None,
+        case_title=None,
+        parties_data=[],
+    )
+
+    assert parties_data == [{"name": "OnlyD", "role": "defendant"}]
+    assert methods == {"parties": "llm_enrichment"}
+
+
+def test_apply_enrichment_result_empty_result_yields_no_changes() -> None:
+    """An LlmEnrichmentResult with all fields None/empty produces no changes."""
+    from framework.llm_enrichment import LlmEnrichmentResult
+
+    result = LlmEnrichmentResult()  # all fields default: None / empty lists
+
+    outcome, motion_type, case_title, parties_data, methods = (
+        IngestionWorker._apply_enrichment_result(
+            result,
+            outcome=None,
+            motion_type=None,
+            case_title=None,
+            parties_data=[],
+        )
+    )
+
+    assert outcome is None
+    assert motion_type is None
+    assert case_title is None
+    assert parties_data == []
+    assert methods == {}
+
+
+def test_apply_enrichment_result_case_title_empty_string_treated_as_missing() -> None:
+    """An empty string case_title is treated as missing and overwritten (matches original)."""
+    from framework.llm_enrichment import LlmEnrichmentResult
+
+    result = LlmEnrichmentResult(case_title="Filled Title")
+
+    _, _, case_title, _, methods = IngestionWorker._apply_enrichment_result(
+        result,
+        outcome=None,
+        motion_type=None,
+        case_title="",  # falsy — original code uses `not case_title`
+        parties_data=[],
+    )
+
+    assert case_title == "Filled Title"
+    assert methods == {"case_title": "llm_enrichment"}
+
+
+# ---------------------------------------------------------------------------
 # Worker-level guards for Ventura (#2370): implausible hearing date, repeated
 # title segments, trailing case number, probate decedent as judge.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Refactor the LLM enrichment result application logic in `IngestionWorker.process_event()` into a new shared static helper `_apply_enrichment_result()`. The helper preserves the "fill only when currently missing" precedence, converts `EnrichmentParties` plaintiffs/defendants lists into the pipeline's `list[dict]` format, and returns the updated field values plus an `extraction_methods` delta dict.

Also introduces a module-level `_ENRICHMENT_METHOD_TAG = "llm_enrichment"` constant so the per-field method label appears only once. The grep count of the literal string `"llm_enrichment"` in `worker.py` drops from 8 to 5.

**Scope note:** The issue description references two inline enrichment blocks (standard and multimodal), but PR #2178 already consolidated those into a single block. The refactor still applies — it extracts that single block into a reusable helper and reduces the literal-string duplication.

Closes #2286

## Test plan

### Automated checks
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/` passes (scraper-framework)
- [x] Diff coverage on changed lines >= 90%
- [x] `grep -c "llm_enrichment" packages/scraper-framework/src/ingestion/worker.py` returns fewer matches (was 8, now 5)
- [x] 11 new unit tests for `_apply_enrichment_result` cover every branch
- [x] All 8 existing `test_llm_enrichment_*` integration tests pass unchanged
- [x] CI green

### Post-deploy verification
- [x] Ingestion worker image `c7122cf` deployed on dev as task definition revision 472 (PRIMARY). Smoke test via `scripts/ecs-run-task.sh --latest-image` confirms the new helper `_apply_enrichment_result` + constant `_ENRICHMENT_METHOD_TAG` load cleanly and the None-result branch preserves inputs — see verification evidence on #2286. Note: `Deploy Ingestion Worker to Dev` reported a false failure due to `wait-for-rollout.sh` timing out on services at `desiredCount=0`; filed as #2585. Underlying ECS deployment actually completed successfully.
