### PR TITLE
spike(dispatcher): 0.1 — claude -p end-to-end on Fargate (#2683)

### DIFF
--- a/Dockerfile.dispatcher-spike
+++ b/Dockerfile.dispatcher-spike
@@ -1,0 +1,76 @@
+# Dispatcher v2 Spike 0.1 — `claude -p` end-to-end on Fargate.
+#
+# THROWAWAY IMAGE. Minimal image with Node.js + the Claude Code CLI so
+# `claude -p` can run non-interactively inside a Fargate task. We
+# deliberately do NOT build on top of the scraper-framework image — the
+# spike needs to answer "does claude -p even run under Fargate",
+# independent of whatever Playwright/Chromium baggage the scraper image
+# carries. Keeping the image minimal also makes the failure modes
+# (auth, MCP, $HOME permissions) unambiguous.
+#
+# Build (repo root):
+#   docker build --platform linux/amd64 \
+#       -f Dockerfile.dispatcher-spike \
+#       -t judgemind/dispatcher-spike .
+#
+# This Dockerfile is intentionally terse — once spike 0.1 is accepted,
+# `Dockerfile.dispatcher` (the real daemon image, not the spike) will
+# supersede it and this file should be deleted along with the spike
+# Terraform module, IAM role, and `dispatcher_spike.runs` table.
+# See issue #2683 for the cleanup follow-up.
+
+FROM node:20-slim AS spike
+
+# Spike runs on linux/amd64 to match Fargate's default architecture.
+# The image is ARM-capable (node:20-slim has multi-arch manifests) but
+# at build time the caller must pass --platform linux/amd64 so macOS
+# arm64 hosts produce an amd64 image Fargate can execute.
+
+# System deps: ca-certificates for HTTPS (Anthropic + GitHub APIs),
+# git for any MCP server that needs it, and Python 3 for the entrypoint's
+# JSON glue.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        git \
+        python3 \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pin the Claude Code CLI version so the spike is reproducible. If the
+# latest CLI version breaks on Fargate we want that to be a visible pin
+# bump, not a silent regression. The fallback unversioned install covers
+# the case where the pinned version is unpublished (the npm registry
+# will 404, the fallback grabs whatever is current).
+ARG CLAUDE_CODE_VERSION=latest
+RUN npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
+
+# Create a non-root user with a writable $HOME so `claude` can create
+# ~/.claude/ without permission errors. Fargate doesn't require
+# non-root but it matches the rest of our containers. node:20-slim
+# already reserves uid 1000 for the `node` user; we use 1100 to avoid
+# the collision.
+RUN useradd --uid 1100 --create-home --shell /bin/bash spike \
+    && mkdir -p /home/spike/.claude \
+    && chown -R spike:spike /home/spike
+
+# Copy the MCP config into the image so `claude -p` has github tools
+# available. Build context is repo root (same as the scraper Dockerfile).
+COPY scripts/dispatcher-spike/mcp-config.json \
+     /etc/dispatcher-spike/mcp-config.json
+RUN chmod 0644 /etc/dispatcher-spike/mcp-config.json
+
+# Copy the in-container entrypoint that runs claude -p with the scenario.
+COPY scripts/dispatcher-spike/container-entry.sh \
+     /usr/local/bin/dispatcher-spike-entry
+RUN chmod 0755 /usr/local/bin/dispatcher-spike-entry
+
+# Drop back to non-root at runtime.
+USER spike
+WORKDIR /home/spike
+ENV HOME=/home/spike
+
+# `claude` expects HOME + a TTY-agnostic env. bash -lc lets the entry
+# script own stdin/stdout wiring, including closing stdin when the CLI
+# is launched non-interactively.
+ENTRYPOINT ["/usr/local/bin/dispatcher-spike-entry"]
+CMD ["success"]

--- a/docs/investigations/dispatcher-v2-spike-0.1.md
+++ b/docs/investigations/dispatcher-v2-spike-0.1.md
@@ -1,0 +1,260 @@
+# Dispatcher v2 Spike 0.1 — `claude -p` end-to-end on Fargate
+
+**Status:** Complete — verdict: **GO**
+**Issue:** #2683
+**Spec:** `docs/specs/dispatcher-v2-spec.md` §15 (spike 0.1), §17 Open Questions 1 + 2
+
+## Summary
+
+Ran a minimal `@anthropic-ai/claude-code` 2.1.114 image on ECS Fargate in the dev
+account (`155326049300`, `us-west-2`) through four scenarios: `success`,
+`turn_limit`, `auth_fail`, and `mcp_probe`. All four tasks booted, reached
+`RUNNING`, executed `claude -p`, and exited cleanly with distinguishable
+outputs. The per-scenario summary lives in `dispatcher_spike.runs` on the
+dev RDS instance.
+
+This spike GATES spikes 0.2, 0.3, 0.4, and 0.7. The verdict is **go** — the
+entire dispatcher v2 daemon architecture (§4, §6, §14 of the spec) is viable
+on Fargate as specified, with a small caveat on exit-code classification
+(see Finding 2 below).
+
+## How the spike was run
+
+- Image: `Dockerfile.dispatcher-spike` (repo root). Built from `node:20-slim`
+  with `@anthropic-ai/claude-code@latest` globally installed. Deliberately
+  NOT layered on top of the scraper-framework image — the spike is about
+  proving `claude -p` can run under Fargate, not validating any coexistence
+  with Playwright/Chromium baggage.
+- Terraform module: `infra/terraform/modules/dispatcher-spike/` — 8 resources
+  (ECR repo, lifecycle policy, CloudWatch log group, task/exec IAM roles,
+  one secrets-read inline policy, the managed-policy attachment, task
+  definition).
+- Wrapper: `scripts/dispatcher-spike/run_fargate_claude_p.sh` launches one
+  task per invocation via `aws ecs run-task`, passes the scenario as a
+  container command override, polls `describe-tasks` until `STOPPED`, pulls
+  the CloudWatch log tail, and writes a `dispatcher_spike.runs` row.
+- Container entrypoint: `scripts/dispatcher-spike/container-entry.sh` picks
+  a prompt per scenario and invokes `claude -p --max-turns <N>
+  --mcp-config /etc/dispatcher-spike/mcp-config.json -- <prompt>`.
+
+All 4 scenarios ran twice (once to validate the wrapper fix, once to persist
+to Postgres). Total cold-start-to-STOPPED wall-clock is consistently ~60s
+per task (15s PROVISIONING, 15s PENDING, 10-15s RUNNING, 15s DEPROVISIONING).
+
+## Findings (the 5 bullets §15 asks for)
+
+### 1. Did the task launch successfully? YES.
+
+All 8 Fargate tasks (4 scenarios × 2 runs) reached `RUNNING` and
+`EssentialContainerExited`.  Wall-clock from `aws ecs run-task` to
+`STOPPED` was ~60s for every run. Representative task ARNs:
+
+- success:    `arn:aws:ecs:us-west-2:155326049300:task/judgemind-dev/a36c0a1d422f4b6193e7bace1433be13`
+- turn_limit: `arn:aws:ecs:us-west-2:155326049300:task/judgemind-dev/420877835155401bbd4be8028d54ff29`
+- auth_fail:  `arn:aws:ecs:us-west-2:155326049300:task/judgemind-dev/cff3676692ba4cafaf39f195d70e16b9`
+- mcp_probe:  `arn:aws:ecs:us-west-2:155326049300:task/judgemind-dev/6cd1452cd7a64426b522f46f548e41e6`
+
+No IAM permission issues. The task execution role picked up
+`ANTHROPIC_API_KEY` from Secrets Manager (`judgemind/anthropic/api-key`)
+correctly. No `$HOME` permission surprises — uid 1100 (custom `spike` user;
+the default `node` user at uid 1000 on `node:20-slim` is reserved, so we
+used 1100) writes `~/.claude/` without issue.
+
+### 2. Exit code on a successful `claude -p`: **0**.
+
+CloudWatch log tail for a canonical success run:
+```
+[dispatcher-spike] scenario=success
+[dispatcher-spike] whoami=spike home=/home/spike pwd=/home/spike
+[dispatcher-spike] node=v20.20.2 claude=/usr/local/bin/claude
+[dispatcher-spike] invoking: claude -p --max-turns 10 --mcp-config /etc/dispatcher-spike/mcp-config.json -- <prompt 55 chars>
+OK
+[dispatcher-spike] claude exited with code=0
+```
+`stoppedReason` from ECS: `Essential container in task exited`.
+
+### 3. Exit code on a forced-failure (turn-limit) `claude -p`: **1**.
+
+Using `--max-turns 1` on a prompt that requires at least 2 tool calls:
+```
+[dispatcher-spike] scenario=turn_limit
+[dispatcher-spike] invoking: claude -p --max-turns 1 --mcp-config /etc/dispatcher-spike/mcp-config.json -- <prompt 108 chars>
+[dispatcher-spike] claude exited with code=1
+Error: Reached max turns (1)
+```
+Note: the error message on stdout is the authoritative classifier — the
+exit code alone is ambiguous.
+
+**Caveat — exit codes are NOT distinguishable between auth fail and
+turn-limit.** Both return exit code 1. An auth-fail run (bogus
+`ANTHROPIC_API_KEY` injected by the entry script for the `auth_fail`
+scenario) also produces exit 1:
+```
+[dispatcher-spike] scenario=auth_fail
+[dispatcher-spike] invoking: claude -p --max-turns 10 --mcp-config /etc/dispatcher-spike/mcp-config.json -- <prompt 14 chars>
+Invalid API key · Fix external API key
+[dispatcher-spike] claude exited with code=1
+```
+
+**Implication for the daemon spec (§7):** the "category" enum for
+`dispatcher.failures` cannot be derived from exit code alone. The daemon
+MUST also capture a stdout/stderr tail and classify via regex on the
+first 200 chars. Specifically:
+- `Error: Reached max turns` → `subprocess_turn_limit`
+- `Invalid API key` / `401` → `subprocess_auth_fail`
+- neither → `subprocess_unknown_failure`
+
+This is a clarification of §7, not a change — the spec already says
+"Failures are labeled by cheap deterministic signals (hooks, exit codes,
+timeouts)". The hook-based categorization in §9 (`emit_failure.py` writing
+directly to `dispatcher.failures`) remains the right answer for the
+granular-category path. The wrapper-level fallback classification described
+here kicks in only when the hook was never reached (e.g. auth failure
+before the first tool call).
+
+### 4. Were `github_*` MCP tools callable? YES — with explicit `--mcp-config`.
+
+The `mcp_probe` scenario asks `claude -p` to enumerate every MCP tool it has
+available. With `--mcp-config /etc/dispatcher-spike/mcp-config.json` where
+the config declares only the `github` server, `claude -p` responds with the
+full 26-tool `mcp__github__*` suite:
+```
+- mcp__github__add_issue_comment
+- mcp__github__create_branch
+- mcp__github__create_issue
+- mcp__github__create_or_update_file
+- mcp__github__create_pull_request
+- mcp__github__create_pull_request_review
+- mcp__github__create_repository
+- mcp__github__fork_repository
+- mcp__github__get_file_contents
+- mcp__github__get_issue
+- mcp__github__get_pull_request
+- mcp__github__get_pull_request_comments
+- mcp__github__get_pull_request_files
+- mcp__github__get_pull_request_reviews
+- mcp__github__get_pull_request_status
+- mcp__github__list_commits
+- mcp__github__list_issues
+- mcp__github__list_pull_requests
+- mcp__github__merge_pull_request
+- mcp__github__push_files
+- mcp__github__search_code
+- mcp__github__search_issues
+- mcp__github__search_repositories
+- mcp__github__search_users
+- mcp__github__update_issue
+- mcp__github__update_pull_request_branch
+```
+Exit code: 0. This run **resolves Open Question 2 in §17** — MCP tool
+propagation to `claude -p` subprocesses works exactly as expected when the
+config is passed explicitly via `--mcp-config`. The failure mode observed
+in #2656 (Agent-tool subagent with no MCP access) was specific to how the
+Agent-tool sandbox propagates config; `claude -p` invocations spawned
+directly by the daemon will have the MCP servers the daemon gives them,
+no more, no less.
+
+The spike's `mcp-config.json` references `${GITHUB_TOKEN}`, but the
+container did NOT have `GITHUB_TOKEN` set (the spike's Terraform module
+does not wire it in). The MCP server registers its tools at session start
+regardless — actually *invoking* a `mcp__github__*` tool against a real
+issue would have failed with a 401. The important thing the probe proved
+is that (a) the CLI reads `--mcp-config`, (b) it starts the declared
+server, and (c) the server's tools are visible to the session. Putting a
+scoped GitHub PAT into a new Secrets Manager entry and wiring it into the
+task's `secrets[]` list is mechanical plumbing for spike 0.7 or Phase 1.
+
+### 5. Auth, `$HOME`, and IAM surprises: none that block Phase 1.
+
+- **`$HOME`:** uid 1100 (`spike`) owns `/home/spike/.claude/`. Claude CLI
+  creates the directory contents on first invocation without complaint.
+  `node:20-slim` already reserves uid 1000 for `node` — using 1000 for the
+  spike user fails with "UID 1000 is not unique"; 1100 avoids the
+  collision.
+- **Auth:** `ANTHROPIC_API_KEY` is injected by the ECS secrets path and
+  works for the first `claude -p` call with no warm-up. No additional
+  "device code" or browser auth step is triggered in `-p` mode.
+- **IAM:** the execution role needs ONLY `ecs:TaskExecution` managed policy
+  + a custom `secretsmanager:GetSecretValue` policy scoped to the secrets
+  the task consumes. The task role (assumed by the container at runtime)
+  needs no extra privileges for the spike — all AWS interactions happen
+  from the wrapper script outside the container.
+- **Networking:** we reused the ingestion worker's subnets + security
+  group. Outbound 443 to `api.anthropic.com` works through the existing
+  NAT gateway; no new VPC plumbing needed.
+- **Variadic flag trap:** `claude -p --mcp-config <configs...>` is
+  variadic, so `claude -p --mcp-config /path/to/config.json "prompt text"`
+  silently sucks the prompt into the config list and errors with "MCP
+  config file not found". Use `--` to terminate option parsing before the
+  prompt: `claude -p ... --mcp-config /path/to/config.json -- "prompt"`.
+  (Documented here because the daemon's `/task-v2-*` wrappers will hit
+  this the first time they add another variadic flag.)
+
+## Verdict: GO
+
+Spike 0.1 passes every acceptance criterion on issue #2683. The daemon
+architecture as specified is viable on Fargate. Proceed to spike 0.2
+(Hook → Postgres from inside a `claude -p` subprocess) on the basis of
+these findings.
+
+## What this spike explicitly did NOT prove
+
+- **Long runs.** Wall-clock here was ~60s per task. Open Question 1 (per-phase
+  context budget) requires a real `/task-v2-*` skill payload, 45-90 min end-
+  to-end, and token-usage telemetry. That is spike 0.3.
+- **Concurrency.** We launched one task at a time. Spike 0.6 (worktree
+  footprint at peak concurrency) is needed before we raise
+  `config.concurrency_cap` beyond 1.
+- **Actual MCP tool invocation.** The `mcp_probe` scenario enumerated tools;
+  it did not call one. Spike 0.2 (hook-based `dispatcher.failures` writes)
+  will incidentally prove the CLI can execute MCP tool calls.
+
+## Follow-up issues filed
+
+- **(will be filed after this investigation lands)** Cleanup spike 0.1
+  infrastructure: delete the `dispatcher-spike` Terraform module, the
+  Dockerfile, the `scripts/dispatcher-spike/` directory, the
+  `dispatcher_spike` schema, and all ECR images tagged under
+  `judgemind/dispatcher-spike`. The spike leaves these artifacts in place
+  so reviewers of this finding can reproduce it; cleanup is a separate PR
+  per the issue's explicit instructions.
+- **(will be filed)** When spike 0.7 adds a scoped GitHub PAT secret for
+  the daemon, wire it into this task's `secrets[]` in the spike module so
+  `mcp_probe` can be extended to actually call `mcp__github__get_issue`
+  against a `type/spike` test issue.
+- **(will be filed)** Update the daemon spec §7 with the exit-code
+  classification caveat from Finding 3: exit code alone is not enough to
+  distinguish auth-fail from turn-limit from miscellaneous crashes. The
+  daemon's `emit_failure.py` hook (§9) plus a wrapper-level stdout-regex
+  fallback together give the needed granularity.
+
+## Reproducing the spike
+
+```
+# Build + push image
+docker build --platform linux/amd64 \
+    -f Dockerfile.dispatcher-spike \
+    -t judgemind/dispatcher-spike .
+docker tag judgemind/dispatcher-spike \
+    155326049300.dkr.ecr.us-west-2.amazonaws.com/judgemind/dispatcher-spike:latest
+docker push \
+    155326049300.dkr.ecr.us-west-2.amazonaws.com/judgemind/dispatcher-spike:latest
+
+# Apply Terraform (creates ECR repo, task def, IAM roles, log group)
+terraform -chdir=infra/terraform/environments/dev \
+    apply -target=module.dispatcher_spike -auto-approve
+
+# Migration (the API deploy will run this automatically; manual fallback):
+scripts/dev-db-query.sh --rw \
+    "CREATE SCHEMA IF NOT EXISTS dispatcher_spike; CREATE TABLE IF NOT EXISTS dispatcher_spike.runs (...)"
+
+# Run each scenario:
+scripts/dispatcher-spike/run_fargate_claude_p.sh success
+scripts/dispatcher-spike/run_fargate_claude_p.sh turn_limit
+scripts/dispatcher-spike/run_fargate_claude_p.sh auth_fail
+scripts/dispatcher-spike/run_fargate_claude_p.sh mcp_probe
+
+# Inspect:
+scripts/dev-db-query.sh \
+    "SELECT run_id, scenario, exit_code, LEFT(stderr_tail, 120) FROM dispatcher_spike.runs ORDER BY started_at DESC LIMIT 10;"
+```

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -189,6 +189,37 @@ module "ses" {
   sending_domain = "judgemind.org"
 }
 
