### PR TITLE
docs(agent): promote memory-cleanup rules to CLAUDE.md, docs, and dispatcher skill

### DIFF
--- a/.claude/skills/dispatcher/SKILL.md
+++ b/.claude/skills/dispatcher/SKILL.md
@@ -432,6 +432,10 @@ The checkpoint is a Markdown file (human-readable, easy for the LLM to parse) wi
 - task-notification events from the <N> active agents above
 (or "Nothing -- no agents running, ready to dispatch" if slots are empty)
 
+## Recently Completed (cap at 10, drop oldest)
+- #<issue> -> PR #<N> merged + deployed -- <one-line note>
+(keep only the most recent 10 entries; older ones are dead weight and can be dropped)
+
 ## Do NOT
 - Sleep-and-poll for PR CI status -- agents manage their own PRs
 - Merge PRs while agents are still running -- only merge orphaned PRs
@@ -911,6 +915,10 @@ Shutdown triggers:
 - User types `/stop` or asks to stop
 - All issues in the queue are complete and no agents are running
 - **Context rotation threshold reached** (see "Context-Aware Rotation" above) — this is a **rotation**, not a full shutdown
+
+### Queue low or empty → spawn /spotcheck instead of idling
+
+When `gh issue list --label agent/ready` returns fewer issues than available `/task` slots and there are no in-flight agents with follow-ups pending, the correct idle behavior (especially overnight) is to spawn `/spotcheck` as a subagent (`isolation: worktree`) rather than winding down. /spotcheck samples across counties, compares DB records to source PDFs, and files per-pattern data-quality issues — which refills the queue with concrete work the dispatcher picks up in the next cycle. Treat this as standing instruction; do not ask permission when operating autonomously. Only move to full shutdown when /spotcheck itself produces no new work AND the queue is genuinely empty.
 
 ### Full shutdown procedure (user-initiated or queue empty)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,8 @@ These are the most frequently violated rules. **A PreToolUse hook enforces the s
 - **NEVER** share venvs between worktrees. Each worktree gets its own `.venv`.
 - **NEVER** create additional worktrees from inside a worktree via `git worktree add`. Subagents must work in their assigned worktree only. If the worktree gets into a bad state, fix it (e.g., `git checkout -- .`, `git clean -fd`) rather than creating a new one. Child worktrees become orphaned — `cleanup_worktree.sh` cannot track them, and the dispatcher does not know about them.
 - **NEVER** close a task or remove a worktree without posting a verification evidence comment on the issue. Every task completion requires concrete evidence that the change works (deployed services) or an explicit skip reason (docs/CI/tooling). See §4.10 Step 3.
