### PR TITLE
feat(dispatcher): 3E — retro orchestration + worktree cleanup + diagnoser effectiveness tracking (#2798)

### DIFF
--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -90,6 +90,93 @@ When adding a new module that wraps a resource with a maintenance window, check 
 
 See `docs/terraform-checklist.md` for the full checklist.
 
+## Dispatcher v2 Cutover
+
+The dispatcher v2 daemon is an opt-in production replacement for the laptop-dispatcher's `/dispatcher` skill. It runs on Fargate, claims `agent/ready` issues from GitHub, and drives each one end-to-end through `claude -p '/task-v2-*'` subprocesses (plan → ralph → summary → push → CI watch → merge → deploy watch → verify → retro → cleanup). Phase 3 (#2782) shipped all the orchestration code; Phase 3E (#2798) was the final code piece. **The cutover from `concurrency_cap=0` (cold) to `concurrency_cap=1` (one in-flight agent) is an explicit operator action — not part of any PR.**
+
+Spec: `docs/specs/dispatcher-v2-spec.md` §6 (state machine), §8 (failure taxonomy + diagnoser), §15 (Phase 3 gate).
+
+### Phase 3 cut-over: `concurrency_cap=0` → `1`
+
+**Prerequisites (all required):**
+
+- All Phase 3 sub-tasks merged: #2783 (3A), #2787 (3B), #2792 (3C), #2796 (3D), #2798 (3E).
+- `deploy-dispatcher.yml` workflow is green for the most recent commit on `main`.
+- Daemon stable on dev for ≥ 1 hour at `cap=0` with the new code (check the CloudWatch log group `/ecs/judgemind-dispatcher-dev` — only `daemon.scheduler_tick` / `daemon.supervisor_tick` events; no `daemon.advance_failed` / `daemon.subprocess_*_failed` events at the new code revision).
+- No active `dispatcher.agents` rows: the cutover assumes the next agent claimed will be the first new one to exercise the orchestration path end-to-end.
+  ```
+  scripts/dev-db-query.sh "SELECT count(*) FROM dispatcher.agents WHERE status IN ('running', 'retrying');"
+  ```
+  Expected: `0`.
+
+**Cut-over procedure:**
+
+1. Flip the cap (single-row UPDATE):
+   ```
+   scripts/dev-db-query.sh --rw "UPDATE dispatcher.config SET value = '1', updated_by = '<your-handle>', updated_at = now() WHERE key = 'concurrency_cap';"
+   ```
+   `updated_by` lets the next operator distinguish migration-seeded rows (`init`) from a manual cap flip.
+2. Watch daemon logs for the next ~1 hour. The first `daemon.candidate_picked` event indicates the daemon claimed an issue.
+   ```
+   scripts/ecs-logs.sh /ecs/judgemind-dispatcher-dev --follow
+   ```
+   Or a CloudWatch Logs Insights query: filter on `event = "candidate_picked"` to spot the first claim immediately.
+3. Watch the agent through every phase: plan → ralph → summary → PR open → CI watch → merge → deploy watch → verify → retro → cleanup. The expected event sequence in CloudWatch is:
+   - `daemon.candidate_picked` → `daemon.atomic_claim_inserted` → `daemon.phase_started phase=plan` → `daemon.phase_started phase=ralph` → `daemon.phase_started phase=summary` → `daemon.pr_opened` → `daemon.ci_poll` (one or more) → `daemon.pr_merged` → `daemon.deploy_poll` (one or more) → `daemon.verify_started` → `daemon.evidence_comment_posted` → `daemon.agent_completed` → `daemon.retro_started` → `daemon.retro_done` → `daemon.cleanup_done`.
+   - Any failure the diagnoser doesn't recover from = pause cutover by flipping `cap` back to `0` (see Rollback below).
+4. If the first agent reaches `phase='cleanup_done'` cleanly, the cutover is validated. Leave `cap=1` and let the daemon continue claiming one issue at a time. **Phase 4 (#2782 follow-up)** raises `cap` to `5` after enough single-agent runs accumulate to satisfy the gate criteria below.
+
+### Phase 3 gate (per spec §15 post-#2758 wording)
+
+Phase 3 is considered "done" once the daemon has:
+
+- ≥ 10 successful task completions (`dispatcher.agents.status='succeeded' AND PR merged AND phase IN ('cleanup_done', 'cleanup_blocked')`).
+- Zero stuck agents at the gate-check moment (`status='running' AND phase NOT IN ('done', 'retro_done', 'retro_failed', 'cleanup_done', 'cleanup_blocked')` for ≥ 30 min).
+- All retries resolved correctly — every `dispatcher.diagnoses` row from the gate window has a non-NULL `outcome` consistent with the agent's final status. The Phase 3E (#2798) effectiveness-tracking write-back guarantees this populates automatically; the operator only needs to confirm coverage.
+
+Quick gate-check SQL:
+
+```
+scripts/dev-db-query.sh "
+SELECT
+  count(*) FILTER (WHERE status = 'succeeded' AND phase IN ('cleanup_done', 'cleanup_blocked')) AS successes,
+  count(*) FILTER (WHERE status = 'running' AND phase NOT IN ('done', 'retro_done', 'retro_failed', 'cleanup_done', 'cleanup_blocked')
+                   AND started_at < now() - interval '30 minutes')                                AS stuck_running,
+  (SELECT count(*) FROM dispatcher.diagnoses WHERE outcome IS NULL AND completed_at IS NOT NULL) AS unresolved_diagnoses
+FROM dispatcher.agents
+WHERE started_at >= now() - interval '7 days';
+"
+```
+
+`successes ≥ 10`, `stuck_running = 0`, `unresolved_diagnoses = 0` ⇒ proceed to Phase 4. Otherwise stay at `cap=1` and investigate the gap.
+
+### Rollback (any time)
+
+```
+scripts/dev-db-query.sh --rw "UPDATE dispatcher.config SET value = '0', updated_by = '<your-handle>', updated_at = now() WHERE key = 'concurrency_cap';"
+```
+
+The daemon stops claiming new candidates on the next scheduler tick (≤ 30 s). Any in-flight agent finishes naturally — supervisor ticks continue advancing it through CI watch / merge / deploy / verify / retro / cleanup until it lands in a terminal phase. If the in-flight agent is stuck, the supervisor's `_check_stuck_agents` (Phase 3C, 30-min window) flips it to `crashed` and the retry-marker processor takes over.
+
+### Per-agent phase enumeration (Phase 3E)
+
+`dispatcher.agents.phase` is free-form `text` per migration 21 — no schema enum to maintain. The daemon-side enumeration (centralised in constants `PHASE_*` in `scripts/dispatcher/daemon.py`):
+
+| Phase | Status | Meaning |
+|---|---|---|
+| `claiming` | `running` | Initial state at INSERT. |
+| `planning` / `ralph` / `summary` | `running` | Mid-orchestration, `claude -p` subprocess in flight. |
+| `awaiting_ci` | `running` | Push + PR done; waiting on CI. |
+| `awaiting_deploy` | `running` | PR merged; waiting on deploy workflow. |
+| `done` | `succeeded` | Verify posted evidence; ready for retro. |
+| `retro_done` | `succeeded` | Retro phase ran cleanly; ready for cleanup. |
+| `retro_failed` | `succeeded` | Retro skill failed but agent itself succeeded; cleanup still runs. |
+| `cleanup_done` | `succeeded` | Final terminal state — worktree removed. |
+| `cleanup_blocked` | `succeeded` | Final terminal state — `cleanup_worktree.sh` refused (locked / no session log); operator sweep needed. |
+| `awaiting_*` / `claiming` | `crashed` / `failed` | Supervisor flipped status; phase preserved for diagnostics. |
+
+The daemon validates phase strings via the `PHASE_*` constants — adding a new phase value requires a code change but no migration. See `scripts/dispatcher/daemon.py` constants section for the canonical list.
+
 ## ECS Script Execution
 
 > **Important:** The dev database is in a private VPC and is not reachable from localhost. Do not attempt to connect to it locally using `scripts/with-secret.sh` with `DATABASE_URL` — the connection will fail. All data scripts must run inside the VPC via `ecs-run-task.sh`.

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -166,25 +166,31 @@ CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS = 180 * 60
 #: ``.claude/skills/task-v2-*/SKILL.md`` file. Sonnet-backed ralph gets
 #: the long tail; plan and summary stay tight. Post-PR phases added
 #: in Phase 3B (#2787) — fix-ci is a targeted patch so 100 turns is
-#: generous; verify is read-mostly so 50 turns fits.
+#: generous; verify is read-mostly so 50 turns fits. Retro added in
+#: Phase 3E (#2798) — a read-only review producing zero-to-many issue
+#: bodies; 30 turns matches the retro skill's frontmatter.
 PHASE_MAX_TURNS = {
     "plan": 50,
     "ralph": 500,
     "summary": 30,
     "fix-ci": 100,
     "verify": 50,
+    "retro": 30,
 }
 
 #: Per-phase ``--model`` values. Matches ``dispatcher.config.model_by_phase``
 #: seeded in migration 21. Fix-ci uses Sonnet — the CI-fixing skill's
 #: own frontmatter selects it. Verify uses Haiku — it only reads the
 #: deploy status and poses structured evidence, no complex reasoning.
+#: Retro uses Haiku — a quick review of structured input that produces
+#: structured output; no complex reasoning required.
 PHASE_MODELS = {
     "plan": "opus",
     "ralph": "sonnet",
     "summary": "haiku",
     "fix-ci": "sonnet",
     "verify": "haiku",
+    "retro": "haiku",
 }
 
 #: The three happy-path phases 3A orchestrates, in execution order.
@@ -246,6 +252,62 @@ WORKTREE_PARENT_DIR = Path(".claude/worktrees")
 #: the lifetime of the dispatcher is negligible and the short form
 #: keeps path lengths sane.
 AGENT_SHORT_ID_HEX_CHARS = 8
+
+# --------------------------------------------------------------------------
+# Phase 3E — retro orchestration + worktree cleanup + diagnoser
+# effectiveness tracking (issue #2798)
+# --------------------------------------------------------------------------
+
+#: Phase value written to ``dispatcher.agents.phase`` after a successful
+#: ``/task-v2-retro`` invocation. The agent's ``status`` stays
+#: ``succeeded`` — only the post-success phase advances. Any retro
+#: issues the skill produced have already been filed by this point.
+PHASE_RETRO_DONE = "retro_done"
+
+#: Phase value written when ``/task-v2-retro`` fails (timeout, non-zero
+#: exit, missing/malformed output). The agent itself succeeded, so
+#: ``status='succeeded'`` is preserved — only the retro phase failed.
+#: Cleanup still runs from this terminal-with-retro-failed state.
+PHASE_RETRO_FAILED = "retro_failed"
+
+#: Phase value written after ``scripts/cleanup_worktree.sh`` succeeds.
+#: This is the final terminal phase for a successful agent — no further
+#: supervisor advances apply.
+PHASE_CLEANUP_DONE = "cleanup_done"
+
+#: Phase value written when ``scripts/cleanup_worktree.sh`` refuses to
+#: remove the worktree (locked, no session log, etc.). The daemon does
+#: NOT bypass the safety check with ``--force`` — an operator sweep can
+#: clean up the worktree manually. This is also a terminal phase.
+PHASE_CLEANUP_BLOCKED = "cleanup_blocked"
+
+#: Hard wall-clock timeout for the ``scripts/cleanup_worktree.sh``
+#: subprocess. The script does at most a single ``git worktree remove``
+#: + a JSONL inspection — 60s is generous.
+CLEANUP_WORKTREE_SUBPROCESS_TIMEOUT_SECONDS = 60
+
+#: Hard timeout on the ``gh issue create`` subprocess used by the retro
+#: phase to file follow-up issues. Short — the call is a single write
+#: against github.com with no pagination.
+RETRO_GH_ISSUE_CREATE_TIMEOUT_SECONDS = 15
+
+#: Cap on retro issues filed per agent. A retro that wants to file more
+#: than this is a strong signal something is wrong (the skill is meant
+#: to identify high-signal findings, not generate process theater) —
+#: log + truncate to keep DB load bounded if the skill misbehaves.
+MAX_RETRO_ISSUES_PER_AGENT = 20
+
+#: Max length on retro issue body files passed via ``--body-file``.
+#: Matches the skill's own "keep each issue body under 3000 characters
+#: where possible" guidance with 5x headroom for edge cases. Strictly
+#: a defensive cap — the daemon truncates with a "[truncated]" suffix
+#: rather than failing the file write.
+MAX_RETRO_ISSUE_BODY_CHARS = 15000
+
+#: Default labels added to every retro-filed issue when the retro skill
+#: omits ``labels``. Kept tight — the skill's own ``labels`` array is
+#: the authoritative source; this is just the fallback.
+DEFAULT_RETRO_LABELS = ("type/dx", "agent/ready", "priority/p2")
 
 # --------------------------------------------------------------------------
 # Phase 3C — failure detection + retry machinery (issue #2791)
@@ -607,13 +669,33 @@ class DispatcherDaemon:
         * On SIGTERM / SIGINT, UPDATE ``dispatcher.runs.stopped_at`` and
           exit 0.
 
-    What this daemon still does **NOT** do (deferred to later 3.x):
-        * Stuck-timeout detection (no phase transition for >30min) —
-          tracked in 3C.
-        * Retry markers / backoff for crash recovery — 3C.
-        * Diagnoser tier 2/3 (judgment-required failure analysis) — 3D.
-        * Retro spawn + worktree cleanup + ``concurrency_cap=1`` flip
-          — 3E.
+    What this daemon still does **NOT** do:
+        * Flip ``concurrency_cap`` from 0 to 1 — that is an explicit
+          operator action documented in
+          ``docs/agent/infrastructure-reference.md``. Phase 3E added
+          all the orchestration plumbing but left the flip to a
+          human-approved cutover.
+
+    **Phase 3E (#2798)** completes the per-agent lifecycle by adding
+    two more advance branches to ``_advance_running_agents`` for
+    ``status='succeeded'`` agents:
+
+        * ``phase='done'`` → spawn ``/task-v2-retro`` and file every
+          retro issue it produced via ``gh issue create``. Transition
+          to ``phase='retro_done'`` on success or ``phase='retro_failed'``
+          on subprocess failure. ``status='succeeded'`` is preserved.
+        * ``phase IN ('retro_done', 'retro_failed')`` → run
+          ``scripts/cleanup_worktree.sh``. Transition to
+          ``phase='cleanup_done'`` on success or
+          ``phase='cleanup_blocked'`` on safety-check refusal. Per
+          CLAUDE.md §Critical Rules the daemon never bypasses with
+          ``--force`` — operators sweep blocked worktrees manually.
+
+    Phase 3E also adds **diagnoser effectiveness tracking** (spec §8
+    line 305) — ``_mark_agent_terminal`` writes the resolved outcome
+    back to any pending ``dispatcher.diagnoses`` rows for that agent
+    so the weekly report can measure "diagnoser recommended X →
+    outcome Y". Idempotent under repeated terminal transitions.
 
     **Phase 3B (#2787)** adds the post-PR transitions via
     ``_advance_running_agents``, invoked from the supervisor tick:
@@ -1655,13 +1737,16 @@ class DispatcherDaemon:
     ) -> None:
         """UPDATE ``dispatcher.agents`` with terminal status + metadata.
 
-        Used for ``succeeded``, ``failed``, and the Phase 3A post-PR
-        hand-off state (``status='running'``, ``phase='awaiting_ci'``).
-        For terminal statuses (``succeeded`` / ``failed``) also sets
-        ``ended_at`` so the admin page can compute duration.
+        Used for ``succeeded``, ``failed``, ``crashed``, and the
+        Phase 3A post-PR hand-off state (``status='running'``,
+        ``phase='awaiting_ci'``). For terminal statuses (``succeeded`` /
+        ``failed`` / ``crashed``) also sets ``ended_at`` so the admin
+        page can compute duration AND writes back the resolved outcome
+        to any pending ``dispatcher.diagnoses`` rows for this agent
+        (Phase 3E #2798, spec §8 line 305).
         """
         assert self._conn is not None, "connect() must run before update"
-        terminal = status in ("succeeded", "failed")
+        terminal = status in ("succeeded", "failed", "crashed")
         try:
             with self._conn.cursor() as cur:
                 if terminal:
@@ -1696,6 +1781,28 @@ class DispatcherDaemon:
                 self._conn.rollback()
             except Exception:  # pragma: no cover
                 pass
+            return
+
+        # Phase 3E (#2798): diagnoser effectiveness tracking. After the
+        # agent reaches a terminal status, write the outcome back to
+        # any ``dispatcher.diagnoses`` rows for this agent that don't
+        # yet have an outcome set. Idempotent — running twice produces
+        # the same state because we filter on ``outcome IS NULL``.
+        # Wrapped in its own try/except so a write-back failure cannot
+        # roll back the terminal-status update above.
+        if terminal:
+            try:
+                self._write_diagnosis_outcome_for_agent(agent_id, status)
+            except Exception:
+                self._log.exception(
+                    "daemon.diagnosis_outcome_write_failed",
+                    extra={
+                        "event": "diagnosis_outcome_write_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "status": status,
+                    },
+                )
 
     def _spawn_phase_subprocess(
         self, phase: str, worktree: Path, agent_id: str
@@ -2794,15 +2901,25 @@ class DispatcherDaemon:
     # the supervisor tick continues with the next agent.
 
     def _list_advanceable_agents(self) -> list[dict[str, Any]]:
-        """Return agents waiting on CI or deploy, ready for a state step.
+        """Return agents waiting for the next state-machine step.
 
-        SELECT rows with ``status='running'`` and
-        ``phase IN ('awaiting_ci', 'awaiting_deploy')``. Returns a list
-        of small dicts with the fields the advance methods need —
-        ``agent_id``, ``issue_number``, ``phase``, ``pr_number``,
-        ``worktree_path``, ``retries_used``. An empty list is
-        returned on DB error (with a rollback), so the supervisor tick
-        can continue without this work.
+        SELECT covers two distinct branches:
+
+        * ``status='running' AND phase IN ('awaiting_ci', 'awaiting_deploy')``
+          — Phase 3B's CI watch + deploy watch + verify chain.
+        * ``status='succeeded' AND phase IN ('done', 'retro_failed')``
+          — Phase 3E's post-success retro + cleanup chain. ``phase='done'``
+          rows trigger the retro phase; ``phase='retro_done'`` and
+          ``phase='retro_failed'`` rows trigger the worktree cleanup.
+
+        Returns a list of small dicts with the fields the advance methods
+        need — ``agent_id``, ``issue_number``, ``phase``, ``status``,
+        ``pr_number``, ``worktree_path``, ``retries_used``. An empty
+        list is returned on DB error (with a rollback), so the
+        supervisor tick can continue without this work.
+
+        Cleanup_done / cleanup_blocked are deliberately excluded — they
+        are terminal phases with no further advance to perform.
         """
         assert self._conn is not None, "connect() must run before reading"
 
@@ -2811,10 +2928,12 @@ class DispatcherDaemon:
             with self._conn.cursor() as cur:
                 cur.execute(
                     "SELECT agent_id, issue_number, phase, pr_number, "
-                    "       worktree_path, retries_used "
+                    "       worktree_path, retries_used, status "
                     "FROM dispatcher.agents "
-                    "WHERE status = 'running' "
-                    "  AND phase IN ('awaiting_ci', 'awaiting_deploy') "
+                    "WHERE (status = 'running' "
+                    "       AND phase IN ('awaiting_ci', 'awaiting_deploy')) "
+                    "   OR (status = 'succeeded' "
+                    "       AND phase IN ('done', 'retro_done', 'retro_failed')) "
                     "ORDER BY started_at ASC",
                 )
                 for row in cur.fetchall():
@@ -2826,6 +2945,7 @@ class DispatcherDaemon:
                             "pr_number": int(row[3]) if row[3] is not None else None,
                             "worktree_path": str(row[4]),
                             "retries_used": int(row[5]) if row[5] is not None else 0,
+                            "status": str(row[6]) if len(row) > 6 else "running",
                         }
                     )
             self._conn.commit()
@@ -2867,18 +2987,40 @@ class DispatcherDaemon:
         for agent in agents:
             agent_id = agent["agent_id"]
             phase = agent["phase"]
+            status = agent.get("status", "running")
             try:
                 if phase == "awaiting_ci":
                     self._advance_awaiting_ci(agent)
                 elif phase == "awaiting_deploy":
                     self._advance_awaiting_deploy(agent)
+                elif phase == "done" and status == "succeeded":
+                    # Phase 3E (#2798): post-success retro phase.
+                    # ``status='succeeded'`` is preserved across this
+                    # advance — the retro is bookkeeping for a
+                    # successful run, not part of the success itself.
+                    self._run_retro_phase(agent)
+                elif (
+                    phase in (PHASE_RETRO_DONE, PHASE_RETRO_FAILED)
+                    and status == "succeeded"
+                ):
+                    # Phase 3E (#2798): post-retro worktree cleanup.
+                    # Fires regardless of whether the retro itself
+                    # succeeded or failed — both phases mean "the agent
+                    # is done with all the LLM work".
+                    self._cleanup_agent_worktree(agent)
                 else:  # pragma: no cover — SELECT filter guarantees this
                     continue
                 advanced += 1
             except Exception as exc:
                 # Unhandled exception in one agent's advance must not
-                # stall the daemon. Flip to ``status='crashed'`` so 3C
-                # picks it up with a fresh worktree.
+                # stall the daemon. For ``status='running'`` agents,
+                # flip to ``status='crashed'`` so 3C picks it up with a
+                # fresh worktree. For ``status='succeeded'`` agents
+                # (Phase 3E retro/cleanup branches), keep the success
+                # status — only log the failure. The agent itself
+                # succeeded; an unexpected exception in the post-success
+                # bookkeeping should not retroactively flip it to
+                # crashed.
                 self._log.exception(
                     "daemon.advance_failed",
                     extra={
@@ -2886,15 +3028,27 @@ class DispatcherDaemon:
                         "run_id": self._run_id,
                         "agent_id": agent_id,
                         "phase": phase,
+                        "status": status,
                         "detail": str(exc),
                     },
                 )
-                self._mark_agent_terminal(
-                    agent_id,
-                    status="crashed",
-                    phase=phase,
-                    exit_code=None,
-                )
+                if status == "succeeded":
+                    # Mark the post-success phase failed without
+                    # touching the success status. retro phase failure
+                    # → flip to retro_failed so cleanup still runs;
+                    # cleanup phase failure → flip to cleanup_blocked
+                    # so an operator can investigate.
+                    if phase == "done":
+                        self._update_agent_phase(agent_id, PHASE_RETRO_FAILED)
+                    elif phase in (PHASE_RETRO_DONE, PHASE_RETRO_FAILED):
+                        self._update_agent_phase(agent_id, PHASE_CLEANUP_BLOCKED)
+                else:
+                    self._mark_agent_terminal(
+                        agent_id,
+                        status="crashed",
+                        phase=phase,
+                        exit_code=None,
+                    )
         return advanced
 
     # ── awaiting_ci branch ──────────────────────────────────────────────
@@ -4100,6 +4254,766 @@ class DispatcherDaemon:
                 "evidence_chars": len(evidence_md),
             },
         )
+
+    # ── Phase 3E retro orchestration + worktree cleanup (issue #2798) ──
+    #
+    # After an agent reaches ``status='succeeded' AND phase='done'``
+    # (the verify-success path in Phase 3B), the supervisor tick drives
+    # two more state-machine steps:
+    #
+    #   1. Retro phase. ``_run_retro_phase`` builds the input bundle
+    #      for ``/task-v2-retro``, spawns the subprocess, reads the
+    #      output, and files each retro issue via ``gh issue create``.
+    #      Transitions to ``phase='retro_done'`` on success or
+    #      ``phase='retro_failed'`` on subprocess failure.
+    #   2. Worktree cleanup. ``_cleanup_agent_worktree`` runs
+    #      ``scripts/cleanup_worktree.sh``. Transitions to
+    #      ``phase='cleanup_done'`` on success or
+    #      ``phase='cleanup_blocked'`` on safety-check refusal.
+    #      Never bypasses with ``--force`` (CLAUDE.md §Critical Rules).
+    #
+    # Both branches preserve ``status='succeeded'`` — the agent itself
+    # succeeded; only the post-success bookkeeping varies.
+
+    def _run_retro_phase(self, agent: dict[str, Any]) -> None:
+        """Spawn ``/task-v2-retro`` and file any retro issues it produces.
+
+        Reads ``dispatcher.phase_transitions`` + ``dispatcher.failures``
+        for this agent, writes the retro input bundle, runs the
+        subprocess, parses the output, and calls ``gh issue create``
+        once per entry in ``retro_issues``. Transitions the agent's
+        phase to :data:`PHASE_RETRO_DONE` on success or
+        :data:`PHASE_RETRO_FAILED` on subprocess / parse failure.
+
+        ``status='succeeded'`` is preserved across this advance — the
+        retro is bookkeeping for an already-successful run.
+        """
+        agent_id = agent["agent_id"]
+        issue_number = agent["issue_number"]
+        pr_number = agent.get("pr_number")
+        worktree = Path(agent["worktree_path"])
+
+        # Best-effort defense: if the worktree directory is gone (e.g.
+        # an operator manually removed it before retro ran), skip
+        # straight to cleanup_done — there is no LLM to spawn against.
+        if not worktree.exists():
+            self._log.warning(
+                "daemon.retro_worktree_missing",
+                extra={
+                    "event": "retro_worktree_missing",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "worktree_path": str(worktree),
+                },
+            )
+            self._update_agent_phase(agent_id, PHASE_CLEANUP_DONE)
+            return
+
+        # Build the retro input bundle. The retro skill's SKILL.md
+        # documents the contract — we satisfy the required fields and
+        # the optional ones we can derive cheaply from DB state.
+        retro_input = self._build_retro_input(agent)
+        self._write_phase_input(worktree, "retro", retro_input)
+
+        self._log.info(
+            "daemon.retro_started",
+            extra={
+                "event": "retro_started",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "pr_number": pr_number,
+                "ralph_iterations": retro_input.get("ralph_iterations"),
+                "ci_attempts": retro_input.get("ci_attempts"),
+            },
+        )
+
+        # Spawn the retro subprocess. Failure here flips to retro_failed
+        # but does NOT touch the agent's succeeded status.
+        try:
+            exit_code, duration_s = self._spawn_phase_subprocess(
+                "retro", worktree, agent_id
+            )
+        except subprocess.TimeoutExpired:
+            self._log.warning(
+                "daemon.retro_timeout",
+                extra={
+                    "event": "retro_timeout",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            self._update_agent_phase(agent_id, PHASE_RETRO_FAILED)
+            return
+        except (FileNotFoundError, OSError) as exc:
+            self._log.warning(
+                "daemon.retro_subprocess_error",
+                extra={
+                    "event": "retro_subprocess_error",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "detail": str(exc),
+                },
+            )
+            self._update_agent_phase(agent_id, PHASE_RETRO_FAILED)
+            return
+
+        if exit_code != 0:
+            self._log.warning(
+                "daemon.retro_nonzero_exit",
+                extra={
+                    "event": "retro_nonzero_exit",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "exit_code": exit_code,
+                    "duration_s": duration_s,
+                },
+            )
+            self._update_agent_phase(agent_id, PHASE_RETRO_FAILED)
+            return
+
+        retro_output = self._read_phase_output(worktree, "retro")
+        if retro_output is None:
+            self._log.warning(
+                "daemon.retro_output_missing",
+                extra={
+                    "event": "retro_output_missing",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            self._update_agent_phase(agent_id, PHASE_RETRO_FAILED)
+            return
+
+        # Persist the retro output to dispatcher.phase_outputs +
+        # phase_transitions so the admin page sees the run.
+        self._persist_phase_output(agent_id, "retro", retro_output)
+
+        # File the retro issues. Each entry becomes a separate
+        # ``gh issue create``. Honour the per-agent cap defensively —
+        # the skill is supposed to produce only high-signal findings.
+        retro_issues = retro_output.get("retro_issues") or []
+        if not isinstance(retro_issues, list):
+            retro_issues = []
+        if len(retro_issues) > MAX_RETRO_ISSUES_PER_AGENT:
+            self._log.warning(
+                "daemon.retro_issue_cap_truncate",
+                extra={
+                    "event": "retro_issue_cap_truncate",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_count": len(retro_issues),
+                    "cap": MAX_RETRO_ISSUES_PER_AGENT,
+                },
+            )
+            retro_issues = retro_issues[:MAX_RETRO_ISSUES_PER_AGENT]
+
+        filed = 0
+        for entry in retro_issues:
+            if not isinstance(entry, dict):
+                continue
+            new_issue = self._file_retro_issue(agent_id, worktree, entry)
+            if new_issue is not None:
+                filed += 1
+
+        self._update_agent_phase(agent_id, PHASE_RETRO_DONE)
+        self._log.info(
+            "daemon.retro_done",
+            extra={
+                "event": "retro_done",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "pr_number": pr_number,
+                "no_findings": bool(retro_output.get("no_findings")),
+                "issues_filed": filed,
+                "issues_attempted": len(retro_issues),
+                "duration_s": duration_s,
+            },
+        )
+
+    def _build_retro_input(self, agent: dict[str, Any]) -> dict[str, Any]:
+        """Assemble the input bundle the retro skill reads.
+
+        Pulls ``phase_transitions`` + ``failures`` for this agent from
+        the DB, plus a few summary counters derived from those rows.
+        Optional fields like ``scope_check_followups`` /
+        ``plan_follow_ups`` are populated when the corresponding
+        ``dispatcher.phase_outputs`` row exists; missing data is fine
+        (the retro skill tolerates missing optional fields).
+        """
+        agent_id = agent["agent_id"]
+        worktree_path = str(agent["worktree_path"])
+
+        phase_transitions = self._fetch_phase_transitions(agent_id)
+        failures = self._fetch_failures_grouped(agent_id)
+
+        # Derive counters from the persisted phase_transitions log.
+        ralph_iterations = sum(
+            1 for p in phase_transitions if p.get("phase") == "ralph"
+        )
+        ci_attempts = sum(
+            1 for p in phase_transitions if p.get("phase") == "awaiting_ci"
+        )
+        fix_ci_attempts = sum(
+            1 for p in phase_transitions if p.get("phase") == "fix_ci"
+        )
+        # Floor of 1 for ralph_iterations + ci_attempts so a clean
+        # single-pass run still satisfies the retro skill's
+        # short-circuit (== 1) check. A successful agent ran ralph
+        # at least once and CI at least once even if the daemon's
+        # phase log only captured a single transition row.
+        if ralph_iterations < 1:
+            ralph_iterations = 1
+        if ci_attempts < 1:
+            ci_attempts = 1
+
+        # Wall-clock duration from started_at to now (the retro phase
+        # itself counts as the verify-completed marker — close enough
+        # for the weekly report).
+        total_duration_s = self._fetch_agent_total_duration_s(agent_id)
+
+        # Best-effort scope-check + plan-follow-ups extraction from the
+        # persisted plan output, if present.
+        plan_output = self._fetch_phase_output(agent_id, "plan")
+        scope_check_followups = []
+        plan_follow_ups = []
+        if isinstance(plan_output, dict):
+            scope_raw = plan_output.get("scope_check_followups") or []
+            if isinstance(scope_raw, list):
+                scope_check_followups = [str(x) for x in scope_raw if x]
+            follow_raw = (
+                plan_output.get("follow_ups")
+                or plan_output.get("plan_follow_ups")
+                or []
+            )
+            if isinstance(follow_raw, list):
+                plan_follow_ups = [str(x) for x in follow_raw if x]
+
+        # Verify evidence — derived from the verify phase output if
+        # persisted. The retro skill uses this to summarize the run
+        # for the weekly report.
+        verify_output = self._fetch_phase_output(agent_id, "verify")
+        verify_evidence_md = ""
+        if isinstance(verify_output, dict):
+            verify_evidence_md = str(verify_output.get("evidence_md") or "")
+
+        # diff_stats is left empty — it's optional in the retro
+        # contract and would require shelling out to git just for the
+        # input bundle. The retro skill tolerates missing fields.
+        diff_stats: dict[str, int] = {
+            "files_changed": 0,
+            "insertions": 0,
+            "deletions": 0,
+        }
+
+        return {
+            "agent_id": agent_id,
+            "issue_number": agent["issue_number"],
+            "pr_number": agent.get("pr_number"),
+            "phase_transitions": phase_transitions,
+            "failures": failures,
+            "ralph_iterations": ralph_iterations,
+            "ci_attempts": ci_attempts,
+            "fix_ci_attempts": fix_ci_attempts,
+            "total_duration_s": total_duration_s,
+            "diff_stats": diff_stats,
+            "worktree_path": worktree_path,
+            "repo_root": worktree_path,
+            "scope_check_followups": scope_check_followups,
+            "plan_follow_ups": plan_follow_ups,
+            "verify_evidence_md": verify_evidence_md,
+        }
+
+    def _fetch_phase_transitions(self, agent_id: str) -> list[dict[str, Any]]:
+        """SELECT ``dispatcher.phase_transitions`` rows for this agent.
+
+        Returns oldest-first list of ``{phase, ts}`` dicts. ``ts`` is
+        ISO-8601 string. Empty list on DB error (logged + rolled back).
+        """
+        assert self._conn is not None, "connect() must run before reading"
+        rows: list[dict[str, Any]] = []
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT phase, ts FROM dispatcher.phase_transitions "
+                    "WHERE agent_id = %s ORDER BY ts ASC",
+                    (agent_id,),
+                )
+                for row in cur.fetchall():
+                    rows.append(
+                        {
+                            "phase": str(row[0]) if row[0] is not None else "",
+                            "ts": (
+                                row[1].isoformat()
+                                if hasattr(row[1], "isoformat")
+                                else str(row[1])
+                            ),
+                        }
+                    )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.fetch_phase_transitions_failed",
+                extra={
+                    "event": "fetch_phase_transitions_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+        return rows
+
+    def _fetch_failures_grouped(self, agent_id: str) -> list[dict[str, Any]]:
+        """SELECT ``dispatcher.failures`` rows grouped by category for this agent.
+
+        Returns list of ``{category, count, first_seen, last_seen}``
+        dicts. Empty list on DB error.
+        """
+        assert self._conn is not None, "connect() must run before reading"
+        rows: list[dict[str, Any]] = []
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT category, count(*), min(ts), max(ts) "
+                    "FROM dispatcher.failures "
+                    "WHERE agent_id = %s "
+                    "GROUP BY category "
+                    "ORDER BY count(*) DESC",
+                    (agent_id,),
+                )
+                for row in cur.fetchall():
+                    rows.append(
+                        {
+                            "category": str(row[0]) if row[0] is not None else "",
+                            "count": int(row[1] or 0),
+                            "first_seen": (
+                                row[2].isoformat()
+                                if hasattr(row[2], "isoformat")
+                                else str(row[2])
+                            ),
+                            "last_seen": (
+                                row[3].isoformat()
+                                if hasattr(row[3], "isoformat")
+                                else str(row[3])
+                            ),
+                        }
+                    )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.fetch_failures_failed",
+                extra={
+                    "event": "fetch_failures_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+        return rows
+
+    def _fetch_agent_total_duration_s(self, agent_id: str) -> int:
+        """Compute wall-clock seconds since the agent claimed."""
+        assert self._conn is not None, "connect() must run before reading"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT EXTRACT(EPOCH FROM (now() - started_at))::int "
+                    "FROM dispatcher.agents WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.fetch_duration_failed",
+                extra={
+                    "event": "fetch_duration_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return 0
+        if row is None or row[0] is None:
+            return 0
+        return int(row[0])
+
+    def _fetch_phase_output(self, agent_id: str, phase: str) -> dict[str, Any] | None:
+        """SELECT a single ``dispatcher.phase_outputs`` row JSON, or None."""
+        assert self._conn is not None, "connect() must run before reading"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT output_json FROM dispatcher.phase_outputs "
+                    "WHERE agent_id = %s AND phase = %s",
+                    (agent_id, phase),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.fetch_phase_output_failed",
+                extra={
+                    "event": "fetch_phase_output_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": phase,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return None
+        if row is None:
+            return None
+        raw = row[0]
+        # psycopg returns JSONB as already-parsed Python objects when
+        # the connection is configured normally. Guard against the
+        # JSON-as-string case for tests that pass strings through.
+        if isinstance(raw, dict):
+            return raw
+        if isinstance(raw, str):
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError:
+                return None
+            return parsed if isinstance(parsed, dict) else None
+        return None
+
+    def _file_retro_issue(
+        self,
+        agent_id: str,
+        worktree: Path,
+        entry: dict[str, Any],
+    ) -> int | None:
+        """Run ``gh issue create`` for one retro issue body.
+
+        Returns the new issue number on success, ``None`` on failure.
+        Failures log a warning but do not raise — one bad retro entry
+        should not block the others or stop the cleanup phase.
+        """
+        title = str(entry.get("title") or "").strip()
+        body = str(entry.get("body") or "").strip()
+        if not title or not body:
+            self._log.warning(
+                "daemon.retro_issue_missing_fields",
+                extra={
+                    "event": "retro_issue_missing_fields",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "has_title": bool(title),
+                    "has_body": bool(body),
+                },
+            )
+            return None
+
+        # Defensive truncation on body length.
+        if len(body) > MAX_RETRO_ISSUE_BODY_CHARS:
+            body = body[:MAX_RETRO_ISSUE_BODY_CHARS] + "\n\n[truncated]"
+
+        labels = entry.get("labels")
+        if not isinstance(labels, list) or not labels:
+            labels = list(DEFAULT_RETRO_LABELS)
+        labels = [str(label) for label in labels if label]
+
+        # Write body to a tmp file (no heredocs / inline body per
+        # CLAUDE.md). One file per retro issue keeps reads idempotent.
+        body_dir = worktree / "tmp" / "dispatcher-retro"
+        try:
+            body_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            self._log.warning(
+                "daemon.retro_body_dir_failed",
+                extra={
+                    "event": "retro_body_dir_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "detail": str(exc),
+                },
+            )
+            return None
+
+        # Filename uses a uuid suffix so multiple retro entries don't
+        # collide on disk if their titles happen to slugify the same.
+        body_path = body_dir / f"retro-{uuid.uuid4().hex[:8]}.md"
+        try:
+            body_path.write_text(body, encoding="utf-8")
+        except OSError as exc:
+            self._log.warning(
+                "daemon.retro_body_write_failed",
+                extra={
+                    "event": "retro_body_write_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "detail": str(exc),
+                },
+            )
+            return None
+
+        cmd = [
+            "gh",
+            "issue",
+            "create",
+            "--repo",
+            self._cfg.github_repo,
+            "--title",
+            title,
+            "--body-file",
+            str(body_path),
+        ]
+        for label in labels:
+            cmd.extend(["--label", label])
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=RETRO_GH_ISSUE_CREATE_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            self._log.warning(
+                "daemon.retro_issue_create_subprocess_error",
+                extra={
+                    "event": "retro_issue_create_subprocess_error",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "title": title,
+                    "detail": str(exc),
+                },
+            )
+            return None
+
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.retro_issue_create_failed",
+                extra={
+                    "event": "retro_issue_create_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "title": title,
+                    "exit_code": result.returncode,
+                    "stderr_tail": (result.stderr or "")[:200],
+                },
+            )
+            return None
+
+        # ``gh issue create`` prints the issue URL on stdout. Parse the
+        # trailing ``/issues/<N>`` segment for logging.
+        new_issue_number = self._parse_issue_url(result.stdout or "")
+        self._log.info(
+            "daemon.retro_issue_created",
+            extra={
+                "event": "retro_issue_created",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "title": title,
+                "labels": labels,
+                "new_issue_number": new_issue_number,
+            },
+        )
+        return new_issue_number
+
+    @staticmethod
+    def _parse_issue_url(stdout: str) -> int | None:
+        """Extract the trailing ``/issues/<N>`` integer from a gh URL."""
+        import re  # noqa: PLC0415 — lazy import
+
+        match = re.search(r"/issues/(\d+)", stdout)
+        if not match:
+            return None
+        try:
+            return int(match.group(1))
+        except (TypeError, ValueError):  # pragma: no cover — regex guarantees digits
+            return None
+
+    def _cleanup_agent_worktree(self, agent: dict[str, Any]) -> None:
+        """Run ``scripts/cleanup_worktree.sh`` against the agent's worktree.
+
+        Transitions to :data:`PHASE_CLEANUP_DONE` on success or
+        :data:`PHASE_CLEANUP_BLOCKED` on safety-check refusal. Per
+        CLAUDE.md §Critical Rules, never bypass with ``--force`` —
+        an operator can sweep blocked worktrees manually.
+        """
+        agent_id = agent["agent_id"]
+        worktree_path = str(agent.get("worktree_path") or "")
+
+        if not worktree_path:
+            self._log.warning(
+                "daemon.cleanup_missing_worktree_path",
+                extra={
+                    "event": "cleanup_missing_worktree_path",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            self._update_agent_phase(agent_id, PHASE_CLEANUP_BLOCKED)
+            return
+
+        # Worktree may already be gone (operator manually cleaned, or
+        # cleanup ran in a prior tick that crashed before phase update).
+        # Treat missing-directory as cleanup_done — there's nothing
+        # left to remove.
+        if not Path(worktree_path).exists():
+            self._log.info(
+                "daemon.cleanup_already_gone",
+                extra={
+                    "event": "cleanup_already_gone",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "worktree_path": worktree_path,
+                },
+            )
+            self._update_agent_phase(agent_id, PHASE_CLEANUP_DONE)
+            return
+
+        repo_root = self._repo_root()
+        cleanup_script = repo_root / "scripts" / "cleanup_worktree.sh"
+
+        if not cleanup_script.exists():
+            self._log.warning(
+                "daemon.cleanup_script_missing",
+                extra={
+                    "event": "cleanup_script_missing",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "expected_path": str(cleanup_script),
+                },
+            )
+            self._update_agent_phase(agent_id, PHASE_CLEANUP_BLOCKED)
+            return
+
+        try:
+            result = subprocess.run(
+                [str(cleanup_script), worktree_path],
+                capture_output=True,
+                text=True,
+                timeout=CLEANUP_WORKTREE_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            self._log.warning(
+                "daemon.cleanup_subprocess_error",
+                extra={
+                    "event": "cleanup_subprocess_error",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "worktree_path": worktree_path,
+                    "detail": str(exc),
+                },
+            )
+            self._update_agent_phase(agent_id, PHASE_CLEANUP_BLOCKED)
+            return
+
+        if result.returncode == 0:
+            self._update_agent_phase(agent_id, PHASE_CLEANUP_DONE)
+            self._log.info(
+                "daemon.cleanup_done",
+                extra={
+                    "event": "cleanup_done",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "worktree_path": worktree_path,
+                },
+            )
+            return
+
+        # Non-zero exit means the safety check refused (locked / no
+        # session log / etc.). Per CLAUDE.md §Critical Rules, do NOT
+        # bypass with ``--force``. An operator can sweep manually.
+        self._update_agent_phase(agent_id, PHASE_CLEANUP_BLOCKED)
+        self._log.warning(
+            "daemon.cleanup_blocked",
+            extra={
+                "event": "cleanup_blocked",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "worktree_path": worktree_path,
+                "exit_code": result.returncode,
+                "stderr_tail": (result.stderr or "").strip()[:200],
+                "stdout_tail": (result.stdout or "").strip()[:200],
+            },
+        )
+
+    def _write_diagnosis_outcome_for_agent(
+        self, agent_id: str, final_status: str
+    ) -> None:
+        """Write back the resolved outcome to pending diagnoser rows.
+
+        Per spec §8 line 305: "once a retry resolves (success,
+        escalation, or close), its outcome is written back to
+        ``dispatcher.diagnoses.outcome``."
+
+        Updates ``dispatcher.diagnoses.outcome`` for any rows where
+        ``agent_id = %s AND outcome IS NULL`` with the JSONB shape::
+
+            {
+              "retry_outcome": "succeeded" | "failed",
+              "final_status":  "<agent.status>",
+              "resolved_at":   "<ISO-8601 ts>"
+            }
+
+        Idempotent — the ``outcome IS NULL`` predicate prevents a
+        repeat call from overwriting existing outcome data.
+        """
+        assert self._conn is not None, "connect() must run before update"
+
+        retry_outcome = "succeeded" if final_status == "succeeded" else "failed"
+        outcome = {
+            "retry_outcome": retry_outcome,
+            "final_status": final_status,
+            "resolved_at": _now_iso(),
+        }
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.diagnoses "
+                    "SET outcome = %s::jsonb "
+                    "WHERE agent_id = %s AND outcome IS NULL",
+                    (json.dumps(outcome), agent_id),
+                )
+                rowcount = cur.rowcount or 0
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.diagnosis_outcome_update_failed",
+                extra={
+                    "event": "diagnosis_outcome_update_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "final_status": final_status,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return
+
+        if rowcount > 0:
+            self._log.info(
+                "daemon.diagnosis_outcome_written",
+                extra={
+                    "event": "diagnosis_outcome_written",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "final_status": final_status,
+                    "retry_outcome": retry_outcome,
+                    "rows_updated": rowcount,
+                },
+            )
 
     # ── Phase 3C failure detection + retry machinery (supervisor-tick) ─
     #

--- a/scripts/dispatcher/tests/test_daemon_phase3e.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3e.py
@@ -1,0 +1,1123 @@
+"""Unit tests for the Phase 3E retro orchestration + worktree cleanup +
+diagnoser effectiveness tracking (issue #2798).
+
+Covers the post-success state-machine extensions added to
+``_advance_running_agents``:
+
+* ``status='succeeded' AND phase='done'`` → spawn ``/task-v2-retro``,
+  parse output, file zero-to-many ``gh issue create`` calls. Transitions
+  to ``phase='retro_done'`` on success or ``phase='retro_failed'`` on
+  subprocess / parse failure. ``status='succeeded'`` is preserved.
+* ``status='succeeded' AND phase IN ('retro_done', 'retro_failed')`` →
+  run ``scripts/cleanup_worktree.sh``. Transitions to
+  ``phase='cleanup_done'`` on success or ``phase='cleanup_blocked'`` on
+  safety-check refusal. Daemon never bypasses with ``--force``.
+* Diagnoser effectiveness tracking: ``_mark_agent_terminal`` writes
+  back the resolved outcome to any pending ``dispatcher.diagnoses``
+  rows for that agent. Idempotent under repeated terminal transitions.
+
+All external calls (``gh``, ``claude -p``, ``scripts/cleanup_worktree.sh``,
+psycopg) are mocked. The subprocess used by ``_spawn_phase_subprocess``
+is stubbed so no real LLM is invoked.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+# Provide a stub ``psycopg`` module before importing the daemon — same
+# pattern as test_daemon_phase3a/3b/3c/3d.py. Reuse the prior test
+# files' stub when present so the daemon's ``except
+# psycopg.errors.UniqueViolation`` resolves to the same class across
+# all test files.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — same shape as test_daemon_phase3b/3c/3d.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.phase3e.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+def _succeeded_agent(
+    tmp_path: Path,
+    agent_id: str = "agent-3e-success",
+    phase: str = "done",
+    pr_number: int = 999,
+    issue_number: int = 4242,
+) -> dict[str, Any]:
+    """Build the dict shape ``_advance_*`` methods consume."""
+    worktree = tmp_path / agent_id
+    worktree.mkdir(parents=True, exist_ok=True)
+    (worktree / "tmp").mkdir(parents=True, exist_ok=True)
+    return {
+        "agent_id": agent_id,
+        "issue_number": issue_number,
+        "phase": phase,
+        "pr_number": pr_number,
+        "worktree_path": str(worktree),
+        "retries_used": 0,
+        "status": "succeeded",
+    }
+
+
+# --------------------------------------------------------------------------
+# Phase constants — name-stability checks. The runbook + admin page
+# reference these strings verbatim, so the values must not drift.
+# --------------------------------------------------------------------------
+
+
+class TestPhase3EPhaseConstants:
+    def test_constants_match_documented_values(self) -> None:
+        assert daemon.PHASE_RETRO_DONE == "retro_done"
+        assert daemon.PHASE_RETRO_FAILED == "retro_failed"
+        assert daemon.PHASE_CLEANUP_DONE == "cleanup_done"
+        assert daemon.PHASE_CLEANUP_BLOCKED == "cleanup_blocked"
+
+    def test_retro_phase_in_max_turns(self) -> None:
+        assert "retro" in daemon.PHASE_MAX_TURNS
+        assert daemon.PHASE_MAX_TURNS["retro"] == 30
+
+    def test_retro_phase_in_models(self) -> None:
+        assert "retro" in daemon.PHASE_MODELS
+        assert daemon.PHASE_MODELS["retro"] == "haiku"
+
+
+# --------------------------------------------------------------------------
+# _list_advanceable_agents — extended SELECT covers succeeded phases
+# --------------------------------------------------------------------------
+
+
+class TestListAdvanceableIncludesSucceededPhases:
+    def test_select_includes_succeeded_done_and_retro_phases(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        # Only verify the SQL — empty fetchall is fine for shape check.
+        conn.cursor_instance.fetchall_queue = [[]]
+        d._list_advanceable_agents()
+        assert conn.cursor_instance.executed
+        sql, _params = conn.cursor_instance.executed[0]
+        assert "status = 'succeeded'" in sql
+        assert "'done'" in sql
+        assert "'retro_done'" in sql
+        assert "'retro_failed'" in sql
+        # Existing 3B coverage must still be in the SQL.
+        assert "'awaiting_ci'" in sql
+        assert "'awaiting_deploy'" in sql
+
+    def test_returns_status_field(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue = [
+            [
+                (
+                    "agent-1",
+                    1,
+                    "done",
+                    101,
+                    str(tmp_path),
+                    0,
+                    "succeeded",
+                ),
+                (
+                    "agent-2",
+                    2,
+                    "awaiting_ci",
+                    102,
+                    str(tmp_path),
+                    0,
+                    "running",
+                ),
+            ]
+        ]
+        rows = d._list_advanceable_agents()
+        assert len(rows) == 2
+        assert rows[0]["status"] == "succeeded"
+        assert rows[0]["phase"] == "done"
+        assert rows[1]["status"] == "running"
+
+
+# --------------------------------------------------------------------------
+# _advance_running_agents — dispatch to retro / cleanup branches
+# --------------------------------------------------------------------------
+
+
+class TestAdvanceRunningAgentsRoutesToRetroAndCleanup:
+    def test_succeeded_done_routes_to_retro(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        d._list_advanceable_agents = lambda: [_succeeded_agent(tmp_path)]  # type: ignore[method-assign]
+        called: dict[str, Any] = {}
+        d._run_retro_phase = lambda agent: called.setdefault("retro", agent)  # type: ignore[method-assign]
+        d._cleanup_agent_worktree = lambda agent: called.setdefault(  # type: ignore[method-assign]
+            "cleanup", agent
+        )
+        d._advance_running_agents()
+        assert "retro" in called
+        assert "cleanup" not in called
+
+    def test_succeeded_retro_done_routes_to_cleanup(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        d._list_advanceable_agents = lambda: [  # type: ignore[method-assign]
+            _succeeded_agent(tmp_path, phase=daemon.PHASE_RETRO_DONE)
+        ]
+        called: dict[str, Any] = {}
+        d._run_retro_phase = lambda agent: called.setdefault("retro", agent)  # type: ignore[method-assign]
+        d._cleanup_agent_worktree = lambda agent: called.setdefault(  # type: ignore[method-assign]
+            "cleanup", agent
+        )
+        d._advance_running_agents()
+        assert "cleanup" in called
+        assert "retro" not in called
+
+    def test_succeeded_retro_failed_still_routes_to_cleanup(
+        self, tmp_path: Path
+    ) -> None:
+        # retro_failed → cleanup must still run; the agent succeeded.
+        d, _conn, _handler = _make_daemon(tmp_path)
+        d._list_advanceable_agents = lambda: [  # type: ignore[method-assign]
+            _succeeded_agent(tmp_path, phase=daemon.PHASE_RETRO_FAILED)
+        ]
+        called: dict[str, Any] = {}
+        d._cleanup_agent_worktree = lambda agent: called.setdefault(  # type: ignore[method-assign]
+            "cleanup", agent
+        )
+        d._advance_running_agents()
+        assert "cleanup" in called
+
+    def test_exception_in_retro_does_not_flip_to_crashed(self, tmp_path: Path) -> None:
+        # Status='succeeded' must be preserved even if retro raises.
+        d, conn, handler = _make_daemon(tmp_path)
+        d._list_advanceable_agents = lambda: [_succeeded_agent(tmp_path)]  # type: ignore[method-assign]
+
+        def boom(agent: dict[str, Any]) -> None:
+            raise RuntimeError("retro blew up")
+
+        d._run_retro_phase = boom  # type: ignore[method-assign]
+        d._advance_running_agents()
+        # No status='crashed' UPDATE was issued; only an UPDATE phase
+        # to retro_failed.
+        crashed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "crashed" in str(e[1])
+        ]
+        assert not crashed_updates, "should not flip to crashed for succeeded agent"
+        # advance_failed event was logged.
+        failed = handler.events("advance_failed")
+        assert failed
+        assert failed[0].status == "succeeded"
+        # phase update to retro_failed was issued (one of the executes).
+        retro_failed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and daemon.PHASE_RETRO_FAILED in str(e[1])
+        ]
+        assert retro_failed_updates
+
+
+# --------------------------------------------------------------------------
+# _run_retro_phase — happy path with zero retro issues (clean run)
+# --------------------------------------------------------------------------
+
+
+class TestRunRetroPhaseZeroFindings:
+    def test_zero_retro_issues_transitions_to_retro_done(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path)
+
+        # Stub the retro spawn to write a no-findings output.
+        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+            assert phase == "retro"
+            output_dir = wt / "tmp" / "dispatcher-output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_dir.joinpath("retro.json").write_text(
+                json.dumps(
+                    {
+                        "agent_id": agent_id,
+                        "issue_number": agent["issue_number"],
+                        "pr_number": agent["pr_number"],
+                        "no_findings": True,
+                        "retro_issues": [],
+                    }
+                )
+            )
+            return 0, 1.5
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        # Monkeypatch subprocess.run so that any unexpected gh call
+        # would surface clearly. With zero retro issues, no gh call
+        # should happen.
+        gh_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            gh_calls.append(list(cmd))
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        d._run_retro_phase(agent)
+
+        # No gh issue create calls.
+        gh_creates = [c for c in gh_calls if c[:3] == ["gh", "issue", "create"]]
+        assert gh_creates == []
+
+        # Phase transitioned to retro_done.
+        retro_done_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and daemon.PHASE_RETRO_DONE in str(e[1])
+        ]
+        assert retro_done_updates
+
+        # retro_done event logged with no_findings=True.
+        events = handler.events("retro_done")
+        assert events
+        assert events[0].no_findings is True
+        assert events[0].issues_filed == 0
+
+
+# --------------------------------------------------------------------------
+# _run_retro_phase — happy path with multiple retro issues
+# --------------------------------------------------------------------------
+
+
+class TestRunRetroPhaseMultipleIssues:
+    def test_multiple_retro_issues_files_each_via_gh_create(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path)
+
+        retro_payload = {
+            "agent_id": agent["agent_id"],
+            "issue_number": agent["issue_number"],
+            "pr_number": agent["pr_number"],
+            "no_findings": False,
+            "retro_issues": [
+                {
+                    "title": "fix(dx): tighten retro pre-push check",
+                    "body": "## Problem\n\nRetro found CI was caught too late.",
+                    "labels": ["type/dx", "agent/ready", "priority/p2"],
+                    "priority": "priority/p2",
+                },
+                {
+                    "title": "feat(area/devops): add retry budgeting hint",
+                    "body": "## Problem\n\nRalph took 4 iterations.",
+                    "labels": ["type/dx", "agent/ready", "priority/p2"],
+                    "priority": "priority/p2",
+                },
+            ],
+        }
+
+        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+            output_dir = wt / "tmp" / "dispatcher-output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_dir.joinpath("retro.json").write_text(json.dumps(retro_payload))
+            return 0, 5.0
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        gh_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            gh_calls.append(list(cmd))
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = "https://github.com/judgemind/judgemind/issues/9999\n"
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        d._run_retro_phase(agent)
+
+        gh_creates = [c for c in gh_calls if c[:3] == ["gh", "issue", "create"]]
+        assert len(gh_creates) == 2
+
+        # Each call passes --title, --body-file (file), and at least
+        # one --label.
+        for call in gh_creates:
+            assert "--title" in call
+            assert "--body-file" in call
+            assert "--label" in call
+            # Labels include the ones from the retro payload.
+            assert "type/dx" in call
+
+        # Phase transitioned to retro_done.
+        retro_done_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and daemon.PHASE_RETRO_DONE in str(e[1])
+        ]
+        assert retro_done_updates
+
+        # retro_issue_created event logged for each filing.
+        created_events = handler.events("retro_issue_created")
+        assert len(created_events) == 2
+
+        # retro_done event captured the count.
+        done_events = handler.events("retro_done")
+        assert done_events
+        assert done_events[0].issues_filed == 2
+
+    def test_default_labels_used_when_entry_omits_them(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path)
+
+        retro_payload = {
+            "no_findings": False,
+            "retro_issues": [
+                {
+                    "title": "chore(dx): polish",
+                    "body": "## Problem\n\nMinor tidy.",
+                    # labels intentionally omitted.
+                }
+            ],
+        }
+
+        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+            output_dir = wt / "tmp" / "dispatcher-output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_dir.joinpath("retro.json").write_text(json.dumps(retro_payload))
+            return 0, 1.0
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        gh_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            gh_calls.append(list(cmd))
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = "https://github.com/judgemind/judgemind/issues/1\n"
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d._run_retro_phase(agent)
+
+        creates = [c for c in gh_calls if c[:3] == ["gh", "issue", "create"]]
+        assert creates
+        # All default labels present.
+        for label in daemon.DEFAULT_RETRO_LABELS:
+            assert label in creates[0]
+
+
+# --------------------------------------------------------------------------
+# _run_retro_phase — failure paths
+# --------------------------------------------------------------------------
+
+
+class TestRunRetroPhaseFailures:
+    def test_subprocess_nonzero_exit_marks_retro_failed(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path)
+
+        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+            return 1, 2.0  # non-zero exit, no output written
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        d._run_retro_phase(agent)
+
+        # Phase flipped to retro_failed.
+        retro_failed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and daemon.PHASE_RETRO_FAILED in str(e[1])
+        ]
+        assert retro_failed_updates
+
+        # No status='succeeded'/'failed' UPDATE — succeeded must be
+        # preserved (only the phase is updated).
+        status_changes = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "status" in e[0]
+            and "phase" in e[0]
+            and "ended_at" in e[0]
+        ]
+        assert not status_changes
+
+        # retro_nonzero_exit event logged.
+        assert handler.events("retro_nonzero_exit")
+
+    def test_timeout_marks_retro_failed(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path)
+
+        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+            raise subprocess.TimeoutExpired(cmd="claude", timeout=300)
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        d._run_retro_phase(agent)
+
+        retro_failed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and daemon.PHASE_RETRO_FAILED in str(e[1])
+        ]
+        assert retro_failed_updates
+        assert handler.events("retro_timeout")
+
+    def test_missing_output_marks_retro_failed(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path)
+
+        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+            # Exit 0 but no output file.
+            return 0, 1.0
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        d._run_retro_phase(agent)
+
+        retro_failed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and daemon.PHASE_RETRO_FAILED in str(e[1])
+        ]
+        assert retro_failed_updates
+        assert handler.events("retro_output_missing")
+
+    def test_gh_issue_create_failure_does_not_block_remaining(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path)
+
+        retro_payload = {
+            "no_findings": False,
+            "retro_issues": [
+                {"title": "first", "body": "ok"},
+                {"title": "second", "body": "ok"},
+            ],
+        }
+
+        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+            output_dir = wt / "tmp" / "dispatcher-output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_dir.joinpath("retro.json").write_text(json.dumps(retro_payload))
+            return 0, 1.0
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        call_n = {"i": 0}
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            call_n["i"] += 1
+            # First call fails, second succeeds.
+            if call_n["i"] == 1:
+                r.returncode = 1
+                r.stdout = ""
+                r.stderr = "github 503"
+            else:
+                r.returncode = 0
+                r.stdout = "https://github.com/judgemind/judgemind/issues/2\n"
+                r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d._run_retro_phase(agent)
+
+        # Both calls happened.
+        assert call_n["i"] == 2
+        # First failed, second succeeded → 1 issue created.
+        created = handler.events("retro_issue_created")
+        assert len(created) == 1
+        # Failure logged.
+        failures = handler.events("retro_issue_create_failed")
+        assert len(failures) == 1
+
+    def test_missing_worktree_directory_short_circuits_to_cleanup_done(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path)
+        # Remove the worktree directory before calling.
+        worktree = Path(agent["worktree_path"])
+        # Drop the tmp/ subdir AND the worktree dir itself so .exists() is False.
+        for p in sorted(
+            worktree.rglob("*"), key=lambda p: -len(str(p))
+        ):  # remove deepest first
+            if p.is_file():
+                p.unlink()
+            elif p.is_dir():
+                p.rmdir()
+        worktree.rmdir()
+
+        d._run_retro_phase(agent)
+
+        # cleanup_done phase update issued (skips retro entirely).
+        cleanup_done_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and daemon.PHASE_CLEANUP_DONE in str(e[1])
+        ]
+        assert cleanup_done_updates
+        assert handler.events("retro_worktree_missing")
+
+    def test_retro_issue_cap_truncates(self, monkeypatch: Any, tmp_path: Path) -> None:
+        # Defensive: a runaway retro that wants to file 100 issues
+        # should get truncated to MAX_RETRO_ISSUES_PER_AGENT.
+        d, _conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path)
+
+        many_issues = [
+            {"title": f"issue {i}", "body": "ok"}
+            for i in range(daemon.MAX_RETRO_ISSUES_PER_AGENT + 5)
+        ]
+        retro_payload = {"no_findings": False, "retro_issues": many_issues}
+
+        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+            output_dir = wt / "tmp" / "dispatcher-output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_dir.joinpath("retro.json").write_text(json.dumps(retro_payload))
+            return 0, 1.0
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        n = {"i": 0}
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            n["i"] += 1
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = f"https://github.com/judgemind/judgemind/issues/{n['i']}\n"
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d._run_retro_phase(agent)
+
+        # Calls capped at MAX_RETRO_ISSUES_PER_AGENT.
+        assert n["i"] == daemon.MAX_RETRO_ISSUES_PER_AGENT
+        # Truncation event logged.
+        assert handler.events("retro_issue_cap_truncate")
+
+
+# --------------------------------------------------------------------------
+# _file_retro_issue — input validation
+# --------------------------------------------------------------------------
+
+
+class TestFileRetroIssueValidation:
+    def test_missing_title_returns_none(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+        # subprocess.run should never be called.
+        called = {"n": 0}
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            called["n"] += 1
+            r = MagicMock()
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        result = d._file_retro_issue(
+            "agent-1", tmp_path, {"title": "", "body": "non-empty"}
+        )
+        assert result is None
+        assert called["n"] == 0
+        assert handler.events("retro_issue_missing_fields")
+
+    def test_missing_body_returns_none(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+        called = {"n": 0}
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            called["n"] += 1
+            return MagicMock(returncode=0)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        result = d._file_retro_issue(
+            "agent-1", tmp_path, {"title": "real title", "body": ""}
+        )
+        assert result is None
+        assert called["n"] == 0
+        assert handler.events("retro_issue_missing_fields")
+
+    def test_truncates_oversize_body(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        oversize = "x" * (daemon.MAX_RETRO_ISSUE_BODY_CHARS + 100)
+        captured: dict[str, str] = {}
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            # Pull the --body-file path out of the command.
+            idx = cmd.index("--body-file")
+            captured["body_path"] = cmd[idx + 1]
+            captured["body"] = Path(cmd[idx + 1]).read_text()
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = "https://github.com/judgemind/judgemind/issues/1\n"
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d._file_retro_issue(
+            "agent-1", tmp_path, {"title": "oversize", "body": oversize}
+        )
+        assert "[truncated]" in captured["body"]
+        assert len(captured["body"]) <= daemon.MAX_RETRO_ISSUE_BODY_CHARS + 50
+
+
+# --------------------------------------------------------------------------
+# _parse_issue_url — pure helper
+# --------------------------------------------------------------------------
+
+
+class TestParseIssueUrl:
+    def test_extracts_trailing_issue_number(self) -> None:
+        assert (
+            daemon.DispatcherDaemon._parse_issue_url(
+                "https://github.com/judgemind/judgemind/issues/2812\n"
+            )
+            == 2812
+        )
+
+    def test_no_match_returns_none(self) -> None:
+        assert daemon.DispatcherDaemon._parse_issue_url("nothing here") is None
+
+
+# --------------------------------------------------------------------------
+# _cleanup_agent_worktree — success + blocked branches
+# --------------------------------------------------------------------------
+
+
+class TestCleanupAgentWorktree:
+    def test_success_transitions_to_cleanup_done(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path, phase=daemon.PHASE_RETRO_DONE)
+
+        # Force a known repo root with a real cleanup script present.
+        repo_root = tmp_path / "repo"
+        scripts_dir = repo_root / "scripts"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        (scripts_dir / "cleanup_worktree.sh").write_text("#!/bin/sh\nexit 0\n")
+        monkeypatch.setattr(d, "_repo_root", lambda: repo_root)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            assert cmd[0].endswith("cleanup_worktree.sh")
+            assert cmd[1] == agent["worktree_path"]
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d._cleanup_agent_worktree(agent)
+
+        cleanup_done_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and daemon.PHASE_CLEANUP_DONE in str(e[1])
+        ]
+        assert cleanup_done_updates
+        assert handler.events("cleanup_done")
+
+    def test_safety_check_refusal_marks_cleanup_blocked(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path, phase=daemon.PHASE_RETRO_DONE)
+
+        repo_root = tmp_path / "repo"
+        scripts_dir = repo_root / "scripts"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        (scripts_dir / "cleanup_worktree.sh").write_text("#!/bin/sh\nexit 1\n")
+        monkeypatch.setattr(d, "_repo_root", lambda: repo_root)
+
+        force_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            if "--force" in cmd:
+                force_calls.append(list(cmd))
+            r.returncode = 1
+            r.stdout = ""
+            r.stderr = "agent still running\n"
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d._cleanup_agent_worktree(agent)
+
+        # Phase flipped to cleanup_blocked.
+        blocked_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and daemon.PHASE_CLEANUP_BLOCKED in str(e[1])
+        ]
+        assert blocked_updates
+
+        # CRITICAL: daemon must NOT have called git worktree remove --force.
+        assert not force_calls, "daemon must not bypass cleanup safety with --force"
+
+        assert handler.events("cleanup_blocked")
+
+    def test_subprocess_timeout_marks_blocked(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path, phase=daemon.PHASE_RETRO_DONE)
+
+        repo_root = tmp_path / "repo"
+        (repo_root / "scripts").mkdir(parents=True, exist_ok=True)
+        (repo_root / "scripts" / "cleanup_worktree.sh").write_text(
+            "#!/bin/sh\nexit 0\n"
+        )
+        monkeypatch.setattr(d, "_repo_root", lambda: repo_root)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=60)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d._cleanup_agent_worktree(agent)
+
+        blocked_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and daemon.PHASE_CLEANUP_BLOCKED in str(e[1])
+        ]
+        assert blocked_updates
+        assert handler.events("cleanup_subprocess_error")
+
+    def test_missing_worktree_path_marks_blocked(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path, phase=daemon.PHASE_RETRO_DONE)
+        agent["worktree_path"] = ""
+        d._cleanup_agent_worktree(agent)
+
+        blocked_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and daemon.PHASE_CLEANUP_BLOCKED in str(e[1])
+        ]
+        assert blocked_updates
+        assert handler.events("cleanup_missing_worktree_path")
+
+    def test_already_gone_worktree_marks_done(self, tmp_path: Path) -> None:
+        # If the worktree directory is missing, treat as already-cleaned.
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path, phase=daemon.PHASE_RETRO_DONE)
+        # Remove the worktree directory.
+        worktree = Path(agent["worktree_path"])
+        for p in sorted(worktree.rglob("*"), key=lambda x: -len(str(x))):
+            if p.is_file():
+                p.unlink()
+            elif p.is_dir():
+                p.rmdir()
+        worktree.rmdir()
+        d._cleanup_agent_worktree(agent)
+
+        cleanup_done_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and daemon.PHASE_CLEANUP_DONE in str(e[1])
+        ]
+        assert cleanup_done_updates
+        assert handler.events("cleanup_already_gone")
+
+    def test_missing_cleanup_script_marks_blocked(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path, phase=daemon.PHASE_RETRO_DONE)
+        # Repo root with no cleanup script present.
+        empty_repo = tmp_path / "empty-repo"
+        empty_repo.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(d, "_repo_root", lambda: empty_repo)
+        d._cleanup_agent_worktree(agent)
+        blocked_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and daemon.PHASE_CLEANUP_BLOCKED in str(e[1])
+        ]
+        assert blocked_updates
+        assert handler.events("cleanup_script_missing")
+
+
+# --------------------------------------------------------------------------
+# _write_diagnosis_outcome_for_agent + _mark_agent_terminal integration
+# --------------------------------------------------------------------------
+
+
+class TestDiagnosisOutcomeWriteback:
+    def test_succeeded_terminal_writes_succeeded_outcome(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        # The execute that updates dispatcher.diagnoses sets rowcount.
+        conn.cursor_instance.rowcount = 1
+
+        d._mark_agent_terminal(
+            "agent-success", status="succeeded", phase="cleanup_done", exit_code=0
+        )
+
+        # An UPDATE dispatcher.diagnoses query was executed.
+        diag_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.diagnoses" in e[0]
+        ]
+        assert diag_updates
+        sql, params = diag_updates[0]
+        assert "outcome IS NULL" in sql
+        # Outcome JSON contains succeeded.
+        outcome_json = params[0]
+        outcome_dict = json.loads(outcome_json)
+        assert outcome_dict["retry_outcome"] == "succeeded"
+        assert outcome_dict["final_status"] == "succeeded"
+        assert "resolved_at" in outcome_dict
+        assert params[1] == "agent-success"
+        # diagnosis_outcome_written event logged.
+        assert handler.events("diagnosis_outcome_written")
+
+    def test_failed_terminal_writes_failed_outcome(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.rowcount = 1
+
+        d._mark_agent_terminal(
+            "agent-failed", status="failed", phase="awaiting_ci", exit_code=1
+        )
+
+        diag_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.diagnoses" in e[0]
+        ]
+        assert diag_updates
+        outcome_dict = json.loads(diag_updates[0][1][0])
+        assert outcome_dict["retry_outcome"] == "failed"
+        assert outcome_dict["final_status"] == "failed"
+
+    def test_crashed_terminal_writes_failed_outcome(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.rowcount = 1
+
+        d._mark_agent_terminal(
+            "agent-crashed", status="crashed", phase="awaiting_ci", exit_code=None
+        )
+
+        diag_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.diagnoses" in e[0]
+        ]
+        assert diag_updates
+        outcome_dict = json.loads(diag_updates[0][1][0])
+        # crashed counts as failed for the outcome enum.
+        assert outcome_dict["retry_outcome"] == "failed"
+        assert outcome_dict["final_status"] == "crashed"
+
+    def test_non_terminal_status_skips_outcome_write(self, tmp_path: Path) -> None:
+        # When the daemon transitions to e.g. awaiting_ci (non-terminal),
+        # no diagnoses outcome write should happen.
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        d._mark_agent_terminal(
+            "agent-running", status="running", phase="awaiting_ci", exit_code=None
+        )
+
+        diag_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.diagnoses" in e[0]
+        ]
+        assert not diag_updates
+
+    def test_idempotent_update_uses_outcome_is_null_predicate(
+        self, tmp_path: Path
+    ) -> None:
+        # Calling _write_diagnosis_outcome_for_agent twice should issue
+        # the same UPDATE; the WHERE clause's outcome IS NULL means the
+        # second run is a no-op against rows that already have outcome.
+        d, conn, _handler = _make_daemon(tmp_path)
+        # First call sees 1 row, second sees 0 — but both issue the same SQL.
+        conn.cursor_instance.rowcount = 1
+        d._write_diagnosis_outcome_for_agent("agent-1", "succeeded")
+        first_executes = list(conn.cursor_instance.executed)
+        conn.cursor_instance.rowcount = 0
+        d._write_diagnosis_outcome_for_agent("agent-1", "succeeded")
+        second_executes = list(conn.cursor_instance.executed)
+
+        # SQL pattern is identical (idempotent) — same WHERE clause.
+        assert first_executes[0][0] == second_executes[len(first_executes)][0], (
+            "SQL must be identical across calls (idempotency)"
+        )
+        # Both invocations include the outcome IS NULL predicate so
+        # repeated calls cannot overwrite an already-set outcome.
+        assert "outcome IS NULL" in second_executes[len(first_executes)][0]
+
+    def test_db_error_during_outcome_write_does_not_propagate(
+        self, tmp_path: Path
+    ) -> None:
+        # Even if the outcome write fails, _mark_agent_terminal must
+        # not raise (it has already committed the agent terminal
+        # transition). The failure is logged.
+        d, conn, handler = _make_daemon(tmp_path)
+        # First execute succeeds (the agent UPDATE), second raises.
+        original_execute = conn.cursor_instance.execute
+        call_n = {"i": 0}
+
+        def patched(sql: str, params: Any = None) -> None:
+            call_n["i"] += 1
+            if "UPDATE dispatcher.diagnoses" in sql:
+                raise RuntimeError("db lost")
+            original_execute(sql, params)
+
+        conn.cursor_instance.execute = patched  # type: ignore[method-assign]
+        # Should not raise.
+        d._mark_agent_terminal("agent-1", status="succeeded", phase="done", exit_code=0)
+        # Failure event logged.
+        assert handler.events("diagnosis_outcome_update_failed")


