### PR TITLE
feat(web): add ESLint rule to prevent misleading TableRow hover affordance (#2156)

### DIFF
--- a/docs/web-patterns.md
+++ b/docs/web-patterns.md
@@ -252,6 +252,48 @@ const { handleLoadMore } = useInfiniteScroll<MyData>({
 - Place the `<InfiniteScrollTrigger>` immediately after the last rendered row, inside the same container.
 - The component renders an invisible 1px sentinel div and hides itself while loading to prevent duplicate fetches.
 
+### Clickable Table Rows
+
+Shadcn's `TableRow` component applies `hover:bg-muted/50` by default, which makes every row *look* clickable on hover. This is a misleading affordance unless the row itself is actually navigable. The same UX bug has been fixed reactively on the cases, rulings, and judges tables — this pattern prevents future regressions.
+
+**Rule:** if a `TableRow` contains a navigation `<Link>` or `<a>`, the entire row must be clickable.
+
+- Put `onClick={() => router.push(...)}` on the `TableRow`, with `cursor-pointer`.
+- Put `onClick={(e) => e.stopPropagation()}` on any interactive elements inside the row — checkboxes, buttons, and the nested link itself (so cmd+click / right-click still open the link in a new tab without triggering the row's navigation).
+- Header rows (`<TableRow>` inside `<TableHeader>`, i.e. rows containing only `<TableHead>` children) are not expected to be clickable — they can safely contain `<Link>` without a row-level `onClick`.
+
+**Pattern (from `JudgesList.tsx`):**
+
+```tsx
+<TableRow
+  key={node.id}
+  className="cursor-pointer"
+  onClick={() => router.push(`/judges/${node.id}`)}
+>
+  <TableCell className="w-10" onClick={(e) => e.stopPropagation()}>
+    <Checkbox
+      checked={isSelected}
+      onCheckedChange={() => toggleSelection(node.id)}
+      aria-label={`Select ${node.canonicalName}`}
+    />
+  </TableCell>
+  <TableCell>
+    <Link
+      href={`/judges/${node.id}`}
+      className="rounded-sm font-medium hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      onClick={(e) => e.stopPropagation()}
+    >
+      {node.canonicalName}
+    </Link>
+  </TableCell>
+  {/* ... */}
+</TableRow>
+```
+
+**Enforcement:** an ESLint rule (`local/clickable-table-row`) flags any `<TableRow>` that contains a nested `<Link>` or `<a>` without an `onClick` handler on the row itself. See `packages/web/eslint-rules/clickable-table-row.js`.
+
+**Alternative:** for list pages where every column is informational (no checkboxes, no inline buttons), prefer the `<Link>`-wrapped row pattern used in `CasesList` and `RulingsFeed` — the entire row is a `<Link>` with `className="block ..."`. This gives native right-click / cmd-click behavior without needing `stopPropagation` plumbing. The `TableRow` + `onClick` pattern is appropriate when the row contains selection checkboxes or other interactive controls that cannot live inside an `<a>` tag.
+
 ### Loading States
 
 - Skeleton loaders matching the shape of the content they replace

--- a/packages/web/.eslintrc.json
+++ b/packages/web/.eslintrc.json
@@ -18,6 +18,12 @@
       }
     },
     {
+      "files": ["src/app/**/*.{ts,tsx}", "src/components/**/*.{ts,tsx}"],
+      "rules": {
+        "local/clickable-table-row": "error"
+      }
+    },
+    {
       "files": ["**/__tests__/**", "**/*.test.ts", "**/*.test.tsx", "tests/**"],
       "rules": {
         "local/no-client-utility-import": "off"

--- a/packages/web/eslint-plugin-local/index.js
+++ b/packages/web/eslint-plugin-local/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   rules: {
+    'clickable-table-row': require('../eslint-rules/clickable-table-row'),
     'no-client-utility-import': require('../eslint-rules/no-client-utility-import'),
     'no-ssr-incompatible-import': require('../eslint-rules/no-ssr-incompatible-import'),
     'prefer-path-alias': require('../eslint-rules/prefer-path-alias'),

--- a/packages/web/eslint-rules/clickable-table-row.js
+++ b/packages/web/eslint-rules/clickable-table-row.js
@@ -1,0 +1,234 @@
+/**
+ * ESLint rule: clickable-table-row
+ *
+ * Flags `<TableRow>` elements that contain a nested `<Link>` (or `<a>`) but
+ * no `onClick` handler on the row itself. The shadcn `TableRow` component
+ * applies a default `hover:bg-muted/50` highlight that makes every row
+ * *look* clickable on hover, even when only a nested link is navigable.
+ * This mismatched affordance has produced the same UX bug three separate
+ * times (cases, rulings, judges) before this rule existed.
+ *
+ * The approved pattern — documented in `docs/web-patterns.md` §Clickable
+ * Table Rows — is:
+ *
+ *   <TableRow
+ *     className="cursor-pointer"
+ *     onClick={() => router.push(`/detail/${id}`)}
+ *   >
+ *     <TableCell onClick={(e) => e.stopPropagation()}>
+ *       <Checkbox ... />
+ *     </TableCell>
+ *     <TableCell>
+ *       <Link href={...} onClick={(e) => e.stopPropagation()}>...</Link>
+ *     </TableCell>
+ *   </TableRow>
+ *
+ * The row itself navigates; nested interactive elements (checkboxes, buttons,
+ * the link itself for right-click / cmd-click affordance) stop propagation.
+ *
+ * Header rows (the `<TableRow>` inside `<TableHeader>`) are NOT expected to
+ * be clickable. The rule detects header rows by looking at their cell
+ * children: a row containing only `<TableHead>` children is treated as a
+ * header row and skipped.
+ *
+ * @see https://github.com/judgemind/judgemind/issues/2156
+ */
+
+'use strict';
+
+/**
+ * Extract the element name from a JSX opening element.
+ * Returns the full dotted name (e.g. "foo.Bar") for member expressions.
+ */
+function getElementName(openingElement) {
+  const name = openingElement.name;
+  if (name.type === 'JSXIdentifier') {
+    return name.name;
+  }
+  if (name.type === 'JSXMemberExpression') {
+    const parts = [];
+    let current = name;
+    while (current.type === 'JSXMemberExpression') {
+      parts.unshift(current.property.name);
+      current = current.object;
+    }
+    if (current.type === 'JSXIdentifier') {
+      parts.unshift(current.name);
+    }
+    return parts.join('.');
+  }
+  return null;
+}
+
+/**
+ * Check whether a JSX element has an attribute with the given name, either
+ * as a named attribute (`onClick={...}`) or via JSX spread (`{...props}`).
+ *
+ * Spread attributes may contain `onClick` at runtime — we cannot statically
+ * determine this. To avoid false positives for reasonable patterns like
+ * `<TableRow {...rowProps}>`, treat any spread attribute as potentially
+ * providing `onClick`.
+ */
+function hasAttributeOrSpread(openingElement, attrName) {
+  for (const attr of openingElement.attributes) {
+    if (attr.type === 'JSXSpreadAttribute') {
+      return true;
+    }
+    if (
+      attr.type === 'JSXAttribute' &&
+      attr.name.type === 'JSXIdentifier' &&
+      attr.name.name === attrName
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Walk all JSX descendants of a node and invoke the visitor for each
+ * JSXElement encountered. Stops descending into a subtree if the visitor
+ * returns the sentinel value `SKIP_SUBTREE`.
+ */
+const SKIP_SUBTREE = Symbol('SKIP_SUBTREE');
+
+function walkJsxChildren(node, visit) {
+  if (!node || !node.children) return;
+  for (const child of node.children) {
+    if (child.type === 'JSXElement') {
+      const result = visit(child);
+      if (result !== SKIP_SUBTREE) {
+        walkJsxChildren(child, visit);
+      }
+    } else if (child.type === 'JSXFragment') {
+      walkJsxChildren(child, visit);
+    } else if (child.type === 'JSXExpressionContainer') {
+      // Descend into expression containers to find JSX inside map callbacks,
+      // ternaries, logical expressions, etc.
+      walkExpression(child.expression, visit);
+    }
+  }
+}
+
+function walkExpression(expr, visit) {
+  if (!expr || typeof expr !== 'object') return;
+
+  if (expr.type === 'JSXElement') {
+    const result = visit(expr);
+    if (result !== SKIP_SUBTREE) {
+      walkJsxChildren(expr, visit);
+    }
+    return;
+  }
+  if (expr.type === 'JSXFragment') {
+    walkJsxChildren(expr, visit);
+    return;
+  }
+
+  // Traverse common expression shapes that can contain JSX.
+  const childKeys = [
+    'consequent', 'alternate', 'body', 'argument', 'left', 'right',
+    'expression', 'expressions', 'elements', 'callee', 'arguments',
+    'object', 'property', 'value',
+  ];
+  for (const key of childKeys) {
+    const child = expr[key];
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        walkExpression(item, visit);
+      }
+    } else if (child && typeof child === 'object' && child.type) {
+      walkExpression(child, visit);
+    }
+  }
+}
+
+/**
+ * Determine whether a TableRow is a header row. Heuristic: a header row
+ * contains `<TableHead>` children but no `<TableCell>` children. We only
+ * inspect direct children (not descendants) so a data row with a nested
+ * header-like element is not accidentally skipped.
+ */
+function isHeaderRow(tableRowElement) {
+  let sawTableHead = false;
+  let sawTableCell = false;
+  for (const child of tableRowElement.children) {
+    if (child.type !== 'JSXElement') continue;
+    const name = getElementName(child.openingElement);
+    if (name === 'TableHead') sawTableHead = true;
+    if (name === 'TableCell') sawTableCell = true;
+  }
+  return sawTableHead && !sawTableCell;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Enforce that <TableRow> elements containing a nested <Link> or <a> ' +
+        'also have an onClick handler. Rows look clickable on hover but are ' +
+        'not navigable unless the row itself handles the click.',
+      recommended: false,
+    },
+    messages: {
+      missingOnClick:
+        '<TableRow> contains a nested <{{linkName}}> but has no onClick handler. ' +
+        'The row appears clickable due to the default hover highlight, but only ' +
+        'the inner link is navigable — a misleading affordance. Add ' +
+        'onClick={() => router.push(...)} with cursor-pointer on the row, and ' +
+        'onClick={(e) => e.stopPropagation()} on the nested <{{linkName}}>. ' +
+        'See docs/web-patterns.md §Clickable Table Rows. ' +
+        'Tracked in https://github.com/judgemind/judgemind/issues/2156',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      JSXElement(node) {
+        const name = getElementName(node.openingElement);
+        if (name !== 'TableRow') {
+          return;
+        }
+
+        // Header rows are not expected to navigate — skip them.
+        if (isHeaderRow(node)) {
+          return;
+        }
+
+        // If the row already has onClick (or a spread that might provide it),
+        // the affordance is correct.
+        if (hasAttributeOrSpread(node.openingElement, 'onClick')) {
+          return;
+        }
+
+        // Search descendants for a <Link> or <a> element. Stop descending
+        // into any nested <TableRow> — those are a separate concern and
+        // will be visited on their own by the JSXElement visitor.
+        let foundLinkName = null;
+        walkJsxChildren(node, (descendant) => {
+          if (foundLinkName) return SKIP_SUBTREE;
+          const descName = getElementName(descendant.openingElement);
+          if (descName === 'TableRow') {
+            return SKIP_SUBTREE;
+          }
+          if (descName === 'Link' || descName === 'a') {
+            foundLinkName = descName;
+            return SKIP_SUBTREE;
+          }
+          return undefined;
+        });
+
+        if (foundLinkName) {
+          context.report({
+            node: node.openingElement,
+            messageId: 'missingOnClick',
+            data: { linkName: foundLinkName },
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/web/tests/eslint-rules/clickable-table-row.test.ts
+++ b/packages/web/tests/eslint-rules/clickable-table-row.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+
+// Load the rule
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const rule = require('../../eslint-rules/clickable-table-row');
+
+// ---------------------------------------------------------------------------
+// Helper: lint JSX code with the rule using ESLint's Linter API
+//
+// The default espree parser supports JSX when ecmaFeatures.jsx is enabled.
+// We do not need @typescript-eslint/parser for the JS/JSX-level constructs
+// this rule inspects (opening element names, attribute names, JSX children).
+// ---------------------------------------------------------------------------
+
+function lintCode(code: string): Linter.LintMessage[] {
+  const linter = new Linter();
+  linter.defineRule('clickable-table-row', rule);
+  return linter.verify(
+    code,
+    {
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+      },
+      rules: { 'clickable-table-row': 'error' },
+    },
+    { filename: '/fake/src/app/rulings/page.tsx' },
+  );
+}
+
+// Wrap a JSX snippet in a minimal component so the parser can handle it.
+function wrap(jsx: string): string {
+  return [
+    `import React from 'react';`,
+    `import Link from 'next/link';`,
+    `import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';`,
+    ``,
+    `export function Component() {`,
+    `  return (`,
+    `    ${jsx}`,
+    `  );`,
+    `}`,
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('clickable-table-row', () => {
+  // --- Valid cases (no errors) ---
+
+  it('allows a TableRow with onClick and a nested Link', () => {
+    const messages = lintCode(
+      wrap(`
+        <TableRow onClick={() => {}}>
+          <TableCell>
+            <Link href="/foo" onClick={(e) => e.stopPropagation()}>Name</Link>
+          </TableCell>
+        </TableRow>
+      `),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows a TableRow without any Link (plain data row)', () => {
+    const messages = lintCode(
+      wrap(`
+        <TableRow>
+          <TableCell>Plain text</TableCell>
+          <TableCell>More text</TableCell>
+        </TableRow>
+      `),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows a header TableRow containing Link inside TableHead', () => {
+    const messages = lintCode(
+      wrap(`
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>
+                <Link href="/judges/1">Judge Name</Link>
+              </TableHead>
+              <TableHead>Metric</TableHead>
+            </TableRow>
+          </TableHeader>
+        </Table>
+      `),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows a TableRow with a spread attribute (may provide onClick at runtime)', () => {
+    // Spread attributes cannot be statically analyzed for onClick — we treat
+    // them as potentially providing the handler to avoid false positives.
+    const messages = lintCode(
+      wrap(`
+        <TableRow {...rowProps}>
+          <TableCell>
+            <Link href="/foo">Name</Link>
+          </TableCell>
+        </TableRow>
+      `),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows multiple TableRows with the correct pattern', () => {
+    const messages = lintCode(
+      wrap(`
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow onClick={() => {}}>
+              <TableCell>
+                <Link href="/foo" onClick={(e) => e.stopPropagation()}>Alice</Link>
+              </TableCell>
+            </TableRow>
+            <TableRow onClick={() => {}}>
+              <TableCell>
+                <Link href="/bar" onClick={(e) => e.stopPropagation()}>Bob</Link>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      `),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  // --- Invalid cases (should produce errors) ---
+
+  it('reports error for TableRow with nested Link but no onClick', () => {
+    const messages = lintCode(
+      wrap(`
+        <TableRow>
+          <TableCell>
+            <Link href="/foo">Name</Link>
+          </TableCell>
+        </TableRow>
+      `),
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('onClick');
+    expect(messages[0].message).toContain('<TableRow>');
+    expect(messages[0].message).toContain('Link');
+    expect(messages[0].message).toContain('2156');
+    expect(messages[0].severity).toBe(2); // error
+  });
+
+  it('reports error for TableRow with nested <a> tag but no onClick', () => {
+    const messages = lintCode(
+      wrap(`
+        <TableRow>
+          <TableCell>
+            <a href="/foo">Name</a>
+          </TableCell>
+        </TableRow>
+      `),
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('onClick');
+  });
+
+  it('reports error for TableRow with deeply nested Link (inside a div inside TableCell)', () => {
+    const messages = lintCode(
+      wrap(`
+        <TableRow>
+          <TableCell>
+            <div className="wrapper">
+              <span><Link href="/foo">Name</Link></span>
+            </div>
+          </TableCell>
+        </TableRow>
+      `),
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('onClick');
+  });
+
+  it('reports error for TableRow rendered inside a map without onClick', () => {
+    const messages = lintCode(
+      wrap(`
+        <TableBody>
+          {items.map((item) => (
+            <TableRow key={item.id}>
+              <TableCell>
+                <Link href={\`/foo/\${item.id}\`}>{item.name}</Link>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      `),
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('onClick');
+  });
+
+  it('reports only one error per offending row, not per nested link', () => {
+    const messages = lintCode(
+      wrap(`
+        <TableRow>
+          <TableCell>
+            <Link href="/foo">Primary</Link>
+            <Link href="/bar">Secondary</Link>
+          </TableCell>
+        </TableRow>
+      `),
+    );
+    expect(messages).toHaveLength(1);
+  });
+
+  it('reports error for each offending row independently', () => {
+    const messages = lintCode(
+      wrap(`
+        <TableBody>
+          <TableRow>
+            <TableCell>
+              <Link href="/foo">Alice</Link>
+            </TableCell>
+          </TableRow>
+          <TableRow onClick={() => {}}>
+            <TableCell>
+              <Link href="/bar" onClick={(e) => e.stopPropagation()}>Bob</Link>
+            </TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>
+              <Link href="/baz">Charlie</Link>
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      `),
+    );
+    expect(messages).toHaveLength(2);
+  });
+
+  it('does not flag the same link twice when a parent TableRow was already flagged', () => {
+    // A Link nested inside a TableRow should attribute to the outer row only.
+    // This is the same as the "one error per row" case above, but verifies
+    // the rule does not double-count by separately considering each Link.
+    const messages = lintCode(
+      wrap(`
+        <TableRow>
+          <TableCell>
+            <div>
+              <Link href="/a">A</Link>
+              <Link href="/b">B</Link>
+              <Link href="/c">C</Link>
+            </div>
+          </TableCell>
+        </TableRow>
+      `),
+    );
+    expect(messages).toHaveLength(1);
+  });
+
+  it('error message references docs/web-patterns.md', () => {
+    const messages = lintCode(
+      wrap(`
+        <TableRow>
+          <TableCell>
+            <Link href="/foo">Name</Link>
+          </TableCell>
+        </TableRow>
+      `),
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('docs/web-patterns.md');
+    expect(messages[0].message).toContain('Clickable Table Rows');
+  });
+
+  it('does not flag a TableRow that only contains TableHead children (header row)', () => {
+    const messages = lintCode(
+      wrap(`
+        <TableRow>
+          <TableHead>
+            <Link href="/judges/1">Judge 1</Link>
+          </TableHead>
+          <TableHead>
+            <Link href="/judges/2">Judge 2</Link>
+          </TableHead>
+        </TableRow>
+      `),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('flags a TableRow with a mix of TableCell and Link (not a header row)', () => {
+    const messages = lintCode(
+      wrap(`
+        <TableRow>
+          <TableHead>Label</TableHead>
+          <TableCell>
+            <Link href="/foo">Value</Link>
+          </TableCell>
+        </TableRow>
+      `),
+    );
+    // Mixed rows are treated as data rows (because they contain TableCell),
+    // so the nested Link triggers the rule.
+    expect(messages).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a local ESLint rule (`local/clickable-table-row`) that flags any `<TableRow>` containing a nested `<Link>` or `<a>` but no `onClick` handler on the row itself. This prevents the recurring UX bug where shadcn's default `hover:bg-muted/50` on `TableRow` makes rows *look* clickable but only the inner link is navigable. Also documents the "Clickable Table Rows" pattern in `docs/web-patterns.md` with a concrete code example.

Existing `TableRow` consumers already comply with the pattern or fall into the header-row escape hatch — no remediation was required.

Closes #2156

## Test plan

### Automated checks
- [x] Lint passes (`next lint` on `packages/web/`)
- [x] Format check passes
- [x] Tests pass (15 new tests in `packages/web/tests/eslint-rules/clickable-table-row.test.ts`, plus existing 1118 tests)
- [x] Typecheck passes
- [x] Build passes
- [x] Markdown links check passes
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (ESLint rule + docs only; rule runs at CI/lint time, not in the deployed app)
- [x] Verification evidence posted on issue
