### PR TITLE
feat(agent): prefer github MCP over gh CLI for reads (#2678)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -10,7 +10,9 @@ Perform a comprehensive codebase health audit, filing GitHub issues for every ac
 
 **Trigger:** The dispatcher spawns `/audit` every 20 merged PRs (tracked via `prs_since_last_audit` in `tmp/dispatcher_state.json`). It can also be invoked manually.
 
-**Prerequisites:** Must be in a worktree. No special dependencies required — the audit uses Read, Grep, Glob, and `gh` CLI only.
+**Prerequisites:** Must be in a worktree. No special dependencies required — the audit uses Read, Grep, Glob, `mcp__github__*` tools (preferred for reads), and `gh` CLI (for writes and ops without MCP equivalents).
+
+> **MCP-first for GitHub reads.** Prefer `mcp__github__*` tools (`list_pull_requests`, `list_issues`, `get_pull_request_files`, `search_issues`) over `gh ... --json` for reads. The one call this skill keeps on `gh` is `gh pr diff <N>` — MCP has no unified-diff endpoint (see `docs/agent/gh-to-mcp-migration.md` — the Gap row). Writes (`gh issue create --body-file`) stay on `gh` for now; MCP write path is auth-blocked.
 
 Do not ask for confirmation. Work autonomously through every step.
 
@@ -24,18 +26,28 @@ Create a working directory for audit state:
 {worktree}/tmp/audit/
 ```
 
-Fetch the list of recently merged PRs (the last 20):
+Fetch the list of recently merged PRs (the last 20) via MCP:
 
 ```
-gh pr list --repo judgemind/judgemind --state merged --limit 20 \
-    --json number,title,headRefName,mergedAt,files,body
+mcp__github__list_pull_requests
+  owner: "judgemind"
+  repo: "judgemind"
+  state: "closed"
+  sort: "updated"
+  direction: "desc"
+  per_page: 20
 ```
+
+Client-side filter to `merged_at != null` (the MCP response includes `merged_at`; a closed PR with `merged_at: null` was closed without merging). For each PR you want file-level detail on, call `mcp__github__get_pull_request_files` — the `list_pull_requests` response does not include the changed-file list.
 
 Also fetch the current list of open issues to avoid filing duplicates:
 
 ```
-gh issue list --repo judgemind/judgemind --state open \
-    --json number,title,body,labels --limit 200
+mcp__github__list_issues
+  owner: "judgemind"
+  repo: "judgemind"
+  state: "open"
+  per_page: 200
 ```
 
 Store both results in `{worktree}/tmp/audit/recent_prs.json` and `{worktree}/tmp/audit/open_issues.json` for reference throughout the audit.
@@ -60,7 +72,7 @@ Work through each category in order. For each finding, record it in `{worktree}/
 
 Review the last 20 merged PRs for real bugs that slipped through review:
 
-1. For each PR, read the diff using `gh pr diff <N> --repo judgemind/judgemind`.
+1. For each PR, read the diff using `gh pr diff <N> --repo judgemind/judgemind` (MCP has no unified-diff endpoint — this is the one `gh` read this skill retains). For just the file list without the patch text, prefer `mcp__github__get_pull_request_files`.
 2. Look for:
    - **Logic errors** — off-by-one, wrong comparison operators, inverted conditions, missing null checks.
    - **Race conditions** — shared mutable state without synchronization, TOCTOU patterns.
@@ -254,8 +266,11 @@ For missing headers, file a single `priority/p3` `type/dx` issue listing the scr
 Re-run the same query from Step 0 to get a fresh list of open issues:
 
 ```
-gh issue list --repo judgemind/judgemind --state open \
-    --json number,title,body,labels --limit 200
+mcp__github__list_issues
+  owner: "judgemind"
+  repo: "judgemind"
+  state: "open"
+  per_page: 200
 ```
 
 Overwrite `{worktree}/tmp/audit/open_issues.json` with the fresh data.
@@ -265,8 +280,13 @@ Overwrite `{worktree}/tmp/audit/open_issues.json` with the fresh data.
 Before marking any finding as "skipped — duplicate of #N" based on a matching issue #N, verify that #N is still open:
 
 ```
-gh issue view <N> --repo judgemind/judgemind --json state -q '.state'
+mcp__github__get_issue
+  owner: "judgemind"
+  repo: "judgemind"
+  issue_number: <N>
 ```
+
+Inspect the returned object's `state` field — accept only `"open"`.
 
 If the issue has been closed since the list was fetched, treat the finding as new instead. Do not reference closed issues as duplicates — the fix may have already shipped, or the issue may have been closed as stale.
 

--- a/.claude/skills/dispatcher/SKILL.md
+++ b/.claude/skills/dispatcher/SKILL.md
@@ -9,6 +9,8 @@ Enable dispatcher mode for the current interactive session. This transforms the 
 
 **Dispatcher mode is opt-in.** Interactive sessions are general-purpose by default. The user invokes `/dispatcher` when they want autonomous queue management.
 
+> **MCP-first for GitHub reads.** Prefer `mcp__github__*` tools (`list_issues`, `list_pull_requests`, `get_pull_request`, `get_pull_request_files`, `get_pull_request_status`) over `gh ... --json` for reads — no `-q` jq, no shell quoting, full typed objects. The first use in a session loads the schema via `ToolSearch query="select:mcp__github__list_issues,mcp__github__list_pull_requests,..."`. See `docs/agent/github-api-access.md` for the decision rule. Writes (`gh issue edit`, `gh issue comment`, `gh pr merge`, `gh issue create`, `gh issue close`) stay on `gh` for now — the MCP write path is blocked pending a token (see `docs/agent/gh-to-mcp-migration.md` §Write-path status).
+
 ---
 
 ## Arguments
@@ -54,19 +56,20 @@ When a previous dispatcher or agent session ends unexpectedly (context window ex
 
 **Run this cleanup once at startup, before scanning the work queue.**
 
-1. List all open issues assigned to the agent account that have the `agent/ready` label:
+1. List all open issues assigned to the agent account that have the `agent/ready` label. Use MCP (no `@me` filter — filter client-side on the `assignees` field, matching the agent account login e.g. `drewthaler`):
    ```
-   gh issue list --repo judgemind/judgemind \
-       --label agent/ready --state open --assignee @me \
-       --json number,title \
-       --limit 50
+   mcp__github__list_issues
+     owner: "judgemind"
+     repo: "judgemind"
+     labels: ["agent/ready"]
+     state: "open"
+     per_page: 50
    ```
 
-2. For each assigned issue, check whether an open PR exists that references it:
+2. For each assigned issue, check whether an open PR exists that references it. Use MCP `search_issues` with a `repo:judgemind/judgemind is:pr is:open` qualifier, or reuse the PR list fetched in startup step 5 and match on branch names / body:
    ```
-   gh pr list --repo judgemind/judgemind --state open \
-       --search "Closes #<N> OR Fixes #<N> OR Resolves #<N>" \
-       --json number --limit 1
+   mcp__github__search_issues
+     q: "repo:judgemind/judgemind is:pr is:open in:body #<N>"
    ```
    Alternatively, check the PR list from startup step 5 for branches containing the issue number.
 
@@ -87,13 +90,15 @@ When a previous dispatcher or agent session ends unexpectedly (context window ex
 
 ### 4. Scan the work queue (startup only)
 
-List all open `agent/ready` issues sorted by priority:
+List all open `agent/ready` issues sorted by priority (use MCP — `list_issues` returns full typed objects including labels and assignees):
 
 ```
-gh issue list --repo judgemind/judgemind \
-    --label agent/ready --state open \
-    --json number,title,assignees,labels \
-    --limit 50
+mcp__github__list_issues
+  owner: "judgemind"
+  repo: "judgemind"
+  labels: ["agent/ready"]
+  state: "open"
+  per_page: 50
 ```
 
 Priority order: `priority/p0` > `priority/p1` > `priority/p2` > `priority/p3`. Within the same priority, prefer lower issue numbers (older first).
@@ -104,14 +109,17 @@ If specific issues were passed as arguments, filter to only those issues.
 
 ### 5. Check for in-flight work
 
-Check for any existing open PRs or assigned issues that may need attention (stale CI, merge conflicts, etc.):
+Check for any existing open PRs or assigned issues that may need attention (stale CI, merge conflicts, etc.). Use MCP — returns full PR objects with head ref, mergeable state, and CI status all in one call:
 
 ```
-gh pr list --repo judgemind/judgemind --state open \
-    --json number,title,headRefName,statusCheckRollup,mergeable
+mcp__github__list_pull_requests
+  owner: "judgemind"
+  repo: "judgemind"
+  state: "open"
+  per_page: 50
 ```
 
-Handle any in-flight PRs before launching new work (see "PR Merge Policy" below).
+For detailed CI status on a specific PR, use `mcp__github__get_pull_request_status`. Handle any in-flight PRs before launching new work (see "PR Merge Policy" below).
 
 ### 6. Initialize audit counter
 
@@ -138,7 +146,7 @@ The dispatcher runs a continuous loop:
 3. **Handle in-flight PRs** — merge any that are ready, fix any that are failing
 4. **Sync after merges** — pull latest main after each merge (see "Post-merge sync" in Rules)
 5. **Check audit trigger** — if `prs_since_last_audit >= 20`, spawn `/audit` (see "Periodic Audit" below)
-6. **Fill agent slots** — **run a fresh `gh issue list --label agent/ready` query**, then launch `/task` agents for the highest-priority issues (see "Spawning agents" for the **mandatory fresh query and slot count check**)
+6. **Fill agent slots** — **run a fresh `mcp__github__list_issues labels=["agent/ready"] state="open"` query**, then launch `/task` agents for the highest-priority issues (see "Spawning agents" for the **mandatory fresh query and slot count check**)
 7. **Process completions** — handle agent completion/failure notifications
 8. **Triage** — close done issues, file new issues for discovered problems
 9. **Check context rotation** — increment `loop_iterations` and check if it is time to wind down (see "Context-Aware Rotation" below)
@@ -165,13 +173,15 @@ The dispatcher runs a continuous loop:
 
 **NEVER work from a cached or in-memory issue list.** The work queue changes constantly — issues get unblocked by the `unblock-issues` CI workflow, new issues are filed, priorities change, and other agents claim work. A cached list from startup or a previous cycle will miss newly-available high-priority issues.
 
-Run a fresh query every dispatch cycle:
+Run a fresh query every dispatch cycle (use MCP — fastest and cleanest for repeated reads):
 
 ```
-gh issue list --repo judgemind/judgemind \
-    --label agent/ready --state open \
-    --json number,title,assignees,labels \
-    --limit 50
+mcp__github__list_issues
+  owner: "judgemind"
+  repo: "judgemind"
+  labels: ["agent/ready"]
+  state: "open"
+  per_page: 50
 ```
 
 Use the results of THIS query — not the startup scan, not a previous cycle's results — to pick the next issue to dispatch. Apply the same priority ordering: `priority/p0` > `priority/p1` > `priority/p2` > `priority/p3`, lower issue numbers first within the same priority.
@@ -446,7 +456,7 @@ The checkpoint is a Markdown file (human-readable, easy for the LLM to parse) wi
 
 ## Next Actions
 - Process next task-notification -> cleanup worktree, re-anchor cwd, send Telegram, free slot
-- When slot opens -> fresh `gh issue list --label agent/ready` query, dispatch highest priority
+- When slot opens -> fresh `mcp__github__list_issues labels=["agent/ready"]` query, dispatch highest priority
 - If prs_since_last_audit >= 20 -> spawn /audit
 - Check for Telegram messages
 (adjust based on current state -- e.g., if winding down, note "waiting for agents to finish before exiting")
@@ -672,13 +682,16 @@ This same logic also handles `terraform_apply` instructions from the subagent in
 
 #### Detecting infra PRs
 
-After merging a PR, check whether any changed files match `infra/terraform/**`. Use the PR's file list:
+After merging a PR, check whether any changed files match `infra/terraform/**`. Use MCP to fetch the PR's file list:
 
 ```
-gh pr view <N> --repo judgemind/judgemind --json files --jq '.files[].path'
+mcp__github__get_pull_request_files
+  owner: "judgemind"
+  repo: "judgemind"
+  pull_number: <N>
 ```
 
-If any path starts with `infra/terraform/`, proceed with the apply.
+The response is an array of file objects; inspect each `filename` field. If any path starts with `infra/terraform/`, proceed with the apply.
 
 #### Determining which environments to apply
 
@@ -918,7 +931,7 @@ Shutdown triggers:
 
 ### Queue low or empty → spawn /spotcheck instead of idling
 
-When `gh issue list --label agent/ready` returns fewer issues than available `/task` slots and there are no in-flight agents with follow-ups pending, the correct idle behavior (especially overnight) is to spawn `/spotcheck` as a subagent (`isolation: worktree`) rather than winding down. /spotcheck samples across counties, compares DB records to source PDFs, and files per-pattern data-quality issues — which refills the queue with concrete work the dispatcher picks up in the next cycle. Treat this as standing instruction; do not ask permission when operating autonomously. Only move to full shutdown when /spotcheck itself produces no new work AND the queue is genuinely empty.
+When `mcp__github__list_issues labels=["agent/ready"]` returns fewer issues than available `/task` slots and there are no in-flight agents with follow-ups pending, the correct idle behavior (especially overnight) is to spawn `/spotcheck` as a subagent (`isolation: worktree`) rather than winding down. /spotcheck samples across counties, compares DB records to source PDFs, and files per-pattern data-quality issues — which refills the queue with concrete work the dispatcher picks up in the next cycle. Treat this as standing instruction; do not ask permission when operating autonomously. Only move to full shutdown when /spotcheck itself produces no new work AND the queue is genuinely empty.
 
 ### Full shutdown procedure (user-initiated or queue empty)
 

--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -9,6 +9,8 @@ A guardrail/checklist for filing an issue in `judgemind/judgemind`. This skill d
 
 **Why this exists:** agents routinely file issues with inline bodies, vague acceptance criteria, missing `Verify:` lines, or the wrong priority. The pattern is in the docs, but it's easy to forget under time pressure. This skill is the pre-filing checklist.
 
+> **MCP vs `gh`:** issue creation is a write operation. `mcp__github__create_issue` exists and would let the body be passed as a native string (no tmp file), but the MCP server currently has no auth token and all writes fail with `Requires authentication` (verified from a `/task` subagent). Until that is fixed, this skill keeps `gh issue create --body-file`. See `docs/agent/github-api-access.md` for the decision rule and `docs/agent/gh-to-mcp-migration.md` for the full inventory.
+
 ---
 
 ## Checklist — run through every item before calling `gh issue create`
@@ -116,6 +118,8 @@ Capture the returned URL and reference it in any comment, PR, or Telegram reply 
 
 ## See also
 
+- `docs/agent/github-api-access.md` — MCP vs `gh` decision rule and the write-path note.
+- `docs/agent/gh-to-mcp-migration.md` — full tool-by-tool inventory.
 - `docs/agent/issue-authoring.md` — full authoring reference, priority framework, sub-task mechanics, investigation-task conventions.
 - `docs/agent/task-dependencies.md` — blocking/unblocking mechanics, `Blocked by #N` semantics.
 - `scripts/block-issue.sh` — the helper that satisfies the Blocked-by contract.

--- a/.claude/skills/spotcheck/SKILL.md
+++ b/.claude/skills/spotcheck/SKILL.md
@@ -26,6 +26,8 @@ Bidirectional spot-check across all active counties:
 
 **Do not ask for confirmation. Work autonomously through every step.**
 
+> **MCP vs `gh`:** use `mcp__github__list_issues` for the open-issues lookup in Step 4.1 (no `--json` enumeration, no `-q` jq — returns full typed objects). Keep `gh issue create --body-file` for new-issue writes — the MCP write path (`mcp__github__create_issue`) exists but is currently auth-blocked on this machine. See `docs/agent/github-api-access.md` for the decision rule.
+
 ---
 
 ## Step 0 — Run the one-shot spotcheck script
@@ -145,10 +147,15 @@ Check for garbled titles, missing fields, layout issues. Record in `{worktree}/t
 
 ### 4.1 — Fetch open issues
 
+Use MCP — returns full typed objects (number, title, body, labels, assignees) in one call:
+
 ```
-gh issue list --repo judgemind/judgemind --state open \
-    --label "type/bug" \
-    --json number,title,body,labels --limit 200
+mcp__github__list_issues
+  owner: "judgemind"
+  repo: "judgemind"
+  state: "open"
+  labels: ["type/bug"]
+  per_page: 200
 ```
 
 ### 4.2 — Classify findings

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -12,6 +12,10 @@ Pick up one issue from the Judgemind backlog and complete it autonomously. Do no
 
 **IMPORTANT — Post-compaction recovery.** If your context was just autocompacted (your summary references "previous conversation"), you are NOT done with the task. Autocompaction preserves *what was done* but not the procedural imperative *what still needs to happen next* (see #2545). Before emitting any final report or `end_turn`, run the status-file-driven recovery check described in §A.0 (implementation tasks) or §B.0 (investigation tasks). The status file at `{repo_root}/tmp/agent-status/<agent-id>.txt` is your authoritative "where am I" anchor — re-read this SKILL.md from the section named by your current `phase` and continue. Only `phase=done`, `phase=verified`, or `phase=blocked` means stop.
 
+**IMPORTANT — MCP-first for GitHub reads.** Prefer `mcp__github__*` tools for reads (issue/PR lookup, status, files, comments, search). Keep `gh` for writes (comment, edit, create, merge, close) — the MCP server currently has no auth token so all writes fail. Keep `gh` permanently for `gh run watch`, `gh run list --workflow`, `gh pr edit --body-file`, and anything else without an MCP equivalent. Decision table: `docs/agent/github-api-access.md`. Full inventory: `docs/agent/gh-to-mcp-migration.md`.
+
+Loading a deferred MCP tool requires a one-time `ToolSearch` call to pull its schema — e.g. `ToolSearch query="select:mcp__github__get_issue,mcp__github__list_issues,mcp__github__get_pull_request,mcp__github__get_pull_request_status"`. Once loaded, the tool is callable for the rest of the session.
+
 ---
 
 ## Step 0 — Verify worktree exists
@@ -84,23 +88,29 @@ This writes `{worktree}/tmp/timing.json` with the full phase breakdown and appen
 Interpret `$ARGUMENTS` as follows:
 
 ### Empty or "next"
-List all open, unassigned `agent/ready` issues and pick the highest-priority one:
+List all open, unassigned `agent/ready` issues and pick the highest-priority one using MCP:
+
 ```
-gh issue list --repo judgemind/judgemind \
-    --label agent/ready --state open \
-    --json number,title,assignees,labels \
-    --limit 20
+mcp__github__list_issues
+  owner=judgemind repo=judgemind
+  labels=["agent/ready"] state="open" per_page=20
 ```
+
 Priority order: `priority/p0` > `priority/p1` > `priority/p2` > `priority/p3`. Within the same priority, prefer lower issue numbers (older issues first). Skip issues already assigned to another agent unless their worktree no longer exists in `git -C $REPO_ROOT worktree list`.
 
+MCP does not support filtering by assignee directly — filter the returned list client-side on each issue's `assignees` array.
+
 ### `#N` (e.g. `/task #42`)
-Work on that specific issue regardless of its current labels or assignment. Fetch it:
+Work on that specific issue regardless of its current labels or assignment. Fetch it via MCP:
+
 ```
-gh issue view 42 --repo judgemind/judgemind --json number,title,body,labels,assignees,comments
+mcp__github__get_issue owner=judgemind repo=judgemind issue_number=42
 ```
 
+This returns the full issue object (number, title, body, labels, assignees, state). `get_issue` does **not** embed comments — see Step 4 below for the comments fetch.
+
 ### Natural language (e.g. `/task scrapers`, `/task next perf bug`, `/task SF tentatives`)
-List `agent/ready` issues, then pick the one that best matches the description. Prefer exact label or area matches; fall back to title/body keyword matches. If multiple candidates are equally good, pick the highest-priority unassigned one. Briefly note which issue you chose and why before proceeding.
+List `agent/ready` issues with `mcp__github__list_issues` (same call as above), then pick the one that best matches the description. Prefer exact label or area matches; fall back to title/body keyword matches. If multiple candidates are equally good, pick the highest-priority unassigned one. Briefly note which issue you chose and why before proceeding.
 
 ---
 
@@ -113,7 +123,7 @@ scripts/check-issue-author.sh <issue-number>
 ```
 
 - **Exit 0 (trusted):** proceed to Step 2.
-- **Exit 1 (untrusted):** **do not work on this issue.** Remove the `agent/ready` label and add `status/triage`:
+- **Exit 1 (untrusted):** **do not work on this issue.** Remove the `agent/ready` label and add `status/triage`. Until MCP writes are authenticated, use `gh`:
   ```
   gh issue edit <N> --repo judgemind/judgemind --remove-label agent/ready --add-label status/triage
   ```
@@ -127,16 +137,18 @@ scripts/check-issue-author.sh <issue-number>
 
 ## Step 2 — Claim the issue and rename the conversation
 
-Assign it to yourself:
+Assign it to yourself (write — MCP auth currently blocked, stays on `gh`):
 ```
 gh issue edit <N> --repo judgemind/judgemind --add-assignee @me
 ```
 
-Write the claim comment to a temp file, then post it:
+Write the claim comment to a temp file, then post it (write — stays on `gh`):
 ```
 gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/claim_comment.txt
 ```
 Comment content: `Picking this up in {agent-id}.`
+
+Once MCP writes are unblocked (follow-up issue referenced from `docs/agent/gh-to-mcp-migration.md`), this becomes `mcp__github__update_issue` + `mcp__github__add_issue_comment` with no tmp-file preamble.
 
 **Rename this conversation** so it is identifiable in the sidebar:
 - Format: `#<N> — <short title>` (drop any `[AREA]` prefix tag from the issue title)
@@ -176,7 +188,7 @@ Mark each todo `in_progress` when you start it and `completed` when done. If a t
 
 Read the issue body thoroughly, including linked issues. Check `docs/specs/` for relevant guidance. Look at existing code for patterns — be consistent with what's already there.
 
-**Fetch issue comments for full context.** Issue comments often contain scope clarifications, additional acceptance criteria, and implementation notes from prior attempts. Fetch them:
+**Fetch issue comments for full context.** Issue comments often contain scope clarifications, additional acceptance criteria, and implementation notes from prior attempts. `mcp__github__get_issue` does not embed comments, so fetch them explicitly via `gh` (MCP has `add_issue_comment` for posting but no first-class "list comments on an issue" tool):
 
 ```
 gh issue view <N> --repo judgemind/judgemind --json number,title,body,labels,assignees,comments
@@ -250,7 +262,7 @@ Skip this for Terraform-only or docs-only tasks.
 **POST-RALPH SELF-RECOVERY GUARD:** Before proceeding to A.2b, verify that the task is genuinely incomplete by running these checks:
 1. Run `git -C {worktree} status` to confirm there are uncommitted changes (there should be — ralph implements but does not commit).
 2. Run `git -C {worktree} log --oneline -1` to see the latest commit — it should NOT contain the current issue number (the implementation hasn't been committed yet).
-3. Check whether a PR already exists for this branch: `gh pr list --repo judgemind/judgemind --head <branch-name> --json number --limit 1`. It should return an empty list (no PR yet).
+3. Check whether a PR already exists for this branch: `mcp__github__list_pull_requests owner=judgemind repo=judgemind head="judgemind:<branch-name>" per_page=1`. It should return an empty list (no PR yet).
 4. Run the authoritative recovery check: `{worktree}/scripts/check-task-recovery.sh {worktree}`. It must return exit 1 (`RESUME`). If it returns 0 (`DONE`), that means the status file shows a terminal phase you did not intend — update the status file to reflect the actual phase and re-run the check.
 
 If any of these checks show that work remains (uncommitted changes exist, no PR yet), you MUST continue to A.2b. Do not exit. Do not return. Do not consider the task done. Exiting at this point is a critical workflow failure (#721, #2545).
@@ -287,7 +299,7 @@ Before committing or creating a PR, post a process summary comment on the GitHub
 <Any intentional exclusions or scope boundaries — what was NOT done and why>
 ```
 
-Post it:
+Post it (write — stays on `gh` until MCP writes land):
 ```
 gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/process_summary.txt
 ```
@@ -354,7 +366,7 @@ The **Post-deploy verification** section must include at least one concrete veri
 - [ ] N/A — no deployed component (docs/CI/tooling only)
 ```
 
-Create the PR:
+Create the PR (write — stays on `gh` until MCP writes land):
 ```
 gh pr create --repo judgemind/judgemind \
     --title "..." \
@@ -363,10 +375,13 @@ gh pr create --repo judgemind/judgemind \
 ```
 
 #### A.4 — Verify no merge conflicts
+Read merge status via MCP:
+
 ```
-gh pr view <PR-N> --repo judgemind/judgemind --json mergeable,mergeStateStatus
+mcp__github__get_pull_request owner=judgemind repo=judgemind pull_number=<PR-N>
 ```
-If `mergeable` is `CONFLICTING`, rebase and resolve:
+
+Check the `mergeable` and `mergeable_state` fields in the response. If `mergeable` is `false` or `mergeable_state` is `dirty`/`unstable`, rebase and resolve:
 ```
 git -C {worktree} fetch origin main
 git -C {worktree} rebase origin/main
@@ -379,13 +394,24 @@ Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {wo
 
 **Run CI watches in the foreground** — do not use `run_in_background`. You cannot proceed until CI finishes, so background execution just generates unnecessary `<task-notification>` noise for the dispatcher. **Use `timeout: 1200000`** as CI runs typically take 10-25 minutes.
 
+`gh run watch` has no MCP equivalent — stays on `gh`:
+
 ```
 gh run watch <run-id> --repo judgemind/judgemind --interval 60 --exit-status --compact
 ```
+
+For quick status polls without watching, `mcp__github__get_pull_request_status` returns the combined check rollup in one MCP call.
+
 If CI fails: write status `phase: ci-fix`, `summary: Fixing CI failure: <brief reason>`. Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} ci-fix`. Diagnose, fix locally, push, return to A.4. On the next CI watch, increment the attempt number in the phase name (e.g. `ci-watch (2)`). Repeat until all checks pass.
 
 #### A.6 — Update the PR test plan
-Fetch the current PR body, check off the **Automated checks** items that passed in CI. Do NOT check off **Post-deploy verification** items yet — those are checked in A.8 after merge and deploy. Write the updated body to `{worktree}/tmp/pr_body.txt`, then:
+Fetch the current PR body via MCP:
+
+```
+mcp__github__get_pull_request owner=judgemind repo=judgemind pull_number=<PR-N>
+```
+
+Check off the **Automated checks** items that passed in CI. Do NOT check off **Post-deploy verification** items yet — those are checked in A.8 after merge and deploy. Write the updated body to `{worktree}/tmp/pr_body.txt`, then (write — `gh pr edit` has no MCP equivalent, stays on `gh`):
 ```
 gh pr edit <PR-N> --repo judgemind/judgemind --body-file {worktree}/tmp/pr_body.txt
 ```
@@ -394,7 +420,7 @@ gh pr edit <PR-N> --repo judgemind/judgemind --body-file {worktree}/tmp/pr_body.
 Write status: `phase: merging`, `summary: Squash merging PR #<N>`.
 Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} merging`
 
-The PR has passed the ralph loop review (A.2) and CI is green. Merge it:
+The PR has passed the ralph loop review (A.2) and CI is green. Merge it (stays on `gh` — MCP's `merge_pull_request` has no `--delete-branch` flag):
 ```
 gh pr merge <PR-N> --repo judgemind/judgemind --squash --delete-branch
 ```
@@ -418,7 +444,7 @@ Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {wo
    - `packages/scraper-framework/` or scraper code → `deploy-scraper.yml`
    - `packages/web/` or frontend → `deploy-production.yml`
    - `infra/terraform/` → `terraform.yml`
-2. **Run deploy watches in the foreground** — do not use `run_in_background`. **Use `timeout: 1200000`** as deploys can take several minutes.
+2. **Run deploy watches in the foreground** — do not use `run_in_background`. **Use `timeout: 1200000`** as deploys can take several minutes. (`gh run list --workflow` and `gh run watch` have no MCP equivalent — stay on `gh`.)
    ```
    gh run list --repo judgemind/judgemind --workflow "<deploy-workflow>.yml" --branch main --limit 1 --json databaseId -q '.[0].databaseId'
    gh run watch <run-id> --repo judgemind/judgemind --interval 60 --exit-status --compact
@@ -463,7 +489,7 @@ If functional verification **fails**: diagnose the issue. If it's a simple fix, 
 
 After verification succeeds (or after determining the change has no deployed component), you MUST post a verification evidence comment on the issue. This is a hard gate — the task cannot proceed to A.9 without this comment.
 
-Write the comment to `{worktree}/tmp/verification_evidence.txt`, then post it:
+Write the comment to `{worktree}/tmp/verification_evidence.txt`, then post it (write — stays on `gh` until MCP writes land):
 ```
 gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/verification_evidence.txt
 ```
@@ -507,7 +533,7 @@ Post-deploy verification: N/A (no deployed component)
 **GATE CHECK:** Do not proceed to A.9 until the verification evidence comment has been posted. A task closed without a verification evidence comment is a workflow failure.
 
 After posting, update the PR test plan to check off the post-deploy verification items:
-1. Fetch the current PR body.
+1. Fetch the current PR body via `mcp__github__get_pull_request`.
 2. Check off the **Post-deploy verification** checkboxes.
 3. Write updated body to `{worktree}/tmp/pr_body.txt` and update with `gh pr edit --body-file`.
 
@@ -545,7 +571,7 @@ Write findings to `docs/investigations/<slug>-<YYYY-MM>.md` and/or into the issu
 
 Do not just list recommendations — **create GitHub issues** for each concrete next step so the work is tracked and can be picked up by agents. For each follow-up:
 
-- Write the issue body to `{worktree}/tmp/followup_N.txt`, then create it with `gh issue create --body-file`.
+- Write the issue body to `{worktree}/tmp/followup_N.txt`, then create it with `gh issue create --body-file` (write — stays on `gh` until MCP writes land).
 - Reference the investigation as the parent: include `Parent: #<investigation-issue>` in the body.
 - Label with appropriate area and type labels.
 - Add `agent/ready` if the issue is fully specified and ready for work. If it requires a human decision first, note that in the body and omit `agent/ready`.
@@ -572,7 +598,7 @@ Post a summary comment on the investigation issue listing the findings and linki
 
 **Close the investigation issue after posting findings.** Investigation issues are fully resolved once findings are documented and follow-up issues are filed. Leaving them open causes duplicate agent work — another agent will pick up the still-open issue and re-investigate.
 
-Write the close comment to `{worktree}/tmp/close_comment.txt`, then post and close:
+Write the close comment to `{worktree}/tmp/close_comment.txt`, then post and close (writes — stay on `gh`; `gh issue close --reason completed` has no MCP equivalent):
 ```
 gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/close_comment.txt
 gh issue close <N> --repo judgemind/judgemind --reason completed
@@ -623,7 +649,7 @@ Review the bug or problem you just fixed and ask:
 
 For each actionable finding from 5a and 5b:
 
-- Write the issue body to `{worktree}/tmp/retro_N.txt`, then create it with `gh issue create --body-file`.
+- Write the issue body to `{worktree}/tmp/retro_N.txt`, then create it with `gh issue create --body-file` (write — stays on `gh` until MCP writes land).
 - Label with `type/dx` (workflow improvements) or the appropriate area label (preventative measures).
 - Set priority based on impact: `priority/p1` for things that would prevent production bugs or save significant agent time across many tasks; `priority/p2` for nice-to-have workflow improvements or one-off friction. **Never set `priority/p0`** — that priority is reserved for humans.
 - Add `agent/ready` so the issue can be picked up autonomously.
@@ -660,4 +686,5 @@ Worktree cleanup is handled automatically by Claude Code when the agent exits.
 - **No `run_in_background`.** All commands — CI watches, test suites, deploy watches, and reviewer invocations — must run in the foreground. Subagents are already background tasks from the parent's perspective. Further backgrounding causes `<task-notification>` messages to surface in the wrong context, leading to confusion and lost results.
 - **Use `timeout: 1200000`** on Bash commands that may exceed 2 minutes: `pytest`, `gh run watch`, `pip install`, `npm install`, `npm run build`, `terraform apply`, `ruff check` on large codebases, and any data-processing script.
 - **After any context reset, run §A.0 / §B.0 recovery** — `{worktree}/scripts/check-task-recovery.sh {worktree}` is the authoritative "am I done?" check.
+- **Prefer MCP for reads** (`mcp__github__get_issue`, `get_pull_request`, `list_issues`, `list_pull_requests`, `get_pull_request_status`). Keep `gh` for writes and for workflow-run operations. See `docs/agent/github-api-access.md`.
 - See CLAUDE.md §Unattended Operation Patterns for the full list.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ Consult these docs before making changes in their domain:
 | `docs/agent/infrastructure-reference.md` | ECS script execution, Terraform apply, secrets, Vercel, Reingest vs Rebuild |
 | `docs/agent/local-dev.md` | Docker Compose, local DB rebuild, S3 cache, local env vars |
 | `docs/agent/unattended-patterns.md` | Permission-prompt workarounds for git, curl, secrets, `.claude/` writes |
+| `docs/agent/github-api-access.md` | When to use the GitHub MCP server vs the `gh` CLI — MCP-first for reads, `gh` for writes and gaps |
+| `docs/agent/gh-to-mcp-migration.md` | Full tool-by-tool `gh` → `mcp__github__*` mapping, including the known gaps |
 
 ## Starting a New Session
 
@@ -267,6 +269,8 @@ For agents spawned with `isolation: "worktree"`, Claude Code handles cleanup aut
 - **Use dedicated tools for file operations** — never use Bash for `cat`, `ls`, `grep`, `find`. Use Read, Glob, and Grep instead.
 - **Always Read before Write** — the Write tool requires this for existing files.
 - **Use Bash only for shell-only operations** — git, gh CLI, running tests, pip install, terraform, etc.
+- **MCP-first for GitHub reads.** Prefer `mcp__github__*` tools (`get_issue`, `list_issues`, `get_pull_request`, `list_pull_requests`, `get_pull_request_files`, `get_pull_request_status`, `search_issues`, `search_code`) over `gh ... --json` for reads. MCP returns full typed objects in one call — no `--json` enumeration, no `-q` jq, no shell quoting. Tools are deferred; load via `ToolSearch query="select:mcp__github__get_issue,..."` before first use in a session. See `docs/agent/github-api-access.md` for the decision table and `docs/agent/gh-to-mcp-migration.md` for the full mapping.
+- **`gh` CLI is still the write path** (and the fill-in for MCP gaps). Writes — `gh issue create`, `gh issue comment`, `gh issue edit`, `gh issue close --reason`, `gh pr create`, `gh pr merge --squash --delete-branch`, `gh pr edit`, `gh pr review` — stay on `gh` until the MCP server has a `GITHUB_PERSONAL_ACCESS_TOKEN` (see `docs/agent/gh-to-mcp-migration.md` §Write-path status). Reads without an MCP equivalent also stay on `gh`: `gh run watch`, `gh run list --workflow`, `gh run view`, `gh pr diff`, `gh api rate_limit`, `gh auth status`. Do not invent MCP calls that do not exist.
 - **Parallelize independent Bash calls** — when multiple Bash commands have no dependencies between them (e.g., fetching multiple issue details, running lint + format check), make all calls in a single message rather than sequentially. This significantly reduces wall-clock time for multi-step workflows.
 - `sudo` and `rm` always prompt; split commands to avoid triggering prompts.
 

--- a/docs/agent/gh-to-mcp-migration.md
+++ b/docs/agent/gh-to-mcp-migration.md
@@ -1,0 +1,76 @@
+# `gh` to GitHub MCP migration — audit table
+
+> **Purpose:** concrete mapping of every `gh` subcommand currently used in agent-facing skills and docs to the corresponding `mcp__github__*` tool (or a noted gap). Companion to `docs/agent/github-api-access.md`, which explains the decision rules; this document is the exhaustive inventory.
+
+## Scope of the audit
+
+- **In scope:** every `gh` invocation inside agent-facing markdown — the SKILL.md files under `.claude/skills/` (task, dispatcher, ralph, audit, spotcheck, file-issue), the root `CLAUDE.md`, and the per-topic references under `docs/agent/`.
+- **Out of scope:** shell scripts under `scripts/`, GitHub Actions workflows under `.github/workflows/`, `.githooks/`, and `gh run watch` / `gh auth` / `gh config` (no MCP equivalents). See `docs/agent/github-api-access.md` §Decision rule for the per-situation split.
+
+## Tool-by-tool mapping
+
+| `gh` subcommand | MCP equivalent | Status | Notes |
+|---|---|---|---|
+| `gh issue view <N> --json ...` | `mcp__github__get_issue` | **Available** | MCP returns the full issue object without `--json` enumeration. To get comments too, call `mcp__github__get_issue` then paginate via `mcp__github__list_issues` or GitHub REST if needed (MCP's `get_issue` does not embed comments). |
+| `gh issue list --label agent/ready --state open` | `mcp__github__list_issues` | **Available** | Supports `labels`, `state`, `sort`, `direction`, `since`. No `--assignee` filter — filter client-side on the `assignees` field. |
+| `gh issue create --body-file ...` | `mcp__github__create_issue` | **Available (write — currently blocked, see below)** | Body passed as native `body` string; no tmp-file needed. |
+| `gh issue comment <N> --body-file ...` | `mcp__github__add_issue_comment` | **Available (write — currently blocked)** | |
+| `gh issue edit <N> --add-label X` / `--remove-label X` | `mcp__github__update_issue` with `labels: [...]` | **Partial (write — currently blocked)** | MCP only supports full label replacement, not incremental add/remove. Agents must read current labels via `get_issue`, compute the new list, then pass the full set to `update_issue`. Keep `gh issue edit --add-label` when a single-call incremental add is simpler. |
+| `gh issue edit <N> --add-assignee @me` | `mcp__github__update_issue` with `assignees: [...]` | **Partial (write — currently blocked)** | Same pattern as labels: full replacement only. `@me` resolution is client-side — pass the literal login (e.g. `drewthaler`). |
+| `gh issue close <N> --reason completed` | `mcp__github__update_issue` with `state: "closed"` | **Partial (write — currently blocked)** | MCP does **not** expose `state_reason` — cannot set `completed` vs `not_planned` vs `duplicate`. Keep `gh issue close --reason` when the distinction matters (it does for investigation tasks: see `/task` B.2). |
+| `gh pr list --state open --json ...` | `mcp__github__list_pull_requests` | **Available** | |
+| `gh pr view <N> --json ...` | `mcp__github__get_pull_request` | **Available** | |
+| `gh pr view <N> --json statusCheckRollup` / `gh pr checks <N>` | `mcp__github__get_pull_request_status` | **Available** | Returns combined status. |
+| `gh pr view <N> --json files` | `mcp__github__get_pull_request_files` | **Available** | |
+| `gh pr view <N> --json reviewDecision,reviews` | `mcp__github__get_pull_request_reviews` | **Available** | |
+| `gh pr create --body-file ... --base main` | `mcp__github__create_pull_request` | **Available (write — currently blocked)** | Body as native string. |
+| `gh pr edit <N> --body-file ...` | *(no direct MCP equivalent for PR body edit)* | **Gap** | MCP has no `update_pull_request`. Keep `gh pr edit`. |
+| `gh pr merge <N> --squash --delete-branch` | `mcp__github__merge_pull_request` | **Partial (write — currently blocked)** | MCP supports `merge_method` but has **no flag for `--delete-branch`**. Keep `gh pr merge --squash --delete-branch` for the typical merge-and-cleanup flow. |
+| `gh pr diff <N>` | *(no direct MCP equivalent)* | **Gap** | Use `get_pull_request_files` to list changes; for raw unified diff, keep `gh pr diff`. |
+| `gh pr review <N> --approve` / `--request-changes` / `--comment` | `mcp__github__create_pull_request_review` | **Available (write — currently blocked)** | |
+| `gh run list --workflow X.yml --branch main --limit 1` | *(no MCP equivalent)* | **Gap — stays on `gh`** | MCP has no workflow-runs API exposure. |
+| `gh run watch <run-id> --interval 60 --exit-status` | *(no MCP equivalent)* | **Gap — stays on `gh`** | MCP has no long-poll watcher. Explicitly documented as out of scope. |
+| `gh run view <run-id> --json jobs` | *(no MCP equivalent)* | **Gap — stays on `gh`** | |
+| `gh api rate_limit` | *(no MCP equivalent)* | **Gap — stays on `gh`** | |
+| `gh auth status` / `gh auth token` | *(no MCP equivalent)* | **Gap — stays on `gh`** | |
+| `gh repo view` / `gh label list` / `gh secret ...` | *(no MCP equivalent)* | **Gap — stays on `gh`** | |
+
+## Write-path status — read this before migrating
+
+As of this PR, the `github` MCP server is configured at `local` scope (`claude mcp add github -s local -- npx -y @modelcontextprotocol/server-github`) but **with no `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable**. Consequences, verified live from a `/task` subagent on 2026-04-18:
+
+- **Reads work** against public repos (judgemind/judgemind is public). `mcp__github__get_issue`, `list_issues`, `get_pull_request`, `get_pull_request_status`, etc. all return full payloads.
+- **All writes fail** with `MCP error -32603: Authentication Failed: Requires authentication`. Confirmed against `add_issue_comment`, `update_issue`, and `create_issue`.
+
+Until the MCP server is given a token, agents can only use MCP for reads. Writes must stay on `gh`. **Do not mass-migrate write calls in this PR** — they will break every agent.
+
+Follow-up issue is filed (referenced in this PR's description) to add the token and restart the CLI. Once that lands, write calls can be migrated incrementally in a later PR.
+
+## Migration plan (two phases)
+
+### Phase 1 (this PR) — MCP-first for reads, docs establish the direction
+
+1. Add `docs/agent/github-api-access.md` with the decision rule: **prefer MCP for reads, keep `gh` for writes (temporary until token lands) and for all operations in the "Gap" rows above.**
+2. Update skills so that `gh issue view --json` and `gh pr view --json` reads are replaced with `mcp__github__get_issue` / `get_pull_request` references. `gh issue list` and `gh pr list` become `mcp__github__list_issues` / `list_pull_requests`.
+3. Leave write calls (comment, edit, create, close, merge) on `gh` with a pointer to the follow-up issue that will unblock MCP writes. Mark them explicitly "MCP write path blocked on <follow-up #>".
+4. Update `CLAUDE.md` to point at the new doc rather than duplicating the decision rule.
+
+### Phase 2 (follow-up PR, after MCP token lands)
+
+1. Replace `gh issue comment --body-file` with `mcp__github__add_issue_comment` — this is the biggest ergonomic win (kills the "write body to tmp file first" preamble for all comment posting).
+2. Replace `gh issue create --body-file` with `mcp__github__create_issue`.
+3. Replace `gh pr create --body-file` with `mcp__github__create_pull_request`.
+4. Replace `gh issue edit --add-label X` with the read-current-labels-then-`update_issue` pattern, but only where it is simpler than the current call. Some incremental edits stay on `gh`.
+5. Leave `gh pr merge --squash --delete-branch`, `gh pr edit --body-file`, `gh issue close --reason`, and everything in the Gap rows on `gh`.
+
+## Verification
+
+After this PR:
+
+```
+grep -rnE 'gh (issue|pr) (view|list)' .claude/skills/ CLAUDE.md docs/agent/
+```
+
+Should show no results except in `docs/agent/gh-to-mcp-migration.md` (this file) and `docs/agent/github-api-access.md` — those intentionally contain the old patterns as examples.
+
+Write operations (`gh issue create`, `gh issue comment`, `gh pr create`, `gh pr merge`, `gh issue close`, `gh pr edit`, `gh issue edit`) still appear in skills — that is the intended Phase 1 state.

--- a/docs/agent/github-api-access.md
+++ b/docs/agent/github-api-access.md
@@ -1,0 +1,66 @@
+# GitHub API access — MCP vs `gh` CLI
+
+> **When to read this:** you are writing or editing a skill, agent doc, or CLAUDE.md section that interacts with GitHub, and need to choose between a `mcp__github__*` MCP tool and the `gh` CLI.
+>
+> **TL;DR:** prefer MCP for structured reads. Keep `gh` for writes (temporarily — see the write-path note below), for anything in the Gap rows of `docs/agent/gh-to-mcp-migration.md`, and for shell scripts where MCP is not reachable.
+
+## Why this doc exists
+
+Agents historically used `gh` for every GitHub operation, which forced a handful of annoying patterns:
+
+- Multi-line content needed a `--body-file` preamble — write to a tmp file, then invoke `gh`.
+- Reads required `--json field1,field2,...` enumeration and often `-q .[0].databaseId` jq juggling.
+- The combination of shell quoting and `-q` mixed-quote rules tripped the platform's safety checks (see `docs/agent/unattended-patterns.md` §`gh` jq Quoting).
+
+The `github` MCP server exposes the REST API directly as structured tool calls — body is a native string, the response is parsed JSON, no shell escaping. For reads this is a clear win. For writes it will be a clear win once auth is configured (see below).
+
+## Decision rule
+
+| Situation | Use | Why |
+|---|---|---|
+| Structured read of a single issue, PR, comment list, file contents | **MCP** (`get_issue`, `get_pull_request`, `get_pull_request_comments`, `get_file_contents`, etc.) | No `--json` enumeration, no `-q` jq. Returns full typed object in one call. |
+| Listing issues or PRs with filters (labels, state, assignee) | **MCP** (`list_issues`, `list_pull_requests`) | Native filter params, paginated response. |
+| PR status checks / review state | **MCP** (`get_pull_request_status`, `get_pull_request_reviews`, `get_pull_request_files`) | |
+| Search across the repo (issues, code, commits) | **MCP** (`search_issues`, `search_code`, `list_commits`) | |
+| Posting an issue comment or creating an issue/PR with a multi-line body | **`gh` (today) / MCP (once auth lands)** | See the write-path note below. Once the MCP server has a token, `add_issue_comment` and friends eliminate the tmp-file preamble. |
+| Adding/removing a single label | **`gh issue edit --add-label` / `--remove-label`** | MCP only supports full label replacement (`update_issue` with the full `labels` array). For an incremental add, `gh` is one call, MCP is two (read, then replace). |
+| Closing an issue with `state_reason` (completed / not_planned / duplicate) | **`gh issue close --reason`** | MCP does not expose `state_reason`. |
+| Merging a PR with `--delete-branch` | **`gh pr merge --squash --delete-branch`** | MCP has `merge_pull_request` but no branch-delete flag. |
+| Editing an existing PR's body after CI or pre-merge checklist updates | **`gh pr edit --body-file`** | MCP has no `update_pull_request` body edit. |
+| Watching a workflow run / CI / deploy | **`gh run watch --interval 60 --exit-status`** | MCP has no long-poll watcher. |
+| Listing workflow runs or viewing job detail | **`gh run list` / `gh run view`** | MCP has no `actions` API exposure. |
+| Checking auth state or rate-limit budget | **`gh auth status` / `gh api rate_limit`** | MCP does not cover auth state or the rate-limit endpoint. |
+| Shell script (anything under `scripts/`), GitHub Action, or Git hook | **`gh`** | MCP runs inside Claude Code and is not reachable from shell scripts that execute outside the agent context. |
+
+## The write-path note (read this before migrating writes)
+
+As of this repo's current machine configuration, the `github` MCP server is connected but **no `GITHUB_PERSONAL_ACCESS_TOKEN` is set** in its environment. Live smoke test from a `/task` subagent (2026-04-18):
+
+- `mcp__github__get_issue` — works (unauthenticated reads against this public repo).
+- `mcp__github__add_issue_comment` — fails with `MCP error -32603: Authentication Failed: Requires authentication`.
+- `mcp__github__update_issue`, `mcp__github__create_issue`, `mcp__github__create_pull_request` — same failure.
+
+Until that is fixed:
+
+- **Reads:** prefer MCP.
+- **Writes:** stay on `gh`. Every skill that currently uses `gh issue comment --body-file`, `gh issue edit`, `gh issue create`, `gh pr create`, `gh pr merge`, `gh issue close` etc. keeps those calls unchanged.
+
+Once the MCP server has a token (see follow-up issue referenced in `docs/agent/gh-to-mcp-migration.md`), a Phase 2 PR will migrate the high-value writes (`add_issue_comment`, `create_issue`, `create_pull_request`) to MCP. Writes without an MCP equivalent or with material feature gaps (`gh pr merge --delete-branch`, `gh issue close --reason`, `gh pr edit`) stay on `gh` permanently.
+
+## How to load a deferred MCP tool
+
+MCP tools are **deferred** — they appear as names in the subagent's tool registry but the JSON schema is not loaded until you ask for it. Before the first use in a session, call `ToolSearch`:
+
+```
+ToolSearch query="select:mcp__github__get_issue" max_results=1
+```
+
+You can load several at once by comma-separating them in the `select:` query. After the schema is loaded, the tool is callable like any other function for the rest of the session.
+
+## Quoting / escaping
+
+MCP call arguments are JSON-structured — no shell involved. A comment body with backticks, single quotes, double quotes, dollar signs, and newlines is just a `body: "..."` JSON string. This is the main ergonomic difference from `gh --body-file`.
+
+## Tool-by-tool mapping
+
+For the full inventory of every `gh` subcommand used in skills/docs and its MCP counterpart (including the gaps), see `docs/agent/gh-to-mcp-migration.md`.


### PR DESCRIPTION
## Summary

Phase 1 of the `gh` CLI to `mcp__github__*` MCP migration. Moves GitHub reads to the MCP server in agent-facing skills and docs, keeps writes on `gh` until the MCP server has a `GITHUB_PERSONAL_ACCESS_TOKEN`.

- **New docs:** `docs/agent/github-api-access.md` (decision rule) and `docs/agent/gh-to-mcp-migration.md` (exhaustive tool-by-tool audit with Available / Partial / Gap / Stays-on-`gh` status for every `gh` subcommand used in agent-facing markdown).
- **Skill updates:** `task`, `dispatcher`, `audit`, `spotcheck`, and `file-issue` now prefer MCP tools (`list_issues`, `list_pull_requests`, `get_issue`, `get_pull_request`, `get_pull_request_files`, `get_pull_request_status`) for reads. Each skill has a top-of-file MCP-vs-`gh` block explaining the split.
- **`CLAUDE.md`:** adds an MCP-first-for-reads rule to Tool Use Rules, plus a companion `gh`-is-still-the-write-path rule listing which operations stay on `gh` and why. Both new docs are added to the Key Documentation table.
- **Smoke test:** this PR's `/task` invocation itself used `mcp__github__get_issue` to fetch #2678 — MCP reads are live and working against the public repo. MCP writes still fail with `Requires authentication` against the un-tokened local server; that's the gating constraint for Phase 2.

## Why Phase 1 only

Live verification from this `/task` subagent on 2026-04-18:

- `mcp__github__get_issue` — works.
- `mcp__github__add_issue_comment`, `update_issue`, `create_issue` — all fail with `MCP error -32603: Authentication Failed: Requires authentication`.

Root cause: the MCP server is configured at `local` scope but has no `GITHUB_PERSONAL_ACCESS_TOKEN` environment variable. Reads work because `judgemind/judgemind` is public; writes require a token.

Wholesale write migration would break every agent, so this PR ships reads only. Phase 2 tracked in #2690 (write migration once the token lands).

## Scope boundaries

Explicitly out of scope and still using `gh` (listed in both new docs):

- Shell scripts under `scripts/`, GitHub Actions under `.github/workflows/`, `.githooks/` — MCP is only reachable inside Claude Code.
- `gh run watch`, `gh run list --workflow`, `gh run view` — MCP has no workflow-runs API.
- `gh pr diff`, `gh pr edit --body-file`, `gh issue close --reason`, `gh pr merge --delete-branch`, `gh api rate_limit`, `gh auth status` — MCP gaps with no equivalent.

## Test plan

### Automated checks

- [x] `scripts/check-markdown-links.sh` — 60 files checked, no broken links (ran in pre-push hook).
- [x] CI passes (lint, format, markdown-links-check, existing jobs) — `ci-passed` green in 3s.

### Post-deploy verification

- [x] **No deployed component** — docs / skills-only changes. Verification comment posted on #2678 with live MCP smoke-test evidence (`mcp__github__get_issue`, `get_pull_request`, `get_pull_request_status` all succeeded during this `/task` execution). Phase 2 follow-up filed as #2690.

Closes #2678
