### PR TITLE
fix(api): make migration 15 search_path target current database (#2746)

### DIFF
--- a/packages/api/migrations/15_schema-reorganization.sql
+++ b/packages/api/migrations/15_schema-reorganization.sql
@@ -37,8 +37,14 @@ ALTER TABLE data_quality_metrics        SET SCHEMA telemetry;
 ALTER TABLE validation_results          SET SCHEMA telemetry;
 
 -- Set search_path so unqualified references still resolve.
--- This applies to the judgemind role (used by all services).
-ALTER DATABASE judgemind SET search_path = public, derived, telemetry, staging;
+-- Uses current_database() so the ALTER DATABASE targets whichever DB the
+-- migration is being applied to (dev/prod `judgemind`, throwaway test DBs,
+-- etc.) rather than hardcoding a single name.
+DO $$
+BEGIN
+  EXECUTE format('ALTER DATABASE %I SET search_path = public, derived, telemetry, staging',
+                 current_database());
+END $$;
 
 
 -- Down Migration
@@ -62,7 +68,11 @@ ALTER TABLE telemetry.scraper_runs                SET SCHEMA public;
 ALTER TABLE telemetry.data_quality_metrics        SET SCHEMA public;
 ALTER TABLE telemetry.validation_results          SET SCHEMA public;
 
-ALTER DATABASE judgemind SET search_path = public, staging;
+DO $$
+BEGIN
+  EXECUTE format('ALTER DATABASE %I SET search_path = public, staging',
+                 current_database());
+END $$;
 
 DROP SCHEMA IF EXISTS derived;
 DROP SCHEMA IF EXISTS telemetry;


### PR DESCRIPTION
## Summary

Migration 15 hardcoded the database name (`ALTER DATABASE judgemind SET search_path = ...`), so running `db:migrate` against any database other than `judgemind` silently left `search_path` at the default `"$user", public` — breaking every integration test that uses unqualified names like `SELECT ... FROM courts`. Both ALTER DATABASE statements (up at line 41, down at line 65) now use `DO $$ ... EXECUTE format(..., current_database()) $$` so they target whichever DB the migration is being applied to.

Idempotent on the existing `judgemind` DBs — the migration is already recorded in `pgmigrations` so it won't re-run, and even if it did, `ALTER DATABASE ... SET` on an already-matching value is a no-op.

Closes #2746

## Test plan

### Automated checks
- [x] Lint passes (API package — ran via pre-push)
- [x] Schema drift check passes (real schema-match check in CI-mode, ran via pre-push)
- [x] CI green

### Local verification (per issue acceptance criteria)

- [x] Fresh DB path: created `m15_test`, ran `db:migrate` (migrations 1..22 applied), `SHOW search_path;` returned `public, derived, telemetry, staging`.
- [x] Existing DB path: ran `db:migrate` against primary `judgemind` DB — output was `No migrations to run!`, `search_path` unchanged (`public, derived, telemetry, staging`).

### Post-deploy verification
- [x] N/A — no deployed component (SQL migration in already-applied history). This migration is already in `pgmigrations` on dev and prod, so `npm run db:migrate` will not re-run it. The change is effectively a documentation/correctness fix for anyone who later migrates a fresh DB.
