### PR TITLE
feat(ingestion): add defense-in-depth all-NULL-metadata guard (#2676)

### DIFF
--- a/packages/scraper-framework/src/ingestion/ruling_guards.py
+++ b/packages/scraper-framework/src/ingestion/ruling_guards.py
@@ -17,13 +17,129 @@ See #2084 for the refactoring that introduced this module.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .extract import normalize_motion_type
 from .split_ids import make_split_document_id
 
 if TYPE_CHECKING:
     from framework.llm_schema import ExtractedRuling
+
+
+# ---------------------------------------------------------------------------
+# All-NULL metadata guard (#2676)
+# ---------------------------------------------------------------------------
+#
+# Capture-side filters (#2486) skip non-ruling PDFs (admin notices, cover
+# sheets, "no tentative rulings today" pages) before they ever reach the
+# ingestion worker.  This pipeline-side guard is the defense-in-depth
+# fallback: if a non-ruling PDF slips past the scraper — a new county
+# adds an admin-notice URL, an upstream filter regresses, a one-off
+# capture backfill runs without filters — the guard here prevents a
+# metadata-free row from polluting ``derived.rulings``.
+#
+# The helper is consulted at the worker's pre-DB-write boundary.  When it
+# returns True, the worker skips the upsert and emits a
+# ``data_quality.non_ruling_pdf_dropped`` telemetry event (both as a
+# structured log field and as a row in ``telemetry.data_quality_metrics``).
+
+#: Structured log ``telemetry_event`` value emitted by the worker when the
+#: pipeline-side guard drops a ruling row.  Fully-qualified namespace so
+#: downstream dashboards can filter without ambiguity.
+NON_RULING_PDF_DROPPED_EVENT = "data_quality.non_ruling_pdf_dropped"
+
+#: Short-form ``metric_name`` written to ``telemetry.data_quality_metrics``.
+#: Matches the naming convention of peer metrics (e.g. ``ruling_empty_text``,
+#: ``zero_ruling_extraction``).
+NON_RULING_PDF_DROPPED_METRIC = "non_ruling_pdf_dropped"
+
+#: The six metadata fields the guard inspects.  All six must be NULL/empty
+#: for a ruling to be classified as all-null.
+_METADATA_FIELDS: tuple[str, ...] = (
+    "case_number",
+    "case_title",
+    "judge_name",
+    "department",
+    "motion_type",
+    "outcome",
+)
+
+#: Prefix for synthetic placeholder case numbers assigned during enrichment
+#: when no real case number can be recovered.  A ruling with an
+#: ``UNKNOWN-...`` case_number and no other metadata is still non-ruling
+#: noise — the placeholder alone must not keep the row alive.
+_UNKNOWN_CASE_NUMBER_PREFIX = "UNKNOWN-"
+
+
+def _get_field(ruling: Any, name: str) -> Any:
+    """Return ``ruling[name]`` for dicts, or ``getattr(ruling, name, None)``
+    for objects.  Missing keys/attributes are treated as ``None``."""
+    if isinstance(ruling, dict):
+        return ruling.get(name)
+    return getattr(ruling, name, None)
+
+
+def _is_nullish(value: Any) -> bool:
+    """True when *value* represents NULL/empty for guard purposes.
+
+    ``None``, empty strings, and whitespace-only strings are all treated
+    as NULL.  Non-string truthy values (numbers, enums) are treated as
+    populated.
+    """
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip() == ""
+    return False
+
+
+def is_all_null_metadata(ruling: Any) -> bool:
+    """Return True when a ruling has NO meaningful metadata.
+
+    A ruling is "all-null metadata" when every one of the six core
+    metadata fields (case_number, case_title, judge_name, department,
+    motion_type, outcome) is ``None``, an empty string, or a
+    whitespace-only string.
+
+    A synthetic placeholder ``case_number`` that starts with
+    ``UNKNOWN-`` is treated as equivalent to NULL for this check: the
+    enrichment layer sometimes assigns such a placeholder when nothing
+    real can be extracted, and a row with only that placeholder is
+    still non-ruling noise.  A real case number (no ``UNKNOWN-``
+    prefix) counts as populated even if the rest is NULL.
+
+    The helper works on any object or dict that exposes the metadata
+    field names — ``ConvertedRuling``, the worker's per-ruling dicts,
+    ``SimpleNamespace`` used in tests, etc.  Missing fields are treated
+    as NULL rather than raising.
+
+    Parameters
+    ----------
+    ruling:
+        An object (attribute access) or dict (key access) exposing the
+        six metadata field names.
+
+    Returns
+    -------
+    bool
+        ``True`` if the ruling has no meaningful metadata (pipeline
+        should drop it); ``False`` if at least one real field is
+        populated.
+    """
+    for name in _METADATA_FIELDS:
+        value = _get_field(ruling, name)
+        if _is_nullish(value):
+            continue
+        # case_number has a sentinel placeholder form we treat as NULL.
+        if (
+            name == "case_number"
+            and isinstance(value, str)
+            and value.startswith(_UNKNOWN_CASE_NUMBER_PREFIX)
+        ):
+            continue
+        # Any other populated field -> not all-null.
+        return False
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -93,7 +93,13 @@ from .llm_extract import (
 )
 from .llm_providers import create_client as create_llm_client
 from .ruling_formatter import format_ruling_text
-from .ruling_guards import check_no_orphan_rulings, convert_extracted_rulings
+from .ruling_guards import (
+    NON_RULING_PDF_DROPPED_EVENT,
+    NON_RULING_PDF_DROPPED_METRIC,
+    check_no_orphan_rulings,
+    convert_extracted_rulings,
+    is_all_null_metadata,
+)
 from .ruling_summarizer import summarize_ruling
 from .text_cleanup import clean_ruling_text
 
@@ -2032,6 +2038,81 @@ class IngestionWorker:
                     except Exception:
                         pass
                 return
+
+        # ------------------------------------------------------------------
+        # Defense-in-depth: all-NULL metadata guard (#2676).
+        # ------------------------------------------------------------------
+        # Capture-side filters (#2486) skip non-ruling PDFs (admin notices,
+        # cover sheets, "no tentative rulings today" pages) before they
+        # ever reach this worker.  As a belt-and-suspenders fallback, we
+        # also check here: if every one of the six core metadata fields is
+        # NULL/empty (with ``UNKNOWN-*`` case_numbers treated as NULL),
+        # this is non-ruling noise that would pollute ``derived.rulings``.
+        # Drop it, emit telemetry, and return before the DB upsert.
+        _guard_ruling = {
+            "case_number": case_number,
+            "case_title": case_title,
+            "judge_name": judge_name,
+            "department": department,
+            "motion_type": motion_type,
+            "outcome": outcome,
+        }
+        if is_all_null_metadata(_guard_ruling):
+            s3_key_val = event_data.get("s3_key")
+            logger.warning(
+                "Pipeline-side guard: dropping non-ruling PDF with all-NULL metadata",
+                extra={
+                    "document_id": document_id,
+                    "county": county,
+                    "state": state,
+                    "scraper_id": scraper_id,
+                    "s3_key": s3_key_val,
+                    "telemetry_event": NON_RULING_PDF_DROPPED_EVENT,
+                },
+            )
+            # Best-effort telemetry write (savepoint-protected so a transient
+            # failure does not abort the caller's transaction).
+            try:
+                conn = self._get_connection()
+                with conn.cursor() as cur:
+                    cur.execute("SAVEPOINT non_ruling_pdf_metric")
+                    try:
+                        cur.execute(
+                            """
+                            INSERT INTO data_quality_metrics
+                                (recorded_at, county, metric_name,
+                                 metric_value, metadata)
+                            VALUES (now(), %s, %s, %s, %s::jsonb)
+                            """,
+                            (
+                                county,
+                                NON_RULING_PDF_DROPPED_METRIC,
+                                1,
+                                json.dumps(
+                                    {
+                                        "document_id": document_id,
+                                        "s3_key": s3_key_val,
+                                        "state": state,
+                                        "scraper_id": scraper_id,
+                                    }
+                                ),
+                            ),
+                        )
+                        cur.execute("RELEASE SAVEPOINT non_ruling_pdf_metric")
+                    except Exception:  # noqa: BLE001 — best-effort
+                        cur.execute("ROLLBACK TO SAVEPOINT non_ruling_pdf_metric")
+                        raise
+                conn.commit()
+            except Exception:  # noqa: BLE001 — telemetry is best-effort
+                logger.debug(
+                    "non_ruling_pdf_dropped telemetry write failed",
+                    exc_info=True,
+                )
+                try:
+                    conn.rollback()
+                except Exception:  # noqa: BLE001
+                    pass
+            return
 
         # For split events, each split ruling gets its own document row keyed
         # by the synthetic split document_id.  This ensures the FK from

--- a/packages/scraper-framework/src/telemetry/README.md
+++ b/packages/scraper-framework/src/telemetry/README.md
@@ -1,0 +1,83 @@
+# Ingestion Pipeline Telemetry Events
+
+This document lists the structured telemetry events emitted by the
+ingestion pipeline so dashboards, alerts, and on-call runbooks can
+rely on stable names and field shapes.
+
+Each entry describes:
+
+- **Event name** — value of the ``telemetry_event`` field on the
+  structured log line.
+- **Emitter** — source file / function that emits the event.
+- **Metric name** — corresponding ``metric_name`` in
+  ``telemetry.data_quality_metrics`` (short form, no dotted namespace).
+- **When it fires** — conditions that produce the event.
+- **Fields** — shape of the structured log ``extra`` and/or the
+  ``metadata`` JSON column in ``telemetry.data_quality_metrics``.
+
+## `data_quality.non_ruling_pdf_dropped`
+
+**Emitter:** `packages/scraper-framework/src/ingestion/worker.py` — pipeline-side
+all-NULL metadata guard in `process_event`, immediately after
+deterministic validation and before the DB upsert.
+
+**Metric name:** `non_ruling_pdf_dropped` (written to
+`telemetry.data_quality_metrics`).
+
+**When it fires:** all six core metadata fields — `case_number`,
+`case_title`, `judge_name`, `department`, `motion_type`, `outcome` —
+are NULL / empty / whitespace-only for a ruling that survived LLM
+extraction.  A synthetic placeholder `case_number` matching the
+`UNKNOWN-*` prefix is treated as NULL for this check.
+
+This is a defense-in-depth guard.  Capture-side filters introduced in
+[#2486] skip non-ruling PDFs (admin notices, cover sheets, "no tentative
+rulings today" pages) before they reach the ingestion worker.  This
+event is the pipeline-side fallback: when a non-ruling PDF slips past
+the scraper (new county adds an admin-notice URL, an upstream filter
+regresses, a one-off capture backfill runs without filters), the worker
+drops the row and emits this event instead of inserting metadata-free
+noise into `derived.rulings`.
+
+**Structured log fields** (`extra` on the warning log entry):
+
+| Field           | Type           | Description                                      |
+|-----------------|----------------|--------------------------------------------------|
+| `document_id`   | `str`          | Worker-assigned document ID.                     |
+| `county`        | `str`          | Normalized county slug (e.g. `fresno`).          |
+| `state`         | `str`          | Two-letter state code (e.g. `ca`).               |
+| `scraper_id`    | `str`          | Source scraper identifier.                       |
+| `s3_key`        | `str \| None`  | S3 key of the raw capture that produced the row. |
+| `telemetry_event` | `str`        | Always `data_quality.non_ruling_pdf_dropped`.    |
+
+**`telemetry.data_quality_metrics` row:**
+
+```
+metric_name = 'non_ruling_pdf_dropped'
+metric_value = 1
+metadata = {
+  "document_id": "<uuid>",
+  "s3_key": "<s3 key or null>",
+  "state": "ca",
+  "scraper_id": "<scraper id>"
+}
+```
+
+**Related events:**
+
+- `data_quality.ruling_empty_text_dropped` — deterministic validation
+  earlier in the pipeline drops rulings whose `ruling_text` is empty
+  regardless of metadata state (see [#2646]).
+- `zero_ruling_extraction` — emitted when the LLM returns zero rulings
+  for a document (see [#1337], [#2569]).  The `non_ruling_pdf_dropped`
+  guard runs *after* a ruling has been extracted, so the two paths do
+  not overlap.
+
+**Rationale:** see [#2676] for the defense-in-depth motivation and
+[#2486] for the capture-side filter set this event complements.
+
+[#2486]: https://github.com/judgemind/judgemind/issues/2486
+[#2569]: https://github.com/judgemind/judgemind/issues/2569
+[#2646]: https://github.com/judgemind/judgemind/issues/2646
+[#2676]: https://github.com/judgemind/judgemind/issues/2676
+[#1337]: https://github.com/judgemind/judgemind/issues/1337

--- a/packages/scraper-framework/src/telemetry/__init__.py
+++ b/packages/scraper-framework/src/telemetry/__init__.py
@@ -1,0 +1,10 @@
+"""Telemetry event schemas and constants for the ingestion pipeline.
+
+This package collects the canonical names of data-quality / pipeline
+telemetry events emitted by ``ingestion.worker`` and related modules.
+Event names are kept alongside their emitter (e.g. the
+``NON_RULING_PDF_DROPPED_EVENT`` constant lives in
+``ingestion.ruling_guards``) — this package exists primarily to host
+the human-readable schema documentation (see ``README.md``) so dashboard
+queries and alert owners have one place to consult.
+"""

--- a/packages/scraper-framework/tests/test_deterministic_validation_integration.py
+++ b/packages/scraper-framework/tests/test_deterministic_validation_integration.py
@@ -1460,3 +1460,245 @@ def test_det_validation_multi_case_empty_text_split_rejected(
     # The fail record must be attached to the empty split's document_id,
     # not the parent's — this is the row that would have gone to DB.
     assert fail_calls[0].kwargs["document_id"] == "split-uuid-1"
+
+
+# ---------------------------------------------------------------------------
+# Tests: all-NULL metadata pipeline-side guard (#2676)
+# ---------------------------------------------------------------------------
+#
+# The guard is defense-in-depth for #2644 / #2674: even when the capture-side
+# URL filter fails to reject an admin-notice PDF, the worker drops the row
+# before it reaches ``derived.rulings`` and emits a
+# ``data_quality.non_ruling_pdf_dropped`` telemetry event.
+#
+# These tests mock ``run_deterministic_rules`` to return ``pass`` so the
+# worker reaches the guard.  In the real pipeline most admin-notice PDFs
+# would also be caught by deterministic validation (UNKNOWN case_number +
+# empty case_title → fail), but the guard exists for the minority that
+# slip through (e.g. an admin notice where the LLM synthesised a
+# non-UNKNOWN case_number from stray text).
+
+
+_DET_PASS_RESULT = "ingestion.worker.run_deterministic_rules"
+
+
+def _make_det_pass_result() -> MagicMock:
+    """Mock a ``DeterministicValidationResult`` that reports overall=pass."""
+    det_result = MagicMock()
+    det_result.overall = "pass"
+    det_result.failed_rules = []
+    det_result.flagged_rules = []
+    det_result.reasons = []
+    return det_result
+
+
+@patch("ingestion.worker.insert_document_and_ruling")
+@patch("ingestion.worker.extract_judge_name", return_value=None)
+@patch("ingestion.worker.insert_validation_result")
+@patch(_DET_PASS_RESULT)
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_all_null_metadata_guard_drops_fresno_admin_notice(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_det_rules: MagicMock,
+    mock_insert_validation: MagicMock,
+    mock_extract_judge: MagicMock,
+    mock_insert_doc_ruling: MagicMock,
+) -> None:
+    """Synthetic Fresno admin-notice scenario (#2676).
+
+    With capture-side filters bypassed, a Fresno admin-notice PDF would
+    produce an event with all-NULL metadata (no case_number, no title,
+    no judge, no department, no motion_type, no outcome).  The worker's
+    pipeline-side guard must:
+
+    1. NOT call ``insert_document_and_ruling`` (no ``derived.rulings``
+       row written).
+    2. Write a ``non_ruling_pdf_dropped`` row into
+       ``telemetry.data_quality_metrics``.
+    3. Log a warning with ``telemetry_event`` ==
+       ``data_quality.non_ruling_pdf_dropped``.
+    """
+    mock_det_rules.return_value = _make_det_pass_result()
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+
+    # Event where every metadata field is blank (admin-notice PDF slipping
+    # past the capture-side filter).  ``ruling_text`` is non-empty so
+    # deterministic validation doesn't trip ``ruling_text_not_empty``;
+    # the mock forces overall=pass anyway.
+    event = _make_event(
+        scraper_id="ca-fresno-tentatives",
+        county="Fresno",
+        case_number=None,
+        case_title=None,
+        department=None,
+        judge_name=None,
+        hearing_date=None,
+        ruling_text="ATTENTION: Fresno Superior Court is transitioning to a new e-Court system.",
+    )
+    event.pop("case_number", None)  # truly absent, not empty string
+    event.pop("case_title", None)
+    event.pop("department", None)
+    event.pop("judge_name", None)
+    event.pop("hearing_date", None)
+    event["motion_type"] = None
+    event["outcome"] = None
+
+    worker.process_event(event)
+
+    # 1. No ruling row written.
+    mock_insert_doc_ruling.assert_not_called()
+
+    # 2. data_quality_metrics row written with metric_name=non_ruling_pdf_dropped.
+    metric_inserts = [
+        call
+        for call in mock_cur.execute.call_args_list
+        if call.args
+        and isinstance(call.args[0], str)
+        and "data_quality_metrics" in call.args[0]
+        and "INSERT" in call.args[0]
+    ]
+    assert len(metric_inserts) >= 1, "expected a data_quality_metrics INSERT"
+    # The params tuple contains county, metric_name, metric_value, metadata_json.
+    metric_insert = metric_inserts[0]
+    params = metric_insert.args[1]
+    assert params[0] == "Fresno"
+    assert params[1] == "non_ruling_pdf_dropped"
+    assert params[2] == 1
+    # Fourth positional is the JSON-encoded metadata blob.
+    import json as _json
+
+    metadata = _json.loads(params[3])
+    assert metadata["s3_key"] == event["s3_key"]
+    assert metadata["state"] == "CA"
+    assert metadata["scraper_id"] == "ca-fresno-tentatives"
+    assert "document_id" in metadata
+
+    # 3. OpenSearch index not called — the ruling never made it past the guard.
+    os_mock.index.assert_not_called()
+
+
+@patch("ingestion.worker.insert_document_and_ruling")
+@patch("ingestion.worker.extract_judge_name", return_value=None)
+@patch("ingestion.worker.insert_validation_result")
+@patch(_DET_PASS_RESULT)
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_all_null_metadata_guard_does_not_fire_with_case_title(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_det_rules: MagicMock,
+    mock_insert_validation: MagicMock,
+    mock_extract_judge: MagicMock,
+    mock_insert_doc_ruling: MagicMock,
+) -> None:
+    """Negative test: if even ONE metadata field is populated, the guard
+    does NOT fire and the ruling proceeds to the DB write path.
+
+    This is the critical regression guardrail — a real ruling with a
+    judge_name set but no other extracted fields must still be written.
+    """
+    mock_det_rules.return_value = _make_det_pass_result()
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    # upsert_court + upsert_case + insert_document fetches.
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),
+        ("case-uuid-1",),
+        (True,),
+    ]
+    mock_cur.rowcount = 1
+
+    event = _make_event(
+        county="Fresno",
+        scraper_id="ca-fresno-tentatives",
+        case_number=None,
+        case_title="Smith v. Jones",  # populated → guard does NOT fire
+        judge_name=None,
+        department=None,
+        hearing_date=None,
+        motion_type=None,
+        outcome=None,
+    )
+
+    worker.process_event(event)
+
+    # The ruling proceeds to the DB write path.  No non_ruling_pdf_dropped
+    # metric row is written.
+    metric_inserts = [
+        call
+        for call in mock_cur.execute.call_args_list
+        if call.args
+        and isinstance(call.args[0], str)
+        and "non_ruling_pdf_dropped" in str(call.args)
+    ]
+    assert len(metric_inserts) == 0, (
+        "guard must not fire when case_title is populated; got "
+        f"{len(metric_inserts)} non_ruling_pdf_dropped inserts"
+    )
+
+
+@patch("ingestion.worker.insert_document_and_ruling")
+@patch("ingestion.worker.extract_judge_name", return_value=None)
+@patch("ingestion.worker.insert_validation_result")
+@patch(_DET_PASS_RESULT)
+@patch(_EXTRACT_LLM_MOCK, return_value=None)
+@patch(_SPLIT_MOCK, return_value=False)
+@patch("ingestion.worker.psycopg")
+def test_all_null_metadata_guard_survives_telemetry_db_failure(
+    mock_psycopg: MagicMock,
+    mock_split: MagicMock,
+    mock_extract_llm: MagicMock,
+    mock_det_rules: MagicMock,
+    mock_insert_validation: MagicMock,
+    mock_extract_judge: MagicMock,
+    mock_insert_doc_ruling: MagicMock,
+) -> None:
+    """If the telemetry INSERT raises, the worker still returns cleanly.
+
+    Telemetry is best-effort — a transient failure must not re-raise,
+    and the primary guard behaviour (skip upsert) must still hold.
+    """
+    mock_det_rules.return_value = _make_det_pass_result()
+    worker, os_mock = _make_worker()
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+
+    # First execute is SAVEPOINT (succeeds); second (the INSERT) raises.
+    def _execute_side_effect(*args: object, **kwargs: object) -> None:
+        sql = args[0] if args else ""
+        if isinstance(sql, str) and "INSERT INTO data_quality_metrics" in sql:
+            raise RuntimeError("transient DB error")
+        return None
+
+    mock_cur.execute.side_effect = _execute_side_effect
+
+    event = _make_event(
+        county="Fresno",
+        scraper_id="ca-fresno-tentatives",
+        case_number=None,
+        case_title=None,
+        judge_name=None,
+        department=None,
+        hearing_date=None,
+        ruling_text="ATTENTION: e-Court transition notice.",
+    )
+    event["motion_type"] = None
+    event["outcome"] = None
+
+    # Should not raise despite telemetry INSERT failure.
+    worker.process_event(event)
+
+    # Primary guard behaviour still holds: no ruling row written.
+    mock_insert_doc_ruling.assert_not_called()

--- a/packages/scraper-framework/tests/test_ruling_guards.py
+++ b/packages/scraper-framework/tests/test_ruling_guards.py
@@ -11,6 +11,8 @@ See #2084 for background.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from framework.llm_schema import (
@@ -20,8 +22,11 @@ from framework.llm_schema import (
     ExtractionOutcome,
 )
 from ingestion.ruling_guards import (
+    NON_RULING_PDF_DROPPED_EVENT,
+    NON_RULING_PDF_DROPPED_METRIC,
     _looks_like_raw_html,
     convert_extracted_rulings,
+    is_all_null_metadata,
 )
 from ingestion.split_ids import make_split_document_id
 
@@ -623,3 +628,267 @@ class TestRawHtmlGuardInConvertExtractedRulings:
             fallback_text=huge_html,
         )
         assert results[0].ruling_text is None
+
+
+# ---------------------------------------------------------------------------
+# All-NULL metadata guard (#2676)
+# ---------------------------------------------------------------------------
+
+
+class TestIsAllNullMetadata:
+    """Unit tests for ``is_all_null_metadata`` — the pipeline-side
+    defense-in-depth guard.
+
+    The helper classifies a ruling as "all-NULL metadata" when every one of
+    the six metadata fields (case_number, case_title, judge_name,
+    department, motion_type, outcome) is None / empty / whitespace-only.
+    A synthetic placeholder case_number such as ``UNKNOWN-<hash>`` is
+    treated as equivalent to NULL: when the scraper did not recover a real
+    case number, the row still looks like non-ruling noise.
+
+    The event/metric constants are used by the worker to emit structured
+    telemetry when the guard drops a row.
+
+    See #2676 and #2486 for the corpus-poisoning background.
+    """
+
+    def test_event_constant_is_fully_qualified(self) -> None:
+        """The event name matches the documented telemetry namespace."""
+        assert NON_RULING_PDF_DROPPED_EVENT == "data_quality.non_ruling_pdf_dropped"
+
+    def test_metric_constant_matches_data_quality_metric_name(self) -> None:
+        """The metric_name is short-form (no dotted namespace) so it fits
+        existing ``telemetry.data_quality_metrics`` naming."""
+        assert NON_RULING_PDF_DROPPED_METRIC == "non_ruling_pdf_dropped"
+
+    # ------ positive: all six fields fully NULL -> True ------
+
+    def test_all_none_is_all_null(self) -> None:
+        ruling = SimpleNamespace(
+            case_number=None,
+            case_title=None,
+            judge_name=None,
+            department=None,
+            motion_type=None,
+            outcome=None,
+        )
+        assert is_all_null_metadata(ruling) is True
+
+    def test_all_empty_strings_is_all_null(self) -> None:
+        ruling = SimpleNamespace(
+            case_number="",
+            case_title="",
+            judge_name="",
+            department="",
+            motion_type="",
+            outcome="",
+        )
+        assert is_all_null_metadata(ruling) is True
+
+    def test_all_whitespace_only_is_all_null(self) -> None:
+        """Whitespace-only strings are treated as NULL."""
+        ruling = SimpleNamespace(
+            case_number="   ",
+            case_title="\n",
+            judge_name="\t",
+            department="  \n  ",
+            motion_type=" ",
+            outcome="\r\n",
+        )
+        assert is_all_null_metadata(ruling) is True
+
+    # ------ negative: any one populated field -> False ------
+
+    def test_case_number_populated_is_not_all_null(self) -> None:
+        ruling = SimpleNamespace(
+            case_number="24STCV01234",
+            case_title=None,
+            judge_name=None,
+            department=None,
+            motion_type=None,
+            outcome=None,
+        )
+        assert is_all_null_metadata(ruling) is False
+
+    def test_case_title_populated_is_not_all_null(self) -> None:
+        ruling = SimpleNamespace(
+            case_number=None,
+            case_title="Smith v. Jones",
+            judge_name=None,
+            department=None,
+            motion_type=None,
+            outcome=None,
+        )
+        assert is_all_null_metadata(ruling) is False
+
+    def test_judge_name_populated_is_not_all_null(self) -> None:
+        ruling = SimpleNamespace(
+            case_number=None,
+            case_title=None,
+            judge_name="Hon. Jane Doe",
+            department=None,
+            motion_type=None,
+            outcome=None,
+        )
+        assert is_all_null_metadata(ruling) is False
+
+    def test_department_populated_is_not_all_null(self) -> None:
+        ruling = SimpleNamespace(
+            case_number=None,
+            case_title=None,
+            judge_name=None,
+            department="Dept 11",
+            motion_type=None,
+            outcome=None,
+        )
+        assert is_all_null_metadata(ruling) is False
+
+    def test_motion_type_populated_is_not_all_null(self) -> None:
+        ruling = SimpleNamespace(
+            case_number=None,
+            case_title=None,
+            judge_name=None,
+            department=None,
+            motion_type="msj",
+            outcome=None,
+        )
+        assert is_all_null_metadata(ruling) is False
+
+    def test_outcome_populated_is_not_all_null(self) -> None:
+        ruling = SimpleNamespace(
+            case_number=None,
+            case_title=None,
+            judge_name=None,
+            department=None,
+            motion_type=None,
+            outcome="granted",
+        )
+        assert is_all_null_metadata(ruling) is False
+
+    # ------ UNKNOWN-<hash> case_number sentinel ------
+
+    def test_unknown_case_number_alone_is_all_null(self) -> None:
+        """A synthetic ``UNKNOWN-<hash>`` case_number is treated as NULL.
+
+        Enrichment sometimes assigns a placeholder case number when the
+        PDF has nothing real to extract.  The placeholder must not by
+        itself keep a metadata-free row alive.
+        """
+        ruling = SimpleNamespace(
+            case_number="UNKNOWN-abc123",
+            case_title=None,
+            judge_name=None,
+            department=None,
+            motion_type=None,
+            outcome=None,
+        )
+        assert is_all_null_metadata(ruling) is True
+
+    def test_unknown_case_number_with_real_case_title_is_not_all_null(self) -> None:
+        """A placeholder case_number combined with any real metadata is NOT
+        all-null — the row has at least one genuine signal."""
+        ruling = SimpleNamespace(
+            case_number="UNKNOWN-abc123",
+            case_title="Smith v. Jones",
+            judge_name=None,
+            department=None,
+            motion_type=None,
+            outcome=None,
+        )
+        assert is_all_null_metadata(ruling) is False
+
+    def test_unknown_case_number_with_judge_name_is_not_all_null(self) -> None:
+        ruling = SimpleNamespace(
+            case_number="UNKNOWN-abc123",
+            case_title=None,
+            judge_name="Hon. Jane Doe",
+            department=None,
+            motion_type=None,
+            outcome=None,
+        )
+        assert is_all_null_metadata(ruling) is False
+
+    def test_real_case_number_with_unknown_prefix_in_title_is_not_all_null(self) -> None:
+        """The ``UNKNOWN-`` prefix only triggers on the case_number field."""
+        ruling = SimpleNamespace(
+            case_number="24STCV01234",
+            case_title="UNKNOWN-something",  # not a sentinel here
+            judge_name=None,
+            department=None,
+            motion_type=None,
+            outcome=None,
+        )
+        assert is_all_null_metadata(ruling) is False
+
+    # ------ dict input shape ------
+
+    def test_accepts_dict_input(self) -> None:
+        """Helper works on a dict shape (not just objects with attributes).
+
+        Callers in worker.py and reingest paths sometimes have dicts
+        before they are converted into dataclasses."""
+        ruling = {
+            "case_number": None,
+            "case_title": None,
+            "judge_name": None,
+            "department": None,
+            "motion_type": None,
+            "outcome": None,
+        }
+        assert is_all_null_metadata(ruling) is True
+
+    def test_accepts_dict_input_with_one_field_populated(self) -> None:
+        ruling = {
+            "case_number": None,
+            "case_title": "Smith v. Jones",
+            "judge_name": None,
+            "department": None,
+            "motion_type": None,
+            "outcome": None,
+        }
+        assert is_all_null_metadata(ruling) is False
+
+    # ------ works on ConvertedRuling (real pipeline shape) ------
+
+    def test_works_on_converted_ruling_no_metadata(self) -> None:
+        """A ConvertedRuling with all NULL metadata fields is all-null."""
+        ruling = convert_extracted_rulings(
+            [ExtractedRuling(ruling_text="some text")],  # no metadata
+            _DOC_ID,
+        )[0]
+        assert is_all_null_metadata(ruling) is True
+
+    def test_works_on_converted_ruling_with_metadata(self) -> None:
+        """A ConvertedRuling with real metadata is NOT all-null."""
+        ruling = convert_extracted_rulings([_RULING_WITH_TEXT], _DOC_ID)[0]
+        assert is_all_null_metadata(ruling) is False
+
+    # ------ missing attributes are treated as NULL ------
+
+    def test_missing_attributes_treated_as_null(self) -> None:
+        """If the object is missing some metadata attributes entirely,
+        treat them as NULL — don't raise."""
+        ruling = SimpleNamespace(case_number=None, case_title=None)
+        # judge_name / department / motion_type / outcome not set
+        assert is_all_null_metadata(ruling) is True
+
+    def test_missing_attributes_with_one_present_and_populated(self) -> None:
+        ruling = SimpleNamespace(case_title="Smith v. Jones")
+        assert is_all_null_metadata(ruling) is False
+
+    def test_non_string_non_none_field_counts_as_populated(self) -> None:
+        """If a metadata field is a non-string, non-None value (e.g. a
+        numeric or enum type that slipped through), treat it as populated.
+
+        The guard is conservative: it never falsely drops rows whose
+        metadata shape we do not recognise.
+        """
+        ruling = SimpleNamespace(
+            case_number=None,
+            case_title=None,
+            judge_name=None,
+            department=None,
+            motion_type=None,
+            outcome=42,  # unexpected non-string value
+        )
+        assert is_all_null_metadata(ruling) is False


### PR DESCRIPTION
## Summary

Adds defense-in-depth pipeline-side guard that drops non-ruling PDFs (admin notices, cover sheets, "no tentative rulings today" pages) before they reach `derived.rulings`. Complements the capture-side filter (#2486, PR #2674) — if a non-ruling PDF slips past the scraper, the ingestion worker drops it and emits a `data_quality.non_ruling_pdf_dropped` telemetry event so dashboards/alerts can detect scraper-filter drift.

- New `ingestion.ruling_guards.is_all_null_metadata(ruling)` returns `True` when `case_number`, `case_title`, `judge_name`, `department`, `motion_type`, `outcome` are all NULL / empty / whitespace-only. `UNKNOWN-*` case_numbers count as NULL per the issue spec.
- Worker `process_event` calls the guard after deterministic validation and before the DB upsert. On True: warning log with `telemetry_event=data_quality.non_ruling_pdf_dropped`, savepoint-protected INSERT into `telemetry.data_quality_metrics` (`metric_name="non_ruling_pdf_dropped"`), early return — no `derived.rulings` row written.
- New `packages/scraper-framework/src/telemetry/README.md` documents the event schema (structured-log fields, DB row shape, related events, cross-references).

Closes #2676

## Test plan

### Automated checks
- [x] `ruff check packages/scraper-framework/src packages/scraper-framework/tests` passes
- [x] `ruff format --check packages/scraper-framework/src packages/scraper-framework/tests` passes
- [x] `pytest packages/scraper-framework/tests` passes (6,387 tests, 2 skipped; 20 new `TestIsAllNullMetadata` unit tests + 3 new integration tests for synthetic Fresno admin-notice scenarios)
- [x] Diff coverage >= 90% on changed lines (observed 95%, `ruling_guards.py` at 100%)
- [x] `scripts/check-markdown-links.sh` passes for the new `src/telemetry/README.md`
- [x] CI workflow green on this PR

### Post-deploy verification
- [x] Ingestion worker on dev processes messages without errors after deploy — 4,611 log events in window 2026-04-19T00:12-00:25 UTC on `/ecs/judgemind-ingestion-worker-dev`, zero errors/tracebacks
- [x] Confirm guard-path code is live: worker healthy on the new image (commit `f9f79058`); normal rulings flowing through (LLM enrichment, case/party resolution, upsert path); `UNKNOWN-*` documents with other populated fields correctly do NOT trigger guard (expected per spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
