### PR TITLE
feat(dispatcher-v2): add dispatcher.* schema migration (#2727)

### DIFF
--- a/packages/api/migrations/21_dispatcher-schema.sql
+++ b/packages/api/migrations/21_dispatcher-schema.sql
@@ -1,0 +1,268 @@
+-- Up Migration
+--
+-- Dispatcher v2 — Phase 1 Sub-task A. Full `dispatcher.*` schema per
+-- `docs/specs/dispatcher-v2-spec.md` §18 (DDL sketch).
+--
+-- Issue #2727 (Parent: #2725, Phase 1 epic).
+--
+-- This is the state foundation for dispatcher v2. Downstream in Phase 1:
+--   - daemon.py skeleton (sub-task C) reads/writes these tables
+--   - admin GraphQL queries (sub-task D) expose them to the admin page
+--   - admin page (sub-task E) renders them
+--
+-- Design notes
+-- ------------
+-- - The schema is *not* added to `search_path`. Dispatcher-internal code
+--   uses fully-qualified `dispatcher.*` names exclusively. This mirrors
+--   the convention we adopted for `derived.*` / `telemetry.*` after the
+--   schema reorganization (migration 15) and keeps the dispatcher state
+--   clearly separated from application data.
+-- - All FKs between dispatcher tables are intra-schema; no dispatcher
+--   table references anything in `public`, `derived`, etc.
+-- - `phase_transitions.phase` is intentionally free-form text (not an
+--   enum) so adding a new phase name does not require a migration —
+--   validation lives in the daemon (see §17 operational trap 7).
+-- - `dispatcher_daemon` role + GRANTs are deferred to sub-task B
+--   (#2725). Today, the API role (`judgemind`, i.e. the DB owner) has
+--   implicit full access. Sub-task B will introduce a least-privilege
+--   daemon role and narrow the API role's permissions. A TODO is left
+--   at the bottom of this migration so the grant story stays visible.
+--
+-- Seed: `dispatcher.config` is populated with the seven live-editable
+-- settings from §18 (concurrency_cap, subprocess_timeout_s,
+-- backoff_seconds, idle_audit_every_n_prs, idle_spotcheck_cron,
+-- runner_by_phase, model_by_phase, runner_shadow). `updated_by='init'`
+-- marks these rows as migration-seeded — the admin page will set
+-- `updated_by` to a GitHub login when operators edit them.
+
+CREATE SCHEMA dispatcher;
+
+-- --------------------------------------------------------------------
+-- runs — one row per daemon boot; lease token for the double-daemon
+-- race described in §17 operational trap 2.
+-- --------------------------------------------------------------------
+CREATE TABLE dispatcher.runs (
+    run_id        UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    started_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    stopped_at    TIMESTAMPTZ,
+    heartbeat_ts  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    version_sha   TEXT        NOT NULL,
+    host          TEXT        NOT NULL,
+    pid           INT         NOT NULL
+);
+
+COMMENT ON TABLE  dispatcher.runs                 IS 'One row per daemon boot. Latest row is the active lease.';
+COMMENT ON COLUMN dispatcher.runs.heartbeat_ts    IS 'Daemon updates every tick. CloudWatch alarm pages if stale > 5min.';
+COMMENT ON COLUMN dispatcher.runs.version_sha     IS 'Git SHA of the daemon build; supports forensic questions after a crash.';
+
+-- --------------------------------------------------------------------
+-- agents — one row per /task (or audit/spotcheck/security-review)
+-- invocation. Replaces the ad-hoc worktree/issue bookkeeping that
+-- lives in `tmp/agent-status/*.txt` today.
+-- --------------------------------------------------------------------
+CREATE TABLE dispatcher.agents (
+    agent_id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    parent_run_id    UUID        REFERENCES dispatcher.runs(run_id),
+    kind             TEXT        NOT NULL DEFAULT 'task',      -- task | audit | spotcheck | security-review
+    issue_number     INT         NOT NULL,
+    worktree_path    TEXT        NOT NULL,
+    phase            TEXT        NOT NULL DEFAULT 'claiming',
+    status           TEXT        NOT NULL DEFAULT 'running',   -- running | succeeded | failed | retrying | crashed
+    started_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    ended_at         TIMESTAMPTZ,
+    exit_code        INT,
+    pr_number        INT,
+    retries_used     INT         NOT NULL DEFAULT 0,
+    pid              INT,
+    runner_override  JSONB,                                     -- per-agent override of runner_by_phase; NULL = use config default
+    model_override   JSONB                                      -- per-agent override of model_by_phase; NULL = use config default
+);
+
+CREATE INDEX idx_dispatcher_agents_running
+    ON dispatcher.agents (status)
+    WHERE status = 'running';
+
+CREATE INDEX idx_dispatcher_agents_issue_number
+    ON dispatcher.agents (issue_number);
+
+COMMENT ON TABLE  dispatcher.agents                  IS 'One row per /task (or audit/spotcheck/security-review) agent invocation.';
+COMMENT ON COLUMN dispatcher.agents.runner_override  IS 'Per-agent override of dispatcher.config.runner_by_phase; NULL = use config default.';
+COMMENT ON COLUMN dispatcher.agents.model_override   IS 'Per-agent override of dispatcher.config.model_by_phase; NULL = use config default.';
+
+-- --------------------------------------------------------------------
+-- phase_transitions — append-only log. Replaces tmp/agent-status/*.txt.
+-- `phase` is intentionally free-form TEXT (not an enum).
+-- --------------------------------------------------------------------
+CREATE TABLE dispatcher.phase_transitions (
+    transition_id      BIGSERIAL   PRIMARY KEY,
+    agent_id           UUID        NOT NULL REFERENCES dispatcher.agents(agent_id),
+    phase              TEXT        NOT NULL,
+    ts                 TIMESTAMPTZ NOT NULL DEFAULT now(),
+    autocompact_count  INT         NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_dispatcher_phase_transitions_agent_ts
+    ON dispatcher.phase_transitions (agent_id, ts DESC);
+
+COMMENT ON TABLE dispatcher.phase_transitions IS 'Append-only phase log; replaces tmp/agent-status/*.txt. Phase is free-form text; validation is daemon-side.';
+
+-- --------------------------------------------------------------------
+-- failures — direct-write from hooks + daemon-side detectors.
+-- --------------------------------------------------------------------
+CREATE TABLE dispatcher.failures (
+    failure_id    BIGSERIAL   PRIMARY KEY,
+    agent_id      UUID        REFERENCES dispatcher.agents(agent_id),
+    category      TEXT        NOT NULL,
+    detected_by   TEXT        NOT NULL,
+    details       JSONB       NOT NULL DEFAULT '{}',
+    ts            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_dispatcher_failures_ts
+    ON dispatcher.failures (ts DESC);
+
+CREATE INDEX idx_dispatcher_failures_category_ts
+    ON dispatcher.failures (category, ts DESC);
+
+COMMENT ON COLUMN dispatcher.failures.detected_by IS 'hook | scheduler | diagnoser — who wrote this row.';
+
+-- --------------------------------------------------------------------
+-- retry_markers — mechanical-failure retry queue with exponential
+-- backoff (60 → 300 → 900s; attempt capped at 3 per §8).
+-- --------------------------------------------------------------------
+CREATE TABLE dispatcher.retry_markers (
+    marker_id       BIGSERIAL   PRIMARY KEY,
+    agent_id        UUID        NOT NULL REFERENCES dispatcher.agents(agent_id),
+    reason          TEXT        NOT NULL,
+    attempt         INT         NOT NULL CHECK (attempt BETWEEN 1 AND 3),
+    retry_after_ts  TIMESTAMPTZ NOT NULL,
+    resolved_at     TIMESTAMPTZ
+);
+
+CREATE INDEX idx_dispatcher_retry_markers_pending
+    ON dispatcher.retry_markers (retry_after_ts)
+    WHERE resolved_at IS NULL;
+
+-- --------------------------------------------------------------------
+-- commands — operator-issued actions consumed by the daemon.
+-- --------------------------------------------------------------------
+CREATE TABLE dispatcher.commands (
+    command_id    BIGSERIAL   PRIMARY KEY,
+    command       TEXT        NOT NULL,                         -- start | stop | drain | pause | resume | retry | force_kill
+    issued_by     TEXT        NOT NULL,
+    issued_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    consumed_at   TIMESTAMPTZ,
+    payload       JSONB       NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX idx_dispatcher_commands_unconsumed
+    ON dispatcher.commands (consumed_at)
+    WHERE consumed_at IS NULL;
+
+-- --------------------------------------------------------------------
+-- config — live-editable key/value settings. Seeded below.
+-- --------------------------------------------------------------------
+CREATE TABLE dispatcher.config (
+    key         TEXT        PRIMARY KEY,
+    value       JSONB       NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_by  TEXT        NOT NULL
+);
+
+-- --------------------------------------------------------------------
+-- diagnoses — tiered diagnoser output (§8). One row per invocation.
+-- --------------------------------------------------------------------
+CREATE TABLE dispatcher.diagnoses (
+    diagnosis_id    BIGSERIAL   PRIMARY KEY,
+    failure_id      BIGINT      NOT NULL REFERENCES dispatcher.failures(failure_id),
+    agent_id        UUID        NOT NULL REFERENCES dispatcher.agents(agent_id),
+    status          TEXT        NOT NULL DEFAULT 'pending',     -- pending | completed | failed
+    context         JSONB       NOT NULL,                       -- serialized bundle passed to the diagnoser
+    recommendation  JSONB,                                      -- {action, reasoning, hint?, new_scope?}
+    outcome         JSONB,                                      -- filled in after the retry resolves
+    started_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at    TIMESTAMPTZ
+);
+
+CREATE INDEX idx_dispatcher_diagnoses_pending
+    ON dispatcher.diagnoses (status)
+    WHERE status = 'pending';
+
+CREATE INDEX idx_dispatcher_diagnoses_agent_id
+    ON dispatcher.diagnoses (agent_id);
+
+-- --------------------------------------------------------------------
+-- phase_outputs — structured JSON output from each phase, read from
+-- {worktree}/tmp/dispatcher-output/<phase>.json by the daemon.
+-- UNIQUE (agent_id, phase) — one output per phase per agent.
+-- --------------------------------------------------------------------
+CREATE TABLE dispatcher.phase_outputs (
+    output_id    BIGSERIAL   PRIMARY KEY,
+    agent_id     UUID        NOT NULL REFERENCES dispatcher.agents(agent_id),
+    phase        TEXT        NOT NULL,                          -- plan | ralph | summary | fix_ci | verify | retro
+    output_json  JSONB       NOT NULL,
+    ts           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX idx_dispatcher_phase_outputs_agent_phase
+    ON dispatcher.phase_outputs (agent_id, phase);
+
+-- --------------------------------------------------------------------
+-- notifications — Telegram + admin-page notification history.
+-- Preserves escalation history even when Telegram itself is down (§12).
+-- --------------------------------------------------------------------
+CREATE TABLE dispatcher.notifications (
+    notification_id  BIGSERIAL   PRIMARY KEY,
+    kind             TEXT        NOT NULL,                       -- stuck_timeout | deploy_failure | diagnoser_escalate | api_overload | claude_p_broken | boot | daily_summary
+    severity         TEXT        NOT NULL,                       -- human_attention | status
+    issue_number     INT,
+    pr_number        INT,
+    body             TEXT        NOT NULL,
+    issue_url        TEXT,                                       -- denormalized for admin-page display; NULL on status-class messages
+    sent_at          TIMESTAMPTZ,
+    send_error       TEXT,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_dispatcher_notifications_created_at
+    ON dispatcher.notifications (created_at DESC);
+
+CREATE INDEX idx_dispatcher_notifications_human_attention_unsent
+    ON dispatcher.notifications (severity, sent_at)
+    WHERE severity = 'human_attention';
+
+-- --------------------------------------------------------------------
+-- Seed config. The seven live-editable keys from §18. `updated_by`
+-- distinguishes migration-seeded rows ('init') from operator edits.
+-- --------------------------------------------------------------------
+INSERT INTO dispatcher.config (key, value, updated_by) VALUES
+    ('concurrency_cap',         '5',                                                                                                                                               'init'),
+    ('subprocess_timeout_s',    '10800',                                                                                                                                           'init'),  -- 180 min ceiling; covers known outliers (#2513 107min, #2628 98min)
+    ('backoff_seconds',         '[60,300,900]',                                                                                                                                    'init'),
+    ('idle_audit_every_n_prs',  '20',                                                                                                                                              'init'),
+    ('idle_spotcheck_cron',     '"0 14 * * *"',                                                                                                                                    'init'),
+    ('runner_by_phase',         '{"plan":"claude","ralph":"claude","summary":"claude","fix_ci":"claude","verify":"claude","retro":"claude","diagnose":"claude"}',                  'init'),
+    ('model_by_phase',          '{"plan":"opus","ralph":"sonnet","summary":"haiku","fix_ci":"sonnet","verify":"haiku","retro":"haiku","diagnose":"opus"}',                         'init'),
+    ('runner_shadow',           '{}',                                                                                                                                              'init');
+
+-- --------------------------------------------------------------------
+-- GRANTs — deferred to sub-task B (#2725, Phase 1 sub-task B).
+--
+-- Today every service connects as the `judgemind` role, which is the DB
+-- owner and therefore has implicit full access to dispatcher.*. Sub-task
+-- B will:
+--   1. Create a least-privilege `dispatcher_daemon` DB role.
+--   2. Narrow the API role so only admin GraphQL queries can read
+--      dispatcher.* (no writes from the API service).
+--   3. Add the corresponding `GRANT USAGE ON SCHEMA dispatcher TO ...`
+--      and `GRANT SELECT / INSERT / UPDATE / DELETE ON ... TO ...`.
+--
+-- Keeping the GRANT story in a single follow-up migration is cleaner
+-- than threading partial grants through this foundation migration.
+-- --------------------------------------------------------------------
+
+
+-- Down Migration
+-- Wipes all dispatcher.* state. `CASCADE` handles the bigserial
+-- sequences, indexes, and inter-table FKs in one statement.
+DROP SCHEMA IF EXISTS dispatcher CASCADE;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 20 migrations.
+-- Generated from 21 migrations.
 
 
 
@@ -19,6 +19,9 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 CREATE SCHEMA derived;
+
+
+CREATE SCHEMA dispatcher;
 
 
 CREATE SCHEMA staging;
@@ -308,6 +311,221 @@ COMMENT ON COLUMN derived.rulings.summary IS 'Cached AI summary. Served from cac
 COMMENT ON COLUMN derived.rulings.ruling_text_hash IS 'SHA-256 of normalized (lowercased, whitespace-collapsed) ruling text. Used for content-based dedup.';
 
 
+CREATE TABLE dispatcher.agents (
+    agent_id uuid DEFAULT gen_random_uuid() NOT NULL,
+    parent_run_id uuid,
+    kind text DEFAULT 'task'::text NOT NULL,
+    issue_number integer NOT NULL,
+    worktree_path text NOT NULL,
+    phase text DEFAULT 'claiming'::text NOT NULL,
+    status text DEFAULT 'running'::text NOT NULL,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    ended_at timestamp with time zone,
+    exit_code integer,
+    pr_number integer,
+    retries_used integer DEFAULT 0 NOT NULL,
+    pid integer,
+    runner_override jsonb,
+    model_override jsonb
+);
+
+
+COMMENT ON TABLE dispatcher.agents IS 'One row per /task (or audit/spotcheck/security-review) agent invocation.';
+
+
+COMMENT ON COLUMN dispatcher.agents.runner_override IS 'Per-agent override of dispatcher.config.runner_by_phase; NULL = use config default.';
+
+
+COMMENT ON COLUMN dispatcher.agents.model_override IS 'Per-agent override of dispatcher.config.model_by_phase; NULL = use config default.';
+
+
+CREATE TABLE dispatcher.commands (
+    command_id bigint NOT NULL,
+    command text NOT NULL,
+    issued_by text NOT NULL,
+    issued_at timestamp with time zone DEFAULT now() NOT NULL,
+    consumed_at timestamp with time zone,
+    payload jsonb DEFAULT '{}'::jsonb NOT NULL
+);
+
+
+CREATE SEQUENCE dispatcher.commands_command_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE dispatcher.commands_command_id_seq OWNED BY dispatcher.commands.command_id;
+
+
+CREATE TABLE dispatcher.config (
+    key text NOT NULL,
+    value jsonb NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_by text NOT NULL
+);
+
+
+CREATE TABLE dispatcher.diagnoses (
+    diagnosis_id bigint NOT NULL,
+    failure_id bigint NOT NULL,
+    agent_id uuid NOT NULL,
+    status text DEFAULT 'pending'::text NOT NULL,
+    context jsonb NOT NULL,
+    recommendation jsonb,
+    outcome jsonb,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    completed_at timestamp with time zone
+);
+
+
+CREATE SEQUENCE dispatcher.diagnoses_diagnosis_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE dispatcher.diagnoses_diagnosis_id_seq OWNED BY dispatcher.diagnoses.diagnosis_id;
+
+
+CREATE TABLE dispatcher.failures (
+    failure_id bigint NOT NULL,
+    agent_id uuid,
+    category text NOT NULL,
+    detected_by text NOT NULL,
+    details jsonb DEFAULT '{}'::jsonb NOT NULL,
+    ts timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+COMMENT ON COLUMN dispatcher.failures.detected_by IS 'hook | scheduler | diagnoser — who wrote this row.';
+
+
+CREATE SEQUENCE dispatcher.failures_failure_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE dispatcher.failures_failure_id_seq OWNED BY dispatcher.failures.failure_id;
+
+
+CREATE TABLE dispatcher.notifications (
+    notification_id bigint NOT NULL,
+    kind text NOT NULL,
+    severity text NOT NULL,
+    issue_number integer,
+    pr_number integer,
+    body text NOT NULL,
+    issue_url text,
+    sent_at timestamp with time zone,
+    send_error text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+CREATE SEQUENCE dispatcher.notifications_notification_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE dispatcher.notifications_notification_id_seq OWNED BY dispatcher.notifications.notification_id;
+
+
+CREATE TABLE dispatcher.phase_outputs (
+    output_id bigint NOT NULL,
+    agent_id uuid NOT NULL,
+    phase text NOT NULL,
+    output_json jsonb NOT NULL,
+    ts timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+CREATE SEQUENCE dispatcher.phase_outputs_output_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE dispatcher.phase_outputs_output_id_seq OWNED BY dispatcher.phase_outputs.output_id;
+
+
+CREATE TABLE dispatcher.phase_transitions (
+    transition_id bigint NOT NULL,
+    agent_id uuid NOT NULL,
+    phase text NOT NULL,
+    ts timestamp with time zone DEFAULT now() NOT NULL,
+    autocompact_count integer DEFAULT 0 NOT NULL
+);
+
+
+COMMENT ON TABLE dispatcher.phase_transitions IS 'Append-only phase log; replaces tmp/agent-status/*.txt. Phase is free-form text; validation is daemon-side.';
+
+
+CREATE SEQUENCE dispatcher.phase_transitions_transition_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE dispatcher.phase_transitions_transition_id_seq OWNED BY dispatcher.phase_transitions.transition_id;
+
+
+CREATE TABLE dispatcher.retry_markers (
+    marker_id bigint NOT NULL,
+    agent_id uuid NOT NULL,
+    reason text NOT NULL,
+    attempt integer NOT NULL,
+    retry_after_ts timestamp with time zone NOT NULL,
+    resolved_at timestamp with time zone,
+    CONSTRAINT retry_markers_attempt_check CHECK (((attempt >= 1) AND (attempt <= 3)))
+);
+
+
+CREATE SEQUENCE dispatcher.retry_markers_marker_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE dispatcher.retry_markers_marker_id_seq OWNED BY dispatcher.retry_markers.marker_id;
+
+
+CREATE TABLE dispatcher.runs (
+    run_id uuid DEFAULT gen_random_uuid() NOT NULL,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    stopped_at timestamp with time zone,
+    heartbeat_ts timestamp with time zone DEFAULT now() NOT NULL,
+    version_sha text NOT NULL,
+    host text NOT NULL,
+    pid integer NOT NULL
+);
+
+
+COMMENT ON TABLE dispatcher.runs IS 'One row per daemon boot. Latest row is the active lease.';
+
+
+COMMENT ON COLUMN dispatcher.runs.heartbeat_ts IS 'Daemon updates every tick. CloudWatch alarm pages if stale > 5min.';
+
+
+COMMENT ON COLUMN dispatcher.runs.version_sha IS 'Git SHA of the daemon build; supports forensic questions after a crash.';
+
+
 CREATE TABLE public.alert_events (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     subscription_id uuid NOT NULL,
@@ -467,6 +685,27 @@ COMMENT ON COLUMN telemetry.validation_results.latency_ms IS 'Wall-clock time fo
 ALTER TABLE ONLY derived.court_directory_snapshots ALTER COLUMN id SET DEFAULT nextval('derived.court_directory_snapshots_id_seq'::regclass);
 
 
+ALTER TABLE ONLY dispatcher.commands ALTER COLUMN command_id SET DEFAULT nextval('dispatcher.commands_command_id_seq'::regclass);
+
+
+ALTER TABLE ONLY dispatcher.diagnoses ALTER COLUMN diagnosis_id SET DEFAULT nextval('dispatcher.diagnoses_diagnosis_id_seq'::regclass);
+
+
+ALTER TABLE ONLY dispatcher.failures ALTER COLUMN failure_id SET DEFAULT nextval('dispatcher.failures_failure_id_seq'::regclass);
+
+
+ALTER TABLE ONLY dispatcher.notifications ALTER COLUMN notification_id SET DEFAULT nextval('dispatcher.notifications_notification_id_seq'::regclass);
+
+
+ALTER TABLE ONLY dispatcher.phase_outputs ALTER COLUMN output_id SET DEFAULT nextval('dispatcher.phase_outputs_output_id_seq'::regclass);
+
+
+ALTER TABLE ONLY dispatcher.phase_transitions ALTER COLUMN transition_id SET DEFAULT nextval('dispatcher.phase_transitions_transition_id_seq'::regclass);
+
+
+ALTER TABLE ONLY dispatcher.retry_markers ALTER COLUMN marker_id SET DEFAULT nextval('dispatcher.retry_markers_marker_id_seq'::regclass);
+
+
 ALTER TABLE ONLY telemetry.data_quality_metrics ALTER COLUMN id SET DEFAULT nextval('telemetry.data_quality_metrics_id_seq'::regclass);
 
 
@@ -548,6 +787,46 @@ ALTER TABLE ONLY derived.case_parties
 
 ALTER TABLE ONLY derived.rulings
     ADD CONSTRAINT uq_rulings_document_id UNIQUE (document_id);
+
+
+ALTER TABLE ONLY dispatcher.agents
+    ADD CONSTRAINT agents_pkey PRIMARY KEY (agent_id);
+
+
+ALTER TABLE ONLY dispatcher.commands
+    ADD CONSTRAINT commands_pkey PRIMARY KEY (command_id);
+
+
+ALTER TABLE ONLY dispatcher.config
+    ADD CONSTRAINT config_pkey PRIMARY KEY (key);
+
+
+ALTER TABLE ONLY dispatcher.diagnoses
+    ADD CONSTRAINT diagnoses_pkey PRIMARY KEY (diagnosis_id);
+
+
+ALTER TABLE ONLY dispatcher.failures
+    ADD CONSTRAINT failures_pkey PRIMARY KEY (failure_id);
+
+
+ALTER TABLE ONLY dispatcher.notifications
+    ADD CONSTRAINT notifications_pkey PRIMARY KEY (notification_id);
+
+
+ALTER TABLE ONLY dispatcher.phase_outputs
+    ADD CONSTRAINT phase_outputs_pkey PRIMARY KEY (output_id);
+
+
+ALTER TABLE ONLY dispatcher.phase_transitions
+    ADD CONSTRAINT phase_transitions_pkey PRIMARY KEY (transition_id);
+
+
+ALTER TABLE ONLY dispatcher.retry_markers
+    ADD CONSTRAINT retry_markers_pkey PRIMARY KEY (marker_id);
+
+
+ALTER TABLE ONLY dispatcher.runs
+    ADD CONSTRAINT runs_pkey PRIMARY KEY (run_id);
 
 
 ALTER TABLE ONLY public.alert_events
@@ -707,6 +986,42 @@ CREATE INDEX idx_rulings_posted_at ON derived.rulings USING btree (posted_at DES
 CREATE UNIQUE INDEX uq_rulings_case_text_hash ON derived.rulings USING btree (case_id, ruling_text_hash) WHERE (ruling_text_hash IS NOT NULL);
 
 
+CREATE INDEX idx_dispatcher_agents_issue_number ON dispatcher.agents USING btree (issue_number);
+
+
+CREATE INDEX idx_dispatcher_agents_running ON dispatcher.agents USING btree (status) WHERE (status = 'running'::text);
+
+
+CREATE INDEX idx_dispatcher_commands_unconsumed ON dispatcher.commands USING btree (consumed_at) WHERE (consumed_at IS NULL);
+
+
+CREATE INDEX idx_dispatcher_diagnoses_agent_id ON dispatcher.diagnoses USING btree (agent_id);
+
+
+CREATE INDEX idx_dispatcher_diagnoses_pending ON dispatcher.diagnoses USING btree (status) WHERE (status = 'pending'::text);
+
+
+CREATE INDEX idx_dispatcher_failures_category_ts ON dispatcher.failures USING btree (category, ts DESC);
+
+
+CREATE INDEX idx_dispatcher_failures_ts ON dispatcher.failures USING btree (ts DESC);
+
+
+CREATE INDEX idx_dispatcher_notifications_created_at ON dispatcher.notifications USING btree (created_at DESC);
+
+
+CREATE INDEX idx_dispatcher_notifications_human_attention_unsent ON dispatcher.notifications USING btree (severity, sent_at) WHERE (severity = 'human_attention'::text);
+
+
+CREATE UNIQUE INDEX idx_dispatcher_phase_outputs_agent_phase ON dispatcher.phase_outputs USING btree (agent_id, phase);
+
+
+CREATE INDEX idx_dispatcher_phase_transitions_agent_ts ON dispatcher.phase_transitions USING btree (agent_id, ts DESC);
+
+
+CREATE INDEX idx_dispatcher_retry_markers_pending ON dispatcher.retry_markers USING btree (retry_after_ts) WHERE (resolved_at IS NULL);
+
+
 CREATE INDEX idx_alert_events_sub_id ON public.alert_events USING btree (subscription_id);
 
 
@@ -841,6 +1156,34 @@ ALTER TABLE ONLY derived.rulings
 
 ALTER TABLE ONLY derived.rulings
     ADD CONSTRAINT rulings_judge_id_fkey FOREIGN KEY (judge_id) REFERENCES derived.judges(id);
+
+
+ALTER TABLE ONLY dispatcher.agents
+    ADD CONSTRAINT agents_parent_run_id_fkey FOREIGN KEY (parent_run_id) REFERENCES dispatcher.runs(run_id);
+
+
+ALTER TABLE ONLY dispatcher.diagnoses
+    ADD CONSTRAINT diagnoses_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES dispatcher.agents(agent_id);
+
+
+ALTER TABLE ONLY dispatcher.diagnoses
+    ADD CONSTRAINT diagnoses_failure_id_fkey FOREIGN KEY (failure_id) REFERENCES dispatcher.failures(failure_id);
+
+
+ALTER TABLE ONLY dispatcher.failures
+    ADD CONSTRAINT failures_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES dispatcher.agents(agent_id);
+
+
+ALTER TABLE ONLY dispatcher.phase_outputs
+    ADD CONSTRAINT phase_outputs_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES dispatcher.agents(agent_id);
+
+
+ALTER TABLE ONLY dispatcher.phase_transitions
+    ADD CONSTRAINT phase_transitions_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES dispatcher.agents(agent_id);
+
+
+ALTER TABLE ONLY dispatcher.retry_markers
+    ADD CONSTRAINT retry_markers_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES dispatcher.agents(agent_id);
 
 
 ALTER TABLE ONLY public.alert_events


### PR DESCRIPTION
## Summary

Creates the full `dispatcher.*` schema per `docs/specs/dispatcher-v2-spec.md` §18 — the state foundation for dispatcher v2 Phase 1 (daemon skeleton in sub-task C, admin GraphQL queries in D, admin page in E). Ten tables, five partial indexes, and eight seeded `dispatcher.config` rows. `dispatcher_daemon` role + GRANTs are deferred to sub-task B (TODO documented in the migration) so this PR stays focused on the state foundation.

Closes #2727

## Changes

- `packages/api/migrations/21_dispatcher-schema.sql` — new migration creating `dispatcher.runs / agents / phase_transitions / failures / retry_markers / commands / config / diagnoses / phase_outputs / notifications` + indexes + config seed.
- `packages/api/src/data-access/schema.sql` — regenerated from migrations (now "Generated from 21 migrations").

## Design notes

- Dispatcher schema is intentionally NOT added to `search_path`. All dispatcher references are fully-qualified (`dispatcher.runs`, `dispatcher.config`, etc.), mirroring the convention adopted for `derived.*` and `telemetry.*` in migration 15.
- `phase_transitions.phase` is free-form TEXT (not an enum) so adding a new phase name does not require a migration — validation lives in the daemon (§17 operational trap 7).
- Config seed has 8 keys (matching §18 DDL). Acceptance criterion #3 said "7 keys" but §18 lists 8 — flagged in the process summary on the issue so reviewers can confirm the AC number is a typo.

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green (especially `schema-drift-check` and `migration-files-check`)

### Local verification (already run)
- `scripts/check-migration-files.sh` → "Migrations 1 through 21 are present and sequential."
- `scripts/check_schema_drift.sh --ci` → `=== PASS: schema.sql matches migrations ===`
- Applied to local Postgres and verified all 10 tables, 8 config keys, and all 5 partial indexes exist (evidence in the process-summary comment on #2727).

### Post-deploy verification
- [ ] After `deploy-api.yml` runs migrations on dev, run `scripts/dev-db-query.sh "SELECT tablename FROM pg_tables WHERE schemaname='dispatcher' ORDER BY tablename;"` and confirm all 10 tables.
- [ ] `scripts/dev-db-query.sh "SELECT key FROM dispatcher.config ORDER BY key;"` returns all 8 seeded keys.
- [ ] Verification evidence posted on issue (see task skill A.8).
