### PR TITLE
fix(dispatcher): drop invalid --cwd flag + retry branch collision + full-log capture (#2821)

### DIFF
--- a/packages/api/migrations/27_dispatcher-phase-outputs-log-text.sql
+++ b/packages/api/migrations/27_dispatcher-phase-outputs-log-text.sql
@@ -1,0 +1,45 @@
+-- Up Migration
+--
+-- Dispatcher v2 — add ``log_text`` column to ``dispatcher.phase_outputs``
+-- so the full ephemeral phase log (merged stdout+stderr captured from
+-- ``{worktree}/tmp/claude-p-<phase>.log``) survives worktree cleanup,
+-- container restart, and daemon redeploy.
+--
+-- Issue #2821 (scope amendment on the ``--cwd`` fix — folds the
+-- full-log-capture gap into the same PR since both touch the
+-- subprocess-spawn helper).
+--
+-- Design notes
+-- ------------
+-- - ``text`` (not ``jsonb``) — the log is plain text (stdout+stderr
+--   stream), not structured JSON. PostgreSQL's native TOAST + pglz
+--   compression applies automatically for any row that exceeds the
+--   TOAST threshold (default ~2kB), so no explicit compression setting
+--   is needed.
+-- - Nullable — historical rows inserted before this migration have no
+--   log content to back-fill, and phases that fail before producing any
+--   log (e.g. ``claude`` not on PATH) legitimately have no body. Writing
+--   ``NULL`` keeps the "no signal" case distinguishable from an empty
+--   file.
+-- - Capped by the caller, not the DB — ``scripts/dispatcher/daemon.py``
+--   passes whatever the phase log produced, and the housekeeping tick
+--   (#2778/#2779) prunes rows at 30 days along with ``output_json``.
+--   Adding a DB-side ``CHECK (char_length(log_text) <= N)`` would turn
+--   an operational cap into a hard failure the daemon has to handle;
+--   the current convention is "daemon trims, DB stores". A runaway
+--   multi-MB log is a daemon bug to fix at source, not a DB guard to
+--   trip.
+-- - No index — readers are always keyed on ``(agent_id, phase)`` which
+--   is already covered by ``idx_dispatcher_phase_outputs_agent_phase``
+--   (migration 21). The ``log_text`` column is read-through, never
+--   searched.
+
+ALTER TABLE dispatcher.phase_outputs
+    ADD COLUMN log_text TEXT;
+
+COMMENT ON COLUMN dispatcher.phase_outputs.log_text IS
+    'Full ephemeral phase log (stdout+stderr) captured from {worktree}/tmp/claude-p-<phase>.log at phase-finish time. Nullable for historical rows and for phases that failed before producing a log. Housekeeping tick prunes at 30 days along with output_json. See #2821.';
+
+
+-- Down Migration
+ALTER TABLE dispatcher.phase_outputs DROP COLUMN log_text;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -446,8 +446,12 @@ CREATE TABLE dispatcher.phase_outputs (
     agent_id uuid NOT NULL,
     phase text NOT NULL,
     output_json jsonb NOT NULL,
-    ts timestamp with time zone DEFAULT now() NOT NULL
+    ts timestamp with time zone DEFAULT now() NOT NULL,
+    log_text text
 );
+
+
+COMMENT ON COLUMN dispatcher.phase_outputs.log_text IS 'Full ephemeral phase log (stdout+stderr) captured from {worktree}/tmp/claude-p-<phase>.log at phase-finish time. Nullable for historical rows and for phases that failed before producing a log. Housekeeping tick prunes at 30 days along with output_json. See #2821.';
 
 
 CREATE SEQUENCE dispatcher.phase_outputs_output_id_seq

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -162,6 +162,38 @@ PHASE_2_REQUIRED_CONCURRENCY_CAP = 0
 #: seed value (10800s). Enforced via ``subprocess.run(..., timeout=...)``.
 CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS = 180 * 60
 
+#: Character cap on the ``stderr_tail`` field attached to
+#: ``daemon.subprocess_failed`` structured events. Previously 500; raised
+#: to 2000 (#2821) because the tail-oriented truncation loses signal for
+#: noisy failures where the useful "failed: X" line appears early — e.g.
+#: ralph running 1000 tests plus one real error, or terraform plan noise
+#: plus one actual error. 2000 covers most real failure modes without
+#: paying the cost of a full-log embed in the primary event. The full
+#: log is still durably captured via :data:`PHASE_FAILURE_LOG_MAX_CHARS`
+#: in the secondary ``phase_failure_log`` event and via
+#: ``dispatcher.phase_outputs.log_text``.
+PHASE_STDERR_TAIL_MAX_CHARS = 2000
+
+#: Character cap on the ``stderr_preview`` field attached to
+#: ``daemon.phase_output_missing`` and retro-failure structured events.
+#: Previously 200; raised to 2000 (#2821) for the same rationale as
+#: :data:`PHASE_STDERR_TAIL_MAX_CHARS`. Unlike ``stderr_tail``, the
+#: ``stderr_preview`` flows through
+#: :meth:`DispatcherDaemon._extract_log_preview` which additionally
+#: ``strip()``s the content, so the effective cap is still 2000 post-strip.
+PHASE_STDERR_PREVIEW_MAX_CHARS = 2000
+
+#: Character cap on the ``log_body`` field in the secondary
+#: ``daemon.phase_failure_log`` CloudWatch event emitted alongside each
+#: ``daemon.subprocess_failed`` (#2821). CloudWatch Logs allows up to
+#: 256KB per event but 10k is plenty for triage in practice. The primary
+#: failure event stays keyed on a small ``stderr_tail`` so common filter
+#: queries don't double-scan the full log body; the secondary event is
+#: the "full context when a human clicks in" payload. Both events share
+#: ``agent_id`` so ``aws logs filter-log-events --filter-pattern
+#: '<agent_id>'`` returns the pair.
+PHASE_FAILURE_LOG_MAX_CHARS = 10000
+
 #: Per-phase ``--max-turns`` values. Matches the frontmatter on each
 #: ``.claude/skills/task-v2-*/SKILL.md`` file. Sonnet-backed ralph gets
 #: the long tail; plan and summary stay tight. Post-PR phases added
@@ -1883,6 +1915,32 @@ class DispatcherDaemon:
         if self._cfg.baseline_repo_root is not None:
             self._baseline_fetch_origin_main()
 
+        # Defensive branch-delete — the tier-1 retry path (Phase 3C,
+        # #2791) re-runs ``_create_worktree`` against the same agent_id
+        # after a prior attempt's subprocess_crash. ``agent/<short_id>``
+        # is derived from agent_id so the retry would collide with the
+        # branch left behind by attempt 1 (`fatal: a branch named
+        # 'agent/<short_id>' already exists`). Deleting the branch first
+        # makes ``worktree add -b`` idempotent regardless of attempt
+        # number (#2821). Exit code is intentionally ignored: ``git
+        # branch -D`` returns 1 when the branch doesn't exist, which is
+        # the happy case on first attempt. The 10s timeout guards
+        # against a wedged git process without blocking normal flow.
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(git_parent),
+                "branch",
+                "-D",
+                branch,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+
         cmd = [
             "git",
             "-C",
@@ -2055,22 +2113,40 @@ class DispatcherDaemon:
             return None
 
     def _persist_phase_output(
-        self, agent_id: str, phase: str, output_json: dict[str, Any]
+        self,
+        agent_id: str,
+        phase: str,
+        output_json: dict[str, Any],
+        log_text: str | None = None,
     ) -> None:
         """INSERT the phase's output into ``dispatcher.phase_outputs``
         and append a row to ``dispatcher.phase_transitions``.
 
         Both tables share a single transaction so the observed state
         stays consistent under partial failure.
+
+        ``log_text`` (added in #2821, migration 27) persists the full
+        ephemeral phase log body so operators can ``SELECT log_text FROM
+        dispatcher.phase_outputs WHERE agent_id = '<uuid>' ORDER BY ts
+        DESC`` at any time, even after the worktree has been cleaned up
+        and the ephemeral ``{worktree}/tmp/claude-p-<phase>.log`` file
+        deleted. Nullable for historical rows and for phases that
+        completed with no log content to capture. Housekeeping tick
+        (#2778/#2779) prunes rows at 30 days along with ``output_json``.
         """
         assert self._conn is not None, "connect() must run before persisting"
         try:
             with self._conn.cursor() as cur:
                 cur.execute(
                     "INSERT INTO dispatcher.phase_outputs "
-                    "    (agent_id, phase, output_json) "
-                    "VALUES (%s, %s, %s)",
-                    (agent_id, phase, json.dumps(output_json, default=str)),
+                    "    (agent_id, phase, output_json, log_text) "
+                    "VALUES (%s, %s, %s, %s)",
+                    (
+                        agent_id,
+                        phase,
+                        json.dumps(output_json, default=str),
+                        log_text,
+                    ),
                 )
                 cur.execute(
                     "INSERT INTO dispatcher.phase_transitions "
@@ -2207,6 +2283,13 @@ class DispatcherDaemon:
         :class:`subprocess.TimeoutExpired` on wall-clock timeout so the
         caller can mark the agent failed. Other subprocess errors bubble
         up as their native exception types.
+
+        The worktree is passed as the subprocess's CWD via
+        ``subprocess.run(..., cwd=...)`` — NOT as a ``--cwd`` flag. The
+        ``claude`` CLI does not accept a ``--cwd`` flag; passing one
+        makes every phase subprocess exit 1 within 400ms with
+        ``error: unknown option '--cwd'`` (#2821). Python's stdlib ``cwd=``
+        is the correct knob for "start the child process in this directory".
         """
         max_turns = PHASE_MAX_TURNS[phase]
         model = PHASE_MODELS[phase]
@@ -2217,8 +2300,6 @@ class DispatcherDaemon:
             "claude",
             "-p",
             f"/task-v2-{phase} {agent_id}",
-            "--cwd",
-            str(worktree),
             "--max-turns",
             str(max_turns),
             "--model",
@@ -2246,6 +2327,7 @@ class DispatcherDaemon:
                 text=True,
                 timeout=CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS,
                 check=False,
+                cwd=str(worktree),
             )
         duration = time.monotonic() - start
         return result.returncode, duration
@@ -2520,7 +2602,12 @@ class DispatcherDaemon:
             )
             return False
 
-        self._persist_phase_output(agent_id, "plan", plan_output)
+        self._persist_phase_output(
+            agent_id,
+            "plan",
+            plan_output,
+            log_text=self._read_full_phase_log(worktree, "plan") or None,
+        )
         self._log.info(
             "daemon.phase_succeeded",
             extra={
@@ -2598,7 +2685,12 @@ class DispatcherDaemon:
             )
             return False
 
-        self._persist_phase_output(agent_id, "ralph", ralph_output)
+        self._persist_phase_output(
+            agent_id,
+            "ralph",
+            ralph_output,
+            log_text=self._read_full_phase_log(worktree, "ralph") or None,
+        )
         verdict = ralph_output.get("verdict", "")
         self._log.info(
             "daemon.phase_succeeded",
@@ -2748,7 +2840,12 @@ class DispatcherDaemon:
             )
             return False
 
-        self._persist_phase_output(agent_id, "summary", summary_output)
+        self._persist_phase_output(
+            agent_id,
+            "summary",
+            summary_output,
+            log_text=self._read_full_phase_log(worktree, "summary") or None,
+        )
         self._log.info(
             "daemon.phase_succeeded",
             extra={
@@ -2808,15 +2905,21 @@ class DispatcherDaemon:
             # Timeout = subprocess runaway (spec §17 Risk 4). Treat as
             # a generic ``subprocess_crash`` — the subprocess didn't
             # actually crash but the next retry needs a fresh worktree
-            # just the same.
+            # just the same. Capture the log tail for triage — a runaway
+            # ralph spinning on a failing test still produces useful log
+            # output before the timeout fires.
+            tail = self._log_tail(
+                worktree, phase, max_chars=PHASE_STDERR_TAIL_MAX_CHARS
+            )
             self._handle_subprocess_failure(
                 agent_id=agent_id,
                 phase=phase,
                 reason="timeout",
                 exit_code=None,
-                stderr_tail="",
+                stderr_tail=tail,
                 duration_s=None,
                 extra={"timeout_seconds": CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS},
+                worktree=worktree,
             )
             return None
         except FileNotFoundError:
@@ -2871,7 +2974,12 @@ class DispatcherDaemon:
             # context but don't include verbatim in the structured
             # log envelope (may contain secrets). The classifier only
             # sees a short tail so a bad regex cannot echo a secret.
-            tail = self._log_tail(worktree, phase, max_chars=500)
+            # Tail size matches :data:`PHASE_STDERR_TAIL_MAX_CHARS` —
+            # 500 was too tight for noisy failures where the useful
+            # "failed: X" line appears early (#2821).
+            tail = self._log_tail(
+                worktree, phase, max_chars=PHASE_STDERR_TAIL_MAX_CHARS
+            )
             self._handle_subprocess_failure(
                 agent_id=agent_id,
                 phase=phase,
@@ -2880,6 +2988,7 @@ class DispatcherDaemon:
                 stderr_tail=tail,
                 duration_s=duration,
                 extra={},
+                worktree=worktree,
             )
             return None
 
@@ -2906,6 +3015,7 @@ class DispatcherDaemon:
         stderr_tail: str,
         duration_s: float | None,
         extra: dict[str, Any],
+        worktree: Path | None = None,
     ) -> None:
         """Classify a subprocess failure, write failure row, enqueue retry.
 
@@ -2919,6 +3029,15 @@ class DispatcherDaemon:
         diagnoser can pick up. Future: 3D may flip turn-limit to a
         single retry-with-hint — the classifier already returns the
         distinct category so that wiring is a one-line change.
+
+        When ``worktree`` is provided, a secondary
+        ``daemon.phase_failure_log`` event is emitted carrying up to
+        :data:`PHASE_FAILURE_LOG_MAX_CHARS` chars of the full phase log
+        body (#2821). Both events share ``agent_id`` so a single
+        CloudWatch filter-log-events query returns the pair. The full
+        log is the "click-in" payload for triage — the primary event's
+        ``stderr_tail`` stays narrow so filter queries against the
+        primary event don't double-scan the full body.
         """
         # ``claude`` is the Phase-3 default runner. When multi-runner
         # support lands (per dispatcher.config.runner_by_phase), this
@@ -2949,6 +3068,17 @@ class DispatcherDaemon:
         log_extra.update(extra)
         log_extra["stderr_tail"] = stderr_tail
         self._log.warning("daemon.subprocess_failed", extra=log_extra)
+
+        # Secondary event: full-log dump for triage (#2821). Emitted
+        # when we have a worktree reference (all real failure paths) and
+        # the log file actually has content. Cap at 10k chars — the tail
+        # is preserved because failures surface at the tail, not the
+        # head, and merged stdout+stderr logs commonly start with env
+        # dumps or prompt echoes that are noise.
+        if worktree is not None:
+            self._emit_phase_failure_log_event(
+                agent_id=agent_id, phase=phase, worktree=worktree
+            )
 
         self._write_failure(
             agent_id=agent_id,
@@ -2992,30 +3122,90 @@ class DispatcherDaemon:
         return data[-max_chars:]
 
     def _extract_log_preview(
-        self, worktree: Path, phase: str, max_chars: int = 200
+        self,
+        worktree: Path,
+        phase: str,
+        max_chars: int = PHASE_STDERR_PREVIEW_MAX_CHARS,
     ) -> str:
         """Return a short preview of the phase log for triage-in-CloudWatch.
 
-        Mirrors the ``stderr_preview`` convention used by
-        :meth:`_create_worktree` and :meth:`ensure_baseline_clone`
-        (`(result.stderr or "").strip()[:200]`). For phase subprocesses the
-        stream is merged stdout+stderr (see
+        For phase subprocesses the stream is merged stdout+stderr (see
         :meth:`_spawn_phase_subprocess` which redirects stderr to stdout into
         ``{worktree}/tmp/claude-p-<phase>.log``) — we return the last
         ``max_chars`` of the stripped log because failures surface at the
         tail, not the head.
 
-        The full text is preserved on disk at ``claude-p-<phase>.log`` and
-        the structured output (when present) at ``dispatcher.phase_outputs``
-        — this helper is for triage, not archival. Callers should omit the
+        The full text is preserved on disk at ``claude-p-<phase>.log``,
+        at ``dispatcher.phase_outputs.log_text`` (durable across worktree
+        cleanup — #2821), and in the secondary
+        ``daemon.phase_failure_log`` CloudWatch event — this helper is
+        for triage, not archival. Callers should omit the
         ``stderr_preview`` log field when this returns an empty string
         (avoids `stderr_preview: ""` noise on CloudWatch for phases that
         never produced a log, e.g. a preflight exception before spawn).
 
-        Issue #2809.
+        Default cap bumped from 200 → 2000 in #2821 — the old tail was
+        too tight for noisy failures where the useful line appeared
+        early. See :data:`PHASE_STDERR_PREVIEW_MAX_CHARS`. Introduced in
+        issue #2809.
         """
         tail = self._log_tail(worktree, phase, max_chars=max_chars)
         return tail.strip()[:max_chars]
+
+    def _read_full_phase_log(self, worktree: Path, phase: str) -> str:
+        """Return the full phase log text, or empty string on any error.
+
+        Unlike :meth:`_log_tail` / :meth:`_extract_log_preview`, this
+        returns the complete file with no truncation. Used to populate
+        ``dispatcher.phase_outputs.log_text`` (durable archival per
+        #2821) and as the input to :meth:`_emit_phase_failure_log_event`
+        which then applies the :data:`PHASE_FAILURE_LOG_MAX_CHARS` cap.
+        """
+        log_path = worktree / "tmp" / f"claude-p-{phase}.log"
+        if not log_path.exists():
+            return ""
+        try:
+            return log_path.read_text(errors="replace")
+        except Exception:  # pragma: no cover — defensive
+            return ""
+
+    def _emit_phase_failure_log_event(
+        self, agent_id: str, phase: str, worktree: Path
+    ) -> None:
+        """Emit ``daemon.phase_failure_log`` with up to 10k chars of full log.
+
+        Paired with each ``daemon.subprocess_failed`` event emitted by
+        :meth:`_handle_subprocess_failure` (#2821). Skipped when the
+        phase log is empty (avoids a blank event for phases that failed
+        before any output was produced). Tail-truncated at
+        :data:`PHASE_FAILURE_LOG_MAX_CHARS` — failures surface at the
+        tail, and merged stdout+stderr logs commonly start with env
+        dumps or prompt echoes that are noise.
+
+        The envelope carries both ``log_chars_total`` (full size) and
+        ``log_chars_emitted`` (what made it into this event) so
+        operators know whether the truncation lost context.
+        """
+        body = self._read_full_phase_log(worktree, phase)
+        if not body:
+            return
+        total = len(body)
+        if total <= PHASE_FAILURE_LOG_MAX_CHARS:
+            emitted_body = body
+        else:
+            emitted_body = body[-PHASE_FAILURE_LOG_MAX_CHARS:]
+        self._log.warning(
+            "daemon.phase_failure_log",
+            extra={
+                "event": "phase_failure_log",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "phase": phase,
+                "log_chars_total": total,
+                "log_chars_emitted": len(emitted_body),
+                "log_body": emitted_body,
+            },
+        )
 
     def _push_and_open_pr(
         self, agent_id: str, issue_number: int, worktree: Path
@@ -3898,7 +4088,12 @@ class DispatcherDaemon:
             )
             return
 
-        self._persist_phase_output(agent_id, "fix-ci", fix_ci_output)
+        self._persist_phase_output(
+            agent_id,
+            "fix-ci",
+            fix_ci_output,
+            log_text=self._read_full_phase_log(worktree, "fix-ci") or None,
+        )
         verdict = str(fix_ci_output.get("verdict") or "").upper()
 
         if verdict == "PATCHED":
@@ -4462,7 +4657,12 @@ class DispatcherDaemon:
             )
             return
 
-        self._persist_phase_output(agent_id, "verify", verify_output)
+        self._persist_phase_output(
+            agent_id,
+            "verify",
+            verify_output,
+            log_text=self._read_full_phase_log(worktree, "verify") or None,
+        )
 
         evidence_md = str(verify_output.get("evidence_md") or "").strip()
         if evidence_md:
@@ -4814,7 +5014,12 @@ class DispatcherDaemon:
 
         # Persist the retro output to dispatcher.phase_outputs +
         # phase_transitions so the admin page sees the run.
-        self._persist_phase_output(agent_id, "retro", retro_output)
+        self._persist_phase_output(
+            agent_id,
+            "retro",
+            retro_output,
+            log_text=self._read_full_phase_log(worktree, "retro") or None,
+        )
 
         # File the retro issues. Each entry becomes a separate
         # ``gh issue create``. Honour the per-agent cap defensively —
@@ -5978,11 +6183,22 @@ class DispatcherDaemon:
         warning). The caller proceeds with the retry even on False —
         spec §8 calls this a mechanical fix, and an orphaned worktree
         is a much smaller problem than a stuck retry marker.
+
+        The cleanup-script lookup uses ``_repo_root()`` (the daemon's
+        CWD, which contains the ``scripts/`` tree in both the Fargate
+        image and local-dev mode). The ``git worktree remove`` fallback
+        uses ``_git_parent_root()`` instead — in Fargate, ``_repo_root()``
+        is ``/app`` (no ``.git`` child), while ``_git_parent_root()`` is
+        the baseline clone at ``/var/lib/dispatcher/judgemind``. Running
+        ``git worktree remove`` from ``/app`` fails with "not a git
+        repository" (#2821); running it with ``-C <git_parent>`` works
+        from any CWD.
         """
         if not worktree_path:
             return False
 
         repo_root = self._repo_root()
+        git_parent = self._git_parent_root()
         cleanup_script = repo_root / "scripts" / "cleanup_worktree.sh"
 
         if cleanup_script.exists():
@@ -6022,12 +6238,14 @@ class DispatcherDaemon:
         # bypass a safety check), but the retry marker processor has
         # already decided the worktree is toast — the only question is
         # whether we leave an orphan entry in ``git worktree list``.
+        # ``-C <git_parent>`` anchors the command to the baseline clone's
+        # ``.git`` rather than the daemon's CWD — see docstring.
         try:
             result = subprocess.run(
                 [
                     "git",
                     "-C",
-                    str(repo_root),
+                    str(git_parent),
                     "worktree",
                     "remove",
                     "--force",

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -436,10 +436,10 @@ class TestCreateWorktree:
     ) -> None:
         d, _conn, handler = _make_daemon(tmp_path)
 
-        captured: dict[str, Any] = {}
+        calls: list[list[str]] = []
 
         def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
-            captured["cmd"] = cmd
+            calls.append(cmd)
             r = MagicMock()
             r.returncode = 0
             r.stdout = ""
@@ -451,24 +451,84 @@ class TestCreateWorktree:
         agent_id = "aabbccdd-eeff-0011-2233-445566778899"
 
         wt = d._create_worktree(agent_id)
-        assert "git" == captured["cmd"][0]
-        assert "worktree" in captured["cmd"]
-        assert "add" in captured["cmd"]
+        # The defensive branch-delete (see #2821) runs first, then
+        # ``git worktree add``.
+        worktree_add = calls[-1]
+        assert "git" == worktree_add[0]
+        assert "worktree" in worktree_add
+        assert "add" in worktree_add
         # short id = first 8 of hex-collapsed uuid = "aabbccdd".
         assert str(wt).endswith(".claude/worktrees/agent-aabbccdd")
-        assert "-b" in captured["cmd"]
-        branch_idx = captured["cmd"].index("-b") + 1
-        assert captured["cmd"][branch_idx] == "agent/aabbccdd"
+        assert "-b" in worktree_add
+        branch_idx = worktree_add.index("-b") + 1
+        assert worktree_add[branch_idx] == "agent/aabbccdd"
         assert handler.events("worktree_created") != []
+
+    def test_defensive_branch_delete_precedes_worktree_add(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Retry-path branch collision fix (#2821).
+
+        The tier-1 retry path re-runs ``_create_worktree`` with the same
+        ``agent_id``. Without a defensive ``git branch -D`` first, the
+        second ``worktree add -b agent/<short_id>`` fails with ``fatal:
+        a branch named 'agent/<short_id>' already exists``. This test
+        asserts ``branch -D`` is called before ``worktree add``, with
+        the same branch name.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            calls.append(cmd)
+            r = MagicMock()
+            # ``branch -D`` can legitimately return 1 when the branch
+            # doesn't exist (first-attempt happy path) — the daemon
+            # must ignore the exit code. Simulate that here.
+            if "branch" in cmd and "-D" in cmd:
+                r.returncode = 1
+                r.stderr = "error: branch 'agent/aabbccdd' not found.\n"
+            else:
+                r.returncode = 0
+                r.stderr = ""
+            r.stdout = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        agent_id = "aabbccdd-eeff-0011-2233-445566778899"
+
+        # Should NOT raise despite branch -D returning 1.
+        d._create_worktree(agent_id)
+
+        # Ordering: branch -D, then worktree add.
+        branch_delete_idx = next(
+            (i for i, c in enumerate(calls) if "branch" in c and "-D" in c), None
+        )
+        worktree_add_idx = next(
+            (i for i, c in enumerate(calls) if "worktree" in c and "add" in c), None
+        )
+        assert branch_delete_idx is not None, "no branch -D call was made"
+        assert worktree_add_idx is not None, "no worktree add call was made"
+        assert branch_delete_idx < worktree_add_idx
+        # Branch name matches the same convention the worktree-add uses.
+        branch_delete_cmd = calls[branch_delete_idx]
+        assert branch_delete_cmd[-1] == "agent/aabbccdd"
 
     def test_git_failure_raises(self, monkeypatch: Any, tmp_path: Path) -> None:
         d, _conn, _handler = _make_daemon(tmp_path)
 
         def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
             r = MagicMock()
-            r.returncode = 128
+            # Only the worktree-add failure should raise — the defensive
+            # branch-delete's exit code is intentionally ignored.
+            if "worktree" in cmd and "add" in cmd:
+                r.returncode = 128
+                r.stderr = "fatal: branch already exists\n"
+            else:
+                r.returncode = 1
+                r.stderr = ""
             r.stdout = ""
-            r.stderr = "fatal: branch already exists\n"
             return r
 
         monkeypatch.setattr(subprocess, "run", fake_run)
@@ -648,6 +708,7 @@ class TestSpawnPhaseSubprocess:
         def fake_run(cmd: list[str], **kwargs: Any) -> Any:
             captured["cmd"] = cmd
             captured["timeout"] = kwargs.get("timeout")
+            captured["cwd"] = kwargs.get("cwd")
             r = MagicMock()
             r.returncode = 0
             return r
@@ -660,8 +721,10 @@ class TestSpawnPhaseSubprocess:
         assert captured["cmd"][0] == "claude"
         assert "-p" in captured["cmd"]
         assert "/task-v2-plan agent-uuid" in captured["cmd"]
-        assert "--cwd" in captured["cmd"]
-        assert str(tmp_path) in captured["cmd"]
+        # --cwd is NOT a claude CLI flag; the worktree goes through
+        # subprocess.run's cwd= kwarg instead (#2821).
+        assert "--cwd" not in captured["cmd"]
+        assert captured["cwd"] == str(tmp_path)
         assert "--max-turns" in captured["cmd"]
         assert "50" in captured["cmd"]  # plan
         assert "--model" in captured["cmd"]

--- a/scripts/dispatcher/tests/test_daemon_phase3c.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3c.py
@@ -1064,3 +1064,329 @@ class TestSchedulerTickRateLimit:
         assert summary["orchestration_attempted"] == 0
         assert d._claim_and_orchestrate_one.call_count == 0  # type: ignore[attr-defined]
         assert handler.events("claim_skipped_rate_limited")
+
+
+# --------------------------------------------------------------------------
+# #2821 — phase_failure_log secondary event + stderr_tail/preview 2000 cap
+# + cleanup uses _git_parent_root
+# --------------------------------------------------------------------------
+
+
+def _write_phase_log(worktree: Path, phase: str, body: str) -> None:
+    log_dir = worktree / "tmp"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    (log_dir / f"claude-p-{phase}.log").write_text(body)
+
+
+class TestPhaseFailureLogEvent:
+    """Full-log capture via secondary CloudWatch event (#2821).
+
+    Each ``daemon.subprocess_failed`` is followed by a
+    ``daemon.phase_failure_log`` event carrying up to 10k chars of the
+    full merged stdout+stderr log. Both share ``agent_id`` so a single
+    ``filter-log-events`` query returns the pair.
+    """
+
+    def test_emits_secondary_event_with_full_log_under_cap(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,), ("[60,300,900]",)]
+        worktree = tmp_path / "wt"
+        body = "short full log body"
+        _write_phase_log(worktree, "plan", body)
+
+        d._handle_subprocess_failure(
+            agent_id="a1",
+            phase="plan",
+            reason="nonzero_exit",
+            exit_code=1,
+            stderr_tail="tail here",
+            duration_s=1.0,
+            extra={},
+            worktree=worktree,
+        )
+
+        primary = handler.events("subprocess_failed")
+        secondary = handler.events("phase_failure_log")
+        assert primary and secondary, "both events must fire"
+        # Both share agent_id for the single-query triage pattern.
+        assert getattr(primary[0], "agent_id", None) == "a1"
+        assert getattr(secondary[0], "agent_id", None) == "a1"
+        assert getattr(secondary[0], "phase", None) == "plan"
+        assert getattr(secondary[0], "log_body", None) == body
+        assert getattr(secondary[0], "log_chars_total", None) == len(body)
+        assert getattr(secondary[0], "log_chars_emitted", None) == len(body)
+
+    def test_truncates_log_body_at_10k_chars(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,), ("[60,300,900]",)]
+        worktree = tmp_path / "wt"
+        # 15k-char log: 10k emitted, 15k total.
+        body = "A" * 15000
+        _write_phase_log(worktree, "plan", body)
+
+        d._handle_subprocess_failure(
+            agent_id="a2",
+            phase="plan",
+            reason="nonzero_exit",
+            exit_code=1,
+            stderr_tail="...",
+            duration_s=1.0,
+            extra={},
+            worktree=worktree,
+        )
+
+        secondary = handler.events("phase_failure_log")
+        assert secondary
+        record = secondary[0]
+        emitted = getattr(record, "log_body", "")
+        assert len(emitted) == 10000
+        assert getattr(record, "log_chars_total", None) == 15000
+        assert getattr(record, "log_chars_emitted", None) == 10000
+        # Tail preserved — failures surface at the tail, not the head.
+        assert emitted == "A" * 10000
+
+    def test_secondary_event_skipped_when_log_empty(self, tmp_path: Path) -> None:
+        """No worktree log on disk → no secondary event.
+
+        Prevents the no-signal edge case (e.g. preflight exception
+        before subprocess spawn) from spamming CloudWatch with empty
+        ``phase_failure_log`` envelopes.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,), ("[60,300,900]",)]
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        # No claude-p-plan.log written.
+
+        d._handle_subprocess_failure(
+            agent_id="a3",
+            phase="plan",
+            reason="timeout",
+            exit_code=None,
+            stderr_tail="",
+            duration_s=None,
+            extra={"timeout_seconds": 60},
+            worktree=worktree,
+        )
+
+        primary = handler.events("subprocess_failed")
+        secondary = handler.events("phase_failure_log")
+        assert primary, "primary event still fires"
+        assert not secondary, "secondary event must be skipped when log is empty"
+
+    def test_secondary_event_skipped_when_worktree_arg_omitted(
+        self, tmp_path: Path
+    ) -> None:
+        """Legacy callers that predate the worktree arg don't emit the event."""
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,), ("[60,300,900]",)]
+
+        d._handle_subprocess_failure(
+            agent_id="a4",
+            phase="plan",
+            reason="nonzero_exit",
+            exit_code=1,
+            stderr_tail="tail",
+            duration_s=1.0,
+            extra={},
+        )
+        assert handler.events("subprocess_failed")
+        assert not handler.events("phase_failure_log")
+
+
+class TestStderrTailSizeCap:
+    """Primary ``subprocess_failed`` event's ``stderr_tail`` capped at 2000 (#2821)."""
+
+    def test_stderr_tail_emitted_verbatim_at_2000_chars(self, tmp_path: Path) -> None:
+        """``_handle_subprocess_failure`` forwards the caller's tail verbatim.
+
+        The 2000-char cap is applied at the call-site via
+        ``_log_tail(max_chars=PHASE_STDERR_TAIL_MAX_CHARS)`` in
+        ``_run_subprocess_or_fail``. This test verifies the pipeline
+        preserves whatever size the caller hands in — the companion
+        test below exercises the call-site cap end-to-end.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,), ("[60,300,900]",)]
+        tail = "T" * 2000
+
+        d._handle_subprocess_failure(
+            agent_id="a5",
+            phase="plan",
+            reason="nonzero_exit",
+            exit_code=1,
+            stderr_tail=tail,
+            duration_s=1.0,
+            extra={},
+        )
+        primary = handler.events("subprocess_failed")
+        assert primary
+        assert getattr(primary[0], "stderr_tail", None) == tail
+        assert len(getattr(primary[0], "stderr_tail", "")) == 2000
+
+    def test_run_subprocess_or_fail_caps_tail_at_2000(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """The call-site tail read in ``_run_subprocess_or_fail`` honours
+        :data:`PHASE_STDERR_TAIL_MAX_CHARS` (2000)."""
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,), ("[60,300,900]",)]
+        worktree = tmp_path / "wt"
+        # 3000 chars — if the old 500 cap were still in place the tail
+        # would be 500; with 2000 the tail is 2000.
+        _write_phase_log(worktree, "plan", "X" * 3000)
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", lambda *a, **k: (1, 1.0))
+        result = d._run_subprocess_or_fail("a6", "plan", worktree)
+        assert result is None  # subprocess failed
+
+        primary = handler.events("subprocess_failed")
+        assert primary
+        tail = getattr(primary[0], "stderr_tail", "")
+        assert len(tail) == 2000
+        assert tail == "X" * 2000
+
+
+class TestDropWorktreeBestEffortGitParent:
+    """#2821 — ``git worktree remove`` anchored to ``_git_parent_root``.
+
+    In Fargate, ``_repo_root()`` returns ``/app`` (container CWD), which
+    does NOT contain a ``.git`` directory — the baseline clone lives at
+    ``_git_parent_root()`` instead. Before this fix, the cleanup
+    fallback ran ``git -C /app worktree remove`` and failed with "fatal:
+    not a git repository".
+    """
+
+    def test_uses_git_parent_root_when_baseline_set(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        # Simulate Fargate layout: _repo_root = /app (no .git),
+        # _git_parent_root = baseline clone at /var/lib/.../judgemind.
+        repo_root = tmp_path / "app"
+        repo_root.mkdir()
+        baseline = tmp_path / "var" / "lib" / "dispatcher" / "judgemind"
+        baseline.mkdir(parents=True)
+        monkeypatch.setattr(d, "_repo_root", lambda: repo_root)
+        monkeypatch.setattr(d, "_git_parent_root", lambda: baseline)
+
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            captured.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        # No cleanup_worktree.sh at the repo_root — forces git fallback.
+        assert d._drop_worktree_best_effort("/some/worktree") is True
+
+        # Only one call (the fallback), anchored to the baseline via -C.
+        git_remove = [c for c in captured if "worktree" in c and "remove" in c]
+        assert git_remove
+        cmd = git_remove[0]
+        assert cmd[0] == "git"
+        assert cmd[1] == "-C"
+        assert cmd[2] == str(baseline)  # NOT str(repo_root)
+
+    def test_uses_git_parent_root_even_when_cwd_outside_baseline(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Regression test for the actual #2821 symptom — ``git worktree
+        remove`` was running with no ``-C`` anchored correctly and
+        failing with "fatal: not a git repository" because the daemon's
+        CWD had no ``.git`` child. The fix anchors to
+        ``_git_parent_root()`` so the command works regardless of CWD.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        repo_root = tmp_path / "somewhere_else"
+        repo_root.mkdir()
+        baseline = tmp_path / "baseline_clone"
+        baseline.mkdir()
+        monkeypatch.setattr(d, "_repo_root", lambda: repo_root)
+        monkeypatch.setattr(d, "_git_parent_root", lambda: baseline)
+
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            captured.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert d._drop_worktree_best_effort("/some/worktree") is True
+
+        git_remove = [c for c in captured if "worktree" in c and "remove" in c]
+        assert git_remove
+        assert git_remove[0][2] == str(baseline)
+        assert git_remove[0][2] != str(repo_root)
+
+
+class TestPersistPhaseOutputLogText:
+    """#2821 — ``dispatcher.phase_outputs.log_text`` column is written."""
+
+    def test_insert_includes_log_text_column(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        d._persist_phase_output(
+            agent_id="a1",
+            phase="plan",
+            output_json={"go": True},
+            log_text="the full phase log body",
+        )
+
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_outputs" in e[0]
+        ]
+        assert inserts
+        sql, params = inserts[0]
+        assert "log_text" in sql
+        # Params ordering: (agent_id, phase, output_json_dumped, log_text)
+        assert params[0] == "a1"
+        assert params[1] == "plan"
+        assert params[3] == "the full phase log body"
+
+    def test_log_text_defaults_to_none_when_omitted(self, tmp_path: Path) -> None:
+        """Backwards-compat for any caller that forgot to pass log_text."""
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        d._persist_phase_output("a2", "plan", {"go": True})
+
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_outputs" in e[0]
+        ]
+        assert inserts
+        _, params = inserts[0]
+        assert params[3] is None
+
+
+class TestReadFullPhaseLog:
+    """#2821 — full log body read helper."""
+
+    def test_returns_full_body_no_truncation(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        body = "Z" * 50000
+        _write_phase_log(worktree, "plan", body)
+        assert d._read_full_phase_log(worktree, "plan") == body
+
+    def test_returns_empty_when_log_missing(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        assert d._read_full_phase_log(worktree, "plan") == ""

--- a/scripts/dispatcher/tests/test_daemon_phase_failure_preview.py
+++ b/scripts/dispatcher/tests/test_daemon_phase_failure_preview.py
@@ -175,12 +175,13 @@ class TestExtractLogPreview:
     def test_truncates_at_max_chars(self, tmp_path: Path) -> None:
         d, _conn, _handler = _make_daemon(tmp_path)
         worktree = tmp_path / "worktree"
-        # A log with 400 chars of tail content — preview should be 200.
-        tail = "X" * 400
+        # A log >2000 chars — preview caps at PHASE_STDERR_PREVIEW_MAX_CHARS
+        # (2000, raised from 200 in #2821).
+        tail = "X" * 3000
         _write_phase_log(worktree, "plan", tail)
         preview = d._extract_log_preview(worktree, "plan")
-        assert len(preview) == 200
-        assert preview == "X" * 200
+        assert len(preview) == 2000
+        assert preview == "X" * 2000
 
     def test_honours_custom_max_chars(self, tmp_path: Path) -> None:
         d, _conn, _handler = _make_daemon(tmp_path)
@@ -551,13 +552,22 @@ class TestRetroFailurePreviews:
         assert preview is not None
         assert "JSON write failed" in preview
 
-    def test_preview_truncated_to_200_chars_on_retro_nonzero(
+    def test_preview_truncated_to_2000_chars_on_retro_nonzero(
         self, monkeypatch: Any, tmp_path: Path
     ) -> None:
+        """The preview cap was raised from 200 → 2000 in #2821.
+
+        Noisy failures (ralph running 1000 tests with one real error,
+        terraform plan with a single actual error) routinely push the
+        useful line past the old 200-char boundary. 2000 covers real
+        failure modes without pulling in the full log (the full log is
+        captured separately via ``daemon.phase_failure_log`` +
+        ``dispatcher.phase_outputs.log_text``).
+        """
         d, _conn, handler = _make_daemon(tmp_path)
         agent = _succeeded_agent(tmp_path)
         worktree = Path(agent["worktree_path"])
-        _write_phase_log(worktree, "retro", "Z" * 500)
+        _write_phase_log(worktree, "retro", "Z" * 3000)
         self._prep(d, agent)
 
         def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
@@ -569,4 +579,4 @@ class TestRetroFailurePreviews:
         events = handler.events("retro_nonzero_exit")
         assert events
         preview = getattr(events[0], "stderr_preview", "")
-        assert len(preview) == 200
+        assert len(preview) == 2000


### PR DESCRIPTION
## Summary

Phase 3 cap=1 production blocker fix plus three adjacent cleanups:

- **Primary:** drop the non-existent `--cwd` flag from the `claude -p` argv in `_spawn_phase_subprocess` and pass the worktree via `subprocess.run(..., cwd=...)` instead. Every phase subprocess was exiting 1 within 400ms with `error: unknown option '--cwd'` — Phase 3 cap=1 was entirely non-functional.
- **Retry branch collision:** `_create_worktree` now runs `git branch -D agent/<short>` defensively before `git worktree add`, so the tier-1 retry path's second attempt doesn't collide on the branch left behind by attempt 1.
- **Cleanup CWD:** `_drop_worktree_best_effort` anchors `git worktree remove` to `_git_parent_root()` (the baseline clone with `.git`) rather than `_repo_root()` (Fargate CWD `/app`, no `.git`). Cleanup now works from any CWD.

Scope-amended full-log capture (#2821 comment):

- `stderr_tail` / `stderr_preview` sizes raised from 500 / 200 → 2000 chars via two new `PHASE_STDERR_TAIL_MAX_CHARS` / `PHASE_STDERR_PREVIEW_MAX_CHARS` constants.
- New `daemon.phase_failure_log` CloudWatch event emitted alongside each `daemon.subprocess_failed`, carrying up to 10k chars of the full phase log body. Keyed by `agent_id` for single-query triage.
- New `dispatcher.phase_outputs.log_text TEXT` column (migration 27, nullable) persists the full log across worktree cleanup, container restart, and daemon redeploy. All six `_run_<phase>` helpers write it on success and failure paths.

Closes #2821

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] After `deploy-dispatcher.yml` runs, flip cap=1 briefly with a small safe test issue (e.g. #2712) and confirm CloudWatch shows `daemon.phase_started phase=plan` followed by either `daemon.phase_completed` or a sensible plan-phase failure — NOT the `error: unknown option '--cwd'` tail.
- [ ] After a controlled test subprocess failure, run `aws logs filter-log-events --log-group-name /ecs/judgemind-dispatcher-dev --filter-pattern '<agent_id>'` and confirm both `daemon.subprocess_failed` AND `daemon.phase_failure_log` events are returned, with `log_body` non-empty.
- [ ] After a successful test phase, run `scripts/dev-db-query.sh "SELECT log_text IS NOT NULL AS has_log, length(log_text) FROM dispatcher.phase_outputs ORDER BY ts DESC LIMIT 1;"` and confirm `has_log = true` with a plausible length.
- [ ] Verification evidence posted on #2821 (see A.8)