### PR DESCRIPTION
## Summary

Phase 3 sub-task E: completes the per-agent lifecycle in the dispatcher daemon by adding the post-success state-machine extensions (retro orchestration + worktree cleanup) and diagnoser effectiveness tracking. This is the final Phase 3 code piece; the `concurrency_cap=0 → 1` cutover is the operator's next step (documented in the new runbook section).

Closes #2798

## What's in

- **Retro phase.** After verify-success (`status='succeeded' AND phase='done'`), `_run_retro_phase` builds the input bundle, spawns `/task-v2-retro`, files each retro issue via `gh issue create --body-file`, and transitions to `retro_done` (or `retro_failed` on subprocess / parse failure). `status='succeeded'` is preserved.
- **Worktree cleanup.** After `retro_done`/`retro_failed`, `_cleanup_agent_worktree` runs `scripts/cleanup_worktree.sh` and transitions to `cleanup_done` (or `cleanup_blocked` on safety-check refusal). Per CLAUDE.md §Critical Rules the daemon never bypasses with `--force`.
- **Diagnoser effectiveness tracking** (spec §8 line 305). `_mark_agent_terminal` writes back the resolved outcome to any pending `dispatcher.diagnoses` rows for that agent on terminal status. Idempotent via `outcome IS NULL` predicate.
- **Operator runbook.** New `## Dispatcher v2 Cutover` section in `docs/agent/infrastructure-reference.md` covering prerequisites, cut-over UPDATE, watch sequence, Phase 3 gate, rollback, and the per-agent phase enumeration.
- **35 new unit tests** in `scripts/dispatcher/tests/test_daemon_phase3e.py`.

