### PR TITLE
fix(ingestion): populate previous_version_id on content-hash dedup + zero-derived telemetry (#2569)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -15,6 +15,7 @@ Write order per event:
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import re
 import time
@@ -1722,25 +1723,127 @@ def insert_ruling(
     # deleted first so the superseded document leaves no orphaned ruling
     # behind.
     #
+    # We also link the loser to the winner via
+    # ``documents.previous_version_id`` and set ``change_type =
+    # 'duplicate_content'`` so downstream consumers (spotcheck, reporting)
+    # can trace a loser-doc to its canonical rulings (#2569).  Without
+    # this link, loser docs look like "zero derived rulings" to naive
+    # queries keyed on ``documents.s3_key`` — the rulings really exist
+    # but live on the winner's doc_id.
+    #
+    # A structured WARN is emitted (promoted from info in #2569) and a
+    # ``content_hash_dedup_supersede`` row is written to
+    # ``telemetry.data_quality_metrics`` so the historically silent dedup
+    # path now has observability and a classable log level.
+    #
     # Matches the existing ``_supersede_document`` pattern in
     # ``scripts/reingest_from_s3.py`` used for split-child dedup.
+    winner_document_id: str | None = None
+    county_for_metric: str | None = None
+    s3_key_for_log: str | None = None
     with conn.cursor() as cur:
+        # Look up the winner's document_id by the (case_id, text_hash)
+        # pair that caused the UniqueViolation.  ``text_hash`` is non-NULL
+        # here because a NULL hash cannot trigger the partial unique
+        # index ``uq_rulings_case_text_hash``.  The winner is whichever
+        # document inserted its ruling row first.
+        cur.execute(
+            "SELECT document_id::text FROM rulings "
+            "WHERE case_id = %s::uuid AND ruling_text_hash = %s "
+            "LIMIT 1",
+            (case_id, text_hash),
+        )
+        winner_row = cur.fetchone()
+        if winner_row is not None:
+            winner_document_id = winner_row[0]
+
+        # Fetch county and s3_key for the loser so we can emit a
+        # per-county telemetry metric and a structured WARN log.  Best-
+        # effort — failure to fetch doesn't prevent the supersede.
+        try:
+            cur.execute(
+                "SELECT c.county, d.s3_key FROM documents d "
+                "JOIN courts c ON d.court_id = c.id "
+                "WHERE d.id = %s::uuid",
+                (document_id,),
+            )
+            ctx_row = cur.fetchone()
+            if ctx_row is not None:
+                county_for_metric = ctx_row[0]
+                s3_key_for_log = ctx_row[1]
+        except Exception:  # noqa: BLE001 — telemetry lookup is best-effort
+            pass
+
         cur.execute(
             "DELETE FROM rulings WHERE document_id = %s::uuid",
             (document_id,),
         )
         deleted = cur.rowcount
-        cur.execute(
-            "UPDATE documents SET status = 'superseded' WHERE id = %s::uuid",
-            (document_id,),
-        )
-    logger.info(
-        "insert_ruling: content-hash dedup — superseded losing document "
-        "%s (case_id=%s, ruling_text_hash=%s, deleted %d stale ruling row(s))",
-        document_id,
-        case_id,
-        text_hash,
-        deleted,
+
+        if winner_document_id is not None:
+            cur.execute(
+                "UPDATE documents "
+                "SET status = 'superseded', "
+                "    previous_version_id = %s::uuid, "
+                "    change_type = 'duplicate_content' "
+                "WHERE id = %s::uuid",
+                (winner_document_id, document_id),
+            )
+        else:
+            # Defensive fallback: if we couldn't resolve the winner
+            # (unexpected — the constraint only fires when a winner row
+            # exists), still mark the loser superseded with the classifier
+            # so reporting knows why.
+            cur.execute(
+                "UPDATE documents "
+                "SET status = 'superseded', "
+                "    change_type = 'duplicate_content' "
+                "WHERE id = %s::uuid",
+                (document_id,),
+            )
+
+        # Emit a per-county telemetry metric.  If county lookup failed
+        # (e.g. the document row doesn't exist yet in this transaction's
+        # visible snapshot), skip — we don't want a telemetry write to
+        # break the primary supersede path.
+        if county_for_metric is not None:
+            try:
+                cur.execute(
+                    """
+                    INSERT INTO data_quality_metrics
+                        (recorded_at, county, metric_name, metric_value, metadata)
+                    VALUES (now(), %s, %s, %s, %s::jsonb)
+                    """,
+                    (
+                        county_for_metric,
+                        "content_hash_dedup_supersede",
+                        1,
+                        json.dumps(
+                            {
+                                "loser_document_id": document_id,
+                                "winner_document_id": winner_document_id,
+                                "case_id": case_id,
+                                "ruling_text_hash": text_hash,
+                                "s3_key": s3_key_for_log,
+                            }
+                        ),
+                    ),
+                )
+            except Exception:  # noqa: BLE001 — telemetry is best-effort
+                pass
+
+    logger.warning(
+        "insert_ruling: content-hash dedup — superseded losing document",
+        extra={
+            "loser_document_id": document_id,
+            "winner_document_id": winner_document_id,
+            "case_id": case_id,
+            "ruling_text_hash": text_hash,
+            "s3_key": s3_key_for_log,
+            "county": county_for_metric,
+            "deleted_stale_rulings": deleted,
+            "event": "content_hash_dedup_supersede",
+        },
     )
 
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -2474,6 +2474,9 @@ class IngestionWorker:
             # (those that produce zero ruling records) via a structured, easily
             # searchable warning so operators can detect when probate PDFs or
             # other problematic content fail extraction.
+            #
+            # A per-county telemetry row is also written so the zero-extraction
+            # rate is dashboard-queryable rather than grep-only (#2569).
             orphan_result = check_no_orphan_rulings(0)
             if orphan_result.is_orphan:
                 logger.warning(
@@ -2488,8 +2491,49 @@ class IngestionWorker:
                         "llm_latency_ms": llm_latency_ms,
                         "extraction_method": extraction_method,
                         "reason": orphan_result.reason,
+                        "event": "zero_ruling_extraction",
                     },
                 )
+                # Best-effort telemetry write (savepoint-protected so a
+                # transient failure does not abort the caller's
+                # transaction).
+                try:
+                    conn = self._get_connection()
+                    with conn.cursor() as cur:
+                        cur.execute("SAVEPOINT zero_ruling_metric")
+                        try:
+                            cur.execute(
+                                """
+                                INSERT INTO data_quality_metrics
+                                    (recorded_at, county, metric_name,
+                                     metric_value, metadata)
+                                VALUES (now(), %s, %s, %s, %s::jsonb)
+                                """,
+                                (
+                                    county,
+                                    "zero_ruling_extraction",
+                                    1,
+                                    json.dumps(
+                                        {
+                                            "document_id": document_id,
+                                            "s3_key": event_data.get("s3_key"),
+                                            "state": state,
+                                            "scraper_id": event_data.get("scraper_id"),
+                                            "extraction_method": extraction_method,
+                                            "reason": orphan_result.reason,
+                                        }
+                                    ),
+                                ),
+                            )
+                            cur.execute("RELEASE SAVEPOINT zero_ruling_metric")
+                        except Exception:  # noqa: BLE001 — best-effort
+                            cur.execute("ROLLBACK TO SAVEPOINT zero_ruling_metric")
+                            raise
+                except Exception:  # noqa: BLE001 — telemetry is best-effort
+                    logger.debug(
+                        "zero_ruling_extraction telemetry write failed",
+                        exc_info=True,
+                    )
             return False
 
         logger.info(

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -5576,6 +5576,79 @@ def test_llm_split_logs_orphan_warning_when_no_rulings_extracted(
     assert getattr(record, "reason", None)  # non-empty
 
 
+def test_llm_split_writes_zero_ruling_extraction_metric_on_orphan(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Orphan branch also writes a ``zero_ruling_extraction`` telemetry row (#2569).
+
+    When ``_llm_split_document`` takes the orphan branch, it must (a)
+    emit the WARN log (covered by #1337 test above) AND (b) write a
+    per-county telemetry row so the rate is dashboard-queryable rather
+    than log-grep-only.
+    """
+    worker, _ = _make_worker()
+    worker._llm_client = MagicMock()
+
+    mock_extractor = MagicMock()
+    mock_extractor.extract.return_value = []  # orphan.
+
+    event = _make_event(
+        document_id="orphan-doc-id-0000-0000-000000000001",
+        scraper_id="ca-oc-tentatives-probate",
+        state="CA",
+        county="Orange",
+        s3_key="ca/orange/superior_court/raw/probate-orphan.pdf",
+        ruling_text="Some text that the LLM cannot classify as a ruling",
+    )
+
+    mock_conn, mock_cur = _make_mock_conn()
+
+    with (
+        patch.object(worker, "_get_framework_extractor", return_value=mock_extractor),
+        patch.object(worker, "_get_multimodal_extractor", return_value=None),
+        patch.object(worker, "_get_connection", return_value=mock_conn),
+        caplog.at_level("WARNING", logger="ingestion.worker"),
+    ):
+        result = worker._llm_split_document(
+            event,
+            event["document_id"],
+            event["ruling_text"],
+            event["state"],
+            event["county"],
+            raw_pdf_bytes=None,
+        )
+
+    assert result is False
+    # The orphan branch must have attempted a data_quality_metrics
+    # INSERT inside a savepoint-protected block.
+    executed_sql = [call[0][0] for call in mock_cur.execute.call_args_list]
+    assert any("INSERT INTO data_quality_metrics" in s for s in executed_sql), (
+        "Orphan branch must write a data_quality_metrics row so the zero-"
+        "extraction rate is dashboard-visible (#2569)."
+    )
+    # Find the INSERT call and verify its params.
+    metric_calls = [
+        call
+        for call in mock_cur.execute.call_args_list
+        if "INSERT INTO data_quality_metrics" in call[0][0]
+    ]
+    assert len(metric_calls) == 1
+    params = metric_calls[0][0][1]
+    # (county, metric_name, metric_value, metadata_json)
+    assert params[0] == "Orange"
+    assert params[1] == "zero_ruling_extraction"
+    assert params[2] == 1
+    import json as _json
+
+    meta = _json.loads(params[3])
+    assert meta["document_id"] == "orphan-doc-id-0000-0000-000000000001"
+    assert meta["s3_key"] == "ca/orange/superior_court/raw/probate-orphan.pdf"
+    assert meta["state"] == "CA"
+    # Savepoint is used so a transient telemetry failure doesn't abort
+    # the caller's transaction.
+    assert any("SAVEPOINT zero_ruling_metric" in s for s in executed_sql)
+
+
 def test_llm_split_does_not_log_orphan_warning_when_rulings_extracted(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -5971,8 +6044,11 @@ def test_insert_ruling_content_hash_collision_supersedes_loser_default() -> None
     update_sql, update_params = supersede_stmts[1]
     assert "DELETE FROM rulings WHERE document_id" in delete_sql
     assert delete_params == (losing_doc_id,)
-    assert "UPDATE documents SET status = 'superseded'" in update_sql
-    assert update_params == (losing_doc_id,)
+    assert "UPDATE documents" in update_sql and "superseded" in update_sql
+    # After #2569, the UPDATE also carries the winner_id in earlier
+    # positions when a winner row was resolved.  The loser id is always
+    # the LAST positional param.
+    assert update_params[-1] == losing_doc_id
     # The old buggy fallback UPDATE that targeted (case_id, ruling_text_hash)
     # must not run — it silently mutated the winner's row (#2458).
     all_sql = [call.args[0] if call.args else "" for call in cur.execute.call_args_list]
@@ -6004,7 +6080,9 @@ def test_insert_ruling_content_hash_collision_supersedes_loser_force_update() ->
     _, delete_params = supersede_stmts[0]
     _, update_params = supersede_stmts[1]
     assert delete_params == (losing_doc_id,)
-    assert update_params == (losing_doc_id,)
+    # After #2569, the UPDATE params may include winner_id in earlier
+    # positions; the loser id is always the LAST positional param.
+    assert update_params[-1] == losing_doc_id
     # No UPDATE rulings SET of any form should run — the supersede path
     # must not touch the winner's ruling row.
     all_sql = [call.args[0] if call.args else "" for call in cur.execute.call_args_list]

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -1681,11 +1681,15 @@ class TestInsertRulingContentDedup:
         )
 
         doc_update_calls = [
-            c for c in execute_calls if "UPDATE documents SET status = 'superseded'" in c[0][0]
+            c for c in execute_calls if "UPDATE documents" in c[0][0] and "superseded" in c[0][0]
         ]
         assert len(doc_update_calls) == 1
-        assert doc_update_calls[0][0][1] == ("losing-doc",), (
-            "UPDATE documents must target the losing document_id."
+        # The loser's document_id is always the LAST positional param
+        # (after #2569, the UPDATE also carries the winner_id in earlier
+        # positions when a winner is resolved).
+        update_params = doc_update_calls[0][0][1]
+        assert update_params[-1] == "losing-doc", (
+            f"UPDATE documents must target the losing document_id (got params={update_params!r})."
         )
 
     def test_unique_violation_supersede_in_force_update_mode(self) -> None:
@@ -1726,6 +1730,284 @@ class TestInsertRulingContentDedup:
         assert any("UPDATE documents SET status = 'superseded'" in s for s in sql_stmts)
         # Under no mode should the old fallback UPDATE run.
         assert not any("UPDATE rulings SET" in s and "ruling_text_hash" in s for s in sql_stmts)
+
+    def test_supersede_populates_previous_version_id(self) -> None:
+        """Loser doc's ``previous_version_id`` is set to the winner's id (#2569).
+
+        Without this link, loser docs look like "zero derived rulings" to
+        naive spotcheck queries that filter on ``documents.s3_key``.  The
+        link lets downstream tooling trace the loser back to the
+        canonical rulings on the winner.
+        """
+        import psycopg.errors
+
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        exc = psycopg.errors.UniqueViolation("duplicate key value violates unique constraint")
+
+        def side_effect_execute(sql: str, params: tuple | None = None) -> None:
+            if "INSERT INTO rulings" in sql:
+                raise exc
+
+        cur.execute = MagicMock(side_effect=side_effect_execute)
+        # First fetchone() — winner lookup — returns the winner id.
+        # Second fetchone() — county/s3_key — returns a 1-tuple (mock
+        # default); the except clause in db.py swallows the resulting
+        # IndexError, which is fine for this test.
+        cur.fetchone = MagicMock(return_value=("winner-doc-id",))
+
+        insert_ruling(
+            conn,
+            document_id="losing-doc",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+        )
+
+        execute_calls = cur.execute.call_args_list
+        # The UPDATE documents statement should set previous_version_id.
+        doc_update_calls = [
+            c for c in execute_calls if "UPDATE documents" in c[0][0] and "superseded" in c[0][0]
+        ]
+        assert len(doc_update_calls) == 1
+        update_sql = doc_update_calls[0][0][0]
+        assert "previous_version_id = %s::uuid" in update_sql, (
+            "Supersede UPDATE must set previous_version_id to the winner's id."
+        )
+        assert "change_type = 'duplicate_content'" in update_sql, (
+            "Supersede UPDATE must set change_type='duplicate_content' "
+            "for downstream classification."
+        )
+        # Params are (winner_id, loser_id).
+        update_params = doc_update_calls[0][0][1]
+        assert update_params == ("winner-doc-id", "losing-doc"), (
+            f"UPDATE params must be (winner_id, loser_id); got {update_params!r}"
+        )
+
+    def test_supersede_queries_winner_document_id(self) -> None:
+        """The supersede path first queries the winner's document_id.
+
+        It joins on (case_id, ruling_text_hash) — the same pair that
+        triggered the UniqueViolation.
+        """
+        import psycopg.errors
+
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        exc = psycopg.errors.UniqueViolation("duplicate key value violates unique constraint")
+
+        def side_effect_execute(sql: str, params: tuple | None = None) -> None:
+            if "INSERT INTO rulings" in sql:
+                raise exc
+
+        cur.execute = MagicMock(side_effect=side_effect_execute)
+        cur.fetchone = MagicMock(return_value=("winner-doc-id",))
+
+        insert_ruling(
+            conn,
+            document_id="losing-doc",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+        )
+
+        execute_calls = cur.execute.call_args_list
+        winner_lookup_calls = [
+            c
+            for c in execute_calls
+            if "SELECT document_id" in c[0][0] and "FROM rulings" in c[0][0]
+        ]
+        assert len(winner_lookup_calls) >= 1, (
+            "Supersede path must query the winner's document_id before the UPDATE."
+        )
+
+    def test_supersede_falls_back_when_winner_not_found(self) -> None:
+        """If the winner lookup returns no row, still supersede the loser.
+
+        Defensive branch — the UniqueViolation means a winner SHOULD
+        exist, but if the mock/fetchone returns None the supersede path
+        must still run and mark the loser with change_type so reporting
+        is not silent.
+        """
+        import psycopg.errors
+
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        exc = psycopg.errors.UniqueViolation("duplicate key value violates unique constraint")
+
+        def side_effect_execute(sql: str, params: tuple | None = None) -> None:
+            if "INSERT INTO rulings" in sql:
+                raise exc
+
+        cur.execute = MagicMock(side_effect=side_effect_execute)
+        cur.fetchone = MagicMock(return_value=None)
+
+        insert_ruling(
+            conn,
+            document_id="losing-doc",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+        )
+
+        execute_calls = cur.execute.call_args_list
+        doc_update_calls = [
+            c for c in execute_calls if "UPDATE documents" in c[0][0] and "superseded" in c[0][0]
+        ]
+        assert len(doc_update_calls) == 1
+        update_sql = doc_update_calls[0][0][0]
+        # Fallback UPDATE: status + change_type but NO previous_version_id.
+        assert "change_type = 'duplicate_content'" in update_sql
+        assert "previous_version_id" not in update_sql, (
+            "Fallback UPDATE (no winner found) must omit previous_version_id."
+        )
+
+    def test_supersede_logs_warning_with_structured_fields(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The supersede path emits a WARN-level log with structured fields (#2569).
+
+        Promoted from info to warning so operators can alert on this
+        class of dedup event.
+        """
+        import logging
+
+        import psycopg.errors
+
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        exc = psycopg.errors.UniqueViolation("duplicate key value violates unique constraint")
+
+        def side_effect_execute(sql: str, params: tuple | None = None) -> None:
+            if "INSERT INTO rulings" in sql:
+                raise exc
+
+        cur.execute = MagicMock(side_effect=side_effect_execute)
+        cur.fetchone = MagicMock(return_value=("winner-doc-id",))
+
+        caplog.set_level(logging.WARNING, logger="ingestion.db")
+        insert_ruling(
+            conn,
+            document_id="losing-doc",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+        )
+
+        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert warning_records, (
+            "Supersede path must emit at least one WARN-level log (promoted from info in #2569)."
+        )
+        rec = warning_records[0]
+        assert "content-hash dedup" in rec.getMessage().lower()
+        # Structured fields available via ``extra``.
+        assert getattr(rec, "loser_document_id", None) == "losing-doc"
+        assert getattr(rec, "winner_document_id", None) == "winner-doc-id"
+        assert getattr(rec, "event", None) == "content_hash_dedup_supersede"
+
+    def test_supersede_writes_data_quality_metric(self) -> None:
+        """The supersede path emits a ``content_hash_dedup_supersede`` metric (#2569).
+
+        This gives the previously-silent dedup path a dashboard-queryable
+        observability signal so the 50%+ content-hash dedup rate in
+        multi-case-PDF counties is visible.
+        """
+        import psycopg.errors
+
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        exc = psycopg.errors.UniqueViolation("duplicate key value violates unique constraint")
+
+        def side_effect_execute(sql: str, params: tuple | None = None) -> None:
+            if "INSERT INTO rulings" in sql:
+                raise exc
+
+        cur.execute = MagicMock(side_effect=side_effect_execute)
+        # fetchone() returns values for (a) winner lookup, (b) county/s3
+        # lookup.  Two-tuple on the second call so county branch is taken.
+        cur.fetchone = MagicMock(
+            side_effect=[
+                ("winner-doc-id",),
+                ("Contra Costa", "ca-contra_costa/some.pdf"),
+            ]
+        )
+
+        insert_ruling(
+            conn,
+            document_id="losing-doc",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+        )
+
+        execute_calls = cur.execute.call_args_list
+        metric_calls = [c for c in execute_calls if "INSERT INTO data_quality_metrics" in c[0][0]]
+        assert len(metric_calls) == 1, (
+            "Supersede path must write exactly one data_quality_metrics "
+            "row when the county is resolvable."
+        )
+        metric_params = metric_calls[0][0][1]
+        # (county, metric_name, metric_value, metadata_json)
+        assert metric_params[0] == "Contra Costa"
+        assert metric_params[1] == "content_hash_dedup_supersede"
+        assert metric_params[2] == 1
+        # metadata is a JSON string containing loser/winner/case/s3 fields
+        import json as _json
+
+        meta = _json.loads(metric_params[3])
+        assert meta["loser_document_id"] == "losing-doc"
+        assert meta["winner_document_id"] == "winner-doc-id"
+        assert meta["case_id"] == "case-1"
+        assert meta["s3_key"] == "ca-contra_costa/some.pdf"
+
+    def test_supersede_skips_metric_when_county_unresolvable(self) -> None:
+        """If the context lookup fails, the primary supersede still succeeds.
+
+        The metric write is skipped — we never let a best-effort
+        telemetry write break the primary supersede path (#2569).
+        """
+        import psycopg.errors
+
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        exc = psycopg.errors.UniqueViolation("duplicate key value violates unique constraint")
+
+        def side_effect_execute(sql: str, params: tuple | None = None) -> None:
+            if "INSERT INTO rulings" in sql:
+                raise exc
+
+        cur.execute = MagicMock(side_effect=side_effect_execute)
+        # Winner lookup returns a row; county lookup returns None.
+        cur.fetchone = MagicMock(side_effect=[("winner-doc-id",), None])
+
+        insert_ruling(
+            conn,
+            document_id="losing-doc",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+        )
+
+        execute_calls = cur.execute.call_args_list
+        sql_stmts = [call[0][0] for call in execute_calls]
+        # Supersede still ran.
+        assert any("UPDATE documents" in s and "superseded" in s for s in sql_stmts)
+        # Metric was skipped.
+        assert not any("INSERT INTO data_quality_metrics" in s for s in sql_stmts), (
+            "Metric write must be skipped when county is unresolvable."
+        )
 
     def test_unknown_constraint_violation_is_reraised(self) -> None:
         """UniqueViolation from an unrelated constraint should be re-raised.
@@ -3243,10 +3525,14 @@ class TestInsertRulingContentHashSupersede:
         assert delete_calls[0][0][1] == ("losing-doc-id",)
 
         doc_update_calls = [
-            c for c in execute_calls if "UPDATE documents SET status = 'superseded'" in c[0][0]
+            c for c in execute_calls if "UPDATE documents" in c[0][0] and "superseded" in c[0][0]
         ]
         assert doc_update_calls
-        assert doc_update_calls[0][0][1] == ("losing-doc-id",)
+        # The loser's document_id is always the LAST positional param
+        # (after #2569, the UPDATE also carries the winner_id in earlier
+        # positions when a winner is resolved).
+        update_params = doc_update_calls[0][0][1]
+        assert update_params[-1] == "losing-doc-id"
 
     def test_supersede_does_not_run_legacy_fallback_update(self) -> None:
         """The legacy ``UPDATE rulings SET ... WHERE case_id = ? AND

--- a/scripts/spotcheck/fetch.py
+++ b/scripts/spotcheck/fetch.py
@@ -19,6 +19,7 @@ one item at a time.
 Expansion strategies are registered in STRATEGIES. To add a new entity
 type, implement an ExpansionStrategy subclass and register it.
 """
+
 from __future__ import annotations
 
 import abc
@@ -70,7 +71,9 @@ def register_strategy(entity_type: str) -> Any:
 # ---------------------------------------------------------------------------
 
 
-def _run_db_query(sql: str, params: tuple[Any, ...] | None = None) -> list[dict[str, Any]]:
+def _run_db_query(
+    sql: str, params: tuple[Any, ...] | None = None
+) -> list[dict[str, Any]]:
     """Run a SQL query and return parsed results as a list of dicts.
 
     Uses psycopg directly if DATABASE_URL is set (ECS environment).
@@ -266,14 +269,18 @@ class RulingsStrategy(ExpansionStrategy):
         for rec in records:
             full_text = rec.get("ruling_text", "")
             if full_text:
-                (item_dir / "ruling_text.txt").write_text(str(full_text), encoding="utf-8")
+                (item_dir / "ruling_text.txt").write_text(
+                    str(full_text), encoding="utf-8"
+                )
                 result["artifacts"].append("ruling_text.txt")
                 rec["ruling_text_length"] = len(str(full_text))
                 rec["ruling_text_preview"] = str(full_text)[:300]
                 del rec["ruling_text"]
             html_text = rec.get("ruling_text_html")
             if html_text:
-                (item_dir / "ruling_text.html").write_text(str(html_text), encoding="utf-8")
+                (item_dir / "ruling_text.html").write_text(
+                    str(html_text), encoding="utf-8"
+                )
                 result["artifacts"].append("ruling_text.html")
                 del rec["ruling_text_html"]
             elif "ruling_text_html" in rec:
@@ -341,9 +348,31 @@ class OriginalsStrategy(ExpansionStrategy):
             result["artifacts"].append(f"original.{ext}")
 
         # 2. Fetch all derived rulings from DB
-        # Escape single quotes in the S3 key for SQL safety
+        #
+        # A naive ``WHERE d.s3_key = <key>`` misses rulings when the
+        # queried S3 key is a content-hash-dedup *loser* (#2569): the
+        # loser's document row is marked superseded with its rulings
+        # deleted, while the actual rulings for those cases live on the
+        # *winner*'s document (a different s3_key).  We follow the
+        # ``documents.previous_version_id`` link so either the winner or
+        # the loser S3 key surfaces the canonical rulings.
+        #
+        # The subquery collects (a) any document that currently has this
+        # s3_key and (b) any document that points to one of those docs
+        # via ``previous_version_id`` (the winner when this key is a
+        # loser), then the outer query fetches rulings linked to ANY of
+        # those doc ids.
+        #
+        # Escape single quotes in the S3 key for SQL safety.
         safe_key = entity_id.replace("'", "''")
         query = (
+            "WITH target_docs AS ("
+            "  SELECT id FROM documents WHERE s3_key = '" + safe_key + "' "
+            "  UNION "
+            "  SELECT previous_version_id AS id FROM documents "
+            "  WHERE s3_key = '" + safe_key + "' "
+            "    AND previous_version_id IS NOT NULL "
+            ") "
             "SELECT r.id::text AS ruling_id, r.outcome::text, "
             "r.motion_type, r.hearing_date::text, r.department, "
             "cs.case_number, cs.case_title, "
@@ -351,10 +380,9 @@ class OriginalsStrategy(ExpansionStrategy):
             "length(r.ruling_text) AS ruling_text_length, "
             "left(r.ruling_text, 300) AS ruling_text_preview "
             "FROM rulings r "
-            "JOIN documents d ON r.document_id = d.id "
+            "JOIN target_docs td ON r.document_id = td.id "
             "JOIN cases cs ON r.case_id = cs.id "
-            "LEFT JOIN judges j ON r.judge_id = j.id "
-            f"WHERE d.s3_key = '{safe_key}'"
+            "LEFT JOIN judges j ON r.judge_id = j.id"
         )
         derived = _run_db_query(query)
         derived_path = item_dir / "derived_rulings.json"
@@ -374,9 +402,7 @@ class OriginalsStrategy(ExpansionStrategy):
                     ruling_id = ruling.get("ruling_id", "")
                     if ruling_id:
                         screenshot_path = screenshots_dir / f"{ruling_id}.png"
-                        if _take_screenshot(
-                            f"/rulings/{ruling_id}", screenshot_path
-                        ):
+                        if _take_screenshot(f"/rulings/{ruling_id}", screenshot_path):
                             result["artifacts"].append(
                                 f"ruling_screenshots/{ruling_id}.png"
                             )
@@ -413,9 +439,7 @@ def fetch_manifest(
 
     # Copy manifest into output
     manifest_path = output_dir / "manifest.json"
-    manifest_path.write_text(
-        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
-    )
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
     summary: dict[str, Any] = {
         "entity": entity_type,
@@ -477,7 +501,10 @@ def main() -> None:
             sys.exit(1)
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     else:
-        print("ERROR: Provide either a manifest file path or --manifest-json", file=sys.stderr)
+        print(
+            "ERROR: Provide either a manifest file path or --manifest-json",
+            file=sys.stderr,
+        )
         sys.exit(1)
     output_dir = Path(args.output)
 


### PR DESCRIPTION
## Summary

- Fix root cause of "60% zero derived rulings" in CC calendar PDFs: content-hash dedup losers silently dropped their link to the winning document, making their rulings appear to have vanished even though they were correctly superseded.
- Populate `previous_version_id` + `change_type='duplicate_content'` on superseded losers in `db.py::insert_ruling`, promote the dedup log from info to WARN with structured fields, and write a `content_hash_dedup_supersede` row to `telemetry.data_quality_metrics`.
- Add `zero_ruling_extraction` telemetry in `worker.py::_llm_split_document` orphan branch so the rarer genuine zero-extraction case becomes dashboard-visible.
- Update `scripts/spotcheck/fetch.py` `OriginalsStrategy` to follow the `previous_version_id` chain so sampling the loser's S3 key still surfaces the canonical rulings.
- Regression tests for all new behavior (7 new tests, 4 existing tests updated for the UPDATE param tuple change).

Cross-county scope (dev DB): SC 57.4%, CC 53.3%, OC 50.8%, LA 6.9% of multi-case PDFs have this content-hash dedup pattern — previously silent, now traceable.

Closes #2569

## Test plan

### Automated checks
- [x] `ruff check` passes on scraper-framework
- [x] `ruff format --check` passes on scraper-framework
- [x] `pytest` passes on scraper-framework (6290 tests; 7 new regression tests)
- [x] CI green

### Post-deploy verification
- [x] Dev ECS ingestion worker running on post-merge binary (task ccb5cdda, "Starting ingestion worker" at 14:38:05Z) — no errors related to supersede path or telemetry write; successful LLM extraction logs post-deploy
- [x] `telemetry.data_quality_metrics` query against dev runs cleanly (schema/column-count correct); no metric rows yet in 30-min window because content-hash dedup only fires on duplicate multi-case PDFs — infrastructure confirmed live
- [x] Deploy Scraper health check passed (1m14s post-deploy)

## Follow-ups (filed after merge)

- #2653 — Backfill script to populate `previous_version_id` on pre-existing superseded losers
- #2654 — Dashboard/query for dedup + zero-extraction rate per county
- #2655 — Capture-path content-hash dedup (root-cause fix)
