### PR TITLE
docs(dispatcher-v2): replace wall-clock Phase 2/3 gates with event-count gates (#2758)

### DIFF
--- a/docs/specs/dispatcher-v2-spec.md
+++ b/docs/specs/dispatcher-v2-spec.md
@@ -465,12 +465,11 @@ Gate: admin page loads with "0 agents, daemon stopped" on dev. Each `/task-v2-*`
 - Daemon scales to 1, but `config.concurrency_cap=0`. Polls queue, writes state, but spawns nothing.
 - Laptop `/dispatcher` continues running — its state is NOT mirrored into `dispatcher.*` (we don't want to double-book).
 
-Gate: daemon has been running for 48h without crashing; admin page shows accurate queue depth matching `gh issue list`.
+Gate: daemon has observed ≥20 queue-state update cycles without crashing; admin page queue depth matches `gh issue list` to within 1 at 3 consecutive checks.
 
 **Phase 3: Single-slot production (1 PR).**
 - `config.concurrency_cap=1`. Daemon spawns one agent at a time, driving the full phase state machine in §6 via `claude -p` invocations of `/task-v2-*`.
 - Laptop dispatcher paused (user stops invoking `/dispatcher`). The skill file stays on disk.
-- Monitor for 1 week.
 
 Gate: ≥10 successful task completions via the daemon; zero stuck agents; all retries resolved correctly.
 


### PR DESCRIPTION
## Summary

Replaces wall-clock phase gates in `docs/specs/dispatcher-v2-spec.md` §15 with event-count gates. Phase 2 swaps "48h without crashing" for "≥20 queue-state update cycles + queue-depth agreement at 3 consecutive checks"; Phase 3 drops the "Monitor for 1 week" bullet and keeps the existing ≥10-completions event-count gate. §16 "≥14 days autonomy" is intentionally preserved — that's a robustness assertion about unattended operation, not a phase gate.

Closes #2758

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green
- [x] `scripts/check-markdown-links.sh` passes (verified locally + enforced in pre-push and CI's `markdown-links-check`)

### Post-deploy verification
- [x] N/A — no deployed component (spec doc only)
