### PR TITLE
feat(dispatcher): 3D — diagnoser (skill, tier 2/3, circuit breaker) (#2795)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -1,0 +1,221 @@
+---
+description: Diagnose a tier 2/3 dispatcher failure. Reads context from dispatcher.diagnoses.context, returns a structured recommendation that the daemon consumes deterministically.
+argument-hint: "<diagnosis_id>"
+maxTurns: 30
+model: opus
+---
+
+# /diagnose-failure skill
+
+Diagnoser for the dispatcher v2 tier-2/3 failure flow (`docs/specs/dispatcher-v2-spec.md` §8). Invoked as `claude -p '/diagnose-failure <diagnosis_id>'` by the daemon when a tier-2 failure recurs after its mechanical retry, or when a tier-3 failure fires on first occurrence (`ci_red_after_retries`). Reads the context bundle the daemon wrote to `dispatcher.diagnoses.context`, proposes one of five deterministic actions (`retry`, `retry_with_hint`, `reissue`, `escalate`, `close`), and writes a structured recommendation back to the same row. The daemon executes the chosen action — this skill does not write to GitHub directly.
+
+**Prerequisites:** The daemon has already (a) written a `dispatcher.diagnoses` row with `status='pending'` and a serialized context bundle, (b) spawned this skill with the `diagnosis_id` as the argument.
+
+**Goal:** Update `dispatcher.diagnoses.recommendation` (JSONB) with `{action, reasoning, hint?, new_scope?}` and set `status='completed'`, `completed_at=now()`. The daemon's next supervisor tick consumes the recommendation.
+
+**IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation. This subprocess is already a dispatcher-spawned background task.
+
+**IMPORTANT — No side effects on GitHub or the filesystem.** This skill does NOT comment on issues, edit labels, close issues, edit PRs, or modify the worktree. The daemon owns all of those operations — the skill's only write is the UPDATE on `dispatcher.diagnoses`. The skill MAY read from GitHub (`gh issue view`, `gh pr view`, `gh run view --log-failed`) and from local files in the failed agent's worktree when the context bundle references them.
+
+**IMPORTANT — 5-minute wall-clock budget.** The daemon kills this subprocess after 5 minutes. Aim for the simplest viable recommendation within that budget; default to `escalate` when genuinely uncertain — a human can always re-classify. Do not chase rabbit holes.
+
+---
+
+## Input contract
+
+The argument is a single integer `diagnosis_id` (from `dispatcher.diagnoses.diagnosis_id`).
+
+Read the context bundle directly from Postgres. The daemon is running inside a Fargate task with `DATABASE_URL` already exported; use the existing repo convention (psycopg3) via a small helper — the simplest path is:
+
+```bash
+python3 {worktree}/tmp/dispatcher-diagnoser/read_context.py <diagnosis_id>
+```
+
+where the helper (which you write into the worktree's tmp/ first) looks roughly like:
+
+```python
+import json, os, sys
+import psycopg
+
+diagnosis_id = int(sys.argv[1])
+with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT context FROM dispatcher.diagnoses WHERE diagnosis_id = %s",
+            (diagnosis_id,),
+        )
+        row = cur.fetchone()
+print(json.dumps(row[0] if row else {}, default=str))
+```
+
+You may also shell out with `scripts/dev-db-query.sh` for quick SELECTs. Either path works — the contract is "read the JSONB, parse it, reason about it".
+
+The `context` JSONB contains (schema stable — the daemon serializes this):
+
+- `agent_id` (str) — the failing agent's UUID.
+- `failure_id` (int) — `dispatcher.failures.failure_id` for the triggering failure.
+- `failure_category` (str) — one of `subprocess_turn_limit`, `stuck_timeout`, `gh_rate_exhausted`, `subprocess_crash`, `ci_red_after_retries`, or any other §8 category the daemon has routed here.
+- `tier` (int) — `2` or `3`.
+- `issue_number` (int).
+- `issue_title` (str).
+- `issue_body` (str).
+- `recent_phase_transitions` (list of `{phase, ts}`) — last ~10 transitions for this agent, newest first.
+- `prior_failures` (list of `{failure_id, category, ts, details}`) — prior `dispatcher.failures` rows on the same issue across all agents (not just this one).
+- `ralph_done_content` (str | null) — contents of `{worktree}/tmp/ralph/ralph-done.txt` if present, else null.
+- `pr_url` (str | null) — if a PR was opened.
+- `pr_number` (int | null).
+- `ci_log_url` (str | null) — URL of the most recent failing CI run (for `ci_red_after_retries` tier-3).
+- `prior_mechanical_fix` (dict | null) — **tier 2 only**. What the daemon already tried that didn't stick. Shape: `{category, attempt, retry_after_ts, outcome}`. Null for tier 3.
+- `worktree_path` (str) — absolute path to the failing agent's worktree (may or may not still exist; the daemon may have dropped it during retry processing).
+
+---
+
+## Output contract
+
+Update the `dispatcher.diagnoses` row. Use a second tiny helper:
+
+```bash
+python3 {worktree}/tmp/dispatcher-diagnoser/write_recommendation.py <diagnosis_id> <recommendation_json_file>
+```
+
+where the helper runs:
+
+```python
+import json, os, sys
+import psycopg
+
+diagnosis_id = int(sys.argv[1])
+with open(sys.argv[2], "r", encoding="utf-8") as f:
+    recommendation = json.load(f)
+with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE dispatcher.diagnoses "
+            "SET recommendation = %s, "
+            "    status = 'completed', "
+            "    completed_at = now() "
+            "WHERE diagnosis_id = %s",
+            (json.dumps(recommendation), diagnosis_id),
+        )
+    conn.commit()
+```
+
+The recommendation JSON has this shape:
+
+```json
+{
+  "action": "retry" | "retry_with_hint" | "reissue" | "escalate" | "close",
+  "reasoning": "<one paragraph — why this action fits>",
+  "hint": "<optional — comment text to post on the issue before retry>",
+  "new_scope": "<optional — rewritten issue body for action='reissue'>"
+}
+```
+
+Field rules:
+
+- `action` (required) — exactly one of the five strings above.
+- `reasoning` (required) — a single paragraph (≤500 chars) explaining the choice in plain English. This gets surfaced in operator dashboards and the §8 weekly report.
+- `hint` (conditional) — required when `action='retry_with_hint'`; the daemon posts it verbatim as an issue comment before enqueueing the retry marker. Ignored for other actions.
+- `new_scope` (conditional) — required when `action='reissue'`; the daemon replaces the issue body with this string. Should be a full, well-formed issue body with acceptance criteria — not a diff.
+
+Exit 0 regardless of recommendation. If the recommendation cannot be written (DB down, malformed JSON, subprocess error), exit non-zero so the daemon marks the diagnosis `status='failed'` and falls back to the fixed mechanical escalation policy.
+
+---
+
+## Action selection — decision tree
+
+Work through these questions in order. The first "yes" determines the action.
+
+1. **Is this failure caused by an external dependency outage or a transient GitHub/Anthropic/AWS hiccup?** (Signs: `subprocess_crash` category, stderr mentions 5xx / timeouts / DNS / network errors, prior failures on unrelated issues in the same window.)
+   - → **`retry`**. The mechanical retry already ran once (tier 2), but if the root cause was a transient that has since cleared, a second attempt may succeed. No comment needed.
+
+2. **Is the failure caused by a scope ambiguity or a missing piece of context the agent needed?** (Signs: `subprocess_turn_limit` with ralph spinning on the same scope item; `ci_red_after_retries` where the fix-CI phase kept trying to fix symptoms of a larger design issue.)
+   - → **`retry_with_hint`**. Write a short, concrete `hint` that tells the next agent what to focus on or narrow to. Example hints:
+     - "ralph hit max turns trying to fix a rebase conflict. Resolve the conflict first (`git rebase origin/main`), then re-run the implementation."
+     - "Three fix-CI attempts failed because the test fixture is stale. Regenerate the fixture by running `scripts/regenerate_fixtures.sh` before re-running the implementation."
+
+3. **Is the issue's scope wrong — i.e. the agent correctly implemented what was asked, but the acceptance criteria no longer match reality?** (Signs: ralph completed with SHIP but CI caught a drift; the issue was filed against an older codebase state; the AC uses a field/endpoint that has been renamed/removed.)
+   - → **`reissue`**. Write a `new_scope` issue body with corrected acceptance criteria. Include `Parent: #<parent>` if the original had one. Keep the `Verify:` lines concrete.
+
+4. **Does the failure require a human decision that the agent cannot make safely?** (Signs: `subprocess_auth_fail`, missing secret, security question, architectural decision, vendor billing concern, any issue label with `type/decision`.)
+   - → **`escalate`**. The daemon will add `status/needs-human` + `priority/p1` and post the reasoning as a comment. No retry.
+
+5. **Is the issue itself invalid — duplicate, already-completed, out-of-date, or not actually reproducible?** (Signs: a PR already merged that Closes this issue; the behavior described is the current behavior; the issue is a duplicate of another open issue.)
+   - → **`close`**. The daemon will close with `status/invalid` and post the reasoning as the close comment.
+
+**When uncertain, prefer `escalate` over a wrong guess.** A human re-classification is cheap; a wrong `close` or `reissue` can destroy context.
+
+---
+
+## Investigation steps — only as needed
+
+The context bundle should usually be enough. Shell out sparingly:
+
+- `gh issue view <N> --repo judgemind/judgemind --json number,title,body,state,labels,comments` — when the context is stale and the issue may have been edited or commented on since the daemon fetched it.
+- `gh pr view <PR> --repo judgemind/judgemind --json statusCheckRollup,files,commits,mergeable,mergeStateStatus` — for tier-3 `ci_red_after_retries` where the failing checks tell you the fix approach.
+- `gh run view <run_id> --repo judgemind/judgemind --log-failed` — to read the specific failing CI log. Cap at ~200 lines; the relevant signal is usually at the start or end.
+- `git -C {worktree} log --oneline -20` — to see the commit history of the failing agent's branch.
+- `git -C {worktree} diff origin/main...HEAD` — the full PR diff. Only needed when deciding between `retry_with_hint` and `reissue`.
+
+**Do NOT:**
+- Edit files, run tests, or try to implement the fix yourself.
+- Post comments, edit labels, or close issues via `gh`. The daemon owns all writes based on your recommendation.
+- Read unrelated parts of the codebase. The context bundle exists so you don't have to.
+
+---
+
+## Step-by-step procedure
+
+1. **Set up.** Write `{worktree}/tmp/dispatcher-diagnoser/read_context.py` and `{worktree}/tmp/dispatcher-diagnoser/write_recommendation.py` helpers (code above). Run the reader with the `diagnosis_id` argument to pull the JSONB context into memory.
+
+2. **Classify.** Identify `failure_category` and `tier` from the context. Read `prior_mechanical_fix` (tier 2) or `ci_log_url` (tier 3) to understand what already failed.
+
+3. **Decide.** Walk the decision tree above. Do not fetch anything you don't need — context bundle first, GitHub reads only when a specific question remains.
+
+4. **Write recommendation.** Serialize the recommendation dict to `{worktree}/tmp/dispatcher-diagnoser/recommendation.json`, then run the writer helper with the `diagnosis_id` and the JSON file path.
+
+5. **Exit 0.** Done. The daemon picks up the recommendation on the next supervisor tick.
+
+---
+
+## Examples
+
+### Example 1 — tier 3 `ci_red_after_retries`, reissue
+
+```json
+{
+  "action": "reissue",
+  "reasoning": "The failing test was checking a field name that has since been renamed from `ruling_text` to `ruling_text_html`. Ralph correctly implemented against the issue's AC (which used the old name), and fix-CI kept trying to revert the field name change. The AC is outdated, not the code.",
+  "new_scope": "## Goal\n\nExpose `ruling_text_html` on the /api/rulings/{id} endpoint.\n\n## Acceptance criteria\n- [ ] GraphQL `Ruling.rulingTextHtml` returns the HTML variant.\n  **Verify:** `curl dev.api.judgemind.org/graphql` with a sample ruling id returns `rulingTextHtml` populated.\n\nParent: #2782"
+}
+```
+
+### Example 2 — tier 2 `subprocess_turn_limit`, retry_with_hint
+
+```json
+{
+  "action": "retry_with_hint",
+  "reasoning": "Ralph hit max turns on a merge conflict in `packages/api/src/graphql/schema.ts` that was introduced while this agent was running. A fresh worktree and a rebase-first hint will fix the next attempt.",
+  "hint": "Previous attempt exhausted turns on a merge conflict. Run `git -C {worktree} rebase origin/main` first, resolve conflicts in packages/api/src/graphql/schema.ts, then proceed with the implementation."
+}
+```
+
+### Example 3 — tier 2 `stuck_timeout` recurring, escalate
+
+```json
+{
+  "action": "escalate",
+  "reasoning": "This agent got stuck in phase=ralph for 30 min on both the original attempt and the retry. Both times the last phase transition was on a specific test that depends on a flaky external API (`httpbin.org`). Needs human to either mark the test xfail or replace with a local fixture.",
+  "hint": null
+}
+```
+
+---
+
+## Reminders
+
+- No `$()`, no heredocs, no `python -c`. See `CLAUDE.md` Critical Rules. Write helper scripts to `{worktree}/tmp/dispatcher-diagnoser/` first, then invoke them.
+- All temp files go under `{worktree}/tmp/`, never `/tmp/`.
+- This skill is Opus-tier per spec §18 — but the task is narrow. Do NOT over-investigate. The decision tree is intentionally short.
+- **The five actions are exhaustive.** Do not invent a sixth (`defer`, `split`, `merge`, etc.) — the daemon's consumer has five deterministic branches and will fall back to escalation on any other string.
+- Exit 0 means "recommendation written". Exit non-zero means "I could not diagnose" — the daemon falls back to fixed mechanical escalation.

--- a/packages/api/migrations/26_dispatcher-diagnoser-config-seeds.sql
+++ b/packages/api/migrations/26_dispatcher-diagnoser-config-seeds.sql
@@ -1,0 +1,37 @@
+-- Up Migration
+--
+-- Dispatcher v2 — Phase 3 sub-task D. Seeds two config rows that gate
+-- the §8 tier-2/3 diagnoser added in `scripts/dispatcher/daemon.py`.
+--
+-- Issue #2795 (Parent: #2782, Phase 3 epic).
+--
+-- Design notes
+-- ------------
+-- - `diagnoser_enabled` is the kill switch. Default `true`. The daemon
+--   reads this value once per supervisor tick; circuit-breaker logic
+--   in the daemon flips it to `false` when the 24h fallback rate
+--   (diagnoses that timed out, crashed, or returned malformed JSON)
+--   exceeds the threshold below AND at least 5 diagnoses have run.
+--   Operators manually re-enable by `UPDATE dispatcher.config SET
+--   value = 'true' WHERE key = 'diagnoser_enabled';`.
+-- - `diagnoser_fallback_rate_threshold` is the circuit-breaker knob.
+--   `0.30` (30%) matches spec §8 "Budget & safety". Stored as a JSONB
+--   number so operators can tune live (e.g. `'0.50'` for more
+--   tolerance during early bring-up).
+-- - No DDL changes — both rows are pure seeds. `ON CONFLICT DO NOTHING`
+--   keeps the migration idempotent on re-runs (e.g. if an operator
+--   already inserted the rows manually) and means a down-migration
+--   that deletes them by key is safe even if the row was never
+--   inserted in the first place.
+-- - `updated_by='init'` matches the convention in migration 21:
+--   migration-seeded rows are distinguishable from operator edits.
+
+INSERT INTO dispatcher.config (key, value, updated_by) VALUES
+    ('diagnoser_enabled',                 'true',   'init'),
+    ('diagnoser_fallback_rate_threshold', '0.30',   'init')
+ON CONFLICT (key) DO NOTHING;
+
+
+-- Down Migration
+DELETE FROM dispatcher.config
+WHERE key IN ('diagnoser_enabled', 'diagnoser_fallback_rate_threshold');

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 25 migrations.
+-- Generated from 26 migrations.
 
 
 

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -297,6 +297,14 @@ FAILURE_CATEGORY_SUBPROCESS_CRASH = "subprocess_crash"
 FAILURE_CATEGORY_SUBPROCESS_TURN_LIMIT = "subprocess_turn_limit"
 FAILURE_CATEGORY_SUBPROCESS_AUTH_FAIL = "subprocess_auth_fail"
 
+#: Tier-3 failure category from spec §8 (``ci_red_after_retries``).
+#: Written by 3B's fix-CI exhaustion path when ``retries_used >=
+#: FIX_CI_MAX_RETRIES`` before the agent is marked failed. 3D's
+#: diagnoser picks it up on the next supervisor tick for immediate
+#: (tier-3) diagnosis — there is no mechanical retry that reliably
+#: fixes "the CI-fixing skill couldn't fix CI three times in a row".
+FAILURE_CATEGORY_CI_RED_AFTER_RETRIES = "ci_red_after_retries"
+
 #: Which failure categories auto-create a retry marker (tier 1 per
 #: spec §8 table). ``subprocess_turn_limit`` (tier 2) and
 #: ``subprocess_auth_fail`` (halt — no retry) are intentionally
@@ -330,6 +338,98 @@ _SUBPROCESS_STDERR_PATTERNS: tuple[tuple[str, str], ...] = (
     (r"401\s+Unauthorized", FAILURE_CATEGORY_SUBPROCESS_AUTH_FAIL),
     (r"Reached max turns", FAILURE_CATEGORY_SUBPROCESS_TURN_LIMIT),
 )
+
+
+# --------------------------------------------------------------------------
+# Phase 3D — diagnoser (issue #2795, spec §8 "Diagnosis Step")
+# --------------------------------------------------------------------------
+
+#: Tier-2 categories that trigger the diagnoser ONLY after a tier-1
+#: mechanical retry has already fired once and the same failure category
+#: recurs for the same agent within a recent window. Matches spec §8:
+#: "only after the mechanical fix has been tried once and the failure
+#: recurs". ``stuck_timeout``, ``gh_rate_exhausted``, ``subprocess_crash``
+#: are tier-1 retry categories whose **recurrence** escalates to tier 2;
+#: ``subprocess_turn_limit`` is explicitly tier 2 on first occurrence
+#: (see §8 table — "Retry once with narrower scope hint; second trip
+#: escalates" — our policy is to diagnose on first occurrence so the
+#: diagnoser can choose retry_with_hint vs escalate).
+TIER_2_RECURRENCE_CATEGORIES: frozenset[str] = frozenset(
+    {
+        FAILURE_CATEGORY_STUCK_TIMEOUT,
+        FAILURE_CATEGORY_GH_RATE_EXHAUSTED,
+        FAILURE_CATEGORY_SUBPROCESS_CRASH,
+    }
+)
+
+#: Tier-2 categories that diagnose on **first** occurrence (no mechanical
+#: retry runs). Spec §8 table classifies ``subprocess_turn_limit`` as
+#: tier 2 with mechanical hint = "retry once with narrower scope"; we
+#: delegate that retry-vs-escalate choice to the diagnoser immediately
+#: rather than hard-coding one mechanical retry.
+TIER_2_FIRST_OCCURRENCE_CATEGORIES: frozenset[str] = frozenset(
+    {
+        FAILURE_CATEGORY_SUBPROCESS_TURN_LIMIT,
+    }
+)
+
+#: Tier-3 categories that diagnose on first occurrence (spec §8). Today
+#: only ``ci_red_after_retries`` qualifies — the 3B fix-CI loop has
+#: already burned its 3 mechanical retries, so there is no reliable
+#: mechanical remedy left.
+TIER_3_CATEGORIES: frozenset[str] = frozenset(
+    {
+        FAILURE_CATEGORY_CI_RED_AFTER_RETRIES,
+    }
+)
+
+#: Window inside which a recurring tier-2 failure for the same agent +
+#: category triggers the diagnoser. 24 h is generous enough to catch
+#: same-day pattern recurrences (e.g. a flaky external API that breaks
+#: again in the afternoon) while not re-triggering on unrelated failures
+#: weeks later.
+TIER_2_RECURRENCE_WINDOW_SECONDS = 24 * 60 * 60
+
+#: Hard wall-clock timeout for the ``/diagnose-failure`` subprocess
+#: (``claude -p``). Matches spec §8 "5-min hard wall-clock timeout".
+#: Timeout, non-zero exit, or malformed recommendation JSON → fall
+#: back to fixed mechanical escalation policy (spec §8 "Budget &
+#: safety").
+DIAGNOSER_SUBPROCESS_TIMEOUT_SECONDS = 5 * 60
+
+#: ``--max-turns`` value for the diagnoser. 30 is generous for a
+#: read-only reasoning task — the skill reads a JSONB context, maybe
+#: fetches an issue/PR/CI log, and writes a recommendation. Matches
+#: the frontmatter in ``.claude/skills/diagnose-failure/SKILL.md``.
+DIAGNOSER_MAX_TURNS = 30
+
+#: Default model for the diagnoser. Matches
+#: ``dispatcher.config.model_by_phase.diagnose`` seed (``opus``) from
+#: migration 21. The decision is low-frequency but high-impact —
+#: Opus's reasoning headroom is cheap insurance against a wrong
+#: ``close`` / ``reissue``.
+DIAGNOSER_MODEL = "opus"
+
+#: Valid ``action`` strings a diagnoser recommendation may set. The
+#: daemon's deterministic consumer switches on these; any other value
+#: falls through to ``escalate`` as a safe default (logged as
+#: ``daemon.diagnosis_action_unknown``).
+DIAGNOSER_ACTIONS: frozenset[str] = frozenset(
+    {"retry", "retry_with_hint", "reissue", "escalate", "close"}
+)
+
+#: Circuit-breaker bounds (spec §8 "Budget & safety"). When the
+#: fallback rate (diagnoses with ``status='failed'``) over the last 24 h
+#: exceeds the configured threshold AND at least this many diagnoses
+#: have run, the daemon flips ``dispatcher.config.diagnoser_enabled``
+#: to ``false``. Matches the spec's "≥5 diagnoses" floor so a single
+#: early failure cannot trip the breaker.
+CIRCUIT_BREAKER_MIN_DIAGNOSES = 5
+CIRCUIT_BREAKER_WINDOW_SECONDS = 24 * 60 * 60
+
+#: Default fallback-rate threshold when the ``dispatcher.config`` row
+#: is missing or malformed. Matches the migration-26 seed ``0.30``.
+DEFAULT_CIRCUIT_BREAKER_THRESHOLD = 0.30
 
 
 # --------------------------------------------------------------------------
@@ -3148,6 +3248,23 @@ class DispatcherDaemon:
                     "retries_used": retries_used,
                 },
             )
