### PR TITLE
fix(scraping): skip non-ruling admin PDFs in Fresno scraper (#2644)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/fresno_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/fresno_tentatives.py
@@ -23,6 +23,11 @@ Link text format: date only — e.g. "March 10, 2026"
 
 PDF URL pattern: /system/files/tentative-rulings/{MM}-{DD}-{YY}-dept-{NNN}[_N].pdf
   The optional "_N" suffix (e.g. "_0") appears on revised uploads.
+  Links whose URL filename does not match this pattern are skipped at
+  capture time via ``_HREF_FILTER_RE`` — the court occasionally posts
+  non-ruling PDFs (e-Court transition notices, holiday closure
+  announcements) to the same index page, and those must not be captured
+  as rulings (#2644).
 
 PDF structure (multi-ruling, similar to Riverside):
   Page 1: boilerplate header with "Tentative Rulings for March 10, 2026\nDepartment 403"
@@ -89,6 +94,18 @@ _FILENAME_DEPT_RE = re.compile(
 # Hearing date from filename: "03-10-26-dept-403.pdf" → MM-DD-YY
 _FILENAME_DATE_RE = re.compile(
     r"^(\d{2})-(\d{2})-(\d{2})-dept-",
+)
+
+# URL filter: a legitimate Fresno tentative-ruling PDF has a filename in the
+# format "MM-DD-YY-dept-NNN[_N].pdf".  Non-ruling PDFs (e-Court transition
+# notices, holiday closure announcements, "we moved" banners) the court
+# occasionally posts to the same index page have filenames that do not
+# match this pattern (e.g. "eCourt-transition-notice.pdf").  Skipping
+# non-matching URLs at capture time prevents all-NULL-metadata noise rows
+# in derived.rulings (#2644).
+_HREF_FILTER_RE = re.compile(
+    r"/\d{2}-\d{2}-\d{2}-dept-\d{2,3}(?:_\d+)?\.pdf$",
+    re.IGNORECASE,
 )
 
 # Hearing date from PDF text: "Tentative Rulings for March 10, 2026"
@@ -493,6 +510,7 @@ class FresnoTentativeRulingsScraper(PdfLinkScraper):
             courthouse_from_dept=_fresno_courthouse,
             verify_ssl=True,
             filter_by_link_text=False,  # link text is a date, not dept/judge
+            href_filter_re=_HREF_FILTER_RE,  # #2644: skip non-ruling admin PDFs
             case_number_re=_CASE_NUMBER_RE,
         )
         super().__init__(config, pdf_config=pdf_config, **kwargs)

--- a/packages/scraper-framework/src/courts/ca/pdf_link_scraper.py
+++ b/packages/scraper-framework/src/courts/ca/pdf_link_scraper.py
@@ -73,6 +73,15 @@ class PdfLinkConfig:
     # text is a date and department is extracted from the URL filename).
     filter_by_link_text: bool = True
 
+    # Optional regex applied to the PDF URL (or its filename).  When set,
+    # links whose URL does not match are skipped before fetching.  Used by
+    # courts like Fresno where link text is uninformative but the URL
+    # filename encodes a predictable pattern (e.g. "MM-DD-YY-dept-NNN.pdf").
+    # This filters out non-ruling PDFs (e-Court transition notices, holiday
+    # closure banners, "we moved" announcements) linked from the same index
+    # page as tentative rulings (#2644).
+    href_filter_re: re.Pattern | None = None
+
     # Case number regex applied to extracted PDF text
     case_number_re: re.Pattern = field(default_factory=lambda: re.compile(r"\b\d{2}-\d{8}\b"))
 
@@ -143,6 +152,23 @@ class PdfLinkScraper(BaseScraper):
                         link_text=link_text,
                         url=href,
                         pattern=pc.link_text_re.pattern,
+                    )
+                    continue
+
+                # Filter: skip links whose URL does not match the expected
+                # filename pattern (#2644).  Used by courts where link text
+                # is uninformative (e.g. Fresno "March 10, 2026") but the URL
+                # filename follows a strict format (e.g. "dept-NNN.pdf").
+                # Non-matching URLs are e-Court transition notices, holiday
+                # closure announcements, and other admin PDFs posted to the
+                # same index page — they must be skipped to avoid emitting
+                # all-NULL-metadata noise rows.
+                if pc.href_filter_re is not None and not pc.href_filter_re.search(href):
+                    self._log.warning(
+                        "Skipping PDF link — URL does not match expected pattern",
+                        link_text=link_text,
+                        url=href,
+                        pattern=pc.href_filter_re.pattern,
                     )
                     continue
 

--- a/packages/scraper-framework/tests/courts/test_fresno_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_fresno_tentatives.py
@@ -19,6 +19,7 @@ import pytest
 import respx
 
 from courts.ca.fresno_tentatives import (
+    _HREF_FILTER_RE,
     _ISSUED_BY_RE,
     _NO_RULINGS_RE,
     BASE_URL,
@@ -1390,3 +1391,113 @@ def test_base_process_document_salted_id_for_pre_split() -> None:
     parent_id = str(_uuid.uuid5(_uuid.NAMESPACE_URL, sha256_hex(b"shared-bytes-for-all-children")))
     for idx, observed in zip((3, 20, 47), ids_observed, strict=True):
         assert observed == make_split_document_id(parent_id, idx)
+
+
+# ---------------------------------------------------------------------------
+# #2644: Non-ruling admin PDF filtering via URL filename pattern
+# ---------------------------------------------------------------------------
+
+
+def test_fresno_href_filter_accepts_ruling_urls() -> None:
+    """_HREF_FILTER_RE matches legitimate tentative-ruling PDF filenames."""
+    assert (
+        _HREF_FILTER_RE.search("/system/files/tentative-rulings/03-10-26-dept-403.pdf") is not None
+    )
+    assert (
+        _HREF_FILTER_RE.search("/system/files/tentative-rulings/03-04-26-dept-403_0.pdf")
+        is not None
+    )
+    assert (
+        _HREF_FILTER_RE.search("/system/files/tentative-rulings/02-26-26-dept-501.pdf") is not None
+    )
+    # 2-digit department codes should also match (defensive)
+    assert (
+        _HREF_FILTER_RE.search("/system/files/tentative-rulings/03-10-26-dept-12.pdf") is not None
+    )
+
+
+def test_fresno_href_filter_rejects_admin_notice_urls() -> None:
+    """_HREF_FILTER_RE rejects non-ruling PDFs (e-Court transition notices, etc.)."""
+    # The real #2644 scenario: an e-Court transition notice PDF posted to
+    # the same index page as the tentative-ruling PDFs.  Its URL does not
+    # contain the "MM-DD-YY-dept-NNN" pattern.
+    assert (
+        _HREF_FILTER_RE.search("/system/files/tentative-rulings/eCourt-transition-notice.pdf")
+        is None
+    )
+    assert (
+        _HREF_FILTER_RE.search("/system/files/tentative-rulings/holiday-closure-2026.pdf") is None
+    )
+    assert _HREF_FILTER_RE.search("/system/files/tentative-rulings/we-have-moved.pdf") is None
+    # Totally unrelated paths must also be rejected.
+    assert _HREF_FILTER_RE.search("/some/other/path/admin.pdf") is None
+    # Missing department number.
+    assert _HREF_FILTER_RE.search("/system/files/tentative-rulings/03-10-26-dept-.pdf") is None
+    # Wrong extension.
+    assert (
+        _HREF_FILTER_RE.search("/system/files/tentative-rulings/03-10-26-dept-403.pdf.bak") is None
+    )
+
+
+@respx.mock
+def test_fresno_fetch_documents_skips_admin_notice_pdfs() -> None:
+    """Mixed index page with admin-notice PDFs: only ruling PDFs are captured (#2644).
+
+    The fixture ``fresno_index_with_admin_notice.html`` contains 3 ruling PDFs
+    (matching ``MM-DD-YY-dept-NNN.pdf``) and 2 admin-notice PDFs that do NOT
+    match.  After filtering, only 3 documents should be fetched — the admin
+    notices must be skipped at capture time, not emitted with all-NULL metadata.
+    """
+    from unittest.mock import patch
+
+    html = _load_html("fresno_index_with_admin_notice.html")
+    pdf_bytes = _load_bytes("fresno_403_20260310_d019042f.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+
+    # Track which URLs are actually fetched so we can assert the admin
+    # notices are never requested (capture-time filter, not download-then-drop).
+    fetched_urls: list[str] = []
+
+    def pdf_side_effect(request: httpx.Request) -> httpx.Response:
+        fetched_urls.append(str(request.url))
+        return httpx.Response(200, content=pdf_bytes)
+
+    respx.get(url__regex=r"\.pdf").mock(side_effect=pdf_side_effect)
+
+    config = fresno_default_config()
+    config.request_delay_seconds = 0
+    scraper = FresnoTentativeRulingsScraper(config=config)
+
+    # Patch _extract_pdf_text to avoid invoking pdfplumber on real bytes for
+    # every link — the test is about URL filtering, not PDF splitting.
+    with patch(
+        "courts.ca.fresno_tentatives._extract_pdf_text",
+        return_value="No Tentative Rulings for this date.",
+    ):
+        docs = scraper.fetch_documents()
+
+    # Admin notice URLs must never be fetched.
+    admin_fetches = [u for u in fetched_urls if "transition" in u or "holiday" in u]
+    assert admin_fetches == [], (
+        f"Admin notice PDFs should be filtered at capture time, but were fetched: {admin_fetches}"
+    )
+
+    # All 3 legitimate ruling PDFs should be fetched.
+    ruling_fetches = [u for u in fetched_urls if "dept-" in u]
+    assert len(ruling_fetches) == 3
+
+    # No docs should have NULL department — the filter guarantees every
+    # captured doc has a filename with a matching dept pattern.
+    for doc in docs:
+        assert doc.department is not None, (
+            f"Expected non-null department; got doc with department=None "
+            f"and filename={doc.extra.get('filename')!r}"
+        )
+
+
+def test_fresno_scraper_wires_href_filter() -> None:
+    """FresnoTentativeRulingsScraper sets href_filter_re on its PdfLinkConfig."""
+    config = fresno_default_config()
+    scraper = FresnoTentativeRulingsScraper(config=config)
+    assert scraper._pdf_config.href_filter_re is _HREF_FILTER_RE

--- a/packages/scraper-framework/tests/fixtures/fresno_index_with_admin_notice.html
+++ b/packages/scraper-framework/tests/fixtures/fresno_index_with_admin_notice.html
@@ -1,0 +1,13 @@
+<html><body>
+<h3>Dept. 403</h3>
+<ul><li><a data-entity-bundle="file" href="/system/files/tentative-rulings/03-10-26-dept-403.pdf" target="_blank">March 10, 2026</a></li>
+<li><a data-entity-bundle="file" href="/system/files/tentative-rulings/03-05-26-dept-403.pdf" target="_blank">March 5, 2026</a></li>
+</ul>
+<h3>Announcements</h3>
+<ul><li><a data-entity-bundle="file" href="/system/files/tentative-rulings/eCourt-transition-notice.pdf" target="_blank">Fresno Superior Court e-Court Transition Notice</a></li>
+<li><a data-entity-bundle="file" href="/system/files/tentative-rulings/holiday-closure-2026.pdf" target="_blank">Holiday Closure Notice</a></li>
+</ul>
+<h3>Dept. 501</h3>
+<ul><li><a data-entity-bundle="file" href="/system/files/tentative-rulings/03-11-26-dept-501.pdf" target="_blank">March 11, 2026</a></li>
+</ul>
+</body></html>


### PR DESCRIPTION
## Summary

Fresno's tentative-rulings index page occasionally includes non-ruling PDFs (e-Court transition notices, holiday closures, admin announcements) alongside dated ruling PDFs. Before this change the scraper captured every PDF link, producing all-NULL-metadata noise rows in `derived.rulings` that polluted judge analytics and wasted downstream LLM enrichment (#2644).

Adds a capture-side URL filename filter. A new optional `href_filter_re` field on `PdfLinkConfig` causes `PdfLinkScraper.fetch_documents()` to skip PDF links whose URL does not match the expected pattern before downloading. Fresno sets this to match the strict ruling filename format `MM-DD-YY-dept-NNN[_N].pdf`, which accepts every real ruling PDF on the index page and rejects the admin notices that produced the original noise row (S3 `4d33d00541...`).

Closes #2644

## Test plan

### Automated checks
- [x] Lint passes (`ruff check` — verified locally and in CI)
- [x] Format check passes (`ruff format --check` — verified locally and in CI)
- [x] Tests pass (113 Fresno tests pass; 4 new tests cover the filter)
- [x] CI green (all 75 checks success/skipped)

### Post-deploy verification
- [ ] Fresno scraper's next scheduled run produces zero admin-notice captures. Verify via dev DB query from issue acceptance criteria: count of Fresno rulings with all-NULL judge/department/motion/outcome should stop growing on new captures.
- [ ] Verification evidence posted on issue (see A.8)