### PR TITLE
fix(dispatcher-daemon): skip IAM secret policies when all ARNs empty (#2739)

### DIFF
--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -36,6 +36,23 @@ data "aws_caller_identity" "current" {}
 locals {
   service_name   = "judgemind-dispatcher-${var.environment}"
   log_group_name = "/ecs/judgemind-dispatcher-${var.environment}"
+
+  # Secret-ARN lists for the two policies below. `compact()` drops any empty
+  # string, so placeholder secrets that aren't yet provisioned (e.g.
+  # GITHUB_TOKEN before #2700, or the full Phase-1 inert wiring where all
+  # ARNs are "") do not leak into the policy's `Resource` list. If the
+  # compacted list is empty, the policy resource itself is skipped via
+  # `count = 0` — IAM rejects `Resource = []` with
+  # `MalformedPolicyDocument: Policy statement must contain resources`
+  # (see #2739).
+  execution_secret_arns = compact([
+    var.anthropic_api_key_secret_arn,
+    var.db_connection_secret_arn,
+    var.github_token_secret_arn,
+    var.telegram_bot_token_secret_arn,
+    var.gemini_api_key_secret_arn,
+  ])
+  task_db_secret_arns = compact([var.db_connection_secret_arn])
 }
 
 # ─── CloudWatch Log Group ───────────────────────────────────────────────────
@@ -107,10 +124,15 @@ resource "aws_iam_role_policy_attachment" "execution_managed" {
 }
 
 # Allow the execution role to fetch every secret wired into the task
-# definition. `compact()` drops any empty string, so placeholder secrets
-# that aren't yet provisioned (e.g. GITHUB_TOKEN before #2700) don't
-# generate an invalid empty-Resource statement.
+# definition. The secret-ARN list is pre-compacted into
+# `local.execution_secret_arns` so that empty-string placeholders
+# (e.g. GITHUB_TOKEN before #2700) are dropped. When no ARNs are wired
+# in — the Phase-1 inert wiring passes "" for all five — the policy
+# resource itself is skipped via `count = 0`; IAM rejects a statement
+# with `Resource = []` as `MalformedPolicyDocument` (see #2739).
 resource "aws_iam_role_policy" "execution_secrets" {
+  count = length(local.execution_secret_arns) > 0 ? 1 : 0
+
   name = "${local.service_name}-exec-secrets"
   role = aws_iam_role.execution.id
 
@@ -118,16 +140,10 @@ resource "aws_iam_role_policy" "execution_secrets" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "ReadDispatcherSecrets"
-        Effect = "Allow"
-        Action = "secretsmanager:GetSecretValue"
-        Resource = compact([
-          var.anthropic_api_key_secret_arn,
-          var.db_connection_secret_arn,
-          var.github_token_secret_arn,
-          var.telegram_bot_token_secret_arn,
-          var.gemini_api_key_secret_arn,
-        ])
+        Sid      = "ReadDispatcherSecrets"
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = local.execution_secret_arns
       }
     ]
   })
@@ -171,7 +187,14 @@ resource "aws_iam_role" "task" {
 # identity only needs to fetch its own connection secret at runtime (the
 # execution role already fetches it for env injection, but the daemon may
 # also want to rotate / re-fetch during long-running operation).
+#
+# Phase 1 passes `db_connection_secret_arn = ""`; the compacted
+# `local.task_db_secret_arns` is therefore empty and `count = 0` skips
+# the policy entirely. Same rationale as `execution_secrets` above —
+# IAM rejects `Resource = []` (see #2739).
 resource "aws_iam_role_policy" "task_read_db_secret" {
+  count = length(local.task_db_secret_arns) > 0 ? 1 : 0
+
   name = "${local.service_name}-task-read-db-secret"
   role = aws_iam_role.task.id
 
@@ -179,12 +202,10 @@ resource "aws_iam_role_policy" "task_read_db_secret" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "ReadDispatcherDBSecret"
-        Effect = "Allow"
-        Action = "secretsmanager:GetSecretValue"
-        Resource = compact([
-          var.db_connection_secret_arn,
-        ])
+        Sid      = "ReadDispatcherDBSecret"
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = local.task_db_secret_arns
       }
     ]
   })


### PR DESCRIPTION
## Summary

Wraps the two `dispatcher-daemon` IAM role policies that build their `Resource` list from optional secret-ARN variables (`execution_secrets`, `task_read_db_secret`) in `count = length(<local>) > 0 ? 1 : 0`, backed by a `locals` block that `compact()`s the inputs once. The Phase-1 wiring in `environments/dev/main.tf` passes `""` for every secret, which previously produced `Resource = []` and tripped IAM's `MalformedPolicyDocument: Policy statement must contain resources` during `terraform apply` for PR #2737 (`0885794c`). With this fix the two policies are skipped entirely at Phase 1 and only materialize once at least one ARN is wired in.

Closes #2739

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes (`terraform fmt -recursive -check` on the module — already green locally)
- [x] Tests pass (terraform-only change; test jobs path-filter-skipped as expected)
- [x] CI green (infra-validate SUCCESS, ci-passed SUCCESS)

### Post-deploy verification
- [ ] Operator re-runs `terraform -chdir=infra/terraform/environments/dev apply -auto-approve` after merge and the apply completes with no `MalformedPolicyDocument` errors — the two policies stay absent (count=0) and the `dispatcher_spike` ECR repo destroy finishes.
- [ ] Operator confirms `aws ecs describe-services --cluster judgemind-dev --services judgemind-dispatcher-dev --region us-west-2 --query "services[0].{desired:desiredCount,status:status}" --output json` returns `{"desired": 0, "status": "ACTIVE"}`.
- [ ] Operator confirms `aws ecs describe-task-definition --task-definition judgemind-dispatcher-spike --region us-west-2` returns `ResourceNotFoundException`.
- [ ] Verification evidence posted on issue #2739 once operator re-applies (or explicit "pending operator re-apply" skip noted per CLAUDE.md §A.8 Step 3).

## Verification done locally

- `terraform fmt -recursive -check infra/terraform/modules/dispatcher-daemon/` — clean.
- `terraform -chdir=infra/terraform/environments/dev init -lockfile=readonly` — no provider churn, lockfile unchanged.
- `terraform -chdir=infra/terraform/environments/dev validate` — Success.
- `terraform -chdir=infra/terraform/environments/dev plan` — 0 to add, 1 to change (unrelated scraper SG egress), 1 to destroy (`dispatcher_spike` ECR repo — matches known state). Neither `module.dispatcher_daemon.aws_iam_role_policy.execution_secrets` nor `task_read_db_secret` appears in the refresh list or the actions summary: count=0 is taking both out of the graph, exactly as the acceptance criteria require. All pre-existing dispatcher_daemon resources (roles, log group, task def, service, heartbeat alarm, and the three other task-role policies) refresh without drift.
