### PR TITLE
feat(dispatcher): housekeeping tick prunes queue_snapshots > 30d (#2778)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -87,6 +87,19 @@ LEASE_HEARTBEAT_WINDOW_SECONDS = 60
 DEFAULT_SCHEDULER_TICK_SECONDS = 30
 DEFAULT_SUPERVISOR_TICK_SECONDS = 120
 
+#: Default housekeeping tick cadence — hourly. Cheap DELETEs that prune
+#: transient dispatcher tables. Separate from scheduler/supervisor so a
+#: slow DELETE (or DB hiccup) does not delay the hot-path queue scan or
+#: heartbeat. Issue #2778 (closes the TODO in migration 24).
+DEFAULT_HOUSEKEEPING_TICK_SECONDS = 3600
+
+#: Default retention window for ``dispatcher.queue_snapshots``. Matches
+#: the ``dispatcher_daemon`` CloudWatch log group default retention and
+#: covers the longest plausible multi-week post-mortem window. Overridable
+#: per-environment via the ``queue_snapshot_retention_days`` row in
+#: ``dispatcher.config`` (operator knob — no redeploy needed).
+DEFAULT_QUEUE_SNAPSHOT_RETENTION_DAYS = 30
+
 #: Default repo the daemon watches. Overridden by the ``GITHUB_REPO``
 #: env var, wired in the terraform module.
 DEFAULT_GITHUB_REPO = "judgemind/judgemind"
@@ -209,6 +222,10 @@ class DaemonConfig:
     database_url: str
     tick_scheduler_seconds: int = DEFAULT_SCHEDULER_TICK_SECONDS
     tick_supervisor_seconds: int = DEFAULT_SUPERVISOR_TICK_SECONDS
+    #: Housekeeping tick cadence (hourly by default). Controls how often
+    #: :meth:`DispatcherDaemon._housekeeping_tick` prunes transient
+    #: dispatcher tables. See ``DEFAULT_HOUSEKEEPING_TICK_SECONDS``.
+    tick_housekeeping_seconds: int = DEFAULT_HOUSEKEEPING_TICK_SECONDS
     log_level: str = "INFO"
     version_sha: str = "unknown"
     host: str = ""
@@ -273,6 +290,14 @@ class DispatcherDaemon:
               so the alarm defined in the terraform module
               (``infra/terraform/modules/dispatcher-daemon``) sees fresh
               data and does not fire.
+        * Run the housekeeping loop every ``tick_housekeeping_seconds``
+          (hourly by default):
+            - prune ``dispatcher.queue_snapshots`` rows older than
+              ``queue_snapshot_retention_days`` (default 30;
+              ``dispatcher.config`` overridable). Issue #2778.
+            - Additional tables (``phase_outputs``, ``notifications``)
+              plug into the same tick via the ``_HOUSEKEEPING_TARGETS``
+              table — issue #2779 extends it.
         * On SIGTERM / SIGINT, UPDATE ``dispatcher.runs.stopped_at`` and
           exit 0.
 
@@ -290,6 +315,7 @@ class DispatcherDaemon:
         self._stop = threading.Event()
         self._scheduler_ticks = 0
         self._supervisor_ticks = 0
+        self._housekeeping_ticks = 0
         self._last_heartbeat_at: datetime | None = None
         # CloudWatch client is created lazily on first publish so tests can
         # mock it via ``_make_cloudwatch_client``. Shared across supervisor
@@ -788,6 +814,142 @@ class DispatcherDaemon:
         )
         return True
 
