### PR TITLE
fix(ingestion): prevent OC calendar-PDF duplicate-caption extraction (#2577)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -220,7 +220,11 @@ PDF_PER_PAGE_PROMPT = (
     "printed, including any letter prefix (e.g. 'C22-01971', "
     "'2024-01393434', 'CVRI2401570', '22SMCV01940', 'N25-2112'). "
     "The letter prefix (C, N, etc.) is part of the case number, not "
-    "part of the case title. Empty string if not visible.\n"
+    "part of the case title. Empty string if not visible. **Do NOT "
+    "put the case title, party names, or the word 'v.'/'vs.' in "
+    "case_number — if the PDF row shows no explicit alphanumeric "
+    "case number (many OC calendar PDFs have only a # column and a "
+    "CASE NAME column), return case_number as empty string.**\n"
     "- **case_title** (string): ONLY the party names from the case "
     "caption (e.g. 'Constantina Marquez vs. Kohl\\'s Department "
     "Stores, Inc.'). This is JUST the names — plaintiff vs. "
@@ -2269,6 +2273,25 @@ def _parse_page_rows(raw_text: str, page_index: int) -> list[dict]:
         if "case_number" in item or "case_title" in item:
             case_number = str(item.get("case_number") or "").strip()
             case_title = str(item.get("case_title") or "").strip()
+            # Sanitize bogus case_number values (#2577).
+            # The multimodal LLM sometimes copies the case title into the
+            # case_number field when the PDF has no actual case numbers —
+            # e.g. returning ``case_number="Ayala v. Castillo"`` on an OC
+            # N17/C10 calendar PDF where no case numbers are printed.  If
+            # that fused value is passed through unchanged, downstream
+            # ``_split_fused_case_info`` sees a duplicated
+            # ``"Ayala v. Castillo\nAyala v. Castillo"`` case_info, detects
+            # two "v." clauses, splits on the repeating-plaintiff tier, and
+            # produces TWO identical rulings (one with the real text, one
+            # with ``ruling_text=None``).  Reject values that don't look
+            # like a case number: if case_number matches the "v." caption
+            # pattern OR is byte-identical to case_title, discard it.
+            if case_number:
+                looks_like_case_number = bool(_CASE_NUMBER_RE.search(case_number))
+                looks_like_caption = bool(_VS_RE.search(case_number))
+                duplicates_title = case_title and case_number == case_title
+                if not looks_like_case_number and (looks_like_caption or duplicates_title):
+                    case_number = ""
             # Post-process: strip trailing artifacts from case_title.
             # The LLM sometimes appends county prefix letters, motion
             # descriptions, or cause of action text to the case title.
@@ -2605,6 +2628,17 @@ def _split_fused_case_info(case_info: str | None) -> list[str]:
     # fall back to no split to avoid losing content.
     if not sub1 or not sub2_raw:
         return [case_info]
+
+    # If sub1 and sub2 are byte-identical (or differ only in whitespace),
+    # the "fusion" is actually a duplicated line — the LLM returned the
+    # same caption twice in case_info.  Splitting would produce two
+    # identical rulings where the second silently loses its ruling_text
+    # in ``_join_page_rows``.  Return the single de-duplicated sub-case
+    # instead of a phantom split (#2577).
+    norm1 = re.sub(r"\s+", " ", sub1)
+    norm2 = re.sub(r"\s+", " ", sub2_raw)
+    if norm1 == norm2:
+        return [sub1]
 
     # Recurse on the tail to handle triple+ fusion.
     tail_parts = _split_fused_case_info(sub2_raw)

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -438,6 +438,101 @@ class TestParsePageRows:
         rows = _parse_page_rows(raw, page_index=0)
         assert rows == []
 
+    # --- case_number sanitization (#2577) ---
+
+    def test_case_number_equal_to_case_title_is_discarded(self) -> None:
+        """The LLM sometimes copies the caption into case_number on OC
+        calendar PDFs that have no explicit case numbers (Dept N17/C10).
+
+        When that happens, case_info would become
+        ``"Ayala v. Castillo\\nAyala v. Castillo"`` and
+        ``_split_fused_case_info`` would phantom-split it into two
+        identical rulings.  ``_parse_page_rows`` must detect the
+        duplication and discard the bogus case_number.
+        """
+        raw = json.dumps(
+            {
+                "rulings": [
+                    {
+                        "entry_number": "4",
+                        "case_number": "Ayala v. Castillo",
+                        "case_title": "Ayala v. Castillo",
+                        "ruling_text": "Demurrer OVERRULED.",
+                    }
+                ]
+            }
+        )
+        rows = _parse_page_rows(raw, page_index=0)
+        assert len(rows) == 1
+        # case_info should contain ONE copy of "Ayala v. Castillo",
+        # not two — and must not contain the "v." boundary that would
+        # trip _split_fused_case_info.
+        assert rows[0]["case_info"].count("Ayala v. Castillo") == 1
+
+    def test_case_number_with_vs_clause_and_no_digits_discarded(self) -> None:
+        """case_number values that look like captions (contain "v." or
+        "vs." and have no digits at all) are not real case numbers —
+        discard them to keep case_info clean."""
+        raw = json.dumps(
+            {
+                "rulings": [
+                    {
+                        "entry_number": "1",
+                        "case_number": "Smith vs. Jones",
+                        "case_title": "Smith vs. Jones, et al.",
+                        "ruling_text": "Denied.",
+                    }
+                ]
+            }
+        )
+        rows = _parse_page_rows(raw, page_index=0)
+        # Only case_title should remain in case_info.
+        assert "Smith vs. Jones, et al." in rows[0]["case_info"]
+        # The bogus case_number must not produce a second "v." clause.
+        assert rows[0]["case_info"].count("vs.") == 1
+
+    def test_valid_case_number_with_vs_in_title_preserved(self) -> None:
+        """A real case number alongside a "v."-bearing title is kept:
+        sanitizer must not over-reach and strip legitimate case numbers.
+        """
+        raw = json.dumps(
+            {
+                "rulings": [
+                    {
+                        "entry_number": "1",
+                        "case_number": "C22-01971",
+                        "case_title": "Marquez vs. Kohl's",
+                        "ruling_text": "Denied.",
+                    }
+                ]
+            }
+        )
+        rows = _parse_page_rows(raw, page_index=0)
+        assert "C22-01971" in rows[0]["case_info"]
+        assert "Marquez vs. Kohl's" in rows[0]["case_info"]
+
+    def test_bogus_case_number_different_from_title_kept_if_has_digits(
+        self,
+    ) -> None:
+        """If case_number has digits, it's *probably* a real number even
+        if it doesn't match our strict regex — keep it rather than
+        discard (avoid false positives that strip legitimate numbers)."""
+        raw = json.dumps(
+            {
+                "rulings": [
+                    {
+                        "entry_number": "1",
+                        "case_number": "12345-weird-format",
+                        "case_title": "Smith v. Jones",
+                        "ruling_text": "Granted.",
+                    }
+                ]
+            }
+        )
+        rows = _parse_page_rows(raw, page_index=0)
+        # The "weird-format" case_number is retained as-is.
+        assert "12345-weird-format" in rows[0]["case_info"]
+
 
 class TestExtractCaseTitleTruncation:
     """Tests for case_title truncation in _extract_case_title_from_info."""
@@ -3221,6 +3316,35 @@ class TestSplitFusedCaseInfo:
         assert "Xy v." in joined
         assert "Yz" in joined
 
+    # --- #2577: duplicate-caption fusion (defense-in-depth) ---
+
+    def test_duplicated_caption_returns_single_subcase(self) -> None:
+        """Two byte-identical captions joined by a newline must NOT be
+        split into two rulings (#2577).
+
+        Upstream bug: on OC N17/C10 PDFs with no case numbers, the LLM
+        sometimes returns ``case_number="Ayala v. Castillo"`` alongside
+        ``case_title="Ayala v. Castillo"``.  ``_parse_page_rows``
+        concatenates them into ``case_info = "Ayala v. Castillo\\nAyala
+        v. Castillo"``.  With two "v." clauses, the repeating-plaintiff
+        tier would match and produce ``["Ayala v. Castillo", "Ayala v.
+        Castillo"]`` — two identical rulings, the second silently
+        losing its ruling_text in ``_join_page_rows``.  The splitter
+        must detect byte-equal halves and collapse them.
+        """
+        fused = "Ayala v. Castillo\nAyala v. Castillo"
+        result = _split_fused_case_info(fused)
+        assert result == ["Ayala v. Castillo"]
+
+    def test_duplicated_caption_whitespace_variant_collapses(self) -> None:
+        """Whitespace-only differences between the two halves still
+        collapse — same bug, triggered by trailing spaces or newlines."""
+        fused = "Ayala v. Castillo  \n  Ayala v. Castillo"
+        result = _split_fused_case_info(fused)
+        # Normalizing whitespace makes the two halves equal — collapse.
+        assert len(result) == 1
+        assert "Ayala v. Castillo" in result[0]
+
 
 # ---------------------------------------------------------------------------
 # _join_page_rows fused-row split integration tests (#2500)
@@ -3410,3 +3534,124 @@ class TestJoinPageRowsFusedRowSplit:
         # text (originally at index 0).
         assert rulings[3].cross_reference_source == 1
         assert rulings[3].ruling_text == long_ruling
+
+
+# ---------------------------------------------------------------------------
+# #2577: OC N17/C10 calendar PDFs — case_number sanitization regression
+# ---------------------------------------------------------------------------
+
+
+class TestOcNoCaseNumberCalendarPdfRegression:
+    """End-to-end regression for the bug described in #2577.
+
+    On OC Dept N17 (01f97e9d...pdf) and OC Dept C10 (15e603da...pdf)
+    calendar PDFs, the multimodal LLM observed in diagnostic runs
+    returned rows shaped like::
+
+        {"entry_number": "4",
+         "case_number": "Ayala v. Castillo",
+         "case_title": "Ayala v. Castillo",
+         "ruling_text": "Demurrer OVERRULED."}
+
+    because the PDFs contain no alphanumeric case numbers at all — just
+    a ``#`` column and a CASE NAME column.  Without the #2577 fix the
+    downstream pipeline would:
+
+    1. ``_parse_page_rows`` concatenates both fields into
+       ``case_info = "Ayala v. Castillo\\nAyala v. Castillo"``.
+    2. ``_split_fused_case_info`` sees two "v." clauses and the
+       repeating-plaintiff tier matches, producing two byte-identical
+       sub-cases.
+    3. ``_join_page_rows`` builds two ExtractedRuling objects — the
+       first with the real ruling text, the second with
+       ``ruling_text=None``.
+
+    With the fix, both the parse-time sanitizer and the
+    ``_split_fused_case_info`` duplicate-detector independently prevent
+    the phantom duplication.  This test verifies the full pipeline by
+    feeding a raw JSON shape that matches the observed LLM output and
+    asserting a single ruling is produced with its ruling_text intact.
+    """
+
+    def test_ayala_duplicate_caption_produces_single_ruling(self) -> None:
+        """Raw LLM JSON → _parse_page_rows → _join_page_rows yields 1
+        ruling, not 2."""
+        raw = json.dumps(
+            {
+                "page_header": {
+                    "department": None,
+                    "judge_name": None,
+                    "hearing_date": None,
+                },
+                "rulings": [
+                    {
+                        "entry_number": "4",
+                        "case_number": "Ayala v. Castillo",
+                        "case_title": "Ayala v. Castillo",
+                        "ruling_text": (
+                            "Defendant Carlos Contreras' Demurrer to all six "
+                            "causes of action contained in the FAC is "
+                            "OVERRULED."
+                        ),
+                    }
+                ],
+            }
+        )
+        rows = _parse_page_rows(raw, page_index=0)
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 1, (
+            f"Expected 1 ruling, got {len(rulings)}: {[r.extracted_case_title for r in rulings]}"
+        )
+        # The single surviving ruling keeps the ruling_text — it is NOT
+        # lost to a phantom second sub-case.
+        assert rulings[0].ruling_text is not None
+        assert "OVERRULED" in rulings[0].ruling_text
+        # The case_title is correctly extracted from case_info.
+        assert rulings[0].extracted_case_title == "Ayala v. Castillo"
+
+    def test_page_with_mixed_duplicate_and_normal_rulings(self) -> None:
+        """A page where one row has the duplicate-caption bug and other
+        rows are normal yields exactly one ruling per input row (not
+        one-plus-phantom for the bad row)."""
+        raw = json.dumps(
+            {
+                "page_header": {
+                    "department": "C10",
+                    "judge_name": "R. Shawn Nelson",
+                    "hearing_date": "2026-03-12",
+                },
+                "rulings": [
+                    {
+                        "entry_number": "3",
+                        "case_number": "Smith v. Jones",
+                        "case_title": "Smith v. Jones",
+                        "ruling_text": "Motion GRANTED.",
+                    },
+                    {
+                        "entry_number": "4",
+                        "case_number": "Ayala v. Castillo",
+                        "case_title": "Ayala v. Castillo",
+                        "ruling_text": "Demurrer OVERRULED.",
+                    },
+                    {
+                        "entry_number": "5",
+                        "case_number": "C22-01971",
+                        "case_title": "Doe v. Roe",
+                        "ruling_text": "Denied.",
+                    },
+                ],
+            }
+        )
+        rows = _parse_page_rows(raw, page_index=0)
+        rulings = _join_page_rows(rows)
+        # Exactly 3 rulings — no phantom duplicates.
+        assert len(rulings) == 3
+        titles = [r.extracted_case_title for r in rulings]
+        assert "Smith v. Jones" in titles
+        assert "Ayala v. Castillo" in titles
+        assert "Doe v. Roe" in titles
+        # All three have ruling_text — the duplicate-caption bug would
+        # have left the phantom duplicate with ruling_text=None.
+        for r in rulings:
+            assert r.ruling_text is not None
+            assert r.ruling_text.strip() != ""


### PR DESCRIPTION
## Summary

Fixes #2577. On OC calendar PDFs with no printed case numbers (Depts N17, C10, W8, etc.) the multimodal LLM occasionally returned the case caption as `case_number` (e.g. `case_number="Ayala v. Castillo"`). Downstream this fused into `case_info`, tripped `_split_fused_case_info`'s repeating-plaintiff tier, and produced byte-identical phantom duplicate rulings — the second with `ruling_text=None`. That is the failure mode behind the three `Zharkova`-titled mis-attributed DB rows for `01f97e9d...pdf` and the cross-applied titles the spotcheck flagged.

Three independent fix layers:

1. **Prompt** (`PDF_PER_PAGE_PROMPT`): explicitly forbids captions / party names / `v.`/`vs.` in `case_number`, and calls out OC-style `#`+CASE NAME PDFs as the layout where `case_number` should be an empty string.
2. **Parse-time sanitizer** (`_parse_page_rows`): rejects `case_number` values that don't match `_CASE_NUMBER_RE` AND either match `_VS_RE` or duplicate `case_title`. Values with digits are kept to avoid stripping legitimate county-specific formats.
3. **Defense-in-depth** (`_split_fused_case_info`): collapses byte-identical sub-cases (whitespace-normalized) into a single de-duplicated sub-case, eliminating the phantom-duplicate path entirely.

Adds 4 unit tests in `TestParsePageRows`, 2 in `TestSplitFusedCaseInfo`, and 2 end-to-end integration tests in a new `TestOcNoCaseNumberCalendarPdfRegression` class that exercises the exact raw LLM JSON shape captured on page 10 of `15e603da`.

### Scope decisions

- Populating real `case_number` values for OC Depts that don't print them (they have only `#` + CASE NAME columns) is out of scope — requires joining with OC calendar-page metadata (scraper-side join). Follow-up issue #2649 will be filed; under #2434's "missing data != wrong data" principle, `UNKNOWN-<uuid>` is the correct placeholder.
- Cleanup of existing contaminated OC rows (3 Zharkova-titled phantoms + 6 dropped cases from `01f97e9d`) will be done via `rebuild_db.py --county "Orange"` in follow-up #2649 (analogous to #2633).

## Test plan

### Automated checks
- [x] CI: `ruff check` passes
- [x] CI: `ruff format --check` passes
- [x] CI: `scraper-framework` tests pass (6283 local, incl. 8 new regression tests)
- [x] CI: diff coverage >= 90%
- [x] CI: all other checks pass

### Post-deploy verification
- [x] After deploy, OC ingestion worker processes documents without emitting duplicate rulings (worker up 14:15:43Z, extracting and indexing end-to-end)
- [x] Follow-up OC rebuild issue filed and linked (#2649)

Generated with [Claude Code](https://claude.com/claude-code)
