### PR TITLE
feat(validation): retroactive audit for document-level deterministic rules (#2567)

### DIFF
--- a/packages/scraper-framework/tests/test_audit_document_validation_rules.py
+++ b/packages/scraper-framework/tests/test_audit_document_validation_rules.py
@@ -1,0 +1,769 @@
+"""Tests for scripts/audit_document_validation_rules.py.
+
+The audit script re-runs document-level deterministic validation rules
+(currently only ``no_cross_case_ruling_text``) against existing rows in
+``derived.rulings`` so that contamination in pre-rule rulings can be
+measured without a full reingest.  These tests exercise the pure-Python
+helpers the CLI is built on — sibling grouping, per-group auditing, and
+the DB writeback.
+
+See issue #2567.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import date
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# Load the script as a module — it lives in scripts/ which is not a package.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "audit_document_validation_rules.py"
+_spec = importlib.util.spec_from_file_location("audit_document_validation_rules", _SCRIPT_PATH)
+assert _spec is not None and _spec.loader is not None
+audit = importlib.util.module_from_spec(_spec)
+sys.modules["audit_document_validation_rules"] = audit
+_spec.loader.exec_module(audit)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ruling(
+    ruling_id: str = "11111111-0000-0000-0000-000000000001",
+    document_id: str = "22222222-0000-0000-0000-000000000001",
+    court_id: str = "33333333-0000-0000-0000-000000000001",
+    s3_key: str = "ca/santa_clara/superior/raw/abc.pdf",
+    case_number: str = "24CV001",
+    case_title: str | None = "Smith v. Jones",
+    ruling_text: str | None = "The motion is GRANTED.",
+    hearing_date: date | None = None,
+    captured_at: date | None = None,
+    county: str = "Santa Clara",
+) -> dict:
+    return {
+        "ruling_id": ruling_id,
+        "document_id": document_id,
+        "court_id": court_id,
+        "s3_key": s3_key,
+        "case_number": case_number,
+        "case_title": case_title,
+        "ruling_text": ruling_text,
+        "hearing_date": hearing_date,
+        "captured_at": captured_at,
+        "county": county,
+    }
+
+
+# ---------------------------------------------------------------------------
+# group_rulings_by_source
+# ---------------------------------------------------------------------------
+
+
+class TestGroupRulingsBySource:
+    def test_singleton_groups_excluded(self) -> None:
+        """Rulings with no siblings cannot trigger cross-case rules."""
+        rulings = [
+            _make_ruling(
+                ruling_id="11111111-0000-0000-0000-000000000001",
+                document_id="22222222-0000-0000-0000-000000000001",
+                s3_key="ca/santa_clara/superior/raw/abc.pdf",
+            ),
+        ]
+        groups = audit.group_rulings_by_source(rulings)
+        assert groups == []
+
+    def test_multi_ruling_group_included(self) -> None:
+        """Two rulings sharing a source document form one group."""
+        r1 = _make_ruling(
+            ruling_id="11111111-0000-0000-0000-000000000001",
+            document_id="22222222-0000-0000-0000-000000000001",
+            s3_key="ca/santa_clara/superior/raw/abc.pdf",
+            case_number="24CV001",
+        )
+        r2 = _make_ruling(
+            ruling_id="11111111-0000-0000-0000-000000000002",
+            document_id="22222222-0000-0000-0000-000000000002",
+            s3_key="ca/santa_clara/superior/raw/abc.pdf",
+            case_number="24CV002",
+        )
+        groups = audit.group_rulings_by_source([r1, r2])
+        assert len(groups) == 1
+        members = groups[0]["rulings"]
+        assert len(members) == 2
+        case_numbers = sorted(r["case_number"] for r in members)
+        assert case_numbers == ["24CV001", "24CV002"]
+
+    def test_missing_court_id_or_s3_key_skipped(self) -> None:
+        """Rows with missing court_id or s3_key are dropped before bucketing."""
+        r1 = _make_ruling(court_id=None, s3_key="k.pdf")
+        r2 = _make_ruling(court_id="c1", s3_key=None)
+        groups = audit.group_rulings_by_source([r1, r2])
+        assert groups == []
+
+    def test_different_courts_not_merged(self) -> None:
+        """Two rulings with the same s3_key but different court_id stay separate."""
+        r1 = _make_ruling(
+            ruling_id="11111111-0000-0000-0000-000000000001",
+            court_id="33333333-0000-0000-0000-000000000001",
+            s3_key="shared/key.pdf",
+        )
+        r2 = _make_ruling(
+            ruling_id="11111111-0000-0000-0000-000000000002",
+            court_id="33333333-0000-0000-0000-000000000002",
+            s3_key="shared/key.pdf",
+        )
+        groups = audit.group_rulings_by_source([r1, r2])
+        # Each is a singleton under its own (court_id, s3_key) — both excluded.
+        assert groups == []
+
+
+# ---------------------------------------------------------------------------
+# audit_group
+# ---------------------------------------------------------------------------
+
+
+class TestAuditGroup:
+    def test_flag_cross_case_reference(self) -> None:
+        """A ruling whose text names a sibling's case number is flagged."""
+        # Use LA-style format (\d{2}[A-Z]{2,6}\d{4,10}) which matches the
+        # deterministic-rule scanner's case-number candidate pattern.
+        r1 = _make_ruling(
+            ruling_id="11111111-0000-0000-0000-000000000001",
+            document_id="22222222-0000-0000-0000-000000000001",
+            case_number="24STCV12345",
+            ruling_text="The court rules on 24STCV99999. Motion GRANTED.",
+        )
+        r2 = _make_ruling(
+            ruling_id="11111111-0000-0000-0000-000000000002",
+            document_id="22222222-0000-0000-0000-000000000002",
+            case_number="24STCV99999",
+            ruling_text="Unrelated motion DENIED.",
+        )
+        flags = audit.audit_group(
+            {"court_id": "ct", "s3_key": "k", "rulings": [r1, r2]},
+            rule_filter=None,
+        )
+        rule_names = [f["rule"] for f in flags]
+        assert "no_cross_case_ruling_text" in rule_names
+        # Only r1 should be flagged for cross-case reference.
+        flagged_ids = {f["ruling_id"] for f in flags if f["rule"] == "no_cross_case_ruling_text"}
+        assert flagged_ids == {"11111111-0000-0000-0000-000000000001"}
+
+    def test_no_flag_clean_text(self) -> None:
+        """Rulings that don't reference siblings produce no cross-case flag."""
+        r1 = _make_ruling(
+            ruling_id="11111111-0000-0000-0000-000000000001",
+            case_number="24STCV12345",
+            ruling_text="Motion GRANTED.",
+        )
+        r2 = _make_ruling(
+            ruling_id="11111111-0000-0000-0000-000000000002",
+            case_number="24STCV99999",
+            ruling_text="Motion DENIED.",
+        )
+        flags = audit.audit_group(
+            {"court_id": "ct", "s3_key": "k", "rulings": [r1, r2]},
+            rule_filter="no_cross_case_ruling_text",
+        )
+        assert flags == []
+
+    def test_rule_filter_scopes_to_single_rule(self) -> None:
+        """--rule no_cross_case_ruling_text only runs that rule."""
+        # Concatenated title would also flag no_multiple_adversarial_patterns,
+        # but that's a per-ruling rule and shouldn't be returned when the
+        # filter is scoped to the document-level cross-case rule.
+        r1 = _make_ruling(
+            ruling_id="11111111-0000-0000-0000-000000000001",
+            case_number="24STCV12345",
+            case_title="Smith v. Jones vs. Acme Corp.",
+            ruling_text="Motion GRANTED.",
+        )
+        r2 = _make_ruling(
+            ruling_id="11111111-0000-0000-0000-000000000002",
+            case_number="24STCV99999",
+            ruling_text="Motion DENIED.",
+        )
+        flags = audit.audit_group(
+            {"court_id": "ct", "s3_key": "k", "rulings": [r1, r2]},
+            rule_filter="no_cross_case_ruling_text",
+        )
+        # No cross-case reference — no flags for the scoped rule.
+        assert flags == []
+
+    def test_skip_rulings_without_ruling_text(self) -> None:
+        """Rulings with empty ruling_text are skipped — nothing to scan."""
+        r1 = _make_ruling(
+            ruling_id="11111111-0000-0000-0000-000000000001",
+            case_number="24STCV12345",
+            ruling_text=None,
+        )
+        r2 = _make_ruling(
+            ruling_id="11111111-0000-0000-0000-000000000002",
+            case_number="24STCV99999",
+            ruling_text="Motion DENIED.",
+        )
+        flags = audit.audit_group(
+            {"court_id": "ct", "s3_key": "k", "rulings": [r1, r2]},
+            rule_filter="no_cross_case_ruling_text",
+        )
+        # No flags because r1 has no text and r2's text doesn't reference r1.
+        assert flags == []
+
+    def test_skip_rulings_without_case_number(self) -> None:
+        """Rulings with missing case numbers don't crash; they are skipped."""
+        r1 = _make_ruling(
+            ruling_id="11111111-0000-0000-0000-000000000001",
+            case_number=None,
+            ruling_text="Text mentions 24STCV99999.",
+        )
+        r2 = _make_ruling(
+            ruling_id="11111111-0000-0000-0000-000000000002",
+            case_number="24STCV99999",
+            ruling_text="Motion DENIED.",
+        )
+        flags = audit.audit_group(
+            {"court_id": "ct", "s3_key": "k", "rulings": [r1, r2]},
+            rule_filter="no_cross_case_ruling_text",
+        )
+        # r1 is skipped (no own_case_number).  r2 has a case number but its
+        # text doesn't reference r1's (None) case number.
+        assert flags == []
+
+
+# ---------------------------------------------------------------------------
+# write_flags_to_db
+# ---------------------------------------------------------------------------
+
+
+class TestWriteFlagsToDb:
+    def _mock_conn(self) -> tuple[MagicMock, MagicMock]:
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_conn, mock_cur
+
+    def test_insert_one_row_per_flag(self) -> None:
+        """Each flag produces one validation_results insert."""
+        conn, cur = self._mock_conn()
+        flags = [
+            {
+                "ruling_id": "11111111-0000-0000-0000-000000000001",
+                "document_id": "22222222-0000-0000-0000-000000000001",
+                "rule": "no_cross_case_ruling_text",
+                "reason": "ruling_text references 1 other case number(s) ...",
+                "result": "flag",
+            },
+        ]
+        inserted = audit.write_flags_to_db(conn, flags)
+        assert inserted == 1
+        assert cur.execute.call_count == 1
+
+    def test_reason_prefixed_with_rule_name(self) -> None:
+        """DB reason column embeds the rule name since there's no rule col."""
+        conn, cur = self._mock_conn()
+        flags = [
+            {
+                "ruling_id": "11111111-0000-0000-0000-000000000001",
+                "document_id": "22222222-0000-0000-0000-000000000001",
+                "rule": "no_cross_case_ruling_text",
+                "reason": "ruling_text references 1 other case",
+                "result": "flag",
+            },
+        ]
+        audit.write_flags_to_db(conn, flags)
+        # The inserted reason must contain both the rule name and the reason.
+        insert_args = cur.execute.call_args
+        params = insert_args.args[1]
+        reason_col = params[3]  # matches INSERT column order in gate.py
+        assert "no_cross_case_ruling_text" in reason_col
+        assert "ruling_text references" in reason_col
+
+    def test_empty_flags_no_inserts(self) -> None:
+        conn, cur = self._mock_conn()
+        inserted = audit.write_flags_to_db(conn, [])
+        assert inserted == 0
+        assert cur.execute.call_count == 0
+
+
+# ---------------------------------------------------------------------------
+# build_report
+# ---------------------------------------------------------------------------
+
+
+class TestBuildReport:
+    def test_per_county_counts(self) -> None:
+        """Report groups flag counts by county."""
+        flags = [
+            {
+                "ruling_id": "1",
+                "document_id": "d1",
+                "rule": "no_cross_case_ruling_text",
+                "reason": "x",
+                "result": "flag",
+                "county": "Santa Clara",
+            },
+            {
+                "ruling_id": "2",
+                "document_id": "d2",
+                "rule": "no_cross_case_ruling_text",
+                "reason": "y",
+                "result": "flag",
+                "county": "Santa Clara",
+            },
+            {
+                "ruling_id": "3",
+                "document_id": "d3",
+                "rule": "no_cross_case_ruling_text",
+                "reason": "z",
+                "result": "flag",
+                "county": "San Diego",
+            },
+        ]
+        report = audit.build_report(flags, groups_scanned=10, rulings_scanned=42)
+        assert report["total_flags"] == 3
+        assert report["groups_scanned"] == 10
+        assert report["rulings_scanned"] == 42
+        per_county = {c["county"]: c["flag_count"] for c in report["per_county"]}
+        assert per_county == {"Santa Clara": 2, "San Diego": 1}
+
+    def test_report_is_json_serializable(self) -> None:
+        import json
+
+        flags = [
+            {
+                "ruling_id": "1",
+                "document_id": "d1",
+                "rule": "no_cross_case_ruling_text",
+                "reason": "x",
+                "result": "flag",
+                "county": "Santa Clara",
+            },
+        ]
+        report = audit.build_report(flags, groups_scanned=1, rulings_scanned=2)
+        # round-trips without raising
+        _ = json.dumps(report)
+
+
+# ---------------------------------------------------------------------------
+# CLI argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseArgs:
+    def test_dry_run_and_write_mutually_exclusive(self) -> None:
+        with pytest.raises(SystemExit):
+            audit.parse_args(["--dry-run", "--write"])
+
+    def test_default_is_dry_run(self) -> None:
+        args = audit.parse_args([])
+        assert args.write is False
+        assert args.dry_run is True
+
+    def test_rule_flag(self) -> None:
+        args = audit.parse_args(["--rule", "no_cross_case_ruling_text"])
+        assert args.rule == "no_cross_case_ruling_text"
+
+    def test_county_flag(self) -> None:
+        args = audit.parse_args(["--county", "Santa Clara"])
+        assert args.county == "Santa Clara"
+
+    def test_json_flag(self) -> None:
+        args = audit.parse_args(["--json"])
+        assert args.json is True
+
+    def test_limit_flag(self) -> None:
+        args = audit.parse_args(["--limit", "100"])
+        assert args.limit == 100
+
+    def test_unknown_rule_rejected(self) -> None:
+        with pytest.raises(SystemExit):
+            audit.parse_args(["--rule", "not_a_real_rule"])
+
+
+# ---------------------------------------------------------------------------
+# _build_query
+# ---------------------------------------------------------------------------
+
+
+class TestBuildQuery:
+    def test_no_filters(self) -> None:
+        """With no county or limit, the clauses are empty strings."""
+        query, params = audit._build_query(county=None, limit=None)
+        assert params == []
+        # Both clause placeholders are blank.
+        assert "{county_clause}" not in query
+        assert "{limit_clause}" not in query
+        assert "AND ct.county" not in query
+        assert "LIMIT" not in query
+
+    def test_county_filter(self) -> None:
+        """--county adds a parameterized county clause."""
+        query, params = audit._build_query(county="Santa Clara", limit=None)
+        assert params == ["Santa Clara"]
+        assert "AND ct.county = %s" in query
+
+    def test_limit_only(self) -> None:
+        """--limit adds a parameterized LIMIT clause."""
+        query, params = audit._build_query(county=None, limit=5)
+        assert params == [5]
+        assert "LIMIT %s" in query
+
+    def test_county_and_limit(self) -> None:
+        """Both flags compose correctly; params are in SQL order."""
+        query, params = audit._build_query(county="San Diego", limit=100)
+        assert params == ["San Diego", 100]
+        assert "AND ct.county = %s" in query
+        assert "LIMIT %s" in query
+
+
+# ---------------------------------------------------------------------------
+# _resolve_rules
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRules:
+    def test_none_returns_all(self) -> None:
+        """None returns the full rule registry."""
+        rules = audit._resolve_rules(None)
+        assert "no_cross_case_ruling_text" in rules
+
+    def test_named_rule_returns_single(self) -> None:
+        """A specific rule returns only that rule."""
+        rules = audit._resolve_rules("no_cross_case_ruling_text")
+        assert list(rules) == ["no_cross_case_ruling_text"]
+
+    def test_unknown_rule_raises(self) -> None:
+        """Unknown rule name raises ValueError with a helpful message."""
+        with pytest.raises(ValueError, match="Unknown rule"):
+            audit._resolve_rules("not_a_rule")
+
+
+# ---------------------------------------------------------------------------
+# _print_human_report
+# ---------------------------------------------------------------------------
+
+
+class TestPrintHumanReport:
+    def test_print_with_flags(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Human report prints per-county and per-rule sections with flags."""
+        report = {
+            "rulings_scanned": 42,
+            "groups_scanned": 5,
+            "total_flags": 3,
+            "per_county": [
+                {"county": "Santa Clara", "flag_count": 2},
+                {"county": "San Diego", "flag_count": 1},
+            ],
+            "per_rule": [
+                {"rule": "no_cross_case_ruling_text", "flag_count": 3},
+            ],
+        }
+        audit._print_human_report(report)
+        captured = capsys.readouterr()
+        assert "Rulings scanned: 42" in captured.out
+        assert "Sibling groups:  5" in captured.out
+        assert "Total flags:     3" in captured.out
+        assert "Santa Clara" in captured.out
+        assert "San Diego" in captured.out
+        assert "no_cross_case_ruling_text" in captured.out
+
+    def test_print_empty_report(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Human report prints (none) when there are no flags."""
+        report = {
+            "rulings_scanned": 10,
+            "groups_scanned": 0,
+            "total_flags": 0,
+            "per_county": [],
+            "per_rule": [],
+        }
+        audit._print_human_report(report)
+        captured = capsys.readouterr()
+        assert "(none)" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# run_audit
+# ---------------------------------------------------------------------------
+
+
+class TestRunAudit:
+    def _fake_connect(
+        self, rows: list[tuple[Any, ...]], cols: list[str]
+    ) -> tuple[MagicMock, MagicMock, MagicMock]:
+        """Build a patched psycopg.connect that returns the given rows/cols."""
+        mock_cur = MagicMock()
+        mock_cur.description = [(c,) for c in cols]
+        mock_cur.execute = MagicMock()
+        mock_cur.__iter__ = lambda self: iter(rows)
+
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_ctx = MagicMock()
+        mock_ctx.__enter__ = MagicMock(return_value=mock_conn)
+        mock_ctx.__exit__ = MagicMock(return_value=False)
+
+        return mock_ctx, mock_conn, mock_cur
+
+    def test_dry_run_returns_report_without_writing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Dry-run detects flags but does not call write_flags_to_db."""
+        cols = [
+            "ruling_id",
+            "document_id",
+            "court_id",
+            "s3_key",
+            "case_number",
+            "case_title",
+            "ruling_text",
+            "hearing_date",
+            "captured_at",
+            "county",
+        ]
+        # Two siblings from the same (court_id, s3_key) where r1 references r2.
+        rows = [
+            (
+                "11111111-0000-0000-0000-000000000001",
+                "22222222-0000-0000-0000-000000000001",
+                "33333333-0000-0000-0000-000000000001",
+                "ca/santa_clara/superior/raw/abc.pdf",
+                "24STCV12345",
+                "Smith v Jones",
+                "Court rules 24STCV99999 GRANTED.",
+                None,
+                None,
+                "Santa Clara",
+            ),
+            (
+                "11111111-0000-0000-0000-000000000002",
+                "22222222-0000-0000-0000-000000000002",
+                "33333333-0000-0000-0000-000000000001",
+                "ca/santa_clara/superior/raw/abc.pdf",
+                "24STCV99999",
+                "Other case",
+                "Motion DENIED.",
+                None,
+                None,
+                "Santa Clara",
+            ),
+        ]
+        ctx, conn, _cur = self._fake_connect(rows, cols)
+        monkeypatch.setattr(audit.psycopg, "connect", lambda dsn: ctx)
+
+        called_write = {"n": 0}
+
+        def fake_write(_conn: Any, flags: list[dict]) -> int:
+            called_write["n"] += len(flags)
+            return len(flags)
+
+        monkeypatch.setattr(audit, "write_flags_to_db", fake_write)
+
+        report = audit.run_audit(
+            "postgresql://fake",
+            county=None,
+            rule_filter=None,
+            write=False,
+            limit=None,
+        )
+        # Cross-case flag detected but NOT written.
+        assert report["rulings_scanned"] == 2
+        assert report["groups_scanned"] == 1
+        assert report["total_flags"] >= 1
+        assert called_write["n"] == 0
+        conn.commit.assert_not_called()
+
+    def test_write_mode_commits_flags(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """--write triggers write_flags_to_db and conn.commit when flags exist."""
+        cols = [
+            "ruling_id",
+            "document_id",
+            "court_id",
+            "s3_key",
+            "case_number",
+            "case_title",
+            "ruling_text",
+            "hearing_date",
+            "captured_at",
+            "county",
+        ]
+        rows = [
+            (
+                "11111111-0000-0000-0000-000000000001",
+                "22222222-0000-0000-0000-000000000001",
+                "33333333-0000-0000-0000-000000000001",
+                "ca/sc/raw.pdf",
+                "24STCV12345",
+                "A",
+                "Rules 24STCV99999 GRANTED.",
+                None,
+                None,
+                "Santa Clara",
+            ),
+            (
+                "11111111-0000-0000-0000-000000000002",
+                "22222222-0000-0000-0000-000000000002",
+                "33333333-0000-0000-0000-000000000001",
+                "ca/sc/raw.pdf",
+                "24STCV99999",
+                "B",
+                "DENIED.",
+                None,
+                None,
+                "Santa Clara",
+            ),
+        ]
+        ctx, conn, _cur = self._fake_connect(rows, cols)
+        monkeypatch.setattr(audit.psycopg, "connect", lambda dsn: ctx)
+
+        calls = {"write": 0}
+
+        def fake_write(_conn: Any, flags: list[dict]) -> int:
+            calls["write"] += len(flags)
+            return len(flags)
+
+        monkeypatch.setattr(audit, "write_flags_to_db", fake_write)
+
+        report = audit.run_audit(
+            "postgresql://fake",
+            county="Santa Clara",
+            rule_filter="no_cross_case_ruling_text",
+            write=True,
+            limit=10,
+        )
+        assert report["total_flags"] >= 1
+        assert calls["write"] == report["total_flags"]
+        conn.commit.assert_called_once()
+
+    def test_write_mode_no_flags_skips_commit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When there are zero flags, no commit is issued."""
+        cols = [
+            "ruling_id",
+            "document_id",
+            "court_id",
+            "s3_key",
+            "case_number",
+            "case_title",
+            "ruling_text",
+            "hearing_date",
+            "captured_at",
+            "county",
+        ]
+        rows: list[tuple[Any, ...]] = []  # empty
+        ctx, conn, _cur = self._fake_connect(rows, cols)
+        monkeypatch.setattr(audit.psycopg, "connect", lambda dsn: ctx)
+        report = audit.run_audit(
+            "postgresql://fake",
+            county=None,
+            rule_filter=None,
+            write=True,
+            limit=None,
+        )
+        assert report["total_flags"] == 0
+        conn.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_missing_dsn_returns_1(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Absent DATABASE_URL exits with code 1."""
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        rc = audit.main([])
+        assert rc == 1
+
+    def test_json_output(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--json emits JSON-parseable stdout."""
+        import json
+
+        monkeypatch.setenv("DATABASE_URL", "postgresql://fake")
+
+        def fake_run_audit(*args: Any, **kwargs: Any) -> dict:
+            return {
+                "generated_at": "2026-04-17T00:00:00+00:00",
+                "rulings_scanned": 0,
+                "groups_scanned": 0,
+                "total_flags": 0,
+                "per_county": [],
+                "per_rule": [],
+                "flags": [],
+            }
+
+        monkeypatch.setattr(audit, "run_audit", fake_run_audit)
+        rc = audit.main(["--json"])
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed["total_flags"] == 0
+        assert rc == 0
+
+    def test_human_output(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Default output is human-readable."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://fake")
+
+        def fake_run_audit(*args: Any, **kwargs: Any) -> dict:
+            return {
+                "generated_at": "2026-04-17T00:00:00+00:00",
+                "rulings_scanned": 5,
+                "groups_scanned": 2,
+                "total_flags": 0,
+                "per_county": [],
+                "per_rule": [],
+                "flags": [],
+            }
+
+        monkeypatch.setattr(audit, "run_audit", fake_run_audit)
+        rc = audit.main([])
+        captured = capsys.readouterr()
+        assert "Rulings scanned: 5" in captured.out
+        assert rc == 0
+
+    def test_nonzero_exit_when_flags_found(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Exit code 1 when there's at least one flag."""
+        monkeypatch.setenv("DATABASE_URL", "postgresql://fake")
+
+        def fake_run_audit(*args: Any, **kwargs: Any) -> dict:
+            return {
+                "generated_at": "2026-04-17T00:00:00+00:00",
+                "rulings_scanned": 1,
+                "groups_scanned": 1,
+                "total_flags": 1,
+                "per_county": [{"county": "Santa Clara", "flag_count": 1}],
+                "per_rule": [{"rule": "no_cross_case_ruling_text", "flag_count": 1}],
+                "flags": [
+                    {
+                        "ruling_id": "1",
+                        "document_id": "d1",
+                        "rule": "no_cross_case_ruling_text",
+                        "reason": "x",
+                        "result": "flag",
+                        "county": "Santa Clara",
+                    }
+                ],
+            }
+
+        monkeypatch.setattr(audit, "run_audit", fake_run_audit)
+        rc = audit.main([])
+        assert rc == 1

--- a/packages/scraper-framework/tests/test_rebuild_db.py
+++ b/packages/scraper-framework/tests/test_rebuild_db.py
@@ -1673,6 +1673,12 @@ class TestMainPoolBreakHandling:
                 {
                     "DATABASE_URL": "postgres://test",
                     "S3_CACHE_DIR": cache_dir,
+                    # Disable retry-cap gates (#2572) so this test exercises
+                    # the retry path even when crashed/total > 10%.  Without
+                    # this, main() aborts with sys.exit(2) before the
+                    # pool-break summary is logged.  See #2567.
+                    "REBUILD_MAX_RETRY_COUNT": "0",
+                    "REBUILD_MAX_RETRY_RATIO": "0",
                 },
             ),
             patch("sys.argv", ["rebuild_db.py"]),
@@ -1759,6 +1765,12 @@ class TestMainPoolBreakHandling:
                 {
                     "DATABASE_URL": "postgres://test",
                     "S3_CACHE_DIR": cache_dir,
+                    # Disable retry-cap gates (#2572) so this test exercises
+                    # the retry path even when crashed/total > 10%.  Without
+                    # this, main() aborts with sys.exit(2) before the
+                    # pool-break summary is logged.  See #2567.
+                    "REBUILD_MAX_RETRY_COUNT": "0",
+                    "REBUILD_MAX_RETRY_RATIO": "0",
                 },
             ),
             patch("sys.argv", ["rebuild_db.py"]),

--- a/scripts/audit_document_validation_rules.py
+++ b/scripts/audit_document_validation_rules.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python3
+"""Retroactive audit for document-level deterministic validation rules.
+
+PR #2396 shipped ``check_no_cross_case_ruling_text`` as a document-level
+deterministic validation rule that runs during ingestion.  It only flags
+rulings at *ingest time* — existing rows in ``derived.rulings`` that were
+ingested before the rule shipped are not flagged, and a full reingest is
+expensive (LLM calls, S3 reads).
+
+This script re-runs document-level deterministic rules against the
+current contents of ``derived.rulings`` and optionally writes flag rows
+to ``telemetry.validation_results`` so the per-county follow-up issues
+(#2562, #2563, #2564, #2565, #2566) can measure baseline contamination
+quantitatively.
+
+The script groups rulings by ``(court_id, s3_key)`` because multi-case
+calendar PDFs are represented as N split-child documents all sharing the
+same raw S3 object (see ``ingestion.split_ids``).  Only groups with
+2+ rulings are audited — singleton groups cannot produce cross-case
+flags because there are no siblings to cross-reference.
+
+Usage (via ECS, for dev DB access):
+
+    scripts/ecs-run-task.sh --script scripts/audit_document_validation_rules.py -- \\
+        --county "San Bernardino" --rule no_cross_case_ruling_text --write
+
+Local / dry-run (connects to whatever ``DATABASE_URL`` points at):
+
+    scripts/run-py.sh scripts/audit_document_validation_rules.py --json
+    scripts/run-py.sh scripts/audit_document_validation_rules.py --county "Santa Clara"
+
+CLI flags:
+  --county NAME   Restrict to a single county (matches ``derived.courts.county``).
+  --rule NAME     Restrict to a single document-level rule.  Currently the only
+                  supported value is ``no_cross_case_ruling_text``.
+  --dry-run       Do not write to the DB.  This is the DEFAULT.
+  --write         Insert one ``telemetry.validation_results`` row per flag.
+                  Mutually exclusive with ``--dry-run``.
+  --json          Emit a machine-readable JSON report on stdout.
+  --limit N       Scan at most N rulings (useful for smoke tests on dev).
+
+Exit code: ``0`` when zero flags are found, ``1`` otherwise — same convention
+as the other ``scripts/audit_*.py`` helpers.
+
+See issue #2567.
+"""
+
+# venv: scraper-framework
+# one-off: true
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json as json_mod
+import logging
+import os
+import sys
+from collections import defaultdict
+from typing import Any
+
+import psycopg
+
+from validation.deterministic import (
+    check_no_cross_case_ruling_text,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Supported rules
+# ---------------------------------------------------------------------------
+
+# Mapping of supported document-level rule names to the callable that
+# evaluates them on a single ruling given its sibling case numbers.
+# Each callable must accept ``(ruling_text, own_case_number, other_case_numbers)``
+# and return a ``DeterministicRuleResult``.
+_DOCUMENT_LEVEL_RULES: dict[str, Any] = {
+    "no_cross_case_ruling_text": check_no_cross_case_ruling_text,
+}
+
+# ---------------------------------------------------------------------------
+# SQL
+# ---------------------------------------------------------------------------
+
+# Fetch the fields needed to re-run document-level rules.  We use
+# ``d.s3_key`` (plus ``d.court_id``) as the sibling grouping key because
+# split-child documents share the same raw S3 object.  ``captured_at`` and
+# ``hearing_date`` are fetched for consistency with per-ruling rules even
+# though no document-level rule currently uses them.
+_AUDIT_QUERY = """
+    SELECT
+        r.id::text          AS ruling_id,
+        d.id::text          AS document_id,
+        d.court_id::text    AS court_id,
+        d.s3_key            AS s3_key,
+        c.case_number       AS case_number,
+        c.case_title        AS case_title,
+        r.ruling_text       AS ruling_text,
+        r.hearing_date      AS hearing_date,
+        d.captured_at       AS captured_at,
+        ct.county           AS county
+    FROM derived.rulings r
+    JOIN derived.documents d ON d.id = r.document_id
+    JOIN derived.courts ct   ON ct.id = d.court_id
+    LEFT JOIN derived.cases c ON c.id = r.case_id
+    WHERE d.status = 'active'
+      {county_clause}
+    ORDER BY d.court_id, d.s3_key, r.id
+    {limit_clause}
+"""
+
+
+def _build_query(county: str | None, limit: int | None) -> tuple[str, list[Any]]:
+    """Build the audit query and parameters, substituting optional clauses."""
+    params: list[Any] = []
+    county_clause = ""
+    if county:
+        county_clause = "AND ct.county = %s"
+        params.append(county)
+    limit_clause = ""
+    if limit is not None:
+        limit_clause = "LIMIT %s"
+        params.append(limit)
+    return (
+        _AUDIT_QUERY.format(
+            county_clause=county_clause,
+            limit_clause=limit_clause,
+        ),
+        params,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Grouping
+# ---------------------------------------------------------------------------
+
+
+def group_rulings_by_source(rulings: list[dict]) -> list[dict]:
+    """Group rulings by ``(court_id, s3_key)`` and drop singletons.
+
+    Parameters
+    ----------
+    rulings:
+        Rows from ``_AUDIT_QUERY`` (or equivalent) as dicts.
+
+    Returns
+    -------
+    list[dict]
+        One group per multi-ruling source document, each shaped as::
+
+            {"court_id": str, "s3_key": str, "rulings": list[dict]}
+
+        Singleton groups are excluded — cross-case rules need at least two
+        siblings.
+    """
+    buckets: dict[tuple[str, str], list[dict]] = defaultdict(list)
+    for r in rulings:
+        court_id = r.get("court_id")
+        s3_key = r.get("s3_key")
+        if not court_id or not s3_key:
+            continue
+        buckets[(str(court_id), str(s3_key))].append(r)
+
+    groups: list[dict] = []
+    for (court_id, s3_key), members in buckets.items():
+        if len(members) < 2:
+            continue
+        groups.append(
+            {
+                "court_id": court_id,
+                "s3_key": s3_key,
+                "rulings": members,
+            }
+        )
+    return groups
+
+
+# ---------------------------------------------------------------------------
+# Auditing
+# ---------------------------------------------------------------------------
+
+
+def _resolve_rules(rule_filter: str | None) -> dict[str, Any]:
+    """Resolve the rule_filter argument into a dict of rule_name → checker."""
+    if rule_filter is None:
+        return dict(_DOCUMENT_LEVEL_RULES)
+    if rule_filter not in _DOCUMENT_LEVEL_RULES:
+        raise ValueError(
+            f"Unknown rule '{rule_filter}'. Supported: {sorted(_DOCUMENT_LEVEL_RULES)}"
+        )
+    return {rule_filter: _DOCUMENT_LEVEL_RULES[rule_filter]}
+
+
+def audit_group(group: dict, *, rule_filter: str | None) -> list[dict]:
+    """Run document-level rules over a single sibling group and return flags.
+
+    For each ruling in the group, evaluate each selected document-level rule
+    using sibling context (the other rulings' case numbers).  Each rule that
+    returns ``flag`` or ``fail`` produces one entry in the returned list.
+
+    Parameters
+    ----------
+    group:
+        A group dict produced by :func:`group_rulings_by_source`.
+    rule_filter:
+        Optional name of a single rule to run.  ``None`` runs all supported
+        document-level rules.
+
+    Returns
+    -------
+    list[dict]
+        Zero or more flag entries, each shaped as::
+
+            {
+                "ruling_id": str,
+                "document_id": str,
+                "rule": str,
+                "reason": str,
+                "result": "flag" | "fail",
+                "county": str,
+            }
+    """
+    rules = _resolve_rules(rule_filter)
+    flags: list[dict] = []
+    members = group["rulings"]
+
+    for member in members:
+        own_case_number = member.get("case_number")
+        # Sibling case numbers = all non-empty case numbers from other rulings.
+        sibling_nums: list[str] = [
+            str(other.get("case_number"))
+            for other in members
+            if other is not member and other.get("case_number")
+        ]
+        if not sibling_nums:
+            continue
+        ruling_text = member.get("ruling_text")
+        # Skip rulings with no text at all — nothing to scan.
+        if not ruling_text:
+            continue
+
+        for rule_name, checker in rules.items():
+            if rule_name == "no_cross_case_ruling_text":
+                # Need an own_case_number to run this rule meaningfully — a
+                # missing own number means we can't exclude own-case matches
+                # from siblings.  Skip rather than emit noise.
+                if not own_case_number:
+                    continue
+                result = checker(
+                    ruling_text=ruling_text,
+                    own_case_number=own_case_number,
+                    other_case_numbers=sibling_nums,
+                )
+            else:  # pragma: no cover - defensive for future rules
+                continue
+
+            if result.result not in ("flag", "fail"):
+                continue
+
+            flags.append(
+                {
+                    "ruling_id": str(member["ruling_id"]),
+                    "document_id": str(member["document_id"]),
+                    "rule": rule_name,
+                    "reason": result.reason or "",
+                    "result": result.result,
+                    "county": member.get("county"),
+                }
+            )
+
+    return flags
+
+
+# ---------------------------------------------------------------------------
+# DB writeback
+# ---------------------------------------------------------------------------
+
+
+def write_flags_to_db(conn: psycopg.Connection, flags: list[dict]) -> int:
+    """Insert one ``telemetry.validation_results`` row per flag.
+
+    The table schema (see ``packages/api/migrations/13_validation-results.sql``)
+    does not include a ``rule`` column — the ``result`` column is constrained
+    to one of ``pass|flag|fail|error`` and the ``model`` column identifies the
+    originating validator.  To preserve per-rule provenance we:
+
+    * Set ``model`` to ``"deterministic"`` (matching the ingestion worker).
+    * Prefix ``reason`` with ``[rule_name]`` so the per-rule query on the
+      issue ticket (``WHERE reason LIKE '[no_cross_case_ruling_text]%%'``)
+      still works even without a dedicated column.
+
+    Parameters
+    ----------
+    conn:
+        Active psycopg connection.  Caller manages commit/rollback.
+    flags:
+        Flag entries returned by :func:`audit_group`.
+
+    Returns
+    -------
+    int
+        Number of rows inserted.
+    """
+    if not flags:
+        return 0
+
+    inserted = 0
+    with conn.cursor() as cur:
+        for f in flags:
+            reason_with_rule = f"[{f['rule']}] {f['reason']}".strip()
+            cur.execute(
+                """
+                INSERT INTO validation_results
+                    (document_id, ruling_id, result, reason, model,
+                     input_tokens, output_tokens, latency_ms)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    f["document_id"],
+                    f["ruling_id"],
+                    f["result"],
+                    reason_with_rule,
+                    "deterministic",
+                    0,
+                    0,
+                    0,
+                ),
+            )
+            inserted += 1
+    return inserted
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def build_report(
+    flags: list[dict],
+    *,
+    groups_scanned: int,
+    rulings_scanned: int,
+) -> dict:
+    """Build a JSON-serialisable audit report."""
+    per_county_counts: dict[str, int] = defaultdict(int)
+    for f in flags:
+        per_county_counts[f.get("county") or "<unknown>"] += 1
+    per_county = [
+        {"county": county, "flag_count": count}
+        for county, count in sorted(per_county_counts.items())
+    ]
+    per_rule_counts: dict[str, int] = defaultdict(int)
+    for f in flags:
+        per_rule_counts[f["rule"]] += 1
+    per_rule = [
+        {"rule": rule, "flag_count": count}
+        for rule, count in sorted(per_rule_counts.items())
+    ]
+    return {
+        "generated_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "groups_scanned": groups_scanned,
+        "rulings_scanned": rulings_scanned,
+        "total_flags": len(flags),
+        "per_county": per_county,
+        "per_rule": per_rule,
+        "flags": flags,
+    }
+
+
+def _print_human_report(report: dict) -> None:
+    """Print a terse human-readable summary to stdout."""
+    print("Document-level validation audit")
+    print("=" * 50)
+    print(f"Rulings scanned: {report['rulings_scanned']}")
+    print(f"Sibling groups:  {report['groups_scanned']}")
+    print(f"Total flags:     {report['total_flags']}")
+    print()
+    print("Flags per county:")
+    if not report["per_county"]:
+        print("  (none)")
+    else:
+        for entry in report["per_county"]:
+            print(f"  {entry['county']:<25s} {entry['flag_count']:>6d}")
+    print()
+    print("Flags per rule:")
+    if not report["per_rule"]:
+        print("  (none)")
+    else:
+        for entry in report["per_rule"]:
+            print(f"  {entry['rule']:<40s} {entry['flag_count']:>6d}")
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def run_audit(
+    dsn: str,
+    *,
+    county: str | None,
+    rule_filter: str | None,
+    write: bool,
+    limit: int | None,
+) -> dict:
+    """Run the full audit against ``dsn`` and return the report dict.
+
+    Opens a single psycopg connection, fetches all candidate rulings, groups
+    them, runs the selected document-level rules, optionally writes flags to
+    ``validation_results``, and returns the report.
+    """
+    query, params = _build_query(county=county, limit=limit)
+
+    rulings: list[dict] = []
+    with psycopg.connect(dsn) as conn:
+        with conn.cursor() as cur:
+            cur.execute(query, params)
+            cols = [desc[0] for desc in cur.description]
+            for row in cur:
+                rulings.append(dict(zip(cols, row, strict=True)))
+
+        groups = group_rulings_by_source(rulings)
+        all_flags: list[dict] = []
+        for group in groups:
+            all_flags.extend(audit_group(group, rule_filter=rule_filter))
+
+        if write and all_flags:
+            inserted = write_flags_to_db(conn, all_flags)
+            conn.commit()
+            logger.info("Wrote %d validation_results rows", inserted)
+
+    return build_report(
+        all_flags,
+        groups_scanned=len(groups),
+        rulings_scanned=len(rulings),
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Retroactively run document-level deterministic validation "
+            "rules against derived.rulings."
+        )
+    )
+    parser.add_argument(
+        "--county",
+        type=str,
+        default=None,
+        help="Restrict audit to a single county.",
+    )
+    parser.add_argument(
+        "--rule",
+        type=str,
+        default=None,
+        choices=sorted(_DOCUMENT_LEVEL_RULES),
+        help="Restrict audit to a single document-level rule.",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Do not write to the DB (default).",
+    )
+    mode.add_argument(
+        "--write",
+        action="store_true",
+        help="Insert one telemetry.validation_results row per flag.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit a machine-readable JSON report on stdout.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Scan at most N rulings (useful for smoke tests).",
+    )
+    args = parser.parse_args(argv)
+
+    # Default to dry-run when neither mode flag is set.
+    if not args.write:
+        args.dry_run = True
+
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        return 1
+
+    report = run_audit(
+        dsn,
+        county=args.county,
+        rule_filter=args.rule,
+        write=args.write,
+        limit=args.limit,
+    )
+
+    if args.json:
+        print(json_mod.dumps(report, indent=2, default=str))
+    else:
+        _print_human_report(report)
+
+    return 0 if report["total_flags"] == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds `scripts/audit_document_validation_rules.py` — a one-off audit that re-runs document-level deterministic validation rules (`no_cross_case_ruling_text` from #2396) against existing rows in `derived.rulings` so the per-county follow-up issues (#2562-#2566) can measure baseline cross-case contamination without a full reingest.
- Groups rulings by `(court_id, s3_key)` (not `document_id`) because `derived.rulings.document_id` is UNIQUE — split-child documents each have their own `document_id` but share the raw S3 object.
- Stores rule provenance via `reason = "[rule_name] ..."` prefix because `telemetry.validation_results` has no `rule` column (same convention used by the ingestion worker).
- Also fixes a preexisting CI regression in `tests/test_rebuild_db.py::TestMainPoolBreakHandling` introduced by #2584 — the retry-cap gate added in `rebuild_db.main()` was tripping on tests with crashed/total > 10%. PR #2584's own CI skipped scraper-framework-tests (path-filter footgun), so the regression merged unnoticed. The two affected tests now disable the gates via `REBUILD_MAX_RETRY_COUNT=0` / `REBUILD_MAX_RETRY_RATIO=0`.

Closes #2567

## Test plan

### Automated checks
- [x] `ruff check src/ tests/ scripts/` passes (scraper-framework + script)
- [x] `ruff format --check src/ tests/ scripts/` passes
- [x] `pytest packages/scraper-framework/tests/` — 3766 passed, 2 skipped (CI run 24562383696)
- [x] New tests in `tests/test_audit_document_validation_rules.py` cover grouping, auditing, DB writeback, report build, CLI parse, `_build_query`, `_resolve_rules`, `_print_human_report`, `run_audit`, and `main` (37 tests, 99% script coverage)
- [x] Script header check (`scripts/check-script-headers.py`) passes
- [x] `TestMainPoolBreakHandling` tests pass (2 tests, both exercise the in-flight-key log path with retry gates disabled)

### Post-deploy verification
- [x] Ran `scripts/ecs-run-task.sh --latest-image scripts/audit_document_validation_rules.py -- --write` on dev — wrote 17 validation_results rows across 6 counties
- [x] Queried `telemetry.validation_results` grouped by county — baseline counts confirmed (see issue #2567 verification evidence comment)
- [x] Posted baseline flag counts as a comment on #2567 mapping each follow-up county (SC, CC, Riverside, SB, SD) to its flag count

Note: the verification query on #2567 uses `WHERE vr.rule = 'no_cross_case_ruling_text'`, but since the schema has no `rule` column the implementation prefixes `reason` with `[no_cross_case_ruling_text]`. Post-deploy queries use `WHERE reason LIKE '[no_cross_case_ruling_text]%'` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
