### PR TITLE
feat(telemetry): N-consecutive-zero-record alert rule across all scrapers (#2666)

### DIFF
--- a/.github/workflows/scraper-zero-record-check.yml
+++ b/.github/workflows/scraper-zero-record-check.yml
@@ -1,0 +1,322 @@
+name: Scraper Zero-Record Streak Check
+
+on:
+  schedule:
+    # Daily at 14:30 UTC (07:30 PT) — after California tentative-ruling
+    # scrapers have had the overnight window to produce data. Offset from
+    # data-quality (:15) and api-error (:45) so schedules do not collide.
+    - cron: '30 14 * * *'
+  # Allow manual trigger for debugging / issue verification.
+  workflow_dispatch:
+    inputs:
+      threshold:
+        description: "Breach threshold for frequent scrapers (default: 3)"
+        required: false
+        type: string
+      daily_threshold:
+        description: "Breach threshold for daily scrapers (default: 2)"
+        required: false
+        type: string
+      scraper:
+        description: "Limit the check to a single scraper ID"
+        required: false
+        type: string
+
+# Only one streak check at a time.
+concurrency:
+  group: scraper-zero-record-check
+  cancel-in-progress: true
+
+permissions:
+  issues: write
+  contents: read
+
+env:
+  AWS_REGION: us-west-2
+
+jobs:
+  zero-record-streak-check:
+    name: Detect scrapers with N consecutive zero-record runs
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            scripts/check-scraper-zero-record-streak.py
+            scripts/ecs-run-task.sh
+            scripts/ecs-logs.sh
+            scripts/notify-telegram.sh
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Build script arguments
+        id: args
+        run: |
+          ARGS="--json"
+          if [ -n "${{ inputs.threshold }}" ]; then
+            ARGS="$ARGS --threshold ${{ inputs.threshold }}"
+          fi
+          if [ -n "${{ inputs.daily_threshold }}" ]; then
+            ARGS="$ARGS --daily-threshold ${{ inputs.daily_threshold }}"
+          fi
+          if [ -n "${{ inputs.scraper }}" ]; then
+            ARGS="$ARGS --scraper ${{ inputs.scraper }}"
+          fi
+          echo "script_args=$ARGS" >> "$GITHUB_OUTPUT"
+
+      - name: Run zero-record streak check on ECS
+        id: check
+        env:
+          SCRIPT_ARGS: ${{ steps.args.outputs.script_args }}
+        run: |
+          # Run on ECS so the script has DATABASE_URL injected from Secrets
+          # Manager and can reach the private VPC. Use --cpu 256/--memory 512
+          # since this is a lightweight SQL-only check.
+          set +e
+          scripts/ecs-run-task.sh \
+            --cpu 256 --memory 512 \
+            --timeout 300 \
+            --latest-image \
+            scripts/check-scraper-zero-record-streak.py -- $SCRIPT_ARGS 2>&1 \
+            | tee /tmp/check_output.txt
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+          # Extract the JSON portion from the mixed ECS log output. The
+          # script prints a single JSON blob to stdout; ECS task wrapper
+          # adds surrounding logs. We grep the first line that starts with
+          # "{" and read until the matching closing brace at column 0.
+          python3 - <<'PY'
+          import json, re, sys
+          text = open("/tmp/check_output.txt").read()
+          # Extract JSON blocks (greedy, starting with "{" at col 0, ending
+          # with "}" at col 0). Take the last matching block — the script
+          # output is the last JSON the ECS wrapper printed.
+          matches = re.findall(r"(?ms)^\{\n.*?^\}", text)
+          if not matches:
+              print("Could not find JSON block in output; assuming healthy.")
+              open("/tmp/check_json.txt", "w").write(
+                  '{"healthy": true, "breaches": [], "insufficient_history": [], "checked_count": 0, "excluded_count": 0}'
+              )
+              sys.exit(0)
+          blob = matches[-1]
+          try:
+              json.loads(blob)
+          except Exception as exc:
+              print(f"Parsed JSON block failed to load: {exc}; assuming healthy.")
+              blob = '{"healthy": true, "breaches": [], "insufficient_history": [], "checked_count": 0, "excluded_count": 0}'
+          open("/tmp/check_json.txt", "w").write(blob)
+          PY
+
+          HEALTHY=$(python3 -c "import json; print(json.load(open('/tmp/check_json.txt'))['healthy'])")
+          if [ "$HEALTHY" = "True" ]; then
+            echo "healthy=true" >> "$GITHUB_OUTPUT"
+            echo "No zero-record streak breaches detected."
+          else
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+            echo "Zero-record streak breaches detected (exit code $EXIT_CODE)."
+          fi
+
+      - name: Extract alert summary
+        if: steps.check.outputs.healthy == 'false'
+        id: summary
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          python3 - <<'PY'
+          import json, os
+          data = json.load(open("/tmp/check_json.txt"))
+          breaches = data.get("breaches", [])
+          lines = [
+              "| Scraper | Consecutive zeros | Threshold | First zero at | Last nonzero at |",
+              "| --- | --- | --- | --- | --- |",
+          ]
+          for b in breaches:
+              lines.append(
+                  "| {sid} | {streak} | {threshold} | {first} | {last_nonzero} |".format(
+                      sid=b["scraper_id"],
+                      streak=b["streak"],
+                      threshold=b["threshold"],
+                      first=b["first_zero_at"],
+                      last_nonzero=b.get("last_nonzero_at") or "(none in window)",
+                  )
+              )
+          open("/tmp/alert_summary.md", "w").write("\n".join(lines))
+
+          # Telegram one-liner
+          parts = [
+              f'{b["scraper_id"]} ({b["streak"]} consecutive zero-record runs)'
+              for b in breaches
+          ]
+          open("/tmp/alert_telegram.txt", "w").write(
+              "; ".join(parts) if parts else "Unknown alert"
+          )
+          PY
+
+          echo "Alert summary:"
+          cat /tmp/alert_summary.md
+
+      - name: Check for existing open issue
+        if: steps.check.outputs.healthy == 'false'
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label "scraper-zero-record-alert" \
+            --json number \
+            --limit 1 \
+            -q '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "number=$EXISTING" >> "$GITHUB_OUTPUT"
+            echo "Open scraper-zero-record-alert issue already exists: #${EXISTING}"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create failure issue
+        id: create-issue
+        if: >-
+          steps.check.outputs.healthy == 'false' &&
+          steps.existing.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          {
+            echo "## Scraper Zero-Record Streak Alert"
+            echo ""
+            echo "One or more scrapers have returned \`records_captured = 0\` for"
+            echo "multiple consecutive runs. This is the silent-outage failure"
+            echo "mode described by #2620 / #2666 — the scraper may technically"
+            echo "report success but is not producing data."
+            echo ""
+            echo "### Breaches"
+            echo ""
+            cat /tmp/alert_summary.md
+            echo ""
+            echo ""
+            echo "### Context"
+            echo ""
+            echo "- **Workflow run:** ${RUN_URL}"
+            echo "- **Timestamp:** ${TIMESTAMP}"
+            echo "- **Check script:** \`scripts/check-scraper-zero-record-streak.py\`"
+            echo ""
+            echo "### Next Steps"
+            echo ""
+            echo "1. Review the affected scraper's ECS logs:"
+            echo "   \`scripts/ecs-logs.sh /ecs/judgemind-scraper-<id>-dev --lines 200\`"
+            echo "2. Visit the source website manually — a zero-record streak"
+            echo "   caused by a court actually having no rulings is still rare"
+            echo "   but possible during extended closures."
+            echo "3. If the source has data but the scraper missed it, file a"
+            echo "   \`priority/p1\` bug against the scraper."
+            echo "4. If the streak is an expected calm period, add the scraper"
+            echo "   to the \`EXCLUSIONS\` set in the check script and re-run"
+            echo "   the workflow."
+            echo ""
+            echo "This issue was created automatically by the zero-record"
+            echo "streak workflow. It will not create duplicates while this"
+            echo "issue is open."
+          } > /tmp/issue_body.md
+
+          ISSUE_URL=$(gh issue create \
+            --repo "${{ github.repository }}" \
+            --title "Scraper zero-record streak: silent outage detected" \
+            --body-file /tmp/issue_body.md \
+            --label "priority/p1,area/scraping,scraper-zero-record-alert,agent/ready")
+
+          echo "issue_url=$ISSUE_URL" >> "$GITHUB_OUTPUT"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Send Telegram notification
+        if: steps.create-issue.outputs.created == 'true'
+        continue-on-error: true
+        run: |
+          ISSUE_URL="${{ steps.create-issue.outputs.issue_url }}"
+          ISSUE_NUM="${ISSUE_URL##*/}"
+          TG_SUMMARY=$(cat /tmp/alert_telegram.txt 2>/dev/null || echo "Alert details unavailable.")
+
+          {
+            echo "<b>Scraper Zero-Record Alert</b>"
+            echo ""
+            echo "${TG_SUMMARY}"
+            echo ""
+            echo "Issue #${ISSUE_NUM}: ${ISSUE_URL}"
+          } > /tmp/tg_message.txt
+
+          scripts/notify-telegram.sh --message-file /tmp/tg_message.txt
+
+      - name: Update existing issue with new failures
+        if: >-
+          steps.check.outputs.healthy == 'false' &&
+          steps.existing.outputs.exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUM: ${{ steps.existing.outputs.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          {
+            echo "### Update: still in breach at ${TIMESTAMP}"
+            echo ""
+            cat /tmp/alert_summary.md
+            echo ""
+            echo ""
+            echo "**Workflow run:** ${RUN_URL}"
+          } > /tmp/comment_body.md
+
+          gh issue comment "$ISSUE_NUM" \
+            --repo "${{ github.repository }}" \
+            --body-file /tmp/comment_body.md
+
+      - name: Auto-close resolved zero-record issues
+        if: steps.check.outputs.healthy == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          ISSUES=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --state open \
+            --label "scraper-zero-record-alert" \
+            --json number \
+            -q '.[].number')
+
+          if [ -z "$ISSUES" ]; then
+            echo "No open scraper-zero-record-alert issues to close."
+            exit 0
+          fi
+
+          for ISSUE_NUM in $ISSUES; do
+            echo "Closing issue #${ISSUE_NUM} — no active streak breach."
+
+            {
+              echo "No scrapers are currently in a zero-record streak breach. Auto-closing."
+              echo ""
+              echo "**Passing workflow run:** ${RUN_URL}"
+            } > /tmp/close_comment.md
+
+            gh issue comment "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --body-file /tmp/close_comment.md
+
+            gh issue close "$ISSUE_NUM" \
+              --repo "${{ github.repository }}" \
+              --reason completed
+          done

--- a/packages/scraper-framework/tests/test_check_scraper_zero_record_streak.py
+++ b/packages/scraper-framework/tests/test_check_scraper_zero_record_streak.py
@@ -1,0 +1,369 @@
+"""Tests for scripts/check-scraper-zero-record-streak.py (see issue #2666).
+
+These tests exercise the streak-counting logic with fabricated
+``scraper_runs`` rows, asserting that:
+
+* N consecutive zero-record runs fires a breach.
+* Scrapers with no historical nonzero run are reported as
+  insufficient-history, NOT as breaches (brand-new scraper false-positive
+  guard).
+* A recent nonzero run breaks the streak even if older runs are zero.
+* Excluded scraper IDs are skipped entirely.
+* The daily-vs-frequent threshold is applied per scraper.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+from importlib import import_module
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Add scripts/ to sys.path so we can import the hyphenated module.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+# ruff: noqa: E402
+
+zrs = import_module("check-scraper-zero-record-streak")
+
+Breach = zrs.Breach
+InsufficientHistory = zrs.InsufficientHistory
+CheckResult = zrs.CheckResult
+compute_streak = zrs.compute_streak
+has_historical_nonzero = zrs.has_historical_nonzero
+check_zero_record_streaks = zrs.check_zero_record_streaks
+format_json = zrs.format_json
+format_text = zrs.format_text
+DEFAULT_STREAK_THRESHOLD = zrs.DEFAULT_STREAK_THRESHOLD
+DEFAULT_DAILY_STREAK_THRESHOLD = zrs.DEFAULT_DAILY_STREAK_THRESHOLD
+
+NOW = datetime(2026, 4, 18, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — compute_streak / has_historical_nonzero
+# ---------------------------------------------------------------------------
+
+
+def _mk_run(hours_ago: int, records: int, status: str = "success") -> tuple[datetime, int, str]:
+    """Helper: make a (started_at, records, status) tuple ``hours_ago`` behind NOW."""
+    return (NOW - timedelta(hours=hours_ago), records, status)
+
+
+class TestComputeStreak:
+    def test_all_zero_runs_full_streak(self) -> None:
+        """Every run has zero records — streak equals row count."""
+        runs = [_mk_run(1, 0), _mk_run(25, 0), _mk_run(49, 0)]
+        streak, first, last, last_nonzero = compute_streak(runs)
+        assert streak == 3
+        assert first == runs[-1][0]
+        assert last == runs[0][0]
+        assert last_nonzero is None
+
+    def test_leading_zero_then_nonzero(self) -> None:
+        """Streak is only the leading consecutive-zero prefix."""
+        runs = [_mk_run(1, 0), _mk_run(25, 0), _mk_run(49, 5), _mk_run(73, 0)]
+        streak, first, last, last_nonzero = compute_streak(runs)
+        assert streak == 2
+        # last_nonzero is the first (newest) nonzero row after the streak
+        assert last_nonzero == runs[2][0]
+
+    def test_most_recent_nonzero_no_streak(self) -> None:
+        """Newest run has records — streak is 0, even with old zeros."""
+        runs = [_mk_run(1, 7), _mk_run(25, 0), _mk_run(49, 0)]
+        streak, first, last, last_nonzero = compute_streak(runs)
+        assert streak == 0
+        assert first is None
+        assert last is None
+        assert last_nonzero == runs[0][0]
+
+    def test_empty_runs(self) -> None:
+        streak, first, last, last_nonzero = compute_streak([])
+        assert streak == 0
+        assert first is None and last is None and last_nonzero is None
+
+    def test_single_zero_run(self) -> None:
+        runs = [_mk_run(1, 0)]
+        streak, first, last, last_nonzero = compute_streak(runs)
+        assert streak == 1
+        assert first == runs[0][0]
+        assert last == runs[0][0]
+        assert last_nonzero is None
+
+
+class TestHasHistoricalNonzero:
+    def test_true_when_any_nonzero_present(self) -> None:
+        runs = [_mk_run(1, 0), _mk_run(25, 3)]
+        assert has_historical_nonzero(runs) is True
+
+    def test_false_when_all_zero(self) -> None:
+        runs = [_mk_run(1, 0), _mk_run(25, 0)]
+        assert has_historical_nonzero(runs) is False
+
+    def test_false_on_empty(self) -> None:
+        assert has_historical_nonzero([]) is False
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — check_zero_record_streaks against a fake DB
+# ---------------------------------------------------------------------------
+
+
+def _mock_conn(rows: list[tuple[str, datetime, int, str]]) -> MagicMock:
+    """Build a MagicMock that mimics psycopg's cursor().execute()/fetchall().
+
+    ``rows`` should be a flat list of ``(scraper_id, started_at, records_captured, status)``
+    tuples in the order the SQL query would return them (grouped by scraper_id,
+    started_at DESC within each group).
+    """
+    cur = MagicMock()
+    cur.fetchall.return_value = list(rows)
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    return conn
+
+
+class TestCheckZeroRecordStreaks:
+    def test_three_consecutive_zeros_frequent_scraper_breaches(self) -> None:
+        """3 zero-record runs for a frequent scraper with history = breach."""
+        rows = [
+            ("ca-sf-tentatives-civil", NOW - timedelta(hours=1), 0, "success"),
+            ("ca-sf-tentatives-civil", NOW - timedelta(hours=7), 0, "success"),
+            ("ca-sf-tentatives-civil", NOW - timedelta(hours=13), 0, "success"),
+            ("ca-sf-tentatives-civil", NOW - timedelta(hours=24), 4, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids={"ca-sf-tentatives-civil"},
+            exclusions=set(),
+        )
+        assert len(result.breaches) == 1
+        b = result.breaches[0]
+        assert b.scraper_id == "ca-sf-tentatives-civil"
+        assert b.streak == 3
+        assert b.threshold == 3
+        assert b.last_nonzero_at is not None
+        assert result.checked_count == 1
+        assert result.excluded_count == 0
+        assert not result.insufficient_history
+
+    def test_two_consecutive_zeros_daily_scraper_breaches(self) -> None:
+        """Daily scraper breaches at 2 consecutive zero-record runs."""
+        rows = [
+            ("ca-oc-tentatives", NOW - timedelta(hours=2), 0, "success"),
+            ("ca-oc-tentatives", NOW - timedelta(hours=26), 0, "success"),
+            ("ca-oc-tentatives", NOW - timedelta(hours=50), 18, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+        )
+        assert len(result.breaches) == 1
+        assert result.breaches[0].threshold == 2
+
+    def test_brand_new_scraper_with_zeros_is_insufficient_history(self) -> None:
+        """No historical nonzero run = insufficient_history, NOT breach."""
+        rows = [
+            ("ca-new-scraper", NOW - timedelta(hours=1), 0, "success"),
+            ("ca-new-scraper", NOW - timedelta(hours=25), 0, "success"),
+            ("ca-new-scraper", NOW - timedelta(hours=49), 0, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+        )
+        assert not result.breaches
+        assert len(result.insufficient_history) == 1
+        ih = result.insufficient_history[0]
+        assert ih.scraper_id == "ca-new-scraper"
+        assert ih.zero_run_count == 3
+
+    def test_recent_nonzero_run_prevents_breach(self) -> None:
+        """Even with older zeros, a fresh nonzero breaks the streak."""
+        rows = [
+            ("ca-la-tentatives-civil", NOW - timedelta(hours=1), 42, "success"),
+            ("ca-la-tentatives-civil", NOW - timedelta(hours=25), 0, "success"),
+            ("ca-la-tentatives-civil", NOW - timedelta(hours=49), 0, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+        )
+        assert not result.breaches
+        assert not result.insufficient_history
+        assert result.checked_count == 1
+
+    def test_excluded_scrapers_are_skipped(self) -> None:
+        """Scrapers in the exclusion set are not checked at all."""
+        rows = [
+            ("ca-oc-dept-judges", NOW - timedelta(hours=1), 0, "success"),
+            ("ca-oc-dept-judges", NOW - timedelta(hours=25), 0, "success"),
+            ("ca-oc-dept-judges", NOW - timedelta(hours=49), 0, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions={"ca-oc-dept-judges"},
+        )
+        assert result.excluded_count == 1
+        assert result.checked_count == 0
+        assert not result.breaches
+        assert not result.insufficient_history
+
+    def test_multiple_scrapers_only_some_breach(self) -> None:
+        """Healthy scrapers do not inflate the breach list."""
+        rows = [
+            # Healthy daily scraper
+            ("ca-la-tentatives-civil", NOW - timedelta(hours=2), 42, "success"),
+            ("ca-la-tentatives-civil", NOW - timedelta(hours=26), 38, "success"),
+            # Breaching daily scraper
+            ("ca-oc-tentatives", NOW - timedelta(hours=3), 0, "success"),
+            ("ca-oc-tentatives", NOW - timedelta(hours=27), 0, "success"),
+            ("ca-oc-tentatives", NOW - timedelta(hours=51), 18, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+        )
+        assert result.checked_count == 2
+        assert len(result.breaches) == 1
+        assert result.breaches[0].scraper_id == "ca-oc-tentatives"
+
+    def test_single_zero_run_no_breach_daily(self) -> None:
+        """A single zero-record run does not breach even a daily scraper."""
+        rows = [
+            ("ca-oc-tentatives", NOW - timedelta(hours=2), 0, "success"),
+            ("ca-oc-tentatives", NOW - timedelta(hours=26), 18, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+        )
+        assert not result.breaches
+
+
+# ---------------------------------------------------------------------------
+# Formatting tests
+# ---------------------------------------------------------------------------
+
+
+class TestOutputFormatting:
+    def test_format_json_healthy(self) -> None:
+        result = CheckResult(
+            breaches=[],
+            insufficient_history=[],
+            checked_count=5,
+            excluded_count=2,
+        )
+        import json as _json
+
+        payload = _json.loads(format_json(result))
+        assert payload["healthy"] is True
+        assert payload["breaches"] == []
+        assert payload["checked_count"] == 5
+        assert payload["excluded_count"] == 2
+
+    def test_format_json_with_breach(self) -> None:
+        result = CheckResult(
+            breaches=[
+                Breach(
+                    scraper_id="ca-sf-tentatives-civil",
+                    streak=3,
+                    threshold=3,
+                    first_zero_at="2026-04-16T12:00:00+00:00",
+                    last_zero_at="2026-04-18T00:00:00+00:00",
+                    last_nonzero_at="2026-04-15T12:00:00+00:00",
+                    message="breach message",
+                ),
+            ],
+            insufficient_history=[],
+            checked_count=1,
+            excluded_count=0,
+        )
+        import json as _json
+
+        payload = _json.loads(format_json(result))
+        assert payload["healthy"] is False
+        assert len(payload["breaches"]) == 1
+        assert payload["breaches"][0]["scraper_id"] == "ca-sf-tentatives-civil"
+
+    def test_format_text_lists_breaches(self) -> None:
+        result = CheckResult(
+            breaches=[
+                Breach(
+                    scraper_id="ca-sf-tentatives-civil",
+                    streak=3,
+                    threshold=3,
+                    first_zero_at="2026-04-16T12:00:00+00:00",
+                    last_zero_at="2026-04-18T00:00:00+00:00",
+                    last_nonzero_at=None,
+                    message="ca-sf-tentatives-civil: 3 consecutive zero-record runs",
+                ),
+            ],
+            insufficient_history=[
+                InsufficientHistory(
+                    scraper_id="ca-new-scraper",
+                    zero_run_count=3,
+                    message="ca-new-scraper: insufficient history",
+                ),
+            ],
+            checked_count=2,
+            excluded_count=1,
+        )
+        text = format_text(result)
+        assert "ca-sf-tentatives-civil" in text
+        assert "BREACHES" in text
+        assert "INSUFFICIENT HISTORY" in text
+        assert "(none)" in text
+
+
+# ---------------------------------------------------------------------------
+# CLI smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def test_missing_database_url_returns_2(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        rc = zrs.main([])
+        assert rc == 2

--- a/scripts/check-scraper-zero-record-streak.py
+++ b/scripts/check-scraper-zero-record-streak.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# permanent: true
+"""Zero-record streak check — detects scrapers silently outputting no data.
+
+Queries ``telemetry.scraper_runs`` for each active scraper and counts the
+number of most-recent consecutive runs where ``records_captured = 0``. A
+streak above the configured threshold fires an alert regardless of the
+``status`` column — the #2620 / SF-civil incident showed that a scraper can
+legitimately report ``status=success`` while producing zero records for days
+(silent outage). This is the structural guard against that failure mode
+across every registered scraper.
+
+See https://github.com/judgemind/judgemind/issues/2666 for context and
+https://github.com/judgemind/judgemind/issues/2620 for the originating
+incident.
+
+Streak-counting rules:
+
+* Runs are ordered by ``started_at DESC``.
+* The streak counts the most-recent uninterrupted run of ``records_captured
+  = 0`` rows. As soon as a row with ``records_captured > 0`` is seen the
+  streak is broken.
+* If the scraper has **no** historical run with ``records_captured > 0`` it
+  is reported as ``insufficient_history`` — never a breach. This avoids
+  false positives on brand-new scrapers and on permanently-quiet feeds
+  (court directory rosters that only record when the roster file changes).
+* An explicit ``EXCLUSIONS`` allowlist suppresses specific scraper IDs
+  regardless of streak length (e.g. roster / directory scrapers that
+  legitimately emit zero-record runs).
+
+Usage:
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- packages/scraper-framework/.venv/bin/python3 \\
+        scripts/check-scraper-zero-record-streak.py
+
+Options:
+    --json              Machine-readable JSON output (default).
+    --text              Human-readable text output.
+    --threshold N       Override the default streak threshold (default: 3).
+    --daily-threshold N Override the daily-scraper threshold (default: 2).
+    --scraper ID        Check only the specified scraper ID.
+    --lookback-days N   Runs older than this are ignored (default: 14).
+
+Exit code: 0 if no breaches, 1 if one or more scrapers are in breach.
+
+Note:
+    The dev database is in a private VPC. Run via
+    ``scripts/ecs-run-task.sh`` or the GH Actions workflow
+    ``scraper-zero-record-check.yml``, not locally.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Defaults & per-scraper configuration
+# ---------------------------------------------------------------------------
+
+# Default streak threshold for scrapers running more than once per day
+# (e.g. frequent polling). 3 consecutive zero-record runs is the breach.
+DEFAULT_STREAK_THRESHOLD = 3
+
+# Daily scrapers breach after 2 consecutive zero-record runs — two missed
+# days is already ~48h of silent outage, which we never want to tolerate.
+DEFAULT_DAILY_STREAK_THRESHOLD = 2
+
+# How far back to pull runs when computing the streak. 14 days is more than
+# enough for any daily or frequent scraper and caps query cost.
+DEFAULT_LOOKBACK_DAYS = 14
+
+# Scrapers that legitimately produce zero-record runs by design.
+# Each entry must include a rationale comment so future maintainers can
+# understand why the scraper is excluded from the check.
+EXCLUSIONS: set[str] = {
+    # Court directory / roster scrapers only capture when the roster file
+    # changes — zero-record runs are the *expected* steady state. These
+    # scrapers do not emit to ``scraper_runs`` today, but are listed for
+    # documentation; if they are ever wired in they must stay excluded.
+    "ca-oc-dept-judges",
+    "ca-la-dept-judges",
+    "ca-fresno-dept-judges",
+    "ca-kern-dept-judges",
+    "ca-sd-dept-judges",
+    "ca-sb-dept-judges",
+    "ca-ventura-dept-judges",
+    "ca-sf-dept-judges",
+    "ca-riverside-dept-judges",
+    # Governor appointments scraper runs quarterly-ish; most runs legitimately
+    # return zero records. Exclude until dedicated health signal is wired.
+    "ca-governor-appointments",
+}
+
+# Scrapers that run more than once per day ("frequent"). All others are
+# treated as daily and use ``DEFAULT_DAILY_STREAK_THRESHOLD``. The list is
+# derived from the per-scraper ``poll_interval_seconds`` in each court
+# module's ``default_config`` — kept here as a flat lookup so the check
+# does not need to import every scraper module.
+FREQUENT_SCRAPER_IDS: set[str] = {
+    # Add scraper IDs here when they poll more than once per day.
+    # All current scrapers poll daily, so this set is intentionally empty.
+}
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Breach:
+    """A single zero-record streak breach."""
+
+    scraper_id: str
+    streak: int
+    threshold: int
+    first_zero_at: str  # ISO-8601
+    last_zero_at: str  # ISO-8601
+    last_nonzero_at: str | None  # ISO-8601 or None if none seen in window
+    message: str
+
+
+@dataclass
+class InsufficientHistory:
+    """Scraper with zero-record runs but no historical nonzero runs."""
+
+    scraper_id: str
+    zero_run_count: int
+    message: str
+
+
+@dataclass
+class CheckResult:
+    """Full result of a zero-record streak check."""
+
+    breaches: list[Breach]
+    insufficient_history: list[InsufficientHistory]
+    checked_count: int
+    excluded_count: int
+
+
+# ---------------------------------------------------------------------------
+# DB query
+# ---------------------------------------------------------------------------
+
+# Pull recent runs for every scraper in one round trip so we don't issue
+# N queries. Ordered by (scraper_id, started_at DESC) so the streak
+# computation can iterate each scraper's slice without re-sorting.
+RECENT_RUNS_QUERY = """
+    SELECT scraper_id, started_at, records_captured, status
+    FROM scraper_runs
+    WHERE started_at >= %s
+    {scraper_filter}
+    ORDER BY scraper_id, started_at DESC
+"""
+
+
+def _fetch_recent_runs(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    cutoff: datetime,
+    scraper_id: str | None,
+) -> dict[str, list[tuple[datetime, int, str]]]:
+    """Return ``{scraper_id: [(started_at, records, status), ...]}`` sorted
+    by ``started_at`` descending for each scraper.
+    """
+    params: list[Any] = [cutoff]
+    scraper_filter = ""
+    if scraper_id:
+        scraper_filter = "AND scraper_id = %s"
+        params.append(scraper_id)
+
+    out: dict[str, list[tuple[datetime, int, str]]] = {}
+    with conn.cursor() as cur:
+        cur.execute(
+            RECENT_RUNS_QUERY.format(scraper_filter=scraper_filter),
+            tuple(params),
+        )
+        for row in cur.fetchall():
+            sid, started_at, records, status = row[0], row[1], row[2], row[3]
+            out.setdefault(sid, []).append((started_at, int(records), status))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Streak logic
+# ---------------------------------------------------------------------------
+
+
+def compute_streak(
+    runs: list[tuple[datetime, int, str]],
+) -> tuple[int, datetime | None, datetime | None, datetime | None]:
+    """Count most-recent consecutive zero-record runs.
+
+    Args:
+        runs: ``[(started_at, records_captured, status), ...]`` ordered by
+            ``started_at`` descending.
+
+    Returns:
+        Tuple ``(streak, first_zero_at, last_zero_at, last_nonzero_at)``:
+          * ``streak`` — length of the leading run of zero-record rows.
+          * ``first_zero_at`` — oldest ``started_at`` inside the streak
+            (i.e. when the streak began).
+          * ``last_zero_at`` — newest ``started_at`` inside the streak.
+          * ``last_nonzero_at`` — newest ``started_at`` with records > 0
+            anywhere in the window, or ``None`` if no such run exists.
+    """
+    streak = 0
+    first_zero_at: datetime | None = None
+    last_zero_at: datetime | None = None
+    last_nonzero_at: datetime | None = None
+    in_leading_streak = True
+
+    for started_at, records, _status in runs:
+        if in_leading_streak and records == 0:
+            streak += 1
+            if last_zero_at is None:
+                last_zero_at = started_at  # first iter = newest zero row
+            first_zero_at = started_at  # keep overwriting = oldest zero row
+        else:
+            in_leading_streak = False
+            if records > 0 and last_nonzero_at is None:
+                last_nonzero_at = started_at
+
+    return streak, first_zero_at, last_zero_at, last_nonzero_at
+
+
+def has_historical_nonzero(runs: list[tuple[datetime, int, str]]) -> bool:
+    """True if any run in the lookup window produced >0 records."""
+    return any(records > 0 for _, records, _ in runs)
+
+
+# ---------------------------------------------------------------------------
+# Main check
+# ---------------------------------------------------------------------------
+
+
+def check_zero_record_streaks(
+    conn: psycopg.Connection,  # type: ignore[type-arg]
+    *,
+    now: datetime,
+    threshold: int = DEFAULT_STREAK_THRESHOLD,
+    daily_threshold: int = DEFAULT_DAILY_STREAK_THRESHOLD,
+    lookback_days: int = DEFAULT_LOOKBACK_DAYS,
+    scraper_id: str | None = None,
+    exclusions: set[str] | None = None,
+    frequent_scraper_ids: set[str] | None = None,
+) -> CheckResult:
+    """Run the zero-record streak check.
+
+    Args:
+        conn: Database connection (must see ``scraper_runs`` via the
+            default search_path — i.e. ``public``/``staging`` paths set by
+            the shared DATABASE_URL, which includes ``telemetry`` reads).
+        now: Reference "current time" used for the lookback cutoff.
+        threshold: Streak length that triggers a breach for frequent
+            scrapers (runs more than once per day).
+        daily_threshold: Streak length that triggers a breach for daily
+            scrapers. Defaults to 2 — two consecutive missed daily runs
+            is already ~48h of silent outage.
+        lookback_days: How far back to consider runs. Runs older than
+            this are ignored entirely.
+        scraper_id: Optional single scraper ID to check.
+        exclusions: Scrapers to skip. Defaults to ``EXCLUSIONS``.
+        frequent_scraper_ids: Scraper IDs that run more than once per day.
+            Defaults to ``FREQUENT_SCRAPER_IDS``.
+
+    Returns:
+        ``CheckResult`` with breaches, insufficient-history entries, and
+        counts for logging/summary output.
+    """
+    excl = exclusions if exclusions is not None else EXCLUSIONS
+    freq = (
+        frequent_scraper_ids
+        if frequent_scraper_ids is not None
+        else FREQUENT_SCRAPER_IDS
+    )
+
+    cutoff = now - timedelta(days=lookback_days)
+    by_scraper = _fetch_recent_runs(conn, cutoff, scraper_id)
+
+    breaches: list[Breach] = []
+    insufficient: list[InsufficientHistory] = []
+    checked = 0
+    excluded = 0
+
+    for sid in sorted(by_scraper.keys()):
+        if sid in excl:
+            excluded += 1
+            continue
+
+        runs = by_scraper[sid]
+        # Defensive: a scraper with runs older than cutoff only would have
+        # been filtered out by the SQL WHERE clause, but if we somehow got
+        # an empty list treat it as nothing to check.
+        if not runs:
+            continue
+
+        checked += 1
+
+        applicable_threshold = threshold if sid in freq else daily_threshold
+
+        streak, first_zero, last_zero, last_nonzero = compute_streak(runs)
+
+        if streak == 0:
+            # Most recent run produced records — healthy.
+            continue
+
+        if not has_historical_nonzero(runs):
+            insufficient.append(
+                InsufficientHistory(
+                    scraper_id=sid,
+                    zero_run_count=streak,
+                    message=(
+                        f"{sid}: {streak} zero-record runs in window but no "
+                        f"historical nonzero run — insufficient history, "
+                        f"not a breach"
+                    ),
+                )
+            )
+            continue
+
+        if streak >= applicable_threshold:
+            breaches.append(
+                Breach(
+                    scraper_id=sid,
+                    streak=streak,
+                    threshold=applicable_threshold,
+                    first_zero_at=_iso(first_zero),
+                    last_zero_at=_iso(last_zero),
+                    last_nonzero_at=_iso(last_nonzero),
+                    message=(
+                        f"{sid}: {streak} consecutive zero-record runs "
+                        f"(threshold: {applicable_threshold}, last nonzero "
+                        f"run: {_iso(last_nonzero) or 'never in window'})"
+                    ),
+                )
+            )
+
+    return CheckResult(
+        breaches=breaches,
+        insufficient_history=insufficient,
+        checked_count=checked,
+        excluded_count=excluded,
+    )
+
+
+def _iso(value: datetime | None) -> str | None:
+    """Format a datetime as ISO-8601 UTC string, or return None."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+
+def format_json(result: CheckResult) -> str:
+    """Machine-readable JSON summary."""
+    payload = {
+        "breaches": [asdict(b) for b in result.breaches],
+        "insufficient_history": [asdict(ih) for ih in result.insufficient_history],
+        "checked_count": result.checked_count,
+        "excluded_count": result.excluded_count,
+        "healthy": len(result.breaches) == 0,
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def format_text(result: CheckResult) -> str:
+    """Human-readable summary."""
+    lines: list[str] = []
+    lines.append(
+        f"Checked {result.checked_count} scraper(s), "
+        f"{result.excluded_count} excluded, "
+        f"{len(result.breaches)} breach(es), "
+        f"{len(result.insufficient_history)} insufficient-history."
+    )
+
+    if result.breaches:
+        lines.append("")
+        lines.append("BREACHES:")
+        for b in result.breaches:
+            lines.append(f"  * {b.message}")
+            lines.append(f"      first_zero_at={b.first_zero_at}")
+            lines.append(f"      last_zero_at={b.last_zero_at}")
+            lines.append(f"      last_nonzero_at={b.last_nonzero_at or '(none)'}")
+
+    if result.insufficient_history:
+        lines.append("")
+        lines.append("INSUFFICIENT HISTORY (not a breach):")
+        for ih in result.insufficient_history:
+            lines.append(f"  * {ih.message}")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Detect scrapers with N consecutive zero-record runs.",
+    )
+    out = parser.add_mutually_exclusive_group()
+    out.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Machine-readable JSON output (default).",
+    )
+    out.add_argument(
+        "--text",
+        action="store_true",
+        help="Human-readable text output.",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=int,
+        default=DEFAULT_STREAK_THRESHOLD,
+        help=(
+            "Streak length that triggers a breach for frequent scrapers "
+            f"(default: {DEFAULT_STREAK_THRESHOLD})."
+        ),
+    )
+    parser.add_argument(
+        "--daily-threshold",
+        type=int,
+        default=DEFAULT_DAILY_STREAK_THRESHOLD,
+        help=(
+            "Streak length that triggers a breach for daily scrapers "
+            f"(default: {DEFAULT_DAILY_STREAK_THRESHOLD})."
+        ),
+    )
+    parser.add_argument(
+        "--scraper",
+        type=str,
+        default=None,
+        help="Check only the specified scraper ID.",
+    )
+    parser.add_argument(
+        "--lookback-days",
+        type=int,
+        default=DEFAULT_LOOKBACK_DAYS,
+        help=(f"Runs older than this are ignored (default: {DEFAULT_LOOKBACK_DAYS})."),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+
+    database_url = os.environ.get("DATABASE_URL", "").strip()
+    if not database_url:
+        logger.error(
+            "DATABASE_URL is not set. Run via scripts/with-secret.sh or "
+            "scripts/ecs-run-task.sh so the connection string is injected."
+        )
+        return 2
+
+    with psycopg.connect(database_url, autocommit=True) as conn:
+        result = check_zero_record_streaks(
+            conn,
+            now=datetime.now(UTC),
+            threshold=args.threshold,
+            daily_threshold=args.daily_threshold,
+            lookback_days=args.lookback_days,
+            scraper_id=args.scraper,
+        )
+
+    if args.text:
+        print(format_text(result))
+    else:
+        print(format_json(result))
+
+    return 0 if not result.breaches else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds `scripts/check-scraper-zero-record-streak.py` and a scheduled `.github/workflows/scraper-zero-record-check.yml` that detect when any scraper has returned `records_captured = 0` for N consecutive runs (default N=2 for daily scrapers, N=3 for frequent scrapers). This is the cross-scraper structural guard against the #2620 SF-civil silent-outage failure mode — a scraper that is technically "running" but producing no data will now surface as a `priority/p1 / agent/ready` issue and a Telegram notification.

Closes #2666

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest tests/test_check_scraper_zero_record_streak.py` — 19 tests, all green locally)
- [x] CI green

### Post-deploy verification
- [ ] `workflow_dispatch` of `Scraper Zero-Record Streak Check` runs successfully against the dev DB (sandbox has no AWS/ECS access — verification deferred until an operator triggers the workflow manually).
- [ ] Scheduled run at 14:30 UTC executes without error and prints a healthy summary (expected: no current breaches).
- [ ] Verification evidence posted on #2666.
