### PR TITLE
feat(scraping): integrate CAPSolver Turnstile API for SF civil session acquisition (#2623)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -28,6 +28,10 @@ data "aws_secretsmanager_secret" "courtlistener_api_token" {
   name = "judgemind/courtlistener/api-token"
 }
 
+data "aws_secretsmanager_secret" "capsolver_api_key" {
+  name = "judgemind/capsolver/api-key"
+}
+
 module "networking" {
   source      = "../../modules/networking"
   environment = "dev"
@@ -112,6 +116,7 @@ module "compute" {
   google_api_key_secret_arn          = data.aws_secretsmanager_secret.google_api_key.arn
   proxy_secret_arn                   = data.aws_secretsmanager_secret.residential_proxy.arn
   courtlistener_api_token_secret_arn = data.aws_secretsmanager_secret.courtlistener_api_token.arn
+  capsolver_api_key_secret_arn       = data.aws_secretsmanager_secret.capsolver_api_key.arn
 
   # Dev: 1 vCPU, 2 GB RAM, daily schedule at 6 AM PT
   # Matches production to prevent OOM kills during the full 17-scraper run.

--- a/infra/terraform/environments/production/main.tf
+++ b/infra/terraform/environments/production/main.tf
@@ -16,6 +16,10 @@ data "aws_secretsmanager_secret" "courtlistener_api_token" {
   name = "judgemind/courtlistener/api-token"
 }
 
+data "aws_secretsmanager_secret" "capsolver_api_key" {
+  name = "judgemind/capsolver/api-key"
+}
+
 module "networking" {
   source      = "../../modules/networking"
   environment = "production"
@@ -66,6 +70,7 @@ module "compute" {
   document_archive_bucket            = module.document_archive.bucket_id
   proxy_secret_arn                   = data.aws_secretsmanager_secret.residential_proxy.arn
   courtlistener_api_token_secret_arn = data.aws_secretsmanager_secret.courtlistener_api_token.arn
+  capsolver_api_key_secret_arn       = data.aws_secretsmanager_secret.capsolver_api_key.arn
 
   # Production: 1 vCPU, 2 GB RAM, daily schedule at 6 AM PT
   task_cpu            = 1024

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -165,6 +165,12 @@ resource "aws_ecs_task_definition" "scraper" {
             valueFrom = var.courtlistener_api_token_secret_arn
           }
         ] : [],
+        var.capsolver_api_key_secret_arn != "" ? [
+          {
+            name      = "CAPSOLVER_API_KEY"
+            valueFrom = var.capsolver_api_key_secret_arn
+          }
+        ] : [],
         var.proxy_secret_arn != "" ? [
           {
             name      = "SD_PROXY_URL"
@@ -348,6 +354,29 @@ resource "aws_iam_role_policy" "ecs_task_execution_courtlistener_secret" {
         Effect   = "Allow"
         Action   = "secretsmanager:GetSecretValue"
         Resource = var.courtlistener_api_token_secret_arn
+      }
+    ]
+  })
+}
+
+# Allow the task execution role to fetch the CAPSolver API key secret
+# so ECS can inject CAPSOLVER_API_KEY into the scraper container.
+# Used by scrapers that need deterministic Cloudflare Turnstile solves
+# (e.g. SF civil tentatives on webapps.sftc.org). See #2623.
+resource "aws_iam_role_policy" "ecs_task_execution_capsolver_secret" {
+  count = var.capsolver_api_key_secret_arn != "" ? 1 : 0
+
+  name = "judgemind-ecs-execution-capsolver-secret-${var.environment}"
+  role = aws_iam_role.ecs_task_execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadCAPSolverSecret"
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = var.capsolver_api_key_secret_arn
       }
     ]
   })

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -141,6 +141,12 @@ variable "courtlistener_api_token_secret_arn" {
   default     = ""
 }
 
