### PR TITLE
fix(dispatcher): bootstrap baseline clone + per-issue cooldown (#2804)

### DIFF
--- a/Dockerfile.dispatcher
+++ b/Dockerfile.dispatcher
@@ -145,6 +145,36 @@ RUN npm install -g @anthropic-ai/claude-code@2.1.114
 ENV HOME=/home/dispatcher
 RUN mkdir -p "$HOME"
 
+# ---------------------------------------------------------------------------
+# Baseline git checkout (issue #2804)
+#
+# Phase 3A (#2783) assumed the daemon's CWD has a `.git` parent so
+# `git -C <cwd> worktree add ...` could carve off per-agent worktrees.
+# The container image does NOT bake in a checkout — adding one here
+# would pin the image to a build-time commit, which breaks the "daemon
+# re-deploys across many merges and wants the latest origin/main for
+# every new worktree" property we actually want.
+#
+# Instead the daemon clones judgemind/judgemind into
+# DISPATCHER_BASELINE_REPO_ROOT at boot (via
+# `DispatcherDaemon.ensure_baseline_clone`), and carves worktrees off
+# that clone at `git -C <baseline> worktree add <abs_path>`. Worktrees
+# live in the sibling `/var/lib/dispatcher/worktrees/` directory so the
+# baseline clone itself is never mixed with per-agent state.
+#
+# We only pre-create the parent directory here; the daemon itself is
+# responsible for the clone (so a restart on already-populated
+# ephemeral storage just does a `git fetch origin main` instead of
+# re-cloning). Writable as root — the container stays on root per the
+# USER note above.
+#
+# Fargate ephemeral storage is 50 GiB (spike 0.6), baseline shallow
+# clone is ~100 MB, worktrees are ~700 MB each — easily fits even at
+# concurrency_cap=5.
+# ---------------------------------------------------------------------------
+RUN mkdir -p /var/lib/dispatcher/worktrees
+ENV DISPATCHER_BASELINE_REPO_ROOT=/var/lib/dispatcher/repo
+
 WORKDIR /app
 
 # ---------------------------------------------------------------------------

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -240,11 +240,15 @@ FIX_CI_LOG_TAIL_MAX_CHARS = 20000
 #: concurrent races via unique-violation).
 ACTIVE_AGENT_STATUSES = ("running", "retrying", "succeeded")
 
-#: Relative path under the repo root where per-agent worktrees land.
-#: Mirrors the laptop-dispatcher convention from
-#: ``.claude/skills/task/SKILL.md`` so human operators can find a
-#: daemon-created worktree with the same ``git worktree list`` command
-#: they use locally.
+#: Relative path under the repo root where per-agent worktrees land in
+#: the local-dev fallback mode (``baseline_repo_root`` unset). Mirrors
+#: the laptop-dispatcher convention from ``.claude/skills/task/SKILL.md``
+#: so human operators can find a daemon-created worktree with the same
+#: ``git worktree list`` command they use locally. When the Fargate
+#: container sets ``DISPATCHER_BASELINE_REPO_ROOT`` (see
+#: :data:`DEFAULT_BASELINE_REPO_ROOT`), worktrees are placed under
+#: ``<baseline_repo_root>.parent / "worktrees" / agent-<uuid>`` instead
+#: and this constant is unused.
 WORKTREE_PARENT_DIR = Path(".claude/worktrees")
 
 #: Length of the short UUID used in worktree + branch names. 8 hex
@@ -252,6 +256,61 @@ WORKTREE_PARENT_DIR = Path(".claude/worktrees")
 #: the lifetime of the dispatcher is negligible and the short form
 #: keeps path lengths sane.
 AGENT_SHORT_ID_HEX_CHARS = 8
+
+#: Default absolute path for the daemon's baseline git clone inside the
+#: Fargate container. When ``DISPATCHER_BASELINE_REPO_ROOT`` is set in
+#: the environment (the Dockerfile wires this to the value below), the
+#: daemon clones ``judgemind/judgemind`` here at boot via
+#: :meth:`DispatcherDaemon.ensure_baseline_clone` and runs
+#: ``git -C <baseline> worktree add <abs_path>`` from it so worktree
+#: creation no longer depends on the container CWD having a ``.git``
+#: directory (issue #2804). Per-agent worktrees live in the sibling
+#: ``worktrees/`` directory so the baseline clone itself is never mixed
+#: with per-agent state. Fargate ephemeral storage is 50 GiB per task
+#: and the baseline shallow clone is ~100 MB; the combined footprint is
+#: well under the quota even at concurrency_cap=5.
+DEFAULT_BASELINE_REPO_ROOT = "/var/lib/dispatcher/repo"
+
+#: Authenticated HTTPS URL used by :meth:`DispatcherDaemon.ensure_baseline_clone`
+#: when the baseline clone is missing. The daemon runs ``gh auth setup-git``
+#: at boot so the GITHUB_TOKEN secret (scoped PAT from spike 0.7 / #2700)
+#: is consulted by git's credential helper automatically. The repo URL
+#: hard-codes ``judgemind/judgemind`` — the daemon is only ever
+#: responsible for that repo, and reading it from ``GITHUB_REPO`` would
+#: let a future test-env mis-config clone a different repo into the
+#: baseline path.
+BASELINE_CLONE_URL = "https://github.com/judgemind/judgemind.git"
+
+#: Hard wall-clock timeout on the boot-time ``git clone``. 300s is
+#: generous even on a slow CI-to-GitHub link for a shallow (~100 MB)
+#: clone; the daemon aborts startup on timeout (exit 1) so the ECS
+#: task restart loop provides a natural retry.
+BASELINE_CLONE_TIMEOUT_SECONDS = 300
+
+#: Hard wall-clock timeout on the ``git fetch origin main`` we run
+#: every time a baseline clone is reused (either at boot or just
+#: before ``git worktree add``). Much shorter than the initial clone
+#: because the delta since the last fetch is small.
+BASELINE_FETCH_TIMEOUT_SECONDS = 120
+
+#: Hard wall-clock timeout on the one-shot ``gh auth setup-git`` call
+#: at daemon boot. The subprocess just writes a credential-helper line
+#: to the container's git config — it is a local operation and should
+#: finish in milliseconds.
+GH_AUTH_SETUP_GIT_TIMEOUT_SECONDS = 10
+
+#: Per-issue cooldown — skip an issue from candidate selection if its
+#: most recent ``dispatcher.agents`` row (any status) was created
+#: within this many seconds. Prevents a systemically-broken issue from
+#: burning through the candidate queue in a failure loop when paired
+#: with the partial UNIQUE INDEX (which only blocks re-claim for
+#: ``running``/``retrying``, not ``failed``/``crashed`` — see spec
+#: §17 Risk 2 and issue #2804). 3600s (60 min) gives the diagnoser a
+#: clear window to file a follow-up or un-fail the agent before the
+#: scheduler retries. Tuned for the cap=1 cutover; a higher cap may
+#: want a shorter cooldown to avoid starving the queue on transient
+#: failures.
+FAILED_AGENT_COOLDOWN_SECONDS = 3600
 
 # --------------------------------------------------------------------------
 # Phase 3E — retro orchestration + worktree cleanup + diagnoser
@@ -604,6 +663,16 @@ class DaemonConfig:
     heartbeat_metric_namespace: str = DEFAULT_HEARTBEAT_METRIC_NAMESPACE
     #: AWS region for the CloudWatch client.
     aws_region: str = DEFAULT_AWS_REGION
+    #: Absolute path to the daemon's baseline git clone, or ``None`` when
+    #: the daemon should fall back to ``os.getcwd()`` as the git parent
+    #: (local-dev / unit-test mode). Populated from the
+    #: ``DISPATCHER_BASELINE_REPO_ROOT`` env var by :func:`_build_config`;
+    #: the Dockerfile wires this to :data:`DEFAULT_BASELINE_REPO_ROOT` so
+    #: the Fargate daemon always runs in baseline-clone mode (issue #2804).
+    #: When set, the daemon clones ``judgemind/judgemind`` here at boot
+    #: and places per-agent worktrees at ``baseline_repo_root.parent /
+    #: "worktrees" / agent-<uuid>`` (see :data:`DEFAULT_BASELINE_REPO_ROOT`).
+    baseline_repo_root: Path | None = None
     # Optional override used by tests to avoid os.environ mutation.
     config_override: dict[str, Any] = field(default_factory=dict)
 
@@ -1268,9 +1337,20 @@ class DispatcherDaemon:
 
         1. Skip if ``dispatcher.agents`` has a row for it with
            ``status IN ('running', 'retrying', 'succeeded')``. A
-           ``failed`` or ``crashed`` row does NOT block re-claim —
-           manual retry is a documented operator flow.
-        2. Run the trust check (``scripts/check-issue-author.sh``). Skip
+           ``failed`` or ``crashed`` row does NOT block re-claim via
+           the partial UNIQUE INDEX — manual retry is a documented
+           operator flow.
+        2. **Per-issue cooldown (issue #2804):** skip if any
+           ``dispatcher.agents`` row for this issue was created within
+           the last :data:`FAILED_AGENT_COOLDOWN_SECONDS`. Guards
+           against the failure-loop amplifier where a systemically-
+           broken issue (e.g. permanently-impossible worktree create,
+           flaky external dep) burns through dozens of agents per hour
+           because the partial UNIQUE INDEX only blocks ``running`` /
+           ``retrying``. The diagnoser gets a clean 60 min window to
+           make a judgment call (escalate / close / un-fail) before
+           the scheduler touches the issue again.
+        3. Run the trust check (``scripts/check-issue-author.sh``). Skip
            on any non-zero exit.
 
         Returns the chosen issue number, or ``None`` if no candidate is
@@ -1288,6 +1368,18 @@ class DispatcherDaemon:
                     },
                 )
                 continue
