### PR TITLE
feat(agent): promote /task-v2-* skills to production (#2732)

### DIFF
--- a/.agents/skills/task-v2-fix-ci
+++ b/.agents/skills/task-v2-fix-ci
@@ -1,0 +1,1 @@
+../../.claude/skills/task-v2-fix-ci

--- a/.agents/skills/task-v2-plan
+++ b/.agents/skills/task-v2-plan
@@ -1,0 +1,1 @@
+../../.claude/skills/task-v2-plan

--- a/.agents/skills/task-v2-ralph
+++ b/.agents/skills/task-v2-ralph
@@ -1,0 +1,1 @@
+../../.claude/skills/task-v2-ralph

--- a/.agents/skills/task-v2-retro
+++ b/.agents/skills/task-v2-retro
@@ -1,0 +1,1 @@
+../../.claude/skills/task-v2-retro

--- a/.agents/skills/task-v2-summary
+++ b/.agents/skills/task-v2-summary
@@ -1,0 +1,1 @@
+../../.claude/skills/task-v2-summary

--- a/.agents/skills/task-v2-verify
+++ b/.agents/skills/task-v2-verify
@@ -1,0 +1,1 @@
+../../.claude/skills/task-v2-verify

--- a/.claude/skills/task-v2-fix-ci/SKILL.md
+++ b/.claude/skills/task-v2-fix-ci/SKILL.md
@@ -1,66 +1,178 @@
 ---
-description: (WIP — dispatcher v2 spike 0.3 stub) Fix-CI phase for the per-phase /task-v2 pipeline. Reads CI failure logs + PR diff, produces a patch commit OR an explicit blocker signal.
-argument-hint: ""
-maxTurns: 50
-model: opus
+description: Fix-CI phase for the per-phase /task-v2 pipeline. Reads CI failure logs and the PR diff, produces a patch commit OR an explicit blocker signal.
+argument-hint: "<agent-id>"
+maxTurns: 100
+model: sonnet
 ---
 
-# /task-v2-fix-ci skill (WIP stub)
+# /task-v2-fix-ci skill
 
-**Status:** WIP — extracted from `.claude/skills/task/SKILL.md` A.5/A.7 (ci-fix loop) for dispatcher v2 spike 0.3.
+Fix-CI phase for the dispatcher v2 per-phase task pipeline (`docs/specs/dispatcher-v2-spec.md` §6a). Invoked by the daemon when `gh run watch` comes back red on a PR opened by the summary phase. Reads the failure logs, diagnoses the root cause, applies a targeted patch, and returns — OR returns an explicit BLOCKED/FLAKY signal so the daemon can route accordingly.
 
-**Goal:** Read failing CI logs from a PR, diagnose the failure, apply a fix in the worktree, and return. The daemon handles committing and pushing; this skill just produces the patch.
+**Prerequisites:** The dispatcher daemon has already (a) detected CI failure on the PR, (b) extracted the log tails from each failing job, (c) written the input bundle to `{worktree}/tmp/dispatcher-input/fix-ci.json`.
 
-**Input:** `{worktree}/tmp/dispatcher-input/fix-ci.json`:
-- `pr_number` (int)
-- `branch` (str)
-- `failing_jobs` (list of `{name, conclusion, log_tail}` objects — log_tail is last ~200 lines of each failing job)
-- `git_diff_base_to_head` (str) — full diff for context
-- `worktree_path` (str)
+**Goal:** Produce `{worktree}/tmp/dispatcher-output/fix-ci.json` with verdict=`PATCHED` (fix applied to working tree), `BLOCKED` (agent cannot fix — human needed), or `FLAKY` (rerun without code change).
 
-**Output:** `{worktree}/tmp/dispatcher-output/fix-ci.json`:
-- `verdict` (str) — `PATCHED`, `BLOCKED`, or `FLAKY`
-- `changed_files` (list of paths) — if verdict=PATCHED
-- `commit_message` (str) — if verdict=PATCHED
-- `block_reason` (str or null) — if verdict=BLOCKED, the specific failure the agent can't fix (e.g., "missing secret", "infrastructure error outside repo control")
-- `flaky_evidence` (str or null) — if verdict=FLAKY, reasoning (e.g., "intermittent timeout in network call, no code change needed — rerun")
+**IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation.
+
+**IMPORTANT — Smallest patch principle.** Apply the smallest patch that resolves the root cause. Do not refactor, do not rename, do not add defensive code unrelated to the failure. CI-fix commits are separately mergeable and must be easy to review — they accrete on top of the original summary commit.
+
+---
+
+## Input contract
+
+Read `{worktree}/tmp/dispatcher-input/fix-ci.json`. Required fields:
+
+- `agent_id` (str).
+- `issue_number` (int).
+- `pr_number` (int).
+- `branch` (str).
+- `failing_jobs` (list of `{name, conclusion, log_tail}`) — `log_tail` is the last ~200 lines of each failing job. The daemon uses `gh run view <id> --log-failed --job <job-id>` or the MCP equivalent.
+- `git_diff_base_to_head` (str) — full unified diff of the PR (so fix-ci can see what ralph changed).
+- `worktree_path` (str).
+- `repo_root` (str).
+- `previous_fix_attempts` (int) — how many times `/task-v2-fix-ci` has already run on this PR. 0 for first attempt.
+
+Optional:
+
+- `change_type` (str) — from plan output; helps categorize expected failure modes.
+
+If the file is missing or malformed, exit 0 with verdict=`BLOCKED, block_reason="input JSON missing or malformed"`.
+
+---
+
+## Output contract
+
+Write `{worktree}/tmp/dispatcher-output/fix-ci.json`:
+
+```
+{
+  "agent_id": "<echo>",
+  "pr_number": <int>,
+  "verdict": "PATCHED" | "BLOCKED" | "FLAKY",
+  "failure_category": "lint" | "format" | "type_error" | "test_failure" | "coverage_floor" |
+                       "infra_external" | "missing_secret_or_config" | "build_failure" |
+                       "markdown_links" | "hygiene_guard" | "ci_config" | "other",
+  "changed_files": ["<path>", ...],
+  "commit_message": "fix(<area>): <what was fixed> — CI (#<PR-N>)",
+  "block_reason": null | "<string>",
+  "flaky_evidence": null | "<string>",
+  "notes": "<optional prose for the retro phase>"
+}
+```
+
+- `PATCHED` — the worktree working tree contains the fix. `changed_files` and `commit_message` are populated. Daemon stages, commits, and pushes.
+- `BLOCKED` — the agent cannot fix this failure (missing secret, repo permissions, external infra beyond repo control, or fix-attempts exhausted). `block_reason` is populated with a concrete one-step human action. Daemon escalates to `status/needs-human` + `priority/p1`.
+- `FLAKY` — transient failure (intermittent timeout, AWS 5xx, etc.) with no code change needed. `flaky_evidence` explains. Daemon reruns the job once; second flaky → escalate.
+
+Always exit 0. Verdict comes from the JSON, not the exit code.
 
 ---
 
 ## Step 1 — Categorize the failure
 
-For each failing job, classify the root cause:
-- **Lint / format** — pattern: `ruff check` errors, `prettier --check` errors. Fix by running the formatter locally (`ruff check --fix`, `ruff format`, `npm run format`).
-- **Type error** — pattern: mypy/pyright/tsc errors. Fix by adjusting types or imports.
-- **Test failure** — pattern: `FAILED tests/...`, specific assertion traces. Fix by correcting code or updating test expectations (prefer correcting code).
-- **Coverage floor** — pattern: `Coverage X% < floor Y%`. Fix by adding tests for uncovered lines.
-- **Infra / external** — pattern: timeouts in network calls, AWS errors, GitHub API 5xx. Classify as FLAKY unless the code under test is demonstrably wrong.
-- **Missing secret / config** — pattern: `Error: KEY is not set`. Classify as BLOCKED (daemon or human must add the secret).
+For each `failing_jobs` entry, classify the root cause from the `log_tail`:
 
-## Step 2 — Apply the fix
+| Category | Pattern / signal | Fix path |
+|---|---|---|
+| `lint` | `ruff check` errors (e.g. `E501`, `F401`), ESLint errors | Run `ruff check --fix <files>` + `ruff format <files>`; for TS run `npm --prefix packages/web run lint -- --fix` |
+| `format` | `ruff format --check` reports diffs, Prettier complains | Run the formatter; commit the result |
+| `type_error` | mypy/pyright/tsc errors | Fix the types or imports; never add `# type: ignore` unless the type system is wrong AND you can justify |
+| `test_failure` | `FAILED tests/...`, assertion traces | Read the failing test, read the code under test, apply the smallest fix |
+| `coverage_floor` | `Coverage X% < floor Y%` or "diff coverage below 90%" | Add targeted tests for uncovered lines in the PR's diff |
+| `infra_external` | timeouts to `api.anthropic.com`, AWS 5xx, GitHub API 5xx, DNS errors | Classify as `FLAKY` |
+| `missing_secret_or_config` | `Error: <KEY> is not set`, `Secret "<name>" not found` | Classify as `BLOCKED` — the daemon or human must provision the secret |
+| `build_failure` | TypeScript build errors, missing module, webpack/next build fail | Read the error, fix the import/path/type |
+| `markdown_links` | `scripts/check-markdown-links.sh` failures | Fix the broken link paths |
+| `hygiene_guard` | `scripts/check-no-*.sh` / `check-forbidden-*.sh` / `check-deprecated-*.sh` guards, or `scripts/check-ci-job-skipped.sh` (the #2410/#2505 footgun) | Follow the guard's error message; per CLAUDE.md, self-matching names in ci.yml are the usual cause |
+| `ci_config` | `.github/workflows/*.yml` parse error, job definition malformed | Edit the workflow — but only if the failure is genuinely in the workflow, not in code that the workflow runs |
+| `other` | Not in the above | If you can't identify, classify as `BLOCKED` with a clear `block_reason` |
+
+**Unsafe shortcuts — do not use:**
+
+- `pytest.skip`, `@pytest.mark.skip`, or `xfail` on a failing test unless the test itself is wrong AND you can explain why in the commit message.
+- `# noqa`, `# type: ignore`, `@ts-ignore`, `eslint-disable` unless the linter/type-checker is wrong AND you can explain why.
+- Disabling a CI check by deleting its step or adding a conditional that skips it. Never.
+- `--force` on pre-push hooks or safety scripts.
+
+If a test is actually flaky (intermittent pass/fail with no code change), document that by marking FLAKY in the output — do NOT pre-emptively add retries or skip markers without filing a follow-up issue.
+
+## Step 2 — Reproduce locally (when feasible)
+
+For `test_failure` and `coverage_floor`, reproduce the failure in the worktree:
+
+- `pytest tests/path/to/test.py::TestClass::test_method -x` — run the single failing test.
+- `npm --prefix packages/web test -- --testPathPattern=<regex>` — narrow TS test run.
+- `ruff check packages/<pkg>/src/path/to/file.py` — reproduce a single lint error.
+
+Local reproduction confirms the fix before pushing. If the failure is environment-specific (only fails in CI), note that in `notes` and apply the fix based on the log analysis.
+
+For `infra_external`, do NOT try to reproduce — the failure is transient by definition.
+
+## Step 3 — Apply the fix
 
 For fixable categories:
-1. Read the specific file(s) referenced in the failure.
-2. Apply the smallest patch that resolves the issue.
-3. Run the same check locally if feasible (`ruff check`, `pytest path/to/test.py::TestClass::test_method`).
-4. Verify the fix resolves the root cause, not just the symptom.
 
-Do NOT disable tests or mask errors (e.g. `# noqa`, `# type: ignore`, `pytest.skip`) unless the test itself is wrong AND you can explain why. Prefer fixing the underlying code.
+1. Read the specific file(s) referenced in the failure. Use the Read tool, not `cat`.
+2. Apply the smallest patch that resolves the root cause. Prefer `Edit` over `Write` for existing files.
+3. Run the same check locally if feasible. Confirm it now passes.
+4. Verify the fix resolves the root cause, not just the symptom. Example: a test that asserts a field is non-null should be fixed by making the field non-null at its source, not by weakening the assertion.
+5. Re-check related files for the same pattern. If the fix applies to sibling files (e.g., the same typo in three similar test fixtures), fix all of them in the same commit.
 
-## Step 3 — Write output JSON
+For `coverage_floor`:
 
-For verdict=PATCHED:
-- `changed_files`: the files you edited.
-- `commit_message`: conventional-commits format, `fix(<area>): <what was fixed> — CI (#<PR-N>)`.
+- Read the diff of the PR to identify which lines are not covered.
+- Add tests that exercise those lines. Prefer tests colocated with existing test files for the same module.
+- Rerun coverage locally to confirm the floor passes.
 
-For verdict=BLOCKED:
-- Write a concrete `block_reason` that a human can act on in one step.
+For `hygiene_guard` failures in `.github/workflows/ci.yml` — the #2410/#2505 footgun is the most common cause. Follow the guard's own error message. If the guard is complaining about a job being SKIPPED on its own CI run, either modify a file that already matches the paths filter, or add `.github/workflows/ci.yml` to the filter.
 
-For verdict=FLAKY:
-- Write `flaky_evidence` describing why this is transient. The daemon will rerun the job once; if it fails again, escalate to human review.
+## Step 4 — Verify the fix locally
+
+Before writing the output JSON:
+
+- Rerun the exact check that failed. Confirm it now passes.
+- If multiple checks failed and you fixed a subset, note the unfixed ones in `notes` and keep verdict=`PATCHED` only if the remaining failures are FLAKY or subsequent to your fix.
+- If your fix introduces new failures in other checks (rare, but possible), iterate until everything passes or escalate to BLOCKED with specifics.
+
+## Step 5 — Write the output JSON
+
+For verdict=`PATCHED`:
+
+- `changed_files` — every file you edited.
+- `commit_message` — conventional commits: `fix(<area>): <what was fixed> — CI (#<PR-N>)`. Keep the subject under 72 chars. Example: `fix(scraping): correct ruff E501 in orange_county.py — CI (#2733)`.
+
+For verdict=`BLOCKED`:
+
+- `block_reason` — a concrete one-step action a human can take. Examples:
+  - `"Secret OPENAI_API_KEY not set in the ci environment — ops must provision via scripts/with-secret.sh or Terraform"`
+  - `"GitHub Actions cache quota exhausted; rerun after cache eviction"`
+  - `"Test hit a permission boundary that cannot be resolved from the agent — owner review needed"`
+
+For verdict=`FLAKY`:
+
+- `flaky_evidence` — explain why this is transient. Example: `"httpx.TimeoutError in packages/api/tests/test_claude_client.py — intermittent Anthropic API hiccup; retry recommended, no code change"`.
+
+---
+
+## What this skill does NOT do
+
+- **Does not commit, push, or call `gh`.** Daemon handles git + GitHub operations after reading this output.
+- **Does not edit CI workflow files unless the failure is genuinely in CI config.** Prefer fixing the code that CI caught.
+- **Does not add retries, timeouts, or flaky-test decorators** without human approval — that hides real bugs.
+- **Does not upgrade dependencies** as a "fix" for a test failure unless the failure is demonstrably caused by a known dependency bug with a filed upstream issue.
+- **Does not touch .env, secrets, or credentials.** BLOCKED is the correct response to missing-secret failures.
+
+## Escalation policy
+
+- **Attempt 1** — try to fix. Verdict=`PATCHED` if successful.
+- **Attempt 2** — if the first fix itself landed but didn't close all failures, try again. Same worktree.
+- **Attempt 3+** — if `previous_fix_attempts >= 2` and the same failure recurs, the pattern suggests a misdiagnosis. Return verdict=`BLOCKED` with `block_reason="CI failure persisted after <N> fix attempts; needs human diagnosis"` and let the daemon escalate.
 
 ## Reminders
 
-- Do not edit CI config (`.github/workflows/`) unless the failure is genuinely in CI config itself. Prefer fixing the underlying code that CI caught.
-- Do not push, commit, or call `gh` — the daemon handles all git and GitHub operations.
-- No `$()`, no heredocs. Output is the JSON file only.
+- No `$()`, no heredocs, no `python -c`. See `CLAUDE.md` Critical Rules.
+- All temp files go in `{worktree}/tmp/`, never `/tmp/`.
+- Prefer `Edit` over `Write` for existing files.
+- Read the log_tail carefully — the real error is often a few lines above where pytest/CI prints the traceback summary.
+- If the root cause is unclear from the log_tail alone, read the related source files before guessing.

--- a/.claude/skills/task-v2-plan/SKILL.md
+++ b/.claude/skills/task-v2-plan/SKILL.md
@@ -1,76 +1,182 @@
 ---
-description: (WIP — dispatcher v2 spike 0.3 stub) Plan phase for the per-phase /task-v2 pipeline. Reads an issue + comments, produces a plan document, scope-check findings, and a go/no-go signal. Called once per task by the dispatcher daemon before /task-v2-ralph.
-argument-hint: "#<issue-number>"
-maxTurns: 40
+description: Plan phase for the per-phase /task-v2 pipeline. Reads an issue + comments, produces a plan document, scope-check findings, and a go/no-go signal. Called once per task by the dispatcher daemon before /task-v2-ralph.
+argument-hint: "<agent-id>"
+maxTurns: 50
 model: opus
 ---
 
-# /task-v2-plan skill (WIP stub)
+# /task-v2-plan skill
 
-**Status:** WIP — extracted from `.claude/skills/task/SKILL.md` for dispatcher v2 spike 0.3 (per-phase context budget measurement, issue #2685). Not production-ready; kept for Phase 1 scaffolding per spec §6a.
+Plan phase for the dispatcher v2 per-phase task pipeline (`docs/specs/dispatcher-v2-spec.md` §6a). Reads an issue + comments handed over by the daemon, performs scope-check, and emits a structured plan for `/task-v2-ralph` to execute.
 
-**Goal:** Read a Judgemind issue, produce a plan document the daemon can feed into `/task-v2-ralph`. No worktree writes, no git operations — pure reading + writing to `{worktree}/tmp/dispatcher-output/plan.json`.
+**Prerequisites:** The dispatcher daemon has already (a) claimed the issue (posted the pickup comment), (b) created the worktree at `{worktree}`, (c) written the input bundle to `{worktree}/tmp/dispatcher-input/plan.json`.
 
-**Input:** `{worktree}/tmp/dispatcher-input/plan.json` with fields:
-- `issue_number` (int)
-- `issue_title` (str)
-- `issue_body` (str)
-- `issue_comments` (list of `{author, date, body}` objects, filtered to non-bots)
-- `worktree_path` (str)
-- `repo_root` (str)
+**Goal:** Produce `{worktree}/tmp/dispatcher-output/plan.json` — a structured plan that ralph can execute mechanically. No worktree writes outside of `tmp/`, no git operations, no issue comments. Pure reading + reasoning + output-JSON.
 
-**Output:** `{worktree}/tmp/dispatcher-output/plan.json` with fields:
-- `go` (bool) — proceed to ralph?
-- `block_reason` (str or null) — if go=false, why
-- `plan_text` (str) — human-readable plan for ralph to execute
-- `acceptance_criteria` (list of str) — extracted from issue body
-- `scope_check` (list of `{search_pattern, locations_found, in_scope}` objects)
-- `relevant_files` (list of paths) — files ralph should touch or reference
-- `relevant_docs` (list of paths) — docs/specs/ entries that guide this work
+**IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation. The `/task-v2-plan` subprocess is already a dispatcher-spawned background task — further backgrounding causes completion notifications to surface in the wrong context and leads to lost results.
+
+**IMPORTANT — No side effects.** This phase is read-only against the repo and GitHub. Do not edit code, do not comment on issues, do not spawn subagents. The only write is the output JSON at `{worktree}/tmp/dispatcher-output/plan.json`.
+
+---
+
+## Input contract
+
+Read `{worktree}/tmp/dispatcher-input/plan.json`. The daemon guarantees it exists before spawning this subprocess (§6 step 6). Required fields:
+
+- `agent_id` (str) — your UUID for correlation.
+- `issue_number` (int) — the issue being worked.
+- `issue_title` (str) — title text.
+- `issue_body` (str) — raw markdown issue body.
+- `issue_comments` (list of `{author, author_association, date, body}` objects) — filtered to non-bot authors by the daemon.
+- `issue_labels` (list of str).
+- `worktree_path` (str) — absolute path to your worktree root.
+- `repo_root` (str) — same as `worktree_path` (retained for symmetry with `/task`).
+
+Optional:
+
+- `blocked_by` (list of int) — any `Blocked by #N` references the daemon parsed. If non-empty and any are still open, you must produce `go=false`.
+- `parent_issue` (int or null) — `Parent: #N`.
+- `linked_specs` (list of path) — any paths under docs/specs that the daemon extracted from issue text.
+
+If the file is missing or malformed, exit with `go=false, block_reason="input JSON missing or malformed"`. Never read from GitHub to reconstruct — the daemon owns the handoff.
+
+---
+
+## Output contract
+
+Write `{worktree}/tmp/dispatcher-output/plan.json` with these fields, then exit 0:
+
+```
+{
+  "agent_id": "<echo from input>",
+  "issue_number": <int>,
+  "go": true|false,
+  "block_reason": null | "<string>",
+  "plan_text": "<markdown, ≤500 words>",
+  "acceptance_criteria": ["<criterion 1>", "<criterion 2>", ...],
+  "scope_check": [
+    {"search_pattern": "<regex or glob>", "locations_found": ["<path>:<line>", ...], "in_scope": true|false, "note": "<why>"}
+  ],
+  "relevant_files": ["<path>", ...],
+  "relevant_docs": ["docs/specs/<name>.md", ...],
+  "change_type": "api" | "scraper" | "ingestion" | "web" | "db_migration" | "dx_tooling" | "backfill_script" | "docs" | "agent_skill" | "no_deployed_component",
+  "dependencies_to_install": ["<package-relative-path>", ...]
+}
+```
+
+Exit 0 regardless of `go=true` or `go=false`. The daemon reads the verdict from the JSON, not the exit code.
 
 ---
 
 ## Step 1 — Understand the problem
 
-Read the issue body thoroughly, including all comments. Identify:
-- The concrete problem or feature.
-- The acceptance criteria (typically `- [ ]` checkboxes).
-- Related issue / PR references.
-- Linked specs in `docs/specs/`.
+Read the issue body thoroughly. Identify:
 
-Examine existing code for patterns. Be consistent with what's there.
+- The concrete problem or feature.
+- The acceptance criteria (typically `- [ ]` checkboxes). Each criterion should become one entry in `acceptance_criteria` — copy the criterion text verbatim.
+- Related issue / PR references (e.g. `Closes #N`, `Parent: #N`, `Blocked by #N`, `See also #N`).
+- Linked specs under `docs/specs/`. Read them if they affect the design.
+- Any implementation notes or scope clarifications in issue comments. Non-bot comments may supersede the original body (re-scoping, adding criteria).
+
+Grep existing code for patterns that match the described change. The goal is to be consistent with what's there.
 
 ## Step 2 — Scope completeness check
 
-Before recommending go, search the codebase for all locations affected by the described change. If the issue mentions fixing or changing X in one file, grep for X across the entire codebase. List all locations that use, render, or implement the same pattern. Either:
-- **Expand scope**: list the additional locations in `relevant_files` with a note.
-- **Out of scope**: list the additional locations in `scope_check[*].locations_found` with `in_scope: false`, and note in `plan_text` that follow-up issues should be filed for the missed locations.
+Before recommending `go=true`, search the codebase for all locations affected by the described change. This is the single most valuable step in plan — it catches "fix X in file Y" issues that should have said "fix X in files Y1, Y2, Y3".
+
+For each thing-to-change, use Grep with the specific identifier:
+
+- Renaming a function? Grep for all call sites.
+- Fixing a data quality bug in one scraper? Grep for the same pattern across other scrapers.
+- Removing a deprecated flag? Grep for every call to the deprecated function.
+
+For each grep, record one entry in `scope_check`:
+
+- `search_pattern` — the pattern used.
+- `locations_found` — relevant matches (prune noise; cap at ~20 per pattern).
+- `in_scope` — `true` if ralph should touch this location; `false` if it's out of scope.
+- `note` — why in/out. Follow-ups go in `plan_text` under "Follow-ups".
+
+If `in_scope=false` locations exist that arguably should have been in scope: mention in `plan_text` under "Follow-ups to file" so `/task-v2-retro` can file them at the end.
 
 ## Step 3 — Resolve ambiguity
 
-If the issue requires a maintainer decision before you can proceed, set `go=false` and write `block_reason` explaining what decision is needed. Do not guess on ambiguous requirements.
+If the issue requires a maintainer decision before you can proceed, set `go=false` and write a concrete `block_reason` in one sentence naming the exact decision needed. Do not guess on ambiguous requirements — a guessed-wrong PR costs more than a blocked-for-review issue.
 
-If acceptance criteria are missing or too vague to verify mechanically, set `go=false` with `block_reason="acceptance criteria need sharpening"`.
+If `acceptance_criteria` is empty or too vague to verify mechanically, set `go=false` with `block_reason="acceptance criteria need sharpening"` and quote the worst-offending criterion in `plan_text`.
 
-## Step 4 — Write the plan
+If `blocked_by` contains open issues, set `go=false` with `block_reason="blocked by open issues: #A, #B"`.
 
-For a go=true task, write a concise plan (≤500 words) that covers:
-1. What will be changed, per file.
-2. What tests will be added or updated.
-3. The scope boundary — what is intentionally NOT done.
-4. How each acceptance criterion will be verified (pointer to test / diff / behavior).
+If the issue is clearly a duplicate of an open issue, set `go=false` with `block_reason="duplicate of #N"`.
 
-Write the output JSON to `{worktree}/tmp/dispatcher-output/plan.json`. Exit 0 on success.
+## Step 4 — Determine change type and dependencies
+
+Set `change_type` from this table (used by `/task-v2-verify` to pick the verification strategy):
+
+| change_type | When |
+|---|---|
+| `api` | `packages/api/` (GraphQL, REST handlers) |
+| `scraper` | `packages/scraper-framework/src/courts/` or framework |
+| `ingestion` | ingestion worker, transcription, enrichment |
+| `web` | `packages/web/` |
+| `db_migration` | `packages/api/migrations/` |
+| `backfill_script` | one-off data script under `scripts/` |
+| `dx_tooling` | agent workflow, CI scripts, pre-push hooks, guards |
+| `docs` | docs-only |
+| `agent_skill` | `.claude/skills/` content |
+| `no_deployed_component` | CI config, docs, agent config with no deploy step |
+
+Set `dependencies_to_install` to the packages ralph's worker will need. The daemon runs `scripts/install-package-venv.sh <pkg>` for each entry in the `setup` phase before spawning ralph. Examples: `scraper-framework`, `nlp-pipeline`, `api`, `web`. Empty list for docs-only, terraform-only, or `.claude/`-only changes.
+
+## Step 5 — Write the plan
+
+For `go=true`, write `plan_text` as ≤500 words of markdown covering:
+
+1. **What will change, per file** — specific files and the shape of the edit. Name the functions/types that ralph will add or modify.
+2. **Tests** — which test files will be added or updated. Per CLAUDE.md, all code has tests. For TypeScript in `packages/web/`, prefer colocated `*.test.tsx`. For Python, `tests/` mirrors `src/`.
+3. **Scope boundary** — what is intentionally NOT done. List follow-ups ralph should NOT touch.
+4. **Acceptance-criterion verification map** — one line per criterion: "Criterion X verified by <test file>::<test name>" or "Criterion X verified by <behavior at runtime>".
+5. **Consistency checks** — if this change follows an existing pattern, name the precedent file that ralph should model the new code after.
+6. **Follow-ups to file** — one-line descriptions of any out-of-scope findings from Step 2. `/task-v2-retro` will file them.
+
+Populate `relevant_files` with every path ralph should Read during implementation. Populate `relevant_docs` with any docs/specs or docs/agent files ralph must honor.
+
+## Step 6 — Write the output JSON
+
+Use the Write tool to produce `{worktree}/tmp/dispatcher-output/plan.json` containing all fields above. Exit 0.
+
+---
 
 ## What this skill does NOT do
 
-- Does not install dependencies (daemon's job before ralph).
-- Does not modify code (ralph's job).
-- Does not commit, push, or open a PR (daemon's job after ralph).
-- Does not post issue comments (handled by `/task-v2-summary` after the implementation is done).
+- **Does not install dependencies.** The daemon's `setup` phase runs `scripts/install-package-venv.sh` based on `dependencies_to_install`.
+- **Does not modify code.** Ralph owns implementation.
+- **Does not commit, push, or open a PR.** Daemon owns git + GitHub operations after ralph.
+- **Does not post issue comments.** `/task-v2-summary` owns the pre-PR process-summary comment; the daemon posts verification-evidence via `/task-v2-verify`.
+- **Does not run tests.** Ralph's worker runs tests as part of the iteration loop.
+
+## Worked example — what a good plan output looks like
+
+For an issue "fix(scraping): Orange County department parsing drops leading zero":
+
+- `acceptance_criteria`: `["Department 03 renders as '03' not '3' on case detail pages.", "Regression test asserts department parsing preserves leading zeros."]`
+- `scope_check`: one entry for `re.search(r"dept=(\d+)"` grep, `locations_found: ["packages/scraper-framework/src/courts/ca/orange.py:142", "packages/scraper-framework/src/courts/ca/riverside.py:98"]`, `in_scope: false, note: "Riverside uses same pattern — file follow-up to audit all counties"`.
+- `relevant_files`: `["packages/scraper-framework/src/courts/ca/orange.py", "packages/scraper-framework/tests/courts/ca/test_orange.py"]`.
+- `change_type`: `scraper`.
+- `dependencies_to_install`: `["scraper-framework"]`.
+- `plan_text`: covers the one-line regex fix, the new regression test against a fixture, the out-of-scope note for Riverside, and the AC verification map.
+- `go`: true.
+
+For an issue "docs(agent): add retro phase to task skill" where the task skill doesn't exist anymore:
+
+- `go`: false.
+- `block_reason`: `"issue references .claude/skills/task/SKILL.md §5 but that section was removed in #2710; acceptance criteria need sharpening against current skill structure"`.
 
 ## Reminders
 
-- No `$()`, no heredocs, no `python -c`. See CLAUDE.md Critical Rules.
-- All temp files go in `{worktree}/tmp/`.
-- Prefer MCP for GitHub reads (`mcp__github__get_issue`). Keep `gh` for writes.
+- No `$()`, no heredocs, no `python -c`. See the repo root `CLAUDE.md` Critical Rules.
+- All temp files go in `{worktree}/tmp/`, never `/tmp/`.
+- Prefer MCP for GitHub reads (`mcp__github__get_issue`, `mcp__github__get_file_contents`). Keep `gh` for writes — but in this phase, you should make no writes to GitHub at all.
+- Use Grep, Glob, and Read tools — never `find`, `cat`, `head`, `tail` from Bash.
+- If context exceeds ~20k tokens from long issue bodies or comment threads: summarize comments >2k tokens in `plan_text` rather than quoting verbatim. The downstream phases only see your `plan.json`, not the raw issue.
+- The dispatcher-daemon owns the agent status in `dispatcher.phase_transitions`. Do NOT write to any file under `{repo_root}/tmp/agent-status/` — that convention belongs to the laptop-dispatcher `/task` skill, not the Fargate daemon.

--- a/.claude/skills/task-v2-ralph/SKILL.md
+++ b/.claude/skills/task-v2-ralph/SKILL.md
@@ -1,82 +1,216 @@
 ---
-description: (WIP — dispatcher v2 spike 0.3 stub) Ralph phase for the per-phase /task-v2 pipeline. Iterative worker + reviewer loop, returns SHIP verdict + committed-ready diff in the worktree. Long-tail phase (~45-90 min internally).
-argument-hint: ""
+description: Ralph phase for the per-phase /task-v2 pipeline. Iterative worker + reviewer loop, returns SHIP verdict plus uncommitted implementation diff in the worktree. Long-tail phase (~45-90 min internally).
+argument-hint: "<agent-id>"
 maxTurns: 500
-model: opus
+model: sonnet
 ---
 
-# /task-v2-ralph skill (WIP stub)
+# /task-v2-ralph skill
 
-**Status:** WIP — extracted from `.claude/skills/task/SKILL.md` + `.claude/skills/ralph/SKILL.md` for dispatcher v2 spike 0.3 (per-phase context budget measurement, issue #2685). The long-tail phase that this spike stress-tests.
+Ralph phase for the dispatcher v2 per-phase task pipeline (`docs/specs/dispatcher-v2-spec.md` §6a). Executes the plan produced by `/task-v2-plan` through an iterative worker + reviewer loop, and exits when the implementation is SHIP-ready (or blocked).
 
-**Goal:** Implement the plan produced by `/task-v2-plan`, iterate with reviewer feedback, return when reviewers agree SHIP (or give up with a blocker signal).
+**Prerequisites:** The dispatcher daemon has already (a) installed dependencies per `dependencies_to_install` from the plan output, (b) written the input bundle to `{worktree}/tmp/dispatcher-input/ralph.json`.
 
-**Input:** `{worktree}/tmp/dispatcher-input/ralph.json`:
-- `plan` (object from `/task-v2-plan` output)
-- `issue_number` (int)
-- `worktree_path` (str)
-- `repo_root` (str)
-- `max_iterations` (int, default 5)
+**Goal:** Produce committed-ready code in the worktree's working tree (staged or unstaged — daemon stages + commits + pushes), plus `{worktree}/tmp/dispatcher-output/ralph.json` with a SHIP/BLOCKED verdict.
 
-**Output:** `{worktree}/tmp/dispatcher-output/ralph.json`:
-- `verdict` (str) — `SHIP` or `BLOCKED`
-- `iterations_used` (int)
-- `block_reason` (str or null) — if verdict=BLOCKED
-- `changed_files` (list of paths)
-- `summary` (str, 1-3 sentences) — what was implemented
+**IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, any Task tool call, or any other operation. `/task-v2-ralph` is already a dispatcher-spawned background subprocess — further backgrounding causes completion notifications to surface in the wrong context and loses results.
 
-On success the worktree has uncommitted changes in working tree; the daemon stages, commits, and pushes.
+**IMPORTANT — Subagent isolation.** The context-budget analysis in spike 0.3 (`docs/investigations/dispatcher-v2-spike-0.3.md`) shows `/task-v2-ralph` stays inside the 200k-token window ONLY if each worker + each reviewer runs as a fresh-context subagent (Task tool). Inline workers break this guarantee. Do not inline.
+
+**Implementation choice (per issue #2732):** This skill invokes the existing `/ralph` skill as its inner loop. `/ralph` already implements the worker + three-reviewer cycle with fresh-context Task-tool subagents and per-iteration state files under `{worktree}/tmp/ralph/`. `/task-v2-ralph` is the thin outer wrapper that (a) seeds `task.md` from `plan.json`, (b) invokes `/ralph`, (c) parses `{worktree}/tmp/ralph/ralph-done.txt` into the output JSON. Keeps the implementation in one place and ensures parity with the current `/task` workflow's ralph behavior.
 
 ---
 
-## Step 0 — Set up ralph state directory
+## Input contract
 
-Create `{worktree}/tmp/ralph/` to hold iteration artifacts. Seed `task.md` from the plan:
+Read `{worktree}/tmp/dispatcher-input/ralph.json`. Required fields:
+
+- `agent_id` (str) — your UUID for correlation.
+- `issue_number` (int).
+- `plan` (object) — the full output from `/task-v2-plan`, i.e. the `plan.json` body. Always includes `plan_text`, `acceptance_criteria`, `relevant_files`, `relevant_docs`, `change_type`, and optionally `scope_check`.
+- `worktree_path` (str) — absolute path to your worktree root.
+- `repo_root` (str).
+- `max_iterations` (int) — defaults to 5.
+- `dependencies_installed` (list of str) — packages the daemon already set up (mirrors `plan.dependencies_to_install`). Ralph may still check `.venv` presence but should not re-install.
+
+If the file is missing or malformed, exit 0 with `verdict=BLOCKED, block_reason="input JSON missing or malformed"`.
+
+---
+
+## Output contract
+
+Write `{worktree}/tmp/dispatcher-output/ralph.json` with these fields, then exit 0:
+
 ```
-task.md           # plan + acceptance criteria + relevant paths
-feedback.md       # reviewer feedback (empty initially, updated each cycle)
-iteration.txt     # current iteration number
-diff.txt          # pre-generated git diff before each review
-changed_files.txt # full content of changed files (pre-generated before review)
+{
+  "agent_id": "<echo>",
+  "issue_number": <int>,
+  "verdict": "SHIP" | "BLOCKED",
+  "iterations_used": <int, 1..max_iterations>,
+  "block_reason": null | "<string>",
+  "changed_files": ["<path>", ...],
+  "summary": "<1-3 sentence implementation summary>",
+  "ralph_done_path": "<worktree>/tmp/ralph/ralph-done.txt",
+  "review_log_path": "<worktree>/tmp/ralph/review-log.jsonl"
+}
 ```
 
-## Step 1 — Iteration loop
+Always exit 0. BLOCKED is not a subprocess error — the daemon reads verdict from JSON.
 
-For iteration 1..max_iterations:
+On SHIP: the worktree working tree contains the implementation diff. It may be staged or unstaged. The daemon stages + commits + pushes in the `summary` and `push_and_pr` phases.
 
-1. **Worker phase.** Spawn a worker subagent (Task tool) with `task.md` + previous `feedback.md` as input. Worker writes failing tests first, implements until green, runs pre-PR checks (ruff, pytest, lint). Worker writes `work-status.txt` = `COMPLETE` when done.
-
-2. **Pre-review artifact generation.** Compute `git diff` into `diff.txt` and capture full content of changed files into `changed_files.txt`. These go to reviewers as input; reviewers receive git state, not raw Read calls.
-
-3. **Reviewer phase.** Spawn three reviewers in sequence (synchronous — no backgrounding):
-   - Gemini standard (`scripts/gemini_review.py` mode=standard) — normal code review.
-   - Gemini adversarial (`scripts/gemini_review.py` mode=adversarial) — devil's advocate: "find what's wrong".
-   - Claude reviewer (Task tool) — final verdict.
-   Each writes verdict `SHIP | REVISE | SKIPPED` and a feedback file.
-
-4. **Verdict check.** If all three reviewers return SHIP, loop exits with `verdict=SHIP`.
-   If any reviewer says REVISE, aggregate feedback into `feedback.md` and continue to iteration N+1.
-   If iteration == max_iterations and we still don't have SHIP, exit with `verdict=BLOCKED`, `block_reason="max_iterations reached without SHIP"`.
-
-5. **STUCK detection.** If worker returns with the same error on two consecutive iterations without improvement, exit with `verdict=BLOCKED`, `block_reason="worker stuck on <error>"`.
-
-## Step 2 — Write output JSON
-
-Write `{worktree}/tmp/dispatcher-output/ralph.json` with the final verdict and iteration count. Exit 0 regardless of SHIP or BLOCKED — the daemon reads the verdict from the JSON, not from the exit code.
+On BLOCKED: the working tree may contain partial work. The daemon decides whether to retry (fresh worktree) or diagnose (`§8` Tier 2/3 flow).
 
 ---
 
-## Context budget note (spike 0.3)
+## Step 0 — Seed ralph state directory
 
-Ralph is the long-tail phase by design. Each iteration (worker + reviewers) is already spawned with fresh context via Task-tool subagents, so the outer `/task-v2-ralph` context only accumulates:
-- `plan.json` input (~5-10k tokens)
-- iteration transitions + verdict aggregation (~1-2k tokens per iteration)
-- no raw file contents, no test logs (those live in worker/reviewer subagent context)
+Create `{worktree}/tmp/ralph/` if it does not exist. Write:
 
-If spike 0.3 measurements show the outer ralph exceeds 150k tokens across 5 iterations, the spec §6a must sub-split into `/task-v2-ralph-worker` + `/task-v2-ralph-review`, with the daemon orchestrating the loop instead of a long-running outer claude -p.
+- `task.md` — the consolidated task brief. Format:
+
+  ```
+  # Issue #<N> — <title>
+
+  ## Plan (from /task-v2-plan)
+
+  <plan.plan_text verbatim>
+
+  ## Acceptance criteria
+
+  - [ ] <criterion 1>
+  - [ ] <criterion 2>
+  ...
+
+  ## Relevant files
+
+  - <path 1>
+  - <path 2>
+
+  ## Relevant docs
+
+  - <doc path 1>
+
+  ## Change type
+
+  <plan.change_type>
+
+  ## Scope boundary
+
+  <any items from plan.scope_check with in_scope=false — so worker does NOT touch them>
+  ```
+
+- `feedback.md` — `No prior feedback. This is the first iteration.`
+
+- `iteration.txt` — `1`
+
+## Step 1 — Invoke `/ralph`
+
+Spawn the `/ralph` skill as a Task-tool subagent (so its own internal worker+reviewer subagents inherit fresh-context isolation). Pass:
+
+- The absolute worktree path.
+- The issue number.
+- `max_iterations`.
+
+`/ralph` handles the full worker → Gemini standard reviewer → Gemini adversarial reviewer → Claude reviewer cycle, with each sub-invocation spawning its own fresh-context subagent (Task tool). It writes `ralph-done.txt` when any of the following is true:
+
+- All three reviewers returned SHIP → SHIP
+- `max_iterations` reached without SHIP → REVISE/BLOCKED (ralph writes the final verdict)
+- Worker returned STUCK on two consecutive iterations → BLOCKED
+
+Wait synchronously for the subagent to complete. Do not time out from the outer skill — the dispatcher owns the subprocess-wide timeout.
+
+## Step 2 — Parse ralph output
+
+Read `{worktree}/tmp/ralph/ralph-done.txt` and `{worktree}/tmp/ralph/review-log.jsonl` (optional, structured, may be empty).
+
+- `ralph-done.txt` first line contains the final verdict token: `SHIP`, `REVISE` (≡ BLOCKED — max iterations), or `BLOCKED` (worker stuck or explicit abort).
+- `review-log.jsonl` rows include per-iteration reviewer verdicts for audit.
+
+Map to output `verdict`:
+
+| ralph-done.txt | output.verdict | block_reason |
+|---|---|---|
+| `SHIP` | `SHIP` | `null` |
+| `REVISE` | `BLOCKED` | `max_iterations reached without SHIP` |
+| `BLOCKED` | `BLOCKED` | `"<text from ralph-done.txt body>"` |
+
+Count iterations from `{worktree}/tmp/ralph/iteration.txt`.
+
+Capture `changed_files` from `git -C {worktree} diff --name-only HEAD`. Do NOT commit — daemon owns that.
+
+Compose `summary` as 1-3 sentences describing what was implemented. Pull from the worker's final status report or the Claude reviewer's SHIP justification.
+
+## Step 3 — Write output JSON and exit
+
+Use the Write tool to emit `{worktree}/tmp/dispatcher-output/ralph.json` with the fields above. Exit 0.
+
+---
+
+## Context-budget note (spike 0.3)
+
+Ralph is the long-tail phase by design. Each iteration (worker + 3 reviewers) is spawned with fresh context via Task-tool subagents, so the outer `/task-v2-ralph` context only accumulates:
+
+- `plan.json` input (~5-10k tokens).
+- Iteration transitions + verdict aggregation (~1-2k tokens per iteration, 5 iterations = ~10k).
+- No raw file contents. No test logs. Those live in worker/reviewer subagent contexts and are discarded when those subagents exit.
+
+Expected peak: ~30-45k tokens across 5 iterations. Well inside the 200k limit.
+
+If real Fargate measurement (follow-up #2714) shows the outer ralph exceeds 100k tokens consistently, the spec §6a must sub-split into `/task-v2-ralph-worker` + `/task-v2-ralph-review`, with the daemon orchestrating the loop instead of a long-running outer `claude -p`. Spike 0.3 already pre-designed that sub-split; the shape is documented in `docs/investigations/dispatcher-v2-spike-0.3.md`.
+
+## What this skill does NOT do
+
+- **Does not install dependencies.** Daemon already did that in the `setup` phase.
+- **Does not commit, push, or open a PR.** Daemon owns git + GitHub.
+- **Does not post issue comments.** `/task-v2-summary` owns the pre-PR comment.
+- **Does not watch CI or merge.** Daemon's `ci_watch` and `merge` phases handle that; if CI fails, the daemon spawns `/task-v2-fix-ci`.
+- **Does not run deploy verification.** `/task-v2-verify` owns that post-deploy.
+
+## Worked example — ralph output for a clean 1-iteration SHIP
+
+Input `plan.json` has one-file scraper fix. Ralph invokes `/ralph`, worker applies the one-line fix + regression test, all three reviewers agree SHIP on iteration 1. Ralph writes `ralph-done.txt` = `SHIP` at iteration 1, exit.
+
+Output `ralph.json`:
+
+```
+{
+  "agent_id": "<uuid>",
+  "issue_number": 1234,
+  "verdict": "SHIP",
+  "iterations_used": 1,
+  "block_reason": null,
+  "changed_files": [
+    "packages/scraper-framework/src/courts/ca/orange.py",
+    "packages/scraper-framework/tests/courts/ca/test_orange.py"
+  ],
+  "summary": "Fixed leading-zero loss in Orange County department regex; added regression test asserting department='03' round-trips.",
+  "ralph_done_path": ".claude/worktrees/agent-<id>/tmp/ralph/ralph-done.txt",
+  "review_log_path": ".claude/worktrees/agent-<id>/tmp/ralph/review-log.jsonl"
+}
+```
+
+## Worked example — BLOCKED on max iterations
+
+Ralph runs 5 iterations, reviewers keep bouncing between SHIP and REVISE (fix-flipping). Ralph writes `ralph-done.txt` = `REVISE` + detail about the last iteration's feedback.
+
+Output `ralph.json`:
+
+```
+{
+  "verdict": "BLOCKED",
+  "iterations_used": 5,
+  "block_reason": "max_iterations reached without SHIP; last iteration reviewers disagreed on whether the department regex should fall back to None or raise on parse failure — design decision needed",
+  ...
+}
+```
+
+The daemon consumes BLOCKED, routes to the diagnoser (§8 Tier 2/3), which may `retry_with_hint` (tighter acceptance criterion on error handling) or `escalate` (ask human).
 
 ## Reminders
 
-- No backgrounding. Reviewers run synchronously.
-- No `$()`, no heredocs, no `python -c`. See CLAUDE.md Critical Rules.
-- All temp files go in `{worktree}/tmp/`.
+- No `$()`, no heredocs, no `python -c`. See `CLAUDE.md` Critical Rules.
+- All temp files go in `{worktree}/tmp/`, never `/tmp/`.
+- Reviewers run synchronously via Task-tool subagents — no `run_in_background`.
+- Pre-PR checks (ruff, pytest, lint/typecheck/build) run INSIDE ralph's worker or final verification step — the daemon does NOT re-run them before `git push`, but `.githooks/pre-push` will bail if anything is red. If your worker skipped pre-PR checks, ralph must run them at the end of the final iteration.
+- `/ralph` writes status updates to `{repo_root}/tmp/agent-status/<agent-id>.txt` per its convention. `/task-v2-ralph` may read this file for monitoring but should not write to it — the dispatcher daemon owns agent status via `dispatcher.phase_transitions` rows.

--- a/.claude/skills/task-v2-retro/SKILL.md
+++ b/.claude/skills/task-v2-retro/SKILL.md
@@ -1,66 +1,211 @@
 ---
-description: (WIP — dispatcher v2 spike 0.3 stub) Retrospective phase for the per-phase /task-v2 pipeline. Reads full agent history (phase_transitions, failures, PR URL), produces zero-to-many retro issue bodies for the daemon to file.
-argument-hint: ""
-maxTurns: 20
-model: sonnet
+description: Retrospective phase for the per-phase /task-v2 pipeline. Reads the full agent history (phase_transitions, failures, PR URL), produces zero-to-many retro issue bodies for the daemon to file.
+argument-hint: "<agent-id>"
+maxTurns: 30
+model: haiku
 ---
 
-# /task-v2-retro skill (WIP stub)
+# /task-v2-retro skill
 
-**Status:** WIP — extracted from `.claude/skills/task/SKILL.md` §5 (retrospective) for dispatcher v2 spike 0.3.
+Retrospective phase for the dispatcher v2 per-phase task pipeline (`docs/specs/dispatcher-v2-spec.md` §6a). After a task succeeds end-to-end (verify=VERIFIED or SKIPPED), this phase reviews the run for workflow-efficiency and preventative-measures findings. Produces zero or more retro issue bodies; the daemon files them as GitHub issues.
 
-**Goal:** After a task succeeds end-to-end, review the run for workflow-efficiency and preventative-measures findings. Produce zero or more retro issue bodies; the daemon files them as GitHub issues.
+**Prerequisites:** The dispatcher daemon has already (a) posted the verification-evidence comment from `/task-v2-verify`, (b) pulled the full `phase_transitions` and `failures` history for this agent from `dispatcher.*`, (c) written the input bundle to `{worktree}/tmp/dispatcher-input/retro.json`.
 
-**Input:** `{worktree}/tmp/dispatcher-input/retro.json`:
-- `issue_number` (int)
-- `pr_number` (int)
-- `phase_transitions` (list of `{phase, started_at, ended_at, duration_s, outcome}` — the full per-phase timing log)
-- `failures` (list of `{category, details, first_seen, last_seen, count}` — dispatcher.failures rows for this agent)
-- `ralph_iterations` (int) — how many worker/reviewer cycles ralph needed
-- `ci_attempts` (int) — how many times CI ran (>1 means we hit failures and retried)
-- `total_duration_s` (int)
-- `diff_stats` (object with `files_changed`, `insertions`, `deletions`)
+**Goal:** Produce `{worktree}/tmp/dispatcher-output/retro.json` with a list of retro issue bodies (possibly empty) the daemon will file.
 
-**Output:** `{worktree}/tmp/dispatcher-output/retro.json`:
-- `retro_issues` (list of `{title, body, labels, priority}` — one per actionable finding)
-- `no_findings` (bool) — true if the run was clean and nothing is worth filing
+**IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation.
+
+**IMPORTANT — Do not fabricate findings.** A clean run (ralph=1 iteration, ci_attempts=1, no failures) is supposed to be boring. Setting `no_findings=true` is the correct answer for those runs. Retro issues should be high-signal and actionable — not "process theater".
+
+**IMPORTANT — No GitHub writes.** The daemon files the issues after reading this output. Do not call `gh issue create`.
 
 ---
 
-## Step 1 — Workflow-efficiency review
+## Input contract
 
-Look at the phase_transitions + failures + ralph_iterations to identify friction:
+Read `{worktree}/tmp/dispatcher-input/retro.json`. Required fields:
 
-- **Was there agent work that a script could do cheaper?** Mechanical transformations, boilerplate setup, repeated fix-retry cycles — file a `type/dx` issue.
-- **Did CI fail on something the pre-push hook should have caught?** (e.g., a hygiene check that only exists in CI). File a `type/dx` issue to add the check to `.githooks/pre-push`.
-- **Did ralph take more iterations than expected?** If >3 iterations, note what the reviewer kept flagging; a clearer task description or better fixture might reduce iterations next time.
-- **Did the agent hit permission prompts?** File a `type/dx` issue to add the pattern to `.claude/settings.json` allow-list.
+- `agent_id` (str).
+- `issue_number` (int) — the original task issue.
+- `pr_number` (int).
+- `phase_transitions` (list of `{phase, started_at, ended_at, duration_s, outcome}`) — full per-phase timing log from `dispatcher.phase_transitions`.
+- `failures` (list of `{category, details, first_seen, last_seen, count}`) — `dispatcher.failures` rows for this agent grouped by category.
+- `ralph_iterations` (int) — how many worker/reviewer cycles ralph needed.
+- `ci_attempts` (int) — how many times CI ran (>1 means we hit failures and retried via fix-ci).
+- `fix_ci_attempts` (int) — how many times `/task-v2-fix-ci` ran.
+- `total_duration_s` (int) — wall-clock from claim to verify.
+- `diff_stats` (object with `files_changed`, `insertions`, `deletions`).
+- `worktree_path` (str).
+- `repo_root` (str).
 
-## Step 2 — Preventative-measures review
+Optional:
 
-Look at the bug or feature and ask:
+- `scope_check_followups` (list of str) — out-of-scope findings from plan's `scope_check` that should become follow-up issues.
+- `plan_follow_ups` (list of str) — explicit "Follow-ups to file" lines from the plan_text (see `/task-v2-plan` Step 5).
 
-- **What would have caught this earlier?** A lint rule, type check, test, CI check, or runtime assertion. File an area-labeled issue with `type/dx` or `type/bug` depending on severity.
-- **Is this a pattern that could recur?** If the fix pattern applies to other scrapers/endpoints/modules, file an audit-and-fix issue.
-- **Were there misleading docs/specs?** If the bug was partially caused by stale docs, file a `type/docs` issue.
+If the file is missing or malformed, exit 0 with `no_findings=true` and an error note — the retro phase missing is not fatal.
 
-## Step 3 — Write retro issue bodies
+---
 
-For each finding, produce a `{title, body, labels, priority}` entry:
+## Output contract
 
-- `title` — conventional-commits format for the fix that would close it: `feat(...): add ...`, `fix(...): audit ...`.
-- `body` — concrete context + concrete next step an agent can pick up.
-- `labels` — include `type/dx` or `type/bug` + relevant area label + `agent/ready` if the issue is fully specified.
-- `priority` — `priority/p1` (high-leverage: prevents production bugs or saves significant agent time) or `priority/p2` (nice-to-have / one-off friction). **Never `priority/p0`** — human-only.
+Write `{worktree}/tmp/dispatcher-output/retro.json`:
 
-Each issue should be scoped tightly — one improvement per issue, pickup-able in a single session.
+```
+{
+  "agent_id": "<echo>",
+  "issue_number": <int>,
+  "pr_number": <int>,
+  "no_findings": true|false,
+  "retro_issues": [
+    {
+      "title": "<conventional-commits title for the fix>",
+      "body": "<full markdown issue body with Acceptance criteria + Verify lines>",
+      "labels": ["type/dx", "area/<X>", "agent/ready", "priority/p2"],
+      "priority": "priority/p1" | "priority/p2" | "priority/p3",
+      "blocked_by": [<int>, ...]
+    }
+  ],
+  "notes": "<optional prose summarizing the run for the weekly report>"
+}
+```
 
-## Step 4 — Handle "no findings" cleanly
+`blocked_by` is used by the daemon to call `scripts/block-issue.sh` if any of the new follow-ups should not go to `agent/ready` until a prerequisite lands.
 
-If the run was clean (ralph=1 iteration, ci_attempts=1, no failures), set `no_findings=true` and `retro_issues=[]`. That's fine — don't fabricate issues to seem productive.
+Exit 0 regardless. Empty `retro_issues` + `no_findings=true` is a valid happy-path result.
+
+---
+
+## Step 1 — Clean-run short-circuit
+
+If ALL of these are true, skip the review entirely and set `no_findings=true`:
+
+- `ralph_iterations == 1`
+- `ci_attempts == 1`
+- `fix_ci_attempts == 0`
+- `failures == []` or `failures == [{category: 'benign_hook', ...}]`
+- `scope_check_followups == []`
+- `plan_follow_ups == []`
+
+Write the output JSON with empty `retro_issues` and exit. Skipping this short-circuit on a clean run is fabrication.
+
+## Step 2 — Workflow-efficiency review
+
+Look at `phase_transitions`, `failures`, `ralph_iterations`, `fix_ci_attempts`, and `total_duration_s`. Identify actionable friction:
+
+- **Agent work a script could do cheaper.** Mechanical transformations, boilerplate setup, repeated fix-retry cycles that follow a pattern. → file `type/dx`.
+- **CI caught something the pre-push hook should have caught.** (A hygiene check that exists in CI but not in `.githooks/pre-push`.) → file `type/dx` to add the check to pre-push. Common symptom: `fix_ci_attempts >= 1` with category `markdown_links`, `lint`, `format`, `hygiene_guard`, `ci_config`.
+- **Ralph took more iterations than expected.** `ralph_iterations >= 3` → note what reviewers kept flagging. If a single reviewer flag pattern recurred, the plan probably missed it — file a `type/dx` to sharpen the plan template or the ralph reviewer prompt.
+- **Agent hit permission prompts.** Look in `failures` for categories like `permission_denied`, `tool_blocked`. → file `type/dx` to add the pattern to `.claude/settings.json` allow-list (or to `docs/agent/unattended-patterns.md` if it's a known pattern).
+- **Phase took significantly longer than the per-phase budget in §6a.** Plan >15 min, verify >20 min, fix-ci >45 min, retro >15 min. → note in `notes` for the weekly report; file an issue only if the slowdown has a structural cause.
+- **Agent hit the 529 rate-limit backoff** (`category='rate_limit_529'`). → file an issue to tighten batching or add retry budgeting, only if it happened more than once in this run.
+
+## Step 3 — Preventative-measures review
+
+Look at the merged diff and ask:
+
+- **What would have caught this earlier?** A lint rule, type check, test, CI check, or runtime assertion that would have flagged the bug before it reached human review. → file an area-labeled issue with `type/dx` (if tooling) or `type/bug` (if the test/assertion is missing).
+- **Is this a pattern that could recur?** If the fix pattern applies to other scrapers/endpoints/modules, file a single audit-and-fix issue covering all of them. Do not file N identical issues — file one "audit + fix N places" issue. Per `CLAUDE.md` §Collaboration, root cause > symptom.
+- **Were there misleading docs/specs?** If the bug was partially caused by a stale doc, out-of-date acceptance criterion template, or missing cross-reference, file a `type/docs` issue.
+- **Did this reveal a gap in the agent's workflow rules?** Missing preflight check, unclear CLAUDE.md rule, permission prompt pattern — file a `type/dx` issue and consider whether CLAUDE.md itself should be updated (that goes in the PR body of the resulting fix, not a separate issue).
+
+## Step 4 — Convert scope-check follow-ups into issues
+
+For each entry in `scope_check_followups` and `plan_follow_ups`:
+
+- Read the description.
+- Synthesize a concrete acceptance criterion with a `Verify:` line.
+- If the follow-up is "audit + fix N sibling locations the original issue didn't cover", file one issue that lists all N sibling locations (do not file N).
+
+## Step 5 — Write retro issue bodies
+
+For each finding, produce a `{title, body, labels, priority, blocked_by}` entry.
+
+### Title format
+
+Conventional-commits format for the fix that would close the issue: `feat(area): add …`, `fix(area): repair …`, `docs(area): clarify …`, `chore(dx): automate …`. Match the repo's existing title style.
+
+### Body template
+
+```
+## Problem
+
+<Concrete context pulled from this retro — what happened in the run that surfaced this>
+
+Example: In PR #<PR-N> (issue #<N>), ralph took <X> iterations because the reviewer kept flagging <pattern>. Root cause: <one-sentence>.
+
+## Proposed fix
+
+<Concrete next step an agent can pick up in a single session.>
+
+## Acceptance criteria
+
+- [ ] <criterion>
+  Verify: <SQL query / curl response / URL / test file path — whatever can be checked mechanically>
+
+- [ ] <criterion>
+  Verify: <…>
+
+## References
+
+- Surfaced by retro of #<N> (PR #<PR-N>)
+- Related phase transitions: <list the relevant phases from phase_transitions>
+- <any additional links>
+```
+
+### Labels
+
+Always include:
+
+- `agent/ready` if the issue is fully specified and pickup-able.
+- `status/triage` if the issue needs human review first (use when the finding is exploratory or needs a decision).
+
+One of: `type/dx`, `type/bug`, `type/docs`, `type/feature`, `type/decision`.
+
+One `area/*` label matching the primary affected package (e.g. `area/scraping`, `area/api`, `area/devops`).
+
+Exactly one `priority/*`.
+
+### Priority
+
+Per `CLAUDE.md` §Task Dependencies, §Priority Framework:
+
+- `priority/p1` — prevents future production bugs, eliminates a repeated-failure pattern that costs significant agent time, or catches a correctness issue.
+- `priority/p2` — most agent-friction improvements, documentation fixes, nice-to-have consistency.
+- `priority/p3` — large slow work (new framework, redesign).
+- **Never `priority/p0`** — human-only per `CLAUDE.md`.
+
+If unsure between p1 and p2: p1 if skipping this causes measurable agent-hours of waste over the next month; p2 otherwise.
+
+### Blocking
+
+If a finding depends on another in-flight or newly-filed retro issue, populate `blocked_by` with that issue's number (or `null` placeholder for "to be filed"). The daemon handles `scripts/block-issue.sh` calls — do not attempt that from this skill. For placeholder forward-references, use descriptive text in the body under "References" and leave `blocked_by` empty; the maintainer will link them manually.
+
+## Step 6 — Write the output JSON
+
+Emit `{worktree}/tmp/dispatcher-output/retro.json` with all fields above. Exit 0.
+
+---
+
+## Scope limits
+
+- One finding per issue. Don't bundle.
+- Scoped tightly — each issue should be pickup-able in a single `/task` session.
+- Do not fabricate findings to seem productive. A clean run → `no_findings=true`.
+- Do not file issues about this retro itself (do not file a "retro was slow" issue).
+- Do not file issues for intentional prompts (git push, PR create, merge, deploy) per `CLAUDE.md` §Permission prompt workarounds.
+
+## What this skill does NOT do
+
+- **Does not file issues.** Daemon does that after reading this output.
+- **Does not comment on the original issue.** The verification-evidence comment from `/task-v2-verify` is the last comment on the original issue.
+- **Does not close the original issue.** PR merge auto-closed it.
+- **Does not open subsequent PRs or tasks.** Only produces issue bodies; the dispatcher's queue scan eventually picks them up.
+- **Does not read historical failures from other agents.** Only this agent's own `failures` rows, provided by the daemon in the input bundle.
 
 ## Reminders
 
-- Do not file issues — the daemon does that after reading this skill's output.
-- Do not `gh` or MCP write here.
-- No `$()`, no heredocs.
+- No `$()`, no heredocs, no `python -c`. See `CLAUDE.md` Critical Rules.
+- All temp files go in `{worktree}/tmp/`, never `/tmp/`.
+- Match the body template shape — the daemon's `gh issue create --body-file` call passes the body verbatim, so malformed markdown lands malformed in GitHub.
+- Keep each issue body under 3000 characters where possible. Reference this retro (PR + agent_id) rather than duplicating long context.

--- a/.claude/skills/task-v2-summary/SKILL.md
+++ b/.claude/skills/task-v2-summary/SKILL.md
@@ -1,112 +1,218 @@
 ---
-description: (WIP — dispatcher v2 spike 0.3 stub) Summary phase for the per-phase /task-v2 pipeline. Reads the issue body + the git diff, produces a process-summary comment (AC mapping), a conventional commit message, and a PR body.
-argument-hint: ""
+description: Summary phase for the per-phase /task-v2 pipeline. Reads the issue body and the git diff, produces a process-summary issue comment (with AC mapping), a conventional commit message, a PR title, and a PR body.
+argument-hint: "<agent-id>"
 maxTurns: 30
-model: opus
+model: haiku
 ---
 
-# /task-v2-summary skill (WIP stub)
+# /task-v2-summary skill
 
-**Status:** WIP — extracted from `.claude/skills/task/SKILL.md` A.2b + A.3 (PR body template) for dispatcher v2 spike 0.3.
+Summary phase for the dispatcher v2 per-phase task pipeline (`docs/specs/dispatcher-v2-spec.md` §6a). Maps the ralph-produced diff back to the issue's acceptance criteria and emits three artifacts the daemon needs before opening the PR.
 
-**Goal:** Map the ralph-produced diff back to the issue's acceptance criteria, produce three artifacts the daemon needs before opening the PR.
+**Prerequisites:** The dispatcher daemon has already (a) run `/task-v2-ralph` with verdict=SHIP, (b) captured the full git diff and changed-file list into the input bundle, (c) written the input bundle to `{worktree}/tmp/dispatcher-input/summary.json`.
 
-**Input:** `{worktree}/tmp/dispatcher-input/summary.json`:
-- `issue_number` (int)
-- `issue_title` (str)
-- `issue_body` (str)
-- `issue_comments` (list, filtered to non-bots)
-- `ralph_summary` (str — from ralph's output)
-- `changed_files` (list of paths)
-- `git_diff` (str — full unified diff)
-- `worktree_path` (str)
+**Goal:** Produce `{worktree}/tmp/dispatcher-output/summary.json` with the process-summary comment, commit message, PR title, and PR body. No GitHub writes — the daemon posts the comment and creates the PR after reading this skill's output.
 
-**Output:** `{worktree}/tmp/dispatcher-output/summary.json`:
-- `process_summary_md` (str) — the markdown comment to post on the issue before PR creation
-- `commit_message` (str) — conventional-commits: `feat(area): description (#N)`
-- `pr_title` (str) — matches commit subject
-- `pr_body_md` (str) — full PR body with Summary + Test plan sections
-- `unmet_criteria` (list of str) — any AC the implementation didn't meet (triggers daemon to block/return to ralph)
+**IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation. This subprocess is already a dispatcher-spawned background task.
+
+**IMPORTANT — No side effects.** This phase does not modify code, does not commit, does not push, does not comment on GitHub. The only write is the output JSON at `{worktree}/tmp/dispatcher-output/summary.json`.
+
+---
+
+## Input contract
+
+Read `{worktree}/tmp/dispatcher-input/summary.json`. Required fields:
+
+- `agent_id` (str).
+- `issue_number` (int).
+- `issue_title` (str).
+- `issue_body` (str).
+- `issue_comments` (list of `{author, date, body}` — non-bots only).
+- `ralph_summary` (str) — the 1-3 sentence summary from ralph output.
+- `changed_files` (list of path).
+- `git_diff` (str) — full unified diff from `git diff origin/main...HEAD` (or `git diff HEAD` if commits not yet made).
+- `worktree_path` (str).
+- `repo_root` (str).
+- `branch` (str) — worktree branch name.
+
+Optional:
+
+- `plan_acceptance_criteria` (list of str) — from plan output, useful if the issue body AC got edited mid-flight.
+- `scope_check` (list) — from plan output; informs the "Scope decisions" section.
+
+If the file is missing or malformed, exit 0 with empty output and `error` field populated; daemon will retry.
+
+---
+
+## Output contract
+
+Write `{worktree}/tmp/dispatcher-output/summary.json`:
+
+```
+{
+  "agent_id": "<echo>",
+  "issue_number": <int>,
+  "process_summary_md": "<markdown comment body>",
+  "commit_message": "<conventional-commits subject + body>",
+  "pr_title": "<subject line, matches commit subject without body>",
+  "pr_body_md": "<full PR body markdown with Summary + Test plan>",
+  "unmet_criteria": ["<criterion text>", ...],
+  "pre_pr_check_notes": "<optional notes about lint/tests — prose>"
+}
+```
+
+`unmet_criteria` signals the daemon: **non-empty means the daemon must NOT open the PR**. Instead it returns the agent to the ralph phase with the list as a hint, or escalates to diagnose if ralph already completed with SHIP.
+
+Exit 0 regardless. The output JSON's shape is the contract — empty `unmet_criteria` == proceed.
 
 ---
 
 ## Step 1 — Extract acceptance criteria
 
-Read the issue body and issue comments. Identify all `- [ ]` checkboxes under an "Acceptance criteria" or similar heading. Also capture any criterion mentioned in comments that supersedes the original body.
+Read the issue body and `issue_comments`. Identify all `- [ ]` checkboxes under an "Acceptance criteria" heading (or similar). Also capture any criterion mentioned in a non-bot comment that supersedes the original body (re-scoping, adding criteria).
+
+If `plan_acceptance_criteria` is populated, cross-check against your extracted list. If they diverge, prefer the issue body + comments (the source of truth). Note the divergence in `pre_pr_check_notes` so the retro phase can file a follow-up.
 
 ## Step 2 — Map each criterion to the diff
 
-For each criterion, determine from the `git_diff` and `changed_files` list whether it is:
-- **Met** — describe specifically how: which file, which function/test, which line range.
-- **Not met** — explain why (out of scope, blocked, requires post-deploy verification).
-- **Not applicable** — explain why.
+For each criterion, determine from `git_diff` and `changed_files` whether it is:
 
-If any criterion is "not met" and the reason is NOT "post-deploy verification" or "not applicable", add it to `unmet_criteria`. The daemon treats `unmet_criteria[]` as a signal to NOT open the PR yet.
+- **Met** — describe specifically how: which file, which function/test, which line range. Cite the test name if a criterion has a `Verify:` line that maps to a test.
+- **Not met — post-deploy verification** — criteria that require running against dev (e.g., "GET /api/foo returns 200"). These are legitimately not verifiable pre-deploy; they belong to `/task-v2-verify`.
+- **Not met — scope expansion** — criterion was sharpened mid-flight and the diff does not cover it. Add to `unmet_criteria`.
+- **Not met — blocked** — criterion is blocked by a dependency that was out of scope. Add to `unmet_criteria` with explanation.
+- **Not applicable** — criterion was made obsolete by an earlier PR or the approach shifted. Explain in evidence cell.
 
-## Step 3 — Write the process summary comment
+If `unmet_criteria` is non-empty, the daemon will NOT open the PR. Add detail to each entry explaining what's missing so the retry hint is actionable.
 
-Use this markdown structure in `process_summary_md`:
+## Step 3 — Write the process-summary comment
+
+Use this markdown structure in `process_summary_md`. The daemon posts this comment on the issue **before** creating the PR (captures the acceptance-criteria reasoning in the issue thread for maintainer review).
 
 ```
 ## Process Summary
 
 ### What was implemented
-<Brief description of the approach — 2-4 sentences, drawn from ralph_summary>
+
+<2-4 sentences drawn from ralph_summary — what changed, where, and at a high level>
 
 ### Acceptance criteria mapping
 
 | # | Criterion | Status | Evidence |
 |---|-----------|--------|----------|
-| 1 | <criterion text> | Met | <file:function or test> |
-| 2 | <criterion text> | Met | <file:function or test> |
-| 3 | <criterion text> | Not met | <reason — e.g., requires post-deploy verification> |
+| 1 | <criterion text, truncate at 80 chars with …> | Met | `path/to/file.py::test_or_function` |
+| 2 | <criterion text> | Met | `path/to/other.py` — line range |
+| 3 | <criterion text> | Not met — post-deploy | Will be verified by /task-v2-verify |
 
 ### Scope decisions
-<Any intentional exclusions — what was NOT done and why>
+
+<Any intentional exclusions — what was NOT done and why. Pull from plan.scope_check if present.>
+
+### Follow-ups filed
+
+<Issues the retro phase will file based on scope_check out-of-scope findings. Leave empty if none.>
 ```
 
-## Step 4 — Write commit message + PR title
+Keep the comment under ~4000 characters. The issue thread gets noisy if summary comments are long.
 
-Conventional commits: `<type>(<area>): <short description> (#<N>)`. Keep under 72 chars for the subject.
+## Step 4 — Write the commit message and PR title
+
+Conventional-commits format: `<type>(<area>): <short description> (#<N>)`.
+
+Keep the subject under 72 characters.
+
+Derive `type` from the nature of the change:
+- `feat` — new user-visible feature.
+- `fix` — bug fix.
+- `docs` — documentation only.
+- `refactor` — no behavior change.
+- `perf` — performance improvement.
+- `test` — test-only change.
+- `chore` — tooling, build, config.
+- `cleanup` — removing dead code, deprecated features.
+- `spike` — investigation.
 
 Derive `area` from the primary package changed:
-- `packages/scraper-framework/` → `scraping`
-- `packages/api/` → `api`
-- `packages/web/` → `web`
-- `packages/nlp-pipeline/` → `nlp`
-- `docs/` → `docs`
-- `.claude/` → `agent`
-- `infra/terraform/` → `infra`
 
-## Step 5 — Write PR body
+| Path | Area |
+|---|---|
+| `packages/scraper-framework/` | `scraping` |
+| `packages/api/` | `api` |
+| `packages/web/` | `web` |
+| `packages/nlp-pipeline/` | `nlp` |
+| `docs/` | `docs` |
+| `.claude/` | `agent` |
+| `infra/terraform/` | `infra` |
+| `scripts/` (agent/dev tooling) | `dx` |
+| `.github/workflows/` | `ci` |
+| cross-package | most-affected, or omit `(area)` |
+
+If the diff spans multiple areas, pick the dominant one by line count. Example subjects:
+
+- `feat(scraping): capture Orange County PDF metadata (#1234)`
+- `fix(ingestion): handle multi-page rulings correctly (#1235)`
+- `docs(agent): update task dependencies reference (#1236)`
+
+Set `pr_title` equal to the subject line only (no body — GitHub uses the title separately from the body).
+
+Set `commit_message` to the subject plus an optional body (separated by a blank line). Include `Closes #<N>` in the body if applicable.
+
+## Step 5 — Write the PR body
+
+Use this template for `pr_body_md`:
 
 ```
 ## Summary
 
-<1-3 sentences describing the change>
+<1-3 sentences describing the change and motivation — pull from ralph_summary, sharpen for PR reviewers who have not read the issue>
 
 Closes #<N>
 
 ## Test plan
 
 ### Automated checks
-- [ ] Lint passes
-- [ ] Format check passes
-- [ ] Tests pass
+
+- [ ] Lint passes (`ruff check` / `npm run lint`)
+- [ ] Format check passes (`ruff format --check` / prettier)
+- [ ] Tests pass (`pytest` / `npm test`)
 - [ ] CI green
 
 ### Post-deploy verification
-- [ ] <Verification step specific to the change type>
-- [ ] Verification evidence posted on issue (see A.8)
+
+<Fill in with the verification steps specific to change_type — see /task-v2-verify for the matrix>
+- [ ] <verification step 1>
+- [ ] Verification evidence posted on #<N> (see /task-v2-verify output)
 ```
 
-If the change has no deployed component, use:
+If the change has no deployed component (docs, CI, agent config, infra-only with no service restart):
+
 ```
 ### Post-deploy verification
-- [ ] N/A — no deployed component (docs/CI/tooling only)
+
+- [ ] N/A — no deployed component (<specify: docs / CI / agent config / …>)
 ```
+
+If there is a breaking change or schema migration, add a `## Breaking changes` section naming what callers must do.
+
+If new dependencies were introduced, add a `## Dependencies` section listing them with a one-line justification each.
+
+## Step 6 — Write the output JSON
+
+Emit `{worktree}/tmp/dispatcher-output/summary.json` with all fields above. Exit 0.
+
+---
+
+## What this skill does NOT do
+
+- **Does not open the PR.** Daemon does that after consuming this output.
+- **Does not post comments.** Daemon posts `process_summary_md` on the issue.
+- **Does not commit or push.** Daemon handles git operations.
+- **Does not read GitHub directly.** All issue + comment + diff data comes through the input JSON.
+- **Does not run tests.** Any pre-PR check reruns happen in ralph's final iteration or the daemon's pre-push hook.
 
 ## Reminders
 
-- No `$()`, no heredocs. All outputs go in the JSON file.
-- The daemon does NOT invoke `gh pr create` itself — it reads this output and passes the commit_message + pr_body_md to `gh pr create`.
+- No `$()`, no heredocs, no `python -c`. See `CLAUDE.md` Critical Rules.
+- All temp files go in `{worktree}/tmp/`, never `/tmp/`.
+- This skill is Haiku-tier per spec §18 — keep reasoning tight. The input already contains everything needed; no exploratory Reads or greps beyond the input JSON should be necessary in the common case.
+- If the `git_diff` in the input is truncated (>50k chars), the daemon will have flagged it; in that case note "diff truncated" in `pre_pr_check_notes` and base the mapping on the truncated view.

--- a/.claude/skills/task-v2-verify/SKILL.md
+++ b/.claude/skills/task-v2-verify/SKILL.md
@@ -1,107 +1,211 @@
 ---
-description: (WIP — dispatcher v2 spike 0.3 stub) Verify phase for the per-phase /task-v2 pipeline. Reads merged PR + deploy status + AC list, produces a verification-evidence comment with per-criterion proof.
-argument-hint: ""
-maxTurns: 40
-model: opus
+description: Verify phase for the per-phase /task-v2 pipeline. Reads the merged PR plus deploy status plus acceptance criteria, produces a verification-evidence comment with per-criterion proof against dev.
+argument-hint: "<agent-id>"
+maxTurns: 50
+model: haiku
 ---
 
-# /task-v2-verify skill (WIP stub)
+# /task-v2-verify skill
 
-**Status:** WIP — extracted from `.claude/skills/task/SKILL.md` A.8 (deploy verification + evidence comment) for dispatcher v2 spike 0.3.
+Verify phase for the dispatcher v2 per-phase task pipeline (`docs/specs/dispatcher-v2-spec.md` §6a). Invoked by the daemon after the deploy workflow finishes green. Runs functional verification against dev and produces the per-criterion evidence comment the daemon will post on the issue (mandatory per `CLAUDE.md` §PR Workflow — every task completion requires concrete evidence or an explicit skip reason).
 
-**Goal:** After the daemon watches the deploy workflow to SUCCESS, this skill runs functional verification against dev and produces the per-criterion evidence comment the daemon will post on the issue.
+**Prerequisites:** The dispatcher daemon has already (a) merged the PR, (b) watched the deploy workflow (when applicable) to SUCCESS, (c) written the input bundle to `{worktree}/tmp/dispatcher-input/verify.json`.
 
-**Input:** `{worktree}/tmp/dispatcher-input/verify.json`:
-- `issue_number` (int)
-- `pr_number` (int)
-- `acceptance_criteria` (list of str) — from the plan
-- `change_type` (str) — `api`, `scraper`, `ingestion`, `web`, `db_migration`, `dx_tooling`, `backfill_script`, `no_deployed_component`
-- `touched_services` (list of str) — ECS service names / URL endpoints / DB tables affected
-- `worktree_path` (str)
-- `repo_root` (str)
+**Goal:** Produce `{worktree}/tmp/dispatcher-output/verify.json` with verdict=`VERIFIED`, `SKIPPED`, or `FAILED`, and the evidence markdown the daemon will post on the issue.
 
-**Output:** `{worktree}/tmp/dispatcher-output/verify.json`:
-- `verdict` (str) — `VERIFIED`, `FAILED`, `SKIPPED`
-- `evidence_md` (str) — the markdown comment to post on the issue
-- `per_criterion_results` (list of `{criterion, verified, evidence}`)
-- `failure_reason` (str or null) — if verdict=FAILED, what was broken
+**IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation.
+
+**IMPORTANT — Never deploy to production.** Verification runs against dev only. Production deploys are human-only per `CLAUDE.md`.
+
+**IMPORTANT — Post the comment? No.** The daemon posts the comment after reading this skill's output. This skill does not call `gh issue comment` — it only produces the markdown.
+
+---
+
+## Input contract
+
+Read `{worktree}/tmp/dispatcher-input/verify.json`. Required fields:
+
+- `agent_id` (str).
+- `issue_number` (int).
+- `pr_number` (int).
+- `acceptance_criteria` (list of str) — from plan output or extracted from issue body.
+- `change_type` (str) — one of `api`, `scraper`, `ingestion`, `web`, `db_migration`, `dx_tooling`, `backfill_script`, `docs`, `agent_skill`, `no_deployed_component`.
+- `touched_services` (list of str) — ECS service names, URL endpoints, or DB tables affected. Examples: `judgemind-api-dev`, `https://dev.api.judgemind.org/api/rulings`, `derived.documents`.
+- `deploy_status` (object) — `{workflow_name, run_id, conclusion, duration_s}` for the deploy run, or `null` if no-deploy change.
+- `merged_commit_sha` (str).
+- `worktree_path` (str).
+- `repo_root` (str).
+
+Optional:
+
+- `plan_text` (str) — from plan output; can clarify ambiguous criteria.
+- `scope_check` (list) — for context on what's intentionally out of scope.
+
+If the file is missing or malformed, exit 0 with verdict=`FAILED, failure_reason="input JSON missing or malformed"`.
+
+---
+
+## Output contract
+
+Write `{worktree}/tmp/dispatcher-output/verify.json`:
+
+```
+{
+  "agent_id": "<echo>",
+  "issue_number": <int>,
+  "pr_number": <int>,
+  "verdict": "VERIFIED" | "SKIPPED" | "FAILED",
+  "change_type": "<echo>",
+  "evidence_md": "<full markdown comment body the daemon will post>",
+  "per_criterion_results": [
+    {"criterion": "<text>", "verified": true|false, "evidence": "<1-3 lines of proof>"}
+  ],
+  "failure_reason": null | "<string>",
+  "unblock_issues": [<int>, ...]
+}
+```
+
+`unblock_issues` is a list of issue numbers this completion unblocks — the daemon passes them to `scripts/unblock-dependents.sh`. Typically empty unless the issue body contains `Unblocks: #N` references.
+
+Exit 0 regardless. Verdict comes from JSON.
 
 ---
 
 ## Step 1 — Determine verification path
 
-Use the change_type to pick the verification strategy:
+Use `change_type` to pick the verification strategy:
 
 | change_type | Verification approach | Required evidence |
 |---|---|---|
-| `api` | `curl` against `dev.api.judgemind.org`, confirm expected response | status code + body snippet |
-| `scraper` | Read ECS logs via `scripts/ecs-logs.sh /ecs/judgemind-scraper-dev --lines 50` | log lines showing successful capture |
-| `ingestion` | Read ECS logs `/ecs/judgemind-ingestion-worker-dev` | log lines showing successful processing |
-| `web` | Fetch page content from `dev.judgemind.org` | rendered HTML / screenshot |
-| `db_migration` | `scripts/dev-db-query.sh` to confirm column/table exists | DB query output |
-| `backfill_script` | Run script via `scripts/ecs-run-task.sh`, verify data changes | row counts / sample records |
-| `dx_tooling` | Run the tool in a representative scenario | command output |
-| `no_deployed_component` | Skip functional verification — go directly to Step 3 with verdict=SKIPPED | n/a |
+| `api` | `curl -fsS https://dev.api.judgemind.org/<endpoint>` — confirm expected response | status code + body snippet (first 500 chars) |
+| `scraper` | Read ECS logs via `mcp__awslabs_cloudwatch-mcp-server__execute_log_insights_query` against `/ecs/judgemind-scraper-dev` | log lines showing successful capture of the relevant court |
+| `ingestion` | Read ECS logs via MCP CloudWatch against `/ecs/judgemind-ingestion-worker-dev` | log lines showing successful document processing (plus sample downstream DB query confirming the row) |
+| `web` | Fetch a rendered page from `https://dev.judgemind.org/<path>`, or screenshot via `scripts/run-py.sh scripts/screenshot.py <url>` | rendered HTML or screenshot filepath |
+| `db_migration` | `scripts/dev-db-query.sh` to confirm the column/table/constraint exists and the schema matches | DB query output |
+| `backfill_script` | The daemon or prior step ran the script via `scripts/ecs-run-task.sh`. Verify row counts / sample records via `scripts/dev-db-query.sh` | before/after row counts, or sample rows |
+| `dx_tooling` | Run the tool in a representative scenario (e.g. invoke the new script on a known input) | command output demonstrating expected behavior |
+| `docs` | No functional verification possible. `verdict=SKIPPED` with reason. Optional: confirm `scripts/check-markdown-links.sh` passed in CI | n/a |
+| `agent_skill` | No runtime verification. Confirm the skill file is present on `main`, has production-ready frontmatter (not a stub marker), and (if feasible) a dry `claude -p /<skill> <fixture>` produces non-empty output | file-presence + content-shape check |
+| `no_deployed_component` | `verdict=SKIPPED` with reason | n/a |
+
+If `deploy_status` is `null` or `conclusion != 'success'` and `change_type` is deploy-requiring, set `verdict=FAILED` with `failure_reason="deploy did not reach SUCCESS: <conclusion>"`. Do not run functional checks against stale code.
 
 ## Step 2 — Per-criterion verification
 
-For each acceptance criterion, pick the right verification action and capture concrete evidence:
-- **Frontend criteria**: screenshot via `scripts/run-py.sh scripts/screenshot.py <url>`, or fetch page content.
-- **Data criteria**: run the specific SQL query (prefer `scripts/dev-db-query.sh`).
-- **API criteria**: hit the specific endpoint and confirm response.
-- **Behavior criteria**: trigger the scenario and capture result.
+For each acceptance criterion in `acceptance_criteria`, execute the verification action that the criterion's `Verify:` line names (per `docs/agent/issue-authoring.md`). Capture concrete evidence into `per_criterion_results[].evidence`:
 
-If any criterion fails to verify, set `verdict=FAILED` and include the diagnostic output in `failure_reason`.
+- **Frontend criteria** ("Verify: page renders without errors") — screenshot or page-fetch. Evidence = screenshot filepath or first 500 chars of rendered HTML.
+- **Data criteria** ("Verify: SELECT count(*) FROM derived.documents WHERE …") — run the exact SQL via `scripts/dev-db-query.sh`. Evidence = the query + result.
+- **API criteria** ("Verify: curl returns 200 with field `x`") — run the curl. Evidence = status code + relevant body fragment.
+- **Behavior criteria** ("Verify: ingestion worker processes a sample fixture without errors") — trigger the scenario (or find a recent occurrence in logs) and capture result.
+- **Log criteria** — MCP CloudWatch Logs Insights query; capture the matching log line(s). Limit to 5-10 lines per criterion to keep the evidence comment readable.
+
+If any criterion fails to verify, record `verified=false` in that row, and set the overall `verdict=FAILED` with `failure_reason` summarizing which criteria failed.
+
+For criteria that are explicitly "post-deploy only" and were marked `unmet` by summary, this phase is the one that resolves them.
 
 ## Step 3 — Build the evidence comment
 
-For verdict=VERIFIED:
+For `verdict=VERIFIED`:
 
 ```
 ## Verification Evidence
 
 **Change type:** <change_type>
 **Environment:** dev
+**PR:** #<PR-N> merged at <sha>
+**Deploy workflow:** <workflow_name> run <run_id> — SUCCESS in <duration>
 
-**Deployment health:**
-<curl/log/DB query output>
+### Deployment health
 
-**Acceptance criteria verification:**
+<curl output / log lines / DB query output demonstrating the service is live after deploy>
+
+### Acceptance criteria verification
 
 | # | Criterion | Verified | Evidence |
 |---|-----------|----------|----------|
-| 1 | <criterion> | Yes | <proof> |
+| 1 | <criterion> | Yes | <proof, 1-3 lines> |
 | 2 | <criterion> | Yes | <proof> |
 
-Post-deploy verification: PASSED
+**Post-deploy verification: PASSED**
 ```
 
-For verdict=SKIPPED (no deployed component):
+For `verdict=SKIPPED` (no deployed component):
 
 ```
 ## Verification Evidence
 
 **Change type:** <change_type>
-**Skip reason:** No deployed component — <docs/CI/tooling only, etc.>
+**PR:** #<PR-N> merged at <sha>
 
-Post-deploy verification: N/A (no deployed component)
+**Skip reason:** No deployed component — <docs / CI / tooling / agent config, specify which>
+
+### Acceptance criteria
+
+| # | Criterion | Status |
+|---|-----------|--------|
+| 1 | <criterion> | Merged to main — file present |
+| 2 | <criterion> | Merged to main — <description of static verification> |
+
+**Post-deploy verification: N/A (no deployed component)**
 ```
 
-For verdict=FAILED:
+For `verdict=FAILED`:
 
 ```
 ## Verification Evidence — FAILED
 
 **Change type:** <change_type>
+**PR:** #<PR-N> merged at <sha>
+**Deploy workflow:** <workflow_name> run <run_id> — <conclusion>
+
 **Failure:** <failure_reason>
 
-<diagnostic output>
+### Diagnostic output
 
-Post-deploy verification: FAILED — daemon will file priority/p1 follow-up issue.
 ```
+<log lines / curl error / DB query output showing the failure>
+```
+
+### Acceptance criteria verification
+
+| # | Criterion | Verified | Evidence |
+|---|-----------|----------|----------|
+| 1 | <criterion> | No | <why it failed> |
+
+**Post-deploy verification: FAILED — daemon will file priority/p1 follow-up issue for rollback or hotfix.**
+```
+
+Keep the comment under ~8000 characters. For long log dumps, truncate to the most relevant 20-30 lines.
+
+## Step 4 — Populate unblock_issues
+
+Check the issue body for `Unblocks: #<N>` lines (rare but useful for the spec's dependency graph). Add each to `unblock_issues`. The daemon runs `scripts/unblock-dependents.sh <issue_number>` after this phase, which uses GitHub's `Closes #N` + `Blocked by` mechanics — `unblock_issues` is an explicit override for cases where the automatic path misses.
+
+## Step 5 — Write the output JSON
+
+Emit `{worktree}/tmp/dispatcher-output/verify.json`. Exit 0.
+
+---
+
+## What this skill does NOT do
+
+- **Does not post the comment.** Daemon does that after reading this output.
+- **Does not deploy anything.** Daemon ran the deploy watch; this skill only verifies the already-deployed code.
+- **Does not close the issue.** The PR merge auto-closes via `Closes #N`. If verdict=`FAILED`, the issue is NOT reopened by this skill — the daemon decides whether to file a rollback/hotfix issue.
+- **Does not run backfills or data rewrites.** If verification reveals data needs repair, this skill reports that; a human or a follow-up task does the repair.
+
+## Verification quality notes
+
+- **Correctness > completeness** per `CLAUDE.md`. If the deployed code returns a field, check it against the source document / fixture — do not just confirm the field is populated.
+- **Use MCP first** for AWS reads: `mcp__awslabs_cloudwatch-mcp-server__execute_log_insights_query` is faster and cleaner than shelling out to `aws logs`. Load via `ToolSearch query="select:mcp__awslabs_cloudwatch-mcp-server__execute_log_insights_query,mcp__awslabs_cloudwatch-mcp-server__describe_log_groups"` before first use.
+- **Evidence must be reproducible.** Someone reading the comment should be able to copy the curl/SQL/log query and get the same result.
+- **Truncate, don't hide.** If a log dump is 200 lines long, show the 20 most relevant with `...` to indicate truncation. Never drop the evidence to "it worked".
 
 ## Reminders
 
-- Do not post the comment — the daemon does that after reading this skill's output.
-- Prefer MCP for AWS reads (`mcp__awslabs_cloudwatch-mcp-server__execute_log_insights_query`) over shelling out to `aws logs`.
-- No `$()`, no heredocs. All outputs go in the JSON file.
+- No `$()`, no heredocs, no `python -c`. See `CLAUDE.md` Critical Rules.
+- All temp files go in `{worktree}/tmp/`, never `/tmp/`.
+- Never call `aws secretsmanager get-secret-value` directly — use `scripts/with-secret.sh`.
+- Never run production scraping. Dev only.
+- If you need to run a data query, use `scripts/dev-db-query.sh` (ECS Exec path) — direct DB connection from the worktree is blocked by VPC per `CLAUDE.md` §Infrastructure.


### PR DESCRIPTION
## Summary

Dispatcher v2 Phase 1 sub-task F: promote the six `/task-v2-*` WIP stubs landed by spike 0.3 (#2685) to production skills wired to the contract in `docs/specs/dispatcher-v2-spec.md` §6a. Each skill strips the WIP banner, gets phase-tuned frontmatter (maxTurns + model per spec §18 seed), and documents its input/output JSON contract and step-by-step procedure.

Also creates the `.agents/skills/task-v2-*` symlinks for cross-tool (Gemini CLI + OpenCode) discovery per spike 0.5 (#2687) — the AC text referenced pre-existing symlinks, but spike cleanup (#2699) never created them for task-v2 (only for `spike-hello`), so they land here.

Closes #2732

## What changed per skill

| Skill | Model | maxTurns | Owns |
|---|---|---|---|
| `/task-v2-plan` | opus | 50 | issue → plan.json with go/no-go + scope-check |
| `/task-v2-ralph` | sonnet | 500 | plan → SHIP diff in worktree (invokes `/ralph` via Task-tool subagent) |
| `/task-v2-summary` | haiku | 30 | issue + diff → process-summary comment + commit message + PR body |
| `/task-v2-fix-ci` | sonnet | 100 | CI failure logs + diff → patch OR BLOCKED/FLAKY signal |
| `/task-v2-verify` | haiku | 50 | merged PR + deploy + AC → verification-evidence comment |
| `/task-v2-retro` | haiku | 30 | phase_transitions + failures → retro issue bodies |

## Design choices documented in the skills

- `/task-v2-ralph` invokes the existing `/ralph` skill as its inner loop — one implementation, fresh-context worker/reviewer subagents preserved, matches current `/task` behavior. Called out in the skill's "Implementation choice" note.
- Every skill is read-only against the repo/GitHub except for its own output JSON. Daemon owns all git + GitHub writes after reading skill outputs.
- Every skill explicitly lists what it does NOT do (side-effect boundary).

## Non-goals (unchanged, per issue body)

- No daemon wiring — Phase 2 drives `claude -p /task-v2-<phase>` from `daemon.py`.
- No changes to the existing `/task` skill or `/ralph` skill.

## Test plan

### Automated checks

- [x] Markdown link check passes locally (`scripts/check-markdown-links.sh` — all clean, 77 files)
- [x] No WIP/stub markers — `grep -rln "WIP\|spike 0.3 stub" .claude/skills/task-v2-*/` returns empty
- [x] Line count ≥ 1200 — `wc -l .claude/skills/task-v2-*/SKILL.md | tail -1` reports 1216 total
- [x] Cross-tool symlinks resolve — `.agents/skills/task-v2-*` point at `.claude/skills/task-v2-*` directories, verified `SKILL.md` reads through each
- [ ] CI green

### Post-deploy verification

- [ ] N/A — no deployed component (agent skill promotion only; skills are discovered at `claude -p` launch, no service restart needed)
- [ ] Verification evidence posted on #2732 referencing the merged PR and confirming the skills are present on `main`

## Dependencies

None — pure skill-file content + six directory symlinks.

## Unblocks

Merge unblocks #2714 (empirical Fargate re-measurement against production skills) and is a prerequisite for Phase 2 daemon wiring.
