### PR TITLE
feat(infra): add apply_immediately toggle to database module, enable in dev (#2573)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -70,6 +70,12 @@ module "database" {
   # documented in #2549. See docs/agent/infrastructure-reference.md
   # §Dev DB Connection Budget.
   instance_class = "db.t4g.small"
+
+  # Dev applies instance-class and parameter-group changes on the next apply
+  # rather than deferring to the weekly maintenance window (Sun 05:00-06:00 UTC).
+  # Production keeps the default (false) to minimize surprise reboots during
+  # business hours. See #2573.
+  apply_immediately = true
 }
 
 module "cache" {

--- a/infra/terraform/modules/database/main.tf
+++ b/infra/terraform/modules/database/main.tf
@@ -42,6 +42,12 @@ variable "sslmode" {
   }
 }
 
+variable "apply_immediately" {
+  description = "Apply RDS modifications immediately instead of deferring to the next maintenance window. Defaults to false so production-grade environments keep the safer maintenance-window behavior; set to true in dev so changes land on the next apply rather than waiting for Sunday 05:00 UTC."
+  type        = bool
+  default     = false
+}
+
 # ─── Password ──────────────────────────────────────────────
 
 resource "random_password" "db" {
@@ -115,6 +121,8 @@ resource "aws_db_instance" "main" {
   final_snapshot_identifier = var.environment == "production" ? "judgemind-${var.environment}-final" : null
 
   performance_insights_enabled = true
+
+  apply_immediately = var.apply_immediately
 
   tags = {
     Name = "judgemind-${var.environment}"


### PR DESCRIPTION
## Summary

Adds an `apply_immediately` variable (default `false`) to the Terraform `database` module and sets it to `true` in the dev environment. This makes RDS modifications (instance-class changes, parameter-group changes) land on the next `terraform apply` in dev instead of deferring to the Sun 05:00-06:00 UTC maintenance window. Production does not instantiate the module and is unaffected.

Context: #2549 / PR #2554 — the merged dev `db.t4g.micro → db.t4g.small` resize required a manual `aws rds modify-db-instance --apply-immediately` to run the same day.

Closes #2573

## Test plan

### Automated checks
- [x] `terraform fmt -check -recursive` passes
- [x] `terraform validate` passes for `environments/dev`
- [x] `terraform validate` passes for `environments/production`
- [x] CI green

### Post-deploy verification
- [x] Dev `terraform plan` confirms `apply_immediately = false -> true` on `module.database.aws_db_instance.main` with no unintended drift on the DB resource.
- [x] `aws rds describe-db-instances --db-instance-identifier judgemind-dev` shows `PendingModifiedValues = {}` and `DBInstanceStatus = "available"`.
- [x] Verification evidence posted on issue #2573.
