### PR TITLE
feat(dispatcher): prune phase_outputs + notifications in housekeeping tick (#2779)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -100,6 +100,17 @@ DEFAULT_HOUSEKEEPING_TICK_SECONDS = 3600
 #: ``dispatcher.config`` (operator knob — no redeploy needed).
 DEFAULT_QUEUE_SNAPSHOT_RETENTION_DAYS = 30
 
+#: Default retention window for ``dispatcher.phase_outputs``. Matches the
+#: queue-snapshot default so every dispatcher housekeeping target shares
+#: the same cutoff. Overridable via the ``phase_output_retention_days``
+#: row in ``dispatcher.config``. Issue #2779.
+DEFAULT_PHASE_OUTPUT_RETENTION_DAYS = 30
+
+#: Default retention window for ``dispatcher.notifications``. Matches the
+#: queue-snapshot default. Overridable via the
+#: ``notification_retention_days`` row in ``dispatcher.config``. Issue #2779.
+DEFAULT_NOTIFICATION_RETENTION_DAYS = 30
+
 #: Default repo the daemon watches. Overridden by the ``GITHUB_REPO``
 #: env var, wired in the terraform module.
 DEFAULT_GITHUB_REPO = "judgemind/judgemind"
@@ -295,9 +306,10 @@ class DispatcherDaemon:
             - prune ``dispatcher.queue_snapshots`` rows older than
               ``queue_snapshot_retention_days`` (default 30;
               ``dispatcher.config`` overridable). Issue #2778.
-            - Additional tables (``phase_outputs``, ``notifications``)
-              plug into the same tick via the ``_HOUSEKEEPING_TARGETS``
-              table — issue #2779 extends it.
+            - prune ``dispatcher.phase_outputs`` rows older than
+              ``phase_output_retention_days`` (default 30). Issue #2779.
+            - prune ``dispatcher.notifications`` rows older than
+              ``notification_retention_days`` (default 30). Issue #2779.
         * On SIGTERM / SIGINT, UPDATE ``dispatcher.runs.stopped_at`` and
           exit 0.
 
@@ -831,14 +843,28 @@ class DispatcherDaemon:
     #: with an f-string is safe from SQL injection here. Cutoff days are
     #: parameterized normally via psycopg's ``%s`` placeholder.
     #:
-    #: Extending: issue #2779 appends ``phase_outputs`` and
-    #: ``notifications`` entries here with their own retention keys.
+    #: Extending: issue #2779 added ``phase_outputs`` (ts column) and
+    #: ``notifications`` (created_at column). Both default to 30 days,
+    #: overridable via ``phase_output_retention_days`` and
+    #: ``notification_retention_days`` rows in ``dispatcher.config``.
     _HOUSEKEEPING_TARGETS: tuple[tuple[str, str, str, int], ...] = (
         (
             "queue_snapshots",
             "observed_at",
             "queue_snapshot_retention_days",
             DEFAULT_QUEUE_SNAPSHOT_RETENTION_DAYS,
+        ),
+        (
+            "phase_outputs",
+            "ts",
+            "phase_output_retention_days",
+            DEFAULT_PHASE_OUTPUT_RETENTION_DAYS,
+        ),
+        (
+            "notifications",
+            "created_at",
+            "notification_retention_days",
+            DEFAULT_NOTIFICATION_RETENTION_DAYS,
         ),
     )
 

--- a/scripts/dispatcher/tests/test_daemon_housekeeping.py
+++ b/scripts/dispatcher/tests/test_daemon_housekeeping.py
@@ -1,15 +1,22 @@
-"""Unit tests for the daemon housekeeping tick (issue #2778).
+"""Unit tests for the daemon housekeeping tick (issues #2778, #2779).
 
-Covers the three behaviours added on top of Phase 2:
+Covers the behaviours added on top of Phase 2:
 
-* ``_housekeeping_tick`` issues a parameterised DELETE against
-  ``dispatcher.queue_snapshots`` using the retention window read from
-  ``dispatcher.config`` (falls back to the 30-day default).
+* ``_housekeeping_tick`` issues a parameterised DELETE per target in
+  ``_HOUSEKEEPING_TARGETS`` using the retention window read from
+  ``dispatcher.config`` (falls back to the per-target default).
+* Per-target behaviour is verified for all three live targets:
+  ``queue_snapshots``, ``phase_outputs``, ``notifications``.
 * Idempotency — calling the tick twice is safe; the second call commits
   (possibly deleting zero rows) without raising.
-* Failure isolation — a DB error during the DELETE is caught, logged as
-  ``housekeeping_failed``, rolled back, and does not propagate. The
-  tick still returns (so sibling tables in the targets list can proceed).
+* Failure isolation — a DB error during one target's DELETE is caught,
+  logged as ``housekeeping_failed``, rolled back, and does not propagate;
+  the tick still runs sibling targets.
+
+Single-target tests monkeypatch ``_HOUSEKEEPING_TARGETS`` to isolate the
+target under test. Siblings are covered by
+``test_failure_on_one_target_does_not_stop_siblings`` and
+``test_live_targets_all_prune_in_one_tick``.
 
 All DB interaction is against the same ``_FakeCursor`` / ``_FakeConnection``
 stubs used by ``test_daemon_phase2.py``; no real Postgres is needed.
@@ -181,10 +188,30 @@ class TestReadRetentionDays:
 # --------------------------------------------------------------------------
 
 
-class TestHousekeepingTick:
-    """DELETE + structured log matches the spec in the issue body."""
+def _isolate_targets_to(
+    monkeypatch: pytest.MonkeyPatch, table: str
+) -> tuple[str, str, str, int]:
+    """Monkeypatch ``_HOUSEKEEPING_TARGETS`` to a single live-target entry.
 
-    def test_deletes_with_default_cutoff_and_logs(self) -> None:
+    Looks up the real tuple in the daemon module and narrows it to the
+    one target under test. Avoids hand-copying column names (which would
+    drift from the production tuple) and ensures the per-target tests
+    exercise the real configuration, not synthetic stand-ins.
+    """
+    entry = next(
+        t for t in daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS if t[0] == table
+    )
+    monkeypatch.setattr(daemon.DispatcherDaemon, "_HOUSEKEEPING_TARGETS", (entry,))
+    return entry
+
+
+class TestHousekeepingTickQueueSnapshots:
+    """DELETE + structured log for the ``queue_snapshots`` target (#2778)."""
+
+    def test_deletes_with_default_cutoff_and_logs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_targets_to(monkeypatch, "queue_snapshots")
         d, conn, handler = _make_daemon_with_capture()
         # First execute() is the config SELECT (returns None → default).
         # Second execute() is the DELETE; 1234 rows swept.
@@ -226,7 +253,10 @@ class TestHousekeepingTick:
         # Counter advances.
         assert d._housekeeping_ticks == 1
 
-    def test_uses_config_override_when_set(self) -> None:
+    def test_uses_config_override_when_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_targets_to(monkeypatch, "queue_snapshots")
         d, conn, handler = _make_daemon_with_capture()
         # Config row sets retention to 7 days.
         conn.cursor_instance.fetch_queue = [(7,)]
@@ -252,13 +282,16 @@ class TestHousekeepingTick:
         ticks = handler.events("housekeeping_tick")
         assert ticks[0].cutoff_days == 7
 
-    def test_idempotent_second_call_logs_zero_deletes(self) -> None:
+    def test_idempotent_second_call_logs_zero_deletes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Running the tick twice with no new rows to prune is safe.
 
         Mirrors the real-world steady state: after the first hourly
         sweep catches up, subsequent ticks should delete 0 rows and emit
         a clean ``housekeeping_tick`` event with ``rows_deleted=0``.
         """
+        _isolate_targets_to(monkeypatch, "queue_snapshots")
         d, conn, handler = _make_daemon_with_capture()
         # Two ticks × (config lookup returns None → default, DELETE → 0 rows).
         conn.cursor_instance.fetch_queue = [None, None]
@@ -282,13 +315,16 @@ class TestHousekeepingTick:
         )
         assert d._housekeeping_ticks == 2
 
-    def test_db_failure_logs_housekeeping_failed_and_continues(self) -> None:
+    def test_db_failure_logs_housekeeping_failed_and_continues(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A DB error during the DELETE must not crash the daemon.
 
         The tick catches the exception, rolls back, emits a
         ``housekeeping_failed`` event, and returns a ``-1`` sentinel for
         the failing table so the caller knows the sweep failed.
         """
+        _isolate_targets_to(monkeypatch, "queue_snapshots")
         d, conn, handler = _make_daemon_with_capture()
         # Config lookup returns None → default.
         conn.cursor_instance.fetch_queue = [None]
@@ -321,19 +357,385 @@ class TestHousekeepingTick:
         # loop-level counter, not a success counter.
         assert d._housekeeping_ticks == 1
 
+
+class TestHousekeepingTickPhaseOutputs:
+    """DELETE + structured log for the ``phase_outputs`` target (#2779).
+
+    Mirrors ``TestHousekeepingTickQueueSnapshots`` but targets the
+    ``phase_outputs`` entry added in #2779. The cutoff column is ``ts``
+    and the default retention is ``DEFAULT_PHASE_OUTPUT_RETENTION_DAYS``.
+    """
+
+    def test_deletes_with_default_cutoff_and_logs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_targets_to(monkeypatch, "phase_outputs")
+        d, conn, handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetch_queue = [None]
+
+        original_execute = conn.cursor_instance.execute
+
+        def patched_execute(sql: str, params: Any = None) -> None:
+            original_execute(sql, params)
+            if "DELETE FROM dispatcher.phase_outputs" in sql:
+                conn.cursor_instance.rowcount = 77
+
+        conn.cursor_instance.execute = patched_execute  # type: ignore[method-assign]
+
+        result = d._housekeeping_tick()
+
+        deletes = [
+            e
+            for e in conn.cursor_instance.executed
+            if e[0].startswith("DELETE FROM dispatcher.phase_outputs")
+        ]
+        assert len(deletes) == 1
+        sql, params = deletes[0]
+        # phase_outputs uses the ``ts`` column (see migration 21).
+        assert "ts < now() - make_interval(days => %s)" in sql
+        assert params == (daemon.DEFAULT_PHASE_OUTPUT_RETENTION_DAYS,)
+
+        ticks = handler.events("housekeeping_tick")
+        assert len(ticks) == 1
+        record = ticks[0]
+        assert record.table == "phase_outputs"
+        assert record.rows_deleted == 77
+        assert record.cutoff_days == daemon.DEFAULT_PHASE_OUTPUT_RETENTION_DAYS
+        assert record.run_id == "test-run-id"
+
+        assert result == {"phase_outputs": 77}
+        assert d._housekeeping_ticks == 1
+
+    def test_uses_config_override_when_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_targets_to(monkeypatch, "phase_outputs")
+        d, conn, handler = _make_daemon_with_capture()
+        # Operator shortens phase_outputs retention to 14 days.
+        conn.cursor_instance.fetch_queue = [(14,)]
+
+        original_execute = conn.cursor_instance.execute
+
+        def patched_execute(sql: str, params: Any = None) -> None:
+            original_execute(sql, params)
+            if "DELETE FROM dispatcher.phase_outputs" in sql:
+                conn.cursor_instance.rowcount = 5
+
+        conn.cursor_instance.execute = patched_execute  # type: ignore[method-assign]
+
+        d._housekeeping_tick()
+
+        # Config lookup hit the right key.
+        configs = [
+            e
+            for e in conn.cursor_instance.executed
+            if "SELECT value FROM dispatcher.config" in e[0]
+        ]
+        assert configs[0][1] == ("phase_output_retention_days",)
+        # DELETE bound to the override.
+        deletes = [
+            e
+            for e in conn.cursor_instance.executed
+            if e[0].startswith("DELETE FROM dispatcher.phase_outputs")
+        ]
+        assert deletes[0][1] == (14,)
+        ticks = handler.events("housekeeping_tick")
+        assert ticks[0].cutoff_days == 14
+
+    def test_idempotent_second_call_logs_zero_deletes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_targets_to(monkeypatch, "phase_outputs")
+        d, conn, handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetch_queue = [None, None]
+
+        d._housekeeping_tick()
+        d._housekeeping_tick()
+
+        ticks = handler.events("housekeeping_tick")
+        assert len(ticks) == 2
+        assert all(t.table == "phase_outputs" for t in ticks)
+        assert all(t.rows_deleted == 0 for t in ticks)
+        deletes = [
+            e
+            for e in conn.cursor_instance.executed
+            if e[0].startswith("DELETE FROM dispatcher.phase_outputs")
+        ]
+        assert len(deletes) == 2
+        assert all(
+            p == (daemon.DEFAULT_PHASE_OUTPUT_RETENTION_DAYS,) for _, p in deletes
+        )
+        assert d._housekeeping_ticks == 2
+
+    def test_db_failure_logs_housekeeping_failed_and_continues(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_targets_to(monkeypatch, "phase_outputs")
+        d, conn, handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetch_queue = [None]
+
+        original_execute = conn.cursor_instance.execute
+
+        def failing_execute(sql: str, params: Any = None) -> None:
+            if "DELETE FROM dispatcher.phase_outputs" in sql:
+                raise RuntimeError("connection reset")
+            original_execute(sql, params)
+
+        conn.cursor_instance.execute = failing_execute  # type: ignore[method-assign]
+
+        result = d._housekeeping_tick()
+
+        failures = handler.events("housekeeping_failed")
+        assert len(failures) == 1
+        assert failures[0].table == "phase_outputs"
+        assert failures[0].cutoff_days == daemon.DEFAULT_PHASE_OUTPUT_RETENTION_DAYS
+        assert "connection reset" in failures[0].detail
+        assert handler.events("housekeeping_tick") == []
+        assert conn.rollbacks >= 1
+        assert result == {"phase_outputs": -1}
+        assert d._housekeeping_ticks == 1
+
+
+class TestHousekeepingTickNotifications:
+    """DELETE + structured log for the ``notifications`` target (#2779).
+
+    Mirrors ``TestHousekeepingTickQueueSnapshots`` but targets the
+    ``notifications`` entry added in #2779. The cutoff column is
+    ``created_at`` and the default retention is
+    ``DEFAULT_NOTIFICATION_RETENTION_DAYS``.
+    """
+
+    def test_deletes_with_default_cutoff_and_logs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_targets_to(monkeypatch, "notifications")
+        d, conn, handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetch_queue = [None]
+
+        original_execute = conn.cursor_instance.execute
+
+        def patched_execute(sql: str, params: Any = None) -> None:
+            original_execute(sql, params)
+            if "DELETE FROM dispatcher.notifications" in sql:
+                conn.cursor_instance.rowcount = 321
+
+        conn.cursor_instance.execute = patched_execute  # type: ignore[method-assign]
+
+        result = d._housekeeping_tick()
+
+        deletes = [
+            e
+            for e in conn.cursor_instance.executed
+            if e[0].startswith("DELETE FROM dispatcher.notifications")
+        ]
+        assert len(deletes) == 1
+        sql, params = deletes[0]
+        # notifications uses the ``created_at`` column (see migration 21).
+        assert "created_at < now() - make_interval(days => %s)" in sql
+        assert params == (daemon.DEFAULT_NOTIFICATION_RETENTION_DAYS,)
+
+        ticks = handler.events("housekeeping_tick")
+        assert len(ticks) == 1
+        record = ticks[0]
+        assert record.table == "notifications"
+        assert record.rows_deleted == 321
+        assert record.cutoff_days == daemon.DEFAULT_NOTIFICATION_RETENTION_DAYS
+        assert record.run_id == "test-run-id"
+
+        assert result == {"notifications": 321}
+        assert d._housekeeping_ticks == 1
+
+    def test_uses_config_override_when_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_targets_to(monkeypatch, "notifications")
+        d, conn, handler = _make_daemon_with_capture()
+        # Operator shortens notification retention to 3 days.
+        conn.cursor_instance.fetch_queue = [(3,)]
+
+        original_execute = conn.cursor_instance.execute
+
+        def patched_execute(sql: str, params: Any = None) -> None:
+            original_execute(sql, params)
+            if "DELETE FROM dispatcher.notifications" in sql:
+                conn.cursor_instance.rowcount = 1
+
+        conn.cursor_instance.execute = patched_execute  # type: ignore[method-assign]
+
+        d._housekeeping_tick()
+
+        configs = [
+            e
+            for e in conn.cursor_instance.executed
+            if "SELECT value FROM dispatcher.config" in e[0]
+        ]
+        assert configs[0][1] == ("notification_retention_days",)
+        deletes = [
+            e
+            for e in conn.cursor_instance.executed
+            if e[0].startswith("DELETE FROM dispatcher.notifications")
+        ]
+        assert deletes[0][1] == (3,)
+        ticks = handler.events("housekeeping_tick")
+        assert ticks[0].cutoff_days == 3
+
+    def test_idempotent_second_call_logs_zero_deletes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_targets_to(monkeypatch, "notifications")
+        d, conn, handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetch_queue = [None, None]
+
+        d._housekeeping_tick()
+        d._housekeeping_tick()
+
+        ticks = handler.events("housekeeping_tick")
+        assert len(ticks) == 2
+        assert all(t.table == "notifications" for t in ticks)
+        assert all(t.rows_deleted == 0 for t in ticks)
+        deletes = [
+            e
+            for e in conn.cursor_instance.executed
+            if e[0].startswith("DELETE FROM dispatcher.notifications")
+        ]
+        assert len(deletes) == 2
+        assert all(
+            p == (daemon.DEFAULT_NOTIFICATION_RETENTION_DAYS,) for _, p in deletes
+        )
+        assert d._housekeeping_ticks == 2
+
+    def test_db_failure_logs_housekeeping_failed_and_continues(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _isolate_targets_to(monkeypatch, "notifications")
+        d, conn, handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetch_queue = [None]
+
+        original_execute = conn.cursor_instance.execute
+
+        def failing_execute(sql: str, params: Any = None) -> None:
+            if "DELETE FROM dispatcher.notifications" in sql:
+                raise RuntimeError("serialization failure")
+            original_execute(sql, params)
+
+        conn.cursor_instance.execute = failing_execute  # type: ignore[method-assign]
+
+        result = d._housekeeping_tick()
+
+        failures = handler.events("housekeeping_failed")
+        assert len(failures) == 1
+        assert failures[0].table == "notifications"
+        assert failures[0].cutoff_days == daemon.DEFAULT_NOTIFICATION_RETENTION_DAYS
+        assert "serialization failure" in failures[0].detail
+        assert handler.events("housekeeping_tick") == []
+        assert conn.rollbacks >= 1
+        assert result == {"notifications": -1}
+        assert d._housekeeping_ticks == 1
+
+
+class TestHousekeepingTickAllLiveTargets:
+    """Whole-tuple checks — the live ``_HOUSEKEEPING_TARGETS`` tuple.
+
+    These run against the production tuple (no monkeypatch) so they
+    catch regressions where someone drops a target or reorders entries.
+    """
+
+    def test_live_targets_all_prune_in_one_tick(self) -> None:
+        """Every live target runs its DELETE in a single tick.
+
+        Covers the issue #2779 acceptance criterion that
+        ``phase_outputs`` and ``notifications`` DELETEs both appear in
+        the housekeeping path alongside ``queue_snapshots``.
+        """
+        d, conn, handler = _make_daemon_with_capture()
+        # One config lookup per target returning None → each falls back
+        # to its per-target default.
+        target_count = len(daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS)
+        conn.cursor_instance.fetch_queue = [None] * target_count
+        # rowcount stays at 0 — we only care that each DELETE fires.
+
+        d._housekeeping_tick()
+
+        # One housekeeping_tick event per live target.
+        ticks = handler.events("housekeeping_tick")
+        tick_tables = {t.table for t in ticks}
+        assert tick_tables == {"queue_snapshots", "phase_outputs", "notifications"}
+
+        # One DELETE per live target, and each uses the right column.
+        deletes_by_table = {}
+        for sql, params in conn.cursor_instance.executed:
+            if sql.startswith("DELETE FROM dispatcher."):
+                # Extract table name from "DELETE FROM dispatcher.<table> ..."
+                table = sql.split("dispatcher.", 1)[1].split()[0]
+                deletes_by_table[table] = (sql, params)
+        assert set(deletes_by_table) == {
+            "queue_snapshots",
+            "phase_outputs",
+            "notifications",
+        }
+        # Per-target column assertions — matches the migration schema.
+        assert "observed_at <" in deletes_by_table["queue_snapshots"][0]
+        assert "ts <" in deletes_by_table["phase_outputs"][0]
+        assert "created_at <" in deletes_by_table["notifications"][0]
+
+    def test_per_target_failure_isolation_across_live_targets(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A DB error on ``phase_outputs`` must not starve ``notifications``.
+
+        Directly exercises the AC "Each DELETE is independently
+        try/except wrapped — one table's DB error doesn't skip the
+        others" on the new targets added in #2779.
+        """
+        d, conn, handler = _make_daemon_with_capture()
+        target_count = len(daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS)
+        conn.cursor_instance.fetch_queue = [None] * target_count
+
+        original_execute = conn.cursor_instance.execute
+
+        def failing_execute(sql: str, params: Any = None) -> None:
+            if "DELETE FROM dispatcher.phase_outputs" in sql:
+                raise RuntimeError("phase_outputs deadlock")
+            original_execute(sql, params)
+            if "DELETE FROM dispatcher.notifications" in sql:
+                conn.cursor_instance.rowcount = 9
+
+        conn.cursor_instance.execute = failing_execute  # type: ignore[method-assign]
+
+        result = d._housekeeping_tick()
+
+        # phase_outputs logged failure; queue_snapshots and notifications
+        # still logged success.
+        failures = handler.events("housekeeping_failed")
+        assert [f.table for f in failures] == ["phase_outputs"]
+
+        successes = {t.table for t in handler.events("housekeeping_tick")}
+        assert "queue_snapshots" in successes
+        assert "notifications" in successes
+        assert "phase_outputs" not in successes
+
+        # Result surfaces the -1 sentinel for the failing target and the
+        # rowcount for the siblings (which ran to completion).
+        assert result["phase_outputs"] == -1
+        assert result["notifications"] == 9
+
     def test_failure_on_one_target_does_not_stop_siblings(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Per-target failure isolation — siblings still run.
+        """Abstract-mechanism check: per-target failure isolation.
 
-        Protects issue #2779's extension path: when ``phase_outputs``
-        and ``notifications`` join the targets tuple, a ``queue_snapshots``
-        DELETE failure must not starve them of their cleanup.
+        Complements ``test_per_target_failure_isolation_across_live_targets``
+        (which uses the live tuple) by exercising the generic iteration
+        contract with synthetic targets — if a future target is added
+        and the loop ever becomes short-circuited, this test fails even
+        when the live-tuple test does not.
         """
         d, conn, handler = _make_daemon_with_capture()
 
         # Two fake targets. First one raises on DELETE; second one
         # succeeds. Both have their own config lookup returning None.
+        # Column names are synthetic — the test only cares about the
+        # loop contract, not the real schema.
         fake_targets = (
             ("queue_snapshots", "observed_at", "queue_snapshot_retention_days", 30),
             ("phase_outputs", "emitted_at", "phase_outputs_retention_days", 14),
@@ -390,7 +792,7 @@ class TestHousekeepingConfigPlumbing:
         assert cfg.tick_housekeeping_seconds == 300
 
     def test_housekeeping_targets_includes_queue_snapshots(self) -> None:
-        """The AC mandates a queue_snapshots entry with the expected defaults."""
+        """The #2778 AC mandates a queue_snapshots entry with expected defaults."""
         targets = daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS
         names = [t[0] for t in targets]
         assert "queue_snapshots" in names
@@ -398,3 +800,25 @@ class TestHousekeepingConfigPlumbing:
         assert entry[1] == "observed_at"
         assert entry[2] == "queue_snapshot_retention_days"
         assert entry[3] == daemon.DEFAULT_QUEUE_SNAPSHOT_RETENTION_DAYS
+
+    def test_housekeeping_targets_includes_phase_outputs(self) -> None:
+        """#2779 AC: phase_outputs entry uses ``ts`` and 30-day default."""
+        targets = daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS
+        names = [t[0] for t in targets]
+        assert "phase_outputs" in names
+        entry = next(t for t in targets if t[0] == "phase_outputs")
+        assert entry[1] == "ts"
+        assert entry[2] == "phase_output_retention_days"
+        assert entry[3] == daemon.DEFAULT_PHASE_OUTPUT_RETENTION_DAYS
+        assert entry[3] == 30
+
+    def test_housekeeping_targets_includes_notifications(self) -> None:
+        """#2779 AC: notifications entry uses ``created_at`` and 30-day default."""
+        targets = daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS
+        names = [t[0] for t in targets]
+        assert "notifications" in names
+        entry = next(t for t in targets if t[0] == "notifications")
+        assert entry[1] == "created_at"
+        assert entry[2] == "notification_retention_days"
+        assert entry[3] == daemon.DEFAULT_NOTIFICATION_RETENTION_DAYS
+        assert entry[3] == 30


### PR DESCRIPTION
## Summary

Extends the dispatcher daemon's `_housekeeping_tick` (added in #2778) to also prune `dispatcher.phase_outputs` and `dispatcher.notifications` rows older than 30 days. Uses the existing tuple-driven loop — just two new entries in `_HOUSEKEEPING_TARGETS` plus matching retention constants. No migration, no new infrastructure.

Closes #2779

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (26 housekeeping tests; 75 dispatcher tests total)
- [x] CI green

### Post-deploy verification
- [x] Daemon redeployed on dev with new code (verified: `version_sha=e6e558a` + task def `judgemind-dispatcher-dev:4` running)
- [ ] `housekeeping_tick` events for `table=phase_outputs` and `table=notifications` appear in CloudWatch Logs ≥1h after deploy (deferred — hourly cadence; first tick fires at ~2026-04-19T11:57Z)
- [x] Verification evidence posted on issue #2779 (https://github.com/judgemind/judgemind/issues/2779#issuecomment-4275756084)

## Notes for reviewer

- **Existing queue_snapshots tests were refactored, not rewritten.** The original `TestHousekeepingTick` class asserted single-target outcomes (`len(ticks) == 1`, `result == {"queue_snapshots": ...}`). With three targets in the tuple those assertions would have failed. I split the class into three parallel classes — one per target — each monkeypatching `_HOUSEKEEPING_TARGETS` to a single live entry via a shared `_isolate_targets_to` helper. Behavioral semantics are preserved.
- **A new whole-tuple test class (`TestHousekeepingTickAllLiveTargets`)** runs against the production tuple so regressions like "someone dropped notifications" fail loudly.
- **No config seeds.** The `_read_retention_days` helper handles missing keys via the per-target default; a migration for two seed rows is not justified.
