### PR TITLE
fix(hooks): ignore semicolons and && inside quoted args in preflight-bash.sh (#2589)

### DIFF
--- a/.claude/hooks/preflight-bash.sh
+++ b/.claude/hooks/preflight-bash.sh
@@ -28,6 +28,19 @@ RUN_IN_BG=$(echo "$INPUT" | python3 -c "import sys,json; d=json.load(sys.stdin);
 # Allow tests to override the working directory for check 9 and 10.
 EFFECTIVE_CWD="${PREFLIGHT_CWD:-$PWD}"
 
+# Produce a copy of $COMMAND with single- and double-quoted substrings removed.
+# This is used by checks 4 and 5 so that `&&` / `;` / `cd` that appear inside
+# quoted arguments (e.g. `--title "feat: foo; bar"`) are NOT misread as shell-
+# level compound-command operators. This is an approximation — it does not
+# handle escaped quotes, nested quotes, $'...' strings, or here-strings — but
+# it covers the common case of plain quoted arguments without regressing the
+# true positives (`cmd1; cmd2`, `cmd1 "foo" && cmd2`, `cd /x && ls`).
+#
+# The sed strips:
+#   's/'"'"'[^'"'"']*'"'"'//g'  — single-quoted runs (no single-quote escaping)
+#   's/"[^"]*"//g'              — double-quoted runs (no double-quote escaping)
+STRIPPED_COMMAND=$(printf '%s' "$COMMAND" | sed -E "s/'[^']*'//g; s/\"[^\"]*\"//g")
+
 # --- Forbidden pattern checks ---
 # Note: uses grep -E (POSIX extended regex) for macOS compatibility. Do NOT use grep -P.
 
@@ -74,7 +87,10 @@ if echo "$COMMAND" | grep -qE 'python3?[[:space:]]+-c[[:space:]]' ; then
 fi
 
 # 4. Quoted strings combined with && or ;
-if echo "$COMMAND" | grep -qE '&&|;' ; then
+#    Uses $STRIPPED_COMMAND so that `;` / `&&` inside quoted arguments (e.g.
+#    `--title "feat: foo; bar"`) do not trigger the check. Only unquoted `&&`
+#    and `;` count as real compound-command operators. See issue #2589.
+if echo "$STRIPPED_COMMAND" | grep -qE '&&|;' ; then
     if echo "$COMMAND" | grep -qE "[\"']" ; then
         echo "BLOCKED: Command contains quoted strings combined with && or ;. Split into separate tool calls. See CLAUDE.md §Unattended Operation Patterns." >&2
         exit 2
@@ -82,8 +98,11 @@ if echo "$COMMAND" | grep -qE '&&|;' ; then
 fi
 
 # 5. cd in compound commands (use git -C, npm --prefix, or separate tool calls)
-if echo "$COMMAND" | grep -qE '&&|;' ; then
-    if echo "$COMMAND" | grep -qE '\bcd\b' ; then
+#    Uses $STRIPPED_COMMAND so that `cd` inside a quoted string (e.g.
+#    `--name "cd into foo"`) and `;` / `&&` inside quoted arguments do not
+#    trigger the check. See issue #2589.
+if echo "$STRIPPED_COMMAND" | grep -qE '&&|;' ; then
+    if echo "$STRIPPED_COMMAND" | grep -qE '\bcd\b' ; then
         echo "BLOCKED: Do not use cd in compound commands. Use 'git -C /path', 'npm --prefix /path', or separate tool calls instead. See CLAUDE.md §Unattended Operation Patterns." >&2
         exit 2
     fi

--- a/.claude/hooks/test_preflight_hook.py
+++ b/.claude/hooks/test_preflight_hook.py
@@ -101,9 +101,73 @@ run_test(
 )
 run_test("no quotes with && allowed", "ls && pwd", 0)
 
+# Issue #2589 regression tests: semicolons / && inside quoted arguments must
+# NOT trigger the check. The check exists to prevent shell-level compound
+# commands that mix quoted strings with &&/;, not to block a `;` that is part
+# of a single argument value.
+run_test(
+    "semicolon inside double-quoted --title arg allowed (#2589 AC1)",
+    f"gh pr create --title {DQ}feat(infra): extend apply_immediately to ElastiCache; document OpenSearch (#2581){DQ} --body-file tmp/pr_body.txt",
+    0,
+)
+run_test(
+    "semicolon inside single-quoted arg allowed (#2589)",
+    f"gh pr create --title {SQ}feat: foo; bar{SQ} --body-file tmp/b.txt",
+    0,
+)
+run_test(
+    "&& inside double-quoted arg allowed (#2589)",
+    f"echo {DQ}x && y{DQ}",
+    0,
+)
+run_test(
+    "&& inside single-quoted arg allowed (#2589)",
+    f"echo {SQ}x && y{SQ}",
+    0,
+)
+run_test(
+    "quoted args on both sides of real && still blocked (#2589 AC2)",
+    f"echo {DQ}quoted{DQ} && echo {DQ}more{DQ}",
+    2,
+)
+run_test(
+    "semicolon after quoted arg is still a real compound-command (#2589 AC2)",
+    f"echo {DQ}hi{DQ}; echo bye",
+    2,
+)
+run_test(
+    "unquoted cmd1 ; cmd2 still treated as compound (not blocked by check 4, quotes absent)",
+    "echo hi ; echo bye",
+    0,
+)
+run_test(
+    "real semicolon-separated with quotes on one side still blocked (#2589 AC2)",
+    f"echo hi; echo {SQ}bye{SQ}",
+    2,
+)
+
 # --- Check 5: cd in compound commands ---
 print("\nCheck 5: cd in compound commands")
 run_test("cd && cmd blocked", "cd /tmp && ls", 2)
+
+# Issue #2589 regression tests for check 5: a literal `cd` inside a quoted
+# argument is not an actual `cd` shell command, and &&/; inside a quoted
+# argument are not compound-command operators.
+run_test(
+    "cd inside double-quoted arg with && elsewhere in quoted arg allowed (#2589 AC3)",
+    f"gh issue create --title {DQ}docs: explain how to cd into foo && bar{DQ}",
+    0,
+)
+run_test(
+    "cd inside single-quoted arg allowed (#2589 AC3)",
+    f"some_cmd --name {SQ}cd into foo{SQ}",
+    0,
+)
+run_test(
+    "cd inside quoted arg with unquoted && still blocked by cd check (#2589)",
+    f"cd /tmp && some_cmd --name {SQ}foo{SQ}",
+    2,
+)
 
 # --- Check 6: empty quotes before flags (bypass attempts) ---
 print("\nCheck 6: Empty quotes before flags")


### PR DESCRIPTION
## Summary

Fix the false-positive in `.claude/hooks/preflight-bash.sh` rules #4 and #5 where a `;` or `&&` inside a quoted argument (e.g. `gh pr create --title "feat: foo; bar"`) would be misread as a shell-level compound operator and block the command. The fix introduces a `$STRIPPED_COMMAND` variable — the command with single- and double-quoted substrings removed — and uses it for the compound-operator grep in both checks.

Closes #2589

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`.claude/hooks/test_preflight_hook.py` — 115 tests, including 11 new regression tests)
- [x] CI green (`preflight-hook-test` job runs the hook tests when `.claude/hooks/` changes)

### Post-deploy verification
- [x] N/A — no deployed component (PreToolUse hook runs locally per-agent). Verification evidence: https://github.com/judgemind/judgemind/issues/2589#issuecomment-4267485805
