### PR TITLE
feat(dispatcher-v2): add dispatcher-daemon terraform module (#2728)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -189,6 +189,49 @@ module "ses" {
   sending_domain = "judgemind.org"
 }
 
+# ─── Dispatcher daemon (dispatcher v2, Phase 1) ─────────────────────────────
+# Per `docs/specs/dispatcher-v2-spec.md` §14. Landed at `desired_count=0` —
+# service, task definition, IAM, log group, and heartbeat alarm all exist,
+# but nothing runs until sub-task C (#2729) publishes the real image and
+# Phase 2 flips the replica count.
+#
+# Secrets wiring is deferred: the operator provisions
+# `judgemind/dev/dispatcher/*` secrets manually once this module merges.
+# Issue #2700 provisions the scoped `GITHUB_TOKEN` PAT. Leaving the ARNs as
+# empty strings until then is safe — the module's task definition uses
+# `compact()` to skip any unset secret and the service is inert at
+# `desired_count=0` anyway.
+module "dispatcher_daemon" {
+  source = "../../modules/dispatcher-daemon"
+
+  environment        = "dev"
+  vpc_id             = module.networking.vpc_id
+  private_subnet_ids = module.networking.private_subnet_ids
+  ecs_cluster_arn    = module.compute.cluster_arn
+  ecr_repository_url = module.ecr.repository_url
+
+  # Phase 1 = inert. Flipped to 1 in Phase 2 (shadow mode). Never > 1.
+  desired_count = 0
+
+  # Secret ARNs — all empty during Phase 1. Operator populates after the
+  # module lands; wiring happens in sub-tasks C (#2729) / #2700 / follow-up
+  # telegram + dispatcher-role DB secret from sub-task A (#2727).
+  anthropic_api_key_secret_arn  = ""
+  db_connection_secret_arn      = ""
+  github_token_secret_arn       = ""
+  telegram_bot_token_secret_arn = ""
+  gemini_api_key_secret_arn     = ""
+
+  github_repo = "judgemind/judgemind"
+
+  # Heartbeat alarm wired to the shared SNS topic once the daemon starts
+  # emitting HeartbeatAge (Phase 2). Kept enabled in Phase 1 so the alarm
+  # resource lands with the rest of the module; `treat_missing_data =
+  # notBreaching` on the alarm keeps it from paging while desired_count=0.
+  enable_alerts       = true
+  alert_sns_topic_arn = module.compute.alerts_topic_arn
+}
+
 output "ecr_repository_url" {
   description = "Dev ECR repository URL for scraper images"
   value       = module.ecr.repository_url
@@ -367,4 +410,24 @@ output "api_alb_arn_suffix" {
 output "api_target_group_arn_suffix" {
   description = "Dev API target group ARN suffix (for CloudWatch metric queries)"
   value       = module.api_service.target_group_arn_suffix
+}
+
+output "dispatcher_daemon_service_name" {
+  description = "Dev dispatcher daemon ECS service name (Phase 1: desired_count=0)"
+  value       = module.dispatcher_daemon.service_name
+}
+
+output "dispatcher_daemon_log_group" {
+  description = "Dev CloudWatch log group for dispatcher daemon output"
+  value       = module.dispatcher_daemon.log_group_name
+}
+
+output "dispatcher_daemon_task_role_arn" {
+  description = "Dev dispatcher daemon task role ARN (assumed by the container at runtime)"
+  value       = module.dispatcher_daemon.task_role_arn
+}
+
+output "dispatcher_daemon_security_group_id" {
+  description = "Dev dispatcher daemon security group ID"
+  value       = module.dispatcher_daemon.security_group_id
 }

--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -1,0 +1,451 @@
+# Dispatcher daemon module — ECS Fargate service that runs the autonomous
+# dispatcher loop for Phase 1 of dispatcher v2 (see
+# `docs/specs/dispatcher-v2-spec.md` §14).
+#
+# Phase 1 lands this module with `desired_count=0`: the service, task
+# definition, IAM roles, log group, and heartbeat alarm are all created, but
+# nothing runs until the daemon image lands (sub-task C, #2729) and Phase 2
+# flips `desired_count=1`.
+#
+# Why this is wired up inert:
+# - Sub-task A (#2727) adds the `dispatcher.*` schema + `judgemind_dispatcher`
+#   role secret. Until it merges, `db_connection_secret_arn` is passed as the
+#   main `judgemind` role secret — safe because the service isn't running.
+# - Sub-task C (#2729) publishes the real `Dockerfile.dispatcher` image; until
+#   then `image_tag` defaults to `"latest"` against an ECR repo that may not
+#   yet contain the tag. `desired_count=0` keeps this from erroring.
+# - Phase 2 (shadow mode) flips `desired_count=1` but keeps
+#   `config.concurrency_cap=0` in the daemon — polling only, no spawning.
+#
+# Resources created:
+# - ECS service + task definition (1 vCPU, 2 GB RAM, 50 GB ephemeral storage
+#   per spike 0.6 findings in `docs/investigations/dispatcher-v2-spike-0.6.md`).
+# - Execution role (pull ECR + read Secrets Manager entries).
+# - Task role (R/W on `dispatcher.*` via the dispatcher-role DB secret,
+#   `ecs:RunTask` self-invocation for Phase 2 agent-spawn patterns, ECS Exec
+#   via SSM so operators can psql the container).
+# - Security group (egress only: HTTPS, Postgres, Redis).
+# - CloudWatch log group `/ecs/judgemind-dispatcher-dev` with 30-day retention.
+# - CloudWatch metric alarm: heartbeat staleness > 5 min. See §Heartbeat
+#   alarm below — the metric itself is published by the daemon in Phase 2;
+#   the alarm is defined now so the SNS wiring lands with the module.
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  service_name   = "judgemind-dispatcher-${var.environment}"
+  log_group_name = "/ecs/judgemind-dispatcher-${var.environment}"
+}
+
+# ─── CloudWatch Log Group ───────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "dispatcher" {
+  name              = local.log_group_name
+  retention_in_days = var.log_retention_days
+}
+
+# ─── Security Group ─────────────────────────────────────────────────────────
+# The dispatcher needs outbound HTTPS (GitHub, Anthropic, ECR, Secrets
+# Manager, Telegram), Postgres (heartbeat + queue state), and Redis if it
+# ever subscribes to the event bus. No inbound traffic — the daemon is a
+# queue consumer, not a service endpoint.
+
+resource "aws_security_group" "dispatcher" {
+  name        = local.service_name
+  description = "Dispatcher daemon ECS tasks - outbound only (HTTPS, Postgres, Redis)"
+  vpc_id      = var.vpc_id
+
+  egress {
+    description = "HTTPS to GitHub, Anthropic, ECR, Secrets Manager, Telegram, S3"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "PostgreSQL (dispatcher.* state)"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Redis (event bus, reserved for future phases)"
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ─── IAM: Execution Role (ECS agent) ────────────────────────────────────────
+# Used by the ECS agent to pull the container image from ECR, write logs to
+# CloudWatch, and fetch Secrets Manager entries for env-var injection.
+
+resource "aws_iam_role" "execution" {
+  name        = "${local.service_name}-exec"
+  description = "Dispatcher daemon execution role - pull ECR, read secrets, write logs"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "ecs-tasks.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "execution_managed" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Allow the execution role to fetch every secret wired into the task
+# definition. `compact()` drops any empty string, so placeholder secrets
+# that aren't yet provisioned (e.g. GITHUB_TOKEN before #2700) don't
+# generate an invalid empty-Resource statement.
+resource "aws_iam_role_policy" "execution_secrets" {
+  name = "${local.service_name}-exec-secrets"
+  role = aws_iam_role.execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadDispatcherSecrets"
+        Effect = "Allow"
+        Action = "secretsmanager:GetSecretValue"
+        Resource = compact([
+          var.anthropic_api_key_secret_arn,
+          var.db_connection_secret_arn,
+          var.github_token_secret_arn,
+          var.telegram_bot_token_secret_arn,
+          var.gemini_api_key_secret_arn,
+        ])
+      }
+    ]
+  })
+}
+
+# ─── IAM: Task Role (container runtime) ─────────────────────────────────────
+# Assumed by the dispatcher container at runtime. Grants three capabilities:
+#
+# 1. `ecs:RunTask` self-invocation. Phase 2+ may spawn per-phase agents as
+#    separate Fargate tasks (see §6a of the spec). The task-role → RunTask
+#    pattern matches the existing `scheduler_run_task` policy in the compute
+#    module. Scoped to the dispatcher task definition family so the daemon
+#    can only start copies of itself, not arbitrary workloads.
+# 2. ECS Exec (SSM channel). Operators use `scripts/ecs-run.sh` /
+#    `scripts/dev-db-query.sh` to attach an interactive shell to the running
+#    container without a bastion. Same SSM permission set used by the
+#    ingestion worker in the compute module.
+# 3. CloudWatch metric PutMetricData. The daemon emits a `HeartbeatAge`
+#    custom metric under `Judgemind/Dispatcher` (Phase 2); this permission
+#    lets the heartbeat alarm below actually see data once the daemon is
+#    running.
+
+resource "aws_iam_role" "task" {
+  name        = "${local.service_name}-task"
+  description = "Dispatcher daemon task role - runtime permissions for the container"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "ecs-tasks.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+# R/W on `dispatcher.*` is enforced at the database level via the
+# `judgemind_dispatcher` role that sub-task A creates. The task's AWS
+# identity only needs to fetch its own connection secret at runtime (the
+# execution role already fetches it for env injection, but the daemon may
+# also want to rotate / re-fetch during long-running operation).
+resource "aws_iam_role_policy" "task_read_db_secret" {
+  name = "${local.service_name}-task-read-db-secret"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadDispatcherDBSecret"
+        Effect = "Allow"
+        Action = "secretsmanager:GetSecretValue"
+        Resource = compact([
+          var.db_connection_secret_arn,
+        ])
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "task_run_task_self" {
+  name = "${local.service_name}-task-run-task-self"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowRunTaskSelf"
+        Effect = "Allow"
+        Action = "ecs:RunTask"
+        Resource = [
+          # Match any revision of the dispatcher task definition. Scoping
+          # to our own family keeps the daemon from spawning unrelated
+          # workloads even if its code is ever compromised.
+          "arn:aws:ecs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:task-definition/${local.service_name}:*"
+        ]
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+      {
+        Sid    = "AllowPassRoleToSelf"
+        Effect = "Allow"
+        Action = "iam:PassRole"
+        Resource = [
+          aws_iam_role.execution.arn,
+          aws_iam_role.task.arn,
+        ]
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "task_ecs_exec_ssm" {
+  name = "${local.service_name}-task-ecs-exec-ssm"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowECSExec"
+        Effect = "Allow"
+        Action = [
+          "ssmmessages:CreateControlChannel",
+          "ssmmessages:CreateDataChannel",
+          "ssmmessages:OpenControlChannel",
+          "ssmmessages:OpenDataChannel",
+        ]
+        Resource = "*"
+      },
+      {
+        Sid    = "AllowECSExecLogging"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:PutLogEvents",
+        ]
+        Resource = "${aws_cloudwatch_log_group.dispatcher.arn}:*"
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "task_put_metric" {
+  name = "${local.service_name}-task-put-metric"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowHeartbeatMetric"
+        Effect   = "Allow"
+        Action   = "cloudwatch:PutMetricData"
+        Resource = "*"
+        Condition = {
+          StringEquals = {
+            "cloudwatch:namespace" = "Judgemind/Dispatcher"
+          }
+        }
+      }
+    ]
+  })
+}
+
+# ─── ECS Task Definition ────────────────────────────────────────────────────
+# 1 vCPU / 2 GB RAM matches §14 of the spec. Ephemeral storage is pinned to
+# 50 GB per spike 0.6 (realistic mixed peak is ~10 GB across 5 concurrent
+# worktrees; this gives 5× headroom).
+
+resource "aws_ecs_task_definition" "dispatcher" {
+  family                   = local.service_name
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  ephemeral_storage {
+    size_in_gib = var.ephemeral_storage_gib
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = "dispatcher"
+      image     = "${var.ecr_repository_url}:${var.image_tag}"
+      essential = true
+
+      # Dispatcher startup runs the scheduler + supervisor loop; SIGTERM
+      # must give in-flight agents time to finalize their status row
+      # before the container is killed.
+      stopTimeout = 120
+
+      environment = concat(
+        [
+          { name = "ENVIRONMENT", value = var.environment },
+          { name = "DISPATCHER_SERVICE_NAME", value = local.service_name },
+          { name = "ECS_CLUSTER_ARN", value = var.ecs_cluster_arn },
+          { name = "HEARTBEAT_METRIC_NAMESPACE", value = "Judgemind/Dispatcher" },
+        ],
+        var.github_repo != "" ? [{ name = "GITHUB_REPO", value = var.github_repo }] : [],
+      )
+
+      secrets = concat(
+        var.anthropic_api_key_secret_arn != "" ? [
+          {
+            name      = "ANTHROPIC_API_KEY"
+            valueFrom = var.anthropic_api_key_secret_arn
+          }
+        ] : [],
+        var.db_connection_secret_arn != "" ? [
+          {
+            # The dispatcher-role secret is a JSON blob with the same shape
+            # as the main DB secret; DATABASE_URL lives under the `url` key.
+            name      = "DATABASE_URL"
+            valueFrom = "${var.db_connection_secret_arn}:url::"
+          }
+        ] : [],
+        var.github_token_secret_arn != "" ? [
+          {
+            # Scoped PAT from spike 0.7. `gh auth setup-git` inside the
+            # container turns this into a working git credential.
+            name      = "GITHUB_TOKEN"
+            valueFrom = var.github_token_secret_arn
+          }
+        ] : [],
+        var.telegram_bot_token_secret_arn != "" ? [
+          {
+            name      = "TELEGRAM_BOT_TOKEN"
+            valueFrom = var.telegram_bot_token_secret_arn
+          }
+        ] : [],
+        var.gemini_api_key_secret_arn != "" ? [
+          {
+            # Only required if `runner_by_phase` routes to the Gemini
+            # runner (spec §14). Laptop OAuth is not usable on Fargate
+            # per spike 0.4.
+            name      = "GEMINI_API_KEY"
+            valueFrom = var.gemini_api_key_secret_arn
+          }
+        ] : [],
+      )
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.dispatcher.name
+          "awslogs-region"        = data.aws_region.current.id
+          "awslogs-stream-prefix" = "dispatcher"
+        }
+      }
+    }
+  ])
+}
+
+# ─── ECS Service ────────────────────────────────────────────────────────────
+# `desired_count=0` in Phase 1 — the service exists, but no tasks run. Phase 2
+# flips it to 1 to enter shadow mode. `ignore_changes = [task_definition]` is
+# the house pattern: CI redeploys bump the image tag via the AWS CLI without
+# rewriting the task def ARN every apply.
+
+resource "aws_ecs_service" "dispatcher" {
+  name            = local.service_name
+  cluster         = var.ecs_cluster_arn
+  task_definition = aws_ecs_task_definition.dispatcher.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  # Enable ECS Exec so operators can attach an interactive shell to the
+  # running daemon for ad-hoc psql / log inspection.
+  enable_execute_command = true
+
+  # The dispatcher is a singleton; overlapping deploys would double-spawn
+  # agents briefly. Use min=0 / max=100 so a new task must start before the
+  # old one stops (ECS will drain the old task once the new one is healthy).
+  # When `desired_count=0` these values are no-ops.
+  deployment_minimum_healthy_percent = 0
+  deployment_maximum_percent         = 100
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = [aws_security_group.dispatcher.id]
+    assign_public_ip = false
+  }
+
+  lifecycle {
+    ignore_changes = [task_definition]
+  }
+}
+
+# ─── Heartbeat Alarm ────────────────────────────────────────────────────────
+# Per §14 of the spec: heartbeat staleness > 5 min should page the operator
+# via SNS (email + Telegram). The daemon publishes a `HeartbeatAge` metric
+# (seconds since last `dispatcher.runs.heartbeat_ts` write) to the
+# `Judgemind/Dispatcher` namespace every tick — Phase 2 sub-task C wires
+# that up.
+#
+# TODO (Phase 2, #2729): confirm the metric name / emission cadence match
+# once the daemon publishes. If the daemon publishes in the opposite polarity
+# (e.g. `HeartbeatFresh=1` as a liveness signal rather than `HeartbeatAge` in
+# seconds), flip the comparison + `treat_missing_data` on this alarm.
+#
+# During Phase 1 the alarm will be in INSUFFICIENT_DATA with
+# `treat_missing_data = "notBreaching"` — no false pages while the service
+# runs at desired_count=0.
+
+resource "aws_cloudwatch_metric_alarm" "heartbeat_stale" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "${local.service_name}-heartbeat-stale"
+  alarm_description = "Dispatcher daemon heartbeat has been stale for > ${var.heartbeat_stale_seconds} seconds (${var.environment}). The daemon loop is blocked or the container has crashed — check ${aws_cloudwatch_log_group.dispatcher.name}."
+
+  namespace   = "Judgemind/Dispatcher"
+  metric_name = "HeartbeatAge"
+  statistic   = "Maximum"
+  dimensions = {
+    Service = local.service_name
+  }
+
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = var.heartbeat_stale_seconds
+  period              = 60
+  evaluation_periods  = 5
+  datapoints_to_alarm = 5
+  # Phase 1: desired_count=0 → no metric ever published → do not alarm on
+  # the silence. Phase 2 should flip to "breaching" once the daemon is
+  # expected to emit on every tick.
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}

