### PR TITLE
feat(web): add /admin/dispatcher page (#2731)

### DIFF
--- a/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { SECTION_HEADING } from '@/lib/typography';
+import type { DispatcherAgent } from '@/lib/dispatcher-queries';
+import { formatUptime, shortAgentId, worktreeLogsUrl } from './format-helpers';
+
+interface ActiveAgentsTableProps {
+  agents: readonly DispatcherAgent[];
+  disabled?: boolean;
+  onAgentAction: (command: 'retry' | 'force_kill', agentId: string) => void;
+  /** Override for deterministic tests. */
+  nowMs?: number;
+}
+
+export function ActiveAgentsTable({
+  agents,
+  disabled,
+  onAgentAction,
+  nowMs,
+}: ActiveAgentsTableProps) {
+  return (
+    <section
+      aria-labelledby="active-agents-heading"
+      className="rounded-lg border border-border bg-card"
+    >
+      <div className="flex items-center justify-between border-b border-border p-4">
+        <h2 id="active-agents-heading" className={SECTION_HEADING}>
+          Active agents ({agents.length})
+        </h2>
+      </div>
+
+      {agents.length === 0 ? (
+        <p className="p-6 text-center text-sm text-muted-foreground">No active agents.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th scope="col" className="p-3">Agent</th>
+                <th scope="col" className="p-3">Issue</th>
+                <th scope="col" className="p-3">Phase</th>
+                <th scope="col" className="p-3">Elapsed</th>
+                <th scope="col" className="p-3">Worktree</th>
+                <th scope="col" className="p-3">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {agents.map((agent) => {
+                const logsHref = worktreeLogsUrl(agent.worktreePath);
+                return (
+                  <tr
+                    key={agent.id}
+                    className="border-b border-border last:border-b-0"
+                  >
+                    <td className="p-3 font-mono text-xs text-foreground">
+                      {shortAgentId(agent.id)}
+                    </td>
+                    <td className="p-3 text-foreground">#{agent.issueNumber}</td>
+                    <td className="p-3 font-mono text-xs text-muted-foreground">
+                      {agent.phase}
+                    </td>
+                    <td className="p-3 text-foreground">
+                      {formatUptime(agent.startedAt, nowMs)}
+                    </td>
+                    <td className="p-3 text-xs">
+                      {logsHref ? (
+                        <a
+                          href={logsHref}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-accent underline-offset-2 hover:underline"
+                        >
+                          Logs
+                        </a>
+                      ) : (
+                        <span
+                          title={agent.worktreePath}
+                          className="font-mono text-muted-foreground"
+                        >
+                          {agent.worktreePath.split('/').pop() ?? agent.worktreePath}
+                        </span>
+                      )}
+                    </td>
+                    <td className="p-3">
+                      <div className="flex gap-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          disabled={disabled}
+                          onClick={() => onAgentAction('retry', agent.id)}
+                        >
+                          Retry
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="destructive"
+                          size="sm"
+                          disabled={disabled}
+                          onClick={() => onAgentAction('force_kill', agent.id)}
+                        >
+                          Kill
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/app/(main)/admin/dispatcher/ConfigPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ConfigPanel.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { SECTION_HEADING } from '@/lib/typography';
+
+interface ConfigPanelProps {
+  configKeys: ReadonlyArray<{ key: string; label: string }>;
+  spawnFrozenUntil: string | null;
+}
+
+/**
+ * Read-only config panel for Phase 1. The `concurrency_cap`, `idle_mode`,
+ * and `backoff_seconds` keys live in `dispatcher.config`; Phase 1's
+ * GraphQL surface does not yet expose per-key values except
+ * `spawnFrozenUntil`. Editing is a Phase 2 follow-up.
+ */
+export function ConfigPanel({ configKeys, spawnFrozenUntil }: ConfigPanelProps) {
+  return (
+    <section
+      aria-labelledby="config-heading"
+      className="rounded-lg border border-border bg-card p-4"
+    >
+      <h2 id="config-heading" className={SECTION_HEADING}>
+        Config
+      </h2>
+      <dl className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
+        {configKeys.map((item) => (
+          <div key={item.key} className="flex flex-col">
+            <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+              {item.label}
+            </dt>
+            <dd className="mt-1 font-mono text-sm text-foreground">
+              seeded (see <code>dispatcher.config</code>)
+            </dd>
+          </div>
+        ))}
+        <div className="flex flex-col">
+          <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+            Spawn frozen until
+          </dt>
+          <dd className="mt-1 font-mono text-sm text-foreground">
+            {spawnFrozenUntil ?? '—'}
+          </dd>
+        </div>
+      </dl>
+      <p className="mt-3 text-xs text-muted-foreground">
+        Read-only in Phase 1. Inline editing ships with the Phase 2 follow-up.
+      </p>
+    </section>
+  );
+}

--- a/packages/web/src/app/(main)/admin/dispatcher/ConfirmDialog.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ConfirmDialog.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import type { DispatcherCommand } from '@/lib/dispatcher-queries';
+
+interface ConfirmDialogProps {
+  /** Non-null when the dialog should be open for this command. */
+  command: DispatcherCommand | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const DESCRIPTIONS: Partial<Record<DispatcherCommand, { title: string; body: string }>> = {
+  stop: {
+    title: 'Force-stop daemon?',
+    body: 'This blocks new spawns and does not wait for in-flight agents to finish. In-flight agents may be killed abruptly, leaking worktrees. Prefer Stop (drain) unless the daemon is unresponsive.',
+  },
+  drain: {
+    title: 'Stop (drain) daemon?',
+    body: 'This blocks new spawns but lets in-flight agents finish their current /task iteration. Safer than Force-stop but may take several minutes.',
+  },
+  force_kill: {
+    title: 'Force-kill agent?',
+    body: 'Terminates the agent subprocess without waiting for a clean exit. Leaves the worktree in place for manual inspection. This cannot be undone.',
+  },
+};
+
+export function ConfirmDialog({ command, onConfirm, onCancel }: ConfirmDialogProps) {
+  const open = command !== null;
+  const content = command ? DESCRIPTIONS[command] : null;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onCancel();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{content?.title ?? 'Confirm'}</DialogTitle>
+          <DialogDescription>{content?.body ?? ''}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" size="sm" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            size="sm"
+            onClick={onConfirm}
+            data-testid="confirm-dialog-confirm"
+          >
+            Confirm
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherControls.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherControls.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { SECTION_HEADING } from '@/lib/typography';
+import type { DispatcherCommand, DispatcherRun } from '@/lib/dispatcher-queries';
+
+interface DispatcherControlsProps {
+  currentRun: DispatcherRun | null;
+  disabled?: boolean;
+  onControlClick: (command: DispatcherCommand) => void;
+}
+
+/**
+ * Five control buttons matching spec §11: Start, Stop (drain), Force-stop,
+ * Pause, Resume. Destructive commands (`stop`, `drain`, `force_kill`)
+ * trigger a confirmation modal — handled by the parent dashboard.
+ */
+export function DispatcherControls({
+  currentRun,
+  disabled,
+  onControlClick,
+}: DispatcherControlsProps) {
+  const daemonActive = currentRun !== null && !currentRun.stoppedAt;
+
+  return (
+    <section
+      aria-labelledby="dispatcher-controls-heading"
+      className="rounded-lg border border-border bg-card p-4"
+    >
+      <h2 id="dispatcher-controls-heading" className={SECTION_HEADING}>
+        Controls
+      </h2>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="default"
+          size="sm"
+          disabled={disabled}
+          onClick={() => onControlClick('start')}
+        >
+          Start
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled || !daemonActive}
+          onClick={() => onControlClick('pause')}
+        >
+          Pause
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          onClick={() => onControlClick('resume')}
+        >
+          Resume
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled || !daemonActive}
+          onClick={() => onControlClick('drain')}
+        >
+          Stop (drain)
+        </Button>
+        <Button
+          type="button"
+          variant="destructive"
+          size="sm"
+          disabled={disabled || !daemonActive}
+          onClick={() => onControlClick('stop')}
+        >
+          Force-stop
+        </Button>
+      </div>
+      <p className="mt-3 text-xs text-muted-foreground">
+        Destructive commands (Stop, Force-stop, Force-kill) require confirmation. Commands
+        are written to <code className="font-mono">dispatcher.commands</code> and picked
+        up on the daemon&apos;s next tick.
+      </p>
+    </section>
+  );
+}

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { notFound } from 'next/navigation';
+import { useMutation, useQuery } from '@apollo/client';
+import { useAuth } from '@/providers/AuthProvider';
+import { ErrorBanner } from '@/components/ErrorBanner';
+import { PAGE_TITLE } from '@/lib/typography';
+import {
+  DISPATCHER_CONTROL_MUTATION,
+  DISPATCHER_STATE_QUERY,
+  DESTRUCTIVE_COMMANDS,
+  type DispatcherCommand,
+  type DispatcherControlData,
+  type DispatcherStateData,
+} from '@/lib/dispatcher-queries';
+import { DispatcherHeader } from './DispatcherHeader';
+import { DispatcherControls } from './DispatcherControls';
+import { ActiveAgentsTable } from './ActiveAgentsTable';
+import { QueuePanel } from './QueuePanel';
+import { RecentFailuresPanel } from './RecentFailuresPanel';
+import { ConfigPanel } from './ConfigPanel';
+import { ConfirmDialog } from './ConfirmDialog';
+
+/**
+ * Polling interval for `dispatcherState`. Per spec §11, the daemon runs on
+ * 30s/2min cadences, so a 2s polling delay is invisible.
+ */
+const POLL_INTERVAL_MS = 2000;
+
+/**
+ * Static config shown in the read-only config panel (§11 says "editable"
+ * but the issue body carves editing out of Phase 1). These labels describe
+ * the keys that live in `dispatcher.config` — the values themselves are
+ * not yet exposed via GraphQL, so Phase 1 shows placeholders with a note
+ * pointing at the follow-up work.
+ */
+const CONFIG_KEYS = [
+  { key: 'concurrency_cap', label: 'Concurrency cap' },
+  { key: 'idle_mode', label: 'Idle mode' },
+  { key: 'backoff_seconds', label: 'Backoff seconds' },
+] as const;
+
+function SkeletonShell() {
+  return (
+    <div className="space-y-6">
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div key={i} className="h-24 animate-pulse rounded-lg bg-muted motion-reduce:animate-none" />
+      ))}
+    </div>
+  );
+}
+
+export function DispatcherDashboard() {
+  const { user, loading: authLoading } = useAuth();
+
+  // Non-admin 404: only after auth has resolved. Until then render the
+  // skeleton so we don't flash a 404 for an admin session that is still
+  // hydrating. notFound() terminates rendering and hands off to Next's
+  // not-found boundary.
+  if (!authLoading && (!user || user.role !== 'admin')) {
+    notFound();
+  }
+
+  return <DispatcherDashboardInner authReady={!authLoading} />;
+}
+
+/**
+ * Inner dashboard — split out so the admin check in `DispatcherDashboard`
+ * can early-return via `notFound()` without first mounting any of the
+ * Apollo hooks (which would otherwise fire `dispatcherState` requests from
+ * non-admin sessions, producing misleading NOT_FOUND errors in logs).
+ */
+function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
+  const [pendingCommand, setPendingCommand] = useState<DispatcherCommand | null>(null);
+  const [commandError, setCommandError] = useState<string | null>(null);
+
+  const { data, loading, error, refetch } = useQuery<DispatcherStateData>(
+    DISPATCHER_STATE_QUERY,
+    {
+      skip: !authReady,
+      pollInterval: authReady ? POLL_INTERVAL_MS : 0,
+      fetchPolicy: 'cache-and-network',
+    },
+  );
+
+  const [dispatcherControl, { loading: controlLoading }] =
+    useMutation<DispatcherControlData>(DISPATCHER_CONTROL_MUTATION);
+
+  const runControlCommand = useCallback(
+    async (command: DispatcherCommand, payload: Record<string, unknown> = {}) => {
+      setCommandError(null);
+      try {
+        await dispatcherControl({
+          variables: { command, payload },
+          // Destructive commands require a non-empty X-MFA-Token header per
+          // the Phase 1 placeholder in `dispatcher/auth.ts`. A follow-up
+          // issue will wire a real MFA challenge flow; for now we always
+          // send a non-empty placeholder so the destructive flow succeeds.
+          context: DESTRUCTIVE_COMMANDS.has(command)
+            ? { headers: { 'X-MFA-Token': 'phase1-placeholder' } }
+            : undefined,
+        });
+        // Kick an immediate refetch so the page doesn't wait up to 2s for
+        // the next poll to reflect the newly-written command row.
+        await refetch();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Command failed';
+        setCommandError(message);
+      }
+    },
+    [dispatcherControl, refetch],
+  );
+
+  const handleControlClick = useCallback(
+    (command: DispatcherCommand) => {
+      setCommandError(null);
+      if (DESTRUCTIVE_COMMANDS.has(command)) {
+        setPendingCommand(command);
+        return;
+      }
+      void runControlCommand(command);
+    },
+    [runControlCommand],
+  );
+
+  const handleConfirm = useCallback(() => {
+    if (pendingCommand === null) return;
+    const cmd = pendingCommand;
+    setPendingCommand(null);
+    void runControlCommand(cmd);
+  }, [pendingCommand, runControlCommand]);
+
+  const handleCancel = useCallback(() => {
+    setPendingCommand(null);
+  }, []);
+
+  const handleAgentAction = useCallback(
+    (command: 'retry' | 'force_kill', agentId: string) => {
+      setCommandError(null);
+      if (DESTRUCTIVE_COMMANDS.has(command)) {
+        // For per-agent destructive actions we could open the same modal;
+        // to keep Phase 1 minimal we reuse the non-agent modal path by
+        // encoding the agentId in a sentinel field. `force_kill` is the
+        // only destructive per-agent command today.
+        const confirmed = window.confirm(
+          `Force-kill agent ${agentId.slice(0, 8)}? This cannot be undone.`,
+        );
+        if (!confirmed) return;
+      }
+      void runControlCommand(command, { agentId });
+    },
+    [runControlCommand],
+  );
+
+  // Loading states — show the skeleton while either auth or the first
+  // dispatcherState fetch is still in flight.
+  if (!authReady) {
+    return <SkeletonShell />;
+  }
+
+  // GraphQL errors — the server returns NOT_FOUND for non-admins; that
+  // path is already handled by the admin check above, so any error here
+  // is an actual infrastructure problem.
+  if (error) {
+    return <ErrorBanner message="Failed to load dispatcher state." onRetry={() => void refetch()} />;
+  }
+
+  const state = data?.dispatcherState;
+  const showInitialLoad = loading && !state;
+
+  return (
+    <div>
+      <h1 className={PAGE_TITLE}>Dispatcher</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Monitor and control the dispatcher daemon. Polls every {POLL_INTERVAL_MS / 1000}s.
+      </p>
+
+      {showInitialLoad ? (
+        <div className="mt-6">
+          <SkeletonShell />
+        </div>
+      ) : (
+        <div className="mt-6 space-y-8">
+          <DispatcherHeader currentRun={state?.currentRun ?? null} />
+
+          {commandError && (
+            <div
+              role="alert"
+              className="rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200"
+            >
+              Command failed: {commandError}
+            </div>
+          )}
+
+          <DispatcherControls
+            currentRun={state?.currentRun ?? null}
+            disabled={controlLoading}
+            onControlClick={handleControlClick}
+          />
+
+          <ActiveAgentsTable
+            agents={state?.activeAgents ?? []}
+            disabled={controlLoading}
+            onAgentAction={handleAgentAction}
+          />
+
+          <QueuePanel queueDepth={state?.queueDepth ?? 0} />
+
+          <RecentFailuresPanel failures={state?.recentFailures ?? []} />
+
+          <ConfigPanel configKeys={CONFIG_KEYS} spawnFrozenUntil={state?.spawnFrozenUntil ?? null} />
+        </div>
+      )}
+
+      <ConfirmDialog
+        command={pendingCommand}
+        onConfirm={handleConfirm}
+        onCancel={handleCancel}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherHeader.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherHeader.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import type { DispatcherRun } from '@/lib/dispatcher-queries';
+import { formatUptime } from './format-helpers';
+
+type DaemonStatus = 'running' | 'paused' | 'stopped' | 'unhealthy';
+
+const STATUS_STYLES: Record<DaemonStatus, string> = {
+  running: 'bg-green-100 border-green-300 text-green-800 dark:bg-green-900/30 dark:border-green-700 dark:text-green-300',
+  paused: 'bg-yellow-100 border-yellow-300 text-yellow-800 dark:bg-yellow-900/30 dark:border-yellow-700 dark:text-yellow-300',
+  stopped: 'bg-stone-100 border-stone-300 text-stone-800 dark:bg-stone-800 dark:border-stone-600 dark:text-stone-300',
+  unhealthy: 'bg-red-100 border-red-300 text-red-800 dark:bg-red-900/30 dark:border-red-700 dark:text-red-300',
+};
+
+const STATUS_DOT: Record<DaemonStatus, string> = {
+  running: 'bg-green-500',
+  paused: 'bg-yellow-500',
+  stopped: 'bg-stone-400',
+  unhealthy: 'bg-red-500',
+};
+
+/**
+ * Derive daemon status from the latest `dispatcher.runs` row.
+ *
+ * - `null` run → never booted → "stopped"
+ * - `stoppedAt` populated → clean shutdown → "stopped"
+ * - heartbeat older than 3 minutes (well outside the 2-min supervisor
+ *   tick) → "unhealthy"
+ * - otherwise → "running". The daemon pauses via `dispatcher.commands`
+ *   without writing a new runs row, so Phase 1 does not distinguish
+ *   paused-vs-running from the `runs` table alone. A follow-up will
+ *   surface pause state via a `dispatcherState.paused` field.
+ */
+export function deriveDaemonStatus(
+  run: DispatcherRun | null,
+  nowMs: number = Date.now(),
+): DaemonStatus {
+  if (!run) return 'stopped';
+  if (run.stoppedAt) return 'stopped';
+  const heartbeat = new Date(run.heartbeatTs).getTime();
+  // Malformed heartbeatTs → cannot verify liveness → treat as unhealthy.
+  if (!Number.isFinite(heartbeat)) return 'unhealthy';
+  const ageMs = nowMs - heartbeat;
+  if (ageMs > 3 * 60 * 1000) return 'unhealthy';
+  return 'running';
+}
+
+interface DispatcherHeaderProps {
+  currentRun: DispatcherRun | null;
+  /** Override for deterministic tests. Defaults to `Date.now()`. */
+  nowMs?: number;
+}
+
+export function DispatcherHeader({ currentRun, nowMs }: DispatcherHeaderProps) {
+  const status = deriveDaemonStatus(currentRun, nowMs);
+  const uptime = currentRun && !currentRun.stoppedAt
+    ? formatUptime(currentRun.startedAt, nowMs)
+    : null;
+  const versionSha = currentRun?.versionSha ?? null;
+
+  return (
+    <section
+      aria-labelledby="dispatcher-header-heading"
+      className="flex flex-wrap items-center gap-x-6 gap-y-3 rounded-lg border border-border bg-card p-4"
+    >
+      <h2 id="dispatcher-header-heading" className="sr-only">
+        Daemon status
+      </h2>
+
+      <span
+        data-testid="daemon-status-pill"
+        className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm font-medium ${STATUS_STYLES[status]}`}
+      >
+        <span
+          aria-hidden="true"
+          className={`inline-block h-2.5 w-2.5 rounded-full ${STATUS_DOT[status]}`}
+        />
+        <span className="capitalize">{status}</span>
+      </span>
+
+      <div className="text-sm">
+        <span className="text-muted-foreground">Uptime: </span>
+        <span className="font-medium text-foreground">{uptime ?? '—'}</span>
+      </div>
+
+      <div className="text-sm">
+        <span className="text-muted-foreground">Version: </span>
+        <span className="font-mono text-xs text-foreground">
+          {versionSha ? versionSha.slice(0, 8) : '—'}
+        </span>
+      </div>
+
+      {currentRun?.host && (
+        <div className="text-sm">
+          <span className="text-muted-foreground">Host: </span>
+          <span className="font-mono text-xs text-foreground">{currentRun.host}</span>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherHeader.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherHeader.tsx
@@ -5,17 +5,20 @@ import { formatUptime } from './format-helpers';
 
 type DaemonStatus = 'running' | 'paused' | 'stopped' | 'unhealthy';
 
+// "Stopped" intentionally uses the neutral design tokens rather than a
+// status color — per BRAND.md, only running/paused/unhealthy carry
+// semantic significance, and a "stopped" daemon is a calm neutral state.
 const STATUS_STYLES: Record<DaemonStatus, string> = {
   running: 'bg-green-100 border-green-300 text-green-800 dark:bg-green-900/30 dark:border-green-700 dark:text-green-300',
   paused: 'bg-yellow-100 border-yellow-300 text-yellow-800 dark:bg-yellow-900/30 dark:border-yellow-700 dark:text-yellow-300',
-  stopped: 'bg-stone-100 border-stone-300 text-stone-800 dark:bg-stone-800 dark:border-stone-600 dark:text-stone-300',
+  stopped: 'bg-muted border-border text-muted-foreground',
   unhealthy: 'bg-red-100 border-red-300 text-red-800 dark:bg-red-900/30 dark:border-red-700 dark:text-red-300',
 };
 
 const STATUS_DOT: Record<DaemonStatus, string> = {
   running: 'bg-green-500',
   paused: 'bg-yellow-500',
-  stopped: 'bg-stone-400',
+  stopped: 'bg-muted-foreground/60',
   unhealthy: 'bg-red-500',
 };
 

--- a/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { SECTION_HEADING } from '@/lib/typography';
+
+interface QueuePanelProps {
+  queueDepth: number;
+}
+
+/**
+ * Queue panel. In Phase 1 the GraphQL resolver returns queueDepth = 0
+ * until the daemon's queue-scan lands (see sub-task C follow-up), so this
+ * is a minimal summary card. Phase 2 will expand to a full per-issue
+ * listing with blocked-by counts.
+ */
+export function QueuePanel({ queueDepth }: QueuePanelProps) {
+  return (
+    <section
+      aria-labelledby="queue-heading"
+      className="rounded-lg border border-border bg-card p-4"
+    >
+      <h2 id="queue-heading" className={SECTION_HEADING}>
+        Queue
+      </h2>
+      <div className="mt-3">
+        <p className="text-sm text-foreground">
+          <span className="font-semibold">{queueDepth}</span>{' '}
+          <span className="text-muted-foreground">
+            {queueDepth === 1 ? 'issue' : 'issues'} ready for pickup
+          </span>
+        </p>
+        <p className="mt-2 text-xs text-muted-foreground">
+          Per-issue listing with blocked-by counts lands with the daemon queue-scan
+          follow-up.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentFailuresPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentFailuresPanel.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { SECTION_HEADING } from '@/lib/typography';
+import type { DispatcherFailure } from '@/lib/dispatcher-queries';
+import { groupFailuresByCategory } from './format-helpers';
+
+interface RecentFailuresPanelProps {
+  failures: readonly DispatcherFailure[];
+}
+
+export function RecentFailuresPanel({ failures }: RecentFailuresPanelProps) {
+  const groups = groupFailuresByCategory(failures);
+
+  return (
+    <section
+      aria-labelledby="recent-failures-heading"
+      className="rounded-lg border border-border bg-card"
+    >
+      <div className="border-b border-border p-4">
+        <h2 id="recent-failures-heading" className={SECTION_HEADING}>
+          Recent failures (last 24h)
+        </h2>
+      </div>
+
+      {groups.length === 0 ? (
+        <p className="p-6 text-center text-sm text-muted-foreground">
+          No failures in the last 24 hours.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
+                <th scope="col" className="p-3">Category</th>
+                <th scope="col" className="p-3">Count</th>
+                <th scope="col" className="p-3">Most recent</th>
+                <th scope="col" className="p-3">Issue</th>
+              </tr>
+            </thead>
+            <tbody>
+              {groups.map((group) => (
+                <tr
+                  key={group.category}
+                  className="border-b border-border last:border-b-0"
+                >
+                  <td className="p-3 font-mono text-xs text-foreground">
+                    {group.category}
+                  </td>
+                  <td className="p-3 text-foreground">{group.count}</td>
+                  <td className="p-3 text-xs text-muted-foreground">
+                    {group.mostRecent.ts}
+                  </td>
+                  <td className="p-3 text-foreground">
+                    {group.mostRecent.issueNumber !== null
+                      ? `#${group.mostRecent.issueNumber}`
+                      : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/app/(main)/admin/dispatcher/format-helpers.ts
+++ b/packages/web/src/app/(main)/admin/dispatcher/format-helpers.ts
@@ -1,0 +1,105 @@
+/**
+ * Pure formatting helpers used across the dispatcher admin page. Kept
+ * separate so they can be unit tested without mounting React.
+ */
+
+/**
+ * Format a duration (milliseconds) into a compact human string.
+ * Examples: "12s", "4m 12s", "2h 15m", "1d 4h".
+ *
+ * - < 60s: seconds
+ * - < 60m: minutes + seconds
+ * - < 24h: hours + minutes
+ * - >= 24h: days + hours
+ */
+export function formatDurationMs(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '—';
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const remSeconds = totalSeconds % 60;
+  if (totalMinutes < 60) return `${totalMinutes}m ${remSeconds}s`;
+  const totalHours = Math.floor(totalMinutes / 60);
+  const remMinutes = totalMinutes % 60;
+  if (totalHours < 24) return `${totalHours}h ${remMinutes}m`;
+  const totalDays = Math.floor(totalHours / 24);
+  const remHours = totalHours % 24;
+  return `${totalDays}d ${remHours}h`;
+}
+
+/**
+ * Compute elapsed time from an ISO-8601 `startedAt` to `nowMs`, returning
+ * a formatted string. Returns `—` for invalid or future timestamps.
+ */
+export function formatUptime(startedAt: string, nowMs: number = Date.now()): string {
+  const started = new Date(startedAt).getTime();
+  if (!Number.isFinite(started)) return '—';
+  const ageMs = nowMs - started;
+  if (ageMs < 0) return '—';
+  return formatDurationMs(ageMs);
+}
+
+/** Truncate an agent id for display: first 8 chars + ellipsis if longer. */
+export function shortAgentId(agentId: string): string {
+  if (agentId.length <= 8) return agentId;
+  return `${agentId.slice(0, 8)}…`;
+}
+
+/**
+ * Build a CloudWatch Logs console URL for a given agent's worktree path
+ * when the worktree name encodes the agent id (e.g.
+ * `.claude/worktrees/agent-aca547d3`). Dispatcher daemon agents log to
+ * `/ecs/judgemind-dispatcher-dev` with stream prefix derived from the
+ * agent id. Returns `null` when we cannot derive a stream from the path
+ * (e.g. local-dev runs with a non-standard worktree layout).
+ *
+ * Phase 1 only uses the dev log group. Phase 2 will thread the
+ * environment through via the GraphQL payload.
+ */
+export function worktreeLogsUrl(worktreePath: string): string | null {
+  const match = worktreePath.match(/(agent-[a-zA-Z0-9]+)$/);
+  if (!match) return null;
+  const stream = match[1];
+  const region = 'us-west-2';
+  // CloudWatch console URLs use a bespoke encoding where `/` is `$252F`
+  // (double-URL-encoded `/`). Use literal replacement rather than relying
+  // on encodeURIComponent → substitution, which would also encode safe
+  // characters like `-` inconsistently.
+  const encodedGroup = '$252Fecs$252Fjudgemind-dispatcher-dev';
+  return (
+    `https://${region}.console.aws.amazon.com/cloudwatch/home` +
+    `?region=${region}#logsV2:log-groups/log-group/${encodedGroup}` +
+    `/log-events/${stream}`
+  );
+}
+
+/**
+ * Group failures by the `category` field and return an ordered list of
+ * `{ category, count, mostRecent }` entries, sorted by count desc. Used
+ * by the Recent failures panel.
+ */
+export interface FailureGroup<F> {
+  category: string;
+  count: number;
+  mostRecent: F;
+}
+
+export function groupFailuresByCategory<F extends { category: string; ts: string }>(
+  failures: readonly F[],
+): FailureGroup<F>[] {
+  if (failures.length === 0) return [];
+  const groups = new Map<string, FailureGroup<F>>();
+  for (const f of failures) {
+    const existing = groups.get(f.category);
+    if (!existing) {
+      groups.set(f.category, { category: f.category, count: 1, mostRecent: f });
+      continue;
+    }
+    existing.count += 1;
+    // Keep whichever has the newer ts.
+    if (f.ts > existing.mostRecent.ts) {
+      existing.mostRecent = f;
+    }
+  }
+  return Array.from(groups.values()).sort((a, b) => b.count - a.count);
+}

--- a/packages/web/src/app/(main)/admin/dispatcher/page.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/page.tsx
@@ -1,0 +1,23 @@
+import { DispatcherDashboard } from './DispatcherDashboard';
+
+/**
+ * /admin/dispatcher — dispatcher v2 admin page (see docs/specs/dispatcher-v2-spec.md §11).
+ *
+ * The 404 behavior for non-admins is implemented in `DispatcherDashboard`
+ * (client component) because the admin role is only known after the
+ * `AuthProvider` has hydrated on the client. Rendering a server `notFound()`
+ * would require reading the session cookie on the server, which the web
+ * app intentionally does not do (auth state is Apollo-client only).
+ *
+ * The GraphQL resolver also returns a generic `NOT_FOUND` error for
+ * non-admins — see `packages/api/src/graphql/dispatcher/auth.ts` — so the
+ * existence of the dispatcher schema is not enumerable from a non-admin
+ * session.
+ */
+export default function DispatcherPage() {
+  return (
+    <div className="mx-auto max-w-6xl">
+      <DispatcherDashboard />
+    </div>
+  );
+}

--- a/packages/web/src/components/layout/Sidebar.tsx
+++ b/packages/web/src/components/layout/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Search, FileText, FolderOpen, Gavel, BarChart3 } from 'lucide-react';
+import { Search, FileText, FolderOpen, Gavel, BarChart3, Activity } from 'lucide-react';
 import { useAuth } from '@/providers/AuthProvider';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
@@ -79,6 +79,14 @@ function useNavItems(): NavItem[] {
       icon: <BarChart3 className="h-4 w-4" aria-hidden="true" />,
       label: 'Data Health',
       activeFn: (p) => p.startsWith('/admin/data-quality'),
+      group: 'admin',
+      adminOnly: true,
+    });
+    items.push({
+      href: '/admin/dispatcher/',
+      icon: <Activity className="h-4 w-4" aria-hidden="true" />,
+      label: 'Dispatcher',
+      activeFn: (p) => p.startsWith('/admin/dispatcher'),
       group: 'admin',
       adminOnly: true,
     });

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -1,0 +1,156 @@
+/**
+ * GraphQL queries, mutations, and result types for the /admin/dispatcher page.
+ *
+ * Backed by the dispatcher admin GraphQL surface landed in #2730
+ * (`packages/api/src/graphql/dispatcher/`). Non-admins receive a generic
+ * "not found" error from the resolver (see `dispatcher/auth.ts`) — the page
+ * handles that gracefully without leaking the route's existence.
+ *
+ * Apollo `keyFields` for these types live in `apollo-client.ts`
+ * (`DispatcherRun`, `DispatcherFailure`, `PhaseTransition`,
+ * `DispatcherCommandResult`, and `keyFields: false` for `DispatcherState`).
+ */
+import { gql } from '@apollo/client';
+
+export const DISPATCHER_STATE_QUERY = gql`
+  query DispatcherState {
+    dispatcherState {
+      currentRun {
+        runId
+        startedAt
+        stoppedAt
+        heartbeatTs
+        versionSha
+        host
+        pid
+      }
+      activeAgents {
+        id
+        kind
+        issueNumber
+        worktreePath
+        phase
+        status
+        startedAt
+        endedAt
+        exitCode
+        prNumber
+        retriesUsed
+      }
+      recentFailures(sinceHours: 24) {
+        failureId
+        agentId
+        category
+        detectedBy
+        details
+        ts
+        issueNumber
+      }
+      queueDepth
+      spawnFrozenUntil
+    }
+  }
+`;
+
+export const DISPATCHER_CONTROL_MUTATION = gql`
+  mutation DispatcherControl($command: DispatcherCommand!, $payload: JSON) {
+    dispatcherControl(command: $command, payload: $payload) {
+      commandId
+      command
+      issuedBy
+      issuedAt
+      consumedAt
+      payload
+      created
+    }
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// Result types — shapes mirror the dispatcher GraphQL schema in
+// packages/api/src/graphql/dispatcher/schema.ts.
+// ---------------------------------------------------------------------------
+
+export interface DispatcherRun {
+  runId: string;
+  startedAt: string;
+  stoppedAt: string | null;
+  heartbeatTs: string;
+  versionSha: string;
+  host: string;
+  pid: number;
+}
+
+export interface DispatcherAgent {
+  id: string;
+  kind: string;
+  issueNumber: number;
+  worktreePath: string;
+  phase: string;
+  status: string;
+  startedAt: string;
+  endedAt: string | null;
+  exitCode: number | null;
+  prNumber: number | null;
+  retriesUsed: number;
+}
+
+export interface DispatcherFailure {
+  failureId: string;
+  agentId: string | null;
+  category: string;
+  detectedBy: string;
+  details: Record<string, unknown>;
+  ts: string;
+  issueNumber: number | null;
+}
+
+export interface DispatcherState {
+  currentRun: DispatcherRun | null;
+  activeAgents: DispatcherAgent[];
+  recentFailures: DispatcherFailure[];
+  queueDepth: number;
+  spawnFrozenUntil: string | null;
+}
+
+export interface DispatcherStateData {
+  dispatcherState: DispatcherState;
+}
+
+/** Control commands accepted by `dispatcherControl`.
+ *
+ * Mirrors the `DispatcherCommand` enum in the API schema. The subset marked
+ * "destructive" in the server's `DESTRUCTIVE_COMMANDS` set triggers a
+ * confirmation modal in the UI before invoking the mutation.
+ */
+export type DispatcherCommand =
+  | 'start'
+  | 'stop'
+  | 'drain'
+  | 'pause'
+  | 'resume'
+  | 'retry'
+  | 'force_kill';
+
+/** Commands that mutate in-flight agent state. Matches the server-side
+ * `DESTRUCTIVE_COMMANDS` set in `packages/api/src/graphql/dispatcher/auth.ts`.
+ * The admin page always raises a confirmation modal for these. */
+export const DESTRUCTIVE_COMMANDS: ReadonlySet<DispatcherCommand> = new Set([
+  'stop',
+  'drain',
+  'force_kill',
+]);
+
+export interface DispatcherCommandResult {
+  commandId: string;
+  command: DispatcherCommand;
+  issuedBy: string;
+  issuedAt: string;
+  consumedAt: string | null;
+  payload: Record<string, unknown>;
+  created: boolean;
+}
+
+export interface DispatcherControlData {
+  dispatcherControl: DispatcherCommandResult;
+}

--- a/packages/web/tests/dispatcher-dashboard.test.tsx
+++ b/packages/web/tests/dispatcher-dashboard.test.tsx
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks — declared before imports
+// ---------------------------------------------------------------------------
+
+let mockAuthResult: {
+  user: {
+    id: string;
+    email: string;
+    emailVerified: boolean;
+    displayName: string | null;
+    role: string;
+    createdAt: string;
+  } | null;
+  loading: boolean;
+  setUser: ReturnType<typeof vi.fn>;
+  logout: ReturnType<typeof vi.fn>;
+};
+
+let mockQueryResult: {
+  data: unknown;
+  loading: boolean;
+  error: Error | undefined;
+  refetch: ReturnType<typeof vi.fn>;
+};
+
+let mockMutationFn: ReturnType<typeof vi.fn>;
+let mockMutationLoading: boolean;
+let notFoundCallCount = 0;
+
+vi.mock('@/providers/AuthProvider', () => ({
+  useAuth: () => mockAuthResult,
+}));
+
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    notFoundCallCount += 1;
+    // Throw to mimic Next.js behavior (aborts render).
+    throw new Error('NEXT_NOT_FOUND');
+  },
+}));
+
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual<typeof import('@apollo/client')>('@apollo/client');
+  return {
+    ...actual,
+    useQuery: () => mockQueryResult,
+    useMutation: () => [mockMutationFn, { loading: mockMutationLoading }],
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { DispatcherDashboard } from '../src/app/(main)/admin/dispatcher/DispatcherDashboard';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeAdminUser() {
+  return {
+    id: 'user-1',
+    email: 'admin@example.com',
+    emailVerified: true,
+    displayName: 'Admin',
+    role: 'admin',
+    createdAt: '2026-01-01T00:00:00Z',
+  };
+}
+
+function makeEmptyState() {
+  return {
+    dispatcherState: {
+      currentRun: null,
+      activeAgents: [],
+      recentFailures: [],
+      queueDepth: 0,
+      spawnFrozenUntil: null,
+    },
+  };
+}
+
+function makeActiveState() {
+  return {
+    dispatcherState: {
+      currentRun: {
+        runId: 'run-1',
+        startedAt: '2026-04-18T11:59:00Z',
+        stoppedAt: null,
+        heartbeatTs: '2026-04-18T11:59:45Z',
+        versionSha: 'abcdef12345678',
+        host: 'dispatcher-prod-1',
+        pid: 1234,
+      },
+      activeAgents: [
+        {
+          id: 'agent-aca547d3-long-id',
+          kind: 'task',
+          issueNumber: 2731,
+          worktreePath: '.claude/worktrees/agent-aca547d3',
+          phase: 'ralph-worker (2)',
+          status: 'running',
+          startedAt: '2026-04-18T11:30:00Z',
+          endedAt: null,
+          exitCode: null,
+          prNumber: null,
+          retriesUsed: 0,
+        },
+      ],
+      recentFailures: [
+        {
+          failureId: 'f-1',
+          agentId: 'agent-aca547d3-long-id',
+          category: 'autocompact_loop',
+          detectedBy: 'supervisor',
+          details: {},
+          ts: '2026-04-18T11:45:00Z',
+          issueNumber: 2731,
+        },
+      ],
+      queueDepth: 5,
+      spawnFrozenUntil: null,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DispatcherDashboard', () => {
+  beforeEach(() => {
+    notFoundCallCount = 0;
+    mockAuthResult = {
+      user: makeAdminUser(),
+      loading: false,
+      setUser: vi.fn(),
+      logout: vi.fn(),
+    };
+    mockQueryResult = {
+      data: undefined,
+      loading: true,
+      error: undefined,
+      refetch: vi.fn().mockResolvedValue({ data: undefined }),
+    };
+    mockMutationFn = vi.fn().mockResolvedValue({ data: undefined });
+    mockMutationLoading = false;
+  });
+
+  it('renders a skeleton while auth is loading', () => {
+    mockAuthResult.loading = true;
+    mockAuthResult.user = null;
+    const { container } = render(<DispatcherDashboard />);
+    const skeletons = container.querySelectorAll('.animate-pulse');
+    expect(skeletons.length).toBeGreaterThan(0);
+    expect(notFoundCallCount).toBe(0);
+  });
+
+  it('calls notFound for unauthenticated users', () => {
+    mockAuthResult.user = null;
+    expect(() => render(<DispatcherDashboard />)).toThrowError('NEXT_NOT_FOUND');
+    // React may retry rendering a throwing component; assert the mock was
+    // invoked at least once rather than pinning the exact count.
+    expect(notFoundCallCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('calls notFound for non-admin users', () => {
+    mockAuthResult.user = { ...makeAdminUser(), role: 'user' };
+    expect(() => render(<DispatcherDashboard />)).toThrowError('NEXT_NOT_FOUND');
+    expect(notFoundCallCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders the empty shell with "stopped" status and empty states', () => {
+    mockQueryResult.data = makeEmptyState();
+    mockQueryResult.loading = false;
+    render(<DispatcherDashboard />);
+    expect(screen.getByRole('heading', { level: 1, name: /Dispatcher/i })).toBeInTheDocument();
+    // Status pill
+    const pill = screen.getByTestId('daemon-status-pill');
+    expect(pill).toHaveTextContent(/stopped/i);
+    // Active agents empty state
+    expect(screen.getByText(/No active agents\./i)).toBeInTheDocument();
+    // Recent failures empty state
+    expect(screen.getByText(/No failures in the last 24 hours\./i)).toBeInTheDocument();
+    // Queue depth section
+    expect(screen.getByText(/issues ready for pickup/i)).toBeInTheDocument();
+    // "0" appears in both "Active agents (0)" heading and queue panel — the
+    // heading carries the exact "Active agents (0)" text we want to assert.
+    expect(screen.getByText(/Active agents \(0\)/)).toBeInTheDocument();
+    // Config panel headings
+    expect(screen.getByText('Concurrency cap')).toBeInTheDocument();
+    expect(screen.getByText('Idle mode')).toBeInTheDocument();
+    expect(screen.getByText('Backoff seconds')).toBeInTheDocument();
+    expect(notFoundCallCount).toBe(0);
+  });
+
+  it('renders active agents with phase and issue number', () => {
+    mockQueryResult.data = makeActiveState();
+    mockQueryResult.loading = false;
+    render(<DispatcherDashboard />);
+    // Agents table heading with count
+    expect(screen.getByText(/Active agents \(1\)/)).toBeInTheDocument();
+    // "#2731" appears both in the agents row and the recent-failures row.
+    expect(screen.getAllByText('#2731').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/ralph-worker \(2\)/)).toBeInTheDocument();
+    // Short agent id
+    expect(screen.getByText(/agent-ac/i)).toBeInTheDocument();
+  });
+
+  it('renders a "running" status pill for a healthy run', () => {
+    mockQueryResult.data = makeActiveState();
+    mockQueryResult.loading = false;
+    // Stub Date.now so the heartbeat appears fresh.
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-04-18T12:00:00Z'));
+    try {
+      render(<DispatcherDashboard />);
+      const pill = screen.getByTestId('daemon-status-pill');
+      expect(pill).toHaveTextContent(/running/i);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
+  it('invokes dispatcherControl with "pause" when the Pause button is clicked', () => {
+    mockQueryResult.data = makeActiveState();
+    mockQueryResult.loading = false;
+    render(<DispatcherDashboard />);
+    const pauseButton = screen.getByRole('button', { name: /Pause/i });
+    fireEvent.click(pauseButton);
+    expect(mockMutationFn).toHaveBeenCalledTimes(1);
+    expect(mockMutationFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: { command: 'pause', payload: {} },
+      }),
+    );
+  });
+
+  it('requires confirmation for destructive commands', () => {
+    mockQueryResult.data = makeActiveState();
+    mockQueryResult.loading = false;
+    render(<DispatcherDashboard />);
+    const drainButton = screen.getByRole('button', { name: /Stop \(drain\)/i });
+    fireEvent.click(drainButton);
+    // Mutation NOT yet invoked — waiting on confirm modal.
+    expect(mockMutationFn).not.toHaveBeenCalled();
+    // Confirm dialog should have appeared.
+    const confirmButton = screen.getByTestId('confirm-dialog-confirm');
+    fireEvent.click(confirmButton);
+    expect(mockMutationFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: { command: 'drain', payload: {} },
+        context: expect.objectContaining({
+          headers: expect.objectContaining({ 'X-MFA-Token': expect.any(String) }),
+        }),
+      }),
+    );
+  });
+
+  it('renders an error banner when the query errors', () => {
+    mockQueryResult.data = undefined;
+    mockQueryResult.loading = false;
+    mockQueryResult.error = new Error('network');
+    render(<DispatcherDashboard />);
+    expect(screen.getByText(/Failed to load dispatcher state/i)).toBeInTheDocument();
+  });
+});

--- a/packages/web/tests/dispatcher-format-helpers.test.ts
+++ b/packages/web/tests/dispatcher-format-helpers.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatDurationMs,
+  formatUptime,
+  groupFailuresByCategory,
+  shortAgentId,
+  worktreeLogsUrl,
+} from '../src/app/(main)/admin/dispatcher/format-helpers';
+import { deriveDaemonStatus } from '../src/app/(main)/admin/dispatcher/DispatcherHeader';
+import type { DispatcherRun } from '../src/lib/dispatcher-queries';
+
+describe('formatDurationMs', () => {
+  it('formats sub-minute durations in seconds', () => {
+    expect(formatDurationMs(0)).toBe('0s');
+    expect(formatDurationMs(59_000)).toBe('59s');
+  });
+  it('formats sub-hour durations in minutes + seconds', () => {
+    expect(formatDurationMs(60_000)).toBe('1m 0s');
+    expect(formatDurationMs(252_000)).toBe('4m 12s');
+  });
+  it('formats sub-day durations in hours + minutes', () => {
+    expect(formatDurationMs(3_600_000)).toBe('1h 0m');
+    expect(formatDurationMs(8_100_000)).toBe('2h 15m');
+  });
+  it('formats multi-day durations in days + hours', () => {
+    expect(formatDurationMs(86_400_000)).toBe('1d 0h');
+    expect(formatDurationMs(101_400_000)).toBe('1d 4h');
+  });
+  it('returns em-dash for negative or invalid input', () => {
+    expect(formatDurationMs(-1)).toBe('—');
+    expect(formatDurationMs(Number.NaN)).toBe('—');
+    expect(formatDurationMs(Number.POSITIVE_INFINITY)).toBe('—');
+  });
+});
+
+describe('formatUptime', () => {
+  const now = Date.parse('2026-04-18T12:00:00Z');
+  it('returns formatted duration from a valid ISO string', () => {
+    expect(formatUptime('2026-04-18T11:59:00Z', now)).toBe('1m 0s');
+  });
+  it('returns em-dash for unparseable input', () => {
+    expect(formatUptime('not-a-date', now)).toBe('—');
+  });
+  it('returns em-dash for timestamps in the future', () => {
+    expect(formatUptime('2026-04-18T12:01:00Z', now)).toBe('—');
+  });
+});
+
+describe('shortAgentId', () => {
+  it('keeps short ids intact', () => {
+    expect(shortAgentId('abc123')).toBe('abc123');
+  });
+  it('truncates long ids', () => {
+    expect(shortAgentId('agent-aca547d3-and-more')).toBe('agent-ac…');
+  });
+});
+
+describe('worktreeLogsUrl', () => {
+  it('returns a CloudWatch URL for worktree paths with agent-<id>', () => {
+    const url = worktreeLogsUrl('.claude/worktrees/agent-aca547d3');
+    expect(url).toBeTruthy();
+    expect(url).toContain('us-west-2');
+    expect(url).toContain('agent-aca547d3');
+    expect(url).toContain('$252Fecs$252Fjudgemind-dispatcher-dev');
+  });
+  it('returns null when no agent id can be extracted', () => {
+    expect(worktreeLogsUrl('/tmp/random')).toBeNull();
+  });
+});
+
+describe('deriveDaemonStatus', () => {
+  const now = Date.parse('2026-04-18T12:00:00Z');
+  function makeRun(overrides: Partial<DispatcherRun>): DispatcherRun {
+    return {
+      runId: 'run-1',
+      startedAt: '2026-04-18T11:00:00Z',
+      stoppedAt: null,
+      heartbeatTs: '2026-04-18T11:59:00Z',
+      versionSha: 'abcdef12',
+      host: 'dispatcher-host',
+      pid: 1234,
+      ...overrides,
+    };
+  }
+
+  it('returns "stopped" when no run exists', () => {
+    expect(deriveDaemonStatus(null, now)).toBe('stopped');
+  });
+
+  it('returns "stopped" when the run has stoppedAt populated', () => {
+    expect(deriveDaemonStatus(makeRun({ stoppedAt: '2026-04-18T11:30:00Z' }), now)).toBe('stopped');
+  });
+
+  it('returns "running" when heartbeat is fresh', () => {
+    expect(deriveDaemonStatus(makeRun({ heartbeatTs: '2026-04-18T11:59:30Z' }), now)).toBe('running');
+  });
+
+  it('returns "unhealthy" when heartbeat is older than 3 minutes', () => {
+    expect(deriveDaemonStatus(makeRun({ heartbeatTs: '2026-04-18T11:55:00Z' }), now)).toBe('unhealthy');
+  });
+
+  it('returns "unhealthy" for malformed heartbeatTs', () => {
+    expect(deriveDaemonStatus(makeRun({ heartbeatTs: 'bogus' }), now)).toBe('unhealthy');
+  });
+});
+
+describe('groupFailuresByCategory', () => {
+  type F = { category: string; ts: string; id: string };
+
+  it('returns empty array for no input', () => {
+    expect(groupFailuresByCategory<F>([])).toEqual([]);
+  });
+
+  it('groups by category and counts occurrences', () => {
+    const failures: F[] = [
+      { id: '1', category: 'runtime_error', ts: '2026-04-18T10:00:00Z' },
+      { id: '2', category: 'runtime_error', ts: '2026-04-18T11:00:00Z' },
+      { id: '3', category: 'autocompact', ts: '2026-04-18T09:00:00Z' },
+    ];
+    const groups = groupFailuresByCategory(failures);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].category).toBe('runtime_error');
+    expect(groups[0].count).toBe(2);
+    expect(groups[0].mostRecent.id).toBe('2');
+    expect(groups[1].category).toBe('autocompact');
+    expect(groups[1].count).toBe(1);
+  });
+
+  it('sorts categories by count desc', () => {
+    const failures: F[] = [
+      { id: '1', category: 'a', ts: '2026-04-18T10:00:00Z' },
+      { id: '2', category: 'b', ts: '2026-04-18T11:00:00Z' },
+      { id: '3', category: 'b', ts: '2026-04-18T09:00:00Z' },
+      { id: '4', category: 'b', ts: '2026-04-18T08:00:00Z' },
+    ];
+    const groups = groupFailuresByCategory(failures);
+    expect(groups.map((g) => g.category)).toEqual(['b', 'a']);
+  });
+});

--- a/packages/web/tests/sidebar.test.tsx
+++ b/packages/web/tests/sidebar.test.tsx
@@ -103,6 +103,26 @@ describe('Sidebar', () => {
     expect(href).toMatch(/^\/admin\/data-quality\/?$/);
   });
 
+  it('shows Dispatcher link for admin users', () => {
+    mockAuthResult.user = makeUser('admin');
+    render(<Sidebar />);
+    expect(screen.getByText('Dispatcher')).toBeInTheDocument();
+  });
+
+  it('admin Dispatcher link points to /admin/dispatcher/', () => {
+    mockAuthResult.user = makeUser('admin');
+    render(<Sidebar />);
+    const link = screen.getByText('Dispatcher');
+    const href = link.closest('a')?.getAttribute('href') ?? '';
+    expect(href).toMatch(/^\/admin\/dispatcher\/?$/);
+  });
+
+  it('does not show Dispatcher link for non-admin users', () => {
+    mockAuthResult.user = makeUser('user');
+    render(<Sidebar />);
+    expect(screen.queryByText('Dispatcher')).not.toBeInTheDocument();
+  });
+
   it('highlights the active route with accent styling', () => {
     mockPathname = '/search';
     render(<Sidebar />);

--- a/scripts/tests/test_check_graphql_queries.sh
+++ b/scripts/tests/test_check_graphql_queries.sh
@@ -429,6 +429,67 @@ write_query_file "app/Page.tsx" '
 '
 assert_passes "Schema with escaped backticks in descriptions is parsed correctly"
 
+# ─── Test 15: Module schema files extend the core schema ─────────────
+# Mirrors the real layout where `packages/api/src/graphql/dispatcher/schema.ts`
+# declares `extend type Query` additions that the frontend references via
+# gql queries. The validator must concatenate all per-module SDL blocks so
+# those additions are visible.
+setup_repo
+write_schema '
+  type Query {
+    health: String!
+  }
+'
+# Write a per-module schema file that extends Query with a new field.
+mkdir -p "$TMPDIR_TEST/packages/api/src/graphql/dispatcher"
+cat > "$TMPDIR_TEST/packages/api/src/graphql/dispatcher/schema.ts" <<'MODULE_EOF'
+export const dispatcherTypeDefs = `#graphql
+  type DispatcherState {
+    queueDepth: Int!
+  }
+  extend type Query {
+    dispatcherState: DispatcherState!
+  }
+`;
+MODULE_EOF
+write_query_file "app/DispatcherPage.tsx" '
+  query DispatcherState {
+    dispatcherState {
+      queueDepth
+    }
+  }
+'
+assert_passes "Per-module schema.ts files extend the core schema"
+
+# ─── Test 16: Module schema referencing missing core type still fails ─
+setup_repo
+write_schema '
+  type Query {
+    health: String!
+  }
+'
+mkdir -p "$TMPDIR_TEST/packages/api/src/graphql/dispatcher"
+cat > "$TMPDIR_TEST/packages/api/src/graphql/dispatcher/schema.ts" <<'MODULE_EOF'
+export const dispatcherTypeDefs = `#graphql
+  type DispatcherState {
+    queueDepth: Int!
+  }
+  extend type Query {
+    dispatcherState: DispatcherState!
+  }
+`;
+MODULE_EOF
+# Query references a field not present in either core or module schema.
+write_query_file "app/DispatcherPage.tsx" '
+  query DispatcherState {
+    dispatcherState {
+      queueDepth
+      missingField
+    }
+  }
+'
+assert_fails "Module schema still surfaces invalid fields"
+
 # ─── Summary ──────────────────────────────────────────────────────────
 echo ""
 echo "Results: $((TESTS - FAILURES))/$TESTS passed"

--- a/scripts/validate-graphql-queries.mjs
+++ b/scripts/validate-graphql-queries.mjs
@@ -22,45 +22,90 @@ import { buildSchema, parse, validate } from 'graphql';
 
 const repoRoot = process.argv[2] || process.cwd();
 const schemaFile = join(repoRoot, 'packages/api/src/graphql/schema.ts');
+const graphqlDir = join(repoRoot, 'packages/api/src/graphql');
 const webSrcDir = join(repoRoot, 'packages/web/src');
 
 // ---------------------------------------------------------------------------
 // 1. Extract and build the GraphQL schema
 // ---------------------------------------------------------------------------
 
-function extractSchemaSDL(filePath) {
+/**
+ * Extract every `#graphql-tagged template literal from a file. The main
+ * schema file (packages/api/src/graphql/schema.ts) contains the core
+ * Query / Mutation types; per-module schema files under subdirectories
+ * (e.g. `dispatcher/schema.ts`) extend them via `extend type Query`.
+ * Returning an array lets the caller concatenate them all into a single
+ * SDL string for validation.
+ */
+function extractAllSchemaSDL(filePath) {
   const content = readFileSync(filePath, 'utf-8');
-  // The schema is exported as: export const typeDefs = `#graphql ... `;
-  // The template literal may contain escaped backticks (\`) in description
-  // strings. We need to match the full template literal including those.
-  // Strategy: find the opening `#graphql marker, then scan forward,
-  // skipping escaped backticks (\`) until we hit an unescaped backtick.
   const startMarker = '`#graphql\n';
-  const startIdx = content.indexOf(startMarker);
-  if (startIdx === -1) {
+  const results = [];
+  let cursor = 0;
+  while (cursor < content.length) {
+    const startIdx = content.indexOf(startMarker, cursor);
+    if (startIdx === -1) break;
+    const sdlStart = startIdx + startMarker.length;
+
+    // Scan for the closing backtick, skipping escaped ones.
+    let i = sdlStart;
+    while (i < content.length) {
+      if (content[i] === '\\' && i + 1 < content.length && content[i + 1] === '`') {
+        i += 2; // skip escaped backtick
+      } else if (content[i] === '`') {
+        break; // found unescaped closing backtick
+      } else {
+        i++;
+      }
+    }
+    if (i >= content.length) {
+      throw new Error(`Could not find closing backtick for schema in ${filePath}`);
+    }
+    const rawSDL = content.slice(sdlStart, i);
+    results.push(rawSDL.replace(/\\`/g, '`'));
+    cursor = i + 1;
+  }
+  return results;
+}
+
+/** Back-compat wrapper — returns the first SDL block. Preserves the
+ * original behaviour for callers (tests) that assume a single block. */
+function extractSchemaSDL(filePath) {
+  const blocks = extractAllSchemaSDL(filePath);
+  if (blocks.length === 0) {
     throw new Error(`Could not find #graphql template literal in ${filePath}`);
   }
-  const sdlStart = startIdx + startMarker.length;
+  return blocks[0];
+}
 
-  // Scan for the closing backtick, skipping escaped ones
-  let i = sdlStart;
-  while (i < content.length) {
-    if (content[i] === '\\' && i + 1 < content.length && content[i + 1] === '`') {
-      i += 2; // skip escaped backtick
-    } else if (content[i] === '`') {
-      break; // found unescaped closing backtick
-    } else {
-      i++;
+/** Collect SDL blocks from all module `schema.ts` files under the graphql/
+ * tree. Modules (e.g. dispatcher) declare their SDL alongside their
+ * resolvers; concatenating them gives the full schema the running API
+ * serves. */
+function collectModuleSchemaSDLs(baseDir) {
+  const blocks = [];
+  function walk(dir) {
+    for (const entry of readdirSync(dir)) {
+      const fullPath = join(dir, entry);
+      const stat = statSync(fullPath);
+      if (stat.isDirectory()) {
+        walk(fullPath);
+      } else if (entry === 'schema.ts') {
+        // Skip the top-level schema file — the caller handles it
+        // explicitly so the module schemas can be appended after it.
+        if (fullPath === schemaFile) continue;
+        try {
+          blocks.push(...extractAllSchemaSDL(fullPath));
+        } catch (_err) {
+          // Module schema files without a #graphql template literal are
+          // tolerated (e.g. a helper file that happened to be named
+          // schema.ts).
+        }
+      }
     }
   }
-
-  if (i >= content.length) {
-    throw new Error(`Could not find closing backtick for schema in ${filePath}`);
-  }
-
-  // Extract the SDL and unescape backticks
-  const rawSDL = content.slice(sdlStart, i);
-  return rawSDL.replace(/\\`/g, '`');
+  walk(baseDir);
+  return blocks;
 }
 
 // ---------------------------------------------------------------------------
@@ -124,10 +169,16 @@ function extractGqlQueries(filePath) {
 // ---------------------------------------------------------------------------
 
 function main() {
-  // Build the schema
+  // Build the schema. Start with the core SDL block, then append per-module
+  // SDL blocks (e.g. `packages/api/src/graphql/dispatcher/schema.ts`) so
+  // `extend type Query` / `extend type Mutation` declarations in those
+  // modules are part of the schema the validator sees. This mirrors what
+  // `typeDefs` in `schema.ts` actually exports at runtime.
   let schema;
   try {
-    const sdl = extractSchemaSDL(schemaFile);
+    const coreBlocks = extractAllSchemaSDL(schemaFile);
+    const moduleBlocks = collectModuleSchemaSDLs(graphqlDir);
+    const sdl = [...coreBlocks, ...moduleBlocks].join('\n\n');
     schema = buildSchema(sdl);
   } catch (err) {
     console.error(`ERROR: Failed to build GraphQL schema: ${err.message}`);


### PR DESCRIPTION
## Summary

Phase 1 sub-task E — dispatcher v2 admin page at `/admin/dispatcher` per spec §11. Consumes the GraphQL surface from #2730 (`dispatcherState`, `dispatcherControl`) with a 2s Apollo poll, renders six panels (status header, controls, active agents, queue, recent failures, config), and gates destructive commands behind a confirmation modal with the Phase-1 placeholder `X-MFA-Token` header. Non-admins receive `notFound()`, consistent with the resolver's `NOT_FOUND` behaviour, so the route is not enumerable.

Closes #2731. Closes Phase 1 scaffolding epic #2725.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `https://dev.judgemind.org/admin/dispatcher` returns HTTP 200 on dev (automated); admin-authenticated 5-panel render needs drewthaler screenshot (flagged in issue comment)
- [x] Non-admin session visits the URL → Next.js 404 (screenshot attached in issue comment)
- [x] Header status pill shows "stopped" for the existing `dispatcher.runs` row (stopped_at populated)
- [x] `dispatcher.commands` table exists on dev; Pause mutation wire-up covered by Vitest; admin click-through needs drewthaler
- [x] Verification evidence posted on #2731

## Notes

- **Scope completeness check.** Grepped for existing admin-route patterns, `user.role === 'admin'` gates (found 7 call sites, all aligned with the pattern in `Sidebar.tsx:43`), and existing admin sidebar entries (added Dispatcher alongside Data Health). No other locations needed parallel changes.
- **Apollo keyFields.** #2730 already wired `DispatcherRun` / `DispatcherFailure` / `PhaseTransition` / `DispatcherCommandResult` and `keyFields: false` for `DispatcherState` in `apollo-client.ts` — these cover every type this PR consumes.
- **Out of scope per issue body.** Pretty visual polish, real MFA flow, editable config, per-issue queue listing with blocked-by counts. Each is tracked as a follow-up (see retrospective issues).
- **CI infrastructure fix.** The first CI run surfaced a latent bug in `scripts/validate-graphql-queries.mjs`: it only extracted the top-level `coreTypeDefs` block and missed per-module SDL extensions (e.g. the dispatcher schema under `packages/api/src/graphql/dispatcher/schema.ts`). This PR extends the validator to walk the `graphql/` tree, collecting every `#graphql` template literal and concatenating them before validation. Two new test cases in `test_check_graphql_queries.sh` cover the happy-path and regression.
