### PR TITLE
feat(admin/dispatcher): Phase 1 information-density overhaul (#2805)

### DIFF
--- a/packages/api/src/graphql/dispatcher/github.ts
+++ b/packages/api/src/graphql/dispatcher/github.ts
@@ -1,0 +1,194 @@
+/**
+ * Thin GitHub REST client + in-memory TTL cache for the dispatcher admin
+ * page (#2805). Used to enrich `dispatcher.queue_snapshots.issue_numbers`
+ * with title/labels/created_at/priority and to fetch open blocked issues
+ * that are NOT tracked in the snapshots (which only cover `agent/ready`).
+ *
+ * Rate-limit strategy:
+ *   - Honour `process.env.GITHUB_TOKEN` when set (bumps rate to 5 000/hr).
+ *   - Otherwise fall back to unauthenticated (60/hr) with aggressive caching.
+ *   - Cache per-issue lookups for 30 s (matches the daemon's scheduler
+ *     cadence — by the time an issue changes, the next snapshot-triggered
+ *     refresh will see it).
+ *   - Cache the `status/blocked` search for 30 s.
+ *
+ * Graceful degradation:
+ *   - On any fetch/parse failure we return `null` (or an empty list for
+ *     the search endpoint). Callers fill in a minimal `QueueItem`/
+ *     `RecentCompletion` with just the issue number — the UI renders
+ *     `#N — (title unavailable)` rather than failing the whole page.
+ *
+ * NOTE: intentionally uses the global `fetch` (Node 18+). No runtime
+ * dependencies added.
+ */
+
+const DEFAULT_REPO = process.env.JUDGEMIND_GITHUB_REPO ?? 'judgemind/judgemind';
+const API_BASE = 'https://api.github.com';
+
+const ISSUE_CACHE_TTL_MS = 30 * 1000;
+const SEARCH_CACHE_TTL_MS = 30 * 1000;
+
+export interface GitHubIssue {
+  number: number;
+  title: string;
+  labels: string[];
+  createdAt: string;
+  body: string | null;
+}
+
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+const issueCache = new Map<number, CacheEntry<GitHubIssue | null>>();
+const searchCache = new Map<string, CacheEntry<GitHubIssue[]>>();
+
+function now(): number {
+  return Date.now();
+}
+
+function authHeaders(): Record<string, string> {
+  const token = process.env.GITHUB_TOKEN ?? process.env.JUDGEMIND_GITHUB_TOKEN;
+  const headers: Record<string, string> = {
+    'user-agent': 'judgemind-api/dispatcher-admin',
+    accept: 'application/vnd.github+json',
+    'x-github-api-version': '2022-11-28',
+  };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+/** Parse a GitHub Issue JSON payload into the reduced shape we use. */
+function parseIssue(raw: unknown): GitHubIssue | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const record = raw as Record<string, unknown>;
+  const number = record.number;
+  if (typeof number !== 'number') return null;
+  const title = typeof record.title === 'string' ? record.title : '';
+  const createdAt = typeof record.created_at === 'string' ? record.created_at : '';
+  const body = typeof record.body === 'string' ? record.body : null;
+  const labelsRaw = Array.isArray(record.labels) ? record.labels : [];
+  const labels = labelsRaw
+    .map((l) => {
+      if (typeof l === 'string') return l;
+      if (l && typeof l === 'object' && 'name' in l) {
+        const name = (l as { name: unknown }).name;
+        return typeof name === 'string' ? name : null;
+      }
+      return null;
+    })
+    .filter((l): l is string => typeof l === 'string');
+  return { number, title, labels, createdAt, body };
+}
+
+/**
+ * Fetch a single GitHub issue by number. Returns null on any failure.
+ * Cached for 30 s per issue.
+ */
+export async function fetchIssue(
+  issueNumber: number,
+  repo: string = DEFAULT_REPO,
+): Promise<GitHubIssue | null> {
+  const cached = issueCache.get(issueNumber);
+  if (cached && cached.expiresAt > now()) {
+    return cached.value;
+  }
+  const url = `${API_BASE}/repos/${repo}/issues/${issueNumber}`;
+  try {
+    const response = await fetch(url, { headers: authHeaders() });
+    if (!response.ok) {
+      // 404 or rate-limit — cache null briefly so we don't hammer the API.
+      issueCache.set(issueNumber, { value: null, expiresAt: now() + ISSUE_CACHE_TTL_MS });
+      return null;
+    }
+    const json = await response.json();
+    const parsed = parseIssue(json);
+    issueCache.set(issueNumber, { value: parsed, expiresAt: now() + ISSUE_CACHE_TTL_MS });
+    return parsed;
+  } catch {
+    issueCache.set(issueNumber, { value: null, expiresAt: now() + ISSUE_CACHE_TTL_MS });
+    return null;
+  }
+}
+
+/**
+ * Fetch many GitHub issues concurrently. Simple batched Promise.all —
+ * cache hits return synchronously. Caps at the caller-supplied `limit`.
+ */
+export async function fetchIssues(
+  numbers: readonly number[],
+  repo: string = DEFAULT_REPO,
+): Promise<Array<GitHubIssue | null>> {
+  return Promise.all(numbers.map((n) => fetchIssue(n, repo)));
+}
+
+/**
+ * Search for open issues matching a query. Cached per-query for 30 s.
+ * Returns an empty array on any failure.
+ */
+export async function searchIssues(
+  query: string,
+  repo: string = DEFAULT_REPO,
+  limit = 10,
+): Promise<GitHubIssue[]> {
+  const cacheKey = `${repo}::${query}::${limit}`;
+  const cached = searchCache.get(cacheKey);
+  if (cached && cached.expiresAt > now()) {
+    return cached.value;
+  }
+  const fullQuery = encodeURIComponent(`repo:${repo} is:open is:issue ${query}`);
+  const url = `${API_BASE}/search/issues?q=${fullQuery}&per_page=${limit}`;
+  try {
+    const response = await fetch(url, { headers: authHeaders() });
+    if (!response.ok) {
+      searchCache.set(cacheKey, { value: [], expiresAt: now() + SEARCH_CACHE_TTL_MS });
+      return [];
+    }
+    const json = (await response.json()) as { items?: unknown[] };
+    const items = Array.isArray(json.items) ? json.items : [];
+    const parsed = items
+      .map((item) => parseIssue(item))
+      .filter((x): x is GitHubIssue => x !== null);
+    searchCache.set(cacheKey, { value: parsed, expiresAt: now() + SEARCH_CACHE_TTL_MS });
+    return parsed;
+  } catch {
+    searchCache.set(cacheKey, { value: [], expiresAt: now() + SEARCH_CACHE_TTL_MS });
+    return [];
+  }
+}
+
+/**
+ * Extract `Blocked by #N` numbers from an issue body. Matches the same
+ * pattern the `unblock-issues` workflow uses.
+ */
+export function parseBlockedBy(body: string | null): number[] {
+  if (!body) return [];
+  const matches = body.matchAll(/Blocked by #(\d+)/g);
+  const numbers: number[] = [];
+  for (const match of matches) {
+    const n = Number.parseInt(match[1], 10);
+    if (Number.isFinite(n)) numbers.push(n);
+  }
+  return numbers;
+}
+
+/**
+ * Extract a priority label (`p0`/`p1`/`p2`/`p3`) from a label list.
+ * Returns `null` when no `priority/pN` label is present.
+ */
+export function extractPriority(labels: readonly string[]): string | null {
+  for (const label of labels) {
+    const match = label.match(/^priority\/(p[0-3])$/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+/** Test-only hook — clear the caches between tests. */
+export function __resetCaches(): void {
+  issueCache.clear();
+  searchCache.clear();
+}

--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -16,6 +16,13 @@ import type { Pool } from 'pg';
 import { GraphQLError, GraphQLScalarType, Kind } from 'graphql';
 import type { AuthUser } from '../../auth';
 import { DESTRUCTIVE_COMMANDS, requireDispatcherAdmin } from './auth';
+import {
+  extractPriority,
+  fetchIssues,
+  parseBlockedBy,
+  searchIssues,
+  type GitHubIssue,
+} from './github';
 
 // Minimal Context subset the dispatcher resolvers read.
 interface DispatcherContext {
@@ -170,6 +177,149 @@ async function queryQueueDepth(pool: Pool): Promise<number> {
   return typeof raw === 'number' ? raw : Number(raw);
 }
 
+async function queryLatestQueueSnapshotIssueNumbers(pool: Pool): Promise<number[]> {
+  const { rows } = await pool.query<{ issue_numbers: number[] | null }>(
+    `SELECT issue_numbers
+       FROM dispatcher.queue_snapshots
+       ORDER BY observed_at DESC
+       LIMIT 1`,
+  );
+  if (rows.length === 0) return [];
+  const raw = rows[0].issue_numbers;
+  return Array.isArray(raw) ? raw : [];
+}
+
+async function queryRecentCompletions(pool: Pool, limit: number): Promise<Row[]> {
+  const { rows } = await pool.query<Row>(
+    `SELECT agent_id, issue_number, status, ended_at, pr_number
+       FROM dispatcher.agents
+      WHERE status IN ('succeeded', 'failed', 'crashed')
+        AND ended_at IS NOT NULL
+      ORDER BY ended_at DESC
+      LIMIT $1`,
+    [limit],
+  );
+  return rows;
+}
+
+async function queryConfig(pool: Pool): Promise<Row[]> {
+  const { rows } = await pool.query<Row>(
+    `SELECT key, value, updated_at, updated_by
+       FROM dispatcher.config
+      ORDER BY key ASC`,
+  );
+  return rows;
+}
+
+function configRowToGraphQL(row: Row): Record<string, unknown> {
+  // `value` is jsonb; serialize back to a JSON-encoded string so the
+  // client always sees the same on-wire shape (e.g. `"1"` for a number,
+  // `"\"on\""` for a string, `"[60,300]"` for an array).
+  return {
+    key: row.key,
+    value: JSON.stringify(row.value ?? null),
+    updatedAt: row.updated_at,
+    updatedBy: row.updated_by,
+  };
+}
+
+/**
+ * Fetch up to `limit` queue-ready QueueItem rows. Reads issue numbers
+ * from the most recent `dispatcher.queue_snapshots` row, then hits the
+ * GitHub API (cached) for title/labels/created_at/body.
+ *
+ * Graceful degradation: when the GitHub lookup fails we still return a
+ * minimal row with `title` = `(title unavailable — #N)` so the UI renders
+ * the hot link. Items for which `fetchIssue` returned null are dropped
+ * entirely to avoid polluting the queue with stale placeholders.
+ */
+async function queryQueueReady(pool: Pool, limit: number): Promise<Array<Record<string, unknown>>> {
+  const numbers = await queryLatestQueueSnapshotIssueNumbers(pool);
+  if (numbers.length === 0) return [];
+  const top = numbers.slice(0, limit);
+  const issues = await fetchIssues(top);
+  const result: Array<Record<string, unknown>> = [];
+  for (let i = 0; i < top.length; i += 1) {
+    const number = top[i];
+    const issue = issues[i];
+    if (issue) {
+      result.push(queueItemFromIssue(issue, /* includeBlockedBy */ false));
+    } else {
+      // Placeholder when GitHub lookup failed — still renders as a hot
+      // link but with muted "(title unavailable)" copy.
+      result.push({
+        issueNumber: number,
+        title: '(title unavailable)',
+        priority: null,
+        labels: [],
+        createdAt: new Date(0).toISOString(),
+        blockedBy: [],
+      });
+    }
+  }
+  return result;
+}
+
+/**
+ * Fetch up to `limit` queueBlocked QueueItem rows. `status/blocked` is
+ * not tracked in `dispatcher.queue_snapshots`, so this queries the
+ * GitHub search API (cached).
+ */
+async function queryQueueBlocked(limit: number): Promise<Array<Record<string, unknown>>> {
+  const issues = await searchIssues('label:status/blocked', undefined, limit);
+  const result: Array<Record<string, unknown>> = [];
+  for (const issue of issues) {
+    result.push(queueItemFromIssue(issue, /* includeBlockedBy */ true));
+  }
+  // Sort newest first per spec.
+  result.sort((a, b) => String(b.createdAt).localeCompare(String(a.createdAt)));
+  return result;
+}
+
+function queueItemFromIssue(
+  issue: GitHubIssue,
+  includeBlockedBy: boolean,
+): Record<string, unknown> {
+  return {
+    issueNumber: issue.number,
+    title: issue.title,
+    priority: extractPriority(issue.labels),
+    labels: issue.labels,
+    createdAt: issue.createdAt,
+    blockedBy: includeBlockedBy ? parseBlockedBy(issue.body) : [],
+  };
+}
+
+async function recentCompletionsToGraphQL(
+  rows: readonly Row[],
+): Promise<Array<Record<string, unknown>>> {
+  const issueNumbers: number[] = [];
+  for (const row of rows) {
+    const n = row.issue_number;
+    if (typeof n === 'number') issueNumbers.push(n);
+  }
+  // Dedupe before the GitHub fetch — multiple completions may share a
+  // single issue number (retries).
+  const uniqueNumbers = Array.from(new Set(issueNumbers));
+  const issues = await fetchIssues(uniqueNumbers);
+  const titleByNumber = new Map<number, string>();
+  for (let i = 0; i < uniqueNumbers.length; i += 1) {
+    const issue = issues[i];
+    if (issue) titleByNumber.set(uniqueNumbers[i], issue.title);
+  }
+  return rows.map((row) => {
+    const number = typeof row.issue_number === 'number' ? row.issue_number : null;
+    return {
+      agentId: row.agent_id,
+      issueNumber: number,
+      issueTitle: number !== null ? (titleByNumber.get(number) ?? null) : null,
+      status: row.status,
+      endedAt: row.ended_at,
+      prNumber: row.pr_number ?? null,
+    };
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Data access — dispatcherAgent
 // ---------------------------------------------------------------------------
@@ -254,6 +404,100 @@ async function insertCommandIdempotent(
 }
 
 // ---------------------------------------------------------------------------
+// Data access — dispatcherSetConfig mutation (live-edit config + audit)
+// ---------------------------------------------------------------------------
+
+/**
+ * Server-side validation for `dispatcher.config` edits (#2805 §1.6). The
+ * admin UI restricts the inputs it shows, but we also enforce the
+ * constraints here so an unauthorised (but admin) bulk update can't
+ * corrupt the daemon. Return value is the parsed (JSON-native) value
+ * that will be written into the jsonb column. Throws a GraphQLError on
+ * invalid input.
+ */
+export function validateConfigValue(key: string, raw: unknown): unknown {
+  switch (key) {
+    case 'concurrency_cap': {
+      const n = typeof raw === 'number' ? raw : Number.NaN;
+      if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0 || n > 5) {
+        throw new GraphQLError(
+          'concurrency_cap must be an integer in [0, 5]',
+          { extensions: { code: 'BAD_USER_INPUT' } },
+        );
+      }
+      return n;
+    }
+    case 'subprocess_timeout_s':
+    case 'idle_audit_every_n_prs': {
+      const n = typeof raw === 'number' ? raw : Number.NaN;
+      if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+        throw new GraphQLError(
+          `${key} must be a non-negative integer`,
+          { extensions: { code: 'BAD_USER_INPUT' } },
+        );
+      }
+      return n;
+    }
+    case 'backoff_seconds': {
+      if (
+        !Array.isArray(raw) ||
+        !raw.every((v) => typeof v === 'number' && Number.isInteger(v) && v >= 0)
+      ) {
+        throw new GraphQLError(
+          'backoff_seconds must be an array of non-negative integers',
+          { extensions: { code: 'BAD_USER_INPUT' } },
+        );
+      }
+      return raw;
+    }
+    case 'idle_spotcheck_cron': {
+      if (typeof raw !== 'string' || raw.length === 0) {
+        throw new GraphQLError(
+          'idle_spotcheck_cron must be a non-empty string',
+          { extensions: { code: 'BAD_USER_INPUT' } },
+        );
+      }
+      return raw;
+    }
+    case 'runner_by_phase':
+    case 'model_by_phase':
+    case 'runner_shadow': {
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+        throw new GraphQLError(
+          `${key} must be a JSON object`,
+          { extensions: { code: 'BAD_USER_INPUT' } },
+        );
+      }
+      return raw;
+    }
+    default:
+      // Unknown keys are rejected — operators should not be able to
+      // freehand new config entries through the admin page.
+      throw new GraphQLError(`Unknown config key: ${key}`, {
+        extensions: { code: 'BAD_USER_INPUT' },
+      });
+  }
+}
+
+async function updateConfigEntry(
+  pool: Pool,
+  key: string,
+  value: unknown,
+  updatedBy: string,
+): Promise<Row | null> {
+  const { rows } = await pool.query<Row>(
+    `UPDATE dispatcher.config
+        SET value = $2::jsonb,
+            updated_at = NOW(),
+            updated_by = $3
+      WHERE key = $1
+    RETURNING key, value, updated_at, updated_by`,
+    [key, JSON.stringify(value), updatedBy],
+  );
+  return rows[0] ?? null;
+}
+
+// ---------------------------------------------------------------------------
 // Resolvers
 // ---------------------------------------------------------------------------
 
@@ -320,6 +564,41 @@ export const dispatcherResolvers = {
       );
       return commandRowToGraphQL(row, created);
     },
+
+    dispatcherSetConfig: async (
+      _: unknown,
+      { key, value }: { key: string; value: string },
+      { pool, user, mfaToken }: DispatcherContext,
+    ) => {
+      const admin = requireDispatcherAdmin(user);
+
+      // Config edits materially change daemon behaviour — require the
+      // same MFA placeholder gate as destructive commands (§17 Risk 6).
+      if (!mfaToken || mfaToken.trim().length === 0) {
+        throw new GraphQLError('MFA re-auth required for config updates', {
+          extensions: { code: 'MFA_REQUIRED' },
+        });
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(value);
+      } catch {
+        throw new GraphQLError('value must be a JSON-encoded string', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      const validated = validateConfigValue(key, parsed);
+
+      const row = await updateConfigEntry(pool, key, validated, admin.email);
+      if (!row) {
+        throw new GraphQLError(`Unknown config key: ${key}`, {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+      return configRowToGraphQL(row);
+    },
   },
 
   DispatcherState: {
@@ -349,6 +628,32 @@ export const dispatcherResolvers = {
     queueDepth: async (_: unknown, __: unknown, { pool, user }: DispatcherContext) => {
       requireDispatcherAdmin(user);
       return queryQueueDepth(pool);
+    },
+
+    queueReady: async (_: unknown, __: unknown, { pool, user }: DispatcherContext) => {
+      requireDispatcherAdmin(user);
+      return queryQueueReady(pool, 10);
+    },
+
+    queueBlocked: async (_: unknown, __: unknown, { user }: DispatcherContext) => {
+      requireDispatcherAdmin(user);
+      return queryQueueBlocked(10);
+    },
+
+    recentCompletions: async (
+      _: unknown,
+      __: unknown,
+      { pool, user }: DispatcherContext,
+    ) => {
+      requireDispatcherAdmin(user);
+      const rows = await queryRecentCompletions(pool, 10);
+      return recentCompletionsToGraphQL(rows);
+    },
+
+    config: async (_: unknown, __: unknown, { pool, user }: DispatcherContext) => {
+      requireDispatcherAdmin(user);
+      const rows = await queryConfig(pool);
+      return rows.map(configRowToGraphQL);
     },
 
     spawnFrozenUntil: (parent: Record<string, unknown>) => {
@@ -455,8 +760,12 @@ export const dispatcherScalarResolvers = {
 export {
   agentRowToGraphQL,
   commandRowToGraphQL,
+  configRowToGraphQL,
   failureRowToGraphQL,
   insertCommandIdempotent,
+  queueItemFromIssue,
+  recentCompletionsToGraphQL,
   runRowToGraphQL,
   transitionRowToGraphQL,
+  updateConfigEntry,
 };

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -106,6 +106,53 @@ export const dispatcherTypeDefs = `#graphql
     failures: [DispatcherFailure!]!
   }
 
+  """One row in the queue side-panels (#2805 §1.3). Capped at 10 server-side.
+
+  - \`queueReady\` entries are open issues labelled \`agent/ready\` + not
+    assigned + not blocked. Sorted by priority asc then created_at asc.
+  - \`queueBlocked\` entries are open issues labelled \`status/blocked\`.
+    Sorted by created_at desc. \`blockedBy\` is parsed from the issue body's
+    \`Blocked by #N\` lines.
+  """
+  type QueueItem {
+    issueNumber: Int!
+    title: String!
+    """One of p0 | p1 | p2 | p3 | null (parsed from priority/pN label)."""
+    priority: String
+    labels: [String!]!
+    createdAt: DateTime!
+    """Issue numbers this issue is blocked by (from the 'Blocked by #N' lines
+    in the body). Empty for queueReady items."""
+    blockedBy: [Int!]!
+  }
+
+  """One row in the 'Recently completed' panel (#2805 §1.5). Derived from
+  \`dispatcher.agents\` where status IN ('succeeded','failed','crashed'),
+  newest first. Capped at 10 server-side."""
+  type RecentCompletion {
+    """Agent id (UUID)."""
+    agentId: ID!
+    """Issue the agent was working on."""
+    issueNumber: Int!
+    """Issue title (fetched live from GitHub; null if the lookup failed)."""
+    issueTitle: String
+    """One of succeeded | failed | crashed."""
+    status: String!
+    endedAt: DateTime!
+    """PR number if the agent produced one; null otherwise."""
+    prNumber: Int
+  }
+
+  """One key/value entry from \`dispatcher.config\` (#2805 §1.6)."""
+  type DispatcherConfigEntry {
+    key: String!
+    """JSON-encoded string — the on-disk jsonb \`value\` column.
+    Clients parse this on read and send a JSON-encoded string on write."""
+    value: String!
+    updatedAt: DateTime!
+    updatedBy: String!
+  }
+
   """Result of \`dispatcherControl\` — the command row that was written (or an existing one, if idempotent hit)."""
   type DispatcherCommandResult {
     commandId: ID!
@@ -131,6 +178,22 @@ export const dispatcherTypeDefs = `#graphql
     tick (Phase 2+). Returns 0 before the daemon has booted or when every
     recent scan has failed — the admin page treats that as "queue unknown / 0"."""
     queueDepth: Int!
+    """Top 10 ready-for-pickup issues (#2805 §1.3). Sourced from the most
+    recent \`dispatcher.queue_snapshots\` row, joined with a GitHub API
+    lookup for title/labels. Empty list when the queue is empty OR when
+    the daemon has not yet written a snapshot."""
+    queueReady: [QueueItem!]!
+    """Top 10 blocked issues (#2805 §1.3). Fetched live from the GitHub
+    API — \`status/blocked\` issues are not tracked in
+    \`dispatcher.queue_snapshots\`. Empty list when the lookup fails or
+    when nothing is blocked."""
+    queueBlocked: [QueueItem!]!
+    """Top 10 recently-completed agents (#2805 §1.5). Rows from
+    \`dispatcher.agents\` where status IN ('succeeded','failed','crashed')
+    ordered by \`ended_at\` DESC."""
+    recentCompletions: [RecentCompletion!]!
+    """All live-editable \`dispatcher.config\` entries (#2805 §1.6)."""
+    config: [DispatcherConfigEntry!]!
     """\`dispatcher.config.value\` for \`spawn_frozen_until\` (§10), or null if not set."""
     spawnFrozenUntil: DateTime
   }
@@ -172,5 +235,23 @@ export const dispatcherTypeDefs = `#graphql
       include \`agentId\`. For others, \`{}\` is fine."""
       payload: JSON
     ): DispatcherCommandResult!
+
+    """Update a single \`dispatcher.config\` entry (#2805 §1.6). Writes the
+    new value as JSONB, stamps \`updated_at\`, and records the admin's email
+    in \`updated_by\` for audit. Like \`dispatcherControl\`, this requires a
+    non-empty \`X-MFA-Token\` header — config edits can materially change
+    daemon behaviour (e.g. lowering \`concurrency_cap\` mid-flight).
+
+    Admin-only; non-admins receive "not found".
+    """
+    dispatcherSetConfig(
+      """The \`dispatcher.config.key\` to update. Must match an existing row."""
+      key: String!
+      """The new value, as a JSON-encoded string (e.g. \`"1"\` for a number,
+      \`"\\"on\\""\` for a string, \`"[60,300]"\` for an array). The server
+      validates the parsed value per-key — see resolver for the per-key
+      constraints."""
+      value: String!
+    ): DispatcherConfigEntry!
   }
 `;

--- a/packages/api/tests/dispatcher-github.unit.test.ts
+++ b/packages/api/tests/dispatcher-github.unit.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the dispatcher GitHub helper (#2805). Focuses on the
+ * pure parsing + cache behaviour — the network path is exercised via the
+ * integration suite.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetCaches,
+  extractPriority,
+  fetchIssue,
+  parseBlockedBy,
+  searchIssues,
+} from '../src/graphql/dispatcher/github';
+
+describe('extractPriority', () => {
+  it('returns the priority for a priority/pN label', () => {
+    expect(extractPriority(['area/frontend', 'priority/p1', 'agent/ready'])).toBe('p1');
+    expect(extractPriority(['priority/p0'])).toBe('p0');
+  });
+
+  it('returns null when no priority label is present', () => {
+    expect(extractPriority(['area/frontend'])).toBeNull();
+    expect(extractPriority([])).toBeNull();
+  });
+
+  it('ignores malformed labels', () => {
+    expect(extractPriority(['priority/p9'])).toBeNull();
+    expect(extractPriority(['priority/high'])).toBeNull();
+  });
+});
+
+describe('parseBlockedBy', () => {
+  it('returns [] on null/empty body', () => {
+    expect(parseBlockedBy(null)).toEqual([]);
+    expect(parseBlockedBy('')).toEqual([]);
+  });
+
+  it('extracts Blocked by #N references', () => {
+    const body = 'Some description.\n\nBlocked by #1234\nBlocked by #5678\nParent: #2805';
+    expect(parseBlockedBy(body)).toEqual([1234, 5678]);
+  });
+
+  it('ignores Parent: #N', () => {
+    expect(parseBlockedBy('Parent: #1\n')).toEqual([]);
+  });
+});
+
+describe('fetchIssue — cache behaviour', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    __resetCaches();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('caches the response and does not re-fetch inside the TTL', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        number: 42,
+        title: 'Hello',
+        labels: [{ name: 'priority/p2' }],
+        created_at: '2026-04-18T00:00:00Z',
+        body: 'Some body',
+      }),
+    });
+
+    const first = await fetchIssue(42);
+    expect(first).not.toBeNull();
+    expect(first?.title).toBe('Hello');
+    expect(first?.labels).toEqual(['priority/p2']);
+
+    // Second call — should be served from cache (fetchMock called once).
+    const second = await fetchIssue(42);
+    expect(second).toEqual(first);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null + caches null when the response is not ok', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 404 });
+    const result = await fetchIssue(999);
+    expect(result).toBeNull();
+    // Second call inside TTL — still null, still only one fetch.
+    const second = await fetchIssue(999);
+    expect(second).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when fetch itself rejects', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network fail'));
+    expect(await fetchIssue(1)).toBeNull();
+  });
+});
+
+describe('searchIssues — cache + parse', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    __resetCaches();
+    fetchMock.mockReset();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('parses the search result items and caches them', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            number: 1,
+            title: 'a',
+            labels: [{ name: 'status/blocked' }],
+            created_at: '2026-04-18T00:00:00Z',
+            body: 'Blocked by #50\n',
+          },
+          {
+            number: 2,
+            title: 'b',
+            labels: ['priority/p2'],
+            created_at: '2026-04-17T00:00:00Z',
+            body: null,
+          },
+        ],
+      }),
+    });
+
+    const first = await searchIssues('label:status/blocked');
+    expect(first).toHaveLength(2);
+    expect(first[0].labels).toEqual(['status/blocked']);
+    expect(first[1].labels).toEqual(['priority/p2']);
+
+    // Cached — fetch count stays 1.
+    const second = await searchIssues('label:status/blocked');
+    expect(second).toEqual(first);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns [] on fetch failure', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 });
+    expect(await searchIssues('label:status/blocked')).toEqual([]);
+  });
+});

