### PR TITLE
feat(dispatcher): wire scoped GitHub PAT for MCP tool execution (#2700)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -195,12 +195,11 @@ module "ses" {
 # but nothing runs until sub-task C (#2729) publishes the real image and
 # Phase 2 flips the replica count.
 #
-# Secrets wiring is deferred: the operator provisions
-# `judgemind/dev/dispatcher/*` secrets manually once this module merges.
-# Issue #2700 provisions the scoped `GITHUB_TOKEN` PAT. Leaving the ARNs as
-# empty strings until then is safe — the module's task definition uses
-# `compact()` to skip any unset secret and the service is inert at
-# `desired_count=0` anyway.
+# Secrets wiring lands incrementally. #2700 wires `GITHUB_TOKEN` (the
+# scoped PAT from spike 0.7, stored in `judgemind/dispatcher/github-token`).
+# The remaining ARNs stay as empty strings until their owning sub-tasks
+# land — the module's task definition uses `compact()` to skip any unset
+# secret and the service is inert at `desired_count=0` anyway.
 module "dispatcher_daemon" {
   source = "../../modules/dispatcher-daemon"
 
@@ -215,12 +214,16 @@ module "dispatcher_daemon" {
   # Phase 1 = inert. Flipped to 1 in Phase 2 (shadow mode). Never > 1.
   desired_count = 0
 
-  # Secret ARNs — all empty during Phase 1. Operator populates after the
-  # module lands; wiring happens in sub-tasks C (#2729) / #2700 / follow-up
-  # telegram + dispatcher-role DB secret from sub-task A (#2727).
+  # Secret ARNs — populated incrementally as their owning issues land.
+  # #2700 wires `github_token_secret_arn` (this ARN is the scoped PAT from
+  # spike 0.7, provisioned in Secrets Manager by the operator and pinned
+  # here so the execution role's `execution_secrets` policy resolves
+  # against it). Other ARNs stay empty until their owning sub-tasks
+  # land — the module's `compact()` guard drops unset entries and the
+  # service is inert at `desired_count=0` anyway.
   anthropic_api_key_secret_arn  = ""
   db_connection_secret_arn      = ""
-  github_token_secret_arn       = ""
+  github_token_secret_arn       = "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/dispatcher/github-token-QOmHlJ"
   telegram_bot_token_secret_arn = ""
   gemini_api_key_secret_arn     = ""
 

--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -38,11 +38,14 @@ locals {
   log_group_name = "/ecs/judgemind-dispatcher-${var.environment}"
 
   # Secret-ARN lists for the two policies below. `compact()` drops any empty
-  # string, so placeholder secrets that aren't yet provisioned (e.g.
-  # GITHUB_TOKEN before #2700, or the full Phase-1 inert wiring where all
-  # ARNs are "") do not leak into the policy's `Resource` list. If the
-  # compacted list is empty, the policy resource itself is skipped via
-  # `count = 0` — IAM rejects `Resource = []` with
+  # string, so placeholder secrets that aren't yet provisioned (e.g. the
+  # Phase-1 inert wiring where some sub-task owners haven't landed their
+  # ARN yet) do not leak into the policy's `Resource` list. As of #2700
+  # the dev wiring pins `github_token_secret_arn`, so the compacted list
+  # is non-empty in dev — the count-guard still matters for callers that
+  # stand up the module with all ARNs blank. If the compacted list is
+  # empty, the policy resource itself is skipped via `count = 0` — IAM
+  # rejects `Resource = []` with
   # `MalformedPolicyDocument: Policy statement must contain resources`
   # (see #2739).
   execution_secret_arns = compact([
@@ -126,10 +129,13 @@ resource "aws_iam_role_policy_attachment" "execution_managed" {
 # Allow the execution role to fetch every secret wired into the task
 # definition. The secret-ARN list is pre-compacted into
 # `local.execution_secret_arns` so that empty-string placeholders
-# (e.g. GITHUB_TOKEN before #2700) are dropped. When no ARNs are wired
-# in — the Phase-1 inert wiring passes "" for all five — the policy
+# (e.g. sub-tasks that haven't landed their secret yet) are dropped.
+# When no ARNs are wired in — a fully blank test stack — the policy
 # resource itself is skipped via `count = 0`; IAM rejects a statement
-# with `Resource = []` as `MalformedPolicyDocument` (see #2739).
+# with `Resource = []` as `MalformedPolicyDocument` (see #2739). The
+# dev env (#2700) wires `github_token_secret_arn`, so the compacted
+# list is non-empty and this policy is created with `GITHUB_TOKEN`'s
+# ARN in the `Resource` array.
 resource "aws_iam_role_policy" "execution_secrets" {
   count = length(local.execution_secret_arns) > 0 ? 1 : 0
 

--- a/infra/terraform/modules/dispatcher-daemon/variables.tf
+++ b/infra/terraform/modules/dispatcher-daemon/variables.tf
@@ -78,8 +78,9 @@ variable "log_retention_days" {
 # Each `*_secret_arn` is the Secrets Manager ARN that will be injected into
 # the container as the corresponding env var. Leave empty to skip wiring
 # that secret — useful during Phase 1 when some of these don't exist yet
-# (e.g. the dispatcher-role DB secret is created by sub-task A, #2727, and
-# the scoped GitHub PAT is provisioned by #2700).
+# (e.g. the dispatcher-role DB secret is created by sub-task A, #2727).
+# The scoped GitHub PAT (#2700) is wired in `environments/dev/main.tf`
+# against `judgemind/dispatcher/github-token`.
 
 variable "anthropic_api_key_secret_arn" {
   description = "Secrets Manager ARN for ANTHROPIC_API_KEY. Required for the daemon to spawn `claude -p` subprocesses."
@@ -94,7 +95,7 @@ variable "db_connection_secret_arn" {
 }
 
 variable "github_token_secret_arn" {
-  description = "Secrets Manager ARN for GITHUB_TOKEN (scoped PAT from spike 0.7). Populated by #2700; placeholder empty string is safe while desired_count=0."
+  description = "Secrets Manager ARN for GITHUB_TOKEN (scoped PAT from spike 0.7). Wired in dev by #2700 to `judgemind/dispatcher/github-token`; the `github` MCP server reads this env var to authenticate `mcp__github__*` tool calls. Empty-string default stays supported so environments without the secret (e.g. a fresh `staging` / throwaway test stack) can still plan the module; the execution role's `execution_secrets` policy uses `compact()` to drop unset entries."
   type        = string
   default     = ""
 }

--- a/scripts/dispatcher/tests/mcp-config.json
+++ b/scripts/dispatcher/tests/mcp-config.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "MCP config used by scripts/dispatcher/tests/test_mcp_github_integration.py to exercise mcp__github__* tool execution end-to-end (issue #2700). The test spawns `claude -p --mcp-config <this-file>` with GITHUB_TOKEN set from a real scoped PAT (via scripts/with-secret.sh in the manual/Fargate run; fetched from dev secrets in CI-bypass mode) and calls mcp__github__get_issue against a known closed test issue to prove the scoped-PAT + MCP-server pair round-trips correctly. The `github` MCP server package itself reads GITHUB_TOKEN (or GITHUB_PERSONAL_ACCESS_TOKEN) from the process env, so we pass `env: {}` here to let the subprocess inherit whichever is set — mirrors the spike 0.1 pattern (docs/investigations/dispatcher-v2-spike-0.1.md §4).",
+  "mcpServers": {
+    "github": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {}
+    }
+  }
+}

--- a/scripts/dispatcher/tests/test_mcp_github_integration.py
+++ b/scripts/dispatcher/tests/test_mcp_github_integration.py
@@ -1,0 +1,286 @@
+"""Integration test: `mcp__github__*` tools execute inside `claude -p` (#2700).
+
+Spike 0.1 (#2683) proved that `claude -p` on Fargate can **enumerate** the
+``mcp__github__*`` suite when given an explicit ``--mcp-config``; it did
+NOT prove the tools actually execute because no ``GITHUB_TOKEN`` was
+provisioned at the time (see
+``docs/investigations/dispatcher-v2-spike-0.1.md`` §4 bullet "The spike's
+mcp-config.json references ${GITHUB_TOKEN} but the container did NOT
+have GITHUB_TOKEN set"). Spike 0.7 (#2689) proved the scoped PAT in
+Secrets Manager works for ``git`` and ``gh`` from inside the Fargate
+task — but again, never actually invoked an ``mcp__github__*`` tool.
+
+This test closes that remaining unknown. Structure:
+
+**Preflight (always runs, including CI):** asserts the MCP config file
+ships with the test fixture list, is valid JSON, and declares the
+``github`` server with the expected command + args. Cheap to run, no
+external dependencies.
+
+**Full integration (gated):** only runs when all of the following are
+true — ``CLAUDE_MCP_INTEGRATION_TEST=1``, ``GITHUB_TOKEN`` (or
+``GITHUB_PERSONAL_ACCESS_TOKEN``) set, and the ``claude`` CLI present
+on PATH. Anthropic auth is whatever ``claude`` picks up natively:
+``ANTHROPIC_API_KEY`` in the env when present (the Fargate path —
+wired via Secrets Manager), otherwise the local OAuth token from
+``~/.claude/`` (the laptop-operator path). In that mode the test
+spawns a real ``claude -p`` subprocess, asks it to call
+``mcp__github__get_issue`` against issue #2683 (the spike 0.1 issue,
+closed, ``type/spike`` label), and asserts:
+
+1. The subprocess exits 0 (the spike 0.1 success-code signal from
+   ``docs/investigations/dispatcher-v2-spike-0.1.md`` §2).
+2. The output contains the expected issue title (proves the tool
+   actually returned a structured response, not a generic "I couldn't
+   call the tool" failure).
+3. No 401 / 403 / "Invalid API key" markers appear anywhere in stdout
+   or stderr — this is what would indicate the token reached the
+   server but was rejected.
+
+CI runs pytest with none of the gating env vars set, so the integration
+section skips cleanly. Operators validating the Fargate wiring set
+``CLAUDE_MCP_INTEGRATION_TEST=1`` + inject the scoped PAT (via
+``scripts/with-secret.sh -e
+GITHUB_TOKEN=judgemind/dispatcher/github-token``) before running
+pytest, either locally (with ``claude`` on PATH) or inside the daemon
+container image (same `claude` pinned at 2.1.114 per
+``Dockerfile.dispatcher``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# --------------------------------------------------------------------------
+# Constants
+# --------------------------------------------------------------------------
+
+#: The closed test issue we interrogate. Picked because it is closed (will
+#: not shift state under us), has a stable ``type/spike`` label, and its
+#: title carries the exact substring we assert on.
+TEST_ISSUE_NUMBER = 2683
+TEST_ISSUE_TITLE_SUBSTRING = "claude -p end-to-end on Fargate"
+
+#: Path to the shipped MCP config. Lives next to this test file so the
+#: path is stable whether pytest runs from the repo root or from
+#: scripts/dispatcher/.
+MCP_CONFIG_PATH = Path(__file__).resolve().parent / "mcp-config.json"
+
+#: Regexes that indicate the PAT was rejected by GitHub. Any of these
+#: appearing in the subprocess output means the scoped-PAT → MCP server
+#: handshake failed and we should fail the test loudly.
+AUTH_ERROR_MARKERS = (
+    "401",
+    "403",
+    "Invalid API key",
+    "Bad credentials",
+    "Requires authentication",
+)
+
+
+# --------------------------------------------------------------------------
+# Preflight (always runs)
+# --------------------------------------------------------------------------
+
+
+class TestMcpConfigPreflight:
+    """Assertions about the MCP config that ship with the test.
+
+    These run in CI without any credentials — they guard against
+    accidental drift (e.g. someone deleting the config file, or breaking
+    its JSON, or renaming the ``github`` server). Breaking any of these
+    breaks the integration test silently on Fargate, which is hard to
+    detect because the log output there is much noisier than a CI run.
+    """
+
+    def test_config_file_exists(self) -> None:
+        assert MCP_CONFIG_PATH.exists(), (
+            f"MCP config fixture missing: {MCP_CONFIG_PATH}. "
+            "Check that scripts/dispatcher/tests/mcp-config.json ships "
+            "alongside this test."
+        )
+
+    def test_config_is_valid_json(self) -> None:
+        data = json.loads(MCP_CONFIG_PATH.read_text())
+        assert isinstance(data, dict)
+
+    def test_declares_github_server_with_expected_package(self) -> None:
+        data = json.loads(MCP_CONFIG_PATH.read_text())
+        servers = data.get("mcpServers")
+        assert isinstance(servers, dict), "mcpServers missing or not an object"
+        github = servers.get("github")
+        assert isinstance(github, dict), "github server missing from mcpServers"
+
+        # The daemon's spike 0.1 config used exactly this command+package.
+        # Keeping them pinned means the MCP server we load in the test is
+        # the same one the real dispatcher subprocesses will load.
+        assert github.get("command") == "npx"
+        args = github.get("args", [])
+        assert "@modelcontextprotocol/server-github" in args, (
+            f"github server args must include @modelcontextprotocol/server-github, "
+            f"got {args!r}"
+        )
+
+    def test_server_env_passthrough(self) -> None:
+        """The server env must be empty (or explicit) so GITHUB_TOKEN is inherited.
+
+        The ``@modelcontextprotocol/server-github`` package reads
+        ``GITHUB_TOKEN`` / ``GITHUB_PERSONAL_ACCESS_TOKEN`` from its
+        process env. If the MCP config hard-codes an ``env`` block that
+        overrides these, the token the daemon fetches from Secrets
+        Manager never reaches the MCP server and every tool call 401s.
+        """
+        data = json.loads(MCP_CONFIG_PATH.read_text())
+        github_env = data["mcpServers"]["github"].get("env", {})
+        assert isinstance(github_env, dict)
+        # It is legal to set _unrelated_ env keys here; what we explicitly
+        # forbid is the config taking over the auth variables and
+        # clobbering the inherited scoped PAT.
+        for banned in ("GITHUB_TOKEN", "GITHUB_PERSONAL_ACCESS_TOKEN"):
+            assert banned not in github_env, (
+                f"MCP config must not set {banned} in mcpServers.github.env — "
+                "the scoped PAT is supposed to flow through from the "
+                "subprocess's environment (wired via Secrets Manager in "
+                "the Fargate task definition, #2700)."
+            )
+
+
+# --------------------------------------------------------------------------
+# Gating helpers (module-scoped so fixtures and test can share them)
+# --------------------------------------------------------------------------
+
+
+def _integration_mode_enabled() -> bool:
+    """Return True when the caller has opted into the real subprocess run."""
+    return os.environ.get("CLAUDE_MCP_INTEGRATION_TEST") == "1"
+
+
+def _missing_integration_prereqs() -> list[str]:
+    """List the prereqs the full integration run needs but doesn't see.
+
+    ``ANTHROPIC_API_KEY`` is intentionally NOT on this list — it is only
+    one of the two auth paths ``claude`` supports (the other being the
+    laptop OAuth token in ``~/.claude/``). Flagging it here would force
+    laptop operators to stub a fake API key to run the test, which adds
+    nothing. On Fargate the daemon subprocess inherits
+    ``ANTHROPIC_API_KEY`` from the task definition's ``secrets[]`` and
+    the test works the same way.
+    """
+    missing: list[str] = []
+    if not os.environ.get("GITHUB_TOKEN") and not os.environ.get(
+        "GITHUB_PERSONAL_ACCESS_TOKEN"
+    ):
+        missing.append("GITHUB_TOKEN (or GITHUB_PERSONAL_ACCESS_TOKEN)")
+    if shutil.which("claude") is None:
+        missing.append("`claude` CLI on PATH")
+    return missing
+
+
+# --------------------------------------------------------------------------
+# Full integration (gated on CLAUDE_MCP_INTEGRATION_TEST=1)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not _integration_mode_enabled(),
+    reason=(
+        "Full integration run gated on CLAUDE_MCP_INTEGRATION_TEST=1. "
+        "Set it plus GITHUB_TOKEN (Anthropic auth can be the local "
+        "OAuth token or ANTHROPIC_API_KEY, whichever claude picks up) "
+        "and run `pytest "
+        "scripts/dispatcher/tests/test_mcp_github_integration.py -k integration` "
+        "(locally or inside the daemon image) to exercise the real "
+        "mcp__github__get_issue call against issue #2683."
+    ),
+)
+class TestMcpGithubGetIssueIntegration:
+    """Spawn `claude -p` and call mcp__github__get_issue against #2683.
+
+    This is the test that actually closes the unknown spike 0.1 and 0.7
+    left on the table: *can a `claude -p` subprocess running with the
+    scoped PAT in its environment successfully invoke an
+    ``mcp__github__*`` tool and get back a structured GitHub response?*
+    """
+
+    def _require_prereqs(self) -> None:
+        missing = _missing_integration_prereqs()
+        if missing:
+            pytest.skip(
+                f"Integration mode enabled but prerequisites missing: "
+                f"{', '.join(missing)}. See the docstring on this test "
+                "class for the required env vars."
+            )
+
+    def _run_claude(self, prompt: str) -> subprocess.CompletedProcess[str]:
+        """Spawn `claude -p` with the test MCP config and return the result."""
+        # `--` terminates option parsing so the prompt is never slurped
+        # into the variadic `--mcp-config` list. Spike 0.1 caught this
+        # trap; it is still the #1 way to misuse `claude -p --mcp-config`.
+        argv = [
+            "claude",
+            "-p",
+            "--max-turns",
+            "5",
+            "--output-format",
+            "json",
+            "--mcp-config",
+            str(MCP_CONFIG_PATH),
+            "--allow-dangerously-skip-permissions",
+            "--",
+            prompt,
+        ]
+        # subprocess.run with a 120-second cap — a real mcp__github__get_issue
+        # call against a closed issue returns in well under a second on a
+        # warm CLI; anything over 2 minutes means the CLI is stuck
+        # (container crash, exhausted API budget, etc.) and the test
+        # should fail rather than wait indefinitely.
+        return subprocess.run(
+            argv,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+    def test_get_issue_returns_expected_title(self) -> None:
+        self._require_prereqs()
+
+        prompt = (
+            f"Call the mcp__github__get_issue tool with "
+            f"owner='judgemind', repo='judgemind', "
+            f"issue_number={TEST_ISSUE_NUMBER}. Then print the exact "
+            f"title of the returned issue on a single line, nothing else."
+        )
+        result = self._run_claude(prompt)
+
+        combined = f"{result.stdout}\n{result.stderr}"
+
+        # 1. Exit code 0 is the success signal per spike 0.1 Finding 2.
+        assert result.returncode == 0, (
+            f"`claude -p` exited {result.returncode}. "
+            f"stdout={result.stdout[:500]!r} stderr={result.stderr[:500]!r}"
+        )
+
+        # 2. No auth-error markers. A 401/403 from the GitHub API would
+        # bubble up as an MCP tool result — which `claude -p` prints
+        # verbatim, so the substrings would land in stdout.
+        for marker in AUTH_ERROR_MARKERS:
+            assert marker not in combined, (
+                f"Auth-error marker {marker!r} found in claude -p output — "
+                f"the scoped PAT appears to have been rejected. "
+                f"stdout={result.stdout[:500]!r} stderr={result.stderr[:500]!r}"
+            )
+
+        # 3. The issue title substring is in the final text. We assert
+        # on a stable substring (not the full title) so that tiny title
+        # edits upstream don't break this test.
+        assert TEST_ISSUE_TITLE_SUBSTRING in result.stdout, (
+            f"Expected to see {TEST_ISSUE_TITLE_SUBSTRING!r} in claude -p "
+            f"stdout, got stdout={result.stdout[:1000]!r}"
+        )


### PR DESCRIPTION
## Summary

Wires the scoped GitHub PAT into the dispatcher daemon's Fargate task definition and adds a daemon-side integration test that proves `mcp__github__*` tools actually execute inside a `claude -p` subprocess — the remaining unknown spike 0.1 (#2683) and spike 0.7 (#2689) left open.

- `infra/terraform/environments/dev/main.tf`: pins `github_token_secret_arn = "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/dispatcher/github-token-QOmHlJ"` on the `dispatcher_daemon` module call. The module already injects via `containerDefinitions[0].secrets[]` (not `environment[]`) and the execution-role `execution_secrets` policy (from #2739) resolves now that the compacted ARN list is non-empty.
- `scripts/dispatcher/tests/test_mcp_github_integration.py` + `mcp-config.json`: preflight tests (always run in CI) guard the MCP config shape; the gated full integration test (on `CLAUDE_MCP_INTEGRATION_TEST=1` + `GITHUB_TOKEN`) spawns real `claude -p --mcp-config <fixture>`, calls `mcp__github__get_issue` against spike 0.1 issue #2683, and asserts exit 0 + title match + no auth-error markers. Passes locally in ~13s against the real scoped PAT.

Closes #2700

## Test plan

### Automated checks
- [x] Lint passes (`ruff check scripts/dispatcher/`)
- [x] Format check passes (`ruff format --check scripts/dispatcher/`)
- [x] Dispatcher test suite green (`pytest scripts/dispatcher/tests/`) — 23 passed, 1 skipped (integration gated)
- [x] Terraform fmt passes (`terraform fmt -check -recursive infra/terraform/`)
- [x] Terraform validate passes (`terraform -chdir=infra/terraform/environments/dev validate`)
- [x] CI green

### Post-deploy verification
- [ ] Operator re-runs `terraform -chdir=infra/terraform/environments/dev apply -auto-approve` (per task instructions, apply is NOT done from this subagent).
- [ ] `aws ecs describe-task-definition --task-definition judgemind-dispatcher-dev` shows `GITHUB_TOKEN` in `containerDefinitions[0].secrets[]` with the expected `valueFrom` ARN (deferred-pending-operator-reapply).
- [ ] Verification evidence posted on issue #2700 with the new task-def revision + plan evidence (see A.8).
