### PR TITLE
fix(scripts): default rebuild_db.py --max-worker-memory-mb to 1024 (#2576)

### DIFF
--- a/packages/scraper-framework/tests/test_rebuild_db.py
+++ b/packages/scraper-framework/tests/test_rebuild_db.py
@@ -1675,7 +1675,20 @@ class TestMainPoolBreakHandling:
                     "S3_CACHE_DIR": cache_dir,
                 },
             ),
-            patch("sys.argv", ["rebuild_db.py"]),
+            # Disable the retry-abort gate so the pool-break test can
+            # exercise its serial-retry path.  The 100% crash ratio in this
+            # scenario would otherwise trip the #2572 abort and sys.exit(2)
+            # before the rebuild summary is logged.
+            patch(
+                "sys.argv",
+                [
+                    "rebuild_db.py",
+                    "--max-retry-count",
+                    "0",
+                    "--max-retry-ratio",
+                    "0",
+                ],
+            ),
             patch.object(rebuild_db, "logger", mock_logger),
         ):
             rebuild_db.main()
@@ -1761,7 +1774,20 @@ class TestMainPoolBreakHandling:
                     "S3_CACHE_DIR": cache_dir,
                 },
             ),
-            patch("sys.argv", ["rebuild_db.py"]),
+            # Disable the retry-abort gate so the serial-retry recovery
+            # path runs.  The 100% crash ratio in this scenario would
+            # otherwise trip the #2572 abort and sys.exit(2) before the
+            # rebuild summary is logged.
+            patch(
+                "sys.argv",
+                [
+                    "rebuild_db.py",
+                    "--max-retry-count",
+                    "0",
+                    "--max-retry-ratio",
+                    "0",
+                ],
+            ),
             patch.object(rebuild_db, "logger", mock_logger),
         ):
             rebuild_db.main()

--- a/packages/scraper-framework/tests/test_rebuild_db.py
+++ b/packages/scraper-framework/tests/test_rebuild_db.py
@@ -1856,8 +1856,13 @@ class TestMaxWorkerMemoryCLI:
         # The main-pass pool gets max_workers=2 (2048/1024), not 64.
         assert captured_max_workers[0] == 2
 
-    def test_flag_default_preserves_old_behavior(self, tmp_path: Any) -> None:
-        """Without ``--max-worker-memory-mb`` the old concurrency wins."""
+    def test_flag_default_autoscales_with_memory_budget(self, tmp_path: Any) -> None:
+        """Without an explicit ``--max-worker-memory-mb``, the default (1024)
+        applies.  With 16 GB available that yields 16 capacity, so
+        ``--concurrency 4`` still wins via ``min(4, 16)`` and the pool gets
+        ``max_workers=4`` — verifying the default does not over-throttle
+        when memory is plentiful.  See #2576.
+        """
         keys = ["ca/orange/superior_court/raw/abc123.html"]
         cache_dir = str(tmp_path / "cache")
         full = tmp_path / "cache" / keys[0]
@@ -1892,6 +1897,10 @@ class TestMaxWorkerMemoryCLI:
             patch("rebuild_db.seed_courts", return_value={}),
             patch("rebuild_db._fetch_rosters"),
             patch(
+                "rebuild_db._available_memory_mb",
+                return_value=16384,
+            ),
+            patch(
                 "concurrent.futures.ProcessPoolExecutor",
                 side_effect=_pool_factory,
             ),
@@ -1913,6 +1922,79 @@ class TestMaxWorkerMemoryCLI:
                     "rebuild_db.py",
                     "--concurrency",
                     "4",
+                ],
+            ),
+        ):
+            rebuild_db.main()
+
+        assert captured_max_workers[0] == 4
+
+    def test_flag_default_throttles_on_low_memory(self, tmp_path: Any) -> None:
+        """With the default ``--max-worker-memory-mb=1024`` and only 4 GB
+        available (ECS ecs-run-task.sh default), ``--concurrency 64`` must
+        autoscale down to 4 (4096/1024) — preventing the OOM footgun from
+        #2576.  This is the regression test for the issue's acceptance
+        criterion.
+        """
+        keys = ["ca/orange/superior_court/raw/abc123.html"]
+        cache_dir = str(tmp_path / "cache")
+        full = tmp_path / "cache" / keys[0]
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_bytes(b"<html>x</html>")
+
+        mock_future = MagicMock()
+        mock_future.result.return_value = {
+            "status": "ok",
+            "content_format": "html",
+            "had_hearing_date": False,
+            "hash_mismatch": False,
+        }
+        mock_pool = MagicMock()
+        mock_pool.__enter__ = MagicMock(return_value=mock_pool)
+        mock_pool.__exit__ = MagicMock(return_value=False)
+        mock_pool.submit.return_value = mock_future
+
+        captured_max_workers: list[int] = []
+
+        def _pool_factory(*args: Any, **kwargs: Any) -> MagicMock:
+            captured_max_workers.append(kwargs.get("max_workers", -1))
+            return mock_pool
+
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=keys,
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db._fetch_rosters"),
+            patch(
+                "rebuild_db._available_memory_mb",
+                return_value=4096,
+            ),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                side_effect=_pool_factory,
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([mock_future]),
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://test",
+                    "S3_CACHE_DIR": cache_dir,
+                },
+                clear=False,
+            ),
+            patch(
+                "sys.argv",
+                [
+                    "rebuild_db.py",
+                    "--concurrency",
+                    "64",
                 ],
             ),
         ):

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -23,11 +23,13 @@
 #                     Reserve ~N MB of RAM per worker when auto-scaling
 #                     concurrency.  Computes ``min(--concurrency,
 #                     available_memory_mb / N)`` and uses the smaller value.