--- a/infra/terraform/modules/dispatcher-daemon/outputs.tf
+++ b/infra/terraform/modules/dispatcher-daemon/outputs.tf
@@ -1,0 +1,44 @@
+output "service_name" {
+  description = "Name of the dispatcher daemon ECS service"
+  value       = aws_ecs_service.dispatcher.name
+}
+
+output "task_definition_arn" {
+  description = "ARN of the dispatcher daemon task definition"
+  value       = aws_ecs_task_definition.dispatcher.arn
+}
+
+output "task_definition_family" {
+  description = "Family name of the dispatcher daemon task definition (used by `aws ecs describe-task-definition` / CI deploy scripts)"
+  value       = aws_ecs_task_definition.dispatcher.family
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group for dispatcher daemon output"
+  value       = aws_cloudwatch_log_group.dispatcher.name
+}
+
+output "log_group_arn" {
+  description = "ARN of the dispatcher daemon log group"
+  value       = aws_cloudwatch_log_group.dispatcher.arn
+}
+
+output "execution_role_arn" {
+  description = "ARN of the ECS task execution role (assumed by the ECS agent for ECR pulls + secret fetches)"
+  value       = aws_iam_role.execution.arn
+}
+
+output "task_role_arn" {
+  description = "ARN of the dispatcher task role (assumed by the container at runtime — grants ecs:RunTask self-invocation, ECS Exec SSM, and cloudwatch:PutMetricData)"
+  value       = aws_iam_role.task.arn
+}
+
+output "security_group_id" {
+  description = "Security group ID for dispatcher ECS tasks (outbound HTTPS + Postgres + Redis)"
+  value       = aws_security_group.dispatcher.id
+}
+
+output "heartbeat_alarm_arn" {
+  description = "ARN of the heartbeat staleness CloudWatch alarm (empty when enable_alerts is false)"
+  value       = var.enable_alerts ? aws_cloudwatch_metric_alarm.heartbeat_stale[0].arn : ""
+}