+            # Phase 3D (#2795): write a tier-3 `ci_red_after_retries`
+            # failure row BEFORE flipping the agent to 'failed' so the
+            # supervisor tick's tier-3 detector can pick it up and
+            # spawn the diagnoser. The failure row carries just enough
+            # context for the diagnoser's context-bundle assembly to
+            # find the PR + CI log URL.
+            self._write_failure(
+                agent_id=agent_id,
+                category=FAILURE_CATEGORY_CI_RED_AFTER_RETRIES,
+                detected_by="scheduler",
+                details={
+                    "phase": "awaiting_ci",
+                    "pr_number": pr_number,
+                    "issue_number": issue_number,
+                    "retries_used": retries_used,
+                },
+            )
             self._mark_agent_terminal(
                 agent_id, status="failed", phase="awaiting_ci", exit_code=None
             )
@@ -4717,6 +4834,1251 @@ class DispatcherDaemon:
                     pass
         return processed
 
+    # ── Phase 3D (#2795): tier-2/3 diagnoser ───────────────────────────
+
+    def _diagnoser_enabled(self) -> bool:
+        """Read ``dispatcher.config.diagnoser_enabled`` and coerce to bool.
+
+        Defaults to ``True`` when the config row is missing or malformed.
+        The circuit breaker (:meth:`_check_diagnoser_circuit_breaker`)
+        flips this to ``false`` via UPDATE when the 24h fallback rate
+        exceeds :meth:`_diagnoser_fallback_threshold`.
+        """
+        assert self._conn is not None, "connect() must run before config read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    ("diagnoser_enabled",),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return True
+
+        if row is None or row[0] is None:
+            return True
+        raw = row[0]
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return True
+        if isinstance(raw, bool):
+            return raw
+        # JSON ``true``/``false`` → Python bool; anything else (numbers,
+        # strings, dicts) is malformed — default to enabled.
+        return True
+
+    def _diagnoser_fallback_threshold(self) -> float:
+        """Read ``diagnoser_fallback_rate_threshold`` from ``dispatcher.config``.
+
+        Falls back to :data:`DEFAULT_CIRCUIT_BREAKER_THRESHOLD` (0.30)
+        on missing row, malformed JSON, or out-of-range value
+        (<0 or >1). The circuit breaker compares the 24h fallback
+        ratio against this and trips when ratio > threshold AND the
+        minimum diagnosis count is reached.
+        """
+        assert self._conn is not None, "connect() must run before config read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    ("diagnoser_fallback_rate_threshold",),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return DEFAULT_CIRCUIT_BREAKER_THRESHOLD
+
+        if row is None or row[0] is None:
+            return DEFAULT_CIRCUIT_BREAKER_THRESHOLD
+        raw = row[0]
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return DEFAULT_CIRCUIT_BREAKER_THRESHOLD
+        try:
+            threshold = float(raw)
+        except (TypeError, ValueError):
+            return DEFAULT_CIRCUIT_BREAKER_THRESHOLD
+        if threshold < 0.0 or threshold > 1.0:
+            return DEFAULT_CIRCUIT_BREAKER_THRESHOLD
+        return threshold
+
+    def _check_diagnoser_circuit_breaker(self) -> bool:
+        """Trip the circuit breaker if the 24h fallback rate is too high.
+
+        Spec §8 "Budget & safety": when >30% of diagnoses in the last
+        24 h fell back (timeout, malformed JSON, subprocess crash) AND
+        at least :data:`CIRCUIT_BREAKER_MIN_DIAGNOSES` diagnoses have
+        run in the same window, flip
+        ``dispatcher.config.diagnoser_enabled`` to ``false`` and log a
+        ``daemon.diagnoser_circuit_breaker_tripped`` event. Operator
+        manually re-enables.
+
+        Returns True if the breaker was tripped this call, False
+        otherwise. Called once per supervisor tick (cheap — one COUNT
+        aggregation over a narrow time range).
+        """
+        assert self._conn is not None, "connect() must run before breaker check"
+
+        threshold = self._diagnoser_fallback_threshold()
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT "
+                    "    COUNT(*) FILTER (WHERE status = 'failed'), "
+                    "    COUNT(*) "
+                    "FROM dispatcher.diagnoses "
+                    "WHERE started_at > now() - make_interval(secs => %s)",
+                    (CIRCUIT_BREAKER_WINDOW_SECONDS,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.diagnoser_circuit_breaker_scan_failed",
+                extra={
+                    "event": "diagnoser_circuit_breaker_scan_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return False
+
+        if row is None:
+            return False
+        failed_n = int(row[0] or 0)
+        total_n = int(row[1] or 0)
+
+        if total_n < CIRCUIT_BREAKER_MIN_DIAGNOSES:
+            # Not enough samples to judge — noisy early runs must not
+            # trip the breaker. Spec §8 gates on both "rate > threshold"
+            # AND "total diagnoses ≥ 5".
+            return False
+
+        fallback_rate = failed_n / total_n if total_n else 0.0
+        if fallback_rate <= threshold:
+            return False
+
+        # Trip the breaker. Write the config update and log.
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.config "
+                    "SET value = 'false', "
+                    "    updated_at = now(), "
+                    "    updated_by = 'diagnoser_circuit_breaker' "
+                    "WHERE key = %s",
+                    ("diagnoser_enabled",),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.diagnoser_circuit_breaker_flip_failed",
+                extra={
+                    "event": "diagnoser_circuit_breaker_flip_failed",
+                    "run_id": self._run_id,
+                    "fallback_rate": round(fallback_rate, 3),
+                    "total_diagnoses": total_n,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return False
+
+        self._log.warning(
+            "daemon.diagnoser_circuit_breaker_tripped",
+            extra={
+                "event": "diagnoser_circuit_breaker_tripped",
+                "run_id": self._run_id,
+                "fallback_rate": round(fallback_rate, 3),
+                "threshold": threshold,
+                "total_diagnoses_24h": total_n,
+                "failed_diagnoses_24h": failed_n,
+                "min_diagnoses": CIRCUIT_BREAKER_MIN_DIAGNOSES,
+            },
+        )
+        return True
+
+    def _find_diagnoser_candidates(self) -> list[dict[str, Any]]:
+        """Find tier-2/3 failures that need a diagnosis this tick.
+
+        A "candidate" is a ``dispatcher.failures`` row that:
+
+        * Has not yet triggered a diagnosis (no ``dispatcher.diagnoses``
+          row with matching ``failure_id``).
+        * Is in a tier-2 recurrence category with a prior failure of
+          the same category for the same agent within the recurrence
+          window, OR in :data:`TIER_2_FIRST_OCCURRENCE_CATEGORIES`,
+          OR in :data:`TIER_3_CATEGORIES`.
+
+        Returns a list of ``{failure_id, agent_id, category, tier,
+        issue_number, details, failure_ts}`` dicts, newest first.
+        Caller spawns one diagnoser subprocess per candidate.
+        """
+        assert self._conn is not None, "connect() must run before candidate scan"
+
+        all_trigger_categories = list(
+            TIER_2_RECURRENCE_CATEGORIES
+            | TIER_2_FIRST_OCCURRENCE_CATEGORIES
+            | TIER_3_CATEGORIES
+        )
+
+        candidates: list[dict[str, Any]] = []
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT f.failure_id, f.agent_id, f.category, f.details, f.ts "
+                    "FROM dispatcher.failures f "
+                    "LEFT JOIN dispatcher.diagnoses d "
+                    "    ON d.failure_id = f.failure_id "
+                    "WHERE d.failure_id IS NULL "
+                    "  AND f.agent_id IS NOT NULL "
+                    "  AND f.category = ANY(%s) "
+                    "  AND f.ts > now() - make_interval(secs => %s) "
+                    "ORDER BY f.ts DESC "
+                    "LIMIT 20",
+                    (all_trigger_categories, TIER_2_RECURRENCE_WINDOW_SECONDS),
+                )
+                rows = cur.fetchall()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.diagnoser_candidate_scan_failed",
+                extra={
+                    "event": "diagnoser_candidate_scan_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return []
+
+        for row in rows:
+            failure_id = int(row[0])
+            agent_id = str(row[1]) if row[1] is not None else None
+            category = str(row[2])
+            details = row[3] or {}
+            failure_ts = row[4]
+            if agent_id is None:
+                # Daemon-level failures (``gh_rate_exhausted`` with
+                # ``agent_id=NULL``) are never diagnosed — no agent to
+                # recover.
+                continue
+            # Parse details if it's a JSON string.
+            if isinstance(details, str):
+                try:
+                    details = json.loads(details)
+                except json.JSONDecodeError:
+                    details = {}
+
+            issue_number: int | None = None
+            if isinstance(details, dict):
+                issue_number = details.get("issue_number")
+                if issue_number is not None:
+                    try:
+                        issue_number = int(issue_number)
+                    except (TypeError, ValueError):
+                        issue_number = None
+
+            # Determine tier. First-occurrence and tier-3 categories
+            # diagnose immediately. Tier-2 recurrence categories
+            # diagnose ONLY if a prior failure of the same category
+            # exists for the same agent within the recurrence window.
+            tier: int
+            if category in TIER_3_CATEGORIES:
+                tier = 3
+            elif category in TIER_2_FIRST_OCCURRENCE_CATEGORIES:
+                tier = 2
+            elif category in TIER_2_RECURRENCE_CATEGORIES:
+                if not self._has_prior_same_category_failure(
+                    agent_id=agent_id,
+                    category=category,
+                    before_failure_id=failure_id,
+                ):
+                    # First occurrence of a tier-1 mechanical category —
+                    # the mechanical retry path handles it, not the
+                    # diagnoser.
+                    continue
+                tier = 2
+            else:
+                # Defensive: category was in the SQL filter but doesn't
+                # match any known bucket.
+                continue
+
+            candidates.append(
+                {
+                    "failure_id": failure_id,
+                    "agent_id": agent_id,
+                    "category": category,
+                    "tier": tier,
+                    "issue_number": issue_number,
+                    "details": details if isinstance(details, dict) else {},
+                    "failure_ts": failure_ts,
+                }
+            )
+        return candidates
+
+    def _has_prior_same_category_failure(
+        self, *, agent_id: str, category: str, before_failure_id: int
+    ) -> bool:
+        """True if the agent has a prior failure of ``category`` within the window.
+
+        Used by :meth:`_find_diagnoser_candidates` to gate tier-2
+        recurrence categories — the diagnoser only fires on the second
+        failure in the pair, not the first.
+        """
+        assert self._conn is not None, "connect() must run before recurrence check"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM dispatcher.failures "
+                    "WHERE agent_id = %s "
+                    "  AND category = %s "
+                    "  AND failure_id < %s "
+                    "  AND ts > now() - make_interval(secs => %s) "
+                    "LIMIT 1",
+                    (
+                        agent_id,
+                        category,
+                        before_failure_id,
+                        TIER_2_RECURRENCE_WINDOW_SECONDS,
+                    ),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return False
+        return row is not None
+
+    def _build_diagnoser_context(self, candidate: dict[str, Any]) -> dict[str, Any]:
+        """Assemble the JSONB context bundle passed to ``/diagnose-failure``.
+
+        The skill reads this via
+        ``SELECT context FROM dispatcher.diagnoses`` after the daemon
+        INSERTs the pending row. Shape matches the input contract in
+        ``.claude/skills/diagnose-failure/SKILL.md``.
+
+        All sub-queries are individually try/except'd and fall back to
+        empty/null on failure — a stale or missing context is better
+        than no diagnosis. The skill's decision-tree defaults to
+        ``escalate`` on sparse context.
+        """
+        assert self._conn is not None, "connect() must run before context build"
+
+        agent_id = candidate["agent_id"]
+        failure_id = candidate["failure_id"]
+
+        # Fetch the agent row for worktree_path + the failure envelope.
+        agent_row: dict[str, Any] = {}
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT issue_number, worktree_path, pr_number "
+                    "FROM dispatcher.agents WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+            if row is not None:
+                agent_row = {
+                    "issue_number": int(row[0]) if row[0] is not None else None,
+                    "worktree_path": str(row[1]) if row[1] is not None else "",
+                    "pr_number": int(row[2]) if row[2] is not None else None,
+                }
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+
+        issue_number = candidate.get("issue_number") or agent_row.get("issue_number")
+
+        # Recent phase transitions — last ~10.
+        phase_transitions: list[dict[str, Any]] = []
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT phase, ts FROM dispatcher.phase_transitions "
+                    "WHERE agent_id = %s "
+                    "ORDER BY ts DESC LIMIT 10",
+                    (agent_id,),
+                )
+                rows = cur.fetchall()
+            self._conn.commit()
+            for r in rows:
+                phase_transitions.append(
+                    {
+                        "phase": str(r[0]) if r[0] is not None else None,
+                        "ts": r[1].isoformat() if r[1] is not None else None,
+                    }
+                )
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+
+        # Prior failures on the same issue — across all agents.
+        prior_failures: list[dict[str, Any]] = []
+        if issue_number is not None:
+            try:
+                with self._conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT f.failure_id, f.category, f.ts, f.details "
+                        "FROM dispatcher.failures f "
+                        "JOIN dispatcher.agents a "
+                        "    ON a.agent_id = f.agent_id "
+                        "WHERE a.issue_number = %s "
+                        "  AND f.failure_id <> %s "
+                        "ORDER BY f.ts DESC LIMIT 20",
+                        (issue_number, failure_id),
+                    )
+                    rows = cur.fetchall()
+                self._conn.commit()
+                for r in rows:
+                    prior_failures.append(
+                        {
+                            "failure_id": int(r[0]),
+                            "category": str(r[1]),
+                            "ts": r[2].isoformat() if r[2] is not None else None,
+                            "details": r[3] if isinstance(r[3], dict) else {},
+                        }
+                    )
+            except Exception:
+                try:
+                    self._conn.rollback()
+                except Exception:  # pragma: no cover
+                    pass
+
+        # ralph-done.txt content if present.
+        ralph_done_content: str | None = None
+        worktree_path = agent_row.get("worktree_path") or ""
+        if worktree_path:
+            ralph_done_path = Path(worktree_path) / "tmp" / "ralph" / "ralph-done.txt"
+            try:
+                if ralph_done_path.exists():
+                    ralph_done_content = ralph_done_path.read_text(
+                        encoding="utf-8", errors="replace"
+                    )
+            except Exception:  # pragma: no cover — best-effort read
+                ralph_done_content = None
+
+        # Issue title + body — fetch lazily via gh so the daemon does
+        # not duplicate the ``_fetch_issue_bundle`` MCP path. The skill
+        # can always re-fetch if the context is stale.
+        issue_title = ""
+        issue_body = ""
+        if issue_number is not None:
+            try:
+                result = subprocess.run(
+                    [
+                        "gh",
+                        "issue",
+                        "view",
+                        str(issue_number),
+                        "--repo",
+                        self._cfg.github_repo,
+                        "--json",
+                        "title,body",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                    check=False,
+                )
+                if result.returncode == 0 and result.stdout:
+                    payload = json.loads(result.stdout)
+                    issue_title = str(payload.get("title") or "")
+                    issue_body = str(payload.get("body") or "")
+            except (
+                FileNotFoundError,
+                subprocess.TimeoutExpired,
+                json.JSONDecodeError,
+            ):
+                pass
+
+        # prior_mechanical_fix — tier 2 only, describes what was tried.
+        prior_mechanical_fix: dict[str, Any] | None = None
+        if (
+            candidate["tier"] == 2
+            and candidate["category"] in TIER_2_RECURRENCE_CATEGORIES
+        ):
+            try:
+                with self._conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT attempt, retry_after_ts, resolved_at "
+                        "FROM dispatcher.retry_markers "
+                        "WHERE agent_id = %s AND reason = %s "
+                        "ORDER BY created_at DESC LIMIT 1",
+                        (agent_id, candidate["category"]),
+                    )
+                    r = cur.fetchone()
+                self._conn.commit()
+                if r is not None:
+                    prior_mechanical_fix = {
+                        "category": candidate["category"],
+                        "attempt": int(r[0]) if r[0] is not None else None,
+                        "retry_after_ts": r[1].isoformat()
+                        if r[1] is not None
+                        else None,
+                        "outcome": "resolved" if r[2] is not None else "pending",
+                    }
+            except Exception:
+                try:
+                    self._conn.rollback()
+                except Exception:  # pragma: no cover
+                    pass
+
+        details = candidate.get("details") or {}
+        pr_number = agent_row.get("pr_number")
+        if pr_number is None and isinstance(details, dict):
+            pr_number = details.get("pr_number")
+        pr_url: str | None = None
+        if pr_number is not None:
+            pr_url = f"https://github.com/{self._cfg.github_repo}/pull/{pr_number}"
+        ci_log_url: str | None = None
+        if isinstance(details, dict):
+            ci_log_url = details.get("ci_log_url") or None
+
+        return {
+            "agent_id": agent_id,
+            "failure_id": failure_id,
+            "failure_category": candidate["category"],
+            "tier": candidate["tier"],
+            "issue_number": issue_number,
+            "issue_title": issue_title,
+            "issue_body": issue_body,
+            "recent_phase_transitions": phase_transitions,
+            "prior_failures": prior_failures,
+            "ralph_done_content": ralph_done_content,
+            "pr_url": pr_url,
+            "pr_number": pr_number,
+            "ci_log_url": ci_log_url,
+            "prior_mechanical_fix": prior_mechanical_fix,
+            "worktree_path": worktree_path,
+        }
+
+    def _insert_pending_diagnosis(
+        self,
+        *,
+        failure_id: int,
+        agent_id: str,
+        context: dict[str, Any],
+    ) -> int | None:
+        """INSERT a ``status='pending'`` row and return the new diagnosis_id.
+
+        Returns None on DB error. The caller falls back to the fixed
+        mechanical escalation policy when this returns None.
+        """
+        assert self._conn is not None, "connect() must run before diagnosis insert"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO dispatcher.diagnoses "
+                    "    (failure_id, agent_id, status, context) "
+                    "VALUES (%s, %s, 'pending', %s) "
+                    "RETURNING diagnosis_id",
+                    (failure_id, agent_id, json.dumps(context, default=str)),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.diagnosis_insert_failed",
+                extra={
+                    "event": "diagnosis_insert_failed",
+                    "run_id": self._run_id,
+                    "failure_id": failure_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return None
+        if row is None:
+            return None
+        return int(row[0])
+
+    def _mark_diagnosis_failed(self, diagnosis_id: int, reason: str) -> None:
+        """UPDATE diagnosis row to ``status='failed'`` with a reason log event.
+
+        Used by every fallback path (timeout, non-zero exit, malformed
+        recommendation JSON, unknown action). The circuit breaker
+        counts these rows against the fallback threshold.
+        """
+        assert self._conn is not None, "connect() must run before diagnosis update"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.diagnoses "
+                    "SET status = 'failed', "
+                    "    completed_at = now() "
+                    "WHERE diagnosis_id = %s",
+                    (diagnosis_id,),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.diagnosis_mark_failed_failed",
+                extra={
+                    "event": "diagnosis_mark_failed_failed",
+                    "run_id": self._run_id,
+                    "diagnosis_id": diagnosis_id,
+                    "reason": reason,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+        self._log.warning(
+            "daemon.diagnoser_fallback",
+            extra={
+                "event": "diagnoser_fallback",
+                "run_id": self._run_id,
+                "diagnosis_id": diagnosis_id,
+                "reason": reason,
+            },
+        )
+
+    def _spawn_diagnoser_subprocess(self, diagnosis_id: int) -> tuple[int | None, str]:
+        """Spawn ``claude -p /diagnose-failure <diagnosis_id>`` synchronously.
+
+        Returns ``(exit_code, stderr_tail)``. ``exit_code=None`` means
+        the subprocess timed out or could not be launched. Isolated
+        here so tests can monkeypatch ``subprocess.run`` without
+        touching the surrounding DB-write logic.
+        """
+        cmd = [
+            "claude",
+            "-p",
+            f"/diagnose-failure {diagnosis_id}",
+            "--max-turns",
+            str(DIAGNOSER_MAX_TURNS),
+            "--model",
+            DIAGNOSER_MODEL,
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=DIAGNOSER_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            tail = ""
+            if exc.stderr:
+                tail = (
+                    exc.stderr.decode("utf-8", errors="replace")
+                    if isinstance(exc.stderr, bytes)
+                    else str(exc.stderr)
+                )[-500:]
+            return None, tail
+        except FileNotFoundError:
+            return None, "claude binary not found"
+
+        stderr_tail = (result.stderr or "")[-500:]
+        return result.returncode, stderr_tail
+
+    def _read_recommendation(self, diagnosis_id: int) -> dict[str, Any] | None:
+        """Read ``dispatcher.diagnoses.recommendation`` for the given row.
+
+        Returns the recommendation dict, or None if the row is missing,
+        the recommendation column is NULL, or the JSON is malformed.
+        None means "fall back to mechanical escalation".
+        """
+        assert self._conn is not None, "connect() must run before recommendation read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT recommendation FROM dispatcher.diagnoses "
+                    "WHERE diagnosis_id = %s",
+                    (diagnosis_id,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return None
+
+        if row is None or row[0] is None:
+            return None
+        raw = row[0]
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return None
+        if not isinstance(raw, dict):
+            return None
+        return raw
+
+    def _validate_recommendation(self, recommendation: dict[str, Any]) -> str | None:
+        """Return the action string if valid, None otherwise.
+
+        Shape check: ``action`` must be in :data:`DIAGNOSER_ACTIONS`.
+        ``retry_with_hint`` requires a non-empty string ``hint``;
+        ``reissue`` requires a non-empty string ``new_scope``. All
+        other fields are advisory.
+        """
+        action = recommendation.get("action")
+        if not isinstance(action, str) or action not in DIAGNOSER_ACTIONS:
+            return None
+        if action == "retry_with_hint":
+            hint = recommendation.get("hint")
+            if not isinstance(hint, str) or not hint.strip():
+                return None
+        if action == "reissue":
+            new_scope = recommendation.get("new_scope")
+            if not isinstance(new_scope, str) or not new_scope.strip():
+                return None
+        return action
+
+    def _consume_diagnosis(self, diagnosis_id: int, candidate: dict[str, Any]) -> str:
+        """Read the recommendation and execute the deterministic action.
+
+        Returns the action string that was consumed (one of
+        :data:`DIAGNOSER_ACTIONS`, or ``"escalate_fallback"`` when the
+        recommendation was malformed and we escalated mechanically).
+        """
+        recommendation = self._read_recommendation(diagnosis_id)
+        if recommendation is None:
+            self._mark_diagnosis_failed(
+                diagnosis_id, reason="recommendation_missing_or_malformed_json"
+            )
+            self._apply_mechanical_escalation(candidate)
+            return "escalate_fallback"
+
+        action = self._validate_recommendation(recommendation)
+        if action is None:
+            self._log.warning(
+                "daemon.diagnosis_action_unknown",
+                extra={
+                    "event": "diagnosis_action_unknown",
+                    "run_id": self._run_id,
+                    "diagnosis_id": diagnosis_id,
+                    "raw_recommendation": recommendation,
+                },
+            )
+            self._mark_diagnosis_failed(
+                diagnosis_id, reason="recommendation_failed_validation"
+            )
+            self._apply_mechanical_escalation(candidate)
+            return "escalate_fallback"
+
+        # Valid action — dispatch.
+        agent_id = candidate["agent_id"]
+        issue_number = candidate.get("issue_number")
+        reasoning = str(recommendation.get("reasoning") or "")
+
+        self._log.info(
+            "daemon.diagnosis_consumed",
+            extra={
+                "event": "diagnosis_consumed",
+                "run_id": self._run_id,
+                "diagnosis_id": diagnosis_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "action": action,
+            },
+        )
+
+        if action == "retry":
+            self._consume_action_retry(agent_id=agent_id)
+        elif action == "retry_with_hint":
+            self._consume_action_retry_with_hint(
+                agent_id=agent_id,
+                issue_number=issue_number,
+                hint=str(recommendation.get("hint") or ""),
+            )
+        elif action == "reissue":
+            self._consume_action_reissue(
+                agent_id=agent_id,
+                issue_number=issue_number,
+                diagnosis_id=diagnosis_id,
+                reasoning=reasoning,
+                new_scope=str(recommendation.get("new_scope") or ""),
+            )
+        elif action == "escalate":
+            self._consume_action_escalate(
+                agent_id=agent_id,
+                issue_number=issue_number,
+                reasoning=reasoning,
+            )
+        elif action == "close":
+            self._consume_action_close(
+                agent_id=agent_id,
+                issue_number=issue_number,
+                reasoning=reasoning,
+            )
+
+        return action
+
+    def _consume_action_retry(self, *, agent_id: str) -> None:
+        """Create a tier-1-shaped retry marker via the existing machinery.
+
+        Reuses :data:`FAILURE_CATEGORY_SUBPROCESS_CRASH` as the marker
+        reason — all three :data:`AUTO_RETRY_CATEGORIES` are functionally
+        equivalent at this point (they share the backoff schedule and
+        the worktree-drop step), and ``subprocess_crash`` is the most
+        neutral category for a diagnoser-initiated retry.
+        """
+        self._create_retry_marker(
+            agent_id=agent_id, reason=FAILURE_CATEGORY_SUBPROCESS_CRASH
+        )
+
+    def _consume_action_retry_with_hint(
+        self, *, agent_id: str, issue_number: int | None, hint: str
+    ) -> None:
+        """Post the hint as an issue comment, then create a retry marker."""
+        if issue_number is not None and hint:
+            self._gh_issue_comment(issue_number, hint)
+        self._create_retry_marker(
+            agent_id=agent_id, reason=FAILURE_CATEGORY_SUBPROCESS_CRASH
+        )
+
+    def _consume_action_reissue(
+        self,
+        *,
+        agent_id: str,
+        issue_number: int | None,
+        diagnosis_id: int,
+        reasoning: str,
+        new_scope: str,
+    ) -> None:
+        """Post diagnosis summary, replace issue body, ensure agent/ready, retry."""
+        if issue_number is not None:
+            summary = (
+                "## Diagnosis (3D reissue)\n\n"
+                f"{reasoning}\n\n"
+                "_Scope replaced below — see updated body._"
+            )
+            self._gh_issue_comment(issue_number, summary)
+            if new_scope:
+                self._gh_issue_set_body(issue_number, new_scope)
+            # Ensure agent/ready remains so the next scheduler tick can
+            # re-claim. --add-label is idempotent.
+            self._gh_issue_add_labels(issue_number, ["agent/ready"])
+        self._create_retry_marker(
+            agent_id=agent_id, reason=FAILURE_CATEGORY_SUBPROCESS_CRASH
+        )
+
+    def _consume_action_escalate(
+        self,
+        *,
+        agent_id: str,
+        issue_number: int | None,
+        reasoning: str,
+    ) -> None:
+        """Add needs-human + p1 labels, post diagnosis, mark agent failed."""
+        if issue_number is not None:
+            summary = (
+                "## Diagnosis (3D escalation)\n\n"
+                f"{reasoning}\n\n"
+                "_Needs human review — diagnoser could not auto-resolve._"
+            )
+            self._gh_issue_comment(issue_number, summary)
+            self._gh_issue_add_labels(
+                issue_number, ["status/needs-human", "priority/p1"]
+            )
+        self._mark_agent_terminal(
+            agent_id, status="failed", phase="diagnoser_escalate", exit_code=None
+        )
+
+    def _consume_action_close(
+        self,
+        *,
+        agent_id: str,
+        issue_number: int | None,
+        reasoning: str,
+    ) -> None:
+        """Add status/invalid, close with diagnosis as close comment."""
+        if issue_number is not None:
+            summary = (
+                "## Diagnosis (3D close)\n\n"
+                f"{reasoning}\n\n"
+                "_Diagnoser determined this issue is not actionable as filed._"
+            )
+            self._gh_issue_add_labels(issue_number, ["status/invalid"])
+            self._gh_issue_close(issue_number, comment=summary, reason="not planned")
+        self._mark_agent_terminal(
+            agent_id, status="failed", phase="diagnoser_close", exit_code=None
+        )
+
+    def _apply_mechanical_escalation(self, candidate: dict[str, Any]) -> None:
+        """Fallback path: behave like ``escalate`` with a canned reasoning.
+
+        Spec §8 "Budget & safety": diagnoser timeout / malformed JSON /
+        subprocess crash → fall back to fixed mechanical policy, which
+        for tier 2/3 means escalate-to-human. No retry — if the
+        diagnoser itself is broken, another retry won't help.
+        """
+        agent_id = candidate["agent_id"]
+        issue_number = candidate.get("issue_number")
+        category = candidate.get("category")
+        reasoning = (
+            f"Diagnoser fallback after {category} failure. "
+            "Diagnoser subprocess returned no valid recommendation "
+            "(timeout, non-zero exit, or malformed JSON). Escalating "
+            "to human review per spec §8 Budget & safety."
+        )
+        self._consume_action_escalate(
+            agent_id=agent_id,
+            issue_number=issue_number,
+            reasoning=reasoning,
+        )
+
+    def _gh_issue_comment(self, issue_number: int, body: str) -> None:
+        """Post a comment on the given issue via ``gh issue comment``.
+
+        Writes the body to a temp file first (CLAUDE.md preflight
+        blocks heredocs; shelling out with ``--body`` inline has quoting
+        pitfalls for markdown comments). Subprocess failures are logged
+        and swallowed — the diagnoser's decision already landed in the
+        DB, a missing comment is a visibility regression but not a
+        correctness regression.
+        """
+        tmp_file = self._write_gh_tmp_body(body, prefix="diagnoser-comment")
+        if tmp_file is None:
+            return
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "comment",
+                    str(issue_number),
+                    "--repo",
+                    self._cfg.github_repo,
+                    "--body-file",
+                    str(tmp_file),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            self._log.warning(
+                "daemon.diagnoser_gh_comment_failed",
+                extra={
+                    "event": "diagnoser_gh_comment_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "detail": str(exc),
+                },
+            )
+            return
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.diagnoser_gh_comment_nonzero",
+                extra={
+                    "event": "diagnoser_gh_comment_nonzero",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "exit_code": result.returncode,
+                    "stderr_tail": (result.stderr or "").strip()[:200],
+                },
+            )
+
+    def _gh_issue_set_body(self, issue_number: int, new_body: str) -> None:
+        """Replace the issue body via ``gh issue edit --body-file``."""
+        tmp_file = self._write_gh_tmp_body(new_body, prefix="diagnoser-body")
+        if tmp_file is None:
+            return
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "edit",
+                    str(issue_number),
+                    "--repo",
+                    self._cfg.github_repo,
+                    "--body-file",
+                    str(tmp_file),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            self._log.warning(
+                "daemon.diagnoser_gh_body_failed",
+                extra={
+                    "event": "diagnoser_gh_body_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "detail": str(exc),
+                },
+            )
+            return
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.diagnoser_gh_body_nonzero",
+                extra={
+                    "event": "diagnoser_gh_body_nonzero",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "exit_code": result.returncode,
+                    "stderr_tail": (result.stderr or "").strip()[:200],
+                },
+            )
+
+    def _gh_issue_add_labels(self, issue_number: int, labels: list[str]) -> None:
+        """Add one or more labels via ``gh issue edit --add-label``.
+
+        ``gh`` accepts a comma-separated label list. Idempotent — adding
+        a label that already exists is a no-op.
+        """
+        if not labels:
+            return
+        label_csv = ",".join(labels)
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "edit",
+                    str(issue_number),
+                    "--repo",
+                    self._cfg.github_repo,
+                    "--add-label",
+                    label_csv,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            self._log.warning(
+                "daemon.diagnoser_gh_label_failed",
+                extra={
+                    "event": "diagnoser_gh_label_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "detail": str(exc),
+                },
+            )
+            return
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.diagnoser_gh_label_nonzero",
+                extra={
+                    "event": "diagnoser_gh_label_nonzero",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "exit_code": result.returncode,
+                    "stderr_tail": (result.stderr or "").strip()[:200],
+                },
+            )
+
+    def _gh_issue_close(self, issue_number: int, *, comment: str, reason: str) -> None:
+        """Close the issue via ``gh issue close`` with a close comment."""
+        tmp_file = self._write_gh_tmp_body(comment, prefix="diagnoser-close")
+        if tmp_file is None:
+            return
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "close",
+                    str(issue_number),
+                    "--repo",
+                    self._cfg.github_repo,
+                    "--reason",
+                    reason,
+                    "--comment",
+                    comment,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            self._log.warning(
+                "daemon.diagnoser_gh_close_failed",
+                extra={
+                    "event": "diagnoser_gh_close_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "detail": str(exc),
+                },
+            )
+            return
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.diagnoser_gh_close_nonzero",
+                extra={
+                    "event": "diagnoser_gh_close_nonzero",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "exit_code": result.returncode,
+                    "stderr_tail": (result.stderr or "").strip()[:200],
+                },
+            )
+
+    def _write_gh_tmp_body(self, body: str, *, prefix: str) -> Path | None:
+        """Write ``body`` to a temp file under the repo root's ``tmp/``.
+
+        Returns the Path on success or None on failure. Using the repo
+        root's tmp/ (rather than /tmp/ or each worktree's tmp/) keeps
+        diagnoser-generated comments inspectable after the worktree is
+        cleaned up.
+        """
+        try:
+            tmp_dir = self._repo_root() / "tmp" / "dispatcher-diagnoser"
+            tmp_dir.mkdir(parents=True, exist_ok=True)
+            # Use monotonic time + pid to keep the filename unique across
+            # concurrent diagnoser calls in the same tick.
+            name = f"{prefix}-{int(time.time() * 1000)}-{os.getpid()}.txt"
+            tmp_file = tmp_dir / name
+            tmp_file.write_text(body, encoding="utf-8")
+            return tmp_file
+        except Exception:
+            self._log.exception(
+                "daemon.diagnoser_tmp_body_write_failed",
+                extra={
+                    "event": "diagnoser_tmp_body_write_failed",
+                    "run_id": self._run_id,
+                    "prefix": prefix,
+                },
+            )
+            return None
+
+    def _run_diagnoser_pass(self) -> int:
+        """Find tier-2/3 candidates, spawn diagnosers, consume recommendations.
+
+        Returns the number of diagnoses that ran this tick (regardless
+        of action). Called from the supervisor tick. Gated on
+        ``dispatcher.config.diagnoser_enabled = true`` at the top —
+        a tripped circuit breaker short-circuits the whole pass. Each
+        candidate is handled independently so a bad subprocess crash
+        on one cannot stall the others.
+        """
+        if not self._diagnoser_enabled():
+            return 0
+
+        candidates = self._find_diagnoser_candidates()
+        if not candidates:
+            return 0
+
+        ran = 0
+        for candidate in candidates:
+            try:
+                context = self._build_diagnoser_context(candidate)
+                diagnosis_id = self._insert_pending_diagnosis(
+                    failure_id=candidate["failure_id"],
+                    agent_id=candidate["agent_id"],
+                    context=context,
+                )
+                if diagnosis_id is None:
+                    # Could not create the diagnosis row — fall back
+                    # directly without spawning.
+                    self._apply_mechanical_escalation(candidate)
+                    continue
+
+                self._log.info(
+                    "daemon.diagnoser_spawn",
+                    extra={
+                        "event": "diagnoser_spawn",
+                        "run_id": self._run_id,
+                        "diagnosis_id": diagnosis_id,
+                        "failure_id": candidate["failure_id"],
+                        "agent_id": candidate["agent_id"],
+                        "category": candidate["category"],
+                        "tier": candidate["tier"],
+                    },
+                )
+
+                exit_code, stderr_tail = self._spawn_diagnoser_subprocess(diagnosis_id)
+                ran += 1
+
+                if exit_code is None:
+                    # Timeout or subprocess could not be launched.
+                    self._mark_diagnosis_failed(
+                        diagnosis_id,
+                        reason="subprocess_timeout_or_launch_failure",
+                    )
+                    self._apply_mechanical_escalation(candidate)
+                    continue
+                if exit_code != 0:
+                    self._log.warning(
+                        "daemon.diagnoser_nonzero_exit",
+                        extra={
+                            "event": "diagnoser_nonzero_exit",
+                            "run_id": self._run_id,
+                            "diagnosis_id": diagnosis_id,
+                            "exit_code": exit_code,
+                            "stderr_tail": stderr_tail,
+                        },
+                    )
+                    self._mark_diagnosis_failed(
+                        diagnosis_id, reason="subprocess_nonzero_exit"
+                    )
+                    self._apply_mechanical_escalation(candidate)
+                    continue
+
+                # Exit 0 — read the recommendation and consume it.
+                self._consume_diagnosis(diagnosis_id, candidate)
+            except Exception:
+                self._log.exception(
+                    "daemon.diagnoser_pass_iteration_failed",
+                    extra={
+                        "event": "diagnoser_pass_iteration_failed",
+                        "run_id": self._run_id,
+                        "failure_id": candidate.get("failure_id"),
+                        "agent_id": candidate.get("agent_id"),
+                    },
+                )
+                # Best-effort fallback — don't let one bad candidate
+                # block later ones.
+                try:
+                    self._apply_mechanical_escalation(candidate)
+                except Exception:
+                    self._log.exception(
+                        "daemon.diagnoser_pass_fallback_failed",
+                        extra={
+                            "event": "diagnoser_pass_fallback_failed",
+                            "run_id": self._run_id,
+                        },
+                    )
+
+        return ran
+
     # ── supervisor tick (every ``tick_supervisor_seconds``) ─────────────
 
     def supervisor_tick(self) -> dict[str, int]:
@@ -4852,6 +6214,39 @@ class DispatcherDaemon:
                 },
             )
 
