### PR TITLE
refactor(ci): extract inline post-deploy health check into testable script (#2608)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,6 +548,8 @@ jobs:
         run: scripts/check-aws-bool-flags.sh
       - name: Check for forbidden ECS services-stable waiter usage
         run: scripts/check-no-ecs-wait-services-stable.sh
+      - name: Check workflows use the extracted ECS post-deploy healthcheck
+        run: scripts/check-no-inline-ecs-healthcheck.sh
       - name: Check docs describe the actual rebuild_db.py CLI
         run: scripts/check-no-rebuild-db-skip-reset.sh
       # Auto-discover and run every executable shell test under

--- a/.github/workflows/deploy-scraper.yml
+++ b/.github/workflows/deploy-scraper.yml
@@ -11,6 +11,12 @@ on:
       # action. Changes to the shared script must trigger this deploy so the
       # fix is exercised against a real rollout on its own PR (see #2592).
       - "scripts/wait-for-rollout.sh"
+      # scripts/ecs-post-deploy-healthcheck.sh is invoked by the
+      # post-deploy-health-check job below. Same paths-filter contract as
+      # wait-for-rollout.sh — changes to the shared health-check script
+      # must trigger this deploy so regressions surface on the PR that
+      # introduces them, not on the next unrelated deploy (see #2608/#2592).
+      - "scripts/ecs-post-deploy-healthcheck.sh"
   workflow_dispatch:
     inputs:
       image_tag:
@@ -219,147 +225,32 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ env.AWS_REGION }}
 
+      - name: Checkout (for post-deploy-healthcheck script)
+        uses: actions/checkout@v6
+
       - name: Wait for new tasks to start
         run: |
           echo "Waiting 60 seconds for new ingestion worker task to fully start..."
           sleep 60
 
-      - name: Health check — verify service is running
-        id: service-check
-        run: |
-          SERVICE_DESC=$(aws ecs describe-services \
-            --cluster "$ECS_CLUSTER" \
-            --services "$INGESTION_SERVICE" \
-            --query 'services[0]' \
-            --output json)
-
-          RUNNING_COUNT=$(echo "$SERVICE_DESC" | jq -r '.runningCount')
-          DESIRED_COUNT=$(echo "$SERVICE_DESC" | jq -r '.desiredCount')
-
-          echo "Running tasks: $RUNNING_COUNT / Desired: $DESIRED_COUNT"
-
-          # Treat running==desired as success. This includes the scale-to-zero
-          # case (desired=0, running=0): the dev ingestion worker is kept at
-          # desiredCount=0 and runs on-demand, so "no tasks running" is the
-          # expected steady state. Mirrors the #2585 fix in
-          # scripts/wait-for-rollout.sh (see #2605).
-          if [ "$DESIRED_COUNT" -eq 0 ] && [ "$RUNNING_COUNT" -eq 0 ]; then
-            echo "Service is scaled to zero (desired=0, running=0) — treating as healthy."
-          elif [ "$RUNNING_COUNT" -ge "$DESIRED_COUNT" ] && [ "$RUNNING_COUNT" -gt 0 ]; then
-            echo "Service has expected number of running tasks."
-          else
-            echo "ERROR: Service running count ($RUNNING_COUNT) does not match desired ($DESIRED_COUNT)."
-            exit 1
-          fi
-
-      - name: Health check — verify no crash-loop
-        id: crash-check
-        run: |
-          # When the service is scaled to zero (desired=0), there are no tasks
-          # to inspect — no running tasks is the expected state, not a
-          # crash-loop. Skip the task inspection entirely. Mirrors the #2585
-          # fix in scripts/wait-for-rollout.sh (see #2605).
-          DESIRED_COUNT=$(aws ecs describe-services \
-            --cluster "$ECS_CLUSTER" \
-            --services "$INGESTION_SERVICE" \
-            --query 'services[0].desiredCount' \
-            --output text)
-
-          if [ "$DESIRED_COUNT" -eq 0 ]; then
-            echo "Service is scaled to zero (desired=0) — skipping crash-loop check (no tasks to inspect)."
-            exit 0
-          fi
-
-          # Check that the most recent task has been running for at least 30 seconds
-          # (a crash-looping container restarts quickly)
-          TASKS=$(aws ecs list-tasks \
-            --cluster "$ECS_CLUSTER" \
-            --service-name "$INGESTION_SERVICE" \
-            --desired-status RUNNING \
-            --query 'taskArns' \
-            --output json)
-
-          TASK_COUNT=$(echo "$TASKS" | jq 'length')
-
-          if [ "$TASK_COUNT" -eq 0 ]; then
-            echo "ERROR: No running tasks found for service."
-            exit 1
-          fi
-
-          FIRST_TASK=$(echo "$TASKS" | jq -r '.[0]')
-          TASK_DESC=$(aws ecs describe-tasks \
-            --cluster "$ECS_CLUSTER" \
-            --tasks "$FIRST_TASK" \
-            --query 'tasks[0]' \
-            --output json)
-
-          LAST_STATUS=$(echo "$TASK_DESC" | jq -r '.lastStatus')
-          HEALTH_STATUS=$(echo "$TASK_DESC" | jq -r '.healthStatus // "UNKNOWN"')
-
-          echo "Task status: $LAST_STATUS, health: $HEALTH_STATUS"
-
-          # Check container exit codes — if any container has stopped with non-zero, it's crash-looping
-          STOPPED_CONTAINERS=$(echo "$TASK_DESC" | jq '[.containers[] | select(.lastStatus == "STOPPED" and .exitCode != 0)] | length')
-
-          if [ "$STOPPED_CONTAINERS" -gt 0 ]; then
-            echo "ERROR: Found $STOPPED_CONTAINERS stopped containers with non-zero exit codes — possible crash-loop."
-            echo "$TASK_DESC" | jq '.containers[] | {name, lastStatus, exitCode, reason}'
-            exit 1
-          fi
-
-          echo "No crash-loop detected. Service appears healthy."
-
-      - name: Health check — verify recent log output (no errors)
-        id: log-check
-        run: |
-          # Fetch the last 20 log events from the ingestion worker
-          LOG_GROUP="/ecs/judgemind-ingestion-worker-dev"
-
-          # Get the most recent log stream
-          LATEST_STREAM=$(aws logs describe-log-streams \
-            --log-group-name "$LOG_GROUP" \
-            --order-by LastEventTime \
-            --descending \
-            --limit 1 \
-            --query 'logStreams[0].logStreamName' \
-            --output text 2>/dev/null || echo "")
-
-          if [ -z "$LATEST_STREAM" ] || [ "$LATEST_STREAM" = "None" ]; then
-            echo "WARNING: No log streams found. Service may still be starting."
-            exit 0
-          fi
-
-          echo "Checking latest log stream: $LATEST_STREAM"
-
-          # Get recent log events
-          EVENTS=$(aws logs get-log-events \
-            --log-group-name "$LOG_GROUP" \
-            --log-stream-name "$LATEST_STREAM" \
-            --limit 20 \
-            --start-from-head false \
-            --output json 2>/dev/null || echo '{"events":[]}')
-
-          EVENT_COUNT=$(echo "$EVENTS" | jq '.events | length')
-          echo "Found $EVENT_COUNT recent log events."
-
-          # Check for critical errors (not warnings or info-level mentions of "error")
-          CRITICAL_ERRORS=$(echo "$EVENTS" | jq -r '.events[].message' | grep -ic "CRITICAL\|Traceback\|InfrastructureError\|crash" || true)
-
-          if [ "$CRITICAL_ERRORS" -gt 0 ]; then
-            echo "WARNING: Found $CRITICAL_ERRORS critical error indicators in recent logs."
-            echo "Recent log events:"
-            echo "$EVENTS" | jq -r '.events[].message' | tail -10
-            # Warning only — don't fail the whole deploy for log noise
-          else
-            echo "No critical errors found in recent logs."
-          fi
+      # Post-deploy health check — delegates to the extracted, unit-tested
+      # script at scripts/ecs-post-deploy-healthcheck.sh. The extraction
+      # keeps the scale-to-zero rule (running==desired==0 treated as
+      # healthy) codified in one place so drift like #2605 cannot recur.
+      - name: Post-deploy ingestion worker health check
+        id: healthcheck
+        env:
+          ECS_CLUSTER: ${{ env.ECS_CLUSTER }}
+          INGESTION_SERVICE: ${{ env.INGESTION_SERVICE }}
+          LOG_GROUP: /ecs/judgemind-ingestion-worker-dev
+        run: bash scripts/ecs-post-deploy-healthcheck.sh
 
       - name: Set health check status
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HEALTH_STATUS: ${{ (steps.service-check.outcome == 'success' && steps.crash-check.outcome == 'success') && 'success' || 'failure' }}
-          HEALTH_DESC: ${{ (steps.service-check.outcome == 'success' && steps.crash-check.outcome == 'success') && 'Ingestion worker health check passed' || 'Ingestion worker health check failed' }}
+          HEALTH_STATUS: ${{ steps.healthcheck.outcome == 'success' && 'success' || 'failure' }}
+          HEALTH_DESC: ${{ steps.healthcheck.outcome == 'success' && 'Ingestion worker health check passed' || 'Ingestion worker health check failed' }}
         run: |
           curl -s -X POST \
             -H "Authorization: token $GH_TOKEN" \