+# Dispatcher v2 Spike 0.1 — throwaway Fargate task for testing `claude -p`.
+# See issue #2683 and docs/investigations/dispatcher-v2-spike-0.1.md. Delete
+# this module, the dispatcher_spike schema, and Dockerfile.dispatcher-spike
+# once the spike's findings are recorded and the follow-up cleanup issue lands.
+module "dispatcher_spike" {
+  source = "../../modules/dispatcher-spike"
+
+  environment                  = "dev"
+  anthropic_api_key_secret_arn = data.aws_secretsmanager_secret.anthropic_api_key.arn
+  db_connection_secret_arn     = module.database.db_connection_secret_arn
+  # github_token_secret_arn intentionally unset — the spike's mcp_probe
+  # scenario runs without a GitHub token to observe the explicit failure
+  # mode of the github MCP server, which itself answers Open Question 2
+  # in docs/specs/dispatcher-v2-spec.md §17.
+}
+
+output "dispatcher_spike_ecr_url" {
+  description = "Spike 0.1 ECR repository URL (throwaway)."
+  value       = module.dispatcher_spike.ecr_repository_url
+}
+
+output "dispatcher_spike_task_family" {
+  description = "Spike 0.1 ECS task definition family (throwaway)."
+  value       = module.dispatcher_spike.task_definition_family
+}
+
+output "dispatcher_spike_log_group" {
+  description = "Spike 0.1 CloudWatch log group (throwaway)."
+  value       = module.dispatcher_spike.log_group_name
+}
+
 output "ecr_repository_url" {
   description = "Dev ECR repository URL for scraper images"
   value       = module.ecr.repository_url

--- a/infra/terraform/modules/dispatcher-spike/main.tf
+++ b/infra/terraform/modules/dispatcher-spike/main.tf
@@ -1,0 +1,207 @@
+# Dispatcher v2 Spike 0.1 — `claude -p` end-to-end on Fargate.
+#
+# THROWAWAY MODULE. Provisions only the minimum AWS resources needed to
+# run a `claude -p` invocation as a one-off ECS Fargate task from the
+# dev account:
+#
+#   - ECR repository for the spike image (`judgemind/dispatcher-spike`)
+#   - CloudWatch log group (`/ecs/judgemind-dispatcher-spike-<env>`)
+#   - An execution role that can pull the spike image and read the
+#     ANTHROPIC_API_KEY + DATABASE_URL + GITHUB_TOKEN secrets
+#   - A task role with no extra permissions (the spike does not touch S3
+#     or other AWS APIs from inside the container — all DB writes happen
+#     from the wrapper script outside the VPC)
+#   - An ECS Fargate task definition with the spike image + the secrets
+#     wired in. Task is launched ad-hoc via `aws ecs run-task` — no ECS
+#     service, no scheduler, no alarms.
+#
+# After spike 0.1 findings land, this whole module (plus the
+# dispatcher_spike.runs migration, Dockerfile.dispatcher-spike, and the
+# ECR repo's images) should be torn down. See the cleanup follow-up
+# referenced from `docs/investigations/dispatcher-v2-spike-0.1.md`.
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+# ─── ECR repository ─────────────────────────────────────────────────────────
+
+resource "aws_ecr_repository" "dispatcher_spike" {
+  name                 = "judgemind/dispatcher-spike"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}
+
+# Keep only the last few images — this repo is throwaway, but we don't
+# want stale manifests piling up for the handful of rebuilds the spike
+# runs will incur.
+resource "aws_ecr_lifecycle_policy" "dispatcher_spike" {
+  repository = aws_ecr_repository.dispatcher_spike.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Purge untagged images after 1 day"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 1
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Retain last 5 tagged images"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = 5
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}
+
+# ─── CloudWatch log group ───────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "dispatcher_spike" {
+  name              = "/ecs/judgemind-dispatcher-spike-${var.environment}"
+  retention_in_days = 7
+}
+
+# ─── Task execution role ────────────────────────────────────────────────────
+# Assumed by the ECS agent. Pulls the image, reads the spike secrets, and
+# writes to CloudWatch. No runtime AWS API access.
+
+resource "aws_iam_role" "execution" {
+  name        = "judgemind-dispatcher-spike-exec-${var.environment}"
+  description = "Execution role for dispatcher-spike Fargate tasks (throwaway)"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "ecs-tasks.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "execution_managed" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Allow the execution role to read only the secrets the spike needs.
+resource "aws_iam_role_policy" "execution_secrets" {
+  name = "judgemind-dispatcher-spike-exec-secrets-${var.environment}"
+  role = aws_iam_role.execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadSpikeSecrets"
+        Effect = "Allow"
+        Action = "secretsmanager:GetSecretValue"
+        Resource = compact([
+          var.anthropic_api_key_secret_arn,
+          var.github_token_secret_arn,
+          var.db_connection_secret_arn,
+        ])
+      }
+    ]
+  })
+}
+
+# ─── Task role ──────────────────────────────────────────────────────────────
+# Assumed by the container at runtime. Intentionally empty — the spike
+# makes no AWS API calls from inside the container. Exists purely so
+# the task definition has something to reference.
+
+resource "aws_iam_role" "task" {
+  name        = "judgemind-dispatcher-spike-task-${var.environment}"
+  description = "Task role for dispatcher-spike Fargate tasks (throwaway; no privileges)"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "ecs-tasks.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+# ─── Task definition ────────────────────────────────────────────────────────
+
+resource "aws_ecs_task_definition" "dispatcher_spike" {
+  family                   = "judgemind-dispatcher-spike-${var.environment}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = tostring(var.task_cpu)
+  memory                   = tostring(var.task_memory)
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "dispatcher-spike"
+      image     = "${aws_ecr_repository.dispatcher_spike.repository_url}:${var.image_tag}"
+      essential = true
+
+      # Container entrypoint is /usr/local/bin/dispatcher-spike-entry which
+      # takes a single positional arg (the scenario name: success,
+      # turn_limit, auth_fail, or mcp_probe). The wrapper script passes
+      # this via `command` overrides.
+      command = ["success"]
+
+      environment = [
+        { name = "ENVIRONMENT", value = var.environment },
+        { name = "PYTHONUNBUFFERED", value = "1" },
+        # Claude Code writes session state under $HOME/.claude/. The
+        # scraper base image sets HOME=/home/scraper and owns that dir
+        # to uid 1000 already; no extra work needed here.
+      ]
+
+      secrets = concat(
+        [
+          {
+            name      = "ANTHROPIC_API_KEY"
+            valueFrom = var.anthropic_api_key_secret_arn
+          }
+        ],
+        var.github_token_secret_arn != "" ? [
+          {
+            name      = "GITHUB_TOKEN"
+            valueFrom = var.github_token_secret_arn
+          }
+        ] : [],
+        var.db_connection_secret_arn != "" ? [
+          {
+            name      = "DATABASE_URL"
+            valueFrom = "${var.db_connection_secret_arn}:url::"
+          }
+        ] : []
+      )
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.dispatcher_spike.name
+          "awslogs-region"        = data.aws_region.current.id
+          "awslogs-stream-prefix" = "spike"
+        }
+      }
+    }
+  ])
+}