+        # Phase 3D (#2795): circuit breaker + diagnoser pass. The
+        # breaker check runs FIRST so a bad 24h window disables the
+        # diagnoser before the pass tries to spawn more subprocesses.
+        # The pass is gated on ``dispatcher.config.diagnoser_enabled``
+        # inside :meth:`_run_diagnoser_pass`; rate-limit-skipped ticks
+        # still run the pass because diagnoses can proceed without
+        # calling ``gh`` when the issue + PR context is available via
+        # DB state alone. (The skill itself makes GH reads; the daemon
+        # side only writes comments/labels if the recommendation
+        # action requires them, and those are unavoidable regardless
+        # of budget.)
+        try:
+            self._check_diagnoser_circuit_breaker()
+        except Exception:
+            self._log.exception(
+                "daemon.diagnoser_circuit_breaker_check_failed",
+                extra={
+                    "event": "diagnoser_circuit_breaker_check_failed",
+                    "run_id": self._run_id,
+                },
+            )
+        diagnoses_ran = 0
+        try:
+            diagnoses_ran = self._run_diagnoser_pass()
+        except Exception:
+            self._log.exception(
+                "daemon.diagnoser_pass_failed",
+                extra={
+                    "event": "diagnoser_pass_failed",
+                    "run_id": self._run_id,
+                },
+            )
+
         self._supervisor_ticks += 1
         self._last_heartbeat_at = datetime.now(UTC)
 