-#                     Use this after bumping Fargate memory with
-#                     ``scripts/ecs-run-task.sh --memory <mb>`` so concurrency
-#                     adapts to the new allocation.  Set to 0 (default) to
-#                     disable auto-scaling and use --concurrency as-is.
-#                     See #2495.
+#                     Default: 1024 — sized so the ECS 4 GB Fargate default
+#                     (from ``scripts/ecs-run-task.sh``) autoscales to ~4
+#                     workers instead of blindly spawning 64 and OOM-ing
+#                     (exit 137).  Bump ``--memory`` on ecs-run-task.sh to
+#                     unlock more concurrency; this flag auto-adapts.  Set
+#                     to 0 to disable auto-scaling and use --concurrency
+#                     as-is.  See #2495, #2576.
 #   --reset           Truncate derived tables before rebuilding.  When combined
 #                     with --county, the reset is scoped to just that county's
 #                     rows (per-county reset); otherwise it truncates the
@@ -1051,12 +1053,15 @@ def main() -> None:
     parser.add_argument(
         "--max-worker-memory-mb",
         type=int,
-        default=int(os.environ.get("REBUILD_MAX_WORKER_MEMORY_MB", "0")),
+        default=int(os.environ.get("REBUILD_MAX_WORKER_MEMORY_MB", "1024")),
         help=(
             "Reserve ~N MB of RAM per worker when auto-scaling concurrency "
-            "(default: 0, disabled).  Computes min(--concurrency, "
-            "available_memory_mb / N) and uses the smaller value so "
-            "concurrency adapts to the Fargate allocation.  See #2495."
+            "(default: 1024, sized for ECS 4 GB Fargate default so effective "
+            "concurrency drops to ~4 instead of OOM-ing at 64).  Computes "
+            "min(--concurrency, available_memory_mb / N) and uses the "
+            "smaller value so concurrency adapts to the Fargate allocation. "
+            "Set to 0 to disable auto-scaling and use --concurrency as-is. "
+            "See #2495, #2576."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary

Change `scripts/rebuild_db.py --max-worker-memory-mb` default from `0` (disabled) to `1024` so autoscaling kicks in automatically on `scripts/ecs-run-task.sh` defaults (4 GB Fargate) — effective concurrency drops from 64 to ~4, preventing the OOM (exit 137) that blocked agents on #2551 and #2549. Operators who have tuned `--memory` still get more effective concurrency automatically; operators wanting to disable autoscaling can still set `--max-worker-memory-mb 0`.

Also closes #2574 (p3 duplicate proposing either raising the ECS memory default or documenting per-county sizing). Autoscaling at the rebuild_db level is a cleaner root-cause fix — it works for every county (Santa Clara / Orange / Riverside / Fresno included) without callers needing to know per-county quirks, and it respects bumped `--memory` budgets by using them.

Second commit fixes two `TestMainPoolBreakHandling` tests that were broken on main (collateral damage from #2572) but undetected because the `scraper-framework-tests` CI job was SKIPPED on #2572's paths-filter. My PR touches both `scripts/rebuild_db.py` AND `packages/scraper-framework/tests/**`, so the filter fires and these tests finally run — forcing the fix.

Closes #2576
Closes #2574

## Test plan

### Automated checks
- [x] Lint passes (ruff check)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (62 tests in test_rebuild_db.py, including 2 newly-fixed pool-break tests and 2 new CLI regression tests for the default)
- [x] CI green

### Post-deploy verification
- [x] Confirmed deployed image on dev shows new `--max-worker-memory-mb` default of 1024 via `scripts/ecs-run-task.sh --latest-image scripts/rebuild_db.py -- --help` (task exit 0; see evidence comment on #2576). Full end-to-end `--county "Contra Costa" --reset` rebuild deferred to next operator-initiated rebuild — unit tests deterministically cover the same code path.
- [x] Verification evidence posted on issue #2576
