### PR TITLE
fix(scraping): fix three LA tentatives extraction gaps (#2578)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -154,6 +154,20 @@ _HTML_TAG_RE = re.compile(r"<[^>]+>")
 # Judge name: "<div>William A. Crowfoot Judge of the Superior Court</div>"
 _JUDGE_DIV_RE = re.compile(r"(.+?)\s+Judge of the Superior Court", re.DOTALL)
 
+# Judge name: "JUDGE/DEPT:  Mkrtchyan/25" form-layout header (Dept 25 pattern, #2578).
+# Some LA dept pages print the presiding judge as a surname followed by a
+# slash and the department identifier in a header row.  The surname may be
+# a single word (Mkrtchyan) or a compound (Van Der Berg, O'Connor, etc.).
+# We stop at the first "/" that precedes a short dept token (letters + digits,
+# typically <=8 chars), so "O'Connor/25" and "Van Der Berg/F46" both match
+# cleanly without swallowing unrelated trailing text.
+_JUDGE_DEPT_RE = re.compile(
+    r"JUDGE\s*/\s*DEPT\s*:\s*"
+    r"(?P<name>[A-Za-z][A-Za-z\-\'\. ]*?)"
+    r"\s*/\s*[A-Za-z0-9]{1,8}\b",
+    re.IGNORECASE,
+)
+
 # Case title extraction from party caption block.
 # The party section text typically looks like:
 #   "SUMAYYA AASI, et al.,\n  Plaintiff(s),\n  vs.\n  AMERICAN HONDA...,\n  Defendant(s)."
@@ -752,6 +766,11 @@ def _sanitize_title(
         return None
 
     title = raw_title
+
+    # Strip U+00BF inverted question mark — the LA clerk's Word-to-HTML export
+    # injects literal "¿" in place of soft hyphens or non-breaking spaces,
+    # leaking into titles as e.g. "Company, Inc.¿" (#2578).
+    title = title.replace("\u00bf", "")
 
     # Normalize "vs.", "vs", "V." etc. to " v. " so splitting works consistently.
     title = re.sub(r"\s+[Vv][Ss]?\.?\s+", " v. ", title)
@@ -1620,16 +1639,24 @@ def _extract_ruling_fields(soup: BeautifulSoup, doc: CapturedDocument) -> None:
     # Party extraction
     doc.parties = _extract_parties(content)
 
-    # Judge name from the signature div
-    for div in content.find_all("div"):
-        div_text = div.get_text(separator=" ", strip=True)
-        m = _JUDGE_DIV_RE.match(div_text)
-        if m:
-            # Normalize whitespace in name
-            doc.judge_name = " ".join(m.group(1).split())
-            break
+    # Judge name — strategy 1: "JUDGE/DEPT: <Surname>/<dept>" form-layout
+    # header (Dept 25 Mkrtchyan pattern, #2578).  This is a compact form-style
+    # header that the signature-line regex below never matches.
+    judge_dept_match = _JUDGE_DEPT_RE.search(full_text)
+    if judge_dept_match:
+        doc.judge_name = " ".join(judge_dept_match.group("name").split())
 
-    # Fallback: use the broader regex patterns from extract.py
+    # Judge name — strategy 2: "<X> Judge of the Superior Court" signature div.
+    if not doc.judge_name:
+        for div in content.find_all("div"):
+            div_text = div.get_text(separator=" ", strip=True)
+            m = _JUDGE_DIV_RE.match(div_text)
+            if m:
+                # Normalize whitespace in name
+                doc.judge_name = " ".join(m.group(1).split())
+                break
+
+    # Judge name — strategy 3 (fallback): broader regex patterns from extract.py.
     if not doc.judge_name and doc.ruling_text:
         from ingestion.extract import extract_judge_name
 

--- a/packages/scraper-framework/src/framework/la_parser_utils.py
+++ b/packages/scraper-framework/src/framework/la_parser_utils.py
@@ -116,9 +116,21 @@ VS_RE = re.compile(r"\bv(?:s)?\.", re.IGNORECASE)
 # Case name / title field pattern
 # ---------------------------------------------------------------------------
 
-# Inline "Case Name: [text]" or "Case Title: [text]" field
+# Inline "Case Name: [text]" or "Case Title: [text]" field.
+#
+# Some LA dept pages (Dept 25 Mkrtchyan pattern) render CASE NAME on the same
+# visual line as a FILED metadata field — e.g.:
+#   "CASE NAME:  Landaverde v. Meller      COMP. FILED:  07-03-25"
+# Without the FILED boundary below, the lazy ".+?" keeps matching through
+# the COMP/PET/FAC FILED metadata looking for the CASE NUMBER boundary on a
+# later line, which leaks the filing date into the extracted title (#2578).
 CASE_NAME_FIELD_RE = re.compile(
-    r"CASE\s+(?:NAME|TITLE)\s*:\s*(?P<title>.+?)(?:\s+CASE\s+NUMBER|\s*$)",
+    r"CASE\s+(?:NAME|TITLE)\s*:\s*(?P<title>.+?)"
+    r"(?:"
+    r"\s+(?:COMP|COMPLAINT|PET|PETITION|FAC)\.?\s*FILED"
+    r"|\s+CASE\s+NUMBER"
+    r"|\s*$"
+    r")",
     re.IGNORECASE | re.MULTILINE,
 )
 

--- a/packages/scraper-framework/tests/courts/test_la_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_la_tentatives.py
@@ -3652,3 +3652,293 @@ def test_appellate_parse_document_swallows_parse_errors() -> None:
     # No exception bubbled up; static appellate metadata is still stamped.
     assert result.courthouse == APPELLATE_COURTHOUSE
     assert result.department == APPELLATE_DEPARTMENT
+
+
+# ---------------------------------------------------------------------------
+# LA extraction fixes — Bug fixes for #2578
+#
+# LA HTML has three extraction gaps documented in #2578:
+#   1. Judge NULL when the page uses "JUDGE/DEPT: <surname>/<dept>" form layout
+#      (Dept 25 Mkrtchyan pattern) — the classic "X Judge of the Superior Court"
+#      signature regex never matches.
+#   2. case_title contaminated by metadata like "COMP. FILED : 07-03-25" or
+#      "PET. FILED : 11-26-25" because the inline CASE NAME: field runs on the
+#      same line as the FILED metadata and the regex only stopped at
+#      "CASE NUMBER".
+#   3. Trailing U+00BF inverted question mark (¿) in titles because the LA
+#      clerk's Word-to-HTML conversion injects literal ¿ where soft hyphens or
+#      non-breaking spaces should be.
+# ---------------------------------------------------------------------------
+
+
+def test_extract_ruling_fields_judge_dept_form_layout() -> None:
+    """Bug 1: JUDGE/DEPT: <surname>/<dept> layout populates doc.judge_name (#2578)."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_dept25_judge_dept_format.html")
+    soup = BeautifulSoup(html, "lxml")
+    doc = CapturedDocument(
+        scraper_id="test",
+        state="CA",
+        county="Los Angeles",
+        court="Superior Court",
+        source_url=CIVIL_URL,
+        capture_timestamp=datetime(2026, 3, 26),
+        content_format=ContentFormat.HTML,
+        raw_content=html.encode("utf-8"),
+        content_hash="",
+    )
+    _extract_ruling_fields(soup, doc)
+    assert doc.judge_name is not None, "judge_name must be extracted from JUDGE/DEPT line"
+    assert doc.judge_name == "Mkrtchyan"
+
+
+def test_extract_ruling_fields_judge_dept_regex_direct() -> None:
+    """Bug 1: JUDGE/DEPT regex handles simple surname/department pairs."""
+    from bs4 import BeautifulSoup
+
+    html = (
+        "<div id='speechSynthesis'>"
+        "<p>HEARING DATE: Thursday, March 26, 2026 "
+        "JUDGE/DEPT: Mkrtchyan/25</p>"
+        "<p>Case Number: 25STLC05162</p>"
+        "</div>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    doc = CapturedDocument(
+        scraper_id="test",
+        state="CA",
+        county="Los Angeles",
+        court="Superior Court",
+        source_url=CIVIL_URL,
+        capture_timestamp=datetime(2026, 3, 26),
+        content_format=ContentFormat.HTML,
+        raw_content=html.encode("utf-8"),
+        content_hash="",
+    )
+    _extract_ruling_fields(soup, doc)
+    assert doc.judge_name == "Mkrtchyan"
+
+
+def test_extract_ruling_fields_judge_dept_with_compound_surname() -> None:
+    """Bug 1: JUDGE/DEPT regex accepts compound surnames with spaces."""
+    from bs4 import BeautifulSoup
+
+    html = (
+        "<div id='speechSynthesis'>"
+        "<p>HEARING DATE: Thursday, March 26, 2026 "
+        "JUDGE/DEPT: Van Der Berg/F46</p>"
+        "<p>Case Number: 25STLC99999</p>"
+        "</div>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    doc = CapturedDocument(
+        scraper_id="test",
+        state="CA",
+        county="Los Angeles",
+        court="Superior Court",
+        source_url=CIVIL_URL,
+        capture_timestamp=datetime(2026, 3, 26),
+        content_format=ContentFormat.HTML,
+        raw_content=html.encode("utf-8"),
+        content_hash="",
+    )
+    _extract_ruling_fields(soup, doc)
+    assert doc.judge_name == "Van Der Berg"
+
+
+def test_extract_ruling_fields_judge_div_still_works() -> None:
+    """Bug 1 regression: JUDGE/DEPT extraction does not break the existing
+    'X Judge of the Superior Court' signature path."""
+    from bs4 import BeautifulSoup
+
+    html = (
+        "<div id='speechSynthesis'>"
+        "<p>Case Number: 24NNCV02551</p>"
+        "<div>William A. Crowfoot Judge of the Superior Court</div>"
+        "</div>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    doc = CapturedDocument(
+        scraper_id="test",
+        state="CA",
+        county="Los Angeles",
+        court="Superior Court",
+        source_url=CIVIL_URL,
+        capture_timestamp=datetime(2026, 3, 26),
+        content_format=ContentFormat.HTML,
+        raw_content=html.encode("utf-8"),
+        content_hash="",
+    )
+    _extract_ruling_fields(soup, doc)
+    assert doc.judge_name == "William A. Crowfoot"
+
+
+def test_extract_case_title_stops_at_comp_filed() -> None:
+    """Bug 2: CASE NAME: ... COMP. FILED : <date> must not leak FILED text (#2578)."""
+    from bs4 import BeautifulSoup
+
+    html = (
+        "<div id='speechSynthesis'>"
+        "<p>CASE NAME: Landaverde v. Meller    COMP. FILED: 07-03-25</p>"
+        "<p>CASE NUMBER: 25STLC05162    PET. FILED: 10-01-25</p>"
+        "</div>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    title = _extract_case_title(content)
+    assert title is not None
+    assert "FILED" not in title.upper()
+    assert "07-03-25" not in title
+    assert "Landaverde" in title
+    assert "Meller" in title
+
+
+def test_extract_case_title_stops_at_pet_filed() -> None:
+    """Bug 2: PET. FILED boundary also stops the CASE NAME capture."""
+    from bs4 import BeautifulSoup
+
+    html = (
+        "<div id='speechSynthesis'>"
+        "<p>CASE NAME: Smith v. Jones    PET. FILED: 11-26-25</p>"
+        "<p>CASE NUMBER: 25STPB12345</p>"
+        "</div>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    title = _extract_case_title(content)
+    assert title is not None
+    assert "FILED" not in title.upper()
+    assert "11-26-25" not in title
+    assert "Smith" in title
+    assert "Jones" in title
+
+
+def test_extract_case_title_stops_at_fac_filed() -> None:
+    """Bug 2: FAC FILED (First Amended Complaint) also stops the capture."""
+    from bs4 import BeautifulSoup
+
+    html = (
+        "<div id='speechSynthesis'>"
+        "<p>CASE NAME: Acme Corp v. Beta Industries   FAC FILED: 02-15-25</p>"
+        "<p>CASE NUMBER: 25STCV00001</p>"
+        "</div>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    title = _extract_case_title(content)
+    assert title is not None
+    assert "FILED" not in title.upper()
+    assert "02-15-25" not in title
+    assert "Acme" in title
+    assert "Beta" in title
+
+
+def test_extract_case_title_stops_at_complaint_filed() -> None:
+    """Bug 2: Long-form 'COMPLAINT FILED' variant also works."""
+    from bs4 import BeautifulSoup
+
+    html = (
+        "<div id='speechSynthesis'>"
+        "<p>CASE NAME: Doe v. Roe    COMPLAINT FILED: 01-01-25</p>"
+        "<p>CASE NUMBER: 25STCV22222</p>"
+        "</div>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    title = _extract_case_title(content)
+    assert title is not None
+    assert "FILED" not in title.upper()
+    assert "01-01-25" not in title
+    assert "Doe" in title
+
+
+def test_extract_case_title_case_number_boundary_still_works() -> None:
+    """Bug 2 regression: The original CASE NUMBER boundary still fires."""
+    from bs4 import BeautifulSoup
+
+    html = (
+        "<div id='speechSynthesis'>"
+        "<p>CASE NAME: Porsche Leasing Ltd. et al. v. Tsisana Mikia, et al. "
+        "CASE NUMBER: 25SMCV01132</p>"
+        "</div>"
+    )
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    title = _extract_case_title(content)
+    assert title is not None
+    assert "25SMCV01132" not in title
+    assert "Porsche" in title
+
+
+def test_sanitize_title_strips_inverted_question_mark() -> None:
+    """Bug 3: U+00BF inverted question mark is stripped from titles (#2578)."""
+    raw = "Abigail Rodriguez And Iliana Mendez v. American Honda Motor Company, Inc.\u00bf"
+    result = _sanitize_title(raw)
+    assert result is not None
+    assert "\u00bf" not in result
+    assert "American Honda" in result
+    assert "Abigail Rodriguez" in result
+
+
+def test_sanitize_title_strips_multiple_inverted_question_marks() -> None:
+    """Bug 3: Multiple ¿ characters are all removed."""
+    raw = "A\u00bfBC Corp v. XY\u00bfZ Industries\u00bf"
+    result = _sanitize_title(raw)
+    assert result is not None
+    assert "\u00bf" not in result
+
+
+def test_sanitize_title_inverted_question_mark_only_below_min_length() -> None:
+    """Bug 3: If stripping ¿ leaves the title below the 5-char minimum, return None."""
+    raw = "A\u00bf\u00bf\u00bf"
+    result = _sanitize_title(raw)
+    assert result is None
+
+
+def test_extract_case_title_honda_fixture_strips_question_mark() -> None:
+    """Bug 3 end-to-end: Honda fixture (has literal ¿ in defendant caption)
+    yields a title without ¿."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_honda_inverted_qmark.html")
+    soup = BeautifulSoup(html, "lxml")
+    content = soup.find("div", id="speechSynthesis")
+    title = _extract_case_title(content)
+    # Honda may not produce a title from the parties anchor if cleaning removes
+    # too much, but if it does, ¿ must not appear.
+    if title is not None:
+        assert "\u00bf" not in title
+
+
+def test_extract_ruling_fields_landaverde_fixture_end_to_end() -> None:
+    """Bug 1+2 end-to-end: Dept 25 Landaverde fixture yields clean title and judge."""
+    from bs4 import BeautifulSoup
+
+    html = _load("la_ruling_dept25_judge_dept_format.html")
+    soup = BeautifulSoup(html, "lxml")
+    doc = CapturedDocument(
+        scraper_id="test",
+        state="CA",
+        county="Los Angeles",
+        court="Superior Court",
+        source_url=CIVIL_URL,
+        capture_timestamp=datetime(2026, 3, 26),
+        content_format=ContentFormat.HTML,
+        raw_content=html.encode("utf-8"),
+        content_hash="",
+    )
+    _extract_ruling_fields(soup, doc)
+
+    # Judge extracted from JUDGE/DEPT line
+    assert doc.judge_name == "Mkrtchyan"
+    # case_number extracted via deterministic header (#2330 path)
+    assert doc.case_number == "25STLC05162"
+    # Department extracted
+    assert doc.department == "25"
+    # Title extracted from CASE NAME: field, without COMP. FILED contamination
+    if doc.case_title is not None:
+        assert "FILED" not in doc.case_title.upper()
+        assert "07-03-25" not in doc.case_title
+        assert "Landaverde" in doc.case_title
+        assert "Meller" in doc.case_title

--- a/packages/scraper-framework/tests/fixtures/la_ruling_dept25_judge_dept_format.html
+++ b/packages/scraper-framework/tests/fixtures/la_ruling_dept25_judge_dept_format.html
@@ -1,0 +1,278 @@
+<html><body><div id="speechSynthesis"><b> Case Number: </b> 25STLC05162   <b> Hearing Date: </b>  March 26, 2026   <b> Dept: </b> 25</p><p> </p><p class="MsoNormal" style="text-align:justify"></p><p class="MsoNoSpacing" style="tab-stops:1.75in"><b style="mso-bidi-font-weight:
+normal"><span style='font-size:12.0pt;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'>HEARING DATE</span></b><span style='font-size:12.0pt;font-family:"Times New Roman",serif;color:black;
+mso-themecolor:text1'>: <span style="mso-tab-count:1">         </span>Thurs., March
+26, 2026<span style="mso-tab-count:1">    </span><span style="mso-spacerun:yes">  </span><span style="mso-tab-count:1">          </span><b style="mso-bidi-font-weight:normal">JUDGE/DEPT:<span style="mso-tab-count:1">                                          </span></b>Mkrtchyan/25<o:p></o:p></span></p>
+<p class="MsoNoSpacing" style="margin-left:1.75in;text-indent:-1.75in;tab-stops:
+1.75in"><b style="mso-bidi-font-weight:normal"><span style='font-size:12.0pt;
+font-family:"Times New Roman",serif;color:black;mso-themecolor:text1'>CASE NAME</span></b><span style='font-size:12.0pt;font-family:"Times New Roman",serif;color:black;
+mso-themecolor:text1'>:<span style="mso-tab-count:1">                 </span><u>Landaverde
+v. Meller</u><span style="mso-tab-count:2">                   </span><b style="mso-bidi-font-weight:normal">COMP. FILED</b>:<span style="mso-tab-count:
+1">         </span>07-03-25<o:p></o:p></span></p>
+<p class="MsoNoSpacing" style="margin-left:1.75in;text-indent:-1.75in;tab-stops:
+1.75in"><b style="mso-bidi-font-weight:normal"><span style='font-size:12.0pt;
+font-family:"Times New Roman",serif;color:black;mso-themecolor:text1'>CASE
+NUMBER</span></b><span style='font-size:12.0pt;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'>: <span style="mso-tab-count:1">          </span>25STLC05162<span style="mso-tab-count:3">                              </span> <b style="mso-bidi-font-weight:normal">PET. FILED</b>:<span style="mso-tab-count:
+1">            </span>10-01-25<o:p></o:p></span></p>
+<div style="mso-element:para-border-div;border:none;border-bottom:solid windowtext 1.0pt;
+mso-border-bottom-alt:solid windowtext .75pt;padding:0in 0in 1.0pt 0in">
+<p class="MsoNoSpacing" style="margin-left:1.75in;text-indent:-1.75in;tab-stops:
+1.75in;border:none;mso-border-bottom-alt:solid windowtext .75pt;padding:0in;
+mso-padding-alt:0in 0in 1.0pt 0in"><b style="mso-bidi-font-weight:normal"><span style='font-size:12.0pt;font-family:"Times New Roman",serif;color:black;
+mso-themecolor:text1'>NOTICE:</span></b><span style='font-size:12.0pt;
+font-family:"Times New Roman",serif;color:black;mso-themecolor:text1'><span style="mso-tab-count:1">                         </span>OK<span style="mso-tab-count:1"> </span> <span style="mso-tab-count:4">                                               </span><span style="mso-spacerun:yes"> </span><o:p></o:p></span></p>
+<p class="MsoNoSpacing" style="margin-left:1.75in;text-indent:-1.75in;tab-stops:
+1.75in;border:none;mso-border-bottom-alt:solid windowtext .75pt;padding:0in;
+mso-padding-alt:0in 0in 1.0pt 0in"><b style="mso-bidi-font-weight:normal"><span style='font-size:12.0pt;font-family:"Times New Roman",serif;color:black;
+mso-themecolor:text1'><span style="mso-tab-count:1">                                          </span><o:p></o:p></span></b></p>
+</div>
+<p class="MsoNormal" style="margin-top:0in;margin-right:-.9pt;margin-bottom:0in;
+margin-left:1.5in;margin-bottom:.0001pt;text-indent:-1.5in;tab-stops:-1.0in"><span style="color:black;mso-themecolor:text1;mso-bidi-font-weight:bold"><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-top:0in;margin-right:22.5pt;margin-bottom:
+0in;margin-left:1.5in;margin-bottom:.0001pt;text-indent:-1.5in;tab-stops:-1.0in"><b style="mso-bidi-font-weight:normal"><span style="color:black;mso-themecolor:
+text1">PROCEEDINGS</span></b><span style="color:black;mso-themecolor:text1">: <b style="mso-bidi-font-weight:normal"><span style="mso-tab-count:1">     </span>SECOND
+AMENDED PETITION FOR APPROVAL OF COMPROMISE OF CLAIM OR ACTION OR DISPOSITION
+OF PROCEEDS OF JUDGMENT FOR MINOR<span style="mso-spacerun:yes">  </span><o:p></o:p></b></span></p>
+<p class="MsoNormal" style="margin-top:0in;margin-right:22.5pt;margin-bottom:
+0in;margin-left:1.5in;margin-bottom:.0001pt;text-indent:-1.5in;tab-stops:-1.0in"><b style="mso-bidi-font-weight:normal"><span style="color:black;mso-themecolor:
+text1"><o:p> </o:p></span></b></p>
+<p class="MsoNormal" style="margin-top:0in;margin-right:22.5pt;margin-bottom:
+0in;margin-left:1.5in;margin-bottom:.0001pt;text-indent:-1.5in;tab-stops:-1.0in"><b style="mso-bidi-font-weight:normal"><span style="color:black;mso-themecolor:
+text1">MOVING PARTY</span></b><span style="color:black;mso-themecolor:text1">:<b style="mso-bidi-font-weight:normal"> </b><span style="mso-tab-count:1">  </span>Petitioner
+Aleyda Landaverde on behalf of minor Plaintiff Christopher Gutierrez Landaverde<o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-top:0in;margin-right:22.5pt;margin-bottom:
+0in;margin-left:1.5in;margin-bottom:.0001pt;text-indent:-1.5in;tab-stops:-1.0in"><b style="mso-bidi-font-weight:normal"><span style="color:black;mso-themecolor:
+text1">RESP. PARTY</span></b><span style="color:black;mso-themecolor:text1">:<span style="mso-tab-count:1">         </span>None <b style="mso-bidi-font-weight:
+normal"><o:p></o:p></b></span></p>
+<p align="center" class="MsoNormal" style="margin-right:22.5pt;text-align:center"><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></p>
+<p align="center" class="MsoNormal" style="margin-right:22.5pt;text-align:center"><b style="mso-bidi-font-weight:normal"><u><span style="color:black;mso-themecolor:
+text1">PETITION TO APPROVE COMPROMISE OF A DISPUTED CLAIM<o:p></o:p></span></u></b></p>
+<p align="center" class="MsoNormal" style="margin-right:22.5pt;text-align:center"><b style="mso-bidi-font-weight:normal"><span style="color:black;mso-themecolor:
+text1">(CCP § 372, CRC, rule 7.950.5.)<o:p></o:p></span></b></p>
+<p class="MsoNormal" style="margin-right:22.5pt"><span style="color:black;
+mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoNormal"><b style="mso-bidi-font-weight:normal"><span style="color:black;mso-themecolor:text1">TENTATIVE RULING</span></b><span style="color:black;mso-themecolor:text1">:<b style="mso-bidi-font-weight:normal"><o:p></o:p></b></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-indent:.5in"><b style="mso-bidi-font-weight:normal"><span style="color:black;mso-themecolor:
+text1"><o:p> </o:p></span></b></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;text-indent:
+.5in"><span style="color:black;mso-themecolor:text1;mso-bidi-font-weight:bold">The
+Amended Petition for Approval of Compromise of Claim or Action or Disposition
+of Proceeds of Judgment for Minor is GRANTED.<o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;text-indent:
+.5in"><span style="color:black;mso-themecolor:text1;mso-bidi-font-weight:bold"><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-indent:.5in"><span style="color:black;mso-themecolor:text1;mso-bidi-font-weight:bold">Moving party
+is ordered to give notice. <o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt"><b style="mso-bidi-font-weight:
+normal"><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></b></p>
+<p class="MsoNormal" style="margin-right:22.5pt"><b style="mso-bidi-font-weight:
+normal"><span style="color:black;mso-themecolor:text1">SERVICE</span></b><span style="color:black;mso-themecolor:text1">:<span style="mso-spacerun:yes"> 
+</span><o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt"><span style="color:black;
+mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-indent:.5in"><span style="color:black;mso-themecolor:text1">[<b>X</b>] Proof of Service Timely
+Filed (CRC, rule 3.1300) <span style="mso-tab-count:2">                    </span><b style="mso-bidi-font-weight:normal">OK</b><o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-indent:.5in"><span style="color:black;mso-themecolor:text1">[<b>X</b>] Correct Address (CCP §§
+1013, 1013a) <span style="mso-tab-count:4">                                     </span><b style="mso-bidi-font-weight:normal">OK</b><o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-indent:.5in"><span style="color:black;mso-themecolor:text1">[<b>X</b>] 16/21 Court Days Lapsed
+(CCP §§ 12c, 1005(b)) <span style="mso-tab-count:2">                      </span><b style="mso-bidi-font-weight:normal">OK<o:p></o:p></b></span></p>
+<p class="MsoNormal"><b><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></b></p>
+<p class="MsoNormal" style="line-height:110%"><b><span style="color:black;
+mso-themecolor:text1">OPPOSITION</span></b><span style="color:black;mso-themecolor:
+text1;mso-bidi-font-weight:bold">:</span><span style="color:black;mso-themecolor:
+text1"> <span style="mso-tab-count:1">         </span>None filed as of March 24,
+2026<span style="mso-tab-count:1">        </span><b><span style="mso-tab-count:
+1">            </span></b>[<b style="mso-bidi-font-weight:normal"><span style="mso-spacerun:yes">   </span></b>] Late<span style="mso-tab-count:1">          </span><span style="mso-tab-count:1">            </span>[<b>X</b>] None<o:p></o:p></span></p>
+<p class="MsoNormal" style="line-height:110%"><b><span style="color:black;
+mso-themecolor:text1">REPLY</span></b><span style="color:black;mso-themecolor:
+text1;mso-bidi-font-weight:bold">:</span><span style="color:black;mso-themecolor:
+text1"> <span style="mso-tab-count:2">                    </span>None filed as
+of March 24, 2026<span style="mso-tab-count:1">        </span><b><span style="mso-tab-count:1">            </span></b>[<b style="mso-bidi-font-weight:
+normal"><span style="mso-spacerun:yes">   </span></b>] Late<span style="mso-tab-count:1">          </span><span style="mso-tab-count:1">            </span>[<b>X</b>]
+None<o:p></o:p></span></p>
+<p class="MsoNormal" style="line-height:110%"><span style="color:black;
+mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoNormal"><b style="mso-bidi-font-weight:normal"><span style="color:black;mso-themecolor:text1">ANALYSIS:<o:p></o:p></span></b></p>
+<p class="MsoNormal"><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoListParagraph" style="text-align:justify;text-indent:-.5in;
+mso-pagination:none;mso-list:l0 level1 lfo1;mso-layout-grid-align:none;
+text-autospace:none"><!--[if !supportLists]--><span style='mso-fareast-font-family:
+"Times New Roman";color:black;mso-themecolor:text1'><span style="mso-list:Ignore">I.<span style='font:7.0pt "Times New Roman"'>               
+</span></span></span><!--[endif]--><u><span style="color:black;mso-themecolor:text1">Background<o:p></o:p></span></u></p>
+<p class="MsoNormal" style="text-align:justify"><u><span style="color:black;
+mso-themecolor:text1"><o:p><span style="text-decoration:none"> </span></o:p></span></u></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><span style="mso-tab-count:1">            </span>On
+or about October 27, 2024, minor Plaintiff Christopher Gutierrez Landaverde
+(“minor Plaintiff”) and Plaintiff Aleyda Landaverde (“Plaintiff”) were in a
+motor vehicle accident with Defendant Alexandra Meller (“Defendant”) at “I-10
+FWY at Pomona, California.” (Compl., MV-1.) <o:p></o:p></span></p>
+<p class="MsoNoSpacing" style="margin-left:.5in;mso-add-space:auto;text-align:
+justify;line-height:110%;tab-stops:0in"><span style='font-size:12.0pt;
+line-height:110%;font-family:"Times New Roman",serif;color:black;mso-themecolor:
+text1'><o:p> </o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><span style="mso-tab-count:1">            </span>On
+July 3, 2025, minor Plaintiff and Plaintiff filed this action against Defendant
+and Does 1-50, alleging a Motor Vehicle cause of action. (Compl., pp. 1, 3.) <o:p></o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><o:p> </o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><span style="mso-tab-count:1">            </span>On
+July 10, 2025, the Court appointed Plaintiff as minor Plaintiff’s Guardian Ad
+Litem. (7/10/25 Order.) <o:p></o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><o:p> </o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><span style="mso-tab-count:1">            </span>On
+October 1, 2025, minor Plaintiff by and through Plaintiff (“Petitioner”)
+brought the instant Petition for Approval of Compromise of Claim or Action or
+Disposition of Proceeds of Judgment for Minor (the “Petition”).<o:p></o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><o:p> </o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><span style="mso-tab-count:1">            </span>On
+December 2, 2025, the Court continued the hearing on the Petition due to
+various deficiencies. (12/2/25 Order.)<o:p></o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><o:p> </o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><span style="mso-tab-count:1">            </span>On
+December 29, 2025, Petitioner filed and served an Amended Petition and
+accompanying orders.<o:p></o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><o:p> </o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><span style="mso-tab-count:1">            </span>On
+January 29, 2026, the Court continued the hearing on the Amended Petition due
+to various deficiencies. (1/29/26 Order.)<o:p></o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><o:p> </o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><span style="mso-tab-count:1">            </span>On
+February 3, 2026, Petitioner filed and served the instant Second Amended
+Petition and accompanying orders.<o:p></o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><o:p> </o:p></span></p>
+<p class="MsoNoSpacing" style="text-align:justify;line-height:110%;tab-stops:
+0in"><span style='font-size:12.0pt;line-height:110%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'><span style="mso-tab-count:1">            </span>To
+date, no opposition or response to the Second Amended Petition has been filed. <o:p></o:p></span></p>
+<p class="MsoNormal" style="text-align:justify;mso-pagination:none;mso-layout-grid-align:
+none;text-autospace:none"><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoListParagraph" style="text-align:justify;text-indent:-.5in;
+mso-pagination:none;mso-list:l0 level1 lfo1;mso-layout-grid-align:none;
+text-autospace:none"><!--[if !supportLists]--><span style='mso-fareast-font-family:
+"Times New Roman";color:black;mso-themecolor:text1'><span style="mso-list:Ignore">II.<span style='font:7.0pt "Times New Roman"'>             
+</span></span></span><!--[endif]--><u><span style="color:black;mso-themecolor:text1">Legal
+Standard &amp; Discussion <o:p></o:p></span></u></p>
+<p class="MsoNormal" style="text-align:justify"><u><span style="color:black;
+mso-themecolor:text1"><o:p><span style="text-decoration:none"> </span></o:p></span></u></p>
+<p class="MsoNormal" style="margin-right:22.5pt;mso-add-space:auto;text-align:
+justify;line-height:110%"><span style="color:black;mso-themecolor:text1"><span style="mso-tab-count:1">            </span>Court approval <span style="mso-no-proof:yes">is required</span> for all settlements of a minor’s
+claim. (Prob. Code §§ 3500, 3600, <i style="mso-bidi-font-style:normal">et seq</i>.;
+Code of Civ. Proc., § 372.) “ ‘[W]ithout trial court approval of the proposed
+compromise of the ward’s claim, the settlement cannot be valid.<span style="mso-spacerun:yes">  </span>[Citation.] [¶] Nor is the settlement binding
+[on the minor] until it is endorsed by the trial court.’ ” (<i style="mso-bidi-font-style:normal">Pearson v. Superior Court</i> (2012) 202
+Cal.App.4th 1333, 1338.) A minor, like Claimant, “shall appear either by a
+guardian or conservator of the estate or by a guardian ad litem appointed by
+the court in which the action or proceeding is pending, or by a judge thereof,
+in each case.” (Code Civ. Proc., § 372, subd. (a)(1).) <o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;mso-add-space:auto;text-align:
+justify;line-height:110%"><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;mso-add-space:auto;text-align:
+justify;line-height:110%"><span style="color:black;mso-themecolor:text1"><span style="mso-tab-count:1">            </span>Regarding the substance of the
+Petition, to obtain court approval of the settlement of a minor’s claims, the
+petitioner must file a <i style="mso-bidi-font-style:normal">complete</i> and
+“verified petition for approval of the settlement and must disclose ‘all
+information that has any bearing upon the reasonableness of the compromise.’ ”
+(<i style="mso-bidi-font-style:normal">Barnes v. Western Heritage Ins. Co. </i>(2013)
+217 Cal.App.4th 249, 256, italics added; Cal. Rules of Court, rule 7.950.)<span style="mso-spacerun:yes">  </span><o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;mso-add-space:auto;text-align:
+justify;line-height:110%"><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;mso-add-space:auto;text-align:
+justify;line-height:110%"><span style="color:black;mso-themecolor:text1"><span style="mso-tab-count:1">            </span><i>Amended Petition</i><o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;mso-add-space:auto;text-align:
+justify;line-height:110%"><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;mso-add-space:auto;text-align:
+justify;line-height:110%"><span style="color:black;mso-themecolor:text1"><span style="mso-tab-count:1">            </span>Previously, the Court found the
+following deficiencies in the Amended Petition:<o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;line-height:
+110%"><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;line-height:
+110%"><span style="color:black;mso-themecolor:text1"><span style="mso-tab-count:
+1">            </span>¶ 3: While ¶ 3(a) is marked, the Court notes that the underlying
+action in this matter constitutes a pending action or proceeding. <span style="mso-spacerun:yes"> </span><o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;text-indent:
+.5in;line-height:110%"><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;text-indent:
+.5in;line-height:110%"><span style="color:black;mso-themecolor:text1">¶ 12: While
+¶ 12(b)(5)(b) is filled out, it is unclear whether the medical expenses to paid
+from the proceedings are for liens or reimbursement for payments made by
+Petitioner. Whether the amounts stated in ¶ 12(b)(5)(b) are liens or payment
+reimbursements for Petitioner also impacts the items to be filled out in ¶¶
+12(a)-12(b)(5)(a). The Court notes that, based on ¶ 14(a) being marked, it
+appears that the medical expenses are liens. Should this be the case, then ¶
+12(a)(5) and ¶ 12 (b)(5)(a) must be adjusted accordingly.<o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;text-indent:
+.5in;line-height:110%"><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;text-indent:
+.5in;line-height:110%"><span style="color:black;mso-themecolor:text1">¶ 14:
+While ¶ 14(b)(1)-(3) are filled out, ¶ 14(b) is not marked.<o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;line-height:
+110%"><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;text-indent:
+.5in;line-height:110%"><span style="color:black;mso-themecolor:text1">¶ 23 is
+blank. <span style="mso-spacerun:yes"> </span><o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;line-height:
+110%"><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;line-height:
+110%"><span style="color:black;mso-themecolor:text1"><span style="mso-tab-count:
+1">            </span><i>Second Amended Petition</i><o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;line-height:
+110%"><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;mso-add-space:auto;text-align:
+justify;text-indent:.5in;line-height:110%"><span style="color:black;mso-themecolor:
+text1">While the Court previously noted various deficiencies in the Amended
+Petition, the Court finds the Second Amended Petition, Proposed Order, and
+Proposed Order to Deposit Funds in Blocked Account are now substantially
+complete. The Court also finds that Petitioner provided timely and proper proof
+of service of the Second Amended Petition and proposed orders. Finally, the
+Court finds the proposed settlement to be fair and reasonable in light of minor
+Plaintiff’s damages.<o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;line-height:
+110%"><span style="color:black;mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-left:.5in;text-align:justify"><span style="color:black;mso-themecolor:text1">Thus, the Second Amended Petition is GRANTED.<o:p></o:p></span></p>
+<p class="MsoNormal" style="text-align:justify"><span style="color:black;
+mso-themecolor:text1"><o:p> </o:p></span></p>
+<p class="MsoListParagraph" style="text-align:justify;text-indent:-.5in;
+mso-pagination:none;mso-list:l0 level1 lfo1;mso-layout-grid-align:none;
+text-autospace:none"><!--[if !supportLists]--><span style='mso-fareast-font-family:
+"Times New Roman";color:black;mso-themecolor:text1'><span style="mso-list:Ignore">III.<span style='font:7.0pt "Times New Roman"'>           
+</span></span></span><!--[endif]--><u><span style="color:black;mso-themecolor:text1">Conclusion
+&amp; Order<o:p></o:p></span></u></p>
+<p class="MsoNormal" style="text-align:justify"><u><span style="color:black;
+mso-themecolor:text1"><o:p><span style="text-decoration:none"> </span></o:p></span></u></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-align:justify;text-indent:
+.5in"><span style="color:black;mso-themecolor:text1;mso-bidi-font-weight:bold">The
+Amended Petition for Approval of Compromise of Claim or Action or Disposition
+of Proceeds of Judgment for Minor is GRANTED.<o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt"><span style="color:black;
+mso-themecolor:text1;mso-bidi-font-weight:bold"><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-right:22.5pt;text-indent:.5in"><span style="color:black;mso-themecolor:text1;mso-bidi-font-weight:bold">Moving party
+is ordered to give notice. <o:p></o:p></span></p><br/><span name="wp"><hr/></span></div></body></html>

--- a/packages/scraper-framework/tests/fixtures/la_ruling_honda_inverted_qmark.html
+++ b/packages/scraper-framework/tests/fixtures/la_ruling_honda_inverted_qmark.html
@@ -1,0 +1,472 @@
+<html><body><div id="speechSynthesis"><b> Case Number: </b> 25STCV07437   <b> Hearing Date: </b>  March 24, 2026   <b> Dept: </b> 73</p><p> </p><p align="center" class="MsoNormal" style="text-align:center"><b style="mso-bidi-font-weight:
+normal"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>SUPERIOR
+COURT OF THE STATE OF CALIFORNIA <o:p></o:p></span></b></p>
+<p align="center" class="MsoNormal" style="text-align:center"><b style="mso-bidi-font-weight:
+normal"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>FOR
+THE COUNTY OF LOS ANGELES <o:p></o:p></span></b></p>
+<p align="center" class="MsoNormal" style="text-align:center"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'><o:p> </o:p></span></p>
+<table border="0" cellpadding="0" cellspacing="0" class="MsoNormalTable" style="border-collapse:collapse;mso-table-layout-alt:fixed;mso-padding-alt:
+ 0in 0in 0in 0in" width="624">
+<tbody><tr style="mso-yfti-irow:0;mso-yfti-firstrow:yes;mso-yfti-lastrow:yes;
+  height:.2in">
+<td style="width:227.1pt;border:none;border-bottom:solid windowtext 1.0pt;
+  mso-border-bottom-alt:solid windowtext .5pt;padding:0in 0in 0in 0in;
+  height:.2in" valign="top" width="303">
+<p class="MsoNormal" style="line-height:normal"><a name="Parties"></a><span style='font-size:12.0pt;font-family:"Times New Roman",serif'><w:sdt docpart="78841CBD414241349B0FE0B83ABB95E7" id="-1303536842" text="t">ABIGAIL
+   RODRIGUEZ AND ILIANA MENDEZ</w:sdt>, <o:p></o:p></span></p>
+<p class="MsoNormal"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'><span style="mso-tab-count:2">                        </span>Plaintiffs,<o:p></o:p></span></p>
+<p class="MsoNormal"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'><span style="mso-tab-count:1">            </span>vs.<o:p></o:p></span></p>
+<p class="MsoNormal" style="line-height:normal"><span style='font-size:12.0pt;
+  font-family:"Times New Roman",serif'><o:p> </o:p></span></p>
+<p class="MsoNormal" style="line-height:normal"><span style='font-size:12.0pt;
+  font-family:"Times New Roman",serif'><w:sdt docpart="7F68FBE8A7674F40B5F67DC41531FA74" id="2119015003" text="t">AMERICAN
+   HONDA MOTOR COMPANY, INC.¿; and DOES 1 through 10, inclusive,</w:sdt><o:p></o:p></span></p>
+<p class="MsoNormal" style="line-height:normal"><span style='font-size:12.0pt;
+  font-family:"Times New Roman",serif'><o:p> </o:p></span></p>
+<p class="MsoNormal" style="line-height:normal"><span style='font-size:12.0pt;
+  font-family:"Times New Roman",serif'><span style="mso-tab-count:2">                        </span>Defendants.<o:p></o:p></span></p>
+</td>
+<td style="width:13.8pt;padding:0in 0in 0in 0in;
+  height:.2in" valign="top" width="18">
+<p class="SingleSpacing"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>)<o:p></o:p></span></p>
+<p class="SingleSpacing"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>)<o:p></o:p></span></p>
+<p class="SingleSpacing"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>)<o:p></o:p></span></p>
+<p class="SingleSpacing"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>)<o:p></o:p></span></p>
+<p class="SingleSpacing"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>)<o:p></o:p></span></p>
+<p class="SingleSpacing"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>)<o:p></o:p></span></p>
+<p class="SingleSpacing"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>)<o:p></o:p></span></p>
+<p class="SingleSpacing"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>)<o:p></o:p></span></p>
+<p class="SingleSpacing"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>)<o:p></o:p></span></p>
+<p class="SingleSpacing"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>)<o:p></o:p></span></p>
+<p class="SingleSpacing"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>)<o:p></o:p></span></p>
+</td>
+<td style="width:227.1pt;padding:0in 0in 0in 0in;
+  height:.2in" valign="top" width="303">
+<p class="SingleSpacing" style="margin-left:20.0pt"><a name="CaseNumber"></a><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>CASE NO.: <w:sdt docpart="0209C012EE794169BF0554FBBE681A5B" id="-1821655229" text="t">25STCV07437</w:sdt><o:p></o:p></span></p>
+<p class="SingleSpacing"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'><o:p> </o:p></span></p>
+<p class="SingleSpacing" style="margin-left:.25in"><span style='font-size:12.0pt;
+  font-family:"Times New Roman",serif'>[TENTATIVE] ORDER RE: DEFENDANT AMERICAN
+  HONDA MOTOR COMPANY, INC.’s DEMURRER AND MOTION TO STRIKE FIRST AMENDED
+  COMPLAINT<o:p></o:p></span></p>
+<p class="SingleSpacing"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'><o:p> </o:p></span></p>
+<p class="SingleSpacing" style="margin-left:.25in"><span style='font-size:12.0pt;
+  font-family:"Times New Roman",serif'>Dept. 73<o:p></o:p></span></p>
+<p class="SingleSpacing" style="margin-left:.25in"><span style='font-size:12.0pt;
+  font-family:"Times New Roman",serif'>8:30 a.m.<o:p></o:p></span></p>
+<p class="SingleSpacing" style="margin-left:.25in"><span style='font-size:12.0pt;
+  font-family:"Times New Roman",serif'>March 24, 2026<o:p></o:p></span></p>
+</td>
+</tr>
+</tbody></table>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif'><o:p> </o:p></span></p>
+<p class="MsoListParagraph" style="text-indent:-.5in;line-height:200%;mso-list:
+l1 level1 lfo1"><!--[if !supportLists]--><b><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'><span style="mso-list:
+Ignore">I.<span style='font:7.0pt "Times New Roman"'>                  
+</span></span></span></b><!--[endif]--><b><span style='font-size:12.0pt;line-height:
+200%;font-family:"Times New Roman",serif'>INTRODUCTION<o:p></o:p></span></b></p>
+<p class="MsoNormal" style="margin-left:.5in;line-height:200%"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif'>This
+is a Song-Beverly action. <o:p></o:p></span></p>
+<p class="MsoNormal" style="margin-left:.5in;line-height:200%"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif'>On
+March 14, 2025, Plaintiffs Abigail Rodriguez and Iliana Mendez <span style="mso-spacerun:yes"> </span><o:p></o:p></span></p>
+<p class="MsoNormal" style="line-height:200%"><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'>(“Plaintiffs”) filed a complaint
+against Defendant American Honda Motor Company (“Defendant” or “Honda”).<o:p></o:p></span></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif'>On
+September 24, 2025 Plaintiffs filed a first amended complaint (“FAC”), alleging
+causes of action for (1) Violation of Subdivision (d) of Civil Code section
+1793.2, (2) Violation of Subdivision (b) of Civil Code section 1793.2, (3) Violation
+of Subdivision (a)(3) of Civil Code section 1793.2, (4) Breach of Implied
+Warranty of Merchantability, and (5) Fraudulent Inducement – Concealment. <o:p></o:p></span></p>
+<p class="MsoNormal" style="line-height:200%"><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'><span style="mso-tab-count:
+1">            </span>On October 28, 2025, Honda filed the instant demurrer and
+motion to strike. <o:p></o:p></span></p>
+<p class="MsoNormal" style="line-height:200%"><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'><span style="mso-tab-count:
+1">            </span>On February 18, 2025, Plaintiffs filed an opposition.<o:p></o:p></span></p>
+<p class="MsoNormal" style="line-height:200%"><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'><span style="mso-tab-count:
+1">            </span>No reply was filed.<span style="mso-spacerun:yes"> 
+</span><o:p></o:p></span></p>
+<p class="MsoListParagraph" style="text-indent:-.5in;line-height:200%;mso-list:
+l1 level1 lfo1"><!--[if !supportLists]--><b><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'><span style="mso-list:
+Ignore">II.<span style='font:7.0pt "Times New Roman"'>               
+</span></span></span></b><!--[endif]--><b><span style='font-size:12.0pt;line-height:
+200%;font-family:"Times New Roman",serif'>LEGAL STANDARD<o:p></o:p></span></b></p>
+<p class="MsoNormal" style="line-height:200%"><i><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif;mso-fareast-font-family:
+SimSun;mso-fareast-language:JA'>Demurrer <o:p></o:p></span></i></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif;
+mso-fareast-font-family:SimSun;mso-fareast-language:JA'>A demurrer is an
+objection to a pleading, the grounds for which are apparent from either the
+face of the complaint or a matter of which the court may take judicial notice.
+(Code Civ. Proc., § 430.30, subd. (a); see also <i>Blank v. Kirwan</i> (1985)
+39 Cal.3d 311, 318.) The purpose of a demurrer is to challenge the sufficiency
+of a pleading “by raising questions of law.” (<i>Postley v. Harvey</i> (1984)
+153 Cal.App.3d 280, 286.) “In the construction of a pleading, for the purpose
+of determining its effect, its allegations must be liberally construed, with a
+view to substantial justice between the parties.” (Code Civ. Proc., § 452.) The
+court “‘treat[s] the demurrer as admitting all material facts properly pleaded,
+but not contentions, deductions or conclusions of fact or law . . ..’” (<i>Berkley
+v. Dowds</i> (2007) 152 Cal.App.4th 518, 525.)<span style="mso-spacerun:yes"> 
+</span><o:p></o:p></span></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif;
+color:black'>When a demurrer is sustained, leave to amend must be al</span><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'>lowed where there is a reasonable possibility
+of successful amendment. (<i>Goodman v. Kennedy</i> (1976) 18 Cal.3d 335, 348.)
+The burden is on the plaintiff to show the court that a pleading can be amended
+successfully. (<i>Ibid.</i>; <i>Lewis v. YouTube, LLC </i>(2015) 244
+Cal.App.4th 118, 226.)<o:p></o:p></span></p>
+<p class="MsoNormal" style="line-height:200%"><i><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif;color:black;mso-themecolor:
+text1'>Motion to Strike<o:p></o:p></span></i></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'>Any party, within the time allowed to respond
+to a pleading may serve and file a notice of motion to strike a pleading or any
+part thereof.¿ (Code Civ. Proc., § 435, subd. (b)(1).)¿ The court¿may, upon a
+motion, or at any time in its discretion, and upon terms it deems proper,
+strike any irrelevant, false, or improper matter inserted in any pleading.¿
+(Code Civ. Proc., § 436, subd. (a).)¿ The court may also strike all or any part
+of any pleading not drawn or filed in conformity with California law, a court rule,
+or an order of the court.¿ (Code Civ. Proc., § 436, subd. (b).)¿ An immaterial
+or irrelevant allegation is one that is not essential to the statement of a
+claim or defense; is neither pertinent to nor supported by an otherwise
+sufficient claim or defense; or a demand for judgment requesting relief not
+supported by the allegations of the complaint.¿ (Code Civ. Proc., 431.10, subd.
+(b).)¿ The grounds for moving to strike must appear on the face of the pleading
+or by way of judicial notice.¿ (Code Civ. Proc., § 437.)</span><b><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif'><o:p></o:p></span></b></p>
+<p class="MsoListParagraph" style="text-indent:-.5in;line-height:200%;mso-list:
+l1 level1 lfo1"><!--[if !supportLists]--><b><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'><span style="mso-list:
+Ignore">III.<span style='font:7.0pt "Times New Roman"'>            
+</span></span></span></b><!--[endif]--><b><span style='font-size:12.0pt;line-height:
+200%;font-family:"Times New Roman",serif'>DISCUSSION<o:p></o:p></span></b></p>
+<p class="MsoNormal" style="line-height:200%"><i><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif;color:black;mso-themecolor:
+text1'>Demurrer<o:p></o:p></span></i></p>
+<p class="MsoListParagraph" style="line-height:200%"><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif;color:black;mso-themecolor:
+text1'>Honda demurs to the fifth cause of action for Fraudulent Inducement –
+Concealment <o:p></o:p></span></p>
+<p class="MsoNormal" style="line-height:200%"><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif;color:black;mso-themecolor:
+text1'>on the grounds that Plaintiffs fail to state a cause of action and the
+claim is barred by the economic loss rule. <o:p></o:p></span></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span class="normaltextrun"><span style='font-size:12.0pt;line-height:200%;font-family:
+"Times New Roman",serif;color:black;background:white'>“’[T]he elements of an
+action for fraud and deceit based on concealment are: (1) the defendant must
+have concealed or suppressed a material fact, (2) the defendant must have been
+under a duty to disclose the fact to the plaintiff, (3) the defendant must have
+intentionally concealed or suppressed the fact with the intent to defraud the
+plaintiff, (4) the plaintiff must have been unaware of the fact and would not
+have acted as he did if he had known of the concealed or suppressed fact, and
+(5) as a result of the concealment or suppression of the fact, the plaintiff
+must have sustained damage.’ [Citation].” (<i>Blickman Turkus, LP v. MF
+Downtown Sunnyvale, LLC</i> (2008) 162 Cal.App.4th 858, 868 (<i>Blickman</i>).)
+<o:p></o:p></span></span></p>
+<p class="MsoListParagraph" style="text-indent:-.25in;line-height:200%;
+mso-list:l0 level1 lfo2"><!--[if !supportLists]--><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif;color:black'><span style="mso-list:Ignore">a.<span style='font:7.0pt "Times New Roman"'>      
+</span></span></span><!--[endif]--><u><span style='font-size:12.0pt;line-height:
+200%;font-family:"Times New Roman",serif;color:black;background:white'>Specificity
+</span></u><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif;
+color:black;background:white'><o:p></o:p></span></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span class="normaltextrun"><span style='font-size:12.0pt;line-height:200%;font-family:
+"Times New Roman",serif'>Honda argues that Plaintiffs failed to adequately
+allege fraudulent concealment with specificity.<o:p></o:p></span></span></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span class="normaltextrun"><span style='font-size:12.0pt;line-height:200%;font-family:
+"Times New Roman",serif'>Honda argues that Plaintiffs failed to adequately
+allege fraudulent concealment with specificity because Plaintiffs failed to </span></span><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif'>“allege
+the names of the persons who made the allegedly fraudulent representations,
+their authority to speak, to whom they spoke, what they said or wrote, and when
+it was said or written.” (<i>Tarmann v. State Farm Mutual Auto. Ins. Co</i>.
+(1991) 2 Cal.App.4th 153, 157.) <span class="normaltextrun"><span style="mso-spacerun:yes"> </span>However, this rule is inapplicable to a claim
+of fraudulent concealment. (<i>Alfaro v. Community Housing Improvement System
+&amp; Planning Association, Inc</i>. (2009) 171 Cal.App.4th 1356, 1384 [“How
+does one show ‘how’ and ‘by what means’ something didn’t happen, or ‘when’ it
+never happened, or ‘where’ it never happened?”].) Instead, such details, in the
+context of a fraudulent concealment claim, “are properly the subject of
+discovery, not demurrer.” (<i>Id.</i> at pp. 1384-1385; <i>Tarmann, supra, </i>2
+Cal.App.4th at p. 158 [“</span><span style="color:black">We acknowledge that
+the requirement of specificity is <span style="border:none windowtext 1.0pt;
+mso-border-alt:none windowtext 0in;padding:0in;background:white">relaxed</span>
+when the allegations indicate that ‘the <span style="border:none windowtext 1.0pt;
+mso-border-alt:none windowtext 0in;padding:0in;background:white">defendant</span>
+must necessarily possess full information concerning the facts of the controversy’
+[Citation.]”].)<o:p></o:p></span></span></p>
+<p class="MsoNormal" style="line-height:200%"><span class="normaltextrun"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif'><span style="mso-tab-count:1">            </span><span style="color:black;background:
+white">The Supreme Court’s recent decision in <i>Rattagan</i> re-affirms and
+clarifies this rule; although it held that the same specificity pleading
+standard for affirmative fraud applies to fraudulent concealment claims, it
+clarified that “the focus of inquiry shifts to the unique elements of the
+claim. [Citations.]” (</span></span></span><i><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'>Rattagan v. Uber
+Technologies, Inc. </span></i><span style='font-size:12.0pt;line-height:200%;
+font-family:"Times New Roman",serif'>(2024) 17 Cal.5th 1, <span class="normaltextrun"><span style="color:black;background:white">43.) Thus, in a
+concealment claim based on a defendant’s duty to disclose arising from the
+defendant’s exclusive knowledge, the complaint must specifically allege “(1)
+the content of the omitted facts, (2) defendant’s awareness of the materiality
+of those facts, (3) the inaccessibility of the facts to plaintiff, (4) the
+general point at which the omitted facts should or could have been revealed,
+and (5) justifiable and actual reliance, either through action or forbearance,
+based on the defendant’s omission.” (<i>Id</i>. at pp. 43-44.)</span></span><span class="eop"><span style="color:black;background:white"> <o:p></o:p></span></span></span></p>
+<p class="MsoNormal" style="line-height:200%"><span class="eop"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif;
+color:black;background:white'><span style="mso-tab-count:1">            </span>In
+support of the Fraudulent Inducement – Concealment claim, Plaintiffs allege the
+following facts: (1) </span></span><span style='font-size:12.0pt;line-height:
+200%;font-family:"Times New Roman",serif'>Honda was well aware and knew that
+the ECVT transmission installed in the Vehicle was defective but failed to
+disclose this fact to Plaintiffs at the time of sale and thereafter. (FAC, ¶ 55);
+(2) Specifically, Honda knew (or should have known) that the transmission had
+one or more defects that can cause the vehicles and their transmissions to
+experience hesitation and/or delayed acceleration; harsh and/or hard shifting;
+jerking, shuddering, juddering; valve body failure; and/or transmission failure
+("Transmission Defect"). These conditions present a safety hazard and
+are unreasonably dangerous to consumers because they can suddenly and
+unexpectedly affect the driver's ability to control the vehicle's speed,
+acceleration, deceleration, and/or overall responsiveness of the vehicle in
+various driving conditions. (<i>id. </i>¶ 56); (3) Honda acquired its knowledge
+of the Transmission Defect and its potential consequences prior to Plaintiffs
+acquiring the Vehicle, through sources not available to consumers such as
+Plaintiffs, including but not limited to pre-production testing data, early consumer
+complaints about the Transmission Defect made directly to Defendant Honda and
+its network of dealers, aggregate warranty data compiled from Defendant Honda
+'s network of dealers, testing conducted by Defendant Honda in response to
+these complaints, as well as warranty repair and part replacements data
+received by Defendant Honda from Defendant Honda’s network of dealers, amongst
+other sources of internal information (<i>id. </i>¶ 60(a)); (4) Honda was in a
+superior position from various internal sources to know (or should have known)
+the true state of facts about the material defects contained in vehicles
+equipped with the transmission; (<i>id. ¶ </i>60(b)); (5) Plaintiffs are
+reasonable consumers who did not expect their Vehicle and its transmission to
+fail and not work properly (<i>id. </i>¶ 63), (6) Plaintiffs were harmed
+by purchasing a vehicle that Plaintiffs would not have leased and/or purchased
+had Plaintiffs known the true facts about the Transmission Defect (<i>id. </i>¶
+65). <span class="normaltextrun"><span style="color:black;background:white"><o:p></o:p></span></span></span></p>
+<p class="MsoNormal" style="line-height:200%"><span class="normaltextrun"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif;
+color:black;background:white'><span style="mso-tab-count:1">            </span>The
+Court finds that Plaintiffs alleged the elements of fraud with the requisite
+particularity. (See </span></span><i><span style='font-size:12.0pt;line-height:
+200%;font-family:"Times New Roman",serif'>Dhital v. Nissan N. Am., Inc.</span></i><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif'>
+(2022) 84 Cal.App.5th 828<span class="normaltextrun"><span style="color:black;
+background:white">, 844 [“</span></span><span style="color:black">[P]laintiffs
+alleged the CVT transmissions installed in numerous Nissan vehicles (including
+the one plaintiffs purchased) were defective; Nissan knew of the defects and
+the hazards they posed; Nissan had exclusive knowledge of the defects but
+intentionally concealed and failed to disclose that information; Nissan
+intended to deceive plaintiffs by concealing known transmission problems;
+plaintiffs would not have purchased the car if they had known of the defects;
+and plaintiffs suffered damages in the form of money paid to purchase the
+car.”].)<span class="eop"><span style="background:white"><o:p></o:p></span></span></span></span></p>
+<p class="MsoListParagraph" style="text-indent:-.25in;line-height:200%;
+mso-list:l0 level1 lfo2"><!--[if !supportLists]--><span class="eop"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif;
+color:black'><span style="mso-list:Ignore">b.<span style='font:7.0pt "Times New Roman"'>     
+</span></span></span></span><!--[endif]--><span class="eop"><u><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif;
+color:black;background:white'>Duty to Disclose<o:p></o:p></span></u></span></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span class="normaltextrun"><span lang="EN" style='font-size:12.0pt;line-height:200%;
+font-family:"Times New Roman",serif;mso-ansi-language:EN'>Alternatively, </span></span><span class="normaltextrun"><span style='font-size:12.0pt;line-height:200%;font-family:
+"Times New Roman",serif'>Honda argues that the Fraudulent Inducement –
+Concealment cause of action is subject to demurrer because Plaintiffs failed to
+sufficiently allege a duty to disclose.</span></span><span class="eop"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif'> <o:p></o:p></span></span></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span class="normaltextrun"><span lang="EN" style='font-size:12.0pt;line-height:200%;
+font-family:"Times New Roman",serif;mso-ansi-language:EN'>Absent a fiduciary
+relationship between the parties (which Plaintiffs do not allege here), a duty
+to disclose can arise in only three circumstances: (1) the defendant had
+exclusive knowledge of the material fact; (2) the defendant actively concealed
+the material fact; or (3) the defendant made partial representations while also
+suppressing the material fact. (<i>Bigler-Engler, supra</i>, 7 Cal.App.5th at
+311<i>; LiMandri v. Judkins</i> (1997) 52 Cal.App.4th 326, 336.) The California
+Supreme Court “has described the necessary relationship giving rise to a duty
+to disclose as a ‘transaction’ between the plaintiff and defendant ….” (<i>Bigler-Engler,
+supra</i>, 7 Cal.App.5th at p. 311; <i>Warner Construction Corp. v. City of Los
+Angeles</i> (1970) 2 Cal.3d 285, 294 [“In transactions which do not involve
+fiduciary or confidential relations”]; <i>Hoffman v. 162 North Wolfe LLC </i>(2014)
+228 Cal.App.4th 1178, 1187–89 [rejecting concealment claim where plaintiffs
+“were not involved in a transaction with the parties they claim defrauded
+them”]; <i>LiMandri, supra,</i> 52 Cal.App.4th at p. 337 [“such a relationship
+can only come into being as a result of some sort of transaction between the
+parties”].)</span></span><span class="normaltextrun"><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'>¿</span></span><span class="eop"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif'> <span style="color:black;background:white"><o:p></o:p></span></span></span></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span class="normaltextrun"><span style='font-size:12.0pt;line-height:200%;font-family:
+"Times New Roman",serif;color:black;mso-themecolor:text1'>The <i>Bigler-Engler</i>
+Court explained that a duty to disclose facts “arises only when the parties are
+in a relationship that gives rise to the duty, such as ‘“seller and buyer,
+employer and prospective employee, doctor and patient, or parties entering into
+any kind of contractual arrangement[]”’” and, in the absence of a fiduciary
+relationship, a fraudulent omission case may be grounded on one party's
+exclusive knowledge of material facts, active concealment of material facts or
+suppression of material facts in the context of a partial disclosure, but only
+where the parties share some sort of relationship in which a duty to disclose
+may arise.  (<i>Bigler-Engler</i>, <i>supra</i>, 7 Cal.App.5th at p. 311
+[citing to <i>Shin v. Kong</i> (2000) 80 Cal.App.4th 498, 509].)  The <i>Bigler-Engler</i>
+Court goes further to state that “[s]uch a transaction must necessarily arise
+from direct dealings between the plaintiff and the defendant; it cannot arise
+between the defendant and the public at large.”  (<i>Id.</i> at p. 312.)</span></span><span class="eop"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'> <o:p></o:p></span></span></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span class="eop"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'>In <i>D</i></span></span><span class="normaltextrun"><i><span style='font-size:12.0pt;line-height:200%;
+font-family:"Times New Roman",serif;color:black;mso-themecolor:text1'>hital,
+supra</span></i></span><span class="normaltextrun"><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif;color:black;mso-themecolor:
+text1'>, 84 Cal.App.5th at p. 844, the Court concluded that allegations were
+sufficient to support the existence of a buyer-seller relationship between the
+parties as “Plaintiffs alleged that they bought the car from a Nissan
+dealership, that Nissan backed the car with an express warranty, and that
+Nissan's authorized dealerships are [the manufacturer’s] agents for purposes of
+the sale of Nissan vehicles to consumers. In light of these allegations, we
+decline to hold plaintiffs’ claim is barred on the ground there was no
+relationship requiring Nissan to disclose known defects."  (<i>Dhital,
+supra</i>, 84 Cal.App.5th at p. 845.) <o:p></o:p></span></span></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span class="normaltextrun"><span style='font-size:12.0pt;line-height:200%;font-family:
+"Times New Roman",serif;color:black;mso-themecolor:text1'>The Court finds that
+Plaintiffs have sufficiently alleged facts supporting a duty to disclose. </span></span><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif'>Here,
+Plaintiffs alleged a direct transaction between them and Honda. (FAC, ¶ 6.)
+Plaintiffs specifically allege that “[o]n or about February 17, 2023, </span>Plaintiffs
+entered into a warranty contract with Defendant, regarding a 2022 Honda Accord,
+vehicle identification number 1HGCV3F94NA021183 ("Vehicle"), which
+was manufactured and or distributed by Defendant.<span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'>” (<i>Ibid.</i>) This
+alone is sufficient to impose upon Honda a duty to disclose.<span class="normaltextrun"><span style="color:black;mso-themecolor:text1"> (<i>Dhital,
+supra</i>, 84 Cal.App.5th at p. 844.) </span><span style="color:black;
+background:white">Although Plaintiffs did not purchase the vehicle directly
+from Honda, they did enter a direct contractual warranty agreement with it. (FAC,
+¶¶ 6-7, Ex. A; see <i>LiMandri, supra</i>, 52 Cal.App.4th at p. 336 [“parties
+entering into any kind of contractual agreement”] (emphasis added); <i>Rattagan,
+supra,</i> 17 Cal.5th 1 [same].) Plaintiffs have pled sufficient facts to
+establish a duty to disclose. The alleged parties to the warranty are Plaintiffs
+and Honda and the warranty itself is “some sort of transaction” between the two
+parties giving rise to a duty to disclose.</span><span style="color:black;
+mso-themecolor:text1"><o:p></o:p></span></span></span></p>
+<p class="MsoListParagraph" style="text-indent:-.25in;line-height:200%;
+mso-list:l0 level1 lfo2"><!--[if !supportLists]--><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'><span style="mso-list:
+Ignore">c.<span style='font:7.0pt "Times New Roman"'>      
+</span></span></span><!--[endif]--><u><span style='font-size:12.0pt;line-height:
+200%;font-family:"Times New Roman",serif'>Economic Loss Rule<o:p></o:p></span></u></p>
+<p class="MsoNormal" style="margin-left:.5in;line-height:200%"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif'>Honda
+lastly argues that the economic loss rule bars Plaintiffs’ fraud cause of
+action. <o:p></o:p></span></p>
+<p class="MsoNormal" style="line-height:200%"><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'>The Court does not agree.<o:p></o:p></span></p>
+<p class="MsoNormal" style="line-height:200%"><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'><span style="mso-tab-count:
+1">            </span>As the <i>Dhital </i>Court explained, “<span style="color:black">under California law, the economic loss rule does not bar
+[P]laintiff’s claim here for fraudulent inducement by concealment. Fraudulent
+inducement claims fall within an exception to the economic loss rule recognized
+by our Supreme Court (</span><span style="color:#3D3D3D;border:none windowtext 1.0pt;
+mso-border-alt:none windowtext 0in;padding:0in">Citation) </span><span style="color:black">and [P]laintiff[] allege[s] fraudulent conduct that is
+independent of [Defendant’s] alleged warranty breaches.” </span><span class="normaltextrun"><span style="color:black;mso-themecolor:text1">(<i>Dhital,
+supra</i>, 84 Cal.App.5th at p. 843.) </span><span style="color:black;
+background:white">“[T]he economic loss rule does not apply to limit recovery
+for intentional tort claims like fraud,” but applies instead to negligently
+inflicted economic losses devoid of physical or property damage. (<i>Rattagan,
+supra</i>, 17 Cal.5th at p. 38</span><span style="color:black;mso-themecolor:
+text1"> </span><span style="color:black;background:white">[“A plaintiff may
+assert a tort claim for fraudulent concealment based on conduct occurring in
+the course of a contractual relationship …. [T]he independent tort duty to
+refrain from engaging in fraudulent conduct is well established by statute and
+common law”].) <o:p></o:p></span></span></span></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span class="normaltextrun"><span style='font-size:12.0pt;line-height:200%;font-family:
+"Times New Roman",serif;color:black;border:none windowtext 1.0pt;mso-border-alt:
+none windowtext 0in;padding:0in'>Because Plaintiffs have adequately alleged
+fraud, the claim is not barred by the economic loss rule.<o:p></o:p></span></span></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span class="normaltextrun"><span style='font-size:12.0pt;line-height:200%;font-family:
+"Times New Roman",serif;color:black;border:none windowtext 1.0pt;mso-border-alt:
+none windowtext 0in;padding:0in'>The demurrer to the fifth cause of action is
+overruled.<o:p></o:p></span></span></p>
+<p class="MsoNormal" style="line-height:200%"><span class="normaltextrun"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif;
+color:black;border:none windowtext 1.0pt;mso-border-alt:none windowtext 0in;
+padding:0in'><span style="mso-spacerun:yes"> </span><i>Motion to Strike<o:p></o:p></i></span></span></p>
+<p class="MsoNormal" style="line-height:200%"><span class="normaltextrun"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif;
+color:black;border:none windowtext 1.0pt;mso-border-alt:none windowtext 0in;
+padding:0in'><span style="mso-tab-count:1">            </span>Honda seeks to
+strike Plaintiffs’ prayer for punitive damages. <o:p></o:p></span></span></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%;background:white"><span class="normaltextrun"><span style='font-size:12.0pt;line-height:200%;font-family:
+"Times New Roman",serif;color:black;border:none windowtext 1.0pt;mso-border-alt:
+none windowtext 0in;padding:0in'>P</span></span><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif;color:black;mso-color-alt:
+windowtext'>unitive damages may be imposed where it is proven by clear and
+convincing evidence that the defendant has been guilty of oppression, fraud, or
+malice. (Civ. Code, § 3294, subd. (a).) A motion to strike punitive damages is
+properly granted where a plaintiff does not state a prima facie claim for
+punitive damages, including allegations that defendant is guilty of oppression,
+fraud or malice. (<i>Turman v. Turning Point of Cent. California, Inc.</i>
+(2010) 191 Cal.App.4th 53, 63.) Moreover, conclusory allegations are not
+sufficient to support a claim for punitive damages. (<i>Brousseau v. Jarrett</i>
+(1977) 73 Cal.App.3d 864, 872.) Lastly, “[t]he mere allegation an intentional
+tort was committed is not sufficient to warrant an award of punitive damages.
+Not only must there be circumstances of oppression, fraud, or malice, but facts
+must be alleged in the pleading to support such a claim.” (<i>Grieves v.
+Superior Court</i> (1984) 157 Cal.App.3d 159, 166.)</span><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif'><o:p></o:p></span></p>
+<p class="MsoNormal" style="text-indent:.5in;line-height:200%"><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif;
+color:black;mso-themecolor:text1'>Given the Court conclusion as to the fifth cause
+of action for Fraudulent Inducement - Concealment, the Court does not strike </span><span style='font-size:12.0pt;line-height:200%;font-family:"Times New Roman",serif'>Plaintiffs’
+prayer for punitive damages. (See <i>Walton v. Anderson </i>(1970) 6 Cal.App.3d
+1003, 1010 [“When there is express fraud there is evil motive (malice)”]; <i>Oakes
+v. McCarthy Co.</i> (1968) 267 Cal.App.2d 231, 263 [“Fraud alone is an adequate
+basis for awarding punitive damages”].)<span style="color:black;border:none windowtext 1.0pt;
+mso-border-alt:none windowtext 0in;padding:0in"><o:p></o:p></span></span></p>
+<p class="MsoListParagraph" style="text-indent:-.5in;line-height:200%;mso-list:
+l1 level1 lfo1"><!--[if !supportLists]--><b><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'><span style="mso-list:
+Ignore">IV.<span style='font:7.0pt "Times New Roman"'>            
+</span></span></span></b><!--[endif]--><b><span style='font-size:12.0pt;line-height:
+200%;font-family:"Times New Roman",serif'>CONCLUSION<o:p></o:p></span></b></p>
+<p class="MsoNormal" style="margin-left:.5in;mso-add-space:auto;text-align:justify;
+text-justify:inter-ideograph;line-height:200%"><span style='font-size:12.0pt;
+line-height:200%;font-family:"Times New Roman",serif'>Based on the foregoing, Honda’s
+demurrer is OVERRULED. Honda must file an <o:p></o:p></span></p>
+<p class="MsoNormal" style="text-align:justify;text-justify:inter-ideograph;
+line-height:200%"><span style='font-size:12.0pt;line-height:200%;font-family:
+"Times New Roman",serif'>answer or other responsive pleading within 20 days of
+this order. <o:p></o:p></span></p>
+<p class="MsoNormal" style="text-align:justify;text-justify:inter-ideograph;
+line-height:200%"><span style='font-size:12.0pt;line-height:200%;font-family:
+"Times New Roman",serif'><span style="mso-tab-count:1">            </span>Honda’s
+motion to strike is DENIED.<o:p></o:p></span></p>
+<p class="MsoNormal" style="text-align:justify;text-justify:inter-ideograph;
+line-height:200%"><span style='font-size:12.0pt;line-height:200%;font-family:
+"Times New Roman",serif'><o:p> </o:p></span></p>
+<p class="MsoNormal" style="text-align:justify;text-justify:inter-ideograph;
+line-height:200%"><span style='font-size:12.0pt;line-height:200%;font-family:
+"Times New Roman",serif'><o:p> </o:p></span></p>
+<p class="MsoNormal" style="margin-left:3.5in"><span style='font-size:12.0pt;
+font-family:"Times New Roman",serif'>Dated this <w:sdt docpart="F8598FE8D3404726A43BE383C20C7DDF" id="-1441372030" text="t">24th</w:sdt>
+day of <w:sdt docpart="5DFFC42CAA5E4FBDB440565CFED303CB" id="-746652804" text="t">March</w:sdt> 2026<o:p></o:p></span></p>
+<p class="SignatureBlock"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'><o:p> </o:p></span></p>
+<p class="SignatureBlock"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'><o:p> </o:p></span></p>
+<p class="SignatureBlock"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'><o:p> </o:p></span></p>
+<p class="SignatureBlock" style="margin-left:0in"><span style='font-size:12.0pt;
+font-family:"Times New Roman",serif'><o:p> </o:p></span></p>
+<div align="right">
+<table border="0" cellpadding="0" cellspacing="0" class="MsoNormalTable" style="border-collapse:collapse;mso-table-layout-alt:fixed;mso-padding-alt:
+ 0in 0in 0in 0in">
+<tbody><tr style="mso-yfti-irow:0;mso-yfti-firstrow:yes;page-break-inside:avoid">
+<td style="width:1.0pt;padding:0in 0in 0in 0in" valign="top" width="1">
+<p align="right" class="SingleSpacing" style="text-align:right;page-break-after:
+  avoid"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'><span style="mso-spacerun:yes"> </span><o:p></o:p></span></p>
+</td>
+<td style="width:199.0pt;border:none;border-bottom:solid windowtext 1.0pt;
+  mso-border-bottom-alt:solid windowtext .5pt;padding:0in 0in 0in 0in" valign="top" width="265">
+<p class="SingleSpacing" style="page-break-after:avoid"><span style='font-size:
+  12.0pt;font-family:"Times New Roman",serif'><o:p> </o:p></span></p>
+</td>
+</tr>
+<tr style="mso-yfti-irow:1;mso-yfti-lastrow:yes;page-break-inside:avoid">
+<td style="width:1.0pt;padding:0in 0in 0in 0in" valign="top" width="1">
+<p class="SingleSpacing" style="page-break-after:avoid"><span style='font-size:
+  12.0pt;font-family:"Times New Roman",serif'><o:p> </o:p></span></p>
+</td>
+<td style="width:199.0pt;border:none;mso-border-top-alt:
+  solid windowtext .5pt;padding:0in 0in 0in 0in" valign="top" width="265">
+<p class="SingleSpacing" style="margin-left:.15in;page-break-after:avoid"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>Hon. Gary D.
+  Roberts<o:p></o:p></span></p>
+<p class="SingleSpacing" style="margin-left:.15in;page-break-after:avoid"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'>Judge of the
+  Superior Court<o:p></o:p></span></p>
+<p class="SingleSpacing" style="margin-left:.15in;page-break-after:avoid"><span style='font-size:12.0pt;font-family:"Times New Roman",serif'><o:p> </o:p></span></p>
+</td>
+</tr>
+</tbody></table>
+</div><br class="yui-cursor"/><span name="wp"></div></body></html>

--- a/packages/scraper-framework/tests/test_la_parser_utils.py
+++ b/packages/scraper-framework/tests/test_la_parser_utils.py
@@ -205,6 +205,50 @@ class TestCaseNameFieldRe:
         assert m is not None
         assert "Smith v. Jones" in m.group("title")
 
+    # Regression tests for #2578 — FILED metadata boundary.  Some LA dept pages
+    # (Dept 25 Mkrtchyan pattern) render CASE NAME on the same visual line as
+    # a COMP/PET/FAC FILED metadata field — the old regex only stopped at
+    # "CASE NUMBER" so it leaked the filing date into the title.
+
+    def test_case_name_stops_at_comp_filed(self) -> None:
+        text = "CASE NAME: Landaverde v. Meller    COMP. FILED: 07-03-25"
+        m = CASE_NAME_FIELD_RE.search(text)
+        assert m is not None
+        title = m.group("title").strip()
+        assert title == "Landaverde v. Meller"
+        assert "FILED" not in title.upper()
+        assert "07-03-25" not in title
+
+    def test_case_name_stops_at_pet_filed(self) -> None:
+        text = "CASE NAME: Smith v. Jones    PET. FILED: 11-26-25"
+        m = CASE_NAME_FIELD_RE.search(text)
+        assert m is not None
+        title = m.group("title").strip()
+        assert title == "Smith v. Jones"
+        assert "FILED" not in title.upper()
+
+    def test_case_name_stops_at_fac_filed(self) -> None:
+        text = "CASE NAME: Acme Corp v. Beta Industries   FAC FILED: 02-15-25"
+        m = CASE_NAME_FIELD_RE.search(text)
+        assert m is not None
+        title = m.group("title").strip()
+        assert title == "Acme Corp v. Beta Industries"
+        assert "FILED" not in title.upper()
+
+    def test_case_name_stops_at_complaint_filed_longform(self) -> None:
+        text = "CASE NAME: Doe v. Roe    COMPLAINT FILED: 01-01-25"
+        m = CASE_NAME_FIELD_RE.search(text)
+        assert m is not None
+        title = m.group("title").strip()
+        assert title == "Doe v. Roe"
+
+    def test_case_name_stops_at_petition_filed_longform(self) -> None:
+        text = "CASE NAME: In re Smith    PETITION FILED: 03-12-25"
+        m = CASE_NAME_FIELD_RE.search(text)
+        assert m is not None
+        title = m.group("title").strip()
+        assert title == "In re Smith"
+
 
 # ---------------------------------------------------------------------------
 # Constants tests


### PR DESCRIPTION
## Summary

Closes #2578.

Fixes three LA County tentative rulings extraction gaps surfaced by dev DB audits:

- **Bug 1 — Judge NULL on compact header form.** `_JUDGE_DIV_RE` only matched the `"X Judge of the Superior Court"` signature div; compact `JUDGE/DEPT: <Name>/<dept>` headers left `judge_name` NULL (~60 LA rulings per issue; 2 remained after #2599 and #2602 landed). Added `_JUDGE_DEPT_RE` and wired it as strategy 1 in `_extract_ruling_fields`; existing signature-div and `extract.py` fallbacks preserved as strategies 2 and 3.
- **Bug 2 — FILED metadata leaks into titles.** `CASE_NAME_FIELD_RE` only stopped at `CASE NUMBER`, letting `COMP.|PET.|FAC FILED: ...` tails into `case_title` (~81 at issue filing; 97 at merge time). Extended the regex to stop at `COMP/COMPLAINT/PET/PETITION/FAC FILED` in addition to `CASE NUMBER`.
- **Bug 3 — Trailing `¿` (U+00BF) in titles.** LA clerk's Word-to-HTML export injects literal inverted question marks in place of soft hyphens. Added explicit strip in `_sanitize_title`.

Fixtures `la_ruling_dept25_judge_dept_format.html` (Landaverde v. Meller, Dept 25 Mkrtchyan) and `la_ruling_honda_inverted_qmark.html` (Rodriguez/Mendez v. Honda) are real LA captures that reproduce the bugs end-to-end.

LA is HTML-native, so the fix is in capture/transcription — no LLM prompt changes, no other counties touched.

## Test plan

### Automated checks
- [x] `ruff check src/ tests/` — "All checks passed!"
- [x] `ruff format --check src/ tests/` — 216 files formatted
- [x] `pytest tests/` — 6251 passed, 2 skipped, 96% coverage
- [x] `diff-cover coverage.xml --compare-branch=origin/main --fail-under=90` — 100% on 12 changed lines
- [x] CI passes

### Post-deploy verification
- [x] Deploy Scraper workflow run 24568965383 succeeded (build + deploy + post-deploy health check all green).
- [x] Worker processing LA documents healthily post-deploy (see verification evidence comment on #2578 for log lines).
- [x] Reingest of LA documents from 2026-01-01 launched on task `27e85c19c690494b80a51a02494508f6`; extraction summary logs confirm the scraper-side paths are in effect (`"case_title": "scraper"` instead of `"llm"`).
- [ ] After reingest completes, `SELECT COUNT(*) FROM rulings r WHERE r.court_id = '<LA uuid>' AND r.judge_id IS NULL AND r.ruling_text LIKE '%JUDGE/DEPT:%'` drops from 2 to 0.
- [ ] After reingest completes, `SELECT COUNT(*) FROM cases c JOIN rulings r ON r.case_id = c.id WHERE c.court_id = '<LA uuid>' AND (c.case_title LIKE '%FILED%' OR c.case_title LIKE '%FILED:%')` drops from 97 to 0.
- [ ] After reingest completes, `SELECT COUNT(*) FROM cases c JOIN rulings r ON r.case_id = c.id WHERE c.court_id = '<LA uuid>' AND c.case_title LIKE '%¿%'` drops from 1 to 0.