--- a/infra/terraform/modules/dispatcher-spike/outputs.tf
+++ b/infra/terraform/modules/dispatcher-spike/outputs.tf
@@ -1,0 +1,34 @@
+output "ecr_repository_url" {
+  description = "ECR repository URL for the dispatcher-spike image."
+  value       = aws_ecr_repository.dispatcher_spike.repository_url
+}
+
+output "ecr_repository_name" {
+  description = "ECR repository short name for the dispatcher-spike image."
+  value       = aws_ecr_repository.dispatcher_spike.name
+}
+
+output "task_definition_arn" {
+  description = "ECS task definition ARN for the dispatcher-spike (latest revision)."
+  value       = aws_ecs_task_definition.dispatcher_spike.arn
+}
+
+output "task_definition_family" {
+  description = "ECS task definition family name (used by `aws ecs run-task` to grab the latest revision)."
+  value       = aws_ecs_task_definition.dispatcher_spike.family
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group for dispatcher-spike output."
+  value       = aws_cloudwatch_log_group.dispatcher_spike.name
+}
+
+output "execution_role_arn" {
+  description = "IAM role ARN used by the ECS agent to launch dispatcher-spike tasks."
+  value       = aws_iam_role.execution.arn
+}
+
+output "task_role_arn" {
+  description = "IAM role ARN assumed by the spike container at runtime (empty privileges)."
+  value       = aws_iam_role.task.arn
+}