+    # ── housekeeping tick (every ``tick_housekeeping_seconds``) ─────────
+
+    #: Retention targets the housekeeping tick prunes. Each entry is a
+    #: ``(table, timestamp_column, config_key, default_days)`` tuple.
+    #: - ``table``: short name under the ``dispatcher.`` schema.
+    #: - ``timestamp_column``: the column the cutoff compares against
+    #:   (``now() - INTERVAL 'N days'``).
+    #: - ``config_key``: row in ``dispatcher.config`` that overrides the
+    #:   default retention window. Missing or invalid value = fall back
+    #:   to ``default_days``.
+    #: - ``default_days``: hardcoded floor used when no config row is set.
+    #:
+    #: Table names and column names are hardcoded class constants (never
+    #: interpolated from user input or config), so composing the DELETE
+    #: with an f-string is safe from SQL injection here. Cutoff days are
+    #: parameterized normally via psycopg's ``%s`` placeholder.
+    #:
+    #: Extending: issue #2779 appends ``phase_outputs`` and
+    #: ``notifications`` entries here with their own retention keys.
+    _HOUSEKEEPING_TARGETS: tuple[tuple[str, str, str, int], ...] = (
+        (
+            "queue_snapshots",
+            "observed_at",
+            "queue_snapshot_retention_days",
+            DEFAULT_QUEUE_SNAPSHOT_RETENTION_DAYS,
+        ),
+    )
+
+    def _read_retention_days(self, config_key: str, default_days: int) -> int:
+        """Look up the retention override for ``config_key`` in ``dispatcher.config``.
+
+        Returns the configured value if present and castable to a
+        positive int, otherwise ``default_days``. The lookup runs in its
+        own tiny transaction so a missing/malformed row does not poison
+        the surrounding DELETE.
+        """
+        assert self._conn is not None, "connect() must run before reading config"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    (config_key,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            # Config read failure is non-fatal — the caller will fall
+            # back to the hardcoded default. Rollback is best-effort.
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return default_days
+
+        if row is None:
+            return default_days
+        value = row[0]
+        if value is None:
+            return default_days
+        try:
+            configured = int(value)
+        except (TypeError, ValueError):
+            return default_days
+        if configured <= 0:
+            return default_days
+        return configured
+
+    def _housekeeping_tick(self) -> dict[str, int]:
+        """Run one housekeeping tick. Prunes stale rows from dispatcher tables.
+
+        Iterates :attr:`_HOUSEKEEPING_TARGETS` and issues a DELETE per
+        target bounded by the target's retention window. Each target is
+        a separate transaction so one failure does not poison siblings.
+
+        Returns a mapping of ``table`` → ``rows_deleted`` (with ``-1``
+        sentinel on per-target failure). The return value is surfaced to
+        tests — the daemon itself just logs and continues.
+        """
+        assert self._conn is not None, "connect() must run before ticks"
+
+        per_table: dict[str, int] = {}
+        for (
+            table,
+            timestamp_column,
+            config_key,
+            default_days,
+        ) in self._HOUSEKEEPING_TARGETS:
+            cutoff_days = self._read_retention_days(config_key, default_days)
+            # ``table`` and ``timestamp_column`` are class constants
+            # (never user-controlled), so composing the SQL with f-string
+            # is safe. The cutoff is bound via %s.
+            delete_sql = (
+                f"DELETE FROM dispatcher.{table} "
+                f"WHERE {timestamp_column} < now() - make_interval(days => %s)"
+            )
+            try:
+                with self._conn.cursor() as cur:
+                    cur.execute(delete_sql, (cutoff_days,))
+                    rows_deleted = cur.rowcount or 0
+                self._conn.commit()
+            except Exception as exc:
+                # DB hiccup on one table must not crash the daemon or
+                # starve sibling tables of their housekeeping. Log, roll
+                # back, record the sentinel, and keep going.
+                try:
+                    self._conn.rollback()
+                except Exception:  # pragma: no cover — best-effort
+                    pass
+                self._log.warning(
+                    "daemon.housekeeping_failed",
+                    extra={
+                        "event": "housekeeping_failed",
+                        "run_id": self._run_id,
+                        "table": table,
+                        "cutoff_days": cutoff_days,
+                        "detail": str(exc),
+                    },
+                )
+                per_table[table] = -1
+                continue
+
+            per_table[table] = rows_deleted
+            self._log.info(
+                "daemon.housekeeping_tick",
+                extra={
+                    "event": "housekeeping_tick",
+                    "run_id": self._run_id,
+                    "table": table,
+                    "rows_deleted": rows_deleted,
+                    "cutoff_days": cutoff_days,
+                },
+            )
+
+        self._housekeeping_ticks += 1
+        return per_table
+
     # ── signal handling ────────────────────────────────────────────────
 
     def request_stop(self, signum: int | None = None, _frame: Any = None) -> None:
@@ -811,14 +973,20 @@ class DispatcherDaemon:
 
         last_scheduler = 0.0
         last_supervisor = 0.0
+        last_housekeeping = 0.0
         # Tick once on boot so the first scheduler/supervisor cycle is
         # observable immediately in logs + DB, rather than after the
-        # first full cadence elapses.
+        # first full cadence elapses. Housekeeping is NOT fired on boot
+        # — it would double-emit on every deploy (rolling restart) and
+        # hourly cadence already bounds the worst-case staleness at 1h.
         try:
             self.scheduler_tick()
             last_scheduler = time.monotonic()
             self.supervisor_tick()
             last_supervisor = time.monotonic()
+            # Seed the housekeeping timer so the first prune happens
+            # after a full interval, not immediately.
+            last_housekeeping = time.monotonic()
         except Exception:
             self._log.exception("daemon.initial_tick_failed")
             return 1
@@ -833,6 +1001,9 @@ class DispatcherDaemon:
                 if now - last_supervisor >= self._cfg.tick_supervisor_seconds:
                     self.supervisor_tick()
                     last_supervisor = now
+                if now - last_housekeeping >= self._cfg.tick_housekeeping_seconds:
+                    self._housekeeping_tick()
+                    last_housekeeping = now
             except Exception:
                 # Any tick exception is logged and the loop continues —
                 # the next tick will try again. Real DB failure will
@@ -875,6 +1046,12 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         type=int,
         default=DEFAULT_SUPERVISOR_TICK_SECONDS,
         help="Seconds between supervisor ticks (default: 120).",
+    )
+    parser.add_argument(
+        "--tick-housekeeping-seconds",
+        type=int,
+        default=DEFAULT_HOUSEKEEPING_TICK_SECONDS,
+        help="Seconds between housekeeping ticks (default: 3600).",
     )
     parser.add_argument(
         "--log-level",
@@ -925,6 +1102,7 @@ def _build_config(
         database_url=database_url,
         tick_scheduler_seconds=args.tick_scheduler_seconds,
         tick_supervisor_seconds=args.tick_supervisor_seconds,
+        tick_housekeeping_seconds=args.tick_housekeeping_seconds,
         log_level=args.log_level,
         version_sha=version_sha,
         host=host,
@@ -984,6 +1162,7 @@ def main(argv: list[str] | None = None) -> int:
             "pid": cfg.pid,
             "tick_scheduler_seconds": cfg.tick_scheduler_seconds,
             "tick_supervisor_seconds": cfg.tick_supervisor_seconds,
+            "tick_housekeeping_seconds": cfg.tick_housekeeping_seconds,
         },
     )
 

