### PR TITLE
fix(ingestion): fall back to earliest snapshot for pre-snapshot hearings (#2602)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -1081,6 +1081,16 @@ def resolve_judge_from_department(
     closest to (but not after) that date for historical accuracy.  Otherwise
     uses the most recent snapshot.
 
+    When ``hearing_date`` predates every snapshot for this court (i.e. the
+    hearing happened before we started snapshotting the judicial assignments
+    directory), the function falls back to the **earliest** snapshot on record.
+    Judicial assignments change infrequently, so the earliest snapshot is the
+    best available approximation for pre-snapshot-window hearings — better
+    than returning ``None`` and leaving the ruling's judge unresolved
+    (regression: #2602 Ventura J6 probate rulings had NULL judge because
+    every hearing in the affected window predated the first snapshot by a
+    few days).
+
     This is the universal dept-to-judge fallback that works for ALL counties
     with roster data, replacing the LA-specific hardcoded lookup.  It fires
     during both normal ingestion and rebuilds, regardless of ``_llm_extracted``
@@ -1130,6 +1140,22 @@ def resolve_judge_from_department(
                 """,
                 (snapshot_court_id, hearing_date),
             )
+            row = cur.fetchone()
+            if row is None:
+                # Hearing predates every snapshot for this court.  Fall back to
+                # the earliest snapshot on record — judicial assignments change
+                # infrequently, so this is the best available approximation
+                # for pre-snapshot-window hearings (#2602).
+                cur.execute(
+                    """
+                    SELECT mapping FROM court_directory_snapshots
+                    WHERE court_id = %s
+                    ORDER BY captured_at ASC
+                    LIMIT 1
+                    """,
+                    (snapshot_court_id,),
+                )
+                row = cur.fetchone()
         else:
             cur.execute(
                 """
@@ -1140,7 +1166,7 @@ def resolve_judge_from_department(
                 """,
                 (snapshot_court_id,),
             )
-        row = cur.fetchone()
+            row = cur.fetchone()
 
     if row is None or row[0] is None:
         return None

--- a/packages/scraper-framework/tests/courts/test_la_dept_judges.py
+++ b/packages/scraper-framework/tests/courts/test_la_dept_judges.py
@@ -67,6 +67,66 @@ class TestNormalizeDepartment:
     def test_whitespace_stripped(self) -> None:
         assert normalize_department(" F46 ") == "F46"
 
+    # ---------------------------------------------------------------------
+    # Alphanumeric dept codes — locked in for #2602
+    # ---------------------------------------------------------------------
+    # Ventura (J6), SB (S*), Riverside (M*, PS*, C*, MV*), OC (CX*, CM*, N*,
+    # W*, L*) all share this helper via import.  The helper only strips zeros
+    # from *purely numeric* strings (isdigit() check), so alphanumerics pass
+    # through unchanged — which is what the dept-to-judge map keys expect.
+    # Do not add letter-stripping here; LA County's letter+digits ->
+    # letter-only normalization lives in ingestion.department_normalize and
+    # must stay out of this helper (see the Ventura import site in
+    # ``courts/ca/ventura_dept_judges.py``).
+
+    def test_issue_2602_j6(self) -> None:
+        """Exact case from #2602 — Ventura J6 must pass through."""
+        assert normalize_department("J6") == "J6"
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "J6",
+            "S1",
+            "M4",
+            "M205",
+            "M301",
+            "M302",
+            "MV1",
+            "C1",
+            "C3",
+            "N1",
+            "N15",
+            "W5",
+            "CM01",
+            "CM7",
+            "L10",
+            "PS1",
+            "PS2",
+            "PS4",
+            "CX02",
+            "T1",
+        ],
+    )
+    def test_alphanumeric_codes_preserved(self, raw: str) -> None:
+        """All alphanumeric codes from non-LA counties pass through
+        unchanged."""
+        assert normalize_department(raw) == raw
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("020", "20"),
+            ("007", "7"),
+            ("001", "1"),
+            ("0", "0"),
+            ("00", "0"),
+        ],
+    )
+    def test_numeric_zero_stripping_still_works(self, raw: str, expected: str) -> None:
+        """AC #4: numeric zero-stripping still works for numeric-only codes."""
+        assert normalize_department(raw) == expected
+
 
 # ---------------------------------------------------------------------------
 # _parse_combined_name — unit tests

