### PR TITLE
fix(ingestion): handle S3 content-hash mismatch in reingest_from_s3 (#2628)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -7,6 +7,7 @@ error handling, and CLI flag behavior. All database and S3 access is mocked.
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
 import os
@@ -9609,6 +9610,170 @@ class TestRunReingestFromPrefix:
         # Limit should have capped to 2 keys
         assert stats["total_keys"] == 2
 
+    @patch.dict(
+        os.environ,
+        {
+            "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+            "REDIS_URL": "redis://localhost:6379",
+            "OPENSEARCH_URL": "",
+        },
+    )
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3._list_s3_keys")
+    @patch("reingest_from_s3._seed_courts")
+    @patch("reingest_from_s3._discover_courts")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.ProcessPoolExecutor")
+    def test_summary_reports_hash_mismatch_warnings(
+        self,
+        mock_pool_cls: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_discover: MagicMock,
+        mock_seed: MagicMock,
+        mock_list: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """The prefix-reingest summary must aggregate ``hash_mismatch`` flags
+        from ``_process_prefix_document`` dict results and surface the count
+        as ``hash_mismatch_warnings`` in the stats.  See #2628."""
+        keys = [
+            "federal/federal/courtlistener/raw/aaa111.html",
+            "federal/federal/courtlistener/raw/bbb222.html",
+            "federal/federal/courtlistener/raw/ccc333.html",
+        ]
+        mock_list.return_value = keys
+        mock_discover.return_value = [
+            {
+                "state": "Federal",
+                "county": "Federal",
+                "court_name": "Courtlistener, County of Federal",
+                "court_code": "federal-federal",
+                "timezone": "America/Los_Angeles",
+            }
+        ]
+        conn_mock = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_seed.return_value = {"federal-federal": "court-id-1"}
+
+        pool = MagicMock()
+        mock_pool_cls.return_value.__enter__ = MagicMock(return_value=pool)
+        mock_pool_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Two successful docs flag hash_mismatch, one is clean.
+        future1 = MagicMock()
+        future1.result.return_value = {"status": "ok", "hash_mismatch": True}
+        future2 = MagicMock()
+        future2.result.return_value = {"status": "ok", "hash_mismatch": True}
+        future3 = MagicMock()
+        future3.result.return_value = {"status": "ok", "hash_mismatch": False}
+        pool.submit.side_effect = [future1, future2, future3]
+
+        mock_logger = MagicMock()
+        with (
+            patch(
+                "reingest_from_s3.as_completed",
+                return_value=[future1, future2, future3],
+            ),
+            patch.object(reingest, "logger", mock_logger),
+        ):
+            stats = reingest.run_reingest_from_prefix(
+                "postgresql://test",
+                prefix="federal/",
+                concurrency=4,
+            )
+
+        assert stats["total_keys"] == 3
+        assert stats["processed"] == 3
+        assert stats["errors"] == 0
+        assert stats["hash_mismatch_warnings"] == 2
+
+        # Aggregate summary warning is emitted at the end of the run.
+        warn_calls = mock_logger.warning.call_args_list
+        aggregate_warnings = [
+            call for call in warn_calls if call.kwargs.get("hash_mismatch_warnings") is not None
+        ]
+        assert aggregate_warnings, (
+            f"Expected aggregate hash_mismatch_warnings warning. Got warning calls: {warn_calls!r}"
+        )
+        assert aggregate_warnings[0].kwargs["hash_mismatch_warnings"] == 2
+
+    @patch.dict(
+        os.environ,
+        {
+            "JUDGEMIND_ARCHIVE_BUCKET": "test-bucket",
+            "REDIS_URL": "redis://localhost:6379",
+            "OPENSEARCH_URL": "",
+        },
+    )
+    @patch("reingest_from_s3.boto3")
+    @patch("reingest_from_s3._list_s3_keys")
+    @patch("reingest_from_s3._seed_courts")
+    @patch("reingest_from_s3._discover_courts")
+    @patch("reingest_from_s3.psycopg")
+    @patch("reingest_from_s3.ProcessPoolExecutor")
+    def test_summary_no_warning_when_all_hashes_match(
+        self,
+        mock_pool_cls: MagicMock,
+        mock_psycopg: MagicMock,
+        mock_discover: MagicMock,
+        mock_seed: MagicMock,
+        mock_list: MagicMock,
+        mock_boto3: MagicMock,
+    ) -> None:
+        """When no documents have hash mismatches, ``hash_mismatch_warnings``
+        is zero and no aggregate warning is emitted.  See #2628."""
+        keys = [
+            "federal/federal/courtlistener/raw/aaa111.html",
+            "federal/federal/courtlistener/raw/bbb222.html",
+        ]
+        mock_list.return_value = keys
+        mock_discover.return_value = [
+            {
+                "state": "Federal",
+                "county": "Federal",
+                "court_name": "Courtlistener, County of Federal",
+                "court_code": "federal-federal",
+                "timezone": "America/Los_Angeles",
+            }
+        ]
+        conn_mock = MagicMock()
+        mock_psycopg.connect.return_value.__enter__ = MagicMock(return_value=conn_mock)
+        mock_psycopg.connect.return_value.__exit__ = MagicMock(return_value=False)
+        mock_seed.return_value = {"federal-federal": "court-id-1"}
+
+        pool = MagicMock()
+        mock_pool_cls.return_value.__enter__ = MagicMock(return_value=pool)
+        mock_pool_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        future1 = MagicMock()
+        future1.result.return_value = {"status": "ok", "hash_mismatch": False}
+        future2 = MagicMock()
+        future2.result.return_value = {"status": "ok", "hash_mismatch": False}
+        pool.submit.side_effect = [future1, future2]
+
+        mock_logger = MagicMock()
+        with (
+            patch(
+                "reingest_from_s3.as_completed",
+                return_value=[future1, future2],
+            ),
+            patch.object(reingest, "logger", mock_logger),
+        ):
+            stats = reingest.run_reingest_from_prefix(
+                "postgresql://test",
+                prefix="federal/",
+                concurrency=4,
+            )
+
+        assert stats["hash_mismatch_warnings"] == 0
+        # No aggregate warning emitted when count is zero.
+        warn_calls = mock_logger.warning.call_args_list
+        for call in warn_calls:
+            assert call.kwargs.get("hash_mismatch_warnings") is None, (
+                f"unexpected hash_mismatch_warnings warning: {call!r}"
+            )
+
 
 class TestProcessPrefixDocument:
     """Tests for _process_prefix_document."""
@@ -9622,25 +9787,117 @@ class TestProcessPrefixDocument:
             "redis://localhost:6379",
             "",
         )
-        assert result == "skip"
+        assert isinstance(result, dict)
+        assert result["status"] == "skip"
+        assert result["hash_mismatch"] is False
 
-    def test_hash_mismatch_returns_error(self) -> None:
-        """When the S3 content hash doesn't match the key hash, return error."""
+    def test_hash_mismatch_logs_warning_and_continues(self) -> None:
+        """Hash mismatch must be non-fatal — reingest proceeds and the
+        result flags ``hash_mismatch=True`` (see #2494, #2628).
+
+        Previously a mismatch short-circuited with ``status="error"``, which
+        is the mechanism producing the ~4% flat-hash orphan rate on Santa
+        Clara: raws captured under a wrong content-hash filename were
+        permanently unreingestable.  Now we log a warning, let the worker
+        process the raw, and the LLM split path re-derives split-children
+        from the raw content.  Mirrors the behavior already in
+        ``rebuild_db._process_one_document`` (see #2494).
+        """
+        # The key claims hash "abc123" but the actual content hashes
+        # elsewhere — _build_prefix_event will still use "abc123" as the
+        # canonical content_hash.
+        key = "federal/federal/courtlistener/raw/abc123.html"
+
         mock_s3 = MagicMock()
         body = MagicMock()
-        body.read.return_value = b"<html>content</html>"
+        body.read.return_value = b"<html>content with wrong hash</html>"
         mock_s3.get_object.return_value = {"Body": body}
 
-        with patch("framework.s3_cache.make_s3_client", return_value=mock_s3):
+        mock_worker = MagicMock()
+        mock_worker.process_event = MagicMock()
+
+        # Clear cached worker to force re-creation.
+        if hasattr(reingest._process_prefix_document, "_worker"):
+            delattr(reingest._process_prefix_document, "_worker")
+
+        mock_logger = MagicMock()
+        with (
+            patch("framework.s3_cache.make_s3_client", return_value=mock_s3),
+            patch("ingestion.worker.IngestionWorker", return_value=mock_worker),
+            patch("redis.Redis.from_url", return_value=MagicMock()),
+            patch.object(reingest, "logger", mock_logger),
+        ):
             result = reingest._process_prefix_document(
-                "federal/federal/courtlistener/raw/abc123.html",
+                key,
                 "test-bucket",
                 "postgresql://test",
                 "redis://localhost:6379",
                 "",
             )
-        # abc123 doesn't match the SHA256 of b"<html>content</html>"
-        assert result == "error"
+
+        # Proceeds to the worker — does NOT return early with status="error".
+        assert isinstance(result, dict)
+        assert result["status"] == "ok"
+        assert result["hash_mismatch"] is True
+        mock_worker.process_event.assert_called_once()
+        # Event passed to the worker must carry the key-hash as canonical
+        # content_hash — the worker's LLM split path derives split-child
+        # hashes from that value.
+        event = mock_worker.process_event.call_args[0][0]
+        assert event["content_hash"] == "abc123"
+        # Warning logged (not error) so ops see the integrity signal but the
+        # reingest proceeds.
+        warn_calls = mock_logger.warning.call_args_list
+        assert any("S3 content hash mismatch" in str(call) for call in warn_calls), (
+            f"expected hash mismatch warning in {warn_calls!r}"
+        )
+        # No logger.error call for the mismatch itself.
+        for call in mock_logger.error.call_args_list:
+            assert "hash mismatch" not in str(call).lower(), (
+                f"hash mismatch must not produce logger.error: {call!r}"
+            )
+
+    def test_matching_hash_returns_ok_without_mismatch_flag(self) -> None:
+        """When the S3 content hash matches the key hash, the result flags
+        ``hash_mismatch=False`` and no mismatch warning is emitted."""
+        content = b"<html>ok</html>"
+        key_hash = hashlib.sha256(content).hexdigest()
+        key = f"federal/federal/courtlistener/raw/{key_hash}.html"
+
+        mock_s3 = MagicMock()
+        body = MagicMock()
+        body.read.return_value = content
+        mock_s3.get_object.return_value = {"Body": body}
+
+        mock_worker = MagicMock()
+        mock_worker.process_event = MagicMock()
+
+        if hasattr(reingest._process_prefix_document, "_worker"):
+            delattr(reingest._process_prefix_document, "_worker")
+
+        mock_logger = MagicMock()
+        with (
+            patch("framework.s3_cache.make_s3_client", return_value=mock_s3),
+            patch("ingestion.worker.IngestionWorker", return_value=mock_worker),
+            patch("redis.Redis.from_url", return_value=MagicMock()),
+            patch.object(reingest, "logger", mock_logger),
+        ):
+            result = reingest._process_prefix_document(
+                key,
+                "test-bucket",
+                "postgresql://test",
+                "redis://localhost:6379",
+                "",
+            )
+
+        assert isinstance(result, dict)
+        assert result["status"] == "ok"
+        assert result["hash_mismatch"] is False
+        # No mismatch warning on a matching hash.
+        for call in mock_logger.warning.call_args_list:
+            assert "S3 content hash mismatch" not in str(call), (
+                f"unexpected hash mismatch warning on matching hash: {call!r}"
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -2884,15 +2884,24 @@ def _process_prefix_document(
     database_url: str,
     redis_url: str,
     os_url: str,
-) -> str:
+) -> dict[str, Any]:
     """Process a single S3 object through the ingestion pipeline.
 
     Creates its own DB connection, Redis client, and IngestionWorker.
     Designed for ProcessPoolExecutor — each call is fully independent.
+
+    Returns a dict with:
+      - ``status``: ``"ok"``, ``"skip"``, or ``"error"``
+      - ``hash_mismatch``: whether the S3 key hash did not match the object
+        bytes' SHA-256.  Non-fatal — reingest proceeds using the key hash as
+        the canonical ``content_hash`` so the worker's LLM split path can
+        re-derive any split-children from the raw content.  Mirrors the
+        behavior already in ``rebuild_db._process_one_document`` (see #2494,
+        #2628).
     """
     parsed = _parse_s3_key(key)
     if not parsed:
-        return "skip"
+        return {"status": "skip", "hash_mismatch": False}
 
     from framework.s3_cache import make_s3_client as _make_s3
 
@@ -2902,20 +2911,28 @@ def _process_prefix_document(
         content = response["Body"].read()
     except Exception:
         logger.warning("Failed to fetch S3 object, skipping", s3_key=key, exc_info=True)
-        return "error"
+        return {"status": "error", "hash_mismatch": False}
 
     if not content:
-        return "skip"
+        return {"status": "skip", "hash_mismatch": False}
 
+    # Byte-integrity check.  A mismatch used to short-circuit with
+    # ``status="error"``, but that caused the ~4% flat-hash orphan rate on
+    # Santa Clara (#2628): raws captured under a wrong content-hash filename
+    # were permanently unreingestable.  Now we log a warning and let the
+    # worker process the raw; the LLM split path derives split-children from
+    # the content and stores them with hashes derived from the canonical key
+    # hash.  Matches ``rebuild_db._process_one_document`` (#2494).
     actual_hash = hashlib.sha256(content).hexdigest()
-    if actual_hash != parsed["content_hash"]:
-        logger.error(
-            "S3 content hash mismatch, skipping document",
+    hash_mismatch = actual_hash != parsed["content_hash"]
+    if hash_mismatch:
+        logger.warning(
+            "S3 content hash mismatch — proceeding with reingest using key "
+            "hash as canonical content_hash (see #2494, #2628)",
             s3_key=key,
             key_hash=parsed["content_hash"],
-            content_hash=actual_hash,
+            actual_content_hash=actual_hash,
         )
-        return "error"
 
     event = _build_prefix_event(key, content, parsed, bucket)
 
@@ -2961,10 +2978,10 @@ def _process_prefix_document(
 
     try:
         worker.process_event(event)
-        return "ok"
+        return {"status": "ok", "hash_mismatch": hash_mismatch}
     except Exception:
         logger.warning("Failed to process document", s3_key=key, exc_info=True)
-        return "error"
+        return {"status": "error", "hash_mismatch": hash_mismatch}
 
 
 def run_reingest_from_prefix(
@@ -3065,6 +3082,7 @@ def run_reingest_from_prefix(
     processed = 0
     errors = 0
     skipped = 0
+    hash_mismatch_warnings = 0
 
     logger.info(
         "Processing documents from S3",
@@ -3088,9 +3106,19 @@ def run_reingest_from_prefix(
             key = futures[future]
             try:
                 result = future.result()
-                if result == "ok":
+                # ``_process_prefix_document`` returns a dict with ``status``
+                # and ``hash_mismatch`` keys.  Older versions returned a bare
+                # string — tolerate that shape for one release to avoid
+                # breaking any callers that pickled intermediate results.
+                if isinstance(result, dict):
+                    status = result.get("status", "error")
+                    if result.get("hash_mismatch"):
+                        hash_mismatch_warnings += 1
+                else:
+                    status = result
+                if status == "ok":
                     processed += 1
-                elif result == "skip":
+                elif status == "skip":
                     skipped += 1
                 else:
                     errors += 1
@@ -3125,6 +3153,7 @@ def run_reingest_from_prefix(
         "processed": processed,
         "errors": errors,
         "skipped": skipped,
+        "hash_mismatch_warnings": hash_mismatch_warnings,
         "wall_time_seconds": wall_time,
     }
 
@@ -3132,6 +3161,17 @@ def run_reingest_from_prefix(
         "Prefix reingest complete",
         **stats,
     )
+
+    if hash_mismatch_warnings > 0:
+        logger.warning(
+            "%d raw S3 objects had content-hash mismatches — reingest "
+            "proceeded using the S3 key hash as canonical content_hash "
+            "(see #2494, #2628).  Investigate the scraper S3 upload path "
+            "if this count is non-trivial.",
+            hash_mismatch_warnings,
+            hash_mismatch_warnings=hash_mismatch_warnings,
+            processed=processed,
+        )
 
     return stats
 


### PR DESCRIPTION
## Summary

Apply the #2494 workaround to `scripts/reingest_from_s3.py` so reingest handles S3 content-hash mismatches the same way `rebuild_db.py` does: log a warning and proceed with the key hash as canonical `content_hash`, letting the worker's LLM split path re-derive split-children from the raw bytes.

**Root cause (from forensic investigation on #2628):** All 11 Santa Clara flat-hash S3 orphans (~4.23% of SC raws) have a key-vs-bytes SHA-256 mismatch. The scraper archived duplicate raws under wrong content-hash filenames at some point (scraper-side mislabel bug — separate issue, filed as #2638). Reingest previously treated these as fatal errors (`logger.error` + `return "error"`), making the orphans permanent. This PR turns those fatal skips into warn-and-continue, matching the pattern `rebuild_db.py` already uses for the same failure mode.

- `_process_prefix_document` now returns `dict[str, Any]` with `status` and `hash_mismatch` keys (was bare string), mirroring `rebuild_db._process_one_document`.
- `run_reingest_from_prefix` counts `hash_mismatch_warnings` across the run, surfaces the count in `stats`, and logs an aggregate warning at end-of-run referencing `#2494` and `#2628`.
- Caller tolerates both dict and bare-string returns for one release (existing tests with mocked string returns still pass).

Closes #2628. Unblocks #2630 (SC + OC orphan backfill).

## Test plan

### Automated checks
- [x] `ruff check` clean on `scripts/reingest_from_s3.py` and `packages/scraper-framework/tests/test_reingest_from_s3.py`
- [x] `ruff format --check` clean on the same files
- [x] `pytest tests/test_reingest_from_s3.py` — all 346 tests pass (includes 3 new: `test_hash_mismatch_logs_warning_and_continues`, `test_matching_hash_returns_ok_without_mismatch_flag`, `test_summary_reports_hash_mismatch_warnings`, `test_summary_no_warning_when_all_hashes_match`)
- [x] `pytest tests/test_rebuild_db.py` — all 62 tests still pass (no regression in reference implementation)
- [x] Full CI green

### Post-deploy verification
- [x] Run `scripts/ecs-run-task.sh scripts/reingest_from_s3.py --prefix ca/santa_clara/ --latest-image` on dev and confirm:
  - [x] Log lines show `"S3 content hash mismatch — proceeding with reingest using key hash as canonical content_hash"` for the previously-orphaned hashes (141 observed in first post-deploy run)
  - [x] End-of-run summary emits `hash_mismatch_warnings=141` (expected — SC S3 has accumulated additional mismatched writes since investigation; the scraper-side root cause tracks in #2638)
  - [x] DB query on `derived.documents` shows rows for the previously-orphaned S3 keys (5 of 5 queryable hashes now present)

Evidence comment: https://github.com/judgemind/judgemind/issues/2628#issuecomment-4268985494

### Follow-up
- [ ] #2638 — investigate the scraper-side mislabel bug that produced the mismatched writes in the first place. This PR addresses the downstream symptom (orphans become recoverable); the upstream capture bug is separate.

Closes #2628
