### PR TITLE
dx(scripts): add hyphen-vs-underscore filename collision check (#2756)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -492,6 +492,27 @@ if [ -n "$changed_migrations" ]; then
 fi
 
 # -------------------------------------------------------------------
+# Filename separator hygiene — always cheap, always run
+# -------------------------------------------------------------------
+# Flags same-directory filename pairs that differ only by `-` vs `_`
+# (see #2751/#2754 for the incident: a broken hyphen variant of
+# check_schema_drift.sh coexisted with the correct underscore version,
+# agents picked the alphabetically-first wrong one). The check only
+# walks scripts/, packages/*/src/, packages/*/tests/, and infra/ — a
+# few hundred dirs on this repo — so it runs unconditionally rather
+# than behind a path filter.
+if [ -x scripts/check-hyphen-underscore-collision.sh ]; then
+    echo "pre-push: checking for filename separator collisions..." >&2
+    if ! scripts/check-hyphen-underscore-collision.sh 2>&1; then
+        echo "" >&2
+        echo "  FAILED: scripts/check-hyphen-underscore-collision.sh" >&2
+        echo "  Two files in the same directory differ only by '-' vs '_'" >&2
+        echo "  — rename one or delete the stale sibling. See #2751/#2754." >&2
+        failures=$((failures + 1))
+    fi
+fi
+
+# -------------------------------------------------------------------
 # Script header marker check — run whenever scripts/*.py changes
 # -------------------------------------------------------------------
 # Mirrors the CI `script-headers-check` job so one-off/permanent marker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -895,6 +895,20 @@ jobs:
         run: scripts/check-script-headers.sh
 
   # ---------------------------------------------------------------
+  # Filename separator hygiene: flag same-directory filename pairs that
+  # differ only by `-` vs `_`. Prevents the #2751 / #2754 recurrence
+  # where `scripts/check-schema-drift.sh` (hyphen, broken) coexisted
+  # with `scripts/check_schema_drift.sh` (underscore, canonical) and
+  # agents picked the alphabetically-first wrong one.
+  # ---------------------------------------------------------------
+  filename-separator-hygiene-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Filename separator hygiene
+        run: scripts/check-hyphen-underscore-collision.sh
+
+  # ---------------------------------------------------------------
   # Markdown link guard: internal .md pointers in CLAUDE.md, docs/,
   # .claude/skills/, packages/*/README.md, packages/*/docs/,
   # infra/, and .github/ must point to files that exist (#2425, #2428)

--- a/scripts/check-hyphen-underscore-collision.sh
+++ b/scripts/check-hyphen-underscore-collision.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# check-hyphen-underscore-collision.sh — Flag filename pairs in the same
+# directory that differ only by `-` vs `_`.
+#
+# Motivating incident (#2751 / #2754):
+#   `scripts/check-schema-drift.sh` (hyphen, broken grep-based checker)
+#   coexisted with `scripts/check_schema_drift.sh` (underscore, correct
+#   implementation used by CI + pre-push).  An agent ran the hyphen one
+#   first (alphabetical), got a false-positive drift report, and burned
+#   diagnostic time before realising the two are different scripts.
+#   #2754 deleted the broken one; this check prevents a recurrence.
+#
+# For each directory in the scan set we list its files, normalise `-`
+# to `_`, and report any normalised name claimed by more than one
+# distinct original filename.
+#
+# Scan set (narrow on purpose — widen only if a real collision shows up
+# outside it):
+#   scripts/                          (top-level files only)
+#   packages/*/src/**                 (recursive, per directory)
+#   packages/*/tests/**               (recursive, per directory)
+#   infra/**                          (recursive, per directory)
+#
+# Directories that are pure vendored state (.git, .venv, node_modules,
+# .next, __pycache__, .terraform, tmp) are skipped even if they appear
+# inside the scan set.
+#
+# Usage:
+#   scripts/check-hyphen-underscore-collision.sh          # scan repo root
+#   scripts/check-hyphen-underscore-collision.sh [dir]    # scan another root
+#
+# Exit codes:
+#   0 — No collisions found.
+#   1 — One or more directories contain a hyphen-vs-underscore pair.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_ROOT="${1:-$REPO_ROOT}"
+
+if [[ ! -d "$SCAN_ROOT" ]]; then
+    echo "ERROR: scan root is not a directory: $SCAN_ROOT" >&2
+    exit 2
+fi
+
+# ─── Directories to scan (relative to SCAN_ROOT) ─────────────────────────
+# `scripts/` is scanned non-recursively — its subdirectories (tests/,
+# spotcheck/, eval/, dispatcher/) have their own conventions and it's
+# the top-level entry points that incident #2751 was about.
+#
+# packages/<pkg>/src and packages/<pkg>/tests are scanned recursively
+# because Python imports and pytest discovery treat `foo_bar.py` and
+# `foo-bar.py` as two different files (the hyphenated one can't even
+# be imported).  Similar reasoning for TypeScript module resolution.
+#
+# infra/ is scanned recursively because Terraform module paths are
+# resolved literally — a hyphen/underscore pair in the same dir is a
+# latent footgun.
+SCAN_DIRS_NONRECURSIVE=(
+    "scripts"
+)
+
+SCAN_DIRS_RECURSIVE=(
+    "packages"
+    "infra"
+)
+
+# ─── Directories to exclude from recursion ───────────────────────────────
+# Standard ignored directories (vendored deps, VCS metadata, build output,
+# local state).  A directory component anywhere in the path matching one
+# of these skips the whole subtree.
+EXCLUDE_DIRS=(
+    ".git"
+    ".venv"
+    "node_modules"
+    ".next"
+    "__pycache__"
+    ".vite"
+    ".terraform"
+    "tmp"
+    "dist"
+    "build"
+    "coverage"
+)
+
+# Return 0 if the path has an excluded directory component.
+path_is_excluded() {
+    local p="$1"
+    local excl
+    for excl in "${EXCLUDE_DIRS[@]}"; do
+        if [[ "$p" == *"/$excl/"* || "$p" == *"/$excl" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# ─── Helper: check a single directory (non-recursive) ───────────────────
+# Prints every collision found on stdout in the format:
+#     <abs_dir>\t<name_a>\t<name_b>
+# and increments the global COLLISION_COUNT for each pair.
+COLLISION_COUNT=0
+
+check_directory() {
+    local dir="$1"
+
+    # List immediate children only, files only.  We print full paths and
+    # strip the directory prefix in awk rather than using `find -printf`,
+    # which is GNU-findutils-only (not available on macOS BSD find).
+    local files
+    files=$(find "$dir" -maxdepth 1 -mindepth 1 -type f 2>/dev/null \
+        | awk -v prefix="$dir/" 'index($0, prefix) == 1 { print substr($0, length(prefix) + 1) }' \
+        | LC_ALL=C sort || true)
+    [[ -z "$files" ]] && return 0
+
+    # Build associative array: normalised name → newline-separated list
+    # of original names.  We can't rely on Bash 4 associative arrays on
+    # every platform (older macOS Bash is 3.2), so use a plain name-based
+    # tempfile approach via awk.
+    echo "$files" | awk -v dir="$dir" '
+        {
+            orig = $0
+            norm = orig
+            gsub(/-/, "_", norm)
+            # Append orig to the list for norm, separated by NUL.
+            if (seen[norm]) {
+                group[norm] = group[norm] "\n" orig
+            } else {
+                group[norm] = orig
+                seen[norm] = 1
+            }
+            count[norm]++
+        }
+        END {
+            for (norm in count) {
+                if (count[norm] < 2) continue
+                # Build a de-duplicated sorted list of originals for this
+                # norm (a single real file can appear once; two different
+                # originals means collision).
+                n = split(group[norm], arr, "\n")
+                # Deduplicate (shouldn\u2019t happen on a real filesystem but be
+                # defensive).
+                delete uniq
+                out_n = 0
+                for (i = 1; i <= n; i++) {
+                    if (!(arr[i] in uniq)) {
+                        uniq[arr[i]] = 1
+                        out_n++
+                        out[out_n] = arr[i]
+                    }
+                }
+                if (out_n < 2) continue
+                # Sort the output names lexicographically for stable output.
+                for (i = 1; i <= out_n; i++) {
+                    for (j = i + 1; j <= out_n; j++) {
+                        if (out[i] > out[j]) {
+                            tmp = out[i]; out[i] = out[j]; out[j] = tmp
+                        }
+                    }
+                }
+                # Emit one line per pair (i, j) for i < j.
+                for (i = 1; i <= out_n; i++) {
+                    for (j = i + 1; j <= out_n; j++) {
+                        printf "%s\t%s\t%s\n", dir, out[i], out[j]
+                    }
+                }
+            }
+        }
+    '
+}
+
+# ─── Scan ────────────────────────────────────────────────────────────────
+
+all_collisions=""
+
+# Non-recursive scan dirs: check just the dir itself.
+for rel in "${SCAN_DIRS_NONRECURSIVE[@]}"; do
+    abs="$SCAN_ROOT/$rel"
+    [[ -d "$abs" ]] || continue
+    result=$(check_directory "$abs")
+    if [[ -n "$result" ]]; then
+        all_collisions+="$result"$'\n'
+    fi
+done
+
+# Recursive scan dirs: enumerate every subdirectory under them (respecting
+# EXCLUDE_DIRS) and check each one.
+for rel in "${SCAN_DIRS_RECURSIVE[@]}"; do
+    abs="$SCAN_ROOT/$rel"
+    [[ -d "$abs" ]] || continue
+
+    # Build a find invocation that prunes excluded dirs.
+    prune_args=()
+    for excl in "${EXCLUDE_DIRS[@]}"; do
+        if [[ ${#prune_args[@]} -gt 0 ]]; then
+            prune_args+=( -o )
+        fi
+        prune_args+=( -name "$excl" )
+    done
+
+    # `find -type d` enumerates every subdir including the scan root.
+    while IFS= read -r subdir; do
+        [[ -z "$subdir" ]] && continue
+        result=$(check_directory "$subdir")
+        if [[ -n "$result" ]]; then
+            all_collisions+="$result"$'\n'
+        fi
+    done < <(
+        find "$abs" \( "${prune_args[@]}" \) -prune -o -type d -print 2>/dev/null | LC_ALL=C sort
+    )
+done
+
+# Strip trailing blank lines.
+all_collisions="${all_collisions%$'\n'}"
+
+if [[ -n "$all_collisions" ]]; then
+    echo "ERROR: Found hyphen-vs-underscore filename collisions." >&2
+    echo "" >&2
+    echo "  Two files in the same directory whose names differ only by" >&2
+    echo "  '-' vs '_' are ambiguous — agents and humans routinely pick" >&2
+    echo "  the wrong one (see #2751 / #2754).  Rename one, or delete" >&2
+    echo "  the stale sibling." >&2
+    echo "" >&2
+    while IFS=$'\t' read -r dir a b; do
+        [[ -z "$dir" ]] && continue
+        COLLISION_COUNT=$((COLLISION_COUNT + 1))
+        echo "    $dir/$a" >&2
+        echo "    $dir/$b" >&2
+        echo "" >&2
+    done <<< "$all_collisions"
+    echo "  Found $COLLISION_COUNT collision pair(s)." >&2
+    exit 1
+fi
+
+echo "All clean — no hyphen-vs-underscore filename collisions detected."
+exit 0

--- a/scripts/tests/test_check_hyphen_underscore_collision.sh
+++ b/scripts/tests/test_check_hyphen_underscore_collision.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# test_check_hyphen_underscore_collision.sh — Tests for
+# check-hyphen-underscore-collision.sh.
+#
+# Creates a throwaway directory tree under TMPDIR_TEST that mirrors the
+# layout the real check scans (scripts/, packages/*/src/, packages/*/tests/,
+# infra/**) and exercises every behaviour that matters:
+#
+#   - no collisions anywhere       → exit 0
+#   - top-level scripts/ collision → exit 1, both paths in stderr
+#   - nested packages/*/src/ pair  → exit 1 (recursive scan works)
+#   - collision under node_modules → exit 0 (excluded)
+#   - collision under .venv        → exit 0 (excluded)
+#   - single-hyphen-only files     → exit 0 (no pair)
+#   - fully-identical normalised
+#       but only ONE distinct orig → exit 0
+#   - CI step name self-match      → extractor returns no match
+#
+# Usage:
+#   scripts/tests/test_check_hyphen_underscore_collision.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-hyphen-underscore-collision.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    : > "$TMPDIR_TEST/$name"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# Assert that running the check produces a failure AND that its stderr
+# contains all of the given substrings.
+assert_fails_with_output_contains() {
+    local desc="$1"
+    shift
+    TESTS=$((TESTS + 1))
+    local output
+    if output=$("$CHECK_SCRIPT" "$TMPDIR_TEST" 2>&1); then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    local needle
+    for needle in "$@"; do
+        if [[ "$output" != *"$needle"* ]]; then
+            echo "FAIL: $desc (output missing substring: $needle)"
+            echo "----- output start -----"
+            echo "$output"
+            echo "----- output end -----"
+            FAILURES=$((FAILURES + 1))
+            return
+        fi
+    done
+    echo "PASS: $desc"
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: Empty directory tree → pass ─────────────────────────────────
+assert_passes "Empty directory passes (no scan dirs present)"
+
+# ─── Test 2: scripts/ with no collisions → pass ──────────────────────────
+create_test_file "scripts/foo.sh"
+create_test_file "scripts/bar-baz.sh"
+create_test_file "scripts/qux_quux.sh"
+assert_passes "scripts/ with no collisions passes"
+reset_tmpdir
+
+# ─── Test 3: scripts/ with hyphen+underscore pair → fail ─────────────────
+create_test_file "scripts/foo-bar.sh"
+create_test_file "scripts/foo_bar.sh"
+assert_fails_with_output_contains \
+    "scripts/ hyphen+underscore pair is detected" \
+    "foo-bar.sh" "foo_bar.sh"
+reset_tmpdir
+
+# ─── Test 4: Nested packages/*/src/ pair → fail ──────────────────────────
+create_test_file "packages/foo/src/sub/my-mod.py"
+create_test_file "packages/foo/src/sub/my_mod.py"
+assert_fails_with_output_contains \
+    "Nested packages/<pkg>/src/ collision detected (recursive scan)" \
+    "my-mod.py" "my_mod.py"
+reset_tmpdir
+
+# ─── Test 5: packages/*/tests/ pair → fail ──────────────────────────────
+create_test_file "packages/foo/tests/test-a.py"
+create_test_file "packages/foo/tests/test_a.py"
+assert_fails "packages/<pkg>/tests/ collision detected"
+reset_tmpdir
+
+# ─── Test 6: infra/ nested pair → fail ──────────────────────────────────
+create_test_file "infra/terraform/modules/my-mod/main.tf"
+create_test_file "infra/terraform/modules/my_mod/main.tf"
+# Each directory contains a single main.tf, but the DIRECTORIES differ
+# only by hyphen vs underscore.  The current check operates on file
+# names within a single directory, not on directory names, so this
+# should PASS — collisions between sibling directory names would be a
+# separate, larger scope.  Document the boundary explicitly.
+assert_passes \
+    "Sibling directory names differing by - vs _ are NOT flagged (files-only scope)"
+reset_tmpdir
+
+# ─── Test 7: infra/ sibling FILES collision → fail ──────────────────────
+create_test_file "infra/lambda/a-b.py"
+create_test_file "infra/lambda/a_b.py"
+assert_fails "infra/ sibling file collision detected"
+reset_tmpdir
+
+# ─── Test 8: node_modules collision → pass (excluded) ───────────────────
+create_test_file "packages/foo/node_modules/some-pkg/a-b.js"
+create_test_file "packages/foo/node_modules/some-pkg/a_b.js"
+assert_passes "Collisions inside node_modules are excluded"
+reset_tmpdir
+
+# ─── Test 9: .venv collision → pass (excluded) ──────────────────────────
+create_test_file "packages/foo/.venv/lib/a-b.py"
+create_test_file "packages/foo/.venv/lib/a_b.py"
+assert_passes "Collisions inside .venv are excluded"
+reset_tmpdir
+
+# ─── Test 10: .git collision → pass (excluded) ──────────────────────────
+create_test_file "packages/foo/.git/hooks/pre-commit"
+create_test_file "packages/foo/.git/hooks/pre_commit"
+assert_passes "Collisions inside .git are excluded"
+reset_tmpdir
+
+# ─── Test 11: .terraform collision → pass (excluded) ────────────────────
+create_test_file "infra/terraform/.terraform/modules/a-b.tf"
+create_test_file "infra/terraform/.terraform/modules/a_b.tf"
+assert_passes "Collisions inside .terraform are excluded"
+reset_tmpdir
+
+# ─── Test 12: tmp/ collision → pass (excluded) ──────────────────────────
+# Some packages have a tmp/ subdir for local scratch state.  Excluded to
+# match the rest of the check suite.
+create_test_file "packages/foo/tmp/a-b.py"
+create_test_file "packages/foo/tmp/a_b.py"
+assert_passes "Collisions inside packages/<pkg>/tmp are excluded"
+reset_tmpdir
+
+# ─── Test 13: Hyphen-only file with no underscore sibling → pass ────────
+create_test_file "scripts/only-hyphenated.sh"
+assert_passes "Single hyphen-only file with no underscore sibling passes"
+reset_tmpdir
+
+# ─── Test 14: Underscore-only file with no hyphen sibling → pass ────────
+create_test_file "scripts/only_underscored.sh"
+assert_passes "Single underscore-only file with no hyphen sibling passes"
+reset_tmpdir
+
+# ─── Test 15: Multiple collisions in the same directory → fail ──────────
+create_test_file "scripts/a-b.sh"
+create_test_file "scripts/a_b.sh"
+create_test_file "scripts/c-d.sh"
+create_test_file "scripts/c_d.sh"
+assert_fails_with_output_contains \
+    "Multiple collision pairs in the same directory are all reported" \
+    "a-b.sh" "a_b.sh" "c-d.sh" "c_d.sh"
+reset_tmpdir
+
+# ─── Test 16: Unrelated-but-similar names with extra chars → pass ───────
+# `foo-bar.sh` and `foo_barx.sh` do NOT collide (different normalised
+# names).  The check must not flag these as a false positive.
+create_test_file "scripts/foo-bar.sh"
+create_test_file "scripts/foo_barx.sh"
+assert_passes "Similar-but-distinct names (foo-bar.sh vs foo_barx.sh) do not collide"
+reset_tmpdir
+
+# ─── Test 17: Same name, different extensions → pass ────────────────────
+# `foo-bar.sh` and `foo_bar.py` collide on normalised stem but differ
+# by extension.  We still flag them because CI discovery (e.g. pytest
+# or run-scripts-tests) won't tell them apart at the normalised stem
+# level, and the motivating incident was `.sh` vs `.sh` anyway.
+# Actually for this implementation they WILL be flagged since we
+# compare full filenames and `foo-bar.sh` → `foo_bar.sh` (still
+# different from `foo_bar.py`), so this should PASS.  Test documents
+# the current behavior.
+create_test_file "scripts/foo-bar.sh"
+create_test_file "scripts/foo_bar.py"
+assert_passes "Same stem with different extensions do not collide (full-name compare)"
+reset_tmpdir
+
+# ─── Test 18: scripts/ subdirectory collision → pass ────────────────────
+# The top-level scripts/ scan is non-recursive.  A collision inside
+# scripts/tests/ or scripts/spotcheck/ is out of the current scope.
+# Document the boundary so future edits don't silently widen it.
+create_test_file "scripts/tests/a-b.sh"
+create_test_file "scripts/tests/a_b.sh"
+assert_passes "Collision inside scripts/tests/ is NOT flagged (scripts/ is non-recursive)"
+reset_tmpdir
+
+# ─── Test 19: No self-match on ci.yml step name ─────────────────────────
+# The step name in .github/workflows/ci.yml that runs this guard must
+# not itself contain the literal `-` / `_` filename-ambiguity pattern
+# (avoid self-match per the CLAUDE.md hygiene-check naming rule, see
+# #2541/#2542 for the failure class).
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-hyphen-underscore-collision.sh" "yml"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/check-hyphen-underscore-collision.sh` — a cheap Bash
hygiene guard that flags filename pairs in the same directory whose
names differ only by `-` vs `_`. Wired into CI (every PR) and
`.githooks/pre-push` so collisions are caught locally. Prevents
recurrence of the #2751 / #2754 incident where two near-identically
named `check_schema_drift` scripts coexisted and agents picked the
wrong one.

Closes #2756

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (19/19 in `scripts/tests/test_check_hyphen_underscore_collision.sh`)
- [x] CI green (including the new `filename-separator-hygiene-check` job itself)

### Post-deploy verification
- [x] N/A — no deployed component (CI/tooling only)
- [x] Verification evidence posted on issue (tooling skip reason)