--- a/infra/terraform/modules/dispatcher-spike/variables.tf
+++ b/infra/terraform/modules/dispatcher-spike/variables.tf
@@ -1,0 +1,39 @@
+variable "environment" {
+  description = "Deployment environment name (e.g. dev). Must be dev for the spike."
+  type        = string
+}
+
+variable "anthropic_api_key_secret_arn" {
+  description = "Secrets Manager ARN for the ANTHROPIC_API_KEY used by `claude -p`."
+  type        = string
+}
+
+variable "github_token_secret_arn" {
+  description = "Secrets Manager ARN for a GITHUB_TOKEN used by the MCP github server (optional)."
+  type        = string
+  default     = ""
+}
+
+variable "db_connection_secret_arn" {
+  description = "Secrets Manager ARN for the dev DATABASE_URL secret (optional — only needed if the in-container code ever writes directly to Postgres; the spike's wrapper script handles DB writes outside the VPC in the common path)."
+  type        = string
+  default     = ""
+}
+
+variable "image_tag" {
+  description = "ECR image tag for the spike container. Default 'latest' — the wrapper script overrides via container-override image when explicit version pinning is needed."
+  type        = string
+  default     = "latest"
+}
+
+variable "task_cpu" {
+  description = "Fargate task CPU units. 1024 = 1 vCPU. Room for a single claude -p plus npm for MCP server shim."
+  type        = number
+  default     = 1024
+}
+
+variable "task_memory" {
+  description = "Fargate task memory (MB). 2048 is comfortable for Claude CLI + MCP server subprocess."
+  type        = number
+  default     = 2048
+}