--- a/scripts/check-no-inline-ecs-healthcheck.sh
+++ b/scripts/check-no-inline-ecs-healthcheck.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# check-no-inline-ecs-healthcheck.sh — Forbid new inline ECS health-check
+# bash in GitHub Actions workflow YAML.
+#
+# Motivation:
+#   Issue #2605 was caused by drift between scripts/wait-for-rollout.sh
+#   (fixed in #2585 to accept desired=0/running=0 as healthy) and the
+#   inline bash in .github/workflows/deploy-scraper.yml's
+#   post-deploy-health-check job, which kept the stricter RUNNING_COUNT>0
+#   requirement and failed every dev deploy for weeks. The fix in #2606
+#   patched the inline bash — but a third copy of the same rule is exactly
+#   the kind of thing that drifts again. Issue #2608 extracts the logic
+#   into scripts/ecs-post-deploy-healthcheck.sh (with unit tests).
+#
+#   This guard keeps new inline ECS health-check logic from reappearing in
+#   workflow YAML. Callers must invoke the extracted script instead.
+#
+# Pattern:
+#   A workflow file is flagged when it contains BOTH
+#       aws ecs describe-services     (or logs describe-log-streams, which
+#                                      is how the log-check half starts)
+#     AND
+#       runningCount                  (the give-away jq field for the
+#                                      RUNNING_COUNT == DESIRED_COUNT rule)
+#   on any two non-comment lines. That combination is the signature of
+#   the inline health-check block; extracted-script callers don't have it
+#   (they have `bash scripts/ecs-post-deploy-healthcheck.sh` and nothing
+#   else).
+#
+# Usage:
+#   scripts/check-no-inline-ecs-healthcheck.sh          # scan default workflow dir
+#   scripts/check-no-inline-ecs-healthcheck.sh [dir]    # scan a specific directory
+#
+# Exit codes:
+#   0 — No violations found.
+#   1 — One or more workflow YAML files contain inline ECS health-check logic.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-$REPO_ROOT}"
+
+# ─── Patterns that together indicate inline health-check bash ──────────────
+DESCRIBE_PATTERN='aws[[:space:]]+ecs[[:space:]]+describe-services'
+COUNT_PATTERN='runningCount'
+
+# ─── Files that legitimately mention the patterns as context ───────────────
+# The guard script itself and its test file have to spell the patterns
+# literally. docs/investigations/* may reference them as post-mortem
+# context. Anything outside .github/workflows/ is ignored by construction
+# (we only scan that dir), but we still defensively exclude the guard's
+# own files by basename.
+EXCLUDE_FILES=(
+    "scripts/check-no-inline-ecs-healthcheck.sh"
+    "scripts/tests/test_check_no_inline_ecs_healthcheck.sh"
+)
+
+# ─── Scan ──────────────────────────────────────────────────────────────────
+# We only scan .github/workflows/*.yml — that's where the drift happened
+# and where the extraction rule applies. Actions composite steps under
+# .github/actions/ deliberately wrap aws-cli calls; they are not the
+# target of this check.
+WORKFLOWS_DIR="$SCAN_DIR/.github/workflows"
+
+# If there is no workflows dir (e.g. when invoked against a test TMPDIR),
+# fall back to scanning SCAN_DIR for *.yml files directly.
+if [[ ! -d "$WORKFLOWS_DIR" ]]; then
+    WORKFLOWS_DIR="$SCAN_DIR"
+fi
+
+# Collect candidate files. Uses a while-read loop instead of mapfile so
+# the script works on bash 3.x (macOS default) as well as bash 4+.
+yml_files=()
+while IFS= read -r f; do
+    yml_files+=("$f")
+done < <(find "$WORKFLOWS_DIR" -maxdepth 3 -type f \
+    \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null | sort)
+
+violations=0
+
+for file in ${yml_files[@]+"${yml_files[@]}"}; do
+    # Skip excluded files by path suffix.
+    skip=false
+    for excl in "${EXCLUDE_FILES[@]}"; do
+        if [[ "$file" == *"$excl" ]]; then
+            skip=true
+            break
+        fi
+    done
+    if "$skip"; then
+        continue
+    fi
+
+    # Skip docs/investigations/* — post-mortems may reference the pattern
+    # as historical context.
+    if [[ "$file" == *"docs/investigations/"* ]]; then
+        continue
+    fi
+
+    # Strip comments (lines whose first non-whitespace char is '#') before
+    # matching. Both patterns must appear on non-comment lines in the same
+    # file for the file to trigger.
+    non_comment_content=$(grep -vE '^[[:space:]]*#' "$file" 2>/dev/null || true)
+
+    if [[ -z "$non_comment_content" ]]; then
+        continue
+    fi
+
+    has_describe=false
+    has_count=false
+    if echo "$non_comment_content" | grep -qE "$DESCRIBE_PATTERN"; then
+        has_describe=true
+    fi
+    if echo "$non_comment_content" | grep -qE "$COUNT_PATTERN"; then
+        has_count=true
+    fi
+
+    if "$has_describe" && "$has_count"; then
+        if [[ $violations -eq 0 ]]; then
+            echo "ERROR: Found inline ECS health-check bash in workflow YAML."
+            echo ""
+            echo "  These workflow files contain both 'aws ecs describe-services'"
+            echo "  and a 'runningCount' check — the signature of inline ECS"
+            echo "  health-check logic. Use scripts/ecs-post-deploy-healthcheck.sh"
+            echo "  instead, which codifies the scale-to-zero rule (running==desired==0"
+            echo "  treated as healthy) in one place. See issues #2605 and #2608."
+            echo ""
+        fi
+        echo "    $file"
+        violations=$((violations + 1))
+    fi
+done
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "  Fix: replace the inline bash with"
+    echo "    - name: Post-deploy health check"
+    echo "      env:"
+    echo "        ECS_CLUSTER: <cluster>"
+    echo "        INGESTION_SERVICE: <service>"
+    echo "        LOG_GROUP: <log-group>"
+    echo "      run: bash scripts/ecs-post-deploy-healthcheck.sh"
+    echo ""
+    echo "  If a workflow must reference these patterns as explanatory"
+    echo "  context, put them in comment lines (starting with '#') or move"
+    echo "  the note to docs/investigations/."
+    exit 1
+fi
+
+echo "All clean — no inline ECS health-check bash detected in workflow YAML."
+exit 0

