### PR TITLE
feat(dispatcher-v2): Phase 2 shadow mode — queue scan + heartbeat + admin wiring (#2768)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -211,18 +211,34 @@ module "dispatcher_daemon" {
   # scraper repo. Sub-task C (#2729) added the ECR resource + output.
   ecr_repository_url = module.ecr.dispatcher_repository_url
 
-  # Phase 1 = inert. Flipped to 1 in Phase 2 (shadow mode). Never > 1.
-  desired_count = 0
+  # Phase 2 shadow mode (#2768): daemon runs a single task that scans the
+  # `agent/ready` queue every 30s, writes snapshots to
+  # `dispatcher.queue_snapshots`, and emits the `HeartbeatAge` CloudWatch
+  # metric. `concurrency_cap=0` in `dispatcher.config` keeps the spawn
+  # path dormant (a defensive no-op guard in the daemon scheduler tick
+  # re-enforces this on every tick). Never > 1 — the dispatcher is a
+  # singleton and overlapping instances would double-spawn agents.
+  desired_count = 1
 
   # Secret ARNs — populated incrementally as their owning issues land.
   # #2700 wires `github_token_secret_arn` (this ARN is the scoped PAT from
   # spike 0.7, provisioned in Secrets Manager by the operator and pinned
   # here so the execution role's `execution_secrets` policy resolves
-  # against it). Other ARNs stay empty until their owning sub-tasks
-  # land — the module's `compact()` guard drops unset entries and the
-  # service is inert at `desired_count=0` anyway.
+  # against it).
+  #
+  # #2768 (Phase 2 shadow mode) wires `db_connection_secret_arn` — the
+  # daemon must now reach Postgres to INSERT into `dispatcher.runs`
+  # (lease / boot row) and `dispatcher.queue_snapshots` (per-tick queue
+  # observations). Until the dedicated `judgemind_dispatcher` DB role
+  # lands (sub-task B follow-up), we point at the main `judgemind`
+  # role's secret — same DB, owner-level privileges. Safe for Phase 2
+  # because `concurrency_cap=0` keeps the daemon from doing any DB
+  # writes outside its own schema.
+  #
+  # Other ARNs stay empty until their owning sub-tasks land — the
+  # module's `compact()` guard drops unset entries.
   anthropic_api_key_secret_arn  = ""
-  db_connection_secret_arn      = ""
+  db_connection_secret_arn      = module.database.db_connection_secret_arn
   github_token_secret_arn       = "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/dispatcher/github-token-QOmHlJ"
   telegram_bot_token_secret_arn = ""
   gemini_api_key_secret_arn     = ""

--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -1,21 +1,25 @@
 # Dispatcher daemon module — ECS Fargate service that runs the autonomous
-# dispatcher loop for Phase 1 of dispatcher v2 (see
+# dispatcher loop for dispatcher v2 (see
 # `docs/specs/dispatcher-v2-spec.md` §14).
 #
-# Phase 1 lands this module with `desired_count=0`: the service, task
-# definition, IAM roles, log group, and heartbeat alarm are all created, but
-# nothing runs until the daemon image lands (sub-task C, #2729) and Phase 2
-# flips `desired_count=1`.
+# Lifecycle:
+# - Phase 1 (#2725 epic): module lands with `desired_count=0`. Service,
+#   task definition, IAM roles, log group, and heartbeat alarm exist,
+#   but nothing runs until the daemon image lands and Phase 2 flips the
+#   replica count.
+# - Phase 2 shadow mode (#2768): `desired_count=1`,
+#   `dispatcher.config.concurrency_cap=0`. Daemon polls the
+#   `agent/ready` queue, writes `dispatcher.queue_snapshots`, and emits
+#   the `HeartbeatAge` CloudWatch metric. No subprocess spawning.
+# - Phase 3: daemon spawns per-phase `/task-v2-*` subprocesses once the
+#   shadow-mode observations confirm stability.
 #
-# Why this is wired up inert:
-# - Sub-task A (#2727) adds the `dispatcher.*` schema + `judgemind_dispatcher`
-#   role secret. Until it merges, `db_connection_secret_arn` is passed as the
-#   main `judgemind` role secret — safe because the service isn't running.
-# - Sub-task C (#2729) publishes the real `Dockerfile.dispatcher` image; until
-#   then `image_tag` defaults to `"latest"` against an ECR repo that may not
-#   yet contain the tag. `desired_count=0` keeps this from erroring.
-# - Phase 2 (shadow mode) flips `desired_count=1` but keeps
-#   `config.concurrency_cap=0` in the daemon — polling only, no spawning.
+# Callers pass `db_connection_secret_arn` from the environment's
+# `module.database` output (Phase 2 requirement — the daemon must reach
+# Postgres to persist `dispatcher.runs` and `dispatcher.queue_snapshots`).
+# Until the dedicated `judgemind_dispatcher` DB role lands (sub-task B
+# follow-up), the daemon connects as the main `judgemind` owner role —
+# safe while `concurrency_cap=0` keeps the spawn path dormant.
 #
 # Resources created:
 # - ECS service + task definition (1 vCPU, 2 GB RAM, 50 GB ephemeral storage
@@ -400,10 +404,11 @@ resource "aws_ecs_task_definition" "dispatcher" {
 }
 
 # ─── ECS Service ────────────────────────────────────────────────────────────
-# `desired_count=0` in Phase 1 — the service exists, but no tasks run. Phase 2
-# flips it to 1 to enter shadow mode. `ignore_changes = [task_definition]` is
-# the house pattern: CI redeploys bump the image tag via the AWS CLI without
-# rewriting the task def ARN every apply.
+# `desired_count` defaults to 0 (Phase 1). Phase 2 callers override to 1
+# for shadow mode (#2768). Never > 1 — the dispatcher is a singleton.
+# `ignore_changes = [task_definition]` is the house pattern: CI redeploys
+# bump the image tag via the AWS CLI without rewriting the task def ARN
+# every apply.
 
 resource "aws_ecs_service" "dispatcher" {
   name            = local.service_name
@@ -438,17 +443,17 @@ resource "aws_ecs_service" "dispatcher" {
 # Per §14 of the spec: heartbeat staleness > 5 min should page the operator
 # via SNS (email + Telegram). The daemon publishes a `HeartbeatAge` metric
 # (seconds since last `dispatcher.runs.heartbeat_ts` write) to the
-# `Judgemind/Dispatcher` namespace every tick — Phase 2 sub-task C wires
-# that up.
+# `Judgemind/Dispatcher` namespace on every supervisor tick (120s) — see
+# `scripts/dispatcher/daemon.py::_emit_heartbeat_metric`. Phase 2 (#2768)
+# lands the emission code; a healthy daemon emits `0` after each DB
+# heartbeat update so the `Maximum` aggregation stays below the
+# `heartbeat_stale_seconds` threshold.
 #
-# TODO (Phase 2, #2729): confirm the metric name / emission cadence match
-# once the daemon publishes. If the daemon publishes in the opposite polarity
-# (e.g. `HeartbeatFresh=1` as a liveness signal rather than `HeartbeatAge` in
-# seconds), flip the comparison + `treat_missing_data` on this alarm.
-#
-# During Phase 1 the alarm will be in INSUFFICIENT_DATA with
-# `treat_missing_data = "notBreaching"` — no false pages while the service
-# runs at desired_count=0.
+# During Phase 1 (`desired_count=0`) the alarm was in INSUFFICIENT_DATA
+# with `treat_missing_data = "notBreaching"` — no false pages. Phase 2+
+# keeps the same behaviour: if the daemon crashes and stops emitting,
+# the alarm fires because the last-published value ages past the
+# threshold (not because of missing-data handling).
 
 resource "aws_cloudwatch_metric_alarm" "heartbeat_stale" {
   count = var.enable_alerts ? 1 : 0

--- a/packages/api/migrations/24_dispatcher-queue-snapshots.sql
+++ b/packages/api/migrations/24_dispatcher-queue-snapshots.sql
@@ -1,0 +1,49 @@
+-- Up Migration
+--
+-- Dispatcher v2 — Phase 2 shadow mode. Adds `dispatcher.queue_snapshots`,
+-- a history table of observed `agent/ready` queue depths written by the
+-- daemon on each scheduler tick (§6, 30s cadence).
+--
+-- Issue #2768 (Parent: #2725, Phase 1 epic; feeds the Phase 2 gate).
+--
+-- Design choice: snapshots (append-only history) rather than a singleton
+-- "current queue state" row. Benefits:
+--   - Clear 20-tick-count audit trail for the Phase 2 gate (daemon has not
+--     crashed after ≥20 scheduler ticks is easier to prove with 20 rows).
+--   - Easy to diff across ticks when diagnosing queue-depth changes.
+--   - No race around "update the singleton" — concurrent writers would be
+--     fine, but Phase 2 only has one writer, and an append table stays
+--     correct under future concurrency.
+--
+-- GraphQL `dispatcherState.queueDepth` resolves `ORDER BY observed_at DESC
+-- LIMIT 1` from this table (see `packages/api/src/graphql/dispatcher/resolvers.ts`).
+--
+-- TODO (post-Phase 2): daemon-side housekeeping tick that prunes old
+-- snapshots (keep latest N or last hour). Not required for the Phase 2
+-- gate — an idle daemon writes two snapshots per minute, so ~2880/day,
+-- which is trivial storage for a ~12-byte row. Revisit if the daemon
+-- stays at Phase 2 for >30 days without enabling pruning.
+
+CREATE TABLE dispatcher.queue_snapshots (
+    snapshot_id     UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    observed_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    queue_depth     INTEGER     NOT NULL,
+    issue_numbers   INTEGER[]   NOT NULL,
+    run_id          UUID        REFERENCES dispatcher.runs(run_id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_dispatcher_queue_snapshots_observed_at
+    ON dispatcher.queue_snapshots (observed_at DESC);
+
+COMMENT ON TABLE  dispatcher.queue_snapshots               IS 'Append-only history of observed agent/ready queue depths. Written by the daemon on each 30s scheduler tick (Phase 2+).';
+COMMENT ON COLUMN dispatcher.queue_snapshots.issue_numbers IS 'Array of the observed issue numbers, ordered by priority as seen by the daemon at scan time.';
+COMMENT ON COLUMN dispatcher.queue_snapshots.run_id        IS 'Owning daemon run. Snapshots cascade-delete with the run row so forensic queries after a crash stay clean.';
+
+
+-- Down Migration
+--
+-- Wipes the snapshot history table and its index. Dispatcher resolvers
+-- fall back to 0 when the table is gone (see `queryQueueDepth` —
+-- `oneOrNone` + null-coalesce to 0), so the admin page stays functional
+-- but reports 0 until the daemon re-lands the table on a forward migration.
+DROP TABLE IF EXISTS dispatcher.queue_snapshots;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 22 migrations.
+-- Generated from 24 migrations.
 
 
 
@@ -484,6 +484,24 @@ CREATE SEQUENCE dispatcher.phase_transitions_transition_id_seq
 ALTER SEQUENCE dispatcher.phase_transitions_transition_id_seq OWNED BY dispatcher.phase_transitions.transition_id;
 
 
+CREATE TABLE dispatcher.queue_snapshots (
+    snapshot_id uuid DEFAULT gen_random_uuid() NOT NULL,
+    observed_at timestamp with time zone DEFAULT now() NOT NULL,
+    queue_depth integer NOT NULL,
+    issue_numbers integer[] NOT NULL,
+    run_id uuid
+);
+
+
+COMMENT ON TABLE dispatcher.queue_snapshots IS 'Append-only history of observed agent/ready queue depths. Written by the daemon on each 30s scheduler tick (Phase 2+).';
+
+
+COMMENT ON COLUMN dispatcher.queue_snapshots.issue_numbers IS 'Array of the observed issue numbers, ordered by priority as seen by the daemon at scan time.';
+
+
+COMMENT ON COLUMN dispatcher.queue_snapshots.run_id IS 'Owning daemon run. Snapshots cascade-delete with the run row so forensic queries after a crash stay clean.';
+
+
 CREATE TABLE dispatcher.retry_markers (
     marker_id bigint NOT NULL,
     agent_id uuid NOT NULL,
@@ -821,6 +839,10 @@ ALTER TABLE ONLY dispatcher.phase_transitions
     ADD CONSTRAINT phase_transitions_pkey PRIMARY KEY (transition_id);
 
 
+ALTER TABLE ONLY dispatcher.queue_snapshots
+    ADD CONSTRAINT queue_snapshots_pkey PRIMARY KEY (snapshot_id);
+
+
 ALTER TABLE ONLY dispatcher.retry_markers
     ADD CONSTRAINT retry_markers_pkey PRIMARY KEY (marker_id);
 
@@ -1019,6 +1041,9 @@ CREATE UNIQUE INDEX idx_dispatcher_phase_outputs_agent_phase ON dispatcher.phase
 CREATE INDEX idx_dispatcher_phase_transitions_agent_ts ON dispatcher.phase_transitions USING btree (agent_id, ts DESC);
 
 
+CREATE INDEX idx_dispatcher_queue_snapshots_observed_at ON dispatcher.queue_snapshots USING btree (observed_at DESC);
+
+
 CREATE INDEX idx_dispatcher_retry_markers_pending ON dispatcher.retry_markers USING btree (retry_after_ts) WHERE (resolved_at IS NULL);
 
 
@@ -1180,6 +1205,10 @@ ALTER TABLE ONLY dispatcher.phase_outputs
 
 ALTER TABLE ONLY dispatcher.phase_transitions
     ADD CONSTRAINT phase_transitions_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES dispatcher.agents(agent_id);
+
+
+ALTER TABLE ONLY dispatcher.queue_snapshots
+    ADD CONSTRAINT queue_snapshots_run_id_fkey FOREIGN KEY (run_id) REFERENCES dispatcher.runs(run_id) ON DELETE CASCADE;
 
 
 ALTER TABLE ONLY dispatcher.retry_markers

--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -146,11 +146,28 @@ async function querySpawnFrozenUntil(pool: Pool): Promise<string | null> {
 }
 
 async function queryQueueDepth(pool: Pool): Promise<number> {
-  // Phase 1: no persisted queue table — always 0. When the daemon queue
-  // scan lands (sub-task C follow-up), swap this for a COUNT(*) against
-  // the real source. Returning 0 keeps the contract (Int!) honored.
-  void pool; // retain signature symmetry
-  return 0;
+  // Phase 2: return the most recent row's `queue_depth` from
+  // `dispatcher.queue_snapshots` (written by the daemon on each 30s
+  // scheduler tick — see `scripts/dispatcher/daemon.py` and migration
+  // `24_dispatcher-queue-snapshots.sql`).
+  //
+  // Fall back to 0 when:
+  //   - The daemon has never booted (no snapshots yet).
+  //   - The table exists but is empty (initial deploy before the first
+  //     successful scan).
+  //   - The daemon's GitHub API calls have failed for the full recent
+  //     history (transient — the next successful scan writes a row).
+  //
+  // Returning 0 keeps the GraphQL contract (`queueDepth: Int!`) honored.
+  const { rows } = await pool.query<{ queue_depth: number | string }>(
+    `SELECT queue_depth
+       FROM dispatcher.queue_snapshots
+       ORDER BY observed_at DESC
+       LIMIT 1`,
+  );
+  if (rows.length === 0) return 0;
+  const raw = rows[0].queue_depth;
+  return typeof raw === 'number' ? raw : Number(raw);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -126,7 +126,10 @@ export const dispatcherTypeDefs = `#graphql
     activeAgents: [DispatcherAgent!]!
     """Failures from \`dispatcher.failures\` in the last \`sinceHours\` (default 24)."""
     recentFailures(sinceHours: Int = 24): [DispatcherFailure!]!
-    """Count of open \`agent/ready\` issues. Returns 0 in Phase 1 until the daemon queue scan lands."""
+    """Count of open \`agent/ready\` issues. Sourced from the most recent row in
+    \`dispatcher.queue_snapshots\`, written by the daemon on each 30s scheduler
+    tick (Phase 2+). Returns 0 before the daemon has booted or when every
+    recent scan has failed — the admin page treats that as "queue unknown / 0"."""
     queueDepth: Int!
     """\`dispatcher.config.value\` for \`spawn_frozen_until\` (§10), or null if not set."""
     spawnFrozenUntil: DateTime

--- a/packages/api/tests/dispatcher.integration.test.ts
+++ b/packages/api/tests/dispatcher.integration.test.ts
@@ -307,6 +307,34 @@ describe('dispatcherState — admin', () => {
     expect(ours!.status).toBe('running');
   });
 
+  it('queueDepth reflects the latest row in dispatcher.queue_snapshots (#2768)', async () => {
+    // Seed two snapshots: an older one with depth 3, a newer one with
+    // depth 7. The resolver should return 7 (latest by observed_at DESC).
+    // We seed via the run we'll insert so cleanup cascades correctly.
+    const runId = await insertRun();
+    await pool.query(
+      `INSERT INTO dispatcher.queue_snapshots (observed_at, queue_depth, issue_numbers, run_id)
+       VALUES (now() - interval '2 minutes', 3, ARRAY[11,22,33]::int[], $1)`,
+      [runId],
+    );
+    await pool.query(
+      `INSERT INTO dispatcher.queue_snapshots (observed_at, queue_depth, issue_numbers, run_id)
+       VALUES (now() - interval '10 seconds', 7, ARRAY[40,41,42,43,44,45,46]::int[], $1)`,
+      [runId],
+    );
+
+    const body = await gql(
+      `{ dispatcherState { queueDepth } }`,
+      undefined,
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const state = body.data?.dispatcherState as Record<string, unknown>;
+    expect(state.queueDepth).toBe(7);
+    // Snapshots are ON DELETE CASCADE on dispatcher.runs, so removing
+    // the inserted run in cleanup tears down the snapshot rows too.
+  });
+
   it('surfaces recent failures within sinceHours window', async () => {
     const agentId = await insertAgent({ issueNumber: 999002, status: 'failed' });
     await insertFailure({

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
-"""Dispatcher v2 daemon entrypoint — Phase 1 skeleton.
+"""Dispatcher v2 daemon entrypoint — Phase 2 shadow mode.
 
-Long-running process that (eventually, Phase 2+) reads ``dispatcher.*``
-state, spawns per-phase ``/task-v2-*`` subprocesses, and emits
-heartbeats. In Phase 1 this is a runnable skeleton only: init, DB
-connection, scheduler + supervisor tick loops, graceful shutdown. **No
-subprocess spawning.**
+Long-running process that reads ``dispatcher.*`` state, observes the
+GitHub ``agent/ready`` queue, writes snapshots to
+``dispatcher.queue_snapshots``, and emits heartbeat metrics to
+CloudWatch. **Phase 2 shadow mode: no subprocess spawning** — the
+``concurrency_cap=0`` guard asserts the spawn path stays dormant.
+
+Phase 3 will add the subprocess spawn (``/task-v2-*`` agents) once
+shadow-mode observations confirm the daemon is stable.
 
 Spec: ``docs/specs/dispatcher-v2-spec.md`` §6 (scheduler loop), §7
-(supervisor loop), §14 (deployment), §17 Risk 2 (double-daemon race),
-§18 (schema DDL). Issue #2729 (Parent: #2725, Phase 1 epic).
+(supervisor loop), §14 (deployment), §15 (Phase 2 definition + gate),
+§17 Risk 2 (double-daemon race), §18 (schema DDL). Issue #2768 (Phase 2
+epic; builds on Phase 1 skeleton from #2729).
 
 Structured logging is JSON-per-line to stdout so CloudWatch Logs
 Insights can query it without a regex layer.
@@ -21,11 +25,23 @@ Usage::
         --tick-supervisor-seconds 120
 
 Env vars read:
-    DATABASE_URL  — Postgres connection string (required).
-    GIT_SHA       — short SHA baked into the image at build time
-                    (optional; falls back to ``unknown``).
-    HOSTNAME      — Fargate task ID lands here by default. Falls back to
-                    ``socket.gethostname()``.
+    DATABASE_URL                — Postgres connection string (required).
+    GIT_SHA                     — short SHA baked into the image at build
+                                  time (optional; falls back to ``unknown``).
+    HOSTNAME                    — Fargate task ID lands here by default.
+                                  Falls back to ``socket.gethostname()``.
+    GITHUB_TOKEN                — scoped PAT (spike 0.7) used by the
+                                  ``gh`` CLI in the queue-scan path. Wired
+                                  into the container via ``secrets[]`` by
+                                  the dispatcher-daemon module (#2700).
+    GITHUB_REPO                 — owner/name the daemon watches
+                                  (default ``judgemind/judgemind``).
+    DISPATCHER_SERVICE_NAME     — used as the ``Service`` dimension on the
+                                  ``HeartbeatAge`` CloudWatch metric.
+    HEARTBEAT_METRIC_NAMESPACE  — CloudWatch metric namespace (default
+                                  ``Judgemind/Dispatcher``).
+    AWS_REGION / AWS_DEFAULT_REGION — boto3 region for the CloudWatch
+                                  client (falls back to ``us-west-2``).
 
 Exit codes:
     0  normal shutdown (SIGTERM / SIGINT).
@@ -43,6 +59,7 @@ import logging
 import os
 import signal
 import socket
+import subprocess
 import sys
 import threading
 import time
@@ -69,6 +86,37 @@ LEASE_HEARTBEAT_WINDOW_SECONDS = 60
 #: Default tick cadence. Mirrors §6 / §7 of the spec.
 DEFAULT_SCHEDULER_TICK_SECONDS = 30
 DEFAULT_SUPERVISOR_TICK_SECONDS = 120
+
+#: Default repo the daemon watches. Overridden by the ``GITHUB_REPO``
+#: env var, wired in the terraform module.
+DEFAULT_GITHUB_REPO = "judgemind/judgemind"
+
+#: Queue-scan defaults. The ``gh issue list`` page size is capped at 200;
+#: Phase 2's ``agent/ready`` queue is typically < 50, so one page is plenty.
+QUEUE_SCAN_PAGE_LIMIT = 200
+
+#: Hard timeout on the ``gh issue list`` subprocess. Short enough to avoid
+#: leaking scheduler ticks if GitHub is slow; long enough that a normal
+#: call (<2s) always finishes. The scheduler tick defaults to 30s, so
+#: anything over ~10s here would conflict with the next tick's own call.
+QUEUE_SCAN_SUBPROCESS_TIMEOUT_SECONDS = 10
+
+#: Default CloudWatch metric namespace. Matches the terraform module's
+#: ``task_put_metric`` policy condition
+#: (``cloudwatch:namespace = Judgemind/Dispatcher``).
+DEFAULT_HEARTBEAT_METRIC_NAMESPACE = "Judgemind/Dispatcher"
+
+#: Default AWS region when neither ``AWS_REGION`` nor ``AWS_DEFAULT_REGION``
+#: is set in the task environment. Matches the dispatcher deployment region
+#: (us-west-2).
+DEFAULT_AWS_REGION = "us-west-2"
+
+#: Phase 2 spawn-safety invariant: this value must be 0. The daemon
+#: asserts this on every scheduler tick and logs a warning if the live
+#: ``dispatcher.config.concurrency_cap`` is anything else. The actual
+#: spawn path does not exist yet (Phase 3) but the guard prevents a
+#: future Phase 3 wiring mistake from activating spawn during Phase 2.
+PHASE_2_REQUIRED_CONCURRENCY_CAP = 0
 
 
 # --------------------------------------------------------------------------
@@ -165,6 +213,18 @@ class DaemonConfig:
     version_sha: str = "unknown"
     host: str = ""
     pid: int = 0
+    #: Repo the queue scan observes (``owner/name``). Falls back to
+    #: ``DEFAULT_GITHUB_REPO`` when ``GITHUB_REPO`` is unset.
+    github_repo: str = DEFAULT_GITHUB_REPO
+    #: ECS service name used as the ``Service`` dimension on the
+    #: ``HeartbeatAge`` CloudWatch metric. Populated from the
+    #: ``DISPATCHER_SERVICE_NAME`` env var; falls back to the hostname.
+    dispatcher_service_name: str = ""
+    #: CloudWatch namespace for the heartbeat metric. Wired by the
+    #: terraform module's ``HEARTBEAT_METRIC_NAMESPACE`` env var.
+    heartbeat_metric_namespace: str = DEFAULT_HEARTBEAT_METRIC_NAMESPACE
+    #: AWS region for the CloudWatch client.
+    aws_region: str = DEFAULT_AWS_REGION
     # Optional override used by tests to avoid os.environ mutation.
     config_override: dict[str, Any] = field(default_factory=dict)
 
@@ -189,27 +249,37 @@ class LeaseError(RuntimeError):
 
 
 class DispatcherDaemon:
-    """Minimal Phase 1 dispatcher daemon.
+    """Phase 2 shadow-mode dispatcher daemon.
 
-    Responsibilities in Phase 1 (this skeleton):
+    Responsibilities:
         * Connect to Postgres via ``DATABASE_URL``.
         * Run the lease check — bail out if another daemon is active
           within the heartbeat window.
         * INSERT a ``dispatcher.runs`` row on boot.
         * Run the scheduler loop every ``tick_scheduler_seconds``:
-          consume unconsumed ``dispatcher.commands``, read
-          ``dispatcher.config`` (no-op use), do NOT spawn subprocesses.
+            - consume unconsumed ``dispatcher.commands`` (no-op handler
+              in shadow mode; commands drain so the queue stays small);
+            - read ``dispatcher.config.concurrency_cap``;
+            - enforce the Phase 2 spawn-safety guard (warn if
+              ``concurrency_cap != 0``);
+            - scan the GitHub ``agent/ready`` queue via ``gh issue list``
+              and INSERT a row into ``dispatcher.queue_snapshots``;
+            - **still does NOT spawn subprocesses** (Phase 3).
         * Run the supervisor loop every ``tick_supervisor_seconds``:
-          UPDATE ``dispatcher.runs.heartbeat_ts``, count recent
-          ``dispatcher.failures`` rows.
+            - UPDATE ``dispatcher.runs.heartbeat_ts``;
+            - count recent ``dispatcher.failures`` rows;
+            - publish a ``HeartbeatAge`` CloudWatch metric under the
+              configured namespace (default ``Judgemind/Dispatcher``)
+              so the alarm defined in the terraform module
+              (``infra/terraform/modules/dispatcher-daemon``) sees fresh
+              data and does not fire.
         * On SIGTERM / SIGINT, UPDATE ``dispatcher.runs.stopped_at`` and
           exit 0.
 
-    What this skeleton does **NOT** do (deferred to Phase 2+):
+    What this daemon still does **NOT** do (deferred to Phase 3):
         * Spawn ``/task-v2-*`` subprocesses.
         * Act on the phase state machine (§6 step 5).
         * Run the failure diagnoser (§8).
-        * Emit CloudWatch metrics.
     """
 
     def __init__(self, cfg: DaemonConfig, logger: logging.Logger):
@@ -221,6 +291,11 @@ class DispatcherDaemon:
         self._scheduler_ticks = 0
         self._supervisor_ticks = 0
         self._last_heartbeat_at: datetime | None = None
+        # CloudWatch client is created lazily on first publish so tests can
+        # mock it via ``_make_cloudwatch_client``. Shared across supervisor
+        # ticks — boto3 clients are thread-safe and reusing one avoids
+        # repeated credential lookups.
+        self._cloudwatch_client: Any | None = None
 
     # ── lifecycle ──────────────────────────────────────────────────────
 
@@ -338,9 +413,20 @@ class DispatcherDaemon:
     # ── scheduler tick (every ``tick_scheduler_seconds``) ───────────────
 
     def scheduler_tick(self) -> dict[str, int]:
-        """Run one scheduler tick. Phase 1 = no-op for subprocess spawn.
+        """Run one scheduler tick. Phase 2 = queue scan + spawn-safety guard.
 
-        Returns a small summary dict for logging + tests.
+        Steps (in order; DB work is one transaction per step for isolation):
+            1. Consume any pending ``dispatcher.commands`` (no-op handler).
+            2. Read ``dispatcher.config.concurrency_cap`` and fire the
+               Phase 2 spawn-safety guard.
+            3. Scan the GitHub ``agent/ready`` queue and write a row to
+               ``dispatcher.queue_snapshots``.
+
+        Returns a small summary dict for logging + tests. Keys:
+
+            * ``commands_consumed``: int, rowcount from step 1.
+            * ``concurrency_cap``: int, or ``-1`` sentinel if unset.
+            * ``queue_depth``: int, ``-1`` if the scan failed.
         """
         assert self._conn is not None, "connect() must run before ticks"
 
@@ -348,7 +434,7 @@ class DispatcherDaemon:
         concurrency_cap: int | None = None
 
         with self._conn.cursor() as cur:
-            # 1. Consume any pending commands. Phase 1 = no-op handler;
+            # 1. Consume any pending commands. Phase 2 = no-op handler;
             # mark consumed anyway so the queue drains and does not fill
             # up during shadow mode.
             cur.execute(
@@ -358,7 +444,7 @@ class DispatcherDaemon:
             )
             commands_consumed = cur.rowcount or 0
 
-            # 2. Read concurrency_cap (for log observability; no spawn).
+            # 2. Read concurrency_cap (for log observability + spawn guard).
             cur.execute(
                 "SELECT value FROM dispatcher.config WHERE key = %s",
                 ("concurrency_cap",),
@@ -369,6 +455,37 @@ class DispatcherDaemon:
                 concurrency_cap = int(row[0]) if row[0] is not None else None
         self._conn.commit()
 
+        # Phase 2 spawn-safety guard: the spawn path does not exist yet,
+        # but a future Phase 3 wiring mistake could activate it. Warn if
+        # the live config disagrees with the Phase 2 invariant. The
+        # guard is advisory only — no subprocess is spawned regardless of
+        # what ``concurrency_cap`` is set to in the database.
+        if (
+            concurrency_cap is not None
+            and concurrency_cap != PHASE_2_REQUIRED_CONCURRENCY_CAP
+        ):
+            self._log.warning(
+                "daemon.phase2_concurrency_cap_nonzero",
+                extra={
+                    "event": "phase2_concurrency_cap_nonzero",
+                    "run_id": self._run_id,
+                    "observed_concurrency_cap": concurrency_cap,
+                    "required_concurrency_cap": PHASE_2_REQUIRED_CONCURRENCY_CAP,
+                    "detail": (
+                        "Phase 2 is shadow mode — daemon must not spawn "
+                        "subprocesses. concurrency_cap should be 0 until "
+                        "Phase 3 cut-over."
+                    ),
+                },
+            )
+
+        # 3. Scan the ``agent/ready`` queue and persist a snapshot.
+        #
+        # Failures here (rate limit, network, auth) log + return -1 but
+        # do NOT raise — the daemon must survive GitHub API hiccups,
+        # and the next tick will try again (§15).
+        queue_depth = self._scan_queue_and_snapshot()
+
         self._scheduler_ticks += 1
         self._log.info(
             "daemon.scheduler_tick",
@@ -378,17 +495,175 @@ class DispatcherDaemon:
                 "tick_n": self._scheduler_ticks,
                 "commands_consumed": commands_consumed,
                 "concurrency_cap": concurrency_cap,
+                "queue_depth": queue_depth,
             },
         )
         return {
             "commands_consumed": commands_consumed,
             "concurrency_cap": -1 if concurrency_cap is None else concurrency_cap,
+            "queue_depth": queue_depth,
         }
+
+    # ── queue scan (scheduler-tick step 3) ─────────────────────────────
+
+    def _fetch_agent_ready_issues(self) -> list[dict[str, Any]]:
+        """Call ``gh issue list`` to observe the ``agent/ready`` queue.
+
+        Returns a list of issue dicts as parsed from ``gh``'s JSON output.
+        Each dict has at minimum ``number``, ``title``, ``labels``,
+        ``createdAt``. Filters out issues that also carry
+        ``status/blocked`` (defensive — the label-filter flag on ``gh``
+        already excludes them in practice, but a label name change on
+        the server side should not silently inflate the queue count).
+
+        Raises :class:`RuntimeError` on subprocess failure so the caller
+        (``_scan_queue_and_snapshot``) can log + return -1 for the tick.
+
+        This is a thin wrapper so tests can monkeypatch it cleanly.
+        """
+        cmd = [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            self._cfg.github_repo,
+            "--label",
+            "agent/ready",
+            "--state",
+            "open",
+            "--json",
+            "number,title,labels,createdAt",
+            "--limit",
+            str(QUEUE_SCAN_PAGE_LIMIT),
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=QUEUE_SCAN_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"gh CLI not on PATH: {exc}") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"gh issue list timed out after "
+                f"{QUEUE_SCAN_SUBPROCESS_TIMEOUT_SECONDS}s"
+            ) from exc
+
+        if result.returncode != 0:
+            # Never include stderr verbatim in the daemon's structured log
+            # at info level — it may echo the PAT on auth errors. A short
+            # prefix is safe and sufficient for triage.
+            stderr_preview = (result.stderr or "").strip().splitlines()[:1]
+            raise RuntimeError(
+                f"gh issue list exit={result.returncode}: "
+                f"{stderr_preview[0] if stderr_preview else '<no stderr>'}"
+            )
+
+        try:
+            issues = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"gh issue list returned invalid JSON: {exc}") from exc
+
+        if not isinstance(issues, list):
+            raise RuntimeError(
+                f"gh issue list returned non-list JSON: {type(issues).__name__}"
+            )
+
+        # Defensive filter: drop rows that also carry ``status/blocked``.
+        # The ``gh --label agent/ready`` call returns issues that carry
+        # the label; a blocked issue that still has ``agent/ready``
+        # attached (e.g. mid-transition) should not inflate the queue
+        # depth because the daemon would never spawn on it.
+        filtered: list[dict[str, Any]] = []
+        for issue in issues:
+            if not isinstance(issue, dict):
+                continue
+            labels = issue.get("labels") or []
+            label_names = {
+                entry.get("name") for entry in labels if isinstance(entry, dict)
+            }
+            if "status/blocked" in label_names:
+                continue
+            filtered.append(issue)
+        return filtered
+
+    def _scan_queue_and_snapshot(self) -> int:
+        """One queue scan + ``dispatcher.queue_snapshots`` INSERT.
+
+        Returns the observed queue depth, or ``-1`` if the scan failed.
+        Exceptions are swallowed + logged so a transient GitHub outage
+        does not crash the daemon.
+        """
+        assert self._conn is not None, "connect() must run before scanning"
+
+        try:
+            issues = self._fetch_agent_ready_issues()
+        except RuntimeError as exc:
+            # Daemon must survive GitHub API hiccups (§15). Log + return
+            # -1 so the caller knows the scan failed without crashing.
+            self._log.warning(
+                "daemon.queue_scan_failed",
+                extra={
+                    "event": "queue_scan_failed",
+                    "run_id": self._run_id,
+                    "detail": str(exc),
+                },
+            )
+            return -1
+
+        issue_numbers: list[int] = []
+        for issue in issues:
+            number = issue.get("number")
+            if isinstance(number, int):
+                issue_numbers.append(number)
+        queue_depth = len(issue_numbers)
+
+        # Persist the snapshot. One INSERT per tick; the table is
+        # append-only and the daemon is a singleton, so no race.
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO dispatcher.queue_snapshots "
+                    "    (observed_at, queue_depth, issue_numbers, run_id) "
+                    "VALUES (now(), %s, %s, %s)",
+                    (queue_depth, issue_numbers, self._run_id),
+                )
+            self._conn.commit()
+        except Exception:
+            # DB failure on the snapshot insert is a tick-level failure;
+            # log and rollback so the next tick's work is not poisoned.
+            self._log.exception(
+                "daemon.queue_snapshot_insert_failed",
+                extra={
+                    "event": "queue_snapshot_insert_failed",
+                    "run_id": self._run_id,
+                    "queue_depth": queue_depth,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return -1
+
+        self._log.info(
+            "daemon.queue_scan",
+            extra={
+                "event": "queue_scan",
+                "run_id": self._run_id,
+                "count": queue_depth,
+                "issues": issue_numbers,
+            },
+        )
+        return queue_depth
 
     # ── supervisor tick (every ``tick_supervisor_seconds``) ─────────────
 
     def supervisor_tick(self) -> dict[str, int]:
-        """Run one supervisor tick. Writes heartbeat; reads failures count."""
+        """Run one supervisor tick. Writes heartbeat; emits CW metric."""
         assert self._conn is not None, "connect() must run before ticks"
         assert self._run_id is not None, "register the run before ticking"
 
@@ -399,7 +674,10 @@ class DispatcherDaemon:
                 "UPDATE dispatcher.runs SET heartbeat_ts = now() WHERE run_id = %s",
                 (self._run_id,),
             )
-            # Smoke-test read for Phase 1 — not used yet.
+            # Smoke-test read — counts are surfaced via the GraphQL
+            # ``DispatcherState.recentFailures`` query separately, but
+            # this read also exercises the connection on every tick so
+            # the daemon notices DB loss quickly.
             cur.execute(
                 "SELECT count(*) FROM dispatcher.failures "
                 "WHERE ts > now() - interval '1 hour'",
@@ -411,6 +689,14 @@ class DispatcherDaemon:
 
         self._supervisor_ticks += 1
         self._last_heartbeat_at = datetime.now(UTC)
+
+        # Emit the ``HeartbeatAge`` CloudWatch metric. Emit AFTER the DB
+        # heartbeat update so a successful metric means the DB round-trip
+        # also just succeeded — "age=0" is the ground-truth freshness
+        # indicator for the alarm in
+        # ``infra/terraform/modules/dispatcher-daemon/main.tf``.
+        metric_emitted = self._emit_heartbeat_metric()
+
         self._log.info(
             "daemon.supervisor_tick",
             extra={
@@ -418,9 +704,89 @@ class DispatcherDaemon:
                 "run_id": self._run_id,
                 "tick_n": self._supervisor_ticks,
                 "failures_last_hour": failures_last_hour,
+                "heartbeat_metric_emitted": metric_emitted,
             },
         )
-        return {"failures_last_hour": failures_last_hour}
+        return {
+            "failures_last_hour": failures_last_hour,
+            "heartbeat_metric_emitted": 1 if metric_emitted else 0,
+        }
+
+    # ── heartbeat metric emission (supervisor-tick step 3) ──────────────
+
+    def _make_cloudwatch_client(self) -> Any:
+        """Build a boto3 CloudWatch client. Isolated so tests can mock it.
+
+        Lazy import of boto3 mirrors psycopg — tests that do not exercise
+        the heartbeat path should not have to install boto3.
+        """
+        import boto3  # noqa: PLC0415  — lazy import
+
+        return boto3.client("cloudwatch", region_name=self._cfg.aws_region)
+
+    def _emit_heartbeat_metric(self) -> bool:
+        """Publish ``HeartbeatAge=0`` to the configured CloudWatch namespace.
+
+        Returns True on success, False on failure. Failures log but do
+        NOT raise — a missing metric point triggers the existing alarm
+        after 5 minutes of staleness, which is the correct behaviour
+        (the daemon either recovers or the alarm fires).
+
+        Value is always ``0`` seconds: the metric is emitted immediately
+        after the DB heartbeat update, so the freshest reading is by
+        definition "0 seconds stale". The alarm in terraform compares
+        the metric's ``Maximum`` over a 1-minute period against a 300s
+        threshold; emitting 0 on every supervisor tick (every 120s by
+        default) means a healthy daemon keeps the alarm in OK.
+        """
+        # Service dimension: the terraform alarm filters on
+        # ``Service = judgemind-dispatcher-<env>``, so we must set the
+        # same dimension here. Fall back to the hostname when the env
+        # var is unset (test / local-dev case).
+        service_dim = self._cfg.dispatcher_service_name or self._cfg.host
+
+        try:
+            if self._cloudwatch_client is None:
+                self._cloudwatch_client = self._make_cloudwatch_client()
+            self._cloudwatch_client.put_metric_data(
+                Namespace=self._cfg.heartbeat_metric_namespace,
+                MetricData=[
+                    {
+                        "MetricName": "HeartbeatAge",
+                        "Dimensions": [
+                            {"Name": "Service", "Value": service_dim},
+                        ],
+                        "Value": 0.0,
+                        "Unit": "Seconds",
+                    }
+                ],
+            )
+        except Exception as exc:
+            # Reset the client so the next tick re-creates it — e.g. a
+            # recoverable credential refresh or endpoint outage should
+            # not poison the whole daemon lifetime.
+            self._cloudwatch_client = None
+            self._log.warning(
+                "daemon.heartbeat_metric_failed",
+                extra={
+                    "event": "heartbeat_metric_failed",
+                    "run_id": self._run_id,
+                    "namespace": self._cfg.heartbeat_metric_namespace,
+                    "detail": str(exc),
+                },
+            )
+            return False
+
+        self._log.info(
+            "daemon.heartbeat_metric_emitted",
+            extra={
+                "event": "heartbeat_metric_emitted",
+                "run_id": self._run_id,
+                "namespace": self._cfg.heartbeat_metric_namespace,
+                "service": service_dim,
+            },
+        )
+        return True
 
     # ── signal handling ────────────────────────────────────────────────
 
@@ -493,7 +859,10 @@ class DispatcherDaemon:
 def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="scripts.dispatcher.daemon",
-        description="Dispatcher v2 daemon — Phase 1 skeleton (no subprocess spawn).",
+        description=(
+            "Dispatcher v2 daemon — Phase 2 shadow mode (queue scan + "
+            "heartbeat metric; no subprocess spawn)."
+        ),
     )
     parser.add_argument(
         "--tick-scheduler-seconds",
@@ -532,6 +901,14 @@ def _build_config(
     database_url = env.get("DATABASE_URL", "")
     version_sha = env.get("GIT_SHA", "unknown")
     host = env.get("HOSTNAME") or socket.gethostname() or "unknown-host"
+    github_repo = env.get("GITHUB_REPO") or DEFAULT_GITHUB_REPO
+    dispatcher_service_name = env.get("DISPATCHER_SERVICE_NAME", "")
+    heartbeat_namespace = (
+        env.get("HEARTBEAT_METRIC_NAMESPACE") or DEFAULT_HEARTBEAT_METRIC_NAMESPACE
+    )
+    aws_region = (
+        env.get("AWS_REGION") or env.get("AWS_DEFAULT_REGION") or DEFAULT_AWS_REGION
+    )
 
     override: dict[str, Any] = {}
     if args.config_override:
@@ -552,6 +929,10 @@ def _build_config(
         version_sha=version_sha,
         host=host,
         pid=os.getpid(),
+        github_repo=github_repo,
+        dispatcher_service_name=dispatcher_service_name,
+        heartbeat_metric_namespace=heartbeat_namespace,
+        aws_region=aws_region,
         config_override=override,
     )
 

--- a/scripts/dispatcher/tests/test_daemon_phase2.py
+++ b/scripts/dispatcher/tests/test_daemon_phase2.py
@@ -1,0 +1,684 @@
+"""Unit tests for Phase 2 additions to ``scripts.dispatcher.daemon``.
+
+Issue #2768. Covers the three Phase 2 behaviours added on top of the
+Phase 1 skeleton:
+
+* Queue scan (``_fetch_agent_ready_issues`` + ``_scan_queue_and_snapshot``)
+  parses ``gh issue list`` output, filters blocked issues, INSERTs into
+  ``dispatcher.queue_snapshots``, and logs structured JSON.
+* Heartbeat metric emission (``_emit_heartbeat_metric``) publishes
+  ``HeartbeatAge=0`` to the configured CloudWatch namespace with the
+  correct ``Service`` dimension.
+* ``concurrency_cap=0`` Phase 2 guard logs a warning when the live DB
+  value is anything else.
+
+All external calls — subprocess (``gh``), boto3 (CloudWatch),
+psycopg — are mocked. The queue-scan subprocess path is monkeypatched
+to avoid requiring ``gh`` on the test runner.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Ensure a `psycopg` module exists in sys.modules before importing the
+# daemon. Mirrors the pattern used in test_daemon_skeleton.py.
+if "psycopg" not in sys.modules:  # pragma: no cover — fresh-venv guard
+    sys.modules["psycopg"] = MagicMock()
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes (mirrors test_daemon_skeleton.py shape)
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    """Collect emitted ``LogRecord``s so tests can assert on them.
+
+    The daemon attaches ``extra={"event": ..., ...}`` to every
+    observability log line; the handler stores those keys on each record
+    so assertions can target them directly.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        """All captured records whose ``extra.event`` equals ``name``."""
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon_with_capture() -> tuple[
+    daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler
+]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger("dispatcher.test.phase2")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake-for-tests",
+        tick_scheduler_seconds=30,
+        tick_supervisor_seconds=120,
+        log_level="DEBUG",
+        version_sha="deadbee",
+        host="test-host",
+        pid=4242,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-dev",
+        heartbeat_metric_namespace="Judgemind/Dispatcher",
+        aws_region="us-west-2",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]  — test stub
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# _fetch_agent_ready_issues — subprocess + JSON parsing
+# --------------------------------------------------------------------------
+
+
+class TestFetchAgentReadyIssues:
+    """Parse ``gh issue list`` output; defensive filters on blocked issues."""
+
+    def test_happy_path_returns_issues(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        d, _conn, _handler = _make_daemon_with_capture()
+
+        def fake_run(
+            cmd: list[str],
+            capture_output: bool = True,
+            text: bool = True,
+            timeout: int = 10,
+            check: bool = False,
+        ) -> Any:
+            assert cmd[0] == "gh"
+            assert "--label" in cmd and "agent/ready" in cmd
+            assert "--state" in cmd and "open" in cmd
+            assert "--json" in cmd
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = json.dumps(
+                [
+                    {
+                        "number": 42,
+                        "title": "First",
+                        "labels": [{"name": "agent/ready"}, {"name": "priority/p1"}],
+                        "createdAt": "2026-04-18T00:00:00Z",
+                    },
+                    {
+                        "number": 99,
+                        "title": "Second",
+                        "labels": [{"name": "agent/ready"}],
+                        "createdAt": "2026-04-18T00:01:00Z",
+                    },
+                ]
+            )
+            result.stderr = ""
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        issues = d._fetch_agent_ready_issues()
+
+        assert len(issues) == 2
+        assert [i["number"] for i in issues] == [42, 99]
+
+    def test_filters_out_blocked_issues(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Issues that carry ``status/blocked`` alongside ``agent/ready`` are dropped.
+
+        Defensive: ``gh --label agent/ready`` should not return them in
+        the first place once the GH search applies label semantics, but
+        mid-transition issues (where both labels are present for a few
+        seconds) should not inflate the count.
+        """
+        d, _conn, _handler = _make_daemon_with_capture()
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = json.dumps(
+                [
+                    {
+                        "number": 1,
+                        "labels": [{"name": "agent/ready"}],
+                        "title": "ok",
+                    },
+                    {
+                        "number": 2,
+                        "labels": [
+                            {"name": "agent/ready"},
+                            {"name": "status/blocked"},
+                        ],
+                        "title": "blocked",
+                    },
+                    {
+                        "number": 3,
+                        "labels": [{"name": "agent/ready"}],
+                        "title": "ok2",
+                    },
+                ]
+            )
+            result.stderr = ""
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        issues = d._fetch_agent_ready_issues()
+        assert [i["number"] for i in issues] == [1, 3]
+
+    def test_empty_queue_returns_empty_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        d, _conn, _handler = _make_daemon_with_capture()
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "[]"
+            result.stderr = ""
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert d._fetch_agent_ready_issues() == []
+
+    def test_gh_nonzero_exit_raises_runtime_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        d, _conn, _handler = _make_daemon_with_capture()
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            result = MagicMock()
+            result.returncode = 1
+            result.stdout = ""
+            result.stderr = "HTTP 401: Bad credentials"
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError) as excinfo:
+            d._fetch_agent_ready_issues()
+        # Error message includes the exit code for triage.
+        assert "exit=1" in str(excinfo.value)
+
+    def test_gh_timeout_raises_runtime_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        d, _conn, _handler = _make_daemon_with_capture()
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=10)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError) as excinfo:
+            d._fetch_agent_ready_issues()
+        assert "timed out" in str(excinfo.value)
+
+    def test_gh_missing_raises_runtime_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        d, _conn, _handler = _make_daemon_with_capture()
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            raise FileNotFoundError(2, "No such file or directory", "gh")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError) as excinfo:
+            d._fetch_agent_ready_issues()
+        assert "gh CLI not on PATH" in str(excinfo.value)
+
+    def test_invalid_json_raises_runtime_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        d, _conn, _handler = _make_daemon_with_capture()
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "not json at all"
+            result.stderr = ""
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError) as excinfo:
+            d._fetch_agent_ready_issues()
+        assert "invalid JSON" in str(excinfo.value)
+
+    def test_non_list_json_raises_runtime_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        d, _conn, _handler = _make_daemon_with_capture()
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = '{"unexpected": "shape"}'
+            result.stderr = ""
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError):
+            d._fetch_agent_ready_issues()
+
+
+# --------------------------------------------------------------------------
+# _scan_queue_and_snapshot — DB INSERT + structured log
+# --------------------------------------------------------------------------
+
+
+class TestScanQueueAndSnapshot:
+    """INSERT into dispatcher.queue_snapshots; survive failures."""
+
+    def test_writes_snapshot_row_and_logs(self) -> None:
+        d, conn, handler = _make_daemon_with_capture()
+
+        # Patch the fetch path to return a canned list.
+        d._fetch_agent_ready_issues = lambda: [  # type: ignore[method-assign]
+            {"number": 10, "labels": [{"name": "agent/ready"}]},
+            {"number": 42, "labels": [{"name": "agent/ready"}]},
+        ]
+
+        depth = d._scan_queue_and_snapshot()
+
+        assert depth == 2
+        # One INSERT, one commit.
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.queue_snapshots" in e[0]
+        ]
+        assert len(inserts) == 1
+        _sql, params = inserts[0]
+        assert params == (2, [10, 42], "test-run-id")
+        assert conn.commits == 1
+        # Structured log emitted.
+        scans = handler.events("queue_scan")
+        assert len(scans) == 1
+        assert scans[0].count == 2
+        assert scans[0].issues == [10, 42]
+
+    def test_empty_queue_still_inserts_zero_depth(self) -> None:
+        d, conn, handler = _make_daemon_with_capture()
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+
+        depth = d._scan_queue_and_snapshot()
+        assert depth == 0
+
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.queue_snapshots" in e[0]
+        ]
+        assert len(inserts) == 1
+        _sql, params = inserts[0]
+        assert params == (0, [], "test-run-id")
+
+        scans = handler.events("queue_scan")
+        assert len(scans) == 1 and scans[0].count == 0
+
+    def test_fetch_failure_returns_sentinel_no_insert(self) -> None:
+        """When ``gh`` fails, the daemon must not crash and must not insert."""
+        d, conn, handler = _make_daemon_with_capture()
+
+        def boom() -> Any:
+            raise RuntimeError("gh exit=1: HTTP 401")
+
+        d._fetch_agent_ready_issues = boom  # type: ignore[method-assign]
+
+        depth = d._scan_queue_and_snapshot()
+        assert depth == -1
+
+        # No INSERT attempted — we didn't get a count to persist.
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.queue_snapshots" in e[0]
+        ]
+        assert inserts == []
+        # Warning logged with detail.
+        fails = handler.events("queue_scan_failed")
+        assert len(fails) == 1
+        assert "HTTP 401" in fails[0].detail
+
+    def test_db_failure_returns_sentinel_rolls_back(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        d._fetch_agent_ready_issues = lambda: [  # type: ignore[method-assign]
+            {"number": 1, "labels": [{"name": "agent/ready"}]},
+        ]
+
+        original_execute = conn.cursor_instance.execute
+
+        def failing_execute(sql: str, params: Any = None) -> None:
+            if "INSERT INTO dispatcher.queue_snapshots" in sql:
+                raise RuntimeError("connection lost")
+            original_execute(sql, params)
+
+        conn.cursor_instance.execute = failing_execute  # type: ignore[method-assign]
+
+        depth = d._scan_queue_and_snapshot()
+        assert depth == -1
+        assert conn.rollbacks >= 1
+
+
+# --------------------------------------------------------------------------
+# scheduler_tick — Phase 2 integration (guard + scan wired in)
+# --------------------------------------------------------------------------
+
+
+class TestSchedulerTickPhase2:
+    """Scheduler tick now runs queue scan + fires the concurrency guard."""
+
+    def test_runs_queue_scan_and_returns_depth(self) -> None:
+        d, conn, handler = _make_daemon_with_capture()
+        # Scheduler's own SELECT on config returns concurrency_cap=0.
+        conn.cursor_instance.fetch_queue = [(0,)]
+        # Stub the fetch path.
+        d._fetch_agent_ready_issues = lambda: [  # type: ignore[method-assign]
+            {"number": 7, "labels": [{"name": "agent/ready"}]},
+        ]
+
+        summary = d.scheduler_tick()
+        assert summary["queue_depth"] == 1
+        assert summary["concurrency_cap"] == 0
+        assert summary["commands_consumed"] == 0
+        # A queue_snapshots INSERT ran.
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.queue_snapshots" in e[0]
+        ]
+        assert len(inserts) == 1
+        # Scheduler_tick log line includes the queue_depth.
+        ticks = handler.events("scheduler_tick")
+        assert len(ticks) == 1
+        assert ticks[0].queue_depth == 1
+
+    def test_warns_when_concurrency_cap_nonzero(self) -> None:
+        d, conn, handler = _make_daemon_with_capture()
+        # Scheduler reads concurrency_cap = 5 (Phase 1 default seed).
+        conn.cursor_instance.fetch_queue = [(5,)]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+
+        d.scheduler_tick()
+        warnings = handler.events("phase2_concurrency_cap_nonzero")
+        assert len(warnings) == 1
+        assert warnings[0].observed_concurrency_cap == 5
+        assert warnings[0].required_concurrency_cap == 0
+
+    def test_no_warning_when_concurrency_cap_zero(self) -> None:
+        d, conn, handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetch_queue = [(0,)]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+
+        d.scheduler_tick()
+        assert handler.events("phase2_concurrency_cap_nonzero") == []
+
+    def test_no_warning_when_concurrency_cap_missing(self) -> None:
+        """Missing config key is a soft no-op; daemon runs but does not warn."""
+        d, conn, handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetch_queue = [None]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+
+        summary = d.scheduler_tick()
+        assert summary["concurrency_cap"] == -1
+        assert handler.events("phase2_concurrency_cap_nonzero") == []
+
+    def test_queue_scan_failure_does_not_crash_tick(self) -> None:
+        d, conn, handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetch_queue = [(0,)]
+
+        def boom() -> Any:
+            raise RuntimeError("gh exit=1")
+
+        d._fetch_agent_ready_issues = boom  # type: ignore[method-assign]
+
+        # No exception out of scheduler_tick even when the scan dies.
+        summary = d.scheduler_tick()
+        assert summary["queue_depth"] == -1
+        assert handler.events("queue_scan_failed") != []
+
+
+# --------------------------------------------------------------------------
+# _emit_heartbeat_metric — CloudWatch PutMetricData
+# --------------------------------------------------------------------------
+
+
+class TestEmitHeartbeatMetric:
+    """``HeartbeatAge=0`` → Judgemind/Dispatcher namespace, Service dim."""
+
+    def test_emits_metric_with_correct_shape(self) -> None:
+        d, _conn, handler = _make_daemon_with_capture()
+        mock_client = MagicMock()
+        d._make_cloudwatch_client = lambda: mock_client  # type: ignore[method-assign]
+
+        ok = d._emit_heartbeat_metric()
+        assert ok is True
+        mock_client.put_metric_data.assert_called_once()
+        call_kwargs = mock_client.put_metric_data.call_args.kwargs
+        assert call_kwargs["Namespace"] == "Judgemind/Dispatcher"
+        md = call_kwargs["MetricData"]
+        assert len(md) == 1
+        assert md[0]["MetricName"] == "HeartbeatAge"
+        assert md[0]["Value"] == 0.0
+        assert md[0]["Unit"] == "Seconds"
+        assert md[0]["Dimensions"] == [
+            {"Name": "Service", "Value": "judgemind-dispatcher-dev"},
+        ]
+        # Structured log recorded.
+        emits = handler.events("heartbeat_metric_emitted")
+        assert len(emits) == 1
+
+    def test_falls_back_to_hostname_when_service_name_unset(self) -> None:
+        d, _conn, _handler = _make_daemon_with_capture()
+        # Blank out DISPATCHER_SERVICE_NAME.
+        d._cfg = daemon.DaemonConfig(
+            database_url="postgres://fake",
+            version_sha="deadbee",
+            host="task-abc123",
+            pid=1,
+            dispatcher_service_name="",
+            heartbeat_metric_namespace="Judgemind/Dispatcher",
+            aws_region="us-west-2",
+        )
+        d._run_id = "test-run-id"
+        mock_client = MagicMock()
+        d._make_cloudwatch_client = lambda: mock_client  # type: ignore[method-assign]
+
+        d._emit_heartbeat_metric()
+        dims = mock_client.put_metric_data.call_args.kwargs["MetricData"][0][
+            "Dimensions"
+        ]
+        assert dims == [{"Name": "Service", "Value": "task-abc123"}]
+
+    def test_reuses_cloudwatch_client_across_ticks(self) -> None:
+        d, _conn, _handler = _make_daemon_with_capture()
+        mock_client = MagicMock()
+        make_calls = {"n": 0}
+
+        def make_once() -> Any:
+            make_calls["n"] += 1
+            return mock_client
+
+        d._make_cloudwatch_client = make_once  # type: ignore[method-assign]
+
+        d._emit_heartbeat_metric()
+        d._emit_heartbeat_metric()
+        d._emit_heartbeat_metric()
+
+        # Client built exactly once; three calls reuse it.
+        assert make_calls["n"] == 1
+        assert mock_client.put_metric_data.call_count == 3
+
+    def test_put_metric_failure_does_not_raise_and_resets_client(self) -> None:
+        d, _conn, handler = _make_daemon_with_capture()
+
+        failing_client = MagicMock()
+        failing_client.put_metric_data.side_effect = RuntimeError("access denied")
+        ok_client = MagicMock()
+
+        clients = [failing_client, ok_client]
+
+        def next_client() -> Any:
+            return clients.pop(0)
+
+        d._make_cloudwatch_client = next_client  # type: ignore[method-assign]
+
+        # First call fails, but returns False rather than raising.
+        first = d._emit_heartbeat_metric()
+        assert first is False
+        fails = handler.events("heartbeat_metric_failed")
+        assert len(fails) == 1
+        assert "access denied" in fails[0].detail
+
+        # Client was reset, so the next call builds a fresh one.
+        second = d._emit_heartbeat_metric()
+        assert second is True
+
+
+# --------------------------------------------------------------------------
+# supervisor_tick — Phase 2 integration (heartbeat metric wired in)
+# --------------------------------------------------------------------------
+
+
+class TestSupervisorTickPhase2:
+    """Supervisor tick now also emits the CloudWatch metric."""
+
+    def test_emits_metric_after_successful_heartbeat(self) -> None:
+        d, conn, handler = _make_daemon_with_capture()
+        # The failures count(*) returns 0.
+        conn.cursor_instance.fetch_queue = [(0,)]
+        mock_client = MagicMock()
+        d._make_cloudwatch_client = lambda: mock_client  # type: ignore[method-assign]
+
+        summary = d.supervisor_tick()
+        # DB heartbeat UPDATE ran.
+        updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if e[0].startswith("UPDATE dispatcher.runs")
+        ]
+        assert len(updates) == 1
+        # CloudWatch metric published.
+        assert mock_client.put_metric_data.call_count == 1
+        assert summary["heartbeat_metric_emitted"] == 1
+        # Supervisor tick log records both.
+        ticks = handler.events("supervisor_tick")
+        assert len(ticks) == 1
+        assert ticks[0].heartbeat_metric_emitted is True
+
+    def test_metric_failure_does_not_crash_supervisor(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetch_queue = [(0,)]
+        failing = MagicMock()
+        failing.put_metric_data.side_effect = RuntimeError("throttled")
+        d._make_cloudwatch_client = lambda: failing  # type: ignore[method-assign]
+
+        # Supervisor tick still returns normally — the DB heartbeat is
+        # the ground truth; the metric is just for the alarm.
+        summary = d.supervisor_tick()
+        assert summary["heartbeat_metric_emitted"] == 0
+
+
+# --------------------------------------------------------------------------
+# DaemonConfig / _build_config env plumbing
+# --------------------------------------------------------------------------
+
+
+class TestPhase2ConfigPlumbing:
+    """New env vars: GITHUB_REPO, DISPATCHER_SERVICE_NAME, etc."""
+
+    def test_build_config_reads_new_env_vars(self) -> None:
+        args = daemon._parse_args([])
+        env = {
+            "DATABASE_URL": "postgres://x",
+            "GIT_SHA": "cafef00d",
+            "HOSTNAME": "task-xyz",
+            "GITHUB_REPO": "acme/widgets",
+            "DISPATCHER_SERVICE_NAME": "judgemind-dispatcher-dev",
+            "HEARTBEAT_METRIC_NAMESPACE": "Judgemind/Dispatcher",
+            "AWS_REGION": "us-west-2",
+        }
+        cfg = daemon._build_config(args, env=env)
+        assert cfg.github_repo == "acme/widgets"
+        assert cfg.dispatcher_service_name == "judgemind-dispatcher-dev"
+        assert cfg.heartbeat_metric_namespace == "Judgemind/Dispatcher"
+        assert cfg.aws_region == "us-west-2"
+
+    def test_build_config_defaults_when_unset(self) -> None:
+        args = daemon._parse_args([])
+        cfg = daemon._build_config(args, env={"DATABASE_URL": "postgres://x"})
+        assert cfg.github_repo == daemon.DEFAULT_GITHUB_REPO
+        assert (
+            cfg.heartbeat_metric_namespace == daemon.DEFAULT_HEARTBEAT_METRIC_NAMESPACE
+        )
+        assert cfg.aws_region == daemon.DEFAULT_AWS_REGION
+
+    def test_build_config_aws_region_env_fallback(self) -> None:
+        """``AWS_DEFAULT_REGION`` is respected when ``AWS_REGION`` is unset."""
+        args = daemon._parse_args([])
+        cfg = daemon._build_config(
+            args,
+            env={"DATABASE_URL": "postgres://x", "AWS_DEFAULT_REGION": "us-east-1"},
+        )
+        assert cfg.aws_region == "us-east-1"

--- a/scripts/dispatcher/tests/test_daemon_skeleton.py
+++ b/scripts/dispatcher/tests/test_daemon_skeleton.py
@@ -173,7 +173,14 @@ class TestLeaseCheck:
 
 
 class TestSchedulerTick:
-    """§6 step 1 — consume any pending commands; Phase 1 stops there."""
+    """§6 step 1 — consume any pending commands.
+
+    Phase 2 additions (queue scan, heartbeat metric) live in
+    ``test_daemon_phase2.py``. These skeleton tests only exercise the
+    step-1 command-consumption + concurrency-cap-read path, and stub
+    ``_fetch_agent_ready_issues`` to isolate that path from the queue
+    scan added in #2768.
+    """
 
     def test_consumes_commands_and_reads_config(self) -> None:
         fake_conn = _FakeConnection()
@@ -181,6 +188,9 @@ class TestSchedulerTick:
         fake_conn.cursor_instance.fetch_queue = [(5,)]
 
         d = _make_daemon(fake_conn=fake_conn)
+        # Stub the queue-scan fetch so the scheduler tick does not try
+        # to shell out to ``gh`` in this skeleton test.
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
         # Set rowcount via a wrapper: execute() sets it before fetchone.
         # _FakeCursor doesn't auto-populate rowcount, so set it directly
         # between execute calls — the daemon calls execute then reads
@@ -199,8 +209,11 @@ class TestSchedulerTick:
         summary = d.scheduler_tick()
         assert summary["commands_consumed"] == 3
         assert summary["concurrency_cap"] == 5
-        # Exactly one commit per tick.
-        assert fake_conn.commits == 1
+        # Two commits per tick: one for command-consumption + config read,
+        # one for the queue_snapshots INSERT (Phase 2 addition). The
+        # scan is isolated in its own transaction so a queue-snapshot
+        # failure does not roll back a successful command drain.
+        assert fake_conn.commits == 2
         # Tick counter incremented.
         assert d._scheduler_ticks == 1
 
@@ -210,6 +223,7 @@ class TestSchedulerTick:
         fake_conn.cursor_instance.fetch_queue = [None]
 
         d = _make_daemon(fake_conn=fake_conn)
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
         summary = d.scheduler_tick()
         assert summary["commands_consumed"] == 0
         assert summary["concurrency_cap"] == -1  # sentinel for "unset"


### PR DESCRIPTION
## Summary

Phase 2 shadow mode for dispatcher v2. Daemon scales to `desired_count=1`, scans the `agent/ready` GitHub queue every 30s, persists observations to a new `dispatcher.queue_snapshots` table, and emits a `HeartbeatAge` CloudWatch metric on every 120s supervisor tick. Still no subprocess spawning — a defensive `concurrency_cap=0` guard logs a warning if the live config disagrees with the Phase 2 invariant.

Closes #2768

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

Local results (captured pre-push):
- `ruff check scripts/dispatcher/` — clean
- `ruff format --check scripts/dispatcher/` — clean
- `pytest scripts/dispatcher/tests/` — 49 passed, 1 skipped
- `npm --prefix packages/api run lint` — clean
- `npm --prefix packages/api run typecheck` — clean
- `npm --prefix packages/api test` — 345 passed across 28 test files (includes new `queueDepth reflects the latest row` integration test)
- `terraform -chdir=infra/terraform fmt -check -recursive` — clean
- `terraform -chdir=infra/terraform/environments/dev validate` — clean
- `terraform -chdir=infra/terraform/environments/dev plan` — shows `desired_count: 0 → 1`, task-def replacement adding `DATABASE_URL` secret mapping, and the new `task_read_db_secret` IAM policy (plan saved as deferred evidence)

### Post-deploy verification
- [ ] `scripts/dev-db-query.sh "\d dispatcher.queue_snapshots"` shows the expected schema (AC 1)
- [ ] After ≥2 min daemon uptime, `SELECT queue_depth, observed_at FROM dispatcher.queue_snapshots ORDER BY observed_at DESC LIMIT 5` returns 5 rows matching the live `gh` count within ±1 (AC 2)
- [ ] `aws cloudwatch get-metric-statistics --namespace Judgemind/Dispatcher --metric-name HeartbeatAge --period 60 --statistics Average` returns datapoints (AC 3)
- [ ] `/admin/dispatcher` shows a non-zero "Queue — N issues ready for pickup" matching the live `gh` count (AC 4)
- [ ] `SELECT COUNT(*) FROM dispatcher.agents WHERE created_at > <run_start>` returns 0 after ≥5 min uptime (AC 5)
- [ ] `SELECT EXTRACT(EPOCH FROM (now() - started_at)) FROM dispatcher.runs ORDER BY started_at DESC LIMIT 1` ≥ 600 with `stopped_at IS NULL` (AC 6)
- [ ] `aws ecs describe-services --cluster judgemind-dev --services judgemind-dispatcher-dev` returns `desired=1, running=1` (AC 7 — operator re-applies terraform)
- [ ] Verification evidence posted on issue (see task skill A.8)

## Notes for reviewer

- Terraform apply is explicitly deferred to the operator per CLAUDE.md. The plan is captured in the local worktree as part of the verification evidence comment so you can eyeball the deltas without re-running.
- `db_connection_secret_arn` is wired in alongside the `desired_count` flip — Phase 2 is non-functional without it (daemon can't INSERT to `dispatcher.runs`). Plan shows the task-def replacement adds the `DATABASE_URL` secret mapping and the `task_read_db_secret` IAM policy.
- No `/task-v2-*` skill touches. Phase 3 territory.
- No spawn code. A defensive guard warns if `concurrency_cap != 0`, but there is no code path that spawns regardless.
