### PR TITLE
feat(dispatcher): extract startup into /dispatcher-startup subagent skill (#2726)

### DIFF
--- a/.claude/skills/dispatcher-startup/SKILL.md
+++ b/.claude/skills/dispatcher-startup/SKILL.md
@@ -1,0 +1,193 @@
+---
+description: Dispatcher startup subagent — runs the heavy one-shot startup queries (stale-worktree sweep, stale-assignment cleanup, agent/ready queue scan, trust-check, orphan-PR triage) in an isolated subagent context and returns a compact markdown summary. Keeps the dispatcher's main context clear of ~100k tokens of raw GitHub output per session.
+argument-hint: "[max_slots=<N>] [skip=<csv>] [only=<#N1,#N2,...>] [agent_account=<login>]"
+---
+
+# /dispatcher-startup skill
+
+**Purpose.** Dispatcher startup historically burns roughly 100k tokens of main-context on raw `gh` / `mcp__github__*` output before the first `/task` agent spawns — `list_issues` over a busy `agent/ready` queue can exceed the MCP token ceiling on its own, and each `gh pr view --json statusCheckRollup,mergeable,mergeStateStatus` adds ~12k characters. The dispatcher rotates every ~40 loop iterations, so the main-context tax is paid fresh on every restart. This skill moves that work into a short-lived isolated subagent that returns ~40 lines of markdown.
+
+**Called by:** `/dispatcher` at startup (once per session), replacing inline startup steps 2–5. Not called by `/task`, `/ralph`, `/audit`, `/spotcheck`, or any other skill.
+
+> **MCP-first for GitHub reads.** Same rules as `/dispatcher` — prefer `mcp__github__list_issues`, `mcp__github__list_pull_requests`, `mcp__github__search_issues`, `mcp__github__get_pull_request`, and `mcp__github__get_pull_request_files` over `gh ... --json`. Load schemas with `ToolSearch query="select:mcp__github__list_issues,mcp__github__list_pull_requests,mcp__github__search_issues,mcp__github__get_pull_request"` on first use. Writes stay on `gh` until the MCP write path has a token (see `docs/agent/gh-to-mcp-migration.md`).
+>
+> **Key MCP gotchas** (copied from `/dispatcher` because they bite immediately):
+>
+> - Params are **snake_case** (`per_page`, `issue_number`), not camelCase.
+> - `list_issues` on a busy queue can exceed the context budget. Use `per_page: 20` and paginate if needed, or fall back to `gh issue list --json number,title,labels,assignees --label agent/ready` for the tighter shape.
+> - `get_pull_request_status` only returns legacy commit statuses (Vercel etc.), not GitHub Actions check runs. For CI check-run status, use `mcp__github__get_pull_request` (returns `mergeable`, `mergeable_state`) and/or `gh pr view <N> --json statusCheckRollup,mergeable,mergeStateStatus` as a fallback.
+
+---
+
+## Arguments
+
+Arguments arrive as a whitespace-separated `key=value` string via `$ARGUMENTS`. Parse the following keys; any unrecognised key is ignored:
+
+- **`max_slots=<N>`** — how many top-of-queue candidates to surface for dispatch (default `5`). Only the top `max_slots` candidates are trust-checked; the rest are listed as "queue depth" without per-issue detail.
+- **`skip=<csv>`** — comma-separated substrings; any issue whose title contains one of these is excluded from the surfaced candidates (e.g. `skip=dispatcher-v2,spotcheck`). Case-insensitive substring match.
+- **`only=<#N1,#N2,...>`** — if set, restrict candidates to the listed issues (in order). Overrides `max_slots` and `skip` for selection, but trust-check and orphan-PR triage still run over the full set.
+- **`agent_account=<login>`** — GitHub login for the agent account used for stale-assignment cleanup (default `drewthaler`; agent account swap per `~/.claude/projects/.../memory/MEMORY.md`). If no argument is given, read the memory file and use whatever it says; otherwise fall back to `drewthaler`.
+
+---
+
+## What this skill does
+
+Runs five short-lived sub-steps, then returns a single compact markdown summary.
+
+### 1. Worktree sweep
+
+Run the sweep script once and capture its summary line:
+
+```
+scripts/sweep_stale_worktrees.sh
+```
+
+The last line is `Cleaned up N stale worktree entries`. Record `N` for the **Cleanups** section of the summary. If `N > 5`, note it — growing orphan counts are a health signal.
+
+### 2. Stale-assignment cleanup
+
+Issues assigned to `<agent_account>` with `agent/ready` that have no open PR referencing them are leftovers from crashed sessions — they block future pickup.
+
+1. List open `agent/ready` issues via MCP (`per_page: 50`). Filter client-side for those whose `assignees` array contains `<agent_account>`.
+2. For each matched issue, check whether an open PR references it. Reuse the PR list fetched in step 4 below (single MCP call for both steps — do not duplicate the query). Match on either the PR body containing `#<N>` or the branch name containing the issue number.
+3. **If an open PR exists:** unassign the issue (work is partial — leave the PR open as evidence):
+   ```
+   gh issue edit <N> --repo judgemind/judgemind --remove-assignee <agent_account>
+   ```
+4. **If no open PR exists:** unassign with the same command. Fully stale assignment.
+5. Record each unassignment in the **Cleanups** section of the summary.
+
+Edge cases — see `/dispatcher` SKILL.md §3. The "no open PR" heuristic handles just-assigned-by-current-session cases safely because the assigning agent will re-assign when it pushes its PR.
+
+### 3. Queue scan — `agent/ready` sorted by priority
+
+```
+mcp__github__list_issues
+  owner: "judgemind"
+  repo: "judgemind"
+  labels: ["agent/ready"]
+  state: "open"
+  per_page: 50
+```
+
+If the returned payload is too large (>100 KB or >2000 lines), fall back to:
+
+```
+gh issue list --repo judgemind/judgemind --label agent/ready --state open \
+    --json number,title,labels,assignees --limit 50
+```
+
+`--json number,title,labels,assignees` is deliberately tight — no `body`, no `createdAt`, no `milestone`. That alone trims ~40% vs. the default shape.
+
+Sort by priority (`priority/p0` > `priority/p1` > `priority/p2` > `priority/p3`), then by issue number ascending within the same priority. Apply filters in this order:
+
+1. **`only=`** — if set, select those issues in the given order (missing issues are listed as "skipped: not found in queue").
+2. **`skip=`** — drop any issue whose title contains one of the substrings (case-insensitive).
+3. **Assignment** — drop issues already assigned to another agent whose worktree still exists in `git worktree list`. Re-use the `git worktree list` output from step 1 if you captured it there.
+
+Take the top `max_slots` remaining. Record the overall queue depth (`total_ready`, `after_filters`) for the summary.
+
+### 4. Trust-check the top `max_slots`
+
+For each of the top `max_slots` candidate issues, run:
+
+```
+scripts/check-issue-author.sh <N>
+```
+
+- **Exit 0 (trusted):** keep in the surfaced queue.
+- **Exit 1 (untrusted):** drop from the surfaced queue. Remove `agent/ready`, add `status/triage`:
+  ```
+  gh issue edit <N> --repo judgemind/judgemind --remove-label agent/ready --add-label status/triage
+  ```
+  Record the drop in the **Skipped (untrusted)** section. Do NOT spawn, do NOT surface this issue to the dispatcher.
+- **Exit 2 (error):** leave labels alone, record in **Skipped (error)** with the exit text, and move on. The next dispatcher cycle will retry.
+
+**Only trust-check the top `max_slots`.** Untrusted issues deeper in the queue will be handled when they bubble up in future cycles.
+
+### 5. Orphan PR triage
+
+```
+mcp__github__list_pull_requests
+  owner: "judgemind"
+  repo: "judgemind"
+  state: "open"
+  per_page: 50
+```
+
+This is the same PR list reused in step 2. For each PR, classify:
+
+- **Ready-to-merge:** CI green, no conflicts, PR was created by the agent account (`user.login == <agent_account>`), ralph-approved (heuristic: branch name starts with `worktree-agent-`). Use `mcp__github__get_pull_request` for `mergeable` / `mergeable_state`; for full check-run rollup fall back to `gh pr view <N> --repo judgemind/judgemind --json statusCheckRollup,mergeable,mergeStateStatus`. **Do not merge from this skill** — just classify and list. The dispatcher merges in its main loop.
+- **Orphaned-conflicting:** agent-authored, `mergeable_state` is `dirty` or `CONFLICTING`, and no active worktree exists for the branch (`git worktree list` check).
+- **Orphaned-CI-failing:** agent-authored, any required check has `FAILURE`, no active worktree exists.
+- **Other-contributor:** `user.login != <agent_account>` — hand off to the human in the summary, never touch.
+- **In-flight:** an active worktree exists for the branch — do not classify as orphaned. The owning agent will handle it.
+
+Cap the orphan-PR section at the 10 most recently updated PRs per class.
+
+**CI check calls are the expensive ones** (~12k characters each). To keep the skill's internal context manageable, only call `get_pull_request` / `gh pr view` for agent-authored PRs with no active worktree — i.e. candidates for "orphaned-conflicting" or "orphaned-CI-failing". Skip it for other-contributor and in-flight PRs.
+
+### 6. Side effects — explicit allow-list
+
+This skill performs exactly these write operations, and nothing else:
+
+1. `scripts/sweep_stale_worktrees.sh` side effects (metadata dir removals).
+2. `gh issue edit <N> --remove-assignee <agent_account>` for stale assignments.
+3. `gh issue edit <N> --remove-label agent/ready --add-label status/triage` for untrusted issues.
+
+**Explicitly forbidden:**
+
+- Never write to `tmp/dispatcher_state.json` or `tmp/dispatcher_checkpoint.md` — those are owned by `/dispatcher`.
+- Never spawn `/task`, `/audit`, or any other Agent subagent.
+- Never call `gh pr merge`, `gh pr create`, `gh issue create`, `gh issue close`, or `gh issue comment`.
+- Never run `terraform apply` or any other infra command.
+
+---
+
+## Output — compact markdown summary
+
+Write the summary to `{worktree}/tmp/dispatcher-startup-summary.md` and print it to stdout so the dispatcher parent sees it in the skill return value. Format:
+
+```
+## Dispatcher Startup
+
+### Queue (top <max_slots> of <total_ready> ready)
+1. [#<N>](url) p<P> <truncated title>
+2. [#<N>](url) p<P> <truncated title>
+...
+
+### Cleanups
+- Worktree sweep: cleaned <N> stale entries
+- Unassigned #<N> (no open PR — stale)
+- Unassigned #<M> (PR #<PR> open, work partial)
+
+### Orphan PRs
+- Ready-to-merge: PR #<M> (#<N>) — CI green, no conflicts
+- Orphaned-conflicting: PR #<M> (#<N>) — rebase needed
+- Orphaned-CI-failing: PR #<M> (#<N>) — <failing check>
+- Other-contributor: PR #<M> (<login>) — hand off
+
+### Skipped
+- Untrusted: #<N> <title> — moved to status/triage (association: <X>)
+- Filter: #<N> <title> — matched skip=<pattern>
+- Error: #<N> — check-issue-author.sh exit 2
+```
+
+**Hard caps:**
+
+- **Total length: ≤40 lines.** If the content would exceed that, truncate each section proportionally (keep queue > cleanups > orphan-PRs > skipped). The dispatcher does not need every detail — counts and top entries are enough.
+- **Titles truncated to 80 characters** (suffix with `…` if truncated).
+- **No raw JSON output.** Every section is structured markdown.
+- **Link format: `[#N](https://github.com/judgemind/judgemind/issues/N)`** — keeps the summary clickable for the user if shared.
+
+If any section is empty, render it as `- (none)` rather than omitting the heading, so the dispatcher can verify that step ran.
+
+---
+
+## Reminders
+
+- No `$()`, no heredocs, no `python -c` — see CLAUDE.md Critical Rules.
+- All temp files go in `{worktree}/tmp/`, not `/tmp/`.
+- Parallelize independent MCP calls where possible (step 3 and step 5 have no dependency on each other once step 2 has the PR list).
+- If an MCP call errors, fall back to the `gh` equivalent immediately — do not retry the MCP call in a loop.
+- This skill is expected to run in ≤60 seconds. If it stalls, the dispatcher will not be able to start work.

--- a/.claude/skills/dispatcher/SKILL.md
+++ b/.claude/skills/dispatcher/SKILL.md
@@ -35,111 +35,64 @@ Enable dispatcher mode for the current interactive session. This transforms the 
 
 If Telegram is available (the MCP Telegram plugin is active and a chat_id is known), send a session started notification using `telegram__reply`. If no chat_id is available yet, skip — the user will see notifications once they send a message.
 
-### 2. Sweep stale worktree metadata
+### 2. Delegate heavy startup queries to `/dispatcher-startup`
 
-Orphan entries in `.git/worktrees/<name>/` can accumulate silently when
-a prior session exits between removing the worktree dir and pruning the
-metadata (hard crash, manual `rm -rf`, buggy cleanup). The reactive fix
-in `cleanup_worktree.sh` (#2388) only heals orphans that are explicitly
-passed to cleanup — it never fires for paths nothing ever names.
+Invoke `/dispatcher-startup` via the Skill tool to run the expensive one-shot startup work in an isolated subagent context. The subagent handles:
 
-Run `scripts/sweep_stale_worktrees.sh` once at startup to proactively
-clear orphan metadata. The script only removes entries whose on-disk
-worktree dir is missing — live worktrees (including locked ones) are
-never touched.
+- Stale worktree metadata sweep (`scripts/sweep_stale_worktrees.sh`)
+- Stale-assignment cleanup (unassign issues whose prior agents crashed)
+- Queue scan — `agent/ready` issues, priority-sorted
+- Author trust-check for the top `max_slots` candidates (untrusted issues moved to `status/triage`)
+- Orphan-PR triage (classify ready-to-merge / orphaned-conflicting / orphaned-CI-failing / other-contributor)
 
-```
-scripts/sweep_stale_worktrees.sh
-```
+Previously these ran inline and burned ~100k tokens of main-context on raw `gh` / `mcp__github__*` output before the first `/task` spawned. Running them in the subagent keeps the dispatcher's main context clear; the subagent returns only a ~40-line markdown summary.
 
-The last line of its output is always `Cleaned up N stale worktree
-entries`. Log that line so it is visible in the session transcript. If
-`N` is large (e.g. > 5), note it — a growing orphan count across
-successive startups is a useful health signal that something is
-mis-behaving in the cleanup path.
-
-### 3. Clean up stale issue assignments
-
-When a previous dispatcher or agent session ends unexpectedly (context window exhaustion, crash, terminal closed), issues assigned to the agent account may remain assigned with `agent/ready` but no agent working them. These look "in progress" but are actually abandoned, blocking future pickup.
-
-**Run this cleanup once at startup, before scanning the work queue.**
-
-1. List all open issues assigned to the agent account that have the `agent/ready` label. Use MCP (no `@me` filter — filter client-side on the `assignees` field, matching the agent account login e.g. `drewthaler`):
-   ```
-   mcp__github__list_issues
-     owner: "judgemind"
-     repo: "judgemind"
-     labels: ["agent/ready"]
-     state: "open"
-     per_page: 50
-   ```
-
-2. For each assigned issue, check whether an open PR exists that references it. Use MCP `search_issues` with a `repo:judgemind/judgemind is:pr is:open` qualifier, or reuse the PR list fetched in startup step 5 and match on branch names / body:
-   ```
-   mcp__github__search_issues
-     q: "repo:judgemind/judgemind is:pr is:open in:body #<N>"
-   ```
-   Alternatively, check the PR list from startup step 5 for branches containing the issue number.
-
-3. **If an open PR exists:** The work is partially complete. Unassign the issue so the next agent can adopt the existing PR, but leave the PR open as evidence of prior work.
-
-4. **If no open PR exists:** The assignment is fully stale — no work product exists. Unassign the issue:
-   ```
-   gh issue edit <N> --repo judgemind/judgemind --remove-assignee @me
-   ```
-
-5. Log each cleanup action. For example: `Cleaned up stale assignment: #107 "Fix OC scraper date parsing" (no open PR — unassigned)`
-
-6. If Telegram is available and any stale assignments were cleaned up, send a summary notification via `telegram__reply`.
-
-**Edge cases:**
-- An issue has an open PR but CI is failing and no agent is working it — still unassign so a fresh agent can pick it up and adopt the PR.
-- An issue was just assigned by another agent in the current session — unlikely at startup, but the "no open PR" heuristic handles this safely. New assignments will not have PRs yet, but the assigning agent will create one shortly. Even if the cleanup unassigns it prematurely, the agent will re-assign when it pushes its PR.
-
-### 4. Scan the work queue (startup only)
-
-List all open `agent/ready` issues sorted by priority (use MCP — `list_issues` returns full typed objects including labels and assignees):
+**Invocation:**
 
 ```
-mcp__github__list_issues
-  owner: "judgemind"
-  repo: "judgemind"
-  labels: ["agent/ready"]
-  state: "open"
-  per_page: 50
+Skill tool with:
+  skill: "dispatcher-startup"
+  args: "max_slots=<max_slots> [skip=<csv>] [only=#N1,#N2] [agent_account=<login>]"
 ```
 
-Priority order: `priority/p0` > `priority/p1` > `priority/p2` > `priority/p3`. Within the same priority, prefer lower issue numbers (older first).
+- Pass `max_slots=` with the value resolved from the current session's argument (default `5`).
+- Pass `only=#N1,#N2` when the dispatcher was invoked with specific issue numbers as arguments.
+- Pass `skip=<csv>` if the dispatcher session has skip patterns configured (usually omitted on a fresh startup).
+- Pass `agent_account=<login>` if the current agent account is not the default `drewthaler` — read the latest value from `~/.claude/projects/.../memory/MEMORY.md` rather than hardcoding.
 
-If specific issues were passed as arguments, filter to only those issues.
+**Returned summary:** The subagent writes `{worktree}/tmp/dispatcher-startup-summary.md` and prints it. Read the returned summary and log it. Sections include `Queue`, `Cleanups`, `Orphan PRs`, and `Skipped` (untrusted / filter / error). The main-context dispatcher never sees the raw `gh` / MCP output that produced the summary.
 
-**This initial scan is for startup orientation only.** Do NOT cache this list for use in later dispatch cycles. Each dispatch cycle in the main loop (step 6) must run its own fresh query. Issues may be unblocked, relabeled, or closed between cycles — working from a stale list causes the dispatcher to miss newly-available high-priority work.
+**Side effects performed by the subagent** (explicit allow-list — no other writes):
 
-### 5. Check for in-flight work
+- Worktree metadata removals via `scripts/sweep_stale_worktrees.sh`.
+- `gh issue edit <N> --remove-assignee <agent_account>` for stale assignments.
+- `gh issue edit <N> --remove-label agent/ready --add-label status/triage` for untrusted-author issues.
 
-Check for any existing open PRs or assigned issues that may need attention (stale CI, merge conflicts, etc.). Use MCP — returns full PR objects with head ref, mergeable state, and CI status all in one call:
+**Constraints enforced in the subagent:**
 
-```
-mcp__github__list_pull_requests
-  owner: "judgemind"
-  repo: "judgemind"
-  state: "open"
-  per_page: 50
-```
+- Does NOT write to `tmp/dispatcher_state.json` or `tmp/dispatcher_checkpoint.md` — those remain owned by the main dispatcher (see step 3 below and "Dispatcher Checkpoint File").
+- Does NOT spawn `/task` or any other Agent subagent.
+- Does NOT merge PRs, create issues, post issue comments, or close issues.
 
-For detailed CI status on a specific PR, use `mcp__github__get_pull_request` (for `mergeable` / `mergeable_state`) — **not** `get_pull_request_status`, which only returns legacy commit statuses (Vercel etc.) and misses GitHub Actions check runs. For the full check-run rollup, fall back to `gh pr view <N> --repo judgemind/judgemind --json statusCheckRollup,mergeable,mergeStateStatus`. Handle any in-flight PRs before launching new work (see "PR Merge Policy" below).
+**After the subagent returns:**
 
-### 6. Initialize audit counter
+- Log the summary line-for-line in the session transcript.
+- If the `Cleanups` section reports any stale-assignment unassigns and Telegram is available, send the **Stale assignments cleaned** template from the Message Templates table.
+- Use the `Queue` section as the initial orientation for the first dispatch cycle. **Do NOT cache it** — step 6 of the main loop must always run its own fresh `mcp__github__list_issues` query. The subagent's queue is a one-shot snapshot, not a permanent cache.
+
+See `.claude/skills/dispatcher-startup/SKILL.md` for the full subagent specification.
+
+### 3. Initialize audit counter
 
 Read `tmp/dispatcher_state.json` to recover the `prs_since_last_audit` counter from a previous session. If the file does not exist or the field is missing, initialize the counter to 0.
 
-### 7. Initialize context rotation counter
+### 4. Initialize context rotation counter
 
 Initialize `loop_iterations` to 0. This counter tracks how many main loop iterations have elapsed in this session. It is used to trigger a graceful exit before the context window fills up and causes compaction-related forgetfulness (see "Context-Aware Rotation" below).
 
 Also read `session_number` from `tmp/dispatcher_state.json` (default to 0 if missing). Increment it by 1 and persist it back — this tracks how many times the dispatcher has been restarted by the outer `while :; do` loop. The first invocation is session 1.
 
-### 8. Store max_slots for enforcement
+### 5. Store max_slots for enforcement
 
 Store the max slot count (from the argument, or 5 if not specified) in a variable `max_slots`. This value is used throughout the session for slot enforcement checks. **Do not change this value during the session** — it is set once at startup and used everywhere.
 


### PR DESCRIPTION
## Summary

Move the dispatcher's heavy one-shot startup queries (stale-worktree sweep, stale-assignment cleanup, `agent/ready` queue scan, author trust-check, orphan-PR triage) into a new `/dispatcher-startup` skill that runs in an isolated subagent context. Keeps the dispatcher's main context clear of ~100k tokens of raw `gh` / MCP output per session, paid fresh on every ~40-iteration rotation.

## Changes

- **New** `.claude/skills/dispatcher-startup/SKILL.md` (193 lines)
  - Five numbered sub-steps (sweep, stale-assignment cleanup, queue scan, trust-check of top `max_slots`, orphan-PR triage)
  - Args: `max_slots=<N>` (default 5), `skip=<csv>`, `only=<#N1,#N2,...>`, `agent_account=<login>`
  - Output: ≤40-line compact markdown summary with `Queue` / `Cleanups` / `Orphan PRs` / `Skipped` sections, 80-char title truncation, clickable `[#N](url)` links, `- (none)` fallback for empty sections
  - Side-effect allow-list: `sweep_stale_worktrees.sh`, `gh issue edit --remove-assignee`, `gh issue edit --remove-label agent/ready --add-label status/triage`. Explicitly forbidden: `dispatcher_state.json` / `dispatcher_checkpoint.md` writes, Agent subagent spawns, PR/issue create/merge/comment writes.
  - MCP-first for GitHub reads (with `gh` fallback for busy-queue `list_issues`), ≤60s expected runtime
- **Modified** `.claude/skills/dispatcher/SKILL.md`
  - Startup section §2 now delegates to the new skill via a single `Skill` tool invocation; old inline steps 2–5 removed
  - Post-return handling: read/log returned summary, fire the existing "Stale assignments cleaned" Telegram template from the subagent's counts
  - Remaining startup steps renumbered: Telegram (1) → Skill invocation (2) → audit counter (3) → loop counter (4) → `max_slots` storage (5)
  - Back-reference to `.claude/skills/dispatcher-startup/SKILL.md` for the full spec

## Acceptance criteria

- [x] `ls -la .claude/skills/dispatcher-startup/SKILL.md` — file exists (193 lines) with `description:` + `argument-hint:` frontmatter
- [x] `grep -n "Skill tool" .claude/skills/dispatcher/SKILL.md` — returns the invocation line in Startup §2 (line 53)
- [x] Subagent returns markdown-formatted summary — template specified in §Output with hard caps and required section headings
- [x] No writes to `dispatcher_state.json` / `dispatcher_checkpoint.md`, no Agent spawns — §6 "Explicitly forbidden" lists both
- [x] Untrusted issues get `agent/ready` removed and `status/triage` added via `gh issue edit` — §4 exit-1 handler codifies this

## Test plan

### Automated checks

- [x] `scripts/check-markdown-links.sh` — passes (verified locally: "All clean — checked 2 file(s)")
- [x] CI `markdown-links-check` job green
- [x] CI `lint` / `test` / `ci-job-skipped-check` all green (no source changes, so most gates SKIP)
- [x] Diff coverage check — N/A (docs/skill-only change, no code)

### Post-deploy verification

- [x] No deployed component — `.claude/skills/` changes only affect the agent workflow at runtime. Verification evidence posted on issue #2726.

Closes #2726

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
