### PR TITLE
docs(infra): drop invalid rebuild_db.py --skip-reset references (#2591)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,6 +548,8 @@ jobs:
         run: scripts/check-aws-bool-flags.sh
       - name: Check for forbidden ECS services-stable waiter usage
         run: scripts/check-no-ecs-wait-services-stable.sh
+      - name: Check docs describe the actual rebuild_db.py CLI
+        run: scripts/check-no-rebuild-db-skip-reset.sh
       # Auto-discover and run every executable shell test under
       # scripts/tests/*.sh. Replaces the old per-script listing (#2505) so
       # that adding a new shell test is just `touch + chmod +x` — no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,7 +361,7 @@ See `docs/agent/infrastructure-reference.md` §ECS Script Execution for full pat
 | Cleanup orphaned/corrupted `derived.*` state (failed run, bad IDs, partial mutation) | `rebuild_db.py --county <name>` | `derived.*` is fully rebuildable from S3. Rebuild is idempotent, validates the real ingestion/enrichment path (fixing inbound data, not just existing rows), and handles edge cases surgical scripts miss. Surgical one-offs often introduce bugs of their own — only write one if rebuild cost is prohibitive at the affected scale. |
 | Re-process existing records after extraction logic changes | `reingest_from_s3.py --county <name>` | Queries the `documents` table — only works when records already exist |
 | Initial population of a county that has S3 data but no DB records | `rebuild_db.py --county <name>` | Discovers documents directly from S3 keys — does not require pre-existing DB records |
-| Full database rebuild from scratch | `rebuild_db.py` (no `--skip-reset`) | Truncates derived tables and re-processes everything from S3 |
+| Full database rebuild from scratch | `rebuild_db.py --reset` | `--reset` is opt-in and truncates derived tables before re-processing everything from S3. |
 
 `reingest_from_s3.py` operates on **existing database records only**. If you run it for a county with no records in the `documents` table, it will process 0 documents silently.
 

--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -111,7 +111,7 @@ scripts/ecs-run-task.sh --detach scripts/reingest_from_s3.py -- --all
 scripts/ecs-run-task.sh --logs <task-arn>
 
 # Initial population of a county with S3 data but no DB records
-scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county "Orange" --skip-reset
+scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county "Orange"
 
 # Tail logs for a task by ID (printed when the task launches)
 scripts/ecs-task-logs.sh <task-id>
@@ -124,9 +124,9 @@ scripts/ecs-run-task.sh --cpu 2048 --memory 8192 scripts/audit_field_completenes
 **Large-county rebuilds need memory override.** `rebuild_db.py --county <name>` holds per-worker OpenSearch/Postgres clients and LLM batch state for every document in the county. At the default 4096 MB, counties with thousands of documents (Los Angeles, Santa Clara, Orange) can exit 137 (OOM). Use `--cpu 2048 --memory 8192` for these rebuilds (see #2481):
 
 ```
-scripts/ecs-run-task.sh --cpu 2048 --memory 8192 scripts/rebuild_db.py -- --county "Los Angeles" --skip-reset
-scripts/ecs-run-task.sh --cpu 2048 --memory 8192 scripts/rebuild_db.py -- --county "Santa Clara" --skip-reset
-scripts/ecs-run-task.sh --cpu 2048 --memory 8192 scripts/rebuild_db.py -- --county "Orange" --skip-reset
+scripts/ecs-run-task.sh --cpu 2048 --memory 8192 scripts/rebuild_db.py -- --county "Los Angeles"
+scripts/ecs-run-task.sh --cpu 2048 --memory 8192 scripts/rebuild_db.py -- --county "Santa Clara"
+scripts/ecs-run-task.sh --cpu 2048 --memory 8192 scripts/rebuild_db.py -- --county "Orange"
 ```
 
 Smaller counties (a few hundred documents or fewer) run fine at the 1024/4096 default.
@@ -195,7 +195,7 @@ Best practices:
    ```
    # Cap a rebuild at 2 hours even if it hangs on something not covered by --max-retry-*
    scripts/ecs-run-task.sh --max-runtime 7200 --cpu 2048 --memory 8192 \
-       scripts/rebuild_db.py -- --county "Los Angeles" --skip-reset
+       scripts/rebuild_db.py -- --county "Los Angeles"
    ```
 
    `timeout` sends `SIGTERM` at the deadline, giving Python's atexit handlers and `psycopg` a chance to close connections cleanly, and escalates to `SIGKILL` 30 seconds later if the script ignores the signal.  The container then exits with the script's own exit code (on clean termination) or `137` (SIGKILL).  Requires coreutils, which is present in the `python:3.12-slim` base image used by the ingestion worker task definition.
@@ -218,8 +218,8 @@ Best practices:
 |---|---|---|
 | Cleanup orphaned/corrupted `derived.*` state (failed run, bad IDs, partial mutation) | `rebuild_db.py --county <name>` | `derived.*` is fully rebuildable from S3. Rebuild is idempotent, validates the real ingestion/enrichment path (fixing inbound data, not just existing rows), and handles edge cases surgical scripts miss. Surgical one-offs often introduce bugs of their own — only write one if rebuild cost is prohibitive at the affected scale. |
 | Re-process existing records after extraction logic changes | `reingest_from_s3.py --county <name>` | Queries `documents` table — only works when records already exist |
-| Initial population of a county that has S3 data but no DB records | `rebuild_db.py --county <name> --skip-reset` | Discovers documents directly from S3 keys — does not require pre-existing DB records |
-| Full database rebuild from scratch | `rebuild_db.py` (no `--skip-reset`) | Truncates derived tables and re-processes everything from S3 |
+| Initial population of a county that has S3 data but no DB records | `rebuild_db.py --county <name>` | Discovers documents directly from S3 keys — does not require pre-existing DB records. The Python script's default already preserves existing data; no flag is needed. |
+| Full database rebuild from scratch | `rebuild_db.py --reset` | `--reset` is opt-in and truncates derived tables before re-processing everything from S3. |
 
 ### One-off / permanent script convention
 

--- a/scripts/check-no-rebuild-db-skip-reset.sh
+++ b/scripts/check-no-rebuild-db-skip-reset.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# check-no-rebuild-db-skip-reset.sh — Forbid `rebuild_db.py ... --skip-reset`
+# references in docs and CLAUDE.md.
+#
+# The `--skip-reset` flag does NOT exist on the Python script
+# `scripts/rebuild_db.py` — it only exists on the shell wrapper
+# `scripts/rebuild_db.sh`.  The Python script's argparse uses the opposite
+# convention: `--reset` is opt-in (default is to keep existing data).
+#
+# Docs that instruct agents to run `scripts/ecs-run-task.sh scripts/rebuild_db.py
+# -- --county X --skip-reset` cause failed ECS runs with
+# `argparse: unrecognized arguments: --skip-reset` — wasting time and ECS
+# capacity.  See issue #2591.
+#
+# The shell wrapper `scripts/rebuild_db.sh --skip-reset` is valid and is NOT
+# flagged by this check — the pattern requires the `.py` extension directly
+# attached to `rebuild_db`.
+#
+# Usage:
+#   scripts/check-no-rebuild-db-skip-reset.sh          # scan repo root
+#   scripts/check-no-rebuild-db-skip-reset.sh [dir]    # scan a specific directory
+#
+# Exit codes:
+#   0 — No violations found.
+#   1 — One or more tracked files reference `rebuild_db.py ... --skip-reset`.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-$REPO_ROOT}"
+
+# ─── Pattern ─────────────────────────────────────────────────────────────
+# Match `rebuild_db.py` followed (somewhere on the same line) by
+# `--skip-reset`.  We intentionally require the `.py` extension so the
+# valid `rebuild_db.sh --skip-reset` shell wrapper is not flagged.
+#
+# `grep -E` works line-by-line, so `.*` is already bounded to a single
+# line — no need for an explicit negated class.
+PATTERN='rebuild_db\.py.*--skip-reset'
+
+# ─── Directories to exclude from the scan ────────────────────────────────
+# Standard ignored directories (vendored deps, VCS metadata, build output)
+# plus local developer state.
+EXCLUDE_DIRS=(
+    ".git"
+    ".venv"
+    "node_modules"
+    ".next"
+    "__pycache__"
+    ".vite"
+    # Local developer scratch dir (not tracked).
+    "tmp"
+)
+
+# ─── Files that legitimately mention the pattern as context ──────────────
+# The check script and its test must spell the pattern literally.  Past
+# incident post-mortems under docs/investigations/ may also reference it
+# as historical context.
+EXCLUDE_FILES=(
+    "scripts/check-no-rebuild-db-skip-reset.sh"
+    "scripts/tests/test_check_no_rebuild_db_skip_reset.sh"
+)
+
+# ─── Build grep arguments ───────────────────────────────────────────────
+
+exclude_args=()
+for dir in "${EXCLUDE_DIRS[@]}"; do
+    exclude_args+=("--exclude-dir=$dir")
+done
+
+# ─── Scan the codebase ──────────────────────────────────────────────────
+
+violations=0
+
+matches=$(grep -rnE "$PATTERN" "$SCAN_DIR" "${exclude_args[@]}" 2>/dev/null || true)
+
+if [[ -n "$matches" ]]; then
+    while IFS= read -r line; do
+        # grep -rn output: <path>:<lineno>:<content>
+        file_path="${line%%:*}"
+        rest="${line#*:}"
+        content="${rest#*:}"
+
+        # Skip matches in the explicitly-excluded files.
+        skip=false
+        for excl in "${EXCLUDE_FILES[@]}"; do
+            if [[ "$file_path" == *"$excl" ]]; then
+                skip=true
+                break
+            fi
+        done
+        if "$skip"; then
+            continue
+        fi
+
+        # Skip docs/investigations/* — post-mortems may reference the
+        # pattern as historical context.
+        if [[ "$file_path" == *"docs/investigations/"* ]]; then
+            continue
+        fi
+
+        # Skip comment lines (first non-whitespace character is `#`).
+        # Covers shell, YAML, Python, and Dockerfile comments.
+        if [[ "$content" =~ ^[[:space:]]*# ]]; then
+            continue
+        fi
+
+        if [[ $violations -eq 0 ]]; then
+            echo "ERROR: Found forbidden 'rebuild_db.py ... --skip-reset' usage."
+            echo ""
+            echo "  The Python script scripts/rebuild_db.py does NOT implement"
+            echo "  a --skip-reset flag — only the shell wrapper"
+            echo "  scripts/rebuild_db.sh does.  Agents running these commands"
+            echo "  via ecs-run-task.sh get argparse errors (see #2591)."
+            echo ""
+        fi
+
+        echo "    $line"
+        violations=$((violations + 1))
+    done <<< "$matches"
+fi
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "  Found $violations occurrence(s) of 'rebuild_db.py ... --skip-reset'."
+    echo ""
+    echo "  Fix: remove the --skip-reset flag.  The Python script's default"
+    echo "  already preserves existing data — no flag is needed to \"skip reset\"."
+    echo "  To truncate derived tables before rebuilding, use --reset (opt-in)."
+    echo ""
+    echo "  Example rewrites:"
+    echo "    scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county X --skip-reset"
+    echo "    →  scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county X"
+    echo ""
+    echo "  The shell wrapper scripts/rebuild_db.sh --skip-reset is still valid"
+    echo "  and is NOT flagged by this check."
+    echo ""
+    echo "  If the pattern must appear as explanatory context, put it in a"
+    echo "  comment (lines starting with '#') or under docs/investigations/."
+    exit 1
+fi
+
+echo "All clean — no 'rebuild_db.py ... --skip-reset' usage detected."
+exit 0

--- a/scripts/tests/test_check_no_rebuild_db_skip_reset.sh
+++ b/scripts/tests/test_check_no_rebuild_db_skip_reset.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# test_check_no_rebuild_db_skip_reset.sh — Tests for
+# check-no-rebuild-db-skip-reset.sh.
+#
+# Creates temporary files to verify that the checker correctly detects
+# forbidden `rebuild_db.py ... --skip-reset` usage while allowing
+# comments, docs/investigations/ post-mortems, the valid shell wrapper
+# (`rebuild_db.sh --skip-reset`), and the check script itself to
+# reference the pattern as context.
+#
+# Usage:
+#   scripts/tests/test_check_no_rebuild_db_skip_reset.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-no-rebuild-db-skip-reset.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo.  Intentionally not
+# under $REPO/tmp (the check excludes any directory named `tmp`) —
+# mktemp -d honours $TMPDIR and defaults to /tmp which is outside the
+# exclusion set.
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: Bare Markdown reference should fail ─────────────────────────
+create_test_file "docs/bad.md" 'Run: rebuild_db.py --county X --skip-reset'
+assert_fails "Bare Markdown reference to rebuild_db.py --skip-reset is detected"
+reset_tmpdir
+
+# ─── Test 2: ecs-run-task.sh wrapper form should fail ────────────────────
+create_test_file "docs/ecs.md" \
+    'scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county "Orange" --skip-reset'
+assert_fails "ecs-run-task.sh wrapper form is detected"
+reset_tmpdir
+
+# ─── Test 3: Table row in markdown should fail ───────────────────────────
+create_test_file "docs/table.md" \
+    '| Full rebuild | `rebuild_db.py` (no `--skip-reset`) | truncates first |'
+assert_fails "Table-row reference with backticks is detected"
+reset_tmpdir
+
+# ─── Test 4: Shell wrapper `rebuild_db.sh --skip-reset` should pass ──────
+# The shell wrapper is the valid caller of --skip-reset.  The check must
+# NOT flag it — this is the critical distinguishing behavior vs the .py
+# script.
+create_test_file "docs/wrapper.md" 'Use: scripts/rebuild_db.sh --skip-reset'
+assert_passes "Valid shell wrapper rebuild_db.sh --skip-reset is not flagged"
+reset_tmpdir
+
+# ─── Test 5: Python script without --skip-reset should pass ──────────────
+create_test_file "docs/rebuild.md" 'Run: scripts/rebuild_db.py --county X'
+assert_passes "rebuild_db.py without --skip-reset passes"
+reset_tmpdir
+
+# ─── Test 6: Python script with --reset (opt-in) should pass ─────────────
+create_test_file "docs/reset.md" 'Run: scripts/rebuild_db.py --county X --reset'
+assert_passes "rebuild_db.py --reset (valid opt-in flag) passes"
+reset_tmpdir
+
+# ─── Test 7: Shell comment lines should pass ─────────────────────────────
+create_test_file "cleanup.sh" '#!/usr/bin/env bash
+# Previously agents were told to run `rebuild_db.py --skip-reset` which
+# does not exist (see issue #2591).  Drop the flag.
+scripts/rebuild_db.py --county X'
+assert_passes "Shell comments referencing the pattern as context are allowed"
+reset_tmpdir
+
+# ─── Test 8: YAML comment lines should pass ──────────────────────────────
+create_test_file "workflow.yml" 'jobs:
+  build:
+    steps:
+      # Do not run: rebuild_db.py --skip-reset (see #2591).
+      - run: scripts/rebuild_db.py --county X'
+assert_passes "YAML comments referencing the pattern as context are allowed"
+reset_tmpdir
+
+# ─── Test 9: docs/investigations/*.md should pass ────────────────────────
+create_test_file "docs/investigations/rebuild-flag-2026-04.md" \
+    '# rebuild_db.py --skip-reset incident
+
+Prior docs instructed agents to pass `--skip-reset` which does not exist
+on the Python script.  This investigation records the cleanup.'
+assert_passes "docs/investigations/*.md post-mortems are allowed to reference the pattern"
+reset_tmpdir
+
+# ─── Test 10: Empty directory should pass ────────────────────────────────
+assert_passes "Empty directory passes"
+
+# ─── Test 11: Non-matching shell content should pass ─────────────────────
+create_test_file "good.sh" 'scripts/rebuild_db.py --county X --concurrency 16'
+assert_passes "Shell script using rebuild_db.py with other flags passes"
+reset_tmpdir
+
+# ─── Test 12: .git directory should be excluded ──────────────────────────
+mkdir -p "$TMPDIR_TEST/.git/objects"
+printf 'rebuild_db.py --skip-reset\n' > "$TMPDIR_TEST/.git/objects/badfile"
+assert_passes ".git directory contents are excluded"
+reset_tmpdir
+
+# ─── Test 13: node_modules should be excluded ────────────────────────────
+mkdir -p "$TMPDIR_TEST/node_modules/some-pkg"
+printf 'rebuild_db.py --skip-reset\n' > "$TMPDIR_TEST/node_modules/some-pkg/index.js"
+assert_passes "node_modules directory is excluded"
+reset_tmpdir
+
+# ─── Test 14: Indented comment with the pattern should pass ──────────────
+create_test_file "indented.sh" '    # Legacy: rebuild_db.py --skip-reset was broken.
+    scripts/rebuild_db.py --county X'
+assert_passes "Indented comment lines are allowed"
+reset_tmpdir
+
+# ─── Test 15: Mixed file — comment OK, code line fails ───────────────────
+create_test_file "mixed.md" '# History
+
+The following command does not work:
+
+    scripts/rebuild_db.py --skip-reset --county X'
+assert_fails "Mixed file: real usage line is caught even when a heading mentions it"
+reset_tmpdir
+
+# ─── Test 16: Multiple violations in one file are detected ───────────────
+create_test_file "multi.md" 'First: rebuild_db.py --county A --skip-reset
+Second: rebuild_db.py --county B --skip-reset'
+assert_fails "Multiple violations in one file are detected"
+reset_tmpdir
+
+# ─── Test 17: Similar-but-not-matching token should pass ─────────────────
+# `rebuild_db_py_skip_reset` as a variable name or filename is not the
+# invocation we care about and should not trigger the check.
+create_test_file "lookalike.sh" 'VAR=rebuild_db_py_skip_reset
+echo "$VAR"'
+assert_passes "Underscore-joined lookalike identifier does not trigger the check"
+reset_tmpdir
+
+# ─── Test 18: --skip-reset on a different line should pass ───────────────
+# The pattern requires rebuild_db.py and --skip-reset on the same line.
+# A sentence break between them (distinct lines) must not match.
+create_test_file "multiline.md" 'Run rebuild_db.py first.
+Then consider --skip-reset on the shell wrapper.'
+assert_passes "rebuild_db.py and --skip-reset on different lines do not match"
+reset_tmpdir
+
+# ─── Test 19: No self-match on ci.yml step name ──────────────────────────
+# The step name in .github/workflows/ci.yml that runs this guard must
+# not itself contain the forbidden pattern.  If it does, the guard
+# fails on its first CI run (see issues #2541/#2542 for the class of
+# bug).  Name the CI step after the replacement or category, not the
+# literal forbidden string.
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-no-rebuild-db-skip-reset.sh" "yml"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Drop invalid `rebuild_db.py --skip-reset` references from agent-facing docs. The Python script only implements `--reset` (opt-in); the flag `--skip-reset` exists only on the shell wrapper `rebuild_db.sh`, so agents who followed the docs via `scripts/ecs-run-task.sh` got argparse errors and wasted ECS runs. Adds a CI guard (`scripts/check-no-rebuild-db-skip-reset.sh`) to prevent the pattern from returning.

Closes #2591

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (new `test_check_no_rebuild_db_skip_reset.sh` — 19/19 local)
- [x] CI green
- [x] New guard step `Check docs describe the actual rebuild_db.py CLI` passes in the `scripts-tests` job
- [x] `ci-job-skipped-check` does not flag this PR (new guard touches `scripts/**` + `ci.yml`, which both match the `scripts-tests` paths filter)
- [x] `markdown-links-check` passes (three `.md` files modified)

### Post-deploy verification
- [ ] N/A — no deployed component (docs + CI hygiene check only)