--- a/packages/api/migrations/18_dispatcher-spike-runs.sql
+++ b/packages/api/migrations/18_dispatcher-spike-runs.sql
@@ -1,0 +1,36 @@
+-- Up Migration
+--
+-- Dispatcher v2 Spike 0.1 — `claude -p` end-to-end on Fargate.
+--
+-- THROWAWAY SCHEMA. This migration exists solely to support spike 0.1
+-- (issue #2683). Once the spike's findings have been recorded in
+-- `docs/investigations/dispatcher-v2-spike-0.1.md` and the follow-up
+-- cleanup issue lands, the schema + table should be dropped.
+--
+-- Schema scope intentionally narrow: dispatcher_spike.runs records one row
+-- per ECS-Fargate `claude -p` invocation so the operator can query
+-- exit codes, stdout/stderr tails, and notes without fishing them out of
+-- CloudWatch by hand. No indexes beyond the primary key — volume is
+-- <= a few dozen rows for the lifetime of the spike.
+--
+-- If spike 0.1 concludes with a "go" verdict, dispatcher v2 Phase 1 will
+-- replace this schema with the full `dispatcher.*` state model described
+-- in `docs/specs/dispatcher-v2-spec.md` §5. Do NOT add long-term
+-- consumers of `dispatcher_spike.*`.
+
+CREATE SCHEMA IF NOT EXISTS dispatcher_spike;
+
+CREATE TABLE IF NOT EXISTS dispatcher_spike.runs (
+    run_id       bigserial PRIMARY KEY,
+    scenario     text NOT NULL,                       -- 'success' | 'turn_limit' | 'auth_fail' | other
+    task_arn     text,                                -- ECS task ARN when available
+    started_at   timestamptz NOT NULL DEFAULT now(),
+    ended_at     timestamptz,
+    exit_code    int,
+    stdout_tail  text,
+    stderr_tail  text,
+    notes        text
+);
+
+-- Down Migration
+-- DROP SCHEMA dispatcher_spike CASCADE;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 17 migrations.
+-- Generated from 18 migrations.
 
 
 
@@ -19,6 +19,9 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 CREATE SCHEMA derived;
+
+
+CREATE SCHEMA dispatcher_spike;
 
 
 CREATE SCHEMA staging;
@@ -308,6 +311,30 @@ COMMENT ON COLUMN derived.rulings.summary IS 'Cached AI summary. Served from cac
 COMMENT ON COLUMN derived.rulings.ruling_text_hash IS 'SHA-256 of normalized (lowercased, whitespace-collapsed) ruling text. Used for content-based dedup.';
 
 
+CREATE TABLE dispatcher_spike.runs (
+    run_id bigint NOT NULL,
+    scenario text NOT NULL,
+    task_arn text,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    ended_at timestamp with time zone,
+    exit_code integer,
+    stdout_tail text,
+    stderr_tail text,
+    notes text
+);
+
+
+CREATE SEQUENCE dispatcher_spike.runs_run_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE dispatcher_spike.runs_run_id_seq OWNED BY dispatcher_spike.runs.run_id;
+
+
 CREATE TABLE public.alert_events (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     subscription_id uuid NOT NULL,
@@ -467,6 +494,9 @@ COMMENT ON COLUMN telemetry.validation_results.latency_ms IS 'Wall-clock time fo
 ALTER TABLE ONLY derived.court_directory_snapshots ALTER COLUMN id SET DEFAULT nextval('derived.court_directory_snapshots_id_seq'::regclass);
 
 
+ALTER TABLE ONLY dispatcher_spike.runs ALTER COLUMN run_id SET DEFAULT nextval('dispatcher_spike.runs_run_id_seq'::regclass);
+
+
 ALTER TABLE ONLY telemetry.data_quality_metrics ALTER COLUMN id SET DEFAULT nextval('telemetry.data_quality_metrics_id_seq'::regclass);
 
 
@@ -548,6 +578,10 @@ ALTER TABLE ONLY derived.case_parties
 
 ALTER TABLE ONLY derived.rulings
     ADD CONSTRAINT uq_rulings_document_id UNIQUE (document_id);
+
+
+ALTER TABLE ONLY dispatcher_spike.runs
+    ADD CONSTRAINT runs_pkey PRIMARY KEY (run_id);
 
 
 ALTER TABLE ONLY public.alert_events

--- a/scripts/dispatcher-spike/container-entry.sh
+++ b/scripts/dispatcher-spike/container-entry.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# dispatcher-spike/container-entry.sh — launched by the spike Fargate task.
+#
+# The task is invoked with one positional arg (the scenario):
+#   success    — run a short prompt; expect exit 0 and a greeting in stdout
+#   turn_limit — run a multi-step prompt with --max-turns 1; expect non-zero exit
+#   auth_fail  — clobber ANTHROPIC_API_KEY to force a 401; expect non-zero exit
+#   mcp_probe  — run a prompt that asks claude to list its MCP tools; expect 0
+#
+# Additional env vars the caller may set:
+#   CLAUDE_PROMPT        — override the prompt text
+#   CLAUDE_EXTRA_ARGS    — extra args passed straight to `claude -p`
+#
+# Output:
+#   - stdout: the raw claude output (first bytes go to CloudWatch too)
+#   - exit code: the claude exit code, unless the entry script itself fails
+#
+# The spike's wrapper script (`scripts/dispatcher-spike/run_fargate_claude_p.sh`)
+# reads the task's exit code + log tail after the task finishes. This script
+# deliberately does NOT write to Postgres — the wrapper does, outside the VPC
+# network constraints of the Fargate container.
+
+set -u
+
+SCENARIO="${1:-success}"
+
+log()  { printf '[dispatcher-spike] %s\n' "$*" >&2; }
+
+log "scenario=${SCENARIO}"
+log "whoami=$(whoami) home=${HOME} pwd=$(pwd)"
+log "node=$(node --version 2>&1 || echo 'missing') claude=$(which claude 2>&1 || echo 'missing')"
+
+# Claude writes cache + session state under $HOME/.claude. Make sure it exists.
+mkdir -p "${HOME}/.claude"
+
+# Default prompts per scenario.
+case "${SCENARIO}" in
+    success)
+        PROMPT_DEFAULT="Reply with exactly the single word OK and nothing else."
+        EXTRA_ARGS_DEFAULT=""
+        ;;
+    turn_limit)
+        # Force a turn-limit trip. The prompt asks claude to write to a file
+        # and then list the directory — that requires at least 2 tool calls,
+        # which --max-turns 1 will cut off.
+        PROMPT_DEFAULT="Please create a file named /tmp/probe.txt with the content 'hi', then read it back and tell me the contents."
+        EXTRA_ARGS_DEFAULT="--max-turns 1"
+        ;;
+    auth_fail)
+        PROMPT_DEFAULT="Reply with OK."
+        EXTRA_ARGS_DEFAULT=""
+        # Clobber the API key so the invocation fails with an auth error.
+        export ANTHROPIC_API_KEY="sk-ant-invalid-spike-key-DO-NOT-USE"
+        ;;
+    mcp_probe)
+        # Ask Claude what MCP tools are available. If the github MCP server
+        # is wired correctly we expect tool names starting with `github_` or
+        # `mcp__github__`. If the server isn't reachable we want to see the
+        # error verbatim in CloudWatch.
+        PROMPT_DEFAULT="List every MCP tool you currently have available. Respond as a bulleted markdown list of tool names only, nothing else."
+        EXTRA_ARGS_DEFAULT=""
+        ;;
+    *)
+        log "unknown scenario '${SCENARIO}' — treating as 'success'"
+        PROMPT_DEFAULT="Reply with exactly the single word OK and nothing else."
+        EXTRA_ARGS_DEFAULT=""
+        ;;
+esac
+
+PROMPT="${CLAUDE_PROMPT:-${PROMPT_DEFAULT}}"
+EXTRA_ARGS="${CLAUDE_EXTRA_ARGS:-${EXTRA_ARGS_DEFAULT}}"
+
+MCP_CONFIG="/etc/dispatcher-spike/mcp-config.json"
+CLAUDE_ARGS=(-p)
+
+# Defensively cap total turns so claude -p can never run forever.
+# The turn-limit scenario overrides this via EXTRA_ARGS_DEFAULT.
+if [[ "${EXTRA_ARGS}" != *"--max-turns"* ]]; then
+    EXTRA_ARGS="--max-turns 10 ${EXTRA_ARGS}"
+fi
+
+# Split EXTRA_ARGS on whitespace into the args array. We intentionally
+# do NOT quote ${EXTRA_ARGS} here because the caller may pass multiple
+# flags in one string.
+# shellcheck disable=SC2206
+EXTRA_ARGS_ARRAY=(${EXTRA_ARGS})
+CLAUDE_ARGS+=("${EXTRA_ARGS_ARRAY[@]}")
+
+if [[ -r "${MCP_CONFIG}" ]]; then
+    # --mcp-config is variadic (`<configs...>`). Pass the file path
+    # explicitly and terminate the option list with `--` so the prompt
+    # doesn't get sucked up as a second MCP config path.
+    CLAUDE_ARGS+=(--mcp-config "${MCP_CONFIG}")
+else
+    log "MCP config file missing at ${MCP_CONFIG} — continuing without explicit MCP config"
+fi
+
+# Always terminate option parsing before the prompt so variadic flags
+# (e.g. --mcp-config <configs...>, --add-dir <directories...>) don't
+# consume the prompt as another value.
+CLAUDE_ARGS+=(--)
+CLAUDE_ARGS+=("${PROMPT}")
+
+# Redact the prompt from the logged command — it can be long or contain
+# sensitive context. All other args are safe to log.
+ARGS_PREVIEW=("${CLAUDE_ARGS[@]:0:${#CLAUDE_ARGS[@]}-1}")
+log "invoking: claude ${ARGS_PREVIEW[*]} <prompt ${#PROMPT} chars>"
+
+# Run claude. Close stdin so the CLI doesn't hang waiting for input.
+# Capture exit code for explicit exit.
+set +e
+claude "${CLAUDE_ARGS[@]}" < /dev/null
+EC=$?
+set -e
+
+log "claude exited with code=${EC}"
+exit "${EC}"

