### PR TITLE
fix(admin-dispatcher): wire GITHUB_TOKEN + strip wasteful columns (#2818)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -166,6 +166,18 @@ module "api_service" {
   ses_configuration_set_name        = module.ses.configuration_set_name
   email_from                        = "no-reply@judgemind.org"
 
+  # #2818 — the dispatcher admin GraphQL resolvers (packages/api/src/graphql/
+  # dispatcher/github.ts) enrich queue/completion rows by hitting the GitHub
+  # REST API. Unauthenticated traffic caps at 60 req/hr, which the
+  # /admin/dispatcher page (polled every 2 s × up to ~40 issues per poll)
+  # exhausts in seconds — every row then renders "(title unavailable)" +
+  # "20562 d ago". Reuse the scoped PAT already provisioned for the
+  # dispatcher daemon (#2700) rather than creating a second secret; its
+  # scopes (contents:read, issues:write, pulls:write, actions:read,
+  # statuses:read) cover `GET /repos/{o}/{r}/issues/{n}` and
+  # `GET /search/issues` cleanly.
+  github_token_secret_arn = "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/dispatcher/github-token-QOmHlJ"
+
   # Dev: 0.25 vCPU, 512 MB, single replica
   task_cpu           = 256
   task_memory        = 512

--- a/infra/terraform/modules/api-service/main.tf
+++ b/infra/terraform/modules/api-service/main.tf
@@ -165,6 +165,10 @@ resource "aws_iam_role_policy" "api_secrets" {
   name = "judgemind-api-secrets-${var.environment}"
   role = element(split("/", var.execution_role_arn), length(split("/", var.execution_role_arn)) - 1)
 
+  # `compact()` drops empty-string ARNs so environments that don't wire a
+  # given optional secret (e.g. a fresh stack with no dispatcher PAT) still
+  # produce a valid policy. Matches the `execution_secrets` pattern in
+  # `modules/dispatcher-daemon/main.tf` (#2700).
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
@@ -175,6 +179,7 @@ resource "aws_iam_role_policy" "api_secrets" {
         Resource = compact([
           var.db_connection_secret_arn,
           var.opensearch_credentials_secret_arn,
+          var.github_token_secret_arn,
         ])
       }
     ]
@@ -293,6 +298,19 @@ resource "aws_ecs_task_definition" "api" {
           {
             name      = "OPENSEARCH_PASSWORD"
             valueFrom = "${var.opensearch_credentials_secret_arn}:password::"
+          }
+        ] : [],
+        var.github_token_secret_arn != "" ? [
+          {
+            # GITHUB_TOKEN for the dispatcher admin GraphQL resolvers
+            # (packages/api/src/graphql/dispatcher/github.ts). Without it,
+            # the /admin/dispatcher page burns through the unauthenticated
+            # 60 req/hr rate limit within seconds and every row renders
+            # "(title unavailable)" + "20562 d ago" (#2818). The dev env
+            # reuses the dispatcher PAT at `judgemind/dispatcher/github-token`;
+            # other envs pass "" and this block is skipped.
+            name      = "GITHUB_TOKEN"
+            valueFrom = var.github_token_secret_arn
           }
         ] : []
       )

--- a/infra/terraform/modules/api-service/variables.tf
+++ b/infra/terraform/modules/api-service/variables.tf
@@ -101,6 +101,12 @@ variable "opensearch_credentials_secret_arn" {
   default     = ""
 }
 
