### PR TITLE
docs(infra): document .terraform.lock.hcl churn hazard and -lockfile=readonly workaround (#2582)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,7 @@ Key paths: framework in `packages/scraper-framework/src/framework/`, California 
 - Terraform for all AWS resources. Every resource must be in a module.
 - **Do NOT add `tags` blocks to individual resources** — the AWS provider's `default_tags` handles this.
 - Never commit AWS credentials or state files.
+- **Always run `terraform init` with `-lockfile=readonly`** for agent-side validation — without this, `init` will silently prune provider hashes the current environment doesn't reference (e.g. `hashicorp/archive` in `environments/dev/`), causing unrelated `.terraform.lock.hcl` churn in `git status` that either pollutes the PR diff or breaks other environments' hashes. Only omit the flag when you are intentionally adding or upgrading a provider alongside a `main.tf` / `terraform.tf` change. See `docs/agent/code-standards.md` §Terraform for full details (#2582).
 - **Dev terraform apply is automated.** After a PR that touches `infra/terraform/` merges to main, the dispatcher automatically runs `terraform apply` for the dev environment. Production applies remain human-only. See `.claude/skills/dispatcher/SKILL.md` and `docs/agent/infrastructure-reference.md` for the full procedure.
 
 ### Running Data Scripts on Dev

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -131,9 +131,15 @@ For `packages/web/`, also run `npm run build`. The same diff coverage and floor 
 
 ```
 terraform fmt -check -recursive
-terraform init -backend=false
+terraform init -backend=false -lockfile=readonly
 terraform validate
 ```
+
+**`.terraform.lock.hcl` churn hazard — always use `-lockfile=readonly` for agent-side validation.** `terraform init` (with or without `-backend=false`) will silently rewrite the environment's `.terraform.lock.hcl` to match the providers the current module set references. If the lock file contains providers that the environment does not currently reference (for example `hashicorp/archive` in `environments/dev/` when no `.tf` in that environment uses the `archive` provider), `init` "helpfully" **prunes** those provider hash blocks from the lock file. The pruned lock file then appears as an unrelated modification in `git status`, and if committed can either (a) pollute the PR with unrelated diff noise or (b) cause a hash mismatch when a different environment that does reference the provider runs `init`. See #2582.
+
+The `-lockfile=readonly` flag tells `terraform init` to fail fast if it would modify the lock file, rather than silently rewriting it. Use it for every pre-PR validation. Only omit the flag when you are intentionally adding or upgrading a provider in the current environment — in that case the lock-file change is the point, and it should be staged and committed together with the corresponding `main.tf` / `terraform.tf` change.
+
+If you run `terraform init` without the flag by mistake and see `.terraform.lock.hcl` in `git status`, revert it with `git checkout -- infra/terraform/environments/<env>/.terraform.lock.hcl` before committing anything else.
 
 ### Docs / Markdown
 

--- a/docs/preflight-checklist.md
+++ b/docs/preflight-checklist.md
@@ -59,7 +59,7 @@ Machine-readable checklist of rules extracted from CLAUDE.md. Agents should vali
 | PR-06b | TypeScript diff coverage | `scripts/check-diff-coverage.sh <package> --skip-tests` (after PR-06) |
 | PR-07 | TypeScript build (web) | `npm run build` (for `packages/web/` only) |
 | PR-08 | Terraform format | `terraform fmt -check -recursive` |
-| PR-09 | Terraform validate | `terraform init -backend=false && terraform validate` |
+| PR-09 | Terraform validate | `terraform init -backend=false -lockfile=readonly && terraform validate` (readonly flag prevents `.terraform.lock.hcl` churn, see #2582) |
 | PR-10 | Check import sites when removing/renaming exports | Grep for removed/renamed symbol names across `src/` and `tests/`; update or remove every import site |
 
 ## Task Workflow Rules

--- a/docs/terraform-checklist.md
+++ b/docs/terraform-checklist.md
@@ -5,9 +5,9 @@ Before marking a Terraform PR ready, complete ALL of the following locally:
 1. `terraform fmt -check -recursive infra/terraform/` — fix any formatting issues.
 2. Validate the **root** `infra/terraform/` config AND each environment:
    ```
-   terraform -chdir=infra/terraform init -backend=false && terraform validate
+   terraform -chdir=infra/terraform init -backend=false -lockfile=readonly && terraform validate
    ```
-   The root config is the CI integration point — new required module variables must be added there too.
+   The root config is the CI integration point — new required module variables must be added there too. The `-lockfile=readonly` flag is required — see `docs/agent/code-standards.md` §Terraform for why (#2582).
 3. **Import any pre-existing resources** that were created outside Terraform before they were managed by code. Run `terraform import` for each, then verify with `terraform plan` that it shows no unexpected changes.
 4. `terraform -chdir=infra/terraform/environments/<env> plan -no-color` (with real backend) — confirm the plan is clean or shows only expected changes (no destroys of existing resources).
 5. `terraform apply` if the plan looks correct — verify `No changes` on a second `plan` afterward.


### PR DESCRIPTION
## Summary

Document the `.terraform.lock.hcl` churn hazard that bit us during #2573 and add `-lockfile=readonly` to the canonical `terraform init` invocation in every agent-facing doc. The flag makes `init` fail fast with a clear error instead of silently pruning provider hashes the current environment does not reference (the exact failure mode that produced the unrelated dev-lockfile diff during #2573).

Empirically verified against `infra/terraform/environments/dev/`: with `-lockfile=readonly`, `terraform init -backend=false` now exits 1 with `Error: Provider dependency changes detected ... the lock file is read-only` — the intended trip — and leaves the lock file byte-identical. Without the flag, the same invocation silently prunes the `hashicorp/archive` block.

Implements Option B from the issue (docs-only). Option A (pre-push guard script + tests) is intentionally skipped — the issue explicitly prefers Option B as cheaper and probably sufficient, and Option A can be filed as a follow-up if the docs guidance turns out to be insufficient.

Closes #2582

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green
- [x] `scripts/check-markdown-links.sh` passes (already passed in pre-push)

### Post-deploy verification
- [x] N/A — docs-only change, no deployed component