--- a/scripts/ecs-post-deploy-healthcheck.sh
+++ b/scripts/ecs-post-deploy-healthcheck.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# ecs-post-deploy-healthcheck.sh — Post-deploy health check for an ECS service.
+#
+# Three checks, run in order:
+#   1. service-check  — describe-services: runningCount matches desiredCount
+#                       (scale-to-zero treated as healthy; see #2585 / #2605).
+#   2. crash-check    — describe-tasks on the most recent running task:
+#                       no stopped container with a non-zero exit code.
+#                       Skipped when desiredCount == 0 (no tasks to inspect).
+#   3. log-check      — CloudWatch Logs: no CRITICAL / Traceback /
+#                       InfrastructureError / crash lines in the most
+#                       recent 20 events of the newest log stream.
+#                       Warning only — does not fail the deploy.
+#
+# Motivation:
+#   Originally three inline bash blocks in .github/workflows/deploy-scraper.yml's
+#   post-deploy-health-check job. Extracted into a shared script so:
+#
+#     - the scale-to-zero rule (running==desired==0 treated as healthy) is
+#       codified in ONE place, not three copies that can drift (this is
+#       exactly how #2605 happened — see also the parallel extraction of
+#       wait-for-rollout.sh in #2585/#2519).
+#
+#     - the logic is unit-testable against a mock aws CLI the way
+#       scripts/wait-for-rollout.sh is tested in
+#       scripts/tests/test_wait_for_rollout.sh.
+#
+# IMPORTANT — paths-filter contract (see #2592):
+#   Any deploy workflow that adopts this script MUST add
+#   `scripts/ecs-post-deploy-healthcheck.sh` to its `on.push.paths:` filter.
+#   Otherwise a PR that changes only this shared script will merge without
+#   triggering any deploy workflow — so the fix is not exercised against a
+#   real rollout on its own PR, and regressions surface on the next
+#   unrelated deploy. Current callers:
+#     - .github/workflows/deploy-scraper.yml
+#
+# Required environment variables:
+#   ECS_CLUSTER         — ECS cluster name (e.g. judgemind-dev)
+#   INGESTION_SERVICE   — ECS service name (e.g. judgemind-ingestion-worker-dev)
+#   LOG_GROUP           — CloudWatch log group for the service (e.g.
+#                         /ecs/judgemind-ingestion-worker-dev)
+#
+# Optional environment variables:
+#   AWS_CLI             — binary name for aws CLI (default: aws; used for
+#                         mocking in tests)
+#
+# Exit codes:
+#   0 — service-check passed AND crash-check passed. log-check is warning-only
+#       and never causes a non-zero exit.
+#   1 — service-check failed (running != desired, not scale-to-zero), OR
+#       crash-check failed (stopped container with non-zero exit code or
+#       no running tasks when desiredCount > 0), OR aws CLI call failed, OR
+#       a required env var was not set.
+
+set -euo pipefail
+
+: "${ECS_CLUSTER:?ECS_CLUSTER is required}"
+: "${INGESTION_SERVICE:?INGESTION_SERVICE is required}"
+: "${LOG_GROUP:?LOG_GROUP is required}"
+
+AWS_CLI="${AWS_CLI:-aws}"
+
+# ─── 1. service-check — verify service is running ───────────────────────────
+
+echo "=== Health check: verify service is running ==="
+
+if ! SERVICE_DESC=$("$AWS_CLI" ecs describe-services \
+      --cluster "$ECS_CLUSTER" \
+      --services "$INGESTION_SERVICE" \
+      --query 'services[0]' \
+      --output json); then
+    echo "ERROR: aws ecs describe-services failed."
+    exit 1
+fi
+
+RUNNING_COUNT=$(echo "$SERVICE_DESC" | jq -r '.runningCount')
+DESIRED_COUNT=$(echo "$SERVICE_DESC" | jq -r '.desiredCount')
+
+echo "Running tasks: $RUNNING_COUNT / Desired: $DESIRED_COUNT"
+
+# Treat running==desired as success. This includes the scale-to-zero case
+# (desired=0, running=0): the dev ingestion worker is kept at desiredCount=0
+# and runs on-demand, so "no tasks running" is the expected steady state.
+# Mirrors the #2585 fix in scripts/wait-for-rollout.sh (see #2605).
+if [ "$DESIRED_COUNT" -eq 0 ] && [ "$RUNNING_COUNT" -eq 0 ]; then
+    echo "Service is scaled to zero (desired=0, running=0) — treating as healthy."
+elif [ "$RUNNING_COUNT" -ge "$DESIRED_COUNT" ] && [ "$RUNNING_COUNT" -gt 0 ]; then
+    echo "Service has expected number of running tasks."
+else
+    echo "ERROR: Service running count ($RUNNING_COUNT) does not match desired ($DESIRED_COUNT)."
+    exit 1
+fi
+
+# ─── 2. crash-check — verify no crash-loop ──────────────────────────────────
+
+echo ""
+echo "=== Health check: verify no crash-loop ==="
+
+# When the service is scaled to zero (desired=0), there are no tasks to
+# inspect — no running tasks is the expected state, not a crash-loop. Skip
+# the task inspection entirely. Mirrors the #2585 fix in
+# scripts/wait-for-rollout.sh (see #2605).
+if [ "$DESIRED_COUNT" -eq 0 ]; then
+    echo "Service is scaled to zero (desired=0) — skipping crash-loop check (no tasks to inspect)."
+else
+    # Check that the most recent running task has no stopped containers with
+    # non-zero exit codes (a crash-looping container restarts quickly).
+    if ! TASKS=$("$AWS_CLI" ecs list-tasks \
+          --cluster "$ECS_CLUSTER" \
+          --service-name "$INGESTION_SERVICE" \
+          --desired-status RUNNING \
+          --query 'taskArns' \
+          --output json); then
+        echo "ERROR: aws ecs list-tasks failed."
+        exit 1
+    fi
+
+    TASK_COUNT=$(echo "$TASKS" | jq 'length')
+
+    if [ "$TASK_COUNT" -eq 0 ]; then
+        echo "ERROR: No running tasks found for service."
+        exit 1
+    fi
+
+    FIRST_TASK=$(echo "$TASKS" | jq -r '.[0]')
+    if ! TASK_DESC=$("$AWS_CLI" ecs describe-tasks \
+          --cluster "$ECS_CLUSTER" \
+          --tasks "$FIRST_TASK" \
+          --query 'tasks[0]' \
+          --output json); then
+        echo "ERROR: aws ecs describe-tasks failed."
+        exit 1
+    fi
+
+    LAST_STATUS=$(echo "$TASK_DESC" | jq -r '.lastStatus')
+    HEALTH_STATUS=$(echo "$TASK_DESC" | jq -r '.healthStatus // "UNKNOWN"')
+
+    echo "Task status: $LAST_STATUS, health: $HEALTH_STATUS"
+
+    # Check container exit codes — any STOPPED container with a non-zero
+    # exitCode indicates a crash-loop.
+    STOPPED_CONTAINERS=$(echo "$TASK_DESC" | jq '[.containers[] | select(.lastStatus == "STOPPED" and .exitCode != 0)] | length')
+
+    if [ "$STOPPED_CONTAINERS" -gt 0 ]; then
+        echo "ERROR: Found $STOPPED_CONTAINERS stopped containers with non-zero exit codes — possible crash-loop."
+        echo "$TASK_DESC" | jq '.containers[] | {name, lastStatus, exitCode, reason}'
+        exit 1
+    fi
+
+    echo "No crash-loop detected. Service appears healthy."
+fi
+
+# ─── 3. log-check — verify recent log output (warning only) ─────────────────
+
+echo ""
+echo "=== Health check: verify recent log output (no critical errors) ==="
+
+# Get the most recent log stream. If this fails or returns nothing, emit a
+# warning and continue — log-check never fails the deploy for log noise or
+# transient CloudWatch issues.
+LATEST_STREAM=$("$AWS_CLI" logs describe-log-streams \
+    --log-group-name "$LOG_GROUP" \
+    --order-by LastEventTime \
+    --descending \
+    --limit 1 \
+    --query 'logStreams[0].logStreamName' \
+    --output text 2>/dev/null || echo "")
+
+if [ -z "$LATEST_STREAM" ] || [ "$LATEST_STREAM" = "None" ]; then
+    echo "WARNING: No log streams found. Service may still be starting."
+    exit 0
+fi
+
+echo "Checking latest log stream: $LATEST_STREAM"
+
+EVENTS=$("$AWS_CLI" logs get-log-events \
+    --log-group-name "$LOG_GROUP" \
+    --log-stream-name "$LATEST_STREAM" \
+    --limit 20 \
+    --start-from-head false \
+    --output json 2>/dev/null || echo '{"events":[]}')
+
+EVENT_COUNT=$(echo "$EVENTS" | jq '.events | length')
+echo "Found $EVENT_COUNT recent log events."
+
+# Grep for critical error indicators. Warning only — don't fail the whole
+# deploy for log noise. (Transient tracebacks or crash mentions in info-level
+# output would otherwise trip every deploy.)
+CRITICAL_ERRORS=$(echo "$EVENTS" | jq -r '.events[].message' | grep -ic "CRITICAL\|Traceback\|InfrastructureError\|crash" || true)
+
+if [ "$CRITICAL_ERRORS" -gt 0 ]; then
+    echo "WARNING: Found $CRITICAL_ERRORS critical error indicators in recent logs."
+    echo "Recent log events:"
+    echo "$EVENTS" | jq -r '.events[].message' | tail -10
+    # Warning only — don't fail the whole deploy.
+else
+    echo "No critical errors found in recent logs."
+fi
+
+exit 0