+variable "capsolver_api_key_secret_arn" {
+  description = "ARN of the Secrets Manager secret holding the CAPSolver API key (plain string). When set, CAPSOLVER_API_KEY is injected into the scraper container, enabling deterministic Cloudflare Turnstile solves (e.g. SF civil tentatives). When unset, scrapers fall back to stealth-only Turnstile auto-solve."
+  type        = string
+  default     = ""
+}
+
 variable "proxy_secret_arn" {
   description = "ARN of the Secrets Manager secret holding the residential proxy URL (plain string). When set, SD_PROXY_URL is injected into the scraper container."
   type        = string

--- a/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import re
 import time
 from dataclasses import dataclass
@@ -55,6 +56,7 @@ from framework import BaseScraper, CapturedDocument, ContentFormat, ScheduleWind
 from framework.browser import apply_stealth as _apply_stealth
 from framework.events import EventBus
 from framework.storage import S3Archiver
+from framework.turnstile_solver import solve_turnstile
 
 logger = structlog.get_logger(__name__)
 
@@ -72,6 +74,18 @@ CIVIL_REST_BASE = f"{CIVIL_API_URL}/datasnap/rest/TServerMethods1/GetRulings"
 # CAPTCHA gateway URL — Turnstile challenge page with referrer to tr.dll.
 CAPTCHA_GATEWAY_URL = "https://webapps.sftc.org/captcha/captcha.dll"
 
+# Cloudflare Turnstile sitekey embedded in the CAPTCHA gateway page's
+# ``data-sitekey`` attribute. Used for CAPSolver-assisted session
+# acquisition (see ``_try_acquire_session_with_solver``).
+TURNSTILE_SITEKEY = "0x4AAAAAAAhseTmUbrk0U5ab"
+
+# Environment variable name for the CAPSolver API key. When set, the
+# scraper uses CAPSolver to deterministically solve the Turnstile
+# challenge. When unset, the scraper falls back to stealth-only auto-solve
+# polling (the legacy path — useful for local dev/tests that don't want
+# to hit CAPSolver).
+CAPSOLVER_API_KEY_ENV_VAR = "CAPSOLVER_API_KEY"
+
 # Turnstile challenge timeout (seconds) — how long to wait for auto-solve.
 TURNSTILE_TIMEOUT = 45.0
 
@@ -84,6 +98,56 @@ SESSION_MAX_RETRIES = 3
 # Regex to extract seshID from the page JavaScript.
 # Matches: var seshID="<hex_string>";
 _SESH_ID_RE = re.compile(r'var\s+seshID\s*=\s*"([A-Fa-f0-9]+)"')
+
+# JavaScript injected into the CAPTCHA page after CAPSolver returns a
+# Turnstile response token. Populates the reCAPTCHA-style hidden input
+# used by Turnstile's compat=recaptcha mode, then invokes the site's
+# ``recaptchaCallBack`` function which submits the form. Also tries the
+# Turnstile-native response input name as a defensive fallback in case
+# the widget renders in non-compat mode on some future deploy. Returns
+# a boolean indicating whether the callback was invoked.
+_TURNSTILE_INJECTION_JS = """
+(token) => {
+    // Populate reCAPTCHA-compat hidden input (primary).
+    let inputs = document.querySelectorAll(
+        'textarea[name="g-recaptcha-response"], input[name="g-recaptcha-response"]'
+    );
+    if (inputs.length === 0) {
+        // Defensive: create the hidden input inside the form if Turnstile
+        // hasn't rendered one yet.
+        const form = document.querySelector('form#WebForm') || document.forms[0];
+        if (form) {
+            const ta = document.createElement('textarea');
+            ta.name = 'g-recaptcha-response';
+            ta.style.display = 'none';
+            form.appendChild(ta);
+            inputs = [ta];
+        }
+    }
+    inputs.forEach((el) => { el.value = token; });
+
+    // Also populate Turnstile-native response input if present
+    // (covers non-compat-recaptcha mode).
+    const cfInputs = document.querySelectorAll(
+        'input[name="cf-turnstile-response"], textarea[name="cf-turnstile-response"]'
+    );
+    cfInputs.forEach((el) => { el.value = token; });
+
+    // Invoke the page's callback, which submits the form.
+    if (typeof window.recaptchaCallBack === 'function') {
+        window.recaptchaCallBack(token);
+        return true;
+    }
+
+    // Fallback: submit the form directly.
+    const form = document.querySelector('form#WebForm') || document.forms[0];
+    if (form) {
+        form.submit();
+        return true;
+    }
+    return false;
+}
+"""
 
 # RulingID → department mapping.
 # Each entry defines the department and a description of the motion types.
@@ -668,6 +732,23 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
     async def _try_acquire_session(self, async_playwright: Any) -> str | None:
         """Single attempt to acquire a session via Playwright.
 
+        The flow has two branches:
+
+        1. **CAPSolver-assisted (preferred, deterministic)**: when the
+           ``CAPSOLVER_API_KEY`` env var is set, call the CAPSolver API to
+           obtain a Turnstile response token, inject it into the hidden
+           ``g-recaptcha-response`` input, and invoke the site's
+           ``recaptchaCallBack`` JavaScript callback, which submits the
+           form and redirects to ``tr.dll?RulingID=N`` where seshID lives.
+
+        2. **Stealth fallback (legacy)**: when the env var is absent,
+           apply stealth evasions and poll for the CAPTCHA to
+           auto-resolve. This worked historically but became unreliable
+           in interactive mode (see #2619).
+
+        Both branches end by calling ``_wait_for_session`` to extract the
+        seshID from the post-CAPTCHA page.
+
         Args:
             async_playwright: The async_playwright context manager factory.
 
@@ -706,7 +787,9 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
 
                 page = await context.new_page()
 
-                # Apply stealth evasions to pass Turnstile
+                # Apply stealth evasions. These still help even with
+                # CAPSolver because the post-CAPTCHA tr.dll page also
+                # performs bot checks.
                 await _apply_stealth(page)
 
                 # Use the first RulingID as the CAPTCHA referrer — all
@@ -722,13 +805,94 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
                     wait_until="domcontentloaded",
                 )
 
-                # Wait for Turnstile to auto-solve and redirect to tr.dll page.
-                # The CAPTCHA page redirects to tr.dll?RulingID=N after solving.
+                # Branch on CAPSolver availability.
+                api_key = os.environ.get(CAPSOLVER_API_KEY_ENV_VAR, "")
+                if api_key:
+                    submitted = await self._submit_captcha_with_solver(
+                        page=page,
+                        captcha_url=captcha_url,
+                        api_key=api_key,
+                    )
+                    if not submitted:
+                        # Solver failed — fall back to stealth polling to
+                        # give auto-solve a chance before declaring defeat.
+                        self._log.info(
+                            "Falling back to stealth polling after solver failure",
+                        )
+
+                # Wait for the page to navigate to tr.dll and extract seshID.
+                # Works for both branches: CAPSolver-triggered redirect or
+                # stealth auto-solve.
                 session_id = await self._wait_for_session(page)
                 return session_id
 
             finally:
                 await browser.close()
+
+    async def _submit_captcha_with_solver(
+        self,
+        page: Any,
+        captcha_url: str,
+        api_key: str,
+    ) -> bool:
+        """Solve the Turnstile CAPTCHA via CAPSolver and submit the form.
+
+        Calls the CAPSolver API for a Turnstile response token, injects it
+        into the hidden ``g-recaptcha-response`` input, and invokes the
+        page's ``recaptchaCallBack(token)`` JavaScript callback (the SF
+        CAPTCHA page uses Turnstile in ``compat=recaptcha`` mode, so the
+        form uses the reCAPTCHA-style hidden input + callback). The
+        callback submits the form and triggers the redirect to tr.dll.
+
+        Args:
+            page: The Playwright page object (already on the CAPTCHA URL).
+            captcha_url: The CAPTCHA gateway URL, passed to CAPSolver as
+                ``websiteURL`` so Turnstile's server-side validation
+                matches the sitekey/origin pair.
+            api_key: The CAPSolver API key.
+
+        Returns:
+            True if the solver returned a token and injection succeeded;
+            False on any failure (solver returned None, JS injection
+            raised, etc.). Caller should fall back to stealth polling.
+        """
+        self._log.info(
+            "Requesting Turnstile solve from CAPSolver",
+            sitekey=TURNSTILE_SITEKEY,
+        )
+
+        token = await solve_turnstile(
+            sitekey=TURNSTILE_SITEKEY,
+            page_url=captcha_url,
+            api_key=api_key,
+        )
+
+        if not token:
+            self._log.warning(
+                "CAPSolver returned no token — falling back to stealth polling",
+            )
+            return False
+
+        # Inject the token and submit the form. The SF gateway page uses
+        # Turnstile in compat=recaptcha mode, so the widget renders a
+        # hidden input named ``g-recaptcha-response`` (some pages also
+        # have ``cf-turnstile-response``), and defines a global
+        # ``recaptchaCallBack`` function that submits the form.
+        js = _TURNSTILE_INJECTION_JS
+        try:
+            await page.evaluate(js, token)
+        except Exception as exc:  # noqa: BLE001 — any JS error is non-fatal
+            self._log.warning(
+                "Failed to inject Turnstile token into page",
+                error=str(exc),
+            )
+            return False
+
+        self._log.info(
+            "Submitted CAPSolver token to page, awaiting redirect",
+            token_prefix=token[:16] if len(token) >= 16 else token,
+        )
+        return True
 
     async def _wait_for_session(self, page: Any) -> str | None:
         """Wait for the Turnstile CAPTCHA to solve and extract the session ID.