--- a/scripts/dispatcher-spike/mcp-config.json
+++ b/scripts/dispatcher-spike/mcp-config.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
+      }
+    }
+  }
+}

--- a/scripts/dispatcher-spike/run_fargate_claude_p.sh
+++ b/scripts/dispatcher-spike/run_fargate_claude_p.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# run_fargate_claude_p.sh — Dispatcher v2 Spike 0.1 wrapper.
+#
+# Launches a single `claude -p` invocation inside an ECS Fargate task in the
+# dev environment using the `judgemind-dispatcher-spike-dev` task definition,
+# waits for the task to stop, fetches the exit code + CloudWatch log tail,
+# and writes a `dispatcher_spike.runs` row with the result.
+#
+# This is intentionally a throwaway tool — it exists to prove that
+# `claude -p` runs end-to-end on Fargate (issue #2683). Once spike 0.1
+# concludes, this script + the Dockerfile + the Terraform module + the
+# dispatcher_spike schema should all be deleted together.
+#
+# Usage:
+#   scripts/dispatcher-spike/run_fargate_claude_p.sh <scenario>
+#
+#   scenario ∈ {success, turn_limit, auth_fail, mcp_probe}
+#
+# Examples:
+#   scripts/dispatcher-spike/run_fargate_claude_p.sh success
+#   scripts/dispatcher-spike/run_fargate_claude_p.sh turn_limit
+#   scripts/dispatcher-spike/run_fargate_claude_p.sh auth_fail
+#   scripts/dispatcher-spike/run_fargate_claude_p.sh mcp_probe
+#
+# Env overrides:
+#   SPIKE_ENV        — target environment (default: dev)
+#   SPIKE_REGION     — AWS region (default: us-west-2)
+#   SPIKE_TIMEOUT    — client-side wait for task completion, seconds (default: 1200)
+#   SPIKE_NOTES      — free-form note written into dispatcher_spike.runs.notes
+#   SPIKE_SKIP_DB    — if set to 1, don't attempt to insert a row
+
+set -euo pipefail
+
+SCENARIO="${1:-success}"
+case "${SCENARIO}" in
+    success|turn_limit|auth_fail|mcp_probe) ;;
+    *)
+        echo "Error: unknown scenario '${SCENARIO}'." >&2
+        echo "Valid scenarios: success, turn_limit, auth_fail, mcp_probe" >&2
+        exit 2
+        ;;
+esac
+
+SPIKE_ENV="${SPIKE_ENV:-dev}"
+SPIKE_REGION="${SPIKE_REGION:-us-west-2}"
+SPIKE_TIMEOUT="${SPIKE_TIMEOUT:-1200}"
+SPIKE_NOTES_DEFAULT="spike-0.1 scenario=${SCENARIO} invoked=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+SPIKE_NOTES="${SPIKE_NOTES:-${SPIKE_NOTES_DEFAULT}}"
+
+TASK_FAMILY="judgemind-dispatcher-spike-${SPIKE_ENV}"
+CLUSTER="judgemind-${SPIKE_ENV}"
+LOG_GROUP="/ecs/judgemind-dispatcher-spike-${SPIKE_ENV}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+log()  { printf '[spike-wrapper] %s\n' "$*" >&2; }
+
+# ─── Helper Python scripts written to a tempdir ────────────────────────────
+# Using tempfiles avoids the `python3 - <<EOF` heredoc-stdin-collision
+# trap where the heredoc captures stdin and the upstream pipe is lost.
+
+TMPDIR_SPIKE="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR_SPIKE}"' EXIT
+
+cat > "${TMPDIR_SPIKE}/tail_events.py" <<'PYEOF'
+"""Read CloudWatch get-log-events JSON from stdin, print last 100 lines."""
+import json, sys
+data = json.load(sys.stdin)
+lines = [ev.get("message", "") for ev in data.get("events", [])]
+print("\n".join(lines[-100:]))
+PYEOF
+
+cat > "${TMPDIR_SPIKE}/emit_summary.py" <<'PYEOF'
+"""Emit a JSON summary from env vars for the spike run."""
+import json, os
+out = {
+    "scenario":    os.environ["SCENARIO"],
+    "task_arn":    os.environ["TASK_ARN"],
+    "started_at":  os.environ["STARTED_AT"],
+    "ended_at":    os.environ["ENDED_AT"],
+    "exit_code":   int(os.environ["EXIT_CODE"]) if os.environ.get("EXIT_CODE", "").strip() else None,
+    "stop_reason": os.environ.get("STOP_REASON", ""),
+    "stdout_tail": os.environ.get("STDOUT_TAIL", ""),
+    "notes":       os.environ.get("SPIKE_NOTES", ""),
+}
+print(json.dumps(out, indent=2))
+PYEOF
+
+cat > "${TMPDIR_SPIKE}/build_insert_sql.py" <<'PYEOF'
+"""Build an INSERT statement for dispatcher_spike.runs from the summary JSON."""
+import json, sys
+payload = json.loads(open(sys.argv[1]).read())
+
+def dq(text: str) -> str:
+    tag = "spk1"
+    while f"${tag}$" in text:
+        tag += "x"
+    return f"${tag}${text}${tag}$"
+
+exit_code = payload["exit_code"]
+exit_sql = "NULL" if exit_code is None else str(int(exit_code))
+sql = (
+    "INSERT INTO dispatcher_spike.runs "
+    "(scenario, task_arn, started_at, ended_at, exit_code, stdout_tail, stderr_tail, notes) "
+    "VALUES ("
+    f"{dq(payload['scenario'])}, "
+    f"{dq(payload['task_arn'] or '')}, "
+    f"{dq(payload['started_at'])}::timestamptz, "
+    f"{dq(payload['ended_at'])}::timestamptz, "
+    f"{exit_sql}, "
+    f"{dq(payload['stdout_tail'] or '')}, "
+    f"{dq(payload['stdout_tail'] or '')}, "
+    f"{dq(payload['notes'])}"
+    ");"
+)
+open(sys.argv[2], "w").write(sql)
+PYEOF
+
+log "scenario=${SCENARIO} env=${SPIKE_ENV} region=${SPIKE_REGION}"
+
+# ─── Resolve networking from the ingestion worker service ──────────────────
+log "resolving networking from ${CLUSTER}..."
+
+SERVICE_NAME="judgemind-ingestion-worker-${SPIKE_ENV}"
+
+SUBNETS=$(aws ecs describe-services \
+    --cluster "${CLUSTER}" \
+    --services "${SERVICE_NAME}" \
+    --region "${SPIKE_REGION}" \
+    --output text \
+    --no-cli-pager \
+    --query 'services[0].networkConfiguration.awsvpcConfiguration.subnets' \
+    | tr '\t' ',')
+
+SECURITY_GROUPS=$(aws ecs describe-services \
+    --cluster "${CLUSTER}" \
+    --services "${SERVICE_NAME}" \
+    --region "${SPIKE_REGION}" \
+    --output text \
+    --no-cli-pager \
+    --query 'services[0].networkConfiguration.awsvpcConfiguration.securityGroups' \
+    | tr '\t' ',')
+
+if [[ -z "${SUBNETS}" || -z "${SECURITY_GROUPS}" ]]; then
+    log "ERROR: could not resolve networking from ${SERVICE_NAME}"
+    exit 1
+fi
+
+log "subnets=${SUBNETS}"
+log "security_groups=${SECURITY_GROUPS}"
+
+# ─── Launch the task ────────────────────────────────────────────────────────
+log "launching ${TASK_FAMILY} with command=[${SCENARIO}]..."
+
+OVERRIDES_JSON="${TMPDIR_SPIKE}/overrides.json"
+printf '{"containerOverrides": [{"name": "dispatcher-spike", "command": ["%s"]}]}' "${SCENARIO}" \
+    > "${OVERRIDES_JSON}"
+
+RUN_OUTPUT_FILE="${TMPDIR_SPIKE}/run-output.json"
+aws ecs run-task \
+    --cluster "${CLUSTER}" \
+    --task-definition "${TASK_FAMILY}" \
+    --launch-type FARGATE \
+    --region "${SPIKE_REGION}" \
+    --output json \
+    --no-cli-pager \
+    --network-configuration "awsvpcConfiguration={subnets=[${SUBNETS}],securityGroups=[${SECURITY_GROUPS}],assignPublicIp=DISABLED}" \
+    --overrides "file://${OVERRIDES_JSON}" \
+    > "${RUN_OUTPUT_FILE}"
+
+cat > "${TMPDIR_SPIKE}/extract_task_arn.py" <<'PYEOF'
+"""Extract the first taskArn from an `aws ecs run-task` JSON output file."""
+import json, sys
+data = json.load(open(sys.argv[1]))
+tasks = data.get("tasks", [])
+print(tasks[0]["taskArn"] if tasks else "")
+PYEOF
+
+TASK_ARN=$(python3 "${TMPDIR_SPIKE}/extract_task_arn.py" "${RUN_OUTPUT_FILE}")
+
+if [[ -z "${TASK_ARN}" ]]; then
+    log "ERROR: failed to launch task"
+    cat "${RUN_OUTPUT_FILE}" >&2
+    exit 1
+fi
+
+TASK_ID=$(printf '%s' "${TASK_ARN}" | awk -F'/' '{print $NF}')
+log "task_arn=${TASK_ARN}"
+log "task_id=${TASK_ID}"
+log "log_group=${LOG_GROUP}"
+log "log_stream=spike/dispatcher-spike/${TASK_ID}"
+
+STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# ─── Poll for completion ────────────────────────────────────────────────────
+ELAPSED=0
+POLL_INTERVAL=15
+LAST_STATUS=""
+CURRENT_STATUS=""
+
+while [[ ${ELAPSED} -lt ${SPIKE_TIMEOUT} ]]; do
+    CURRENT_STATUS=$(aws ecs describe-tasks \
+        --cluster "${CLUSTER}" \
+        --tasks "${TASK_ARN}" \
+        --region "${SPIKE_REGION}" \
+        --output text \
+        --no-cli-pager \
+        --query 'tasks[0].lastStatus')
+
+    if [[ "${CURRENT_STATUS}" != "${LAST_STATUS}" ]]; then
+        log "status=${CURRENT_STATUS} elapsed=${ELAPSED}s"
+        LAST_STATUS="${CURRENT_STATUS}"
+    fi
+
+    if [[ "${CURRENT_STATUS}" == "STOPPED" ]]; then
+        break
+    fi
+
+    sleep "${POLL_INTERVAL}"
+    ELAPSED=$(( ELAPSED + POLL_INTERVAL ))
+done
+
+if [[ "${CURRENT_STATUS}" != "STOPPED" ]]; then
+    log "ERROR: task did not stop within ${SPIKE_TIMEOUT}s"
+    exit 1
+fi
+
+ENDED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# ─── Extract exit code + stop reason using aws --query ──────────────────────
+EXIT_CODE=$(aws ecs describe-tasks \
+    --cluster "${CLUSTER}" \
+    --tasks "${TASK_ARN}" \
+    --region "${SPIKE_REGION}" \
+    --output text \
+    --no-cli-pager \
+    --query 'tasks[0].containers[0].exitCode')
+
+# AWS CLI returns the literal string "None" when exitCode is missing.
+if [[ "${EXIT_CODE}" == "None" ]]; then
+    EXIT_CODE=""
+fi
+
+STOP_REASON=$(aws ecs describe-tasks \
+    --cluster "${CLUSTER}" \
+    --tasks "${TASK_ARN}" \
+    --region "${SPIKE_REGION}" \
+    --output text \
+    --no-cli-pager \
+    --query 'tasks[0].stoppedReason')
+
+if [[ "${STOP_REASON}" == "None" ]]; then
+    STOP_REASON=""
+fi
+
+log "exit_code=${EXIT_CODE:-<none>} stop_reason=${STOP_REASON:-<none>}"
+
+# ─── Fetch a log tail ───────────────────────────────────────────────────────
+LOG_STREAM="spike/dispatcher-spike/${TASK_ID}"
+STDOUT_TAIL=""
+EVENTS_FILE="${TMPDIR_SPIKE}/events.json"
+
+for _retry in 1 2 3 4; do
+    sleep 5
+    if aws logs get-log-events \
+            --log-group-name "${LOG_GROUP}" \
+            --log-stream-name "${LOG_STREAM}" \
+            --region "${SPIKE_REGION}" \
+            --output json \
+            --no-cli-pager \
+            > "${EVENTS_FILE}" 2>/dev/null; then
+        TAIL=$(python3 "${TMPDIR_SPIKE}/tail_events.py" < "${EVENTS_FILE}" || true)
+        if [[ -n "${TAIL}" ]]; then
+            STDOUT_TAIL="${TAIL}"
+            break
+        fi
+    fi
+    log "waiting for CloudWatch log stream (retry ${_retry})..."
+done
+
+if [[ -z "${STDOUT_TAIL}" ]]; then
+    log "WARNING: could not fetch log tail for ${LOG_STREAM}"
+    STDOUT_TAIL="(log stream ${LOG_STREAM} not found after retries)"
+fi
+
+# ─── Emit a structured summary ──────────────────────────────────────────────
+SUMMARY_FILE="${TMPDIR_SPIKE}/summary.json"
+SCENARIO="${SCENARIO}" \
+    TASK_ARN="${TASK_ARN}" \
+    STARTED_AT="${STARTED_AT}" \
+    ENDED_AT="${ENDED_AT}" \
+    EXIT_CODE="${EXIT_CODE}" \
+    STOP_REASON="${STOP_REASON}" \
+    STDOUT_TAIL="${STDOUT_TAIL}" \
+    SPIKE_NOTES="${SPIKE_NOTES}" \
+    python3 "${TMPDIR_SPIKE}/emit_summary.py" \
+    > "${SUMMARY_FILE}"
+
+cat "${SUMMARY_FILE}"
+
+log "summary:"
+log "  scenario:    ${SCENARIO}"
+log "  exit_code:   ${EXIT_CODE:-<none>}"
+log "  task_arn:    ${TASK_ARN}"
+
+# ─── Insert into dispatcher_spike.runs (optional) ──────────────────────────
+if [[ "${SPIKE_SKIP_DB:-0}" == "1" ]]; then
+    log "SPIKE_SKIP_DB=1 — skipping dispatcher_spike.runs insert"
+    exit 0
+fi
+
+INSERT_SQL_FILE="${TMPDIR_SPIKE}/insert.sql"
+python3 "${TMPDIR_SPIKE}/build_insert_sql.py" "${SUMMARY_FILE}" "${INSERT_SQL_FILE}"
+
+SQL_CONTENT=$(cat "${INSERT_SQL_FILE}")
+
+if "${REPO_ROOT}/scripts/dev-db-query.sh" --rw "${SQL_CONTENT}" > /dev/null 2>&1; then
+    log "wrote dispatcher_spike.runs row"
+else
+    log "WARNING: could not insert into dispatcher_spike.runs (schema missing? VPC access?)"
+fi