+            if self._issue_in_cooldown(issue_number):
+                self._log.info(
+                    "daemon.candidate_skipped",
+                    extra={
+                        "event": "candidate_skipped",
+                        "run_id": self._run_id,
+                        "issue_number": issue_number,
+                        "reason": "cooldown",
+                        "cooldown_seconds": FAILED_AGENT_COOLDOWN_SECONDS,
+                    },
+                )
+                continue
             if not self._issue_author_trusted(issue_number):
                 self._log.info(
                     "daemon.candidate_skipped",
@@ -1301,6 +1393,51 @@ class DispatcherDaemon:
                 continue
             return issue_number
         return None
+
+    def _issue_in_cooldown(self, issue_number: int) -> bool:
+        """True if this issue's most recent ``dispatcher.agents`` row is fresh.
+
+        Freshness window is :data:`FAILED_AGENT_COOLDOWN_SECONDS`. All
+        statuses count (not just ``failed``/``crashed``) so a recent
+        ``running`` / ``succeeded`` agent also prevents immediate
+        re-claim — though in practice ``running`` is already caught by
+        :meth:`_issue_already_attempted` (partial UNIQUE INDEX), this
+        extra belt keeps the predicate simple + single-source-of-truth:
+        "did we touch this issue recently? skip".
+
+        Returns True (fail-closed — treat as in cooldown) on DB error
+        to avoid the failure-loop amplification the cooldown exists to
+        prevent.
+        """
+        assert self._conn is not None, "connect() must run before reading"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT 1 FROM dispatcher.agents "
+                    "WHERE issue_number = %s "
+                    "  AND started_at > now() - make_interval(secs => %s) "
+                    "LIMIT 1",
+                    (issue_number, FAILED_AGENT_COOLDOWN_SECONDS),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.cooldown_check_failed",
+                extra={
+                    "event": "cooldown_check_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            # Fail closed — treat as in cooldown on a DB hiccup so we
+            # don't amplify a failure loop on top of a DB problem.
+            return True
+        return row is not None
 
     def _issue_already_attempted(self, issue_number: int) -> bool:
         """True if ``dispatcher.agents`` has any active/succeeded row for this issue.
@@ -1467,16 +1604,255 @@ class DispatcherDaemon:
         return True
 
     def _repo_root(self) -> Path:
-        """Repo root inside the dispatcher container.
+        """Legacy "repo-shaped directory" used by non-git callers.
 
-        The Dockerfile places the daemon code at ``/app/scripts/dispatcher/``
-        but the git working tree used for worktrees is cloned at
-        runtime into ``/app`` (via the startup hook in the Fargate task
-        definition). For unit tests the working directory is the
-        repo-root worktree. ``os.getcwd()`` returns the right thing in
-        both cases; the daemon never ``chdir``s away from it.
+        Returns ``os.getcwd()``. The Dockerfile places the daemon code
+        at ``/app/scripts/dispatcher/`` so the container CWD is ``/app``;
+        for unit tests the CWD is the repo-root worktree. The daemon
+        never ``chdir``s away from it.
+
+        **Not** the git parent for worktree ops. Phase 3A (#2783)
+        originally had ``_create_worktree`` run ``git -C <cwd> worktree
+        add ...``, but the container's ``/app`` has no ``.git`` child
+        and every worktree add failed at cap=1 cutover (#2804). The
+        baseline clone lives at :data:`DEFAULT_BASELINE_REPO_ROOT`
+        instead, and :meth:`_git_parent_root` returns that path when
+        :attr:`DaemonConfig.baseline_repo_root` is set. This method is
+        preserved for callers that need a repo-shaped directory for
+        non-git purposes (tmp file paths, optional script lookups) —
+        migrating every caller would be a larger refactor with the
+        same operational outcome.
         """
         return Path(os.getcwd())
+
+    def _git_parent_root(self) -> Path:
+        """Absolute path of the git directory ``git -C`` should target.
+
+        When ``baseline_repo_root`` is configured (production Fargate
+        path — issue #2804), this is the daemon's baseline clone at
+        :data:`DEFAULT_BASELINE_REPO_ROOT`. When unset, fall back to
+        :meth:`_repo_root` (the legacy local-dev / unit-test path that
+        uses ``os.getcwd()``).
+
+        Separate from :meth:`_repo_root` because existing callers (the
+        diagnoser, cleanup_worktree.sh invocations, etc.) already pass
+        ``self._repo_root()`` as a generic "repo-shaped directory" —
+        they do not all need to switch to the baseline clone. The git
+        parent is the narrow concept "where worktree adds run from".
+        """
+        if self._cfg.baseline_repo_root is not None:
+            return self._cfg.baseline_repo_root
+        return self._repo_root()
+
+    def _compute_worktree_path(self, short_id: str) -> Path:
+        """Absolute path for a new per-agent worktree.
+
+        Must match the path passed to ``git worktree add`` so the DB's
+        ``dispatcher.agents.worktree_path`` row points at the same
+        directory the supervisor / cleanup code later looks for
+        (otherwise the worktree is "orphaned from the DB's perspective"
+        — see spec §17 Risk 1).
+
+        When ``baseline_repo_root`` is set, the worktree lives in the
+        sibling ``worktrees/`` directory next to the baseline clone
+        (``/var/lib/dispatcher/worktrees/agent-<short_id>``). When unset,
+        fall back to the legacy ``<cwd>/.claude/worktrees/`` convention.
+        """
+        baseline = self._cfg.baseline_repo_root
+        if baseline is not None:
+            return baseline.parent / "worktrees" / f"agent-{short_id}"
+        return self._repo_root() / WORKTREE_PARENT_DIR / f"agent-{short_id}"
+
+    def _setup_git_credentials(self) -> None:
+        """Run ``gh auth setup-git`` once so git uses the GITHUB_TOKEN.
+
+        The Fargate task environment exposes a scoped PAT via
+        ``GITHUB_TOKEN`` (spike 0.7 / #2700). ``gh auth setup-git``
+        writes a credential-helper line to the container's git config
+        that makes subsequent ``git clone`` / ``git fetch`` / ``git push``
+        calls over HTTPS consult ``gh`` for credentials, which in turn
+        reads ``GITHUB_TOKEN``. This is idempotent — re-running it is
+        a no-op — so it is safe to call on every boot.
+
+        Any failure here is logged but does NOT abort startup: the
+        baseline clone may still succeed on a pre-auth'd container
+        image or via cached credentials, and the ECS task restart loop
+        will re-run this on the next boot if credentials genuinely are
+        broken. Only the baseline clone / fetch failing is a fatal
+        startup error.
+        """
+        cmd = ["gh", "auth", "setup-git"]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=GH_AUTH_SETUP_GIT_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except FileNotFoundError:
+            self._log.warning(
+                "daemon.gh_setup_git_missing",
+                extra={
+                    "event": "gh_setup_git_missing",
+                    "run_id": self._run_id,
+                    "detail": "gh CLI not on PATH",
+                },
+            )
+            return
+        except subprocess.TimeoutExpired:
+            self._log.warning(
+                "daemon.gh_setup_git_timeout",
+                extra={
+                    "event": "gh_setup_git_timeout",
+                    "run_id": self._run_id,
+                },
+            )
+            return
+
+        if result.returncode == 0:
+            self._log.info(
+                "daemon.gh_setup_git_ok",
+                extra={
+                    "event": "gh_setup_git_ok",
+                    "run_id": self._run_id,
+                },
+            )
+            return
+
+        self._log.warning(
+            "daemon.gh_setup_git_failed",
+            extra={
+                "event": "gh_setup_git_failed",
+                "run_id": self._run_id,
+                "exit_code": result.returncode,
+                "detail": (result.stderr or result.stdout or "").strip()[:200],
+            },
+        )
+
+    def ensure_baseline_clone(self) -> None:
+        """Clone or fetch the baseline git repo used for worktree creation.
+
+        Issue #2804. The dispatcher container image (``Dockerfile.dispatcher``)
+        does not bake in a git checkout; Phase 3A assumed the daemon's
+        CWD already had a ``.git`` parent, which is false in Fargate. At
+        boot the daemon must either clone ``judgemind/judgemind`` into
+        :attr:`DaemonConfig.baseline_repo_root` (first deploy or
+        ephemeral-storage wipe) or fetch ``origin/main`` (every
+        subsequent boot on the same task, though Fargate restarts always
+        start fresh — defensive either way).
+
+        Only runs when ``baseline_repo_root`` is configured. Local dev
+        and unit tests (where :meth:`_repo_root` points at an existing
+        worktree) skip this entirely and leave git operations on
+        whatever repo the developer is running inside.
+
+        Raises :class:`RuntimeError` on subprocess failure so
+        :func:`main` can log + exit 1 — the ECS task then restart-loops,
+        which is the correct handling for a transient network blip.
+        """
+        baseline = self._cfg.baseline_repo_root
+        if baseline is None:
+            self._log.info(
+                "daemon.baseline_clone_skipped",
+                extra={
+                    "event": "baseline_clone_skipped",
+                    "run_id": self._run_id,
+                    "detail": "baseline_repo_root unset (local-dev mode)",
+                },
+            )
+            return
+
+        self._setup_git_credentials()
+
+        if (baseline / ".git").exists():
+            # Existing clone — fetch so worktrees branch from up-to-date
+            # ``origin/main``. Cheap (shallow fetch) and prevents
+            # "worktree branched from a stale main" bugs as the daemon
+            # stays up across many merges.
+            self._baseline_fetch_origin_main()
+            self._log.info(
+                "daemon.baseline_clone_ready",
+                extra={
+                    "event": "baseline_clone_ready",
+                    "run_id": self._run_id,
+                    "baseline_repo_root": str(baseline),
+                    "action": "fetch",
+                },
+            )
+            return
+
+        # Fresh clone. Create the parent directory (e.g. /var/lib/dispatcher/)
+        # so the sibling worktrees directory can also be created later.
+        baseline.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd = [
+            "git",
+            "clone",
+            "--depth=1",
+            "--no-tags",
+            BASELINE_CLONE_URL,
+            str(baseline),
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=BASELINE_CLONE_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"git CLI not on PATH: {exc}") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"git clone timed out after {BASELINE_CLONE_TIMEOUT_SECONDS}s"
+            ) from exc
+
+        if result.returncode != 0:
+            stderr_preview = (result.stderr or "").strip()[:200]
+            raise RuntimeError(f"git clone exit={result.returncode}: {stderr_preview}")
+
+        self._log.info(
+            "daemon.baseline_clone_ready",
+            extra={
+                "event": "baseline_clone_ready",
+                "run_id": self._run_id,
+                "baseline_repo_root": str(baseline),
+                "action": "clone",
+            },
+        )
+
+    def _baseline_fetch_origin_main(self) -> None:
+        """Run ``git -C <baseline> fetch origin main``. Raise on failure.
+
+        Called by :meth:`ensure_baseline_clone` on reboot and by
+        :meth:`_create_worktree` before each ``git worktree add`` so
+        the new worktree branches from up-to-date ``origin/main``.
+        """
+        baseline = self._cfg.baseline_repo_root
+        if baseline is None:  # pragma: no cover — guarded by callers
+            return
+
+        cmd = ["git", "-C", str(baseline), "fetch", "origin", "main"]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=BASELINE_FETCH_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"git CLI not on PATH: {exc}") from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"git fetch timed out after {BASELINE_FETCH_TIMEOUT_SECONDS}s"
+            ) from exc
+
+        if result.returncode != 0:
+            stderr_preview = (result.stderr or "").strip()[:200]
+            raise RuntimeError(f"git fetch exit={result.returncode}: {stderr_preview}")
 
     def _create_worktree(self, agent_id: str) -> Path:
         """``git worktree add`` a fresh worktree + branch for this agent.
@@ -1484,16 +1860,33 @@ class DispatcherDaemon:
         Returns the absolute path to the new worktree. Raises
         :class:`RuntimeError` on subprocess failure so the caller can
         mark the agent failed.
+
+        When ``baseline_repo_root`` is configured (production Fargate
+        mode — issue #2804), runs ``git -C <baseline> fetch origin main``
+        first so the new worktree branches from the freshest possible
+        ``origin/main``; then invokes ``git -C <baseline> worktree add``
+        with an absolute worktree path under
+        :data:`DEFAULT_BASELINE_REPO_ROOT`'s sibling ``worktrees/`` dir.
+        In the legacy local-dev / unit-test mode (``baseline_repo_root``
+        unset), runs ``git -C <cwd> worktree add`` against
+        ``.claude/worktrees/`` as before.
         """
         short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
