### PR TITLE
fix(dx): make screenshot.py --auth actually authenticate as admin (#2760)

### DIFF
--- a/.claude/skills/screenshot/SKILL.md
+++ b/.claude/skills/screenshot/SKILL.md
@@ -56,10 +56,13 @@ scripts/run-py.sh scripts/screenshot.py /rulings --wait 5000 --output tmp/ruling
 **Screenshot an admin page (requires authentication):**
 ```
 scripts/run-py.sh scripts/screenshot.py --auth /admin/data-quality --output tmp/dq.png
+scripts/run-py.sh scripts/screenshot.py --auth /admin/dispatcher --output tmp/dispatcher.png
 ```
 Then: `Read tmp/dq.png`
 
 The `--auth` flag fetches admin credentials from AWS Secrets Manager (`judgemind/dev/agent-admin`), logs in via the web login form, and then navigates to the target page. This is required for any page behind authentication (e.g. `/admin/*` routes).
+
+The `agent-admin` account on dev has `users.role = 'admin'`, so both admin dashboards (`/admin/data-quality`, `/admin/dispatcher`) render with full admin content. To add a new admin-gated page, gate on `user.role === 'admin'` and `--auth` will Just Work.
 
 ### Options
 
@@ -71,7 +74,7 @@ The `--auth` flag fetches admin credentials from AWS Secrets Manager (`judgemind
 | `--width` | 1280 | Viewport width in pixels |
 | `--height` | 720 | Viewport height in pixels |
 | `--wait` | 3000 | Wait time in ms after page load for JS rendering |
-| `--auth` | off | Log in as admin before taking the screenshot. Fetches credentials from AWS Secrets Manager (`judgemind/dev/agent-admin`). Required for admin pages. |
+| `--auth` | off | Log in as admin before taking the screenshot. Fetches credentials from AWS Secrets Manager (`judgemind/dev/agent-admin`, a `role='admin'` user on dev). Required for admin pages. |
 
 ---
 

--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -258,3 +258,18 @@ scripts/with-secret.sh -e DB_USER=judgemind/dev/db/connection:.username -e DB_PA
 ```
 
 The `-e VAR=secret-id` form uses the raw SecretString. The `-e VAR=secret-id:.field` form extracts a JSON key. Multiple `-e` flags can be chained.
+
+## Dev admin account (screenshot + auth-gated flows)
+
+`scripts/screenshot.py --auth` logs into `dev.judgemind.org` using credentials stored in AWS Secrets Manager at `judgemind/dev/agent-admin`. The account has `users.role = 'admin'` on the dev database, so admin-gated pages (e.g. `/admin/data-quality`, `/admin/dispatcher`) render with full admin content rather than the "Access Denied" / 404 fallback. See `.claude/skills/screenshot/SKILL.md` for usage.
+
+The secret's `email` and `password` keys are used by the script; any other consumer needing authenticated dev access should fetch them via `scripts/with-secret.sh`:
+
+```
+scripts/with-secret.sh \
+    -e AGENT_EMAIL=judgemind/dev/agent-admin:.email \
+    -e AGENT_PASSWORD=judgemind/dev/agent-admin:.password \
+    -- <command>
+```
+
+To rotate the password, generate a new strong random value, update both `public.users.password_hash` on dev (via `scripts/dev-db-query.sh --rw`, using a bcrypt cost-12 hash — see `packages/api/src/auth/passwords.ts`) and the `password` field in the Secrets Manager entry. The existing `email` should stay stable unless you are also rotating the account identity.

--- a/scripts/screenshot.py
+++ b/scripts/screenshot.py
@@ -83,13 +83,24 @@ def perform_login(page: Page, email: str, password: str) -> None:
     and waits for the post-login redirect. After this returns, the page's
     browser context holds the auth cookies for subsequent navigation.
 
+    The login form posts a GraphQL ``login`` mutation to dev.api.judgemind.org,
+    which returns an access token and sets the ``refreshToken`` HTTP-only
+    cookie on the api subdomain. The React handler then calls
+    ``router.push('/')`` on success, redirecting to the home page.
+
+    This function waits for that redirect to land on ``/`` before returning —
+    waiting for a broader pattern like ``{BASE_URL}/**`` would match the
+    login page itself and return immediately before the mutation completes,
+    leaving the caller navigating away before the cookie is set (see #2760).
+
     Args:
         page: A Playwright Page object.
         email: The login email address.
         password: The login password.
 
     Raises:
-        TimeoutError: If the login redirect does not complete in time.
+        TimeoutError: If the login redirect does not complete in time
+            (most commonly because the credentials were rejected).
     """
     login_url = f"{BASE_URL}/auth/login"
     print(f"Authenticating via {login_url} ...")
@@ -99,9 +110,11 @@ def perform_login(page: Page, email: str, password: str) -> None:
     page.fill('input[name="password"]', password)
     page.click('button[type="submit"]')
 
-    # Wait for the post-login redirect (the login page navigates to / on success).
-    # Use a glob pattern to accept any path on the allowed host after login.
-    page.wait_for_url(f"{BASE_URL}/**", timeout=15000)
+    # Wait for the post-login redirect. The login page navigates to "/" on
+    # success (router.push('/')), so wait for exactly that URL — a glob like
+    # "/**" would also match "/auth/login" itself and return immediately
+    # without actually waiting for the mutation/redirect to complete.
+    page.wait_for_url(f"{BASE_URL}/", timeout=15000)
     print("Authentication successful.")
 
 

--- a/scripts/tests/test_screenshot.py
+++ b/scripts/tests/test_screenshot.py
@@ -127,13 +127,23 @@ class TestPerformLogin:
             perform_login(mock_page, "admin@example.com", "wrong")
 
     def test_wait_for_url_pattern(self) -> None:
-        """Verify the URL pattern used for post-login redirect detection."""
+        """Verify the URL pattern used for post-login redirect detection.
+
+        Regression test for #2760: the previous ``{BASE_URL}/**`` glob also
+        matched ``/auth/login`` itself, so ``wait_for_url`` returned
+        immediately without actually waiting for the post-login redirect,
+        causing the caller to navigate away before the refresh-token cookie
+        was set. The fixed pattern is an exact match on the home page URL,
+        which is where the login page's ``router.push('/')`` sends the user.
+        """
         mock_page = MagicMock()
         perform_login(mock_page, "a@b.com", "pw")
 
-        # Should wait for any page on the allowed host
         args, kwargs = mock_page.wait_for_url.call_args
-        assert "dev.judgemind.org" in args[0]
+        # Must wait for exactly the home page, not a glob that also matches
+        # the login page itself.
+        assert args[0] == "https://dev.judgemind.org/"
+        assert "**" not in args[0]
         assert kwargs.get("timeout") == 15000
 
 


### PR DESCRIPTION
## Summary

Fix `scripts/screenshot.py --auth` so it actually authenticates as an admin on dev. The `perform_login` helper's `wait_for_url(BASE_URL + "/**")` glob also matched the login page itself, so the wait returned immediately after the submit click — before the login mutation completed and before the refresh-token cookie was set — leaving the caller navigating away on an unauthenticated context. The `judgemind/dev/agent-admin` user already had `users.role = 'admin'` on dev, but this bug made `/admin/dispatcher` 404 and `/admin/data-quality` fall back to "Access Denied" in every agent-run screenshot. Fix waits for an exact match on `BASE_URL + "/"` — the post-login destination.

Also rotates the Secrets Manager password to a fresh 40-char random value (bcrypt cost-12 hash written to `public.users`) and documents the admin account in `.claude/skills/screenshot/SKILL.md` and `docs/agent/infrastructure-reference.md`.

Closes #2760

## Test plan

### Automated checks
- [x] Lint passes (`ruff check scripts/screenshot.py scripts/tests/test_screenshot.py`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest scripts/tests/test_screenshot.py` — 13 passed, includes new regression test asserting exact-match wait pattern and that `**` is absent)
- [x] CI green

### Post-deploy verification
- [ ] `scripts/screenshot.py --auth /admin/dispatcher` renders the full dispatcher page with all 5 panels (Status bar, Controls, Active agents, Queue, ADMIN sidebar)
- [ ] `scripts/screenshot.py --auth /admin/data-quality` renders the full data-quality dashboard (not the "Access Denied" fallback)
- [ ] Verification evidence with screenshots posted on #2760
