### PR TITLE
feat(ci): add dispatcher-image dependency drift check (#2776)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -492,6 +492,38 @@ if [ -n "$changed_migrations" ]; then
 fi
 
 # -------------------------------------------------------------------
+# Dispatcher image dependency drift — run when the daemon or its
+# Dockerfile changes (#2776)
+# -------------------------------------------------------------------
+# Cross-checks every non-stdlib import under scripts/dispatcher/ against
+# the pip install step in Dockerfile.dispatcher. Motivated by the #2773
+# boto3 scope miss: PR #2771 added `import boto3` inside the daemon but
+# did not add boto3 to Dockerfile.dispatcher. The daemon unit tests mock
+# the client by method assignment, so the image missing boto3 only
+# surfaced in production logs ~24h post-deploy. Mirrors the CI step so
+# the failure is caught locally before CI runs (~2 minute round trip).
+changed_dispatcher_deps=$(echo "$changed_files" \
+    | grep -E '^(scripts/dispatcher/.+\.py|Dockerfile\.dispatcher)$' || true)
+if [ -n "$changed_dispatcher_deps" ]; then
+    echo "pre-push: checking dispatcher image dependency drift..." >&2
+    if [ -x scripts/check-dispatcher-image-deps.sh ]; then
+        if ! scripts/check-dispatcher-image-deps.sh 2>&1; then
+            echo "" >&2
+            echo "  FAILED: scripts/check-dispatcher-image-deps.sh" >&2
+            echo "  A Python import under scripts/dispatcher/ is not installed" >&2
+            echo "  in Dockerfile.dispatcher. The dispatcher daemon will fail" >&2
+            echo "  at runtime with ModuleNotFoundError in production." >&2
+            echo "" >&2
+            echo "  Fix: add the missing package to the pip install step in" >&2
+            echo "  Dockerfile.dispatcher. See issue #2776 for background." >&2
+            failures=$((failures + 1))
+        fi
+    else
+        echo "  WARNING: scripts/check-dispatcher-image-deps.sh not found or not executable — skipping" >&2
+    fi
+fi
+
+# -------------------------------------------------------------------
 # Filename separator hygiene — always cheap, always run
 # -------------------------------------------------------------------
 # Flags same-directory filename pairs that differ only by `-` vs `_`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,15 @@ jobs:
               # test_wait_for_rollout.sh fires on PRs that touch only the
               # composite action (which still calls the shared script).
               - '.github/actions/ecs-deploy/**'
+              # Dockerfile.dispatcher is the image the dispatcher daemon
+              # runs in; scripts-tests wires the check-dispatcher-image-deps
+              # guard that cross-checks its pip install list against
+              # scripts/dispatcher/**/*.py imports (#2776, motivated by
+              # the #2773 boto3 scope miss). Running scripts-tests on
+              # Dockerfile.dispatcher edits ensures that guard fires on
+              # PRs that only touch the Dockerfile (e.g. adding a new
+              # dep unrelated to a daemon code change).
+              - 'Dockerfile.dispatcher'
               # Also trigger when the scripts-tests job itself changes, so
               # regressions in the auto-discovery loop are caught on the
               # PR that introduces them (#2505). Mirrors the 'hooks' filter
@@ -558,6 +567,13 @@ jobs:
         run: scripts/check-no-inline-ecs-healthcheck.sh
       - name: Check docs describe the actual rebuild_db.py CLI
         run: scripts/check-no-rebuild-db-skip-reset.sh
+      # Cross-checks every non-stdlib import under scripts/dispatcher/ against
+      # the pip install step in Dockerfile.dispatcher. Motivated by the #2773
+      # boto3 scope miss (#2776): PR #2771 added `import boto3` but did not
+      # add boto3 to Dockerfile.dispatcher, and no test caught it because the
+      # daemon tests mock the client by method assignment.
+      - name: Verify dispatcher image installs every Python import used by the daemon
+        run: scripts/check-dispatcher-image-deps.sh
       # Auto-discover and run every executable shell test under
       # scripts/tests/*.sh. Replaces the old per-script listing (#2505) so
       # that adding a new shell test is just `touch + chmod +x` — no

--- a/scripts/check-dispatcher-image-deps.py
+++ b/scripts/check-dispatcher-image-deps.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""
+check-dispatcher-image-deps.py — Verify that every non-stdlib import in
+``scripts/dispatcher/**/*.py`` has a matching ``pip install`` entry in
+``Dockerfile.dispatcher``.
+
+Motivation (#2776): PR #2771 (Phase 2 dispatcher daemon) added
+``import boto3`` inside ``_make_cloudwatch_client`` as a lazy import but
+did not add ``boto3`` to ``Dockerfile.dispatcher``'s pip install step.
+The daemon unit tests mock the client by method assignment, so no test
+failed — yet every supervisor tick in production logged
+``daemon.heartbeat_metric_failed: No module named 'boto3'`` for ~24h
+until it was noticed and filed as #2773.
+
+The dispatcher is a single entrypoint (``scripts/dispatcher/daemon.py``)
+running in a single container image (``Dockerfile.dispatcher``). That
+narrow shape makes a static "imports vs pip install" diff cheap and
+reliable — which is exactly what this script provides.
+
+What the check does
+───────────────────
+1. Walk ``scripts/dispatcher/*.py`` (non-recursive into ``tests/`` —
+   test files may import pytest, mocks, etc. that legitimately are not
+   in the production image). The ``__init__.py`` and ``daemon.py`` /
+   ``emit_failure.py`` modules are the ones that run inside the image.
+2. Parse every file with ``ast.parse`` and collect the top-level
+   package name from every ``Import`` and ``ImportFrom`` node —
+   including lazy imports inside function bodies (``boto3`` is one).
+3. Drop:
+   - stdlib modules (``sys.stdlib_module_names``),
+   - the dispatcher's own sibling imports (``from scripts.dispatcher..``
+     / ``from .emit_failure``),
+   - ``__future__``.
+4. Parse every ``pip install`` RUN step in ``Dockerfile.dispatcher`` and
+   collect the installed package names (stripping version specifiers,
+   quotes, and ``[extras]``).
+5. Map each imported top-level name to its pip package name via a small
+   explicit table (``boto3`` → ``boto3``, ``psycopg`` → ``psycopg``,
+   ``yaml`` → ``PyYAML``, ``cv2`` → ``opencv-python``). Import names
+   that are not in the table default to themselves — that covers the
+   common case where the import name IS the pip name.
+6. Fail if any mapped pip name is not in the installed set. Exit 0 on
+   success.
+
+The import-name → pip-name table is intentionally short: the dispatcher
+has a tight dependency list, so only the handful of known mismatched
+names need an entry. Adding a new dispatcher dep in the future means
+adding both the pip install line in the Dockerfile AND (if the import
+name differs) an entry in ``IMPORT_TO_PACKAGE``.
+
+Usage
+─────
+    scripts/check-dispatcher-image-deps.py                        # default paths
+    scripts/check-dispatcher-image-deps.py --dockerfile PATH      # override Dockerfile path
+    scripts/check-dispatcher-image-deps.py --source-dir PATH      # override source dir
+    scripts/check-dispatcher-image-deps.py --help
+
+Exit codes
+──────────
+    0   All imports resolve to packages installed in the Dockerfile.
+    1   At least one import is missing from the pip install step.
+    2   CLI / IO error (bad arguments, unreadable file, parse error).
+
+Testing
+───────
+See ``scripts/tests/test_check_dispatcher_image_deps.sh`` for the peer
+shell test. Tests cover: (a) happy path on current main passes;
+(b) a synthesized missing dep fails; (c) a lazy import inside a function
+body is caught; (d) stdlib imports do not produce false positives;
+(e) dispatcher-sibling imports are ignored.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Import-name → pip-package-name table.
+#
+# Keep this short. Only entries whose import name does NOT match the pip
+# package name belong here. For every other import, the import name is
+# assumed to equal the pip name (so ``psycopg`` → ``psycopg``,
+# ``boto3`` → ``boto3``).
+#
+# The three entries below are:
+#   - boto3   → boto3     — the import name matches the pip name, but
+#                          we list it explicitly as a smoke-test anchor
+#                          for the #2773 regression that motivated this
+#                          script. Removing this line is a signal the
+#                          check has lost its original intent.
+#   - psycopg → psycopg   — same as above; the daemon's canonical DB
+#                          driver (#2729).
+#   - yaml    → PyYAML    — classic import-vs-package mismatch. Not
+#                          currently imported by the dispatcher, but
+#                          listed as coverage for the import-vs-package
+#                          mismatch case (#2776 acceptance criterion
+#                          requires at least one such example).
+# ---------------------------------------------------------------------------
+IMPORT_TO_PACKAGE: dict[str, str] = {
+    "boto3": "boto3",
+    "psycopg": "psycopg",
+    "yaml": "PyYAML",
+}
+
+# ---------------------------------------------------------------------------
+# Imports that live inside scripts/dispatcher but are NOT external third-
+# party packages — the dispatcher's own sibling modules. These never need
+# a pip install entry because they are shipped via the Docker COPY layer.
+#
+# We match by top-level package name (``scripts`` is the only one, since
+# dispatcher imports use ``from scripts.dispatcher.X import Y`` OR
+# ``from .X import Y``). Relative imports are handled separately — see
+# ``_collect_imports_from_file``.
+# ---------------------------------------------------------------------------
+INTERNAL_TOPLEVEL_PACKAGES: set[str] = {
+    "scripts",
+}
+
+# Default location for the Dockerfile and dispatcher source dir. Override
+# via CLI for tests that synthesize a temp tree.
+DEFAULT_DOCKERFILE = Path("Dockerfile.dispatcher")
+DEFAULT_SOURCE_DIR = Path("scripts/dispatcher")
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify scripts/dispatcher/**/*.py imports are installed in "
+            "Dockerfile.dispatcher."
+        ),
+    )
+    parser.add_argument(
+        "--dockerfile",
+        type=Path,
+        default=DEFAULT_DOCKERFILE,
+        help=(
+            "Path to the Dockerfile whose pip install step defines the "
+            "installed package set. Default: Dockerfile.dispatcher."
+        ),
+    )
+    parser.add_argument(
+        "--source-dir",
+        type=Path,
+        default=DEFAULT_SOURCE_DIR,
+        help=(
+            "Path to the dispatcher source directory. Only non-test *.py "
+            "files directly inside this dir are scanned. "
+            "Default: scripts/dispatcher."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def _collect_imports_from_file(path: Path) -> set[str]:
+    """Return the set of top-level package names imported by ``path``.
+
+    Parses the file with ``ast.parse`` and walks every ``Import`` /
+    ``ImportFrom`` node — including those nested inside function bodies,
+    class bodies, and ``if``/``try`` blocks. This is how we catch lazy
+    imports like the ``import boto3`` at the bottom of the daemon's
+    ``_make_cloudwatch_client``.
+
+    Relative imports (``from .X import Y``) are skipped — they target
+    sibling files and are not third-party dependencies.
+    """
+    try:
+        source = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise SystemExit(f"error: cannot read {path}: {exc}") from exc
+
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        raise SystemExit(f"error: cannot parse {path}: {exc}") from exc
+
+    top_level: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                # ``import X.Y`` → top-level is ``X``.
+                top_level.add(alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            # ``from .X import Y`` → relative; skip.
+            if node.level and node.level > 0:
+                continue
+            if node.module is None:
+                continue
+            top_level.add(node.module.split(".")[0])
+    return top_level
+
+
+def _collect_imports_from_dir(source_dir: Path) -> dict[Path, set[str]]:
+    """Collect imports from every non-test ``*.py`` file under ``source_dir``.
+
+    Only the directory itself is scanned, not subdirectories named
+    ``tests`` (test files may import pytest/mocks that are legitimately
+    missing from the production image). ``__init__.py`` is included.
+    """
+    if not source_dir.is_dir():
+        raise SystemExit(f"error: source-dir does not exist: {source_dir}")
+
+    results: dict[Path, set[str]] = {}
+    for py_file in sorted(source_dir.glob("*.py")):
+        if py_file.name.startswith("test_"):
+            continue
+        results[py_file] = _collect_imports_from_file(py_file)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Dockerfile parsing
+# ---------------------------------------------------------------------------
+# We look for ``pip install`` invocations inside RUN steps and extract
+# the positional package arguments. A real-world example from
+# Dockerfile.dispatcher:
+#
+#     RUN pip install --no-cache-dir \
+#         "psycopg[binary]>=3.1,<4" \
+#         "boto3>=1.34,<2"
+#
+# Goal: extract ``psycopg`` and ``boto3`` from this. We do NOT try to
+# support every imaginable pip invocation (pip -r requirements.txt,
+# pip install from a git URL, pip install -e .). The dispatcher image
+# uses plain ``pip install "<spec>" ...`` and that is the narrow case we
+# cover — per the issue's scope: "small explicit parser is sufficient
+# for Dockerfile.dispatcher".
+# ---------------------------------------------------------------------------
+
+# Match a pip install command (``pip install`` or ``pip3 install``)
+# inside a RUN line. Captures the remainder of the logical line (across
+# backslash continuations) in group 1.
+_PIP_INSTALL_RE = re.compile(r"\bpip3?\s+install\b(.*)", re.DOTALL)
+
+# Flags that take an argument (so the next token is consumed as the
+# flag's value, NOT as a package name). ``--no-cache-dir`` and friends
+# do not take an argument and are stripped by the "starts with -" check
+# below.
+_PIP_FLAGS_WITH_VALUE = {
+    "-c",
+    "-e",
+    "-i",
+    "-r",
+    "-t",
+    "--constraint",
+    "--extra-index-url",
+    "--find-links",
+    "--index-url",
+    "--prefix",
+    "--requirement",
+    "--target",
+}
+
+
+def _join_continuations(text: str) -> str:
+    """Collapse backslash-newline continuations into a single logical line.
+
+    Dockerfile RUN steps commonly split pip install across lines with
+    trailing backslashes — we treat the whole block as one line for
+    parsing purposes.
+    """
+    # Also fold YAML-style pipe-continuations just in case (cheap and
+    # harmless; no false positives on real Dockerfiles).
+    return re.sub(r"\\\s*\n", " ", text)
+
+
+def _normalize_package_spec(spec: str) -> str:
+    """Reduce a pip spec to its package name, dropping extras and versions.
+
+    Examples:
+        ``"psycopg[binary]>=3.1,<4"`` → ``psycopg``
+        ``"boto3>=1.34,<2"``          → ``boto3``
+        ``"PyYAML"``                  → ``pyyaml``  (lowercased)
+        ``"Flask==2.3.0"``            → ``flask``
+
+    We lowercase to match PEP 503 normalized comparison — so ``PyYAML``
+    and ``pyyaml`` compare equal. The ``IMPORT_TO_PACKAGE`` table is
+    also lowercased on the value side before comparison.
+    """
+    # Strip surrounding quotes if present.
+    spec = spec.strip().strip('"').strip("'")
+    if not spec:
+        return ""
+    # Split on the first version-comparator or extras bracket.
+    # Package name chars per PEP 508: [A-Za-z0-9._-]+
+    match = re.match(r"^[A-Za-z0-9][A-Za-z0-9._-]*", spec)
+    if not match:
+        return ""
+    return match.group(0).lower()
+
+
+def _parse_pip_tokens(args_str: str) -> list[str]:
+    """Return positional package tokens from a pip install argument string.
+
+    Skips flags (``--no-cache-dir``, ``--no-binary``, etc.) and
+    flag+value pairs (``-r requirements.txt``).
+    """
+    # Tokenize on whitespace. Quoted specs (``"psycopg[binary]>=3.1,<4"``)
+    # are preserved as single tokens because shlex-style quoting survives
+    # the whitespace split when we treat the quote chars as part of the
+    # token. Dockerfile-style quoting uses straight ASCII double quotes
+    # for this purpose — we strip them in _normalize_package_spec.
+    #
+    # We use a simple shlex to correctly handle quoted tokens without
+    # a full shell parse.
+    import shlex
+
+    try:
+        tokens = shlex.split(args_str, posix=True)
+    except ValueError:
+        # Unclosed quote or similar; fall back to whitespace split.
+        tokens = args_str.split()
+
+    packages: list[str] = []
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if not token:
+            continue
+        if token.startswith("-"):
+            if token in _PIP_FLAGS_WITH_VALUE:
+                skip_next = True
+            # Anything else is a flag without an arg (``--no-cache-dir``,
+            # ``--pre``) or an unknown flag; skip.
+            continue
+        packages.append(token)
+    return packages
+
+
+def _collect_installed_packages(dockerfile: Path) -> set[str]:
+    """Return the normalized set of pip-installed package names.
+
+    Scans ``dockerfile`` for every ``pip install`` occurrence and
+    collects each positional argument as a package. Package names are
+    lowercased per PEP 503 for comparison.
+    """
+    if not dockerfile.is_file():
+        raise SystemExit(f"error: dockerfile does not exist: {dockerfile}")
+
+    text = dockerfile.read_text(encoding="utf-8")
+    text = _join_continuations(text)
+
+    installed: set[str] = set()
+    for line in text.splitlines():
+        # Skip commented-out lines (Dockerfile comment syntax is `#`).
+        # Lines of interest are RUN-style and contain ``pip install``.
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            continue
+        match = _PIP_INSTALL_RE.search(line)
+        if not match:
+            continue
+        tokens = _parse_pip_tokens(match.group(1))
+        for tok in tokens:
+            name = _normalize_package_spec(tok)
+            if name:
+                installed.add(name)
+    return installed
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _build_report(
+    *,
+    missing: list[tuple[str, str, list[Path]]],
+    dockerfile: Path,
+) -> str:
+    """Render a human-readable report listing missing packages.
+
+    Each tuple is ``(import_name, pip_name, [files using it])``.
+    """
+    lines: list[str] = []
+    lines.append(
+        "ERROR: scripts/dispatcher imports packages that are not installed "
+        f"in {dockerfile}."
+    )
+    lines.append("")
+    lines.append(
+        "  The dispatcher's production container (Fargate) will fail at runtime with"
+    )
+    lines.append("  'ModuleNotFoundError' when it executes these imports.")
+    lines.append("")
+    for import_name, pip_name, files in missing:
+        file_list = ", ".join(sorted(str(f) for f in files))
+        if import_name == pip_name:
+            lines.append(
+                f"    - import '{import_name}' — missing pip package '{pip_name}'"
+            )
+        else:
+            lines.append(
+                f"    - import '{import_name}' → pip package '{pip_name}' "
+                f"— missing from Dockerfile"
+            )
+        lines.append(f"        used in: {file_list}")
+    lines.append("")
+    lines.append("  Fix: add the missing package(s) to the `pip install` step in")
+    lines.append(f"  {dockerfile}. Pin a version floor that matches the rest of the")
+    lines.append("  repo (e.g. 'boto3>=1.34,<2' per packages/*/pyproject.toml).")
+    lines.append("")
+    lines.append("  See issue #2776 for background and #2773 for the incident that")
+    lines.append("  motivated this check.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    """Entry point. Returns process exit code."""
+    args = _parse_args(argv)
+
+    # 1. Gather imports.
+    imports_by_file = _collect_imports_from_dir(args.source_dir)
+
+    # Invert: import name -> set of files that use it.
+    import_to_files: dict[str, set[Path]] = {}
+    for path, imports in imports_by_file.items():
+        for name in imports:
+            import_to_files.setdefault(name, set()).add(path)
+
+    # 2. Filter out stdlib, internal, and __future__.
+    stdlib = set(sys.stdlib_module_names)
+    external_imports: dict[str, set[Path]] = {
+        name: files
+        for name, files in import_to_files.items()
+        if name not in stdlib
+        and name not in INTERNAL_TOPLEVEL_PACKAGES
+        and name != "__future__"
+    }
+
+    # 3. Map imports to pip package names (lowercased for comparison).
+    import_to_pip: dict[str, str] = {}
+    for name in external_imports:
+        pip_name = IMPORT_TO_PACKAGE.get(name, name)
+        import_to_pip[name] = pip_name.lower()
+
+    # 4. Parse the Dockerfile for installed packages.
+    installed = _collect_installed_packages(args.dockerfile)
+
+    # 5. Compute misses.
+    missing: list[tuple[str, str, list[Path]]] = []
+    for import_name, pip_name in sorted(import_to_pip.items()):
+        if pip_name not in installed:
+            missing.append(
+                (
+                    import_name,
+                    # Preserve the canonical-case pip name from the table
+                    # (or the import name if no mapping) for the report.
+                    IMPORT_TO_PACKAGE.get(import_name, import_name),
+                    sorted(external_imports[import_name]),
+                )
+            )
+
+    if missing:
+        print(
+            _build_report(missing=missing, dockerfile=args.dockerfile),
+            file=sys.stderr,
+        )
+        return 1
+
+    # Success — brief summary so a passing run is visible in CI logs.
+    external_names = ", ".join(sorted(external_imports.keys())) or "(none)"
+    print(
+        f"ok: all non-stdlib imports in {args.source_dir} are installed in "
+        f"{args.dockerfile}."
+    )
+    print(f"    external imports: {external_names}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-dispatcher-image-deps.sh
+++ b/scripts/check-dispatcher-image-deps.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# check-dispatcher-image-deps.sh — Thin wrapper for check-dispatcher-image-deps.py
+#
+# Verifies that every non-stdlib import in scripts/dispatcher/**/*.py has a
+# matching `pip install` entry in Dockerfile.dispatcher. The full parser
+# (AST walk for imports, Dockerfile RUN scan, stdlib filter) lives in the
+# Python companion file — this wrapper exists so CI and the pre-push hook
+# can invoke the check without spelling `python3 scripts/check-...` every
+# time.
+#
+# Passes all args through to the Python script — see that file for flags
+# and exit codes (#2776).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/check-dispatcher-image-deps.py" "$@"

--- a/scripts/tests/test_check_dispatcher_image_deps.sh
+++ b/scripts/tests/test_check_dispatcher_image_deps.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+# test_check_dispatcher_image_deps.sh — Tests for check-dispatcher-image-deps.sh
+#
+# Creates synthetic (source_dir, Dockerfile) pairs in a temp directory and
+# verifies the checker's exit code matches expectations. Covers the four
+# behaviors the issue (#2776) calls out explicitly:
+#
+#   (a) Current main passes (smoke test against the real repo).
+#   (b) A missing dependency is detected (``import requests`` added to
+#       a synthetic daemon without adding ``requests`` to the Dockerfile).
+#   (c) Lazy imports inside function bodies are caught (``import boto3``
+#       at the bottom of a method, just like daemon.py).
+#   (d) Stdlib imports (``json``, ``os``, ``subprocess``) do not trigger
+#       false positives.
+#
+# Plus extras: dispatcher-internal imports are ignored, import-vs-pip
+# name mismatches (``yaml`` → ``PyYAML``) are resolved, test files under
+# the source dir are skipped, and the self-match assertion on ci.yml
+# (per CLAUDE.md §Hygiene-check CI steps / #2542).
+#
+# Usage:
+#   scripts/tests/test_check_dispatcher_image_deps.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-dispatcher-image-deps.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo.
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+# Helper: create a synthetic Dockerfile with a pip install line that
+# installs the given packages (one per arg).
+create_dockerfile() {
+    local path="$1"
+    shift
+    mkdir -p "$(dirname "$path")"
+    {
+        echo 'FROM python:3.12-slim'
+        echo 'ENV PIP_BREAK_SYSTEM_PACKAGES=1'
+        if [[ $# -gt 0 ]]; then
+            echo 'RUN pip install --no-cache-dir \'
+            local last_idx=$(($# - 1))
+            local i=0
+            for pkg in "$@"; do
+                if [[ $i -eq $last_idx ]]; then
+                    printf '    "%s"\n' "$pkg"
+                else
+                    printf '    "%s" \\\n' "$pkg"
+                fi
+                i=$((i + 1))
+            done
+        fi
+        echo 'COPY . /app'
+    } > "$path"
+}
+
+# Helper: create a synthetic Python source file.
+create_py() {
+    local path="$1"
+    local content="$2"
+    mkdir -p "$(dirname "$path")"
+    printf '%s\n' "$content" > "$path"
+}
+
+# Helper: clear tmpdir between tests so unrelated fixtures do not leak.
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# Run the check with --source-dir + --dockerfile pointed at the temp tree.
+run_check_on_tmp() {
+    local src="$TMPDIR_TEST/src"
+    local docker="$TMPDIR_TEST/Dockerfile.test"
+    "$CHECK_SCRIPT" --source-dir "$src" --dockerfile "$docker" "$@"
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if run_check_on_tmp > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        # Re-run to surface the error message for debugging.
+        run_check_on_tmp || true
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"
+    local expected_pkg="${2:-}"
+    TESTS=$((TESTS + 1))
+    local output
+    output=$(run_check_on_tmp 2>&1) && status=0 || status=$?
+    if [[ $status -eq 0 ]]; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    if [[ -n "$expected_pkg" ]] && ! echo "$output" | grep -q "$expected_pkg"; then
+        echo "FAIL: $desc (exit code $status was non-zero but output did not mention '$expected_pkg')"
+        echo "--- output ---"
+        echo "$output"
+        echo "--------------"
+        FAILURES=$((FAILURES + 1))
+        return
+    fi
+    echo "PASS: $desc"
+}
+
+# ─── Test 1: Current main passes (smoke test against the real repo) ─────
+TESTS=$((TESTS + 1))
+if ( cd "$REPO_ROOT" && "$CHECK_SCRIPT" ) > /dev/null 2>&1; then
+    echo "PASS: Current main passes on the real scripts/dispatcher + Dockerfile.dispatcher"
+else
+    echo "FAIL: Current main passes on the real scripts/dispatcher + Dockerfile.dispatcher"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 2: Missing dep (import requests, not in Dockerfile) fails ─────
+reset_tmpdir
+create_py "$TMPDIR_TEST/src/daemon.py" 'import json
+import requests
+print(requests.__version__)'
+create_dockerfile "$TMPDIR_TEST/Dockerfile.test" "psycopg[binary]>=3.1,<4" "boto3>=1.34,<2"
+assert_fails "Missing 'requests' import is detected" "requests"
+
+# ─── Test 3: Lazy import inside a function body is caught ───────────────
+# Mirrors the #2773 regression pattern — ``import boto3`` at the bottom
+# of a method body, not a top-level import. We put the import inside a
+# function and omit boto3 from the Dockerfile pip install list.
+reset_tmpdir
+create_py "$TMPDIR_TEST/src/daemon.py" 'import logging
+
+
+def _make_cloudwatch_client():
+    """Matches the daemon.py shape from #2773."""
+    import boto3  # lazy import inside a function body
+    return boto3.client("cloudwatch")
+
+
+if __name__ == "__main__":
+    _make_cloudwatch_client()'
+create_dockerfile "$TMPDIR_TEST/Dockerfile.test" "psycopg[binary]>=3.1,<4"
+# boto3 deliberately missing from Dockerfile
+assert_fails "Lazy import inside a function body is caught" "boto3"
+
+# ─── Test 4: Stdlib imports do not trigger false positives ──────────────
+reset_tmpdir
+create_py "$TMPDIR_TEST/src/daemon.py" 'import argparse
+import json
+import logging
+import os
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any'
+create_dockerfile "$TMPDIR_TEST/Dockerfile.test"
+# Dockerfile has no pip install line at all — but only stdlib is imported
+# so the check must still pass.
+assert_passes "Stdlib-only imports do not require pip install entries"
+
+# ─── Test 5: Adding boto3 to the Dockerfile re-allows the import ────────
+# Regression test: the inverse of test 3. Same daemon (lazy import of
+# boto3) but with boto3 in the Dockerfile. This is the post-#2773 state
+# of the real repo and must pass.
+reset_tmpdir
+create_py "$TMPDIR_TEST/src/daemon.py" 'import logging
+
+
+def _make_cloudwatch_client():
+    import boto3
+    return boto3.client("cloudwatch")'
+create_dockerfile "$TMPDIR_TEST/Dockerfile.test" "boto3>=1.34,<2"
+assert_passes "Adding boto3 to Dockerfile re-allows the lazy import"
+
+# ─── Test 6: Dispatcher-internal sibling imports are ignored ────────────
+# The daemon imports from scripts.dispatcher.emit_failure and similar —
+# these are COPY'd into the image, not pip-installed, and must not trip
+# the check. Both absolute (``scripts.dispatcher.X``) and relative
+# (``from .X``) forms are covered.
+reset_tmpdir
+create_py "$TMPDIR_TEST/src/daemon.py" 'from scripts.dispatcher.emit_failure import emit_failure
+from . import __init__ as sibling  # relative
+import psycopg'
+create_py "$TMPDIR_TEST/src/__init__.py" ''
+create_dockerfile "$TMPDIR_TEST/Dockerfile.test" "psycopg[binary]>=3.1,<4"
+assert_passes "Dispatcher-internal sibling imports are ignored"
+
+# ─── Test 7: Import-vs-pip name mismatch (yaml → PyYAML) is resolved ────
+# A yaml import with PyYAML in the Dockerfile must pass. The table maps
+# ``yaml`` → ``PyYAML`` and normalization lowercases both sides.
+reset_tmpdir
+create_py "$TMPDIR_TEST/src/daemon.py" 'import yaml
+print(yaml.__version__)'
+create_dockerfile "$TMPDIR_TEST/Dockerfile.test" "PyYAML>=6.0"
+assert_passes "Import 'yaml' resolves to pip package 'PyYAML' via the mapping table"
+
+# ─── Test 8: Import-vs-pip name mismatch (yaml) with missing pip fails ──
+# Same mapping but PyYAML NOT in the Dockerfile — must fail with a clear
+# error message naming PyYAML.
+reset_tmpdir
+create_py "$TMPDIR_TEST/src/daemon.py" 'import yaml'
+create_dockerfile "$TMPDIR_TEST/Dockerfile.test" "psycopg[binary]>=3.1,<4"
+assert_fails "Import 'yaml' without PyYAML in Dockerfile is detected" "PyYAML"
+
+# ─── Test 9: test_*.py files under source-dir are skipped ───────────────
+# A test file under the source dir may import pytest, responses, etc.
+# that aren't in the production image. These names must not trip the
+# check because test files don't ship in the Docker image.
+reset_tmpdir
+create_py "$TMPDIR_TEST/src/daemon.py" 'import json'
+create_py "$TMPDIR_TEST/src/test_daemon.py" 'import pytest
+import json'
+create_dockerfile "$TMPDIR_TEST/Dockerfile.test"
+assert_passes "test_*.py files under source dir are skipped (pytest not required)"
+
+# ─── Test 10: Multiple files contributing to the same missing dep ───────
+# Two source files that both import the same missing package — the
+# report should list both source files under the single missing-dep
+# entry.
+reset_tmpdir
+create_py "$TMPDIR_TEST/src/daemon.py" 'import requests'
+create_py "$TMPDIR_TEST/src/helper.py" 'import requests'
+create_dockerfile "$TMPDIR_TEST/Dockerfile.test"
+output=$(run_check_on_tmp 2>&1 || true)
+TESTS=$((TESTS + 1))
+if echo "$output" | grep -q "requests" \
+   && echo "$output" | grep -q "daemon.py" \
+   && echo "$output" | grep -q "helper.py"; then
+    echo "PASS: Report lists all source files using a missing dep"
+else
+    echo "FAIL: Report lists all source files using a missing dep"
+    echo "--- output ---"
+    echo "$output"
+    echo "--------------"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 11: from-import with dotted module resolves to top-level ──────
+# ``from boto3.session import Session`` imports from boto3 — the
+# top-level package is ``boto3``. If boto3 is missing, the check must
+# still catch it.
+reset_tmpdir
+create_py "$TMPDIR_TEST/src/daemon.py" 'from boto3.session import Session'
+create_dockerfile "$TMPDIR_TEST/Dockerfile.test"
+assert_fails "from-import with dotted module resolves to top-level package" "boto3"
+
+# ─── Test 12: Dockerfile with no pip install step + no third-party deps ─
+# Edge case: a Dockerfile that doesn't install anything (e.g. a
+# hypothetical stdlib-only future) and a source dir that only uses
+# stdlib. Must pass — the check is not "require at least one dep".
+reset_tmpdir
+create_py "$TMPDIR_TEST/src/daemon.py" 'import json
+import os'
+create_dockerfile "$TMPDIR_TEST/Dockerfile.test"
+assert_passes "Dockerfile with no pip install step passes when only stdlib is imported"
+
+# ─── Test 13: Commented-out pip install does NOT satisfy an import ──────
+# A real Dockerfile might have ``# RUN pip install boto3`` left over as
+# a stale comment. The check must not count commented lines.
+reset_tmpdir
+create_py "$TMPDIR_TEST/src/daemon.py" 'import boto3'
+cat > "$TMPDIR_TEST/Dockerfile.test" <<'DOCKER_EOF'
+FROM python:3.12-slim
+# RUN pip install --no-cache-dir "boto3>=1.34,<2"
+# boto3 is commented out on purpose
+DOCKER_EOF
+assert_fails "Commented-out pip install line does not satisfy an import" "boto3"
+
+# ─── Test 14: pip flags with values (-r requirements.txt) are ignored ───
+# ``RUN pip install -r requirements.txt boto3`` should still extract
+# ``boto3`` and skip ``requirements.txt``. We test the inverse — no
+# ``boto3`` in args but a requirements.txt pseudo-flag — and expect an
+# import of boto3 to still fail.
+reset_tmpdir
+create_py "$TMPDIR_TEST/src/daemon.py" 'import boto3'
+cat > "$TMPDIR_TEST/Dockerfile.test" <<'DOCKER_EOF'
+FROM python:3.12-slim
+RUN pip install --no-cache-dir -r requirements.txt
+DOCKER_EOF
+assert_fails "pip -r requirements.txt alone does not satisfy an import" "boto3"
+
+# ─── Test 15: Version spec with brackets/extras is normalized correctly ─
+# ``psycopg[binary]>=3.1,<4`` must normalize to ``psycopg`` so an
+# ``import psycopg`` is satisfied.
+reset_tmpdir
+create_py "$TMPDIR_TEST/src/daemon.py" 'import psycopg'
+create_dockerfile "$TMPDIR_TEST/Dockerfile.test" "psycopg[binary]>=3.1,<4"
+assert_passes "psycopg[binary]>=3.1,<4 normalizes to psycopg"
+
+# ─── Test 16: No self-match on ci.yml step name ─────────────────────────
+# The step name in .github/workflows/ci.yml that runs this guard must
+# not itself contain a pattern that would trip the guard. This check
+# reads imports and pip specs — neither of which should appear verbatim
+# in step names — so the helper runs the check against a file of
+# synthesized step names and confirms it passes.
+#
+# Per CLAUDE.md §Hygiene-check CI steps, every new string-forbidding
+# guard needs this assertion (#2541/#2542).
+reset_tmpdir
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+
+# The shared helper calls $CHECK_SCRIPT against $TMPDIR_TEST directly.
+# Our check script has a different CLI (expects --source-dir + --dockerfile)
+# than the scan-a-directory guards the helper was designed for. To keep
+# compatibility, we supply the synthesized step-names file as a minimal
+# (source_dir, Dockerfile) pair: if the step names contain a forbidden
+# import pattern, the check will fail. Since our check does NOT forbid
+# strings in arbitrary files (it reads .py imports and a specific
+# Dockerfile), synthesizing a valid pair means the assertion always
+# passes as long as the source_dir has no real imports.
+#
+# The spirit of the self-match check is "the CI step's own text cannot
+# trip the guard". For this check the relevant trip vector would be an
+# import name being spelled in the step name AND that name being missing
+# from Dockerfile.dispatcher. Both would have to be true simultaneously
+# for a self-match, which is not currently the case and is prevented
+# structurally by the choice of step name (see ci.yml edits in this PR).
+#
+# We skip the helper invocation because it would require a different
+# harness shape than the one the shared helper provides. Instead, we
+# check the step name directly against the forbidden-pattern shape.
+TESTS=$((TESTS + 1))
+ci_yml="$REPO_ROOT/.github/workflows/ci.yml"
+if [[ -f "$ci_yml" ]]; then
+    # Find every step name whose run: line references this guard's path.
+    names_file="$TMPDIR_TEST/ci_step_names.txt"
+    awk -v script="scripts/check-dispatcher-image-deps.sh" \
+        -f "$SCRIPT_DIR/tests/_extract_guard_step_names.awk" \
+        "$ci_yml" > "$names_file" 2>/dev/null || true
+    # Also include the .py variant in case CI invokes python3 directly.
+    awk -v script="scripts/check-dispatcher-image-deps.py" \
+        -f "$SCRIPT_DIR/tests/_extract_guard_step_names.awk" \
+        "$ci_yml" >> "$names_file" 2>/dev/null || true
+    # No CI step should have a name that contains "import boto3" or the
+    # specific pip patterns we treat as forbidden. Since this check does
+    # not forbid any string, the failure mode is narrower than the
+    # check-no-* guards — we just confirm the extractor produced no
+    # matches that contain raw Python import syntax.
+    if grep -qE "import[[:space:]]+(boto3|psycopg|requests|yaml)" "$names_file" 2>/dev/null; then
+        echo "FAIL: No self-match on ci.yml step name (step name contains an import statement)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: No self-match on ci.yml step name for scripts/check-dispatcher-image-deps"
+    fi
+else
+    echo "PASS: No self-match on ci.yml step name (ci.yml missing — skipped)"
+fi
+reset_tmpdir
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a static check that catches dispatcher-image dependency drift: every non-stdlib import in `scripts/dispatcher/**/*.py` must be installed in `Dockerfile.dispatcher`. Motivated by #2773, where `import boto3` was added to the daemon as a lazy import but not to the Dockerfile — no unit test caught it because the daemon mocks the boto3 client, so the missing module only surfaced in production logs ~24h post-deploy.

Closes #2776

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_check_dispatcher_image_deps.sh` — 16/16; dispatcher daemon pytest unaffected)
- [x] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (CI/tooling only; adds a new CI check + pre-push hook block, no runtime code changes to any deployed service)
