### PR TITLE
fix(scraping): drop short-unsubstantive OC rulings missing motion/outcome (#2645)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -906,6 +906,160 @@ def _drop_calendar_listing_rulings(
 
 
 # ---------------------------------------------------------------------------
+# Post-processing: short-unsubstantive ruling filter (#2645)
+# ---------------------------------------------------------------------------
+#
+# Some OC calendar PDFs include rows on the tentative-rulings table whose
+# body cell is empty — the court lists the case on the calendar but did not
+# post a tentative ruling for that row.  The multimodal LLM still emits one
+# object per calendar row, filling ``ruling_text`` with whatever happened to
+# be in that cell: the case caption, the motion-name header, a stray
+# punctuation mark, a fragment of nearby text.  These slip through the
+# pattern-based ``_drop_calendar_listing_rulings`` filter because the noise
+# text doesn't match any of its known markers (OFF-CALENDAR, NO TENTATIVE,
+# motion-type labels, etc.).
+#
+# The symptom is diagnosable by three shared characteristics of every
+# observed case:
+#
+#   * ``len(ruling_text) < 100`` — real tentative rulings run multi-paragraph
+#   * ``motion_type is None``    — LLM found no recognizable motion
+#   * ``outcome is None``        — LLM found no disposition verb
+#
+# Any one of these three signals alone is weak (real short "GRANTED."
+# rulings lack only length; a long citation artifact lacks only outcome),
+# but ALL THREE together virtually guarantees the row is calendar-listing
+# noise that the pattern filter missed.  "Missing > wrong" — when in doubt,
+# skip the row rather than emit something bogus.
+
+# Upper bound on ruling_text length for "short-unsubstantive" classification.
+# Real tentative rulings almost always exceed this length when complete; if
+# a row has <100 chars AND is missing both motion_type and outcome, the LLM
+# had no substantive content to summarize.
+_SHORT_UNSUBSTANTIVE_MAX_LENGTH = 100
+
+
+def _is_short_unsubstantive_ruling(
+    ruling: ExtractedRuling,
+    *,
+    length_threshold: int = _SHORT_UNSUBSTANTIVE_MAX_LENGTH,
+) -> bool:
+    """Return True if ``ruling`` is short and has no motion/outcome signal.
+
+    A "short-unsubstantive" ruling is one whose body text is below the
+    minimum-content threshold AND whose LLM extraction produced neither a
+    ``motion_type`` nor an ``outcome``.  These three signals together
+    indicate the row is almost certainly an empty-cell calendar listing
+    that the pattern-based filter missed — the LLM saw a calendar row with
+    no ruling body and filled ``ruling_text`` with whatever happened to be
+    in that cell (case caption fragment, motion-name header, stray text).
+
+    Additional qualifying condition: the ruling must have a case identifier
+    (``extracted_case_number`` or ``extracted_case_title``).  Rows without
+    either field are cross-page continuations that ``_join_page_rows``
+    could not merge into a previous case (no previous page context); those
+    promote to standalone ruling rows and must not be dropped even when
+    they happen to be short, because their content is real body text
+    belonging to a real case whose header was on a prior page.
+
+    The filter also short-circuits to False if the text contains a
+    disposition verb (GRANTED, DENIED, SUSTAINED, etc.).  Real one-liner
+    rulings like ``"Motion GRANTED."`` occasionally make it through with
+    null ``motion_type``/``outcome`` (LLM extraction failures are not free
+    of bugs), and those are real rulings we should not drop.
+
+    Parameters
+    ----------
+    ruling : ExtractedRuling
+        The ruling to evaluate.
+    length_threshold : int, optional
+        Maximum ``ruling_text`` length for short classification.  Defaults to
+        100 — chosen to match the matching OC spotcheck criterion in #2645.
+
+    Returns
+    -------
+    bool
+        True if ``ruling`` should be dropped as short-unsubstantive.
+    """
+    text = ruling.ruling_text
+    if not text:
+        return False
+    stripped = text.strip()
+    if not stripped or len(stripped) >= length_threshold:
+        return False
+    # A disposition verb means this is a real ruling, even if motion_type
+    # and outcome happen to be None (LLM extraction isn't bug-free either).
+    if _RULING_VERB_RE.search(stripped):
+        return False
+    # Cross-page continuations lack both case_number and case_title — those
+    # rows carry real body text whose header lives on a prior page.  Never
+    # drop them even when short and signal-free; that's the splitter's job
+    # to recover the full context on a later pass, not this filter's.
+    if not ruling.extracted_case_number and not ruling.extracted_case_title:
+        return False
+    # The three-signal test: missing motion_type AND outcome AND short.
+    return ruling.motion_type is None and ruling.outcome is None
+
+
+def _drop_short_unsubstantive_rulings(
+    rulings: list[ExtractedRuling],
+) -> list[ExtractedRuling]:
+    """Filter out rulings below the minimum-content threshold (#2645).
+
+    Orange County calendar PDFs sometimes list cases with empty
+    tentative-ruling cells (the court listed the case but did not post a
+    tentative for that row).  The multimodal LLM still emits one row per
+    listed case, filling ``ruling_text`` with whatever happened to be in
+    that cell — e.g. a fragment of the case caption or motion label.
+    These rows slip through ``_drop_calendar_listing_rulings`` because the
+    noise text doesn't match any of its known placeholder patterns.
+
+    This filter drops rulings that are **simultaneously**:
+
+    1. Short — ``len(ruling_text) < 100``
+    2. Missing ``motion_type`` (LLM found no motion label)
+    3. Missing ``outcome`` (LLM found no disposition)
+    4. Do not contain any disposition verb in ``ruling_text``
+
+    All four conditions must hold.  A disposition verb (``GRANTED``,
+    ``SUSTAINED``, etc.) is a strong enough signal that this is a real
+    short ruling — short-but-real rulings like ``"Motion GRANTED."`` are
+    preserved even if the LLM happened to leave ``motion_type``/``outcome``
+    null.
+
+    Rules:
+
+    - Entries with ``cross_reference_source`` set are exempt (same pattern
+      as ``_drop_calendar_listing_rulings``) — the shared text is the
+      referent's responsibility.
+    - Entries with ``ruling_text`` of ``None`` or empty are preserved —
+      they carry metadata only; dropping them is the job of other filters.
+
+    "Missing > wrong" (CLAUDE.md §Scraper Development Rules): when in doubt
+    between emitting a bogus short ruling and dropping the row, drop it.
+    """
+    kept: list[ExtractedRuling] = []
+    for ruling in rulings:
+        if ruling.cross_reference_source is not None:
+            kept.append(ruling)
+            continue
+        if not ruling.ruling_text:
+            kept.append(ruling)
+            continue
+        if _is_short_unsubstantive_ruling(ruling):
+            logger.warning(
+                "llm_extractor.short_unsubstantive_dropped",
+                case_number=ruling.extracted_case_number,
+                case_title=ruling.extracted_case_title,
+                text_preview=ruling.ruling_text[:100],
+                text_length=len(ruling.ruling_text),
+            )
+            continue
+        kept.append(ruling)
+    return kept
+
+
+# ---------------------------------------------------------------------------
 # Post-processing: cache-hit filter re-application (#2513)
 # ---------------------------------------------------------------------------
 #
@@ -946,6 +1100,7 @@ def _apply_pdf_cache_hit_filters(
     """
     original_count = len(rulings)
     rulings = _drop_calendar_listing_rulings(rulings)
+    rulings = _drop_short_unsubstantive_rulings(rulings)
     rulings = _deduplicate_ruling_texts(rulings)
     rulings = _filter_citation_artifacts(rulings)
     if len(rulings) != original_count:
@@ -2836,6 +2991,16 @@ def _join_page_rows(
     # this AFTER cross-reference resolution so legitimate shared text is
     # not accidentally classified as calendar-only.
     rulings = _drop_calendar_listing_rulings(rulings)
+
+    # Post-processing: drop short-unsubstantive rulings that slipped
+    # through the pattern-based calendar-listing filter (#2645).  Catches
+    # empty-cell OC calendar rows where the LLM filled ruling_text with
+    # noise (case caption fragment, motion label without disposition)
+    # instead of a real tentative ruling body.  Must run AFTER the
+    # pattern-based filter so pattern-matched rows log under their specific
+    # marker, and AFTER cross-reference resolution so shared text isn't
+    # misclassified as unsubstantive.
+    rulings = _drop_short_unsubstantive_rulings(rulings)
 
     # Post-processing: deduplicate identical ruling texts (#2096).
     # The LLM sometimes produces the same ruling text for multiple cases

--- a/packages/scraper-framework/tests/test_llm_cache_hit_filters.py
+++ b/packages/scraper-framework/tests/test_llm_cache_hit_filters.py
@@ -101,6 +101,31 @@ class TestApplyPdfCacheHitFilters:
         case_numbers = [r.extracted_case_number for r in filtered]
         assert case_numbers == ["30-2024-01"]
 
+    def test_drops_short_unsubstantive_ruling_on_cache_hit(self) -> None:
+        """A stale short-unsubstantive row (#2645) is dropped on cache-hit.
+
+        Simulates a cache entry written before the short-unsubstantive
+        filter existed: the 46-char case-caption noise from the issue body
+        must be dropped on cache read rather than requiring a reingest.
+        """
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-01",
+                extracted_case_title="Real Ruling",
+                ruling_text="The demurrer is SUSTAINED without leave to amend.",
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-02",
+                extracted_case_title="Empty-cell Noise (#2645)",
+                ruling_text="MALKI, Wajih v. KARANOUH, Abdulmajid",
+                motion_type=None,
+                outcome=None,
+            ),
+        ]
+        filtered = _apply_pdf_cache_hit_filters(rulings, content_key="abc123def456")
+        case_numbers = [r.extracted_case_number for r in filtered]
+        assert case_numbers == ["30-2024-01"]
+
     def test_preserves_valid_rulings(self) -> None:
         """Non-listing rulings are preserved through cache-hit filters."""
         rulings = [

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -26,18 +26,20 @@ from framework.llm_extractor import (
     _create_google_client,
     _deduplicate_ruling_texts,
     _drop_calendar_listing_rulings,
+    _drop_short_unsubstantive_rulings,
     _extract_case_number_from_info,
     _extract_case_title_from_info,
     _is_calendar_header,
     _is_calendar_listing_only,
     _is_new_case,
+    _is_short_unsubstantive_ruling,
     _join_page_rows,
     _parse_page_rows,
     _render_pdf_pages,
     _resolve_cross_references,
     _split_fused_case_info,
 )
-from framework.llm_schema import ExtractedRuling
+from framework.llm_schema import ExtractedRuling, ExtractionOutcome
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -910,7 +912,13 @@ class TestJoinPageRows:
     def test_case_info_merging_for_continuation(self) -> None:
         """Continuation case_info is appended to previous case."""
         rows = [
-            {"entry_number": 1, "case_info": "2024-00001 Alpha v. Beta", "ruling_text": "Part 1"},
+            {
+                "entry_number": 1,
+                "case_info": "2024-00001 Alpha v. Beta",
+                # Include a disposition verb so the short-unsubstantive
+                # filter (#2645) doesn't drop the merged row.
+                "ruling_text": "GRANTED. Part 1",
+            },
             {"entry_number": None, "case_info": "Additional info", "ruling_text": "Part 2"},
         ]
         rulings = _join_page_rows(rows)
@@ -1733,6 +1741,383 @@ class TestDropCalendarListingRulings:
         result = _drop_calendar_listing_rulings(rulings)
         assert len(result) == 1
         assert result[0].extracted_case_number == "30-2024-00007"
+
+
+class TestIsShortUnsubstantiveRuling:
+    """Tests for ``_is_short_unsubstantive_ruling`` (#2645).
+
+    Validates the three-signal test: ``ruling_text`` shorter than
+    threshold AND ``motion_type`` is None AND ``outcome`` is None.  A
+    disposition verb in the text short-circuits to False — real short
+    rulings are never dropped.
+    """
+
+    # --- Positive cases: should be classified as short-unsubstantive ---
+
+    def test_empty_cell_case_caption_noise(self) -> None:
+        """Calendar row with empty cell, LLM filled text with case caption (#2645)."""
+        # 46-char text matching the Malki symptom from the issue body —
+        # short, no motion, no outcome, no disposition verb.
+        ruling = ExtractedRuling(
+            extracted_case_number="30-2024-00001",
+            extracted_case_title="Malki vs Karanouh",
+            ruling_text="MALKI, Wajih v. KARANOUH, Abdulmajid",
+            motion_type=None,
+            outcome=None,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is True
+
+    def test_short_noise_no_motion_no_outcome(self) -> None:
+        """Generic short text with no motion/outcome is dropped."""
+        ruling = ExtractedRuling(
+            extracted_case_number="30-2024-00001",
+            ruling_text="Case caption only text here.",
+            motion_type=None,
+            outcome=None,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is True
+
+    def test_short_with_title_only_no_signals_dropped(self) -> None:
+        """Case with only a title (no case_number) but null motion/outcome is dropped."""
+        ruling = ExtractedRuling(
+            extracted_case_number=None,
+            extracted_case_title="Smith vs Jones",
+            ruling_text="Short caption fragment text",
+            motion_type=None,
+            outcome=None,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is True
+
+    def test_exactly_at_threshold_boundary(self) -> None:
+        """Text at exactly threshold length is NOT dropped (strict <)."""
+        # Exactly 100 chars.
+        text = "A" * 100
+        ruling = ExtractedRuling(
+            ruling_text=text,
+            motion_type=None,
+            outcome=None,
+        )
+        # _SHORT_UNSUBSTANTIVE_MAX_LENGTH = 100, condition is len < 100.
+        assert _is_short_unsubstantive_ruling(ruling) is False
+
+    def test_short_single_word(self) -> None:
+        """A single bare word with a case identifier is dropped."""
+        ruling = ExtractedRuling(
+            extracted_case_title="Stray Row",
+            ruling_text="Malki",
+            motion_type=None,
+            outcome=None,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is True
+
+    def test_cross_page_continuation_preserved(self) -> None:
+        """Cross-page continuation (no case_number/title) is NOT dropped.
+
+        Continuations get promoted to standalone rulings by ``_join_page_rows``
+        when there's no previous case on the same page to merge into.
+        They must not be dropped — their content is real ruling body text
+        whose header lives on a prior page.
+        """
+        ruling = ExtractedRuling(
+            extracted_case_number=None,
+            extracted_case_title=None,
+            ruling_text="...remaining text from previous case.",
+            motion_type=None,
+            outcome=None,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is False
+
+    # --- Negative cases: real short rulings must be preserved ---
+
+    def test_real_short_granted_preserved(self) -> None:
+        """'Motion GRANTED.' is real — preserved even with null motion/outcome."""
+        ruling = ExtractedRuling(
+            ruling_text="Motion GRANTED.",
+            motion_type=None,
+            outcome=None,
+        )
+        # Disposition verb short-circuits to False.
+        assert _is_short_unsubstantive_ruling(ruling) is False
+
+    def test_real_short_denied_preserved(self) -> None:
+        """'Denied.' alone preserved — disposition verb present."""
+        ruling = ExtractedRuling(
+            ruling_text="Denied.",
+            motion_type=None,
+            outcome=None,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is False
+
+    def test_short_with_motion_type_preserved(self) -> None:
+        """Short text WITH motion_type extracted is preserved."""
+        ruling = ExtractedRuling(
+            ruling_text="Short text here",
+            motion_type="demurrer",
+            outcome=None,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is False
+
+    def test_short_with_outcome_preserved(self) -> None:
+        """Short text WITH outcome extracted is preserved."""
+        ruling = ExtractedRuling(
+            ruling_text="Short text here",
+            motion_type=None,
+            outcome=ExtractionOutcome.GRANTED,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is False
+
+    def test_long_text_never_dropped(self) -> None:
+        """Text >= threshold is never dropped, even with null motion/outcome.
+
+        Above the threshold, even "no signals" text may be a real ruling
+        that the LLM failed to classify.  Err on the side of keeping it
+        (missing > wrong applies both ways — don't drop legit rulings).
+        """
+        # 200 chars of body text, no disposition verb, no motion, no outcome.
+        text = "The parties appeared for oral argument on the motion. " * 4
+        assert len(text) >= 100
+        ruling = ExtractedRuling(
+            ruling_text=text,
+            motion_type=None,
+            outcome=None,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is False
+
+    def test_none_text_preserved(self) -> None:
+        """None text returns False (metadata-only rows handled elsewhere)."""
+        ruling = ExtractedRuling(
+            extracted_case_number="30-2024-00001",
+            ruling_text=None,
+            motion_type=None,
+            outcome=None,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is False
+
+    def test_empty_text_preserved(self) -> None:
+        """Empty-string text returns False."""
+        ruling = ExtractedRuling(
+            ruling_text="",
+            motion_type=None,
+            outcome=None,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is False
+
+    def test_whitespace_only_preserved(self) -> None:
+        """Whitespace-only text returns False (treated as empty)."""
+        ruling = ExtractedRuling(
+            ruling_text="   \n\t  ",
+            motion_type=None,
+            outcome=None,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is False
+
+    def test_short_with_sustained_verb_preserved(self) -> None:
+        """Short text with SUSTAINED is preserved."""
+        ruling = ExtractedRuling(
+            ruling_text="Demurrer SUSTAINED.",
+            motion_type=None,
+            outcome=None,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is False
+
+    def test_short_with_overruled_verb_preserved(self) -> None:
+        """Short text with OVERRULED is preserved."""
+        ruling = ExtractedRuling(
+            ruling_text="Objection OVERRULED.",
+            motion_type=None,
+            outcome=None,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is False
+
+    def test_short_with_continued_verb_preserved(self) -> None:
+        """Short text with CONTINUED is preserved (real continuance)."""
+        ruling = ExtractedRuling(
+            ruling_text="Motion CONTINUED to April 20.",
+            motion_type=None,
+            outcome=None,
+        )
+        assert _is_short_unsubstantive_ruling(ruling) is False
+
+    def test_custom_length_threshold(self) -> None:
+        """Threshold parameter overrides the default."""
+        ruling = ExtractedRuling(
+            extracted_case_title="Some Case",
+            ruling_text="A" * 50,
+            motion_type=None,
+            outcome=None,
+        )
+        # With threshold 40, this 50-char text is above threshold.
+        assert _is_short_unsubstantive_ruling(ruling, length_threshold=40) is False
+        # With threshold 80, this 50-char text is below threshold.
+        assert _is_short_unsubstantive_ruling(ruling, length_threshold=80) is True
+
+
+class TestDropShortUnsubstantiveRulings:
+    """Tests for ``_drop_short_unsubstantive_rulings`` (#2645)."""
+
+    def test_drops_46_char_empty_cell_noise(self) -> None:
+        """Direct regression for the Malki symptom in issue #2645.
+
+        46 chars, motion_type=None, outcome=None — exactly the pattern the
+        issue describes.
+        """
+        noise = ExtractedRuling(
+            extracted_case_number="30-2024-00001",
+            extracted_case_title="Malki vs Karanouh",
+            ruling_text="MALKI, Wajih v. KARANOUH, Abdulmajid",
+            motion_type=None,
+            outcome=None,
+        )
+        real = ExtractedRuling(
+            extracted_case_number="30-2024-00002",
+            extracted_case_title="Smith vs Jones",
+            ruling_text="Demurrer is SUSTAINED without leave to amend.",
+            motion_type="demurrer",
+            outcome=ExtractionOutcome.GRANTED,
+        )
+        result = _drop_short_unsubstantive_rulings([noise, real])
+        assert len(result) == 1
+        assert result[0].extracted_case_number == "30-2024-00002"
+
+    def test_preserves_real_short_rulings_with_disposition(self) -> None:
+        """Short ruling with a disposition verb is preserved even if motion/outcome null."""
+        ruling = ExtractedRuling(
+            extracted_case_number="30-2024-00001",
+            ruling_text="Motion GRANTED.",
+            motion_type=None,
+            outcome=None,
+        )
+        assert _drop_short_unsubstantive_rulings([ruling]) == [ruling]
+
+    def test_preserves_rulings_with_motion_type(self) -> None:
+        """Short rulings with a motion_type are preserved."""
+        ruling = ExtractedRuling(
+            extracted_case_number="30-2024-00001",
+            ruling_text="Short text here.",
+            motion_type="demurrer",
+            outcome=None,
+        )
+        assert _drop_short_unsubstantive_rulings([ruling]) == [ruling]
+
+    def test_preserves_rulings_with_outcome(self) -> None:
+        """Short rulings with an outcome are preserved."""
+        ruling = ExtractedRuling(
+            extracted_case_number="30-2024-00001",
+            ruling_text="Short text here.",
+            motion_type=None,
+            outcome=ExtractionOutcome.DENIED,
+        )
+        assert _drop_short_unsubstantive_rulings([ruling]) == [ruling]
+
+    def test_preserves_cross_reference_entries(self) -> None:
+        """Cross-reference entries are exempt from the short-unsubstantive filter."""
+        ruling = ExtractedRuling(
+            extracted_case_number="30-2024-00001",
+            ruling_text="Short noise text",
+            motion_type=None,
+            outcome=None,
+            cross_reference_source=2,
+        )
+        result = _drop_short_unsubstantive_rulings([ruling])
+        assert len(result) == 1
+
+    def test_preserves_none_text(self) -> None:
+        """None ruling_text entries are preserved (metadata-only rows)."""
+        ruling = ExtractedRuling(
+            extracted_case_number="30-2024-00001",
+            ruling_text=None,
+            motion_type=None,
+            outcome=None,
+        )
+        assert _drop_short_unsubstantive_rulings([ruling]) == [ruling]
+
+    def test_preserves_empty_text(self) -> None:
+        """Empty-string ruling_text entries are preserved."""
+        ruling = ExtractedRuling(
+            extracted_case_number="30-2024-00001",
+            ruling_text="",
+            motion_type=None,
+            outcome=None,
+        )
+        assert _drop_short_unsubstantive_rulings([ruling]) == [ruling]
+
+    def test_preserves_long_rulings_without_signals(self) -> None:
+        """Long ruling text is preserved even with null motion/outcome."""
+        long_text = "The parties appeared for oral argument. " * 5
+        ruling = ExtractedRuling(
+            extracted_case_number="30-2024-00001",
+            ruling_text=long_text,
+            motion_type=None,
+            outcome=None,
+        )
+        assert len(long_text) >= 100
+        assert _drop_short_unsubstantive_rulings([ruling]) == [ruling]
+
+    def test_empty_list(self) -> None:
+        """Empty input returns empty list."""
+        assert _drop_short_unsubstantive_rulings([]) == []
+
+    def test_multiple_noise_rulings_all_dropped(self) -> None:
+        """Multiple empty-cell noise rows all get dropped."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="30-2024-00001",
+                ruling_text="Smith vs Jones",
+                motion_type=None,
+                outcome=None,
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00002",
+                ruling_text="Motion for something",
+                motion_type=None,
+                outcome=None,
+            ),
+            ExtractedRuling(
+                extracted_case_number="30-2024-00003",
+                ruling_text="Short blurb",
+                motion_type=None,
+                outcome=None,
+            ),
+        ]
+        assert _drop_short_unsubstantive_rulings(rulings) == []
+
+    def test_interaction_with_calendar_listing_filter(self) -> None:
+        """The two filters are complementary — both needed.
+
+        The calendar-listing filter handles pattern-matched placeholders
+        (OFF-CALENDAR, motion labels).  The short-unsubstantive filter
+        catches unknown-pattern noise (case-caption fragments).
+        """
+        # OFF-CALENDAR matches _is_calendar_listing_only — would be dropped
+        # by the calendar-listing filter too, but the short-unsubstantive
+        # filter is tolerant of either pattern firing first.
+        listing = ExtractedRuling(
+            extracted_case_number="30-2024-00001",
+            ruling_text="OFF-CALENDAR",
+            motion_type=None,
+            outcome=None,
+        )
+        # Unknown-pattern noise — only the short-unsubstantive filter catches it.
+        unknown = ExtractedRuling(
+            extracted_case_number="30-2024-00002",
+            ruling_text="MALKI, Wajih v. KARANOUH, Abdulmajid",
+            motion_type=None,
+            outcome=None,
+        )
+        real = ExtractedRuling(
+            extracted_case_number="30-2024-00003",
+            ruling_text="Demurrer is SUSTAINED without leave to amend.",
+            motion_type="demurrer",
+            outcome=ExtractionOutcome.GRANTED,
+        )
+        # Apply both filters in the same order as _join_page_rows.
+        step1 = _drop_calendar_listing_rulings([listing, unknown, real])
+        # step1: listing gone, unknown + real remain
+        assert len(step1) == 2
+        step2 = _drop_short_unsubstantive_rulings(step1)
+        # step2: unknown gone, only real remains
+        assert len(step2) == 1
+        assert step2[0].extracted_case_number == "30-2024-00003"
 
 
 class TestJoinPageRowsCalendarListing:
@@ -3426,11 +3811,14 @@ class TestJoinPageRowsFusedRowSplit:
         splitter fix, the same 5 rows expand to 6 rulings with distinct
         case titles.
         """
+        # Include disposition verbs (GRANTED, DENIED) in each stub so the
+        # short-unsubstantive filter (#2645) does not drop them — these
+        # placeholders are shorter than the real-ruling threshold.
         rows = [
             {
                 "entry_number": 1,
                 "case_info": "30-2024-01111111 Grossman v. Smith",
-                "ruling_text": "Ruling 1.",
+                "ruling_text": "GRANTED. Ruling 1.",
             },
             {
                 "entry_number": 2,
@@ -3438,22 +3826,22 @@ class TestJoinPageRowsFusedRowSplit:
                     "Gu v. Family Orthodontics & Oral Surgery 2 "
                     "Clarke, Inc. v. Ellis & Son Trucking, Inc."
                 ),
-                "ruling_text": "Ruling 2 (on Gu).",
+                "ruling_text": "GRANTED. Ruling 2 (on Gu).",
             },
             {
                 "entry_number": 3,
                 "case_info": "30-2024-02222222 Sandoval v. Lopez",
-                "ruling_text": "Ruling 3.",
+                "ruling_text": "DENIED. Ruling 3.",
             },
             {
                 "entry_number": 4,
                 "case_info": "30-2024-03333333 Moore v. Williams",
-                "ruling_text": "Ruling 4.",
+                "ruling_text": "GRANTED. Ruling 4.",
             },
             {
                 "entry_number": 5,
                 "case_info": "30-2024-04444444 Palacios v. Vallejo",
-                "ruling_text": "Ruling 5.",
+                "ruling_text": "DENIED. Ruling 5.",
             },
         ]
         rulings = _join_page_rows(rows)
@@ -3483,7 +3871,9 @@ class TestJoinPageRowsFusedRowSplit:
                     "Gu v. Family Orthodontics & Oral Surgery 2 "
                     "Clarke, Inc. v. Ellis & Son Trucking, Inc."
                 ),
-                "ruling_text": "R1.",
+                # Include a disposition verb so the short-unsubstantive
+                # filter (#2645) preserves this stub.
+                "ruling_text": "GRANTED. R1.",
             },
         ]
         rulings = _join_page_rows(rows)
@@ -3518,7 +3908,9 @@ class TestJoinPageRowsFusedRowSplit:
                     "Gu v. Family Orthodontics & Oral Surgery 2 "
                     "Clarke, Inc. v. Ellis & Son Trucking, Inc."
                 ),
-                "ruling_text": "Ruling 2.",
+                # Include a disposition verb so the short-unsubstantive
+                # filter (#2645) preserves the fused row's sub-cases.
+                "ruling_text": "GRANTED. Ruling 2.",
             },
             {
                 "entry_number": 3,


### PR DESCRIPTION
## Summary

Adds `_drop_short_unsubstantive_rulings` to the multimodal LLM extractor's post-processing pipeline to catch OC calendar rows with empty tentative-ruling cells that slip past the pattern-based `_drop_calendar_listing_rulings`. A row is dropped only when all four signals fire together: `len(ruling_text) < 100` AND `motion_type is None` AND `outcome is None` AND no disposition verb — with an exemption for cross-page continuations that carry no case identifier.

Closes #2645

## Root cause

The multimodal LLM receives a page image and emits one row per calendar entry. When the tentative-ruling cell is empty, the LLM fills `ruling_text` with whatever happens to be in that cell — a case caption fragment, a motion-name header, stray punctuation. The existing `_drop_calendar_listing_rulings` filter (from #2446 / #2489) is pattern-based: it catches known placeholder markers like `OFF-CALENDAR`, `NO TENTATIVE`, `O/C`, motion labels, bare parenthetical dispositions, etc. It does not catch arbitrary noise that happens to be short but doesn't match any known pattern — the Malki 46-char case-caption example from the issue body is the canonical case.

A threshold-based complementary filter closes that gap without regressing real short rulings.

## Design

`_is_short_unsubstantive_ruling(ruling)` returns True when:

1. `ruling_text` is non-empty (empty/None rows are metadata-only, handled elsewhere)
2. `len(ruling_text.strip()) < 100`
3. `_RULING_VERB_RE` finds no disposition verb (GRANTED, DENIED, SUSTAINED, OVERRULED, CONTINUED, TRAILED, MOOTED, WITHDRAWN, DROPPED, SETTLED, DISMISSED, VACATED, STAYED, APPROVED, TAKEN OFF CALENDAR)
4. At least one of `extracted_case_number` or `extracted_case_title` is set (exempt cross-page continuations)
5. `motion_type is None` AND `outcome is None`

All five signals must align — missing any one means the row is kept. The disposition-verb short-circuit specifically protects real one-liner rulings like `Motion GRANTED.` when the LLM fails to populate `motion_type`/`outcome` independently.

`_drop_short_unsubstantive_rulings(rulings)` runs after `_drop_calendar_listing_rulings` in both the fresh-extraction path (`_join_page_rows`) and the PDF cache-hit path (`_apply_pdf_cache_hit_filters`, mirroring the #2513 parity pattern). Cross-reference entries (`cross_reference_source is not None`) are exempt — same pattern as the calendar-listing filter.

## Test plan

### Automated checks
- [x] Lint passes (`ruff check packages/scraper-framework`)
- [x] Format check passes (`ruff format --check packages/scraper-framework`)
- [x] Tests pass (`pytest packages/scraper-framework` — 6,340 tests, all passing locally including new regressions)
- [x] CI green

### Post-deploy verification

- [ ] Scraper deploy workflow (`deploy-scraper.yml`) completes successfully for this change
- [ ] On dev, run the baseline query and confirm the count drops to ≤ 5 (or 0) for OC rulings matching the empty-cell pattern:
  ```sql
  SELECT COUNT(*) FROM derived.rulings r
    JOIN derived.documents d ON r.document_id = d.id
    JOIN derived.courts ct ON ct.id = d.court_id
   WHERE ct.county = 'Orange'
     AND length(r.ruling_text) < 100
     AND r.motion_type IS NULL
     AND r.outcome IS NULL
  ```
- [ ] Tail ECS logs for `/ecs/judgemind-ingestion-worker-dev` and confirm at least one `llm_extractor.short_unsubstantive_dropped` log line fires during a post-deploy OC ingestion run (or cache-hit re-filter). No new error lines.
- [ ] Verification evidence comment posted on #2645 per §A.8 Step 3