### PR TITLE
feat(dx): pre-push schema drift check on migration changes (#2702)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -453,6 +453,45 @@ if [ -n "$changed_markdown" ]; then
 fi
 
 # -------------------------------------------------------------------
+# Schema drift check — run whenever packages/api/migrations/*.sql changes
+# -------------------------------------------------------------------
+# Mirrors the CI `schema-drift-check` job so `schema.sql` falling out of
+# sync with the migrations (e.g. agent added a migration but forgot to
+# run `scripts/regenerate_schema.sh`) is caught locally before the ~10
+# minute CI round trip (#2702). The check requires Docker with a running
+# postgres container — if Docker is unavailable we emit a WARNING and
+# skip, matching the pattern used for ruff/actionlint/terraform above.
+changed_migrations=$(echo "$changed_files" | grep -E '^packages/api/migrations/.+\.sql$' || true)
+if [ -n "$changed_migrations" ]; then
+    echo "pre-push: checking schema drift (packages/api/src/data-access/schema.sql vs migrations)..." >&2
+    if ! command -v docker &>/dev/null; then
+        echo "  WARNING: docker not found — skipping schema drift check" >&2
+        echo "  Install Docker Desktop to enable local schema drift checks." >&2
+    elif ! docker info &>/dev/null; then
+        echo "  WARNING: docker daemon not running — skipping schema drift check" >&2
+        echo "  Start Docker Desktop to enable local schema drift checks." >&2
+    elif [ ! -x scripts/check_schema_drift.sh ]; then
+        echo "  WARNING: scripts/check_schema_drift.sh not found or not executable — skipping" >&2
+    else
+        # Use --ci mode so the check spins up its own ephemeral postgres
+        # container rather than relying on the docker-compose stack being
+        # up. ~15s when postgres image is already cached; ~30-60s cold.
+        if ! scripts/check_schema_drift.sh --ci 2>&1; then
+            echo "" >&2
+            echo "  FAILED: scripts/check_schema_drift.sh" >&2
+            echo "  packages/api/src/data-access/schema.sql is out of sync with the" >&2
+            echo "  migrations in packages/api/migrations/." >&2
+            echo "" >&2
+            echo "  To fix: run scripts/regenerate_schema.sh" >&2
+            echo "" >&2
+            echo "  This same check runs in CI as schema-drift-check (~10 minutes" >&2
+            echo "  round trip). Catching it locally saves a full CI cycle." >&2
+            failures=$((failures + 1))
+        fi
+    fi
+fi
+
+# -------------------------------------------------------------------
 # Script header marker check — run whenever scripts/*.py changes
 # -------------------------------------------------------------------
 # Mirrors the CI `script-headers-check` job so one-off/permanent marker

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -161,6 +161,18 @@ scripts/check-ci-job-skipped.sh
 
 This detects the #2410 / #2505 footgun: a PR modifies a job body whose `if: needs.detect-changes.outputs.X == 'true'` gate's paths-filter does not match anything in the diff, so the job will be SKIPPED on that PR's own CI run and the modification is never actually exercised. The same check runs in CI as the `ci-job-skipped-check` job; the pre-push hook runs it whenever `ci.yml` is in the push. If it fails, either add `.github/workflows/ci.yml` to the offending filter (so the job always runs when ci.yml itself changes) or modify a file that already matches the filter.
 
+### Database migrations — schema drift
+
+When any file under `packages/api/migrations/` changes, regenerate `packages/api/src/data-access/schema.sql`:
+
+```
+scripts/regenerate_schema.sh
+```
+
+Then commit the updated `schema.sql` alongside the migration. `schema.sql` is auto-generated — do not edit it directly. If you prefer to verify before regenerating, run `scripts/check_schema_drift.sh` which compares `schema.sql` against a fresh migration-applied schema and exits non-zero on drift.
+
+The same check runs in CI as the `schema-drift-check` job. The pre-push hook runs it whenever a `packages/api/migrations/*.sql` file is in the push (requires Docker + a running daemon; emits a WARNING and skips if Docker is unavailable), so migration-vs-schema drift is caught locally before the ~10 minute CI round trip. See #2702.
+
 ### Subagent responsibilities
 
 Subagents MUST install dependencies, run ALL lint/format/test commands for every package touched, fix failures before committing, and only push after all local checks pass.

--- a/scripts/tests/test_pre_push.sh
+++ b/scripts/tests/test_pre_push.sh
@@ -366,6 +366,108 @@ else
 fi
 
 # ───────────────────────────────────────────────────────────────────────
+# Scenario 9: Migration change fires schema drift check
+# ───────────────────────────────────────────────────────────────────────
+# A push that touches packages/api/migrations/*.sql must run the
+# schema-drift check. Without Docker we should see the WARNING branch
+# (exit 0); with Docker unavailable in this scratch repo we exercise
+# the "docker not found" path, matching the pattern used for ruff /
+# actionlint / terraform missing-tool tests. See #2702.
+echo "[scenario 9] migration change + missing docker — WARNING only, hook fires"
+init_workspace
+git -C "$WORK" checkout --quiet -b feature-migration
+mkdir -p "$WORK/packages/api/migrations"
+cat > "$WORK/packages/api/migrations/0001_test.sql" <<'SQL'
+-- Up migration
+CREATE TABLE IF NOT EXISTS test_table (id SERIAL PRIMARY KEY);
+
+-- Down migration
+DROP TABLE IF EXISTS test_table;
+SQL
+git -C "$WORK" add packages/api/migrations/0001_test.sql
+git -C "$WORK" commit --quiet -m "migration: add test table"
+feat_sha="$(git -C "$WORK" rev-parse HEAD)"
+
+run_hook_without docker \
+    "refs/heads/feature-migration $feat_sha refs/heads/feature-migration $ZERO_SHA"
+
+if ! echo "$hook_out" | grep -q "checking schema drift"; then
+    report_fail "hook did NOT run schema drift check on migration push (#2702)" "$hook_out"
+elif ! echo "$hook_out" | grep -q "WARNING: docker not found"; then
+    report_fail "expected 'WARNING: docker not found' when docker is missing" "$hook_out"
+elif [ "$hook_rc" -ne 0 ]; then
+    report_fail "missing docker should not fail push, got rc=$hook_rc" "$hook_out"
+else
+    report_pass "migration push fires schema drift check; missing docker -> WARNING only"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 10: Schema drift failure names regenerate_schema.sh verbatim
+# ───────────────────────────────────────────────────────────────────────
+# Acceptance criterion from #2702: "Failure message names the exact fix
+# (scripts/regenerate_schema.sh) verbatim." We stub check_schema_drift.sh
+# to fail and assert the hook's failure message surfaces the fix string.
+echo "[scenario 10] schema drift failure surfaces 'scripts/regenerate_schema.sh' fix text"
+init_workspace
+git -C "$WORK" checkout --quiet -b feature-drift
+mkdir -p "$WORK/packages/api/migrations" "$WORK/scripts"
+cat > "$WORK/packages/api/migrations/0001_drift.sql" <<'SQL'
+-- Up migration
+CREATE TABLE IF NOT EXISTS drift_table (id SERIAL PRIMARY KEY);
+
+-- Down migration
+DROP TABLE IF EXISTS drift_table;
+SQL
+# Stub check_schema_drift.sh: pretend docker is present and fail immediately.
+cat > "$WORK/scripts/check_schema_drift.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "=== FAIL: schema.sql has drifted from migrations ==="
+exit 1
+STUB
+chmod +x "$WORK/scripts/check_schema_drift.sh"
+# Also stub a `docker` binary on PATH that reports `docker info` success,
+# so the hook takes the "run check" branch rather than the WARNING branch.
+STUB_BIN="$TMPDIR/stub-bin"
+rm -rf "$STUB_BIN"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/docker" <<'DOCKER'
+#!/usr/bin/env bash
+# Minimal docker stub — `docker info` succeeds, anything else succeeds too.
+exit 0
+DOCKER
+chmod +x "$STUB_BIN/docker"
+# Symlink the rest of PATH so git/grep/etc still work.
+IFS=:
+for dir in $PATH; do
+    [ -d "$dir" ] || continue
+    for src in "$dir"/*; do
+        [ -e "$src" ] || continue
+        name="$(basename "$src")"
+        [ "$name" = "docker" ] && continue
+        [ -e "$STUB_BIN/$name" ] && continue
+        ln -s "$src" "$STUB_BIN/$name" 2>/dev/null || true
+    done
+done
+unset IFS
+git -C "$WORK" add packages/api/migrations/0001_drift.sql scripts/check_schema_drift.sh
+git -C "$WORK" commit --quiet -m "migration: add drift table"
+feat_sha="$(git -C "$WORK" rev-parse HEAD)"
+
+hook_out="$(cd "$WORK" && echo "refs/heads/feature-drift $feat_sha refs/heads/feature-drift $ZERO_SHA" \
+    | PATH="$STUB_BIN" "$HOOK" origin "$REMOTE" 2>&1)" \
+    && hook_rc=0 || hook_rc=$?
+
+if [ "$hook_rc" -eq 0 ]; then
+    report_fail "expected hook to reject drift, exit was 0" "$hook_out"
+elif ! echo "$hook_out" | grep -q "scripts/regenerate_schema.sh"; then
+    report_fail "expected failure message to name 'scripts/regenerate_schema.sh' verbatim (#2702 AC1)" "$hook_out"
+elif ! echo "$hook_out" | grep -q "FAILED: scripts/check_schema_drift.sh"; then
+    report_fail "expected 'FAILED: scripts/check_schema_drift.sh' in output" "$hook_out"
+else
+    report_pass "hook rejects drift and names regenerate_schema.sh in the fix message"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
 # Summary
 # ───────────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Adds a schema-drift guard to `.githooks/pre-push` that fires whenever a push touches `packages/api/migrations/*.sql`. It runs the same script CI uses (`scripts/check_schema_drift.sh --ci`), so migration-vs-`schema.sql` drift is caught locally (~15-60s) before the ~10 minute CI round trip. On failure, the hook surfaces the fix `run scripts/regenerate_schema.sh` verbatim; on missing Docker / daemon / script it emits a WARNING and lets the push through, matching the ruff/actionlint/terraform pattern.

Dispatcher v2 spike 0.1 (#2683) burned one full CI cycle on this exact footgun.

Closes #2702

## Test plan

### Automated checks
- [x] Lint passes (no Python/TS touched — shell + docs only)
- [x] Format check passes
- [x] Tests pass — `scripts/tests/test_pre_push.sh` 10/10 scenarios (2 new for #2702)
- [x] Markdown links check passes
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (pre-push hook + docs + test suite only)
