### PR TITLE
fix(api): add DISABLE_LOGIN_RATE_LIMIT env opt-out for integration tests (#2744)

### DIFF
--- a/packages/api/src/auth/rate-limit.ts
+++ b/packages/api/src/auth/rate-limit.ts
@@ -24,8 +24,17 @@ async function getRedis(): Promise<RedisClientType | null> {
 /**
  * Check and increment the login attempt counter for an IP address.
  * Returns true if the request should be allowed, false if rate-limited.
+ *
+ * Set `DISABLE_LOGIN_RATE_LIMIT=1` to bypass the check — intended for the
+ * integration test harness (tests/auth.integration.test.ts makes > 10 login
+ * calls from the shared 127.0.0.1 IP, which otherwise trips the limit and
+ * causes flaky failures against a locally-running Redis). See issue #2744.
+ * The dedicated unit tests in tests/auth-rate-limit.unit.test.ts still
+ * exercise the real rate-limit path by explicitly clearing this env var.
  */
 export async function checkLoginRateLimit(ip: string): Promise<boolean> {
+  if (process.env.DISABLE_LOGIN_RATE_LIMIT === '1') return true;
+
   const redis = await getRedis();
   if (!redis) return true; // fail open
 

--- a/packages/api/tests/auth-rate-limit.unit.test.ts
+++ b/packages/api/tests/auth-rate-limit.unit.test.ts
@@ -44,6 +44,10 @@ describe('checkLoginRateLimit', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.resetAllMocks();
+    // Ensure the real rate-limit path is exercised even if the ambient env
+    // (e.g. auth.integration.test.ts running in the same process, or a
+    // developer's shell) has set the opt-out flag. See issue #2744.
+    delete process.env.DISABLE_LOGIN_RATE_LIMIT;
   });
 
   it('allows the first request from an IP', async () => {
@@ -106,5 +110,42 @@ describe('checkLoginRateLimit', () => {
     expect(allowed).toBe(true);
     // incr should not be called since connection failed
     expect(mockIncr).not.toHaveBeenCalled();
+  });
+
+  it('bypasses the rate limit when DISABLE_LOGIN_RATE_LIMIT=1', async () => {
+    vi.resetModules();
+    setupRedisClient();
+    // Even if Redis would report the IP over the limit, the opt-out flag
+    // should short-circuit before any Redis call. See issue #2744.
+    mockIncr.mockResolvedValue(999);
+    process.env.DISABLE_LOGIN_RATE_LIMIT = '1';
+
+    try {
+      const { checkLoginRateLimit: freshCheck } = await import('../src/auth/rate-limit');
+      const allowed = await freshCheck('192.168.1.6');
+
+      expect(allowed).toBe(true);
+      expect(mockCreateClient).not.toHaveBeenCalled();
+      expect(mockIncr).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.DISABLE_LOGIN_RATE_LIMIT;
+    }
+  });
+
+  it('does not bypass the rate limit when DISABLE_LOGIN_RATE_LIMIT is set to something other than "1"', async () => {
+    vi.resetModules();
+    setupRedisClient();
+    mockIncr.mockResolvedValue(11); // over the limit
+    process.env.DISABLE_LOGIN_RATE_LIMIT = 'true'; // wrong value — not "1"
+
+    try {
+      const { checkLoginRateLimit: freshCheck } = await import('../src/auth/rate-limit');
+      const allowed = await freshCheck('192.168.1.7');
+
+      expect(allowed).toBe(false);
+      expect(mockIncr).toHaveBeenCalled();
+    } finally {
+      delete process.env.DISABLE_LOGIN_RATE_LIMIT;
+    }
   });
 });

--- a/packages/api/tests/auth.integration.test.ts
+++ b/packages/api/tests/auth.integration.test.ts
@@ -30,7 +30,15 @@ let app: FastifyInstance;
 // Unique email prefix to avoid collisions with other test runs
 const PREFIX = `test-${Date.now()}`;
 
+// This file makes > 10 login-style requests from the shared 127.0.0.1 IP
+// that app.inject reports. The production login rate limit (MAX_ATTEMPTS = 10
+// per 15 minutes) would trip partway through, causing flaky failures against
+// a locally-running Redis that persists rate-limit keys across test runs.
+// Opt out of the rate limit for the duration of this file; the dedicated unit
+// tests in auth-rate-limit.unit.test.ts still exercise the real rate-limit
+// path. See issue #2744.
 beforeAll(async () => {
+  process.env.DISABLE_LOGIN_RATE_LIMIT = '1';
   applyMigrations();
   app = await buildApp(pool);
 }, 30_000);
@@ -41,6 +49,7 @@ afterAll(async () => {
   await pool.query(`DELETE FROM users WHERE email LIKE $1`, [`${PREFIX}%`]);
   await app?.close();
   await pool.end();
+  delete process.env.DISABLE_LOGIN_RATE_LIMIT;
 }, 15_000);
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`packages/api/tests/auth.integration.test.ts` makes > 10 login-style requests from the shared `127.0.0.1` IP that `app.inject` reports, which trips the production login rate limit (`MAX_ATTEMPTS = 10` per 15 minutes) and causes flaky failures against a locally-running Redis that persists rate-limit keys across test runs. That flakiness was pushing agents toward `--no-verify`, eroding the pre-push safety net.

This PR implements fix Option 1 from the issue: a `DISABLE_LOGIN_RATE_LIMIT=1` env opt-out at the top of `checkLoginRateLimit`, wired from the integration test file's `beforeAll`/`afterAll`. The dedicated unit tests in `auth-rate-limit.unit.test.ts` still exercise the real rate-limit path — their `beforeEach` now explicitly `delete`s the env var, and two new unit tests cover the opt-out itself (flag=`1` bypasses; flag=`"true"` does not — strict `=== '1'` comparison).

Closes #2744

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Ran `FLUSHALL && npm --prefix packages/api test -- auth.integration` locally — all 32 tests green (was: 2 failures before the fix)
- [x] Ran it twice in a row without `FLUSHALL` between runs — still all 32 green (the previous flaky re-run case)
- [x] Ran `npm --prefix packages/api test -- auth-rate-limit.unit` — all 7 unit tests green (5 original + 2 new coverage of the env opt-out and the negative case)
- [x] Ran full pre-push suite (`npm --prefix packages/api test`) on a clean local DB — all 345 tests across 28 files pass
- [x] N/A — no deployed component (library code; the env var is only ever set by the test harness, never in production)