--- a/scripts/ecs-post-deploy-healthcheck.sh
+++ b/scripts/ecs-post-deploy-healthcheck.sh
@@ -177,7 +177,7 @@ EVENTS=$("$AWS_CLI" logs get-log-events \
     --log-group-name "$LOG_GROUP" \
     --log-stream-name "$LATEST_STREAM" \
     --limit 20 \
-    --start-from-head false \
+    --no-start-from-head \
     --output json 2>/dev/null || echo '{"events":[]}')
 
 EVENT_COUNT=$(echo "$EVENTS" | jq '.events | length')

--- a/scripts/tests/test_check_no_inline_ecs_healthcheck.sh
+++ b/scripts/tests/test_check_no_inline_ecs_healthcheck.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# test_check_no_inline_ecs_healthcheck.sh — Tests for
+# scripts/check-no-inline-ecs-healthcheck.sh.
+#
+# Creates temporary workflow YAML files and verifies that the checker
+# correctly detects inline ECS health-check bash while allowing
+# extracted-script callers, comment-only references, and unrelated
+# workflows through.
+#
+# Usage:
+#   scripts/tests/test_check_no_inline_ecs_healthcheck.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-no-inline-ecs-healthcheck.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo.
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local path="$TMPDIR_TEST/$name"
+    local dir
+    dir="$(dirname "$path")"
+    mkdir -p "$dir"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: Inline ECS health check (the exact pattern from #2605) ──────
+# A workflow with `aws ecs describe-services` + `runningCount` in non-
+# comment lines must trip the guard. This is the motivating bug class
+# this check was built for.
+create_test_file ".github/workflows/bad-inline.yml" 'jobs:
+  post-deploy-health-check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          SERVICE_DESC=$(aws ecs describe-services --cluster foo --services bar --query "services[0]" --output json)
+          RUNNING_COUNT=$(echo "$SERVICE_DESC" | jq -r ".runningCount")
+          if [ "$RUNNING_COUNT" -gt 0 ]; then
+            echo "healthy"
+          fi'
+assert_fails "Inline aws ecs describe-services + runningCount is detected"
+reset_tmpdir
+
+# ─── Test 2: Extracted-script caller should pass ─────────────────────────
+# The recommended replacement — a single run step invoking the shared
+# script — must NOT trip the guard.
+create_test_file ".github/workflows/good-extracted.yml" 'jobs:
+  post-deploy-health-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post-deploy ingestion worker health check
+        env:
+          ECS_CLUSTER: judgemind-dev
+          INGESTION_SERVICE: judgemind-ingestion-worker-dev
+          LOG_GROUP: /ecs/judgemind-ingestion-worker-dev
+        run: bash scripts/ecs-post-deploy-healthcheck.sh'
+assert_passes "Extracted-script caller passes"
+reset_tmpdir
+
+# ─── Test 3: Workflow with only comments mentioning the patterns ─────────
+# A workflow whose only references are in YAML comments (starting with
+# # after whitespace) must NOT trip the guard.
+create_test_file ".github/workflows/comments-only.yml" 'jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # Previously ran: aws ecs describe-services to read runningCount.
+      # Replaced with the extracted scripts/ecs-post-deploy-healthcheck.sh
+      - run: bash scripts/ecs-post-deploy-healthcheck.sh'
+assert_passes "Comment-only references to the patterns are allowed"
+reset_tmpdir
+
+# ─── Test 4: Unrelated describe-services use (no runningCount) passes ────
+# A workflow that calls `aws ecs describe-services` but never references
+# runningCount is not an inline health-check — e.g. a step that reads the
+# service's task definition ARN. Must not trip the guard.
+create_test_file ".github/workflows/describe-only.yml" 'jobs:
+  info:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          TASK_DEF=$(aws ecs describe-services --cluster foo --services bar --query "services[0].taskDefinition" --output text)
+          echo "task_def=$TASK_DEF"'
+assert_passes "describe-services without runningCount does not trip the guard"
+reset_tmpdir
+
+# ─── Test 5: runningCount alone (no describe-services) passes ────────────
+# A workflow that references runningCount in another context (e.g. a
+# documentation string) without calling describe-services must not trip.
+create_test_file ".github/workflows/count-only.yml" 'jobs:
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "We trust runningCount values from CloudWatch metrics"'
+assert_passes "runningCount alone without describe-services does not trip"
+reset_tmpdir
+
+# ─── Test 6: Mixed file — non-comment violation is caught even with
+# comments also referencing the patterns ─────────────────────────────────
+create_test_file ".github/workflows/mixed.yml" 'jobs:
+  bad:
+    runs-on: ubuntu-latest
+    steps:
+      # This used to be inline:
+      #   aws ecs describe-services reads runningCount
+      # but we are STILL doing it inline here:
+      - run: |
+          aws ecs describe-services --cluster foo --services bar --query "services[0]" > svc.json
+          jq -r ".runningCount" svc.json'
+assert_fails "Mixed file: real inline code is still caught when comments also mention the patterns"
+reset_tmpdir
+
+# ─── Test 7: Empty workflows directory passes ────────────────────────────
+mkdir -p "$TMPDIR_TEST/.github/workflows"
+assert_passes "Empty .github/workflows directory passes"
+reset_tmpdir
+
+# ─── Test 8: Scanning a directory with no .github/workflows/ falls back
+# to scanning SCAN_DIR directly — confirm bad YAML there still trips. ────
+create_test_file "flat.yml" 'jobs:
+  bad:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          aws ecs describe-services --cluster foo --services bar > out.json
+          jq -r ".runningCount" out.json'
+assert_fails "Flat scan (no .github/workflows) still detects inline pattern"
+reset_tmpdir
+
+# ─── Test 9: Two separate workflows — one bad, one good — the bad one
+# trips the guard. ───────────────────────────────────────────────────────
+create_test_file ".github/workflows/ok.yml" 'jobs:
+  ok:
+    runs-on: ubuntu-latest
+    steps:
+      - run: bash scripts/ecs-post-deploy-healthcheck.sh'
+create_test_file ".github/workflows/bad.yml" 'jobs:
+  bad:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          aws ecs describe-services --cluster x --services y > o.json
+          jq -r ".runningCount" o.json'
+assert_fails "A bad workflow alongside a good one still trips the guard"
+reset_tmpdir
+
+# ─── Test 10: Both patterns in the same multi-line `run` block trigger ──
+# (sanity check — this is the most common real-world signature)
+create_test_file ".github/workflows/multirun.yml" 'jobs:
+  bad:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          SERVICE_DESC=$(aws ecs describe-services --cluster foo --services bar)
+          RUNNING_COUNT=$(echo "$SERVICE_DESC" | jq -r ".runningCount")
+          DESIRED_COUNT=$(echo "$SERVICE_DESC" | jq -r ".desiredCount")
+          if [ "$DESIRED_COUNT" -eq 0 ] && [ "$RUNNING_COUNT" -eq 0 ]; then
+            echo "scale-to-zero healthy"
+          fi'
+assert_fails "Multi-line run block with both patterns trips the guard"
+reset_tmpdir
+
+# ─── Test 11: Non-.yml files in workflows dir are ignored ────────────────
+# find is restricted to *.yml and *.yaml — a README.md in workflows/
+# should not be scanned even if it happens to contain the patterns.
+create_test_file ".github/workflows/README.md" 'This file documents the
+legacy aws ecs describe-services workflow and its runningCount checks.'
+assert_passes "Non-YAML files in workflows/ are not scanned"
+reset_tmpdir
+
+# ─── Test 12: docs/investigations/ is ignored even when it contains the pattern ──
+create_test_file "docs/investigations/healthcheck-drift-2026-04.md" '# Healthcheck drift
+
+The drift happened because we had inline `aws ecs describe-services` that
+read `runningCount` and failed when the service was scaled to zero.'
+# Note: docs/investigations/ does not live under .github/workflows/, so
+# the default scan path (.github/workflows/) will not find it. Even if
+# the scan falls back to SCAN_DIR (because no workflows dir exists), the
+# guard still skips docs/investigations/ by path rule — we test the
+# latter branch here by not creating a workflows dir.
+assert_passes "docs/investigations/ references to the patterns are allowed"
+reset_tmpdir
+
+# ─── Test 13: No self-match on ci.yml step name ──────────────────────────
+# The step name in .github/workflows/ci.yml that runs this guard must
+# not itself contain the forbidden pattern tokens. See #2541/#2542 for
+# the motivating incident and scripts/tests/_guard_self_match_helpers.sh.
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-no-inline-ecs-healthcheck.sh" "yml"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/tests/test_ecs_post_deploy_healthcheck.sh
+++ b/scripts/tests/test_ecs_post_deploy_healthcheck.sh
@@ -1,0 +1,513 @@
+#!/usr/bin/env bash
+# test_ecs_post_deploy_healthcheck.sh — Unit tests for
+# scripts/ecs-post-deploy-healthcheck.sh.
+#
+# Modeled on scripts/tests/test_wait_for_rollout.sh: exercises the script
+# against a mock `aws` CLI that emits pre-canned JSON responses for each
+# AWS subcommand the script calls (describe-services, list-tasks,
+# describe-tasks, describe-log-streams, get-log-events).
+#
+# Covers:
+#   - scale-to-zero success (desired=0, running=0) — the #2605 case
+#   - running==desired>0 success
+#   - running<desired failure (service-check)
+#   - crash-loop detection (stopped container with nonzero exit code)
+#   - log-check warning (critical errors in recent logs) stays non-fatal
+#   - log-check failure (empty stream / CloudWatch unavailable) stays non-fatal
+#   - missing required env vars exits non-zero
+#
+# Usage:
+#   scripts/tests/test_ecs_post_deploy_healthcheck.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/ecs-post-deploy-healthcheck.sh"
+
+if [[ ! -x "$SCRIPT_UNDER_TEST" ]]; then
+    echo "FATAL: $SCRIPT_UNDER_TEST is not executable." >&2
+    exit 1
+fi
+
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+# shellcheck disable=SC2329  # invoked via trap
+cleanup() {
+    set +e
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    echo "$dir"
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Create a mock `aws` CLI that dispatches on the subcommand and emits a
+# pre-canned JSON file from <tmpdir>/<cmd>.json (or <cmd>.txt for the
+# describe-log-streams --query + --output text case).
+#
+# Supported dispatch keys:
+#   ecs describe-services      → describe-services.json
+#   ecs list-tasks             → list-tasks.json
+#   ecs describe-tasks         → describe-tasks.json
+#   logs describe-log-streams  → describe-log-streams.txt  (plain text)
+#   logs get-log-events        → get-log-events.json
+#
+# If a dispatch file does not exist, the mock exits 1 (lets us exercise the
+# "CloudWatch unavailable" path by simply not providing describe-log-streams).
+setup_mock_aws() {
+    local tmpdir="$1"
+    local mock="$tmpdir/aws"
+
+    cat > "$mock" << 'MOCK'
+#!/usr/bin/env bash
+# Mock aws CLI — dispatches on subcommand.
+set -euo pipefail
+
+RESPONSES_DIR="${RESPONSES_DIR:?RESPONSES_DIR required}"
+CALL_LOG="${CALL_LOG:-/dev/null}"
+
+echo "$*" >> "$CALL_LOG"
+
+case "$*" in
+    "ecs describe-services"*)
+        file="$RESPONSES_DIR/describe-services.json"
+        ;;
+    "ecs list-tasks"*)
+        file="$RESPONSES_DIR/list-tasks.json"
+        ;;
+    "ecs describe-tasks"*)
+        file="$RESPONSES_DIR/describe-tasks.json"
+        ;;
+    "logs describe-log-streams"*)
+        file="$RESPONSES_DIR/describe-log-streams.txt"
+        ;;
+    "logs get-log-events"*)
+        file="$RESPONSES_DIR/get-log-events.json"
+        ;;
+    *)
+        echo "MOCK ERROR: unknown aws invocation: $*" >&2
+        exit 1
+        ;;
+esac
+
+if [[ ! -f "$file" ]]; then
+    # Emulate the aws CLI failing for this subcommand. The script under test
+    # handles logs errors gracefully (|| echo '...') and ecs errors by exit 1.
+    echo "MOCK: no fixture for $* (file=$file)" >&2
+    exit 1
+fi
+
+cat "$file"
+MOCK
+    chmod +x "$mock"
+    echo "$mock"
+}
+
+# Write a describe-services response with the given counts.
+# Usage: write_describe_services <tmpdir> <running> <desired>
+write_describe_services() {
+    local tmpdir="$1"
+    local running="$2"
+    local desired="$3"
+    cat > "$tmpdir/describe-services.json" << JSON
+{
+  "serviceName": "test-svc",
+  "desiredCount": $desired,
+  "runningCount": $running,
+  "pendingCount": 0
+}
+JSON
+}
+
+# Write a list-tasks response with N task ARNs.
+# Usage: write_list_tasks <tmpdir> <count>
+write_list_tasks() {
+    local tmpdir="$1"
+    local count="$2"
+    local arns="[]"
+    if [[ "$count" -gt 0 ]]; then
+        arns='["arn:aws:ecs:us-west-2:123:task/test-cluster/abc123"]'
+    fi
+    cat > "$tmpdir/list-tasks.json" << JSON
+$arns
+JSON
+}
+
+# Write a describe-tasks response.
+# Usage: write_describe_tasks <tmpdir> <stopped_with_nonzero_count>
+write_describe_tasks() {
+    local tmpdir="$1"
+    local stopped_count="${2:-0}"
+    # Always include a container named 'ingestion-worker'. If stopped_count>0,
+    # add an extra STOPPED container with exitCode=1.
+    local containers='[{"name":"ingestion-worker","lastStatus":"RUNNING","exitCode":null,"reason":null}]'
+    if [[ "$stopped_count" -gt 0 ]]; then
+        containers='[{"name":"ingestion-worker","lastStatus":"RUNNING","exitCode":null,"reason":null},{"name":"sidecar","lastStatus":"STOPPED","exitCode":1,"reason":"Exited"}]'
+    fi
+    cat > "$tmpdir/describe-tasks.json" << JSON
+{
+  "lastStatus": "RUNNING",
+  "healthStatus": "HEALTHY",
+  "containers": $containers
+}
+JSON
+}
+
+# Write a describe-log-streams response (plain text — aws CLI --query +
+# --output text returns just the log stream name).
+# Usage: write_describe_log_streams <tmpdir> <stream_name_or_None>
+write_describe_log_streams() {
+    local tmpdir="$1"
+    local name="${2:-test-stream}"
+    printf '%s\n' "$name" > "$tmpdir/describe-log-streams.txt"
+}
+
+# Write a get-log-events response.
+# Usage: write_get_log_events <tmpdir> <critical_count>
+#   critical_count=0 → only benign INFO lines
+#   critical_count>N → N lines matching CRITICAL / Traceback / crash
+write_get_log_events() {
+    local tmpdir="$1"
+    local critical_count="${2:-0}"
+    local events='[{"message":"INFO starting worker","timestamp":1}]'
+    if [[ "$critical_count" -gt 0 ]]; then
+        events='[{"message":"INFO starting worker","timestamp":1},{"message":"CRITICAL failure occurred","timestamp":2},{"message":"Traceback (most recent call last):","timestamp":3}]'
+    fi
+    cat > "$tmpdir/get-log-events.json" << JSON
+{"events": $events}
+JSON
+}
+
+# Run the script under test with mocks wired up.
+run_script() {
+    local tmpdir="$1"
+    local mock_aws
+    mock_aws=$(setup_mock_aws "$tmpdir")
+
+    AWS_CLI="$mock_aws" \
+    RESPONSES_DIR="$tmpdir" \
+    CALL_LOG="$tmpdir/calls.log" \
+    ECS_CLUSTER="test-cluster" \
+    INGESTION_SERVICE="test-svc" \
+    LOG_GROUP="/ecs/test-svc" \
+        "$SCRIPT_UNDER_TEST"
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+# Test 1: scale-to-zero success (desired=0, running=0).
+# Reproduces the #2605 case: the dev ingestion worker runs at desiredCount=0
+# and should be treated as healthy when running=0.
+test_scale_to_zero_success() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_describe_services "$tmpdir" 0 0
+    # No list-tasks / describe-tasks needed — crash-check is skipped when
+    # desiredCount == 0. Still need log-check fixtures so the log step
+    # succeeds (or at least doesn't error fatally).
+    write_describe_log_streams "$tmpdir" "test-stream"
+    write_get_log_events "$tmpdir" 0
+
+    local output exit_code
+    exit_code=0
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        pass "scale-to-zero (desired=0, running=0) exits 0"
+    else
+        fail "scale-to-zero (desired=0, running=0) exits 0" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "scaled to zero"; then
+        pass "scale-to-zero emits 'scaled to zero' message"
+    else
+        fail "scale-to-zero emits 'scaled to zero' message" "output=$output"
+    fi
+
+    if echo "$output" | grep -q "skipping crash-loop check"; then
+        pass "scale-to-zero skips crash-loop check"
+    else
+        fail "scale-to-zero skips crash-loop check" "output=$output"
+    fi
+}
+
+# Test 2: running==desired>0 success (normal healthy rollout).
+test_running_equals_desired_success() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_describe_services "$tmpdir" 1 1
+    write_list_tasks "$tmpdir" 1
+    write_describe_tasks "$tmpdir" 0
+    write_describe_log_streams "$tmpdir" "test-stream"
+    write_get_log_events "$tmpdir" 0
+
+    local output exit_code
+    exit_code=0
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        pass "running==desired>0 exits 0"
+    else
+        fail "running==desired>0 exits 0" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "Service has expected number of running tasks"; then
+        pass "running==desired>0 emits expected-count message"
+    else
+        fail "running==desired>0 emits expected-count message" "output=$output"
+    fi
+
+    if echo "$output" | grep -q "No crash-loop detected"; then
+        pass "running==desired>0 passes crash-loop check"
+    else
+        fail "running==desired>0 passes crash-loop check" "output=$output"
+    fi
+}
+
+# Test 3: running<desired failure (service-check rejects).
+test_running_below_desired_failure() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_describe_services "$tmpdir" 0 1
+
+    local output exit_code
+    exit_code=0
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 1 ]]; then
+        pass "running<desired exits 1"
+    else
+        fail "running<desired exits 1" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "does not match desired"; then
+        pass "running<desired emits mismatch error"
+    else
+        fail "running<desired emits mismatch error" "output=$output"
+    fi
+}
+
+# Test 4: crash-loop detected (stopped container with nonzero exit code).
+test_crash_loop_detected() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_describe_services "$tmpdir" 1 1
+    write_list_tasks "$tmpdir" 1
+    write_describe_tasks "$tmpdir" 1  # 1 stopped container w/ exit=1
+    # log-check fixtures omitted — script should exit before getting there.
+
+    local output exit_code
+    exit_code=0
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 1 ]]; then
+        pass "crash-loop exits 1"
+    else
+        fail "crash-loop exits 1" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "possible crash-loop"; then
+        pass "crash-loop emits clear error"
+    else
+        fail "crash-loop emits clear error" "output=$output"
+    fi
+}
+
+# Test 5: crash-check with zero running tasks when desired>0 fails.
+test_no_running_tasks_failure() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    # Service reports running==desired==1 at service-check time (stale read),
+    # but list-tasks returns empty — crash-check must fail cleanly.
+    write_describe_services "$tmpdir" 1 1
+    write_list_tasks "$tmpdir" 0
+
+    local output exit_code
+    exit_code=0
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 1 ]]; then
+        pass "no running tasks with desired>0 exits 1"
+    else
+        fail "no running tasks with desired>0 exits 1" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "No running tasks found"; then
+        pass "no running tasks emits clear error"
+    else
+        fail "no running tasks emits clear error" "output=$output"
+    fi
+}
+
+# Test 6: log-check warning — critical errors in logs, but deploy stays green.
+# Log noise must NOT fail the whole deploy (per inline comment in the
+# original workflow: "Warning only — don't fail the whole deploy for log noise").
+test_log_check_warning_only() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_describe_services "$tmpdir" 1 1
+    write_list_tasks "$tmpdir" 1
+    write_describe_tasks "$tmpdir" 0
+    write_describe_log_streams "$tmpdir" "test-stream"
+    # Critical errors present in recent logs:
+    write_get_log_events "$tmpdir" 2
+
+    local output exit_code
+    exit_code=0
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        pass "critical errors in logs stay warning-only (exit 0)"
+    else
+        fail "critical errors in logs stay warning-only (exit 0)" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "WARNING: Found .* critical error indicators"; then
+        pass "log-check emits warning when critical errors present"
+    else
+        fail "log-check emits warning when critical errors present" "output=$output"
+    fi
+}
+
+# Test 7: log-check with no log stream available — warning, not failure.
+test_log_check_no_stream_warning() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_describe_services "$tmpdir" 1 1
+    write_list_tasks "$tmpdir" 1
+    write_describe_tasks "$tmpdir" 0
+    # describe-log-streams fixture returns "None" (aws CLI text output for
+    # empty result). No get-log-events fixture — the script bails out
+    # before calling it.
+    write_describe_log_streams "$tmpdir" "None"
+
+    local output exit_code
+    exit_code=0
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        pass "no log stream stays warning-only (exit 0)"
+    else
+        fail "no log stream stays warning-only (exit 0)" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "No log streams found"; then
+        pass "no log stream emits 'No log streams found' warning"
+    else
+        fail "no log stream emits 'No log streams found' warning" "output=$output"
+    fi
+}
+
+# Test 8: log-check when describe-log-streams itself fails (CloudWatch
+# unavailable) stays warning-only, not fatal. The script relies on `2>/dev/null
+# || echo ""` redirection — so the downstream branch treats missing data as
+# "no stream", which is a warning.
+test_log_check_cloudwatch_unavailable() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    write_describe_services "$tmpdir" 1 1
+    write_list_tasks "$tmpdir" 1
+    write_describe_tasks "$tmpdir" 0
+    # Intentionally do not create describe-log-streams.txt — the mock will
+    # exit 1, which the script handles with `|| echo ""`.
+
+    local output exit_code
+    exit_code=0
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        pass "CloudWatch describe-log-streams failure stays warning-only"
+    else
+        fail "CloudWatch describe-log-streams failure stays warning-only" "exit=$exit_code output=$output"
+    fi
+}
+
+# Test 9: Missing required env vars exits non-zero.
+test_missing_required_env() {
+    local output exit_code
+    exit_code=0
+    output=$(env -i PATH="$PATH" bash "$SCRIPT_UNDER_TEST" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -ne 0 ]]; then
+        pass "missing required env exits non-zero"
+    else
+        fail "missing required env exits non-zero" "exit=$exit_code output=$output"
+    fi
+}
+
+# Test 10: describe-services failure (aws CLI errors) exits 1.
+test_describe_services_failure() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    # Intentionally do not create describe-services.json — the mock will
+    # exit 1 on the first call.
+
+    local output exit_code
+    exit_code=0
+    output=$(run_script "$tmpdir" 2>&1) || exit_code=$?
+
+    if [[ "$exit_code" -eq 1 ]]; then
+        pass "describe-services failure exits 1"
+    else
+        fail "describe-services failure exits 1" "exit=$exit_code output=$output"
+    fi
+
+    if echo "$output" | grep -q "describe-services failed"; then
+        pass "describe-services failure emits clear error"
+    else
+        fail "describe-services failure emits clear error" "output=$output"
+    fi
+}
+
+# ── Run all tests ──────────────────────────────────────────────────────────
+
+test_scale_to_zero_success
+test_running_equals_desired_success
+test_running_below_desired_failure
+test_crash_loop_detected
+test_no_running_tasks_failure
+test_log_check_warning_only
+test_log_check_no_stream_warning
+test_log_check_cloudwatch_unavailable
+test_missing_required_env
+test_describe_services_failure
+
+echo ""
+echo "────────────────────────────────────────────"
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [[ $FAILURES -gt 0 ]]; then
+    echo "$FAILURES test(s) FAILED"
+    exit 1
+fi
+echo "All tests passed."
+exit 0