+- **NEVER** bypass a safety check (e.g. `cleanup_worktree.sh`, preflight hooks, `.githooks/pre-push`) with `--force` or a manual workaround. When a check blocks you, trust it: skip and retry later, or investigate the root cause. The check is usually right and you are usually wrong about what is happening.
+- **NEVER** run `gh auth switch` or change the active GitHub CLI account without an explicit user instruction. If `gh` fails on auth, report the problem — don't swap accounts as a workaround. A subagent doing this once caused a ghost-PR incident that derailed an agent for multiple iterations.
 
 ### ALWAYS — Before Acting
 - **ALWAYS** Read a file before Writing to it (the Write tool fails on existing files you haven't read).
@@ -129,6 +131,13 @@ Use `/task` to claim and work on an issue: `/task`, `/task #42`, or `/task scrap
 1. **Issue template** — the Task template uses `status/triage` (not `agent/ready`), so new issues require manual labeling.
 2. **GitHub Action** (`issue-triage.yml`) — strips `agent/ready` from issues filed by non-collaborators.
 3. **Runtime check** — dispatcher and `/task` call `scripts/check-issue-author.sh` before spawning work (fail-closed).
+
+## Collaboration & Judgment
+
+These rules govern how you work with the user in interactive sessions, not just the mechanics of a task.
+
+- **Wait for confirmation before acting on proposals.** When you present an approach, options, or questions, end the turn and wait. Don't file issues, don't start implementing, don't spawn agents until the user responds with something like "yes", "go", "file it", or "looks good". Premature action skips the collaborative refinement step and produces issues/PRs that often need to be edited or closed.
+- **Zoom out before planning: root cause vs. symptom.** Before generating a plan or filing a batch of issues, ask: do these share a root cause? Have we fixed similar things before — and if so, why did it recur? Would a structural fix prevent the entire class of problem? Group by cause, not symptom. Present the reasoning to the user, not just the conclusion. Sometimes the honest answer is "this is just iteration on a sound approach" — that's fine — but if we keep re-treading the same ground, question the approach before adding more patches.
 
 ## PR Workflow (authoritative — applies to all task work)
 
@@ -306,6 +315,7 @@ See **`docs/agent/task-dependencies.md`** and **`docs/agent/issue-authoring.md`*
 - **Sub-tasks:** reference the parent as `Parent: #N`; each sub-task should be independently pickup-able.
 - **Acceptance criteria:** concrete and machine-checkable. Each criterion has at least one `Verify:` line (SQL query, curl response, URL/screenshot, etc.). External-integration issues need a one-line HTTP feasibility note before `agent/ready` (see #1979). **Data cleanup on `derived.*` defaults to `rebuild_db.py --county <name>`** — surgical delete/patch scripts are a last resort and must be justified in the issue body.
 - **Investigation tasks:** produce documentation (issue body or `docs/investigations/`) and file follow-up issues for every actionable finding, then close.
+- **Priority:** classify by urgency + workflow impact, not user-visibility. p1 = time-sensitive or workflow accelerators (scraper failures, data quality, DX, process improvements). p2 = most user-facing bugs, backfills, refactoring, docs. p3 = large slow work (features, redesigns). p0 is human-only. See `docs/agent/issue-authoring.md` §Priority Framework for the full table.
 
 ## Ingestion Pipeline — Separation of Concerns
 

--- a/docs/agent/issue-authoring.md
+++ b/docs/agent/issue-authoring.md
@@ -31,6 +31,21 @@ Acceptance criteria must be concrete and machine-checkable wherever possible. Va
 
 Each criterion should have at least one `Verify:` line that an agent can execute to confirm the criterion is met. This applies to issues filed by both humans and agents. If a verification command is not possible (e.g., requires subjective judgment), note that explicitly so reviewers know it requires manual verification.
 
+## Priority Framework
+
+Assign priority by urgency and workflow impact, not by user-visibility.
+
+| Priority | Principle | Categories |
+|---|---|---|
+| **p0** | Human-only; agents set only when explicitly told | Production outages, data loss |
+| **p1** | Time-sensitive or workflow accelerators | Scraper failures, data quality bugs, DX improvements, process fixes |
+| **p2** | Everything else | User-facing bugs, backfills, refactoring, docs, data prevention |
+| **p3** | Large slower units of work | Missing features, UI/UX redesign |
+
+**Rationale:** Scraper data is ephemeral (lost forever if not captured). DX issues directly affect agent throughput — a broken workflow wastes entire agent sessions. Process improvements prevent repeated failures. These justify p1 even though they are not user-facing. Large feature work and redesigns are important but not urgent — p3.
+
+Default DX to p1, not p3. Default features to p3, not p2. Reserve p0 for human-assigned true emergencies.
+
 ## Creating Sub-Tasks
 
 If a task naturally breaks into 2+ independent pieces of work, create child issues:

--- a/docs/agent/local-dev.md
+++ b/docs/agent/local-dev.md
@@ -28,6 +28,18 @@ Set `S3_CACHE_DIR=/tmp/judgemind-archive` to cache S3 objects on local disk. All
 - `S3_LOCAL_ONLY=1` — fully offline mode, no S3 contact at all.
 - Content-addressed keys mean cached files never go stale.
 
+### LLM extraction cache — gotcha when testing post-processing changes
+
+The `_LlmCache` stores final `ExtractedRuling` objects, not raw per-page LLM responses. A cache hit returns a pre-built object that **skips all post-processing** (e.g. `_extract_case_title_from_info`, `_join_page_rows`). Changing downstream parsing logic therefore has zero effect on cached results, and deleting local cache files does not help — `CachedS3Client` silently re-fetches from S3.
+
+When testing post-processing changes, set **both** env vars:
+
+```
+S3_LOCAL_ONLY=1 S3_CACHE_DIR=/tmp/judgemind-archive
+```
+
+When prompt text changes, the cache auto-invalidates via prompt-hash, but old entries persist on S3 as dead weight. The `tests/conftest.py` fixture handles this for pytest; ad-hoc test scripts need it set manually.
+
 ## Full local DB rebuild from S3
 
 ```

--- a/scripts/check-markdown-links.py
+++ b/scripts/check-markdown-links.py
@@ -181,6 +181,9 @@ def find_backtick_repo_paths(line: str) -> list[str]:
     return results
 
 
+SKIP_DIR_PARTS = frozenset({".terraform", "node_modules", ".venv"})
+
+
 def gather_default_files(repo_root: Path) -> list[Path]:
     """Collect the default set of files to scan."""
     files: list[Path] = []
@@ -188,6 +191,8 @@ def gather_default_files(repo_root: Path) -> list[Path]:
     for pattern in DEFAULT_SCAN_GLOBS:
         for path in repo_root.glob(pattern):
             if not path.is_file():
+                continue
+            if SKIP_DIR_PARTS.intersection(path.parts):
                 continue
             resolved = path.resolve()
             if resolved in seen:


### PR DESCRIPTION
## Summary

Memory sweep from an interactive dispatcher session removed 25 stale feedback entries. The durable rules inside those entries are promoted into the repo so future sessions inherit them without per-user memory.

- **CLAUDE.md**
  - Two new NEVER rules: no safety-check bypass with `--force` / manual workarounds, and no `gh auth switch` without explicit user instruction.
  - New "Collaboration & Judgment" section: wait-for-confirmation on proposals, zoom-out-before-planning (root cause vs. symptom).
  - Priority bullet added to the Task Dependencies section pointing at the new framework table.
- **docs/agent/issue-authoring.md** — Priority Framework table: p0 human-only, p1 = time-sensitive or workflow accelerators (scrapers, data quality, DX, process), p2 = most user-facing bugs/backfills/docs, p3 = large slow work (features, redesigns).
- **docs/agent/local-dev.md** — LLM extraction cache gotcha: `_LlmCache` stores final `ExtractedRuling` objects, so testing post-processing changes requires **both** `S3_LOCAL_ONLY=1` and `S3_CACHE_DIR`.
- **.claude/skills/dispatcher/SKILL.md** — cap "Recently Completed" checkpoint entries at 10, and spawn `/spotcheck` when the queue is shorter than available slots instead of idling overnight.
- **scripts/check-markdown-links.py** — skip `.terraform/`, `node_modules/`, and `.venv/` during filesystem scan. Pre-push failed locally whenever `terraform init` had populated `.terraform/providers/...` with vendor README.md files that contain their own broken internal links; `.terraform` is gitignored so CI never saw them, but the local check walks the filesystem.

## Test plan

### Automated checks
- [ ] CI markdown-links-check passes
- [ ] CI ci-job-skipped-check passes (only markdown and script files touched; this PR doesn't modify `.github/workflows/ci.yml`)

### Post-deploy verification
- [ ] No deployed component — docs/CI/skill changes only

Generated with [Claude Code](https://claude.com/claude-code)
