### PR TITLE
feat(scraping): add SF Probate Dept 204 to tentative rulings scraper (#2600)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
@@ -13,7 +13,7 @@ Response: {"result": [<count>, "<html_table>"]}
 The HTML table contains structured <tr> rows with headers:
   Case Number, Case Title, Court Date, Calendar Matter, Rulings
 
-7 RulingIDs map to 5 departments:
+8 RulingIDs map to 6 departments:
   10 → Dept 301 (Law & Motion/Discovery, odd case numbers)
    2 → Dept 302 (Law & Motion/Discovery, even case numbers)
    6 → Dept 304 (Asbestos Discovery)
@@ -21,6 +21,7 @@ The HTML table contains structured <tr> rows with headers:
    8 → Dept 304 (Asbestos Motion Calendar)
    9 → Dept 210 (Real Property Housing Court Motions)
    3 → Dept 501 (Real Property Housing Court Motions)
+   7 → Dept 204 (Probate)
 
 The site is behind Cloudflare Turnstile CAPTCHA. The scraper uses
 Playwright with stealth to navigate the CAPTCHA page, which auto-solves
@@ -94,6 +95,7 @@ RULING_ID_MAP: dict[int, dict[str, str]] = {
     8: {"department": "304", "type": "Asbestos Motion Calendar"},
     9: {"department": "210", "type": "Real Property Housing Court Motions"},
     3: {"department": "501", "type": "Real Property Housing Court Motions"},
+    7: {"department": "204", "type": "Probate"},
 }
 
 # Ordered list of RulingIDs to fetch.

--- a/packages/scraper-framework/tests/courts/test_sf_civil_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_sf_civil_tentatives.py
@@ -353,11 +353,11 @@ class TestNormalizeCaseTitle:
 class TestRulingIdMap:
     """Tests for the RulingID-to-department mapping."""
 
-    def test_seven_ruling_ids(self) -> None:
-        assert len(RULING_ID_MAP) == 7
+    def test_eight_ruling_ids(self) -> None:
+        assert len(RULING_ID_MAP) == 8
 
     def test_all_ids_present(self) -> None:
-        expected_ids = {10, 2, 6, 5, 8, 9, 3}
+        expected_ids = {10, 2, 6, 5, 8, 9, 3, 7}
         assert set(RULING_ID_MAP.keys()) == expected_ids
 
     def test_dept_301(self) -> None:
@@ -376,6 +376,11 @@ class TestRulingIdMap:
 
     def test_dept_501(self) -> None:
         assert RULING_ID_MAP[3]["department"] == "501"
+
+    def test_dept_204_probate(self) -> None:
+        """RulingID 7 maps to Dept 204 (Probate)."""
+        assert RULING_ID_MAP[7]["department"] == "204"
+        assert RULING_ID_MAP[7]["type"] == "Probate"
 
     def test_ruling_ids_sorted(self) -> None:
         """RULING_IDS list should be sorted."""
@@ -479,8 +484,8 @@ class TestSFCivilScraperRun:
 
         health = scraper.run()
         assert health.success is True
-        # 7 RulingIDs * 12 rulings each = 84
-        assert health.records_captured == 7 * 12
+        # 8 RulingIDs * 12 rulings each = 96
+        assert health.records_captured == 8 * 12
 
     @respx.mock
     def test_fetch_documents_populates_fields(self) -> None:
@@ -522,8 +527,8 @@ class TestSFCivilScraperRun:
 
         docs = scraper.fetch_documents()
         departments = {d.department for d in docs}
-        # All 5 departments should be represented (each RulingID returns data)
-        assert departments == {"210", "301", "302", "304", "501"}
+        # All 6 departments should be represented (each RulingID returns data)
+        assert departments == {"204", "210", "301", "302", "304", "501"}
 
     @respx.mock
     def test_fetch_documents_sets_judge_name_from_dept_map(self) -> None:
@@ -537,6 +542,7 @@ class TestSFCivilScraperRun:
             "304": "Anne-Christine Massullo",
             "210": "Samuel K. Feng",
             "501": "Richard B. Ulmer",
+            "204": "Probate Judge Name",
         }
         config = sf_civil_default_config()
         config.request_delay_seconds = 0


### PR DESCRIPTION
## Summary

Adds `RulingID=7 → Dept 204 (Probate)` to `RULING_ID_MAP` in the SF civil tentative rulings scraper so the SF Probate calendar is fetched alongside the 7 existing civil RulingIDs. Probate uses the same Turnstile-gated `tr.dll` REST endpoint — no new infrastructure, session, or parsing logic is required.

Closes #2600

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Deployed image contains the new map entry (verified via `tmp/verify_map.py` on dev ECS; output shows `RULING_IDS: [2, 3, 5, 6, 7, 8, 9, 10]` and `RulingID=7 entry: {'department': '204', 'type': 'Probate'}`)
- [ ] `scripts/dev-db-query.sh "SELECT COUNT(*) … LIKE '%RulingID=7%'"` returns ≥ 1 — **deferred**: no SF civil records (any RulingID) currently landing in dev due to pre-existing Turnstile session-acquisition failure; follow-up issue filed.
- [x] Verification evidence posted on issue
