### PR TITLE
feat(admin-dispatcher): two-column state-flow layout (#2823)

### DIFF
--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -19,7 +19,7 @@ import {
 import { DispatcherHeader } from './DispatcherHeader';
 import { DispatcherControls } from './DispatcherControls';
 import { ActiveAgentsTable } from './ActiveAgentsTable';
-import { QueuePanel } from './QueuePanel';
+import { QueueBlockedPanel, QueueReadyPanel } from './QueuePanel';
 import { RecentCompletionsPanel } from './RecentCompletionsPanel';
 import { RecentFailuresPanel } from './RecentFailuresPanel';
 import { ConfigPanel } from './ConfigPanel';
@@ -54,19 +54,34 @@ function SkeletonShell() {
 }
 
 /**
- * Refreshed, info-dense cockpit for /admin/dispatcher (#2805 Phase 1).
- * Layout:
+ * Refreshed, info-dense cockpit for /admin/dispatcher (#2805 Phase 1;
+ * layout restructured in #2823).
  *
- *   ┌─ h1 Dispatcher  · status pill · uptime · sha · host        · [controls] ─┐
- *   ├─ Queue: Agent-ready ─────────────┬─ Active agents ──────────────────────┤
- *   │   (top 10)                       │  (0-N rows)                          │
- *   ├─ Queue: Blocked ─────────────────┤                                      │
- *   │   (top 10)                       ├─ Recently completed ─────────────────┤
- *   │                                  │  (top 10)                            │
- *   ├─ Config strip ──────────────────────────────────────────────────────────┤
- *   │   cap [N] · backoff [Ns] · spawn frozen: —                              │
- *   ├─ Recent failures (last 24h) ────────────────────────────────────────────┤
- *   └──────────────────────────────────────────────────────────────────────────┘
+ * Layout is a two-column state-flow deck below the header strip. The
+ * columns encode the natural motion of work through the daemon:
+ *
+ *   Queue: Agent-ready  →   Active agents   →   Recently completed
+ *        (bottom-left)      (top-left)           (top-right)
+ *
+ * Claiming an issue moves it upward in the left column (queue → active).
+ * Completing an issue moves it rightward to the top of the right column
+ * (active → recently completed). Blocked issues live bottom-right —
+ * adjacent to the flow but not part of the active cycle. The two columns
+ * are independent vertical stacks, not a 2×2 grid — panels have their
+ * natural heights and do not line up horizontally across columns.
+ *
+ *   ┌─ h1 Dispatcher · status pill · uptime · sha · host · [controls] ─┐
+ *   ├─ Active agents ──────────────────┬─ Recently completed ──────────┤
+ *   │   (0-N rows)                     │   (top 10)                    │
+ *   ├─ Queue: Agent-ready ─────────────┼─ Queue: Blocked ──────────────┤
+ *   │   (top 10)                       │   (top 10)                    │
+ *   ├─ Config strip ──────────────────────────────────────────────────┤
+ *   │   cap [N] · backoff [Ns] · spawn frozen: —                      │
+ *   ├─ Recent failures (last 24h) ────────────────────────────────────┤
+ *   └──────────────────────────────────────────────────────────────────┘
+ *
+ * On mobile (`< lg`) the grid collapses to a single column in DOM order:
+ *   Active → Queue-ready → Recently-completed → Queue-blocked.
  */
 export function DispatcherDashboard() {
   const { user, loading: authLoading } = useAuth();
@@ -287,25 +302,36 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
         <SkeletonShell />
       ) : (
         <>
-          <div className="grid grid-cols-1 gap-x-6 gap-y-6 lg:grid-cols-2">
-            {/* Left column: queue panels */}
-            <div className="space-y-6">
-              <QueuePanel
-                queueReady={state?.queueReady ?? []}
-                queueBlocked={state?.queueBlocked ?? []}
-              />
-            </div>
-
-            {/* Right column: active agents + recently completed */}
-            <div className="space-y-6">
+          <div
+            className="grid grid-cols-1 gap-x-6 gap-y-6 lg:grid-cols-2"
+            data-testid="dispatcher-two-column-deck"
+          >
+            {/*
+             * Left column: Active agents (top) → Queue: Agent-ready
+             * (bottom). An issue moves upward within this column as it
+             * transitions from "next" to "now". See file-level docstring
+             * for the full state-flow rationale (#2823).
+             */}
+            <div className="flex flex-col gap-6" data-testid="dispatcher-column-left">
               <ActiveAgentsTable
                 agents={state?.activeAgents ?? []}
                 disabled={controlLoading}
                 onAgentAction={handleAgentAction}
               />
+              <QueueReadyPanel items={state?.queueReady ?? []} />
+            </div>
+
+            {/*
+             * Right column: Recently completed (top) → Queue: Blocked
+             * (bottom). Work flows rightward from Active to Recently
+             * completed. Blocked sits bottom-right — adjacent to the flow
+             * but not part of the active cycle.
+             */}
+            <div className="flex flex-col gap-6" data-testid="dispatcher-column-right">
               <RecentCompletionsPanel
                 completions={state?.recentCompletions ?? []}
               />
+              <QueueBlockedPanel items={state?.queueBlocked ?? []} />
             </div>
           </div>
 

--- a/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
@@ -19,9 +19,9 @@ interface QueuePanelProps {
 }
 
 /**
- * Two sibling queue panels (#2805 §1.3) — agent-ready on the left,
- * blocked on the right. Each panel is borderless with a subtle heading
- * divider, and each row is a `Link`-able hot link via `IssueLink`.
+ * Two sibling queue panels (#2805 §1.3) — agent-ready and blocked. Each
+ * panel is borderless with a subtle heading divider, and each row is a
+ * `Link`-able hot link via `IssueLink`.
  *
  * Capped server-side at 10 entries per panel; more is dispatcher-internal
  * scheduling state, not useful on the overview page.
@@ -35,6 +35,14 @@ interface QueuePanelProps {
  * from this page. Titles get the freed horizontal space; the title cell
  * wraps onto a second line rather than ellipsis-truncating so the operator
  * can read the full text without hovering.
+ *
+ * Layout note (#2823 — state-flow two-column layout): the two sub-panels
+ * are exposed as independent named exports (`QueueReadyPanel`,
+ * `QueueBlockedPanel`) so the dashboard can place them in different
+ * columns of the state-flow layout — ready sits bottom-left (below Active)
+ * and blocked sits bottom-right (below Recently completed). The wrapping
+ * `QueuePanel` component is retained for backwards compatibility with the
+ * existing test suite but is no longer used by the dashboard itself.
  */
 export function QueuePanel({ queueReady, queueBlocked }: QueuePanelProps) {
   return (
@@ -48,7 +56,7 @@ export function QueuePanel({ queueReady, queueBlocked }: QueuePanelProps) {
   );
 }
 
-function QueueReadyPanel({ items }: { items: readonly QueueItem[] }) {
+export function QueueReadyPanel({ items }: { items: readonly QueueItem[] }) {
   return (
     <section aria-labelledby="queue-ready-heading">
       <div className="flex items-center justify-between border-b border-border pb-2 mb-2">
@@ -74,7 +82,7 @@ function QueueReadyPanel({ items }: { items: readonly QueueItem[] }) {
   );
 }
 
-function QueueBlockedPanel({ items }: { items: readonly QueueItem[] }) {
+export function QueueBlockedPanel({ items }: { items: readonly QueueItem[] }) {
   return (
     <section aria-labelledby="queue-blocked-heading">
       <div className="flex items-center justify-between border-b border-border pb-2 mb-2">

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
@@ -7,6 +7,9 @@
  *   - Config-edit mutations always inject `X-MFA-Token`.
  *   - Lowering `concurrency_cap` pops the ConfirmDialog before committing.
  *   - Raising `concurrency_cap` commits immediately without dialog.
+ *   - State-flow two-column layout (#2823): Active → Queue-ready (left),
+ *     Recently-completed → Queue-blocked (right). Mobile collapses to
+ *     a single column in the same order.
  */
 
 import { describe, expect, it, vi, beforeEach } from 'vitest';
@@ -222,5 +225,78 @@ describe('DispatcherDashboard — config edit lifecycle', () => {
     // First slot updated; subsequent retry delays preserved.
     expect(JSON.parse(call.variables.value)).toEqual([120, 300, 900]);
     expect(call.context?.headers).toEqual({ 'X-MFA-Token': 'phase1-placeholder' });
+  });
+});
+
+describe('DispatcherDashboard — #2823 state-flow two-column layout', () => {
+  beforeEach(() => {
+    mockControlMutate.mockClear();
+    mockSetConfigMutate.mockClear();
+    mockRefetch.mockClear();
+    mockQueryData = { dispatcherState: { ...BASE_STATE } };
+  });
+
+  it('renders both columns inside a single `lg:grid-cols-2` deck', () => {
+    renderDashboard();
+    const deck = screen.getByTestId('dispatcher-two-column-deck');
+    // Outer container is a 1-col grid on mobile, 2-col grid at `lg`.
+    expect(deck.className).toMatch(/grid-cols-1/);
+    expect(deck.className).toMatch(/lg:grid-cols-2/);
+    // Both columns are present.
+    expect(screen.getByTestId('dispatcher-column-left')).toBeInTheDocument();
+    expect(screen.getByTestId('dispatcher-column-right')).toBeInTheDocument();
+  });
+
+  it('left column is a vertical flex stack of Active agents (top) then Queue: Agent-ready (bottom)', () => {
+    renderDashboard();
+    const left = screen.getByTestId('dispatcher-column-left');
+    // Column uses `flex flex-col gap-*` for variable-height panels, not a
+    // fixed-row grid (#2823: panels have natural heights).
+    expect(left.className).toMatch(/\bflex\b/);
+    expect(left.className).toMatch(/flex-col/);
+    // Locate the Active and Ready section headings within the column.
+    const active = left.querySelector('#active-agents-heading');
+    const ready = left.querySelector('#queue-ready-heading');
+    expect(active).not.toBeNull();
+    expect(ready).not.toBeNull();
+    // Active must come before Ready in DOM order.
+    expect(active!.compareDocumentPosition(ready!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    // Blocked is NOT in the left column.
+    expect(left.querySelector('#queue-blocked-heading')).toBeNull();
+  });
+
+  it('right column is a vertical flex stack of Recently completed (top) then Queue: Blocked (bottom)', () => {
+    renderDashboard();
+    const right = screen.getByTestId('dispatcher-column-right');
+    expect(right.className).toMatch(/\bflex\b/);
+    expect(right.className).toMatch(/flex-col/);
+    const completed = right.querySelector('#recent-completions-heading');
+    const blocked = right.querySelector('#queue-blocked-heading');
+    expect(completed).not.toBeNull();
+    expect(blocked).not.toBeNull();
+    expect(
+      completed!.compareDocumentPosition(blocked!) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // Ready is NOT in the right column.
+    expect(right.querySelector('#queue-ready-heading')).toBeNull();
+  });
+
+  it('on mobile collapse (single column), panel DOM order is Active → Queue-ready → Recently-completed → Queue-blocked', () => {
+    // The CSS grid reflows to a single column at `< lg`, but the
+    // document order is stable and determines the mobile stack. Assert
+    // the four section headings appear in the required order.
+    renderDashboard();
+    const deck = screen.getByTestId('dispatcher-two-column-deck');
+    const headings = Array.from(
+      deck.querySelectorAll(
+        '#active-agents-heading, #queue-ready-heading, #recent-completions-heading, #queue-blocked-heading',
+      ),
+    ).map((el) => el.id);
+    expect(headings).toEqual([
+      'active-agents-heading',
+      'queue-ready-heading',
+      'recent-completions-heading',
+      'queue-blocked-heading',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary

Restructure `/admin/dispatcher` from the previous "queue-left / active+completed-right" deck into a **two-column state-flow layout** that encodes the motion of work through the daemon:

```
Queue: Agent-ready  →  Active agents  →  Recently completed
     (bottom-left)     (top-left)         (top-right)
```

Claiming an issue moves it **upward** within the left column (queue → active). Completing moves it **rightward** to the top of the right column (active → recently completed). Blocked issues live bottom-right — adjacent to the flow but not part of the active cycle. The two columns are independent `flex flex-col` stacks, not a 2×2 grid; panels have natural heights. Outer deck is `grid grid-cols-1 lg:grid-cols-2` so mobile collapses to a single column in DOM order: Active → Queue-ready → Recently-completed → Queue-blocked.

Closes #2823

## Changes

- `DispatcherDashboard.tsx` — new layout block (left column: Active → Queue-ready; right column: Recently-completed → Queue-blocked); refreshed file-level docstring.
- `QueuePanel.tsx` — export `QueueReadyPanel` / `QueueBlockedPanel` as independent named components so the dashboard can place them in different columns. Wrapping `QueuePanel` kept for the existing `QueuePanel.test.tsx` (density-pass tests from #2818).
- `DispatcherDashboard.test.tsx` — new `describe` block with four layout assertions (deck grid classes, left-column order, right-column order, mobile single-column DOM order).

No panel internals touched; 1231 / 1231 web tests remain green.

## Test plan

### Automated checks
- [x] Lint passes (`npm --prefix packages/web run lint`)
- [x] Typecheck passes (`npm --prefix packages/web run typecheck`)
- [x] Tests pass (`npm --prefix packages/web test` — 82 files / 1231 tests, includes 4 new `DispatcherDashboard` layout-order cases)
- [x] Build passes (`npm --prefix packages/web run build`)
- [x] CI green

### Post-deploy verification
- [x] `/admin/dispatcher` loads on dev — verified via `scripts/run-py.sh scripts/screenshot.py --auth /admin/dispatcher --output tmp/admin-2823-after.png`
- [x] Screenshot matches the layout: Active (top-left), Queue-ready (bottom-left), Recently-completed (top-right), Queue-blocked (bottom-right)
- [x] Verification evidence posted on #2823 with per-criterion proof
