### PR TITLE
feat(dispatcher): 3B — post-PR orchestration (CI watch → fix-CI → merge → deploy → verify) (#2787)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -164,24 +164,69 @@ CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS = 180 * 60
 
 #: Per-phase ``--max-turns`` values. Matches the frontmatter on each
 #: ``.claude/skills/task-v2-*/SKILL.md`` file. Sonnet-backed ralph gets
-#: the long tail; plan and summary stay tight.
+#: the long tail; plan and summary stay tight. Post-PR phases added
+#: in Phase 3B (#2787) — fix-ci is a targeted patch so 100 turns is
+#: generous; verify is read-mostly so 50 turns fits.
 PHASE_MAX_TURNS = {
     "plan": 50,
     "ralph": 500,
     "summary": 30,
+    "fix-ci": 100,
+    "verify": 50,
 }
 
 #: Per-phase ``--model`` values. Matches ``dispatcher.config.model_by_phase``
-#: seeded in migration 21.
+#: seeded in migration 21. Fix-ci uses Sonnet — the CI-fixing skill's
+#: own frontmatter selects it. Verify uses Haiku — it only reads the
+#: deploy status and poses structured evidence, no complex reasoning.
 PHASE_MODELS = {
     "plan": "opus",
     "ralph": "sonnet",
     "summary": "haiku",
+    "fix-ci": "sonnet",
+    "verify": "haiku",
 }
 
 #: The three happy-path phases 3A orchestrates, in execution order.
 #: Post-PR phases (``fix_ci``, ``verify``, ``retro``) are 3B-3E scope.
 PHASE_SEQUENCE = ("plan", "ralph", "summary")
+
+#: Maximum ``dispatcher.agents.retries_used`` before a fix-ci failure
+#: stops retrying and marks the agent failed. 3 matches spec §8 which
+#: also gates the diagnoser (``ci_red_after_retries``). After this
+#: ceiling the 3C/3D diagnoser escalation takes over.
+FIX_CI_MAX_RETRIES = 3
+
+#: Deploy workflow names we watch after a merge. If the merged commit
+#: triggers none of these (e.g. docs-only PR), the agent advances
+#: straight to verify with a "no deploy applicable" signal. Must match
+#: the ``name:`` field on each deploy workflow in ``.github/workflows/``.
+DEPLOY_WORKFLOW_NAMES = frozenset(
+    {
+        "Deploy API",
+        "Deploy Dispatcher",
+        "Deploy Scraper",
+        "Deploy Production",
+        "Deploy Production (Web)",
+        "Terraform",
+    }
+)
+
+#: Hard timeout on the ``gh pr view`` / ``gh run list`` / ``gh run view``
+#: / ``gh pr merge`` / ``gh issue comment`` subprocess calls used by
+#: ``_advance_running_agents``. Short enough to avoid leaking a
+#: supervisor tick (120s default) if GitHub is slow, long enough that
+#: a normal call (<3s) always finishes.
+GH_POLL_SUBPROCESS_TIMEOUT_SECONDS = 15
+
+#: Cap on how many ``failing_jobs`` entries we hand the fix-ci skill.
+#: Ten is already an unusually bad CI day and keeps the JSON payload
+#: bounded so the skill's context stays small.
+FIX_CI_MAX_FAILING_JOBS = 10
+
+#: Character cap per failing-job log tail handed to fix-ci. ~200 lines
+#: of CI output is typically well under this.
+FIX_CI_LOG_TAIL_MAX_CHARS = 20000
 
 #: Statuses that represent an in-flight claim. Mirrors the partial
 #: UNIQUE INDEX predicate in migration 25. Used by the candidate picker
@@ -379,11 +424,29 @@ class DispatcherDaemon:
           exit 0.
 
     What this daemon still does **NOT** do (deferred to later 3.x):
-        * Post-PR flow — CI watch, fix-ci, merge, deploy watch, verify,
-          retro (3B/3E).
-        * Retry markers / backoff (3C).
-        * Diagnoser (3D).
-        * Worktree cleanup (3E).
+        * Stuck-timeout detection (no phase transition for >30min) —
+          tracked in 3C.
+        * Retry markers / backoff for crash recovery — 3C.
+        * Diagnoser tier 2/3 (judgment-required failure analysis) — 3D.
+        * Retro spawn + worktree cleanup + ``concurrency_cap=1`` flip
+          — 3E.
+
+    **Phase 3B (#2787)** adds the post-PR transitions via
+    ``_advance_running_agents``, invoked from the supervisor tick:
+
+        * ``phase='awaiting_ci'`` → one-shot ``gh pr view`` poll:
+          pending → no-op; green → merge; red → spawn
+          ``/task-v2-fix-ci`` (up to ``FIX_CI_MAX_RETRIES`` times).
+        * ``phase='awaiting_deploy'`` → find the deploy runs triggered
+          by the merge commit, poll: in_progress → no-op;
+          success (or no applicable deploy) → spawn
+          ``/task-v2-verify`` and post evidence comment on the issue;
+          failure → mark agent failed for 3C/3D to handle.
+
+    Per-agent failures inside ``_advance_running_agents`` are caught
+    and logged as ``daemon.advance_failed``; the supervisor tick then
+    moves on to the next agent so one bad row cannot stall the
+    whole daemon.
     """
 
     def __init__(self, cfg: DaemonConfig, logger: logging.Logger):
@@ -2255,10 +2318,1346 @@ class DispatcherDaemon:
                 return int(match.group(1))
         return None
 
+    # ── Phase 3B post-PR orchestration (supervisor-tick step 3) ─────────
+    #
+    # 3B advances agents that 3A handed off in ``phase='awaiting_ci'``.
+    # Each supervisor tick calls ``_advance_running_agents``, which runs
+    # one-shot polls (no blocking ``gh run watch``) and promotes each
+    # agent by at most one state-machine step per tick. The 120s tick
+    # cadence is the effective poll interval.
+    #
+    #   awaiting_ci pending      → no-op (re-check next tick)
+    #   awaiting_ci all-green    → gh pr merge --squash → awaiting_deploy
+    #   awaiting_ci any-failed   → /task-v2-fix-ci subprocess
+    #       verdict=PATCHED      → git commit + push → awaiting_ci (retry)
+    #                              retries_used++; if > FIX_CI_MAX_RETRIES
+    #                              mark status=failed (3C/3D diagnoser)
+    #       verdict=BLOCKED      → mark status=failed with block_reason
+    #       verdict=FLAKY        → no-op; next tick re-polls (GitHub
+    #                              re-runs the flaky job on its own
+    #                              cadence or the operator nudges it)
+    #   awaiting_deploy pending  → no-op
+    #   awaiting_deploy success  → /task-v2-verify subprocess, post
+    #                              evidence comment, status=succeeded
+    #   awaiting_deploy no-run   → treat as "no deploy applicable",
+    #                              proceed to verify with skip-reason
+    #   awaiting_deploy failure  → mark status=failed (3C/3D escalates)
+    #
+    # All subprocess + ``gh`` operations happen in try/except wrappers;
+    # unhandled exceptions flip the agent to ``status='crashed'`` and
+    # the supervisor tick continues with the next agent.
+
+    def _list_advanceable_agents(self) -> list[dict[str, Any]]:
+        """Return agents waiting on CI or deploy, ready for a state step.
+
+        SELECT rows with ``status='running'`` and
+        ``phase IN ('awaiting_ci', 'awaiting_deploy')``. Returns a list
+        of small dicts with the fields the advance methods need —
+        ``agent_id``, ``issue_number``, ``phase``, ``pr_number``,
+        ``worktree_path``, ``retries_used``. An empty list is
+        returned on DB error (with a rollback), so the supervisor tick
+        can continue without this work.
+        """
+        assert self._conn is not None, "connect() must run before reading"
+
+        agents: list[dict[str, Any]] = []
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT agent_id, issue_number, phase, pr_number, "
+                    "       worktree_path, retries_used "
+                    "FROM dispatcher.agents "
+                    "WHERE status = 'running' "
+                    "  AND phase IN ('awaiting_ci', 'awaiting_deploy') "
+                    "ORDER BY started_at ASC",
+                )
+                for row in cur.fetchall():
+                    agents.append(
+                        {
+                            "agent_id": str(row[0]),
+                            "issue_number": int(row[1]),
+                            "phase": str(row[2]),
+                            "pr_number": int(row[3]) if row[3] is not None else None,
+                            "worktree_path": str(row[4]),
+                            "retries_used": int(row[5]) if row[5] is not None else 0,
+                        }
+                    )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.list_advanceable_failed",
+                extra={
+                    "event": "list_advanceable_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return []
+        return agents
+
+    def _advance_running_agents(self) -> int:
+        """Advance each running agent by at most one state-machine step.
+
+        Called from ``supervisor_tick``. One-shot polls only — no
+        blocking ``gh run watch``. Per-agent failures are caught and
+        logged as ``daemon.advance_failed`` with the agent flipped to
+        ``status='crashed'`` so 3C/3D can retry with a fresh worktree.
+
+        Returns the number of agents this tick touched (for logging).
+        The actual phase transition that each advance performed is
+        logged inline via ``daemon.pr_merged``, ``daemon.fix_ci_*``,
+        ``daemon.deploy_*``, and ``daemon.agent_completed`` events.
+        """
+        assert self._conn is not None, "connect() must run before advancing"
+
+        agents = self._list_advanceable_agents()
+        if not agents:
+            return 0
+
+        advanced = 0
+        for agent in agents:
+            agent_id = agent["agent_id"]
+            phase = agent["phase"]
+            try:
+                if phase == "awaiting_ci":
+                    self._advance_awaiting_ci(agent)
+                elif phase == "awaiting_deploy":
+                    self._advance_awaiting_deploy(agent)
+                else:  # pragma: no cover — SELECT filter guarantees this
+                    continue
+                advanced += 1
+            except Exception as exc:
+                # Unhandled exception in one agent's advance must not
+                # stall the daemon. Flip to ``status='crashed'`` so 3C
+                # picks it up with a fresh worktree.
+                self._log.exception(
+                    "daemon.advance_failed",
+                    extra={
+                        "event": "advance_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "phase": phase,
+                        "detail": str(exc),
+                    },
+                )
+                self._mark_agent_terminal(
+                    agent_id,
+                    status="crashed",
+                    phase=phase,
+                    exit_code=None,
+                )
+        return advanced
+
+    # ── awaiting_ci branch ──────────────────────────────────────────────
+
+    def _advance_awaiting_ci(self, agent: dict[str, Any]) -> None:
+        """One supervisor step for an ``awaiting_ci`` agent.
+
+        Polls the PR's combined check rollup via ``gh pr view``. Branches
+        on the aggregate state:
+
+        * **Pending** (any check in_progress/queued) — no-op; re-check
+          next supervisor tick.
+        * **Green** (all SUCCESS/SKIPPED + ``mergeable=MERGEABLE`` +
+          ``mergeStateStatus=CLEAN``) — merge with squash, transition
+          ``phase='awaiting_deploy'``.
+        * **Red** (any FAILURE/CANCELLED/TIMED_OUT/ACTION_REQUIRED) —
+          spawn ``/task-v2-fix-ci``. Verdict PATCHED applies the patch
+          + pushes + stays in awaiting_ci with ``retries_used++``.
+          Verdicts BLOCKED / max-retries-exceeded mark failed.
+        """
+        agent_id = agent["agent_id"]
+        pr_number = agent["pr_number"]
+
+        if pr_number is None:
+            # 3A should never produce an ``awaiting_ci`` row without a
+            # PR number. If it does, that's a 3A bug — mark failed and
+            # log so operators see it.
+            self._log.warning(
+                "daemon.awaiting_ci_missing_pr",
+                extra={
+                    "event": "awaiting_ci_missing_pr",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            )
+            return
+
+        pr_status = self._fetch_pr_status(pr_number)
+        if pr_status is None:
+            # Transient GitHub error — log and re-check next tick. No
+            # terminal transition; the agent keeps its awaiting_ci phase.
+            return
+
+        rollup_state = self._classify_check_rollup(pr_status)
+        self._log.info(
+            "daemon.ci_poll",
+            extra={
+                "event": "ci_poll",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "pr_number": pr_number,
+                "rollup_state": rollup_state,
+                "mergeable": pr_status.get("mergeable"),
+                "merge_state_status": pr_status.get("mergeStateStatus"),
+            },
+        )
+
+        if rollup_state == "pending":
+            return
+
+        if rollup_state == "green":
+            self._merge_pr_and_advance(agent, pr_status)
+            return
+
+        # rollup_state == "red"
+        self._run_fix_ci(agent, pr_status)
+
+    def _fetch_pr_status(self, pr_number: int) -> dict[str, Any] | None:
+        """Fetch the combined check rollup + merge state for a PR.
+
+        Runs ``gh pr view --json statusCheckRollup,mergeable,mergeStateStatus,headRefOid,mergeCommit``
+        as a one-shot call (no blocking watch). Returns the parsed JSON
+        dict, or ``None`` on subprocess failure (logged as a warning so
+        the supervisor can retry next tick).
+        """
+        cmd = [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            self._cfg.github_repo,
+            "--json",
+            "statusCheckRollup,mergeable,mergeStateStatus,headRefOid,mergeCommit",
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except FileNotFoundError:
+            self._log.warning(
+                "daemon.gh_missing",
+                extra={
+                    "event": "gh_missing",
+                    "run_id": self._run_id,
+                    "pr_number": pr_number,
+                },
+            )
+            return None
+        except subprocess.TimeoutExpired:
+            self._log.warning(
+                "daemon.pr_view_timeout",
+                extra={
+                    "event": "pr_view_timeout",
+                    "run_id": self._run_id,
+                    "pr_number": pr_number,
+                },
+            )
+            return None
+
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.pr_view_failed",
+                extra={
+                    "event": "pr_view_failed",
+                    "run_id": self._run_id,
+                    "pr_number": pr_number,
+                    "exit_code": result.returncode,
+                    "stderr_tail": (result.stderr or "").strip()[:200],
+                },
+            )
+            return None
+
+        try:
+            return json.loads(result.stdout or "{}")
+        except json.JSONDecodeError:
+            self._log.warning(
+                "daemon.pr_view_invalid_json",
+                extra={
+                    "event": "pr_view_invalid_json",
+                    "run_id": self._run_id,
+                    "pr_number": pr_number,
+                },
+            )
+            return None
+
+    @staticmethod
+    def _classify_check_rollup(pr_status: dict[str, Any]) -> str:
+        """Return ``'green'``, ``'red'``, or ``'pending'`` for a PR status.
+
+        Logic:
+
+        * Any check in ``IN_PROGRESS`` / ``QUEUED`` / ``PENDING`` /
+          ``WAITING`` → ``'pending'`` (even if others failed — we must
+          wait for the full signal before deciding).
+        * If no pending and any check in ``FAILURE`` / ``CANCELLED`` /
+          ``TIMED_OUT`` / ``ACTION_REQUIRED`` → ``'red'``.
+        * All ``SUCCESS`` / ``SKIPPED`` / ``NEUTRAL`` / ``STALE`` AND
+          ``mergeable='MERGEABLE'`` AND ``mergeStateStatus='CLEAN'`` →
+          ``'green'``.
+        * Otherwise (mergeable=false, conflicting, etc.) → ``'red'``
+          so the fix-ci path runs.
+
+        Accepts both Actions-style (``status``/``conclusion``) and
+        legacy-commit-status-style (``state``) rollup entries so it
+        works with whatever mix ``gh pr view --json statusCheckRollup``
+        returns.
+        """
+        rollup = pr_status.get("statusCheckRollup") or []
+
+        pending_statuses = {"IN_PROGRESS", "QUEUED", "PENDING", "WAITING"}
+        # Values GitHub uses for a failed Actions check.
+        failure_conclusions = {
+            "FAILURE",
+            "CANCELLED",
+            "TIMED_OUT",
+            "ACTION_REQUIRED",
+            "STARTUP_FAILURE",
+        }
+        # Legacy commit-status states.
+        legacy_pending = {"PENDING", "EXPECTED"}
+        legacy_failure = {"FAILURE", "ERROR"}
+
+        has_pending = False
+        has_failure = False
+
+        for check in rollup:
+            if not isinstance(check, dict):
+                continue
+            # Actions-style.
+            raw_status = check.get("status")
+            raw_conclusion = check.get("conclusion")
+            if raw_status is not None:
+                status_up = str(raw_status).upper()
+                conclusion_up = (
+                    str(raw_conclusion).upper() if raw_conclusion is not None else ""
+                )
+                if status_up == "COMPLETED":
+                    if conclusion_up in failure_conclusions:
+                        has_failure = True
+                elif status_up in pending_statuses:
+                    has_pending = True
+                continue
+            # Legacy commit-status-style.
+            raw_state = check.get("state")
+            if raw_state is not None:
+                state_up = str(raw_state).upper()
+                if state_up in legacy_pending:
+                    has_pending = True
+                elif state_up in legacy_failure:
+                    has_failure = True
+
+        if has_pending:
+            return "pending"
+        if has_failure:
+            return "red"
+
+        mergeable = str(pr_status.get("mergeable") or "").upper()
+        merge_state = str(pr_status.get("mergeStateStatus") or "").upper()
+        if mergeable == "MERGEABLE" and merge_state == "CLEAN":
+            return "green"
+
+        # Checks all green but PR not mergeable (conflicts, branch
+        # protection unmet, etc.) — treat as red so fix-ci can try.
+        return "red"
+
+    def _merge_pr_and_advance(
+        self, agent: dict[str, Any], pr_status: dict[str, Any]
+    ) -> None:
+        """Squash-merge the PR, record the merge SHA, advance to deploy."""
+        agent_id = agent["agent_id"]
+        pr_number = agent["pr_number"]
+
+        cmd = [
+            "gh",
+            "pr",
+            "merge",
+            str(pr_number),
+            "--repo",
+            self._cfg.github_repo,
+            "--squash",
+            "--delete-branch",
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS * 2,
+                check=False,
+            )
+        except FileNotFoundError:
+            self._log.warning(
+                "daemon.gh_missing",
+                extra={
+                    "event": "gh_missing",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            return
+        except subprocess.TimeoutExpired:
+            self._log.warning(
+                "daemon.pr_merge_timeout",
+                extra={
+                    "event": "pr_merge_timeout",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "pr_number": pr_number,
+                },
+            )
+            return
+
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.pr_merge_failed",
+                extra={
+                    "event": "pr_merge_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "pr_number": pr_number,
+                    "exit_code": result.returncode,
+                    "stderr_tail": (result.stderr or "").strip()[:200],
+                },
+            )
+            return
+
+        # Extract the merge commit SHA from the PR status if available;
+        # fall back to re-fetching once after the merge.
+        merge_sha = self._extract_merge_sha(pr_status)
+        if not merge_sha:
+            refreshed = self._fetch_pr_status(pr_number)
+            if refreshed is not None:
+                merge_sha = self._extract_merge_sha(refreshed)
+
+        self._update_agent_phase(agent_id, "awaiting_deploy")
+        self._log.info(
+            "daemon.pr_merged",
+            extra={
+                "event": "pr_merged",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "pr_number": pr_number,
+                "merge_sha": merge_sha,
+            },
+        )
+
+    @staticmethod
+    def _extract_merge_sha(pr_status: dict[str, Any]) -> str | None:
+        """Return the merge commit SHA from a ``gh pr view`` payload.
+
+        ``--json mergeCommit`` returns ``{"mergeCommit": {"oid": "..."}}``
+        for merged PRs. Before the merge lands it can be null. We fall
+        back to ``headRefOid`` as a last resort since squash-merges
+        produce a fresh commit on main, but the head SHA is at least
+        a useful correlation key for the deploy-run finder.
+        """
+        merge_commit = pr_status.get("mergeCommit")
+        if isinstance(merge_commit, dict):
+            oid = merge_commit.get("oid")
+            if isinstance(oid, str) and oid:
+                return oid
+        head = pr_status.get("headRefOid")
+        if isinstance(head, str) and head:
+            return head
+        return None
+
+    def _run_fix_ci(self, agent: dict[str, Any], pr_status: dict[str, Any]) -> None:
+        """Gather failing-job logs, spawn ``/task-v2-fix-ci``, handle verdict.
+
+        Escalates to ``status='failed'`` when ``retries_used >=
+        FIX_CI_MAX_RETRIES`` (spec §8 ``ci_red_after_retries``). On
+        ``PATCHED`` verdict, applies the patch via ``git add -A`` +
+        ``git commit`` + ``git push``, increments ``retries_used``, and
+        leaves the agent in ``awaiting_ci`` so the next supervisor
+        tick re-polls. On ``BLOCKED`` — mark failed. On ``FLAKY`` —
+        no-op; let the next tick re-poll (GitHub may re-run flaky jobs
+        automatically, or the operator can nudge).
+        """
+        agent_id = agent["agent_id"]
+        pr_number = agent["pr_number"]
+        issue_number = agent["issue_number"]
+        worktree = Path(agent["worktree_path"])
+        retries_used = agent["retries_used"]
+
+        if retries_used >= FIX_CI_MAX_RETRIES:
+            self._log.warning(
+                "daemon.fix_ci_max_retries_exceeded",
+                extra={
+                    "event": "fix_ci_max_retries_exceeded",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "pr_number": pr_number,
+                    "retries_used": retries_used,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            )
+            return
+
+        # Build fix-ci input bundle.
+        failing_jobs = self._extract_failing_jobs(pr_status)
+        git_diff = self._fetch_pr_diff(worktree, pr_number)
+        branch = self._branch_for_agent(agent_id)
+
+        fix_ci_input = {
+            "agent_id": agent_id,
+            "issue_number": issue_number,
+            "pr_number": pr_number,
+            "branch": branch,
+            "failing_jobs": failing_jobs,
+            "git_diff_base_to_head": git_diff,
+            "worktree_path": str(worktree),
+            "repo_root": str(worktree),
+            "previous_fix_attempts": retries_used,
+        }
+        self._write_phase_input(worktree, "fix-ci", fix_ci_input)
+
+        self._log.info(
+            "daemon.fix_ci_started",
+            extra={
+                "event": "fix_ci_started",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "pr_number": pr_number,
+                "failing_job_count": len(failing_jobs),
+                "retries_used": retries_used,
+            },
+        )
+
+        exit_code = self._run_subprocess_or_fail(agent_id, "fix-ci", worktree)
+        if exit_code is None:
+            # Subprocess infra failure — agent already marked failed
+            # inside _run_subprocess_or_fail. Stop.
+            return
+
+        fix_ci_output = self._read_phase_output(worktree, "fix-ci")
+        if fix_ci_output is None:
+            self._log.warning(
+                "daemon.phase_output_missing",
+                extra={
+                    "event": "phase_output_missing",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": "fix-ci",
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_ci", exit_code=exit_code
+            )
+            return
+
+        self._persist_phase_output(agent_id, "fix-ci", fix_ci_output)
+        verdict = str(fix_ci_output.get("verdict") or "").upper()
+
+        if verdict == "PATCHED":
+            self._apply_fix_ci_patch(agent, fix_ci_output)
+            return
+        if verdict == "FLAKY":
+            # No code change. Next tick will re-poll; GitHub's flaky
+            # re-run path or a manual nudge resolves eventually.
+            self._log.info(
+                "daemon.fix_ci_flaky",
+                extra={
+                    "event": "fix_ci_flaky",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "pr_number": pr_number,
+                    "flaky_evidence": fix_ci_output.get("flaky_evidence"),
+                },
+            )
+            return
+        # verdict == "BLOCKED" or unrecognized
+        self._log.warning(
+            "daemon.fix_ci_blocked",
+            extra={
+                "event": "fix_ci_blocked",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "pr_number": pr_number,
+                "verdict": verdict,
+                "block_reason": fix_ci_output.get("block_reason"),
+            },
+        )
+        self._mark_agent_terminal(
+            agent_id, status="failed", phase="awaiting_ci", exit_code=exit_code
+        )
+
+    @staticmethod
+    def _extract_failing_jobs(pr_status: dict[str, Any]) -> list[dict[str, Any]]:
+        """Pull the failing check-run entries out of the PR rollup.
+
+        Returns a list of ``{name, conclusion, databaseId, detailsUrl}``
+        dicts — the daemon fills ``log_tail`` later via
+        ``_fetch_job_log_tail``. Capped at ``FIX_CI_MAX_FAILING_JOBS``
+        to bound the payload size handed to fix-ci.
+        """
+        failure_conclusions = {
+            "FAILURE",
+            "CANCELLED",
+            "TIMED_OUT",
+            "ACTION_REQUIRED",
+            "STARTUP_FAILURE",
+        }
+        rollup = pr_status.get("statusCheckRollup") or []
+        failing: list[dict[str, Any]] = []
+        for check in rollup:
+            if not isinstance(check, dict):
+                continue
+            conclusion = str(check.get("conclusion") or "").upper()
+            status = str(check.get("status") or "").upper()
+            if status == "COMPLETED" and conclusion in failure_conclusions:
+                failing.append(
+                    {
+                        "name": check.get("name") or check.get("context") or "",
+                        "conclusion": conclusion,
+                        "databaseId": check.get("databaseId"),
+                        "detailsUrl": check.get("detailsUrl"),
+                    }
+                )
+            if len(failing) >= FIX_CI_MAX_FAILING_JOBS:
+                break
+        return failing
+
+    def _fetch_pr_diff(self, worktree: Path, pr_number: int) -> str:
+        """Return the PR's full base-to-head diff, empty string on error."""
+        cmd = [
+            "gh",
+            "pr",
+            "diff",
+            str(pr_number),
+            "--repo",
+            self._cfg.github_repo,
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return ""
+        if result.returncode != 0:
+            return ""
+        return result.stdout or ""
+
+    def _branch_for_agent(self, agent_id: str) -> str:
+        """Return the agent's branch name derived from agent_id."""
+        short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
+        return f"agent/{short_id}"
+
+    def _apply_fix_ci_patch(
+        self, agent: dict[str, Any], fix_ci_output: dict[str, Any]
+    ) -> None:
+        """Stage + commit + push the fix-ci patch; stay in awaiting_ci.
+
+        The fix-ci skill left the patch in the worktree's working tree;
+        ``changed_files`` is the list of files it touched. We run
+        ``git add -A`` (the skill may have created new files too),
+        ``git commit -F <msg-file>``, and ``git push``. On success,
+        increment ``retries_used`` and leave the agent in
+        ``awaiting_ci`` so the next supervisor tick re-polls.
+        """
+        agent_id = agent["agent_id"]
+        worktree = Path(agent["worktree_path"])
+        branch = self._branch_for_agent(agent_id)
+        retries_used = agent["retries_used"]
+
+        commit_message = str(fix_ci_output.get("commit_message") or "").strip()
+        if not commit_message:
+            self._log.warning(
+                "daemon.fix_ci_missing_commit_message",
+                extra={
+                    "event": "fix_ci_missing_commit_message",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            )
+            return
+
+        # git add -A
+        try:
+            add_result = subprocess.run(
+                ["git", "-C", str(worktree), "add", "-A"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except Exception:
+            self._log.exception(
+                "daemon.fix_ci_git_add_failed",
+                extra={
+                    "event": "fix_ci_git_add_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            )
+            return
+        if add_result.returncode != 0:
+            self._log.warning(
+                "daemon.fix_ci_git_add_failed",
+                extra={
+                    "event": "fix_ci_git_add_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "exit_code": add_result.returncode,
+                    "stderr_tail": (add_result.stderr or "")[:200],
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            )
+            return
+
+        # git commit -F <file>
+        commit_msg_path = worktree / "tmp" / "commit_msg_fix_ci.txt"
+        commit_msg_path.parent.mkdir(parents=True, exist_ok=True)
+        commit_msg_path.write_text(commit_message)
+
+        try:
+            commit_result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(worktree),
+                    "commit",
+                    "-F",
+                    str(commit_msg_path),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except Exception:
+            self._log.exception(
+                "daemon.fix_ci_git_commit_failed",
+                extra={
+                    "event": "fix_ci_git_commit_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            )
+            return
+        if commit_result.returncode != 0:
+            # ``git commit`` exits non-zero if nothing is staged —
+            # that means the skill reported PATCHED but wrote no diff.
+            # Treat as block.
+            self._log.warning(
+                "daemon.fix_ci_git_commit_failed",
+                extra={
+                    "event": "fix_ci_git_commit_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "exit_code": commit_result.returncode,
+                    "stderr_tail": (commit_result.stderr or "")[:200],
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            )
+            return
+
+        # git push
+        try:
+            push_result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(worktree),
+                    "push",
+                    "origin",
+                    branch,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=120,
+                check=False,
+            )
+        except Exception:
+            self._log.exception(
+                "daemon.fix_ci_git_push_failed",
+                extra={
+                    "event": "fix_ci_git_push_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            )
+            return
+        if push_result.returncode != 0:
+            self._log.warning(
+                "daemon.fix_ci_git_push_failed",
+                extra={
+                    "event": "fix_ci_git_push_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "exit_code": push_result.returncode,
+                    "stderr_tail": (push_result.stderr or "")[:200],
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            )
+            return
+
+        # Success — bump retries_used, leave awaiting_ci for next tick.
+        self._increment_retries_used(agent_id)
+        self._log.info(
+            "daemon.fix_ci_patched",
+            extra={
+                "event": "fix_ci_patched",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "new_retries_used": retries_used + 1,
+                "commit_message": commit_message,
+            },
+        )
+
+    def _increment_retries_used(self, agent_id: str) -> None:
+        """UPDATE ``dispatcher.agents.retries_used = retries_used + 1``."""
+        assert self._conn is not None, "connect() must run before update"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.agents "
+                    "SET retries_used = retries_used + 1 "
+                    "WHERE agent_id = %s",
+                    (agent_id,),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.increment_retries_failed",
+                extra={
+                    "event": "increment_retries_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+
+    # ── awaiting_deploy branch ──────────────────────────────────────────
+
+    def _advance_awaiting_deploy(self, agent: dict[str, Any]) -> None:
+        """One supervisor step for an ``awaiting_deploy`` agent.
+
+        Finds the deploy runs triggered by the merge commit, polls
+        their conclusions, and advances to verify on success / treats
+        doc-only PRs as "no deploy applicable".
+        """
+        agent_id = agent["agent_id"]
+        pr_number = agent["pr_number"]
+
+        if pr_number is None:  # pragma: no cover — 3A always sets pr_number
+            self._log.warning(
+                "daemon.awaiting_deploy_missing_pr",
+                extra={
+                    "event": "awaiting_deploy_missing_pr",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_deploy", exit_code=None
+            )
+            return
+
+        pr_status = self._fetch_pr_status(pr_number)
+        if pr_status is None:
+            return  # transient — retry next tick
+        merge_sha = self._extract_merge_sha(pr_status)
+        if not merge_sha:
+            self._log.warning(
+                "daemon.awaiting_deploy_no_merge_sha",
+                extra={
+                    "event": "awaiting_deploy_no_merge_sha",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "pr_number": pr_number,
+                },
+            )
+            return  # next tick might see it
+
+        deploy_runs = self._find_deploy_runs(merge_sha)
+        # ``deploy_runs=[]`` means no matching deploy workflow fired on
+        # that SHA. Treat as "no deploy applicable" and proceed to verify.
+        deploy_state = self._classify_deploy_runs(deploy_runs)
+        self._log.info(
+            "daemon.deploy_poll",
+            extra={
+                "event": "deploy_poll",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "pr_number": pr_number,
+                "merge_sha": merge_sha,
+                "deploy_state": deploy_state,
+                "deploy_run_count": len(deploy_runs),
+            },
+        )
+        if deploy_state == "pending":
+            return
+        if deploy_state == "failure":
+            self._log.warning(
+                "daemon.deploy_failed",
+                extra={
+                    "event": "deploy_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "pr_number": pr_number,
+                    "merge_sha": merge_sha,
+                    "deploy_runs": deploy_runs,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_deploy", exit_code=None
+            )
+            return
+
+        # deploy_state in ("success", "none") — run verify.
+        self._run_verify_and_complete(agent, pr_status, merge_sha, deploy_runs)
+
+    def _find_deploy_runs(self, merge_sha: str) -> list[dict[str, Any]]:
+        """Return deploy-workflow runs whose ``headSha`` equals ``merge_sha``.
+
+        Runs ``gh run list --commit <sha> --json
+        databaseId,workflowName,status,conclusion,createdAt`` and filters
+        by ``workflowName in DEPLOY_WORKFLOW_NAMES``. Returns an empty
+        list if no deploy workflow fired on that SHA (doc-only PRs)
+        or on subprocess failure.
+        """
+        cmd = [
+            "gh",
+            "run",
+            "list",
+            "--repo",
+            self._cfg.github_repo,
+            "--commit",
+            merge_sha,
+            "--json",
+            "databaseId,workflowName,status,conclusion,createdAt",
+            "--limit",
+            "20",
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return []
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.run_list_failed",
+                extra={
+                    "event": "run_list_failed",
+                    "run_id": self._run_id,
+                    "merge_sha": merge_sha,
+                    "exit_code": result.returncode,
+                    "stderr_tail": (result.stderr or "")[:200],
+                },
+            )
+            return []
+        try:
+            payload = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError:
+            return []
+        if not isinstance(payload, list):
+            return []
+        runs: list[dict[str, Any]] = []
+        for run in payload:
+            if not isinstance(run, dict):
+                continue
+            if run.get("workflowName") in DEPLOY_WORKFLOW_NAMES:
+                runs.append(run)
+        return runs
+
+    @staticmethod
+    def _classify_deploy_runs(runs: list[dict[str, Any]]) -> str:
+        """Return ``'pending'``, ``'success'``, ``'failure'``, or ``'none'``.
+
+        * ``none`` — no deploy run matched (doc-only PR etc.).
+        * ``pending`` — any run in a non-terminal state.
+        * ``failure`` — at least one run terminal with failure-type
+          conclusion.
+        * ``success`` — all runs terminal with success/skipped/neutral.
+        """
+        if not runs:
+            return "none"
+        success_conclusions = {"SUCCESS", "SKIPPED", "NEUTRAL"}
+        has_pending = False
+        has_failure = False
+        for run in runs:
+            status = str(run.get("status") or "").upper()
+            if status != "COMPLETED":
+                # Any non-terminal status means the deploy is still
+                # running / queued / waiting. Classify as pending and
+                # re-poll next tick.
+                has_pending = True
+                continue
+            conclusion = str(run.get("conclusion") or "").upper()
+            if conclusion in success_conclusions:
+                continue
+            has_failure = True
+        if has_pending:
+            return "pending"
+        if has_failure:
+            return "failure"
+        return "success"
+
+    # ── verify (final) ──────────────────────────────────────────────────
+
+    def _run_verify_and_complete(
+        self,
+        agent: dict[str, Any],
+        pr_status: dict[str, Any],
+        merge_sha: str,
+        deploy_runs: list[dict[str, Any]],
+    ) -> None:
+        """Spawn ``/task-v2-verify``, post evidence comment, mark succeeded."""
+        agent_id = agent["agent_id"]
+        issue_number = agent["issue_number"]
+        pr_number = agent["pr_number"]
+        worktree = Path(agent["worktree_path"])
+
+        # Fetch the issue bundle for acceptance criteria. Best-effort —
+        # the verify skill tolerates an empty AC list with a failure row.
+        try:
+            bundle = self._fetch_issue_bundle(issue_number)
+        except RuntimeError:
+            bundle = {
+                "issue_number": issue_number,
+                "issue_title": "",
+                "issue_body": "",
+                "issue_comments": [],
+                "issue_labels": [],
+                "blocked_by": [],
+                "parent_issue": None,
+            }
+
+        acceptance_criteria = self._extract_acceptance_criteria(
+            bundle.get("issue_body") or ""
+        )
+
+        # Pick a representative deploy run for the input bundle. Prefer
+        # the first non-SKIPPED success; fall back to the first entry.
+        deploy_status = self._select_deploy_status(deploy_runs)
+        change_type = self._infer_change_type(deploy_runs)
+
+        verify_input = {
+            "agent_id": agent_id,
+            "issue_number": issue_number,
+            "pr_number": pr_number,
+            "acceptance_criteria": acceptance_criteria,
+            "change_type": change_type,
+            "touched_services": self._touched_services_from_runs(deploy_runs),
+            "deploy_status": deploy_status,
+            "merged_commit_sha": merge_sha,
+            "worktree_path": str(worktree),
+            "repo_root": str(worktree),
+        }
+        self._write_phase_input(worktree, "verify", verify_input)
+
+        self._log.info(
+            "daemon.verify_started",
+            extra={
+                "event": "verify_started",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "pr_number": pr_number,
+                "change_type": change_type,
+                "deploy_applicable": deploy_status is not None,
+            },
+        )
+
+        exit_code = self._run_subprocess_or_fail(agent_id, "verify", worktree)
+        if exit_code is None:
+            return  # subprocess failure already marked failed
+
+        verify_output = self._read_phase_output(worktree, "verify")
+        if verify_output is None:
+            self._log.warning(
+                "daemon.phase_output_missing",
+                extra={
+                    "event": "phase_output_missing",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": "verify",
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_deploy", exit_code=exit_code
+            )
+            return
+
+        self._persist_phase_output(agent_id, "verify", verify_output)
+
+        evidence_md = str(verify_output.get("evidence_md") or "").strip()
+        if evidence_md:
+            self._post_evidence_comment(agent_id, issue_number, worktree, evidence_md)
+        else:
+            self._log.warning(
+                "daemon.verify_missing_evidence_md",
+                extra={
+                    "event": "verify_missing_evidence_md",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                },
+            )
+
+        verdict = str(verify_output.get("verdict") or "").upper()
+        if verdict == "FAILED":
+            self._log.warning(
+                "daemon.verify_failed",
+                extra={
+                    "event": "verify_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "pr_number": pr_number,
+                    "failure_reason": verify_output.get("failure_reason"),
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="done", exit_code=exit_code
+            )
+            return
+
+        # VERIFIED or SKIPPED — either is a success for the daemon.
+        self._mark_agent_terminal(
+            agent_id, status="succeeded", phase="done", exit_code=0
+        )
+        self._log.info(
+            "daemon.agent_completed",
+            extra={
+                "event": "agent_completed",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "pr_number": pr_number,
+                "merge_sha": merge_sha,
+                "verdict": verdict,
+            },
+        )
+
+    @staticmethod
+    def _extract_acceptance_criteria(body: str) -> list[str]:
+        """Pull ``- [ ] …`` checkboxes out of the issue body.
+
+        Matches any task-list style checkbox (checked or unchecked), so
+        a partially-checked AC still ends up in the list. Returns the
+        text after the checkbox, stripped. Skips the verification
+        checkboxes that live under ``### Post-deploy verification`` or
+        under an ``### Automated checks`` heading, since those are
+        workflow chrome, not issue-level ACs.
+        """
+        import re  # noqa: PLC0415
+
+        lines = body.splitlines()
+        skip_sections = {"post-deploy verification", "automated checks", "test plan"}
+        in_skip_section = False
+        criteria: list[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                # Headings reset the skip-section state.
+                heading_text = stripped.lstrip("#").strip().lower()
+                in_skip_section = any(tag in heading_text for tag in skip_sections)
+                continue
+            if in_skip_section:
+                continue
+            match = re.match(r"^\s*-\s*\[[ xX]\]\s*(.+)$", line)
+            if match:
+                criteria.append(match.group(1).strip())
+        return criteria
+
+    @staticmethod
+    def _select_deploy_status(
+        deploy_runs: list[dict[str, Any]],
+    ) -> dict[str, Any] | None:
+        """Pick one deploy run to describe in the verify input bundle.
+
+        Returns ``None`` when no deploy fired (doc-only PR). Otherwise
+        returns ``{workflow_name, run_id, conclusion, duration_s}`` from
+        the first entry (deploy workflows are usually single-run per
+        commit; multiple runs get picked up pairwise for logging, but
+        verify only needs one for its ``deploy_status`` field).
+        """
+        if not deploy_runs:
+            return None
+        first = deploy_runs[0]
+        return {
+            "workflow_name": first.get("workflowName"),
+            "run_id": first.get("databaseId"),
+            "conclusion": first.get("conclusion"),
+            "duration_s": None,
+        }
+
+    @staticmethod
+    def _infer_change_type(deploy_runs: list[dict[str, Any]]) -> str:
+        """Map the first matching deploy workflow to a ``change_type`` tag.
+
+        The verify skill's ``change_type`` field drives its
+        verification path. If no deploy fired, return
+        ``no_deployed_component`` so the skill emits a SKIPPED verdict.
+        """
+        if not deploy_runs:
+            return "no_deployed_component"
+        # Most-specific match wins.
+        name_to_type = {
+            "Deploy API": "api",
+            "Deploy Dispatcher": "dx_tooling",
+            "Deploy Scraper": "scraper",
+            "Deploy Production": "web",
+            "Deploy Production (Web)": "web",
+            "Terraform": "dx_tooling",
+        }
+        for run in deploy_runs:
+            mapped = name_to_type.get(str(run.get("workflowName") or ""))
+            if mapped:
+                return mapped
+        return "dx_tooling"
+
+    @staticmethod
+    def _touched_services_from_runs(
+        deploy_runs: list[dict[str, Any]],
+    ) -> list[str]:
+        """Return the ECS service names the deploy workflows affected."""
+        name_to_service = {
+            "Deploy API": "judgemind-api-dev",
+            "Deploy Dispatcher": "judgemind-dispatcher-dev",
+            "Deploy Scraper": "judgemind-scraper-dev",
+        }
+        services: list[str] = []
+        for run in deploy_runs:
+            svc = name_to_service.get(str(run.get("workflowName") or ""))
+            if svc and svc not in services:
+                services.append(svc)
+        return services
+
+    def _post_evidence_comment(
+        self,
+        agent_id: str,
+        issue_number: int,
+        worktree: Path,
+        evidence_md: str,
+    ) -> None:
+        """Post the verify skill's ``evidence_md`` as an issue comment.
+
+        Uses ``gh issue comment --body-file`` to avoid shell-quoting the
+        markdown body. Writes the file into the worktree's ``tmp/`` so
+        every subprocess sees the same filesystem layout.
+        """
+        evidence_path = worktree / "tmp" / "verification_evidence.md"
+        evidence_path.parent.mkdir(parents=True, exist_ok=True)
+        evidence_path.write_text(evidence_md)
+
+        cmd = [
+            "gh",
+            "issue",
+            "comment",
+            str(issue_number),
+            "--repo",
+            self._cfg.github_repo,
+            "--body-file",
+            str(evidence_path),
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            self._log.warning(
+                "daemon.evidence_comment_failed",
+                extra={
+                    "event": "evidence_comment_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "reason": "subprocess",
+                },
+            )
+            return
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.evidence_comment_failed",
+                extra={
+                    "event": "evidence_comment_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "exit_code": result.returncode,
+                    "stderr_tail": (result.stderr or "")[:200],
+                },
+            )
+            return
+        self._log.info(
+            "daemon.evidence_comment_posted",
+            extra={
+                "event": "evidence_comment_posted",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "evidence_chars": len(evidence_md),
+            },
+        )
+
     # ── supervisor tick (every ``tick_supervisor_seconds``) ─────────────
 
     def supervisor_tick(self) -> dict[str, int]:
-        """Run one supervisor tick. Writes heartbeat; emits CW metric."""
+        """Run one supervisor tick. Writes heartbeat; advances running agents.
+
+        Steps (in order):
+            1. UPDATE ``dispatcher.runs.heartbeat_ts`` — keeps the lease
+               alive and signals to the ``HeartbeatAge`` CloudWatch
+               alarm that the daemon is healthy.
+            2. Count ``dispatcher.failures`` rows in the last hour — the
+               read doubles as a connection smoke-test.
+            3. **Phase 3B (#2787):** call ``_advance_running_agents``.
+               Iterates agents in ``awaiting_ci``/``awaiting_deploy``
+               and drives each one forward by one state-machine step.
+               Errors are caught per-agent so one bad row cannot stall
+               siblings or crash the tick.
+            4. Emit the ``HeartbeatAge`` CloudWatch metric.
+
+        Returns a summary dict for logs + tests.
+        """
         assert self._conn is not None, "connect() must run before ticks"
         assert self._run_id is not None, "register the run before ticking"
 
@@ -2282,6 +3681,21 @@ class DispatcherDaemon:
                 failures_last_hour = int(row[0] or 0)
         self._conn.commit()
 
+        # Phase 3B (#2787): advance agents that are past push_and_pr.
+        # Wrapped in try/except — the heartbeat + metric emission below
+        # must still run even if the advance pass throws unexpectedly.
+        agents_advanced = 0
+        try:
+            agents_advanced = self._advance_running_agents()
+        except Exception:
+            self._log.exception(
+                "daemon.advance_pass_failed",
+                extra={
+                    "event": "advance_pass_failed",
+                    "run_id": self._run_id,
+                },
+            )
+
         self._supervisor_ticks += 1
         self._last_heartbeat_at = datetime.now(UTC)
 
@@ -2300,11 +3714,13 @@ class DispatcherDaemon:
                 "tick_n": self._supervisor_ticks,
                 "failures_last_hour": failures_last_hour,
                 "heartbeat_metric_emitted": metric_emitted,
+                "agents_advanced": agents_advanced,
             },
         )
         return {
             "failures_last_hour": failures_last_hour,
             "heartbeat_metric_emitted": 1 if metric_emitted else 0,
+            "agents_advanced": agents_advanced,
         }
 
     # ── heartbeat metric emission (supervisor-tick step 3) ──────────────

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -1,0 +1,1384 @@
+"""Unit tests for the Phase 3B post-PR orchestration in ``scripts.dispatcher.daemon``.
+
+Issue #2787. Covers the transitions Phase 3B adds to the supervisor tick:
+
+* ``awaiting_ci`` → pending (no-op)
+* ``awaiting_ci`` → green (merge + advance to awaiting_deploy)
+* ``awaiting_ci`` → red → fix-ci PATCHED (apply patch, push, retry)
+* ``awaiting_ci`` → red → fix-ci BLOCKED (mark failed)
+* ``awaiting_ci`` → red → retries_used >= FIX_CI_MAX_RETRIES (mark failed)
+* ``awaiting_ci`` → red → fix-ci FLAKY (no-op)
+* ``awaiting_deploy`` → in_progress (no-op)
+* ``awaiting_deploy`` → success → verify VERIFIED → succeeded + evidence comment
+* ``awaiting_deploy`` → success → verify SKIPPED (no deploy applicable)
+* ``awaiting_deploy`` → failure (mark failed)
+* Unhandled exception in one agent → status=crashed; next agent still processed.
+
+All external calls (``gh``, ``git``, ``claude -p``, psycopg) are mocked. The
+subprocess used by ``_spawn_phase_subprocess`` is stubbed so no real LLM
+is invoked.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+# Provide a stub ``psycopg`` module before importing the daemon — same
+# pattern as test_daemon_phase3a.py. Reuse phase3a's stub when possible
+# so the ``except psycopg.errors.UniqueViolation`` path in the daemon
+# still resolves to the *same* Exception class both test files reference
+# (otherwise test-collection order makes one file's raise fall through
+# the other file's except and the unique-violation tests break — observed
+# while developing #2787).
+
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — superset of the test_daemon_phase3a fixtures (adds
+# fetchall() support to _FakeCursor so _list_advanceable_agents works).
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.phase3b.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+def _agent_row(
+    agent_id: str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    issue_number: int = 42,
+    phase: str = "awaiting_ci",
+    pr_number: int | None = 101,
+    worktree_path: str | None = None,
+    retries_used: int = 0,
+) -> tuple[Any, ...]:
+    """Build a SELECT row in the shape _list_advanceable_agents expects."""
+    return (
+        agent_id,
+        issue_number,
+        phase,
+        pr_number,
+        worktree_path or "/tmp/test-worktree",
+        retries_used,
+    )
+
+
+# --------------------------------------------------------------------------
+# _classify_check_rollup — pure function
+# --------------------------------------------------------------------------
+
+
+class TestClassifyCheckRollup:
+    def test_all_green_with_mergeable_clean_returns_green(self) -> None:
+        status = {
+            "statusCheckRollup": [
+                {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "lint"},
+                {"status": "COMPLETED", "conclusion": "SKIPPED", "name": "docs"},
+            ],
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+        }
+        assert daemon.DispatcherDaemon._classify_check_rollup(status) == "green"
+
+    def test_any_in_progress_returns_pending(self) -> None:
+        status = {
+            "statusCheckRollup": [
+                {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "lint"},
+                {"status": "IN_PROGRESS", "name": "tests"},
+            ],
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+        }
+        assert daemon.DispatcherDaemon._classify_check_rollup(status) == "pending"
+
+    def test_queued_returns_pending(self) -> None:
+        status = {
+            "statusCheckRollup": [
+                {"status": "QUEUED", "name": "build"},
+            ],
+            "mergeable": "UNKNOWN",
+            "mergeStateStatus": "UNKNOWN",
+        }
+        assert daemon.DispatcherDaemon._classify_check_rollup(status) == "pending"
+
+    def test_any_failure_returns_red(self) -> None:
+        status = {
+            "statusCheckRollup": [
+                {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "lint"},
+                {"status": "COMPLETED", "conclusion": "FAILURE", "name": "tests"},
+            ],
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+        }
+        assert daemon.DispatcherDaemon._classify_check_rollup(status) == "red"
+
+    def test_all_green_but_not_mergeable_returns_red(self) -> None:
+        # Branch protection rules not met, or still waiting on a required
+        # review that CI alone cannot satisfy.
+        status = {
+            "statusCheckRollup": [
+                {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "lint"},
+            ],
+            "mergeable": "CONFLICTING",
+            "mergeStateStatus": "DIRTY",
+        }
+        assert daemon.DispatcherDaemon._classify_check_rollup(status) == "red"
+
+    def test_legacy_commit_status_pending(self) -> None:
+        status = {
+            "statusCheckRollup": [{"state": "PENDING"}],
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+        }
+        assert daemon.DispatcherDaemon._classify_check_rollup(status) == "pending"
+
+    def test_legacy_commit_status_failure(self) -> None:
+        status = {
+            "statusCheckRollup": [{"state": "FAILURE"}],
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+        }
+        assert daemon.DispatcherDaemon._classify_check_rollup(status) == "red"
+
+    def test_empty_rollup_with_mergeable_returns_green(self) -> None:
+        # If there are literally no checks and the branch is mergeable,
+        # treat as green. (Rare in practice since CI filters always run,
+        # but the function must make a call.)
+        status = {
+            "statusCheckRollup": [],
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "CLEAN",
+        }
+        assert daemon.DispatcherDaemon._classify_check_rollup(status) == "green"
+
+
+# --------------------------------------------------------------------------
+# _classify_deploy_runs — pure function
+# --------------------------------------------------------------------------
+
+
+class TestClassifyDeployRuns:
+    def test_empty_returns_none(self) -> None:
+        assert daemon.DispatcherDaemon._classify_deploy_runs([]) == "none"
+
+    def test_in_progress_returns_pending(self) -> None:
+        runs = [
+            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"status": "IN_PROGRESS"},
+        ]
+        assert daemon.DispatcherDaemon._classify_deploy_runs(runs) == "pending"
+
+    def test_all_success_returns_success(self) -> None:
+        runs = [
+            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"status": "COMPLETED", "conclusion": "SKIPPED"},
+        ]
+        assert daemon.DispatcherDaemon._classify_deploy_runs(runs) == "success"
+
+    def test_any_failure_returns_failure(self) -> None:
+        runs = [
+            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"status": "COMPLETED", "conclusion": "FAILURE"},
+        ]
+        assert daemon.DispatcherDaemon._classify_deploy_runs(runs) == "failure"
+
+
+# --------------------------------------------------------------------------
+# _extract_merge_sha
+# --------------------------------------------------------------------------
+
+
+class TestExtractMergeSha:
+    def test_returns_merge_commit_oid(self) -> None:
+        status = {"mergeCommit": {"oid": "abc123"}}
+        assert daemon.DispatcherDaemon._extract_merge_sha(status) == "abc123"
+
+    def test_falls_back_to_head_ref_oid(self) -> None:
+        status = {"mergeCommit": None, "headRefOid": "head456"}
+        assert daemon.DispatcherDaemon._extract_merge_sha(status) == "head456"
+
+    def test_returns_none_when_neither_set(self) -> None:
+        assert daemon.DispatcherDaemon._extract_merge_sha({}) is None
+
+
+# --------------------------------------------------------------------------
+# _extract_failing_jobs
+# --------------------------------------------------------------------------
+
+
+class TestExtractFailingJobs:
+    def test_returns_only_failed_checks(self) -> None:
+        status = {
+            "statusCheckRollup": [
+                {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "lint"},
+                {"status": "COMPLETED", "conclusion": "FAILURE", "name": "tests"},
+                {"status": "COMPLETED", "conclusion": "CANCELLED", "name": "build"},
+            ]
+        }
+        failing = daemon.DispatcherDaemon._extract_failing_jobs(status)
+        names = [f["name"] for f in failing]
+        assert "tests" in names
+        assert "build" in names
+        assert "lint" not in names
+
+    def test_caps_at_max(self) -> None:
+        status = {
+            "statusCheckRollup": [
+                {
+                    "status": "COMPLETED",
+                    "conclusion": "FAILURE",
+                    "name": f"job{i}",
+                }
+                for i in range(20)
+            ]
+        }
+        failing = daemon.DispatcherDaemon._extract_failing_jobs(status)
+        assert len(failing) == daemon.FIX_CI_MAX_FAILING_JOBS
+
+
+# --------------------------------------------------------------------------
+# _extract_acceptance_criteria
+# --------------------------------------------------------------------------
+
+
+class TestExtractAcceptanceCriteria:
+    def test_picks_up_checkbox_lines(self) -> None:
+        body = (
+            "Intro\n\n"
+            "## Acceptance criteria\n\n"
+            "- [ ] Criterion A\n"
+            "- [x] Criterion B\n"
+            "- Not a checkbox\n"
+            "- [ ] Criterion C\n"
+        )
+        acs = daemon.DispatcherDaemon._extract_acceptance_criteria(body)
+        assert acs == ["Criterion A", "Criterion B", "Criterion C"]
+
+    def test_skips_test_plan_and_post_deploy_sections(self) -> None:
+        body = (
+            "## Acceptance criteria\n\n"
+            "- [ ] Real criterion\n\n"
+            "### Automated checks\n"
+            "- [ ] Lint passes\n"
+            "- [ ] Tests pass\n\n"
+            "### Post-deploy verification\n"
+            "- [ ] Evidence posted\n\n"
+            "## Something Else\n"
+            "- [ ] Another real criterion\n"
+        )
+        acs = daemon.DispatcherDaemon._extract_acceptance_criteria(body)
+        assert acs == ["Real criterion", "Another real criterion"]
+
+
+# --------------------------------------------------------------------------
+# _infer_change_type
+# --------------------------------------------------------------------------
+
+
+class TestInferChangeType:
+    def test_no_deploy_returns_no_deployed_component(self) -> None:
+        assert daemon.DispatcherDaemon._infer_change_type([]) == "no_deployed_component"
+
+    def test_deploy_api_maps_to_api(self) -> None:
+        runs = [{"workflowName": "Deploy API"}]
+        assert daemon.DispatcherDaemon._infer_change_type(runs) == "api"
+
+    def test_deploy_scraper_maps_to_scraper(self) -> None:
+        runs = [{"workflowName": "Deploy Scraper"}]
+        assert daemon.DispatcherDaemon._infer_change_type(runs) == "scraper"
+
+
+# --------------------------------------------------------------------------
+# _list_advanceable_agents — DB query + error paths
+# --------------------------------------------------------------------------
+
+
+class TestListAdvanceableAgents:
+    def test_returns_rows_as_dicts(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue = [
+            [
+                _agent_row(
+                    "agent-1", issue_number=42, phase="awaiting_ci", pr_number=101
+                ),
+                _agent_row(
+                    "agent-2",
+                    issue_number=43,
+                    phase="awaiting_deploy",
+                    pr_number=102,
+                ),
+            ]
+        ]
+        rows = d._list_advanceable_agents()
+        assert len(rows) == 2
+        assert rows[0]["agent_id"] == "agent-1"
+        assert rows[0]["phase"] == "awaiting_ci"
+        assert rows[1]["phase"] == "awaiting_deploy"
+
+    def test_db_error_returns_empty(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        def boom(sql: str, params: Any = None) -> None:
+            raise RuntimeError("db lost")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+        rows = d._list_advanceable_agents()
+        assert rows == []
+        assert conn.rollbacks >= 1
+
+
+# --------------------------------------------------------------------------
+# _advance_running_agents — dispatch + crash isolation
+# --------------------------------------------------------------------------
+
+
+class TestAdvanceRunningAgents:
+    def test_empty_list_returns_zero(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        d._list_advanceable_agents = lambda: []  # type: ignore[method-assign]
+        assert d._advance_running_agents() == 0
+
+    def test_routes_awaiting_ci_to_ci_handler(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        d._list_advanceable_agents = lambda: [  # type: ignore[method-assign]
+            {
+                "agent_id": "a1",
+                "issue_number": 1,
+                "phase": "awaiting_ci",
+                "pr_number": 1,
+                "worktree_path": str(tmp_path),
+                "retries_used": 0,
+            }
+        ]
+        called: dict[str, Any] = {}
+        d._advance_awaiting_ci = lambda agent: called.setdefault(  # type: ignore[method-assign]
+            "ci", agent
+        )
+        d._advance_awaiting_deploy = lambda agent: called.setdefault(  # type: ignore[method-assign]
+            "deploy", agent
+        )
+        assert d._advance_running_agents() == 1
+        assert "ci" in called
+        assert "deploy" not in called
+
+    def test_routes_awaiting_deploy_to_deploy_handler(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        d._list_advanceable_agents = lambda: [  # type: ignore[method-assign]
+            {
+                "agent_id": "a1",
+                "issue_number": 1,
+                "phase": "awaiting_deploy",
+                "pr_number": 1,
+                "worktree_path": str(tmp_path),
+                "retries_used": 0,
+            }
+        ]
+        called: dict[str, Any] = {}
+        d._advance_awaiting_ci = lambda agent: called.setdefault(  # type: ignore[method-assign]
+            "ci", agent
+        )
+        d._advance_awaiting_deploy = lambda agent: called.setdefault(  # type: ignore[method-assign]
+            "deploy", agent
+        )
+        d._advance_running_agents()
+        assert "deploy" in called
+        assert "ci" not in called
+
+    def test_exception_in_one_agent_crashes_that_one_continues_with_next(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        d._list_advanceable_agents = lambda: [  # type: ignore[method-assign]
+            {
+                "agent_id": "crasher",
+                "issue_number": 1,
+                "phase": "awaiting_ci",
+                "pr_number": 1,
+                "worktree_path": str(tmp_path),
+                "retries_used": 0,
+            },
+            {
+                "agent_id": "good",
+                "issue_number": 2,
+                "phase": "awaiting_ci",
+                "pr_number": 2,
+                "worktree_path": str(tmp_path),
+                "retries_used": 0,
+            },
+        ]
+        touched: list[str] = []
+
+        def ci_handler(agent: dict[str, Any]) -> None:
+            if agent["agent_id"] == "crasher":
+                raise RuntimeError("boom")
+            touched.append(agent["agent_id"])
+
+        d._advance_awaiting_ci = ci_handler  # type: ignore[method-assign]
+        d._advance_running_agents()
+        # good agent was still processed.
+        assert touched == ["good"]
+        # crash event was logged with agent_id="crasher".
+        crashes = handler.events("advance_failed")
+        assert crashes
+        assert crashes[0].agent_id == "crasher"
+        # crasher got flipped to status=crashed (UPDATE with 'crashed' in params).
+        crashed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "crashed" in e[1]
+        ]
+        assert crashed_updates
+
+
+# --------------------------------------------------------------------------
+# _advance_awaiting_ci — pending (no-op)
+# --------------------------------------------------------------------------
+
+
+class TestAwaitingCiPending:
+    def test_pending_checks_are_noop(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            if cmd[:3] == ["gh", "pr", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "statusCheckRollup": [{"status": "IN_PROGRESS"}],
+                        "mergeable": "UNKNOWN",
+                        "mergeStateStatus": "UNKNOWN",
+                        "headRefOid": "head-sha",
+                        "mergeCommit": None,
+                    }
+                )
+                return r
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        agent = {
+            "agent_id": "a1",
+            "issue_number": 1,
+            "phase": "awaiting_ci",
+            "pr_number": 101,
+            "worktree_path": str(tmp_path),
+            "retries_used": 0,
+        }
+        d._advance_awaiting_ci(agent)
+        polls = handler.events("ci_poll")
+        assert polls and polls[0].rollup_state == "pending"
+        # No UPDATE dispatcher.agents on a no-op.
+        updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+        ]
+        assert updates == []
+
+
+# --------------------------------------------------------------------------
+# _advance_awaiting_ci — green (merge + advance)
+# --------------------------------------------------------------------------
+
+
+class TestAwaitingCiGreen:
+    def test_all_green_merges_and_advances(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        call_log: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            call_log.append(list(cmd))
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            if cmd[:3] == ["gh", "pr", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "statusCheckRollup": [
+                            {"status": "COMPLETED", "conclusion": "SUCCESS"},
+                        ],
+                        "mergeable": "MERGEABLE",
+                        "mergeStateStatus": "CLEAN",
+                        "headRefOid": "head-sha",
+                        "mergeCommit": {"oid": "merge-sha-abc"},
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "pr", "merge"]:
+                r.stdout = ""
+                return r
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        agent = {
+            "agent_id": "a1",
+            "issue_number": 1,
+            "phase": "awaiting_ci",
+            "pr_number": 101,
+            "worktree_path": str(tmp_path),
+            "retries_used": 0,
+        }
+        d._advance_awaiting_ci(agent)
+
+        # gh pr merge was called with --squash --delete-branch.
+        merge_cmds = [c for c in call_log if c[:3] == ["gh", "pr", "merge"]]
+        assert merge_cmds
+        assert "--squash" in merge_cmds[0]
+        assert "--delete-branch" in merge_cmds[0]
+
+        # Agent phase updated to awaiting_deploy.
+        phase_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "awaiting_deploy" in e[1]
+        ]
+        assert phase_updates
+
+        # pr_merged event logged with merge SHA.
+        merged = handler.events("pr_merged")
+        assert merged
+        assert merged[0].merge_sha == "merge-sha-abc"
+
+
+# --------------------------------------------------------------------------
+# _advance_awaiting_ci — red → fix-ci PATCHED (apply + push + retry)
+# --------------------------------------------------------------------------
+
+
+class TestAwaitingCiRedPatched:
+    def test_fix_ci_patched_applies_and_retries(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # Use a real worktree directory so _write_phase_input etc. work.
+        worktree = tmp_path
+        (worktree / "tmp").mkdir(parents=True, exist_ok=True)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = ""
+            if cmd[:3] == ["gh", "pr", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "statusCheckRollup": [
+                            {
+                                "status": "COMPLETED",
+                                "conclusion": "FAILURE",
+                                "name": "tests",
+                                "databaseId": 99999,
+                            },
+                        ],
+                        "mergeable": "MERGEABLE",
+                        "mergeStateStatus": "CLEAN",
+                        "headRefOid": "head-sha",
+                        "mergeCommit": None,
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "pr", "diff"]:
+                r.stdout = "diff --git a/x b/x\n+hi\n"
+                return r
+            # git add/commit/push all succeed.
+            if cmd[:3] == ["git", "-C", str(worktree)]:
+                return r
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        # fix-ci subprocess writes the PATCHED output.
+        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+            out_dir = wt / "tmp" / "dispatcher-output"
+            out_dir.mkdir(parents=True, exist_ok=True)
+            assert phase == "fix-ci"
+            (out_dir / "fix-ci.json").write_text(
+                json.dumps(
+                    {
+                        "agent_id": agent_id,
+                        "pr_number": 101,
+                        "verdict": "PATCHED",
+                        "failure_category": "lint",
+                        "changed_files": ["a.py"],
+                        "commit_message": "fix(x): lint (#101)",
+                        "block_reason": None,
+                        "flaky_evidence": None,
+                        "notes": "",
+                    }
+                )
+            )
+            return 0, 0.1
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        agent = {
+            "agent_id": "aabbccdd-eeff-0011-2233-445566778899",
+            "issue_number": 42,
+            "phase": "awaiting_ci",
+            "pr_number": 101,
+            "worktree_path": str(worktree),
+            "retries_used": 0,
+        }
+        d._advance_awaiting_ci(agent)
+
+        # fix_ci_started event.
+        assert handler.events("fix_ci_started")
+        # fix_ci_patched event (successful apply).
+        patched = handler.events("fix_ci_patched")
+        assert patched
+        assert patched[0].new_retries_used == 1
+        # retries_used UPDATE fired.
+        retry_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and "retries_used = retries_used + 1" in e[0]
+        ]
+        assert retry_updates
+        # Agent NOT marked terminal (stays awaiting_ci).
+        terminal_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and ("failed" in e[1] or "succeeded" in e[1] or "crashed" in e[1])
+        ]
+        assert terminal_updates == []
+
+
+# --------------------------------------------------------------------------
+# _advance_awaiting_ci — red → fix-ci BLOCKED (mark failed)
+# --------------------------------------------------------------------------
+
+
+class TestAwaitingCiRedBlocked:
+    def test_fix_ci_blocked_marks_failed(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = ""
+            if cmd[:3] == ["gh", "pr", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "statusCheckRollup": [
+                            {"status": "COMPLETED", "conclusion": "FAILURE"},
+                        ],
+                        "mergeable": "MERGEABLE",
+                        "mergeStateStatus": "CLEAN",
+                        "headRefOid": "head-sha",
+                        "mergeCommit": None,
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "pr", "diff"]:
+                r.stdout = "diff"
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+            out_dir = wt / "tmp" / "dispatcher-output"
+            out_dir.mkdir(parents=True, exist_ok=True)
+            (out_dir / "fix-ci.json").write_text(
+                json.dumps(
+                    {
+                        "agent_id": agent_id,
+                        "pr_number": 101,
+                        "verdict": "BLOCKED",
+                        "failure_category": "missing_secret_or_config",
+                        "changed_files": [],
+                        "commit_message": "",
+                        "block_reason": "Secret FOO not provisioned",
+                        "flaky_evidence": None,
+                        "notes": "",
+                    }
+                )
+            )
+            return 0, 0.1
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        agent = {
+            "agent_id": "aabbccdd-eeff-0011-2233-445566778899",
+            "issue_number": 42,
+            "phase": "awaiting_ci",
+            "pr_number": 101,
+            "worktree_path": str(tmp_path),
+            "retries_used": 0,
+        }
+        d._advance_awaiting_ci(agent)
+
+        # Fix-ci block event logged.
+        assert handler.events("fix_ci_blocked")
+        # Agent marked failed.
+        failed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "failed" in e[1]
+        ]
+        assert failed_updates
+
+
+# --------------------------------------------------------------------------
+# _advance_awaiting_ci — red → FLAKY verdict is a no-op (no retry bump)
+# --------------------------------------------------------------------------
+
+
+class TestAwaitingCiRedFlaky:
+    def test_fix_ci_flaky_is_noop(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = ""
+            if cmd[:3] == ["gh", "pr", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "statusCheckRollup": [
+                            {"status": "COMPLETED", "conclusion": "FAILURE"},
+                        ],
+                        "mergeable": "MERGEABLE",
+                        "mergeStateStatus": "CLEAN",
+                        "headRefOid": "head-sha",
+                        "mergeCommit": None,
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "pr", "diff"]:
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+            out_dir = wt / "tmp" / "dispatcher-output"
+            out_dir.mkdir(parents=True, exist_ok=True)
+            (out_dir / "fix-ci.json").write_text(
+                json.dumps(
+                    {
+                        "agent_id": agent_id,
+                        "pr_number": 101,
+                        "verdict": "FLAKY",
+                        "failure_category": "infra_external",
+                        "changed_files": [],
+                        "commit_message": "",
+                        "block_reason": None,
+                        "flaky_evidence": "Anthropic 529 in tests",
+                        "notes": "",
+                    }
+                )
+            )
+            return 0, 0.1
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        agent = {
+            "agent_id": "a1",
+            "issue_number": 42,
+            "phase": "awaiting_ci",
+            "pr_number": 101,
+            "worktree_path": str(tmp_path),
+            "retries_used": 0,
+        }
+        d._advance_awaiting_ci(agent)
+        # Flaky event logged.
+        assert handler.events("fix_ci_flaky")
+        # No terminal transitions, no retry bump.
+        retry_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and "retries_used = retries_used + 1" in e[0]
+        ]
+        assert retry_updates == []
+        terminal_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and ("failed" in e[1] or "succeeded" in e[1])
+        ]
+        assert terminal_updates == []
+
+
+# --------------------------------------------------------------------------
+# _advance_awaiting_ci — red and retries_used >= MAX stops fix-ci
+# --------------------------------------------------------------------------
+
+
+class TestAwaitingCiMaxRetries:
+    def test_max_retries_marks_failed_without_fix_ci(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = json.dumps(
+                {
+                    "statusCheckRollup": [
+                        {"status": "COMPLETED", "conclusion": "FAILURE"},
+                    ],
+                    "mergeable": "MERGEABLE",
+                    "mergeStateStatus": "CLEAN",
+                    "headRefOid": "head-sha",
+                    "mergeCommit": None,
+                }
+            )
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        # Fail the test if fix-ci subprocess runs.
+        def fake_spawn(*_a: Any, **_k: Any) -> tuple[int, float]:
+            raise AssertionError("fix-ci must not spawn past max retries")
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        agent = {
+            "agent_id": "a1",
+            "issue_number": 42,
+            "phase": "awaiting_ci",
+            "pr_number": 101,
+            "worktree_path": str(tmp_path),
+            "retries_used": daemon.FIX_CI_MAX_RETRIES,
+        }
+        d._advance_awaiting_ci(agent)
+        # Max-retries event logged + agent marked failed.
+        assert handler.events("fix_ci_max_retries_exceeded")
+        failed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "failed" in e[1]
+        ]
+        assert failed_updates
+
+
+# --------------------------------------------------------------------------
+# _advance_awaiting_deploy — in_progress → no-op
+# --------------------------------------------------------------------------
+
+
+class TestAwaitingDeployInProgress:
+    def test_in_progress_is_noop(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = ""
+            if cmd[:3] == ["gh", "pr", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "statusCheckRollup": [],
+                        "mergeable": "MERGEABLE",
+                        "mergeStateStatus": "CLEAN",
+                        "headRefOid": "head-sha",
+                        "mergeCommit": {"oid": "merge-sha"},
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "run", "list"]:
+                r.stdout = json.dumps(
+                    [
+                        {
+                            "databaseId": 111,
+                            "workflowName": "Deploy API",
+                            "status": "IN_PROGRESS",
+                            "conclusion": None,
+                            "createdAt": "2026-04-18T00:00:00Z",
+                        }
+                    ]
+                )
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        agent = {
+            "agent_id": "a1",
+            "issue_number": 42,
+            "phase": "awaiting_deploy",
+            "pr_number": 101,
+            "worktree_path": str(tmp_path),
+            "retries_used": 0,
+        }
+        d._advance_awaiting_deploy(agent)
+        polls = handler.events("deploy_poll")
+        assert polls and polls[0].deploy_state == "pending"
+        # No terminal transitions.
+        terminal_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and ("failed" in e[1] or "succeeded" in e[1])
+        ]
+        assert terminal_updates == []
+
+
+# --------------------------------------------------------------------------
+# _advance_awaiting_deploy — failure → mark failed
+# --------------------------------------------------------------------------
+
+
+class TestAwaitingDeployFailure:
+    def test_deploy_failure_marks_failed(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = ""
+            if cmd[:3] == ["gh", "pr", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "statusCheckRollup": [],
+                        "mergeable": "MERGEABLE",
+                        "mergeStateStatus": "CLEAN",
+                        "headRefOid": "head-sha",
+                        "mergeCommit": {"oid": "merge-sha"},
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "run", "list"]:
+                r.stdout = json.dumps(
+                    [
+                        {
+                            "databaseId": 111,
+                            "workflowName": "Deploy API",
+                            "status": "COMPLETED",
+                            "conclusion": "FAILURE",
+                            "createdAt": "2026-04-18T00:00:00Z",
+                        }
+                    ]
+                )
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        agent = {
+            "agent_id": "a1",
+            "issue_number": 42,
+            "phase": "awaiting_deploy",
+            "pr_number": 101,
+            "worktree_path": str(tmp_path),
+            "retries_used": 0,
+        }
+        d._advance_awaiting_deploy(agent)
+        # Deploy failure event.
+        assert handler.events("deploy_failed")
+        failed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "failed" in e[1]
+        ]
+        assert failed_updates
+
+
+# --------------------------------------------------------------------------
+# _advance_awaiting_deploy — success → verify + evidence comment
+# --------------------------------------------------------------------------
+
+
+class TestAwaitingDeploySuccess:
+    def test_deploy_success_runs_verify_and_posts_evidence(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # The issue-bundle fetch happens inside _run_verify_and_complete.
+        call_log: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            call_log.append(list(cmd))
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = ""
+            if cmd[:3] == ["gh", "pr", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "statusCheckRollup": [],
+                        "mergeable": "MERGEABLE",
+                        "mergeStateStatus": "CLEAN",
+                        "headRefOid": "head-sha",
+                        "mergeCommit": {"oid": "merge-sha-abc"},
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "run", "list"]:
+                r.stdout = json.dumps(
+                    [
+                        {
+                            "databaseId": 111,
+                            "workflowName": "Deploy API",
+                            "status": "COMPLETED",
+                            "conclusion": "SUCCESS",
+                            "createdAt": "2026-04-18T00:00:00Z",
+                        }
+                    ]
+                )
+                return r
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "number": 42,
+                        "title": "T",
+                        "body": (
+                            "## Acceptance criteria\n\n"
+                            "- [ ] API returns 200\n"
+                            "- [ ] Response has expected field\n"
+                        ),
+                        "labels": [],
+                        "comments": [],
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "issue", "comment"]:
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+            out_dir = wt / "tmp" / "dispatcher-output"
+            out_dir.mkdir(parents=True, exist_ok=True)
+            assert phase == "verify"
+            (out_dir / "verify.json").write_text(
+                json.dumps(
+                    {
+                        "agent_id": agent_id,
+                        "issue_number": 42,
+                        "pr_number": 101,
+                        "verdict": "VERIFIED",
+                        "change_type": "api",
+                        "evidence_md": (
+                            "## Verification Evidence\n\n"
+                            "**Change type:** api\n\n"
+                            "Post-deploy verification: PASSED\n"
+                        ),
+                        "per_criterion_results": [],
+                        "failure_reason": None,
+                        "unblock_issues": [],
+                    }
+                )
+            )
+            return 0, 0.1
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        agent = {
+            "agent_id": "a1",
+            "issue_number": 42,
+            "phase": "awaiting_deploy",
+            "pr_number": 101,
+            "worktree_path": str(tmp_path),
+            "retries_used": 0,
+        }
+        d._advance_awaiting_deploy(agent)
+
+        # verify_started event.
+        assert handler.events("verify_started")
+        # Evidence comment was posted.
+        assert handler.events("evidence_comment_posted")
+        comment_cmds = [c for c in call_log if c[:3] == ["gh", "issue", "comment"]]
+        assert comment_cmds
+        assert "--body-file" in comment_cmds[0]
+        # Agent marked succeeded.
+        succeeded_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "succeeded" in e[1]
+        ]
+        assert succeeded_updates
+        # agent_completed event.
+        completed = handler.events("agent_completed")
+        assert completed
+        assert completed[0].merge_sha == "merge-sha-abc"
+        assert completed[0].verdict == "VERIFIED"
+
+
+# --------------------------------------------------------------------------
+# _advance_awaiting_deploy — no deploy run (doc-only PR) → verify SKIPPED
+# --------------------------------------------------------------------------
+
+
+class TestAwaitingDeployNoDeployRun:
+    def test_no_deploy_proceeds_to_verify_with_skip(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = ""
+            if cmd[:3] == ["gh", "pr", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "statusCheckRollup": [],
+                        "mergeable": "MERGEABLE",
+                        "mergeStateStatus": "CLEAN",
+                        "headRefOid": "head-sha",
+                        "mergeCommit": {"oid": "merge-sha"},
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "run", "list"]:
+                # No deploy workflows in the response — only CI.
+                r.stdout = json.dumps(
+                    [
+                        {
+                            "databaseId": 222,
+                            "workflowName": "CI",
+                            "status": "COMPLETED",
+                            "conclusion": "SUCCESS",
+                            "createdAt": "2026-04-18T00:00:00Z",
+                        }
+                    ]
+                )
+                return r
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "number": 42,
+                        "title": "",
+                        "body": "",
+                        "labels": [],
+                        "comments": [],
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "issue", "comment"]:
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+            out_dir = wt / "tmp" / "dispatcher-output"
+            out_dir.mkdir(parents=True, exist_ok=True)
+            (out_dir / "verify.json").write_text(
+                json.dumps(
+                    {
+                        "agent_id": agent_id,
+                        "issue_number": 42,
+                        "pr_number": 101,
+                        "verdict": "SKIPPED",
+                        "change_type": "no_deployed_component",
+                        "evidence_md": "## Verification Evidence\n\nSkip reason: docs-only",
+                        "per_criterion_results": [],
+                        "failure_reason": None,
+                        "unblock_issues": [],
+                    }
+                )
+            )
+            return 0, 0.1
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        agent = {
+            "agent_id": "a1",
+            "issue_number": 42,
+            "phase": "awaiting_deploy",
+            "pr_number": 101,
+            "worktree_path": str(tmp_path),
+            "retries_used": 0,
+        }
+        d._advance_awaiting_deploy(agent)
+
+        polls = handler.events("deploy_poll")
+        assert polls and polls[0].deploy_state == "none"
+        # Verify still ran and agent marked succeeded.
+        succeeded_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "succeeded" in e[1]
+        ]
+        assert succeeded_updates
+
+
+# --------------------------------------------------------------------------
+# supervisor_tick integration — advance_running_agents is called
+# --------------------------------------------------------------------------
+
+
+class TestSupervisorTickIntegration:
+    def test_supervisor_tick_invokes_advance(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        # First fetchone() = failures count.
+        conn.cursor_instance.fetch_queue = [(0,)]
+        # No agents to advance (fetchall returns []).
+        conn.cursor_instance.fetchall_queue = [[]]
+        # Stub out the CloudWatch client so no real boto3 import happens.
+        d._cloudwatch_client = MagicMock()
+
+        advance_calls: dict[str, int] = {"n": 0}
+
+        def wrapper() -> int:
+            advance_calls["n"] += 1
+            return 0
+
+        d._advance_running_agents = wrapper  # type: ignore[method-assign]
+        summary = d.supervisor_tick()
+        assert advance_calls["n"] == 1
+        assert summary["agents_advanced"] == 0
+        # Regression: tick log now includes agents_advanced.
+        ticks = handler.events("supervisor_tick")
+        assert ticks
+        assert getattr(ticks[0], "agents_advanced", None) == 0
+
+    def test_supervisor_tick_survives_advance_exception(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+        d._cloudwatch_client = MagicMock()
+
+        def boom() -> int:
+            raise RuntimeError("advance blew up")
+
+        d._advance_running_agents = boom  # type: ignore[method-assign]
+        # Tick must not raise — the heartbeat + metric emission still run.
+        summary = d.supervisor_tick()
+        assert handler.events("advance_pass_failed")
+        assert summary["agents_advanced"] == 0


### PR DESCRIPTION
## Summary

Adds the post-PR half of the dispatcher v2 state machine. The supervisor tick (every 120s) now calls a new `_advance_running_agents` method that drives agents past `push_and_pr` through CI watch → fix-CI loop → merge → deploy watch → verify → evidence comment, using only one-shot GitHub polls (no blocking `gh run watch`).

Phase 3 sub-task B. Builds on #2783 (3A). The new path stays cold until 3E flips `concurrency_cap` from 0 → 1.

Closes #2787

## What lands

- `_advance_running_agents` iterates `dispatcher.agents` in `status='running'` AND `phase IN ('awaiting_ci', 'awaiting_deploy')`, processing each independently with try/except → `status='crashed'` on unhandled exceptions.
- **awaiting_ci** transitions: one-shot `gh pr view --json statusCheckRollup,mergeable,mergeStateStatus,headRefOid,mergeCommit`. Pending → no-op. Green → `gh pr merge --squash --delete-branch` + `awaiting_deploy`. Red → `/task-v2-fix-ci` subprocess; verdict PATCHED applies the patch via `git add -A` + commit + push + `retries_used++`; BLOCKED/max-retries mark failed; FLAKY is a no-op.
- **awaiting_deploy** transitions: `gh run list --commit <merge-sha>` filtered by `DEPLOY_WORKFLOW_NAMES` → pending / success / failure / none. Success (or docs-only "none") → `/task-v2-verify` subprocess; daemon posts `evidence_md` verbatim via `gh issue comment --body-file` and flips `status='succeeded'`. Failure → `status='failed'` for 3C/3D to diagnose.
- No schema changes. Merge SHA and deploy run IDs are re-derived each tick from `gh pr view` / `gh run list`, keeping the state machine crash-safe.

## Test plan

### Automated checks
- [x] Lint passes (`ruff check scripts/dispatcher/`)
- [x] Format check passes (`ruff format --check scripts/dispatcher/`)
- [x] Tests pass (165 passed, 1 pre-existing skip in `scripts/dispatcher/tests/`)
- [x] CI green

### Post-deploy verification
- [ ] N/A — live exercise deferred to 3E. `concurrency_cap` stays 0 on dev; no real `awaiting_ci`/`awaiting_deploy` rows exist today. The new advance path is exercised only by unit tests until 3E flips the cap. Post-deploy smoke check: daemon logs should show only `daemon.supervisor_tick` events with `agents_advanced=0` — no `daemon.advance_*` events because there are no agents in those phases.
- [ ] Verification evidence posted on issue (see A.8)
