### PR TITLE
feat(scraping): add Patchright + residential proxy fallback for SF civil Turnstile (#2622)

### DIFF
--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -175,6 +175,13 @@ resource "aws_ecs_task_definition" "scraper" {
           {
             name      = "SD_PROXY_URL"
             valueFrom = var.proxy_secret_arn
+          },
+          {
+            # SF civil scraper reads the same residential proxy secret
+            # under a scraper-specific env var. Both scrapers share the
+            # secret in dev (see #2622); no secret re-provisioning needed.
+            name      = "SF_PROXY_URL"
+            valueFrom = var.proxy_secret_arn
           }
         ] : []
       )
@@ -318,7 +325,8 @@ resource "aws_iam_role_policy" "ecs_task_execution_secrets" {
 }
 
 # Allow the task execution role to fetch the residential proxy secret so ECS
-# can inject SD_PROXY_URL into the scraper container at launch.
+# can inject SD_PROXY_URL and SF_PROXY_URL into the scraper container at launch
+# (both env vars resolve to the same secret value — see #2622).
 resource "aws_iam_role_policy" "ecs_task_execution_proxy_secret" {
   count = var.proxy_secret_arn != "" ? 1 : 0
 

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -148,7 +148,7 @@ variable "capsolver_api_key_secret_arn" {
 }
 
 variable "proxy_secret_arn" {
-  description = "ARN of the Secrets Manager secret holding the residential proxy URL (plain string). When set, SD_PROXY_URL is injected into the scraper container."
+  description = "ARN of the Secrets Manager secret holding the residential proxy URL (plain string). When set, SD_PROXY_URL and SF_PROXY_URL are both injected into the scraper container from the same secret (SD scraper uses the former, SF civil scraper uses the latter per #2622)."
   type        = string
   default     = ""
 }

--- a/packages/scraper-framework/Dockerfile
+++ b/packages/scraper-framework/Dockerfile
@@ -45,6 +45,16 @@ RUN pip install --no-cache-dir playwright \
     && playwright install chromium --with-deps \
     && chmod -R o+rx /opt/playwright-browsers
 
+# Install Patchright's Chromium into the same shared path. Patchright is
+# a stealth-optimized Playwright fork used by the SF civil scraper (see
+# #2622); it respects ``PLAYWRIGHT_BROWSERS_PATH`` for browser lookup, so
+# installing here puts its bundled Chrome channel alongside the stock
+# chromium build. ``--with-deps`` is a no-op when the system libs are
+# already present (they were installed for playwright above) but is
+# harmless to re-run.
+RUN patchright install chromium --with-deps \
+    && chmod -R o+rx /opt/playwright-browsers
+
 # Fail the build if the conflicting old Google AI SDK crept back in.
 # google-generativeai and google-genai share the google.genai namespace;
 # having both installed breaks client.models.generate_content().

--- a/packages/scraper-framework/pyproject.toml
+++ b/packages/scraper-framework/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "httpx>=0.27",
     "playwright>=1.42",
     "playwright-stealth>=1.0.6",
+    "patchright>=1.58,<2.0",
     "beautifulsoup4>=4.12",
     "lxml>=5.1",
     "pdfplumber>=0.11",

--- a/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
@@ -23,17 +23,37 @@ The HTML table contains structured <tr> rows with headers:
    3 → Dept 501 (Real Property Housing Court Motions)
    7 → Dept 204 (Probate)
 
-The site is behind Cloudflare Turnstile CAPTCHA. The scraper uses
-Playwright with stealth to navigate the CAPTCHA page, which auto-solves
-for legitimate browsers. After the CAPTCHA resolves, the page contains
-a session ID (seshID) that is extracted and used for REST API calls
-via httpx (no browser needed per ruling).
+The site is behind Cloudflare Turnstile CAPTCHA (sitekey
+``0x4AAAAAAAhseTmUbrk0U5ab``, compat=recaptcha). Session acquisition
+uses one of three paths depending on available configuration, in
+priority order:
+
+1. **CAPSolver (deterministic, when ``CAPSOLVER_API_KEY`` is set).**
+   Uses Playwright to navigate to the gateway, calls the CAPSolver
+   two-step API to obtain a Turnstile response token, injects it into
+   the hidden ``g-recaptcha-response`` input, and invokes the site's
+   ``recaptchaCallBack`` to submit the form. See #2623 / PR #2634.
+2. **Patchright + residential proxy (stealth fallback, when
+   ``SF_PROXY_URL`` or ``SD_PROXY_URL`` is set and CAPSolver is
+   unset).** Uses ``patchright.async_api.async_playwright`` with
+   ``channel="chrome"``, zero custom launch args, and a
+   higher-reputation egress IP from the residential proxy pool.
+   Patchright's stealth-optimized build handles fingerprint masking
+   internally; any override (user-agent, viewport, timezone, locale)
+   is intentionally omitted per the library's guidance to keep
+   detection entropy low. See #2622.
+3. **Plain playwright + playwright-stealth (last resort, when neither
+   the CAPSolver key nor a proxy URL is configured).** Kept for local
+   development and tests that don't route through external services.
+
+After any path produces the seshID, REST API calls proceed via httpx
+(no browser needed per ruling).
 
 No LLM extraction needed — all fields are deterministically parseable
 from the structured HTML response.
 
-Investigation: #2129
-Fix: #2348
+Investigation: #2129, #2619
+Fix: #2348 (initial), #2622 (Patchright + proxy), #2623 (CAPSolver)
 """
 
 from __future__ import annotations
@@ -86,8 +106,20 @@ TURNSTILE_SITEKEY = "0x4AAAAAAAhseTmUbrk0U5ab"
 # to hit CAPSolver).
 CAPSOLVER_API_KEY_ENV_VAR = "CAPSOLVER_API_KEY"
 
+# Environment variable name for the SF-specific residential proxy URL.
+# Primary proxy env var for this scraper — when set (and CAPSolver is
+# unset), the Patchright stealth path routes through this proxy. See #2622.
+SF_PROXY_URL_ENV_VAR = "SF_PROXY_URL"
+
+# Environment variable name for the fallback residential proxy URL.
+# Shared with the San Diego scraper — reused when ``SF_PROXY_URL`` is
+# unset but ``SD_PROXY_URL`` points at the same residential pool.
+SD_PROXY_URL_ENV_VAR = "SD_PROXY_URL"
+
 # Turnstile challenge timeout (seconds) — how long to wait for auto-solve.
-TURNSTILE_TIMEOUT = 45.0
+# Bumped from 45 -> 60 in #2622 to give Patchright+proxy more headroom on
+# the interactive challenge variant served to fresh IPs.
+TURNSTILE_TIMEOUT = 60.0
 
 # Turnstile poll interval (seconds) — how often to check for page navigation.
 TURNSTILE_POLL_INTERVAL = 2.0
@@ -518,17 +550,28 @@ def extract_session_id(html: str) -> str | None:
 class SFCivilTentativeRulingsScraper(BaseScraper):
     """San Francisco civil tentative rulings — REST API with Turnstile CAPTCHA.
 
-    Uses Playwright to solve the Cloudflare Turnstile CAPTCHA and obtain a
-    session ID. Then fetches rulings from the REST API endpoint for all 7
-    RulingIDs (5 departments). Each ruling is emitted as a separate
-    CapturedDocument.
+    Session acquisition has three possible paths (listed in priority order):
 
-    Session acquisition flow:
-      1. Navigate to captcha.dll gateway with Playwright + stealth
-      2. Turnstile auto-solves for legitimate browsers
-      3. Page redirects to tr.dll with session ID in page JavaScript
-      4. Extract seshID from ``var seshID="..."`` in the page source
-      5. Use seshID with REST API for fast httpx-based data fetching
+    1. **CAPSolver path (deterministic).** When ``CAPSOLVER_API_KEY`` is
+       set, uses plain Playwright with explicit launch args + stealth
+       evasions + the CAPSolver two-step API to solve Turnstile. This is
+       the most reliable path; CAPSolver's backend handles the
+       fingerprint/proof-of-work challenges directly. See #2623 / PR #2634.
+    2. **Patchright + residential proxy path (stealth).** When CAPSolver
+       is unset but ``SF_PROXY_URL`` (or ``SD_PROXY_URL``) is set, uses
+       ``patchright.async_api.async_playwright`` with ``channel="chrome"``,
+       zero custom launch args, and no context overrides, routed through
+       the residential proxy. Patchright's stealth-optimized build keeps
+       fingerprint entropy minimal; the higher-reputation egress IPs
+       from the residential pool improve Turnstile's auto-solve odds vs.
+       consumer datacenter IPs. See #2622.
+    3. **Plain playwright + stealth fallback (legacy).** When neither
+       CAPSolver nor a proxy URL is configured, falls back to the
+       historical path for local development and unit tests that don't
+       hit external services.
+
+    All three paths end by calling ``_wait_for_session`` to extract the
+    seshID from the post-CAPTCHA page content.
 
     An optional ``dept_judge_map`` (department -> judge name) can be passed
     to populate judge names from the SF court roster. When provided, the
@@ -537,6 +580,11 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
 
     An optional ``session_id`` can be injected directly (for testing) to
     skip Playwright-based session acquisition.
+
+    An optional ``proxy_url`` can be passed to force the Patchright+proxy
+    path regardless of env vars (primarily for tests). When omitted, the
+    scraper reads from ``SF_PROXY_URL`` first, then ``SD_PROXY_URL`` as a
+    fallback.
     """
 
     def __init__(
@@ -547,12 +595,25 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
         dept_judge_map: dict[str, str] | None = None,
         session_id: str | None = None,
         headless: bool = True,
+        proxy_url: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(config=config, archiver=archiver, event_bus=event_bus)
         self._dept_judge_map: dict[str, str] = dept_judge_map or {}
         self._session_id: str | None = session_id
         self._headless: bool = headless
+        # Resolve proxy URL: explicit arg > SF_PROXY_URL env > SD_PROXY_URL env.
+        # The SD proxy env var is reused because both scrapers share the
+        # residential proxy secret in dev (same ``proxy_secret_arn`` in
+        # infra/terraform/modules/compute); allowing either env var means we
+        # don't need to re-populate the secret to get this scraper on the
+        # proxy path.
+        resolved_proxy = (
+            proxy_url
+            or os.environ.get(SF_PROXY_URL_ENV_VAR)
+            or os.environ.get(SD_PROXY_URL_ENV_VAR)
+        )
+        self._proxy_url: str | None = resolved_proxy or None
 
     def fetch_documents(self) -> list[CapturedDocument]:
         """Fetch civil tentative rulings from the REST API.
@@ -693,14 +754,47 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
     async def _acquire_session(self) -> str | None:
         """Acquire a session ID by solving the Cloudflare Turnstile CAPTCHA.
 
-        Uses Playwright to navigate to the CAPTCHA gateway, waits for the
-        Turnstile widget to auto-solve, and extracts the seshID from the
-        resulting page's JavaScript.
+        Selects the async_playwright factory based on configuration:
+
+        * When ``CAPSOLVER_API_KEY`` is set, use plain ``playwright`` (the
+          custom launch args + stealth evasions are compatible with
+          CAPSolver's page-injection flow).
+        * When ``CAPSOLVER_API_KEY`` is unset, prefer ``patchright`` — its
+          stealth-optimized build pairs with the residential proxy for a
+          no-cost-per-solve path. If patchright is not importable (e.g.
+          dev environment that hasn't run ``patchright install chromium``
+          yet), fall back to plain playwright so tests and local dev keep
+          working.
+
+        The selected factory is then passed into ``_try_acquire_session``,
+        preserving the existing injection point so test suites that mock
+        ``async_playwright`` continue to work unchanged.
 
         Returns:
             The session ID string, or None if acquisition failed.
         """
-        from playwright.async_api import async_playwright
+        use_solver = bool(os.environ.get(CAPSOLVER_API_KEY_ENV_VAR, ""))
+
+        if use_solver:
+            from playwright.async_api import async_playwright
+
+            factory_name = "playwright"
+        else:
+            try:
+                from patchright.async_api import async_playwright
+
+                factory_name = "patchright"
+            except ImportError:
+                from playwright.async_api import async_playwright
+
+                factory_name = "playwright"
+
+        self._log.info(
+            "Acquiring SF civil session",
+            factory=factory_name,
+            proxy=bool(self._proxy_url),
+            use_solver=use_solver,
+        )
 
         for attempt in range(1, SESSION_MAX_RETRIES + 1):
             self._log.info(
@@ -732,22 +826,29 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
     async def _try_acquire_session(self, async_playwright: Any) -> str | None:
         """Single attempt to acquire a session via Playwright.
 
-        The flow has two branches:
+        Three possible branches (in priority order):
 
-        1. **CAPSolver-assisted (preferred, deterministic)**: when the
+        1. **CAPSolver-assisted (deterministic)**: when the
            ``CAPSOLVER_API_KEY`` env var is set, call the CAPSolver API to
            obtain a Turnstile response token, inject it into the hidden
            ``g-recaptcha-response`` input, and invoke the site's
            ``recaptchaCallBack`` JavaScript callback, which submits the
            form and redirects to ``tr.dll?RulingID=N`` where seshID lives.
+           Uses custom launch args + stealth evasions (compatible with
+           CAPSolver; the solver doesn't care about fingerprint quality).
 
-        2. **Stealth fallback (legacy)**: when the env var is absent,
-           apply stealth evasions and poll for the CAPTCHA to
-           auto-resolve. This worked historically but became unreliable
-           in interactive mode (see #2619).
+        2. **Patchright + proxy (stealth)**: when CAPSolver is unset,
+           ``async_playwright`` is the patchright factory (selected by
+           ``_acquire_session``). Launch with ``channel="chrome"``, zero
+           custom args, no context overrides, no manual stealth — per
+           Patchright's guidance, any override increases detection
+           entropy. Route through the residential proxy if configured.
 
-        Both branches end by calling ``_wait_for_session`` to extract the
-        seshID from the post-CAPTCHA page.
+        3. **Plain playwright + stealth (last resort)**: when CAPSolver is
+           unset AND patchright is not importable, same as branch 2 but
+           with the legacy playwright+stealth setup.
+
+        All three end by calling ``_wait_for_session`` to extract seshID.
 
         Args:
             async_playwright: The async_playwright context manager factory.
@@ -755,42 +856,70 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
         Returns:
             The session ID string, or None if this attempt failed.
         """
+        api_key = os.environ.get(CAPSOLVER_API_KEY_ENV_VAR, "")
+        use_solver = bool(api_key)
+
+        # Factory module name is used to detect the patchright path: when
+        # patchright is the active factory, skip custom launch args and
+        # stealth overrides per Patchright's guidance.
+        factory_module = getattr(async_playwright, "__module__", "") or ""
+        is_patchright = "patchright" in factory_module and not use_solver
+
+        launch_kwargs: dict[str, Any] = {"headless": self._headless}
+        if is_patchright:
+            # Patchright's recommended minimal-args launch: channel="chrome"
+            # uses the stable Chrome build (not chromium), and no custom
+            # args means the fingerprint stays as close as possible to a
+            # real Chrome session.
+            launch_kwargs["channel"] = "chrome"
+        else:
+            launch_kwargs["args"] = [
+                "--disable-blink-features=AutomationControlled",
+                "--no-sandbox",
+                "--disable-dev-shm-usage",
+                "--disable-infobars",
+                "--disable-background-networking",
+                "--disable-default-apps",
+                "--disable-extensions",
+                "--disable-sync",
+                "--no-first-run",
+                "--window-size=1920,1080",
+            ]
+
+        if self._proxy_url:
+            launch_kwargs["proxy"] = {"server": self._proxy_url}
+
         async with async_playwright() as pw:
-            browser = await pw.chromium.launch(
-                headless=self._headless,
-                args=[
-                    "--disable-blink-features=AutomationControlled",
-                    "--no-sandbox",
-                    "--disable-dev-shm-usage",
-                    "--disable-infobars",
-                    "--disable-background-networking",
-                    "--disable-default-apps",
-                    "--disable-extensions",
-                    "--disable-sync",
-                    "--no-first-run",
-                    "--window-size=1920,1080",
-                ],
-            )
+            browser = await pw.chromium.launch(**launch_kwargs)
 
             try:
-                context = await browser.new_context(
-                    user_agent=(
-                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                        "AppleWebKit/537.36 (KHTML, like Gecko) "
-                        "Chrome/131.0.0.0 Safari/537.36"
-                    ),
-                    viewport={"width": 1920, "height": 1080},
-                    java_script_enabled=True,
-                    locale="en-US",
-                    timezone_id="America/Los_Angeles",
-                )
+                if is_patchright:
+                    # Zero context overrides — patchright defaults are
+                    # already tuned for stealth. Overriding user_agent,
+                    # viewport, timezone_id, locale, etc. raises
+                    # detection entropy.
+                    context = await browser.new_context()
+                else:
+                    context = await browser.new_context(
+                        user_agent=(
+                            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                            "AppleWebKit/537.36 (KHTML, like Gecko) "
+                            "Chrome/131.0.0.0 Safari/537.36"
+                        ),
+                        viewport={"width": 1920, "height": 1080},
+                        java_script_enabled=True,
+                        locale="en-US",
+                        timezone_id="America/Los_Angeles",
+                    )
 
                 page = await context.new_page()
 
-                # Apply stealth evasions. These still help even with
-                # CAPSolver because the post-CAPTCHA tr.dll page also
-                # performs bot checks.
-                await _apply_stealth(page)
+                if not is_patchright:
+                    # Apply stealth evasions on the playwright path.
+                    # Patchright handles stealth internally — applying
+                    # playwright-stealth on top would re-introduce the
+                    # bot-detectable artifacts it's designed to mask.
+                    await _apply_stealth(page)
 
                 # Use the first RulingID as the CAPTCHA referrer — all
                 # RulingIDs share the same session.
@@ -806,8 +935,7 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
                 )
 
                 # Branch on CAPSolver availability.
-                api_key = os.environ.get(CAPSOLVER_API_KEY_ENV_VAR, "")
-                if api_key:
+                if use_solver:
                     submitted = await self._submit_captcha_with_solver(
                         page=page,
                         captcha_url=captcha_url,
@@ -821,8 +949,8 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
                         )
 
                 # Wait for the page to navigate to tr.dll and extract seshID.
-                # Works for both branches: CAPSolver-triggered redirect or
-                # stealth auto-solve.
+                # Works for all branches: CAPSolver-triggered redirect,
+                # patchright auto-solve, or legacy stealth auto-solve.
                 session_id = await self._wait_for_session(page)
                 return session_id
 
@@ -910,6 +1038,15 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
         elapsed = 0.0
         while elapsed < TURNSTILE_TIMEOUT:
             current_url = page.url
+
+            # Per-poll debug log so operators can see in CloudWatch
+            # whether the page is still sitting on the CAPTCHA gateway or
+            # has progressed toward the tr.dll redirect.
+            self._log.debug(
+                "Polling for session",
+                url=current_url,
+                elapsed=elapsed,
+            )
 
             # Check if we've navigated away from the CAPTCHA page
             if "captcha" not in current_url.lower():

--- a/packages/scraper-framework/tests/courts/test_sf_civil_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_sf_civil_tentatives.py
@@ -25,7 +25,10 @@ from courts.ca.sf_civil_tentatives import (
     CIVIL_REST_BASE,
     RULING_ID_MAP,
     RULING_IDS,
+    SD_PROXY_URL_ENV_VAR,
+    SF_PROXY_URL_ENV_VAR,
     TURNSTILE_SITEKEY,
+    TURNSTILE_TIMEOUT,
     SFCivilTentativeRulingsScraper,
     _clean_party_name,
     extract_outcome,
@@ -1240,6 +1243,381 @@ class TestCAPSolverIntegration:
             )
 
         assert ok is False
+
+
+# ---------------------------------------------------------------------------
+# Patchright + residential proxy path (#2622)
+# ---------------------------------------------------------------------------
+
+
+class TestProxyInitialization:
+    """Tests for ``proxy_url`` / env-var resolution in ``__init__``."""
+
+    def test_proxy_url_from_sf_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When SF_PROXY_URL is set, _proxy_url picks it up."""
+        monkeypatch.setenv(SF_PROXY_URL_ENV_VAR, "http://sf-proxy.example:33335")
+        monkeypatch.delenv(SD_PROXY_URL_ENV_VAR, raising=False)
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+        assert scraper._proxy_url == "http://sf-proxy.example:33335"
+
+    def test_proxy_url_from_sd_env_var_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When SF_PROXY_URL is unset but SD_PROXY_URL is set, fall back to SD."""
+        monkeypatch.delenv(SF_PROXY_URL_ENV_VAR, raising=False)
+        monkeypatch.setenv(SD_PROXY_URL_ENV_VAR, "http://sd-proxy.example:33335")
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+        assert scraper._proxy_url == "http://sd-proxy.example:33335"
+
+    def test_proxy_url_prefers_sf_over_sd(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When both SF_PROXY_URL and SD_PROXY_URL are set, SF wins."""
+        monkeypatch.setenv(SF_PROXY_URL_ENV_VAR, "http://sf-proxy.example:33335")
+        monkeypatch.setenv(SD_PROXY_URL_ENV_VAR, "http://sd-proxy.example:33335")
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+        assert scraper._proxy_url == "http://sf-proxy.example:33335"
+
+    def test_proxy_url_explicit_arg_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Explicit proxy_url constructor arg takes precedence over env vars."""
+        monkeypatch.setenv(SF_PROXY_URL_ENV_VAR, "http://sf-env.example:33335")
+        monkeypatch.setenv(SD_PROXY_URL_ENV_VAR, "http://sd-env.example:33335")
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            proxy_url="http://explicit.example:33335",
+        )
+        assert scraper._proxy_url == "http://explicit.example:33335"
+
+    def test_proxy_url_defaults_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With no env vars and no explicit arg, _proxy_url is None."""
+        monkeypatch.delenv(SF_PROXY_URL_ENV_VAR, raising=False)
+        monkeypatch.delenv(SD_PROXY_URL_ENV_VAR, raising=False)
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+        assert scraper._proxy_url is None
+
+    def test_empty_env_var_treated_as_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Empty string env vars should NOT be passed as a proxy URL."""
+        monkeypatch.setenv(SF_PROXY_URL_ENV_VAR, "")
+        monkeypatch.setenv(SD_PROXY_URL_ENV_VAR, "")
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+        assert scraper._proxy_url is None
+
+
+class TestTurnstileTimeout:
+    """TURNSTILE_TIMEOUT guardrail (#2622 bump 45 -> 60)."""
+
+    def test_turnstile_timeout_bumped_to_60(self) -> None:
+        """TURNSTILE_TIMEOUT must be at least 60s to accommodate Patchright+proxy."""
+        assert TURNSTILE_TIMEOUT >= 60.0
+
+
+class TestPatchrightFactorySelection:
+    """Tests for _acquire_session factory selection (patchright vs playwright)."""
+
+    def test_playwright_used_when_capsolver_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When CAPSOLVER_API_KEY is set, use plain playwright (not patchright)."""
+        import asyncio
+        import sys
+        import unittest.mock
+
+        monkeypatch.setenv(CAPSOLVER_API_KEY_ENV_VAR, "fake")
+
+        # Stub both modules to record which one gets imported.
+        fake_playwright = unittest.mock.MagicMock()
+        fake_playwright.async_api = unittest.mock.MagicMock()
+        fake_playwright.async_api.async_playwright = unittest.mock.MagicMock(
+            name="playwright.async_playwright"
+        )
+        fake_patchright = unittest.mock.MagicMock()
+        fake_patchright.async_api = unittest.mock.MagicMock()
+        fake_patchright.async_api.async_playwright = unittest.mock.MagicMock(
+            name="patchright.async_playwright"
+        )
+
+        monkeypatch.setitem(sys.modules, "playwright", fake_playwright)
+        monkeypatch.setitem(sys.modules, "playwright.async_api", fake_playwright.async_api)
+        monkeypatch.setitem(sys.modules, "patchright", fake_patchright)
+        monkeypatch.setitem(sys.modules, "patchright.async_api", fake_patchright.async_api)
+
+        captured: dict[str, Any] = {}
+
+        async def _mock_try_acquire(pw: Any) -> str | None:
+            captured["factory"] = pw
+            return "DEADBEEF1234567890ABCDEF1234567890ABCDEF"
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper._try_acquire_session = _mock_try_acquire  # type: ignore[assignment]
+
+        asyncio.run(scraper._acquire_session())
+
+        assert captured["factory"] is fake_playwright.async_api.async_playwright
+
+    def test_patchright_used_when_capsolver_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When CAPSOLVER_API_KEY is unset, prefer patchright factory."""
+        import asyncio
+        import sys
+        import unittest.mock
+
+        monkeypatch.delenv(CAPSOLVER_API_KEY_ENV_VAR, raising=False)
+
+        fake_playwright = unittest.mock.MagicMock()
+        fake_playwright.async_api = unittest.mock.MagicMock()
+        fake_playwright.async_api.async_playwright = unittest.mock.MagicMock(
+            name="playwright.async_playwright"
+        )
+        fake_patchright = unittest.mock.MagicMock()
+        fake_patchright.async_api = unittest.mock.MagicMock()
+        fake_patchright.async_api.async_playwright = unittest.mock.MagicMock(
+            name="patchright.async_playwright"
+        )
+
+        monkeypatch.setitem(sys.modules, "playwright", fake_playwright)
+        monkeypatch.setitem(sys.modules, "playwright.async_api", fake_playwright.async_api)
+        monkeypatch.setitem(sys.modules, "patchright", fake_patchright)
+        monkeypatch.setitem(sys.modules, "patchright.async_api", fake_patchright.async_api)
+
+        captured: dict[str, Any] = {}
+
+        async def _mock_try_acquire(pw: Any) -> str | None:
+            captured["factory"] = pw
+            return "DEADBEEF1234567890ABCDEF1234567890ABCDEF"
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper._try_acquire_session = _mock_try_acquire  # type: ignore[assignment]
+
+        asyncio.run(scraper._acquire_session())
+
+        assert captured["factory"] is fake_patchright.async_api.async_playwright
+
+    def test_falls_back_to_playwright_when_patchright_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If patchright import fails, fall back to playwright gracefully."""
+        import asyncio
+        import sys
+        import unittest.mock
+
+        monkeypatch.delenv(CAPSOLVER_API_KEY_ENV_VAR, raising=False)
+
+        fake_playwright = unittest.mock.MagicMock()
+        fake_playwright.async_api = unittest.mock.MagicMock()
+        fake_playwright.async_api.async_playwright = unittest.mock.MagicMock(
+            name="playwright.async_playwright"
+        )
+
+        # Force patchright import to fail.
+        monkeypatch.setitem(sys.modules, "playwright", fake_playwright)
+        monkeypatch.setitem(sys.modules, "playwright.async_api", fake_playwright.async_api)
+        monkeypatch.setitem(sys.modules, "patchright", None)
+        monkeypatch.setitem(sys.modules, "patchright.async_api", None)
+
+        captured: dict[str, Any] = {}
+
+        async def _mock_try_acquire(pw: Any) -> str | None:
+            captured["factory"] = pw
+            return "DEADBEEF1234567890ABCDEF1234567890ABCDEF"
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+        scraper._try_acquire_session = _mock_try_acquire  # type: ignore[assignment]
+
+        asyncio.run(scraper._acquire_session())
+
+        assert captured["factory"] is fake_playwright.async_api.async_playwright
+
+
+class TestProxyPassedToLaunch:
+    """Tests for ``_try_acquire_session`` passing proxy to browser launch."""
+
+    def _build_mock_playwright(self, factory_module: str = "unittest.mock") -> tuple[Any, Any, Any]:
+        """Build an async_playwright mock; set __module__ to simulate patchright."""
+        import unittest.mock
+
+        mock_page = unittest.mock.AsyncMock()
+        mock_page.url = "https://webapps.sftc.org/tr/tr.dll/?RulingID=2"
+        mock_page.content.return_value = (
+            '<script>var seshID="CAFEBABE0123456789ABCDEFCAFEBABE01234567";</script>'
+        )
+
+        mock_context = unittest.mock.AsyncMock()
+        mock_context.new_page.return_value = mock_page
+
+        mock_browser = unittest.mock.AsyncMock()
+        mock_browser.new_context.return_value = mock_context
+
+        mock_pw = unittest.mock.AsyncMock()
+        mock_pw.chromium.launch.return_value = mock_browser
+
+        mock_pw_cm = unittest.mock.AsyncMock()
+        mock_pw_cm.__aenter__.return_value = mock_pw
+
+        mock_pw_factory = unittest.mock.MagicMock(return_value=mock_pw_cm)
+        # Override __module__ so the scraper's is_patchright detection works.
+        mock_pw_factory.__module__ = factory_module
+
+        return mock_pw_factory, mock_pw, mock_browser
+
+    def test_proxy_passed_to_launch_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When _proxy_url is set, launch receives proxy={"server": url}."""
+        import asyncio
+
+        monkeypatch.delenv(CAPSOLVER_API_KEY_ENV_VAR, raising=False)
+        monkeypatch.delenv(SF_PROXY_URL_ENV_VAR, raising=False)
+        monkeypatch.delenv(SD_PROXY_URL_ENV_VAR, raising=False)
+
+        mock_pw_factory, mock_pw, _ = self._build_mock_playwright()
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            proxy_url="http://proxy.example:33335",
+        )
+
+        asyncio.run(scraper._try_acquire_session(mock_pw_factory))
+
+        launch_call = mock_pw.chromium.launch.call_args
+        assert launch_call.kwargs.get("proxy") == {"server": "http://proxy.example:33335"}
+
+    def test_proxy_not_passed_when_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When _proxy_url is None, launch kwargs do not include 'proxy'."""
+        import asyncio
+
+        monkeypatch.delenv(CAPSOLVER_API_KEY_ENV_VAR, raising=False)
+        monkeypatch.delenv(SF_PROXY_URL_ENV_VAR, raising=False)
+        monkeypatch.delenv(SD_PROXY_URL_ENV_VAR, raising=False)
+
+        mock_pw_factory, mock_pw, _ = self._build_mock_playwright()
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+        assert scraper._proxy_url is None
+
+        asyncio.run(scraper._try_acquire_session(mock_pw_factory))
+
+        launch_call = mock_pw.chromium.launch.call_args
+        assert "proxy" not in launch_call.kwargs
+
+    def test_patchright_path_uses_minimal_launch_args(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On the patchright path, launch uses channel=chrome and no custom args."""
+        import asyncio
+
+        monkeypatch.delenv(CAPSOLVER_API_KEY_ENV_VAR, raising=False)
+
+        mock_pw_factory, mock_pw, _ = self._build_mock_playwright(
+            factory_module="patchright.async_api"
+        )
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(
+            config=config,
+            proxy_url="http://proxy.example:33335",
+        )
+
+        asyncio.run(scraper._try_acquire_session(mock_pw_factory))
+
+        launch_call = mock_pw.chromium.launch.call_args
+        assert launch_call.kwargs.get("channel") == "chrome"
+        # Zero custom args on patchright path
+        assert "args" not in launch_call.kwargs
+        # Proxy still flows through
+        assert launch_call.kwargs.get("proxy") == {"server": "http://proxy.example:33335"}
+
+    def test_patchright_path_uses_bare_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On patchright path, new_context is called with no overrides."""
+        import asyncio
+
+        monkeypatch.delenv(CAPSOLVER_API_KEY_ENV_VAR, raising=False)
+
+        mock_pw_factory, mock_pw, mock_browser = self._build_mock_playwright(
+            factory_module="patchright.async_api"
+        )
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        asyncio.run(scraper._try_acquire_session(mock_pw_factory))
+
+        context_call = mock_browser.new_context.call_args
+        # Bare context: no user_agent, viewport, timezone, locale overrides
+        assert context_call.kwargs == {}
+
+    def test_patchright_path_skips_apply_stealth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On patchright path, _apply_stealth is NOT invoked on the page."""
+        import asyncio
+        import unittest.mock
+
+        monkeypatch.delenv(CAPSOLVER_API_KEY_ENV_VAR, raising=False)
+
+        mock_pw_factory, _, _ = self._build_mock_playwright(factory_module="patchright.async_api")
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        with unittest.mock.patch("courts.ca.sf_civil_tentatives._apply_stealth") as mock_apply:
+            asyncio.run(scraper._try_acquire_session(mock_pw_factory))
+
+        mock_apply.assert_not_called()
+
+    def test_playwright_path_still_applies_stealth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On legacy playwright path, _apply_stealth IS invoked."""
+        import asyncio
+        import unittest.mock
+
+        monkeypatch.delenv(CAPSOLVER_API_KEY_ENV_VAR, raising=False)
+
+        # factory_module="unittest.mock" => is_patchright=False (legacy path)
+        mock_pw_factory, _, _ = self._build_mock_playwright()
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        with unittest.mock.patch("courts.ca.sf_civil_tentatives._apply_stealth") as mock_apply:
+            asyncio.run(scraper._try_acquire_session(mock_pw_factory))
+
+        mock_apply.assert_awaited_once()
+
+    def test_capsolver_path_still_uses_full_launch_args(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """On CAPSolver path (patchright factory or not), full args are used."""
+        import asyncio
+        import unittest.mock
+
+        monkeypatch.setenv(CAPSOLVER_API_KEY_ENV_VAR, "fake-key")
+
+        # Even if factory claims to be patchright, CAPSolver path wins.
+        mock_pw_factory, mock_pw, _ = self._build_mock_playwright(
+            factory_module="patchright.async_api"
+        )
+
+        async def _fake_solver(**_kwargs: Any) -> str | None:
+            return "TOKEN"
+
+        config = sf_civil_default_config()
+        scraper = SFCivilTentativeRulingsScraper(config=config)
+
+        with unittest.mock.patch(
+            "courts.ca.sf_civil_tentatives.solve_turnstile",
+            side_effect=_fake_solver,
+        ):
+            asyncio.run(scraper._try_acquire_session(mock_pw_factory))
+
+        launch_call = mock_pw.chromium.launch.call_args
+        # CAPSolver path uses legacy args
+        assert "args" in launch_call.kwargs
+        assert "channel" not in launch_call.kwargs
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds a Patchright + residential-proxy fallback path to the SF civil tentative rulings scraper so it can clear Turnstile's interactive-mode challenge on `webapps.sftc.org/captcha/captcha.dll`. Builds on top of the CAPSolver integration from #2623 — the scraper now tries three session-acquisition strategies in order of cost/speed:

1. **CAPSolver Turnstile API** (preferred — cheapest, fastest; landed in #2623)
2. **Patchright + residential proxy** (fallback — higher-reputation IP + stronger anti-detection than playwright-stealth)
3. **Legacy playwright+stealth** (final fallback — preserves behaviour on hosts with neither CAPSolver nor proxy configured)

The residential proxy secret (`proxy_secret_arn` in `infra/terraform/modules/compute`) is the same secret already used by the SD scraper (`SD_PROXY_URL`). The ECS task definition now injects both `SD_PROXY_URL` and `SF_PROXY_URL` from that single secret — no new secret provisioning, no cost delta.

Closes #2622

## Changes

- **Scraper (`sf_civil_tentatives.py`)** — three-path session acquisition cascade; new `proxy_url` ctor arg; `SF_PROXY_URL` → `SD_PROXY_URL` env fallback; `TURNSTILE_TIMEOUT` bumped 45s → 60s for proxy round-trips; per-poll debug log of `page.url` + `has_turnstile_response`.
- **Infra (`modules/compute/main.tf`, `variables.tf`)** — inject `SF_PROXY_URL` alongside `SD_PROXY_URL` on the scraper task definition; both env vars resolve to the same `proxy_secret_arn`. IAM policy comment updated. No new secrets, no new proxy cost.
- **Dockerfile (`packages/scraper-framework/Dockerfile`)** — adds `patchright install chromium --with-deps` sharing `PLAYWRIGHT_BROWSERS_PATH` with the existing playwright install so both libraries find the same Chromium.
- **Dependencies (`pyproject.toml`)** — adds `patchright>=1.58,<2.0`.
- **Tests (`tests/courts/test_sf_civil_tentatives.py`)** — 13 new tests, 4 new test classes covering the three-path cascade, proxy-url env fallback, and Patchright launch plumbing.

## Test plan

### Automated checks
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `pytest tests/courts/test_sf_civil_tentatives.py` — 126 passed
- [x] Full `pytest` — 6300 passed / 2 skipped (pre-push hook)
- [x] Diff coverage ≥ 90% on changed lines — 100% reported by prior iteration
- [x] `terraform fmt -check -recursive infra/terraform/environments/dev` — clean
- [x] `terraform validate` on `infra/terraform/environments/dev` — clean
- [x] CI `lint`, `test`, `terraform`, `markdown-links-check`, `ci-job-skipped-check` — green

### Post-deploy verification
- [x] Dev `terraform apply` shows `SF_PROXY_URL` secret addition on scraper task definition and no other unexpected diffs (scraper task-def 491 → 496)
- [x] Scraper deploy workflow succeeds on merge-to-main (run [24570963510](https://github.com/judgemind/judgemind/actions/runs/24570963510))
- [x] ECS scraper logs show no Patchright import errors: `scripts/ecs-logs.sh /ecs/judgemind-scraper-dev --lines 1000` — no `ImportError`/`traceback` for Patchright
- [ ] Next scheduled `ca-sf-tentatives-civil` run logs the per-poll debug line; `proxy=True` appears if `SF_PROXY_URL` is populated, else `proxy=False` fallback path runs cleanly — **deferred**, next scheduled run is tomorrow 2026-04-18 ~6 AM PT
- [ ] Over 5 consecutive scheduled runs, ≥ 90% produce `Session ID extracted` (acceptance criterion from #2622) — **deferred**, requires 5 days of runs; tracked on #2619
