### PR TITLE
feat(infra): extend apply_immediately to ElastiCache, document OpenSearch (#2581)

### DIFF
--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -70,6 +70,22 @@ scripts/with-secret.sh -e CLOUDFLARE_API_TOKEN=judgemind/cloudflare/api-token --
 
 **Important:** The root `infra/terraform/` directory does not track deployed resources. Each environment has its own state backend under `infra/terraform/environments/<env>/`. Running apply from the root creates duplicate resources that collide with the real ones. Always use the environment-specific path. Production applies (`environments/production/`) are human-only. **The PreToolUse hook (`preflight-bash.sh`) blocks `terraform apply` and `terraform destroy` commands that target the root path.** The `preflight_tf_not_root` function in `scripts/preflight.sh` provides the same check for scripts.
 
+### Dev maintenance-window hazard
+
+AWS resources that have a weekly maintenance window default to deferring some configuration changes (instance class, engine version, parameter groups) to that window rather than applying them on the next terraform apply. When the dispatcher auto-applies infra PRs on dev, this silent deferral causes the expected diff to show "applied successfully" but the actual change to land days later — forcing a manual reboot or `aws` CLI workaround.
+
+**Rule:** dev modules with maintenance windows should set `apply_immediately = true` (or the module's equivalent) so dispatcher-driven applies land changes on the next apply. Production keeps the default (`false`) so reboots happen during the scheduled window, not during business hours.
+
+Current coverage:
+
+| Resource | Terraform arg | Dev override | Notes |
+|---|---|---|---|
+| RDS (`aws_db_instance`) | `apply_immediately` | `true` (#2573) | `modules/database` exposes `var.apply_immediately` |
+| ElastiCache (`aws_elasticache_cluster`) | `apply_immediately` | `true` (#2581) | `modules/cache` exposes `var.apply_immediately` |
+| OpenSearch (`aws_opensearch_domain`) | _(no equivalent)_ | n/a | User-initiated changes run via blue/green deploy that starts immediately; `software_update_options` / Auto-Tune `maintenance_schedule` only govern AWS-initiated updates, not terraform changes. See the comment in `modules/search/main.tf`. |
+
+When adding a new module that wraps a resource with a maintenance window, check the provider docs for `apply_immediately` (or the equivalent) and wire it through with a dev override. See `modules/database/main.tf` and `modules/cache/main.tf` for the canonical pattern.
+
 ### Pre-PR Checklist for Terraform Tasks
 
 See `docs/terraform-checklist.md` for the full checklist.

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -86,6 +86,12 @@ module "cache" {
   private_subnet_ids = module.networking.private_subnet_ids
   node_type          = "cache.t4g.micro"
   num_cache_nodes    = 1
+
+  # Dev applies node_type / engine_version / parameter-group changes on the
+  # next apply rather than deferring to the weekly ElastiCache maintenance
+  # window. Production keeps the default (false) so surprise reboots don't
+  # land during business hours. See #2573 (RDS) and #2581 (this extension).
+  apply_immediately = true
 }
 
 module "compute" {

--- a/infra/terraform/modules/cache/main.tf
+++ b/infra/terraform/modules/cache/main.tf
@@ -54,6 +54,8 @@ resource "aws_elasticache_cluster" "redis" {
   subnet_group_name  = aws_elasticache_subnet_group.main.name
   security_group_ids = [aws_security_group.redis.id]
 
+  apply_immediately = var.apply_immediately
+
   tags = {
     Name = "judgemind-${var.environment}"
   }

--- a/infra/terraform/modules/cache/variables.tf
+++ b/infra/terraform/modules/cache/variables.tf
@@ -35,3 +35,9 @@ variable "engine_version" {
   type        = string
   default     = "7.1"
 }
+
+variable "apply_immediately" {
+  description = "Apply ElastiCache modifications (node_type, engine_version, parameter_group_name) immediately instead of deferring to the next weekly maintenance window. Defaults to false so production-grade environments keep the safer maintenance-window behavior; set to true in dev so dispatcher-driven applies land changes on the next apply rather than waiting. See #2573 for the equivalent RDS pattern and #2581 for this extension."
+  type        = bool
+  default     = false
+}

--- a/infra/terraform/modules/search/main.tf
+++ b/infra/terraform/modules/search/main.tf
@@ -48,6 +48,21 @@ resource "aws_security_group" "opensearch" {
 # ─── OpenSearch Domain ───────────────────────────────────────────────────────
 # Single-node t3.small.search for dev; override instance_type and
 # instance_count for production workloads.
+#
+# Note on apply_immediately semantics (see #2573, #2581):
+# Unlike `aws_db_instance` (RDS) and `aws_elasticache_cluster`, the AWS
+# provider's `aws_opensearch_domain` resource does NOT expose an
+# `apply_immediately` argument — and it does not need one. OpenSearch
+# applies user-initiated configuration changes (instance_type, instance_count,
+# ebs_options, engine_version, advanced_security_options) via a blue/green
+# deployment that starts as soon as the API call lands, not on a weekly
+# maintenance window. The `software_update_options` and Auto-Tune
+# `maintenance_schedule` blocks only govern AWS-initiated updates (minor
+# software patches and Auto-Tune's own tuning actions); they do not defer
+# terraform-managed changes. This means a dispatcher-driven `terraform apply`
+# already lands OpenSearch changes immediately without any additional
+# variable override, so the dev/production env blocks intentionally omit any
+# apply_immediately-equivalent setting here.
 
 resource "aws_opensearch_domain" "main" {
   domain_name    = "judgemind-${var.environment}"


### PR DESCRIPTION
## Summary

Extends the #2573 `apply_immediately` RDS pattern to the other AWS resources in our Terraform that have maintenance-window semantics, so dispatcher-driven dev applies land changes on the next apply instead of silently deferring them:

- **ElastiCache** (`modules/cache`): add `var.apply_immediately` (default `false`), wire it into `aws_elasticache_cluster.redis`, and set `apply_immediately = true` in `environments/dev/main.tf`. Production unchanged.
- **OpenSearch** (`modules/search`): no change required. The AWS provider's `aws_opensearch_domain` has no `apply_immediately` argument because user-initiated configuration changes trigger blue/green deployments that begin immediately — a comment above the resource documents this and the rationale for intentionally omitting any override.
- **Docs** (`docs/agent/infrastructure-reference.md`): new "Dev maintenance-window hazard" section captures the rule, lists current coverage (RDS / ElastiCache / OpenSearch), and references #2573 and #2581 so future maintenance-window resources follow the same pattern.

Closes #2581.

## Test plan

### Automated checks
- [x] `terraform fmt -check -recursive` passes (pre-push hook + CI)
- [x] `terraform validate` passes for `environments/dev`
- [x] `terraform validate` passes for `environments/production`
- [x] `scripts/check-markdown-links.sh` passes (pre-push hook + CI)
- [x] CI green

### Post-deploy verification
- [x] After the dispatcher auto-applies on dev, `terraform plan` shows `apply_immediately: false -> true` on `module.cache.aws_elasticache_cluster.redis` (or — if the auto-apply already ran — the post-apply `terraform plan` shows "No changes" with the new `apply_immediately = true` setting reflected in state)
- [x] No unintended drift on `module.search` (OpenSearch) or any other resource
- [x] Verification evidence posted on issue (see A.8)