--- a/packages/scraper-framework/src/framework/__init__.py
+++ b/packages/scraper-framework/src/framework/__init__.py
@@ -58,6 +58,7 @@ from .runner import get_scraper_ids, run_scrapers
 from .s3_cache import CachedS3Client, make_s3_client
 from .search import IndexingConsumer, create_index
 from .storage import S3Archiver, build_s3_key
+from .turnstile_solver import solve_turnstile
 
 __all__ = [
     "BaseScraper",
@@ -115,4 +116,5 @@ __all__ = [
     "retry_async",
     "retry_sync",
     "sha256_hex",
+    "solve_turnstile",
 ]

--- a/packages/scraper-framework/src/framework/turnstile_solver.py
+++ b/packages/scraper-framework/src/framework/turnstile_solver.py
@@ -1,0 +1,288 @@
+"""CAPSolver Turnstile API integration.
+
+Solves Cloudflare Turnstile challenges via the CAPSolver API
+(https://www.capsolver.com/). This is the deterministic fallback path for
+scrapers (e.g. SF civil tentative rulings on ``webapps.sftc.org``) that
+encounter interactive-mode Turnstile challenges that stealth-only browser
+automation cannot silently auto-solve.
+
+Cost (as of 2026-04): $0.80 / 1000 Turnstile solves. The SF civil scraper
+runs twice daily -> ~$0.58/year. Essentially free compared to the data loss
+caused by a broken session flow.
+
+API flow (two-step polling):
+
+1. ``POST /createTask`` with ``clientKey`` + ``task.websiteURL`` + ``task.websiteKey``.
+   -> returns ``taskId``.
+2. ``POST /getTaskResult`` repeatedly until ``status == "ready"``.
+   -> returns ``solution.token`` (the Turnstile response token).
+
+The returned token is a short-lived (2-5 min) response token that the caller
+injects into the site's form and submits via the site's own callback
+(``recaptchaCallBack(token)`` when Turnstile is in ``compat=recaptcha`` mode)
+or a plain ``form.submit()``.
+
+Reference: https://docs.capsolver.com/en/guide/captcha/turnstile/
+
+Issue: #2623 (SF civil Turnstile session acquisition).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import httpx
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+# CAPSolver API base URL.
+CAPSOLVER_API_BASE = "https://api.capsolver.com"
+
+# Default overall timeout in seconds for solve_turnstile (the issue notes
+# typical solve time is 10-30s; we keep 120s headroom for CAPSolver's
+# occasional slow responses).
+DEFAULT_TIMEOUT_SECONDS = 120.0
+
+# Seconds between ``getTaskResult`` polls. 3s matches CAPSolver's
+# recommended polling interval and keeps total request count < 50 per solve.
+POLL_INTERVAL_SECONDS = 3.0
+
+# CAPSolver task type for Turnstile solves without a proxy.
+TASK_TYPE_TURNSTILE_PROXYLESS = "AntiTurnstileTaskProxyLess"
+
+
+async def solve_turnstile(
+    sitekey: str,
+    page_url: str,
+    *,
+    api_key: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    poll_interval: float = POLL_INTERVAL_SECONDS,
+) -> str | None:
+    """Solve a Cloudflare Turnstile challenge via CAPSolver.
+
+    Sends the sitekey and page URL to CAPSolver's ``createTask`` endpoint,
+    then polls ``getTaskResult`` until the task is ready. Returns the
+    solved Turnstile token or ``None`` on any error or timeout.
+
+    Args:
+        sitekey: The Cloudflare Turnstile sitekey (``data-sitekey`` attribute
+            on the challenge widget). For ``webapps.sftc.org`` this is
+            ``0x4AAAAAAAhseTmUbrk0U5ab``.
+        page_url: The URL of the page hosting the challenge (e.g.
+            ``https://webapps.sftc.org/captcha/captcha.dll``). Does not need
+            to be reachable from CAPSolver; Turnstile's server-side validation
+            uses the URL's origin to pair with the sitekey.
+        api_key: The CAPSolver API key (``clientKey``). If omitted, falls
+            back to the ``CAPSOLVER_API_KEY`` environment variable. If
+            neither source yields a key, returns ``None`` immediately without
+            making any API calls.
+        timeout: Maximum total seconds to wait for a solve (across both
+            ``createTask`` and ``getTaskResult`` polls).
+        poll_interval: Seconds to wait between ``getTaskResult`` polls.
+
+    Returns:
+        The Turnstile response token (a JWT-like string) on success, or
+        ``None`` on any failure (missing key, API error, timeout,
+        unexpected response shape).
+    """
+    key = api_key or os.environ.get("CAPSOLVER_API_KEY", "")
+    if not key:
+        logger.debug(
+            "turnstile.solver_skipped",
+            reason="no_api_key",
+            page_url=page_url,
+        )
+        return None
+
+    logger.info(
+        "turnstile.solver_start",
+        page_url=page_url,
+        sitekey_prefix=sitekey[:10],
+        timeout=timeout,
+    )
+
+    async with httpx.AsyncClient(
+        base_url=CAPSOLVER_API_BASE,
+        timeout=30.0,
+        headers={"Content-Type": "application/json"},
+    ) as client:
+        task_id = await _create_task(client, key, sitekey, page_url)
+        if task_id is None:
+            return None
+
+        token = await _poll_task_result(
+            client,
+            key,
+            task_id,
+            timeout=timeout,
+            poll_interval=poll_interval,
+        )
+
+    if token is None:
+        logger.warning(
+            "turnstile.solver_failure",
+            page_url=page_url,
+            reason="poll_timeout_or_error",
+        )
+        return None
+
+    logger.info(
+        "turnstile.solver_success",
+        page_url=page_url,
+        token_prefix=token[:16] if len(token) >= 16 else token,
+    )
+    return token
+
+
+async def _create_task(
+    client: httpx.AsyncClient,
+    api_key: str,
+    sitekey: str,
+    page_url: str,
+) -> str | None:
+    """Create a CAPSolver task and return its task ID.
+
+    Args:
+        client: The configured async HTTP client.
+        api_key: CAPSolver ``clientKey``.
+        sitekey: Turnstile sitekey.
+        page_url: URL of the page hosting the challenge.
+
+    Returns:
+        The task ID string on success, or ``None`` if the request failed
+        or CAPSolver returned a non-zero ``errorId``.
+    """
+    payload = {
+        "clientKey": api_key,
+        "task": {
+            "type": TASK_TYPE_TURNSTILE_PROXYLESS,
+            "websiteURL": page_url,
+            "websiteKey": sitekey,
+        },
+    }
+
+    try:
+        response = await client.post("/createTask", json=payload)
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        logger.error(
+            "turnstile.create_task_http_error",
+            error=str(exc),
+            page_url=page_url,
+        )
+        return None
+
+    try:
+        data = response.json()
+    except ValueError as exc:
+        logger.error(
+            "turnstile.create_task_invalid_json",
+            error=str(exc),
+        )
+        return None
+
+    error_id = data.get("errorId", 0)
+    if error_id != 0:
+        logger.error(
+            "turnstile.create_task_api_error",
+            error_id=error_id,
+            error_code=data.get("errorCode"),
+            error_description=data.get("errorDescription"),
+        )
+        return None
+
+    task_id = data.get("taskId")
+    if not task_id or not isinstance(task_id, str):
+        logger.error(
+            "turnstile.create_task_missing_task_id",
+            response_keys=list(data.keys()),
+        )
+        return None
+
+    logger.debug("turnstile.task_created", task_id=task_id)
+    return task_id
+
+
+async def _poll_task_result(
+    client: httpx.AsyncClient,
+    api_key: str,
+    task_id: str,
+    *,
+    timeout: float,
+    poll_interval: float,
+) -> str | None:
+    """Poll CAPSolver ``getTaskResult`` until the task completes.
+
+    Args:
+        client: The configured async HTTP client.
+        api_key: CAPSolver ``clientKey``.
+        task_id: The task ID returned by ``_create_task``.
+        timeout: Maximum total seconds to poll.
+        poll_interval: Seconds between polls.
+
+    Returns:
+        The Turnstile token on success, or ``None`` on timeout, API error,
+        or unexpected response shape.
+    """
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    payload = {"clientKey": api_key, "taskId": task_id}
+
+    while loop.time() < deadline:
+        try:
+            response = await client.post("/getTaskResult", json=payload)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            logger.error(
+                "turnstile.get_task_result_http_error",
+                error=str(exc),
+                task_id=task_id,
+            )
+            return None
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            logger.error(
+                "turnstile.get_task_result_invalid_json",
+                error=str(exc),
+                task_id=task_id,
+            )
+            return None
+
+        error_id = data.get("errorId", 0)
+        if error_id != 0:
+            logger.error(
+                "turnstile.get_task_result_api_error",
+                error_id=error_id,
+                error_code=data.get("errorCode"),
+                error_description=data.get("errorDescription"),
+                task_id=task_id,
+            )
+            return None
+
+        status = data.get("status")
+        if status == "ready":
+            solution = data.get("solution") or {}
+            token = solution.get("token")
+            if isinstance(token, str) and token:
+                return token
+            logger.error(
+                "turnstile.get_task_result_missing_token",
+                task_id=task_id,
+                solution_keys=list(solution.keys()) if isinstance(solution, dict) else None,
+            )
+            return None
+
+        # status == "processing" or "idle" -> continue polling.
+        await asyncio.sleep(poll_interval)
+
+    logger.warning(
+        "turnstile.get_task_result_timeout",
+        task_id=task_id,
+        timeout=timeout,
+    )
+    return None

--- a/packages/scraper-framework/tests/courts/test_sf_civil_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_sf_civil_tentatives.py
@@ -21,9 +21,11 @@ import pytest
 import respx
 
 from courts.ca.sf_civil_tentatives import (
+    CAPSOLVER_API_KEY_ENV_VAR,
     CIVIL_REST_BASE,
     RULING_ID_MAP,
     RULING_IDS,
+    TURNSTILE_SITEKEY,
     SFCivilTentativeRulingsScraper,
     _clean_party_name,
     extract_outcome,
@@ -1002,6 +1004,242 @@ class TestApplyStealth:
         mock_page.evaluate = unittest.mock.AsyncMock()
         asyncio.run(_apply_stealth(mock_page))
         # Should complete without raising
+
+
+# ---------------------------------------------------------------------------
+# CAPSolver integration — _try_acquire_session branches on API key
+# ---------------------------------------------------------------------------
+
+
+class TestCAPSolverIntegration:
+    """Tests for the CAPSolver-assisted Turnstile session acquisition path.
+
+    ``_try_acquire_session`` branches based on the ``CAPSOLVER_API_KEY``
+    environment variable. When the key is present, the scraper invokes
+    ``framework.turnstile_solver.solve_turnstile`` to obtain a response
+    token and injects it into the gateway page. When the key is absent,
+    the scraper falls back to the legacy stealth-polling path.
+    """
+
+    def _build_mock_playwright(self) -> tuple[Any, Any, Any]:
+        """Build an async_playwright factory with mock page/context/browser.
+
+        Returns:
+            A tuple of (mock_pw_factory, mock_page, mock_browser). The
+            factory can be passed to ``_try_acquire_session`` and the
+            page/browser are exposed so tests can configure URL/content
+            and assert on calls.
+        """
+        import unittest.mock
+
+        mock_page = unittest.mock.AsyncMock()
+        mock_page.url = "https://webapps.sftc.org/tr/tr.dll/?RulingID=2"
+        mock_page.content.return_value = (
+            '<script>var rulingID=2;var seshID="CAFEBABE0123456789ABCDEFCAFEBABE01234567";</script>'
+        )
+
+        mock_context = unittest.mock.AsyncMock()
+        mock_context.new_page.return_value = mock_page
+
+        mock_browser = unittest.mock.AsyncMock()
+        mock_browser.new_context.return_value = mock_context
+
+        mock_pw = unittest.mock.AsyncMock()
+        mock_pw.chromium.launch.return_value = mock_browser
+
+        mock_pw_cm = unittest.mock.AsyncMock()
+        mock_pw_cm.__aenter__.return_value = mock_pw
+        mock_pw_factory = unittest.mock.MagicMock(return_value=mock_pw_cm)
+
+        return mock_pw_factory, mock_page, mock_browser
+
+    def test_solver_invoked_when_api_key_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When CAPSOLVER_API_KEY is set, solve_turnstile is called and token injected."""
+        import asyncio
+        import unittest.mock
+
+        monkeypatch.setenv(CAPSOLVER_API_KEY_ENV_VAR, "fake-key-xyz")
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        mock_pw_factory, mock_page, mock_browser = self._build_mock_playwright()
+
+        # Patch solve_turnstile in the scraper module's namespace.
+        async def _fake_solver(**kwargs: Any) -> str | None:
+            assert kwargs["sitekey"] == TURNSTILE_SITEKEY
+            assert kwargs["api_key"] == "fake-key-xyz"
+            assert "webapps.sftc.org" in kwargs["page_url"]
+            return "SOLVED_TOKEN_ABC123"
+
+        with unittest.mock.patch(
+            "courts.ca.sf_civil_tentatives.solve_turnstile",
+            side_effect=_fake_solver,
+        ) as mock_solver:
+            result = asyncio.run(scraper._try_acquire_session(mock_pw_factory))
+
+        assert result == "CAFEBABE0123456789ABCDEFCAFEBABE01234567"
+        mock_solver.assert_called_once()
+        # The token must have been evaluated into the page via evaluate()
+        mock_page.evaluate.assert_awaited()
+        # evaluate is called with (script, token) — verify token is passed
+        call_args = mock_page.evaluate.call_args
+        assert call_args.args[1] == "SOLVED_TOKEN_ABC123"
+        mock_browser.close.assert_awaited_once()
+
+    def test_solver_skipped_when_api_key_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When CAPSOLVER_API_KEY is unset, solve_turnstile is NOT called."""
+        import asyncio
+        import unittest.mock
+
+        monkeypatch.delenv(CAPSOLVER_API_KEY_ENV_VAR, raising=False)
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        mock_pw_factory, mock_page, mock_browser = self._build_mock_playwright()
+
+        with unittest.mock.patch("courts.ca.sf_civil_tentatives.solve_turnstile") as mock_solver:
+            result = asyncio.run(scraper._try_acquire_session(mock_pw_factory))
+
+        # Stealth fallback still extracts seshID from the mocked page
+        assert result == "CAFEBABE0123456789ABCDEFCAFEBABE01234567"
+        mock_solver.assert_not_called()
+        # evaluate is called by _apply_stealth, but not with our injection
+        # script — assert the token injection path was not triggered.
+        # We check that no call was made with the token string as 2nd arg.
+        for call in mock_page.evaluate.await_args_list:
+            if len(call.args) >= 2:
+                assert call.args[1] != "SOLVED_TOKEN_ABC123"
+        mock_browser.close.assert_awaited_once()
+
+    def test_solver_failure_falls_back_to_stealth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When solve_turnstile returns None, continue to stealth polling."""
+        import asyncio
+        import unittest.mock
+
+        monkeypatch.setenv(CAPSOLVER_API_KEY_ENV_VAR, "fake-key")
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        mock_pw_factory, _mock_page, mock_browser = self._build_mock_playwright()
+
+        async def _failing_solver(**_kwargs: Any) -> str | None:
+            return None
+
+        with unittest.mock.patch(
+            "courts.ca.sf_civil_tentatives.solve_turnstile",
+            side_effect=_failing_solver,
+        ) as mock_solver:
+            result = asyncio.run(scraper._try_acquire_session(mock_pw_factory))
+
+        # Solver was called, returned None, but the mocked page still has
+        # a seshID so _wait_for_session still succeeds.
+        mock_solver.assert_called_once()
+        assert result == "CAFEBABE0123456789ABCDEFCAFEBABE01234567"
+        mock_browser.close.assert_awaited_once()
+
+    def test_submit_captcha_with_solver_injects_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_submit_captcha_with_solver injects token and invokes callback."""
+        import asyncio
+        import unittest.mock
+
+        monkeypatch.setenv(CAPSOLVER_API_KEY_ENV_VAR, "fake-key")
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        mock_page = unittest.mock.AsyncMock()
+
+        async def _fake_solver(**_kwargs: Any) -> str | None:
+            return "TOKEN_XYZ"
+
+        with unittest.mock.patch(
+            "courts.ca.sf_civil_tentatives.solve_turnstile",
+            side_effect=_fake_solver,
+        ):
+            ok = asyncio.run(
+                scraper._submit_captcha_with_solver(
+                    page=mock_page,
+                    captcha_url="https://webapps.sftc.org/captcha/captcha.dll?foo=bar",
+                    api_key="fake-key",
+                )
+            )
+
+        assert ok is True
+        mock_page.evaluate.assert_awaited_once()
+        # Inspect the call — 1st arg should be the JS snippet, 2nd is the token.
+        call_args = mock_page.evaluate.call_args
+        assert "recaptchaCallBack" in call_args.args[0]
+        assert "g-recaptcha-response" in call_args.args[0]
+        assert call_args.args[1] == "TOKEN_XYZ"
+
+    def test_submit_captcha_with_solver_returns_false_on_no_token(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Returns False when CAPSolver returns no token; skips injection."""
+        import asyncio
+        import unittest.mock
+
+        monkeypatch.setenv(CAPSOLVER_API_KEY_ENV_VAR, "fake-key")
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        mock_page = unittest.mock.AsyncMock()
+
+        async def _no_token(**_kwargs: Any) -> str | None:
+            return None
+
+        with unittest.mock.patch(
+            "courts.ca.sf_civil_tentatives.solve_turnstile",
+            side_effect=_no_token,
+        ):
+            ok = asyncio.run(
+                scraper._submit_captcha_with_solver(
+                    page=mock_page,
+                    captcha_url="https://webapps.sftc.org/captcha/captcha.dll",
+                    api_key="fake-key",
+                )
+            )
+
+        assert ok is False
+        mock_page.evaluate.assert_not_awaited()
+
+    def test_submit_captcha_with_solver_returns_false_on_evaluate_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Returns False when page.evaluate raises (e.g., page navigated)."""
+        import asyncio
+        import unittest.mock
+
+        monkeypatch.setenv(CAPSOLVER_API_KEY_ENV_VAR, "fake-key")
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        mock_page = unittest.mock.AsyncMock()
+        mock_page.evaluate.side_effect = RuntimeError("page closed")
+
+        async def _fake_solver(**_kwargs: Any) -> str | None:
+            return "TOKEN_ABC"
+
+        with unittest.mock.patch(
+            "courts.ca.sf_civil_tentatives.solve_turnstile",
+            side_effect=_fake_solver,
+        ):
+            ok = asyncio.run(
+                scraper._submit_captcha_with_solver(
+                    page=mock_page,
+                    captcha_url="https://webapps.sftc.org/captcha/captcha.dll",
+                    api_key="fake-key",
+                )
+            )
+
+        assert ok is False
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_turnstile_solver.py
+++ b/packages/scraper-framework/tests/test_turnstile_solver.py
@@ -1,0 +1,387 @@
+"""Tests for the CAPSolver Turnstile solver integration (#2623)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from framework.turnstile_solver import (
+    CAPSOLVER_API_BASE,
+    solve_turnstile,
+)
+
+SITEKEY = "0x4AAAAAAAhseTmUbrk0U5ab"
+PAGE_URL = "https://webapps.sftc.org/captcha/captcha.dll"
+API_KEY = "test-api-key-1234"
+
+
+class TestSolveTurnstileMissingKey:
+    """solve_turnstile short-circuits when no API key is available."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_api_key_is_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty api_key AND empty env var -> returns None immediately."""
+        monkeypatch.delenv("CAPSOLVER_API_KEY", raising=False)
+        token = await solve_turnstile(sitekey=SITEKEY, page_url=PAGE_URL)
+        assert token is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_api_key_is_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """api_key=None + missing env var -> returns None immediately."""
+        monkeypatch.delenv("CAPSOLVER_API_KEY", raising=False)
+        token = await solve_turnstile(sitekey=SITEKEY, page_url=PAGE_URL, api_key=None)
+        assert token is None
+
+    @pytest.mark.asyncio
+    async def test_does_not_call_api_without_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No API call should be made when no key is present."""
+        monkeypatch.delenv("CAPSOLVER_API_KEY", raising=False)
+        with respx.mock(base_url=CAPSOLVER_API_BASE, assert_all_called=False) as router:
+            create_route = router.post("/createTask").mock(
+                return_value=httpx.Response(200, json={"taskId": "x"})
+            )
+            token = await solve_turnstile(sitekey=SITEKEY, page_url=PAGE_URL)
+            assert token is None
+            assert not create_route.called
+
+
+class TestSolveTurnstileEnvFallback:
+    """solve_turnstile picks up the API key from CAPSOLVER_API_KEY env var."""
+
+    @pytest.mark.asyncio
+    async def test_uses_env_var_when_no_explicit_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Setting CAPSOLVER_API_KEY env var enables the solver."""
+        monkeypatch.setenv("CAPSOLVER_API_KEY", API_KEY)
+
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/createTask").mock(
+                return_value=httpx.Response(
+                    200, json={"errorId": 0, "taskId": "task-123", "status": "idle"}
+                )
+            )
+            router.post("/getTaskResult").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "errorId": 0,
+                        "status": "ready",
+                        "solution": {"token": "TOKEN_FROM_ENV"},
+                    },
+                )
+            )
+            token = await solve_turnstile(sitekey=SITEKEY, page_url=PAGE_URL)
+
+        assert token == "TOKEN_FROM_ENV"
+
+
+class TestSolveTurnstileHappyPath:
+    """solve_turnstile returns the token when CAPSolver succeeds."""
+
+    @pytest.mark.asyncio
+    async def test_returns_token_on_immediate_ready(self) -> None:
+        """getTaskResult returns ready on first poll -> token is returned."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            create = router.post("/createTask").mock(
+                return_value=httpx.Response(
+                    200, json={"errorId": 0, "taskId": "abc", "status": "idle"}
+                )
+            )
+            poll = router.post("/getTaskResult").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "errorId": 0,
+                        "status": "ready",
+                        "solution": {"token": "cf.turnstile.token.value"},
+                    },
+                )
+            )
+            token = await solve_turnstile(sitekey=SITEKEY, page_url=PAGE_URL, api_key=API_KEY)
+
+        assert token == "cf.turnstile.token.value"
+        assert create.called
+        assert poll.called
+
+    @pytest.mark.asyncio
+    async def test_create_task_payload_shape(self) -> None:
+        """createTask request must carry clientKey and the Turnstile task type."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            create = router.post("/createTask").mock(
+                return_value=httpx.Response(
+                    200, json={"errorId": 0, "taskId": "abc", "status": "idle"}
+                )
+            )
+            router.post("/getTaskResult").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "errorId": 0,
+                        "status": "ready",
+                        "solution": {"token": "T"},
+                    },
+                )
+            )
+            await solve_turnstile(sitekey=SITEKEY, page_url=PAGE_URL, api_key=API_KEY)
+
+        assert create.called
+        request = create.calls[0].request
+        import json as _json
+
+        body = _json.loads(request.content)
+        assert body["clientKey"] == API_KEY
+        assert body["task"]["type"] == "AntiTurnstileTaskProxyLess"
+        assert body["task"]["websiteURL"] == PAGE_URL
+        assert body["task"]["websiteKey"] == SITEKEY
+
+    @pytest.mark.asyncio
+    async def test_polls_until_ready(self) -> None:
+        """Solver waits for 'processing' responses then returns the token."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/createTask").mock(
+                return_value=httpx.Response(
+                    200, json={"errorId": 0, "taskId": "abc", "status": "idle"}
+                )
+            )
+            poll_route = router.post("/getTaskResult").mock(
+                side_effect=[
+                    httpx.Response(200, json={"errorId": 0, "status": "processing"}),
+                    httpx.Response(200, json={"errorId": 0, "status": "processing"}),
+                    httpx.Response(
+                        200,
+                        json={
+                            "errorId": 0,
+                            "status": "ready",
+                            "solution": {"token": "FINAL_TOKEN"},
+                        },
+                    ),
+                ]
+            )
+            token = await solve_turnstile(
+                sitekey=SITEKEY,
+                page_url=PAGE_URL,
+                api_key=API_KEY,
+                poll_interval=0.0,
+            )
+
+        assert token == "FINAL_TOKEN"
+        assert poll_route.call_count == 3
+
+
+class TestSolveTurnstileErrors:
+    """solve_turnstile returns None on various error conditions."""
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_create_task_http_error(self) -> None:
+        """HTTP 500 on createTask -> None."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/createTask").mock(return_value=httpx.Response(500, text="boom"))
+            token = await solve_turnstile(sitekey=SITEKEY, page_url=PAGE_URL, api_key=API_KEY)
+        assert token is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_create_task_api_error(self) -> None:
+        """errorId != 0 on createTask -> None."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/createTask").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "errorId": 1,
+                        "errorCode": "ERROR_KEY_DOES_NOT_EXIST",
+                        "errorDescription": "Invalid key",
+                    },
+                )
+            )
+            token = await solve_turnstile(sitekey=SITEKEY, page_url=PAGE_URL, api_key=API_KEY)
+        assert token is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_create_task_invalid_json(self) -> None:
+        """Non-JSON response on createTask -> None."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/createTask").mock(
+                return_value=httpx.Response(200, text="not json at all")
+            )
+            token = await solve_turnstile(sitekey=SITEKEY, page_url=PAGE_URL, api_key=API_KEY)
+        assert token is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_missing_task_id(self) -> None:
+        """createTask response missing taskId -> None."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/createTask").mock(
+                return_value=httpx.Response(200, json={"errorId": 0, "status": "idle"})
+            )
+            token = await solve_turnstile(sitekey=SITEKEY, page_url=PAGE_URL, api_key=API_KEY)
+        assert token is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_poll_http_error(self) -> None:
+        """HTTP 500 on getTaskResult -> None."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/createTask").mock(
+                return_value=httpx.Response(
+                    200, json={"errorId": 0, "taskId": "abc", "status": "idle"}
+                )
+            )
+            router.post("/getTaskResult").mock(return_value=httpx.Response(500, text="boom"))
+            token = await solve_turnstile(
+                sitekey=SITEKEY,
+                page_url=PAGE_URL,
+                api_key=API_KEY,
+                poll_interval=0.0,
+            )
+        assert token is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_poll_api_error(self) -> None:
+        """errorId != 0 on getTaskResult -> None."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/createTask").mock(
+                return_value=httpx.Response(
+                    200, json={"errorId": 0, "taskId": "abc", "status": "idle"}
+                )
+            )
+            router.post("/getTaskResult").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "errorId": 22,
+                        "errorCode": "ERROR_CAPTCHA_UNSOLVABLE",
+                        "errorDescription": "Solver could not solve it.",
+                    },
+                )
+            )
+            token = await solve_turnstile(
+                sitekey=SITEKEY,
+                page_url=PAGE_URL,
+                api_key=API_KEY,
+                poll_interval=0.0,
+            )
+        assert token is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_poll_invalid_json(self) -> None:
+        """Non-JSON response on getTaskResult -> None."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/createTask").mock(
+                return_value=httpx.Response(
+                    200, json={"errorId": 0, "taskId": "abc", "status": "idle"}
+                )
+            )
+            router.post("/getTaskResult").mock(return_value=httpx.Response(200, text="not json"))
+            token = await solve_turnstile(
+                sitekey=SITEKEY,
+                page_url=PAGE_URL,
+                api_key=API_KEY,
+                poll_interval=0.0,
+            )
+        assert token is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_ready_with_empty_token(self) -> None:
+        """status=ready but solution.token is missing/empty -> None."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/createTask").mock(
+                return_value=httpx.Response(
+                    200, json={"errorId": 0, "taskId": "abc", "status": "idle"}
+                )
+            )
+            router.post("/getTaskResult").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "errorId": 0,
+                        "status": "ready",
+                        "solution": {"token": ""},
+                    },
+                )
+            )
+            token = await solve_turnstile(
+                sitekey=SITEKEY,
+                page_url=PAGE_URL,
+                api_key=API_KEY,
+                poll_interval=0.0,
+            )
+        assert token is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_ready_without_solution(self) -> None:
+        """status=ready but no solution key at all -> None."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/createTask").mock(
+                return_value=httpx.Response(
+                    200, json={"errorId": 0, "taskId": "abc", "status": "idle"}
+                )
+            )
+            router.post("/getTaskResult").mock(
+                return_value=httpx.Response(200, json={"errorId": 0, "status": "ready"})
+            )
+            token = await solve_turnstile(
+                sitekey=SITEKEY,
+                page_url=PAGE_URL,
+                api_key=API_KEY,
+                poll_interval=0.0,
+            )
+        assert token is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_poll_timeout(self) -> None:
+        """Solver gives up when total elapsed exceeds timeout."""
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            router.post("/createTask").mock(
+                return_value=httpx.Response(
+                    200, json={"errorId": 0, "taskId": "abc", "status": "idle"}
+                )
+            )
+            router.post("/getTaskResult").mock(
+                return_value=httpx.Response(200, json={"errorId": 0, "status": "processing"})
+            )
+            token = await solve_turnstile(
+                sitekey=SITEKEY,
+                page_url=PAGE_URL,
+                api_key=API_KEY,
+                timeout=0.001,
+                poll_interval=0.0,
+            )
+        assert token is None
+
+
+class TestSolveTurnstileExplicitKeyBeatsEnv:
+    """Explicit api_key argument takes precedence over env var."""
+
+    @pytest.mark.asyncio
+    async def test_explicit_key_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """api_key argument is sent to CAPSolver instead of the env var."""
+        monkeypatch.setenv("CAPSOLVER_API_KEY", "env-key-should-not-be-used")
+
+        import json as _json
+
+        with respx.mock(base_url=CAPSOLVER_API_BASE) as router:
+            create = router.post("/createTask").mock(
+                return_value=httpx.Response(
+                    200, json={"errorId": 0, "taskId": "t", "status": "idle"}
+                )
+            )
+            router.post("/getTaskResult").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "errorId": 0,
+                        "status": "ready",
+                        "solution": {"token": "TOK"},
+                    },
+                )
+            )
+            token = await solve_turnstile(
+                sitekey=SITEKEY,
+                page_url=PAGE_URL,
+                api_key="explicit-key",
+            )
+
+        assert token == "TOK"
+        body = _json.loads(create.calls[0].request.content)
+        assert body["clientKey"] == "explicit-key"


