### PR TITLE
feat(dispatcher): 3A — claim + orchestrate plan/ralph/summary + PR (#2783)

### DIFF
--- a/packages/api/migrations/25_dispatcher-agents-claim-uniqueness.sql
+++ b/packages/api/migrations/25_dispatcher-agents-claim-uniqueness.sql
@@ -1,0 +1,35 @@
+-- Up Migration
+--
+-- Dispatcher v2 — Phase 3 sub-task A. Adds a partial UNIQUE INDEX on
+-- `dispatcher.agents.issue_number` scoped to active agents so the
+-- atomic claim-via-INSERT path in `scripts/dispatcher/daemon.py` can
+-- detect a "lost the race" outcome as a unique-constraint violation,
+-- rather than pre-checking existence + inserting (which is not atomic
+-- under concurrent daemons).
+--
+-- Issue #2783 (Parent: #2782, Phase 3 epic).
+--
+-- Design notes
+-- ------------
+-- - Partial index on `status IN ('running', 'retrying')` — those are
+--   the two statuses the spec (§6, §8) marks as "agent currently
+--   attached to this issue". `succeeded`, `failed`, and `crashed`
+--   rows do NOT block a fresh re-claim: a failed agent may be retried
+--   manually by the operator, and a succeeded agent is ancient history.
+-- - Intentionally NOT adding `agent/ready` trust-check into the index —
+--   the trust check is a daemon-side gate (runs before the INSERT) and
+--   belongs in Python, not SQL.
+-- - The existing `idx_dispatcher_agents_running` (status='running')
+--   index remains — it's a scheduler read path, not a uniqueness
+--   enforcer. Keeping both is cheap (few rows, narrow partial indexes).
+
+CREATE UNIQUE INDEX idx_dispatcher_agents_active_issue
+    ON dispatcher.agents (issue_number)
+    WHERE status IN ('running', 'retrying');
+
+COMMENT ON INDEX dispatcher.idx_dispatcher_agents_active_issue IS
+    'Atomic-claim uniqueness: at most one active (running/retrying) agent per issue. INSERT conflicts on this index mean another daemon claimed first.';
+
+
+-- Down Migration
+DROP INDEX IF EXISTS dispatcher.idx_dispatcher_agents_active_issue;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 24 migrations.
+-- Generated from 25 migrations.
 
 
 
@@ -1006,6 +1006,12 @@ CREATE INDEX idx_rulings_posted_at ON derived.rulings USING btree (posted_at DES
 
 
 CREATE UNIQUE INDEX uq_rulings_case_text_hash ON derived.rulings USING btree (case_id, ruling_text_hash) WHERE (ruling_text_hash IS NOT NULL);
+
+
+CREATE UNIQUE INDEX idx_dispatcher_agents_active_issue ON dispatcher.agents USING btree (issue_number) WHERE (status = ANY (ARRAY['running'::text, 'retrying'::text]));
+
+
+COMMENT ON INDEX dispatcher.idx_dispatcher_agents_active_issue IS 'Atomic-claim uniqueness: at most one active (running/retrying) agent per issue. INSERT conflicts on this index mean another daemon claimed first.';
 
 
 CREATE INDEX idx_dispatcher_agents_issue_number ON dispatcher.agents USING btree (issue_number);

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1,19 +1,29 @@
 #!/usr/bin/env python3
-"""Dispatcher v2 daemon entrypoint — Phase 2 shadow mode.
+"""Dispatcher v2 daemon entrypoint — Phase 2 shadow mode + Phase 3A wiring.
 
 Long-running process that reads ``dispatcher.*`` state, observes the
 GitHub ``agent/ready`` queue, writes snapshots to
 ``dispatcher.queue_snapshots``, and emits heartbeat metrics to
-CloudWatch. **Phase 2 shadow mode: no subprocess spawning** — the
-``concurrency_cap=0`` guard asserts the spawn path stays dormant.
+CloudWatch.
 
-Phase 3 will add the subprocess spawn (``/task-v2-*`` agents) once
-shadow-mode observations confirm the daemon is stable.
+Phase 2 ran in shadow mode (``concurrency_cap=0``) with no subprocess
+spawning. **Phase 3 sub-task A (#2783) wires the happy-path
+orchestration** — claim an ``agent/ready`` issue, create a worktree,
+spawn ``/task-v2-plan`` → ``/task-v2-ralph`` → ``/task-v2-summary`` as
+``claude -p`` subprocesses, then ``git push`` + ``gh pr create``. The
+orchestration path stays **cold** in production (``concurrency_cap`` is
+still 0 until Phase 3E flips it to 1) but the code is exercised by
+unit tests in ``scripts/dispatcher/tests/test_daemon_phase3a.py``.
 
-Spec: ``docs/specs/dispatcher-v2-spec.md`` §6 (scheduler loop), §7
-(supervisor loop), §14 (deployment), §15 (Phase 2 definition + gate),
-§17 Risk 2 (double-daemon race), §18 (schema DDL). Issue #2768 (Phase 2
-epic; builds on Phase 1 skeleton from #2729).
+Post-PR work (CI watch, fix-ci, merge, deploy watch, verify, retro,
+retry markers, diagnoser) is deliberately out of scope for 3A — those
+belong to 3B-3E.
+
+Spec: ``docs/specs/dispatcher-v2-spec.md`` §6 (scheduler loop), §6a
+(per-phase skill contracts), §7 (supervisor loop), §14 (deployment),
+§15 (Phase 2 definition + gate), §17 Risk 2 (double-daemon race),
+§17 Risk 4a (subprocess timeout), §18 (schema DDL). Issues #2768
+(Phase 2), #2783 (Phase 3A).
 
 Structured logging is JSON-per-line to stdout so CloudWatch Logs
 Insights can query it without a regex layer.
@@ -63,8 +73,10 @@ import subprocess
 import sys
 import threading
 import time
+import uuid
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover — types only
@@ -127,9 +139,57 @@ DEFAULT_AWS_REGION = "us-west-2"
 #: Phase 2 spawn-safety invariant: this value must be 0. The daemon
 #: asserts this on every scheduler tick and logs a warning if the live
 #: ``dispatcher.config.concurrency_cap`` is anything else. The actual
-#: spawn path does not exist yet (Phase 3) but the guard prevents a
-#: future Phase 3 wiring mistake from activating spawn during Phase 2.
+#: spawn path was added in Phase 3A (#2783) but remains gated on
+#: ``concurrency_cap > 0`` — until Phase 3E flips it to 1, the
+#: orchestration path stays cold in production and the Phase 2 guard
+#: continues to warn on any non-zero value.
 PHASE_2_REQUIRED_CONCURRENCY_CAP = 0
+
+#: Hard wall-clock timeout for each ``claude -p`` subprocess spawned
+#: from the orchestration path. Matches the 180-minute ceiling from
+#: spec §17 Risk 4a and the ``dispatcher.config.subprocess_timeout_s``
+#: seed value (10800s). Enforced via ``subprocess.run(..., timeout=...)``.
+CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS = 180 * 60
+
+#: Per-phase ``--max-turns`` values. Matches the frontmatter on each
+#: ``.claude/skills/task-v2-*/SKILL.md`` file. Sonnet-backed ralph gets
+#: the long tail; plan and summary stay tight.
+PHASE_MAX_TURNS = {
+    "plan": 50,
+    "ralph": 500,
+    "summary": 30,
+}
+
+#: Per-phase ``--model`` values. Matches ``dispatcher.config.model_by_phase``
+#: seeded in migration 21.
+PHASE_MODELS = {
+    "plan": "opus",
+    "ralph": "sonnet",
+    "summary": "haiku",
+}
+
+#: The three happy-path phases 3A orchestrates, in execution order.
+#: Post-PR phases (``fix_ci``, ``verify``, ``retro``) are 3B-3E scope.
+PHASE_SEQUENCE = ("plan", "ralph", "summary")
+
+#: Statuses that represent an in-flight claim. Mirrors the partial
+#: UNIQUE INDEX predicate in migration 25. Used by the candidate picker
+#: to skip already-claimed issues client-side (the INSERT also catches
+#: concurrent races via unique-violation).
+ACTIVE_AGENT_STATUSES = ("running", "retrying", "succeeded")
+
+#: Relative path under the repo root where per-agent worktrees land.
+#: Mirrors the laptop-dispatcher convention from
+#: ``.claude/skills/task/SKILL.md`` so human operators can find a
+#: daemon-created worktree with the same ``git worktree list`` command
+#: they use locally.
+WORKTREE_PARENT_DIR = Path(".claude/worktrees")
+
+#: Length of the short UUID used in worktree + branch names. 8 hex
+#: chars is ~4 billion distinct values — collision probability across
+#: the lifetime of the dispatcher is negligible and the short form
+#: keeps path lengths sane.
+AGENT_SHORT_ID_HEX_CHARS = 8
 
 
 # --------------------------------------------------------------------------
@@ -266,7 +326,7 @@ class LeaseError(RuntimeError):
 
 
 class DispatcherDaemon:
-    """Phase 2 shadow-mode dispatcher daemon.
+    """Dispatcher daemon — Phase 2 shadow mode + Phase 3A orchestration.
 
     Responsibilities:
         * Connect to Postgres via ``DATABASE_URL``.
@@ -281,7 +341,12 @@ class DispatcherDaemon:
               ``concurrency_cap != 0``);
             - scan the GitHub ``agent/ready`` queue via ``gh issue list``
               and INSERT a row into ``dispatcher.queue_snapshots``;
-            - **still does NOT spawn subprocesses** (Phase 3).
+            - **Phase 3A (#2783):** if ``concurrency_cap > 0`` AND no
+              active agent exists, claim one trusted candidate issue
+              and orchestrate ``/task-v2-plan`` → ``/task-v2-ralph`` →
+              ``/task-v2-summary`` → ``git push`` + ``gh pr create``.
+              The orchestration path stays cold in production because
+              ``concurrency_cap`` is still 0 (Phase 3E flips it).
         * Run the supervisor loop every ``tick_supervisor_seconds``:
             - UPDATE ``dispatcher.runs.heartbeat_ts``;
             - count recent ``dispatcher.failures`` rows;
@@ -301,10 +366,12 @@ class DispatcherDaemon:
         * On SIGTERM / SIGINT, UPDATE ``dispatcher.runs.stopped_at`` and
           exit 0.
 
-    What this daemon still does **NOT** do (deferred to Phase 3):
-        * Spawn ``/task-v2-*`` subprocesses.
-        * Act on the phase state machine (§6 step 5).
-        * Run the failure diagnoser (§8).
+    What this daemon still does **NOT** do (deferred to later 3.x):
+        * Post-PR flow — CI watch, fix-ci, merge, deploy watch, verify,
+          retro (3B/3E).
+        * Retry markers / backoff (3C).
+        * Diagnoser (3D).
+        * Worktree cleanup (3E).
     """
 
     def __init__(self, cfg: DaemonConfig, logger: logging.Logger):
@@ -322,6 +389,12 @@ class DispatcherDaemon:
         # ticks — boto3 clients are thread-safe and reusing one avoids
         # repeated credential lookups.
         self._cloudwatch_client: Any | None = None
+        # Phase 3A: within-tick handoff between phase helpers. Reset at
+        # the start of each orchestration run so a previous failure's
+        # partial state cannot leak into the next attempt.
+        self._agent_plan_output: dict[str, Any] | None = None
+        self._agent_ralph_output: dict[str, Any] | None = None
+        self._agent_summary_output: dict[str, Any] | None = None
 
     # ── lifecycle ──────────────────────────────────────────────────────
 
@@ -512,6 +585,39 @@ class DispatcherDaemon:
         # and the next tick will try again (§15).
         queue_depth = self._scan_queue_and_snapshot()
 
+        # 4. Phase 3A orchestration gate (#2783).
+        #
+        # Only enter the claim + orchestrate path when (a) the live
+        # ``concurrency_cap`` is >0 AND (b) no agent is currently in
+        # flight for this daemon run. Phase 3 runs at ``concurrency_cap=1``
+        # (one subprocess at a time); Phase 3E flips the value from 0 to
+        # 1. Until then the gate stays closed and this branch is a no-op.
+        #
+        # Exceptions here are caught + logged but not re-raised — the
+        # scheduler tick must survive any orchestration failure so the
+        # next tick can try again. Orchestration work itself is wrapped
+        # in per-phase error handling inside ``_claim_and_orchestrate_one``.
+        orchestration_attempted = False
+        if (
+            concurrency_cap is not None
+            and concurrency_cap > 0
+            and not self._has_active_agent()
+        ):
+            orchestration_attempted = True
+            try:
+                self._claim_and_orchestrate_one()
+            except Exception:
+                # Daemon survival takes precedence over any single
+                # orchestration run. The helper logs specific failures
+                # internally; this is the belt-and-braces catch.
+                self._log.exception(
+                    "daemon.orchestration_failed",
+                    extra={
+                        "event": "orchestration_failed",
+                        "run_id": self._run_id,
+                    },
+                )
+
         self._scheduler_ticks += 1
         self._log.info(
             "daemon.scheduler_tick",
@@ -522,12 +628,14 @@ class DispatcherDaemon:
                 "commands_consumed": commands_consumed,
                 "concurrency_cap": concurrency_cap,
                 "queue_depth": queue_depth,
+                "orchestration_attempted": orchestration_attempted,
             },
         )
         return {
             "commands_consumed": commands_consumed,
             "concurrency_cap": -1 if concurrency_cap is None else concurrency_cap,
             "queue_depth": queue_depth,
+            "orchestration_attempted": 1 if orchestration_attempted else 0,
         }
 
     # ── queue scan (scheduler-tick step 3) ─────────────────────────────
@@ -685,6 +793,1455 @@ class DispatcherDaemon:
             },
         )
         return queue_depth
+
+    # ── Phase 3A orchestration (scheduler-tick step 4) ──────────────────
+    #
+    # The happy-path orchestration flow (issue #2783):
+    #
+    #   1. Pick a trusted, never-attempted candidate issue from the most
+    #      recent ``dispatcher.queue_snapshots`` row.
+    #   2. Atomic claim via INSERT on ``dispatcher.agents`` — the
+    #      partial UNIQUE INDEX (migration 25) catches races.
+    #   3. Create a per-agent worktree at ``.claude/worktrees/agent-<id>``.
+    #   4. Fetch the issue bundle from GitHub (body + comments +
+    #      blocked_by) and write ``plan.json`` input.
+    #   5. Spawn ``claude -p '/task-v2-plan <agent_id>'``. Parse output;
+    #      write to ``dispatcher.phase_outputs`` + ``phase_transitions``.
+    #   6. Branch on ``plan.go`` — ``false`` ends the agent as
+    #      ``succeeded`` or ``failed`` depending on ``block_reason``.
+    #   7. Write ``ralph.json`` input; spawn ralph; parse output.
+    #      BLOCKED verdict ends as ``failed``.
+    #   8. Write ``summary.json`` input; spawn summary; parse output.
+    #   9. ``git add -A``, ``git commit``, ``git push`` on the
+    #      per-agent branch.
+    #  10. ``gh pr create`` with the summary-generated title + body;
+    #      capture PR number into ``dispatcher.agents.pr_number``.
+    #  11. Leave ``agents.status='running'``, ``phase='awaiting_ci'`` so
+    #      Phase 3B knows where to pick up. (3B: CI watch + fix-ci +
+    #      merge. 3C: retry markers. 3D: diagnoser. 3E: retro +
+    #      cleanup + cap flip.)
+    #
+    # Subprocess model: in-container ``claude -p`` (spike 0.1). One at
+    # a time per daemon (``concurrency_cap=1`` is the Phase 3
+    # production value). Stdout+stderr captured to
+    # ``{worktree}/tmp/claude-p-<phase>.log``.
+
+    def _has_active_agent(self) -> bool:
+        """Return True when an agent row is already ``running`` for this run.
+
+        Phase 3 concurrency cap is 1 per daemon: no new claim while any
+        existing agent is still in flight. Uses the
+        ``idx_dispatcher_agents_running`` partial index.
+        """
+        assert self._conn is not None, "connect() must run before checking"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM dispatcher.agents WHERE status = 'running' LIMIT 1",
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.has_active_agent_failed",
+                extra={
+                    "event": "has_active_agent_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            # Fail closed — treat as "active agent" so we skip this tick
+            # rather than double-spawn on a confused DB state.
+            return True
+        return row is not None
+
+    def _latest_queue_snapshot_issues(self) -> list[int]:
+        """Return the issue numbers from the most recent queue snapshot.
+
+        The snapshot is written by ``_scan_queue_and_snapshot`` earlier
+        in the same tick, so this is almost always the list we just
+        observed. Returns an empty list if there is no snapshot yet
+        (first-tick edge case) or the read fails.
+        """
+        assert self._conn is not None, "connect() must run before reading"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT issue_numbers FROM dispatcher.queue_snapshots "
+                    "ORDER BY observed_at DESC "
+                    "LIMIT 1",
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.latest_snapshot_failed",
+                extra={
+                    "event": "latest_snapshot_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return []
+        if row is None:
+            return []
+        issues = row[0]
+        if not isinstance(issues, list):
+            return []
+        return [int(n) for n in issues if isinstance(n, int)]
+
+    def _pick_candidate_issue(self, candidates: list[int]) -> int | None:
+        """Pick the first candidate that is trusted and not already claimed.
+
+        For each issue number in ``candidates`` (priority order as
+        observed by the queue scan — the ``gh issue list`` default is
+        already priority-sorted by the GitHub API):
+
+        1. Skip if ``dispatcher.agents`` has a row for it with
+           ``status IN ('running', 'retrying', 'succeeded')``. A
+           ``failed`` or ``crashed`` row does NOT block re-claim —
+           manual retry is a documented operator flow.
+        2. Run the trust check (``scripts/check-issue-author.sh``). Skip
+           on any non-zero exit.
+
+        Returns the chosen issue number, or ``None`` if no candidate is
+        eligible.
+        """
+        for issue_number in candidates:
+            if self._issue_already_attempted(issue_number):
+                self._log.info(
+                    "daemon.candidate_skipped",
+                    extra={
+                        "event": "candidate_skipped",
+                        "run_id": self._run_id,
+                        "issue_number": issue_number,
+                        "reason": "already_attempted",
+                    },
+                )
+                continue
+            if not self._issue_author_trusted(issue_number):
+                self._log.info(
+                    "daemon.candidate_skipped",
+                    extra={
+                        "event": "candidate_skipped",
+                        "run_id": self._run_id,
+                        "issue_number": issue_number,
+                        "reason": "untrusted_author",
+                    },
+                )
+                continue
+            return issue_number
+        return None
+
+    def _issue_already_attempted(self, issue_number: int) -> bool:
+        """True if ``dispatcher.agents`` has any active/succeeded row for this issue.
+
+        The partial UNIQUE INDEX (migration 25) enforces uniqueness on
+        ``running`` and ``retrying``. The extra ``succeeded`` check
+        here is so a successful prior run (not yet cleaned up) doesn't
+        get double-processed before the PR merges.
+        """
+        assert self._conn is not None, "connect() must run before reading"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM dispatcher.agents "
+                    "WHERE issue_number = %s "
+                    "  AND status = ANY(%s) "
+                    "LIMIT 1",
+                    (issue_number, list(ACTIVE_AGENT_STATUSES)),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.issue_attempted_check_failed",
+                extra={
+                    "event": "issue_attempted_check_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            # Fail closed — pretend the issue is already attempted so
+            # we don't double-claim on a DB hiccup.
+            return True
+        return row is not None
+
+    def _issue_author_trusted(self, issue_number: int) -> bool:
+        """Run ``scripts/check-issue-author.sh`` and return True iff exit 0.
+
+        The script prints ``TRUSTED: ...`` on stdout for exit 0 and
+        ``UNTRUSTED: ...`` for exit 1. Exit 2 indicates a transient API
+        error — treat as untrusted (fail closed) and let the next tick
+        retry.
+        """
+        cmd = [
+            "scripts/check-issue-author.sh",
+            str(issue_number),
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=QUEUE_SCAN_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except FileNotFoundError:
+            self._log.warning(
+                "daemon.trust_check_missing",
+                extra={
+                    "event": "trust_check_missing",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                },
+            )
+            return False
+        except subprocess.TimeoutExpired:
+            self._log.warning(
+                "daemon.trust_check_timeout",
+                extra={
+                    "event": "trust_check_timeout",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                },
+            )
+            return False
+        if result.returncode == 0:
+            return True
+        self._log.info(
+            "daemon.trust_check_rejected",
+            extra={
+                "event": "trust_check_rejected",
+                "run_id": self._run_id,
+                "issue_number": issue_number,
+                "exit_code": result.returncode,
+                "detail": (result.stdout or result.stderr or "").strip()[:200],
+            },
+        )
+        return False
+
+    def _atomic_claim(
+        self, issue_number: int, agent_id: str, worktree_path: str
+    ) -> bool:
+        """INSERT a new agent row; return True on success, False on race.
+
+        The partial UNIQUE INDEX on
+        ``dispatcher.agents (issue_number) WHERE status IN ('running',
+        'retrying')`` (migration 25) turns a concurrent second daemon's
+        INSERT into a ``psycopg.errors.UniqueViolation``. Catching that
+        is the race-lost signal — do NOT pre-check + insert, which is
+        not atomic.
+        """
+        assert self._conn is not None, "connect() must run before claiming"
+
+        # Import lazily so tests that run without psycopg installed can
+        # still import the daemon module.
+        import psycopg  # noqa: PLC0415 — lazy import
+
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO dispatcher.agents "
+                    "    (agent_id, parent_run_id, kind, issue_number, "
+                    "     worktree_path, phase, status) "
+                    "VALUES (%s, %s, 'task', %s, %s, 'claiming', 'running')",
+                    (agent_id, self._run_id, issue_number, worktree_path),
+                )
+            self._conn.commit()
+        except psycopg.errors.UniqueViolation:
+            # Another daemon claimed this issue first. Roll back and
+            # return False so the caller skips to the next candidate.
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            self._log.info(
+                "daemon.claim_lost",
+                extra={
+                    "event": "claim_lost",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "agent_id": agent_id,
+                },
+            )
+            return False
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            self._log.exception(
+                "daemon.claim_failed",
+                extra={
+                    "event": "claim_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "agent_id": agent_id,
+                },
+            )
+            return False
+
+        self._log.info(
+            "daemon.claim_succeeded",
+            extra={
+                "event": "claim_succeeded",
+                "run_id": self._run_id,
+                "issue_number": issue_number,
+                "agent_id": agent_id,
+            },
+        )
+        return True
+
+    def _repo_root(self) -> Path:
+        """Repo root inside the dispatcher container.
+
+        The Dockerfile places the daemon code at ``/app/scripts/dispatcher/``
+        but the git working tree used for worktrees is cloned at
+        runtime into ``/app`` (via the startup hook in the Fargate task
+        definition). For unit tests the working directory is the
+        repo-root worktree. ``os.getcwd()`` returns the right thing in
+        both cases; the daemon never ``chdir``s away from it.
+        """
+        return Path(os.getcwd())
+
+    def _create_worktree(self, agent_id: str) -> Path:
+        """``git worktree add`` a fresh worktree + branch for this agent.
+
+        Returns the absolute path to the new worktree. Raises
+        :class:`RuntimeError` on subprocess failure so the caller can
+        mark the agent failed.
+        """
+        short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
+        repo_root = self._repo_root()
+        worktree_path = repo_root / WORKTREE_PARENT_DIR / f"agent-{short_id}"
+        branch = f"agent/{short_id}"
+
+        cmd = [
+            "git",
+            "-C",
+            str(repo_root),
+            "worktree",
+            "add",
+            str(worktree_path),
+            "-b",
+            branch,
+            "origin/main",
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"git CLI not on PATH: {exc}") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError("git worktree add timed out after 60s") from exc
+
+        if result.returncode != 0:
+            stderr_preview = (result.stderr or "").strip()[:200]
+            raise RuntimeError(
+                f"git worktree add exit={result.returncode}: {stderr_preview}"
+            )
+
+        self._log.info(
+            "daemon.worktree_created",
+            extra={
+                "event": "worktree_created",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "worktree_path": str(worktree_path),
+                "branch": branch,
+            },
+        )
+        return worktree_path
+
+    def _fetch_issue_bundle(self, issue_number: int) -> dict[str, Any]:
+        """Fetch issue body, comments, labels for the plan phase input.
+
+        Returns a dict shaped like the ``/task-v2-plan`` SKILL.md input
+        contract. Raises :class:`RuntimeError` on subprocess failure.
+        """
+        cmd = [
+            "gh",
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            self._cfg.github_repo,
+            "--json",
+            "number,title,body,labels,comments",
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"gh CLI not on PATH: {exc}") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError("gh issue view timed out after 30s") from exc
+
+        if result.returncode != 0:
+            stderr_preview = (result.stderr or "").strip()[:200]
+            raise RuntimeError(
+                f"gh issue view exit={result.returncode}: {stderr_preview}"
+            )
+
+        try:
+            payload = json.loads(result.stdout or "{}")
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"gh issue view returned invalid JSON: {exc}") from exc
+
+        # Filter bot comments — the plan skill expects "non-bot authors".
+        raw_comments = payload.get("comments") or []
+        filtered_comments: list[dict[str, Any]] = []
+        for comment in raw_comments:
+            if not isinstance(comment, dict):
+                continue
+            author = comment.get("author") or {}
+            login = author.get("login", "") if isinstance(author, dict) else ""
+            if login.endswith("[bot]"):
+                continue
+            filtered_comments.append(
+                {
+                    "author": login,
+                    "author_association": comment.get("authorAssociation", ""),
+                    "date": comment.get("createdAt", ""),
+                    "body": comment.get("body", ""),
+                }
+            )
+
+        labels = [
+            entry.get("name", "")
+            for entry in (payload.get("labels") or [])
+            if isinstance(entry, dict)
+        ]
+
+        blocked_by = self._parse_blocked_by(payload.get("body") or "")
+        parent_issue = self._parse_parent_issue(payload.get("body") or "")
+
+        return {
+            "issue_number": issue_number,
+            "issue_title": payload.get("title", ""),
+            "issue_body": payload.get("body", ""),
+            "issue_comments": filtered_comments,
+            "issue_labels": labels,
+            "blocked_by": blocked_by,
+            "parent_issue": parent_issue,
+        }
+
+    @staticmethod
+    def _parse_blocked_by(body: str) -> list[int]:
+        """Extract ``Blocked by #N`` references from an issue body.
+
+        Matches the same convention ``scripts/unblock-dependents.sh``
+        uses: one or more ``Blocked by #N`` lines, case-insensitive,
+        anywhere in the body.
+        """
+        import re  # noqa: PLC0415 — lazy import
+
+        matches = re.findall(r"(?im)^\s*blocked by\s+#(\d+)\s*$", body)
+        return [int(m) for m in matches]
+
+    @staticmethod
+    def _parse_parent_issue(body: str) -> int | None:
+        """Extract the first ``Parent: #N`` reference, or None."""
+        import re  # noqa: PLC0415
+
+        match = re.search(r"(?im)^\s*parent\s*:\s*#(\d+)\s*$", body)
+        return int(match.group(1)) if match else None
+
+    def _write_phase_input(
+        self,
+        worktree: Path,
+        phase: str,
+        payload: dict[str, Any],
+    ) -> Path:
+        """Write ``{worktree}/tmp/dispatcher-input/<phase>.json``.
+
+        Creates parent dirs. Returns the absolute path for logging.
+        """
+        input_dir = worktree / "tmp" / "dispatcher-input"
+        input_dir.mkdir(parents=True, exist_ok=True)
+        input_path = input_dir / f"{phase}.json"
+        input_path.write_text(json.dumps(payload, indent=2, default=str))
+        return input_path
+
+    def _read_phase_output(self, worktree: Path, phase: str) -> dict[str, Any] | None:
+        """Read ``{worktree}/tmp/dispatcher-output/<phase>.json``.
+
+        Returns the parsed JSON, or ``None`` if the file is missing /
+        malformed (the caller treats that as a phase failure).
+        """
+        output_path = worktree / "tmp" / "dispatcher-output" / f"{phase}.json"
+        if not output_path.exists():
+            return None
+        try:
+            return json.loads(output_path.read_text())
+        except json.JSONDecodeError:
+            return None
+
+    def _persist_phase_output(
+        self, agent_id: str, phase: str, output_json: dict[str, Any]
+    ) -> None:
+        """INSERT the phase's output into ``dispatcher.phase_outputs``
+        and append a row to ``dispatcher.phase_transitions``.
+
+        Both tables share a single transaction so the observed state
+        stays consistent under partial failure.
+        """
+        assert self._conn is not None, "connect() must run before persisting"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO dispatcher.phase_outputs "
+                    "    (agent_id, phase, output_json) "
+                    "VALUES (%s, %s, %s)",
+                    (agent_id, phase, json.dumps(output_json, default=str)),
+                )
+                cur.execute(
+                    "INSERT INTO dispatcher.phase_transitions "
+                    "    (agent_id, phase) "
+                    "VALUES (%s, %s)",
+                    (agent_id, phase),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.persist_phase_output_failed",
+                extra={
+                    "event": "persist_phase_output_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": phase,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+
+    def _update_agent_phase(self, agent_id: str, phase: str) -> None:
+        """UPDATE ``dispatcher.agents.phase`` so the scheduler + admin
+        page see where the agent currently sits."""
+        assert self._conn is not None, "connect() must run before update"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.agents SET phase = %s WHERE agent_id = %s",
+                    (phase, agent_id),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.update_agent_phase_failed",
+                extra={
+                    "event": "update_agent_phase_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": phase,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+
+    def _mark_agent_terminal(
+        self,
+        agent_id: str,
+        status: str,
+        phase: str,
+        exit_code: int | None = None,
+        pr_number: int | None = None,
+    ) -> None:
+        """UPDATE ``dispatcher.agents`` with terminal status + metadata.
+
+        Used for ``succeeded``, ``failed``, and the Phase 3A post-PR
+        hand-off state (``status='running'``, ``phase='awaiting_ci'``).
+        For terminal statuses (``succeeded`` / ``failed``) also sets
+        ``ended_at`` so the admin page can compute duration.
+        """
+        assert self._conn is not None, "connect() must run before update"
+        terminal = status in ("succeeded", "failed")
+        try:
+            with self._conn.cursor() as cur:
+                if terminal:
+                    cur.execute(
+                        "UPDATE dispatcher.agents "
+                        "SET status = %s, phase = %s, ended_at = now(), "
+                        "    exit_code = %s, pr_number = COALESCE(%s, pr_number) "
+                        "WHERE agent_id = %s",
+                        (status, phase, exit_code, pr_number, agent_id),
+                    )
+                else:
+                    cur.execute(
+                        "UPDATE dispatcher.agents "
+                        "SET status = %s, phase = %s, "
+                        "    pr_number = COALESCE(%s, pr_number) "
+                        "WHERE agent_id = %s",
+                        (status, phase, pr_number, agent_id),
+                    )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.mark_agent_failed",
+                extra={
+                    "event": "mark_agent_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "status": status,
+                    "phase": phase,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+
+    def _spawn_phase_subprocess(
+        self, phase: str, worktree: Path, agent_id: str
+    ) -> tuple[int, float]:
+        """Run ``claude -p '/task-v2-<phase> <agent_id>'`` synchronously.
+
+        Captures stdout + stderr to ``{worktree}/tmp/claude-p-<phase>.log``.
+        Returns ``(exit_code, duration_seconds)``. Raises
+        :class:`subprocess.TimeoutExpired` on wall-clock timeout so the
+        caller can mark the agent failed. Other subprocess errors bubble
+        up as their native exception types.
+        """
+        max_turns = PHASE_MAX_TURNS[phase]
+        model = PHASE_MODELS[phase]
+        log_path = worktree / "tmp" / f"claude-p-{phase}.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            "claude",
+            "-p",
+            f"/task-v2-{phase} {agent_id}",
+            "--cwd",
+            str(worktree),
+            "--max-turns",
+            str(max_turns),
+            "--model",
+            model,
+        ]
+
+        start = time.monotonic()
+        self._log.info(
+            "daemon.phase_started",
+            extra={
+                "event": "phase_started",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "phase": phase,
+                "model": model,
+                "max_turns": max_turns,
+            },
+        )
+
+        with log_path.open("w", encoding="utf-8") as log_file:
+            result = subprocess.run(
+                cmd,
+                stdout=log_file,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        duration = time.monotonic() - start
+        return result.returncode, duration
+
+    def _claim_and_orchestrate_one(self) -> None:
+        """Claim one issue and run the plan → ralph → summary → PR flow.
+
+        The public entry point for Phase 3A. Called by the scheduler
+        tick when ``concurrency_cap > 0`` AND no agent is in flight.
+        All branching lives here so the tick stays flat.
+        """
+        # Reset within-tick handoff so a prior run's partial state
+        # cannot leak into the next attempt (defense-in-depth; the
+        # scheduler only enters this path when no agent is active).
+        self._agent_plan_output = None
+        self._agent_ralph_output = None
+        self._agent_summary_output = None
+
+        candidates = self._latest_queue_snapshot_issues()
+        if not candidates:
+            # No snapshot yet (first tick) or snapshot was empty.
+            return
+
+        issue_number = self._pick_candidate_issue(candidates)
+        if issue_number is None:
+            return
+
+        agent_id = str(uuid.uuid4())
+        short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
+        repo_root = self._repo_root()
+        worktree_path = repo_root / WORKTREE_PARENT_DIR / f"agent-{short_id}"
+
+        self._log.info(
+            "daemon.candidate_picked",
+            extra={
+                "event": "candidate_picked",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+            },
+        )
+
+        if not self._atomic_claim(issue_number, agent_id, str(worktree_path)):
+            # Race lost. Don't try the next candidate on this tick —
+            # the next tick will re-scan the queue.
+            return
+
+        # From here on, any failure must move the agent to status=failed
+        # so operators don't see an endlessly-"running" ghost row.
+        try:
+            worktree = self._create_worktree(agent_id)
+        except RuntimeError as exc:
+            self._log.warning(
+                "daemon.worktree_create_failed",
+                extra={
+                    "event": "worktree_create_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "detail": str(exc),
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="claim", exit_code=None
+            )
+            return
+
+        # Run the three phases in sequence.
+        ok = self._run_plan_phase(agent_id, issue_number, worktree)
+        if not ok:
+            return
+        ok = self._run_ralph_phase(agent_id, issue_number, worktree)
+        if not ok:
+            return
+        ok = self._run_summary_phase(agent_id, issue_number, worktree)
+        if not ok:
+            return
+
+        # Daemon-side git commit + push + PR create.
+        self._push_and_open_pr(agent_id, issue_number, worktree)
+
+    def _run_plan_phase(self, agent_id: str, issue_number: int, worktree: Path) -> bool:
+        """Run ``/task-v2-plan``. Returns True to continue, False to stop."""
+        self._update_agent_phase(agent_id, "planning")
+
+        try:
+            bundle = self._fetch_issue_bundle(issue_number)
+        except RuntimeError as exc:
+            self._log.warning(
+                "daemon.issue_fetch_failed",
+                extra={
+                    "event": "issue_fetch_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "detail": str(exc),
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="planning", exit_code=None
+            )
+            return False
+
+        plan_input = {
+            "agent_id": agent_id,
+            "worktree_path": str(worktree),
+            "repo_root": str(worktree),
+            **bundle,
+        }
+        self._write_phase_input(worktree, "plan", plan_input)
+
+        exit_code = self._run_subprocess_or_fail(agent_id, "plan", worktree)
+        if exit_code is None:
+            return False
+
+        plan_output = self._read_phase_output(worktree, "plan")
+        if plan_output is None:
+            self._log.warning(
+                "daemon.phase_output_missing",
+                extra={
+                    "event": "phase_output_missing",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": "plan",
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="planning", exit_code=exit_code
+            )
+            return False
+
+        self._persist_phase_output(agent_id, "plan", plan_output)
+        self._log.info(
+            "daemon.phase_succeeded",
+            extra={
+                "event": "phase_succeeded",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "phase": "plan",
+                "exit_code": exit_code,
+                "go": plan_output.get("go"),
+            },
+        )
+
+        # Branch on plan.go — false ends orchestration.
+        if not plan_output.get("go"):
+            reason = plan_output.get("block_reason") or ""
+            # A missing block_reason means "no work needed" —
+            # succeed. A populated block_reason indicates a hard
+            # problem — fail so operators see it.
+            status = "failed" if reason else "succeeded"
+            self._log.info(
+                "daemon.plan_go_false",
+                extra={
+                    "event": "plan_go_false",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "block_reason": reason,
+                    "terminal_status": status,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status=status, phase="planning", exit_code=exit_code
+            )
+            return False
+
+        # Stash plan output on the agent for ralph + summary to reuse.
+        self._agent_plan_output = plan_output
+        return True
+
+    def _run_ralph_phase(
+        self, agent_id: str, issue_number: int, worktree: Path
+    ) -> bool:
+        """Run ``/task-v2-ralph``. Returns True to continue, False to stop."""
+        self._update_agent_phase(agent_id, "ralph")
+
+        plan_output = self._agent_plan_output or {}
+        ralph_input = {
+            "agent_id": agent_id,
+            "issue_number": issue_number,
+            "plan": plan_output,
+            "worktree_path": str(worktree),
+            "repo_root": str(worktree),
+            "max_iterations": 5,
+            "dependencies_installed": plan_output.get("dependencies_to_install", []),
+        }
+        self._write_phase_input(worktree, "ralph", ralph_input)
+
+        exit_code = self._run_subprocess_or_fail(agent_id, "ralph", worktree)
+        if exit_code is None:
+            return False
+
+        ralph_output = self._read_phase_output(worktree, "ralph")
+        if ralph_output is None:
+            self._log.warning(
+                "daemon.phase_output_missing",
+                extra={
+                    "event": "phase_output_missing",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": "ralph",
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="ralph", exit_code=exit_code
+            )
+            return False
+
+        self._persist_phase_output(agent_id, "ralph", ralph_output)
+        verdict = ralph_output.get("verdict", "")
+        self._log.info(
+            "daemon.phase_succeeded",
+            extra={
+                "event": "phase_succeeded",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "phase": "ralph",
+                "exit_code": exit_code,
+                "verdict": verdict,
+                "iterations_used": ralph_output.get("iterations_used"),
+            },
+        )
+
+        if verdict != "SHIP":
+            self._log.info(
+                "daemon.ralph_not_ship",
+                extra={
+                    "event": "ralph_not_ship",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "verdict": verdict,
+                    "block_reason": ralph_output.get("block_reason"),
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="ralph", exit_code=exit_code
+            )
+            return False
+
+        self._agent_ralph_output = ralph_output
+        return True
+
+    def _run_summary_phase(
+        self, agent_id: str, issue_number: int, worktree: Path
+    ) -> bool:
+        """Run ``/task-v2-summary``. Returns True to continue, False to stop."""
+        self._update_agent_phase(agent_id, "summary")
+
+        # Capture the git diff from the ralph-produced worktree for the
+        # summary phase to map back to AC. The diff is against
+        # ``origin/main`` since the agent branch was just created from
+        # it in ``_create_worktree``.
+        try:
+            diff_result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(worktree),
+                    "diff",
+                    "origin/main...HEAD",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+            git_diff = diff_result.stdout if diff_result.returncode == 0 else ""
+        except Exception:  # pragma: no cover — defensive; not asserted in unit tests
+            git_diff = ""
+
+        ralph_output = self._agent_ralph_output or {}
+        changed_files = ralph_output.get("changed_files", []) or []
+        # Fall back to a git-state read if ralph didn't populate
+        # changed_files (non-testable short-circuit path).
+        if not changed_files:
+            try:
+                status_result = subprocess.run(
+                    [
+                        "git",
+                        "-C",
+                        str(worktree),
+                        "diff",
+                        "--name-only",
+                        "HEAD",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    check=False,
+                )
+                if status_result.returncode == 0:
+                    changed_files = [
+                        ln.strip()
+                        for ln in (status_result.stdout or "").splitlines()
+                        if ln.strip()
+                    ]
+            except Exception:  # pragma: no cover
+                pass
+
+        # Refetch issue body so a mid-flight edit is reflected in the
+        # summary's AC mapping. Best-effort — fall back to empty on
+        # failure, the summary skill tolerates it.
+        try:
+            bundle = self._fetch_issue_bundle(issue_number)
+        except RuntimeError:
+            bundle = {
+                "issue_number": issue_number,
+                "issue_title": "",
+                "issue_body": "",
+                "issue_comments": [],
+                "issue_labels": [],
+                "blocked_by": [],
+                "parent_issue": None,
+            }
+
+        plan_output = self._agent_plan_output or {}
+        # Branch name matches ``_create_worktree``'s naming convention.
+        short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
+        branch = f"agent/{short_id}"
+
+        summary_input = {
+            "agent_id": agent_id,
+            "issue_number": issue_number,
+            "issue_title": bundle.get("issue_title", ""),
+            "issue_body": bundle.get("issue_body", ""),
+            "issue_comments": bundle.get("issue_comments", []),
+            "ralph_summary": ralph_output.get("summary", ""),
+            "changed_files": changed_files,
+            "git_diff": git_diff,
+            "worktree_path": str(worktree),
+            "repo_root": str(worktree),
+            "branch": branch,
+            "plan_acceptance_criteria": plan_output.get("acceptance_criteria", []),
+            "scope_check": plan_output.get("scope_check", []),
+        }
+        self._write_phase_input(worktree, "summary", summary_input)
+
+        exit_code = self._run_subprocess_or_fail(agent_id, "summary", worktree)
+        if exit_code is None:
+            return False
+
+        summary_output = self._read_phase_output(worktree, "summary")
+        if summary_output is None:
+            self._log.warning(
+                "daemon.phase_output_missing",
+                extra={
+                    "event": "phase_output_missing",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": "summary",
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="summary", exit_code=exit_code
+            )
+            return False
+
+        self._persist_phase_output(agent_id, "summary", summary_output)
+        self._log.info(
+            "daemon.phase_succeeded",
+            extra={
+                "event": "phase_succeeded",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "phase": "summary",
+                "exit_code": exit_code,
+            },
+        )
+
+        unmet = summary_output.get("unmet_criteria") or []
+        if unmet:
+            self._log.info(
+                "daemon.summary_unmet_criteria",
+                extra={
+                    "event": "summary_unmet_criteria",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "unmet_criteria": unmet,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="summary", exit_code=exit_code
+            )
+            return False
+
+        self._agent_summary_output = summary_output
+        return True
+
+    def _run_subprocess_or_fail(
+        self, agent_id: str, phase: str, worktree: Path
+    ) -> int | None:
+        """Run ``claude -p <phase>`` and log the outcome.
+
+        Returns the exit code on clean subprocess exit (even a non-zero
+        one — per-phase skills always exit 0 on structured-output errors
+        so any non-zero code is an infrastructure failure). Returns
+        ``None`` on subprocess timeout or other non-exit-code failure
+        modes, AND marks the agent failed.
+        """
+        try:
+            exit_code, duration = self._spawn_phase_subprocess(
+                phase, worktree, agent_id
+            )
+        except subprocess.TimeoutExpired:
+            self._log.warning(
+                "daemon.subprocess_failed",
+                extra={
+                    "event": "subprocess_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": phase,
+                    "reason": "timeout",
+                    "timeout_seconds": CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id,
+                status="failed",
+                phase=phase,
+                exit_code=None,
+            )
+            return None
+        except FileNotFoundError:
+            self._log.error(
+                "daemon.subprocess_failed",
+                extra={
+                    "event": "subprocess_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": phase,
+                    "reason": "claude_not_on_path",
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase=phase, exit_code=None
+            )
+            return None
+        except Exception as exc:  # pragma: no cover — defensive catch
+            self._log.exception(
+                "daemon.subprocess_failed",
+                extra={
+                    "event": "subprocess_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": phase,
+                    "reason": "unhandled",
+                    "detail": str(exc),
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase=phase, exit_code=None
+            )
+            return None
+
+        if exit_code != 0:
+            # Per-phase skills always exit 0 — a non-zero code is an
+            # infra failure (claude-p crash, OOM, harness error). Tail
+            # the log for forensic context but don't include verbatim
+            # in the structured log (may contain secrets).
+            tail = self._log_tail(worktree, phase, max_chars=500)
+            self._log.warning(
+                "daemon.subprocess_failed",
+                extra={
+                    "event": "subprocess_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": phase,
+                    "exit_code": exit_code,
+                    "duration_s": round(duration, 2),
+                    "stderr_tail": tail,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase=phase, exit_code=exit_code
+            )
+            return None
+
+        self._log.info(
+            "daemon.phase_exited",
+            extra={
+                "event": "phase_exited",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "phase": phase,
+                "exit_code": exit_code,
+                "duration_s": round(duration, 2),
+            },
+        )
+        return exit_code
+
+    def _log_tail(self, worktree: Path, phase: str, max_chars: int = 500) -> str:
+        """Return the last ``max_chars`` of the phase log, or an empty string."""
+        log_path = worktree / "tmp" / f"claude-p-{phase}.log"
+        if not log_path.exists():
+            return ""
+        try:
+            data = log_path.read_text(errors="replace")
+        except Exception:  # pragma: no cover
+            return ""
+        if len(data) <= max_chars:
+            return data
+        return data[-max_chars:]
+
+    def _push_and_open_pr(
+        self, agent_id: str, issue_number: int, worktree: Path
+    ) -> None:
+        """Run the final mechanical steps: commit, push, open PR.
+
+        On failure at any step, the agent is marked ``failed``. On
+        success, ``phase='awaiting_ci'`` so Phase 3B knows where to
+        pick up, and ``status`` stays ``running``.
+        """
+        self._update_agent_phase(agent_id, "push_and_pr")
+
+        summary_output = self._agent_summary_output or {}
+        commit_message = summary_output.get("commit_message") or ""
+        pr_title = summary_output.get("pr_title") or ""
+        pr_body_md = summary_output.get("pr_body_md") or ""
+
+        if not commit_message or not pr_title or not pr_body_md:
+            self._log.warning(
+                "daemon.summary_output_incomplete",
+                extra={
+                    "event": "summary_output_incomplete",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "has_commit": bool(commit_message),
+                    "has_pr_title": bool(pr_title),
+                    "has_pr_body": bool(pr_body_md),
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="push_and_pr", exit_code=None
+            )
+            return
+
+        # git add -A
+        try:
+            add_result = subprocess.run(
+                ["git", "-C", str(worktree), "add", "-A"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except Exception as exc:
+            self._log.exception(
+                "daemon.git_add_failed",
+                extra={
+                    "event": "git_add_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "detail": str(exc),
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="push_and_pr", exit_code=None
+            )
+            return
+        if add_result.returncode != 0:
+            self._log.warning(
+                "daemon.git_add_failed",
+                extra={
+                    "event": "git_add_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "exit_code": add_result.returncode,
+                    "stderr_tail": (add_result.stderr or "")[:200],
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="push_and_pr", exit_code=None
+            )
+            return
+
+        # git commit -F <file>. Write the message to a file in the
+        # worktree's tmp/ so we don't rely on shell quoting.
+        commit_msg_path = worktree / "tmp" / "commit_msg.txt"
+        commit_msg_path.parent.mkdir(parents=True, exist_ok=True)
+        commit_msg_path.write_text(commit_message)
+
+        try:
+            commit_result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(worktree),
+                    "commit",
+                    "-F",
+                    str(commit_msg_path),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except Exception as exc:
+            self._log.exception(
+                "daemon.git_commit_failed",
+                extra={
+                    "event": "git_commit_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "detail": str(exc),
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="push_and_pr", exit_code=None
+            )
+            return
+        if commit_result.returncode != 0:
+            self._log.warning(
+                "daemon.git_commit_failed",
+                extra={
+                    "event": "git_commit_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "exit_code": commit_result.returncode,
+                    "stderr_tail": (commit_result.stderr or "")[:200],
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="push_and_pr", exit_code=None
+            )
+            return
+
+        # git push -u origin <branch>
+        short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
+        branch = f"agent/{short_id}"
+        try:
+            push_result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(worktree),
+                    "push",
+                    "-u",
+                    "origin",
+                    branch,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=120,
+                check=False,
+            )
+        except Exception as exc:
+            self._log.exception(
+                "daemon.git_push_failed",
+                extra={
+                    "event": "git_push_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "detail": str(exc),
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="push_and_pr", exit_code=None
+            )
+            return
+        if push_result.returncode != 0:
+            self._log.warning(
+                "daemon.git_push_failed",
+                extra={
+                    "event": "git_push_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "exit_code": push_result.returncode,
+                    "stderr_tail": (push_result.stderr or "")[:200],
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="push_and_pr", exit_code=None
+            )
+            return
+
+        # gh pr create with --body-file pointing to a scratch file in
+        # the worktree's tmp/.
+        pr_body_path = worktree / "tmp" / "pr_body.md"
+        pr_body_path.write_text(pr_body_md)
+        try:
+            pr_result = subprocess.run(
+                [
+                    "gh",
+                    "pr",
+                    "create",
+                    "--repo",
+                    self._cfg.github_repo,
+                    "--title",
+                    pr_title,
+                    "--body-file",
+                    str(pr_body_path),
+                    "--base",
+                    "main",
+                    "--head",
+                    branch,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=120,
+                check=False,
+            )
+        except Exception as exc:
+            self._log.exception(
+                "daemon.pr_create_failed",
+                extra={
+                    "event": "pr_create_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "detail": str(exc),
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="push_and_pr", exit_code=None
+            )
+            return
+        if pr_result.returncode != 0:
+            self._log.warning(
+                "daemon.pr_create_failed",
+                extra={
+                    "event": "pr_create_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "exit_code": pr_result.returncode,
+                    "stderr_tail": (pr_result.stderr or "")[:200],
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="push_and_pr", exit_code=None
+            )
+            return
+
+        pr_number = self._parse_pr_number(pr_result.stdout or "")
+        pr_url = (
+            (pr_result.stdout or "").strip().splitlines()[-1]
+            if pr_result.stdout
+            else ""
+        )
+        self._log.info(
+            "daemon.pr_opened",
+            extra={
+                "event": "pr_opened",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "pr_number": pr_number,
+                "pr_url": pr_url,
+            },
+        )
+
+        # Final state: keep status=running so Phase 3B picks it up.
+        self._mark_agent_terminal(
+            agent_id,
+            status="running",
+            phase="awaiting_ci",
+            exit_code=None,
+            pr_number=pr_number,
+        )
+
+    @staticmethod
+    def _parse_pr_number(gh_output: str) -> int | None:
+        """Extract the PR number from ``gh pr create`` stdout.
+
+        ``gh pr create`` prints the full PR URL on the last
+        non-empty line, e.g.
+        ``https://github.com/judgemind/judgemind/pull/1234``. Returns
+        the integer PR number, or ``None`` if the URL isn't parseable.
+        """
+        import re  # noqa: PLC0415
+
+        for line in reversed((gh_output or "").splitlines()):
+            line = line.strip()
+            if not line:
+                continue
+            match = re.search(r"/pull/(\d+)", line)
+            if match:
+                return int(match.group(1))
+        return None
 
     # ── supervisor tick (every ``tick_supervisor_seconds``) ─────────────
 

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -1,0 +1,1294 @@
+"""Unit tests for the Phase 3A orchestration path in ``scripts.dispatcher.daemon``.
+
+Issue #2783. Covers the seven behaviors the issue's acceptance criteria
+call out:
+
+* ``_claim_and_orchestrate_one`` picks the highest-priority trusted
+  candidate from the latest ``queue_snapshots`` row.
+* Atomic claim via INSERT catches ``psycopg.errors.UniqueViolation``
+  as the "lost the race" signal.
+* Per-agent worktree created at ``.claude/worktrees/agent-<short-uuid>``
+  from ``origin/main`` (subprocess mocked).
+* ``/task-v2-{plan,ralph,summary}`` invoked sequentially via
+  ``claude -p`` subprocess (subprocess mocked). Phase output JSON
+  written to ``dispatcher.phase_outputs`` after each;
+  ``dispatcher.phase_transitions`` row per phase change.
+* On all-phases-success, daemon pushes + creates PR via ``gh pr
+  create`` (subprocess mocked); PR number recorded in
+  ``dispatcher.agents.pr_number``.
+* Phase failures (subprocess non-zero exit, ralph BLOCKED, plan
+  go=false with block_reason) set ``agents.status='failed'`` and stop
+  orchestration without crashing the daemon.
+* Concurrency cap honored: if ``concurrency_cap=0``, no claims
+  attempted (Phase 2 behavior preserved).
+
+All external calls — subprocess (``claude -p``, ``gh``, ``git``,
+``scripts/check-issue-author.sh``) and psycopg — are mocked. The
+orchestration path does not exercise ``claude`` or ``gh`` binaries on
+the test runner.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+import uuid as uuid_mod
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Provide a stub ``psycopg`` module before importing the daemon. The
+# daemon's ``_atomic_claim`` catches ``psycopg.errors.UniqueViolation``,
+# so that class must be a real Exception subclass. Other tests install
+# a pure ``MagicMock()`` stub (see test_daemon_phase2.py) whose
+# ``errors.UniqueViolation`` is itself a Mock — that trips Python's
+# "catching classes that do not inherit from BaseException" rule when
+# the daemon's ``except psycopg.errors.UniqueViolation`` clause runs.
+# Always overwrite the stub here so our exception class is installed
+# regardless of test-collection order.
+
+
+class _UniqueViolation(Exception):
+    """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+
+_psycopg_stub = MagicMock()
+_psycopg_errors = MagicMock()
+_psycopg_errors.UniqueViolation = _UniqueViolation
+_psycopg_stub.errors = _psycopg_errors
+sys.modules["psycopg"] = _psycopg_stub
+
+import psycopg  # noqa: E402  — re-import after stub install
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.phase3a.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# Gate in scheduler_tick: orchestration only runs when cap>0 and no agent
+# --------------------------------------------------------------------------
+
+
+class TestSchedulerGate:
+    """``_claim_and_orchestrate_one`` runs only when the gate allows."""
+
+    def test_does_not_claim_when_concurrency_cap_zero(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._claim_and_orchestrate_one = MagicMock(  # type: ignore[method-assign]
+            side_effect=AssertionError("must not be called with cap=0")
+        )
+        summary = d.scheduler_tick()
+        assert summary["orchestration_attempted"] == 0
+        assert d._claim_and_orchestrate_one.call_count == 0  # type: ignore[attr-defined]
+
+    def test_does_not_claim_when_concurrency_cap_missing(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._claim_and_orchestrate_one = MagicMock()  # type: ignore[method-assign]
+        d.scheduler_tick()
+        assert d._claim_and_orchestrate_one.call_count == 0  # type: ignore[attr-defined]
+
+    def test_claims_when_cap_nonzero_and_no_active_agent(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        # 1) config read returns 1; 2) _has_active_agent SELECT returns None.
+        conn.cursor_instance.fetch_queue = [(1,), None]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._claim_and_orchestrate_one = MagicMock()  # type: ignore[method-assign]
+        summary = d.scheduler_tick()
+        assert summary["orchestration_attempted"] == 1
+        assert d._claim_and_orchestrate_one.call_count == 1  # type: ignore[attr-defined]
+
+    def test_does_not_claim_when_active_agent_exists(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        # config=1 then _has_active_agent returns (1,) meaning active row exists.
+        conn.cursor_instance.fetch_queue = [(1,), (1,)]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._claim_and_orchestrate_one = MagicMock(  # type: ignore[method-assign]
+            side_effect=AssertionError("must not be called when agent active")
+        )
+        summary = d.scheduler_tick()
+        assert summary["orchestration_attempted"] == 0
+
+    def test_orchestration_exception_does_not_crash_tick(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(1,), None]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._claim_and_orchestrate_one = MagicMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("boom")
+        )
+        # The tick must still return a summary, not raise.
+        summary = d.scheduler_tick()
+        assert summary["orchestration_attempted"] == 1
+        assert handler.events("orchestration_failed") != []
+
+
+# --------------------------------------------------------------------------
+# _has_active_agent
+# --------------------------------------------------------------------------
+
+
+class TestHasActiveAgent:
+    def test_no_running_row_returns_false(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        assert d._has_active_agent() is False
+
+    def test_running_row_returns_true(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(1,)]
+        assert d._has_active_agent() is True
+
+    def test_db_error_returns_true_fail_closed(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        def boom(sql: str, params: Any = None) -> None:
+            raise RuntimeError("connection lost")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+        # Fail-closed: treat DB error as "active" so we skip this tick.
+        assert d._has_active_agent() is True
+        assert conn.rollbacks >= 1
+
+
+# --------------------------------------------------------------------------
+# _latest_queue_snapshot_issues
+# --------------------------------------------------------------------------
+
+
+class TestLatestQueueSnapshot:
+    def test_returns_issue_numbers_from_most_recent_row(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [([100, 200, 300],)]
+        assert d._latest_queue_snapshot_issues() == [100, 200, 300]
+
+    def test_returns_empty_when_no_snapshots(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        assert d._latest_queue_snapshot_issues() == []
+
+    def test_returns_empty_on_db_error(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        def boom(sql: str, params: Any = None) -> None:
+            raise RuntimeError("db lost")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+        assert d._latest_queue_snapshot_issues() == []
+        assert conn.rollbacks >= 1
+
+
+# --------------------------------------------------------------------------
+# _issue_already_attempted
+# --------------------------------------------------------------------------
+
+
+class TestIssueAlreadyAttempted:
+    def test_no_row_returns_false(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        assert d._issue_already_attempted(42) is False
+
+    def test_running_row_returns_true(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(1,)]
+        assert d._issue_already_attempted(42) is True
+
+    def test_db_error_returns_true_fail_closed(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        def boom(sql: str, params: Any = None) -> None:
+            raise RuntimeError("db lost")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+        assert d._issue_already_attempted(42) is True
+
+
+# --------------------------------------------------------------------------
+# _issue_author_trusted (wraps scripts/check-issue-author.sh)
+# --------------------------------------------------------------------------
+
+
+class TestIssueAuthorTrusted:
+    def test_exit_zero_returns_true(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            assert cmd[0].endswith("check-issue-author.sh")
+            assert cmd[1] == "42"
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = "TRUSTED: ...\n"
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert d._issue_author_trusted(42) is True
+
+    def test_exit_nonzero_returns_false(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 1
+            r.stdout = "UNTRUSTED: ...\n"
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert d._issue_author_trusted(42) is False
+        rejects = handler.events("trust_check_rejected")
+        assert len(rejects) == 1
+
+    def test_timeout_returns_false(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=10)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert d._issue_author_trusted(42) is False
+        assert handler.events("trust_check_timeout") != []
+
+    def test_script_missing_returns_false(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            raise FileNotFoundError(2, "nope", cmd[0])
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert d._issue_author_trusted(42) is False
+        assert handler.events("trust_check_missing") != []
+
+
+# --------------------------------------------------------------------------
+# _pick_candidate_issue
+# --------------------------------------------------------------------------
+
+
+class TestPickCandidate:
+    def test_returns_first_eligible_candidate(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        # Mark #1 as already attempted, #2 as untrusted, #3 as eligible.
+        attempted = {1}
+        untrusted = {2}
+
+        d._issue_already_attempted = lambda n: n in attempted  # type: ignore[method-assign]
+        d._issue_author_trusted = lambda n: n not in untrusted  # type: ignore[method-assign]
+
+        assert d._pick_candidate_issue([1, 2, 3, 4]) == 3
+
+    def test_returns_none_when_all_skipped(self, tmp_path: Path) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+        d._issue_already_attempted = lambda n: True  # type: ignore[method-assign]
+        d._issue_author_trusted = lambda n: False  # type: ignore[method-assign]
+        assert d._pick_candidate_issue([1, 2, 3]) is None
+        # Three skip events logged (all "already attempted" since that's
+        # checked first).
+        assert len(handler.events("candidate_skipped")) == 3
+
+
+# --------------------------------------------------------------------------
+# _atomic_claim
+# --------------------------------------------------------------------------
+
+
+class TestAtomicClaim:
+    def test_happy_path_inserts_and_returns_true(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        ok = d._atomic_claim(42, "agent-uuid", "/path")
+        assert ok is True
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.agents" in e[0]
+        ]
+        assert len(inserts) == 1
+        assert conn.commits == 1
+        assert handler.events("claim_succeeded") != []
+
+    def test_unique_violation_returns_false(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def boom(sql: str, params: Any = None) -> None:
+            if "INSERT INTO dispatcher.agents" in sql:
+                raise psycopg.errors.UniqueViolation("dup")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+        ok = d._atomic_claim(42, "agent-uuid", "/path")
+        assert ok is False
+        assert handler.events("claim_lost") != []
+        assert conn.rollbacks >= 1
+
+    def test_unexpected_error_returns_false(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def boom(sql: str, params: Any = None) -> None:
+            raise RuntimeError("other")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+        ok = d._atomic_claim(42, "agent-uuid", "/path")
+        assert ok is False
+        assert handler.events("claim_failed") != []
+
+
+# --------------------------------------------------------------------------
+# _create_worktree / git subprocess
+# --------------------------------------------------------------------------
+
+
+class TestCreateWorktree:
+    def test_happy_path_calls_git_worktree_add(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        captured: dict[str, Any] = {}
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            captured["cmd"] = cmd
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        # Use a canonical uuid so the short_id is deterministic.
+        agent_id = "aabbccdd-eeff-0011-2233-445566778899"
+
+        wt = d._create_worktree(agent_id)
+        assert "git" == captured["cmd"][0]
+        assert "worktree" in captured["cmd"]
+        assert "add" in captured["cmd"]
+        # short id = first 8 of hex-collapsed uuid = "aabbccdd".
+        assert str(wt).endswith(".claude/worktrees/agent-aabbccdd")
+        assert "-b" in captured["cmd"]
+        branch_idx = captured["cmd"].index("-b") + 1
+        assert captured["cmd"][branch_idx] == "agent/aabbccdd"
+        assert handler.events("worktree_created") != []
+
+    def test_git_failure_raises(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 128
+            r.stdout = ""
+            r.stderr = "fatal: branch already exists\n"
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        import pytest
+
+        with pytest.raises(RuntimeError) as excinfo:
+            d._create_worktree("agent-uuid-0000-0000-0000-000000000000")
+        assert "exit=128" in str(excinfo.value)
+
+
+# --------------------------------------------------------------------------
+# _fetch_issue_bundle
+# --------------------------------------------------------------------------
+
+
+class TestFetchIssueBundle:
+    def test_parses_gh_issue_view_output(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            assert cmd[0] == "gh" and cmd[1] == "issue" and cmd[2] == "view"
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = json.dumps(
+                {
+                    "number": 42,
+                    "title": "Title",
+                    "body": "Body\nParent: #99\nBlocked by #7\n",
+                    "labels": [{"name": "priority/p1"}],
+                    "comments": [
+                        {
+                            "author": {"login": "drewthaler"},
+                            "authorAssociation": "MEMBER",
+                            "createdAt": "2026-04-18T00:00:00Z",
+                            "body": "hi",
+                        },
+                        {
+                            "author": {"login": "github-actions[bot]"},
+                            "authorAssociation": "NONE",
+                            "createdAt": "2026-04-18T00:01:00Z",
+                            "body": "bot noise",
+                        },
+                    ],
+                }
+            )
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        bundle = d._fetch_issue_bundle(42)
+        assert bundle["issue_number"] == 42
+        assert bundle["issue_title"] == "Title"
+        assert bundle["issue_labels"] == ["priority/p1"]
+        assert bundle["parent_issue"] == 99
+        assert bundle["blocked_by"] == [7]
+        # Bot comment filtered out.
+        assert len(bundle["issue_comments"]) == 1
+        assert bundle["issue_comments"][0]["author"] == "drewthaler"
+
+    def test_gh_failure_raises(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 1
+            r.stdout = ""
+            r.stderr = "HTTP 404\n"
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        import pytest
+
+        with pytest.raises(RuntimeError):
+            d._fetch_issue_bundle(42)
+
+
+class TestParseBlockedBy:
+    def test_extracts_blocked_by_refs(self) -> None:
+        body = "Intro\nBlocked by #42\nOther\nblocked by #99\n"
+        assert daemon.DispatcherDaemon._parse_blocked_by(body) == [42, 99]
+
+    def test_returns_empty_when_absent(self) -> None:
+        assert daemon.DispatcherDaemon._parse_blocked_by("no refs") == []
+
+
+class TestParseParentIssue:
+    def test_extracts_parent(self) -> None:
+        assert daemon.DispatcherDaemon._parse_parent_issue("Parent: #2782") == 2782
+
+    def test_returns_none_when_absent(self) -> None:
+        assert daemon.DispatcherDaemon._parse_parent_issue("nope") is None
+
+
+class TestParsePrNumber:
+    def test_parses_gh_pr_create_stdout(self) -> None:
+        out = (
+            "Creating pull request for head into main in judgemind/judgemind\n"
+            "https://github.com/judgemind/judgemind/pull/1234\n"
+        )
+        assert daemon.DispatcherDaemon._parse_pr_number(out) == 1234
+
+    def test_returns_none_when_unparseable(self) -> None:
+        assert daemon.DispatcherDaemon._parse_pr_number("nope") is None
+
+
+# --------------------------------------------------------------------------
+# _write_phase_input / _read_phase_output
+# --------------------------------------------------------------------------
+
+
+class TestPhaseInputOutput:
+    def test_roundtrip(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        payload = {"agent_id": "a", "issue_number": 1}
+        d._write_phase_input(tmp_path, "plan", payload)
+        input_path = tmp_path / "tmp" / "dispatcher-input" / "plan.json"
+        assert json.loads(input_path.read_text()) == payload
+
+        # Round-trip through _read_phase_output.
+        output_dir = tmp_path / "tmp" / "dispatcher-output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "plan.json").write_text(json.dumps({"go": True}))
+        assert d._read_phase_output(tmp_path, "plan") == {"go": True}
+
+    def test_read_missing_returns_none(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        assert d._read_phase_output(tmp_path, "plan") is None
+
+    def test_read_malformed_returns_none(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        output_dir = tmp_path / "tmp" / "dispatcher-output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "plan.json").write_text("not json")
+        assert d._read_phase_output(tmp_path, "plan") is None
+
+
+# --------------------------------------------------------------------------
+# _persist_phase_output
+# --------------------------------------------------------------------------
+
+
+class TestPersistPhaseOutput:
+    def test_writes_phase_outputs_and_transitions(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        d._persist_phase_output("a", "plan", {"go": True})
+        # Both INSERTs ran.
+        insert_outputs = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_outputs" in e[0]
+        ]
+        insert_transitions = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_transitions" in e[0]
+        ]
+        assert len(insert_outputs) == 1
+        assert len(insert_transitions) == 1
+        assert conn.commits == 1
+
+
+# --------------------------------------------------------------------------
+# _spawn_phase_subprocess — builds the correct claude -p command
+# --------------------------------------------------------------------------
+
+
+class TestSpawnPhaseSubprocess:
+    def test_builds_command_with_correct_model_and_turns(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        captured: dict[str, Any] = {}
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            captured["cmd"] = cmd
+            captured["timeout"] = kwargs.get("timeout")
+            r = MagicMock()
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        exit_code, duration = d._spawn_phase_subprocess("plan", tmp_path, "agent-uuid")
+        assert exit_code == 0
+        assert duration >= 0.0
+        assert captured["cmd"][0] == "claude"
+        assert "-p" in captured["cmd"]
+        assert "/task-v2-plan agent-uuid" in captured["cmd"]
+        assert "--cwd" in captured["cmd"]
+        assert str(tmp_path) in captured["cmd"]
+        assert "--max-turns" in captured["cmd"]
+        assert "50" in captured["cmd"]  # plan
+        assert "--model" in captured["cmd"]
+        assert "opus" in captured["cmd"]
+        assert captured["timeout"] == 180 * 60
+        assert handler.events("phase_started") != []
+        log_path = tmp_path / "tmp" / "claude-p-plan.log"
+        assert log_path.exists()
+
+    def test_ralph_uses_sonnet_and_500_turns(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        captured: dict[str, Any] = {}
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            captured["cmd"] = cmd
+            r = MagicMock()
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d._spawn_phase_subprocess("ralph", tmp_path, "agent-uuid")
+        assert "500" in captured["cmd"]
+        assert "sonnet" in captured["cmd"]
+
+    def test_summary_uses_haiku_and_30_turns(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        captured: dict[str, Any] = {}
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            captured["cmd"] = cmd
+            r = MagicMock()
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d._spawn_phase_subprocess("summary", tmp_path, "agent-uuid")
+        assert "30" in captured["cmd"]
+        assert "haiku" in captured["cmd"]
+
+
+# --------------------------------------------------------------------------
+# _run_subprocess_or_fail — timeout, non-zero exit, missing claude
+# --------------------------------------------------------------------------
+
+
+class TestRunSubprocessOrFail:
+    def test_happy_path_returns_zero(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", lambda *a, **k: (0, 1.2))
+        assert d._run_subprocess_or_fail("a", "plan", tmp_path) == 0
+
+    def test_timeout_marks_failed_returns_none(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def boom(*_a: Any, **_k: Any) -> None:
+            raise subprocess.TimeoutExpired(cmd=["claude"], timeout=10)
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", boom)
+        result = d._run_subprocess_or_fail("a", "plan", tmp_path)
+        assert result is None
+        fails = handler.events("subprocess_failed")
+        assert fails and fails[0].reason == "timeout"
+        # Agent marked failed — UPDATE on dispatcher.agents ran.
+        updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+        ]
+        assert updates
+
+    def test_claude_missing_marks_failed(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        def boom(*_a: Any, **_k: Any) -> None:
+            raise FileNotFoundError(2, "nope", "claude")
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", boom)
+        assert d._run_subprocess_or_fail("a", "plan", tmp_path) is None
+        fails = handler.events("subprocess_failed")
+        assert fails and fails[0].reason == "claude_not_on_path"
+
+    def test_nonzero_exit_marks_failed(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", lambda *a, **k: (1, 0.1))
+        assert d._run_subprocess_or_fail("a", "plan", tmp_path) is None
+        fails = handler.events("subprocess_failed")
+        assert fails and fails[0].exit_code == 1
+
+
+# --------------------------------------------------------------------------
+# Full happy-path orchestration — plan → ralph → summary → push → PR
+# --------------------------------------------------------------------------
+
+
+def _fixture_plan_output() -> dict[str, Any]:
+    return {
+        "agent_id": "a",
+        "issue_number": 42,
+        "go": True,
+        "block_reason": None,
+        "plan_text": "plan",
+        "acceptance_criteria": ["AC1", "AC2"],
+        "scope_check": [],
+        "relevant_files": [],
+        "relevant_docs": [],
+        "change_type": "scraper",
+        "dependencies_to_install": ["scraper-framework"],
+    }
+
+
+def _fixture_ralph_output() -> dict[str, Any]:
+    return {
+        "agent_id": "a",
+        "issue_number": 42,
+        "verdict": "SHIP",
+        "iterations_used": 1,
+        "block_reason": None,
+        "changed_files": ["packages/scraper-framework/src/thing.py"],
+        "summary": "Fixed a thing",
+        "ralph_done_path": None,
+        "review_log_path": None,
+    }
+
+
+def _fixture_summary_output() -> dict[str, Any]:
+    return {
+        "agent_id": "a",
+        "issue_number": 42,
+        "process_summary_md": "## Process Summary\n...",
+        "commit_message": "fix(scraping): fix thing (#42)",
+        "pr_title": "fix(scraping): fix thing (#42)",
+        "pr_body_md": "## Summary\n\nFix.\n\nCloses #42\n",
+        "unmet_criteria": [],
+        "pre_pr_check_notes": "",
+    }
+
+
+class TestHappyPathOrchestration:
+    """End-to-end: _claim_and_orchestrate_one through to gh pr create."""
+
+    def test_claims_runs_phases_pushes_and_opens_pr(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # 1. Queue snapshot read returns one candidate.
+        # 2. _issue_already_attempted SELECT returns None (not attempted).
+        conn.cursor_instance.fetch_queue = [([42],), None]
+
+        # Trust check passes.
+        def fake_check_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = "TRUSTED: ...\n"
+            r.stderr = ""
+            return r
+
+        # Deterministic agent_id for short-id verification.
+        fixed_uuid = uuid_mod.UUID("aabbccdd-eeff-0011-2233-445566778899")
+        monkeypatch.setattr(uuid_mod, "uuid4", lambda: fixed_uuid)
+        monkeypatch.setattr(daemon.uuid, "uuid4", lambda: fixed_uuid)
+
+        # Repo root = tmp_path so worktrees land under it.
+        monkeypatch.setattr(d, "_repo_root", lambda: tmp_path)
+
+        # Track subprocess calls to assert the sequence.
+        call_log: list[list[str]] = []
+
+        # _spawn_phase_subprocess is mocked below to write the fixture
+        # phase output file and return exit=0.
+
+        def fake_subprocess_run(cmd: list[str], **kwargs: Any) -> Any:
+            call_log.append(list(cmd))
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            # Trust check path.
+            if cmd[0].endswith("check-issue-author.sh"):
+                r.stdout = "TRUSTED: ...\n"
+                return r
+            # gh issue view path (bundle fetch — called twice: plan + summary).
+            if (
+                len(cmd) >= 3
+                and cmd[0] == "gh"
+                and cmd[1] == "issue"
+                and cmd[2] == "view"
+            ):
+                r.stdout = json.dumps(
+                    {
+                        "number": 42,
+                        "title": "Title",
+                        "body": "body",
+                        "labels": [{"name": "priority/p1"}],
+                        "comments": [],
+                    }
+                )
+                return r
+            # git worktree add — pretend it succeeded. Create the dir
+            # so later _write_phase_input / _read_phase_output work.
+            if "worktree" in cmd and "add" in cmd:
+                # Find the path in cmd (it's right after "add").
+                add_idx = cmd.index("add")
+                wt = Path(cmd[add_idx + 1])
+                wt.mkdir(parents=True, exist_ok=True)
+                return r
+            # gh pr create — return URL stdout.
+            if cmd[:3] == ["gh", "pr", "create"]:
+                r.stdout = "https://github.com/judgemind/judgemind/pull/9001\n"
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_subprocess_run)
+
+        # Mock the three phase subprocesses — each writes the expected
+        # output file and returns (0, duration).
+        phase_outputs = {
+            "plan": _fixture_plan_output(),
+            "ralph": _fixture_ralph_output(),
+            "summary": _fixture_summary_output(),
+        }
+
+        def fake_spawn(phase: str, worktree: Path, agent_id: str) -> tuple[int, float]:
+            output_dir_local = worktree / "tmp" / "dispatcher-output"
+            output_dir_local.mkdir(parents=True, exist_ok=True)
+            (output_dir_local / f"{phase}.json").write_text(
+                json.dumps(phase_outputs[phase])
+            )
+            return 0, 0.1
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        # Run orchestration.
+        d._claim_and_orchestrate_one()
+
+        # --- Assertions ---
+
+        # Candidate picked + claim succeeded.
+        assert handler.events("candidate_picked") != []
+        assert handler.events("claim_succeeded") != []
+
+        # Worktree created.
+        assert handler.events("worktree_created") != []
+
+        # Three phase_succeeded events (plan, ralph, summary).
+        phases_succeeded = [r.phase for r in handler.events("phase_succeeded")]
+        assert phases_succeeded == ["plan", "ralph", "summary"]
+
+        # PR opened event captured with PR number.
+        pr_opened = handler.events("pr_opened")
+        assert pr_opened and pr_opened[0].pr_number == 9001
+
+        # dispatcher.agents INSERT (claim) happened once.
+        agent_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.agents" in e[0]
+        ]
+        assert len(agent_inserts) == 1
+
+        # dispatcher.phase_outputs INSERTs: 3 (one per phase).
+        phase_output_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_outputs" in e[0]
+        ]
+        assert len(phase_output_inserts) == 3
+
+        # dispatcher.phase_transitions INSERTs: 3.
+        phase_transition_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_transitions" in e[0]
+        ]
+        assert len(phase_transition_inserts) == 3
+
+        # Final UPDATE: status='running', phase='awaiting_ci', pr_number=9001.
+        final_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "running" in e[1]
+            and "awaiting_ci" in e[1]
+        ]
+        assert final_updates, (
+            f"expected final UPDATE with (running, awaiting_ci, pr=9001); "
+            f"got: {[e[1] for e in conn.cursor_instance.executed if 'UPDATE dispatcher.agents' in e[0]]}"
+        )
+
+        # git commands: worktree add, add -A, commit, push. All use
+        # ``git -C <repo-or-worktree> <verb>`` shape, so just check the
+        # verb appears anywhere in each command.
+        git_cmds = [c for c in call_log if c and c[0] == "git"]
+        flat = [" ".join(c) for c in git_cmds]
+        assert any("worktree add" in s for s in flat)
+        assert any("add -A" in s for s in flat)
+        assert any(" commit" in s for s in flat)
+        assert any(" push " in s for s in flat)
+
+
+# --------------------------------------------------------------------------
+# Branch: plan.go=false stops orchestration cleanly
+# --------------------------------------------------------------------------
+
+
+class TestPlanGoFalse:
+    def test_plan_go_false_with_block_reason_marks_failed(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [([42],), None]
+
+        monkeypatch.setattr(d, "_repo_root", lambda: tmp_path)
+        fixed = uuid_mod.UUID("aabbccdd-eeff-0011-2233-445566778899")
+        monkeypatch.setattr(daemon.uuid, "uuid4", lambda: fixed)
+
+        plan_blocked = dict(_fixture_plan_output())
+        plan_blocked["go"] = False
+        plan_blocked["block_reason"] = "acceptance criteria need sharpening"
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            if cmd[0].endswith("check-issue-author.sh"):
+                r.stdout = "TRUSTED: ...\n"
+                return r
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "number": 42,
+                        "title": "T",
+                        "body": "",
+                        "labels": [],
+                        "comments": [],
+                    }
+                )
+                return r
+            if "worktree" in cmd and "add" in cmd:
+                add_idx = cmd.index("add")
+                Path(cmd[add_idx + 1]).mkdir(parents=True, exist_ok=True)
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        def fake_spawn(phase: str, worktree: Path, agent_id: str) -> tuple[int, float]:
+            (worktree / "tmp" / "dispatcher-output").mkdir(parents=True, exist_ok=True)
+            (worktree / "tmp" / "dispatcher-output" / f"{phase}.json").write_text(
+                json.dumps(plan_blocked)
+            )
+            return 0, 0.1
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        d._claim_and_orchestrate_one()
+
+        # Plan executed; ralph/summary did NOT.
+        phases_succeeded = [r.phase for r in handler.events("phase_succeeded")]
+        assert phases_succeeded == ["plan"]
+        assert handler.events("plan_go_false") != []
+        # Final UPDATE sets status='failed' with phase='planning'.
+        failed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "failed" in e[1]
+        ]
+        assert failed_updates
+
+    def test_plan_go_false_no_block_reason_marks_succeeded(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [([42],), None]
+        monkeypatch.setattr(d, "_repo_root", lambda: tmp_path)
+        fixed = uuid_mod.UUID("aabbccdd-eeff-0011-2233-445566778899")
+        monkeypatch.setattr(daemon.uuid, "uuid4", lambda: fixed)
+
+        plan_nowork = dict(_fixture_plan_output())
+        plan_nowork["go"] = False
+        plan_nowork["block_reason"] = None  # no work needed
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            if cmd[0].endswith("check-issue-author.sh"):
+                r.stdout = "TRUSTED: ...\n"
+                return r
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "number": 42,
+                        "title": "T",
+                        "body": "",
+                        "labels": [],
+                        "comments": [],
+                    }
+                )
+                return r
+            if "worktree" in cmd and "add" in cmd:
+                add_idx = cmd.index("add")
+                Path(cmd[add_idx + 1]).mkdir(parents=True, exist_ok=True)
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        def fake_spawn(phase: str, worktree: Path, agent_id: str) -> tuple[int, float]:
+            (worktree / "tmp" / "dispatcher-output").mkdir(parents=True, exist_ok=True)
+            (worktree / "tmp" / "dispatcher-output" / f"{phase}.json").write_text(
+                json.dumps(plan_nowork)
+            )
+            return 0, 0.1
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        d._claim_and_orchestrate_one()
+
+        # Final UPDATE sets status='succeeded'.
+        succeeded_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "succeeded" in e[1]
+        ]
+        assert succeeded_updates
+
+
+# --------------------------------------------------------------------------
+# Branch: ralph verdict=BLOCKED stops orchestration cleanly
+# --------------------------------------------------------------------------
+
+
+class TestRalphBlocked:
+    def test_ralph_blocked_marks_failed(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [([42],), None]
+        monkeypatch.setattr(d, "_repo_root", lambda: tmp_path)
+        fixed = uuid_mod.UUID("aabbccdd-eeff-0011-2233-445566778899")
+        monkeypatch.setattr(daemon.uuid, "uuid4", lambda: fixed)
+
+        ralph_blocked = dict(_fixture_ralph_output())
+        ralph_blocked["verdict"] = "BLOCKED"
+        ralph_blocked["block_reason"] = "max_iterations reached"
+
+        outputs = {
+            "plan": _fixture_plan_output(),
+            "ralph": ralph_blocked,
+        }
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            if cmd[0].endswith("check-issue-author.sh"):
+                r.stdout = "TRUSTED: ...\n"
+                return r
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "number": 42,
+                        "title": "T",
+                        "body": "",
+                        "labels": [],
+                        "comments": [],
+                    }
+                )
+                return r
+            if "worktree" in cmd and "add" in cmd:
+                add_idx = cmd.index("add")
+                Path(cmd[add_idx + 1]).mkdir(parents=True, exist_ok=True)
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        def fake_spawn(phase: str, worktree: Path, agent_id: str) -> tuple[int, float]:
+            (worktree / "tmp" / "dispatcher-output").mkdir(parents=True, exist_ok=True)
+            (worktree / "tmp" / "dispatcher-output" / f"{phase}.json").write_text(
+                json.dumps(outputs[phase])
+            )
+            return 0, 0.1
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        d._claim_and_orchestrate_one()
+
+        # plan + ralph succeeded (phase subprocess exited 0) but ralph
+        # returned verdict=BLOCKED so summary was not invoked.
+        phases_succeeded = [r.phase for r in handler.events("phase_succeeded")]
+        assert phases_succeeded == ["plan", "ralph"]
+        assert handler.events("ralph_not_ship") != []
+        failed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "failed" in e[1]
+        ]
+        assert failed_updates
+
+
+# --------------------------------------------------------------------------
+# Subprocess non-zero exit marks failed cleanly without crashing
+# --------------------------------------------------------------------------
+
+
+class TestSubprocessNonZeroExit:
+    def test_plan_subprocess_nonzero_exit_marks_failed(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [([42],), None]
+        monkeypatch.setattr(d, "_repo_root", lambda: tmp_path)
+        fixed = uuid_mod.UUID("aabbccdd-eeff-0011-2233-445566778899")
+        monkeypatch.setattr(daemon.uuid, "uuid4", lambda: fixed)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            if cmd[0].endswith("check-issue-author.sh"):
+                r.stdout = "TRUSTED: ...\n"
+                return r
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "number": 42,
+                        "title": "T",
+                        "body": "",
+                        "labels": [],
+                        "comments": [],
+                    }
+                )
+                return r
+            if "worktree" in cmd and "add" in cmd:
+                add_idx = cmd.index("add")
+                Path(cmd[add_idx + 1]).mkdir(parents=True, exist_ok=True)
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        def fake_spawn(phase: str, worktree: Path, agent_id: str) -> tuple[int, float]:
+            # Simulate infra failure (claude-p crash).
+            return 1, 0.1
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        d._claim_and_orchestrate_one()
+
+        # Subprocess failure logged; no plan phase_output persisted;
+        # agent marked failed.
+        assert handler.events("subprocess_failed") != []
+        phase_output_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_outputs" in e[0]
+        ]
+        assert phase_output_inserts == []
+
+
+# --------------------------------------------------------------------------
+# Race-lost path: _atomic_claim unique violation stops this tick's attempt
+# --------------------------------------------------------------------------
+
+
+class TestClaimRace:
+    def test_unique_violation_skips_this_tick(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        # Snapshot has one issue, not-attempted check returns None.
+        conn.cursor_instance.fetch_queue = [([42],), None]
+        monkeypatch.setattr(d, "_repo_root", lambda: tmp_path)
+
+        # Trust check passes.
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = "TRUSTED: ...\n"
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        # Make the INSERT raise UniqueViolation — another daemon won.
+        original_execute = conn.cursor_instance.execute
+
+        def execute_with_uv(sql: str, params: Any = None) -> None:
+            if "INSERT INTO dispatcher.agents" in sql:
+                raise psycopg.errors.UniqueViolation("dup")
+            original_execute(sql, params)
+
+        conn.cursor_instance.execute = execute_with_uv  # type: ignore[method-assign]
+
+        # Also make sure we don't try to create a worktree on lost-race.
+        monkeypatch.setattr(
+            d,
+            "_create_worktree",
+            MagicMock(side_effect=AssertionError("should not create worktree")),
+        )
+
+        d._claim_and_orchestrate_one()
+
+        assert handler.events("claim_lost") != []
+        # No worktree created, no phase output persisted.
+        phase_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_outputs" in e[0]
+        ]
+        assert phase_inserts == []

--- a/scripts/dispatcher/tests/test_daemon_skeleton.py
+++ b/scripts/dispatcher/tests/test_daemon_skeleton.py
@@ -184,8 +184,11 @@ class TestSchedulerTick:
 
     def test_consumes_commands_and_reads_config(self) -> None:
         fake_conn = _FakeConnection()
-        # UPDATE returns rowcount=3; SELECT config returns concurrency_cap=5.
-        fake_conn.cursor_instance.fetch_queue = [(5,)]
+        # UPDATE returns rowcount=3; SELECT config returns concurrency_cap=0
+        # (the Phase 2 safe value — keeps the Phase 3A orchestration gate
+        # closed so this skeleton test isolates the command-drain + config-
+        # read path).
+        fake_conn.cursor_instance.fetch_queue = [(0,)]
 
         d = _make_daemon(fake_conn=fake_conn)
         # Stub the queue-scan fetch so the scheduler tick does not try
@@ -208,11 +211,13 @@ class TestSchedulerTick:
 
         summary = d.scheduler_tick()
         assert summary["commands_consumed"] == 3
-        assert summary["concurrency_cap"] == 5
+        assert summary["concurrency_cap"] == 0
         # Two commits per tick: one for command-consumption + config read,
         # one for the queue_snapshots INSERT (Phase 2 addition). The
         # scan is isolated in its own transaction so a queue-snapshot
-        # failure does not roll back a successful command drain.
+        # failure does not roll back a successful command drain. Phase 3A
+        # gate stays closed at ``concurrency_cap=0`` so no additional
+        # reads/commits happen.
         assert fake_conn.commits == 2
         # Tick counter incremented.
         assert d._scheduler_ticks == 1


### PR DESCRIPTION
## Summary

Wires the dispatcher daemon's happy-path orchestration (Phase 3A / #2783): claim one `agent/ready` issue atomically via a partial UNIQUE INDEX, create a per-agent worktree, spawn `/task-v2-{plan,ralph,summary}` sequentially via `claude -p`, persist each phase's output to `dispatcher.phase_outputs` + `phase_transitions`, then run `git push` + `gh pr create`. The new path stays cold at `concurrency_cap=0` — Phase 3E flips the value to 1 once the post-PR flow (3B-3D) lands.

Closes #2783

### What's in

- Migration 25: partial UNIQUE INDEX on `dispatcher.agents (issue_number) WHERE status IN ('running','retrying')`; `schema.sql` updated to match.
- `scheduler_tick` gate: enter orchestration only when `concurrency_cap > 0` AND no agent is in flight (preserves the Phase 2 shadow-mode behavior at cap=0).
- `_claim_and_orchestrate_one` + helpers:
  - trusted-candidate picker (reuses `scripts/check-issue-author.sh`, skips issues already attempted)
  - atomic claim INSERT catching `psycopg.errors.UniqueViolation` as the race-lost signal (no pre-check + insert)
  - per-agent `.claude/worktrees/agent-<short-uuid>` creation from `origin/main`
  - input JSON → `claude -p /task-v2-<phase> <agent-id>` with 180-min subprocess timeout (spec §17 Risk 4a) → parse output JSON → persist to `phase_outputs` + append to `phase_transitions`
  - branch on `plan.go` / ralph verdict / summary `unmet_criteria`
  - daemon-side `git add -A && git commit -F && git push` + `gh pr create --body-file` + capture PR number
  - final state: `status='running'`, `phase='awaiting_ci'`, `pr_number=<N>` — Phase 3B's starting line.
- Structured JSON events: `daemon.candidate_picked`, `claim_succeeded` / `claim_lost`, `worktree_created`, `phase_started` / `phase_succeeded` / `phase_exited`, `subprocess_failed`, `plan_go_false`, `ralph_not_ship`, `summary_unmet_criteria`, `pr_opened`, `orchestration_failed`.

### What's deliberately NOT in (3B-3E scope)

CI watch, `/task-v2-fix-ci`, `gh pr merge`, deploy watch, `/task-v2-verify`, evidence comment, retro, worktree cleanup, retry markers (3C), diagnoser (3D), `concurrency_cap=1` flip (3E).

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` clean on `scripts/dispatcher/`)
- [x] Format check passes (`ruff format --check` clean)
- [x] Tests pass (113/113 dispatcher tests, 711/711 scripts/ tests locally; 346/346 api tests; 50 new Phase 3A tests added)
- [x] Schema drift check PASSES (`scripts/check_schema_drift.sh` locally)
- [x] CI green

### Post-deploy verification

The orchestration path stays cold in production at `concurrency_cap=0` (Phase 3E flips it), so full end-to-end verification is **deferred-pending-3E**. For 3A:

- [x] `deploy-dispatcher.yml` turns green after merge (auto-triggered).
- [x] Migration 25 applied to dev — confirmed via `scripts/dev-db-query.sh` that `idx_dispatcher_agents_active_issue` exists on `dispatcher.agents`.
- [x] Dispatcher logs on dev show NO `daemon.candidate_picked` events after deploy (orchestration gate stays closed at cap=0; confirms the new code path is wired but dormant).
- [x] Verification-evidence comment posted on #2783 documenting the above + explicit "live orchestration end-to-end deferred to 3E" skip reason.