### PR DESCRIPTION
## Summary

Extracts the inline `post-deploy-health-check` bash from `.github/workflows/deploy-scraper.yml` into a single reusable, unit-tested shell script `scripts/ecs-post-deploy-healthcheck.sh` (modeled on `scripts/wait-for-rollout.sh`). Preserves the scale-to-zero rule from #2605/#2606 (running==desired==0 treated as healthy) in one place so the drift that caused #2605 cannot recur. Adds a `check-no-inline-ecs-healthcheck.sh` guard wired into CI to prevent new inline ECS health-check bash from sneaking back into workflow YAML.

Closes #2608

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (new: `test_ecs_post_deploy_healthcheck.sh` 20/20, `test_check_no_inline_ecs_healthcheck.sh` 13/13)
- [x] CI green (especially `scripts-tests` which auto-discovered and ran both new tests, plus ran the new guard)

### Post-deploy verification
- [x] Next deploy-scraper run on `main` triggers the `post-deploy-health-check` job (run 24564332530)
- [x] `post-deploy-health-check` job uses the extracted script (`bash scripts/ecs-post-deploy-healthcheck.sh`) and stays green — running=1/desired=1, no crash-loop, 20 log events read, no critical errors; HEALTH_STATUS: success
- [x] Verification evidence posted on #2608 (https://github.com/judgemind/judgemind/issues/2608#issuecomment-4267906964)