### PR DESCRIPTION
## Summary

Dispatcher v2 spike 0.1 end-to-end on Fargate. Runs a minimal
`@anthropic-ai/claude-code` image as a one-off Fargate task in the dev
account across four scenarios (`success`, `turn_limit`, `auth_fail`,
`mcp_probe`), records each result in a throwaway `dispatcher_spike.runs`
table, and files a findings note at
`docs/investigations/dispatcher-v2-spike-0.1.md`.

All four scenarios were actually executed on dev Fargate before opening
this PR — the DB already has 4 rows and CloudWatch has 4 streams. Verdict:
**GO** — the daemon architecture in `docs/specs/dispatcher-v2-spec.md` is
viable as specified. Resolves §17 Open Question 2 (MCP propagation). Shifts
§7's category derivation (exit code alone is not enough; pair with
stderr-regex classifier).

Spike artifacts (Dockerfile, Terraform module, migration, wrapper script)
are kept in place per the issue's explicit instructions so reviewers can
reproduce the runs. A follow-up issue will track cleanup.

Closes #2683

## Test plan

### Automated checks
- [x] Lint passes (Terraform fmt, markdown links, script headers)
- [x] Format check passes
- [x] Tests pass (no new unit tests — spike is infra + a wrapper shell
  script validated by real Fargate runs)
- [x] CI green

### Post-deploy verification
- [x] Dev terraform apply for `module.dispatcher_spike` succeeds (applied
  pre-PR; `terraform plan` is a no-op after merge)
- [x] API deploy applies migration 18 (`dispatcher_spike.runs`); the
  table already exists in dev (applied manually for the pre-PR evidence
  runs), and the migration is idempotent via `CREATE ... IF NOT EXISTS`
- [x] `SELECT run_id, scenario, exit_code FROM dispatcher_spike.runs
  ORDER BY run_id` on dev returns at least 4 rows showing success=0,
  turn_limit=1, auth_fail=1, mcp_probe=0
- [x] CloudWatch log group `/ecs/judgemind-dispatcher-spike-dev` contains
  at least one log stream per scenario, each ending with
  `[dispatcher-spike] claude exited with code=<N>`
- [x] Verification evidence posted on issue #2683