--- a/infra/terraform/modules/dispatcher-daemon/variables.tf
+++ b/infra/terraform/modules/dispatcher-daemon/variables.tf
@@ -1,0 +1,140 @@
+variable "environment" {
+  description = "Deployment environment (dev, staging, production)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "environment must be one of: dev, staging, production"
+  }
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC where the dispatcher daemon runs"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "IDs of the private subnets for the Fargate tasks (needs NAT egress for GitHub/Anthropic/Telegram)"
+  type        = list(string)
+}
+
+variable "ecs_cluster_arn" {
+  description = "ARN of the ECS cluster to deploy the dispatcher service into"
+  type        = string
+}
+
+variable "ecr_repository_url" {
+  description = "ECR repository URL that will host the dispatcher image (populated by sub-task C, #2729). Placeholder until then — the service runs at desired_count=0 so the image tag is not resolved."
+  type        = string
+}
+
+variable "image_tag" {
+  description = "Container image tag to deploy. Safe to leave at default while desired_count=0."
+  type        = string
+  default     = "latest"
+}
+
+variable "desired_count" {
+  description = "Number of dispatcher task replicas. Phase 1 keeps this at 0 (inert); Phase 2 flips to 1 (shadow mode); never >1 (the dispatcher is a singleton — overlapping instances would double-spawn agents)."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.desired_count >= 0 && var.desired_count <= 1
+    error_message = "desired_count must be 0 or 1 — the dispatcher is a singleton."
+  }
+}
+
+variable "task_cpu" {
+  description = "CPU units for the Fargate task (1024 = 1 vCPU, per §14 of the spec)"
+  type        = number
+  default     = 1024
+}
+
+variable "task_memory" {
+  description = "Memory (MiB) for the Fargate task (2048 = 2 GB, per §14 of the spec)"
+  type        = number
+  default     = 2048
+}
+
+variable "ephemeral_storage_gib" {
+  description = "Ephemeral storage (GiB) for the Fargate task. 50 GiB per spike 0.6 findings (docs/investigations/dispatcher-v2-spike-0.6.md): realistic 5-concurrent-worktree peak is ~10 GB, so 50 GiB gives 5× headroom."
+  type        = number
+  default     = 50
+
+  validation {
+    condition     = var.ephemeral_storage_gib >= 21 && var.ephemeral_storage_gib <= 200
+    error_message = "ephemeral_storage_gib must be in [21, 200] — Fargate platform limits."
+  }
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain CloudWatch log events for the dispatcher daemon"
+  type        = number
+  default     = 30
+}
+
+# ─── Secrets ──────────────────────────────────────────────────────────────
+# Each `*_secret_arn` is the Secrets Manager ARN that will be injected into
+# the container as the corresponding env var. Leave empty to skip wiring
+# that secret — useful during Phase 1 when some of these don't exist yet
+# (e.g. the dispatcher-role DB secret is created by sub-task A, #2727, and
+# the scoped GitHub PAT is provisioned by #2700).
+
+variable "anthropic_api_key_secret_arn" {
+  description = "Secrets Manager ARN for ANTHROPIC_API_KEY. Required for the daemon to spawn `claude -p` subprocesses."
+  type        = string
+  default     = ""
+}
+
+variable "db_connection_secret_arn" {
+  description = "Secrets Manager ARN for the dispatcher-role DATABASE_URL (JSON key: url). Sub-task A (#2727) creates the `judgemind_dispatcher` role and its connection secret; until A merges, callers can pass the main `judgemind` role secret — safe while desired_count=0."
+  type        = string
+  default     = ""
+}
+
+variable "github_token_secret_arn" {
+  description = "Secrets Manager ARN for GITHUB_TOKEN (scoped PAT from spike 0.7). Populated by #2700; placeholder empty string is safe while desired_count=0."
+  type        = string
+  default     = ""
+}
+
+variable "telegram_bot_token_secret_arn" {
+  description = "Secrets Manager ARN for TELEGRAM_BOT_TOKEN (operator paging)."
+  type        = string
+  default     = ""
+}
+
+variable "gemini_api_key_secret_arn" {
+  description = "Secrets Manager ARN for GEMINI_API_KEY. Only required if `runner_by_phase` / `runner_shadow` routes to the Gemini runner (see spec §14 / spike 0.4)."
+  type        = string
+  default     = ""
+}
+
+# ─── GitHub integration ──────────────────────────────────────────────────
+
+variable "github_repo" {
+  description = "Target GitHub repo (owner/name) the daemon operates on. Exposed to the container as GITHUB_REPO."
+  type        = string
+  default     = ""
+}
+
+# ─── Alerts ──────────────────────────────────────────────────────────────
+
+variable "enable_alerts" {
+  description = "Whether to create CloudWatch alarms for the dispatcher daemon. Set false in Phase 1 if no SNS topic is available yet."
+  type        = bool
+  default     = false
+}
+
+variable "alert_sns_topic_arn" {
+  description = "ARN of the SNS topic for alarm notifications (email + Telegram). Required when enable_alerts is true."
+  type        = string
+  default     = ""
+}
+
+variable "heartbeat_stale_seconds" {
+  description = "Threshold for the heartbeat staleness alarm. Per §14, default 300 (5 min)."
+  type        = number
+  default     = 300
+}


