### PR TITLE
fix(ingestion): reject empty ruling_text with telemetry event (#2646)

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -1853,11 +1853,23 @@ class IngestionWorker:
                 output_tokens=0,
                 latency_ms=0,
             )
+            failed_rule_names = [r.rule for r in det_result.failed_rules]
+            # Surface a dedicated telemetry marker when the drop was driven
+            # by the empty-text rule (#2646).  This lets log-based
+            # dashboards/alerts count drops without string-matching the
+            # aggregated reason field.
+            telemetry_event = (
+                "data_quality.ruling_empty_text_dropped"
+                if "ruling_text_not_empty" in failed_rule_names
+                else None
+            )
             logger.warning(
                 "Deterministic validation FAIL — skipping DB write",
                 extra={
                     "document_id": document_id,
                     "det_reasons": det_result.reasons,
+                    "det_failed_rules": failed_rule_names,
+                    "telemetry_event": telemetry_event,
                     "county": county,
                     "case_number": case_number,
                 },

--- a/packages/scraper-framework/src/validation/deterministic.py
+++ b/packages/scraper-framework/src/validation/deterministic.py
@@ -241,13 +241,30 @@ def check_ruling_text_not_empty(ruling_text: str | None) -> DeterministicRuleRes
     """Check that ruling_text is not null or empty.
 
     An empty ruling text means extraction produced no content for this
-    document, which may indicate a scraping or transcription failure.
+    document.  Rather than storing a row with NULL/empty ``ruling_text``
+    (which pollutes full-text search, judge analytics, and downstream
+    summarisation), this rule returns ``fail`` so the worker skips the
+    DB write entirely and emits a ``data_quality.ruling_empty_text_dropped``
+    telemetry event (#2646).
+
+    Before #2646 this rule returned ``flag``, which allowed NULL-text rows
+    to accumulate in ``derived.rulings`` (most visibly for Santa Clara
+    multi-case splits where the LLM extracted metadata for a case but
+    produced no ruling_text).  The flag-and-write behaviour was
+    inconsistent with the schema's intent: a ``derived.rulings`` row
+    without substantive text has no meaningful content.
+
+    A ruling that genuinely has no text (e.g. an outcome-only docket
+    entry) should not appear in ``derived.rulings`` at all.  If such
+    entries need to be preserved later, that is a separate schema
+    decision — this guard rejects them until then.
     """
     if ruling_text is None or ruling_text.strip() == "":
         return DeterministicRuleResult(
             rule="ruling_text_not_empty",
-            result="flag",
-            reason="ruling_text is null or empty — extraction produced no content",
+            result="fail",
+            reason="ruling_text is null or empty — extraction produced no content "
+            "(data_quality.ruling_empty_text_dropped)",
         )
     return DeterministicRuleResult(rule="ruling_text_not_empty", result="pass")
 

--- a/packages/scraper-framework/tests/test_deterministic_validation.py
+++ b/packages/scraper-framework/tests/test_deterministic_validation.py
@@ -244,24 +244,33 @@ class TestNoMultipleAdversarialPatterns:
 
 
 class TestRulingTextNotEmpty:
-    """Tests for the ruling_text_not_empty rule."""
+    """Tests for the ruling_text_not_empty rule.
+
+    As of #2646 this rule returns ``fail`` (not ``flag``) for null/empty
+    ruling_text so the worker skips the DB write.  Previously-flagged
+    rows accumulated in ``derived.rulings`` as NULL-text ghosts, most
+    visibly for Santa Clara multi-case splits.
+    """
 
     def test_pass_has_content(self) -> None:
         result = check_ruling_text_not_empty("The motion is granted.")
         assert result.result == "pass"
 
-    def test_flag_none(self) -> None:
+    def test_fail_none(self) -> None:
         result = check_ruling_text_not_empty(None)
-        assert result.result == "flag"
+        assert result.result == "fail"
         assert "null or empty" in (result.reason or "")
+        # Includes the telemetry marker so log-based dashboards can count
+        # drops without string-matching the whole reason (#2646).
+        assert "data_quality.ruling_empty_text_dropped" in (result.reason or "")
 
-    def test_flag_empty_string(self) -> None:
+    def test_fail_empty_string(self) -> None:
         result = check_ruling_text_not_empty("")
-        assert result.result == "flag"
+        assert result.result == "fail"
 
-    def test_flag_whitespace_only(self) -> None:
+    def test_fail_whitespace_only(self) -> None:
         result = check_ruling_text_not_empty("   \n\t  ")
-        assert result.result == "flag"
+        assert result.result == "fail"
 
 
 # ---------------------------------------------------------------------------
@@ -933,12 +942,16 @@ class TestRunDeterministicRules:
         assert unknown_null[0].result == "pass"
 
     def test_flag_only(self) -> None:
-        """When only flag rules fire, overall is flag."""
-        # Note: UNKNOWN case_number WITH a real title keeps this test in the
-        # flag-only regime.  UNKNOWN + NULL title now triggers the new #2571
-        # fail rule, so we pass a title here to stay in flag-only territory.
+        """When only flag rules fire, overall is flag.
+
+        Note: since #2646 ``ruling_text=None`` now fails (not flags), so
+        this test uses a non-empty ruling_text and relies on
+        ``case_number_not_unknown`` as the sole flag trigger.  UNKNOWN
+        case_number WITH a real title keeps this in flag-only territory
+        (UNKNOWN + NULL title triggers the #2571 fail rule).
+        """
         result = run_deterministic_rules(
-            ruling_text=None,  # triggers ruling_text_not_empty flag
+            ruling_text="The motion is granted.",  # non-empty — no fail
             case_number="UNKNOWN-abc",  # triggers case_number_not_unknown flag
             case_title="Smith v. Jones",
             hearing_date=None,
@@ -946,6 +959,7 @@ class TestRunDeterministicRules:
         )
         assert result.overall == "flag"
         assert len(result.flagged_rules) >= 1
+        assert result.failed_rules == []
 
     def test_spotcheck_la_html_ruling(self) -> None:
         """LA ruling 65932ec6 — raw HTML should be caught by no_html_in_ruling_text."""

--- a/packages/scraper-framework/tests/test_deterministic_validation_integration.py
+++ b/packages/scraper-framework/tests/test_deterministic_validation_integration.py
@@ -337,40 +337,63 @@ def test_det_validation_flag_multiple_adversarial_patterns_issue_2398_example(
 
 
 # ---------------------------------------------------------------------------
-# Tests: deterministic validation — flag (empty ruling text)
+# Tests: deterministic validation — fail (empty ruling text, #2646)
 # ---------------------------------------------------------------------------
 
 
+@patch("ingestion.worker.insert_document_and_ruling")
 @patch("ingestion.worker.insert_validation_result")
 @patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1")
 @patch(_EXTRACT_LLM_MOCK, return_value=None)
 @patch(_SPLIT_MOCK, return_value=False)
 @patch("ingestion.worker.psycopg")
-def test_det_validation_flag_empty_ruling_text_still_writes(
+def test_det_validation_fail_empty_ruling_text_rejected(
     mock_psycopg: MagicMock,
     mock_split: MagicMock,
     mock_extract_llm: MagicMock,
     mock_resolve_judge: MagicMock,
     mock_insert_validation: MagicMock,
+    mock_insert_doc_ruling: MagicMock,
 ) -> None:
-    """Empty ruling text triggers a flag but still writes to DB."""
+    """Empty ruling text triggers a fail and skips the DB write (#2646).
+
+    Before #2646 this test asserted "flag but still writes" — the rule
+    was ``flag`` and the worker wrote the NULL-text row anyway, polluting
+    ``derived.rulings`` (19 NULL rows accumulated for Santa Clara).  The
+    rule is now ``fail`` and the worker skips the insert.
+    """
     worker, os_mock = _make_worker()
 
     mock_conn, mock_cur = _make_mock_conn()
     mock_psycopg.connect.return_value = mock_conn
+    # upsert_court + upsert_case run before deterministic validation fires.
+    # insert_document (and therefore its (True,) fetch) never runs because
+    # the fail path returns before insert_document_and_ruling.
     mock_cur.fetchone.side_effect = [
-        ("court-uuid-1",),  # upsert_court (flag logging)
         ("court-uuid-1",),  # upsert_court (main flow)
         ("case-uuid-1",),  # upsert_case
-        (True,),  # insert_document: is_new = True
     ]
     mock_cur.rowcount = 1
 
     event = _make_event(ruling_text="")
     worker.process_event(event)
 
-    # Document was still committed to DB (flag doesn't block)
-    assert mock_conn.commit.call_count >= 1
+    # insert_document_and_ruling must NOT have been called — empty text
+    # now fails validation and the worker returns before the DB write.
+    mock_insert_doc_ruling.assert_not_called()
+
+    # A deterministic fail result with the empty-text telemetry marker
+    # was logged instead.
+    fail_calls = [
+        c
+        for c in mock_insert_validation.call_args_list
+        if c.kwargs.get("result")
+        and c.kwargs["result"].model == "deterministic"
+        and c.kwargs["result"].result == "fail"
+        and "ruling_text is null or empty" in (c.kwargs["result"].reason or "")
+    ]
+    assert len(fail_calls) == 1
+    assert "data_quality.ruling_empty_text_dropped" in (fail_calls[0].kwargs["result"].reason or "")
 
 
 # ---------------------------------------------------------------------------
@@ -1301,3 +1324,139 @@ def test_det_validation_case_number_marker_db_error_does_not_crash(
             )
             # Should not raise despite DB error during flag logging.
             worker.process_event(event)
+
+
+# ---------------------------------------------------------------------------
+# Tests: empty-text rejection on split events (#2646)
+# ---------------------------------------------------------------------------
+
+
+@patch("ingestion.worker.insert_document_and_ruling")
+@patch("ingestion.worker.insert_validation_result")
+@patch(_DELETE_STALE_MOCK, return_value=0)
+@patch("ingestion.worker.psycopg")
+def test_det_validation_multi_case_empty_text_split_rejected(
+    mock_psycopg: MagicMock,
+    mock_delete_stale: MagicMock,
+    mock_insert_validation: MagicMock,
+    mock_insert_doc_ruling: MagicMock,
+) -> None:
+    """#2646 regression — multi-case split where one case has text and one
+    does not.  The case with text is written; the empty-text case is
+    rejected with a ``data_quality.ruling_empty_text_dropped`` telemetry
+    marker on the validation-result reason field.
+
+    Reproduces the Santa Clara failure mode: the multi-case-PDF LLM
+    extraction produces N rulings, but extraction yields no text for one
+    of them.  Before this fix the empty-text row silently reached
+    ``derived.rulings`` with NULL ``ruling_text``; after the fix the
+    worker's deterministic-validation path rejects it.  The test uses
+    the default LA event (no county-specific extractor config) so the
+    parent's ``_llm_split_document`` call honours the injected
+    ``_framework_extractor`` mock — the bug is county-agnostic so this
+    is a valid surrogate for the SC production path.
+    """
+    from ingestion.ruling_guards import ConvertedRuling
+
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    # Only the first (non-empty) split needs DB fetches — the second is
+    # rejected before insert_document_and_ruling runs.  upsert_court +
+    # upsert_case are called before deterministic validation for split 0.
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),  # upsert_court (split 0)
+        ("case-uuid-1",),  # upsert_case (split 0)
+        (True,),  # insert_document (split 0)
+        ("court-uuid-1",),  # upsert_court (split 1 — runs before det-validate)
+        ("case-uuid-2",),  # upsert_case (split 1 — runs before det-validate)
+    ]
+    mock_cur.rowcount = 1
+    # insert_document_and_ruling patched — simulate "new row" for split 0.
+    mock_insert_doc_ruling.return_value = True
+
+    # Split 0 has real text.  Split 1 has empty text — simulates the LLM
+    # extracting metadata but failing to transcribe the body for the
+    # second case in the PDF.
+    converted = [
+        ConvertedRuling(
+            document_id="split-uuid-0",
+            original_document_id="parent-uuid-1",
+            split_index=0,
+            split_count=2,
+            is_multi=True,
+            ruling_text="The motion for summary judgment is GRANTED.",
+            case_number="23CV1111",
+            case_title="Alpha v. Beta",
+            judge_name="Smith, John A.",
+            department="6",
+            motion_type="motion_for_summary_judgment",
+            outcome="granted",
+            hearing_date="2026-03-05",
+        ),
+        ConvertedRuling(
+            document_id="split-uuid-1",
+            original_document_id="parent-uuid-1",
+            split_index=1,
+            split_count=2,
+            is_multi=True,
+            ruling_text=None,  # empty — the extraction failure under test
+            case_number="23CV2222",
+            case_title="Gamma v. Delta",
+            judge_name="Smith, John A.",
+            department="6",
+            motion_type=None,
+            outcome=None,
+            hearing_date="2026-03-05",
+        ),
+    ]
+
+    with patch(_CONVERT_MOCK, return_value=converted):
+        with patch("ingestion.worker.resolve_judge", return_value="judge-uuid-1"):
+            # Use the default LA event so _llm_split_document takes the
+            # _get_framework_extractor() path (LA has no custom provider
+            # config), which honours the extractor_mock assigned below.
+            # County-specific configs (SC/Ventura/Fresno) route through
+            # _get_county_extractor() which is harder to mock and would
+            # return None without an API key — causing the parent to fall
+            # through to single-document processing and write the parent
+            # event's document_id instead of the split IDs.
+            extractor_mock = MagicMock()
+            extractor_mock.extract.return_value = MagicMock(rulings=[MagicMock()] * 2)
+            worker._framework_extractor = extractor_mock
+
+            event = _make_event(
+                ruling_text="Full parent-PDF text here " * 20,
+            )
+            worker.process_event(event)
+
+    # Exactly one document+ruling should have been written (the non-empty
+    # split).  The empty-text split is rejected before insert runs.
+    assert mock_insert_doc_ruling.call_count == 1, (
+        f"Expected exactly one DB write, got {mock_insert_doc_ruling.call_count}. "
+        f"The empty-text split should have been rejected by deterministic validation."
+    )
+    written_kwargs = mock_insert_doc_ruling.call_args_list[0].kwargs
+    assert written_kwargs["document_id"] == "split-uuid-0"
+    assert written_kwargs["ruling_text"] == "The motion for summary judgment is GRANTED."
+
+    # The empty-text split must produce a deterministic-validation fail
+    # record citing ruling_text_not_empty and the telemetry marker.
+    fail_calls = [
+        c
+        for c in mock_insert_validation.call_args_list
+        if c.kwargs.get("result")
+        and c.kwargs["result"].model == "deterministic"
+        and c.kwargs["result"].result == "fail"
+        and "ruling_text is null or empty" in (c.kwargs["result"].reason or "")
+    ]
+    assert len(fail_calls) == 1, (
+        f"Expected one empty-text fail record, got: "
+        f"{[c.kwargs.get('result') for c in mock_insert_validation.call_args_list]}"
+    )
+    fail_result = fail_calls[0].kwargs["result"]
+    assert "data_quality.ruling_empty_text_dropped" in (fail_result.reason or "")
+    # The fail record must be attached to the empty split's document_id,
+    # not the parent's — this is the row that would have gone to DB.
+    assert fail_calls[0].kwargs["document_id"] == "split-uuid-1"


### PR DESCRIPTION
## Summary

- Flip `check_ruling_text_not_empty` from `flag` to `fail` so the worker skips the DB write for rulings with NULL / empty / whitespace-only `ruling_text` instead of silently writing NULL-text rows to `derived.rulings`.
- Embed a `data_quality.ruling_empty_text_dropped` telemetry marker in the rule's `reason` and on the structured warning log's `extra` so log-based dashboards and `validation_results` consumers can count drops consistently.
- Add regression test for the multi-case PDF split scenario (criterion #5): one case has text, one does not — only the first writes; the second is rejected with the telemetry marker.

## Root cause

Hypothesis (1) from the issue body: the multi-case PDF splitter produces N `ConvertedRuling` objects but extraction yields `ruling_text=None` for some of them. The previously-`flag`ging `check_ruling_text_not_empty` rule let those NULL-text rows continue to `insert_document_and_ruling`, creating the 19 SC rows with `ruling_text IS NULL`.

## Scope decisions

- Option (b) chosen over (a): a `NOT NULL` constraint wouldn't emit telemetry or let `validation_results` record the rejection.
- The `<100 char` tail (42 rulings) is intentionally NOT in scope — legitimate short SC rulings exist (continuations, brief orders) and a hard minimum-length rule would cause false rejections.
- Cleanup via `rebuild_db.py --county "Santa Clara"` in Step 4.10 verification — no surgical delete needed per CLAUDE.md.

## Test plan

### Automated checks
- [x] Local unit tests green (`TestRulingTextNotEmpty` updated for `fail`)
- [x] Local integration tests green (`test_det_validation_fail_empty_ruling_text_rejected`, `test_det_validation_multi_case_empty_text_split_rejected`)
- [x] Full `packages/scraper-framework` suite green (6310 passed, 2 skipped)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] CI green

### Post-deploy verification
- [ ] ingestion-worker deploy succeeds on dev
- [ ] `rebuild_db.py --county "Santa Clara"` on dev completes cleanly
- [ ] Post-rebuild dev query returns 0 NULL ruling_text rows for SC
- [ ] Broader cross-county query: other counties with NULL ruling_text get follow-up issues (or confirm 0 across the board)

Closes #2646