--- a/scripts/dispatcher/tests/test_daemon_housekeeping.py
+++ b/scripts/dispatcher/tests/test_daemon_housekeeping.py
@@ -1,0 +1,400 @@
+"""Unit tests for the daemon housekeeping tick (issue #2778).
+
+Covers the three behaviours added on top of Phase 2:
+
+* ``_housekeeping_tick`` issues a parameterised DELETE against
+  ``dispatcher.queue_snapshots`` using the retention window read from
+  ``dispatcher.config`` (falls back to the 30-day default).
+* Idempotency — calling the tick twice is safe; the second call commits
+  (possibly deleting zero rows) without raising.
+* Failure isolation — a DB error during the DELETE is caught, logged as
+  ``housekeeping_failed``, rolled back, and does not propagate. The
+  tick still returns (so sibling tables in the targets list can proceed).
+
+All DB interaction is against the same ``_FakeCursor`` / ``_FakeConnection``
+stubs used by ``test_daemon_phase2.py``; no real Postgres is needed.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Ensure a ``psycopg`` module exists in sys.modules before importing
+# the daemon. Mirrors the pattern used in test_daemon_phase2.py.
+if "psycopg" not in sys.modules:  # pragma: no cover — fresh-venv guard
+    sys.modules["psycopg"] = MagicMock()
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes (mirrors test_daemon_phase2.py shape)
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    """Collect emitted ``LogRecord``s so tests can assert on them."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        """All captured records whose ``extra.event`` equals ``name``."""
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon_with_capture() -> tuple[
+    daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler
+]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger("dispatcher.test.housekeeping")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake-for-tests",
+        tick_scheduler_seconds=30,
+        tick_supervisor_seconds=120,
+        tick_housekeeping_seconds=3600,
+        log_level="DEBUG",
+        version_sha="deadbee",
+        host="test-host",
+        pid=4242,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-dev",
+        heartbeat_metric_namespace="Judgemind/Dispatcher",
+        aws_region="us-west-2",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]  — test stub
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# _read_retention_days — config lookup
+# --------------------------------------------------------------------------
+
+
+class TestReadRetentionDays:
+    """Config override falls back cleanly to the hardcoded default."""
+
+    def test_returns_config_override_when_set(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        # dispatcher.config returns 7 for the retention key.
+        conn.cursor_instance.fetch_queue = [(7,)]
+        assert d._read_retention_days("queue_snapshot_retention_days", 30) == 7
+
+    def test_returns_default_when_row_missing(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetch_queue = [None]
+        assert d._read_retention_days("queue_snapshot_retention_days", 30) == 30
+
+    def test_returns_default_when_value_null(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetch_queue = [(None,)]
+        assert d._read_retention_days("queue_snapshot_retention_days", 30) == 30
+
+    def test_returns_default_when_value_non_numeric(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetch_queue = [("banana",)]
+        assert d._read_retention_days("queue_snapshot_retention_days", 30) == 30
+
+    def test_returns_default_when_value_non_positive(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetch_queue = [(0,)]
+        assert d._read_retention_days("queue_snapshot_retention_days", 30) == 30
+
+    def test_returns_default_on_db_error(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+
+        def boom(sql: str, params: Any = None) -> None:
+            raise RuntimeError("connection lost")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+        # Must not raise; returns the hardcoded default.
+        assert d._read_retention_days("queue_snapshot_retention_days", 30) == 30
+        assert conn.rollbacks >= 1
+
+
+# --------------------------------------------------------------------------
+# _housekeeping_tick — DELETE + cutoff + structured log
+# --------------------------------------------------------------------------
+
+
+class TestHousekeepingTick:
+    """DELETE + structured log matches the spec in the issue body."""
+
+    def test_deletes_with_default_cutoff_and_logs(self) -> None:
+        d, conn, handler = _make_daemon_with_capture()
+        # First execute() is the config SELECT (returns None → default).
+        # Second execute() is the DELETE; 1234 rows swept.
+        conn.cursor_instance.fetch_queue = [None]
+
+        original_execute = conn.cursor_instance.execute
+
+        def patched_execute(sql: str, params: Any = None) -> None:
+            original_execute(sql, params)
+            if "DELETE FROM dispatcher.queue_snapshots" in sql:
+                conn.cursor_instance.rowcount = 1234
+
+        conn.cursor_instance.execute = patched_execute  # type: ignore[method-assign]
+
+        result = d._housekeeping_tick()
+
+        # One DELETE bound to the default cutoff (30 days).
+        deletes = [
+            e
+            for e in conn.cursor_instance.executed
+            if e[0].startswith("DELETE FROM dispatcher.queue_snapshots")
+        ]
+        assert len(deletes) == 1
+        sql, params = deletes[0]
+        assert "observed_at < now() - make_interval(days => %s)" in sql
+        assert params == (daemon.DEFAULT_QUEUE_SNAPSHOT_RETENTION_DAYS,)
+
+        # Structured log emitted with the four required fields.
+        ticks = handler.events("housekeeping_tick")
+        assert len(ticks) == 1
+        record = ticks[0]
+        assert record.table == "queue_snapshots"
+        assert record.rows_deleted == 1234
+        assert record.cutoff_days == daemon.DEFAULT_QUEUE_SNAPSHOT_RETENTION_DAYS
+        assert record.run_id == "test-run-id"
+
+        # Result dict surfaces the rowcount.
+        assert result == {"queue_snapshots": 1234}
+        # Counter advances.
+        assert d._housekeeping_ticks == 1
+
+    def test_uses_config_override_when_set(self) -> None:
+        d, conn, handler = _make_daemon_with_capture()
+        # Config row sets retention to 7 days.
+        conn.cursor_instance.fetch_queue = [(7,)]
+
+        original_execute = conn.cursor_instance.execute
+
+        def patched_execute(sql: str, params: Any = None) -> None:
+            original_execute(sql, params)
+            if "DELETE FROM dispatcher.queue_snapshots" in sql:
+                conn.cursor_instance.rowcount = 10
+
+        conn.cursor_instance.execute = patched_execute  # type: ignore[method-assign]
+
+        d._housekeeping_tick()
+
+        deletes = [
+            e
+            for e in conn.cursor_instance.executed
+            if e[0].startswith("DELETE FROM dispatcher.queue_snapshots")
+        ]
+        assert deletes[0][1] == (7,)
+        # Log line also reflects the override.
+        ticks = handler.events("housekeeping_tick")
+        assert ticks[0].cutoff_days == 7
+
+    def test_idempotent_second_call_logs_zero_deletes(self) -> None:
+        """Running the tick twice with no new rows to prune is safe.
+
+        Mirrors the real-world steady state: after the first hourly
+        sweep catches up, subsequent ticks should delete 0 rows and emit
+        a clean ``housekeeping_tick`` event with ``rows_deleted=0``.
+        """
+        d, conn, handler = _make_daemon_with_capture()
+        # Two ticks × (config lookup returns None → default, DELETE → 0 rows).
+        conn.cursor_instance.fetch_queue = [None, None]
+        # rowcount stays at 0 — nothing to delete.
+
+        d._housekeeping_tick()
+        d._housekeeping_tick()
+
+        ticks = handler.events("housekeeping_tick")
+        assert len(ticks) == 2
+        assert all(t.rows_deleted == 0 for t in ticks)
+        # Two DELETE statements, same bound cutoff.
+        deletes = [
+            e
+            for e in conn.cursor_instance.executed
+            if e[0].startswith("DELETE FROM dispatcher.queue_snapshots")
+        ]
+        assert len(deletes) == 2
+        assert all(
+            p == (daemon.DEFAULT_QUEUE_SNAPSHOT_RETENTION_DAYS,) for _, p in deletes
+        )
+        assert d._housekeeping_ticks == 2
+
+    def test_db_failure_logs_housekeeping_failed_and_continues(self) -> None:
+        """A DB error during the DELETE must not crash the daemon.
+
+        The tick catches the exception, rolls back, emits a
+        ``housekeeping_failed`` event, and returns a ``-1`` sentinel for
+        the failing table so the caller knows the sweep failed.
+        """
+        d, conn, handler = _make_daemon_with_capture()
+        # Config lookup returns None → default.
+        conn.cursor_instance.fetch_queue = [None]
+
+        original_execute = conn.cursor_instance.execute
+
+        def failing_execute(sql: str, params: Any = None) -> None:
+            if "DELETE FROM dispatcher.queue_snapshots" in sql:
+                raise RuntimeError("deadlock detected")
+            original_execute(sql, params)
+
+        conn.cursor_instance.execute = failing_execute  # type: ignore[method-assign]
+
+        # Must not raise out of the tick.
+        result = d._housekeeping_tick()
+
+        # ``housekeeping_failed`` emitted with detail + table.
+        failures = handler.events("housekeeping_failed")
+        assert len(failures) == 1
+        assert failures[0].table == "queue_snapshots"
+        assert failures[0].cutoff_days == (daemon.DEFAULT_QUEUE_SNAPSHOT_RETENTION_DAYS)
+        assert "deadlock" in failures[0].detail
+        # No success event.
+        assert handler.events("housekeeping_tick") == []
+        # Rollback happened.
+        assert conn.rollbacks >= 1
+        # Sentinel returned.
+        assert result == {"queue_snapshots": -1}
+        # Counter still advances — ``_housekeeping_ticks`` is a
+        # loop-level counter, not a success counter.
+        assert d._housekeeping_ticks == 1
+
+    def test_failure_on_one_target_does_not_stop_siblings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Per-target failure isolation — siblings still run.
+
+        Protects issue #2779's extension path: when ``phase_outputs``
+        and ``notifications`` join the targets tuple, a ``queue_snapshots``
+        DELETE failure must not starve them of their cleanup.
+        """
+        d, conn, handler = _make_daemon_with_capture()
+
+        # Two fake targets. First one raises on DELETE; second one
+        # succeeds. Both have their own config lookup returning None.
+        fake_targets = (
+            ("queue_snapshots", "observed_at", "queue_snapshot_retention_days", 30),
+            ("phase_outputs", "emitted_at", "phase_outputs_retention_days", 14),
+        )
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon, "_HOUSEKEEPING_TARGETS", fake_targets
+        )
+        conn.cursor_instance.fetch_queue = [None, None]
+
+        original_execute = conn.cursor_instance.execute
+
+        def partial_failure(sql: str, params: Any = None) -> None:
+            if "DELETE FROM dispatcher.queue_snapshots" in sql:
+                raise RuntimeError("deadlock detected")
+            original_execute(sql, params)
+            if "DELETE FROM dispatcher.phase_outputs" in sql:
+                conn.cursor_instance.rowcount = 42
+
+        conn.cursor_instance.execute = partial_failure  # type: ignore[method-assign]
+
+        result = d._housekeeping_tick()
+
+        # Failure event for the first target.
+        failures = handler.events("housekeeping_failed")
+        assert len(failures) == 1
+        assert failures[0].table == "queue_snapshots"
+
+        # Success event for the second target — proves sibling isolation.
+        successes = handler.events("housekeeping_tick")
+        assert len(successes) == 1
+        assert successes[0].table == "phase_outputs"
+        assert successes[0].rows_deleted == 42
+        assert successes[0].cutoff_days == 14
+
+        assert result == {"queue_snapshots": -1, "phase_outputs": 42}
+
+
+# --------------------------------------------------------------------------
+# Config / CLI plumbing
+# --------------------------------------------------------------------------
+
+
+class TestHousekeepingConfigPlumbing:
+    """CLI flag + DaemonConfig default wiring."""
+
+    def test_build_config_default_housekeeping_tick_seconds(self) -> None:
+        args = daemon._parse_args([])
+        cfg = daemon._build_config(args, env={"DATABASE_URL": "postgres://x"})
+        assert cfg.tick_housekeeping_seconds == daemon.DEFAULT_HOUSEKEEPING_TICK_SECONDS
+
+    def test_build_config_respects_cli_override(self) -> None:
+        args = daemon._parse_args(["--tick-housekeeping-seconds", "300"])
+        cfg = daemon._build_config(args, env={"DATABASE_URL": "postgres://x"})
+        assert cfg.tick_housekeeping_seconds == 300
+
+    def test_housekeeping_targets_includes_queue_snapshots(self) -> None:
+        """The AC mandates a queue_snapshots entry with the expected defaults."""
+        targets = daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS
+        names = [t[0] for t in targets]
+        assert "queue_snapshots" in names
+        entry = next(t for t in targets if t[0] == "queue_snapshots")
+        assert entry[1] == "observed_at"
+        assert entry[2] == "queue_snapshot_retention_days"
+        assert entry[3] == daemon.DEFAULT_QUEUE_SNAPSHOT_RETENTION_DAYS


