### PR TITLE
refactor(api): consolidate dispatcher admin auth onto users.role (#2751)

### DIFF
--- a/docs/specs/dispatcher-v2-spec.md
+++ b/docs/specs/dispatcher-v2-spec.md
@@ -335,7 +335,7 @@ Toggling any of these on/off is a single `UPDATE dispatcher.config` row — edit
 
 New route `packages/web/app/admin/dispatcher/`.
 
-**Auth:** gated on `users.is_admin = true` (new column, defaults false; seed drewthaler). Non-admins 404.
+**Auth:** gated on `users.role = 'admin'` (matches existing admin dashboard gate in `data-quality.ts`). Non-admins 404.
 
 **GraphQL additions** (`packages/api/src/graphql/dispatcher/`):
 

--- a/packages/api/migrations/22_users-is-admin.sql
+++ b/packages/api/migrations/22_users-is-admin.sql
@@ -1,5 +1,11 @@
 -- Up Migration
 --
+-- SUPERSEDED BY MIGRATION 23 (#2751). This migration ran on dev and prod
+-- history, so it is left intact — migration 23 drops the `is_admin` column
+-- and the dispatcher admin surface now gates on `users.role = 'admin'`
+-- instead. Do not copy this pattern; see 23_users-drop-is-admin.sql for the
+-- consolidation rationale.
+--
 -- Dispatcher v2 — Phase 1 Sub-task D. Adds the admin auth gate for the
 -- dispatcher admin GraphQL surface (`docs/specs/dispatcher-v2-spec.md` §11).
 --

--- a/packages/api/migrations/23_users-drop-is-admin.sql
+++ b/packages/api/migrations/23_users-drop-is-admin.sql
@@ -1,0 +1,40 @@
+-- Up Migration
+--
+-- Dispatcher v2 — Phase 1 follow-up. Drops the `public.users.is_admin`
+-- column introduced in migration 22 (#2730, PR #2743) and consolidates
+-- the dispatcher admin gate onto the existing `users.role = 'admin'`
+-- convention used by the data-quality dashboards.
+--
+-- Issue #2751 (refactor: consolidate dispatcher admin auth onto users.role).
+--
+-- Rationale
+-- ---------
+-- Migration 22's "orthogonal admin flag" design was a hallucination from
+-- the spec consolidation pass in #2724 — it was never intended. Existing
+-- admin surfaces (e.g. `data-quality.ts:27`) gate on `user.role === 'admin'`,
+-- and the dispatcher admin surface is simpler and more consistent using
+-- the same gate. One admin concept, one gate.
+--
+-- Migration 22 already ran on dev via the #2743 deploy, so we cannot just
+-- revert it in git — we need a new forward migration that drops the column.
+-- Migration 22 is left intact as a historical record.
+--
+-- This migration is idempotent: it uses DROP COLUMN IF EXISTS so re-running
+-- is a no-op, and the UPDATE on public.users is idempotent by its WHERE
+-- clause.
+
+ALTER TABLE public.users DROP COLUMN IF EXISTS is_admin;
+
+-- Seed drewthaler as role='admin' if not already. This preserves the
+-- maintainer-admin grant that migration 22 established via is_admin=true
+-- (now that the dispatcher surface gates on role='admin').
+UPDATE public.users SET role = 'admin' WHERE email = 'drewthaler@gmail.com' AND role <> 'admin';
+
+
+-- Down Migration
+--
+-- Intentionally not re-adding the is_admin column. It was only ever used by
+-- the dispatcher auth gate, which this PR re-points at users.role. A true
+-- rollback would require reverting the application-layer changes too, which
+-- is out of scope for a DB-only down migration.
+SELECT 1;

--- a/packages/api/src/auth/middleware.ts
+++ b/packages/api/src/auth/middleware.ts
@@ -6,13 +6,6 @@ export interface AuthUser {
   id: string;
   email: string;
   role: string;
-  /**
-   * Grants access to the dispatcher admin GraphQL surface (§11).
-   * Orthogonal to `role` — a user may have is_admin=true without role='admin'
-   * (or vice versa). The existing data-quality admin pages gate on
-   * `role='admin'`; the dispatcher admin surface gates on `is_admin`.
-   */
-  isAdmin: boolean;
 }
 
 /**
@@ -36,14 +29,13 @@ export async function extractUser(
       id: string;
       email: string;
       role: string;
-      is_admin: boolean;
     }>(
-      'SELECT id, email, role, is_admin FROM users WHERE id = $1 AND is_active = true',
+      'SELECT id, email, role FROM users WHERE id = $1 AND is_active = true',
       [payload.sub],
     );
     const row = rows[0];
     if (!row) return null;
-    return { id: row.id, email: row.email, role: row.role, isAdmin: row.is_admin };
+    return { id: row.id, email: row.email, role: row.role };
   } catch {
     return null;
   }

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -570,12 +570,8 @@ CREATE TABLE public.users (
     last_login_at timestamp with time zone,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    google_id text,
-    is_admin boolean DEFAULT false NOT NULL
+    google_id text
 );
-
-
-COMMENT ON COLUMN public.users.is_admin IS 'Grants access to the dispatcher admin GraphQL surface (§11). Orthogonal to users.role.';
 
 
 CREATE TABLE staging.captures (

--- a/packages/api/src/graphql/dispatcher/auth.ts
+++ b/packages/api/src/graphql/dispatcher/auth.ts
@@ -5,9 +5,13 @@
  * so the existence and field shape of the dispatcher endpoints is not
  * introspectable by non-admins (§11 Auth).
  *
- * Distinct from the `requireAdmin` helper in `data-quality.ts`, which gates
- * on `role='admin'` and returns an explicit FORBIDDEN error. The two gates
- * are intentionally separate — see `AuthUser.isAdmin` in middleware.ts.
+ * Gates on `user.role === 'admin'` — the same convention used by the
+ * existing data-quality admin dashboards (`data-quality.ts:27`). A single
+ * admin concept across all admin surfaces keeps the auth model simple.
+ * The only behavioural difference from `requireAdmin` in `data-quality.ts`
+ * is the response shape: this gate returns a generic NOT_FOUND so the
+ * dispatcher schema is not enumerable by non-admins, whereas data-quality
+ * returns an explicit FORBIDDEN.
  */
 
 import { GraphQLError } from 'graphql';
@@ -34,7 +38,7 @@ export function notFound(): never {
  * two in responses.
  */
 export function requireDispatcherAdmin(user: AuthUser | null): AuthUser {
-  if (!user || !user.isAdmin) {
+  if (!user || user.role !== 'admin') {
     notFound();
   }
   return user;

--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -4,7 +4,7 @@
  * Phase 1 (the admin page polls every 2s per §11, and the tables are
  * small enough that a cache would hide more than it helps).
  *
- * Gated on `users.is_admin = true` via `requireDispatcherAdmin`. Non-admins
+ * Gated on `user.role === 'admin'` via `requireDispatcherAdmin`. Non-admins
  * receive a generic "not found" error (see `./auth.ts`).
  *
  * `dispatcherControl` is idempotent at the command-row level — identical
@@ -15,7 +15,7 @@
 import type { Pool } from 'pg';
 import { GraphQLError, GraphQLScalarType, Kind } from 'graphql';
 import type { AuthUser } from '../../auth';
-import { DESTRUCTIVE_COMMANDS, notFound, requireDispatcherAdmin } from './auth';
+import { DESTRUCTIVE_COMMANDS, requireDispatcherAdmin } from './auth';
 
 // Minimal Context subset the dispatcher resolvers read.
 interface DispatcherContext {
@@ -313,7 +313,7 @@ export const dispatcherResolvers = {
 
     activeAgents: async (_: unknown, __: unknown, { pool, user }: DispatcherContext) => {
       // Parent resolver already admin-gated; re-check for defence-in-depth.
-      if (!user || !user.isAdmin) notFound();
+      requireDispatcherAdmin(user);
       const rows = await queryActiveAgents(pool);
       return rows.map(agentRowToGraphQL);
     },
@@ -323,14 +323,14 @@ export const dispatcherResolvers = {
       { sinceHours }: { sinceHours?: number | null },
       { pool, user }: DispatcherContext,
     ) => {
-      if (!user || !user.isAdmin) notFound();
+      requireDispatcherAdmin(user);
       const hours = sinceHours ?? 24;
       const rows = await queryRecentFailures(pool, hours);
       return rows.map(failureRowToGraphQL);
     },
 
     queueDepth: async (_: unknown, __: unknown, { pool, user }: DispatcherContext) => {
-      if (!user || !user.isAdmin) notFound();
+      requireDispatcherAdmin(user);
       return queryQueueDepth(pool);
     },
 
@@ -345,7 +345,7 @@ export const dispatcherResolvers = {
       __: unknown,
       { pool, user }: DispatcherContext,
     ) => {
-      if (!user || !user.isAdmin) notFound();
+      requireDispatcherAdmin(user);
       const agentId = parent.__agent_id ?? parent.id;
       const rows = await queryPhaseTransitions(pool, String(agentId));
       return rows.map(transitionRowToGraphQL);
@@ -356,7 +356,7 @@ export const dispatcherResolvers = {
       __: unknown,
       { pool, user }: DispatcherContext,
     ) => {
-      if (!user || !user.isAdmin) notFound();
+      requireDispatcherAdmin(user);
       const agentId = parent.__agent_id ?? parent.id;
       const rows = await queryFailuresForAgent(pool, String(agentId));
       return rows.map(failureRowToGraphQL);

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -5,7 +5,7 @@
  * admin tooling that needs to read or nudge the daemon. See
  * `docs/specs/dispatcher-v2-spec.md` §11.
  *
- * All queries and mutations are gated on `users.is_admin = true`. Non-admins
+ * All queries and mutations are gated on `users.role = 'admin'`. Non-admins
  * receive a generic "not found" error (no field-shape introspection of the
  * underlying tables — see §11 Auth).
  */

--- a/packages/api/tests/auth-middleware.unit.test.ts
+++ b/packages/api/tests/auth-middleware.unit.test.ts
@@ -23,7 +23,7 @@ function mockRequest(authorization?: string): FastifyRequest {
 }
 
 function mockPool(
-  rows: Array<{ id: string; email: string; role: string; is_admin?: boolean }>,
+  rows: Array<{ id: string; email: string; role: string }>,
 ): Pool {
   return {
     query: vi.fn().mockResolvedValue({
@@ -67,7 +67,7 @@ describe('extractUser', () => {
   });
 
   it('returns the user when token is valid and user exists', async () => {
-    const row = { id: 'user-1', email: 'alice@example.com', role: 'user', is_admin: false };
+    const row = { id: 'user-1', email: 'alice@example.com', role: 'user' };
     mockVerifyAccessToken.mockReturnValue({ sub: 'user-1' });
     const pool = mockPool([row]);
 
@@ -78,21 +78,19 @@ describe('extractUser', () => {
       id: 'user-1',
       email: 'alice@example.com',
       role: 'user',
-      isAdmin: false,
     });
     expect(mockVerifyAccessToken).toHaveBeenCalledWith('valid-token');
     expect(pool.query).toHaveBeenCalledWith(
-      'SELECT id, email, role, is_admin FROM users WHERE id = $1 AND is_active = true',
+      'SELECT id, email, role FROM users WHERE id = $1 AND is_active = true',
       ['user-1'],
     );
   });
 
-  it('returns isAdmin=true when the DB row has is_admin=true', async () => {
+  it('returns role="admin" when the DB row has role=admin', async () => {
     const row = {
       id: 'admin-1',
       email: 'admin@example.com',
-      role: 'user',
-      is_admin: true,
+      role: 'admin',
     };
     mockVerifyAccessToken.mockReturnValue({ sub: 'admin-1' });
     const pool = mockPool([row]);
@@ -103,8 +101,7 @@ describe('extractUser', () => {
     expect(result).toEqual({
       id: 'admin-1',
       email: 'admin@example.com',
-      role: 'user',
-      isAdmin: true,
+      role: 'admin',
     });
   });
 

--- a/packages/api/tests/dispatcher.integration.test.ts
+++ b/packages/api/tests/dispatcher.integration.test.ts
@@ -51,10 +51,10 @@ const insertedFailureIds: string[] = [];
 const insertedRunIds: string[] = [];
 
 async function seedData(): Promise<void> {
-  // Admin user — is_admin=true gates the dispatcher surface.
+  // Admin user — role='admin' gates the dispatcher surface.
   const { rows: adminRows } = await pool.query<{ id: string }>(
-    `INSERT INTO public.users (email, email_verified, role, password_hash, is_admin)
-     VALUES ($1, true, 'user', 'not-a-real-hash', true)
+    `INSERT INTO public.users (email, email_verified, role, password_hash)
+     VALUES ($1, true, 'admin', 'not-a-real-hash')
      RETURNING id`,
     [`${MARKER}-admin@test.com`],
   );
@@ -62,10 +62,10 @@ async function seedData(): Promise<void> {
   adminToken = signAccessToken({
     sub: adminUserId,
     email: `${MARKER}-admin@test.com`,
-    role: 'user',
+    role: 'admin',
   });
 
-  // Regular user — is_admin=false (default) must receive "not found".
+  // Regular user — role='user' (non-admin) must receive "not found".
   const { rows: userRows } = await pool.query<{ id: string }>(
     `INSERT INTO public.users (email, email_verified, role, password_hash)
      VALUES ($1, true, 'user', 'not-a-real-hash')


### PR DESCRIPTION
## Summary

Consolidates dispatcher admin auth onto the existing `users.role = 'admin'` convention used by the data-quality dashboards. Drops the orthogonal `public.users.is_admin` column introduced in #2730 (migration 22 — already applied to dev, so this adds a forward-drop migration 23 rather than reverting) and removes the `AuthUser.isAdmin` surface across middleware, dispatcher resolvers, schema, spec, and tests. Unblocks #2731 (tier-3 admin dispatcher page).

Closes #2751

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (345/345 — unit + integration, includes all 15 dispatcher integration tests)
- [x] Schema drift check passes (schema.sql reconciles with migrations 22 + 23)
- [x] Markdown links pass
- [x] CI green

### Post-deploy verification
- [x] `scripts/dev-db-query.sh "SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name='users' AND column_name='is_admin';"` returns 0 rows
- [x] `scripts/dev-db-query.sh "SELECT email, role FROM public.users WHERE email='drewthaler@gmail.com';"` returns `role=admin`
- [x] Verification evidence posted on issue (see A.8)
