### PR TITLE
fix(ci): add scripts/wait-for-rollout.sh to deploy-workflow paths filters (#2592)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -8,6 +8,10 @@ on:
       - ".github/workflows/deploy-api.yml"
       - ".github/actions/ecs-deploy/**"
       - ".github/actions/ecs-oneshot/**"
+      # scripts/wait-for-rollout.sh is invoked by the ecs-deploy composite
+      # action. Changes to the shared script must trigger this deploy so the
+      # fix is exercised against a real rollout on its own PR (see #2592).
+      - "scripts/wait-for-rollout.sh"
   workflow_dispatch:
     inputs:
       image_tag:

--- a/.github/workflows/deploy-scraper.yml
+++ b/.github/workflows/deploy-scraper.yml
@@ -7,6 +7,10 @@ on:
       - "packages/scraper-framework/**"
       - ".github/workflows/deploy-scraper.yml"
       - ".github/actions/ecs-deploy/**"
+      # scripts/wait-for-rollout.sh is invoked by the ecs-deploy composite
+      # action. Changes to the shared script must trigger this deploy so the
+      # fix is exercised against a real rollout on its own PR (see #2592).
+      - "scripts/wait-for-rollout.sh"
   workflow_dispatch:
     inputs:
       image_tag:

--- a/scripts/wait-for-rollout.sh
+++ b/scripts/wait-for-rollout.sh
@@ -11,6 +11,16 @@
 #      redeploy path, see #2523). Same task-def ARN as before, but a new
 #      deployment ID.
 #
+# IMPORTANT — paths-filter contract (see #2592):
+#   Any deploy workflow that adopts this script (directly or via the
+#   ecs-deploy composite action) MUST add `scripts/wait-for-rollout.sh`
+#   to its `on.push.paths:` filter. Otherwise a PR that changes only this
+#   shared script will merge without triggering any deploy workflow — so
+#   the fix is not exercised against a real rollout on its own PR, and
+#   regressions surface on the next unrelated deploy. Current callers:
+#     - .github/workflows/deploy-scraper.yml
+#     - .github/workflows/deploy-api.yml
+#
 # Identifying the deployment:
 #   - CI path knows the new task-def ARN up front.
 #   - Operator redeploy path does not change the task-def ARN; only a new


### PR DESCRIPTION
## Summary

Add `scripts/wait-for-rollout.sh` to the `on.push.paths` filter of `deploy-scraper.yml` and `deploy-api.yml`, and document the paths-filter contract in the script's header. A PR that changes only the shared rollout-wait script now triggers those deploy workflows on merge, so the fix is exercised against a real rollout on its own PR instead of regressing silently into the next unrelated deploy (see the #2519 / #2523 / #2585 chain).

`deploy-production.yml` is intentionally not changed: it is `workflow_dispatch`-only and has no `on.push.paths` filter.

Closes #2592

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] On merge, `Deploy Scraper` (`deploy-scraper.yml`) triggers because `scripts/wait-for-rollout.sh` is in the paths filter — confirmed: run `24561890146` fired on merge commit `ccae578a`.
- [x] On merge, `Deploy API` (`deploy-api.yml`) triggers for the same reason — confirmed: run `24561890161` fired on merge commit `ccae578a`.
- [x] Verification evidence posted on issue (see comment)