### PR DESCRIPTION
Closes #2623.

## Summary

- Adds `framework/turnstile_solver.py` — a CAPSolver two-step polling API client (`async def solve_turnstile(sitekey, page_url, ...) -> str | None`).
- Plumbs `CAPSOLVER_API_KEY` from Secrets Manager (`judgemind/capsolver/api-key`) through Terraform into the scraper container, mirroring the existing `COURTLISTENER_API_TOKEN` pattern.
- Rewrites `_try_acquire_session` in SF civil tentatives to invoke the solver when the key is present and inject the returned token via `page.evaluate` + `recaptchaCallBack`, with a graceful fallback to the legacy stealth-polling path when the key is absent.

## Why

Cloudflare Turnstile moved to interactive mode on `webapps.sftc.org/captcha/captcha.dll` (sitekey `0x4AAAAAAAhseTmUbrk0U5ab`, compat=recaptcha), and prior investigation (#2619) confirmed that client-side stealth approaches (playwright-stealth, Patchright, coordinate clicks) all fail to silently auto-solve. CAPSolver resolves the challenge deterministically for ~$0.0008/solve. At two solves/day this is ~$0.58/year — negligible compared to ~20-40 tentative rulings lost per day the scraper is broken.

## Operational note

The `judgemind/capsolver/api-key` Secrets Manager secret must be populated (human-only) before the automated dev `terraform apply` runs. If the secret doesn't exist at apply time, `terraform plan` will fail with a clear `NotFoundException`.

## Cost monitoring

Spend can be tracked via structured logs: count of `turnstile.solver_success` events in CloudWatch Logs Insights × $0.0008.

## Test plan

### Automated checks
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `pytest packages/scraper-framework/tests/` all pass (6240 tests)
- [x] Diff coverage ≥ 90% on changed lines (actual: 100% on 105 lines)
- [x] `terraform fmt -check -recursive` clean
- [x] `terraform validate` passes in dev and production
- [x] CI workflow green

### Post-deploy verification
- [ ] `judgemind/capsolver/api-key` secret populated in AWS Secrets Manager (dev)
- [ ] Dev `terraform apply` succeeds and injects `CAPSOLVER_API_KEY` into the scraper container
- [ ] SF civil session acquisition succeeds on ≥95% of scheduled runs in dev over 5 consecutive daily runs
- [ ] `scripts/dev-db-query.sh "SELECT COUNT(*) FROM derived.documents d JOIN derived.courts ct ON d.court_id = ct.id WHERE ct.county = 'San Francisco' AND d.source_url LIKE '%tr.dll%' AND d.status = 'active'"` returns > 0
- [ ] #2600 Dept 204 verification closed out