--- a/packages/api/tests/dispatcher-set-config.unit.test.ts
+++ b/packages/api/tests/dispatcher-set-config.unit.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Unit tests for `validateConfigValue` — the per-key config editor
+ * validator used by the `dispatcherSetConfig` mutation (#2805 §1.6).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { validateConfigValue } from '../src/graphql/dispatcher/resolvers';
+
+describe('validateConfigValue — concurrency_cap', () => {
+  it('accepts integers in [0, 5]', () => {
+    expect(validateConfigValue('concurrency_cap', 0)).toBe(0);
+    expect(validateConfigValue('concurrency_cap', 3)).toBe(3);
+    expect(validateConfigValue('concurrency_cap', 5)).toBe(5);
+  });
+
+  it('rejects negatives', () => {
+    expect(() => validateConfigValue('concurrency_cap', -1)).toThrow(/integer in \[0, 5\]/);
+  });
+
+  it('rejects values > 5', () => {
+    expect(() => validateConfigValue('concurrency_cap', 6)).toThrow();
+    expect(() => validateConfigValue('concurrency_cap', 100)).toThrow();
+  });
+
+  it('rejects non-integers', () => {
+    expect(() => validateConfigValue('concurrency_cap', 2.5)).toThrow();
+    expect(() => validateConfigValue('concurrency_cap', 'three')).toThrow();
+    expect(() => validateConfigValue('concurrency_cap', null)).toThrow();
+  });
+});
+
+describe('validateConfigValue — backoff_seconds', () => {
+  it('accepts arrays of non-negative integers', () => {
+    expect(validateConfigValue('backoff_seconds', [60, 300, 900])).toEqual([60, 300, 900]);
+    expect(validateConfigValue('backoff_seconds', [0])).toEqual([0]);
+    expect(validateConfigValue('backoff_seconds', [])).toEqual([]);
+  });
+
+  it('rejects arrays with negatives', () => {
+    expect(() => validateConfigValue('backoff_seconds', [60, -1])).toThrow();
+  });
+
+  it('rejects arrays with non-integers', () => {
+    expect(() => validateConfigValue('backoff_seconds', [60, 'slow'])).toThrow();
+    expect(() => validateConfigValue('backoff_seconds', [60, 1.5])).toThrow();
+  });
+
+  it('rejects non-array input', () => {
+    expect(() => validateConfigValue('backoff_seconds', 60)).toThrow();
+    expect(() => validateConfigValue('backoff_seconds', '60,300,900')).toThrow();
+  });
+});
+
+describe('validateConfigValue — idle_spotcheck_cron', () => {
+  it('accepts non-empty strings', () => {
+    expect(validateConfigValue('idle_spotcheck_cron', '0 14 * * *')).toBe('0 14 * * *');
+  });
+
+  it('rejects empty / non-string', () => {
+    expect(() => validateConfigValue('idle_spotcheck_cron', '')).toThrow();
+    expect(() => validateConfigValue('idle_spotcheck_cron', 42)).toThrow();
+  });
+});
+
+describe('validateConfigValue — unknown key', () => {
+  it('rejects freehand keys', () => {
+    expect(() => validateConfigValue('new_key', 'anything')).toThrow(/Unknown config key/);
+  });
+});

--- a/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { SECTION_HEADING } from '@/lib/typography';
 import type { DispatcherAgent } from '@/lib/dispatcher-queries';
 import { formatUptime, shortAgentId, worktreeLogsUrl } from './format-helpers';
+import { IssueLink } from './ui-primitives';
 
 interface ActiveAgentsTableProps {
   agents: readonly DispatcherAgent[];
@@ -13,6 +14,12 @@ interface ActiveAgentsTableProps {
   nowMs?: number;
 }
 
+/**
+ * Dense per-agent row layout (#2805 §1.4). Replaces the prior thick-bordered
+ * `<table>` card with a borderless section of `<ul>` rows that match the
+ * queue/completed visual rhythm. The issue number is a hot link via
+ * `IssueLink`; every action button uses the new `size="xs"` variant.
+ */
 export function ActiveAgentsTable({
   agents,
   disabled,
@@ -20,97 +27,100 @@ export function ActiveAgentsTable({
   nowMs,
 }: ActiveAgentsTableProps) {
   return (
-    <section
-      aria-labelledby="active-agents-heading"
-      className="rounded-lg border border-border bg-card"
-    >
-      <div className="flex items-center justify-between border-b border-border p-4">
+    <section aria-labelledby="active-agents-heading">
+      <div className="flex items-center justify-between border-b border-border pb-2 mb-2">
         <h2 id="active-agents-heading" className={SECTION_HEADING}>
           Active agents ({agents.length})
         </h2>
       </div>
-
       {agents.length === 0 ? (
-        <p className="p-6 text-center text-sm text-muted-foreground">No active agents.</p>
+        <p className="py-2 text-sm text-muted-foreground">No active agents.</p>
       ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
-                <th scope="col" className="p-3">Agent</th>
-                <th scope="col" className="p-3">Issue</th>
-                <th scope="col" className="p-3">Phase</th>
-                <th scope="col" className="p-3">Elapsed</th>
-                <th scope="col" className="p-3">Worktree</th>
-                <th scope="col" className="p-3">Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {agents.map((agent) => {
-                const logsHref = worktreeLogsUrl(agent.worktreePath);
-                return (
-                  <tr
-                    key={agent.id}
-                    className="border-b border-border last:border-b-0"
-                  >
-                    <td className="p-3 font-mono text-xs text-foreground">
-                      {shortAgentId(agent.id)}
-                    </td>
-                    <td className="p-3 text-foreground">#{agent.issueNumber}</td>
-                    <td className="p-3 font-mono text-xs text-muted-foreground">
-                      {agent.phase}
-                    </td>
-                    <td className="p-3 text-foreground">
-                      {formatUptime(agent.startedAt, nowMs)}
-                    </td>
-                    <td className="p-3 text-xs">
-                      {logsHref ? (
-                        <a
-                          href={logsHref}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-accent underline-offset-2 hover:underline"
-                        >
-                          Logs
-                        </a>
-                      ) : (
-                        <span
-                          title={agent.worktreePath}
-                          className="font-mono text-muted-foreground"
-                        >
-                          {agent.worktreePath.split('/').pop() ?? agent.worktreePath}
-                        </span>
-                      )}
-                    </td>
-                    <td className="p-3">
-                      <div className="flex gap-2">
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          disabled={disabled}
-                          onClick={() => onAgentAction('retry', agent.id)}
-                        >
-                          Retry
-                        </Button>
-                        <Button
-                          type="button"
-                          variant="destructive"
-                          size="sm"
-                          disabled={disabled}
-                          onClick={() => onAgentAction('force_kill', agent.id)}
-                        >
-                          Kill
-                        </Button>
-                      </div>
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
+        <ul className="divide-y divide-border">
+          {agents.map((agent) => (
+            <ActiveAgentRow
+              key={agent.id}
+              agent={agent}
+              disabled={disabled}
+              onAction={onAgentAction}
+              nowMs={nowMs}
+            />
+          ))}
+        </ul>
       )}
     </section>
+  );
+}
+
+function ActiveAgentRow({
+  agent,
+  disabled,
+  onAction,
+  nowMs,
+}: {
+  agent: DispatcherAgent;
+  disabled?: boolean;
+  onAction: (command: 'retry' | 'force_kill', agentId: string) => void;
+  nowMs?: number;
+}) {
+  const logsHref = worktreeLogsUrl(agent.worktreePath);
+  const elapsed = formatUptime(agent.startedAt, nowMs);
+  return (
+    <li className="flex flex-wrap items-center gap-x-3 gap-y-1 py-2 text-sm hover:bg-muted/50">
+      <span
+        className="w-20 flex-shrink-0 font-mono text-xs text-foreground"
+        title={agent.id}
+      >
+        {shortAgentId(agent.id)}
+      </span>
+      <span className="flex-shrink-0">
+        <IssueLink number={agent.issueNumber} />
+      </span>
+      <span className="min-w-0 flex-1 font-mono text-xs text-muted-foreground">
+        {agent.phase}
+      </span>
+      <span className="w-16 flex-shrink-0 text-right font-mono text-xs text-muted-foreground">
+        {elapsed}
+      </span>
+      <span className="flex-shrink-0 text-xs">
+        {logsHref ? (
+          <a
+            href={logsHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent underline-offset-2 hover:underline"
+          >
+            Logs &rarr;
+          </a>
+        ) : (
+          <span
+            title={agent.worktreePath}
+            className="font-mono text-muted-foreground"
+          >
+            {agent.worktreePath.split('/').pop() ?? agent.worktreePath}
+          </span>
+        )}
+      </span>
+      <span className="flex flex-shrink-0 gap-1">
+        <Button
+          type="button"
+          variant="outline"
+          size="xs"
+          disabled={disabled}
+          onClick={() => onAction('retry', agent.id)}
+        >
+          Retry
+        </Button>
+        <Button
+          type="button"
+          variant="destructive"
+          size="xs"
+          disabled={disabled}
+          onClick={() => onAction('force_kill', agent.id)}
+        >
+          Kill
+        </Button>
+      </span>
+    </li>
   );
 }

--- a/packages/web/src/app/(main)/admin/dispatcher/ConfigPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ConfigPanel.tsx
@@ -1,50 +1,343 @@
 'use client';
 
-import { SECTION_HEADING } from '@/lib/typography';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { DispatcherConfigEntry } from '@/lib/dispatcher-queries';
 
 interface ConfigPanelProps {
-  configKeys: ReadonlyArray<{ key: string; label: string }>;
+  entries: readonly DispatcherConfigEntry[];
   spawnFrozenUntil: string | null;
+  /**
+   * Called when the operator commits an edit. The parent wires this to
+   * `dispatcherSetConfig` with the MFA placeholder header + a
+   * `ConfirmDialog` for destructive transitions (e.g. lowering cap).
+   *
+   * - `key`    — config key, e.g. `"concurrency_cap"`.
+   * - `value`  — JSON-encoded string ready for the mutation.
+   *
+   * The parent resolves the returned promise on success and rejects on
+   * failure; the ConfigPanel uses that to show a 1 s green success tint
+   * or surface the error via `errorMessage`.
+   */
+  onCommitEdit: (key: string, value: string) => Promise<void>;
+  /** Transient error surfaced by the parent (e.g. MFA_REQUIRED). */
+  errorMessage?: string | null;
+  /** Transient busy indicator for the last-edited key. */
+  busyKey?: string | null;
 }
 
 /**
- * Read-only config panel for Phase 1. The `concurrency_cap`, `idle_mode`,
- * and `backoff_seconds` keys live in `dispatcher.config`; Phase 1's
- * GraphQL surface does not yet expose per-key values except
- * `spawnFrozenUntil`. Editing is a Phase 2 follow-up.
+ * Compact editable config strip (#2805 §1.6). Replaces the two-column
+ * `<dl>` with a single horizontal row:
+ *
+ *   cap [ 1 ]   backoff [ 300s ]   idle [ on ▾ ]   spawn frozen: —
+ *
+ * Borderless. Sits beneath the main two-column grid.
+ *
+ * Editing semantics:
+ *   - Click a value → switch to input.
+ *   - Enter / blur → parent's `onCommitEdit` (parent handles mutation +
+ *     ConfirmDialog for destructive transitions).
+ *   - Escape → cancel.
+ *
+ * Non-editable display-only: `spawn_frozen_until` (monospace timestamp).
  */
-export function ConfigPanel({ configKeys, spawnFrozenUntil }: ConfigPanelProps) {
+export function ConfigPanel({
+  entries,
+  spawnFrozenUntil,
+  onCommitEdit,
+  errorMessage,
+  busyKey,
+}: ConfigPanelProps) {
+  const entryByKey = new Map(entries.map((e) => [e.key, e] as const));
+
   return (
     <section
       aria-labelledby="config-heading"
-      className="rounded-lg border border-border bg-card p-4"
+      className="border-t border-border pt-3 mt-4"
+      data-testid="config-strip"
     >
-      <h2 id="config-heading" className={SECTION_HEADING}>
-        Config
+      <h2 id="config-heading" className="sr-only">
+        Dispatcher config
       </h2>
-      <dl className="mt-3 grid grid-cols-1 gap-3 sm:grid-cols-2">
-        {configKeys.map((item) => (
-          <div key={item.key} className="flex flex-col">
-            <dt className="text-xs uppercase tracking-wide text-muted-foreground">
-              {item.label}
-            </dt>
-            <dd className="mt-1 font-mono text-sm text-foreground">
-              seeded (see <code>dispatcher.config</code>)
-            </dd>
-          </div>
-        ))}
-        <div className="flex flex-col">
-          <dt className="text-xs uppercase tracking-wide text-muted-foreground">
-            Spawn frozen until
-          </dt>
-          <dd className="mt-1 font-mono text-sm text-foreground">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 font-mono text-sm">
+        <EditableNumberField
+          label="cap"
+          entry={entryByKey.get('concurrency_cap') ?? null}
+          min={0}
+          max={5}
+          busy={busyKey === 'concurrency_cap'}
+          onCommit={(value) => onCommitEdit('concurrency_cap', String(value))}
+        />
+        <span aria-hidden="true" className="text-muted-foreground">&middot;</span>
+        <EditableBackoffField
+          entry={entryByKey.get('backoff_seconds') ?? null}
+          busy={busyKey === 'backoff_seconds'}
+          onCommit={(value) => onCommitEdit('backoff_seconds', value)}
+        />
+        <span aria-hidden="true" className="text-muted-foreground">&middot;</span>
+        <span className="text-muted-foreground">
+          spawn frozen:{' '}
+          <span className="text-foreground" title={spawnFrozenUntil ?? ''}>
             {spawnFrozenUntil ?? '—'}
-          </dd>
-        </div>
-      </dl>
-      <p className="mt-3 text-xs text-muted-foreground">
-        Read-only in Phase 1. Inline editing ships with the Phase 2 follow-up.
-      </p>
+          </span>
+        </span>
+      </div>
+      {errorMessage && (
+        <p
+          role="alert"
+          className="mt-2 text-xs text-red-700 dark:text-red-300"
+          data-testid="config-error"
+        >
+          {errorMessage}
+        </p>
+      )}
     </section>
   );
+}
+
+interface EditableNumberFieldProps {
+  label: string;
+  entry: DispatcherConfigEntry | null;
+  min: number;
+  max: number;
+  busy?: boolean;
+  onCommit: (value: number) => Promise<void> | void;
+}
+
+function EditableNumberField({
+  label,
+  entry,
+  min,
+  max,
+  busy,
+  onCommit,
+}: EditableNumberFieldProps) {
+  const parsed = entry ? safeParseNumber(entry.value) : null;
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<string>(parsed !== null ? String(parsed) : '');
+  const [flashSuccess, setFlashSuccess] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  useEffect(() => {
+    if (!editing && parsed !== null) {
+      setDraft(String(parsed));
+    }
+  }, [editing, parsed]);
+
+  const startEdit = useCallback(() => {
+    setEditing(true);
+    setDraft(parsed !== null ? String(parsed) : '');
+  }, [parsed]);
+
+  const commit = useCallback(async () => {
+    const n = Number.parseInt(draft, 10);
+    if (!Number.isFinite(n) || n < min || n > max) {
+      setEditing(false);
+      if (parsed !== null) setDraft(String(parsed));
+      return;
+    }
+    if (parsed !== null && n === parsed) {
+      setEditing(false);
+      return;
+    }
+    setEditing(false);
+    try {
+      await onCommit(n);
+      setFlashSuccess(true);
+      window.setTimeout(() => setFlashSuccess(false), 1000);
+    } catch {
+      // Parent surfaces the error via `errorMessage`. Restore the prior
+      // value so the UI is not out-of-sync with the server.
+      if (parsed !== null) setDraft(String(parsed));
+    }
+  }, [draft, min, max, onCommit, parsed]);
+
+  const cancel = useCallback(() => {
+    setEditing(false);
+    if (parsed !== null) setDraft(String(parsed));
+  }, [parsed]);
+
+  if (editing) {
+    return (
+      <label className="inline-flex items-center gap-1">
+        <span className="text-muted-foreground">{label}</span>
+        <input
+          ref={inputRef}
+          type="number"
+          min={min}
+          max={max}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => void commit()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              void commit();
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              cancel();
+            }
+          }}
+          className="h-7 w-14 rounded border border-input bg-background px-1 font-mono text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          data-testid={`config-input-${entry?.key ?? label}`}
+        />
+      </label>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={startEdit}
+      disabled={busy}
+      className={`inline-flex items-center gap-1 rounded px-1 hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60 ${
+        flashSuccess ? 'bg-green-100 dark:bg-green-900/30' : ''
+      }`}
+      data-testid={`config-value-${entry?.key ?? label}`}
+      aria-label={`Edit ${label}`}
+    >
+      <span className="text-muted-foreground">{label}</span>
+      <span className="text-foreground">
+        [{parsed !== null ? parsed : '—'}]
+      </span>
+    </button>
+  );
+}
+
+interface EditableBackoffFieldProps {
+  entry: DispatcherConfigEntry | null;
+  busy?: boolean;
+  onCommit: (value: string) => Promise<void> | void;
+}
+
+/**
+ * Specialized editor for `backoff_seconds` — the DB shape is an integer
+ * array, but the operator thinks in terms of the first retry delay. We
+ * show the first entry as "[Ns]" and allow editing it; the commit
+ * preserves the rest of the array (or defaults to [N]).
+ */
+function EditableBackoffField({ entry, busy, onCommit }: EditableBackoffFieldProps) {
+  const parsedArray = entry ? safeParseArray(entry.value) : null;
+  const firstValue = parsedArray && parsedArray.length > 0 ? parsedArray[0] : null;
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<string>(firstValue !== null ? String(firstValue) : '');
+  const [flashSuccess, setFlashSuccess] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [editing]);
+
+  useEffect(() => {
+    if (!editing && firstValue !== null) {
+      setDraft(String(firstValue));
+    }
+  }, [editing, firstValue]);
+
+  const commit = useCallback(async () => {
+    const n = Number.parseInt(draft, 10);
+    if (!Number.isFinite(n) || n < 0) {
+      setEditing(false);
+      if (firstValue !== null) setDraft(String(firstValue));
+      return;
+    }
+    const nextArray = parsedArray && parsedArray.length > 0
+      ? [n, ...parsedArray.slice(1)]
+      : [n];
+    if (firstValue !== null && n === firstValue) {
+      setEditing(false);
+      return;
+    }
+    setEditing(false);
+    try {
+      await onCommit(JSON.stringify(nextArray));
+      setFlashSuccess(true);
+      window.setTimeout(() => setFlashSuccess(false), 1000);
+    } catch {
+      if (firstValue !== null) setDraft(String(firstValue));
+    }
+  }, [draft, firstValue, parsedArray, onCommit]);
+
+  const cancel = useCallback(() => {
+    setEditing(false);
+    if (firstValue !== null) setDraft(String(firstValue));
+  }, [firstValue]);
+
+  if (editing) {
+    return (
+      <label className="inline-flex items-center gap-1">
+        <span className="text-muted-foreground">backoff</span>
+        <input
+          ref={inputRef}
+          type="number"
+          min={0}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => void commit()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              void commit();
+            } else if (e.key === 'Escape') {
+              e.preventDefault();
+              cancel();
+            }
+          }}
+          className="h-7 w-16 rounded border border-input bg-background px-1 font-mono text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          data-testid="config-input-backoff_seconds"
+        />
+        <span className="text-muted-foreground">s</span>
+      </label>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setEditing(true)}
+      disabled={busy}
+      className={`inline-flex items-center gap-1 rounded px-1 hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60 ${
+        flashSuccess ? 'bg-green-100 dark:bg-green-900/30' : ''
+      }`}
+      data-testid="config-value-backoff_seconds"
+      aria-label="Edit backoff"
+    >
+      <span className="text-muted-foreground">backoff</span>
+      <span className="text-foreground">
+        [{firstValue !== null ? `${firstValue}s` : '—'}]
+      </span>
+    </button>
+  );
+}
+
+function safeParseNumber(jsonValue: string): number | null {
+  try {
+    const raw = JSON.parse(jsonValue);
+    if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function safeParseArray(jsonValue: string): number[] | null {
+  try {
+    const raw = JSON.parse(jsonValue);
+    if (Array.isArray(raw) && raw.every((x) => typeof x === 'number' && Number.isFinite(x))) {
+      return raw as number[];
+    }
+    return null;
+  } catch {
+    return null;
+  }
 }

--- a/packages/web/src/app/(main)/admin/dispatcher/ConfirmDialog.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ConfirmDialog.tsx
@@ -11,9 +11,22 @@ import {
 import { Button } from '@/components/ui/button';
 import type { DispatcherCommand } from '@/lib/dispatcher-queries';
 
+/**
+ * Commands that can open the ConfirmDialog. Includes all
+ * `DESTRUCTIVE_COMMANDS` plus the synthetic `'lower_cap'` sentinel used
+ * by the config strip when the operator reduces `concurrency_cap`
+ * (#2805 §1.6; spec §17 Risk 6 Option A).
+ */
+export type ConfirmableCommand = DispatcherCommand | 'lower_cap';
+
 interface ConfirmDialogProps {
   /** Non-null when the dialog should be open for this command. */
-  command: DispatcherCommand | null;
+  command: ConfirmableCommand | null;
+  /**
+   * When `command === 'lower_cap'`, carries the before/after values so
+   * the dialog's copy can explain the transition. Ignored otherwise.
+   */
+  capDetail?: { current: number; next: number } | null;
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -33,9 +46,26 @@ const DESCRIPTIONS: Partial<Record<DispatcherCommand, { title: string; body: str
   },
 };
 
-export function ConfirmDialog({ command, onConfirm, onCancel }: ConfirmDialogProps) {
+export function ConfirmDialog({
+  command,
+  capDetail,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
   const open = command !== null;
-  const content = command ? DESCRIPTIONS[command] : null;
+  let title = 'Confirm';
+  let body = '';
+  if (command === 'lower_cap' && capDetail) {
+    title = `Lower concurrency cap from ${capDetail.current} to ${capDetail.next}?`;
+    body =
+      'In-flight agents continue; the daemon stops claiming new ones until the cap is raised or slots free up.';
+  } else if (command && command !== 'lower_cap') {
+    const content = DESCRIPTIONS[command];
+    if (content) {
+      title = content.title;
+      body = content.body;
+    }
+  }
 
   return (
     <Dialog
@@ -46,8 +76,8 @@ export function ConfirmDialog({ command, onConfirm, onCancel }: ConfirmDialogPro
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{content?.title ?? 'Confirm'}</DialogTitle>
-          <DialogDescription>{content?.body ?? ''}</DialogDescription>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{body}</DialogDescription>
         </DialogHeader>
         <DialogFooter>
           <Button type="button" variant="outline" size="sm" onClick={onCancel}>

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherControls.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherControls.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-import { SECTION_HEADING } from '@/lib/typography';
 import type { DispatcherCommand, DispatcherRun } from '@/lib/dispatcher-queries';
 
 interface DispatcherControlsProps {
@@ -11,9 +10,21 @@ interface DispatcherControlsProps {
 }
 
 /**
- * Five control buttons matching spec §11: Start, Stop (drain), Force-stop,
- * Pause, Resume. Destructive commands (`stop`, `drain`, `force_kill`)
- * trigger a confirmation modal — handled by the parent dashboard.
+ * Five control buttons matching spec §11: Start · Pause · Resume ·
+ * Stop (drain) · Force-stop.
+ *
+ * Rendered as a flat inline cluster — no card wrapper, no explanatory
+ * paragraph — per #2805 §1.1. Same size/variant/enabled rules as the
+ * previous implementation so behaviour is unchanged.
+ *
+ * The implementation-trivia footnote ("commands written to
+ * dispatcher.commands") is intentionally removed — the operator has
+ * internalized it and the page is about visibility, not tutorials.
+ *
+ * Daemon-side command handlers are tracked in #2801 — until that lands
+ * some click handlers write a `dispatcher.commands` row but produce no
+ * observable daemon behaviour change. This UI ships the correct writes
+ * today.
  */
 export function DispatcherControls({
   currentRun,
@@ -23,65 +34,52 @@ export function DispatcherControls({
   const daemonActive = currentRun !== null && !currentRun.stoppedAt;
 
   return (
-    <section
-      aria-labelledby="dispatcher-controls-heading"
-      className="rounded-lg border border-border bg-card p-4"
-    >
-      <h2 id="dispatcher-controls-heading" className={SECTION_HEADING}>
-        Controls
-      </h2>
-      <div className="mt-3 flex flex-wrap gap-2">
-        <Button
-          type="button"
-          variant="default"
-          size="sm"
-          disabled={disabled}
-          onClick={() => onControlClick('start')}
-        >
-          Start
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={disabled || !daemonActive}
-          onClick={() => onControlClick('pause')}
-        >
-          Pause
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={disabled}
-          onClick={() => onControlClick('resume')}
-        >
-          Resume
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={disabled || !daemonActive}
-          onClick={() => onControlClick('drain')}
-        >
-          Stop (drain)
-        </Button>
-        <Button
-          type="button"
-          variant="destructive"
-          size="sm"
-          disabled={disabled || !daemonActive}
-          onClick={() => onControlClick('stop')}
-        >
-          Force-stop
-        </Button>
-      </div>
-      <p className="mt-3 text-xs text-muted-foreground">
-        Destructive commands (Stop, Force-stop, Force-kill) require confirmation. Commands
-        are written to <code className="font-mono">dispatcher.commands</code> and picked
-        up on the daemon&apos;s next tick.
-      </p>
-    </section>
+    <div className="flex flex-wrap items-center gap-2" data-testid="dispatcher-controls">
+      <Button
+        type="button"
+        variant="default"
+        size="sm"
+        disabled={disabled}
+        onClick={() => onControlClick('start')}
+      >
+        Start
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={disabled || !daemonActive}
+        onClick={() => onControlClick('pause')}
+      >
+        Pause
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={disabled}
+        onClick={() => onControlClick('resume')}
+      >
+        Resume
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={disabled || !daemonActive}
+        onClick={() => onControlClick('drain')}
+      >
+        Stop (drain)
+      </Button>
+      <Button
+        type="button"
+        variant="destructive"
+        size="sm"
+        disabled={disabled || !daemonActive}
+        onClick={() => onControlClick('stop')}
+      >
+        Force-stop
+      </Button>
+    </div>
   );
 }

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -7,20 +7,23 @@ import { useAuth } from '@/providers/AuthProvider';
 import { ErrorBanner } from '@/components/ErrorBanner';
 import { PAGE_TITLE } from '@/lib/typography';
 import {
-  DISPATCHER_CONTROL_MUTATION,
-  DISPATCHER_STATE_QUERY,
   DESTRUCTIVE_COMMANDS,
+  DISPATCHER_CONTROL_MUTATION,
+  DISPATCHER_SET_CONFIG_MUTATION,
+  DISPATCHER_STATE_QUERY,
   type DispatcherCommand,
   type DispatcherControlData,
+  type DispatcherSetConfigData,
   type DispatcherStateData,
 } from '@/lib/dispatcher-queries';
 import { DispatcherHeader } from './DispatcherHeader';
 import { DispatcherControls } from './DispatcherControls';
 import { ActiveAgentsTable } from './ActiveAgentsTable';
 import { QueuePanel } from './QueuePanel';
+import { RecentCompletionsPanel } from './RecentCompletionsPanel';
 import { RecentFailuresPanel } from './RecentFailuresPanel';
 import { ConfigPanel } from './ConfigPanel';
-import { ConfirmDialog } from './ConfirmDialog';
+import { ConfirmDialog, type ConfirmableCommand } from './ConfirmDialog';
 
 /**
  * Polling interval for `dispatcherState`. Per spec §11, the daemon runs on
@@ -29,28 +32,42 @@ import { ConfirmDialog } from './ConfirmDialog';
 const POLL_INTERVAL_MS = 2000;
 
 /**
- * Static config shown in the read-only config panel (§11 says "editable"
- * but the issue body carves editing out of Phase 1). These labels describe
- * the keys that live in `dispatcher.config` — the values themselves are
- * not yet exposed via GraphQL, so Phase 1 shows placeholders with a note
- * pointing at the follow-up work.
+ * Sentinel value passed to the `ConfirmDialog` when the operator is
+ * lowering the concurrency cap — the dialog shows tailored copy for the
+ * side-effect warning described in #2805 §1.6 (spec §17 Risk 6).
  */
-const CONFIG_KEYS = [
-  { key: 'concurrency_cap', label: 'Concurrency cap' },
-  { key: 'idle_mode', label: 'Idle mode' },
-  { key: 'backoff_seconds', label: 'Backoff seconds' },
-] as const;
+const LOWER_CAP_CONFIRM = 'lower_cap' as const;
 
 function SkeletonShell() {
   return (
-    <div className="space-y-6">
-      {Array.from({ length: 5 }).map((_, i) => (
-        <div key={i} className="h-24 animate-pulse rounded-lg bg-muted motion-reduce:animate-none" />
-      ))}
+    <div className="space-y-4">
+      <div className="h-6 w-64 animate-pulse rounded bg-muted motion-reduce:animate-none" />
+      <div className="grid grid-cols-1 gap-x-6 gap-y-4 lg:grid-cols-2">
+        <div className="h-48 animate-pulse rounded bg-muted motion-reduce:animate-none" />
+        <div className="h-48 animate-pulse rounded bg-muted motion-reduce:animate-none" />
+        <div className="h-48 animate-pulse rounded bg-muted motion-reduce:animate-none" />
+        <div className="h-48 animate-pulse rounded bg-muted motion-reduce:animate-none" />
+      </div>
+      <div className="h-10 animate-pulse rounded bg-muted motion-reduce:animate-none" />
     </div>
   );
 }
 
+/**
+ * Refreshed, info-dense cockpit for /admin/dispatcher (#2805 Phase 1).
+ * Layout:
+ *
+ *   ┌─ h1 Dispatcher  · status pill · uptime · sha · host        · [controls] ─┐
+ *   ├─ Queue: Agent-ready ─────────────┬─ Active agents ──────────────────────┤
+ *   │   (top 10)                       │  (0-N rows)                          │
+ *   ├─ Queue: Blocked ─────────────────┤                                      │
+ *   │   (top 10)                       ├─ Recently completed ─────────────────┤
+ *   │                                  │  (top 10)                            │
+ *   ├─ Config strip ──────────────────────────────────────────────────────────┤
+ *   │   cap [N] · backoff [Ns] · spawn frozen: —                              │
+ *   ├─ Recent failures (last 24h) ────────────────────────────────────────────┤
+ *   └──────────────────────────────────────────────────────────────────────────┘
+ */
 export function DispatcherDashboard() {
   const { user, loading: authLoading } = useAuth();
 
@@ -72,8 +89,11 @@ export function DispatcherDashboard() {
  * non-admin sessions, producing misleading NOT_FOUND errors in logs).
  */
 function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
-  const [pendingCommand, setPendingCommand] = useState<DispatcherCommand | null>(null);
+  const [pendingCommand, setPendingCommand] = useState<ConfirmableCommand | null>(null);
+  const [pendingCap, setPendingCap] = useState<{ current: number; next: number } | null>(null);
   const [commandError, setCommandError] = useState<string | null>(null);
+  const [configError, setConfigError] = useState<string | null>(null);
+  const [busyConfigKey, setBusyConfigKey] = useState<string | null>(null);
 
   const { data, loading, error, refetch } = useQuery<DispatcherStateData>(
     DISPATCHER_STATE_QUERY,
@@ -87,6 +107,10 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
   const [dispatcherControl, { loading: controlLoading }] =
     useMutation<DispatcherControlData>(DISPATCHER_CONTROL_MUTATION);
 
+  const [dispatcherSetConfig] = useMutation<DispatcherSetConfigData>(
+    DISPATCHER_SET_CONFIG_MUTATION,
+  );
+
   const runControlCommand = useCallback(
     async (command: DispatcherCommand, payload: Record<string, unknown> = {}) => {
       setCommandError(null);
@@ -94,9 +118,11 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
         await dispatcherControl({
           variables: { command, payload },
           // Destructive commands require a non-empty X-MFA-Token header per
-          // the Phase 1 placeholder in `dispatcher/auth.ts`. A follow-up
-          // issue will wire a real MFA challenge flow; for now we always
-          // send a non-empty placeholder so the destructive flow succeeds.
+          // the Phase 1 placeholder in `dispatcher/auth.ts`. We always send
+          // it so the destructive flow succeeds; a follow-up wires the real
+          // MFA challenge flow (#2761). Non-destructive paths omit the
+          // header to avoid any confusion if/when the backend starts
+          // distinguishing admin-with-MFA from admin.
           context: DESTRUCTIVE_COMMANDS.has(command)
             ? { headers: { 'X-MFA-Token': 'phase1-placeholder' } }
             : undefined,
@@ -124,25 +150,60 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
     [runControlCommand],
   );
 
+  /**
+   * Internal helper that actually calls `dispatcherSetConfig` with the
+   * MFA placeholder header + JSON-encoded value. Not exposed directly to
+   * `ConfigPanel` — see `handleConfigEdit` below, which interposes the
+   * "lower cap" confirm dialog.
+   */
+  const commitConfigEdit = useCallback(
+    async (key: string, value: string): Promise<void> => {
+      setConfigError(null);
+      setBusyConfigKey(key);
+      try {
+        await dispatcherSetConfig({
+          variables: { key, value },
+          context: {
+            headers: { 'X-MFA-Token': 'phase1-placeholder' },
+          },
+        });
+        await refetch();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Config update failed';
+        setConfigError(message);
+        throw err;
+      } finally {
+        setBusyConfigKey(null);
+      }
+    },
+    [dispatcherSetConfig, refetch],
+  );
+
   const handleConfirm = useCallback(() => {
     if (pendingCommand === null) return;
+    if (pendingCommand === LOWER_CAP_CONFIRM) {
+      const pc = pendingCap;
+      setPendingCommand(null);
+      setPendingCap(null);
+      if (pc) {
+        void commitConfigEdit('concurrency_cap', String(pc.next));
+      }
+      return;
+    }
     const cmd = pendingCommand;
     setPendingCommand(null);
     void runControlCommand(cmd);
-  }, [pendingCommand, runControlCommand]);
+  }, [pendingCommand, pendingCap, runControlCommand, commitConfigEdit]);
 
   const handleCancel = useCallback(() => {
     setPendingCommand(null);
+    setPendingCap(null);
   }, []);
 
   const handleAgentAction = useCallback(
     (command: 'retry' | 'force_kill', agentId: string) => {
       setCommandError(null);
       if (DESTRUCTIVE_COMMANDS.has(command)) {
-        // For per-agent destructive actions we could open the same modal;
-        // to keep Phase 1 minimal we reuse the non-agent modal path by
-        // encoding the agentId in a sentinel field. `force_kill` is the
-        // only destructive per-agent command today.
         const confirmed = window.confirm(
           `Force-kill agent ${agentId.slice(0, 8)}? This cannot be undone.`,
         );
@@ -151,6 +212,36 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
       void runControlCommand(command, { agentId });
     },
     [runControlCommand],
+  );
+
+  /**
+   * Wrapped config-edit handler passed down to `ConfigPanel`. For
+   * destructive transitions (concurrency_cap lowered) we pop the
+   * ConfirmDialog first (spec §17 Risk 6).
+   */
+  const handleConfigEdit = useCallback(
+    async (key: string, value: string): Promise<void> => {
+      if (key === 'concurrency_cap') {
+        const entries = data?.dispatcherState?.config ?? [];
+        const current = entries.find((e) => e.key === 'concurrency_cap');
+        const currentValue = current ? parsePositiveInt(current.value) : null;
+        const nextValue = parsePositiveInt(value);
+        if (
+          currentValue !== null &&
+          nextValue !== null &&
+          nextValue < currentValue
+        ) {
+          // Lowering the cap — pop the ConfirmDialog and let the commit
+          // happen in `handleConfirm`. Return immediately so ConfigPanel's
+          // local state doesn't stay in "editing".
+          setPendingCap({ current: currentValue, next: nextValue });
+          setPendingCommand(LOWER_CAP_CONFIRM);
+          return;
+        }
+      }
+      await commitConfigEdit(key, value);
+    },
+    [commitConfigEdit, data],
   );
 
   // Loading states — show the skeleton while either auth or the first
@@ -171,53 +262,104 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
 
   return (
     <div>
-      <h1 className={PAGE_TITLE}>Dispatcher</h1>
-      <p className="mt-2 text-sm text-muted-foreground">
-        Monitor and control the dispatcher daemon. Polls every {POLL_INTERVAL_MS / 1000}s.
-      </p>
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-x-6 gap-y-2 border-b border-border pb-3 mb-4">
+        <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+          <h1 className={PAGE_TITLE}>Dispatcher</h1>
+          <DispatcherHeader currentRun={state?.currentRun ?? null} />
+        </div>
+        <DispatcherControls
+          currentRun={state?.currentRun ?? null}
+          disabled={controlLoading}
+          onControlClick={handleControlClick}
+        />
+      </div>
+
+      {commandError && (
+        <div
+          role="alert"
+          className="mb-4 rounded bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-900/30 dark:text-red-200"
+        >
+          Command failed: {commandError}
+        </div>
+      )}
 
       {showInitialLoad ? (
-        <div className="mt-6">
-          <SkeletonShell />
-        </div>
+        <SkeletonShell />
       ) : (
-        <div className="mt-6 space-y-8">
-          <DispatcherHeader currentRun={state?.currentRun ?? null} />
-
-          {commandError && (
-            <div
-              role="alert"
-              className="rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-700 dark:bg-red-900/30 dark:text-red-200"
-            >
-              Command failed: {commandError}
+        <>
+          <div className="grid grid-cols-1 gap-x-6 gap-y-6 lg:grid-cols-2">
+            {/* Left column: queue panels */}
+            <div className="space-y-6">
+              <QueuePanel
+                queueReady={state?.queueReady ?? []}
+                queueBlocked={state?.queueBlocked ?? []}
+              />
             </div>
-          )}
 
-          <DispatcherControls
-            currentRun={state?.currentRun ?? null}
-            disabled={controlLoading}
-            onControlClick={handleControlClick}
+            {/* Right column: active agents + recently completed */}
+            <div className="space-y-6">
+              <ActiveAgentsTable
+                agents={state?.activeAgents ?? []}
+                disabled={controlLoading}
+                onAgentAction={handleAgentAction}
+              />
+              <RecentCompletionsPanel
+                completions={state?.recentCompletions ?? []}
+              />
+            </div>
+          </div>
+
+          <ConfigPanel
+            entries={state?.config ?? []}
+            spawnFrozenUntil={state?.spawnFrozenUntil ?? null}
+            onCommitEdit={handleConfigEdit}
+            errorMessage={configError}
+            busyKey={busyConfigKey}
           />
 
-          <ActiveAgentsTable
-            agents={state?.activeAgents ?? []}
-            disabled={controlLoading}
-            onAgentAction={handleAgentAction}
-          />
+          <div className="mt-6">
+            <RecentFailuresPanel failures={state?.recentFailures ?? []} />
+          </div>
 
-          <QueuePanel queueDepth={state?.queueDepth ?? 0} />
-
-          <RecentFailuresPanel failures={state?.recentFailures ?? []} />
-
-          <ConfigPanel configKeys={CONFIG_KEYS} spawnFrozenUntil={state?.spawnFrozenUntil ?? null} />
-        </div>
+          <p className="mt-4 text-xs text-muted-foreground">
+            Daemon command handlers tracked in{' '}
+            <a
+              href="https://github.com/judgemind/judgemind/issues/2801"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent underline-offset-2 hover:underline"
+            >
+              #2801
+            </a>
+            . Control buttons write to <code className="font-mono">dispatcher.commands</code>{' '}
+            today; daemon-side handlers land with that issue.
+          </p>
+        </>
       )}
 
       <ConfirmDialog
         command={pendingCommand}
+        capDetail={pendingCommand === LOWER_CAP_CONFIRM ? pendingCap : null}
         onConfirm={handleConfirm}
         onCancel={handleCancel}
       />
     </div>
   );
+}
+
+function parsePositiveInt(jsonValue: string): number | null {
+  try {
+    const raw = JSON.parse(jsonValue);
+    if (typeof raw === 'number' && Number.isInteger(raw) && raw >= 0) return raw;
+    if (typeof raw === 'string') {
+      const n = Number.parseInt(raw, 10);
+      return Number.isFinite(n) && n >= 0 ? n : null;
+    }
+    return null;
+  } catch {
+    // jsonValue may already be a bare integer string like "3" from the
+    // config editor — try a direct parse as a fallback.
+    const n = Number.parseInt(jsonValue, 10);
+    return Number.isFinite(n) && n >= 0 ? n : null;
+  }
 }

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherHeader.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherHeader.tsx
@@ -5,21 +5,21 @@ import { formatUptime } from './format-helpers';
 
 type DaemonStatus = 'running' | 'paused' | 'stopped' | 'unhealthy';
 
-// "Stopped" intentionally uses the neutral design tokens rather than a
-// status color — per BRAND.md, only running/paused/unhealthy carry
-// semantic significance, and a "stopped" daemon is a calm neutral state.
-const STATUS_STYLES: Record<DaemonStatus, string> = {
-  running: 'bg-green-100 border-green-300 text-green-800 dark:bg-green-900/30 dark:border-green-700 dark:text-green-300',
-  paused: 'bg-yellow-100 border-yellow-300 text-yellow-800 dark:bg-yellow-900/30 dark:border-yellow-700 dark:text-yellow-300',
-  stopped: 'bg-muted border-border text-muted-foreground',
-  unhealthy: 'bg-red-100 border-red-300 text-red-800 dark:bg-red-900/30 dark:border-red-700 dark:text-red-300',
-};
-
+// Per #2805 §2.3 the pill is informational status, not a CTA — kept
+// compact (text-xs) with a subtle colored dot + neutral surround rather
+// than the previous large filled badge. Borderless.
 const STATUS_DOT: Record<DaemonStatus, string> = {
   running: 'bg-green-500',
   paused: 'bg-yellow-500',
-  stopped: 'bg-muted-foreground/60',
+  stopped: 'bg-stone-400',
   unhealthy: 'bg-red-500',
+};
+
+const STATUS_TEXT: Record<DaemonStatus, string> = {
+  running: 'text-green-700 dark:text-green-300',
+  paused: 'text-yellow-700 dark:text-yellow-300',
+  stopped: 'text-muted-foreground',
+  unhealthy: 'text-red-700 dark:text-red-300',
 };
 
 /**
@@ -41,7 +41,6 @@ export function deriveDaemonStatus(
   if (!run) return 'stopped';
   if (run.stoppedAt) return 'stopped';
   const heartbeat = new Date(run.heartbeatTs).getTime();
-  // Malformed heartbeatTs → cannot verify liveness → treat as unhealthy.
   if (!Number.isFinite(heartbeat)) return 'unhealthy';
   const ageMs = nowMs - heartbeat;
   if (ageMs > 3 * 60 * 1000) return 'unhealthy';
@@ -54,6 +53,14 @@ interface DispatcherHeaderProps {
   nowMs?: number;
 }
 
+/**
+ * Compact left-cluster status block for the one-line header row
+ * (#2805 §1.1). Renders: status pill · uptime · version sha · host,
+ * all inline, borderless, muted/monospace metadata.
+ *
+ * The outer polite live region announces status-pill transitions
+ * without stepping on focused elements (#2805 §3.5).
+ */
 export function DispatcherHeader({ currentRun, nowMs }: DispatcherHeaderProps) {
   const status = deriveDaemonStatus(currentRun, nowMs);
   const uptime = currentRun && !currentRun.stoppedAt
@@ -62,43 +69,38 @@ export function DispatcherHeader({ currentRun, nowMs }: DispatcherHeaderProps) {
   const versionSha = currentRun?.versionSha ?? null;
 
   return (
-    <section
-      aria-labelledby="dispatcher-header-heading"
-      className="flex flex-wrap items-center gap-x-6 gap-y-3 rounded-lg border border-border bg-card p-4"
+    <div
+      aria-live="polite"
+      className="flex flex-wrap items-center gap-x-2 font-mono text-xs text-muted-foreground"
     >
-      <h2 id="dispatcher-header-heading" className="sr-only">
-        Daemon status
-      </h2>
-
       <span
         data-testid="daemon-status-pill"
-        className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 text-sm font-medium ${STATUS_STYLES[status]}`}
+        className="inline-flex items-center gap-1.5"
       >
         <span
           aria-hidden="true"
-          className={`inline-block h-2.5 w-2.5 rounded-full ${STATUS_DOT[status]}`}
+          className={`inline-block h-2 w-2 rounded-full ${STATUS_DOT[status]}`}
         />
-        <span className="capitalize">{status}</span>
-      </span>
-
-      <div className="text-sm">
-        <span className="text-muted-foreground">Uptime: </span>
-        <span className="font-medium text-foreground">{uptime ?? '—'}</span>
-      </div>
-
-      <div className="text-sm">
-        <span className="text-muted-foreground">Version: </span>
-        <span className="font-mono text-xs text-foreground">
-          {versionSha ? versionSha.slice(0, 8) : '—'}
+        <span className={`font-medium capitalize ${STATUS_TEXT[status]}`}>
+          {status}
         </span>
-      </div>
-
+      </span>
+      <span aria-hidden="true">&middot;</span>
+      <span>
+        uptime <span className="text-foreground">{uptime ?? '—'}</span>
+      </span>
+      <span aria-hidden="true">&middot;</span>
+      <span>
+        sha <span className="text-foreground">{versionSha ? versionSha.slice(0, 8) : '—'}</span>
+      </span>
       {currentRun?.host && (
-        <div className="text-sm">
-          <span className="text-muted-foreground">Host: </span>
-          <span className="font-mono text-xs text-foreground">{currentRun.host}</span>
-        </div>
+        <>
+          <span aria-hidden="true">&middot;</span>
+          <span>
+            host <span className="text-foreground">{currentRun.host}</span>
+          </span>
+        </>
       )}
-    </section>
+    </div>
   );
 }

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherHeader.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherHeader.tsx
@@ -11,7 +11,7 @@ type DaemonStatus = 'running' | 'paused' | 'stopped' | 'unhealthy';
 const STATUS_DOT: Record<DaemonStatus, string> = {
   running: 'bg-green-500',
   paused: 'bg-yellow-500',
-  stopped: 'bg-stone-400',
+  stopped: 'bg-muted-foreground/60',
   unhealthy: 'bg-red-500',
 };
 

--- a/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
@@ -1,38 +1,165 @@
 'use client';
 
 import { SECTION_HEADING } from '@/lib/typography';
+import type { QueueItem } from '@/lib/dispatcher-queries';
+import { formatRelativeTime } from './format-helpers';
+import { IssueLink, PriorityBadge } from './ui-primitives';
 
 interface QueuePanelProps {
-  queueDepth: number;
+  /** Agent-ready issues from the latest `dispatcher.queue_snapshots`. */
+  queueReady: readonly QueueItem[];
+  /** Open issues labelled `status/blocked`. */
+  queueBlocked: readonly QueueItem[];
+  /** Override for deterministic tests. */
+  nowMs?: number;
 }
 
 /**
- * Queue panel. In Phase 1 the GraphQL resolver returns queueDepth = 0
- * until the daemon's queue-scan lands (see sub-task C follow-up), so this
- * is a minimal summary card. Phase 2 will expand to a full per-issue
- * listing with blocked-by counts.
+ * Two sibling queue panels (#2805 §1.3) — agent-ready on the left,
+ * blocked on the right. Each panel is borderless with a subtle heading
+ * divider, and each row is a `Link`-able hot link via `IssueLink`.
+ *
+ * Capped server-side at 10 entries per panel; more is dispatcher-internal
+ * scheduling state, not useful on the overview page.
  */
-export function QueuePanel({ queueDepth }: QueuePanelProps) {
+export function QueuePanel({ queueReady, queueBlocked, nowMs }: QueuePanelProps) {
   return (
-    <section
-      aria-labelledby="queue-heading"
-      className="rounded-lg border border-border bg-card p-4"
+    <div
+      className="grid grid-cols-1 gap-x-6 gap-y-4 md:grid-cols-2"
+      data-testid="queue-panels"
     >
-      <h2 id="queue-heading" className={SECTION_HEADING}>
-        Queue
-      </h2>
-      <div className="mt-3">
-        <p className="text-sm text-foreground">
-          <span className="font-semibold">{queueDepth}</span>{' '}
-          <span className="text-muted-foreground">
-            {queueDepth === 1 ? 'issue' : 'issues'} ready for pickup
-          </span>
-        </p>
-        <p className="mt-2 text-xs text-muted-foreground">
-          Per-issue listing with blocked-by counts lands with the daemon queue-scan
-          follow-up.
-        </p>
+      <QueueReadyPanel items={queueReady} nowMs={nowMs} />
+      <QueueBlockedPanel items={queueBlocked} nowMs={nowMs} />
+    </div>
+  );
+}
+
+function QueueReadyPanel({
+  items,
+  nowMs,
+}: {
+  items: readonly QueueItem[];
+  nowMs?: number;
+}) {
+  return (
+    <section aria-labelledby="queue-ready-heading">
+      <div className="flex items-center justify-between border-b border-border pb-2 mb-2">
+        <h2 id="queue-ready-heading" className={SECTION_HEADING}>
+          Queue: Agent-ready
+        </h2>
+        <span className="font-mono text-xs text-muted-foreground">
+          {items.length} shown
+        </span>
       </div>
+      {items.length === 0 ? (
+        <p className="py-2 text-sm text-muted-foreground">
+          Queue empty — file an issue with <code className="font-mono">agent/ready</code> to seed.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border">
+          {items.map((item, index) => (
+            <QueueRow
+              key={item.issueNumber}
+              item={item}
+              slot={index + 1}
+              nowMs={nowMs}
+            />
+          ))}
+        </ul>
+      )}
     </section>
+  );
+}
+
+function QueueBlockedPanel({
+  items,
+  nowMs,
+}: {
+  items: readonly QueueItem[];
+  nowMs?: number;
+}) {
+  return (
+    <section aria-labelledby="queue-blocked-heading">
+      <div className="flex items-center justify-between border-b border-border pb-2 mb-2">
+        <h2 id="queue-blocked-heading" className={SECTION_HEADING}>
+          Queue: Blocked
+        </h2>
+        <span className="font-mono text-xs text-muted-foreground">
+          {items.length} shown
+        </span>
+      </div>
+      {items.length === 0 ? (
+        <p className="py-2 text-sm text-muted-foreground">
+          No blocked issues.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border">
+          {items.map((item) => (
+            <QueueRow
+              key={item.issueNumber}
+              item={item}
+              nowMs={nowMs}
+              blocked
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function QueueRow({
+  item,
+  slot,
+  blocked,
+  nowMs,
+}: {
+  item: QueueItem;
+  slot?: number;
+  blocked?: boolean;
+  nowMs?: number;
+}) {
+  const timestamp = formatRelativeTime(item.createdAt, nowMs);
+  return (
+    <li className="flex items-center gap-3 py-2 text-sm hover:bg-muted/50">
+      <div className="flex-shrink-0" data-testid="queue-row-number">
+        <IssueLink number={item.issueNumber} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <span className="block truncate text-foreground" title={item.title}>
+          {item.title}
+        </span>
+      </div>
+      <div className="flex-shrink-0">
+        <PriorityBadge priority={item.priority} />
+      </div>
+      <div
+        className="w-10 flex-shrink-0 text-right font-mono text-xs text-muted-foreground"
+        data-testid="queue-row-slot"
+      >
+        {blocked ? (
+          item.blockedBy.length > 0 ? (
+            <span
+              className="cursor-help"
+              title={item.blockedBy.map((n) => `#${n}`).join(', ')}
+            >
+              [{item.blockedBy.length}]
+            </span>
+          ) : (
+            <span>—</span>
+          )
+        ) : slot !== undefined ? (
+          <span>#{slot}</span>
+        ) : (
+          <span>—</span>
+        )}
+      </div>
+      <div
+        className="w-20 flex-shrink-0 text-right text-xs text-muted-foreground"
+        title={item.createdAt}
+      >
+        {timestamp}
+      </div>
+    </li>
   );
 }

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { SECTION_HEADING } from '@/lib/typography';
+import type { RecentCompletion } from '@/lib/dispatcher-queries';
+import { formatRelativeTime } from './format-helpers';
+import { IssueLink, OutcomePill, PRLink } from './ui-primitives';
+
+interface RecentCompletionsPanelProps {
+  completions: readonly RecentCompletion[];
+  /** Override for deterministic tests. */
+  nowMs?: number;
+}
+
+/**
+ * The "Recently completed" panel (#2805 §1.5). Newest terminal-state
+ * agents (succeeded / failed / crashed) in the operator's recent history.
+ * Each row links to the issue and, when available, the PR.
+ *
+ * Borderless. Lives in the right column below Active agents.
+ */
+export function RecentCompletionsPanel({
+  completions,
+  nowMs,
+}: RecentCompletionsPanelProps) {
+  return (
+    <section aria-labelledby="recent-completions-heading">
+      <div className="flex items-center justify-between border-b border-border pb-2 mb-2">
+        <h2 id="recent-completions-heading" className={SECTION_HEADING}>
+          Recently completed ({completions.length})
+        </h2>
+      </div>
+      {completions.length === 0 ? (
+        <p className="py-2 text-sm text-muted-foreground">
+          No completed agents yet.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border">
+          {completions.map((completion) => (
+            <RecentCompletionRow
+              key={completion.agentId}
+              completion={completion}
+              nowMs={nowMs}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function RecentCompletionRow({
+  completion,
+  nowMs,
+}: {
+  completion: RecentCompletion;
+  nowMs?: number;
+}) {
+  const relative = formatRelativeTime(completion.endedAt, nowMs);
+  return (
+    <li className="flex items-center gap-3 py-2 text-sm hover:bg-muted/50">
+      <span className="flex-shrink-0">
+        <OutcomePill status={completion.status} />
+      </span>
+      <span className="flex-shrink-0">
+        <IssueLink number={completion.issueNumber} />
+      </span>
+      <span
+        className="min-w-0 flex-1 truncate text-foreground"
+        title={completion.issueTitle ?? ''}
+      >
+        {completion.issueTitle ?? (
+          <span className="italic text-muted-foreground">(title unavailable)</span>
+        )}
+      </span>
+      <span className="w-20 flex-shrink-0 text-right text-xs">
+        {completion.prNumber !== null ? (
+          <span className="inline-flex items-center gap-0.5">
+            <PRLink number={completion.prNumber} />
+            <span aria-hidden="true" className="text-muted-foreground">&nearr;</span>
+          </span>
+        ) : (
+          <span className="italic text-muted-foreground">(no PR)</span>
+        )}
+      </span>
+      <span
+        className="w-20 flex-shrink-0 text-right text-xs text-muted-foreground"
+        title={completion.endedAt}
+      >
+        {relative}
+      </span>
+    </li>
+  );
+}

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentFailuresPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentFailuresPanel.tsx
@@ -2,64 +2,73 @@
 
 import { SECTION_HEADING } from '@/lib/typography';
 import type { DispatcherFailure } from '@/lib/dispatcher-queries';
-import { groupFailuresByCategory } from './format-helpers';
+import { formatRelativeTime, groupFailuresByCategory } from './format-helpers';
+import { IssueLink } from './ui-primitives';
 
 interface RecentFailuresPanelProps {
   failures: readonly DispatcherFailure[];
+  /** Override for deterministic tests. */
+  nowMs?: number;
 }
 
-export function RecentFailuresPanel({ failures }: RecentFailuresPanelProps) {
+/**
+ * Recent failures panel (#2805 §1.7) — same data, borderless. Category
+ * renders as a muted pill; most-recent timestamp is a relative string
+ * with the raw ISO on hover.
+ */
+export function RecentFailuresPanel({ failures, nowMs }: RecentFailuresPanelProps) {
   const groups = groupFailuresByCategory(failures);
 
   return (
-    <section
-      aria-labelledby="recent-failures-heading"
-      className="rounded-lg border border-border bg-card"
-    >
-      <div className="border-b border-border p-4">
+    <section aria-labelledby="recent-failures-heading">
+      <div className="flex items-center justify-between border-b border-border pb-2 mb-2">
         <h2 id="recent-failures-heading" className={SECTION_HEADING}>
           Recent failures (last 24h)
         </h2>
       </div>
-
       {groups.length === 0 ? (
-        <p className="p-6 text-center text-sm text-muted-foreground">
+        <p className="py-2 text-sm text-muted-foreground">
           No failures in the last 24 hours.
         </p>
       ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-muted-foreground">
-                <th scope="col" className="p-3">Category</th>
-                <th scope="col" className="p-3">Count</th>
-                <th scope="col" className="p-3">Most recent</th>
-                <th scope="col" className="p-3">Issue</th>
-              </tr>
-            </thead>
-            <tbody>
-              {groups.map((group) => (
-                <tr
-                  key={group.category}
-                  className="border-b border-border last:border-b-0"
-                >
-                  <td className="p-3 font-mono text-xs text-foreground">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <th scope="col" className="py-2 font-medium">Category</th>
+              <th scope="col" className="py-2 font-medium">Count</th>
+              <th scope="col" className="py-2 font-medium">Most recent</th>
+              <th scope="col" className="py-2 font-medium">Issue</th>
+            </tr>
+          </thead>
+          <tbody>
+            {groups.map((group) => (
+              <tr
+                key={group.category}
+                className="border-t border-border hover:bg-muted/50"
+              >
+                <td className="py-2">
+                  <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
                     {group.category}
-                  </td>
-                  <td className="p-3 text-foreground">{group.count}</td>
-                  <td className="p-3 text-xs text-muted-foreground">
-                    {group.mostRecent.ts}
-                  </td>
-                  <td className="p-3 text-foreground">
-                    {group.mostRecent.issueNumber !== null
-                      ? `#${group.mostRecent.issueNumber}`
-                      : '—'}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+                  </span>
+                </td>
+                <td className="py-2 font-mono text-foreground">{group.count}</td>
+                <td
+                  className="py-2 text-xs text-muted-foreground"
+                  title={group.mostRecent.ts}
+                >
+                  {formatRelativeTime(group.mostRecent.ts, nowMs)}
+                </td>
+                <td className="py-2">
+                  {group.mostRecent.issueNumber !== null ? (
+                    <IssueLink number={group.mostRecent.issueNumber} />
+                  ) : (
+                    <span className="text-muted-foreground">&mdash;</span>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )}
     </section>
   );

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * Tests for the dispatcher admin dashboard (#2805).
+ *
+ * Focus areas:
+ *   - Destructive control mutations always inject `X-MFA-Token` in the
+ *     Apollo `context.headers` (#2805 §1.1 / #2803 Option A).
+ *   - Config-edit mutations always inject `X-MFA-Token`.
+ *   - Lowering `concurrency_cap` pops the ConfirmDialog before committing.
+ *   - Raising `concurrency_cap` commits immediately without dialog.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Apollo mocks — one global `useMutation` that distinguishes by operation
+// name, so the test can inspect the `context.headers` sent on each call.
+// ---------------------------------------------------------------------------
+
+const mockControlMutate = vi.fn().mockResolvedValue({ data: {} });
+const mockSetConfigMutate = vi.fn().mockResolvedValue({ data: {} });
+const mockRefetch = vi.fn().mockResolvedValue({ data: {} });
+
+let mockQueryData: { dispatcherState?: Record<string, unknown> } | undefined;
+
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual<typeof import('@apollo/client')>('@apollo/client');
+  return {
+    ...actual,
+    useQuery: () => ({
+      data: mockQueryData,
+      loading: false,
+      error: undefined,
+      refetch: mockRefetch,
+    }),
+    useMutation: (doc: { definitions?: Array<{ name?: { value?: string } }> }) => {
+      const opName = doc?.definitions?.[0]?.name?.value ?? '';
+      if (opName === 'DispatcherControl') {
+        return [mockControlMutate, { loading: false }];
+      }
+      if (opName === 'DispatcherSetConfig') {
+        return [mockSetConfigMutate, { loading: false }];
+      }
+      return [vi.fn(), { loading: false }];
+    },
+  };
+});
+
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    throw new Error('notFound called in test');
+  },
+}));
+
+vi.mock('@/providers/AuthProvider', () => ({
+  useAuth: () => ({
+    user: { id: '1', email: 'admin@test.com', role: 'admin' },
+    loading: false,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const BASE_STATE = {
+  currentRun: {
+    runId: 'run-1',
+    startedAt: '2026-04-18T10:00:00Z',
+    stoppedAt: null,
+    heartbeatTs: new Date().toISOString(),
+    versionSha: 'deadbeefcafe0000',
+    host: 'ip-10-0-0-1',
+    pid: 1234,
+  },
+  activeAgents: [],
+  recentFailures: [],
+  queueDepth: 0,
+  queueReady: [],
+  queueBlocked: [],
+  recentCompletions: [],
+  config: [
+    {
+      key: 'concurrency_cap',
+      value: '3',
+      updatedAt: '2026-04-18T09:00:00Z',
+      updatedBy: 'init',
+    },
+    {
+      key: 'backoff_seconds',
+      value: '[60,300,900]',
+      updatedAt: '2026-04-18T09:00:00Z',
+      updatedBy: 'init',
+    },
+  ],
+  spawnFrozenUntil: null,
+};
+
+import { DispatcherDashboard } from '../DispatcherDashboard';
+
+function renderDashboard() {
+  return render(<DispatcherDashboard />);
+}
+
+describe('DispatcherDashboard — MFA header plumbing', () => {
+  beforeEach(() => {
+    mockControlMutate.mockClear();
+    mockSetConfigMutate.mockClear();
+    mockRefetch.mockClear();
+    mockQueryData = { dispatcherState: { ...BASE_STATE } };
+  });
+
+  it('non-destructive commands (Pause) do NOT send X-MFA-Token', async () => {
+    renderDashboard();
+    fireEvent.click(screen.getByRole('button', { name: /^pause$/i }));
+    await waitFor(() => {
+      expect(mockControlMutate).toHaveBeenCalled();
+    });
+    const call = mockControlMutate.mock.calls[0][0];
+    expect(call.variables).toEqual({ command: 'pause', payload: {} });
+    expect(call.context).toBeUndefined();
+  });
+
+  it('destructive Stop requires confirm + sends X-MFA-Token on confirm', async () => {
+    renderDashboard();
+    fireEvent.click(screen.getByRole('button', { name: /force-stop/i }));
+    // ConfirmDialog appears — the mutation has NOT fired yet.
+    expect(mockControlMutate).not.toHaveBeenCalled();
+    const confirm = await screen.findByTestId('confirm-dialog-confirm');
+    fireEvent.click(confirm);
+    await waitFor(() => {
+      expect(mockControlMutate).toHaveBeenCalled();
+    });
+    const call = mockControlMutate.mock.calls[0][0];
+    expect(call.variables.command).toBe('stop');
+    expect(call.context?.headers).toEqual({ 'X-MFA-Token': 'phase1-placeholder' });
+  });
+
+  it('destructive Drain (stop drain) sends X-MFA-Token on confirm', async () => {
+    renderDashboard();
+    fireEvent.click(screen.getByRole('button', { name: /stop \(drain\)/i }));
+    const confirm = await screen.findByTestId('confirm-dialog-confirm');
+    fireEvent.click(confirm);
+    await waitFor(() => {
+      expect(mockControlMutate).toHaveBeenCalled();
+    });
+    const call = mockControlMutate.mock.calls[0][0];
+    expect(call.variables.command).toBe('drain');
+    expect(call.context?.headers).toEqual({ 'X-MFA-Token': 'phase1-placeholder' });
+  });
+});
+
+describe('DispatcherDashboard — config edit lifecycle', () => {
+  beforeEach(() => {
+    mockControlMutate.mockClear();
+    mockSetConfigMutate.mockClear();
+    mockRefetch.mockClear();
+    mockQueryData = { dispatcherState: { ...BASE_STATE } };
+  });
+
+  it('raising concurrency_cap commits immediately with MFA header', async () => {
+    renderDashboard();
+    const capButton = screen.getByTestId('config-value-concurrency_cap');
+    fireEvent.click(capButton);
+    const input = screen.getByTestId('config-input-concurrency_cap') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '4' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() => {
+      expect(mockSetConfigMutate).toHaveBeenCalled();
+    });
+    const call = mockSetConfigMutate.mock.calls[0][0];
+    expect(call.variables).toEqual({ key: 'concurrency_cap', value: '4' });
+    expect(call.context?.headers).toEqual({ 'X-MFA-Token': 'phase1-placeholder' });
+  });
+
+  it('lowering concurrency_cap pops confirm dialog before committing', async () => {
+    renderDashboard();
+    const capButton = screen.getByTestId('config-value-concurrency_cap');
+    fireEvent.click(capButton);
+    const input = screen.getByTestId('config-input-concurrency_cap') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '1' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    // Dialog is open — mutation has NOT fired.
+    const confirm = await screen.findByTestId('confirm-dialog-confirm');
+    expect(mockSetConfigMutate).not.toHaveBeenCalled();
+    // Dialog copy mentions the transition.
+    expect(screen.getByText(/lower concurrency cap/i)).toBeInTheDocument();
+    expect(screen.getByText(/from 3 to 1/i)).toBeInTheDocument();
+    fireEvent.click(confirm);
+    await waitFor(() => {
+      expect(mockSetConfigMutate).toHaveBeenCalled();
+    });
+    const call = mockSetConfigMutate.mock.calls[0][0];
+    expect(call.variables).toEqual({ key: 'concurrency_cap', value: '1' });
+    expect(call.context?.headers).toEqual({ 'X-MFA-Token': 'phase1-placeholder' });
+  });
+
+  it('Escape cancels an in-progress cap edit without firing the mutation', async () => {
+    renderDashboard();
+    const capButton = screen.getByTestId('config-value-concurrency_cap');
+    fireEvent.click(capButton);
+    const input = screen.getByTestId('config-input-concurrency_cap') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '2' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+    // Back to the display button — no mutation fired.
+    expect(screen.getByTestId('config-value-concurrency_cap')).toBeInTheDocument();
+    expect(mockSetConfigMutate).not.toHaveBeenCalled();
+  });
+
+  it('backoff edit commits with MFA header + preserves higher attempts in array', async () => {
+    renderDashboard();
+    const backoffButton = screen.getByTestId('config-value-backoff_seconds');
+    fireEvent.click(backoffButton);
+    const input = screen.getByTestId('config-input-backoff_seconds') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '120' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() => {
+      expect(mockSetConfigMutate).toHaveBeenCalled();
+    });
+    const call = mockSetConfigMutate.mock.calls[0][0];
+    expect(call.variables.key).toBe('backoff_seconds');
+    // First slot updated; subsequent retry delays preserved.
+    expect(JSON.parse(call.variables.value)).toEqual([120, 300, 900]);
+    expect(call.context?.headers).toEqual({ 'X-MFA-Token': 'phase1-placeholder' });
+  });
+});

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherHeader.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherHeader.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DispatcherHeader, deriveDaemonStatus } from '../DispatcherHeader';
+
+const now = Date.parse('2026-04-18T12:00:00Z');
+
+describe('deriveDaemonStatus', () => {
+  it('null run → stopped', () => {
+    expect(deriveDaemonStatus(null, now)).toBe('stopped');
+  });
+
+  it('stoppedAt set → stopped', () => {
+    const run = {
+      runId: 'r',
+      startedAt: '2026-04-18T00:00:00Z',
+      stoppedAt: '2026-04-18T11:00:00Z',
+      heartbeatTs: '2026-04-18T11:00:00Z',
+      versionSha: 'deadbeef',
+      host: 'h',
+      pid: 1,
+    };
+    expect(deriveDaemonStatus(run, now)).toBe('stopped');
+  });
+
+  it('stale heartbeat → unhealthy', () => {
+    const run = {
+      runId: 'r',
+      startedAt: '2026-04-18T00:00:00Z',
+      stoppedAt: null,
+      heartbeatTs: '2026-04-18T11:50:00Z',
+      versionSha: 'deadbeef',
+      host: 'h',
+      pid: 1,
+    };
+    expect(deriveDaemonStatus(run, now)).toBe('unhealthy');
+  });
+
+  it('fresh heartbeat → running', () => {
+    const run = {
+      runId: 'r',
+      startedAt: '2026-04-18T00:00:00Z',
+      stoppedAt: null,
+      heartbeatTs: '2026-04-18T11:59:30Z',
+      versionSha: 'deadbeef',
+      host: 'h',
+      pid: 1,
+    };
+    expect(deriveDaemonStatus(run, now)).toBe('running');
+  });
+});
+
+describe('DispatcherHeader', () => {
+  const run = {
+    runId: 'r',
+    startedAt: '2026-04-18T10:00:00Z',
+    stoppedAt: null,
+    heartbeatTs: '2026-04-18T11:59:30Z',
+    versionSha: 'deadbeefcafe0000',
+    host: 'ip-10-0-11-146',
+    pid: 1,
+  };
+
+  it('renders the one-line header with pill + metadata (no borders)', () => {
+    const { container } = render(<DispatcherHeader currentRun={run} nowMs={now} />);
+    const pill = screen.getByTestId('daemon-status-pill');
+    expect(pill.textContent).toMatch(/running/i);
+    // uptime = 2h 0m
+    expect(screen.getByText('2h 0m')).toBeInTheDocument();
+    // sha truncated to 8 chars
+    expect(screen.getByText('deadbeef')).toBeInTheDocument();
+    expect(screen.getByText('ip-10-0-11-146')).toBeInTheDocument();
+    // No decorative border/card wrapper.
+    const outer = container.firstChild as HTMLElement;
+    expect(outer.className).not.toContain('border');
+    expect(outer.className).not.toContain('bg-card');
+    expect(outer.className).not.toContain('rounded');
+  });
+
+  it('renders em-dash placeholders when no run exists', () => {
+    render(<DispatcherHeader currentRun={null} nowMs={now} />);
+    expect(screen.getByTestId('daemon-status-pill').textContent).toMatch(/stopped/i);
+    // uptime and sha both em-dashed.
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('status pill container has aria-live polite for transition announcements', () => {
+    const { container } = render(<DispatcherHeader currentRun={run} nowMs={now} />);
+    const outer = container.firstChild as HTMLElement;
+    expect(outer.getAttribute('aria-live')).toBe('polite');
+  });
+});

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueuePanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueuePanel.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueuePanel } from '../QueuePanel';
+import type { QueueItem } from '@/lib/dispatcher-queries';
+
+const now = Date.parse('2026-04-18T12:00:00Z');
+
+function item(overrides: Partial<QueueItem>): QueueItem {
+  return {
+    issueNumber: 1,
+    title: 'Example issue',
+    priority: 'p1',
+    labels: ['priority/p1', 'agent/ready'],
+    createdAt: '2026-04-18T11:00:00Z',
+    blockedBy: [],
+    ...overrides,
+  };
+}
+
+describe('QueuePanel', () => {
+  it('renders empty states for both panels when no items', () => {
+    render(<QueuePanel queueReady={[]} queueBlocked={[]} nowMs={now} />);
+    expect(screen.getByText(/queue empty/i)).toBeInTheDocument();
+    expect(screen.getByText(/no blocked issues/i)).toBeInTheDocument();
+  });
+
+  it('renders agent-ready rows with hot-linked issue numbers', () => {
+    const items = [
+      item({ issueNumber: 2801, title: 'wire dispatcherControl through to daemon' }),
+      item({ issueNumber: 2802, title: 'recently completed panel', priority: 'p2' }),
+    ];
+    render(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
+    expect(screen.getByTestId('issue-link-2801')).toHaveAttribute(
+      'href',
+      'https://github.com/judgemind/judgemind/issues/2801',
+    );
+    expect(screen.getByTestId('issue-link-2802')).toBeInTheDocument();
+    // Slot numbers #1, #2.
+    expect(screen.getByText('#1')).toBeInTheDocument();
+    expect(screen.getByText('#2')).toBeInTheDocument();
+    // Priority badges present.
+    expect(screen.getByTestId('priority-badge-p1')).toBeInTheDocument();
+    expect(screen.getByTestId('priority-badge-p2')).toBeInTheDocument();
+  });
+
+  it('renders blocked rows with [N] blocker count and tooltip', () => {
+    const blocked = [
+      item({ issueNumber: 2500, title: 'blocked issue', blockedBy: [2500, 2600] }),
+    ];
+    render(<QueuePanel queueReady={[]} queueBlocked={blocked} nowMs={now} />);
+    expect(screen.getByText('[2]')).toBeInTheDocument();
+    // Tooltip exposes the raw blocker list.
+    const slot = screen.getByText('[2]');
+    expect(slot.getAttribute('title')).toBe('#2500, #2600');
+  });
+});

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/format-helpers.test.ts
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/format-helpers.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatDurationMs,
+  formatRelativeTime,
+  formatUptime,
+  groupFailuresByCategory,
+  shortAgentId,
+  worktreeLogsUrl,
+} from '../format-helpers';
+
+describe('formatDurationMs', () => {
+  it('returns em-dash for negative or non-finite input', () => {
+    expect(formatDurationMs(-1)).toBe('—');
+    expect(formatDurationMs(Number.NaN)).toBe('—');
+  });
+
+  it('formats seconds', () => {
+    expect(formatDurationMs(0)).toBe('0s');
+    expect(formatDurationMs(12_000)).toBe('12s');
+  });
+
+  it('formats minutes and seconds', () => {
+    expect(formatDurationMs(252_000)).toBe('4m 12s');
+  });
+
+  it('formats hours and minutes', () => {
+    expect(formatDurationMs(2 * 3600_000 + 15 * 60_000)).toBe('2h 15m');
+  });
+
+  it('formats days and hours', () => {
+    expect(formatDurationMs(28 * 3600_000)).toBe('1d 4h');
+  });
+});
+
+describe('formatUptime', () => {
+  it('returns em-dash on invalid timestamps', () => {
+    expect(formatUptime('nonsense')).toBe('—');
+  });
+
+  it('returns em-dash on future timestamps', () => {
+    const future = new Date(Date.now() + 1000).toISOString();
+    expect(formatUptime(future)).toBe('—');
+  });
+
+  it('returns a duration for past timestamps', () => {
+    const now = Date.parse('2026-04-18T00:00:00Z');
+    const start = new Date(now - 65_000).toISOString();
+    expect(formatUptime(start, now)).toBe('1m 5s');
+  });
+});
+
+describe('formatRelativeTime', () => {
+  const now = Date.parse('2026-04-18T12:00:00Z');
+
+  it('returns em-dash for null/invalid', () => {
+    expect(formatRelativeTime(null, now)).toBe('—');
+    expect(formatRelativeTime('nonsense', now)).toBe('—');
+  });
+
+  it('returns em-dash for future timestamps', () => {
+    const future = new Date(now + 1000).toISOString();
+    expect(formatRelativeTime(future, now)).toBe('—');
+  });
+
+  it('formats seconds', () => {
+    const ts = new Date(now - 5_000).toISOString();
+    expect(formatRelativeTime(ts, now)).toBe('5s ago');
+  });
+
+  it('formats minutes', () => {
+    const ts = new Date(now - 3 * 60_000).toISOString();
+    expect(formatRelativeTime(ts, now)).toBe('3 min ago');
+  });
+
+  it('formats hours', () => {
+    const ts = new Date(now - 2 * 3600_000).toISOString();
+    expect(formatRelativeTime(ts, now)).toBe('2 h ago');
+  });
+
+  it('formats days', () => {
+    const ts = new Date(now - 3 * 24 * 3600_000).toISOString();
+    expect(formatRelativeTime(ts, now)).toBe('3 d ago');
+  });
+});
+
+describe('shortAgentId', () => {
+  it('returns the id unchanged when short', () => {
+    expect(shortAgentId('abcd')).toBe('abcd');
+  });
+
+  it('truncates to 8 chars with ellipsis', () => {
+    expect(shortAgentId('abcdef01234567')).toBe('abcdef01…');
+  });
+});
+
+describe('worktreeLogsUrl', () => {
+  it('returns a CloudWatch link for an agent-<id> path', () => {
+    const url = worktreeLogsUrl('.claude/worktrees/agent-abcd1234');
+    expect(url).not.toBeNull();
+    expect(url).toContain('agent-abcd1234');
+    expect(url).toContain('judgemind-dispatcher-dev');
+  });
+
+  it('returns null for an unrecognized path', () => {
+    expect(worktreeLogsUrl('/tmp/random')).toBeNull();
+  });
+});
+
+describe('groupFailuresByCategory', () => {
+  it('returns [] on empty input', () => {
+    expect(groupFailuresByCategory([])).toEqual([]);
+  });
+
+  it('groups by category and sorts by count desc', () => {
+    const failures = [
+      { category: 'hook_failure', ts: '2026-04-18T12:00:00Z' },
+      { category: 'hook_failure', ts: '2026-04-18T12:05:00Z' },
+      { category: 'supervisor_timeout', ts: '2026-04-18T12:03:00Z' },
+    ];
+    const groups = groupFailuresByCategory(failures);
+    expect(groups).toHaveLength(2);
+    expect(groups[0].category).toBe('hook_failure');
+    expect(groups[0].count).toBe(2);
+    // mostRecent should be the later ts
+    expect(groups[0].mostRecent.ts).toBe('2026-04-18T12:05:00Z');
+    expect(groups[1].category).toBe('supervisor_timeout');
+  });
+});

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { IssueLink, OutcomePill, PriorityBadge, PRLink } from '../ui-primitives';
+
+describe('IssueLink', () => {
+  it('renders an anchor to the github issue that opens in a new tab', () => {
+    render(<IssueLink number={2805} />);
+    const link = screen.getByTestId('issue-link-2805');
+    expect(link).toHaveAttribute('href', 'https://github.com/judgemind/judgemind/issues/2805');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(link.textContent).toBe('#2805');
+  });
+});
+
+describe('PRLink', () => {
+  it('renders an anchor to the github PR', () => {
+    render(<PRLink number={2740} />);
+    const link = screen.getByTestId('pr-link-2740');
+    expect(link).toHaveAttribute('href', 'https://github.com/judgemind/judgemind/pull/2740');
+    expect(link.textContent).toBe('PR #2740');
+  });
+});
+
+describe('PriorityBadge', () => {
+  it('renders p1 with amber tint', () => {
+    render(<PriorityBadge priority="p1" />);
+    const badge = screen.getByTestId('priority-badge-p1');
+    expect(badge.textContent).toBe('p1');
+    expect(badge.className).toContain('amber');
+  });
+
+  it('renders p0 with red tint', () => {
+    render(<PriorityBadge priority="p0" />);
+    const badge = screen.getByTestId('priority-badge-p0');
+    expect(badge.textContent).toBe('p0');
+    expect(badge.className).toContain('red');
+  });
+
+  it('renders em-dash placeholder for null', () => {
+    render(<PriorityBadge priority={null} />);
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+});
+
+describe('OutcomePill', () => {
+  it('renders succeeded with a checkmark glyph', () => {
+    render(<OutcomePill status="succeeded" />);
+    const pill = screen.getByTestId('outcome-pill-succeeded');
+    expect(pill.getAttribute('aria-label')).toBe('succeeded');
+    expect(pill.textContent).toBe('\u2713');
+  });
+
+  it('renders failed with an X glyph', () => {
+    render(<OutcomePill status="failed" />);
+    const pill = screen.getByTestId('outcome-pill-failed');
+    expect(pill.textContent).toBe('\u2717');
+  });
+
+  it('renders crashed with a warning glyph', () => {
+    render(<OutcomePill status="crashed" />);
+    const pill = screen.getByTestId('outcome-pill-crashed');
+    expect(pill.textContent).toBe('\u26A0');
+  });
+
+  it('renders a fallback for unknown status', () => {
+    render(<OutcomePill status="bogus" />);
+    expect(screen.getByText('?')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/app/(main)/admin/dispatcher/format-helpers.ts
+++ b/packages/web/src/app/(main)/admin/dispatcher/format-helpers.ts
@@ -74,6 +74,32 @@ export function worktreeLogsUrl(worktreePath: string): string | null {
 }
 
 /**
+ * Format a past timestamp as a short relative string like "3 min ago",
+ * "2 h ago", "5 d ago". Returns `'—'` for invalid or future timestamps.
+ *
+ * Buckets:
+ *   - < 60 s     → "Ns ago"
+ *   - < 60 min   → "N min ago"
+ *   - < 24 h     → "N h ago"
+ *   - otherwise  → "N d ago"
+ */
+export function formatRelativeTime(iso: string | null, nowMs: number = Date.now()): string {
+  if (!iso) return '—';
+  const ts = new Date(iso).getTime();
+  if (!Number.isFinite(ts)) return '—';
+  const deltaMs = nowMs - ts;
+  if (deltaMs < 0) return '—';
+  const seconds = Math.floor(deltaMs / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} d ago`;
+}
+
+/**
  * Group failures by the `category` field and return an ordered list of
  * `{ category, count, mostRecent }` entries, sorted by count desc. Used
  * by the Recent failures panel.

--- a/packages/web/src/app/(main)/admin/dispatcher/page.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/page.tsx
@@ -15,8 +15,11 @@ import { DispatcherDashboard } from './DispatcherDashboard';
  * session.
  */
 export default function DispatcherPage() {
+  // max-w-cockpit (120rem / 1920px) lifts the reading-width constraint so
+  // the two-column operator deck has room to breathe on wide displays
+  // (#2805 §1.2). Other pages keep the narrower content widths.
   return (
-    <div className="mx-auto max-w-6xl">
+    <div className="mx-auto max-w-cockpit px-4">
       <DispatcherDashboard />
     </div>
   );

--- a/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+/**
+ * Shared tiny components for the dispatcher admin page (#2805).
+ *
+ * All of these are single-purpose, monospace-where-appropriate, and
+ * deliberately flat (no cards, no borders) — they render inside rows
+ * that already have their own visual structure.
+ *
+ * Kept in one file because each component is ~10 lines and a separate
+ * file-per-component would dilute the density-first design.
+ */
+
+const REPO = 'judgemind/judgemind';
+
+/** Hot link to a GitHub issue. Opens in a new tab. */
+export function IssueLink({ number, className }: { number: number; className?: string }) {
+  const href = `https://github.com/${REPO}/issues/${number}`;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`font-mono text-accent underline-offset-2 hover:underline ${className ?? ''}`}
+      data-testid={`issue-link-${number}`}
+    >
+      #{number}
+    </a>
+  );
+}
+
+/** Hot link to a GitHub pull request. Opens in a new tab. */
+export function PRLink({ number, className }: { number: number; className?: string }) {
+  const href = `https://github.com/${REPO}/pull/${number}`;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={`font-mono text-accent underline-offset-2 hover:underline ${className ?? ''}`}
+      data-testid={`pr-link-${number}`}
+    >
+      PR #{number}
+    </a>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Priority badge — p0 (red), p1 (amber), p2 (stone), p3 (stone muted).
+// Amber for p1 is the only amber; per BRAND.md §Design Principles
+// "Minimal accent use". See #2805 §2.3.
+// ---------------------------------------------------------------------------
+
+const PRIORITY_STYLES: Record<string, string> = {
+  p0: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
+  p1: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200',
+  p2: 'bg-stone-200 text-stone-700 dark:bg-stone-700 dark:text-stone-200',
+  p3: 'bg-stone-100 text-stone-500 dark:bg-stone-800 dark:text-stone-400',
+};
+
+export function PriorityBadge({ priority }: { priority: string | null }) {
+  if (!priority) {
+    return (
+      <span className="inline-flex h-5 items-center rounded bg-stone-100 px-1.5 font-mono text-[10px] uppercase tracking-wide text-stone-400 dark:bg-stone-800 dark:text-stone-500">
+        —
+      </span>
+    );
+  }
+  const style = PRIORITY_STYLES[priority] ?? PRIORITY_STYLES.p3;
+  return (
+    <span
+      className={`inline-flex h-5 items-center rounded px-1.5 font-mono text-[10px] font-medium uppercase tracking-wide ${style}`}
+      data-testid={`priority-badge-${priority}`}
+    >
+      {priority}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Outcome glyph pill — succeeded (✓ green), failed (✗ red), crashed (⚠ amber).
+// ---------------------------------------------------------------------------
+
+type OutcomeStatus = 'succeeded' | 'failed' | 'crashed';
+
+const OUTCOME_STYLES: Record<OutcomeStatus, { glyph: string; className: string; label: string }> = {
+  succeeded: {
+    glyph: '\u2713',
+    className: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
+    label: 'succeeded',
+  },
+  failed: {
+    glyph: '\u2717',
+    className: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
+    label: 'failed',
+  },
+  crashed: {
+    glyph: '\u26A0',
+    className: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200',
+    label: 'crashed',
+  },
+};
+
+export function OutcomePill({ status }: { status: string }) {
+  const info = OUTCOME_STYLES[status as OutcomeStatus];
+  if (!info) {
+    return (
+      <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-stone-100 text-[10px] text-stone-500 dark:bg-stone-800 dark:text-stone-400">
+        ?
+      </span>
+    );
+  }
+  return (
+    <span
+      aria-label={info.label}
+      title={info.label}
+      className={`inline-flex h-5 w-5 items-center justify-center rounded-full text-xs ${info.className}`}
+      data-testid={`outcome-pill-${status}`}
+    >
+      {info.glyph}
+    </span>
+  );
+}

--- a/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
@@ -52,16 +52,20 @@ export function PRLink({ number, className }: { number: number; className?: stri
 // ---------------------------------------------------------------------------
 
 const PRIORITY_STYLES: Record<string, string> = {
+  // p0/p1 carry the only non-neutral colour weight (red for emergency,
+  // amber for "time-sensitive"). p2/p3 collapse to the neutral muted
+  // surface — differentiating them with a second shade of amber or
+  // stone would cede the BRAND.md "minimal accent use" principle.
   p0: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300',
   p1: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200',
-  p2: 'bg-stone-200 text-stone-700 dark:bg-stone-700 dark:text-stone-200',
-  p3: 'bg-stone-100 text-stone-500 dark:bg-stone-800 dark:text-stone-400',
+  p2: 'bg-muted text-foreground',
+  p3: 'bg-muted text-muted-foreground',
 };
 
 export function PriorityBadge({ priority }: { priority: string | null }) {
   if (!priority) {
     return (
-      <span className="inline-flex h-5 items-center rounded bg-stone-100 px-1.5 font-mono text-[10px] uppercase tracking-wide text-stone-400 dark:bg-stone-800 dark:text-stone-500">
+      <span className="inline-flex h-5 items-center rounded bg-muted px-1.5 font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
         —
       </span>
     );
@@ -105,7 +109,7 @@ export function OutcomePill({ status }: { status: string }) {
   const info = OUTCOME_STYLES[status as OutcomeStatus];
   if (!info) {
     return (
-      <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-stone-100 text-[10px] text-stone-500 dark:bg-stone-800 dark:text-stone-400">
+      <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[10px] text-muted-foreground">
         ?
       </span>
     );

--- a/packages/web/src/components/ui/button.tsx
+++ b/packages/web/src/components/ui/button.tsx
@@ -19,6 +19,10 @@ const buttonVariants = cva(
       size: {
         default: 'h-10 px-4 py-2',
         sm: 'h-9 rounded-md px-3',
+        // Extra-small — dense per-row action buttons (#2805 §DESIGN_SYSTEM
+        // additions). 28 px tall with tiny text, for tables/rows where
+        // the default 36-40 px sizes cede row density.
+        xs: 'h-7 rounded-md px-2 text-xs',
         lg: 'h-11 rounded-md px-8',
         icon: 'h-10 w-10',
       },

--- a/packages/web/src/lib/apollo-client.ts
+++ b/packages/web/src/lib/apollo-client.ts
@@ -185,14 +185,17 @@ export function createApolloClient(): ApolloClient<unknown> {
         DataQualityMetricEdge: { keyFields: false },
 
         // ---------------------------------------------------------------------
-        // Dispatcher admin types (#2730). DispatcherAgent uses `id`, so it
-        // auto-normalizes — no keyFields needed. The rest lack `id`:
+        // Dispatcher admin types (#2730, #2805). DispatcherAgent uses `id`,
+        // so it auto-normalizes — no keyFields needed. The rest lack `id`:
         //
         // - DispatcherRun: unique by `runId` (single-response in DispatcherState).
         // - DispatcherFailure: unique by `failureId` (appears inside arrays).
         // - PhaseTransition: unique by `transitionId` (appears inside arrays).
         // - DispatcherCommandResult: unique by `commandId` (mutation result).
         // - DispatcherState: singleton root object (no arrays of it); opt out.
+        // - QueueItem: unique by `issueNumber` (#2805 §1.3).
+        // - RecentCompletion: unique by `agentId` (#2805 §1.5).
+        // - DispatcherConfigEntry: unique by `key` (#2805 §1.6).
         // ---------------------------------------------------------------------
 
         DispatcherRun: {
@@ -208,6 +211,15 @@ export function createApolloClient(): ApolloClient<unknown> {
           keyFields: ['commandId'],
         },
         DispatcherState: { keyFields: false },
+        QueueItem: {
+          keyFields: ['issueNumber'],
+        },
+        RecentCompletion: {
+          keyFields: ['agentId'],
+        },
+        DispatcherConfigEntry: {
+          keyFields: ['key'],
+        },
 
         // ---------------------------------------------------------------------
         // Types that intentionally do NOT need keyFields:

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -47,6 +47,36 @@ export const DISPATCHER_STATE_QUERY = gql`
         issueNumber
       }
       queueDepth
+      queueReady {
+        issueNumber
+        title
+        priority
+        labels
+        createdAt
+        blockedBy
+      }
+      queueBlocked {
+        issueNumber
+        title
+        priority
+        labels
+        createdAt
+        blockedBy
+      }
+      recentCompletions {
+        agentId
+        issueNumber
+        issueTitle
+        status
+        endedAt
+        prNumber
+      }
+      config {
+        key
+        value
+        updatedAt
+        updatedBy
+      }
       spawnFrozenUntil
     }
   }
@@ -62,6 +92,17 @@ export const DISPATCHER_CONTROL_MUTATION = gql`
       consumedAt
       payload
       created
+    }
+  }
+`;
+
+export const DISPATCHER_SET_CONFIG_MUTATION = gql`
+  mutation DispatcherSetConfig($key: String!, $value: String!) {
+    dispatcherSetConfig(key: $key, value: $value) {
+      key
+      value
+      updatedAt
+      updatedBy
     }
   }
 `;
@@ -105,12 +146,47 @@ export interface DispatcherFailure {
   issueNumber: number | null;
 }
 
+export interface QueueItem {
+  issueNumber: number;
+  title: string;
+  priority: string | null;
+  labels: string[];
+  createdAt: string;
+  blockedBy: number[];
+}
+
+export interface RecentCompletion {
+  agentId: string;
+  issueNumber: number;
+  issueTitle: string | null;
+  /** One of `succeeded | failed | crashed`. */
+  status: string;
+  endedAt: string;
+  prNumber: number | null;
+}
+
+export interface DispatcherConfigEntry {
+  key: string;
+  /** JSON-encoded string — e.g. `"1"`, `"\"on\""`, `"[60,300]"`. */
+  value: string;
+  updatedAt: string;
+  updatedBy: string;
+}
+
 export interface DispatcherState {
   currentRun: DispatcherRun | null;
   activeAgents: DispatcherAgent[];
   recentFailures: DispatcherFailure[];
   queueDepth: number;
+  queueReady: QueueItem[];
+  queueBlocked: QueueItem[];
+  recentCompletions: RecentCompletion[];
+  config: DispatcherConfigEntry[];
   spawnFrozenUntil: string | null;
+}
+
+export interface DispatcherSetConfigData {
+  dispatcherSetConfig: DispatcherConfigEntry;
 }
 
 export interface DispatcherStateData {

--- a/packages/web/tailwind.config.ts
+++ b/packages/web/tailwind.config.ts
@@ -59,6 +59,12 @@ const config: Config = {
         md: 'calc(var(--radius) - 2px)',
         sm: 'calc(var(--radius) - 4px)',
       },
+      maxWidth: {
+        // Operator-cockpit width (#2805 §1.2). Not for reading pages —
+        // reserved for info-dense admin surfaces like /admin/dispatcher
+        // that need to show many panels side-by-side.
+        cockpit: '120rem',
+      },
       keyframes: {
         'accordion-down': {
           from: { height: '0' },

--- a/packages/web/tests/dispatcher-dashboard.test.tsx
+++ b/packages/web/tests/dispatcher-dashboard.test.tsx
@@ -79,6 +79,17 @@ function makeEmptyState() {
       activeAgents: [],
       recentFailures: [],
       queueDepth: 0,
+      queueReady: [],
+      queueBlocked: [],
+      recentCompletions: [],
+      config: [
+        {
+          key: 'concurrency_cap',
+          value: '3',
+          updatedAt: '2026-04-18T00:00:00Z',
+          updatedBy: 'init',
+        },
+      ],
       spawnFrozenUntil: null,
     },
   };
@@ -123,6 +134,17 @@ function makeActiveState() {
         },
       ],
       queueDepth: 5,
+      queueReady: [],
+      queueBlocked: [],
+      recentCompletions: [],
+      config: [
+        {
+          key: 'concurrency_cap',
+          value: '3',
+          updatedAt: '2026-04-18T00:00:00Z',
+          updatedBy: 'init',
+        },
+      ],
       spawnFrozenUntil: null,
     },
   };
@@ -186,15 +208,15 @@ describe('DispatcherDashboard', () => {
     expect(screen.getByText(/No active agents\./i)).toBeInTheDocument();
     // Recent failures empty state
     expect(screen.getByText(/No failures in the last 24 hours\./i)).toBeInTheDocument();
-    // Queue depth section
-    expect(screen.getByText(/issues ready for pickup/i)).toBeInTheDocument();
-    // "0" appears in both "Active agents (0)" heading and queue panel — the
-    // heading carries the exact "Active agents (0)" text we want to assert.
+    // Queue empty state (split ready/blocked panels per #2805 §1.3)
+    expect(screen.getByText(/Queue empty/i)).toBeInTheDocument();
+    expect(screen.getByText(/No blocked issues\./i)).toBeInTheDocument();
+    // Recently-completed panel empty state (#2805 §1.5)
+    expect(screen.getByText(/No completed agents yet/i)).toBeInTheDocument();
+    // Active agents heading with zero count.
     expect(screen.getByText(/Active agents \(0\)/)).toBeInTheDocument();
-    // Config panel headings
-    expect(screen.getByText('Concurrency cap')).toBeInTheDocument();
-    expect(screen.getByText('Idle mode')).toBeInTheDocument();
-    expect(screen.getByText('Backoff seconds')).toBeInTheDocument();
+    // Config strip shows the inline cap button (editable via click).
+    expect(screen.getByTestId('config-value-concurrency_cap')).toBeInTheDocument();
     expect(notFoundCallCount).toBe(0);
   });
 
@@ -202,13 +224,17 @@ describe('DispatcherDashboard', () => {
     mockQueryResult.data = makeActiveState();
     mockQueryResult.loading = false;
     render(<DispatcherDashboard />);
-    // Agents table heading with count
+    // Agents row heading with count
     expect(screen.getByText(/Active agents \(1\)/)).toBeInTheDocument();
-    // "#2731" appears both in the agents row and the recent-failures row.
-    expect(screen.getAllByText('#2731').length).toBeGreaterThanOrEqual(1);
+    // Issue number is a hot link via IssueLink (#2805 §1.4).
+    // The same issue can appear in multiple panels (active + failures),
+    // so there may be more than one matching element.
+    const issueLinks = screen.getAllByTestId('issue-link-2731');
+    expect(issueLinks.length).toBeGreaterThanOrEqual(1);
+    expect(issueLinks[0]).toHaveAttribute('target', '_blank');
     expect(screen.getByText(/ralph-worker \(2\)/)).toBeInTheDocument();
-    // Short agent id
-    expect(screen.getByText(/agent-ac/i)).toBeInTheDocument();
+    // Short agent id truncated to 8 chars
+    expect(screen.getByText(/agent-ac…/)).toBeInTheDocument();
   });
 
   it('renders a "running" status pill for a healthy run', () => {


### PR DESCRIPTION
## Summary

Phase 1 of the `/admin/dispatcher` design overhaul (issue body §1.1–§1.7). Collapses the stacked six-card layout into a single-viewport operator cockpit: one-line header + controls, two-column deck (queue-ready/blocked on the left, active agents + recently completed on the right), inline-editable config strip, card-less failures. All GitHub identities are hot-linked. Integrates the p1 follow-ups #2762 (editable config), #2763 (split queue), #2802 (recently completed), #2803 (MFA dead-end). #2801 (daemon-side command handlers) stays standalone.

Closes #2805

## Test plan

### Automated checks
- [x] Lint passes (`npm run lint` in packages/web and packages/api)
- [x] Format check passes
- [x] Tests pass (1213 web tests + 368 API tests, all green)
- [x] CI green

### Post-deploy verification
- [ ] Screenshot `/admin/dispatcher` on dev at 1920×1080, verify every panel is above the fold
- [ ] Screenshot `/admin/dispatcher` on dev at 768 width, verify single-column stack order
- [ ] Click through Start / Pause / Stop (drain) / Force-stop: each writes a `dispatcher.commands` row; destructive paths send `X-MFA-Token`
- [ ] Click the `cap` value in the config strip, change from 5 → 3, confirm the ConfirmDialog pops, confirm commits write `dispatcher.config.concurrency_cap = 3` with `updated_by` = admin email
- [ ] Verify an issue hot link opens `https://github.com/judgemind/judgemind/issues/N` in a new tab
- [ ] Verification evidence posted on issue (see A.8)

## Notes for reviewers

- **GitHub API caching.** `packages/api/src/graphql/dispatcher/github.ts` uses an in-process 30s TTL cache with unauthenticated fallback (60 req/hr). When `GITHUB_TOKEN` is present in the API env the rate jumps to 5000/hr. On cache miss + fetch failure the resolver returns a placeholder `{ title: '(title unavailable)' }` so the UI degrades to a hot-link-only row instead of failing the whole query.
- **Config mutation shape.** `dispatcherSetConfig(key: String!, value: String!)` takes a JSON-encoded string for `value` (e.g. `"3"` for a number, `"[60,300]"` for an array). This sidesteps GraphQL scalar polymorphism and mirrors the jsonb storage. Server-side `validateConfigValue` enforces per-key constraints (`concurrency_cap ∈ [0, 5]`, etc.).
- **MFA header plumbing.** Every destructive mutation (`stop`, `drain`, `force_kill`, per-agent `force_kill`) and every config edit sends `X-MFA-Token: phase1-placeholder` in the Apollo `context.headers`. A unit test in `DispatcherDashboard.test.tsx` asserts this directly.
- **Out of scope.** Phase 2 (typography / amber restraint / a11y audit / dark-mode contrast) and Phase 3 (skeletons / micro-interactions / error-state restyle) are deferred. Follow-up issues will be filed before this task closes.
- **Scope completeness check.** `max-w-cockpit` appears in exactly one file (`packages/web/src/app/(main)/admin/dispatcher/page.tsx`). `bg-card` and `rounded-lg border border-border` are gone from all dispatcher components (only remaining reference is an assertion in `DispatcherHeader.test.tsx` that checks they stay gone). The ConfirmDialog still uses modal chrome — that's a true modal surface, explicitly exempted by the issue.