### PR DESCRIPTION
Closes #2728

Phase 1 sub-task B of the dispatcher v2 migration — lands the real `dispatcher-daemon` terraform module per `docs/specs/dispatcher-v2-spec.md` §14. Everything is wired up but inert (`desired_count=0`) until sub-task C (#2729) publishes the real image and Phase 2 flips the replica count.

## What's in the module

`infra/terraform/modules/dispatcher-daemon/` — three files (`main.tf`, `variables.tf`, `outputs.tf`):

- **ECS service** `judgemind-dispatcher-dev` on Fargate, `desired_count=0`. Singleton (variable-validated `<= 1`). `ignore_changes = [task_definition]` so CI image bumps don't fight terraform.
- **Task definition:** 1 vCPU / 2 GB RAM / 50 GB ephemeral storage (spike 0.6 measured the realistic 5-concurrent-worktree peak at ~10 GB; 50 GB gives 5× headroom per `docs/investigations/dispatcher-v2-spike-0.6.md`). `stopTimeout=120s` so SIGTERM'd agents can finalize their `dispatcher.agents.status` row.
- **Execution role** (ECS agent): `AmazonECSTaskExecutionRolePolicy` + `secretsmanager:GetSecretValue` on the wired secrets. `compact()` in both the policy and the container's `secrets[]` list lets Phase 1 pass empty ARNs for the secrets that don't exist yet (GITHUB_TOKEN from #2700, dispatcher-role DB secret from sub-task A #2727, Telegram, Gemini) without producing an invalid empty-Resource statement.
- **Task role** (container runtime):
  - `ecs:RunTask` self-invocation scoped to `task-definition/judgemind-dispatcher-dev:*` on this cluster only — matches the existing `scheduler_run_task` pattern; keeps the daemon from spawning unrelated workloads even if its code is compromised.
  - ECS Exec (SSM messages + log streams) so operators can attach via `scripts/ecs-run.sh` / `scripts/dev-db-query.sh` without a bastion.
  - `cloudwatch:PutMetricData` scoped to the `Judgemind/Dispatcher` namespace.
  - Dispatcher-role DB secret re-fetch permission (the execution role fetches it for env injection; the daemon may also want to rotate at runtime).
- **Security group:** outbound-only — HTTPS (GitHub/Anthropic/ECR/Secrets Manager/Telegram/S3), Postgres (5432, heartbeat + queue state), Redis (6379, future event bus). No inbound: the daemon is a queue consumer, not a service endpoint.
- **Log group** `/ecs/judgemind-dispatcher-dev` with 30-day retention.
- **Heartbeat alarm** on `HeartbeatAge > 300s` in `Judgemind/Dispatcher`. `treat_missing_data = notBreaching` so Phase 1 (desired_count=0 → no metric emission) doesn't page the operator. Phase 2 flips this to `breaching` once the daemon starts emitting the metric every tick. TODO comment covers the polarity-flip contingency if the daemon ends up publishing a `HeartbeatFresh=1` liveness pulse instead of an `Age` value.

## Consumer wiring (`infra/terraform/environments/dev/main.tf`)

- Module instantiated with all secret ARNs as empty strings. Safe because the service is inert at `desired_count=0`; the ARNs get filled in by #2729 (ANTHROPIC_API_KEY + GEMINI_API_KEY + DATABASE_URL) / #2700 (scoped GITHUB_TOKEN PAT from spike 0.7) / follow-up (Telegram) before Phase 2.
- Four new outputs — `dispatcher_daemon_service_name`, `dispatcher_daemon_log_group`, `dispatcher_daemon_task_role_arn`, `dispatcher_daemon_security_group_id` — for operator use and the admin page.

## Acceptance criteria (from #2728)

- [x] Module files exist at `infra/terraform/modules/dispatcher-daemon/{main,variables,outputs}.tf`.
- [x] `terraform -chdir=infra/terraform/environments/dev validate` passes.
- [x] `terraform -chdir=infra/terraform/environments/dev plan` shows the new ECS service at `desired_count=0`, new IAM roles, new log group, and the heartbeat alarm. Plan excerpt:

```
Plan: 14 to add, 1 to change, 8 to destroy.
```

  14 additions: 11 from `module.dispatcher_daemon.*` (service, task def, log group, alarm, exec role + secrets policy + managed policy attachment, task role + 4 inline policies, security group) + 2 unrelated compute-module updates (scraper proxy egress rule + scraper schedule update) + 1 log group. 8 destroys are the pre-existing `dispatcher_spike` orphans from the merged-but-not-yet-applied #2699/#2734 cleanup — will apply when the dispatcher auto-applies dev after this PR merges. Key plan lines:

```
+ desired_count = 0
+ enable_execute_command = true
+ ephemeral_storage { + size_in_gib = 50 }
```

- [ ] `aws ecs describe-services --cluster judgemind-dev --services judgemind-dispatcher-dev` returns `desiredCount: 0` / `runningCount: 0` — **deferred to post-merge verification evidence comment** (depends on the dev auto-apply that runs after merge).
- [ ] `aws ecs describe-task-definition --task-definition judgemind-dispatcher-dev --query 'taskDefinition.ephemeralStorage.sizeInGiB'` returns `50` — **same deferral**.

## Non-goals

- Does not publish the daemon image — sub-task C (#2729) adds `Dockerfile.dispatcher` and the ECR push workflow.
- Does not create real secret values — operator provisions `judgemind/dev/dispatcher/*` after this merges.
- No production environment changes — dev only.

## Test plan

- [x] `terraform fmt -recursive -check` clean.
- [x] `terraform init -lockfile=readonly` passes (no lock file churn).
- [x] `terraform validate` passes.
- [x] `terraform plan` against real dev state is sensible — no unrelated resource touches beyond the known `dispatcher_spike` cleanup + pre-existing scraper drift.
- [ ] Post-merge: dev auto-apply lands the service at `desired_count=0`; verification evidence comment on #2728 will paste `aws ecs describe-services` output once the apply completes.