@@ -4874,6 +6269,7 @@ class DispatcherDaemon:
                 "stuck_flagged": stuck_flagged,
                 "retry_markers_processed": retry_processed,
                 "rate_skip_active": rate_skip_active,
+                "diagnoses_ran": diagnoses_ran,
             },
         )
         return {
@@ -4883,6 +6279,7 @@ class DispatcherDaemon:
             "stuck_flagged": stuck_flagged,
             "retry_markers_processed": retry_processed,
             "rate_skip_active": 1 if rate_skip_active else 0,
+            "diagnoses_ran": diagnoses_ran,
         }
 
     # ── heartbeat metric emission (supervisor-tick step 3) ──────────────

--- a/scripts/dispatcher/tests/test_daemon_phase3d.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3d.py
@@ -1,0 +1,1267 @@
+"""Unit tests for the Phase 3D diagnoser (issue #2795).
+
+Covers the §8 tier-2/3 diagnosis step:
+
+* Tier-2 detection fires ONLY when a mechanical-retry failure category
+  (``stuck_timeout`` / ``gh_rate_exhausted`` / ``subprocess_crash``)
+  recurs for the same agent within 24h of a prior same-category
+  failure. First occurrence of a tier-2 recurrence category does NOT
+  fire (the tier-1 mechanical retry handles it).
+* Tier-2 detection fires on **first** occurrence for
+  ``subprocess_turn_limit`` (the 3D diagnoser directly chooses
+  retry_with_hint vs escalate).
+* Tier-3 detection fires immediately for ``ci_red_after_retries``.
+* The daemon writes a ``dispatcher.diagnoses (status='pending')`` row
+  with a full context bundle before spawning the subprocess.
+* Each of the 5 recommendation actions is consumed deterministically:
+    - ``retry`` → create retry marker, no GH side effects.
+    - ``retry_with_hint`` → ``gh issue comment`` + retry marker.
+    - ``reissue`` → ``gh issue comment`` + ``gh issue edit --body-file``
+      + ``gh issue edit --add-label agent/ready`` + retry marker.
+    - ``escalate`` → ``gh issue comment`` + add labels
+      ``status/needs-human,priority/p1`` + agent status='failed'.
+    - ``close`` → ``gh issue edit --add-label status/invalid`` +
+      ``gh issue close --reason 'not planned'`` + agent status='failed'.
+* Malformed recommendation JSON / unknown action / subprocess timeout /
+  subprocess non-zero exit all flip the diagnosis to
+  ``status='failed'`` AND fall back to the fixed mechanical
+  escalation policy (no retry, add needs-human label).
+* Circuit breaker: with total diagnoses ≥ 5 and failed fraction >
+  threshold, ``dispatcher.config.diagnoser_enabled`` flips to
+  ``'false'``. Insufficient samples or healthy fallback rate do NOT
+  trip the breaker.
+* Migration 26 seeds ``diagnoser_enabled`` + ``diagnoser_fallback_rate_threshold``.
+
+3B fix-CI exhaustion path now writes a
+``dispatcher.failures (category='ci_red_after_retries')`` row BEFORE
+flipping the agent to ``status='failed'`` so the tier-3 detector can
+pick it up.
+
+All external calls (``gh``, ``claude -p``, psycopg) are mocked.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+# Install a psycopg stub whose ``errors.UniqueViolation`` is a real
+# Exception subclass — matches the pattern in earlier phase test files.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — a queue-driven FakeCursor with both fetchone and fetchall.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.phase3d.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# Migration 26 — config seeds (read-path verification)
+# --------------------------------------------------------------------------
+
+
+class TestMigration26ConfigSeeds:
+    """Migration 26 seeds ``diagnoser_enabled`` and ``diagnoser_fallback_rate_threshold``.
+
+    Schema.sql is pg_dump --schema-only (no seed data), so the canonical
+    check is on the migration SQL file itself.
+    """
+
+    def test_migration_file_present(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        migration_path = (
+            repo_root
+            / "packages"
+            / "api"
+            / "migrations"
+            / "26_dispatcher-diagnoser-config-seeds.sql"
+        )
+        assert migration_path.exists(), f"Migration 26 file missing at {migration_path}"
+
+    def test_migration_seeds_both_keys(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        migration_path = (
+            repo_root
+            / "packages"
+            / "api"
+            / "migrations"
+            / "26_dispatcher-diagnoser-config-seeds.sql"
+        )
+        sql = migration_path.read_text(encoding="utf-8")
+        assert "diagnoser_enabled" in sql
+        assert "diagnoser_fallback_rate_threshold" in sql
+        assert "INSERT INTO dispatcher.config" in sql
+        # Default value for enabled is 'true' (string form of a JSON bool).
+        assert "'true'" in sql
+        # Default threshold is 0.30.
+        assert "'0.30'" in sql
+        # Idempotent seed — ON CONFLICT DO NOTHING keeps re-runs safe.
+        assert "ON CONFLICT" in sql
+
+    def test_migration_has_down_migration(self) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        migration_path = (
+            repo_root
+            / "packages"
+            / "api"
+            / "migrations"
+            / "26_dispatcher-diagnoser-config-seeds.sql"
+        )
+        sql = migration_path.read_text(encoding="utf-8")
+        assert "Down Migration" in sql
+        assert "DELETE FROM dispatcher.config" in sql
+
+
+# --------------------------------------------------------------------------
+# _diagnoser_enabled — config read + default true
+# --------------------------------------------------------------------------
+
+
+class TestDiagnoserEnabled:
+    def test_default_true_when_row_missing(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        assert d._diagnoser_enabled() is True
+
+    def test_true_when_row_is_true(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(True,)]
+        assert d._diagnoser_enabled() is True
+
+    def test_false_when_row_is_false(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(False,)]
+        assert d._diagnoser_enabled() is False
+
+    def test_false_when_row_is_json_string_false(self, tmp_path: Path) -> None:
+        # psycopg may hand us a raw JSON string when the column is JSONB.
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("false",)]
+        assert d._diagnoser_enabled() is False
+
+    def test_defaults_true_on_malformed(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("not-json{",)]
+        assert d._diagnoser_enabled() is True
+
+
+class TestFallbackThreshold:
+    def test_reads_float(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("0.50",)]
+        assert d._diagnoser_fallback_threshold() == 0.50
+
+    def test_reads_number(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0.25,)]
+        assert d._diagnoser_fallback_threshold() == 0.25
+
+    def test_default_when_row_missing(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        assert d._diagnoser_fallback_threshold() == (
+            daemon.DEFAULT_CIRCUIT_BREAKER_THRESHOLD
+        )
+
+    def test_default_when_out_of_range(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(1.5,)]
+        assert d._diagnoser_fallback_threshold() == (
+            daemon.DEFAULT_CIRCUIT_BREAKER_THRESHOLD
+        )
+
+
+# --------------------------------------------------------------------------
+# _check_diagnoser_circuit_breaker — §8 budget & safety
+# --------------------------------------------------------------------------
+
+
+class TestCircuitBreaker:
+    def test_does_not_trip_when_total_below_min(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        # 3 total, all failed — below CIRCUIT_BREAKER_MIN_DIAGNOSES (5).
+        # First fetch: threshold lookup (threshold read happens first).
+        conn.cursor_instance.fetch_queue = [
+            ("0.30",),  # threshold
+            (3, 3),  # failed_n, total_n
+        ]
+        tripped = d._check_diagnoser_circuit_breaker()
+        assert tripped is False
+        assert not handler.events("diagnoser_circuit_breaker_tripped")
+        # No UPDATE fired.
+        updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0]
+        ]
+        assert updates == []
+
+    def test_does_not_trip_when_rate_at_or_below_threshold(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        # 10 total, 3 failed → 0.30 rate, equal to threshold → no trip
+        # (spec says "> 30%", not "≥ 30%").
+        conn.cursor_instance.fetch_queue = [
+            ("0.30",),
+            (3, 10),
+        ]
+        tripped = d._check_diagnoser_circuit_breaker()
+        assert tripped is False
+        assert not handler.events("diagnoser_circuit_breaker_tripped")
+
+    def test_trips_when_rate_above_threshold_and_min_samples(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        # 10 total, 4 failed → 0.40 rate > 0.30 → trip.
+        conn.cursor_instance.fetch_queue = [
+            ("0.30",),
+            (4, 10),
+        ]
+        tripped = d._check_diagnoser_circuit_breaker()
+        assert tripped is True
+        events = handler.events("diagnoser_circuit_breaker_tripped")
+        assert events
+        assert events[0].fallback_rate == 0.4
+        # UPDATE fired against diagnoser_enabled.
+        updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0]
+        ]
+        assert len(updates) == 1
+        assert updates[0][1] == ("diagnoser_enabled",)
+
+    def test_db_scan_error_does_not_crash(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        call_count = {"n": 0}
+
+        def boom(sql: str, params: Any = None) -> None:
+            call_count["n"] += 1
+            # First call is the threshold read (succeeds fine in fetchone);
+            # fail on the 2nd call which is the COUNT aggregation.
+            if call_count["n"] >= 2:
+                raise RuntimeError("db lost")
+
+        conn.cursor_instance.fetch_queue = [("0.30",)]
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+        assert d._check_diagnoser_circuit_breaker() is False
+        assert handler.events("diagnoser_circuit_breaker_scan_failed")
+
+
+# --------------------------------------------------------------------------
+# Tier detection
+# --------------------------------------------------------------------------
+
+
+class TestTierDetection:
+    def _seed_failures_fetch(self, conn: _FakeConnection, rows: list[Any]) -> None:
+        """Seed the candidate-scan fetchall queue."""
+        conn.cursor_instance.fetchall_queue = [rows]
+
+    def test_tier_3_ci_red_after_retries_fires_immediately(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        # One tier-3 failure row.
+        failure_row = (
+            42,  # failure_id
+            "agent-1",  # agent_id
+            daemon.FAILURE_CATEGORY_CI_RED_AFTER_RETRIES,  # category
+            {"issue_number": 999, "pr_number": 101},  # details
+            datetime(2026, 4, 18, tzinfo=UTC),  # ts
+        )
+        self._seed_failures_fetch(conn, [failure_row])
+        candidates = d._find_diagnoser_candidates()
+        assert len(candidates) == 1
+        assert candidates[0]["tier"] == 3
+        assert candidates[0]["category"] == (
+            daemon.FAILURE_CATEGORY_CI_RED_AFTER_RETRIES
+        )
+        assert candidates[0]["issue_number"] == 999
+
+    def test_tier_2_turn_limit_fires_on_first_occurrence(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        failure_row = (
+            100,
+            "agent-x",
+            daemon.FAILURE_CATEGORY_SUBPROCESS_TURN_LIMIT,
+            {"issue_number": 42},
+            datetime(2026, 4, 18, tzinfo=UTC),
+        )
+        self._seed_failures_fetch(conn, [failure_row])
+        # No recurrence check expected for turn-limit — it's
+        # TIER_2_FIRST_OCCURRENCE.
+        candidates = d._find_diagnoser_candidates()
+        assert len(candidates) == 1
+        assert candidates[0]["tier"] == 2
+        assert candidates[0]["category"] == (
+            daemon.FAILURE_CATEGORY_SUBPROCESS_TURN_LIMIT
+        )
+
+    def test_tier_2_recurrence_requires_prior_failure(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        failure_row = (
+            100,
+            "agent-x",
+            daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH,
+            {"issue_number": 42},
+            datetime(2026, 4, 18, tzinfo=UTC),
+        )
+        self._seed_failures_fetch(conn, [failure_row])
+        # Recurrence check returns None → first occurrence → skip.
+        conn.cursor_instance.fetch_queue = [None]
+        candidates = d._find_diagnoser_candidates()
+        assert candidates == []
+
+    def test_tier_2_recurrence_fires_on_second_occurrence(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        failure_row = (
+            200,
+            "agent-x",
+            daemon.FAILURE_CATEGORY_STUCK_TIMEOUT,
+            {"issue_number": 55},
+            datetime(2026, 4, 18, tzinfo=UTC),
+        )
+        self._seed_failures_fetch(conn, [failure_row])
+        # Recurrence check returns a row → prior same-category failure exists.
+        conn.cursor_instance.fetch_queue = [(1,)]
+        candidates = d._find_diagnoser_candidates()
+        assert len(candidates) == 1
+        assert candidates[0]["tier"] == 2
+        assert candidates[0]["category"] == (daemon.FAILURE_CATEGORY_STUCK_TIMEOUT)
+
+    def test_daemon_level_failure_ignored(self, tmp_path: Path) -> None:
+        # agent_id=NULL → gh_rate_exhausted daemon-level signal — never diagnosed.
+        d, conn, _handler = _make_daemon(tmp_path)
+        failure_row = (
+            300,
+            None,
+            daemon.FAILURE_CATEGORY_GH_RATE_EXHAUSTED,
+            {"threshold": 100},
+            datetime(2026, 4, 18, tzinfo=UTC),
+        )
+        self._seed_failures_fetch(conn, [failure_row])
+        candidates = d._find_diagnoser_candidates()
+        assert candidates == []
+
+
+# --------------------------------------------------------------------------
+# _insert_pending_diagnosis — schema shape
+# --------------------------------------------------------------------------
+
+
+class TestInsertPendingDiagnosis:
+    def test_inserts_pending_row_and_returns_id(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(777,)]
+        diagnosis_id = d._insert_pending_diagnosis(
+            failure_id=42,
+            agent_id="agent-1",
+            context={"foo": "bar"},
+        )
+        assert diagnosis_id == 777
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.diagnoses" in e[0]
+        ]
+        assert len(inserts) == 1
+        params = inserts[0][1]
+        assert params[0] == 42  # failure_id
+        assert params[1] == "agent-1"  # agent_id
+        # params[2] is the context JSONB serialized via json.dumps.
+        assert "foo" in params[2]
+        # SQL specifies status='pending' inline — verify in the SQL text.
+        assert "'pending'" in inserts[0][0]
+
+
+# --------------------------------------------------------------------------
+# _spawn_diagnoser_subprocess — subprocess wiring
+# --------------------------------------------------------------------------
+
+
+class TestSpawnDiagnoserSubprocess:
+    def test_runs_claude_p_with_opus_and_max_turns(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        captured: dict[str, Any] = {}
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        exit_code, tail = d._spawn_diagnoser_subprocess(777)
+        assert exit_code == 0
+        assert tail == ""
+        assert captured["cmd"][0] == "claude"
+        assert captured["cmd"][1] == "-p"
+        assert "/diagnose-failure 777" in captured["cmd"][2]
+        assert "--model" in captured["cmd"]
+        model_idx = captured["cmd"].index("--model")
+        assert captured["cmd"][model_idx + 1] == daemon.DIAGNOSER_MODEL
+        assert captured["kwargs"]["timeout"] == (
+            daemon.DIAGNOSER_SUBPROCESS_TIMEOUT_SECONDS
+        )
+
+    def test_timeout_returns_none_exit(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=300)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        exit_code, _tail = d._spawn_diagnoser_subprocess(1)
+        assert exit_code is None
+
+    def test_binary_missing_returns_none_exit(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            raise FileNotFoundError("claude missing")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        exit_code, tail = d._spawn_diagnoser_subprocess(1)
+        assert exit_code is None
+        assert "claude" in tail.lower() or "not found" in tail.lower()
+
+
+# --------------------------------------------------------------------------
+# _read_recommendation — JSONB round-trip + validation
+# --------------------------------------------------------------------------
+
+
+class TestReadRecommendation:
+    def test_reads_dict_directly(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [({"action": "retry", "reasoning": "ok"},)]
+        result = d._read_recommendation(1)
+        assert result == {"action": "retry", "reasoning": "ok"}
+
+    def test_reads_json_string(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            (json.dumps({"action": "escalate", "reasoning": "abc"}),)
+        ]
+        result = d._read_recommendation(1)
+        assert result is not None
+        assert result["action"] == "escalate"
+
+    def test_missing_row_returns_none(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        assert d._read_recommendation(1) is None
+
+    def test_null_column_returns_none(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(None,)]
+        assert d._read_recommendation(1) is None
+
+    def test_malformed_json_string_returns_none(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("not-json{",)]
+        assert d._read_recommendation(1) is None
+
+
+class TestValidateRecommendation:
+    def test_retry_valid(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        assert d._validate_recommendation({"action": "retry"}) == "retry"
+
+    def test_unknown_action_rejected(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        assert d._validate_recommendation({"action": "defer"}) is None
+
+    def test_retry_with_hint_needs_hint(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        assert d._validate_recommendation({"action": "retry_with_hint"}) is None
+        assert (
+            d._validate_recommendation({"action": "retry_with_hint", "hint": "  "})
+            is None
+        )
+        assert (
+            d._validate_recommendation(
+                {"action": "retry_with_hint", "hint": "focus on X"}
+            )
+            == "retry_with_hint"
+        )
+
+    def test_reissue_needs_new_scope(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        assert d._validate_recommendation({"action": "reissue"}) is None
+        assert (
+            d._validate_recommendation(
+                {"action": "reissue", "new_scope": "## Goal\n..."}
+            )
+            == "reissue"
+        )
+
+
+# --------------------------------------------------------------------------
+# _consume_diagnosis — deterministic action consumption
+# --------------------------------------------------------------------------
+
+
+class TestConsumeDiagnosis:
+    def _stub_db_reads(
+        self,
+        conn: _FakeConnection,
+        recommendation: dict[str, Any] | None,
+        retry_marker_count: int = 0,
+    ) -> None:
+        """Seed the fetch queue in the order the consumer issues reads.
+
+        Order for the common retry path:
+          1. read_recommendation → (rec,)
+          2. create_retry_marker COUNT → (retry_marker_count,)
+          3. _backoff_seconds → ("[60,300,900]",)
+        """
+        conn.cursor_instance.fetch_queue = [
+            (recommendation,) if recommendation is not None else None,
+            (retry_marker_count,),
+            ("[60,300,900]",),
+        ]
+
+    def test_retry_creates_marker_no_gh(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        # Fail if any subprocess runs — retry must be GH-silent.
+        subprocess_calls = {"n": 0}
+
+        def bad_run(*_a: Any, **_k: Any) -> Any:
+            subprocess_calls["n"] += 1
+            raise AssertionError("retry must not shell out to gh")
+
+        monkeypatch.setattr(subprocess, "run", bad_run)
+
+        self._stub_db_reads(conn, {"action": "retry", "reasoning": "transient"})
+
+        candidate = {
+            "failure_id": 42,
+            "agent_id": "a1",
+            "category": daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH,
+            "tier": 2,
+            "issue_number": 99,
+            "details": {},
+        }
+        action = d._consume_diagnosis(diagnosis_id=1, candidate=candidate)
+        assert action == "retry"
+        assert subprocess_calls["n"] == 0
+        markers = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert markers
+        assert handler.events("diagnosis_consumed")
+
+    def test_retry_with_hint_posts_comment_then_retries(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        gh_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            gh_calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        self._stub_db_reads(
+            conn,
+            {
+                "action": "retry_with_hint",
+                "reasoning": "ralph narrowed too far",
+                "hint": "focus only on the OC scraper file",
+            },
+        )
+        candidate = {
+            "failure_id": 42,
+            "agent_id": "a1",
+            "category": daemon.FAILURE_CATEGORY_SUBPROCESS_TURN_LIMIT,
+            "tier": 2,
+            "issue_number": 123,
+            "details": {},
+        }
+        action = d._consume_diagnosis(diagnosis_id=2, candidate=candidate)
+        assert action == "retry_with_hint"
+        # One gh issue comment should have fired.
+        comment_calls = [c for c in gh_calls if c[:3] == ["gh", "issue", "comment"]]
+        assert len(comment_calls) == 1
+        # Retry marker inserted.
+        markers = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert markers
+
+    def test_reissue_posts_summary_edits_body_ensures_ready_retries(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        gh_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            gh_calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        self._stub_db_reads(
+            conn,
+            {
+                "action": "reissue",
+                "reasoning": "AC is stale",
+                "new_scope": "## Goal\n\nUpdate the scraper.\n",
+            },
+        )
+        candidate = {
+            "failure_id": 42,
+            "agent_id": "a1",
+            "category": daemon.FAILURE_CATEGORY_CI_RED_AFTER_RETRIES,
+            "tier": 3,
+            "issue_number": 77,
+            "details": {},
+        }
+        action = d._consume_diagnosis(diagnosis_id=3, candidate=candidate)
+        assert action == "reissue"
+        # comment + edit --body-file + edit --add-label agent/ready.
+        comment_calls = [c for c in gh_calls if c[:3] == ["gh", "issue", "comment"]]
+        body_edit_calls = [
+            c
+            for c in gh_calls
+            if c[:3] == ["gh", "issue", "edit"] and "--body-file" in c
+        ]
+        label_edit_calls = [
+            c
+            for c in gh_calls
+            if c[:3] == ["gh", "issue", "edit"] and "--add-label" in c
+        ]
+        assert len(comment_calls) == 1
+        assert len(body_edit_calls) == 1
+        # agent/ready must be among the labels added.
+        assert any(
+            "agent/ready" in call for call in [" ".join(c) for c in label_edit_calls]
+        )
+        markers = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert markers
+
+    def test_escalate_adds_labels_posts_comment_marks_failed(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        gh_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            gh_calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        # Escalate doesn't create a retry marker → only 1 fetch: recommendation.
+        conn.cursor_instance.fetch_queue = [
+            (
+                {
+                    "action": "escalate",
+                    "reasoning": "auth broken",
+                },
+            )
+        ]
+        candidate = {
+            "failure_id": 42,
+            "agent_id": "a1",
+            "category": daemon.FAILURE_CATEGORY_SUBPROCESS_TURN_LIMIT,
+            "tier": 2,
+            "issue_number": 88,
+            "details": {},
+        }
+        action = d._consume_diagnosis(diagnosis_id=4, candidate=candidate)
+        assert action == "escalate"
+        # status/needs-human + priority/p1 added.
+        label_edits = [
+            c
+            for c in gh_calls
+            if c[:3] == ["gh", "issue", "edit"] and "--add-label" in c
+        ]
+        assert label_edits
+        joined = " ".join(label_edits[0])
+        assert "status/needs-human" in joined
+        assert "priority/p1" in joined
+        # No retry marker.
+        markers = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert markers == []
+        # Agent flipped to failed.
+        failed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "failed" in e[1]
+        ]
+        assert failed_updates
+
+    def test_close_closes_issue_with_reason_not_planned(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        gh_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            gh_calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        conn.cursor_instance.fetch_queue = [
+            (
+                {
+                    "action": "close",
+                    "reasoning": "duplicate of #1234",
+                },
+            )
+        ]
+        candidate = {
+            "failure_id": 42,
+            "agent_id": "a1",
+            "category": daemon.FAILURE_CATEGORY_CI_RED_AFTER_RETRIES,
+            "tier": 3,
+            "issue_number": 55,
+            "details": {},
+        }
+        action = d._consume_diagnosis(diagnosis_id=5, candidate=candidate)
+        assert action == "close"
+        close_calls = [c for c in gh_calls if c[:3] == ["gh", "issue", "close"]]
+        assert len(close_calls) == 1
+        joined = " ".join(close_calls[0])
+        assert "not planned" in joined
+        # status/invalid label added.
+        label_edits = [
+            c
+            for c in gh_calls
+            if c[:3] == ["gh", "issue", "edit"] and "--add-label" in c
+        ]
+        assert any("status/invalid" in " ".join(c) for c in label_edits)
+        # No retry marker.
+        markers = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert markers == []
+
+    def test_malformed_json_falls_back_to_escalate(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        gh_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            gh_calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        # Recommendation col contains a non-JSON string → read returns None.
+        conn.cursor_instance.fetch_queue = [("corrupt{",)]
+        candidate = {
+            "failure_id": 42,
+            "agent_id": "a1",
+            "category": daemon.FAILURE_CATEGORY_CI_RED_AFTER_RETRIES,
+            "tier": 3,
+            "issue_number": 77,
+            "details": {},
+        }
+        action = d._consume_diagnosis(diagnosis_id=6, candidate=candidate)
+        assert action == "escalate_fallback"
+        assert handler.events("diagnoser_fallback")
+        # Diagnosis row marked failed.
+        mark_failed = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.diagnoses" in e[0] and "'failed'" in e[0]
+        ]
+        assert mark_failed
+        # Mechanical escalation applied → agent marked failed + labels added.
+        label_edits = [
+            c
+            for c in gh_calls
+            if c[:3] == ["gh", "issue", "edit"] and "--add-label" in c
+        ]
+        assert any("status/needs-human" in " ".join(c) for c in label_edits)
+
+    def test_unknown_action_falls_back_to_escalate(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(*_a: Any, **_k: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        conn.cursor_instance.fetch_queue = [
+            ({"action": "defer", "reasoning": "not in the 5"},)
+        ]
+        candidate = {
+            "failure_id": 42,
+            "agent_id": "a1",
+            "category": daemon.FAILURE_CATEGORY_CI_RED_AFTER_RETRIES,
+            "tier": 3,
+            "issue_number": 77,
+            "details": {},
+        }
+        action = d._consume_diagnosis(diagnosis_id=7, candidate=candidate)
+        assert action == "escalate_fallback"
+        assert handler.events("diagnosis_action_unknown")
+
+
+# --------------------------------------------------------------------------
+# _run_diagnoser_pass — full-tick integration
+# --------------------------------------------------------------------------
+
+
+class TestRunDiagnoserPass:
+    def test_disabled_returns_zero(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        monkeypatch.setattr(d, "_diagnoser_enabled", lambda: False)
+        monkeypatch.setattr(
+            d,
+            "_find_diagnoser_candidates",
+            MagicMock(
+                side_effect=AssertionError("must not scan candidates when disabled")
+            ),
+        )
+        assert d._run_diagnoser_pass() == 0
+
+    def test_no_candidates_returns_zero(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        monkeypatch.setattr(d, "_diagnoser_enabled", lambda: True)
+        monkeypatch.setattr(d, "_find_diagnoser_candidates", lambda: [])
+        assert d._run_diagnoser_pass() == 0
+
+    def test_subprocess_timeout_triggers_fallback(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        monkeypatch.setattr(d, "_diagnoser_enabled", lambda: True)
+        monkeypatch.setattr(
+            d,
+            "_find_diagnoser_candidates",
+            lambda: [
+                {
+                    "failure_id": 42,
+                    "agent_id": "a1",
+                    "category": daemon.FAILURE_CATEGORY_CI_RED_AFTER_RETRIES,
+                    "tier": 3,
+                    "issue_number": 77,
+                    "details": {},
+                }
+            ],
+        )
+        monkeypatch.setattr(d, "_build_diagnoser_context", lambda _c: {})
+        monkeypatch.setattr(d, "_insert_pending_diagnosis", lambda **_k: 999)
+        monkeypatch.setattr(d, "_spawn_diagnoser_subprocess", lambda _id: (None, ""))
+        fallback_called = {"n": 0}
+
+        def fake_fallback(candidate: dict[str, Any]) -> None:
+            fallback_called["n"] += 1
+
+        monkeypatch.setattr(d, "_apply_mechanical_escalation", fake_fallback)
+        marked_failed: dict[str, Any] = {}
+
+        def fake_mark_failed(diagnosis_id: int, reason: str) -> None:
+            marked_failed["id"] = diagnosis_id
+            marked_failed["reason"] = reason
+
+        monkeypatch.setattr(d, "_mark_diagnosis_failed", fake_mark_failed)
+
+        ran = d._run_diagnoser_pass()
+        assert ran == 1
+        assert fallback_called["n"] == 1
+        assert marked_failed["id"] == 999
+        assert "timeout" in marked_failed["reason"].lower()
+
+    def test_subprocess_nonzero_exit_triggers_fallback(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+        monkeypatch.setattr(d, "_diagnoser_enabled", lambda: True)
+        monkeypatch.setattr(
+            d,
+            "_find_diagnoser_candidates",
+            lambda: [
+                {
+                    "failure_id": 42,
+                    "agent_id": "a1",
+                    "category": daemon.FAILURE_CATEGORY_CI_RED_AFTER_RETRIES,
+                    "tier": 3,
+                    "issue_number": 77,
+                    "details": {},
+                }
+            ],
+        )
+        monkeypatch.setattr(d, "_build_diagnoser_context", lambda _c: {})
+        monkeypatch.setattr(d, "_insert_pending_diagnosis", lambda **_k: 888)
+        monkeypatch.setattr(d, "_spawn_diagnoser_subprocess", lambda _id: (1, "boom"))
+        fallback_called = {"n": 0}
+        monkeypatch.setattr(
+            d,
+            "_apply_mechanical_escalation",
+            lambda _c: fallback_called.__setitem__("n", fallback_called["n"] + 1),
+        )
+        marked: dict[str, Any] = {}
+        monkeypatch.setattr(
+            d,
+            "_mark_diagnosis_failed",
+            lambda did, reason: marked.update({"id": did, "reason": reason}),
+        )
+        ran = d._run_diagnoser_pass()
+        assert ran == 1
+        assert fallback_called["n"] == 1
+        assert marked["id"] == 888
+        assert handler.events("diagnoser_nonzero_exit")
+
+    def test_insert_failure_still_runs_fallback(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        monkeypatch.setattr(d, "_diagnoser_enabled", lambda: True)
+        monkeypatch.setattr(
+            d,
+            "_find_diagnoser_candidates",
+            lambda: [
+                {
+                    "failure_id": 42,
+                    "agent_id": "a1",
+                    "category": daemon.FAILURE_CATEGORY_CI_RED_AFTER_RETRIES,
+                    "tier": 3,
+                    "issue_number": 77,
+                    "details": {},
+                }
+            ],
+        )
+        monkeypatch.setattr(d, "_build_diagnoser_context", lambda _c: {})
+        monkeypatch.setattr(d, "_insert_pending_diagnosis", lambda **_k: None)
+
+        def bad_spawn(_id: int) -> tuple[int | None, str]:
+            raise AssertionError("must not spawn when insert failed")
+
+        monkeypatch.setattr(d, "_spawn_diagnoser_subprocess", bad_spawn)
+        fallback_called = {"n": 0}
+        monkeypatch.setattr(
+            d,
+            "_apply_mechanical_escalation",
+            lambda _c: fallback_called.__setitem__("n", fallback_called["n"] + 1),
+        )
+        ran = d._run_diagnoser_pass()
+        # Subprocess did not run; count is 0 but fallback still applied.
+        assert ran == 0
+        assert fallback_called["n"] == 1
+
+
+# --------------------------------------------------------------------------
+# Supervisor tick integration — 3D wires into tick
+# --------------------------------------------------------------------------
+
+
+class TestSupervisorTickDiagnoserIntegration:
+    def test_tick_calls_circuit_breaker_and_diagnoser_pass(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+
+        called: dict[str, int] = {"breaker": 0, "pass": 0}
+        d._check_stuck_agents = lambda: 0  # type: ignore[method-assign]
+        d._check_gh_rate_limit = lambda: None  # type: ignore[method-assign]
+        d._advance_running_agents = lambda: 0  # type: ignore[method-assign]
+        d._process_retry_markers = lambda: 0  # type: ignore[method-assign]
+        d._emit_heartbeat_metric = lambda: True  # type: ignore[method-assign]
+        d._check_diagnoser_circuit_breaker = lambda: (  # type: ignore[method-assign]
+            called.__setitem__("breaker", called["breaker"] + 1) or False
+        )
+        d._run_diagnoser_pass = lambda: (  # type: ignore[method-assign]
+            called.__setitem__("pass", called["pass"] + 1) or 0
+        )
+        summary = d.supervisor_tick()
+        assert called["breaker"] == 1
+        assert called["pass"] == 1
+        assert "diagnoses_ran" in summary
+
+    def test_tick_survives_breaker_exception(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+
+        d._check_stuck_agents = lambda: 0  # type: ignore[method-assign]
+        d._check_gh_rate_limit = lambda: None  # type: ignore[method-assign]
+        d._advance_running_agents = lambda: 0  # type: ignore[method-assign]
+        d._process_retry_markers = lambda: 0  # type: ignore[method-assign]
+        d._emit_heartbeat_metric = lambda: True  # type: ignore[method-assign]
+
+        def boom() -> bool:
+            raise RuntimeError("breaker exploded")
+
+        d._check_diagnoser_circuit_breaker = boom  # type: ignore[method-assign]
+        d._run_diagnoser_pass = lambda: 0  # type: ignore[method-assign]
+        summary = d.supervisor_tick()
+        assert handler.events("diagnoser_circuit_breaker_check_failed")
+        assert summary["heartbeat_metric_emitted"] == 1
+
+    def test_tick_survives_pass_exception(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+
+        d._check_stuck_agents = lambda: 0  # type: ignore[method-assign]
+        d._check_gh_rate_limit = lambda: None  # type: ignore[method-assign]
+        d._advance_running_agents = lambda: 0  # type: ignore[method-assign]
+        d._process_retry_markers = lambda: 0  # type: ignore[method-assign]
+        d._emit_heartbeat_metric = lambda: True  # type: ignore[method-assign]
+        d._check_diagnoser_circuit_breaker = lambda: False  # type: ignore[method-assign]
+
+        def boom() -> int:
+            raise RuntimeError("pass exploded")
+
+        d._run_diagnoser_pass = boom  # type: ignore[method-assign]
+        summary = d.supervisor_tick()
+        assert handler.events("diagnoser_pass_failed")
+        assert summary["heartbeat_metric_emitted"] == 1
+        assert summary["diagnoses_ran"] == 0
+
+
+# --------------------------------------------------------------------------
+# 3B fix-CI exhaustion path now writes ci_red_after_retries failure row
+# --------------------------------------------------------------------------
+
+
+class TestFixCiExhaustionWritesFailureRow:
+    """3B's fix-CI max-retries branch writes a tier-3 failure row before
+    flipping the agent to 'failed', so 3D's tier-3 detector can pick it up.
+    """
+
+    def test_max_retries_writes_ci_red_after_retries_failure(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def fake_spawn(*_a: Any, **_k: Any) -> tuple[int, float]:
+            raise AssertionError("fix-ci must not spawn past max retries")
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        agent = {
+            "agent_id": "a1",
+            "issue_number": 42,
+            "phase": "awaiting_ci",
+            "pr_number": 101,
+            "worktree_path": str(tmp_path),
+            "retries_used": daemon.FIX_CI_MAX_RETRIES,
+        }
+        pr_status = {"statusCheckRollup": []}
+        d._run_fix_ci(agent, pr_status)
+
+        # Max-retries event still logged.
+        assert handler.events("fix_ci_max_retries_exceeded")
+        # Failure row written with category='ci_red_after_retries'.
+        failure_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert len(failure_inserts) == 1
+        params = failure_inserts[0][1]
+        assert params[0] == "a1"  # agent_id
+        assert params[1] == daemon.FAILURE_CATEGORY_CI_RED_AFTER_RETRIES
+        # Agent flipped to failed after the failure row.
+        failed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "failed" in e[1]
+        ]
+        assert failed_updates
+
+
+# --------------------------------------------------------------------------
+# Constants
+# --------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_ci_red_after_retries_category_string(self) -> None:
+        assert daemon.FAILURE_CATEGORY_CI_RED_AFTER_RETRIES == "ci_red_after_retries"
+
+    def test_diagnoser_actions_exhaustive(self) -> None:
+        # Spec §8 lists exactly 5 actions. Lock it in so a sixth cannot
+        # be added without also updating the daemon's deterministic
+        # consumer (`_consume_diagnosis` has explicit branches).
+        assert daemon.DIAGNOSER_ACTIONS == frozenset(
+            {"retry", "retry_with_hint", "reissue", "escalate", "close"}
+        )
+
+    def test_tier_sets_are_disjoint(self) -> None:
+        # A category must land in exactly one tier bucket.
+        assert (
+            daemon.TIER_2_RECURRENCE_CATEGORIES
+            & daemon.TIER_2_FIRST_OCCURRENCE_CATEGORIES
+            == frozenset()
+        )
+        assert (
+            daemon.TIER_2_RECURRENCE_CATEGORIES & daemon.TIER_3_CATEGORIES
+            == frozenset()
+        )
+        assert (
+            daemon.TIER_2_FIRST_OCCURRENCE_CATEGORIES & daemon.TIER_3_CATEGORIES
+            == frozenset()
+        )
+
+    def test_diagnoser_timeout_is_five_minutes(self) -> None:
+        # Spec §8 "5-min hard wall-clock timeout on the diagnoser subprocess".
+        assert daemon.DIAGNOSER_SUBPROCESS_TIMEOUT_SECONDS == 5 * 60

--- a/scripts/dispatcher/tests/test_daemon_skeleton.py
+++ b/scripts/dispatcher/tests/test_daemon_skeleton.py
@@ -258,7 +258,13 @@ class TestSupervisorTick:
         assert update_calls[0][1] == ("test-run-id",)
         # And the failures count must fire.
         assert any("dispatcher.failures" in sql for sql, _ in executed)
-        assert fake_conn.commits == 1
+        # At least one commit — the heartbeat + failures-count block.
+        # Later phases (3C, 3D) add optional DB reads inside the tick
+        # (stuck-agent scan, diagnoser gates, retry-marker scan) that
+        # each commit independently when the skeleton fake stubs have
+        # empty fetch queues. The exact count is not a contract; the
+        # "heartbeat round-trips at least once" signal is.
+        assert fake_conn.commits >= 1
         assert d._last_heartbeat_at is not None
 
 


### PR DESCRIPTION
## Summary

Adds the Phase 3 sub-task D diagnoser per spec §8 — a new `/diagnose-failure` skill, daemon-side tier-2/3 detection + invocation + deterministic 5-action consumption, and a circuit breaker that disables the diagnoser when its fallback rate exceeds 30% over 24h. After this PR, the dispatcher can recover from non-mechanical failures without human intervention (once `concurrency_cap=1` lands in 3E).

The 3B fix-CI exhaustion path now writes a `dispatcher.failures(category='ci_red_after_retries')` row before flipping the agent to `failed`, which is what triggers the tier-3 diagnoser. Migration 26 seeds the two new `dispatcher.config` rows that gate the feature.

Still cold in production: `concurrency_cap=0` keeps agents from flowing through this path until 3E.

Closes #2795

## Test plan

### Automated checks

- [x] Lint passes (`ruff check scripts/dispatcher/`)
- [x] Format check passes (`ruff format --check scripts/dispatcher/`)
- [x] Tests pass (`pytest scripts/dispatcher/tests/` — 54 new tests for tier-2/3 detection, each of 5 action branches, all fallback paths, circuit breaker, migration 26 seeds)
- [x] API typecheck passes
- [x] Schema drift check passes (schema.sql regenerated)
- [x] CI green

### Post-deploy verification

- [x] **Live verification deferred to 3E per spec §8 + issue #2795 AC** — `concurrency_cap=0` on dev means no agents flow through this code path. Post-deploy log scan confirms zero `daemon.diagnoser_*` events (as expected) and new daemon is ticking (`diagnoses_ran=0` on every tick).
- [x] Migration 26 seeds present on dev: `scripts/dev-db-query.sh "SELECT key, value FROM dispatcher.config WHERE key LIKE 'diagnoser%';"` returns both `diagnoser_enabled=true` and `diagnoser_fallback_rate_threshold=0.30`.
- [x] Verification evidence posted on issue #2795
