### PR TITLE
fix(ci): accept scale-to-zero ECS deployments as rollout success (#2585)

### DIFF
--- a/scripts/tests/test_wait_for_rollout.sh
+++ b/scripts/tests/test_wait_for_rollout.sh
@@ -413,6 +413,54 @@ test_timeout() {
     fi
 }
 
+# Test 6a: COMPLETED with desiredCount=0 and runningCount=0 exits 0.
+# Mirrors the scale-to-zero deployment case from #2585 — the dev ingestion
+# worker is kept at desiredCount=0, and ECS marks new deployments COMPLETED
+# immediately. The script used to require runningCount>0 and timed out in
+# this case; now it treats running==desired==0 as a valid success state.
+test_scale_to_zero_completed() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    mkdir -p "$tmpdir/responses"
+    write_response "$tmpdir/responses/01.json" "COMPLETED" 0 0 0
+
+    local output exit_code
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        pass "scale-to-zero COMPLETED (desired=0, running=0) exits 0"
+    else
+        fail "scale-to-zero COMPLETED (desired=0, running=0) exits 0" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -qi "success"; then
+        pass "scale-to-zero COMPLETED emits a success message"
+    else
+        fail "scale-to-zero COMPLETED emits a success message" "output=$output"
+    fi
+}
+
+# Test 6b: deployment-id selector also accepts scale-to-zero COMPLETED.
+# Covers the operator --force-new-deployment redeploy path (scripts/ecs-redeploy.sh)
+# when the service is scaled to desiredCount=0.
+test_deployment_id_scale_to_zero_completed() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    mkdir -p "$tmpdir/responses"
+    write_response_redeploy "$tmpdir/responses/01.json" "COMPLETED" 0 0 0
+
+    local output exit_code
+    output=$(run_script_by_deployment_id "$tmpdir" "ecs-svc/new-redeploy" 2>&1) || exit_code=$?
+    exit_code="${exit_code:-0}"
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        pass "deployment-id scale-to-zero COMPLETED exits 0"
+    else
+        fail "deployment-id scale-to-zero COMPLETED exits 0" "exit=$exit_code output=$output"
+    fi
+}
+
 # Test 6: COMPLETED with running!=desired keeps polling until real completion.
 test_completed_but_running_not_yet_matching() {
     local tmpdir
@@ -648,6 +696,8 @@ test_in_progress_then_completed
 test_deployment_missing_then_appears
 test_failed_rollout
 test_timeout
+test_scale_to_zero_completed
+test_deployment_id_scale_to_zero_completed
 test_completed_but_running_not_yet_matching
 test_aws_cli_failure
 test_missing_required_env

--- a/scripts/wait-for-rollout.sh
+++ b/scripts/wait-for-rollout.sh
@@ -33,7 +33,11 @@
 #
 # Exit codes:
 #   0 — Target deployment reached rolloutState=COMPLETED with runningCount==
-#       desiredCount (and desiredCount > 0).
+#       desiredCount. This includes the scale-to-zero case (desired=0,
+#       running=0): when a service is kept at desiredCount=0 (e.g. dev
+#       ingestion worker runs only on-demand), ECS marks the new deployment
+#       COMPLETED immediately with no tasks to launch, and we treat that as
+#       a successful rollout (#2585).
 #   1 — rolloutState=FAILED, or the timeout elapsed, or the aws CLI failed,
 #       or the env-var contract was violated.
 
@@ -108,8 +112,19 @@ while true; do
 
     case "$ROLLOUT_STATE" in
       COMPLETED)
-        if [ "$RUNNING_COUNT" = "$DESIRED_COUNT" ] && [ "$RUNNING_COUNT" != "0" ]; then
-          echo "Service updated successfully after ${ELAPSED}s."
+        # Treat COMPLETED as success when runningCount == desiredCount. This
+        # includes the scale-to-zero case (desired=0, running=0) — see #2585.
+        # Earlier revisions required runningCount!=0 to guard against a race
+        # where COMPLETED is briefly reported with running=0 during a normal
+        # rollout (desired>0); the `running==desired` check preserves that
+        # guard for desired>0 while accepting the legitimate desired=0
+        # terminal state.
+        if [ "$RUNNING_COUNT" = "$DESIRED_COUNT" ]; then
+          if [ "$DESIRED_COUNT" = "0" ]; then
+            echo "Service updated successfully after ${ELAPSED}s (scale-to-zero: running=0 desired=0)."
+          else
+            echo "Service updated successfully after ${ELAPSED}s."
+          fi
           exit 0
         fi
         ;;


### PR DESCRIPTION
## Summary

Fixes the `wait-for-rollout.sh` false-failure where a service at `desiredCount=0` (e.g. dev ingestion worker) causes ECS to mark the new deployment `COMPLETED` immediately, but the script kept polling until its 900s timeout because the success condition required `runningCount != 0`. The running==desired check alone is sufficient — it preserves the original rollout race guard (running=0 cannot match desired=1) and naturally accepts running=0 == desired=0 as a valid terminal state.

Closes #2585

## Test plan

### Automated checks
- [x] Lint passes (shellcheck reports only 2 pre-existing SC2016 info-level warnings on unchanged lines)
- [x] Tests pass — 31/31 `scripts/tests/test_wait_for_rollout.sh` tests pass locally, including 2 new ones (`test_scale_to_zero_completed`, `test_deployment_id_scale_to_zero_completed`) and the preserved race-guard Test 6
- [x] CI green (ci-passed SUCCESS; scripts-tests SUCCESS)

### Post-deploy verification
- [x] The merge-deploy `Deploy Ingestion Worker to Dev` workflow succeeds against the desiredCount=0 service — verified by running the merged `scripts/wait-for-rollout.sh` directly against the live dev ingestion-worker service (desired=0, running=0, COMPLETED): exit 0 in 0s; pre-fix version at same state timed out with exit 1 as in #2585
- [x] Verification evidence posted on issue #2585 (https://github.com/judgemind/judgemind/issues/2585#issuecomment-4267425321)
