### PR TITLE
fix(admin/dispatcher): use brand-accent, not shadcn accent, on link chrome (#2816)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -819,6 +819,18 @@ jobs:
         run: scripts/check-hardcoded-colors.sh
 
   # ---------------------------------------------------------------
+  # Admin dispatcher brand-accent guard: block bare shadcn accent
+  # tokens on `/admin/dispatcher` so readability regressions like
+  # #2816 (invisible gray issue/PR links) don't recur.
+  # ---------------------------------------------------------------
+  admin-dispatcher-brand-accent-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Enforce brand-accent on /admin/dispatcher link chrome
+        run: scripts/check-admin-dispatcher-brand-accent.sh
+
+  # ---------------------------------------------------------------
   # LLM JSON loads guard: flag raw json.loads on LLM response text
   # — should use parse_llm_json (or strict=False) instead (#2550).
   # ---------------------------------------------------------------
@@ -1162,7 +1174,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/docs/BRAND.md
+++ b/docs/BRAND.md
@@ -29,12 +29,18 @@
 
 ### Accent
 
-| Name | Hex | Usage |
-|------|-----|-------|
-| Amber 700 | `#b45309` | Primary accent — links, active states, CTAs, wordmark |
-| Amber 600 | `#d97706` | Hover state for accent elements |
-| Amber 500 | `#f59e0b` | Lighter accent — highlights, selected states |
-| Amber 100 | `#fef3c7` | Accent surface — subtle backgrounds, badges |
+These amber hexes all map to the `brand-accent` Tailwind token (see
+§Tailwind Token Mapping below). **Never** write `text-accent`,
+`bg-accent`, etc. as bare utilities to get this colour — that token
+is a shadcn hover-surface gray. Use `text-brand-accent`.
+
+| Name | Hex | Tailwind token | Usage |
+|------|-----|----------------|-------|
+| Amber 700 | `#b45309` | `brand-accent` (DEFAULT) | Primary accent — links, active states, CTAs, wordmark (light mode) |
+| Amber 800 | `#92400e` | `brand-accent-hover` | Hover on brand-accent chrome |
+| Amber 600 | `#d97706` | `brand-accent-light` | Primary accent on dark mode |
+| Amber 500 | `#f59e0b` | `brand-accent-lighter` | Lighter accent — highlights, selected states |
+| Amber 100 | `#fef3c7` | `brand-accent-surface` | Accent surface — subtle backgrounds, badges |
 
 ### Semantic
 
@@ -53,14 +59,47 @@
 
 ## Tailwind Token Mapping
 
+> **Footgun — `accent` vs `brand-accent`.** shadcn's `accent` token
+> (`hsl(var(--accent))` in `packages/web/tailwind.config.ts`) is a
+> **near-gray hover surface**, not the brand amber. The brand amber
+> lives on the separate `brand-accent` token. The two classes are one
+> character apart — `text-accent` vs `text-brand-accent` — and the
+> shadcn one is nearly invisible on both light and dark backgrounds.
+>
+> - **Use `brand-accent` for always-visible brand chrome** — links,
+>   active states, wordmark accents. Canonical pattern:
+>   `text-brand-accent dark:text-brand-accent-light` (see
+>   `packages/web/src/components/Wordmark.tsx`).
+> - **Use `accent` only in shadcn hover / selected / focused idioms** —
+>   e.g. `hover:bg-accent hover:text-accent-foreground`,
+>   `data-[selected=true]:bg-accent`. Never as a bare class on an
+>   always-visible element.
+>
+> Regressions on `/admin/dispatcher` (#2816) prompted a CI guard
+> (`scripts/check-admin-dispatcher-brand-accent.sh`) that blocks bare
+> `*-accent` utilities on that surface. When in doubt, grep the
+> Wordmark component for the canonical pattern.
+
 ```
+// packages/web/tailwind.config.ts
 colors: {
   stone: { /* Tailwind's built-in stone scale */ },
+
+  // Brand amber — always-visible chrome (links, wordmark, emphasis).
+  'brand-accent': {
+    DEFAULT:    '#b45309',  // amber-700 — light-mode text / fill
+    hover:      '#92400e',  // amber-800
+    light:      '#d97706',  // amber-600 — dark-mode text / fill
+    lighter:    '#f59e0b',  // amber-500
+    surface:    '#fef3c7',  // amber-100 — badge / pill surface
+    foreground: '#ffffff',
+  },
+
+  // shadcn hover-surface token — gray by default, used ONLY with a
+  // modifier (hover:, focus:, data-[...]:). Never as bare `text-accent`.
   accent: {
-    DEFAULT: '#b45309',  // amber-700
-    hover: '#d97706',    // amber-600
-    light: '#f59e0b',    // amber-500
-    surface: '#fef3c7',  // amber-100
+    DEFAULT:    'hsl(var(--accent))',
+    foreground: 'hsl(var(--accent-foreground))',
   },
 }
 ```

--- a/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
@@ -88,7 +88,7 @@ function ActiveAgentRow({
             href={logsHref}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-accent underline-offset-2 hover:underline"
+            className="text-brand-accent dark:text-brand-accent-light underline-offset-2 hover:underline"
           >
             Logs &rarr;
           </a>

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -327,7 +327,7 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
               href="https://github.com/judgemind/judgemind/issues/2801"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-accent underline-offset-2 hover:underline"
+              className="text-brand-accent dark:text-brand-accent-light underline-offset-2 hover:underline"
             >
               #2801
             </a>

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
@@ -11,6 +11,21 @@ describe('IssueLink', () => {
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
     expect(link.textContent).toBe('#2805');
   });
+
+  // Regression guard for #2816: `text-accent` in tailwind.config.ts maps
+  // to shadcn's hover-surface gray, not brand amber.  The correct tokens
+  // are `text-brand-accent` (light mode, amber-700) paired with
+  // `dark:text-brand-accent-light` (dark mode, amber-600).  Both must be
+  // present so link chrome is visible on both themes.
+  it('renders with the brand-accent token pair (light + dark)', () => {
+    render(<IssueLink number={2816} />);
+    const link = screen.getByTestId('issue-link-2816');
+    expect(link.className).toContain('text-brand-accent');
+    expect(link.className).toContain('dark:text-brand-accent-light');
+    // Bare `text-accent` must not appear — it would trigger the #2816
+    // readability regression where links render as low-contrast gray.
+    expect(link.className).not.toMatch(/(^|\s)text-accent(\s|$)/);
+  });
 });
 
 describe('PRLink', () => {
@@ -19,6 +34,15 @@ describe('PRLink', () => {
     const link = screen.getByTestId('pr-link-2740');
     expect(link).toHaveAttribute('href', 'https://github.com/judgemind/judgemind/pull/2740');
     expect(link.textContent).toBe('PR #2740');
+  });
+
+  // Regression guard for #2816 — see note on IssueLink above.
+  it('renders with the brand-accent token pair (light + dark)', () => {
+    render(<PRLink number={2811} />);
+    const link = screen.getByTestId('pr-link-2811');
+    expect(link.className).toContain('text-brand-accent');
+    expect(link.className).toContain('dark:text-brand-accent-light');
+    expect(link.className).not.toMatch(/(^|\s)text-accent(\s|$)/);
   });
 });
 

--- a/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
@@ -13,6 +13,13 @@
 
 const REPO = 'judgemind/judgemind';
 
+// Brand amber token for hot links. Note: `text-accent` is shadcn's
+// hover-surface gray, NOT the brand amber — see docs/BRAND.md §Tailwind
+// Token Mapping and issue #2816. The canonical pattern lives in
+// `packages/web/src/components/Wordmark.tsx`.
+const BRAND_LINK_CLASSES =
+  'font-mono text-brand-accent dark:text-brand-accent-light underline-offset-2 hover:underline';
+
 /** Hot link to a GitHub issue. Opens in a new tab. */
 export function IssueLink({ number, className }: { number: number; className?: string }) {
   const href = `https://github.com/${REPO}/issues/${number}`;
@@ -21,7 +28,7 @@ export function IssueLink({ number, className }: { number: number; className?: s
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className={`font-mono text-accent underline-offset-2 hover:underline ${className ?? ''}`}
+      className={`${BRAND_LINK_CLASSES} ${className ?? ''}`}
       data-testid={`issue-link-${number}`}
     >
       #{number}
@@ -37,7 +44,7 @@ export function PRLink({ number, className }: { number: number; className?: stri
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className={`font-mono text-accent underline-offset-2 hover:underline ${className ?? ''}`}
+      className={`${BRAND_LINK_CLASSES} ${className ?? ''}`}
       data-testid={`pr-link-${number}`}
     >
       PR #{number}

--- a/scripts/check-admin-dispatcher-brand-accent.sh
+++ b/scripts/check-admin-dispatcher-brand-accent.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# check-admin-dispatcher-brand-accent.sh — Enforce brand-accent on admin dispatcher.
+#
+# The shadcn `accent` Tailwind token (mapped via `hsl(var(--accent))` in
+# packages/web/tailwind.config.ts) is a near-gray *hover surface* — not the
+# brand amber.  The brand amber lives on the separate `brand-accent` token
+# (see `docs/BRAND.md §Tailwind Token Mapping` and the canonical usage in
+# `packages/web/src/components/Wordmark.tsx`).  The two classes are one
+# character apart, which is a persistent footgun: on PR #2811 issue + PR
+# links on `/admin/dispatcher` ended up styled with the hover-surface gray
+# and were nearly invisible on both light and dark backgrounds (#2816).
+#
+# This guard blocks bare `text-accent`, `bg-accent`, `border-accent`, and
+# `ring-accent` inside `packages/web/src/app/(main)/admin/dispatcher/`.
+# It does NOT block hover-surface idioms like
+# `hover:bg-accent hover:text-accent-foreground` — those are intentional
+# shadcn patterns (see the button / dropdown primitives).  Only bare
+# always-visible `*-accent` usages trip the check.
+#
+# Algorithm (per line):
+#   1. Pre-process the line with sed to delete any modifier-prefixed
+#      usage (`hover:`, `focus:`, `data-[...]:`, etc.) and any
+#      `*-accent-foreground` suffix usage.  Modifier-prefixed and
+#      foreground-paired accent usages are legitimate.
+#   2. On the remaining line, look for `text-accent`, `bg-accent`,
+#      `border-accent`, or `ring-accent` followed by a word boundary.
+#
+# Usage:
+#   scripts/check-admin-dispatcher-brand-accent.sh          # scan default dir
+#   scripts/check-admin-dispatcher-brand-accent.sh [dir]    # scan custom dir
+#
+# Exit codes:
+#   0 — No violations.
+#   1 — One or more files in the dispatcher admin surface use a bare shadcn
+#       accent token that should be `brand-accent` instead.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-}"
+
+# ─── Target directory ──────────────────────────────────────────────────
+DEFAULT_TARGET="$REPO_ROOT/packages/web/src/app/(main)/admin/dispatcher"
+if [[ -n "$SCAN_DIR" ]]; then
+    target="$SCAN_DIR"
+else
+    target="$DEFAULT_TARGET"
+fi
+
+if [[ ! -d "$target" ]]; then
+    echo "All clean — target directory not found: $target"
+    exit 0
+fi
+
+# ─── sed pre-processor ──────────────────────────────────────────────────
+# Strip every occurrence of:
+#   - `<prefix>:(text|bg|border|ring)-accent`  (any non-space modifier, e.g.
+#     `hover:`, `focus:`, `group-hover:`, `data-[selected=true]:`,
+#     `dark:hover:`, etc.).  `[^[:space:]:]+:` handles single-modifier; we
+#     apply the stripping repeatedly via `g` plus the `-E` grammar so
+#     chained modifiers like `dark:hover:bg-accent` collapse in one pass.
+#     Accept brackets in the modifier (e.g. `data-[...]:`) by allowing
+#     any non-space, non-colon chars plus balanced `[...]` groups.
+#   - `(text|bg|border|ring)-accent-foreground`  (shadcn's
+#     foreground-on-surface pairing).
+#
+# After stripping, any surviving `(text|bg|border|ring)-accent` followed
+# by a word boundary is a bare shadcn accent token and a violation.
+#
+# The prefix pattern uses [^[:space:]:] to match one modifier segment and
+# the outer loop (performed by sed's `s///g` on a single line) is re-run
+# repeatedly until the input is stable — done via `-E` with three passes,
+# which is sufficient for the realistic class-string depths we see (at
+# most 2-3 chained modifiers).
+
+strip_allowed() {
+    # Three passes over the line, each stripping one layer of modifier
+    # prefixes plus the -foreground suffix pair.  Three passes covers up
+    # to `a:b:c:text-accent` which is deeper than anything in this repo.
+    sed -E \
+        -e 's/([^[:space:]"'\'':`]+:)(text|bg|border|ring)-accent/__MASKED__/g' \
+        -e 's/(text|bg|border|ring)-accent-foreground/__MASKED__/g' \
+        -e 's/([^[:space:]"'\'':`]+:)(text|bg|border|ring)-accent/__MASKED__/g' \
+        -e 's/(text|bg|border|ring)-accent-foreground/__MASKED__/g' \
+        -e 's/([^[:space:]"'\'':`]+:)(text|bg|border|ring)-accent/__MASKED__/g' \
+        -e 's/(text|bg|border|ring)-accent-foreground/__MASKED__/g'
+}
+
+# Regex for bare, surviving `(text|bg|border|ring)-accent` followed by a
+# non-identifier character.  Using grep -E for portability (macOS/BSD sed
+# vs GNU sed word boundaries differ — safer to check with grep).
+BAD_TOKEN_RE='(text|bg|border|ring)-accent($|[^a-zA-Z0-9_-])'
+
+# ─── Scan ──────────────────────────────────────────────────────────────
+violations=0
+
+# Find all .tsx/.ts files under the target, excluding tests.
+# Avoid `mapfile -d ''` (bash 4+) so the script runs on macOS bash 3.2 too.
+files=()
+while IFS= read -r -d '' file; do
+    files+=("$file")
+done < <(
+    find "$target" \
+        -type f \
+        \( -name '*.tsx' -o -name '*.ts' \) \
+        ! -path '*/__tests__/*' \
+        ! -name '*.test.tsx' \
+        ! -name '*.test.ts' \
+        -print0
+)
+
+if [[ ${#files[@]} -eq 0 ]]; then
+    echo "All clean — no .tsx/.ts files under $target"
+    exit 0
+fi
+
+for file in "${files[@]}"; do
+    line_no=0
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line_no=$((line_no + 1))
+
+        # Skip comment lines — best-effort: `//`, ` * ` (JSDoc), `/*`.
+        trimmed="${line#"${line%%[![:space:]]*}"}"
+        case "$trimmed" in
+            '//'*) continue ;;
+            '*'*)  continue ;;
+            '/*'*) continue ;;
+        esac
+
+        masked=$(printf '%s' "$line" | strip_allowed)
+
+        if printf '%s\n' "$masked" | grep -qE "$BAD_TOKEN_RE"; then
+            if [[ $violations -eq 0 ]]; then
+                echo "ERROR: Bare shadcn accent token on the admin dispatcher surface."
+                echo ""
+                echo "  The shadcn accent token is a near-gray hover surface, NOT the"
+                echo "  brand amber.  Use brand-accent for always-visible amber chrome:"
+                echo ""
+                echo "    text-accent                -> text-brand-accent dark:text-brand-accent-light"
+                echo "    bg-accent   (not hover:)   -> bg-brand-accent (see docs/BRAND.md)"
+                echo ""
+                echo "  If you actually meant the shadcn hover surface, pair the token"
+                echo "  with a modifier such as 'hover:bg-accent hover:text-accent-foreground'."
+                echo ""
+                echo "  See issue #2816 and packages/web/src/components/Wordmark.tsx."
+                echo ""
+                echo "  Violations:"
+                echo ""
+            fi
+            rel_path="${file#"$REPO_ROOT/"}"
+            echo "    $rel_path:$line_no:$line"
+            violations=$((violations + 1))
+        fi
+    done < "$file"
+done
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "  Found $violations occurrence(s) of bare shadcn accent tokens."
+    echo "  Reference: https://github.com/judgemind/judgemind/issues/2816"
+    exit 1
+fi
+
+echo "All clean — no bare shadcn accent tokens on /admin/dispatcher."
+exit 0

--- a/scripts/tests/test_check_admin_dispatcher_brand_accent.sh
+++ b/scripts/tests/test_check_admin_dispatcher_brand_accent.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# test_check_admin_dispatcher_brand_accent.sh — Tests for
+# scripts/check-admin-dispatcher-brand-accent.sh.
+#
+# Synthesises small .tsx fixtures in a temp dir, runs the guard against
+# the temp dir, and asserts the expected pass/fail outcome for each
+# canonical pattern described in the check script's header comment.
+#
+# Also calls `assert_no_self_match_on_ci_step_name` at the end so the
+# check does not accidentally flag the ci.yml step name that invokes
+# it (see #2541/#2542 and scripts/tests/_guard_self_match_helpers.sh).
+#
+# Usage:
+#   scripts/tests/test_check_admin_dispatcher_brand_accent.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-admin-dispatcher-brand-accent.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: Bare text-accent in TSX should fail ─────────────────────────
+create_test_file "Bad.tsx" \
+    'export const Bad = () => <span className="text-accent">hi</span>;' > /dev/null
+assert_fails "Bare text-accent on a TSX element is flagged"
+reset_tmpdir
+
+# ─── Test 2: Bare bg-accent in TSX should fail ───────────────────────────
+create_test_file "BadBg.tsx" \
+    'export const Bad = () => <div className="bg-accent p-2">hi</div>;' > /dev/null
+assert_fails "Bare bg-accent on a TSX element is flagged"
+reset_tmpdir
+
+# ─── Test 3: Bare border-accent in TSX should fail ───────────────────────
+create_test_file "BadBorder.tsx" \
+    'export const Bad = () => <div className="border border-accent">hi</div>;' > /dev/null
+assert_fails "Bare border-accent on a TSX element is flagged"
+reset_tmpdir
+
+# ─── Test 4: Bare ring-accent in TSX should fail ─────────────────────────
+create_test_file "BadRing.tsx" \
+    'export const Bad = () => <input className="ring-2 ring-accent" />;' > /dev/null
+assert_fails "Bare ring-accent on a TSX element is flagged"
+reset_tmpdir
+
+# ─── Test 5: brand-accent idiom passes ───────────────────────────────────
+create_test_file "Good.tsx" \
+    'export const Ok = () => <span className="text-brand-accent dark:text-brand-accent-light">hi</span>;' > /dev/null
+assert_passes "Brand-accent idiom (text-brand-accent) is allowed"
+reset_tmpdir
+
+# ─── Test 6: hover:bg-accent hover:text-accent-foreground pattern passes ─
+# This is shadcn's canonical hover behaviour — ui/button.tsx, dropdown,
+# select, command, sidebar all use it.  It must not be flagged.
+create_test_file "Hover.tsx" \
+    'export const Hov = () => <button className="hover:bg-accent hover:text-accent-foreground">hi</button>;' > /dev/null
+assert_passes "Hover-state accent pair (hover:bg-accent hover:text-accent-foreground) is allowed"
+reset_tmpdir
+
+# ─── Test 7: focus:bg-accent passes ──────────────────────────────────────
+create_test_file "Focus.tsx" \
+    'export const Foc = () => <input className="focus:bg-accent focus:text-accent-foreground" />;' > /dev/null
+assert_passes "focus:bg-accent pair is allowed"
+reset_tmpdir
+
+# ─── Test 8: data-[selected=true]:bg-accent pattern passes ───────────────
+# Shadcn's command.tsx / dropdown-menu.tsx / select.tsx use this form.
+create_test_file "Selected.tsx" \
+    'export const Sel = () => <li className="data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground">hi</li>;' > /dev/null
+assert_passes "data-[selected=true]:bg-accent pattern is allowed"
+reset_tmpdir
+
+# ─── Test 9: text-accent-foreground alone passes ─────────────────────────
+# Used in sidebar.tsx (expect().toContain('text-accent-foreground')) — the
+# foreground token pairs with an already-styled surface.
+create_test_file "Fg.tsx" \
+    'export const Fg = () => <span className="text-accent-foreground">hi</span>;' > /dev/null
+assert_passes "text-accent-foreground alone is allowed"
+reset_tmpdir
+
+# ─── Test 10: Comment line referencing text-accent passes ────────────────
+create_test_file "Comment.tsx" \
+    '// Note: text-accent is the shadcn hover surface — do not use it here.
+export const Ok = () => <span className="text-brand-accent">hi</span>;' > /dev/null
+assert_passes "// comment referencing text-accent as explanatory context is allowed"
+reset_tmpdir
+
+# ─── Test 11: Test files (.test.tsx) are excluded ────────────────────────
+create_test_file "page.test.tsx" \
+    'it("has text-accent", () => { expect(el).toHaveClass("text-accent"); });' > /dev/null
+assert_passes ".test.tsx files are excluded from the scan"
+reset_tmpdir
+
+# ─── Test 12: Underscore-joined lookalike is not matched ─────────────────
+# `text_accent` as an identifier, `textAccent` as a JS var, must not match.
+create_test_file "Lookalike.tsx" \
+    'const text_accent = 1; const textAccent = 2; export {};' > /dev/null
+assert_passes "Underscore / camelCase lookalikes do not match"
+reset_tmpdir
+
+# ─── Test 13: Empty directory passes ─────────────────────────────────────
+assert_passes "Empty directory passes"
+
+# ─── Test 14: Mixed file — bad line in TSX is caught ─────────────────────
+create_test_file "Mixed.tsx" \
+    'import X from "x";
+// hover:text-accent would be fine on a hover pair.
+export const Bad = () => <span className="text-accent underline">hi</span>;
+export const Good = () => <span className="text-brand-accent">hi</span>;' > /dev/null
+assert_fails "Real usage line in a mixed file is caught"
+reset_tmpdir
+
+# ─── Test 15: No self-match on ci.yml step name ──────────────────────────
+# Mirrors the #2541/#2542 self-match guard used by every string-forbidding
+# check.  If a ci.yml step name quotes the forbidden pattern, the guard
+# matches itself on first CI run — describe what the check does, not what
+# it forbids.
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-admin-dispatcher-brand-accent.sh" "yml"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fix readability regression on `/admin/dispatcher` where issue / PR hot links rendered in shadcn hover-surface gray instead of brand amber (#2811 used `text-accent`, which in `tailwind.config.ts` maps to the gray `hsl(var(--accent))`; the brand amber is `brand-accent`). Replaced the four bare `text-accent` call sites with the canonical `text-brand-accent dark:text-brand-accent-light` pair used by `Wordmark.tsx`. Added a CI guard, peer shell test, and unit-test assertions so the regression cannot recur. Rewrote the stale `docs/BRAND.md` §Tailwind Token Mapping to distinguish shadcn `accent` (hover surface) from `brand-accent` (brand amber).

Closes #2816

## Test plan

### Automated checks
- [x] Lint passes (`npm --prefix packages/web run lint`)
- [x] Typecheck passes (`npm --prefix packages/web run typecheck`)
- [x] Tests pass (`npm --prefix packages/web test` — 81 files, 1215 tests; includes 2 new `IssueLink`/`PRLink` regression cases)
- [x] Build passes (`npm --prefix packages/web run build`)
- [x] Shell tests pass (`scripts/run-scripts-tests.sh` — 36 tests, includes new `test_check_admin_dispatcher_brand_accent.sh` with 15 cases)
- [x] Guard script green against real repo (`scripts/check-admin-dispatcher-brand-accent.sh`)
- [x] Markdown links valid (`scripts/check-markdown-links.sh`)
- [x] CI green

### Post-deploy verification
- [x] `/admin/dispatcher` deployed on dev; `curl` of the live HTML shows `text-brand-accent` and `text-brand-accent-light` classes present and no bare `text-accent`.
- [x] Before/after state captured (`tmp/admin-after-fix.png` in worktree); screenshot shows amber-coloured issue/PR numbers against white surface.
- [x] Verification evidence posted on #2816 with per-criterion proof ([comment](https://github.com/judgemind/judgemind/issues/2816#issuecomment-4276261116)).
