### PR TITLE
fix(dispatcher): add boto3 to Dockerfile.dispatcher (#2773)

### DIFF
--- a/Dockerfile.dispatcher
+++ b/Dockerfile.dispatcher
@@ -92,15 +92,21 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python
 # ---------------------------------------------------------------------------
 # Python dependencies
 #
-# Only psycopg[binary]>=3.1 is needed for the Phase 1 skeleton — all the
-# heavy packages (the scraper-framework itself, Playwright, etc.) are NOT
-# relevant to the daemon process. Pinning psycopg separately also keeps
-# the image layer small enough that future Phase 2 changes only bust the
-# COPY layers below.
+# - psycopg[binary]>=3.1 — Postgres driver for the dispatcher DB. Canonical
+#   interface is `import psycopg` with the `[binary]` extra for the bundled
+#   libpq (spike 0.2 / emit_failure.py), so no separate `libpq-dev` apt
+#   install is needed.
+# - boto3>=1.34 — AWS SDK, required by Phase 2's CloudWatch HeartbeatAge
+#   metric emission in `scripts/dispatcher/daemon.py` (#2773, scope miss
+#   from #2768 / PR #2771). The version floor matches the rest of the repo
+#   (`packages/scraper-framework/pyproject.toml`, `packages/nlp-pipeline/
+#   pyproject.toml`) so the daemon's boto3 stays in sync with the services
+#   the broader codebase targets.
 #
-# Per repo convention (spike 0.2 / emit_failure.py) the canonical
-# interface is `import psycopg` with the `[binary]` extra for the bundled
-# libpq — no separate `libpq-dev` apt install needed.
+# Both are pinned separately rather than combined into a requirements.txt
+# because Phase 1 deliberately keeps the dependency list tight — adding a
+# new layer only for a pip install step means future Phase 2+ changes bust
+# only the COPY layers below, not the Python install.
 # ---------------------------------------------------------------------------
 # Newer pip enforces PEP 668 "externally-managed-environment" on Debian's
 # system Python. We install at the system level (there is only one
@@ -110,7 +116,9 @@ RUN ln -sf /usr/bin/python3 /usr/bin/python
 # image (which doesn't enforce it because its Python comes from the
 # official `python` image, not Debian's system packages).
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
-RUN pip install --no-cache-dir "psycopg[binary]>=3.1,<4"
+RUN pip install --no-cache-dir \
+    "psycopg[binary]>=3.1,<4" \
+    "boto3>=1.34,<2"
 
 # ---------------------------------------------------------------------------
 # Claude Code CLI


### PR DESCRIPTION
## Summary

Adds `boto3>=1.34,<2` to `Dockerfile.dispatcher`'s `pip install` step so the Phase 2 `HeartbeatAge` CloudWatch metric emission in `scripts/dispatcher/daemon.py` actually succeeds in the deployed daemon container — today it lazy-imports `boto3` and the import throws `ModuleNotFoundError` on every supervisor tick.

Floor `>=1.34` matches `packages/scraper-framework/pyproject.toml` and `packages/nlp-pipeline/pyproject.toml`; upper bound `<2` mirrors the range-pin style already used for `psycopg[binary]>=3.1,<4` on the same line. Both pins stay in a single `RUN` layer per the Phase 1 tight-dependency convention.

Closes #2773

## Test plan

### Automated checks

- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts-tests` job SKIPPED by `detect-changes` — Dockerfile-only diff doesn't touch `scripts/**`; local `pytest scripts/dispatcher/tests/` run pre-push: **49 passed, 1 skipped**)
- [x] CI green (`ci-passed` SUCCESS; `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`)

### Post-deploy verification (operator-driven — deferred)

Operator (parent session) will redeploy via `aws ecs update-service --cluster judgemind-dev --service judgemind-dispatcher-dev --task-definition judgemind-dispatcher-dev --force-new-deployment --region us-west-2` after merge (automatic once #2772 lands).

- [ ] `daemon.heartbeat_metric_failed` log line stops appearing with `No module named 'boto3'` reason post-redeploy (AC #2)
- [ ] CloudWatch `HeartbeatAge` in `Judgemind/Dispatcher` namespace has at least one datapoint in the post-deploy 10-min window (AC #3)
- [ ] Verification evidence posted on issue (agent posts a skip-reason comment citing operator-deferred live verification)