+variable "github_token_secret_arn" {
+  description = "Secrets Manager ARN for GITHUB_TOKEN — the scoped PAT used by the dispatcher admin GraphQL resolvers (packages/api/src/graphql/dispatcher/github.ts) to enrich queue/completion rows with issue titles (#2818). Unauthenticated GitHub API caps at 60 req/hr, which the /admin/dispatcher page burns through in seconds; an authenticated PAT lifts the cap to 5 000 req/hr. Dev reuses the dispatcher PAT at `judgemind/dispatcher/github-token` (same precedent as the dispatcher-daemon module, #2700). Empty-string default keeps environments without the secret (e.g. a fresh staging stack) plan-able; `compact()` in the execution-role policy drops unset entries."
+  type        = string
+  default     = ""
+}
+
 variable "cors_allowed_origins" {
   description = "Comma-separated list of allowed CORS origins"
   type        = string

--- a/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
@@ -2,7 +2,6 @@
 
 import { SECTION_HEADING } from '@/lib/typography';
 import type { QueueItem } from '@/lib/dispatcher-queries';
-import { formatRelativeTime } from './format-helpers';
 import { IssueLink, PriorityBadge } from './ui-primitives';
 
 interface QueuePanelProps {
@@ -10,7 +9,12 @@ interface QueuePanelProps {
   queueReady: readonly QueueItem[];
   /** Open issues labelled `status/blocked`. */
   queueBlocked: readonly QueueItem[];
-  /** Override for deterministic tests. */
+  /**
+   * Override for deterministic tests. Currently unused after #2818 stripped
+   * the "filed N d ago" column — kept in the prop signature so existing
+   * callers (`DispatcherDashboard`, the test suite) don't need to refactor
+   * if we re-introduce a time-based cell later.
+   */
   nowMs?: number;
 }
 
@@ -21,26 +25,30 @@ interface QueuePanelProps {
  *
  * Capped server-side at 10 entries per panel; more is dispatcher-internal
  * scheduling state, not useful on the overview page.
+ *
+ * Row density (#2818 — operator density pass): each row shows only
+ *   `issue link + priority badge + title`.
+ * The previous design also rendered `#<slot>` (rank) on the ready side and
+ * `[N]` (blocked-by count) on the blocked side plus a `<N> d ago` filed-time
+ * column — stripped because (a) row position IS the rank, (b) the blocked-by
+ * tooltip belongs on the issue page, and (c) filed-time is never actionable
+ * from this page. Titles get the freed horizontal space; the title cell
+ * wraps onto a second line rather than ellipsis-truncating so the operator
+ * can read the full text without hovering.
  */
-export function QueuePanel({ queueReady, queueBlocked, nowMs }: QueuePanelProps) {
+export function QueuePanel({ queueReady, queueBlocked }: QueuePanelProps) {
   return (
     <div
       className="grid grid-cols-1 gap-x-6 gap-y-4 md:grid-cols-2"
       data-testid="queue-panels"
     >
-      <QueueReadyPanel items={queueReady} nowMs={nowMs} />
-      <QueueBlockedPanel items={queueBlocked} nowMs={nowMs} />
+      <QueueReadyPanel items={queueReady} />
+      <QueueBlockedPanel items={queueBlocked} />
     </div>
   );
 }
 
-function QueueReadyPanel({
-  items,
-  nowMs,
-}: {
-  items: readonly QueueItem[];
-  nowMs?: number;
-}) {
+function QueueReadyPanel({ items }: { items: readonly QueueItem[] }) {
   return (
     <section aria-labelledby="queue-ready-heading">
       <div className="flex items-center justify-between border-b border-border pb-2 mb-2">
@@ -57,13 +65,8 @@ function QueueReadyPanel({
         </p>
       ) : (
         <ul className="divide-y divide-border">
-          {items.map((item, index) => (
-            <QueueRow
-              key={item.issueNumber}
-              item={item}
-              slot={index + 1}
-              nowMs={nowMs}
-            />
+          {items.map((item) => (
+            <QueueRow key={item.issueNumber} item={item} />
           ))}
         </ul>
       )}
@@ -71,13 +74,7 @@ function QueueReadyPanel({
   );
 }
 
-function QueueBlockedPanel({
-  items,
-  nowMs,
-}: {
-  items: readonly QueueItem[];
-  nowMs?: number;
-}) {
+function QueueBlockedPanel({ items }: { items: readonly QueueItem[] }) {
   return (
     <section aria-labelledby="queue-blocked-heading">
       <div className="flex items-center justify-between border-b border-border pb-2 mb-2">
@@ -95,12 +92,7 @@ function QueueBlockedPanel({
       ) : (
         <ul className="divide-y divide-border">
           {items.map((item) => (
-            <QueueRow
-              key={item.issueNumber}
-              item={item}
-              nowMs={nowMs}
-              blocked
-            />
+            <QueueRow key={item.issueNumber} item={item} />
           ))}
         </ul>
       )}
@@ -108,57 +100,23 @@ function QueueBlockedPanel({
   );
 }
 
-function QueueRow({
-  item,
-  slot,
-  blocked,
-  nowMs,
-}: {
-  item: QueueItem;
-  slot?: number;
-  blocked?: boolean;
-  nowMs?: number;
-}) {
-  const timestamp = formatRelativeTime(item.createdAt, nowMs);
+function QueueRow({ item }: { item: QueueItem }) {
   return (
-    <li className="flex items-center gap-3 py-2 text-sm hover:bg-muted/50">
-      <div className="flex-shrink-0" data-testid="queue-row-number">
+    <li className="flex items-start gap-3 py-2 text-sm hover:bg-muted/50">
+      <div className="flex-shrink-0 pt-0.5">
         <IssueLink number={item.issueNumber} />
       </div>
-      <div className="min-w-0 flex-1">
-        <span className="block truncate text-foreground" title={item.title}>
-          {item.title}
-        </span>
-      </div>
-      <div className="flex-shrink-0">
+      <div className="flex-shrink-0 pt-0.5">
         <PriorityBadge priority={item.priority} />
       </div>
-      <div
-        className="w-10 flex-shrink-0 text-right font-mono text-xs text-muted-foreground"
-        data-testid="queue-row-slot"
-      >
-        {blocked ? (
-          item.blockedBy.length > 0 ? (
-            <span
-              className="cursor-help"
-              title={item.blockedBy.map((n) => `#${n}`).join(', ')}
-            >
-              [{item.blockedBy.length}]
-            </span>
-          ) : (
-            <span>—</span>
-          )
-        ) : slot !== undefined ? (
-          <span>#{slot}</span>
-        ) : (
-          <span>—</span>
-        )}
-      </div>
-      <div
-        className="w-20 flex-shrink-0 text-right text-xs text-muted-foreground"
-        title={item.createdAt}
-      >
-        {timestamp}
+      <div className="min-w-0 flex-1">
+        <span
+          className="block break-words text-foreground"
+          data-testid="queue-row-title"
+          title={item.title}
+        >
+          {item.title}
+        </span>
       </div>
     </li>
   );

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -2,12 +2,16 @@
 
 import { SECTION_HEADING } from '@/lib/typography';
 import type { RecentCompletion } from '@/lib/dispatcher-queries';
-import { formatRelativeTime } from './format-helpers';
 import { IssueLink, OutcomePill, PRLink } from './ui-primitives';
 
 interface RecentCompletionsPanelProps {
   completions: readonly RecentCompletion[];
-  /** Override for deterministic tests. */
+  /**
+   * Override for deterministic tests. Currently unused after #2818 stripped
+   * the "N min ago" column — kept in the prop signature so callers
+   * (`DispatcherDashboard`) don't need a refactor if we re-introduce a
+   * time-based cell later.
+   */
   nowMs?: number;
 }
 
@@ -17,10 +21,17 @@ interface RecentCompletionsPanelProps {
  * Each row links to the issue and, when available, the PR.
  *
  * Borderless. Lives in the right column below Active agents.
+ *
+ * Row density (#2818 — operator density pass): each row shows only
+ *   `outcome glyph + issue link + optional PR link + title`.
+ * Dropped the "N min/h/d ago" completion-time column (never actionable
+ * from this page — the agent is already done) and the "(no PR)" filler
+ * when `prNumber` is null — empty space is less noisy than italic copy.
+ * The title cell wraps onto a second line rather than ellipsis-truncating
+ * so the full text is always readable without hover.
  */
 export function RecentCompletionsPanel({
   completions,
-  nowMs,
 }: RecentCompletionsPanelProps) {
   return (
     <section aria-labelledby="recent-completions-heading">
@@ -39,7 +50,6 @@ export function RecentCompletionsPanel({
             <RecentCompletionRow
               key={completion.agentId}
               completion={completion}
-              nowMs={nowMs}
             />
           ))}
         </ul>
@@ -48,45 +58,28 @@ export function RecentCompletionsPanel({
   );
 }
 
-function RecentCompletionRow({
-  completion,
-  nowMs,
-}: {
-  completion: RecentCompletion;
-  nowMs?: number;
-}) {
-  const relative = formatRelativeTime(completion.endedAt, nowMs);
+function RecentCompletionRow({ completion }: { completion: RecentCompletion }) {
   return (
-    <li className="flex items-center gap-3 py-2 text-sm hover:bg-muted/50">
-      <span className="flex-shrink-0">
+    <li className="flex items-start gap-3 py-2 text-sm hover:bg-muted/50">
+      <span className="flex-shrink-0 pt-0.5">
         <OutcomePill status={completion.status} />
       </span>
-      <span className="flex-shrink-0">
+      <span className="flex-shrink-0 pt-0.5">
         <IssueLink number={completion.issueNumber} />
       </span>
+      {completion.prNumber !== null && (
+        <span className="flex-shrink-0 pt-0.5">
+          <PRLink number={completion.prNumber} />
+        </span>
+      )}
       <span
-        className="min-w-0 flex-1 truncate text-foreground"
+        className="min-w-0 flex-1 break-words text-foreground"
+        data-testid="completion-row-title"
         title={completion.issueTitle ?? ''}
       >
         {completion.issueTitle ?? (
           <span className="italic text-muted-foreground">(title unavailable)</span>
         )}
-      </span>
-      <span className="w-20 flex-shrink-0 text-right text-xs">
-        {completion.prNumber !== null ? (
-          <span className="inline-flex items-center gap-0.5">
-            <PRLink number={completion.prNumber} />
-            <span aria-hidden="true" className="text-muted-foreground">&nearr;</span>
-          </span>
-        ) : (
-          <span className="italic text-muted-foreground">(no PR)</span>
-        )}
-      </span>
-      <span
-        className="w-20 flex-shrink-0 text-right text-xs text-muted-foreground"
-        title={completion.endedAt}
-      >
-        {relative}
       </span>
     </li>
   );

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueuePanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueuePanel.test.tsx
@@ -24,7 +24,7 @@ describe('QueuePanel', () => {
     expect(screen.getByText(/no blocked issues/i)).toBeInTheDocument();
   });
 
-  it('renders agent-ready rows with hot-linked issue numbers', () => {
+  it('renders agent-ready rows with hot-linked issue numbers, priority badges, and full titles', () => {
     const items = [
       item({ issueNumber: 2801, title: 'wire dispatcherControl through to daemon' }),
       item({ issueNumber: 2802, title: 'recently completed panel', priority: 'p2' }),
@@ -35,22 +35,63 @@ describe('QueuePanel', () => {
       'https://github.com/judgemind/judgemind/issues/2801',
     );
     expect(screen.getByTestId('issue-link-2802')).toBeInTheDocument();
-    // Slot numbers #1, #2.
-    expect(screen.getByText('#1')).toBeInTheDocument();
-    expect(screen.getByText('#2')).toBeInTheDocument();
     // Priority badges present.
     expect(screen.getByTestId('priority-badge-p1')).toBeInTheDocument();
     expect(screen.getByTestId('priority-badge-p2')).toBeInTheDocument();
+    // Titles render in full.
+    expect(screen.getByText('wire dispatcherControl through to daemon')).toBeInTheDocument();
+    expect(screen.getByText('recently completed panel')).toBeInTheDocument();
   });
 
-  it('renders blocked rows with [N] blocker count and tooltip', () => {
+  it('renders blocked rows with the issue link and title only', () => {
     const blocked = [
       item({ issueNumber: 2500, title: 'blocked issue', blockedBy: [2500, 2600] }),
     ];
     render(<QueuePanel queueReady={[]} queueBlocked={blocked} nowMs={now} />);
-    expect(screen.getByText('[2]')).toBeInTheDocument();
-    // Tooltip exposes the raw blocker list.
-    const slot = screen.getByText('[2]');
-    expect(slot.getAttribute('title')).toBe('#2500, #2600');
+    expect(screen.getByTestId('issue-link-2500')).toBeInTheDocument();
+    expect(screen.getByText('blocked issue')).toBeInTheDocument();
+  });
+
+  // --- #2818 — density pass: rank / blocked-count / filed-time columns removed.
+  it('#2818: strips the #<rank> column from the ready side', () => {
+    const items = [
+      item({ issueNumber: 2801, title: 'first' }),
+      item({ issueNumber: 2802, title: 'second' }),
+    ];
+    render(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
+    expect(screen.queryByText('#1')).not.toBeInTheDocument();
+    expect(screen.queryByText('#2')).not.toBeInTheDocument();
+    expect(screen.queryAllByTestId('queue-row-slot')).toHaveLength(0);
+  });
+
+  it('#2818: strips the [N] blocked-by count column from the blocked side', () => {
+    const blocked = [
+      item({ issueNumber: 2500, title: 'blocked issue', blockedBy: [2500, 2600] }),
+    ];
+    render(<QueuePanel queueReady={[]} queueBlocked={blocked} nowMs={now} />);
+    expect(screen.queryByText('[2]')).not.toBeInTheDocument();
+  });
+
+  it('#2818: does not render a "N d ago" filed-time column', () => {
+    const items = [
+      item({
+        issueNumber: 2801,
+        title: 'first',
+        createdAt: '2026-04-16T11:00:00Z', // 2 d ago from the fixed `now`
+      }),
+    ];
+    render(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
+    expect(screen.queryByText(/\bago\b/i)).not.toBeInTheDocument();
+  });
+
+  it('#2818: renders long titles in full without ellipsis truncation', () => {
+    const longTitle =
+      'fix(admin-dispatcher): (title unavailable) everywhere + 20562-day-ago timestamps + strip wasteful columns';
+    const items = [item({ issueNumber: 2818, title: longTitle })];
+    render(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
+    const titleEl = screen.getByText(longTitle);
+    // Title cell uses `break-words` (soft wrap) rather than `truncate`.
+    expect(titleEl.className).toMatch(/break-words/);
+    expect(titleEl.className).not.toMatch(/\btruncate\b/);
   });
 });

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RecentCompletionsPanel } from '../RecentCompletionsPanel';
+import type { RecentCompletion } from '@/lib/dispatcher-queries';
+
+const now = Date.parse('2026-04-18T12:00:00Z');
+
+function completion(overrides: Partial<RecentCompletion>): RecentCompletion {
+  return {
+    agentId: 'agent-1',
+    issueNumber: 2805,
+    issueTitle: 'wire dispatcher admin dashboard',
+    status: 'succeeded',
+    endedAt: '2026-04-18T11:55:00Z',
+    prNumber: 2811,
+    ...overrides,
+  };
+}
+
+describe('RecentCompletionsPanel', () => {
+  it('renders the empty state when completions is empty', () => {
+    render(<RecentCompletionsPanel completions={[]} nowMs={now} />);
+    expect(screen.getByText(/no completed agents yet/i)).toBeInTheDocument();
+  });
+
+  it('renders outcome glyph + issue link + PR link + title', () => {
+    const items = [completion({})];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    expect(screen.getByTestId('outcome-pill-succeeded')).toBeInTheDocument();
+    expect(screen.getByTestId('issue-link-2805')).toBeInTheDocument();
+    expect(screen.getByTestId('pr-link-2811')).toBeInTheDocument();
+    expect(screen.getByText('wire dispatcher admin dashboard')).toBeInTheDocument();
+  });
+
+  // --- #2818 — density pass: "(no PR)" filler and "N min ago" column removed.
+  it('#2818: renders nothing in place of a missing PR (no "(no PR)" text)', () => {
+    const items = [completion({ prNumber: null, agentId: 'agent-2' })];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    expect(screen.queryByText(/\(no PR\)/i)).not.toBeInTheDocument();
+    // No PR link rendered for this row.
+    expect(screen.queryByTestId('pr-link-null')).not.toBeInTheDocument();
+  });
+
+  it('#2818: does not render a "N min ago" completion-time column', () => {
+    const items = [
+      completion({
+        endedAt: '2026-04-18T11:55:00Z', // 5 min ago from the fixed `now`
+        agentId: 'agent-3',
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    expect(screen.queryByText(/\bago\b/i)).not.toBeInTheDocument();
+  });
+
+  it('#2818: still shows the "(title unavailable)" placeholder when issueTitle is null', () => {
+    const items = [completion({ issueTitle: null, agentId: 'agent-4' })];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    expect(screen.getByText(/\(title unavailable\)/i)).toBeInTheDocument();
+  });
+
+  it('#2818: renders long titles in full without ellipsis truncation', () => {
+    const longTitle =
+      'fix(admin-dispatcher): (title unavailable) everywhere + 20562-day-ago timestamps + strip wasteful columns';
+    const items = [completion({ issueTitle: longTitle, agentId: 'agent-5' })];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    const titleEl = screen.getByText(longTitle);
+    expect(titleEl.className).toMatch(/break-words/);
+    expect(titleEl.className).not.toMatch(/\btruncate\b/);
+  });
+});

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/format-helpers.test.ts
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/format-helpers.test.ts
@@ -62,6 +62,19 @@ describe('formatRelativeTime', () => {
     expect(formatRelativeTime(future, now)).toBe('—');
   });
 
+  // #2818 — defensive against backend fallbacks that emit
+  // `new Date(0).toISOString()` to satisfy a non-null `DateTime!` field.
+  // Without this guard, callers saw "20562 d ago" on every such row.
+  it('#2818: returns em-dash for the unix epoch (new Date(0))', () => {
+    expect(formatRelativeTime(new Date(0).toISOString(), now)).toBe('—');
+  });
+
+  it('#2818: returns em-dash for any pre-2000 timestamp (epoch sentinel)', () => {
+    expect(formatRelativeTime('1970-01-01T00:00:00.000Z', now)).toBe('—');
+    expect(formatRelativeTime('1985-06-15T12:00:00Z', now)).toBe('—');
+    expect(formatRelativeTime('1999-12-31T23:59:59Z', now)).toBe('—');
+  });
+
   it('formats seconds', () => {
     const ts = new Date(now - 5_000).toISOString();
     expect(formatRelativeTime(ts, now)).toBe('5s ago');

--- a/packages/web/src/app/(main)/admin/dispatcher/format-helpers.ts
+++ b/packages/web/src/app/(main)/admin/dispatcher/format-helpers.ts
@@ -74,19 +74,42 @@ export function worktreeLogsUrl(worktreePath: string): string | null {
 }
 
 /**
+ * Epoch-origin sentinel threshold. Any timestamp at or before this date is
+ * treated as "unset / unknown" rather than a real past time. This catches
+ * the failure mode where a backend fallback uses `new Date(0).toISOString()`
+ * (or `0` as a ms epoch) to satisfy a non-nullable `DateTime!` GraphQL field
+ * — without this guard, the helper cheerfully formats it as "20562 d ago"
+ * (#2818).
+ *
+ * Threshold is 2000-01-01 UTC: the project has never emitted a legitimate
+ * timestamp older than this, and real-world calendar drift shouldn't push
+ * a genuine recent timestamp below it.
+ */
+const EPOCH_SANITY_THRESHOLD_MS = Date.UTC(2000, 0, 1);
+
+/**
  * Format a past timestamp as a short relative string like "3 min ago",
- * "2 h ago", "5 d ago". Returns `'—'` for invalid or future timestamps.
+ * "2 h ago", "5 d ago". Returns `'—'` for invalid, future, null, zero,
+ * or pre-2000 (epoch-sentinel) timestamps.
  *
  * Buckets:
  *   - < 60 s     → "Ns ago"
  *   - < 60 min   → "N min ago"
  *   - < 24 h     → "N h ago"
  *   - otherwise  → "N d ago"
+ *
+ * The null/zero/pre-2000 handling is defensive against backend fallbacks
+ * that substitute `new Date(0).toISOString()` for a missing upstream
+ * timestamp (#2818). Without it, callers see "20562 d ago" (≈56 years)
+ * for every such row, which is worse than showing nothing.
  */
 export function formatRelativeTime(iso: string | null, nowMs: number = Date.now()): string {
   if (!iso) return '—';
   const ts = new Date(iso).getTime();
   if (!Number.isFinite(ts)) return '—';
+  // Treat zero / pre-2000 timestamps as unset. See EPOCH_SANITY_THRESHOLD_MS
+  // above for the rationale.
+  if (ts <= EPOCH_SANITY_THRESHOLD_MS) return '—';
   const deltaMs = nowMs - ts;
   if (deltaMs < 0) return '—';
   const seconds = Math.floor(deltaMs / 1000);


### PR DESCRIPTION
## Summary

Three linked fixes for `/admin/dispatcher` (#2805 / #2811):

- **Wire `GITHUB_TOKEN` into `judgemind-api-dev`** via the existing
  `judgemind/dispatcher/github-token` secret — unauthenticated GitHub API
  caps at 60 req/hr, which the 2 s admin poll burned through in seconds,
  causing every row to render `(title unavailable)`. Reuses the scoped
  PAT already provisioned for the dispatcher daemon (#2700) per the
  issue body; a new secret would add blast-radius isolation but also a
  second secret to rotate.
- **Defensive `formatRelativeTime`** — returns `—` for any pre-2000
  timestamp, catching the `new Date(0).toISOString()` fallback the API
  resolver emits when `fetchIssue` returns null. Without this, the
  helper rendered "20562 d ago" for every such row.
- **Strip density-eating columns** — `QueuePanel` drops `#<rank>`,
  `[N]` blocked-by count, and filed-time; `RecentCompletionsPanel` drops
  "(no PR)" filler and "N min ago". Titles wrap onto a second line via
  `break-words` rather than ellipsis-truncate, so the operator reads the
  full text without hover.

Closes #2818

### Terraform plan (dev)

```
  # module.api_service.aws_ecs_task_definition.api must be replaced
-/+ resource "aws_ecs_task_definition" "api" {
    ...
      ~ secrets = [
          { name = "DATABASE_URL", valueFrom = "...:judgemind/dev/db/connection-V1mIHV:url::" },
        + { name = "GITHUB_TOKEN", valueFrom = "...:judgemind/dispatcher/github-token-QOmHlJ" },
          { name = "OPENSEARCH_PASSWORD", valueFrom = "...:judgemind/dev/opensearch/master-jszjKj:password::" },
          { name = "OPENSEARCH_USERNAME", valueFrom = "...:judgemind/dev/opensearch/master-jszjKj:username::" },
        ]
    }

  # module.api_service.aws_iam_role_policy.api_secrets will be updated in-place
  ~ resource "aws_iam_role_policy" "api_secrets" {
      ~ Resource = [
            "...:judgemind/dev/db/connection-V1mIHV",
            "...:judgemind/dev/opensearch/master-jszjKj",
          + "...:judgemind/dispatcher/github-token-QOmHlJ",
        ]
    }
```

Plan summary: `1 to add, 2 to change, 1 to destroy` (the add/destroy is
the task-def replacement; the 1 additional unrelated `change` is
pre-existing scraper SG egress drift — not from this PR).

## Test plan

### Automated checks
- [x] Lint passes (web + api)
- [x] Typecheck passes (web + api)
- [x] Tests pass (web: 1225, api: 368 — api-tests CI job is path-gated and skipped since no packages/api/ changes)
- [x] Terraform fmt / validate / plan clean
- [x] CI green

### Post-deploy verification
- [ ] `aws ecs describe-task-definition --task-definition judgemind-api-dev --region us-west-2 --query 'taskDefinition.containerDefinitions[0].secrets[?name==\`GITHUB_TOKEN\`]'` returns the new entry
- [ ] `/admin/dispatcher` screenshot shows real issue titles on every row (no `(title unavailable)`)
- [ ] No `20562 d ago` string anywhere on the page
- [ ] Columns are just `issue link + priority + title` (queue) and `outcome + issue + optional PR + title` (completions)
- [ ] Verification evidence posted on issue

**Note:** `terraform apply` is operator-only per established pattern —
post-deploy verification (screenshot, `describe-task-definition` check)
is deferred-pending-operator-reapply.
