### PR TITLE
feat(dx): add scripts/check-duplicate-pr.sh wrapper (#2706)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -325,9 +325,10 @@ Commit message format: `feat(area): description (#N)` (conventional commits).
 Immediately open a PR after the first push — never push without creating one. **Before creating, check for duplicate PRs** to avoid wasting CI minutes on conflicting duplicates:
 
 ```
-source {worktree}/scripts/preflight.sh
-preflight_no_duplicate_pr <N>
+{worktree}/scripts/check-duplicate-pr.sh <N>
 ```
+
+(`check-duplicate-pr.sh` is a thin wrapper around `preflight_no_duplicate_pr` in `scripts/preflight.sh`. The wrapper lets the check run in a single Bash tool call — `source scripts/preflight.sh && preflight_no_duplicate_pr <N>` trips the preflight hook's "quoted strings combined with &&" check. See #2706.)
 
 - If it returns **0** (duplicate found), the existing PR number is printed to stdout. **Adopt that PR** instead of creating a new one — push to the existing branch and use `gh pr edit` to update the body if needed.
 - If it returns **1** (no duplicate), proceed to create the PR normally.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ git -C {worktree} rebase origin/main
 git push -u origin <branch>
 ```
 
-Before creating a PR, check for duplicates using `preflight_no_duplicate_pr` from `scripts/preflight.sh`. If a duplicate is found (return code 0), adopt the existing PR instead of creating a new one. If no duplicate (return code 1) or on error (return code 2), proceed normally:
+Before creating a PR, check for duplicates with `scripts/check-duplicate-pr.sh <N>` (a thin wrapper around `preflight_no_duplicate_pr` that avoids the `source && fn` preflight-hook friction). If a duplicate is found (return code 0), adopt the existing PR instead of creating a new one. If no duplicate (return code 1) or on error (return code 2), proceed normally:
 
 ```
 gh pr create --repo judgemind/judgemind ...

--- a/scripts/check-duplicate-pr.sh
+++ b/scripts/check-duplicate-pr.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# check-duplicate-pr.sh — Standalone wrapper around preflight_no_duplicate_pr.
+#
+# Checks whether an open PR already exists for the given issue number, so a
+# /task agent can adopt the existing PR instead of creating a duplicate.
+#
+# This exists because calling the underlying function in a single Bash tool
+# invocation requires `source scripts/preflight.sh && preflight_no_duplicate_pr
+# <N>`, which the preflight hook blocks (quoted strings combined with `&&`).
+# A standalone script under scripts/ is covered by the `Bash(scripts/*)`
+# permission and runs without prompts. See #2706.
+#
+# Usage:
+#   scripts/check-duplicate-pr.sh <issue_number>
+#   scripts/check-duplicate-pr.sh 42
+#   scripts/check-duplicate-pr.sh '#42'       # leading # is stripped
+#
+# Exit codes (pass-through from preflight_no_duplicate_pr):
+#   0 — Duplicate PR found. The existing PR number is printed to stdout.
+#       Caller should adopt that PR instead of creating a new one.
+#   1 — No duplicate PR. Safe to create a new one.
+#   2 — Error (missing argument, gh CLI unavailable, or API failure).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+
+preflight_no_duplicate_pr "$@"

--- a/scripts/tests/test_check_duplicate_pr.sh
+++ b/scripts/tests/test_check_duplicate_pr.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# test_check_duplicate_pr.sh — Tests for scripts/check-duplicate-pr.sh
+#
+# Covers the three documented exit codes of the wrapper (and the underlying
+# preflight_no_duplicate_pr function it delegates to):
+#   0 — duplicate PR found; the existing PR number is printed to stdout
+#   1 — no duplicate PR
+#   2 — error (missing argument, gh CLI unavailable, or API failure)
+#
+# Usage:
+#   scripts/tests/test_check_duplicate_pr.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$SCRIPT_DIR/check-duplicate-pr.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+ORIG_PATH_SAVE=""
+
+cleanup() {
+    set +eu
+    for d in "${TEMP_DIRS[@]}"; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+    if [[ -n "$ORIG_PATH_SAVE" ]]; then
+        export PATH="$ORIG_PATH_SAVE"
+    fi
+}
+trap cleanup EXIT
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Precondition: wrapper exists and is executable ─────────────────────────
+
+if [[ ! -x "$WRAPPER" ]]; then
+    echo "FAIL: $WRAPPER is not executable (or does not exist)" >&2
+    exit 1
+fi
+
+# ── Test 1: exit 2 when called with no argument ────────────────────────────
+
+exit_code=0
+"$WRAPPER" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "exits 2 with no argument"
+else
+    fail "exits 2 with no argument" "expected exit 2, got $exit_code"
+fi
+
+# ── Set up a mock gh CLI on PATH for the remaining tests ──────────────────
+
+MOCK_BIN_DIR=$(mktemp -d)
+TEMP_DIRS+=("$MOCK_BIN_DIR")
+ORIG_PATH_SAVE="$PATH"
+export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
+
+# ── Test 2: exit 1 when no duplicate PR exists ─────────────────────────────
+
+# Mock gh pr list returning an empty array for both the title search and the
+# branch-name search.
+cat > "$MOCK_BIN_DIR/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+# Any gh pr list call returns "[]".
+if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+    echo "[]"
+    exit 0
+fi
+exit 0
+MOCKGH
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+"$WRAPPER" 99999 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "exits 1 when no duplicate PR exists"
+else
+    fail "exits 1 when no duplicate PR exists" "expected exit 1, got $exit_code"
+fi
+
+# ── Test 3: exit 0 and prints PR number when a duplicate exists ────────────
+
+# Mock gh pr list returning a PR whose title contains "(#42)" on the first
+# (title-search) call, then an empty array for the branch-name call if reached.
+cat > "$MOCK_BIN_DIR/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+    # Check whether this is the title search (has --search) or branch search (has --head).
+    for arg in "$@"; do
+        if [[ "$arg" == "--search" ]]; then
+            echo '[{"number": 1234, "title": "feat(dx): add duplicate PR wrapper (#42)"}]'
+            exit 0
+        fi
+    done
+    echo "[]"
+    exit 0
+fi
+exit 0
+MOCKGH
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+output=$("$WRAPPER" 42 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "exits 0 when a duplicate PR exists"
+else
+    fail "exits 0 when a duplicate PR exists" "expected exit 0, got $exit_code"
+fi
+
+if [[ "$output" == "1234" ]]; then
+    pass "prints duplicate PR number to stdout"
+else
+    fail "prints duplicate PR number to stdout" "expected '1234', got '$output'"
+fi
+
+# ── Test 4: strips a leading '#' from the issue argument ───────────────────
+
+exit_code=0
+output=$("$WRAPPER" "#42" 2>/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == "1234" ]]; then
+    pass "strips leading '#' from the issue argument"
+else
+    fail "strips leading '#' from the issue argument" "exit=$exit_code output='$output'"
+fi
+
+# ── Test 5: exit 2 when gh CLI call fails (API error) ──────────────────────
+
+cat > "$MOCK_BIN_DIR/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+# Simulate gh pr list failing (e.g. unauthenticated, API down).
+exit 1
+MOCKGH
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+"$WRAPPER" 42 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "exits 2 when gh pr list fails"
+else
+    fail "exits 2 when gh pr list fails" "expected exit 2, got $exit_code"
+fi
+
+# ── Test 6: exit 2 when gh is not installed ────────────────────────────────
+
+# Remove the mock gh and restrict PATH to only system dirs that hold core
+# utilities (bash, python3, grep, awk, mktemp). `gh` typically lives in
+# /opt/homebrew/bin or /usr/local/bin and is absent from /bin:/usr/bin on a
+# stock install — so this PATH cleanly simulates "gh not installed" while
+# leaving the utilities the preflight function relies on intact.
+rm -f "$MOCK_BIN_DIR/gh"
+
+if command -v gh > /dev/null 2>&1 && PATH="/bin:/usr/bin" command -v gh > /dev/null 2>&1; then
+    # Environment has `gh` on /bin or /usr/bin — we cannot reliably construct
+    # a PATH that hides it without also hiding the utilities the function
+    # depends on. Skip this test rather than produce a false failure.
+    echo "SKIP: gh is on /bin or /usr/bin; cannot simulate 'gh not installed'"
+else
+    exit_code=0
+    PATH="/bin:/usr/bin" "$WRAPPER" 42 > /dev/null 2>&1 || exit_code=$?
+    if [[ "$exit_code" -eq 2 ]]; then
+        pass "exits 2 when gh CLI is not installed"
+    else
+        fail "exits 2 when gh CLI is not installed" "expected exit 2, got $exit_code"
+    fi
+fi
+
+# Restore PATH
+export PATH="$ORIG_PATH_SAVE"
+
+# ── Summary ───────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/check-duplicate-pr.sh` — a thin standalone wrapper around `preflight_no_duplicate_pr` in `scripts/preflight.sh` — so `/task` agents can run the duplicate-PR check in one Bash tool call without tripping the preflight hook's "quoted strings combined with `&&`" rule. Updates `.claude/skills/task/SKILL.md` §A.3 and `CLAUDE.md` §PR Workflow to reference the wrapper.

Closes #2706

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_check_duplicate_pr.sh` 7/7 locally; `scripts-tests` CI job green)
- [x] Markdown links check passes (pre-push + CI `markdown-links-check` green)
- [x] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (docs + tooling script only)

The wrapper is dogfooded in this PR itself: ran `scripts/check-duplicate-pr.sh 2706` right after pushing the branch → exit 1 (no duplicate), so this PR was created normally. Also ran `scripts/check-duplicate-pr.sh 99999` → exit 1, as specified by AC #1.
