### PR TITLE
docs(spotcheck): drop stale #2193 gate and default new issues to agent/ready

### DIFF
--- a/.claude/skills/spotcheck/SKILL.md
+++ b/.claude/skills/spotcheck/SKILL.md
@@ -124,7 +124,7 @@ The originals sampled in Step 2 come from the documents table, so they always ha
 scripts/run-py.sh scripts/spotcheck/sample.py --from originals --county "<County>" --n 10 --output {worktree}/tmp/spotcheck/s3_sample_<county>.json
 ```
 
-Compare the sampled S3 keys against the `originals_by_county` data. Any S3 key not in the documents table is an orphan — note the count per county. This is a known issue (#2193) but tracking the orphan rate over time helps measure progress.
+Compare the sampled S3 keys against the `originals_by_county` data. Any S3 key not in the documents table is an orphan — note the count per county. Tracking the orphan rate over time helps measure progress (see #2583).
 
 ---
 
@@ -167,19 +167,17 @@ Write each issue body to `{worktree}/tmp/spotcheck/issue_N.txt`. Include:
 - **Affected counties** with example ruling IDs
 - **Acceptance criteria** with `Verify:` lines
 
+**File spotcheck issues with `agent/ready` by default.** The dispatcher should be able to pick them up immediately — spotcheck findings are concrete, evidence-backed, and per-pattern, so they meet the bar. Only omit `agent/ready` when there's a specific reason:
+- **Blocked by an open dependency** — use `scripts/block-issue.sh <new-issue> <blocker>` instead. This adds `status/blocked` and a `Blocked by #N` line that auto-unblocks when the blocker closes.
+- **Acceptance criteria not yet concrete** — e.g. "investigate X" with no clear success condition. Tighten the AC before filing, or file with `status/triage` for human review.
+- **Needs a maintainer decision** — scope/priority ambiguity that an agent can't resolve.
+
 ```
 gh issue create --repo judgemind/judgemind \
     --title "fix(scraping): <description>" \
-    --label "type/bug,priority/<p1|p2>,area/scraping" \
+    --label "type/bug,priority/<p1|p2>,area/scraping,agent/ready" \
     --body-file {worktree}/tmp/spotcheck/issue_N.txt
 ```
-
-Check if #2193 (S3 restructure) is still open. If so, block new issues on it:
-```
-scripts/block-issue.sh <new-issue> 2193
-```
-
-Do NOT add `agent/ready` while #2193 is open.
 
 ---
 


### PR DESCRIPTION
## Summary

Updates `.claude/skills/spotcheck/SKILL.md` to remove a stale gate on the now-closed #2193 and to default newly filed spotcheck issues to `agent/ready` so the dispatcher can pick them up immediately.

### Context

#2193 (S3 restructure) closed on 2026-03-29. The skill still instructed agents to block new spotcheck-filed issues on #2193 and to omit `agent/ready`. As a result, six spotcheck-filed issues sat unreachable to the dispatcher for weeks — the user has since labeled them manually:

- #2568
- #2569
- #2571
- #2577
- #2578
- #2583

This change prevents future spotcheck runs from repeating the mistake.

### Diffs

1. **§2.5 S3 orphan check** — replaces the stale `known issue (#2193)` reference with the current spotcheck-filed S3 orphan tracking issue: `Tracking the orphan rate over time helps measure progress (see #2583).`
2. **§4.3 File new issues** — drops the `scripts/block-issue.sh <new-issue> 2193` instruction and the "Do NOT add `agent/ready` while #2193 is open" sentence. Replaces with a paragraph instructing agents to file spotcheck issues with `agent/ready` by default (dispatcher-pickable), with an explicit short list of reasons to omit it:
   - Blocked by an open dependency (use `block-issue.sh` for that)
   - AC not yet concrete (tighten or file as `status/triage`)
   - Needs a maintainer decision (scope/priority ambiguity)

   Also adds `agent/ready` to the example `--label` list.

No other content changes.

## Test plan

### Automated checks
- [x] `scripts/check-markdown-links.sh` passes locally (55 files, no broken links)
- [x] CI green (markdown-links-check job)

### Post-deploy verification
- [ ] No deployed component — skill file updated in repo; next `/spotcheck` invocation will load the new version.