--- a/packages/scraper-framework/tests/test_department_normalize.py
+++ b/packages/scraper-framework/tests/test_department_normalize.py
@@ -237,3 +237,104 @@ class TestEdgeCases:
         """Test SSC- prefix combined with letter+digits pattern."""
         # "SSC-X14": strip SSC- -> "X14", letter+digits -> "X"
         assert normalize_department("Los Angeles", "SSC-X14") == "X"
+
+
+# ---------------------------------------------------------------------------
+# Alphanumeric department codes — locked in for #2602
+# ---------------------------------------------------------------------------
+
+
+class TestAlphanumericDepartmentCodes:
+    """Lock in that alphanumeric dept codes (J6, S1, M4, C3, N1, W5, CM01, L10,
+    PS2, MV1, CX02, etc.) are preserved for non-LA counties.
+
+    Regression guard for #2602: Ventura J6 rulings had NULL judge because the
+    caller suspected ``normalize_department`` was stripping the ``J`` or the
+    ``6``.  In fact the pass-through already preserves these codes for non-LA
+    counties (LA has its own letter+digits -> letter rule, intentional for
+    LA's courtroom-number convention).  These tests document and lock in the
+    correct pass-through behavior so that any future normalization changes
+    do not silently break dept-to-judge lookups.
+    """
+
+    def test_issue_2602_j6(self) -> None:
+        """The exact case from #2602: Ventura J6 must pass through unchanged."""
+        assert normalize_department("Ventura", "J6") == "J6"
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "J6",
+            "J1",
+            "20",
+            "42",
+            "43",
+            "44",
+        ],
+    )
+    def test_ventura_passthrough(self, raw: str) -> None:
+        """Ventura has no county-specific rules — all codes pass through."""
+        assert normalize_department("Ventura", raw) == raw
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "M4",
+            "M205",
+            "M301",
+            "M302",
+            "MV1",
+            "C1",
+            "C3",
+            "PS1",
+            "PS2",
+            "PS4",
+            "T1",
+        ],
+    )
+    def test_riverside_alphanumeric_passthrough(self, raw: str) -> None:
+        """Riverside alphanumeric codes must not be altered (only numeric-only
+        codes have leading zeros stripped)."""
+        assert normalize_department("Riverside", raw) == raw
+
+    def test_riverside_numeric_zero_strip_still_works(self) -> None:
+        """AC #4: numeric zero-stripping still works for numeric-only codes."""
+        assert normalize_department("Riverside", "07") == "7"
+        assert normalize_department("Riverside", "007") == "7"
+        assert normalize_department("Riverside", "01") == "1"
+        # Edge case: bare zero stays zero, not empty
+        assert normalize_department("Riverside", "0") == "0"
+        # Edge case: double-zero normalizes to "0"
+        assert normalize_department("Riverside", "00") == "0"
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("S17", "S17"),
+            ("S-17", "S17"),
+            ("R14", "R14"),
+            ("R-14", "R14"),
+            ("S1", "S1"),
+        ],
+    )
+    def test_san_bernardino_alpha_prefix_preserved(self, raw: str, expected: str) -> None:
+        """SB strips the hyphen but must preserve the alpha prefix (S*, R*)."""
+        assert normalize_department("San Bernardino", raw) == expected
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "N1",
+            "N15",
+            "C44",
+            "CM01",
+            "CM7",
+            "CX02",
+            "W5",
+            "L10",
+        ],
+    )
+    def test_orange_alphanumeric_passthrough(self, raw: str) -> None:
+        """Orange uses alphanumeric codes (CX*, CM*, N*, W*, L*, C*) — all
+        must pass through."""
+        assert normalize_department("Orange", raw) == raw

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -2803,6 +2803,77 @@ class TestResolveJudgeFromDepartment:
         result = resolve_judge_from_department(conn, "court-uuid-1", "3")
         assert result is None
 
