### PR TITLE
feat(infra): cap zombie oneshot ECS tasks via retry gate + runtime timeout (#2572)

### DIFF
--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -159,6 +159,41 @@ Best practices:
 
 **History.** The instance was bumped from `db.t4g.micro` (max_connections ≈ 84) to `db.t4g.small` in #2549 after rebuild + backfill contention reliably triggered connection-slot exhaustion.
 
+### Zombie oneshot prevention (retry cap + lifetime cap)
+
+**Problem.** A `rebuild_db.py` run against a dev database that is already near its connection limit can hit `BrokenProcessPool` in every worker, then enter the serial-retry pass.  The serial pass re-runs each crashed key in its own `max_workers=1` subprocess — fine for a handful of bad PDFs, catastrophic when *every* key crashed because of a systemic cause (DB exhaustion, OOM, network partition).  A 1,694-key rebuild then tries to serially retry all 1,694 keys at roughly one every few minutes, turning a 10-minute rebuild into a 12+ hour zombie task while the exhausted resources never recover (#2572, #2549).
+
+**Defense in depth.** Two independent caps now prevent this pattern:
+
+1. **In-script retry cap — `scripts/rebuild_db.py`.**  Before entering the serial retry pass, the script checks whether the crash count exceeds a configurable threshold.  If it does, the pass is aborted with a terminal error that names the systemic cause (pool exhaustion, OOM) and exits non-zero so the orchestrator surfaces the failure.
+
+   | Flag | Default | Env var | Purpose |
+   |---|---|---|---|
+   | `--max-retry-count` | `200` | `REBUILD_MAX_RETRY_COUNT` | Absolute ceiling on crashed keys eligible for serial retry.  Set to `0` to disable. |
+   | `--max-retry-ratio` | `0.10` | `REBUILD_MAX_RETRY_RATIO` | Fraction of total keys that crashed.  A high ratio (e.g. 15%) signals systemic failure.  Set to `0` to disable. |
+
+   Strict `>` comparisons on both thresholds: `--max-retry-count 200` means "up to and including 200 retries, abort above that."  The abort also logs a sample of 20 crashed keys so operators have a starting point for manual diagnosis.  Exit code is `2` (distinct from the normal `0`/`1`) so alerting can distinguish retry-cap aborts from per-doc failures.
+
+2. **Container-level lifetime cap — `scripts/ecs-run-task.sh --max-runtime <secs>`.**  Independently of what the script does, ECS oneshot tasks can be wrapped with `timeout --preserve-status --signal=TERM --kill-after=30 <secs>` so the container self-terminates after a bounded wall-clock deadline.  This is opt-in (no default) to preserve behavior for existing callers — pass it explicitly for long-running jobs:
+
+   ```
+   # Cap a rebuild at 2 hours even if it hangs on something not covered by --max-retry-*
+   scripts/ecs-run-task.sh --max-runtime 7200 --cpu 2048 --memory 8192 \
+       scripts/rebuild_db.py -- --county "Los Angeles" --skip-reset
+   ```
+
+   `timeout` sends `SIGTERM` at the deadline, giving Python's atexit handlers and `psycopg` a chance to close connections cleanly, and escalates to `SIGKILL` 30 seconds later if the script ignores the signal.  The container then exits with the script's own exit code (on clean termination) or `137` (SIGKILL).  Requires coreutils, which is present in the `python:3.12-slim` base image used by the ingestion worker task definition.
+
+**When to use which.**  The in-script cap is always-on for `rebuild_db.py` and handles the specific pool-break-storm pattern surgically.  The lifetime cap is a blanket backstop for any oneshot that could hang for reasons the script doesn't know about (slow network, LLM API outage, stuck DB query).  Use both together for rebuilds on dev.
+
+**Manual stop runbook.**  If you spot a zombie oneshot already running (ECS task that has been `RUNNING` far longer than expected, or dev DB showing `rds_reserved` errors):
+
+1. `aws ecs list-tasks --cluster judgemind-dev --desired-status RUNNING --region us-west-2` — find the task ARN.
+2. `aws ecs describe-tasks --cluster judgemind-dev --tasks <arn> --region us-west-2` — confirm it's the oneshot and check `startedAt` vs now.
+3. `aws ecs stop-task --cluster judgemind-dev --task <arn> --reason "zombie retry-loop (#2572)" --region us-west-2` — sends SIGTERM then SIGKILL.
+4. Wait for the task to fully STOP (connection slots release as psycopg closes).  Verify with `scripts/dev-db-query.sh "SELECT count(*) FROM pg_stat_activity WHERE application_name LIKE '%rebuild%'"`.
+5. Diagnose the root cause before re-running — if connection exhaustion, confirm no other rebuild is running; if OOM, bump `--memory`; if the retry cap was tripped, consult the crashed-key sample in the CloudWatch logs.
+
 ### Reingest vs Rebuild
 
 `reingest_from_s3.py` operates on **existing database records only** — it queries the `documents` table to find S3 keys to reprocess. If you run it for a county with no records in the `documents` table, it will process 0 documents silently.

--- a/scripts/ecs-run-task.sh
+++ b/scripts/ecs-run-task.sh
@@ -46,7 +46,19 @@
 #   --logs <task-arn>   Retrieve logs and status for a previously launched task.
 #                       Accepts a full task ARN.
 #   --dry-run           Show what would be done without running
-#   --timeout <secs>    Max seconds to wait for task completion (default: 1800)
+#   --timeout <secs>    Max seconds to wait for task completion (default: 1800).
+#                       This is a client-side wait: if the task does not stop
+#                       within this window the script exits but the task keeps
+#                       running on ECS (possibly for hours).  Use --max-runtime
+#                       to enforce a server-side lifetime cap inside the task.
+#   --max-runtime <secs> Wrap the container command with `timeout` so the task
+#                       self-terminates after this many seconds even if the
+#                       Python script hangs or retry-loops.  Default: unset
+#                       (opt-in).  A value of 0 also disables the cap.  This
+#                       is a belt-and-suspenders complement to in-script
+#                       retry caps — use it for long-running jobs where a
+#                       runaway retry loop could exhaust shared resources
+#                       (e.g. dev DB connection slots).  See #2572.
 #   --help              Show this help message
 #
 # Examples:
@@ -66,6 +78,7 @@ DRY_RUN=false
 DETACH=false
 LOGS_TASK_ARN=""
 TIMEOUT=1800
+MAX_RUNTIME=""
 CPU_OVERRIDE=""
 MEMORY_OVERRIDE=""
 SCRIPT_PATH=""
@@ -125,8 +138,12 @@ while [[ $# -gt 0 ]]; do
             TIMEOUT="$2"
             shift 2
             ;;
+        --max-runtime)
+            MAX_RUNTIME="$2"
+            shift 2
+            ;;
         --help|-h)
-            head -n 54 "$0" | tail -n +2 | sed 's/^# \?//'
+            head -n 66 "$0" | tail -n +2 | sed 's/^# \?//'
             exit 0
             ;;
         --)
@@ -299,6 +316,17 @@ if ! validate_fargate_resources "$CPU" "$MEMORY"; then
     echo "  2048 CPU: 4096-16384 MB (1 GB increments)" >&2
     echo "  4096 CPU: 8192-30720 MB (1 GB increments)" >&2
     exit 1
+fi
+
+# ─── Validate --max-runtime ───────────────────────────────────────────────
+# --max-runtime must be a non-negative integer (seconds).  An empty value
+# means "no cap" (the default).  A value of 0 also disables the cap, so
+# operators can override env defaults without juggling unset-vs-zero.
+if [[ -n "$MAX_RUNTIME" ]]; then
+    if ! [[ "$MAX_RUNTIME" =~ ^[0-9]+$ ]]; then
+        echo "Error: --max-runtime must be a non-negative integer (seconds), got: '${MAX_RUNTIME}'" >&2
+        exit 1
+    fi
 fi
 
 # ─── Cleanup trap ────────────────────────────────────────────────────────────
@@ -488,6 +516,27 @@ for arg in "${SCRIPT_ARGS[@]+"${SCRIPT_ARGS[@]}"}"; do
     ARGS_STR="${ARGS_STR} '${escaped}'"
 done
 
+# Build the interpreter invocation, optionally wrapped with `timeout` so
+# the container self-terminates after --max-runtime seconds even if the
+# script retry-loops or hangs (#2572).  The coreutils `timeout` command is
+# present at /usr/bin/timeout in the python:3.12-slim base image used by
+# the ingestion worker task definition.
+#
+# Flags:
+#   --preserve-status   exit with the script's exit status when it finishes
+#                       before the deadline (instead of timeout's own 124);
+#                       this keeps the normal exit-code path unchanged
+#   --signal=TERM       send SIGTERM first so Python can run atexit handlers
+#                       and psycopg can close its connections cleanly
+#   --kill-after=30     escalate to SIGKILL 30s later if the script ignores
+#                       SIGTERM; bounds total wall-clock overhead
+# When `timeout` kills the script it exits 124 + 128 = 137, which propagates
+# through bash -c and surfaces in the task's containers[].exitCode.
+INVOCATION="${INTERPRETER} /tmp/_oneshot_script${ARGS_STR}"
+if [[ -n "$MAX_RUNTIME" && "$MAX_RUNTIME" -gt 0 ]]; then
+    INVOCATION="timeout --preserve-status --signal=TERM --kill-after=30 ${MAX_RUNTIME} ${INVOCATION}"
+fi
+
 # The ECS run-task command override limit is 8192 bytes total for the
 # containerOverrides JSON. The base64-encoded script plus the wrapper
 # command must fit within this limit. We use ~6000 bytes as the threshold
@@ -521,19 +570,22 @@ if [[ "$ENCODED_SIZE" -gt 6000 ]]; then
 
     # Use Python's urllib to download — always available in the container
     # image (python:3.12-slim). Avoids "curl: command not found" noise.
-    COMMAND_STR="python3 -c \"import urllib.request; urllib.request.urlretrieve('${PRESIGNED_URL}', '/tmp/_oneshot_script')\" && ${INTERPRETER} /tmp/_oneshot_script${ARGS_STR}"
+    COMMAND_STR="python3 -c \"import urllib.request; urllib.request.urlretrieve('${PRESIGNED_URL}', '/tmp/_oneshot_script')\" && ${INVOCATION}"
 else
     # Strip newlines from base64 output: Linux base64 wraps at 76 chars by
     # default, and the newlines break the ECS command override when bash -c
     # interprets them as separate commands.  macOS base64 does not wrap, but
     # tr -d '\n' is harmless there.
     ENCODED=$(base64 < "$SCRIPT_PATH" | tr -d '\n')
-    COMMAND_STR="echo ${ENCODED} | base64 -d > /tmp/_oneshot_script && ${INTERPRETER} /tmp/_oneshot_script${ARGS_STR}"
+    COMMAND_STR="echo ${ENCODED} | base64 -d > /tmp/_oneshot_script && ${INVOCATION}"
 fi
 
 echo "Script: ${SCRIPT_PATH} (${SCRIPT_SIZE} bytes)" >&2
 echo "Interpreter: ${INTERPRETER}" >&2
 echo "Resources: ${CPU} CPU / ${MEMORY} MB memory" >&2
+if [[ -n "$MAX_RUNTIME" && "$MAX_RUNTIME" -gt 0 ]]; then
+    echo "Max runtime: ${MAX_RUNTIME}s (timeout --signal=TERM --kill-after=30)" >&2
+fi
 if [[ -n "$OVERRIDE_ROLE_ARN" ]]; then
     echo "Task role: ${ROLE_OVERRIDE} (override)" >&2
 fi

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -473,6 +473,123 @@ def _autoscale_concurrency(
     return max(1, min(requested, capped))
 
 
+def _should_abort_retry_pass(
+    crashed_count: int,
+    total_count: int,
+    max_count: int,
+    max_ratio: float,
+) -> tuple[bool, str]:
+    """Return (should_abort, reason) for the serial retry pass.
+
+    The serial retry pass in ``_retry_crashed_keys_serially`` is designed to
+    recover from single-worker segfaults on individual bad PDFs: one crashed
+    key at a time, in its own subprocess, under the theory that the C
+    extension died on THIS specific input.  That's a valid recovery strategy
+    when the crash rate is low.
+
+    But when the pool breaks for a systemic reason (DB connection slots
+    exhausted, OOM across many workers, network partition), *every*
+    in-flight future gets ``BrokenProcessPool``, so effectively every key
+    lands in ``crashed_keys``.  Serially retrying thousands of keys — at
+    roughly one every several minutes, since each retry opens fresh DB
+    connections and reloads all worker state — turns a 10-minute rebuild
+    into a 12+ hour zombie task, during which the exhausted resources never
+    recover (#2572, #2549).
+
+    This function gates entry into the serial retry pass:
+
+    - ``max_count``: absolute ceiling on keys eligible for serial retry.
+      Above this count we assume a systemic cause (not per-doc bad PDFs)
+      and abort with a terminal error rather than churning for hours.
+      Set to 0 to disable.
+    - ``max_ratio``: fraction of total keys that crashed.  A high ratio
+      similarly signals systemic failure (e.g. 15% pool-break rate means
+      every worker is failing, not specific PDFs).  Set to 0 to disable.
+
+    Strict ``>`` comparison on both thresholds so operators who set the
+    flag to e.g. ``--max-retry-count 200`` get exactly what they asked for
+    — up to and including 200 retries, abort only above that.
+
+    Returns a tuple of (should_abort, reason).  ``reason`` is a human-
+    readable string suitable for logging; empty when should_abort is False.
+    """
+    if total_count <= 0:
+        return False, ""
+
+    # Check count threshold first: it's the more actionable signal for
+    # operators (bounds retry wall-clock time directly), and the message
+    # puts the specific tripped threshold first.
+    if max_count > 0 and crashed_count > max_count:
+        return True, (
+            f"crashed_count={crashed_count} exceeds --max-retry-count={max_count} "
+            f"(out of total_count={total_count})"
+        )
+
+    if max_ratio > 0:
+        ratio = crashed_count / total_count
+        if ratio > max_ratio:
+            return True, (
+                f"crashed_count/total_count={crashed_count}/{total_count}="
+                f"{ratio:.1%} exceeds --max-retry-ratio={max_ratio:.1%}"
+            )
+
+    return False, ""
+
+
+def _default_max_retry_count(env: dict[str, str] | None = None) -> int:
+    """Resolve the default for ``--max-retry-count`` from the environment.
+
+    Extracted as a pure function so argparse's default-at-import-time
+    pattern doesn't hide the env-var lookup from tests.  Accepts an
+    optional env dict for testability (defaults to ``os.environ``).
+
+    The default (200) is deliberately conservative: most healthy rebuilds
+    see fewer than a dozen crashed keys from per-doc bad PDFs, so 200
+    comfortably absorbs a bad batch while still tripping on a systemic
+    pool-break storm.  See #2572.
+    """
+    source = env if env is not None else os.environ
+    return int(source.get("REBUILD_MAX_RETRY_COUNT", "200"))
+
+
+def _default_max_retry_ratio(env: dict[str, str] | None = None) -> float:
+    """Resolve the default for ``--max-retry-ratio`` from the environment.
+
+    Extracted as a pure function for the same reason as
+    ``_default_max_retry_count``.  The default (0.10 = 10%) catches the
+    small-rebuild case where all-keys-crashed is under the absolute count
+    cap but is still clearly systemic.  See #2572.
+    """
+    source = env if env is not None else os.environ
+    return float(source.get("REBUILD_MAX_RETRY_RATIO", "0.10"))
+
+
+def _build_abort_log_sample(
+    crashed_keys: list[str], sample_size: int = 20
+) -> tuple[list[str], bool]:
+    """Return (sample, truncated) for the retry-abort log record.
+
+    When the retry pass aborts on a systemic failure (#2572), we want
+    operators to have a few real S3 keys in CloudWatch so they can jump
+    straight to the raw document that failed.  But we also don't want to
+    dump thousands of keys into a single log record — it's unreadable, it
+    may hit CloudWatch's per-event size limits, and the first few are
+    enough to kick off diagnosis.
+
+    This helper exists as a pure function (not an inline slice in main())
+    so the sample-truncation behavior can be unit-tested without standing
+    up the whole rebuild pipeline.  Returns a tuple of:
+
+    - ``sample``: up to ``sample_size`` keys (the first N); empty list if
+      ``crashed_keys`` is empty.
+    - ``truncated``: True when ``crashed_keys`` had more than ``sample_size``
+      entries, so the log record can flag that more keys exist.
+    """
+    sample = crashed_keys[:sample_size]
+    truncated = len(crashed_keys) > len(sample)
+    return sample, truncated
+
+
 def _retry_crashed_keys_serially(
     crashed_keys: list[str],
     cache_dir: str,
@@ -970,6 +1087,32 @@ def main() -> None:
             "ignored."
         ),
     )
+    parser.add_argument(
+        "--max-retry-count",
+        type=int,
+        default=_default_max_retry_count(),
+        help=(
+            "Abort the serial retry pass when more than N keys crashed the "
+            "concurrent pool (default: 200).  A high absolute count almost "
+            "always means a systemic failure (DB connection exhaustion, OOM "
+            "across many workers) rather than per-document bad PDFs, in "
+            "which case serially retrying each key for minutes will "
+            "compound the problem for hours without recovery.  Set to 0 to "
+            "disable the absolute cap.  See #2572."
+        ),
+    )
+    parser.add_argument(
+        "--max-retry-ratio",
+        type=float,
+        default=_default_max_retry_ratio(),
+        help=(
+            "Abort the serial retry pass when the ratio of crashed keys to "
+            "total keys exceeds this fraction (default: 0.10 = 10%%).  Paired "
+            "with --max-retry-count as a second-axis check: a small rebuild "
+            "of 50 keys where all 50 crashed is systemic, but under the "
+            "absolute count cap.  Set to 0 to disable the ratio cap.  See #2572."
+        ),
+    )
     args = parser.parse_args()
 
     if args.force_split_child_loss:
@@ -1016,6 +1159,11 @@ def main() -> None:
         # Write rebuild-in-progress marker so the data quality check
         # downgrades P1 alerts during the rebuild window (#2222).
         _write_rebuild_marker(conn, in_progress=True)
+
+    # Initialize the retry-abort reason outside the try block so it's
+    # always in scope for the post-finally exit check below, even if the
+    # rebuild raises before reaching the retry gate.  See #2572.
+    retry_aborted_reason: str | None = None
 
     # Wrap the rebuild in try/finally so the completion marker is always
     # written when --reset was used, even if the rebuild fails partway (#2222).
@@ -1207,32 +1355,73 @@ def main() -> None:
         # Step 4b: Retry the keys that were in flight when the pool broke.
         # Each retry runs in its own ``max_workers=1`` subprocess so a
         # segfault only kills the single retry worker.  See #2495.
+        #
+        # Gate entry to the retry pass: if too many keys crashed the pool
+        # (by absolute count or by ratio of total keys), that's almost
+        # certainly a systemic failure (DB exhaustion, OOM across workers)
+        # rather than per-doc bad PDFs, and the serial retry pass will
+        # churn for hours without recovery.  See #2572.
         retry_summary: dict[str, Any] | None = None
         if crashed_keys:
-            logger.warning(
-                "Pool break detected during concurrent pass — %d key(s) "
-                "affected across %d distinct crash event(s).  Retrying "
-                "serially.",
-                len(crashed_keys),
-                pool_break_events,
-                crashed_keys_count=len(crashed_keys),
-                pool_break_events=pool_break_events,
+            should_abort, abort_reason = _should_abort_retry_pass(
+                crashed_count=len(crashed_keys),
+                total_count=len(keys),
+                max_count=args.max_retry_count,
+                max_ratio=args.max_retry_ratio,
             )
-            retry_summary = _retry_crashed_keys_serially(
-                crashed_keys,
-                cache_dir,
-                BUCKET,
-                database_url,
-                redis_url,
-                os_url,
-            )
-            # Fold retry counters back into the overall totals.  We already
-            # counted ``len(crashed_keys)`` errors during the concurrent pass
-            # (one per future that got ``BrokenProcessPool``).  Each retry
-            # resolves one of those: success → convert error into processed,
-            # skip → convert error into skipped, error → error stays.  Net
-            # effect: subtract the whole ``len(crashed_keys)`` from errors
-            # and re-add only the retry-level errors.
+            if should_abort:
+                retry_aborted_reason = abort_reason
+                # Log a sample of crashed keys so operators have a starting
+                # point for manual investigation.  Cap at 20 so logs don't
+                # explode when thousands crashed.  See #2572.
+                sample_keys, sample_truncated = _build_abort_log_sample(crashed_keys)
+                logger.error(
+                    "Aborting serial retry pass — systemic failure signal. "
+                    "%d key(s) crashed the concurrent pool, which exceeds "
+                    "the configured retry cap (%s).  Serial retry would "
+                    "churn for hours without recovery; likely root cause "
+                    "is DB connection exhaustion, OOM across workers, or "
+                    "network partition.  Diagnose before re-running.  See "
+                    "#2572.",
+                    len(crashed_keys),
+                    abort_reason,
+                    crashed_keys_count=len(crashed_keys),
+                    pool_break_events=pool_break_events,
+                    abort_reason=abort_reason,
+                    sample_crashed_keys=sample_keys,
+                    sample_crashed_keys_truncated=sample_truncated,
+                )
+            else:
+                logger.warning(
+                    "Pool break detected during concurrent pass — %d key(s) "
+                    "affected across %d distinct crash event(s).  Retrying "
+                    "serially.",
+                    len(crashed_keys),
+                    pool_break_events,
+                    crashed_keys_count=len(crashed_keys),
+                    pool_break_events=pool_break_events,
+                )
+                retry_summary = _retry_crashed_keys_serially(
+                    crashed_keys,
+                    cache_dir,
+                    BUCKET,
+                    database_url,
+                    redis_url,
+                    os_url,
+                )
+        # Fold retry counters back into the overall totals only when the
+        # retry pass actually ran.  If we aborted before entering it
+        # (``retry_summary is None``), ``errors`` already includes every
+        # crashed key from the concurrent pass — no adjustment needed.
+        # See #2572 for the abort path.
+        if retry_summary is not None:
+            # We already counted ``len(crashed_keys)`` errors during the
+            # concurrent pass (one per future that got
+            # ``BrokenProcessPool``).  Each retry resolves one of those:
+            # success → convert error into processed, skip → convert error
+            # into skipped, error → error stays.  Net effect: subtract the
+            # whole ``len(crashed_keys)`` from errors and re-add only the
+            # retry-level errors.
             errors = max(0, errors - len(crashed_keys)) + retry_summary["errors"]
             processed += retry_summary["processed"]
             skipped += retry_summary["skipped"]
@@ -1295,6 +1484,18 @@ def main() -> None:
             _write_rebuild_marker(conn, in_progress=False)
 
     conn.close()
+
+    # Propagate retry-cap abort as a non-zero exit so the ECS orchestrator
+    # surfaces the failure.  We do this AFTER closing the DB connection and
+    # clearing the rebuild marker so the dev environment returns to a clean
+    # state before the task exits.  See #2572.
+    if retry_aborted_reason is not None:
+        logger.error(
+            "Exiting non-zero because serial retry pass was aborted — "
+            "systemic failure requires manual diagnosis before re-running.",
+            retry_aborted_reason=retry_aborted_reason,
+        )
+        sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_ecs_run_task.sh
+++ b/scripts/tests/test_ecs_run_task.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# test_ecs_run_task.sh — Tests for ecs-run-task.sh option parsing and the
+# --max-runtime wrapping behavior (#2572).
+#
+# Focuses on the --max-runtime flag added to cap runaway oneshot tasks at
+# the container level.  Exercises the --dry-run path so no AWS calls are
+# made; the dry-run JSON includes the final container command, which lets
+# us assert whether `timeout` was prepended correctly.
+#
+# Usage:
+#   scripts/tests/test_ecs_run_task.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ECS_RUN_TASK="$SCRIPT_DIR/ecs-run-task.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+cleanup() {
+    set +e
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    echo "$dir"
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Create a mock aws CLI that provides just enough responses for --dry-run.
+# The real ecs-run-task.sh calls describe-task-definition and describe-images
+# during setup (before hitting the DRY_RUN exit).  We return minimal valid
+# JSON so setup completes and the script reaches the dry-run exit.
+setup_mock_aws() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    local mock_bin="$tmpdir/bin"
+    mkdir -p "$mock_bin"
+
+    cat > "$mock_bin/aws" << 'MOCK_AWS'
+#!/usr/bin/env bash
+# Mock aws CLI for ecs-run-task.sh dry-run tests
+
+# Parse subcommand family
+case "${1:-}" in
+    ecs)
+        shift
+        case "${1:-}" in
+            describe-task-definition)
+                # Return a minimal task definition that matches the shape
+                # expected by the downstream Python extraction helpers.
+                cat <<'JSON'
+{
+    "taskDefinition": {
+        "executionRoleArn": "arn:aws:iam::155326049300:role/exec",
+        "taskRoleArn": "arn:aws:iam::155326049300:role/task",
+        "containerDefinitions": [
+            {
+                "name": "worker",
+                "image": "155326049300.dkr.ecr.us-west-2.amazonaws.com/judgemind/scraper:latest",
+                "environment": [],
+                "secrets": [],
+                "logConfiguration": {
+                    "logDriver": "awslogs",
+                    "options": {
+                        "awslogs-group": "/ecs/judgemind-ingestion-worker-dev",
+                        "awslogs-region": "us-west-2"
+                    }
+                }
+            }
+        ]
+    }
+}
+JSON
+                exit 0
+                ;;
+            *)
+                echo "Mock aws ecs: unused subcommand $1 in dry-run path" >&2
+                exit 0
+                ;;
+        esac
+        ;;
+    ecr)
+        shift
+        case "${1:-}" in
+            describe-images)
+                # Print digest string so the script's digest-equality check
+                # succeeds and no image override is applied (the tests below
+                # don't care which branch executes).
+                cat <<'JSON'
+{"digest":"sha256:deadbeef","pushed":"2025-01-01T00:00:00Z"}
+JSON
+                exit 0
+                ;;
+        esac
+        exit 0
+        ;;
+    iam)
+        # Used when --role is passed; tests here don't exercise it.
+        echo "arn:aws:iam::155326049300:role/mock"
+        exit 0
+        ;;
+esac
+
+echo "Mock aws: unhandled service $1" >&2
+exit 0
+MOCK_AWS
+    chmod +x "$mock_bin/aws"
+
+    echo "$tmpdir"
+}
+
+# Write a tiny fake script so ecs-run-task.sh has something to encode.
+make_fake_script() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    local path="$tmpdir/hello.py"
+    printf 'print("hi")\n' > "$path"
+    echo "$path"
+}
+
+# Extract the container command string from the dry-run JSON output.
+# The dry-run block prints the task def JSON via `python3 -m json.tool`;
+# the container command lives at .containerDefinitions[0].command[0].
+extract_command_str() {
+    local dry_output="$1"
+    python3 - "$dry_output" <<'PY'
+import sys, json, re
+
+output = sys.argv[1]
+# Find the JSON block — it starts with "{" at column 0 and ends with "}"
+# at column 0.  The json.tool output in the dry-run section uses 4-space
+# indentation, so the outermost braces are flush-left.
+match = re.search(r'^\{.*?^\}', output, re.MULTILINE | re.DOTALL)
+if not match:
+    sys.exit(0)
+
+try:
+    data = json.loads(match.group(0))
+except json.JSONDecodeError:
+    sys.exit(0)
+
+containers = data.get("containerDefinitions", [])
+if not containers:
+    sys.exit(0)
+command = containers[0].get("command", [])
+if command:
+    print(command[0])
+PY
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+# Test 1: --help prints usage including the new flag
+test_help_documents_max_runtime() {
+    local output
+    output=$("$ECS_RUN_TASK" --help 2>&1 || true)
+    if echo "$output" | grep -q -- "--max-runtime"; then
+        pass "--help documents --max-runtime"
+    else
+        fail "--help documents --max-runtime" "output was: $output"
+    fi
+}
+
+# Test 2: Invalid --max-runtime value is rejected
+test_invalid_max_runtime_rejected() {
+    local fake_script tmpdir output exit_code
+    fake_script=$(make_fake_script)
+    tmpdir=$(setup_mock_aws)
+
+    exit_code=0
+    output=$(
+        PATH="$tmpdir/bin:$PATH" \
+        "$ECS_RUN_TASK" --dry-run --max-runtime abc "$fake_script" 2>&1
+    ) || exit_code=$?
+
+    if [[ $exit_code -ne 0 ]]; then
+        pass "non-numeric --max-runtime exits non-zero"
+    else
+        fail "non-numeric --max-runtime exits non-zero" "exit code: $exit_code, output: $output"
+    fi
+
+    if echo "$output" | grep -q "must be a non-negative integer"; then
+        pass "non-numeric --max-runtime produces clear error"
+    else
+        fail "non-numeric --max-runtime produces clear error" "got: $output"
+    fi
+}
+
+# Test 3: Without --max-runtime, COMMAND does NOT start with `timeout`
+test_without_max_runtime_no_timeout_wrapper() {
+    local fake_script tmpdir output command
+    fake_script=$(make_fake_script)
+    tmpdir=$(setup_mock_aws)
+
+    output=$(
+        PATH="$tmpdir/bin:$PATH" \
+        "$ECS_RUN_TASK" --dry-run "$fake_script" 2>&1
+    ) || true
+
+    command=$(extract_command_str "$output")
+    if [[ -z "$command" ]]; then
+        fail "dry-run emits container command" "could not parse JSON; output was: $output"
+        return
+    fi
+
+    if echo "$command" | grep -q "timeout --"; then
+        fail "no --max-runtime ⇒ no timeout wrapper" "command was: $command"
+    else
+        pass "no --max-runtime ⇒ no timeout wrapper"
+    fi
+}
+
+# Test 4: With --max-runtime 3600, COMMAND is wrapped with `timeout 3600`
+test_with_max_runtime_wraps_timeout() {
+    local fake_script tmpdir output command
+    fake_script=$(make_fake_script)
+    tmpdir=$(setup_mock_aws)
+
+    output=$(
+        PATH="$tmpdir/bin:$PATH" \
+        "$ECS_RUN_TASK" --dry-run --max-runtime 3600 "$fake_script" 2>&1
+    ) || true
+
+    command=$(extract_command_str "$output")
+    if [[ -z "$command" ]]; then
+        fail "dry-run emits container command (with --max-runtime)" "could not parse JSON; output was: $output"
+        return
+    fi
+
+    # Check for the timeout invocation with the expected flags.
+    if echo "$command" | grep -q -- "timeout --preserve-status --signal=TERM --kill-after=30 3600"; then
+        pass "--max-runtime 3600 wraps command with timeout"
+    else
+        fail "--max-runtime 3600 wraps command with timeout" "command was: $command"
+    fi
+}
+
+# Test 5: --max-runtime 0 disables the wrapper (explicit opt-out)
+test_max_runtime_zero_disables() {
+    local fake_script tmpdir output command
+    fake_script=$(make_fake_script)
+    tmpdir=$(setup_mock_aws)
+
+    output=$(
+        PATH="$tmpdir/bin:$PATH" \
+        "$ECS_RUN_TASK" --dry-run --max-runtime 0 "$fake_script" 2>&1
+    ) || true
+
+    command=$(extract_command_str "$output")
+    if [[ -z "$command" ]]; then
+        fail "dry-run emits container command (--max-runtime 0)" "could not parse JSON; output was: $output"
+        return
+    fi
+
+    if echo "$command" | grep -q "timeout --"; then
+        fail "--max-runtime 0 disables wrapper" "command was: $command"
+    else
+        pass "--max-runtime 0 disables wrapper"
+    fi
+}
+
+# Test 6: Timeout wrapper appears before interpreter, not after
+test_timeout_wraps_interpreter_not_download() {
+    local fake_script tmpdir output command
+    fake_script=$(make_fake_script)
+    tmpdir=$(setup_mock_aws)
+
+    output=$(
+        PATH="$tmpdir/bin:$PATH" \
+        "$ECS_RUN_TASK" --dry-run --max-runtime 600 "$fake_script" 2>&1
+    ) || true
+
+    command=$(extract_command_str "$output")
+    if [[ -z "$command" ]]; then
+        fail "timeout wraps only the interpreter invocation" "no JSON parsed; output was: $output"
+        return
+    fi
+
+    # For inline (base64) delivery, the command is:
+    #   echo ... | base64 -d > /tmp/_oneshot_script && <INVOCATION>
+    # where <INVOCATION> begins with `timeout ...`.  We assert the order.
+    if echo "$command" | grep -qE '&& timeout --preserve-status --signal=TERM --kill-after=30 600 python3 /tmp/_oneshot_script'; then
+        pass "timeout wraps only the interpreter invocation (not base64 decode)"
+    else
+        fail "timeout wraps only the interpreter invocation (not base64 decode)" "command was: $command"
+    fi
+}
+
+# ── Run all tests ──────────────────────────────────────────────────────────
+
+test_help_documents_max_runtime
+test_invalid_max_runtime_rejected
+test_without_max_runtime_no_timeout_wrapper
+test_with_max_runtime_wraps_timeout
+test_max_runtime_zero_disables
+test_timeout_wraps_interpreter_not_download
+
+echo ""
+echo "────────────────────────────────────────────"
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [[ $FAILURES -gt 0 ]]; then
+    echo "$FAILURES test(s) FAILED"
+    exit 1
+fi
+echo "All tests passed."
+exit 0

--- a/scripts/tests/test_rebuild_db.py
+++ b/scripts/tests/test_rebuild_db.py
@@ -1,0 +1,246 @@
+"""Tests for the retry-cap gate in rebuild_db.
+
+Covers the pure decision function that determines whether the serial retry
+pass should be skipped because the crash rate signals a systemic failure
+(connection exhaustion, OOM across many workers) rather than per-document
+bad PDFs.
+
+Run with:
+    python3 -m pytest scripts/tests/test_rebuild_db.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+# Add scripts/ to path so we can import rebuild_db as a module.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Guard against environment missing scraper-framework venv — rebuild_db
+# imports framework.s3_cache at module level, which needs the venv. Tests
+# that need the full module import are gated behind this guard.
+#
+# We split the import test in two: first try to import the module (which
+# requires the venv), then import the target function (which requires the
+# implementation to exist). This keeps skip messages accurate — "module
+# not importable" vs "symbol not yet implemented" are different failure
+# modes, though pytest treats both the same.
+try:
+    import rebuild_db  # type: ignore[import-not-found]
+
+    REBUILD_DB_IMPORTABLE = True
+    _should_abort_retry_pass = getattr(rebuild_db, "_should_abort_retry_pass", None)
+    _build_abort_log_sample = getattr(rebuild_db, "_build_abort_log_sample", None)
+    _default_max_retry_count = getattr(rebuild_db, "_default_max_retry_count", None)
+    _default_max_retry_ratio = getattr(rebuild_db, "_default_max_retry_ratio", None)
+    FUNC_IMPLEMENTED = _should_abort_retry_pass is not None
+    HELPERS_IMPLEMENTED = all(
+        [_build_abort_log_sample, _default_max_retry_count, _default_max_retry_ratio]
+    )
+except ImportError:
+    REBUILD_DB_IMPORTABLE = False
+    FUNC_IMPLEMENTED = False
+    HELPERS_IMPLEMENTED = False
+    _should_abort_retry_pass = None
+    _build_abort_log_sample = None
+    _default_max_retry_count = None
+    _default_max_retry_ratio = None
+
+
+@unittest.skipUnless(
+    REBUILD_DB_IMPORTABLE and FUNC_IMPLEMENTED,
+    "rebuild_db._should_abort_retry_pass not available (module or symbol missing)",
+)
+class TestShouldAbortRetryPass(unittest.TestCase):
+    """Tests for the _should_abort_retry_pass pure function."""
+
+    def test_no_crashes_does_not_abort(self) -> None:
+        should_abort, reason = _should_abort_retry_pass(
+            crashed_count=0, total_count=1000, max_count=200, max_ratio=0.10
+        )
+        self.assertFalse(should_abort)
+        self.assertEqual(reason, "")
+
+    def test_small_crash_count_does_not_abort(self) -> None:
+        # 5 crashes out of 1000 keys: 0.5% — well below the 10% ratio and
+        # the 200 absolute cap.
+        should_abort, reason = _should_abort_retry_pass(
+            crashed_count=5, total_count=1000, max_count=200, max_ratio=0.10
+        )
+        self.assertFalse(should_abort)
+        self.assertEqual(reason, "")
+
+    def test_absolute_count_exceeded_aborts(self) -> None:
+        # 250 crashes: exceeds 200 absolute cap even though 250/10000 is only
+        # 2.5% (below the 10% ratio).
+        should_abort, reason = _should_abort_retry_pass(
+            crashed_count=250, total_count=10000, max_count=200, max_ratio=0.10
+        )
+        self.assertTrue(should_abort)
+        self.assertIn("max-retry-count", reason)
+
+    def test_ratio_exceeded_aborts(self) -> None:
+        # 150 crashes out of 1000 keys: 15% — exceeds the 10% ratio even
+        # though 150 is below the 200 absolute cap.
+        should_abort, reason = _should_abort_retry_pass(
+            crashed_count=150, total_count=1000, max_count=200, max_ratio=0.10
+        )
+        self.assertTrue(should_abort)
+        self.assertIn("max-retry-ratio", reason)
+
+    def test_both_thresholds_exceeded_reports_count_first(self) -> None:
+        # When both thresholds trip, count is reported first because it is
+        # the more actionable signal for operators (it bounds retry time).
+        should_abort, reason = _should_abort_retry_pass(
+            crashed_count=500, total_count=1000, max_count=200, max_ratio=0.10
+        )
+        self.assertTrue(should_abort)
+        self.assertIn("max-retry-count", reason)
+
+    def test_zero_total_does_not_divide_by_zero(self) -> None:
+        # total_count=0 can't happen in practice (we'd exit earlier) but the
+        # function must not divide-by-zero if it ever does.
+        should_abort, reason = _should_abort_retry_pass(
+            crashed_count=0, total_count=0, max_count=200, max_ratio=0.10
+        )
+        self.assertFalse(should_abort)
+        self.assertEqual(reason, "")
+
+    def test_ratio_at_boundary_does_not_abort(self) -> None:
+        # Exactly at the ratio threshold: the check is strict ">", so 10%
+        # does not abort. This keeps the behavior predictable — operators
+        # who set --max-retry-ratio 0.10 mean "up to and including 10%".
+        should_abort, reason = _should_abort_retry_pass(
+            crashed_count=100, total_count=1000, max_count=200, max_ratio=0.10
+        )
+        self.assertFalse(should_abort)
+
+    def test_count_at_boundary_does_not_abort(self) -> None:
+        # Exactly at the count threshold: the check is strict ">".
+        should_abort, reason = _should_abort_retry_pass(
+            crashed_count=200, total_count=10000, max_count=200, max_ratio=0.10
+        )
+        self.assertFalse(should_abort)
+
+    def test_count_above_boundary_aborts(self) -> None:
+        should_abort, reason = _should_abort_retry_pass(
+            crashed_count=201, total_count=10000, max_count=200, max_ratio=0.10
+        )
+        self.assertTrue(should_abort)
+        self.assertIn("max-retry-count", reason)
+
+    def test_reason_includes_actual_values(self) -> None:
+        # Operators reading the error in CloudWatch need to know the values
+        # that tripped the gate so they can adjust thresholds if needed.
+        should_abort, reason = _should_abort_retry_pass(
+            crashed_count=201, total_count=10000, max_count=200, max_ratio=0.10
+        )
+        self.assertTrue(should_abort)
+        self.assertIn("201", reason)
+        self.assertIn("200", reason)
+
+    def test_disable_count_cap_with_zero(self) -> None:
+        # max_count=0 disables the absolute cap; only ratio applies. This
+        # lets operators who trust the ratio bypass the count check.
+        should_abort, _ = _should_abort_retry_pass(
+            crashed_count=500, total_count=10000, max_count=0, max_ratio=0.10
+        )
+        # 500/10000 = 5%, under the 10% ratio, and count cap disabled.
+        self.assertFalse(should_abort)
+
+    def test_disable_ratio_cap_with_zero(self) -> None:
+        # max_ratio=0 disables the ratio cap; only count applies.
+        should_abort, _ = _should_abort_retry_pass(
+            crashed_count=100, total_count=200, max_count=200, max_ratio=0.0
+        )
+        # 100/200 = 50%, but ratio disabled and count below cap.
+        self.assertFalse(should_abort)
+
+
+@unittest.skipUnless(
+    REBUILD_DB_IMPORTABLE and HELPERS_IMPLEMENTED,
+    "rebuild_db retry-cap helpers not available (module or symbols missing)",
+)
+class TestBuildAbortLogSample(unittest.TestCase):
+    """Tests for the _build_abort_log_sample pure function."""
+
+    def test_empty_returns_empty_and_not_truncated(self) -> None:
+        sample, truncated = _build_abort_log_sample([])
+        self.assertEqual(sample, [])
+        self.assertFalse(truncated)
+
+    def test_under_sample_size_returns_all_not_truncated(self) -> None:
+        keys = [f"key-{i}" for i in range(5)]
+        sample, truncated = _build_abort_log_sample(keys)
+        self.assertEqual(sample, keys)
+        self.assertFalse(truncated)
+
+    def test_exactly_sample_size_not_truncated(self) -> None:
+        # Exactly 20 keys fits in the default sample — no truncation.
+        keys = [f"key-{i}" for i in range(20)]
+        sample, truncated = _build_abort_log_sample(keys)
+        self.assertEqual(len(sample), 20)
+        self.assertFalse(truncated)
+
+    def test_above_sample_size_truncates_and_flags(self) -> None:
+        keys = [f"key-{i}" for i in range(50)]
+        sample, truncated = _build_abort_log_sample(keys)
+        self.assertEqual(len(sample), 20)
+        self.assertTrue(truncated)
+        # The first 20 keys are preserved in order — operators reading
+        # the log should see the same slice every time for a given input.
+        self.assertEqual(sample, keys[:20])
+
+    def test_custom_sample_size(self) -> None:
+        keys = [f"key-{i}" for i in range(10)]
+        sample, truncated = _build_abort_log_sample(keys, sample_size=3)
+        self.assertEqual(sample, keys[:3])
+        self.assertTrue(truncated)
+
+
+@unittest.skipUnless(
+    REBUILD_DB_IMPORTABLE and HELPERS_IMPLEMENTED,
+    "rebuild_db retry-cap helpers not available (module or symbols missing)",
+)
+class TestDefaultMaxRetryCount(unittest.TestCase):
+    """Tests for the _default_max_retry_count env-var default resolver."""
+
+    def test_returns_200_when_env_unset(self) -> None:
+        # Pass an empty dict so the helper can't fall through to os.environ.
+        self.assertEqual(_default_max_retry_count({}), 200)
+
+    def test_reads_from_env(self) -> None:
+        self.assertEqual(
+            _default_max_retry_count({"REBUILD_MAX_RETRY_COUNT": "500"}), 500
+        )
+
+    def test_reads_zero_from_env(self) -> None:
+        # Zero disables the cap entirely (see _should_abort_retry_pass).
+        self.assertEqual(_default_max_retry_count({"REBUILD_MAX_RETRY_COUNT": "0"}), 0)
+
+
+@unittest.skipUnless(
+    REBUILD_DB_IMPORTABLE and HELPERS_IMPLEMENTED,
+    "rebuild_db retry-cap helpers not available (module or symbols missing)",
+)
+class TestDefaultMaxRetryRatio(unittest.TestCase):
+    """Tests for the _default_max_retry_ratio env-var default resolver."""
+
+    def test_returns_0_10_when_env_unset(self) -> None:
+        self.assertAlmostEqual(_default_max_retry_ratio({}), 0.10)
+
+    def test_reads_from_env(self) -> None:
+        self.assertAlmostEqual(
+            _default_max_retry_ratio({"REBUILD_MAX_RETRY_RATIO": "0.25"}), 0.25
+        )
+
+    def test_reads_zero_from_env(self) -> None:
+        self.assertEqual(
+            _default_max_retry_ratio({"REBUILD_MAX_RETRY_RATIO": "0"}), 0.0
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Defense-in-depth against zombie oneshot ECS tasks like the one that exhausted dev DB connections in #2549 (a `--reset --county Orange` oneshot retry-looped for ~12h on 1694 keys). Combines:

- **Option A (script-level retry cap)** — `rebuild_db.py` aborts the serial retry pass when crash volume exceeds `--max-retry-count` (default 200) OR `--max-retry-ratio` (default 0.10). Logs a sample of up to 20 crashed keys and exits with `sys.exit(2)` so the ECS task exit code surfaces the systemic-failure signal.
- **Option B (container-level lifetime cap)** — `scripts/ecs-run-task.sh --max-runtime <secs>` wraps the oneshot invocation in `timeout --preserve-status --signal=TERM --kill-after=30 <secs>` (coreutils `timeout` from `python:3.12-slim`). SIGTERM gives the script a chance to drain; SIGKILL escalation after 30s if the drain hangs.
- **Option C (CloudWatch alarm) intentionally skipped** — A+B meet the acceptance criterion without adding Lambda + log-metric-filter plumbing.

Documented under a new "Zombie oneshot prevention (retry cap + lifetime cap)" subsection in `docs/agent/infrastructure-reference.md`, including flag reference tables and a manual stop runbook (`aws ecs list-tasks` / `describe-tasks` / `stop-task`).

Both defenses are opt-in / conservative-by-default: existing callers see no behavior change until they pass `--max-runtime`, and the retry cap only triggers on the kind of catastrophic loop (>200 absolute crashes or >10% ratio) that would indicate systemic failure rather than per-doc bad PDFs.

Closes #2572.

## Test plan

### Automated checks
- [x] `ruff check` clean on `scripts/rebuild_db.py`, `scripts/tests/test_rebuild_db.py`
- [x] `ruff format --check` clean
- [x] 23 unit tests passing in `scripts/tests/test_rebuild_db.py` (retry-gate decision function, abort log sampler, env-var default resolvers)
- [x] 7 shell tests passing in `scripts/tests/test_ecs_run_task.sh` (help text, input validation, wrapping behavior, opt-in by default)
- [x] `scripts/check-markdown-links.sh` passes (54 files checked)
- [x] Pre-push hooks pass
- [x] CI green on PR (all CI jobs SUCCESS or SKIPPED; ECS smoke test passed)

### Post-deploy verification
- [x] No deployed component — this PR only changes `scripts/*`, `docs/*`, and adds tests. `rebuild_db.py` and `ecs-run-task.sh` are invoked on-demand by operators/dispatcher, not running services. Next real exercise of the retry-gate will be the next `rebuild_db.py --reset` run; next real exercise of `--max-runtime` will be the next `ecs-run-task.sh` invocation that opts in. Post-merge check confirmed no ECS/API deploy workflow fired (only CI and Vercel Deploy Status — Vercel unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