## What's deliberately out

- **The `concurrency_cap=0 → 1` flip.** Explicit operator action, documented in the runbook.
- **§8 weekly report** observability tooling — would be a follow-up p2 issue if pursued.
- **Phase 4** (`cap=5`, full handoff, CLAUDE.md updates) — separate epic.
- **Migration 27.** Phase column is free-form `text`; no DDL needed; enumeration documented in `PHASE_*` constants and the runbook table.

## Test plan

### Automated checks
- [x] Lint passes (`ruff check scripts/dispatcher/`)
- [x] Format check passes (`ruff format --check scripts/dispatcher/`)
- [x] Tests pass (`pytest scripts/dispatcher/tests/` — 306 passed, 1 skipped)
- [x] Markdown links pass (`scripts/check-markdown-links.sh`)
- [x] Schema drift check passes (no schema changes)
- [x] CI green

### Post-deploy verification
- [ ] **Deferred to operator cap-flip per CLAUDE.md §A.8 Step 3.** The daemon can't exercise this code path at `cap=0` (no agents reach `succeeded`). Once the operator runs the runbook UPDATE (`concurrency_cap=1`), the first claimed agent will exercise the full `done → retro_done → cleanup_done` chain plus the diagnoser-outcome write-back on the agent's terminal transition. Until then, post-deploy logs should show only normal `daemon.scheduler_tick` / `daemon.supervisor_tick` events with no `daemon.retro_*` / `daemon.cleanup_*` events — that's the correct cold state.

## References

- Parent epic: #2782 (Phase 3)
- Predecessors: #2783 (3A), #2787 (3B), #2792 (3C), #2796 (3D)
- Spec: `docs/specs/dispatcher-v2-spec.md` §6 (state machine), §8 (diagnoser effectiveness tracking line 305), §15 (Phase 3 gate)
- Skill: `.claude/skills/task-v2-retro/SKILL.md`