+    def test_falls_back_to_earliest_snapshot_when_hearing_date_predates_all(
+        self,
+    ) -> None:
+        """When hearing_date predates all snapshots, fall back to earliest snapshot.
+
+        Regression: #2602 — Ventura J6 probate rulings (and numeric depts) were
+        NULL-judge because their hearing_date predated the oldest court directory
+        snapshot (2026-03-31). The <= hearing_date query returned no row, and
+        the function returned None with no fallback.
+
+        Judicial assignments change infrequently, so the earliest snapshot is
+        the best available approximation for pre-snapshot-window hearings.
+        """
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        # Call sequence:
+        #   1. court_code lookup -> ("ca-ventura",)
+        #   2. historical snapshot (<= hearing_date) -> None (no row)
+        #   3. earliest snapshot fallback (ASC LIMIT 1) -> ({"J6": "..."},)
+        earliest_mapping = {"J6": "Gilbert A. Romero", "20": "Ronda J. McKaig"}
+        cur.fetchone.side_effect = [
+            ("ca-ventura",),
+            None,
+            (earliest_mapping,),
+        ]
+        hearing_dt = date(2026, 3, 17)
+
+        result = resolve_judge_from_department(conn, "court-uuid-1", "J6", hearing_date=hearing_dt)
+        assert result == "Gilbert A. Romero"
+
+        # Verify the fallback query is ORDER BY captured_at ASC LIMIT 1
+        assert len(cur.execute.call_args_list) == 3
+        fallback_call = cur.execute.call_args_list[2]
+        fallback_sql = fallback_call[0][0]
+        assert "ORDER BY captured_at ASC" in fallback_sql
+        assert "LIMIT 1" in fallback_sql
+        fallback_params = fallback_call[0][1]
+        assert "ca_ventura" in fallback_params
+
+    def test_returns_none_when_no_snapshots_at_all_with_hearing_date(self) -> None:
+        """When hearing_date is set and no snapshots exist at all, return None.
+
+        The historical-snapshot query returns None, the earliest-snapshot
+        fallback also returns None, and the function returns None.
+        """
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        cur.fetchone.side_effect = [
+            ("ca-ventura",),
+            None,  # historical snapshot: no row
+            None,  # earliest snapshot fallback: no row either
+        ]
+        hearing_dt = date(2026, 3, 17)
+
+        result = resolve_judge_from_department(conn, "court-uuid-1", "J6", hearing_date=hearing_dt)
+        assert result is None
+
+    def test_no_fallback_needed_when_historical_snapshot_exists(self) -> None:
+        """When a snapshot predates hearing_date, use it and do NOT run the fallback."""
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        mapping = {"J6": "Gilbert A. Romero"}
+        cur.fetchone.side_effect = [("ca-ventura",), (mapping,)]
+        hearing_dt = date(2026, 4, 16)
+
+        result = resolve_judge_from_department(conn, "court-uuid-1", "J6", hearing_date=hearing_dt)
+        assert result == "Gilbert A. Romero"
+
+        # Only two execute calls: court_code + historical snapshot — no fallback
+        assert len(cur.execute.call_args_list) == 2
+
 
 # ---------------------------------------------------------------------------
 # delete_stale_split_children


### PR DESCRIPTION
## Summary

- Fix `resolve_judge_from_department` so pre-snapshot-window hearings fall back to the earliest `court_directory_snapshots` entry instead of returning `None`.
- Explains #2602: Ventura J6 rulings on 2026-03-17 through 2026-03-27 were NULL because every hearing predated Ventura's first snapshot (2026-03-31), even though `ventura_dept_judges.py` had correctly populated `J6 → Gilbert A. Romero`.
- Systemic fix, not Ventura-specific — also recovers NULL judges for Orange N15/C44, Riverside MV1/M301/M302/PS1/C1, and any other county where hearings predate the first snapshot.
- Issue's original hypothesis ("`normalize_department` strips `J6` → `J` or `6`") turned out to be wrong; the normalization already preserves `J6`. Added regression-guard tests locking in pass-through for alphanumeric codes (J6, S1, M4, C3, N1, W5, CM01, L10, PS2, MV1, CX02, etc.) across Ventura / Riverside / San Bernardino / Orange and for the 1-arg LA helper used by the other counties' dept_judges modules.

Closes #2602

## Test plan

### Automated checks
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] `pytest tests/` passes (410 tests in touched files, 6197 total)
- [x] `diff-cover --fail-under=90` passes (100% diff-coverage on `db.py` changes)
- [x] CI green

### Post-deploy verification
- [x] After merge, reingest ran successfully on dev via `scripts/ecs-run-task.sh scripts/reingest_from_s3.py --county Ventura` (347 docs processed, 0 failures)
- [x] `scripts/dev-db-query.sh "SELECT COUNT(*) FROM derived.rulings ... WHERE ... AND r.department = 'J6' AND r.judge_id IS NULL"` dropped from 143 to 0
- [x] All 224 Ventura J6 rulings now resolve to Hon. Gilbert A. Romero (verified via `derived.judges.canonical_name` join)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
