### PR TITLE
fix(dispatcher-daemon): wire ANTHROPIC_API_KEY secret into terraform (#2834)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -244,9 +244,15 @@ module "dispatcher_daemon" {
   # because `concurrency_cap=0` keeps the daemon from doing any DB
   # writes outside its own schema.
   #
+  # #2834 wires `anthropic_api_key_secret_arn` — Phase 3 (cap=1) needs
+  # the daemon's `claude -p` subprocess to authenticate, so
+  # `ANTHROPIC_API_KEY` must be present in the container environment.
+  # Reuses the shared `judgemind/anthropic/api-key` secret already used
+  # by the compute module (above) via the `data` block at the top.
+  #
   # Other ARNs stay empty until their owning sub-tasks land — the
   # module's `compact()` guard drops unset entries.
-  anthropic_api_key_secret_arn  = ""
+  anthropic_api_key_secret_arn  = data.aws_secretsmanager_secret.anthropic_api_key.arn
   db_connection_secret_arn      = module.database.db_connection_secret_arn
   github_token_secret_arn       = "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/dispatcher/github-token-QOmHlJ"
   telegram_bot_token_secret_arn = ""


### PR DESCRIPTION
## Summary

Single-line consumer-wiring change in `infra/terraform/environments/dev/main.tf`: set `anthropic_api_key_secret_arn = data.aws_secretsmanager_secret.anthropic_api_key.arn` on the `dispatcher_daemon` module block. Reuses the `data` block already declared at the top of the file (same pattern the compute module uses). Without this, the dispatcher daemon container boots without `ANTHROPIC_API_KEY` and `claude -p` subprocesses fail with "Not logged in · Please run /login" — blocking every Phase 3 cap=1 attempt.

The `dispatcher-daemon` module itself already declares the variable, wires it into `containerDefinitions[0].secrets[]` as `ANTHROPIC_API_KEY`, and grants `secretsmanager:GetSecretValue` via the count-guarded `execution_secrets` policy (from #2739/#2740). So this is purely consumer-side; no module changes.

Closes #2834

## Plan excerpt

`terraform -chdir=infra/terraform/environments/dev plan` (post-rebase onto main at bf148670):

```
  # module.dispatcher_daemon.aws_ecs_task_definition.dispatcher must be replaced
-/+ resource "aws_ecs_task_definition" "dispatcher" {
      ~ container_definitions    = jsonencode(
          ~ [
              ~ {
                    name             = "dispatcher"
                  ~ secrets          = [
                      + {
                          + name      = "ANTHROPIC_API_KEY"
                          + valueFrom = "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/anthropic/api-key-DhEOsz"
                        },
                        {
                            name      = "DATABASE_URL"
                            valueFrom = "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/dev/db/connection-V1mIHV:url::"
                        },
                        # (1 unchanged element hidden)
                    ]
                },
            ] # forces replacement
        )
      ~ revision                 = 4 -> (known after apply)
    }

  # module.dispatcher_daemon.aws_iam_role_policy.execution_secrets[0] will be updated in-place
  ~ resource "aws_iam_role_policy" "execution_secrets" {
      ~ policy      = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Resource = [
                          + "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/anthropic/api-key-DhEOsz",
                            "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/dev/db/connection-V1mIHV",
                            # (1 unchanged element hidden)
                        ]
                    },
                ]
            }
        )
    }

Plan: 1 to add, 2 to change, 1 to destroy.
```

Two changes caused by this PR:
1. `module.dispatcher_daemon.aws_ecs_task_definition.dispatcher` — `ANTHROPIC_API_KEY` added to `containerDefinitions[0].secrets[]`.
2. `module.dispatcher_daemon.aws_iam_role_policy.execution_secrets[0]` — secret ARN added to the policy's Resource list.

The plan also shows a `module.compute.aws_security_group.scraper` in-place update removing a `33335` residential-proxy egress rule — that's pre-existing state drift unrelated to this PR (it appears identically in the pre-rebase plan and would surface on any subsequent apply). Flagging rather than touching per single-issue rule.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes (`terraform fmt -check -recursive infra/terraform/` — ran locally, exit 0; CI `infra-validate` green)
- [x] Tests pass (all testable jobs SKIPPED by paths-filter — this is a terraform-only PR)
- [x] CI green (CI + Terraform workflows both SUCCESS; `ci-passed` green)

### Post-deploy verification (deferred-pending-operator-apply per CLAUDE.md §A.8 Step 3)
- [ ] Operator applies `terraform apply` on dev
- [ ] `aws ecs describe-task-definition --task-definition judgemind-dispatcher-dev --region us-west-2 --query 'taskDefinition.containerDefinitions[0].secrets[?name==`ANTHROPIC_API_KEY`]'` returns the entry
- [ ] Dispatcher daemon boots and Phase 3 cap=1 `claude -p` subprocess authenticates (no "Not logged in" error)
- [x] Verification evidence posted on issue (deferred-pending-operator-apply)