### PR DESCRIPTION
## Summary

Adds a third independent tick (`_housekeeping_tick`) on the dispatcher daemon that runs once per hour and prunes `dispatcher.queue_snapshots` rows older than 30 days, closing the TODO in migration 24. The retention window is operator-tunable via `dispatcher.config.queue_snapshot_retention_days`, and the tick is driven by a class-level `_HOUSEKEEPING_TARGETS` tuple so #2779 can append `phase_outputs` and `notifications` without touching the tick implementation. Per-target transactions isolate failures — a DB hiccup on one table logs `daemon.housekeeping_failed` and never crashes the daemon.

Closes #2778

## Test plan

### Automated checks
- [x] Lint passes (`ruff check scripts/dispatcher/`)
- [x] Format check passes (`ruff format --check scripts/dispatcher/`)
- [x] Tests pass (`pytest scripts/dispatcher/tests/` — 63 passed, 1 skipped locally)
- [x] CI green

### Post-deploy verification
- [x] Auto-deploy completed (Deploy Dispatcher run `24627106378`, task def rev 4, runningCount=1, rolloutState COMPLETED).
- [x] Daemon startup log confirms `tick_housekeeping_seconds: 3600` is active.
- [ ] After ≥1h uptime: log filter returns `housekeeping_tick` event with `table=queue_snapshots`, `cutoff_days=30` (deferred per task spec — tick intentionally not fired on boot; operator can verify at `aws logs filter-log-events --log-group-name /ecs/judgemind-dispatcher-dev --filter-pattern '"event":"housekeeping_tick"'`).
- [x] Verification evidence posted on #2778.
