### PR TITLE
feat(dispatcher-v2): C — daemon.py skeleton + Dockerfile.dispatcher (#2729)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -544,6 +544,12 @@ jobs:
         run: npm install --no-save graphql@^16.8
       - name: Test
         run: pytest scripts/tests/ -v --tb=short
+      # Dispatcher v2 daemon skeleton tests (scripts/dispatcher/tests/).
+      # Separate invocation because these live in their own package dir
+      # (scripts/dispatcher/tests/) rather than under scripts/tests/.
+      # Mocks psycopg — no DB required in CI. See issue #2729.
+      - name: Test dispatcher daemon skeleton
+        run: pytest scripts/dispatcher/tests/ -v --tb=short
       - name: Check AWS CLI boolean flag usage
         run: scripts/check-aws-bool-flags.sh
       - name: Check for forbidden ECS services-stable waiter usage

--- a/.github/workflows/deploy-dispatcher.yml
+++ b/.github/workflows/deploy-dispatcher.yml
@@ -1,0 +1,99 @@
+name: Deploy Dispatcher
+
+# Builds and pushes the dispatcher v2 daemon image to ECR on merge to
+# main. Follows the `deploy-api.yml` pattern verbatim for the build job
+# — the dispatcher service runs at `desired_count=0` in Phase 1, so no
+# ECS deploy step is needed yet. Phase 2 will add a deploy-dev job that
+# flips the image on the existing task definition.
+#
+# Per `docs/specs/dispatcher-v2-spec.md` §14 and issue #2729.
+#
+# Build outputs:
+#   ECR image  `<acct>.dkr.ecr.us-west-2.amazonaws.com/judgemind/dispatcher:<sha7>`
+#   Tags: `<sha7>`, `latest`, `<branch>`, and optional `image_tag` input.
+#
+# Triggers:
+#   push to main when anything that affects the image content changes,
+#   plus workflow_dispatch for manual rebuild without a code change.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Dockerfile.dispatcher"
+      - "scripts/dispatcher/**"
+      - "scripts/check-issue-author.sh"
+      - ".github/workflows/deploy-dispatcher.yml"
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Optional image tag (defaults to git SHA)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  statuses: write
+
+concurrency:
+  group: deploy-dispatcher-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: us-west-2
+  ECR_REPOSITORY: judgemind/dispatcher
+
+jobs:
+  build-and-push:
+    name: Build and Push to ECR
+    runs-on: ubuntu-latest
+    outputs:
+      image_uri: ${{ steps.build.outputs.image_uri }}
+      sha_tag: ${{ steps.build.outputs.sha_tag }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Get AWS account ID
+        id: aws-account
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          echo "id=$ACCOUNT_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push Docker image
+        id: build
+        env:
+          ECR_REGISTRY: ${{ steps.aws-account.outputs.id }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+        run: |
+          IMAGE_BASE="$ECR_REGISTRY/$ECR_REPOSITORY"
+          SHA_TAG="${GITHUB_SHA::7}"
+          BRANCH_TAG="${GITHUB_REF_NAME//\//-}"
+          CUSTOM_TAG="${{ inputs.image_tag }}"
+
+          TAGS=("-t" "$IMAGE_BASE:$SHA_TAG" "-t" "$IMAGE_BASE:latest" "-t" "$IMAGE_BASE:$BRANCH_TAG")
+
+          if [ -n "$CUSTOM_TAG" ]; then
+            TAGS+=("-t" "$IMAGE_BASE:$CUSTOM_TAG")
+          fi
+
+          # `GIT_SHA` is baked into the image as an env var so the running
+          # daemon can self-report its build SHA into `dispatcher.runs.version_sha`.
+          docker build \
+              --build-arg "GIT_SHA=$SHA_TAG" \
+              -f Dockerfile.dispatcher \
+              "${TAGS[@]}" .
+          docker push "$IMAGE_BASE" --all-tags
+
+          echo "image_uri=$IMAGE_BASE:$SHA_TAG" >> "$GITHUB_OUTPUT"
+          echo "sha_tag=$SHA_TAG" >> "$GITHUB_OUTPUT"

--- a/Dockerfile.dispatcher
+++ b/Dockerfile.dispatcher
@@ -1,0 +1,181 @@
+# Dispatcher v2 daemon container image.
+#
+# Phase 1 scaffolding (issue #2729 / docs/specs/dispatcher-v2-spec.md §14).
+# Packages the long-running dispatcher daemon (`scripts/dispatcher/daemon.py`)
+# together with the `@anthropic-ai/claude-code` CLI so that Phase 2+ can
+# spawn per-phase `/task-v2-*` subprocesses. Phase 1 itself does not spawn
+# anything — the image just has to boot, tick, heartbeat, and exit cleanly
+# on SIGTERM.
+#
+# Base image choice — `node:20-slim`:
+# - Spike 0.1 (docs/investigations/dispatcher-v2-spike-0.1.md) validated
+#   this exact base for `claude -p` on Fargate.
+# - Python is installed on top via apt. The dispatcher is Python 3.12; the
+#   Claude Code CLI is a Node binary published as
+#   `@anthropic-ai/claude-code`. Running both from one image avoids a
+#   second-language multi-stage build.
+# - We do NOT layer this on top of `packages/scraper-framework/Dockerfile`
+#   (which is `python:3.12-slim`) because the scraper image carries
+#   Playwright + Chromium — ~400 MB of browser binaries the daemon has no
+#   use for. Starting from `node:20-slim` keeps the image under ~600 MB
+#   even after pip installs.
+#
+# $HOME policy:
+# - The base image lands at `/root`; we override to `/home/dispatcher` so
+#   a future non-root switch is a one-line `USER` change without rewriting
+#   every path that depends on `$HOME`. Per-subprocess isolation (spec
+#   §14) happens via `HOME=/tmp/agents/<agent_id>` env overrides on the
+#   daemon's per-phase spawn — NOT by mutating this container-level
+#   `$HOME`. The container-level value is only used by the daemon process
+#   itself, which does not touch `~/.claude/` since it does not run
+#   `claude -p` at Phase 1.
+#
+# Build (from repo root):
+#     docker build -f Dockerfile.dispatcher -t judgemind-dispatcher-local \
+#         --build-arg GIT_SHA=$(git rev-parse --short HEAD) .
+#
+# Run locally (requires DATABASE_URL reachable from the container):
+#     docker run --rm \
+#         -e DATABASE_URL="postgres://..." \
+#         judgemind-dispatcher-local \
+#         --tick-scheduler-seconds 5 --tick-supervisor-seconds 10
+
+FROM node:20-slim
+
+# ---------------------------------------------------------------------------
+# System deps: Python 3 (Debian bookworm ships Python 3.11, which is fine
+# — the daemon only uses 3.11-compatible features: `datetime.UTC` landed
+# in 3.11, no 3.12-only syntax is used. See `pyproject.toml` /
+# `.python-version` in the repo for local dev on 3.12; the Fargate image
+# pinning 3.11 means we can keep the single `node:20-slim` base without
+# needing to install Python from source or pull in deadsnakes).
+#
+# Also installed: git + gh CLI (needed by future /task-v2-* phases —
+# spike 0.7 wired these into the spike image and confirmed
+# `gh auth setup-git` + `git push` work with the scoped PAT secret),
+# plus ca-certificates and curl for the claude-code install and any
+# outbound HTTPS (GitHub API, Anthropic API, ECR, Telegram, Secrets
+# Manager).
+# ---------------------------------------------------------------------------
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+        git \
+        python3 \
+        python3-venv \
+        python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the GitHub CLI from the official apt repository. The
+# `cli.github.com` keyring + source pattern is the same one spike 0.7
+# used and is the path `gh auth setup-git` depends on for its
+# `credential.https://github.com.helper = !gh auth git-credential`
+# configuration.
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Make `python` resolve to the installed system python3 so
+# `python -m scripts.dispatcher.daemon` in the CMD below always picks
+# the interpreter we installed (node:20-slim has no `python` alias
+# out-of-the-box).
+RUN ln -sf /usr/bin/python3 /usr/bin/python
+
+# ---------------------------------------------------------------------------
+# Python dependencies
+#
+# Only psycopg[binary]>=3.1 is needed for the Phase 1 skeleton — all the
+# heavy packages (the scraper-framework itself, Playwright, etc.) are NOT
+# relevant to the daemon process. Pinning psycopg separately also keeps
+# the image layer small enough that future Phase 2 changes only bust the
+# COPY layers below.
+#
+# Per repo convention (spike 0.2 / emit_failure.py) the canonical
+# interface is `import psycopg` with the `[binary]` extra for the bundled
+# libpq — no separate `libpq-dev` apt install needed.
+# ---------------------------------------------------------------------------
+# Newer pip enforces PEP 668 "externally-managed-environment" on Debian's
+# system Python. We install at the system level (there is only one
+# Python process in the container and it is the daemon itself), so
+# opt out of the marker explicitly — same pattern used by the public
+# `claude-code` Dockerfile and the python:3.12-slim base of our scraper
+# image (which doesn't enforce it because its Python comes from the
+# official `python` image, not Debian's system packages).
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
+RUN pip install --no-cache-dir "psycopg[binary]>=3.1,<4"
+
+# ---------------------------------------------------------------------------
+# Claude Code CLI
+#
+# Pinned to 2.1.114 — the version spike 0.1 validated end-to-end on
+# Fargate. Phase 2+ bumps this whenever we re-spike a newer CLI.
+# ---------------------------------------------------------------------------
+RUN npm install -g @anthropic-ai/claude-code@2.1.114
+
+# ---------------------------------------------------------------------------
+# Dispatcher user + HOME
+#
+# We stay on root for Phase 1 (ECS Fargate isolates the task at the
+# kernel level; an in-container non-root boundary adds complexity for no
+# additional security benefit against the attacker the daemon actually
+# faces — compromised issue content). Setting HOME explicitly so:
+#   (a) the daemon's `socket.gethostname()` + env lookups are predictable;
+#   (b) any Node/NPM global caches from `claude-code` live somewhere
+#       other than /root, simplifying a future non-root switch.
+# Per-subprocess HOME isolation for the `/task-v2-*` workers happens on
+# spawn (spec §14) — the daemon sets HOME=/tmp/agents/<agent_id> on each
+# child process so ~/.claude/ state cannot leak across agents.
+# ---------------------------------------------------------------------------
+ENV HOME=/home/dispatcher
+RUN mkdir -p "$HOME"
+
+WORKDIR /app
+
+# ---------------------------------------------------------------------------
+# Application code
+#
+# COPY scripts/dispatcher/ (the daemon + emit_failure hook + tests)
+# plus scripts/check-issue-author.sh (used by Phase 2 before spawning
+# /task-v2-plan on an issue per §Step 1b of the /task skill).
+#
+# We deliberately do not COPY the whole `scripts/` directory — those
+# scripts are laptop-side helpers that don't need to ship in the daemon
+# image. Keeping the COPY list tight reduces layer churn from unrelated
+# scripts/*.py edits.
+# ---------------------------------------------------------------------------
+COPY scripts/dispatcher/ /app/scripts/dispatcher/
+COPY scripts/check-issue-author.sh /app/scripts/check-issue-author.sh
+RUN chmod +x /app/scripts/check-issue-author.sh
+
+# ---------------------------------------------------------------------------
+# Image provenance — GIT_SHA from build-args (CI sets it to the merge
+# commit SHA). The daemon reads GIT_SHA from the environment at startup
+# and persists it to `dispatcher.runs.version_sha` so post-hoc crash
+# forensics can map a run to a specific image.
+# ---------------------------------------------------------------------------
+ARG GIT_SHA=unknown
+ENV GIT_SHA=${GIT_SHA}
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+#
+# `python -m scripts.dispatcher.daemon` so the module path resolves with
+# `/app` on sys.path (the default CWD). Any CLI flags passed via ECS
+# `command` override just follow through as argv. Tick-scheduler and
+# tick-supervisor default to the spec's 30s / 120s.
+#
+# NOTE: `node:20-slim` inherits a `docker-entrypoint.sh` that wraps
+# every CMD with `exec node`; ours runs Python, not Node, so we reset
+# ENTRYPOINT explicitly. Without this, `docker run <img> --help` would
+# route the `--help` to node and print Node's help text.
+# ---------------------------------------------------------------------------
+ENTRYPOINT ["python", "-m", "scripts.dispatcher.daemon"]
+CMD []

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -208,7 +208,9 @@ module "dispatcher_daemon" {
   vpc_id             = module.networking.vpc_id
   private_subnet_ids = module.networking.private_subnet_ids
   ecs_cluster_arn    = module.compute.cluster_arn
-  ecr_repository_url = module.ecr.repository_url
+  # Dispatcher has its own ECR repo (`judgemind/dispatcher`) — NOT the
+  # scraper repo. Sub-task C (#2729) added the ECR resource + output.
+  ecr_repository_url = module.ecr.dispatcher_repository_url
 
   # Phase 1 = inert. Flipped to 1 in Phase 2 (shadow mode). Never > 1.
   desired_count = 0
@@ -430,4 +432,9 @@ output "dispatcher_daemon_task_role_arn" {
 output "dispatcher_daemon_security_group_id" {
   description = "Dev dispatcher daemon security group ID"
   value       = module.dispatcher_daemon.security_group_id
+}
+
+output "dispatcher_ecr_repository_url" {
+  description = "Dev ECR repository URL for dispatcher v2 daemon images"
+  value       = module.ecr.dispatcher_repository_url
 }

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -1,8 +1,9 @@
 # ECR repositories for Judgemind container images.
 #
-# Each service (scraper, api) gets its own repository following the
-# org/service naming pattern (judgemind/scraper, judgemind/api).
-# Repositories are shared across environments via image tags (e.g. staging, latest).
+# Each service (scraper, api, dispatcher) gets its own repository following
+# the org/service naming pattern (judgemind/scraper, judgemind/api,
+# judgemind/dispatcher). Repositories are shared across environments via
+# image tags (e.g. staging, latest).
 
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
@@ -120,6 +121,76 @@ resource "aws_ecr_lifecycle_policy" "api" {
 resource "aws_ecr_repository_policy" "api" {
   count      = var.enable_pull_policy ? 1 : 0
   repository = aws_ecr_repository.api.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowECSTaskExecutionPull"
+        Effect = "Allow"
+        Principal = {
+          AWS = var.ecs_task_execution_role_arn
+        }
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability"
+        ]
+      }
+    ]
+  })
+}
+
+# ─── Dispatcher Repository ───────────────────────────────────────────────────
+# Dispatcher v2 daemon image (spec §14, issue #2729). Same lifecycle +
+# pull-policy pattern as the scraper and api repos. The dispatcher-daemon
+# Terraform module wires this URL into the ECS task definition via
+# `ecr_repository_url`; CI pushes images on merge to main (see
+# `.github/workflows/deploy-dispatcher.yml`).
+
+resource "aws_ecr_repository" "dispatcher" {
+  name                 = "judgemind/dispatcher"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "dispatcher" {
+  repository = aws_ecr_repository.dispatcher.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Purge untagged images after 1 day"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 1
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Retain last 10 tagged images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["v", "staging", "prod", "sha-"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 10
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}
+
+resource "aws_ecr_repository_policy" "dispatcher" {
+  count      = var.enable_pull_policy ? 1 : 0
+  repository = aws_ecr_repository.dispatcher.name
 
   policy = jsonencode({
     Version = "2012-10-17"

--- a/infra/terraform/modules/ecr/outputs.tf
+++ b/infra/terraform/modules/ecr/outputs.tf
@@ -17,3 +17,13 @@ output "api_repository_url" {
   description = "ECR repository URL for API images"
   value       = aws_ecr_repository.api.repository_url
 }
+
+output "dispatcher_repository_url" {
+  description = "ECR repository URL for dispatcher v2 daemon images"
+  value       = aws_ecr_repository.dispatcher.repository_url
+}
+
+output "dispatcher_repository_arn" {
+  description = "ARN of the dispatcher v2 ECR repository"
+  value       = aws_ecr_repository.dispatcher.arn
+}

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python3
+"""Dispatcher v2 daemon entrypoint — Phase 1 skeleton.
+
+Long-running process that (eventually, Phase 2+) reads ``dispatcher.*``
+state, spawns per-phase ``/task-v2-*`` subprocesses, and emits
+heartbeats. In Phase 1 this is a runnable skeleton only: init, DB
+connection, scheduler + supervisor tick loops, graceful shutdown. **No
+subprocess spawning.**
+
+Spec: ``docs/specs/dispatcher-v2-spec.md`` §6 (scheduler loop), §7
+(supervisor loop), §14 (deployment), §17 Risk 2 (double-daemon race),
+§18 (schema DDL). Issue #2729 (Parent: #2725, Phase 1 epic).
+
+Structured logging is JSON-per-line to stdout so CloudWatch Logs
+Insights can query it without a regex layer.
+
+Usage::
+
+    DATABASE_URL=postgres://... python -m scripts.dispatcher.daemon \\
+        --tick-scheduler-seconds 30 \\
+        --tick-supervisor-seconds 120
+
+Env vars read:
+    DATABASE_URL  — Postgres connection string (required).
+    GIT_SHA       — short SHA baked into the image at build time
+                    (optional; falls back to ``unknown``).
+    HOSTNAME      — Fargate task ID lands here by default. Falls back to
+                    ``socket.gethostname()``.
+
+Exit codes:
+    0  normal shutdown (SIGTERM / SIGINT).
+    1  unrecoverable startup error (DB unreachable, lease contention).
+    2  argparse failure.
+"""
+# venv: scraper-framework
+# permanent: true
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import signal
+import socket
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover — types only
+    from psycopg import Connection
+
+
+# --------------------------------------------------------------------------
+# Constants
+# --------------------------------------------------------------------------
+
+#: Postgres schema that owns every table the daemon reads or writes.
+DISPATCHER_SCHEMA = "dispatcher"
+
+#: Lease window — another running daemon whose heartbeat is newer than
+#: this many seconds blocks this one from spawning (§17 Risk 2). 60 s is
+#: 2× the scheduler tick, so a healthy peer is always seen as active.
+LEASE_HEARTBEAT_WINDOW_SECONDS = 60
+
+#: Default tick cadence. Mirrors §6 / §7 of the spec.
+DEFAULT_SCHEDULER_TICK_SECONDS = 30
+DEFAULT_SUPERVISOR_TICK_SECONDS = 120
+
+
+# --------------------------------------------------------------------------
+# Logging — structured JSON per line to stdout.
+# --------------------------------------------------------------------------
+
+
+class _JsonFormatter(logging.Formatter):
+    """Emit one log record as a single JSON object per line.
+
+    The dispatcher runs under Fargate → CloudWatch Logs → Logs Insights;
+    Insights queries parse JSON-formatted log lines natively, which is
+    the cheapest way to get structured queryability without a separate
+    telemetry store. Any ``extra={...}`` passed to a ``logger.info`` call
+    is merged into the envelope under its own keys.
+    """
+
+    #: Attributes ``LogRecord`` sets that we reformat into the envelope.
+    _BUILTIN_ATTRS = frozenset(
+        {
+            "args",
+            "asctime",
+            "created",
+            "exc_info",
+            "exc_text",
+            "filename",
+            "funcName",
+            "levelname",
+            "levelno",
+            "lineno",
+            "message",
+            "module",
+            "msecs",
+            "msg",
+            "name",
+            "pathname",
+            "process",
+            "processName",
+            "relativeCreated",
+            "stack_info",
+            "thread",
+            "threadName",
+            "taskName",
+        }
+    )
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401
+        envelope: dict[str, Any] = {
+            "ts": datetime.now(UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+        # Merge in anything the caller attached via ``extra=``.
+        for key, value in record.__dict__.items():
+            if key in self._BUILTIN_ATTRS or key.startswith("_"):
+                continue
+            try:
+                json.dumps(value)  # ensure JSON-serializable
+            except TypeError:
+                value = repr(value)
+            envelope[key] = value
+        if record.exc_info:
+            envelope["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(envelope, default=str)
+
+
+def _configure_logging(level: str) -> logging.Logger:
+    """Install the JSON formatter on stdout and return the daemon logger."""
+    handler = logging.StreamHandler(stream=sys.stdout)
+    handler.setFormatter(_JsonFormatter())
+    root = logging.getLogger()
+    # Replace any existing handlers (e.g. pytest's) so our output is
+    # pure JSON when the daemon runs standalone. In tests this is
+    # harmless; tests don't assert on log output.
+    root.handlers = [handler]
+    root.setLevel(level.upper())
+    return logging.getLogger("dispatcher.daemon")
+
+
+# --------------------------------------------------------------------------
+# Configuration + context
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class DaemonConfig:
+    """Parsed CLI + env configuration."""
+
+    database_url: str
+    tick_scheduler_seconds: int = DEFAULT_SCHEDULER_TICK_SECONDS
+    tick_supervisor_seconds: int = DEFAULT_SUPERVISOR_TICK_SECONDS
+    log_level: str = "INFO"
+    version_sha: str = "unknown"
+    host: str = ""
+    pid: int = 0
+    # Optional override used by tests to avoid os.environ mutation.
+    config_override: dict[str, Any] = field(default_factory=dict)
+
+
+# --------------------------------------------------------------------------
+# DB helpers — every call lives inside ``DispatcherDaemon`` so tests can
+# substitute a fake psycopg module via ``sys.modules``.
+# --------------------------------------------------------------------------
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class LeaseError(RuntimeError):
+    """Another daemon is holding the active-heartbeat lease."""
+
+
+# --------------------------------------------------------------------------
+# Daemon
+# --------------------------------------------------------------------------
+
+
+class DispatcherDaemon:
+    """Minimal Phase 1 dispatcher daemon.
+
+    Responsibilities in Phase 1 (this skeleton):
+        * Connect to Postgres via ``DATABASE_URL``.
+        * Run the lease check — bail out if another daemon is active
+          within the heartbeat window.
+        * INSERT a ``dispatcher.runs`` row on boot.
+        * Run the scheduler loop every ``tick_scheduler_seconds``:
+          consume unconsumed ``dispatcher.commands``, read
+          ``dispatcher.config`` (no-op use), do NOT spawn subprocesses.
+        * Run the supervisor loop every ``tick_supervisor_seconds``:
+          UPDATE ``dispatcher.runs.heartbeat_ts``, count recent
+          ``dispatcher.failures`` rows.
+        * On SIGTERM / SIGINT, UPDATE ``dispatcher.runs.stopped_at`` and
+          exit 0.
+
+    What this skeleton does **NOT** do (deferred to Phase 2+):
+        * Spawn ``/task-v2-*`` subprocesses.
+        * Act on the phase state machine (§6 step 5).
+        * Run the failure diagnoser (§8).
+        * Emit CloudWatch metrics.
+    """
+
+    def __init__(self, cfg: DaemonConfig, logger: logging.Logger):
+        self._cfg = cfg
+        self._log = logger
+        self._conn: Connection[Any] | None = None
+        self._run_id: str | None = None
+        self._stop = threading.Event()
+        self._scheduler_ticks = 0
+        self._supervisor_ticks = 0
+        self._last_heartbeat_at: datetime | None = None
+
+    # ── lifecycle ──────────────────────────────────────────────────────
+
+    def connect(self) -> None:
+        """Open the psycopg connection. Imported lazily so tests can mock."""
+        import psycopg  # noqa: PLC0415  — lazy import
+
+        self._log.info(
+            "daemon.connect",
+            extra={
+                "event": "connect",
+                "database_url_set": bool(self._cfg.database_url),
+            },
+        )
+        self._conn = psycopg.connect(self._cfg.database_url, connect_timeout=10)
+        # Autocommit off — every daemon step is one small transaction.
+        self._conn.autocommit = False
+
+    def check_lease_and_register_run(self) -> str:
+        """Claim the active-daemon lease and INSERT ``dispatcher.runs``.
+
+        Raises :class:`LeaseError` if another daemon's heartbeat is
+        within ``LEASE_HEARTBEAT_WINDOW_SECONDS`` of now.
+
+        Returns the new ``run_id``.
+        """
+        assert self._conn is not None, "connect() must run before registering"
+
+        # Under SERIALIZABLE we would be free of races here, but the
+        # check + insert happens fast enough that two daemons booting
+        # simultaneously during a rolling deploy (§17 Risk 2) still race
+        # on the millisecond window. That is acceptable: the second
+        # daemon's supervisor tick will observe the first one's heartbeat
+        # within the next 120s and can be watchdog-killed. The lease
+        # here is a best-effort "don't start if we can see another
+        # active peer".
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "SELECT run_id, heartbeat_ts "
+                "FROM dispatcher.runs "
+                "WHERE stopped_at IS NULL "
+                "  AND heartbeat_ts > now() - make_interval(secs => %s) "
+                "ORDER BY heartbeat_ts DESC "
+                "LIMIT 1",
+                (LEASE_HEARTBEAT_WINDOW_SECONDS,),
+            )
+            row = cur.fetchone()
+            if row is not None:
+                existing_run_id, existing_hb = row
+                self._conn.rollback()
+                raise LeaseError(
+                    f"another dispatcher run is active: run_id={existing_run_id} "
+                    f"heartbeat_ts={existing_hb!s}"
+                )
+
+            cur.execute(
+                "INSERT INTO dispatcher.runs "
+                "    (started_at, heartbeat_ts, version_sha, host, pid) "
+                "VALUES (now(), now(), %s, %s, %s) "
+                "RETURNING run_id",
+                (self._cfg.version_sha, self._cfg.host, self._cfg.pid),
+            )
+            new_row = cur.fetchone()
+            if (
+                new_row is None
+            ):  # pragma: no cover — INSERT ... RETURNING always returns
+                raise RuntimeError("INSERT dispatcher.runs returned no row")
+            self._run_id = str(new_row[0])
+        self._conn.commit()
+
+        self._log.info(
+            "daemon.run_registered",
+            extra={
+                "event": "run_registered",
+                "run_id": self._run_id,
+                "version_sha": self._cfg.version_sha,
+                "host": self._cfg.host,
+                "pid": self._cfg.pid,
+            },
+        )
+        return self._run_id
+
+    def mark_stopped(self) -> None:
+        """UPDATE ``dispatcher.runs.stopped_at`` on shutdown."""
+        if self._conn is None or self._run_id is None:
+            return
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.runs SET stopped_at = now() "
+                    "WHERE run_id = %s AND stopped_at IS NULL",
+                    (self._run_id,),
+                )
+            self._conn.commit()
+            self._log.info(
+                "daemon.run_stopped",
+                extra={"event": "run_stopped", "run_id": self._run_id},
+            )
+        except Exception:  # pragma: no cover — best-effort on shutdown
+            self._log.exception("daemon.mark_stopped_failed")
+            try:
+                self._conn.rollback()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        """Close the psycopg connection. Safe to call multiple times."""
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except Exception:  # pragma: no cover
+                pass
+            self._conn = None
+
+    # ── scheduler tick (every ``tick_scheduler_seconds``) ───────────────
+
+    def scheduler_tick(self) -> dict[str, int]:
+        """Run one scheduler tick. Phase 1 = no-op for subprocess spawn.
+
+        Returns a small summary dict for logging + tests.
+        """
+        assert self._conn is not None, "connect() must run before ticks"
+
+        commands_consumed = 0
+        concurrency_cap: int | None = None
+
+        with self._conn.cursor() as cur:
+            # 1. Consume any pending commands. Phase 1 = no-op handler;
+            # mark consumed anyway so the queue drains and does not fill
+            # up during shadow mode.
+            cur.execute(
+                "UPDATE dispatcher.commands "
+                "SET consumed_at = now() "
+                "WHERE consumed_at IS NULL",
+            )
+            commands_consumed = cur.rowcount or 0
+
+            # 2. Read concurrency_cap (for log observability; no spawn).
+            cur.execute(
+                "SELECT value FROM dispatcher.config WHERE key = %s",
+                ("concurrency_cap",),
+            )
+            row = cur.fetchone()
+            if row is not None:
+                # Stored as JSONB — a bare number comes back as int.
+                concurrency_cap = int(row[0]) if row[0] is not None else None
+        self._conn.commit()
+
+        self._scheduler_ticks += 1
+        self._log.info(
+            "daemon.scheduler_tick",
+            extra={
+                "event": "scheduler_tick",
+                "run_id": self._run_id,
+                "tick_n": self._scheduler_ticks,
+                "commands_consumed": commands_consumed,
+                "concurrency_cap": concurrency_cap,
+            },
+        )
+        return {
+            "commands_consumed": commands_consumed,
+            "concurrency_cap": -1 if concurrency_cap is None else concurrency_cap,
+        }
+
+    # ── supervisor tick (every ``tick_supervisor_seconds``) ─────────────
+
+    def supervisor_tick(self) -> dict[str, int]:
+        """Run one supervisor tick. Writes heartbeat; reads failures count."""
+        assert self._conn is not None, "connect() must run before ticks"
+        assert self._run_id is not None, "register the run before ticking"
+
+        failures_last_hour = 0
+
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "UPDATE dispatcher.runs SET heartbeat_ts = now() WHERE run_id = %s",
+                (self._run_id,),
+            )
+            # Smoke-test read for Phase 1 — not used yet.
+            cur.execute(
+                "SELECT count(*) FROM dispatcher.failures "
+                "WHERE ts > now() - interval '1 hour'",
+            )
+            row = cur.fetchone()
+            if row is not None:
+                failures_last_hour = int(row[0] or 0)
+        self._conn.commit()
+
+        self._supervisor_ticks += 1
+        self._last_heartbeat_at = datetime.now(UTC)
+        self._log.info(
+            "daemon.supervisor_tick",
+            extra={
+                "event": "supervisor_tick",
+                "run_id": self._run_id,
+                "tick_n": self._supervisor_ticks,
+                "failures_last_hour": failures_last_hour,
+            },
+        )
+        return {"failures_last_hour": failures_last_hour}
+
+    # ── signal handling ────────────────────────────────────────────────
+
+    def request_stop(self, signum: int | None = None, _frame: Any = None) -> None:
+        """SIGTERM / SIGINT handler — sets the stop event; the run loop checks it."""
+        if signum is not None:
+            self._log.info(
+                "daemon.signal_received",
+                extra={"event": "signal_received", "signum": int(signum)},
+            )
+        self._stop.set()
+
+    # ── run loop ───────────────────────────────────────────────────────
+
+    def run_forever(self) -> int:
+        """Block until SIGTERM/SIGINT; run scheduler + supervisor on their cadences.
+
+        Returns an exit code (0 on clean shutdown).
+        """
+        assert self._conn is not None, "connect() must run before run_forever"
+        assert self._run_id is not None, "register the run before run_forever"
+
+        last_scheduler = 0.0
+        last_supervisor = 0.0
+        # Tick once on boot so the first scheduler/supervisor cycle is
+        # observable immediately in logs + DB, rather than after the
+        # first full cadence elapses.
+        try:
+            self.scheduler_tick()
+            last_scheduler = time.monotonic()
+            self.supervisor_tick()
+            last_supervisor = time.monotonic()
+        except Exception:
+            self._log.exception("daemon.initial_tick_failed")
+            return 1
+
+        # Poll the stop flag in 1-second slices so SIGTERM lands promptly.
+        while not self._stop.is_set():
+            now = time.monotonic()
+            try:
+                if now - last_scheduler >= self._cfg.tick_scheduler_seconds:
+                    self.scheduler_tick()
+                    last_scheduler = now
+                if now - last_supervisor >= self._cfg.tick_supervisor_seconds:
+                    self.supervisor_tick()
+                    last_supervisor = now
+            except Exception:
+                # Any tick exception is logged and the loop continues —
+                # the next tick will try again. Real DB failure will
+                # repeat and show up in the logs; the ECS task does not
+                # crash-restart for a single blip.
+                self._log.exception("daemon.tick_failed")
+                # Back off briefly before retrying to avoid a tight loop
+                # on a persistent DB outage.
+                self._stop.wait(1.0)
+                continue
+            # Sleep at most 1s at a time so shutdown is snappy.
+            self._stop.wait(1.0)
+
+        self._log.info("daemon.shutdown_begin", extra={"event": "shutdown_begin"})
+        self.mark_stopped()
+        return 0
+
+
+# --------------------------------------------------------------------------
+# Argparse + entrypoint
+# --------------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="scripts.dispatcher.daemon",
+        description="Dispatcher v2 daemon — Phase 1 skeleton (no subprocess spawn).",
+    )
+    parser.add_argument(
+        "--tick-scheduler-seconds",
+        type=int,
+        default=DEFAULT_SCHEDULER_TICK_SECONDS,
+        help="Seconds between scheduler ticks (default: 30).",
+    )
+    parser.add_argument(
+        "--tick-supervisor-seconds",
+        type=int,
+        default=DEFAULT_SUPERVISOR_TICK_SECONDS,
+        help="Seconds between supervisor ticks (default: 120).",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Log level (default: INFO).",
+    )
+    parser.add_argument(
+        "--config-override",
+        default=None,
+        help=(
+            "JSON object merged into DaemonConfig.config_override for testing; "
+            "unused at runtime by Phase 1 skeleton."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _build_config(
+    args: argparse.Namespace, env: dict[str, str] | None = None
+) -> DaemonConfig:
+    """Build a :class:`DaemonConfig` from argparse + environment variables."""
+    env = env if env is not None else dict(os.environ)
+    database_url = env.get("DATABASE_URL", "")
+    version_sha = env.get("GIT_SHA", "unknown")
+    host = env.get("HOSTNAME") or socket.gethostname() or "unknown-host"
+
+    override: dict[str, Any] = {}
+    if args.config_override:
+        try:
+            parsed = json.loads(args.config_override)
+            if isinstance(parsed, dict):
+                override = parsed
+        except (json.JSONDecodeError, ValueError):
+            # Intentionally swallow — bad --config-override is a test-path nit,
+            # not a startup failure. Logged by caller once the logger is up.
+            override = {"__parse_error__": args.config_override}
+
+    return DaemonConfig(
+        database_url=database_url,
+        tick_scheduler_seconds=args.tick_scheduler_seconds,
+        tick_supervisor_seconds=args.tick_supervisor_seconds,
+        log_level=args.log_level,
+        version_sha=version_sha,
+        host=host,
+        pid=os.getpid(),
+        config_override=override,
+    )
+
+
+def _install_signal_handlers(daemon: DispatcherDaemon) -> None:
+    """Wire SIGTERM + SIGINT to :meth:`DispatcherDaemon.request_stop`."""
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            signal.signal(sig, daemon.request_stop)
+        except (ValueError, OSError):  # pragma: no cover — non-main thread in tests
+            # Tests that drive the daemon off the main thread (e.g. to
+            # simulate SIGTERM via request_stop() directly) can't install
+            # signal handlers — that's fine, call the handler directly.
+            continue
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint. Returns an exit code."""
+    try:
+        args = _parse_args(argv if argv is not None else sys.argv[1:])
+    except SystemExit as exc:
+        return int(exc.code) if isinstance(exc.code, int) else 2
+
+    cfg = _build_config(args)
+    log = _configure_logging(cfg.log_level)
+
+    if not cfg.database_url:
+        log.error(
+            "daemon.startup_failed",
+            extra={"event": "startup_failed", "reason": "DATABASE_URL not set"},
+        )
+        return 1
+
+    if "__parse_error__" in cfg.config_override:
+        log.warning(
+            "daemon.config_override_parse_error",
+            extra={
+                "event": "config_override_parse_error",
+                "raw": cfg.config_override["__parse_error__"],
+            },
+        )
+
+    log.info(
+        "daemon.startup",
+        extra={
+            "event": "startup",
+            "version_sha": cfg.version_sha,
+            "host": cfg.host,
+            "pid": cfg.pid,
+            "tick_scheduler_seconds": cfg.tick_scheduler_seconds,
+            "tick_supervisor_seconds": cfg.tick_supervisor_seconds,
+        },
+    )
+
+    daemon = DispatcherDaemon(cfg, log)
+    _install_signal_handlers(daemon)
+
+    try:
+        daemon.connect()
+    except Exception as exc:
+        log.exception("daemon.connect_failed", extra={"event": "connect_failed"})
+        # Ensure we return 1 without swallowing the traceback in logs.
+        del exc
+        return 1
+
+    try:
+        daemon.check_lease_and_register_run()
+    except LeaseError as exc:
+        log.error(
+            "daemon.lease_held",
+            extra={"event": "lease_held", "detail": str(exc)},
+        )
+        daemon.close()
+        return 1
+    except Exception:
+        log.exception("daemon.register_failed", extra={"event": "register_failed"})
+        daemon.close()
+        return 1
+
+    try:
+        return daemon.run_forever()
+    finally:
+        daemon.close()
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised via `python -m`
+    sys.exit(main())

--- a/scripts/dispatcher/tests/test_daemon_skeleton.py
+++ b/scripts/dispatcher/tests/test_daemon_skeleton.py
@@ -1,0 +1,412 @@
+"""Unit tests for ``scripts.dispatcher.daemon`` — Phase 1 skeleton.
+
+Issue #2729. Mocks ``psycopg`` to exercise the daemon's DB interactions
+without a real Postgres. Covers the five behaviors the issue explicitly
+asks about:
+
+- Lease check fires when an active peer row exists.
+- Run registration inserts one row and captures the returned run_id.
+- Supervisor tick UPDATEs ``dispatcher.runs.heartbeat_ts`` at least once.
+- Scheduler tick marks all pending ``dispatcher.commands`` consumed.
+- SIGTERM-equivalent (``request_stop``) sets ``stopped_at`` on shutdown.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Ensure a `psycopg` module exists in sys.modules before importing the
+# daemon. The daemon lazily imports psycopg inside connect(); tests that
+# patch `dispatcher.daemon.psycopg` via the real module path can still
+# inject a mock through sys.modules, which is the pattern used for
+# other scripts/ daemons (test_dev_db_query_runner.py et al.).
+if "psycopg" not in sys.modules:  # pragma: no cover — exercised in fresh venvs only
+    sys.modules["psycopg"] = MagicMock()
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Test helpers
+# --------------------------------------------------------------------------
+
+
+def _make_logger() -> logging.Logger:
+    """Return a silent logger — tests shouldn't care about log output."""
+    logger = logging.getLogger("dispatcher.test")
+    logger.addHandler(logging.NullHandler())
+    logger.propagate = False
+    return logger
+
+
+class _FakeCursor:
+    """Tiny stand-in for a psycopg cursor with scripted ``fetchone`` outputs.
+
+    Records every ``execute`` call in ``executed`` so tests can assert on
+    the SQL the daemon issues without parsing real SQL. Each test pushes
+    the exact sequence of fetchone return values via ``fetch_queue``.
+    """
+
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+
+class _FakeConnection:
+    """Tracks commits / rollbacks and hands out a single cursor."""
+
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _make_daemon(
+    *,
+    fake_conn: _FakeConnection,
+    tick_scheduler: int = 30,
+    tick_supervisor: int = 120,
+) -> daemon.DispatcherDaemon:
+    """Build a daemon wired to ``fake_conn`` — skips the real connect() path."""
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake-for-tests",
+        tick_scheduler_seconds=tick_scheduler,
+        tick_supervisor_seconds=tick_supervisor,
+        log_level="DEBUG",
+        version_sha="deadbee",
+        host="test-host",
+        pid=4242,
+    )
+    d = daemon.DispatcherDaemon(cfg, _make_logger())
+    d._conn = fake_conn  # type: ignore[assignment]  — test stub
+    return d
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+
+class TestLeaseCheck:
+    """§17 Risk 2 — second daemon bails when first one's heartbeat is fresh."""
+
+    def test_lease_held_raises(self) -> None:
+        fake_conn = _FakeConnection()
+        # SELECT ... returns a row → another daemon is active.
+        fake_conn.cursor_instance.fetch_queue = [
+            ("existing-run-id", "2026-04-18T00:00:00Z")
+        ]
+
+        d = _make_daemon(fake_conn=fake_conn)
+        with pytest.raises(daemon.LeaseError) as excinfo:
+            d.check_lease_and_register_run()
+        assert "existing-run-id" in str(excinfo.value)
+        # Lease contention rolls back, does not commit.
+        assert fake_conn.rollbacks == 1
+        assert fake_conn.commits == 0
+
+    def test_no_active_peer_inserts_run(self) -> None:
+        fake_conn = _FakeConnection()
+        # SELECT returns None (no peer), INSERT RETURNING yields new run_id.
+        fake_conn.cursor_instance.fetch_queue = [None, ("new-run-id",)]
+
+        d = _make_daemon(fake_conn=fake_conn)
+        run_id = d.check_lease_and_register_run()
+
+        assert run_id == "new-run-id"
+        assert d._run_id == "new-run-id"
+        # Both lease SELECT and INSERT ran in the same transaction.
+        executed = fake_conn.cursor_instance.executed
+        assert any("FROM dispatcher.runs" in sql for sql, _ in executed)
+        assert any("INSERT INTO dispatcher.runs" in sql for sql, _ in executed)
+        assert fake_conn.commits == 1
+
+    def test_insert_returns_no_row_raises(self) -> None:
+        fake_conn = _FakeConnection()
+        # Weird state: lease OK, but INSERT ... RETURNING yields nothing.
+        fake_conn.cursor_instance.fetch_queue = [None, None]
+
+        d = _make_daemon(fake_conn=fake_conn)
+        with pytest.raises(RuntimeError):
+            d.check_lease_and_register_run()
+
+
+class TestSchedulerTick:
+    """§6 step 1 — consume any pending commands; Phase 1 stops there."""
+
+    def test_consumes_commands_and_reads_config(self) -> None:
+        fake_conn = _FakeConnection()
+        # UPDATE returns rowcount=3; SELECT config returns concurrency_cap=5.
+        fake_conn.cursor_instance.fetch_queue = [(5,)]
+
+        d = _make_daemon(fake_conn=fake_conn)
+        # Set rowcount via a wrapper: execute() sets it before fetchone.
+        # _FakeCursor doesn't auto-populate rowcount, so set it directly
+        # between execute calls — the daemon calls execute then reads
+        # self._conn.cursor().rowcount, which is a single attribute, so
+        # we set rowcount on the cursor after the UPDATE by patching.
+
+        original_execute = fake_conn.cursor_instance.execute
+
+        def execute_with_rowcount(sql: str, params: Any = None) -> None:
+            original_execute(sql, params)
+            if sql.startswith("UPDATE dispatcher.commands"):
+                fake_conn.cursor_instance.rowcount = 3
+
+        fake_conn.cursor_instance.execute = execute_with_rowcount  # type: ignore[method-assign]
+
+        summary = d.scheduler_tick()
+        assert summary["commands_consumed"] == 3
+        assert summary["concurrency_cap"] == 5
+        # Exactly one commit per tick.
+        assert fake_conn.commits == 1
+        # Tick counter incremented.
+        assert d._scheduler_ticks == 1
+
+    def test_no_commands_to_consume(self) -> None:
+        fake_conn = _FakeConnection()
+        # No concurrency_cap row → fetchone returns None.
+        fake_conn.cursor_instance.fetch_queue = [None]
+
+        d = _make_daemon(fake_conn=fake_conn)
+        summary = d.scheduler_tick()
+        assert summary["commands_consumed"] == 0
+        assert summary["concurrency_cap"] == -1  # sentinel for "unset"
+
+
+class TestSupervisorTick:
+    """§7 — UPDATE heartbeat_ts every tick; read failures count for smoke test."""
+
+    def test_heartbeat_update_and_failures_read(self) -> None:
+        fake_conn = _FakeConnection()
+        # count(*) from failures → 7 rows in the last hour.
+        fake_conn.cursor_instance.fetch_queue = [(7,)]
+
+        d = _make_daemon(fake_conn=fake_conn)
+        d._run_id = "test-run-id"  # simulate post-registration state
+
+        summary = d.supervisor_tick()
+
+        assert summary["failures_last_hour"] == 7
+        assert d._supervisor_ticks == 1
+        # The UPDATE must fire with the run_id as a bound parameter.
+        executed = fake_conn.cursor_instance.executed
+        update_calls = [
+            e for e in executed if e[0].startswith("UPDATE dispatcher.runs")
+        ]
+        assert len(update_calls) == 1
+        assert update_calls[0][1] == ("test-run-id",)
+        # And the failures count must fire.
+        assert any("dispatcher.failures" in sql for sql, _ in executed)
+        assert fake_conn.commits == 1
+        assert d._last_heartbeat_at is not None
+
+
+class TestShutdown:
+    """SIGTERM-equivalent: ``request_stop`` sets the flag and mark_stopped UPDATEs the row."""
+
+    def test_request_stop_sets_event(self) -> None:
+        fake_conn = _FakeConnection()
+        d = _make_daemon(fake_conn=fake_conn)
+        assert not d._stop.is_set()
+        d.request_stop(15, None)  # 15 = SIGTERM
+        assert d._stop.is_set()
+
+    def test_mark_stopped_updates_run_row(self) -> None:
+        fake_conn = _FakeConnection()
+        d = _make_daemon(fake_conn=fake_conn)
+        d._run_id = "test-run-id"
+        d.mark_stopped()
+
+        executed = fake_conn.cursor_instance.executed
+        assert len(executed) == 1
+        sql, params = executed[0]
+        assert "UPDATE dispatcher.runs SET stopped_at" in sql
+        assert params == ("test-run-id",)
+        assert fake_conn.commits == 1
+
+    def test_mark_stopped_noop_if_not_registered(self) -> None:
+        """No run_id → don't issue a UPDATE with a NULL key."""
+        fake_conn = _FakeConnection()
+        d = _make_daemon(fake_conn=fake_conn)
+        # run_id is None — mark_stopped must be a silent no-op.
+        d.mark_stopped()
+        assert fake_conn.cursor_instance.executed == []
+        assert fake_conn.commits == 0
+
+    def test_close_idempotent(self) -> None:
+        fake_conn = _FakeConnection()
+        d = _make_daemon(fake_conn=fake_conn)
+        d.close()
+        d.close()
+        assert fake_conn.closed
+
+
+class TestRunLoop:
+    """Smoke-test ``run_forever`` wires initial ticks + exits on stop event."""
+
+    def test_stop_before_first_tick_still_runs_initial_ticks(self) -> None:
+        """run_forever does the initial boot-tick pair before checking _stop."""
+        fake_conn = _FakeConnection()
+        # Boot scheduler + supervisor ticks each need one fetchone result:
+        # scheduler: config → (5,); supervisor: failures count → (0,).
+        fake_conn.cursor_instance.fetch_queue = [(5,), (0,)]
+
+        d = _make_daemon(fake_conn=fake_conn)
+        d._run_id = "test-run-id"
+        # Pre-set the stop event so run_forever exits immediately after the
+        # initial tick pair.
+        d._stop.set()
+
+        exit_code = d.run_forever()
+        assert exit_code == 0
+        assert d._scheduler_ticks == 1
+        assert d._supervisor_ticks == 1
+
+    def test_run_forever_honors_stop_event_within_one_second(self) -> None:
+        """Trigger ``request_stop`` from another thread; loop exits quickly."""
+        fake_conn = _FakeConnection()
+        # Initial boot ticks only — don't need fetches for further ticks
+        # because we stop the loop before the next cadence fires.
+        fake_conn.cursor_instance.fetch_queue = [(5,), (0,)]
+
+        d = _make_daemon(
+            fake_conn=fake_conn,
+            tick_scheduler=3600,  # arbitrarily far out
+            tick_supervisor=3600,
+        )
+        d._run_id = "test-run-id"
+
+        # Schedule a stop after 0.1s; run_forever's 1s poll slice guarantees
+        # we exit within ~1.1s even on slow runners.
+        t = threading.Timer(0.1, d.request_stop)
+        t.start()
+        try:
+            exit_code = d.run_forever()
+        finally:
+            t.cancel()
+
+        assert exit_code == 0
+
+
+class TestArgparseAndConfig:
+    """CLI: flag defaults + config-override JSON + env-var plumbing."""
+
+    def test_default_flags(self) -> None:
+        args = daemon._parse_args([])
+        assert args.tick_scheduler_seconds == daemon.DEFAULT_SCHEDULER_TICK_SECONDS
+        assert args.tick_supervisor_seconds == daemon.DEFAULT_SUPERVISOR_TICK_SECONDS
+        assert args.log_level == "INFO"
+        assert args.config_override is None
+
+    def test_build_config_reads_env(self) -> None:
+        args = daemon._parse_args(
+            ["--tick-scheduler-seconds", "5", "--tick-supervisor-seconds", "10"]
+        )
+        env = {
+            "DATABASE_URL": "postgres://x",
+            "GIT_SHA": "feedc0de",
+            "HOSTNAME": "task-abc",
+        }
+        cfg = daemon._build_config(args, env=env)
+        assert cfg.database_url == "postgres://x"
+        assert cfg.version_sha == "feedc0de"
+        assert cfg.host == "task-abc"
+        assert cfg.tick_scheduler_seconds == 5
+        assert cfg.tick_supervisor_seconds == 10
+        assert cfg.pid > 0
+
+    def test_build_config_falls_back_to_unknown_sha(self) -> None:
+        args = daemon._parse_args([])
+        cfg = daemon._build_config(args, env={"DATABASE_URL": "postgres://x"})
+        assert cfg.version_sha == "unknown"
+        assert cfg.host  # non-empty fallback via socket.gethostname
+
+    def test_build_config_override_parses_json(self) -> None:
+        args = daemon._parse_args(["--config-override", '{"concurrency_cap": 0}'])
+        cfg = daemon._build_config(args, env={"DATABASE_URL": "postgres://x"})
+        assert cfg.config_override == {"concurrency_cap": 0}
+
+    def test_build_config_override_bad_json_captured(self) -> None:
+        args = daemon._parse_args(["--config-override", "{not json}"])
+        cfg = daemon._build_config(args, env={"DATABASE_URL": "postgres://x"})
+        assert "__parse_error__" in cfg.config_override
+
+
+class TestMainEntrypoint:
+    """End-to-end ``main()`` wiring — mocks the psycopg module."""
+
+    def test_main_missing_database_url_returns_1(self) -> None:
+        with patch.dict("os.environ", {"DATABASE_URL": ""}, clear=False):
+            rc = daemon.main(
+                ["--tick-scheduler-seconds", "1", "--tick-supervisor-seconds", "1"]
+            )
+        assert rc == 1
+
+    def test_main_lease_held_returns_1(self) -> None:
+        """Simulate a live peer row → main() should exit 1 without running ticks."""
+        fake_conn = _FakeConnection()
+        # SELECT returns a peer row → LeaseError.
+        fake_conn.cursor_instance.fetch_queue = [
+            ("peer-run-id", "2026-04-18T00:00:00Z")
+        ]
+
+        # Patch the psycopg module the daemon imports lazily.
+        mock_psycopg = MagicMock()
+        mock_psycopg.connect.return_value = fake_conn
+
+        with (
+            patch.dict("sys.modules", {"psycopg": mock_psycopg}),
+            patch.dict(
+                "os.environ",
+                {"DATABASE_URL": "postgres://fake", "GIT_SHA": "abc1234"},
+                clear=False,
+            ),
+        ):
+            rc = daemon.main(
+                ["--tick-scheduler-seconds", "1", "--tick-supervisor-seconds", "1"]
+            )
+        assert rc == 1
+        # Connection still closed despite the lease-held bail-out.
+        assert fake_conn.closed


### PR DESCRIPTION
## Summary

Phase 1 sub-task C of dispatcher v2 (parent #2725): runnable-but-inert daemon skeleton + container image. The daemon connects to Postgres, claims the lease via `dispatcher.runs`, ticks scheduler/supervisor loops, updates `heartbeat_ts`, and exits cleanly on SIGTERM — **no subprocess spawning** (Phase 2's job).

Bundles: `scripts/dispatcher/daemon.py` (+19 unit tests), `Dockerfile.dispatcher` (node:20-slim + psycopg + claude-code@2.1.114 + gh + git), new `judgemind/dispatcher` ECR repo in terraform, `.github/workflows/deploy-dispatcher.yml`, and extends the scripts-tests CI job to cover `scripts/dispatcher/tests/`.

Closes #2729

## Test plan

### Automated checks
- [x] Lint passes (`ruff check scripts/dispatcher/` — clean)
- [x] Format check passes (`ruff format --check scripts/dispatcher/` — 5 files already formatted)
- [x] Tests pass (`pytest scripts/dispatcher/tests/` — 19 passed locally + in CI)
- [x] Terraform validate passes (`terraform validate` on environments/dev — Success)
- [x] Terraform fmt check passes (`terraform fmt -check -recursive infra/terraform/`)
- [x] Docker image builds cleanly (local + CI)
- [x] CI green (mergeStateStatus=CLEAN, all checks SUCCESS/SKIPPED-for-unrelated-paths)

### Post-deploy verification
- [x] `aws ecr describe-images --repository-name judgemind/dispatcher` returns image `d98f13e` pushed 2026-04-18T19:34:40-07:00.
- [x] `aws ecs run-task` on a verify-task-def based on `judgemind-dispatcher-dev` (with DATABASE_URL wired for verification) — daemon booted, registered `dispatcher.runs` row `49388a30-1035-4a93-ac18-455c8c0c6a3b`, emitted 3 supervisor ticks (heartbeat_ts advanced), received SIGTERM (signum=15), wrote `stopped_at`, exited with container exitCode=0.
- [x] Verification evidence posted on issue (https://github.com/judgemind/judgemind/issues/2729#issuecomment-4275026561)

## Notes for reviewers

- **Python 3.11 vs 3.12 in the image.** Issue body said 3.12; image uses Debian bookworm's stock `python3` (3.11). Rationale: `node:20-slim` (the spike-0.1-validated base) is bookworm; pulling 3.12 would mean deadsnakes or a multi-stage build. The daemon only uses 3.11-compatible syntax (`from datetime import UTC` is 3.11+). If a Phase-2 feature needs 3.12-only APIs, we can revisit then. Called out explicitly in the process-summary comment on #2729.
- **ECR repo wiring.** #2728 (sub-task B) passed `module.ecr.repository_url` (the scraper repo) into the dispatcher-daemon module as a placeholder because no dispatcher repo existed yet. This PR adds the real repo and flips the wiring to `module.ecr.dispatcher_repository_url`.
- **`desiredCount` unchanged at 0.** Per the issue's Non-goals section, this PR does not flip the service to 1 — Phase 2 does that.
- **Deploy workflow doesn't deploy.** `deploy-dispatcher.yml` only builds and pushes. Because the ECS service runs at `desired_count=0`, there's nothing to redeploy; Phase 2 will add a deploy-dev job analogous to `deploy-api.yml`.
- **First push failed, rerun succeeded.** The initial post-merge run of `deploy-dispatcher.yml` raced the terraform apply that creates the new ECR repo. Re-triggered manually via `gh workflow run deploy-dispatcher.yml` after apply; second run succeeded. Phase-2 or the next agent who lands both the daemon module + a new repo at once may want an explicit terraform-apply gate before the deploy workflow fires.
