### PR TITLE
feat(scraping): add LA Appellate Division tentative rulings scraper (#2599)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -1,9 +1,18 @@
-"""LA County Superior Court — Civil Tentative Rulings Scraper (Pattern 1).
+"""LA County Superior Court — Civil and Appellate Tentative Rulings Scrapers.
 
-Strategy: enumerate all (courthouse, department, date) combinations from the
-ASP.NET dropdown, POST for each, archive the raw HTML per-department response.
+LA Court publishes tentative rulings for two divisions through the *same*
+ASP.NET portal at different ``casetype`` query-string values:
 
-Verified against live site 2026-03-02:
+- ``casetype=civil`` (main.aspx) — every courthouse × department × date triple
+  has its own dropdown option; see :data:`CIVIL_URL`.
+- ``casetype=appellate`` (main.aspx) — a single Appellate Division (Stanley
+  Mosk Courthouse, Room 607) with only *hearing dates* in the dropdown; see
+  :data:`APPELLATE_URL`.
+
+Strategy for both: enumerate every dropdown option, POST the ASP.NET form for
+each, archive the raw HTML per-option response.
+
+Verified against live civil site 2026-03-02:
 - URL: https://www.lacourt.ca.gov/tentativeRulingNet/ui/main.aspx?casetype=civil
 - Select name: ctl00$ctl00$siteMasterHolder$basicBodyHolder$List2DeptDate
 - Select id:   siteMasterHolder_basicBodyHolder_List2DeptDate
@@ -14,6 +23,20 @@ Verified against live site 2026-03-02:
 - Judge name in: <div>...Name Judge of the Superior Court</div>
 - No CAPTCHA on civil tentatives; simple HTTP sufficient (no Playwright needed)
 - Recommended schedule: 6 PM primary, 2 AM catch-up
+
+Verified against live appellate site 2026-04-17:
+- URL: https://www.lacourt.ca.gov/tentativeRulingNet/ui/main.aspx?casetype=appellate
+- Select (when populated): ctl00$ctl00$siteMasterHolder$basicBodyHolder$List1DeptDate
+- Empty-state marker: a ``#siteMasterHolder_basicBodyHolder_NoRuling`` table
+  with the text "No rulings have been published at this time." — the dropdown
+  is absent in that case, and scraping yields zero documents.  LA Court's own
+  page comment confirms the format difference::
+      appellate division does not include the location and department
+      in the drop down box since there's only only location and department.
+      The drop down box displays Hearing date only.
+- Division metadata is static: courthouse="Stanley Mosk Courthouse",
+  department="Appellate Division" — stamped onto every captured doc so
+  downstream ranking/search can filter appellate separately from civil.
 """
 
 from __future__ import annotations
@@ -85,6 +108,32 @@ _OPTION_VALUE_RE = re.compile(
 _OPTION_TEXT_RE = re.compile(
     r"\((?P<courthouse>[^:]+):\s+Dept\.\s+(?P<dept>[^)]+)\)\s+(?P<date>.+)"
 )
+
+# ---------------------------------------------------------------------------
+# Appellate Division constants (#2599)
+# ---------------------------------------------------------------------------
+APPELLATE_URL = "https://www.lacourt.ca.gov/tentativeRulingNet/ui/main.aspx?casetype=appellate"
+
+# Appellate dropdown uses a different named ASP.NET control (List1DeptDate vs
+# civil's List2DeptDate).  Verified from the live page's JS/HTML on 2026-04-17.
+APPELLATE_SELECT_NAME = "ctl00$ctl00$siteMasterHolder$basicBodyHolder$List1DeptDate"
+APPELLATE_SELECT_ID = "siteMasterHolder_basicBodyHolder_List1DeptDate"
+
+# LA Appellate Division is a single physical department — static metadata.
+APPELLATE_COURTHOUSE = "Stanley Mosk Courthouse"
+APPELLATE_DEPARTMENT = "Appellate Division"
+
+# Appellate option value format: "MM/DD/YYYY" (hearing date only — no
+# courthouse/dept, per LA Court's own HTML comment "appellate division does
+# not include the location and department in the drop down box").
+_APPELLATE_OPTION_VALUE_RE = re.compile(r"^(?P<date>\d{2}/\d{2}/\d{4})$")
+
+# Empty-state marker on the appellate main page.  When no rulings are
+# published the page renders a #siteMasterHolder_basicBodyHolder_NoRuling
+# table with the text "No rulings have been published at this time.".  In
+# that state the dropdown is absent and scraping correctly yields zero docs.
+_APPELLATE_NO_RULING_TABLE_ID = "siteMasterHolder_basicBodyHolder_NoRuling"
+_APPELLATE_NO_RULING_MARKER = "No rulings have been published at this time."
 
 # Case numbers in ruling text: "Case Number:24NNCV02551" (no space)
 _CASE_NUMBER_RE = re.compile(r"Case Number:\s*(\w+)")
@@ -927,6 +976,126 @@ class LATentativeRulingsScraper(BaseScraper):
         return doc
 
 
+class LAAppellateTentativeRulingsScraper(BaseScraper):
+    """Scrapes LA County **Appellate Division** tentative rulings (#2599).
+
+    The Appellate Division shares the same ASP.NET portal as civil but at
+    ``casetype=appellate``.  Differences from civil:
+
+    - Dropdown name is ``List1DeptDate`` (not ``List2DeptDate``).
+    - Each option's value is a hearing date only (``MM/DD/YYYY``) — no
+      courthouse or department encoded, per LA Court's own HTML comment.
+    - Metadata is static: courthouse="Stanley Mosk Courthouse",
+      department="Appellate Division".
+    - Empty state ("No rulings have been published at this time.") is the
+      common case; the dropdown is absent and scraping yields 0 docs
+      without raising.
+
+    Shares per-case HTML parsing helpers (``_split_cases_html``,
+    ``_extract_ruling_fields``, etc.) with the civil scraper, since both
+    use the same ``speechSynthesis`` ruling format once a POST response
+    arrives.
+    """
+
+    def __init__(
+        self,
+        config: ScraperConfig,
+        archiver: S3Archiver | None = None,
+        event_bus: EventBus | None = None,
+    ) -> None:
+        super().__init__(config, archiver=archiver, event_bus=event_bus)
+
+    def fetch_documents(self) -> list[CapturedDocument]:
+        docs: list[CapturedDocument] = []
+        with httpx.Client(
+            timeout=self.config.request_timeout_seconds,
+            follow_redirects=True,
+            headers={"User-Agent": "Judgemind/1.0 (+https://judgemind.org/scraper)"},
+        ) as client:
+            self._log.info("Fetching appellate main page", url=APPELLATE_URL)
+            response = client.get(APPELLATE_URL)
+            response.raise_for_status()
+
+            if _has_no_rulings_appellate(response.text):
+                self._log.info(
+                    "Appellate division has no published rulings",
+                    context="empty_state",
+                )
+                return docs
+
+            tokens = _extract_aspnet_tokens(response.text)
+            options = _parse_appellate_dropdown_options(response.text)
+            self._log.info("Found appellate dropdown options", count=len(options))
+
+            for opt in options:
+                time.sleep(self.config.request_delay_seconds)
+                try:
+                    ruling_html = _post_for_ruling_appellate(client, tokens, opt)
+                    if _is_stale_viewstate_response(ruling_html):
+                        self._log.warning(
+                            "Stale ViewState error page; skipping",
+                            dept=opt.department,
+                            date=str(opt.hearing_date),
+                            context="stale_viewstate",
+                        )
+                        continue
+
+                    case_htmls = _split_cases_html(ruling_html)
+                    for case_html in case_htmls:
+                        doc = self._make_base_doc(
+                            source_url=APPELLATE_URL,
+                            raw_content=case_html.encode("utf-8"),
+                            content_format=ContentFormat.HTML,
+                        )
+                        doc.courthouse = opt.courthouse
+                        doc.department = opt.department
+                        doc.hearing_date = opt.hearing_date
+                        doc.extra["courthouse_code"] = opt.courthouse_code
+                        doc.extra["dropdown_value"] = opt.value
+                        doc.extra["casetype"] = "appellate"
+                        docs.append(doc)
+                    self._log.debug(
+                        "Fetched appellate ruling",
+                        dept=opt.department,
+                        date=str(opt.hearing_date),
+                        cases=len(case_htmls),
+                    )
+                except Exception as exc:
+                    self._log.error(
+                        "Failed to fetch appellate ruling",
+                        dept=opt.department,
+                        date=str(opt.hearing_date),
+                        error=str(exc),
+                    )
+        return docs
+
+    def parse_document(self, doc: CapturedDocument) -> CapturedDocument:
+        # Guard against re-parsing LLM-pre-split documents (#2469, #2484).
+        # The shared module-level ``_llm_extract_rulings`` is registered in
+        # ``_LLM_SPLIT_REGISTRY``; if a future run marks appellate docs with
+        # ``pre_split`` or ``_llm_extracted`` we must not clobber their
+        # LLM-populated fields by re-running regex over the full HTML.
+        if doc.extra.get("pre_split") or doc.extra.get("_llm_extracted"):
+            doc.courthouse = doc.courthouse or APPELLATE_COURTHOUSE
+            doc.department = doc.department or APPELLATE_DEPARTMENT
+            return doc
+
+        # Appellate uses the same per-case HTML format as civil, so reuse
+        # the civil regex extractor.  LLM extraction is not yet enabled
+        # for appellate — appellate rulings are low volume, and regex
+        # handles the deterministic <b>-tag headers reliably (#2599).
+        try:
+            soup = BeautifulSoup(doc.raw_content, "lxml")
+            _extract_ruling_fields(soup, doc)
+        except Exception as exc:
+            self._log.warning("Parse error", error=str(exc))
+
+        # Stamp static appellate metadata in case it was cleared during parse.
+        doc.courthouse = doc.courthouse or APPELLATE_COURTHOUSE
+        doc.department = doc.department or APPELLATE_DEPARTMENT
+        return doc
+
+
 # ---------------------------------------------------------------------------
 # ASP.NET helpers
 # ---------------------------------------------------------------------------
@@ -1014,6 +1183,89 @@ def _post_for_ruling(
         "submit2": "Search",
     }
     response = client.post(CIVIL_URL, data=form_data)
+    response.raise_for_status()
+    return response.text
+
+
+# ---------------------------------------------------------------------------
+# Appellate helpers (#2599)
+# ---------------------------------------------------------------------------
+
+
+def _has_no_rulings_appellate(html: str) -> bool:
+    """Return True if the appellate page is in its empty state.
+
+    The LA Court appellate portal renders a
+    ``#siteMasterHolder_basicBodyHolder_NoRuling`` table with the text
+    "No rulings have been published at this time." when no rulings are
+    published.  The dropdown is absent in that case and scraping correctly
+    yields zero documents (without raising).
+    """
+    if _APPELLATE_NO_RULING_TABLE_ID in html and _APPELLATE_NO_RULING_MARKER in html:
+        return True
+    # Fallback: strict marker check even if the table id is renamed.
+    return _APPELLATE_NO_RULING_MARKER in html
+
+
+def _parse_appellate_dropdown_options(html: str) -> list[DropdownOption]:
+    """Parse the appellate-division dropdown options.
+
+    Appellate options carry only a hearing date (e.g. value
+    ``04/17/2026``).  Static courthouse and department metadata is
+    stamped from :data:`APPELLATE_COURTHOUSE` / :data:`APPELLATE_DEPARTMENT`
+    since the Appellate Division is a single physical department.
+
+    Returns an empty list if the dropdown is absent (e.g. the page is in
+    its "No rulings have been published at this time." empty state).
+    """
+    soup = BeautifulSoup(html, "lxml")
+    select = soup.find("select", {"id": APPELLATE_SELECT_ID}) or soup.find(
+        "select", {"name": APPELLATE_SELECT_NAME}
+    )
+    if not select:
+        return []
+
+    options: list[DropdownOption] = []
+    for opt_el in select.find_all("option"):
+        value = opt_el.get("value", "").strip()
+        if not value:
+            continue
+        vm = _APPELLATE_OPTION_VALUE_RE.match(value)
+        if not vm:
+            logger.debug("Unparseable appellate option value", value=value)
+            continue
+        date_str = vm.group("date")
+        hearing_date: datetime | None = None
+        try:
+            hearing_date = datetime.strptime(date_str, "%m/%d/%Y")
+        except ValueError:
+            pass
+        options.append(
+            DropdownOption(
+                value=value,
+                courthouse_code="APPELLATE",
+                courthouse=APPELLATE_COURTHOUSE,
+                department=APPELLATE_DEPARTMENT,
+                hearing_date=hearing_date,
+            )
+        )
+    return options
+
+
+def _post_for_ruling_appellate(
+    client: httpx.Client,
+    tokens: dict[str, str],
+    option: DropdownOption,
+) -> str:
+    """POST the ASP.NET form for one appellate dropdown selection."""
+    form_data = {
+        "__VIEWSTATE": tokens.get("__VIEWSTATE", ""),
+        "__VIEWSTATEGENERATOR": tokens.get("__VIEWSTATEGENERATOR", ""),
+        "__EVENTVALIDATION": tokens.get("__EVENTVALIDATION", ""),
+        APPELLATE_SELECT_NAME: option.value,
+        "submit2": "Search",
+    }
+    response = client.post(APPELLATE_URL, data=form_data)
     response.raise_for_status()
     return response.text
 
@@ -1680,3 +1932,47 @@ def default_config(s3_bucket: str = "") -> ScraperConfig:
         max_retries=3,
         s3_bucket=s3_bucket,
     )
+
+
+def default_config_appellate(s3_bucket: str = "") -> ScraperConfig:
+    """Default config for the LA Appellate Division tentative rulings scraper (#2599).
+
+    Shares the civil scraper's twice-daily cadence (6 PM primary, 2 AM
+    catch-up) since appellate rulings post on the same portal.  The
+    Appellate Division is low-volume (empty state is the common case)
+    but the capture-to-S3 step is still critical on the rare days when
+    rulings are posted.
+    """
+    from datetime import time as dtime
+
+    from framework import ScheduleWindow
+
+    return ScraperConfig(
+        scraper_id="ca-la-tentatives-appellate",
+        state="CA",
+        county="Los Angeles",
+        court="Superior Court",
+        target_urls=[APPELLATE_URL],
+        poll_interval_seconds=43200,  # twice daily
+        schedule_windows=[
+            ScheduleWindow(start=dtime(18, 0), end=dtime(19, 0)),  # 6 PM sweep
+            ScheduleWindow(start=dtime(2, 0), end=dtime(3, 0)),  # 2 AM catch-up
+        ],
+        request_delay_seconds=1.5,
+        request_timeout_seconds=30.0,
+        max_retries=3,
+        s3_bucket=s3_bucket,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Multi-scraper module registry hint (#2599)
+# ---------------------------------------------------------------------------
+# This module exposes two scrapers; the ``_load_scraper_registry`` discovery
+# in ``scripts/reingest_from_s3.py`` uses this mapping to pair each
+# ``scraper_id`` with its concrete class.  Without it, alphabetical class
+# iteration picks the wrong class for ``ca-la-tentatives-civil``.
+_SCRAPER_CLASS_BY_ID: dict[str, type] = {
+    "ca-la-tentatives-civil": LATentativeRulingsScraper,
+    "ca-la-tentatives-appellate": LAAppellateTentativeRulingsScraper,
+}

--- a/packages/scraper-framework/src/framework/runner.py
+++ b/packages/scraper-framework/src/framework/runner.py
@@ -231,8 +231,12 @@ def _build_registry() -> list[tuple[str, type, callable]]:
     from courts.ca.fresno_tentatives import default_config as fresno_config
     from courts.ca.governor_appointments import GovernorAppointmentsScraper
     from courts.ca.governor_appointments import default_config as gov_appt_config
-    from courts.ca.la_tentatives import LATentativeRulingsScraper
+    from courts.ca.la_tentatives import (
+        LAAppellateTentativeRulingsScraper,
+        LATentativeRulingsScraper,
+    )
     from courts.ca.la_tentatives import default_config as la_config
+    from courts.ca.la_tentatives import default_config_appellate as la_appellate_config
     from courts.ca.oc_family_law_tentatives import OCFamilyLawTentativeRulingsScraper
     from courts.ca.oc_family_law_tentatives import default_config as oc_fl_config
     from courts.ca.oc_probate_tentatives import OCProbateTentativeRulingsScraper
@@ -266,6 +270,11 @@ def _build_registry() -> list[tuple[str, type, callable]]:
             ("ca-fresno-tentatives-civil", FresnoTentativeRulingsScraper, fresno_config),
             ("ca-governor-appointments", GovernorAppointmentsScraper, gov_appt_config),
             ("ca-la-tentatives-civil", LATentativeRulingsScraper, la_config),
+            (
+                "ca-la-tentatives-appellate",
+                LAAppellateTentativeRulingsScraper,
+                la_appellate_config,
+            ),
             ("ca-oc-tentatives", OCTentativeRulingsScraper, oc_config),
             ("ca-oc-tentatives-family-law", OCFamilyLawTentativeRulingsScraper, oc_fl_config),
             ("ca-oc-tentatives-probate", OCProbateTentativeRulingsScraper, oc_probate_config),

--- a/packages/scraper-framework/tests/courts/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_la_tentatives.py
@@ -18,8 +18,12 @@ import pytest
 import respx
 
 from courts.ca.la_tentatives import (
+    APPELLATE_COURTHOUSE,
+    APPELLATE_DEPARTMENT,
+    APPELLATE_URL,
     CIVIL_URL,
     LA_SYSTEM_PROMPT,
+    LAAppellateTentativeRulingsScraper,
     LASplitRuling,
     LATentativeRulingsScraper,
     _extract_aspnet_tokens,
@@ -28,11 +32,13 @@ from courts.ca.la_tentatives import (
     _extract_parties,
     _extract_parties_from_anchor,
     _extract_ruling_fields,
+    _has_no_rulings_appellate,
     _is_dept_header_boilerplate,
     _is_name_fragment,
     _is_stale_viewstate_response,
     _la_llm_enabled,
     _llm_extract_rulings,
+    _parse_appellate_dropdown_options,
     _parse_dropdown_options,
     _parse_option,
     _replace_ruling_text_from_html,
@@ -42,6 +48,7 @@ from courts.ca.la_tentatives import (
     _split_rulings,
     _truncate_party_list,
     default_config,
+    default_config_appellate,
     is_la_html,
     sanitize_ruling_html,
 )
@@ -3311,3 +3318,209 @@ def test_split_rulings_extracts_real_case_numbers_from_full_page(
     for r in rulings:
         assert r.case_number is not None
         assert not r.case_number.startswith("UNKNOWN-")
+
+
+# ---------------------------------------------------------------------------
+# Appellate Division scraper (#2599)
+#
+# Fixtures:
+#   la_appellate_main_empty.html — real capture 2026-04-17, empty state
+#                                   (#siteMasterHolder_basicBodyHolder_NoRuling
+#                                    "No rulings have been published at this
+#                                    time.")
+#
+# The appellate dropdown uses a different ASP.NET control name
+# (List1DeptDate vs civil's List2DeptDate) and each option's value is a
+# hearing date only — no courthouse/dept, per LA Court's own HTML comment.
+# ---------------------------------------------------------------------------
+
+
+def _synthetic_appellate_main_with_dropdown(dates: list[str]) -> str:
+    """Build a minimal appellate main page with a populated dropdown.
+
+    We don't have a live-fixture of a populated appellate dropdown (the
+    division is very low volume and was empty on every Wayback snapshot
+    plus the live fetch) so this helper composes the exact structure
+    documented by LA Court's own HTML comment:
+      appellate division does not include the location and department
+      in the drop down box since there's only only location and
+      department.  The drop down box displays Hearing date only.
+    """
+    options = "\n".join(f'<option value="{d}">{d}</option>' for d in dates)
+    return f"""
+<html>
+<head></head>
+<body>
+<form method="post" action="./main.aspx?casetype=appellate" id="lascwebform">
+<input type="hidden" name="__VIEWSTATE" value="/wEFAKE" />
+<input type="hidden" name="__VIEWSTATEGENERATOR" value="APPEFAKE" />
+<input type="hidden" name="__EVENTVALIDATION" value="/wEWFAKE" />
+<select name="ctl00$ctl00$siteMasterHolder$basicBodyHolder$List1DeptDate"
+        id="siteMasterHolder_basicBodyHolder_List1DeptDate">
+{options}
+</select>
+<input type="submit" name="submit2" value="Search" />
+</form>
+</body>
+</html>
+"""
+
+
+def _synthetic_appellate_ruling_response(case_number: str = "BV033456") -> str:
+    """Build a minimal per-date ruling response following the civil speechSynthesis format."""
+    return f"""
+<html><body>
+<div id="speechSynthesis">
+<B> Case Number: </B> {case_number}&nbsp;&nbsp;&nbsp;<br>
+<B> Hearing Date: </B> April 17, 2026&nbsp;&nbsp;&nbsp;<br>
+<B> Dept: </B> Appellate<br>
+<P>JOHN SMITH, Plaintiff(s),
+vs.
+JANE DOE, Defendant(s).</P>
+<P>The appeal is DENIED.</P>
+<div>Hon. Helen I. Bendix Judge of the Superior Court</div>
+</div>
+</body></html>
+"""
+
+
+def test_has_no_rulings_appellate_detects_empty_state() -> None:
+    html = _load("la_appellate_main_empty.html")
+    assert _has_no_rulings_appellate(html) is True
+
+
+def test_has_no_rulings_appellate_negative_on_civil_page() -> None:
+    # Civil main page does not have the appellate empty-state marker.
+    html = _load("la_main_page.html")
+    assert _has_no_rulings_appellate(html) is False
+
+
+def test_has_no_rulings_appellate_negative_on_populated_fixture() -> None:
+    html = _synthetic_appellate_main_with_dropdown(["04/17/2026"])
+    assert _has_no_rulings_appellate(html) is False
+
+
+def test_parse_appellate_dropdown_options_empty_state_returns_empty() -> None:
+    html = _load("la_appellate_main_empty.html")
+    options = _parse_appellate_dropdown_options(html)
+    assert options == []
+
+
+def test_parse_appellate_dropdown_options_parses_hearing_dates() -> None:
+    html = _synthetic_appellate_main_with_dropdown(["04/17/2026", "04/24/2026"])
+    options = _parse_appellate_dropdown_options(html)
+    assert len(options) == 2
+    first = options[0]
+    assert first.value == "04/17/2026"
+    assert first.hearing_date == datetime(2026, 4, 17)
+    assert first.courthouse == APPELLATE_COURTHOUSE
+    assert first.department == APPELLATE_DEPARTMENT
+    assert first.courthouse_code == "APPELLATE"
+
+
+def test_parse_appellate_dropdown_options_skips_malformed_values() -> None:
+    # Malformed values (not MM/DD/YYYY) should be skipped, not raise.
+    html = _synthetic_appellate_main_with_dropdown(["2026-04-17", "04/17/2026"])
+    options = _parse_appellate_dropdown_options(html)
+    # Only the correctly-formatted date parses.
+    assert len(options) == 1
+    assert options[0].value == "04/17/2026"
+
+
+def test_default_config_appellate() -> None:
+    config = default_config_appellate(s3_bucket="judgemind-document-archive-dev")
+    assert config.scraper_id == "ca-la-tentatives-appellate"
+    assert config.state == "CA"
+    assert config.county == "Los Angeles"
+    assert config.court == "Superior Court"
+    assert config.s3_bucket == "judgemind-document-archive-dev"
+    assert config.target_urls == [APPELLATE_URL]
+    # Twice-daily cadence mirrors civil.
+    assert len(config.schedule_windows) == 2
+
+
+@respx.mock
+def test_appellate_full_run_empty_state_yields_zero_docs() -> None:
+    """Real empty-state fixture: scraper completes successfully with 0 docs."""
+    main_html = _load("la_appellate_main_empty.html")
+    respx.get(APPELLATE_URL).mock(return_value=httpx.Response(200, text=main_html))
+
+    config = default_config_appellate()
+    config.request_delay_seconds = 0
+    scraper = LAAppellateTentativeRulingsScraper(config=config)
+    health = scraper.run()
+
+    assert health.success is True
+    assert health.records_captured == 0
+
+
+@respx.mock
+def test_appellate_full_run_populated_dropdown_captures_docs() -> None:
+    """When rulings are published, fetch_documents POSTs per hearing date and
+    stamps static Appellate Division metadata on each doc."""
+    main_html = _synthetic_appellate_main_with_dropdown(["04/17/2026", "04/24/2026"])
+    ruling_html = _synthetic_appellate_ruling_response()
+
+    respx.get(APPELLATE_URL).mock(return_value=httpx.Response(200, text=main_html))
+    respx.post(APPELLATE_URL).mock(return_value=httpx.Response(200, text=ruling_html))
+
+    config = default_config_appellate()
+    config.request_delay_seconds = 0
+    scraper = LAAppellateTentativeRulingsScraper(config=config)
+    docs = scraper.fetch_documents()
+
+    # Two dropdown options, one case per response.
+    assert len(docs) == 2
+    for doc in docs:
+        assert doc.courthouse == APPELLATE_COURTHOUSE
+        assert doc.department == APPELLATE_DEPARTMENT
+        assert doc.source_url == APPELLATE_URL
+        assert doc.extra.get("casetype") == "appellate"
+
+
+@respx.mock
+def test_appellate_full_run_stamps_metadata_through_parse() -> None:
+    """End-to-end via scraper.run() — records_captured reflects parsed docs
+    and static appellate metadata is preserved after parse_document."""
+    main_html = _synthetic_appellate_main_with_dropdown(["04/17/2026"])
+    ruling_html = _synthetic_appellate_ruling_response()
+
+    respx.get(APPELLATE_URL).mock(return_value=httpx.Response(200, text=main_html))
+    respx.post(APPELLATE_URL).mock(return_value=httpx.Response(200, text=ruling_html))
+
+    config = default_config_appellate()
+    config.request_delay_seconds = 0
+    scraper = LAAppellateTentativeRulingsScraper(config=config)
+    health = scraper.run()
+
+    assert health.success is True
+    assert health.records_captured == 1
+
+
+@respx.mock
+def test_appellate_full_run_handles_stale_viewstate() -> None:
+    """Stale-ViewState POST responses are skipped without failing the run."""
+    main_html = _synthetic_appellate_main_with_dropdown(["04/17/2026"])
+    # Reuse real LA stale-ViewState error fixture — same portal, same marker.
+    stale_html = _load("la_ruling_smc49.html")
+
+    respx.get(APPELLATE_URL).mock(return_value=httpx.Response(200, text=main_html))
+    respx.post(APPELLATE_URL).mock(return_value=httpx.Response(200, text=stale_html))
+
+    config = default_config_appellate()
+    config.request_delay_seconds = 0
+    scraper = LAAppellateTentativeRulingsScraper(config=config)
+    health = scraper.run()
+
+    assert health.success is True
+    assert health.records_captured == 0
+
+
+def test_appellate_scraper_registered_in_runner() -> None:
+    """The appellate scraper is registered and discoverable via the runner."""
+    from framework.runner import get_scraper_ids
+
+    ids = get_scraper_ids()
+    assert "ca-la-tentatives-appellate" in ids
+    # Civil is still registered separately.
+    assert "ca-la-tentatives-civil" in ids

--- a/packages/scraper-framework/tests/courts/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_la_tentatives.py
@@ -3524,3 +3524,131 @@ def test_appellate_scraper_registered_in_runner() -> None:
     assert "ca-la-tentatives-appellate" in ids
     # Civil is still registered separately.
     assert "ca-la-tentatives-civil" in ids
+
+
+def test_parse_appellate_dropdown_options_skips_empty_value_option() -> None:
+    """Options with empty ``value`` attribute (e.g. a placeholder) are skipped."""
+    html = """
+<html><body>
+<select name="ctl00$ctl00$siteMasterHolder$basicBodyHolder$List1DeptDate"
+        id="siteMasterHolder_basicBodyHolder_List1DeptDate">
+<option value="">-- select a date --</option>
+<option value="04/17/2026">04/17/2026</option>
+</select>
+</body></html>
+"""
+    options = _parse_appellate_dropdown_options(html)
+    assert len(options) == 1
+    assert options[0].value == "04/17/2026"
+
+
+def test_parse_appellate_dropdown_options_skips_invalid_calendar_date() -> None:
+    """Values matching the regex but not a real calendar date (e.g. 02/30/2026)
+    parse with ``hearing_date=None`` rather than raising."""
+    # 02/30/2026 matches the MM/DD/YYYY regex but is not a valid date —
+    # datetime.strptime raises ValueError, which the parser swallows.
+    html = _synthetic_appellate_main_with_dropdown(["02/30/2026"])
+    options = _parse_appellate_dropdown_options(html)
+    assert len(options) == 1
+    assert options[0].value == "02/30/2026"
+    assert options[0].hearing_date is None
+
+
+@respx.mock
+def test_appellate_fetch_documents_logs_and_continues_on_per_date_fetch_error() -> None:
+    """If the POST for one dropdown date raises, the scraper logs and moves on.
+
+    Covers the ``except Exception`` branch inside the per-option loop in
+    ``fetch_documents()`` (#2599).
+    """
+    main_html = _synthetic_appellate_main_with_dropdown(["04/17/2026", "04/24/2026"])
+    ruling_html = _synthetic_appellate_ruling_response()
+
+    respx.get(APPELLATE_URL).mock(return_value=httpx.Response(200, text=main_html))
+    # First POST raises a network error, second POST succeeds.
+    respx.post(APPELLATE_URL).mock(
+        side_effect=[
+            httpx.ConnectError("simulated network failure"),
+            httpx.Response(200, text=ruling_html),
+        ]
+    )
+
+    config = default_config_appellate()
+    config.request_delay_seconds = 0
+    scraper = LAAppellateTentativeRulingsScraper(config=config)
+    docs = scraper.fetch_documents()
+
+    # First date errored, second date produced one doc.
+    assert len(docs) == 1
+
+
+def _make_appellate_ruling_doc(
+    raw_content: bytes = b"<html>no speechSynthesis div here</html>",
+    **overrides: object,
+) -> CapturedDocument:
+    """Build a bare CapturedDocument for appellate parse_document tests."""
+    kwargs: dict[str, object] = {
+        "scraper_id": "ca-la-tentatives-appellate",
+        "state": "CA",
+        "county": "Los Angeles",
+        "court": "Superior Court",
+        "source_url": APPELLATE_URL,
+        "capture_timestamp": datetime(2026, 4, 17, 18, 0, 0),
+        "content_format": ContentFormat.HTML,
+        "raw_content": raw_content,
+        "content_hash": "",
+    }
+    kwargs.update(overrides)
+    return CapturedDocument(**kwargs)  # type: ignore[arg-type]
+
+
+def test_appellate_parse_document_respects_pre_split_guard() -> None:
+    """parse_document must not re-run regex on docs already LLM-pre-split.
+
+    Covers the ``pre_split``/``_llm_extracted`` early-return in
+    ``parse_document()`` (#2469, #2484, #2599).
+    """
+    config = default_config_appellate()
+    scraper = LAAppellateTentativeRulingsScraper(config=config)
+
+    # Construct a doc that has already been LLM-pre-split: fields already
+    # populated by the LLM path, and the pre_split marker set.  The method
+    # must return it unchanged (except for default courthouse/department
+    # fallbacks if either was cleared).
+    doc = _make_appellate_ruling_doc(
+        raw_content=b"<html>ignored - guard short-circuits before parse</html>",
+        case_number="BV999999",
+        ruling_text="Pre-populated by LLM",
+        extra={"pre_split": True, "_llm_extracted": True},
+    )
+    result = scraper.parse_document(doc)
+
+    # Guard kicked in: the raw HTML was NOT re-parsed (case_number would
+    # have been cleared if it had been).
+    assert result.case_number == "BV999999"
+    assert result.ruling_text == "Pre-populated by LLM"
+    # Static appellate metadata fallbacks applied.
+    assert result.courthouse == APPELLATE_COURTHOUSE
+    assert result.department == APPELLATE_DEPARTMENT
+
+
+def test_appellate_parse_document_swallows_parse_errors() -> None:
+    """Malformed HTML must not raise — parse errors are logged and skipped.
+
+    Covers the ``except Exception`` branch around ``_extract_ruling_fields``
+    in ``parse_document()`` (#2599).
+    """
+    config = default_config_appellate()
+    scraper = LAAppellateTentativeRulingsScraper(config=config)
+
+    doc = _make_appellate_ruling_doc()
+    # Force the extractor to raise so we hit the except branch.
+    with patch(
+        "courts.ca.la_tentatives._extract_ruling_fields",
+        side_effect=RuntimeError("boom"),
+    ):
+        result = scraper.parse_document(doc)
+
+    # No exception bubbled up; static appellate metadata is still stamped.
+    assert result.courthouse == APPELLATE_COURTHOUSE
+    assert result.department == APPELLATE_DEPARTMENT

--- a/packages/scraper-framework/tests/fixtures/la_appellate_main_empty.html
+++ b/packages/scraper-framework/tests/fixtures/la_appellate_main_empty.html
@@ -1,0 +1,282 @@
+
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+<head id="head1"><title>
+	LASC - Tentative Rulings
+</title><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /><link rel="icon" type="image/png" href="../commonv4/images/favicon-16x16.png" sizes="16x16" /><link rel="icon" type="image/png" href="../commonv4/images/favicon-32x32.png" sizes="32x32" />
+
+<!-- Stylesheet -->
+<link id="Link5" rel="stylesheet" type="text/css" href="../commonv4/styles/sitemaster.css" media="all" /><link id="Link4" rel="stylesheet" type="text/css" href="../commonv4/styles/fonts.css" media="all" /><link id="Link3" rel="stylesheet" type="text/css" href="../commonv4/styles/common.css" media="all" /><link id="Link10" rel="stylesheet" type="text/css" href="../commonv4/styles/home.css" media="all" /><link id="Link6" rel="stylesheet" type="text/css" href="../commonv4/styles/wrapper.css" media="all" /><link id="Link7" rel="stylesheet" type="text/css" href="../commonv4/styles/breadcrumb.css" media="all" /><link id="Link8" rel="stylesheet" type="text/css" href="../commonv4/styles/screen.css" media="all" /><link id="Link9" rel="stylesheet" type="text/css" href="../commonv4/styles/pending.css" media="all" /><link rel="stylesheet" type="text/css" href="../commonv4/styles/styles3.css" media="all" /><link rel="stylesheet" type="text/css" href="../commonv4/styles/template.css" media="all" /><link href="../commonv4/styles/jquery-ui.css" rel="stylesheet" /><link href="../commonv4/styles/jquery-ui-smoothness.css" rel="stylesheet" /><link id="Link1" rel="stylesheet" type="text/css" href="../commonv4/styles/tooltip.css" media="all" /><link id="Link2" rel="stylesheet" type="text/css" href="../commonv4/styles/global508.css" media="all" />
+    
+    
+		<SCRIPT language="JavaScript">
+<!-- 
+    function checkFields2(thisForm) {
+        if (thisForm.CaseNumber.value == "" & thisForm.List2DeptDate.selectedIndex < 0) {
+            alert("You must enter a case number or select a department");
+            return false;
+        }
+
+        if (thisForm.CaseNumber.value != "" & thisForm.List2DeptDate.selectedIndex >= 0) {
+            alert("You may search for a case number or a department, not both.");
+            return false;
+        }
+        return true;
+    }
+
+    function checkFields1(thisForm) {
+
+        if (thisForm.List1DeptDate.selectedIndex == -1) {
+            alert("You must select a Hearing Date.");
+            return false;
+        }
+
+        return true;
+    }
+
+    function displayNewWindow(thisObj) {
+        newwindow = window.open(thisObj.href, 'offworld', 'width=630,height=500,directories=yes,resizable=yes,status=yes,menubar=yes,location=yes,scrollbars=yes');
+        newwindow.focus();
+        return false;
+    }
+
+
+    // -->
+		</SCRIPT>
+
+</head>
+
+
+<body>
+    <!--JQuery-->
+    <script src="/TentativeRulingNet/commonv4/scripts/jquery-1.11.1.min.js" type="text/javascript"></script>
+ 
+
+    <div id="mainContainer">
+
+        <div id="headerWrap" style="display:none">
+            <!-- Start Translate -->
+            <!-- End Translate -->
+
+            
+            
+
+            <!-- Font Size -->
+            
+
+            <!-- Start Logo -->
+            <div class="logo">
+                <a href="/page/HO0000" onclick="return processLink(this)"><img src="../commonv4/images/logo.gif" id="Img1" alt="Banner Image - The Superior Court of California County of Los Angeles " /></a>
+            </div>
+            <!-- End Logo -->
+
+   	        <!-- Start Search -->
+            <div class="searchWrap"  role="search" >
+            <form name="searchForm" method="get" onsubmit="doSearch(); return false;">
+    
+    	        <div id="searchfieldWrap">
+    		        <input aria-label="Enter Search Criteria" id="searchfield" type="text" name="search" value="Search" onclick="selectSearchText()" onkeydown=""/>
+    	        </div>
+        
+            <div id="btngoWrap">
+                    <a id="searchLink" href="#" onclick="return doSearch(this)"><img src="../commonv4/images/blank.gif" id="Img2" style="margin-left:1px;margin-top:1px" alt="Start Site Search" width="33" height="33" /></a>
+            </div>
+        
+            </form>
+	        </div> 
+            
+            <!-- Survey -->
+              
+        </div>
+
+        <!-- Start MainMenu -->
+        <!---#include virtual="includes/menu2aa.html" --->
+        <!-- End MainMenu -->
+
+        <form method="post" action="./main.aspx?casetype=appellate" id="lascwebform">
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUKLTY1NDY1MDkwMg9kFgJmD2QWAmYPZBYCAgQPZBYCAgEPZBYCAgcPZBYEAgUPFgIeB1Zpc2libGVoFgJmD2QWAmYPZBYCAgEPEGRkFgBkAgcPDxYCHwBoZBYCAgEPEGRkFgBkZGYiLXCcGfuQQzkg+QZCIsDoRwtJlgELo/LmtPOS5i/D" />
+
+<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="65B48B29" />
+            <!--<h1><span style="display:none" role="heading">Main Content</span></h1>-->
+            <div class="pageWrap">
+                
+    <div style="display:none">
+    
+    
+    </div>
+    
+    <div class="mainContentWrap" id="divMainContent">
+        <div class="basicWrap">
+            <div class="contentCategory" style="padding-top: 28px; padding-bottom: 10px; display:none">
+                
+    Online Services
+
+            </div>
+            <div class="contentTitle" style="display:none">
+                
+    Tentative Rulings
+
+
+            </div>
+            <div class="contentText">
+                
+    
+     <div id="siteMasterHolder_basicBodyHolder_RemoteAppearance">
+	
+    <div>
+        <ul style="margin: 0px 25px 10px 30px; padding: 0px 0px 0px 0px">
+            <li>Tentative rulings will be available after 2:00 p.m. on the day before the hearing.</li>
+            <li>Tentative rulings are accessible online, posted outside the courtroom or by contacting the Appellate Division at (213)633-1070 after 2 p.m. and before 4:30 p.m. on the day before the hearing.</li>
+            <li>The tentative rulings are not final, and the court is not bound by a tentative ruling.</li>
+        </ul>
+    </div>
+
+</div>
+
+    <!-- begin content -->
+											
+<table id="siteMasterHolder_basicBodyHolder_NoRuling" cellspacing="0" cellpadding="0" width="98%" border="0">
+	<tr>
+		<td><br /><hr>
+																				<span style="color:#B30000">No rulings have been published at this time.</span>
+                                                                                <hr />
+																			</td>
+	</tr>
+	<tr>
+		<td>
+											<div>
+												<br />
+<p style="margin: 6px 0 22px 0; font-family: 'open_sans_condensedbold'; font-size: 30px; line-height: 36px;color: #555555;">Remote Hearings for the Appellate Division  </p>
+    <p style="font-weight: bold">You May Appear Remotely for Oral Arguments in the Appellate Division via LACourtConnect.</p>
+	<p>LACourtConnect is part of the Court’s Access LACourt | Your Way initiative.  <a href="https://my.lacourt.org/laccwelcome" target="_blank">Click here</a> for further resources and information.</p>
+    <ul style="margin: 0px 25px 10px 30px; padding: 0px 0px 0px 0px">
+        <li>Refer to California Rules of Court, rules <a href="https://courts.ca.gov/cms/rules/index/eight/rule8_885" target="_blank">8.885(b)(1)(A)</a> and <a href="https://courts.ca.gov/cms/rules/index/eight/rule8_929" target="_blank">8.929(b)(1)(A)</a> regarding Oral Argument by videoconference for Appellate Division. </li>
+        <li>No fee is required for a remote appearance.  </li>
+        <li>The public and parties can remotely access the “courtroom” by selecting this link <a href="https://lacc.lacourt.org/" target="_blank">https://lacc.lacourt.org/</a>.</li>
+        <li>The oral argument hearings dates for the Appellate Division can be obtained <a href="https://www.lacourt.org/newsmedia/uploads/142024101141655NTA24-10-01-2024-APPELLATEDIVISION2025HEARINGS(2).pdf" target="_blank">HERE</a>.</li>
+        <li>Parties will be served with a “Notice Setting Cause for Hearing” providing notification of their specific hearing date and time.</li>
+    </ul>
+	<p>Instructions for Parties: </p>
+	<ul style="margin: 0px 25px 10px 30px; padding: 0px 0px 0px 0px">
+		<li>Test your equipment before your hearing. Both audio and video are required to participate remotely.</li>
+		<li>Parties must log in a minimum of 15 minutes prior to their hearing through the link below: <a href="https://lacc.lacourt.org/" target="_blank">https://lacc.lacourt.org/</a>.</li>
+		<li>If you are not present when your case is ready to be heard, you will be deemed to have waived oral argument, and the appeal will be deemed to have been submitted on the brief(s) of the non-appearing party or parties. </li>
+		<li>You must be visible, and your statements must be audible to all other participants. </li>
+	</ul>
+	<p>Instructions for the Public:</p>
+	<ul style="margin: 0px 25px 10px 30px; padding: 0px 0px 0px 0px">
+	<li>When accessing the Appellate Division remotely to observe as a member of the public and not a party to the case, select any case scheduled for that day’s hearing and identify yourself as “other” and “observer.”</li>
+	<li>Observers are to turn off their video camera and mute their audio throughout the proceedings.</li>
+</ul>
+</div>
+		</td>
+	</tr>
+</table>
+
+			                
+            <!--	' Civil division and appellate division display this page differently.
+				' appellate division does not include the location and department
+				' in the drop down box since there's only only location and department.
+				' The drop down box displays Hearing date only.
+			-->
+																
+																
+
+							<!-- display appellate division table -->
+                                    
+									<!-- end appellate division table -->
+							
+			
+
+            </div>
+        </div>
+        <script>var contentArea = "#divMainContent";</script>
+    </div>
+    <div class="moreContentWrap" style="display:none">
+        <div class="moreLeftWrap">
+            
+            
+        </div>
+        <div class="moreMidWrap">
+            
+            
+        </div>
+        <div class="moreRightWrap">
+            
+                <!--<div id="siteMasterHolder_rightMoreHolder_returnLink_returnLinkContainer" style="text-align:right; display:none">
+    <a href="../commonv4/source/uc/x" id="siteMasterHolder_rightMoreHolder_returnLink_homeButtonLink" type="button" class="btn btn-default btn-sm" onclick="return processLink(this);">
+        <span class="glyphicon glyphicon-screenshot"></span>  Home
+    </a>
+
+</div>
+-->
+            
+        </div>
+    </div>
+
+    <div class="lastContentWrap" style="display:none">
+        <div class="lastLeftWrap">
+            
+
+        </div>
+        <div class="lastRightWrap">
+
+            
+
+        </div>
+    </div>
+    
+
+            </div>
+        </form>
+        <div id="footerWrap" style="display:none">
+                <!-- Start MainMenu -->
+                <!-- End MainMenu -->
+        </div>
+    </div>
+
+    <!-- Scripts Loaded at End -->
+    <!-- Provides performance benefit. Also fix for Asp.Net error, "The Controls collection cannot be modified because the control contains code blocks (i.e. < % ... % >)" -->
+    <!-- See http://www.aspdotnet-suresh.com/2011/12/aspnet-controls-collection-cannot-be.html -->
+
+    <!--JQuery-->
+    
+    <script src="/TentativeRulingNet/commonv4/scripts/jquery-ui.min.js" type="text/javascript"></script>
+    <script src="/TentativeRulingNet/commonv4/scripts/jquery.cookie.js" type="text/javascript"></script>
+
+    <!--Google Analytics-->
+    <script src="/TentativeRulingNet/commonv4/scripts/analytics.js" type="text/javascript"></script>
+
+    <!-- lascweb -->   
+    <script src="/TentativeRulingNet/commonv4/scripts/config.js" type="text/javascript" ></script>
+    <script src="/TentativeRulingNet/commonv4/scripts/common.js" type="text/javascript" ></script>
+    <script src="/TentativeRulingNet/commonv4/scripts/tooltip.js" type="text/javascript"></script>
+    <script src="/TentativeRulingNet/commonv4/scripts/linkredirect.js" type="text/javascript"></script>
+    <script src="/TentativeRulingNet/commonv4/scripts/globaljs.js" type="text/javascript" ></script>  <!-- Nav Menu -->
+
+    <!-- text-2-speech -->
+    <!--script src="/TentativeRulingNet/commonv4/scripts/text2speech.js" type="text/javascript" ></!--script-->
+
+    <!-- ajax control toolkit extension -->
+    <script src="/TentativeRulingNet/commonv4/scripts/ajaxcontroltoolkit.js" type="text/javascript"></script>
+
+    <script type="text/javascript">
+        <!-- Executes OnFocus. Highlights the text in the search box. -->
+        function selectSearchText() {
+            $("#searchfield").select();
+        }
+        function doSearch() {
+            $("#searchLink").attr("href", "/page/ho0100/" + escape($("#searchfield").val().trim()));
+            return processLink($("#searchLink"));
+        }
+    </script>
+    <!-- End Lascweb -->
+
+    
+    
+    
+            
+</body>
+</html>
+

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -2511,6 +2511,10 @@ class TestScraperRegistryAutoDiscovery:
 
         Auto-discovers expected scraper IDs rather than maintaining a hardcoded
         set, so adding a new scraper never requires updating this test (#680).
+
+        Multi-scraper modules (those exporting ``_SCRAPER_CLASS_BY_ID`` with
+        multiple ``default_config_<suffix>`` factories) contribute one expected
+        scraper_id per factory (#2599).
         """
         import inspect
         import pkgutil
@@ -2541,7 +2545,13 @@ class TestScraperRegistryAutoDiscovery:
             )
             if not has_scraper:
                 continue
-            expected_ids.add(config_fn().scraper_id)
+            # Collect every ``default_config*`` factory's scraper_id.  Multi-
+            # scraper modules contribute multiple entries (#2599).
+            for _name, obj in inspect.getmembers(mod, inspect.isfunction):
+                if (
+                    _name == "default_config" or _name.startswith("default_config_")
+                ) and obj.__module__ == mod.__name__:
+                    expected_ids.add(obj().scraper_id)
 
         reingest._load_scraper_registry()
         assert expected_ids == set(reingest._SCRAPER_REGISTRY.keys())
@@ -2773,15 +2783,28 @@ class TestReparsePdfDocuments:
             )
 
     def test_registry_keys_match_default_config_scraper_id(self) -> None:
-        """Each registry key should match the scraper_id from default_config()."""
+        """Each registry key should match a ``default_config*()`` factory's scraper_id.
+
+        Multi-scraper modules (#2599) expose multiple factories; walk them all
+        and verify that every registered ``scraper_id`` is produced by some
+        ``default_config*()`` factory in the class's module.
+        """
+        import importlib
+        import inspect
+
         reingest._load_scraper_registry()
         for scraper_id, cls in reingest._SCRAPER_REGISTRY.items():
-            # Find the module that defines this class and call default_config()
-            import importlib
-
             mod = importlib.import_module(cls.__module__)
-            config = mod.default_config()
-            assert config.scraper_id == scraper_id
+            factory_ids: set[str] = set()
+            for _name, obj in inspect.getmembers(mod, inspect.isfunction):
+                if (
+                    _name == "default_config" or _name.startswith("default_config_")
+                ) and obj.__module__ == mod.__name__:
+                    factory_ids.add(obj().scraper_id)
+            assert scraper_id in factory_ids, (
+                f"scraper_id {scraper_id!r} not produced by any default_config* "
+                f"factory in {mod.__name__}"
+            )
 
     def test_idempotent_load(self) -> None:
         """Calling _load_scraper_registry() twice does not duplicate entries."""

--- a/packages/scraper-framework/tests/test_reingest_registry.py
+++ b/packages/scraper-framework/tests/test_reingest_registry.py
@@ -42,11 +42,14 @@ reingest = importlib.import_module("reingest_from_s3")
 
 
 def _discover_scraper_modules() -> list[tuple[str, str]]:
-    """Return [(module_path, class_name)] for every scraper with default_config().
+    """Return [(module_path, class_name)] for every (scraper_id, class) pair.
 
     Mirrors the discovery logic in ``_load_scraper_registry()`` — walks the
     ``courts`` package tree and collects modules that expose a
     ``default_config()`` callable and a concrete ``BaseScraper`` subclass.
+
+    Multi-scraper modules (those exporting ``_SCRAPER_CLASS_BY_ID``) emit
+    one tuple per registered scraper_id (#2599).
     """
     import courts
 
@@ -64,7 +67,16 @@ def _discover_scraper_modules() -> list[tuple[str, str]]:
         if config_fn is None or not callable(config_fn):
             continue
 
-        # Find the concrete BaseScraper subclass defined in this module.
+        # Multi-scraper opt-in: module-level ``_SCRAPER_CLASS_BY_ID`` maps
+        # each scraper_id to its concrete class.  Each entry produces one
+        # (module_path, class_name) tuple.
+        scraper_class_by_id: dict[str, type] | None = getattr(mod, "_SCRAPER_CLASS_BY_ID", None)
+        if scraper_class_by_id:
+            for _sid, cls in scraper_class_by_id.items():
+                result.append((modname, cls.__name__))
+            continue
+
+        # Fallback: single-class auto-detect (backward compat).
         scraper_cls_name: str | None = None
         for name, obj in inspect.getmembers(mod, inspect.isclass):
             if (
@@ -91,13 +103,37 @@ def _load_module(module_path: str) -> ModuleType:
     return importlib.import_module(module_path)
 
 
+def _discover_config_factories(mod: ModuleType) -> list:
+    """Return all ``default_config`` / ``default_config_<suffix>`` callables.
+
+    Multi-scraper modules (#2599) expose multiple factories; single-scraper
+    modules expose just ``default_config``.
+    """
+    factories = []
+    for name, obj in inspect.getmembers(mod, inspect.isfunction):
+        if (name == "default_config" or name.startswith("default_config_")) and (
+            obj.__module__ == mod.__name__
+        ):
+            factories.append(obj)
+    return factories
+
+
 def _get_all_scraper_ids() -> dict[str, str]:
-    """Return {scraper_id: module_path} for every known scraper module."""
+    """Return {scraper_id: module_path} for every known scraper module.
+
+    Multi-scraper modules contribute one entry per ``default_config*``
+    factory (#2599).
+    """
     result: dict[str, str] = {}
+    seen_modules: set[str] = set()
     for module_path, _class_name in _SCRAPER_MODULES:
+        if module_path in seen_modules:
+            continue
+        seen_modules.add(module_path)
         mod = _load_module(module_path)
-        config = mod.default_config()
-        result[config.scraper_id] = module_path
+        for factory in _discover_config_factories(mod):
+            config = factory()
+            result[config.scraper_id] = module_path
     return result
 
 
@@ -137,22 +173,27 @@ class TestScraperRegistryNonEmpty:
 
 
 class TestRegistryKeysMatchDefaultConfig:
-    """Every registered key must match the scraper_id from default_config()."""
+    """Every registered key must match a ``default_config*`` factory's scraper_id."""
 
     def test_all_keys_match_default_config_scraper_id(self) -> None:
-        """Each key in the registry must equal the class's default_config().scraper_id."""
+        """Each key must equal some ``default_config*()`` factory's scraper_id."""
         reingest._SCRAPER_REGISTRY.clear()
         reingest._load_scraper_registry()
 
         for registry_key, scraper_cls in reingest._SCRAPER_REGISTRY.items():
-            # Find which module this class comes from
+            # Find which module this class comes from.
             module_name = scraper_cls.__module__
             mod = importlib.import_module(module_name)
-            config = mod.default_config()
-            assert registry_key == config.scraper_id, (
-                f"Registry key {registry_key!r} does not match "
-                f"default_config().scraper_id {config.scraper_id!r} "
-                f"from {module_name}"
+
+            # Collect all scraper_ids this module's factories produce —
+            # for single-scraper modules this is one id; for multi-scraper
+            # modules (#2599) it's one per factory.
+            factory_ids = {f().scraper_id for f in _discover_config_factories(mod)}
+
+            assert registry_key in factory_ids, (
+                f"Registry key {registry_key!r} does not match any "
+                f"default_config*().scraper_id in {module_name} "
+                f"(module offers {sorted(factory_ids)})"
             )
 
 
@@ -180,19 +221,60 @@ class TestRegistryCoverage:
         )
 
 
+def _instantiable_params() -> list[tuple[str, str]]:
+    """Return (module_path, class_name) pairs with duplicates collapsed.
+
+    Multi-scraper modules show up once per class in ``_SCRAPER_MODULES``
+    but we only need to test one instantiation per class.
+    """
+    seen: set[tuple[str, str]] = set()
+    out: list[tuple[str, str]] = []
+    for m, c in _SCRAPER_MODULES:
+        if (m, c) in seen:
+            continue
+        seen.add((m, c))
+        out.append((m, c))
+    return out
+
+
+_INSTANTIABLE_PARAMS = _instantiable_params()
+
+
 class TestRegistryClassesInstantiable:
     """Every scraper class in the registry must be instantiable."""
 
     @pytest.mark.parametrize(
         "module_path,class_name",
-        _SCRAPER_MODULES,
-        ids=[m for m, _c in _SCRAPER_MODULES],
+        _INSTANTIABLE_PARAMS,
+        ids=[f"{m}::{c}" for m, c in _INSTANTIABLE_PARAMS],
     )
     def test_scraper_class_instantiable(self, module_path: str, class_name: str) -> None:
-        """Each registered scraper class can be instantiated with its default config."""
+        """Each registered scraper class can be instantiated with a default config.
+
+        For multi-scraper modules (#2599), each class is instantiated with
+        whichever ``default_config*()`` factory returns the scraper_id for
+        this class (looked up via ``_SCRAPER_CLASS_BY_ID``).
+        """
         mod = _load_module(module_path)
-        config = mod.default_config()
         scraper_cls = getattr(mod, class_name)
+
+        # Resolve the matching factory for this class.
+        scraper_class_by_id: dict[str, type] | None = getattr(mod, "_SCRAPER_CLASS_BY_ID", None)
+        if scraper_class_by_id:
+            scraper_id = next(sid for sid, cls in scraper_class_by_id.items() if cls is scraper_cls)
+            # Find the factory that returns this scraper_id.
+            config = None
+            for factory in _discover_config_factories(mod):
+                candidate = factory()
+                if candidate.scraper_id == scraper_id:
+                    config = candidate
+                    break
+            assert config is not None, (
+                f"No default_config*() factory in {module_path} returns scraper_id {scraper_id!r}"
+            )
+        else:
+            config = mod.default_config()
+
         scraper = scraper_cls(config=config)
         assert scraper is not None
         assert scraper.config.scraper_id == config.scraper_id
@@ -202,19 +284,28 @@ class TestLlmSplitRegistryDiscovery:
     """Verify that _load_scraper_registry() discovers _llm_extract_rulings functions (#1969)."""
 
     def test_llm_split_registry_populated(self) -> None:
-        """Modules that export _llm_extract_rulings must be in _LLM_SPLIT_REGISTRY."""
+        """Modules that export _llm_extract_rulings must be in _LLM_SPLIT_REGISTRY.
+
+        Multi-scraper modules (#2599) register the LLM split function under
+        every scraper_id the module exposes.
+        """
         reingest._SCRAPER_REGISTRY.clear()
         reingest._LLM_SPLIT_REGISTRY.clear()
         reingest._SPLIT_REGISTRY.clear()
         reingest._load_scraper_registry()
 
-        # Discover which modules export _llm_extract_rulings
+        # Discover which scraper_ids live in modules that export
+        # _llm_extract_rulings.
         expected_llm_ids: set[str] = set()
+        seen_modules: set[str] = set()
         for module_path, _class_name in _SCRAPER_MODULES:
+            if module_path in seen_modules:
+                continue
+            seen_modules.add(module_path)
             mod = _load_module(module_path)
             if hasattr(mod, "_llm_extract_rulings") and callable(mod._llm_extract_rulings):
-                config = mod.default_config()
-                expected_llm_ids.add(config.scraper_id)
+                for factory in _discover_config_factories(mod):
+                    expected_llm_ids.add(factory().scraper_id)
 
         if not expected_llm_ids:
             pytest.skip("No scraper modules export _llm_extract_rulings")

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -244,6 +244,13 @@ def _load_scraper_registry() -> None:
     such module the ``scraper_id`` from the config is mapped to the scraper
     class.  This eliminates the need to maintain a hardcoded import list —
     adding a new scraper module automatically registers it.
+
+    Multi-scraper modules (e.g. LA civil + appellate in ``la_tentatives``)
+    can opt-in to explicit registration by exporting a module-level
+    ``_SCRAPER_CLASS_BY_ID: dict[str, type]`` mapping each ``scraper_id``
+    to its concrete ``BaseScraper`` subclass and pairing ``default_config``
+    factories (``default_config``, ``default_config_<suffix>``, ...).
+    See ``courts.ca.la_tentatives`` for the canonical example.
     """
     if _SCRAPER_REGISTRY:
         return
@@ -271,27 +278,65 @@ def _load_scraper_registry() -> None:
             logger.debug("Could not import module, skipping", module=modname)
             continue
 
-        config_fn = getattr(mod, "default_config", None)
-        if config_fn is None or not callable(config_fn):
+        # Collect all default_config* factory functions in this module.
+        # Single-scraper modules expose just ``default_config``; multi-
+        # scraper modules expose additional ``default_config_<suffix>``.
+        config_factories: list = []
+        for _attr_name, _attr in inspect.getmembers(mod, inspect.isfunction):
+            if _attr_name == "default_config" or _attr_name.startswith(
+                "default_config_"
+            ):
+                if _attr.__module__ == mod.__name__:
+                    config_factories.append(_attr)
+
+        if not config_factories:
             continue
 
-        # Find the concrete BaseScraper subclass in this module.
-        scraper_cls: type | None = None
+        # Module-level hint: explicit scraper_id → class mapping.  Required
+        # for multi-scraper modules where class-by-alphabetical-order would
+        # be ambiguous.  Optional for single-scraper modules (we fall back
+        # to auto-detection).
+        scraper_class_by_id: dict[str, type] | None = getattr(
+            mod, "_SCRAPER_CLASS_BY_ID", None
+        )
+
+        # Auto-detect single scraper class in the module (backward compat
+        # for modules that don't export _SCRAPER_CLASS_BY_ID).
+        auto_scraper_cls: type | None = None
         for _name, obj in inspect.getmembers(mod, inspect.isclass):
             if (
                 issubclass(obj, BaseScraper)
                 and obj is not BaseScraper
                 and obj.__module__ == mod.__name__
             ):
-                scraper_cls = obj
+                auto_scraper_cls = obj
                 break
 
-        if scraper_cls is None:
-            continue
+        for config_fn in config_factories:
+            try:
+                config = config_fn()
+            except Exception:
+                logger.warning(
+                    "default_config factory failed, skipping",
+                    module=modname,
+                    factory=config_fn.__name__,
+                    exc_info=True,
+                )
+                continue
 
-        try:
-            config = config_fn()
-            _SCRAPER_REGISTRY[config.scraper_id] = scraper_cls
+            scraper_id = config.scraper_id
+            scraper_cls: type | None = None
+            if scraper_class_by_id is not None:
+                scraper_cls = scraper_class_by_id.get(scraper_id)
+            if scraper_cls is None:
+                # Fall back to the auto-detected single class.  Only safe
+                # when there is exactly one scraper in the module.
+                scraper_cls = auto_scraper_cls
+
+            if scraper_cls is None:
+                continue
+
+            _SCRAPER_REGISTRY[scraper_id] = scraper_cls
 
             # Register split function if the module exports one.
             # Convention: a module-level ``_split_rulings`` callable
@@ -299,7 +344,7 @@ def _load_scraper_registry() -> None:
             # that need splitting during full reparse.
             split_fn = getattr(mod, "_split_rulings", None)
             if split_fn is not None and callable(split_fn):
-                _SPLIT_REGISTRY[config.scraper_id] = split_fn
+                _SPLIT_REGISTRY[scraper_id] = split_fn
 
             # Register LLM-based split function if available.
             # Convention: a module-level ``_llm_extract_rulings`` callable
@@ -307,11 +352,7 @@ def _load_scraper_registry() -> None:
             # produces higher-quality ruling_text than regex splitting.
             llm_split_fn = getattr(mod, "_llm_extract_rulings", None)
             if llm_split_fn is not None and callable(llm_split_fn):
-                _LLM_SPLIT_REGISTRY[config.scraper_id] = llm_split_fn
-        except Exception:
-            logger.warning(
-                "default_config() failed, skipping", module=modname, exc_info=True
-            )
+                _LLM_SPLIT_REGISTRY[scraper_id] = llm_split_fn
 
 
 FETCH_DOCUMENTS_QUERY = """


### PR DESCRIPTION
## Summary

Adds a sibling scraper `LAAppellateTentativeRulingsScraper` for LA Superior Court's Appellate Division, driving the same ASP.NET portal as civil at `casetype=appellate`. Dropdown name is `List1DeptDate` and option values are hearing-date-only — per LA Court's own HTML comment: "appellate division does not include the location and department in the drop down box since there's only only location and department." Division metadata (Stanley Mosk Courthouse / Appellate Division) is static and stamped on every captured doc.

Closes #2599.

## Scope

- New `LAAppellateTentativeRulingsScraper` class in `packages/scraper-framework/src/courts/ca/la_tentatives.py`.
- New `default_config_appellate()` factory returning `ca-la-tentatives-appellate` with the twice-daily cadence (6 PM / 2 AM) that mirrors civil.
- Registered in `framework/runner.py`.
- Shares per-case HTML parsing helpers with the civil scraper (`_split_cases_html`, `_extract_ruling_fields`, etc.) — no duplication.
- Gracefully handles the common empty state (`#siteMasterHolder_basicBodyHolder_NoRuling` + "No rulings have been published at this time.") — returns zero docs without failing.
- **Registry discovery fix:** `scripts/reingest_from_s3.py` auto-discovery previously picked the first `BaseScraper` subclass alphabetically per module, which would have silently mapped `ca-la-tentatives-civil` → `LAAppellateTentativeRulingsScraper`. Introduced an opt-in `_SCRAPER_CLASS_BY_ID` module-level hint so multi-scraper modules explicitly pair each `scraper_id` with its class. Single-scraper modules are unchanged.

## Fixtures

- `la_appellate_main_empty.html` — real capture from live site 2026-04-17, empty state (the common case — Appellate Division was empty on every Wayback Machine snapshot checked plus the live fetch today).

## Test plan

### Automated checks
- [x] `ruff check` clean on all modified files
- [x] `ruff format --check` clean on all modified files
- [x] Full `scraper-framework` pytest suite green (6216 passed, 2 skipped in the pre-push run)
- [x] 17 new appellate tests (empty-state detection, dropdown parsing including empty/malformed-value skips, `default_config_appellate`, end-to-end run via respx, stale-ViewState handling, per-date fetch-error handling, `pre_split` guard, parse-error handling, runner registration)
- [x] Diff coverage ≥ 90% on scraper-framework (98% reported by diff-cover)
- [x] Pre-push hook passes (lint + format + tests)
- [x] CI: all checks SUCCESS or SKIPPED (`ci-passed` green)

### Post-deploy verification
- [x] `Deploy Scraper` workflow run `24565948369` all-green (Build/Push ECR, Deploy to Staging, Deploy Ingestion Worker, Post-Deploy Health Check).
- [x] New scraper registered in deployed ECS image — verified via one-shot `ecs-run-task.sh --latest-image` against the dev image: `ca-la-tentatives-appellate` appears in `get_scraper_ids()`. See [verification evidence comment](https://github.com/judgemind/judgemind/issues/2599#issuecomment-4268194337).
- [ ] On the first day Appellate Division publishes a ruling, confirm non-zero S3 archival via `scripts/ecs-logs.sh /ecs/judgemind-scraper-dev --lines 200 | grep -E "ca-la-tentatives-appellate|Appellate division"`. Deferred — Appellate Division is low volume and was empty on every Wayback snapshot + the live fetch today, so the expected first-run outcome is the empty-state path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