-        repo_root = self._repo_root()
-        worktree_path = repo_root / WORKTREE_PARENT_DIR / f"agent-{short_id}"
+        git_parent = self._git_parent_root()
+        worktree_path = self._compute_worktree_path(short_id)
         branch = f"agent/{short_id}"
+
+        # In baseline-clone mode, refresh ``origin/main`` before
+        # branching. Any fetch failure bubbles up as a RuntimeError so
+        # the caller marks the agent failed — consistent with the
+        # existing worktree-add failure path.
+        if self._cfg.baseline_repo_root is not None:
+            self._baseline_fetch_origin_main()
 
         cmd = [
             "git",
             "-C",
-            str(repo_root),
+            str(git_parent),
             "worktree",
             "add",
             str(worktree_path),
@@ -1899,8 +2292,7 @@ class DispatcherDaemon:
 
         agent_id = str(uuid.uuid4())
         short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
-        repo_root = self._repo_root()
-        worktree_path = repo_root / WORKTREE_PARENT_DIR / f"agent-{short_id}"
+        worktree_path = self._compute_worktree_path(short_id)
 
         self._log.info(
             "daemon.candidate_picked",
@@ -7558,6 +7950,15 @@ def _build_config(
     aws_region = (
         env.get("AWS_REGION") or env.get("AWS_DEFAULT_REGION") or DEFAULT_AWS_REGION
     )
+    # Baseline clone path is opt-in via env var. The Dockerfile sets it
+    # to :data:`DEFAULT_BASELINE_REPO_ROOT` so Fargate always runs in
+    # baseline-clone mode; local dev and unit tests leave it unset and
+    # the daemon falls back to ``os.getcwd()`` (preserves pre-#2804
+    # behavior). An empty-string value is treated the same as unset so
+    # operators can disable baseline-clone mode without touching the
+    # task definition.
+    raw_baseline = env.get("DISPATCHER_BASELINE_REPO_ROOT", "").strip()
+    baseline_repo_root = Path(raw_baseline) if raw_baseline else None
 
     override: dict[str, Any] = {}
     if args.config_override:
@@ -7583,6 +7984,7 @@ def _build_config(
         dispatcher_service_name=dispatcher_service_name,
         heartbeat_metric_namespace=heartbeat_namespace,
         aws_region=aws_region,
+        baseline_repo_root=baseline_repo_root,
         config_override=override,
     )
 
@@ -7660,6 +8062,21 @@ def main(argv: list[str] | None = None) -> int:
         return 1
     except Exception:
         log.exception("daemon.register_failed", extra={"event": "register_failed"})
+        daemon.close()
+        return 1
+
+    # Bootstrap the baseline git clone before the first scheduler tick
+    # so ``_create_worktree`` has a ``.git`` parent to run ``git -C ...
+    # worktree add`` from (issue #2804). No-op in local-dev / unit-test
+    # mode (``DISPATCHER_BASELINE_REPO_ROOT`` unset).
+    try:
+        daemon.ensure_baseline_clone()
+    except Exception:
+        log.exception(
+            "daemon.baseline_clone_failed",
+            extra={"event": "baseline_clone_failed"},
+        )
+        daemon.mark_stopped()
         daemon.close()
         return 1
 

--- a/scripts/dispatcher/tests/test_daemon_baseline_clone.py
+++ b/scripts/dispatcher/tests/test_daemon_baseline_clone.py
@@ -1,0 +1,532 @@
+"""Unit tests for the baseline-clone bootstrap + failure-loop cooldown.
+
+Issue #2804 — dispatcher container has no git checkout, so Phase 3A's
+``git -C <cwd> worktree add`` path fails at cap=1. Fix:
+
+* ``DispatcherDaemon.ensure_baseline_clone`` runs at boot and either
+  clones ``judgemind/judgemind`` into
+  :data:`DISPATCHER_BASELINE_REPO_ROOT` (first boot / empty ephemeral
+  storage) or fetches ``origin/main`` (subsequent boot on existing
+  clone).
+* ``DispatcherDaemon._create_worktree`` invokes
+  ``git -C <baseline_repo_root> worktree add <abs_worktree_path>``
+  (was ``git -C <cwd>``) so worktree creation no longer depends on the
+  container CWD having a ``.git`` directory.
+* ``DispatcherDaemon._pick_candidate_issue`` skips any issue whose most
+  recent ``dispatcher.agents`` row is within
+  :data:`FAILED_AGENT_COOLDOWN_SECONDS` (60 min). Prevents the
+  failure-loop amplifier where a systemically-broken issue burns
+  through dozens of agents per hour because the partial UNIQUE INDEX
+  only blocks re-claim for ``running``/``retrying``.
+
+The tests in :mod:`test_daemon_phase3a` cover the legacy
+``baseline_repo_root=None`` path (local-dev / unit-test fallback). This
+module covers the new baseline-clone path plus the cooldown behavior,
+both of which are strictly additive to the Phase 3A contract.
+
+All external calls — subprocess (``git clone``, ``git fetch``,
+``git worktree add``, ``gh auth setup-git``) and psycopg — are mocked.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+class _UniqueViolation(Exception):
+    """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+
+_psycopg_stub = MagicMock()
+_psycopg_errors = MagicMock()
+_psycopg_errors.UniqueViolation = _UniqueViolation
+_psycopg_stub.errors = _psycopg_errors
+sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — intentionally duplicated from test_daemon_phase3a so the
+# test modules stay independently runnable (pytest collection order is
+# unstable; importing helpers across test files creates fragile coupling).
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+    baseline_repo_root: Path | None = None,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.baseline_clone.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+        baseline_repo_root=baseline_repo_root,
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# Constants sanity — cooldown is the expected 60 min
+# --------------------------------------------------------------------------
+
+
+class TestCooldownConstant:
+    def test_default_cooldown_is_one_hour(self) -> None:
+        # Spec §17 Risk 2 / issue #2804 — 60 min gives the diagnoser a
+        # clean window between retries.
+        assert daemon.FAILED_AGENT_COOLDOWN_SECONDS == 3600
+
+
+# --------------------------------------------------------------------------
+# DaemonConfig plumbing — DISPATCHER_BASELINE_REPO_ROOT env var flows through
+# --------------------------------------------------------------------------
+
+
+class TestBaselineConfigPlumbing:
+    def test_env_var_populates_baseline_repo_root(self) -> None:
+        args = daemon._parse_args(
+            [
+                "--tick-scheduler-seconds",
+                "30",
+                "--tick-supervisor-seconds",
+                "120",
+                "--tick-housekeeping-seconds",
+                "3600",
+            ]
+        )
+        env = {
+            "DATABASE_URL": "postgres://fake",
+            "DISPATCHER_BASELINE_REPO_ROOT": "/var/lib/dispatcher/repo",
+        }
+        cfg = daemon._build_config(args, env=env)
+        assert cfg.baseline_repo_root == Path("/var/lib/dispatcher/repo")
+
+    def test_unset_env_var_leaves_baseline_none(self) -> None:
+        args = daemon._parse_args([])
+        env = {"DATABASE_URL": "postgres://fake"}
+        cfg = daemon._build_config(args, env=env)
+        assert cfg.baseline_repo_root is None
+
+    def test_empty_env_var_treated_as_unset(self) -> None:
+        # Operator lever to disable baseline-clone mode without editing
+        # the task definition.
+        args = daemon._parse_args([])
+        env = {
+            "DATABASE_URL": "postgres://fake",
+            "DISPATCHER_BASELINE_REPO_ROOT": "   ",
+        }
+        cfg = daemon._build_config(args, env=env)
+        assert cfg.baseline_repo_root is None
+
+
+# --------------------------------------------------------------------------
+# ensure_baseline_clone — clone path missing → invokes git clone;
+# path exists → invokes git fetch
+# --------------------------------------------------------------------------
+
+
+class TestEnsureBaselineClone:
+    def test_no_baseline_config_is_a_noop(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, handler = _make_daemon(tmp_path, baseline_repo_root=None)
+
+        def fake_run(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("subprocess must not run when baseline unset")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d.ensure_baseline_clone()
+        assert handler.events("baseline_clone_skipped") != []
+
+    def test_missing_path_invokes_git_clone(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        baseline = tmp_path / "repo"  # does NOT exist
+        d, _conn, handler = _make_daemon(tmp_path, baseline_repo_root=baseline)
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d.ensure_baseline_clone()
+
+        # gh auth setup-git runs first, then git clone.
+        assert any(c[:3] == ["gh", "auth", "setup-git"] for c in calls)
+        clone_calls = [c for c in calls if c[:2] == ["git", "clone"]]
+        assert len(clone_calls) == 1
+        clone_cmd = clone_calls[0]
+        assert "--depth=1" in clone_cmd
+        assert "--no-tags" in clone_cmd
+        assert daemon.BASELINE_CLONE_URL in clone_cmd
+        assert str(baseline) in clone_cmd
+        # No fetch when the path is missing — clone already pulls main.
+        assert not any(c[:2] == ["git", "-C"] and "fetch" in c for c in calls)
+
+        ready = handler.events("baseline_clone_ready")
+        assert len(ready) == 1
+        assert getattr(ready[0], "action", None) == "clone"
+
+    def test_existing_path_invokes_git_fetch(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        baseline = tmp_path / "repo"
+        (baseline / ".git").mkdir(parents=True)
+        d, _conn, handler = _make_daemon(tmp_path, baseline_repo_root=baseline)
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d.ensure_baseline_clone()
+
+        # gh auth setup-git then git -C <baseline> fetch origin main.
+        assert any(c[:3] == ["gh", "auth", "setup-git"] for c in calls)
+        fetch_calls = [
+            c
+            for c in calls
+            if c[:2] == ["git", "-C"] and "fetch" in c and "origin" in c
+        ]
+        assert len(fetch_calls) == 1
+        fetch_cmd = fetch_calls[0]
+        assert fetch_cmd[2] == str(baseline)
+        assert fetch_cmd[-2:] == ["origin", "main"]
+        # No clone when the path exists.
+        assert not any(c[:2] == ["git", "clone"] for c in calls)
+
+        ready = handler.events("baseline_clone_ready")
+        assert len(ready) == 1
+        assert getattr(ready[0], "action", None) == "fetch"
+
+    def test_clone_failure_raises_runtime_error(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        baseline = tmp_path / "repo"
+        d, _conn, _handler = _make_daemon(tmp_path, baseline_repo_root=baseline)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            if cmd[:2] == ["git", "clone"]:
+                r.returncode = 128
+                r.stderr = "fatal: could not read Username\n"
+                r.stdout = ""
+                return r
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        import pytest
+
+        with pytest.raises(RuntimeError) as excinfo:
+            d.ensure_baseline_clone()
+        assert "exit=128" in str(excinfo.value)
+
+    def test_gh_setup_git_missing_does_not_abort(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        # On a minimal image without gh, clone should still proceed —
+        # credentials may already be cached.
+        baseline = tmp_path / "repo"
+        d, _conn, handler = _make_daemon(tmp_path, baseline_repo_root=baseline)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            if cmd[:3] == ["gh", "auth", "setup-git"]:
+                raise FileNotFoundError(2, "nope", cmd[0])
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        # Should not raise.
+        d.ensure_baseline_clone()
+        assert handler.events("gh_setup_git_missing") != []
+        assert handler.events("baseline_clone_ready") != []
+
+
+# --------------------------------------------------------------------------
+# _create_worktree in baseline-clone mode — uses -C <baseline> and absolute
+# worktree path under /var/lib/dispatcher/worktrees/
+# --------------------------------------------------------------------------
+
+
+class TestCreateWorktreeBaselineMode:
+    def test_uses_baseline_as_git_parent_and_absolute_worktree_path(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        baseline = tmp_path / "repo"
+        (baseline / ".git").mkdir(parents=True)
+        d, _conn, handler = _make_daemon(tmp_path, baseline_repo_root=baseline)
+
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            captured.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        agent_id = "aabbccdd-eeff-0011-2233-445566778899"
+        wt = d._create_worktree(agent_id)
+
+        # Fetch-before-worktree ran.
+        fetch = [
+            c
+            for c in captured
+            if c[:2] == ["git", "-C"] and "fetch" in c and "origin" in c
+        ]
+        assert len(fetch) == 1
+        assert fetch[0][2] == str(baseline)
+
+        # worktree add invoked with -C <baseline> and absolute path
+        # under <baseline>.parent / "worktrees".
+        wt_calls = [c for c in captured if c[:2] == ["git", "-C"] and "worktree" in c]
+        assert len(wt_calls) == 1
+        wt_cmd = wt_calls[0]
+        assert wt_cmd[2] == str(baseline)
+        assert "add" in wt_cmd
+        assert str(wt).startswith(str(tmp_path))
+        assert str(wt) == str(baseline.parent / "worktrees" / "agent-aabbccdd")
+        # returned path is absolute.
+        assert wt.is_absolute()
+        # branch name preserved.
+        assert "-b" in wt_cmd
+        branch_idx = wt_cmd.index("-b") + 1
+        assert wt_cmd[branch_idx] == "agent/aabbccdd"
+        assert handler.events("worktree_created") != []
+
+    def test_fetch_failure_aborts_worktree_add(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        baseline = tmp_path / "repo"
+        (baseline / ".git").mkdir(parents=True)
+        d, _conn, _handler = _make_daemon(tmp_path, baseline_repo_root=baseline)
+
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            captured.append(cmd)
+            r = MagicMock()
+            if "fetch" in cmd:
+                r.returncode = 1
+                r.stderr = "fatal: unable to access remote\n"
+                r.stdout = ""
+                return r
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        import pytest
+
+        with pytest.raises(RuntimeError) as excinfo:
+            d._create_worktree("aabbccdd-eeff-0011-2233-445566778899")
+        assert "fetch" in str(excinfo.value)
+        # No worktree-add attempt after fetch failure.
+        assert not any(c[:2] == ["git", "-C"] and "worktree" in c for c in captured)
+
+    def test_legacy_mode_still_uses_cwd_and_relative_path(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        # Backward compatibility guard for the laptop / unit-test path
+        # — when baseline_repo_root is None, the daemon must keep the
+        # pre-#2804 behavior (git -C <cwd> worktree add <cwd>/.claude/worktrees/...).
+        d, _conn, _handler = _make_daemon(tmp_path, baseline_repo_root=None)
+
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            captured.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        agent_id = "aabbccdd-eeff-0011-2233-445566778899"
+        wt = d._create_worktree(agent_id)
+
+        # No pre-fetch in legacy mode.
+        assert not any("fetch" in c for c in captured)
+        assert str(wt).endswith(".claude/worktrees/agent-aabbccdd")
+
+
+# --------------------------------------------------------------------------
+# _compute_worktree_path — consistent across claim path and _create_worktree
+# --------------------------------------------------------------------------
+
+
+class TestComputeWorktreePath:
+    def test_baseline_mode_path_is_sibling_to_clone(self, tmp_path: Path) -> None:
+        baseline = tmp_path / "repo"
+        d, _conn, _handler = _make_daemon(tmp_path, baseline_repo_root=baseline)
+        assert d._compute_worktree_path("abcd1234") == (
+            baseline.parent / "worktrees" / "agent-abcd1234"
+        )
+
+    def test_legacy_mode_path_is_under_cwd(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path, baseline_repo_root=None)
+        wt = d._compute_worktree_path("abcd1234")
+        assert str(wt).endswith(".claude/worktrees/agent-abcd1234")
+
+
+# --------------------------------------------------------------------------
+# Per-issue cooldown in _pick_candidate_issue
+# --------------------------------------------------------------------------
+
+
+class TestCooldownSkip:
+    def test_skips_issue_in_cooldown(self, tmp_path: Path) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+        attempted: set[int] = set()
+        cooldown: set[int] = {2}
+
+        d._issue_already_attempted = lambda n: n in attempted  # type: ignore[method-assign]
+        d._issue_in_cooldown = lambda n: n in cooldown  # type: ignore[method-assign]
+        d._issue_author_trusted = lambda _n: True  # type: ignore[method-assign]
+
+        # Issue 2 is in cooldown — picker should skip to 3.
+        assert d._pick_candidate_issue([1, 2, 3]) == 1
+        # Confirm the skip for 2 would be cooldown if we drop 1.
+        assert d._pick_candidate_issue([2, 3]) == 3
+        cooldown_skips = [
+            r
+            for r in handler.events("candidate_skipped")
+            if getattr(r, "reason", None) == "cooldown"
+        ]
+        assert len(cooldown_skips) >= 1
+        assert getattr(cooldown_skips[0], "issue_number", None) == 2
+
+    def test_cooldown_db_query_returns_true_when_row_fresh(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(1,)]
+        assert d._issue_in_cooldown(42) is True
+        # Confirm the SQL fires against dispatcher.agents with a
+        # started_at interval bound.
+        executed = conn.cursor_instance.executed
+        assert any(
+            "dispatcher.agents" in sql and "started_at" in sql and "secs => %s" in sql
+            for sql, _params in executed
+        )
+        # And the parameters include the issue number + cooldown seconds.
+        params = [p for _sql, p in executed][0]
+        assert params[0] == 42
+        assert params[1] == daemon.FAILED_AGENT_COOLDOWN_SECONDS
+
+    def test_cooldown_db_query_returns_false_when_no_row(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        assert d._issue_in_cooldown(42) is False
+
+    def test_cooldown_fail_closed_on_db_error(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        def boom(sql: str, params: Any = None) -> None:
+            raise RuntimeError("db lost")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+        # Fail closed — treat as in cooldown so we don't amplify the
+        # failure loop on top of a DB issue.
+        assert d._issue_in_cooldown(42) is True
+        assert conn.rollbacks >= 1


### PR DESCRIPTION
## Summary

Fix the Phase 3 cap=1 cutover blocker: the dispatcher daemon container has no git checkout, so Phase 3A's `git -C <cwd> worktree add` fails on every attempt (10 failed-loop agents on #2803 in 5 minutes when operator tried cap=1). Adds baseline-clone bootstrap at boot, switches worktree creation to run from inside the baseline clone with absolute paths, and adds a 60 min per-issue cooldown so a systemically-broken issue cannot amplify into dozens of failed agents per hour.

Closes #2804

## Test plan

### Automated checks
- [x] Lint passes (`ruff check scripts/dispatcher/`)
- [x] Format check passes (`ruff format --check scripts/dispatcher/`)
- [x] Tests pass (`pytest scripts/dispatcher/tests/`) — **324 passed locally (+18 new)**
- [x] CI green

### Post-deploy verification

Verified via smoke test at cap=1 on dev (~2 min window). Full evidence in the verification-evidence comment on #2804.

- [x] `deploy-dispatcher.yml` runs to green after merge
- [x] Dispatcher task-definition revision bumps on dev ECS (`judgemind-dispatcher-dev:4`)
- [x] CloudWatch `/ecs/judgemind-dispatcher-dev` logs show `baseline_clone_ready` event on first boot (action=clone, 14:05:10 UTC)
- [x] Smoke test at cap=1: `daemon.worktree_created` (5 agents, all at `/var/lib/dispatcher/worktrees/agent-<id>`) + `daemon.phase_started phase=plan` events observed. Cooldown skip (`reason=cooldown, cooldown_seconds=3600`) confirmed on re-pick ticks.
- [x] Verification evidence posted on issue (see A.8)
