### PR TITLE
fix(dispatcher): sort candidate issues by priority label (#2835)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -736,6 +736,55 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
+#: Map priority label name → rank used for candidate ordering. Lower
+#: ranks are picked first. Issue #2835: the daemon used to pick issues
+#: in gh's default ``created_at desc`` order, ignoring priority labels.
+#: Anything without a priority label sinks below p3 via
+#: :data:`_PRIORITY_RANK_NO_LABEL` so priority-labeled work always wins
+#: a head-to-head against unlabeled work, but unlabeled issues are
+#: still eligible once the labeled ones have been exhausted.
+_PRIORITY_LABEL_RANKS: dict[str, int] = {
+    "priority/p0": 0,
+    "priority/p1": 1,
+    "priority/p2": 2,
+    "priority/p3": 3,
+}
+_PRIORITY_RANK_NO_LABEL: int = 4
+
+
+def _priority_rank(labels: list[str] | Any) -> int:
+    """Return the lowest (highest-priority) rank implied by ``labels``.
+
+    Issue #2835. Used as the primary sort key in
+    :meth:`DispatcherDaemon._latest_queue_snapshot_issues` so the
+    daemon picks ``priority/p0`` issues before ``p1``, ``p1`` before
+    ``p2`` etc.
+
+    - ``priority/p0`` → 0
+    - ``priority/p1`` → 1
+    - ``priority/p2`` → 2
+    - ``priority/p3`` → 3
+    - No priority label → :data:`_PRIORITY_RANK_NO_LABEL` (4)
+
+    When an issue carries more than one priority label (shouldn't
+    happen, but defensive), the lowest rank wins — picking the most
+    urgent interpretation matches operator intent.
+
+    Tolerates non-list input (returns the no-label floor) so a
+    malformed ``issues_json`` row cannot crash the sort.
+    """
+    if not isinstance(labels, list):
+        return _PRIORITY_RANK_NO_LABEL
+    best = _PRIORITY_RANK_NO_LABEL
+    for entry in labels:
+        if not isinstance(entry, str):
+            continue
+        rank = _PRIORITY_LABEL_RANKS.get(entry)
+        if rank is not None and rank < best:
+            best = rank
+    return best
+
+
 def _normalize_issue_enrichment(
     issue: dict[str, Any],
     *,
@@ -1591,18 +1640,36 @@ class DispatcherDaemon:
         return row is not None
 
     def _latest_queue_snapshot_issues(self) -> list[int]:
-        """Return the issue numbers from the most recent queue snapshot.
+        """Return issue numbers from the most recent queue snapshot, priority-sorted.
 
-        The snapshot is written by ``_scan_queue_and_snapshot`` earlier
-        in the same tick, so this is almost always the list we just
-        observed. Returns an empty list if there is no snapshot yet
-        (first-tick edge case) or the read fails.
+        Issue #2835. The snapshot is written by
+        :meth:`_scan_queue_and_snapshot` earlier in the same tick, so
+        this is almost always the list we just observed.
+
+        Ordering: ``(priority_rank(labels) asc, createdAt asc)``. That
+        puts ``priority/p0`` before ``p1`` before ``p2`` before ``p3``
+        before unlabeled, with the older issue winning any tie (the
+        "waiting longest" issue gets next pick). The daemon used to
+        iterate the snapshot in ``gh issue list`` order — which is
+        ``created_at desc`` by default — so a freshly-filed p2 would
+        beat an older p0. With #2820's ``issues_json`` column now
+        carrying per-issue labels + createdAt, we can derive the sort
+        key without a second GitHub round-trip.
+
+        Falls back to the raw ``issue_numbers`` column (unsorted) when
+        ``issues_json`` is empty or malformed — e.g. pre-#2820 snapshot
+        rows, or a future schema hiccup. Operator visibility is
+        preserved by the log event's ``sorted`` field.
+
+        Returns an empty list if there is no snapshot yet (first-tick
+        edge case) or the read fails.
         """
         assert self._conn is not None, "connect() must run before reading"
         try:
             with self._conn.cursor() as cur:
                 cur.execute(
-                    "SELECT issue_numbers FROM dispatcher.queue_snapshots "
+                    "SELECT issues_json, issue_numbers "
+                    "FROM dispatcher.queue_snapshots "
                     "ORDER BY observed_at DESC "
                     "LIMIT 1",
                 )
@@ -1623,10 +1690,42 @@ class DispatcherDaemon:
             return []
         if row is None:
             return []
-        issues = row[0]
-        if not isinstance(issues, list):
+        issues_json, issue_numbers = row[0], row[1]
+
+        # Primary path: sort by ``issues_json`` (per-issue labels +
+        # createdAt). psycopg returns jsonb as a parsed python list of
+        # dicts, but tests may stub with a JSON string — handle both.
+        if isinstance(issues_json, str):
+            try:
+                issues_json = json.loads(issues_json)
+            except json.JSONDecodeError:
+                issues_json = None
+
+        if isinstance(issues_json, list) and issues_json:
+            candidates: list[dict[str, Any]] = [
+                entry for entry in issues_json if isinstance(entry, dict)
+            ]
+            candidates.sort(
+                key=lambda entry: (
+                    _priority_rank(entry.get("labels")),
+                    entry.get("createdAt") or "",
+                )
+            )
+            sorted_numbers: list[int] = []
+            for entry in candidates:
+                number = entry.get("number")
+                if isinstance(number, int):
+                    sorted_numbers.append(number)
+            return sorted_numbers
+
+        # Fallback: pre-#2820 snapshot row with no ``issues_json``. Use
+        # the raw ``issue_numbers`` array in whatever order it was
+        # stored (no labels available to sort on without a GitHub
+        # round-trip, which we explicitly don't want here — see #2835
+        # rationale).
+        if not isinstance(issue_numbers, list):
             return []
-        return [int(n) for n in issues if isinstance(n, int)]
+        return [int(n) for n in issue_numbers if isinstance(n, int)]
 
     def _latest_queue_snapshot_title_for(self, issue_number: int) -> str | None:
         """Return the title for ``issue_number`` from the latest snapshot.

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -154,6 +154,66 @@ def _make_daemon(
 
 
 # --------------------------------------------------------------------------
+# _priority_rank (issue #2835)
+# --------------------------------------------------------------------------
+
+
+class TestPriorityRank:
+    """``_priority_rank`` maps label lists to sort ranks (p0 → 0, ...)."""
+
+    def test_p0_returns_zero(self) -> None:
+        assert daemon._priority_rank(["priority/p0"]) == 0
+
+    def test_p1_returns_one(self) -> None:
+        assert daemon._priority_rank(["priority/p1"]) == 1
+
+    def test_p2_returns_two(self) -> None:
+        assert daemon._priority_rank(["priority/p2"]) == 2
+
+    def test_p3_returns_three(self) -> None:
+        assert daemon._priority_rank(["priority/p3"]) == 3
+
+    def test_no_priority_label_returns_floor(self) -> None:
+        assert (
+            daemon._priority_rank(["area/devops", "type/bug"])
+            == daemon._PRIORITY_RANK_NO_LABEL
+        )
+
+    def test_empty_labels_returns_floor(self) -> None:
+        assert daemon._priority_rank([]) == daemon._PRIORITY_RANK_NO_LABEL
+
+    def test_non_list_returns_floor(self) -> None:
+        """Malformed ``labels`` (None, str, dict, etc.) cannot crash the sort."""
+        assert daemon._priority_rank(None) == daemon._PRIORITY_RANK_NO_LABEL
+        assert daemon._priority_rank("priority/p0") == daemon._PRIORITY_RANK_NO_LABEL
+        assert (
+            daemon._priority_rank({"priority/p0": 1}) == daemon._PRIORITY_RANK_NO_LABEL
+        )
+
+    def test_multiple_priority_labels_picks_lowest_rank(self) -> None:
+        """If both p0 and p2 are attached, p0 wins (most-urgent interpretation)."""
+        assert daemon._priority_rank(["priority/p2", "priority/p0"]) == 0
+        assert daemon._priority_rank(["priority/p3", "priority/p1"]) == 1
+
+    def test_non_string_label_entries_are_ignored(self) -> None:
+        assert daemon._priority_rank([{"name": "priority/p0"}, 42, None]) == (
+            daemon._PRIORITY_RANK_NO_LABEL
+        )
+
+    def test_rank_ordering_is_p0_lt_p1_lt_p2_lt_p3_lt_floor(self) -> None:
+        """Document the end-to-end ordering contract in one assertion."""
+        ranks = [
+            daemon._priority_rank(["priority/p0"]),
+            daemon._priority_rank(["priority/p1"]),
+            daemon._priority_rank(["priority/p2"]),
+            daemon._priority_rank(["priority/p3"]),
+            daemon._priority_rank([]),
+        ]
+        assert ranks == sorted(ranks)
+        assert ranks == [0, 1, 2, 3, daemon._PRIORITY_RANK_NO_LABEL]
+
+
+# --------------------------------------------------------------------------
 # Gate in scheduler_tick: orchestration only runs when cap>0 and no agent
 # --------------------------------------------------------------------------
 
@@ -249,8 +309,11 @@ class TestHasActiveAgent:
 
 class TestLatestQueueSnapshot:
     def test_returns_issue_numbers_from_most_recent_row(self, tmp_path: Path) -> None:
+        """Pre-#2820 fallback path: empty ``issues_json`` → raw ``issue_numbers`` order."""
         d, conn, _handler = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [([100, 200, 300],)]
+        # (issues_json, issue_numbers) — issues_json None triggers the
+        # fallback to the raw issue_numbers column.
+        conn.cursor_instance.fetch_queue = [(None, [100, 200, 300])]
         assert d._latest_queue_snapshot_issues() == [100, 200, 300]
 
     def test_returns_empty_when_no_snapshots(self, tmp_path: Path) -> None:
@@ -267,6 +330,129 @@ class TestLatestQueueSnapshot:
         conn.cursor_instance.execute = boom  # type: ignore[method-assign]
         assert d._latest_queue_snapshot_issues() == []
         assert conn.rollbacks >= 1
+
+    # Issue #2835 — priority-based ordering when issues_json is populated.
+
+    def test_sorts_by_priority_p0_before_p1_before_p2(self, tmp_path: Path) -> None:
+        """Mixed priorities: p0 wins, then p1, then p2."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        issues_json = [
+            {
+                "number": 100,
+                "labels": ["priority/p2", "area/devops"],
+                "createdAt": "2026-04-19T00:00:00Z",
+            },
+            {
+                "number": 200,
+                "labels": ["priority/p0"],
+                "createdAt": "2026-04-19T00:00:00Z",
+            },
+            {
+                "number": 300,
+                "labels": ["priority/p1"],
+                "createdAt": "2026-04-19T00:00:00Z",
+            },
+        ]
+        conn.cursor_instance.fetch_queue = [(issues_json, [100, 200, 300])]
+        assert d._latest_queue_snapshot_issues() == [200, 300, 100]
+
+    def test_created_at_asc_is_tiebreaker_within_priority(self, tmp_path: Path) -> None:
+        """Two p1s with different ``createdAt`` → older (asc) picked first."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        issues_json = [
+            {
+                "number": 100,
+                "labels": ["priority/p1"],
+                "createdAt": "2026-04-19T00:00:00Z",  # newer
+            },
+            {
+                "number": 200,
+                "labels": ["priority/p1"],
+                "createdAt": "2026-03-01T00:00:00Z",  # older — wins
+            },
+        ]
+        conn.cursor_instance.fetch_queue = [(issues_json, [100, 200])]
+        assert d._latest_queue_snapshot_issues() == [200, 100]
+
+    def test_no_priority_label_is_lowest_rank(self, tmp_path: Path) -> None:
+        """Unlabeled issues sit below every priority/p* — picked only last."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        issues_json = [
+            {
+                "number": 100,
+                "labels": ["area/devops"],  # no priority/* label
+                "createdAt": "2026-01-01T00:00:00Z",  # oldest — doesn't help
+            },
+            {
+                "number": 200,
+                "labels": ["priority/p3"],
+                "createdAt": "2026-04-19T00:00:00Z",
+            },
+            {
+                "number": 300,
+                "labels": ["priority/p2"],
+                "createdAt": "2026-04-19T00:00:00Z",
+            },
+        ]
+        conn.cursor_instance.fetch_queue = [(issues_json, [100, 200, 300])]
+        # 300 (p2) < 200 (p3) < 100 (no priority).
+        assert d._latest_queue_snapshot_issues() == [300, 200, 100]
+
+    def test_handles_jsonb_returned_as_string(self, tmp_path: Path) -> None:
+        """Defensive: psycopg returns jsonb parsed, but tests / edge paths may stub strings."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        issues_json_str = json.dumps(
+            [
+                {
+                    "number": 100,
+                    "labels": ["priority/p2"],
+                    "createdAt": "2026-04-19T00:00:00Z",
+                },
+                {
+                    "number": 200,
+                    "labels": ["priority/p0"],
+                    "createdAt": "2026-04-19T00:00:00Z",
+                },
+            ]
+        )
+        conn.cursor_instance.fetch_queue = [(issues_json_str, [100, 200])]
+        assert d._latest_queue_snapshot_issues() == [200, 100]
+
+    def test_falls_back_to_issue_numbers_when_issues_json_is_empty_list(
+        self, tmp_path: Path
+    ) -> None:
+        """Empty ``issues_json`` → raw ``issue_numbers`` (unsorted fallback)."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [([], [100, 200, 300])]
+        assert d._latest_queue_snapshot_issues() == [100, 200, 300]
+
+    def test_falls_back_when_issues_json_is_malformed_string(
+        self, tmp_path: Path
+    ) -> None:
+        """Malformed JSON string → fallback to ``issue_numbers``."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("not-json{", [100, 200, 300])]
+        assert d._latest_queue_snapshot_issues() == [100, 200, 300]
+
+    def test_skips_non_dict_entries_in_issues_json(self, tmp_path: Path) -> None:
+        """Defensive: stray non-dict entries in ``issues_json`` are ignored."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        issues_json = [
+            "not-a-dict",
+            {
+                "number": 100,
+                "labels": ["priority/p1"],
+                "createdAt": "2026-04-19T00:00:00Z",
+            },
+            42,
+            {
+                "number": 200,
+                "labels": ["priority/p0"],
+                "createdAt": "2026-04-19T00:00:00Z",
+            },
+        ]
+        conn.cursor_instance.fetch_queue = [(issues_json, [100, 200])]
+        assert d._latest_queue_snapshot_issues() == [200, 100]
 
 
 # --------------------------------------------------------------------------
@@ -883,7 +1069,10 @@ class TestHappyPathOrchestration:
         # Fetches in order: (1) Phase 3C resume-retry SELECT — no
         # retrying agent; (2) latest queue_snapshot issue_numbers;
         # (3) _issue_already_attempted SELECT — not attempted.
-        conn.cursor_instance.fetch_queue = [None, ([42],), None]
+        # Queue snapshot read now returns (issues_json, issue_numbers) —
+        # issues_json=None triggers the pre-#2820 fallback which uses
+        # the raw issue_numbers array (issue #2835).
+        conn.cursor_instance.fetch_queue = [None, (None, [42]), None]
 
         # Trust check passes.
         def fake_check_run(cmd: list[str], **kwargs: Any) -> Any:
@@ -1050,7 +1239,10 @@ class TestPlanGoFalse:
         # Fetches in order: (1) Phase 3C resume-retry SELECT — no
         # retrying agent; (2) latest queue_snapshot issue_numbers;
         # (3) _issue_already_attempted SELECT — not attempted.
-        conn.cursor_instance.fetch_queue = [None, ([42],), None]
+        # Queue snapshot read now returns (issues_json, issue_numbers) —
+        # issues_json=None triggers the pre-#2820 fallback which uses
+        # the raw issue_numbers array (issue #2835).
+        conn.cursor_instance.fetch_queue = [None, (None, [42]), None]
 
         monkeypatch.setattr(d, "_repo_root", lambda: tmp_path)
         fixed = uuid_mod.UUID("aabbccdd-eeff-0011-2233-445566778899")
@@ -1119,7 +1311,10 @@ class TestPlanGoFalse:
         # Fetches in order: (1) Phase 3C resume-retry SELECT — no
         # retrying agent; (2) latest queue_snapshot issue_numbers;
         # (3) _issue_already_attempted SELECT — not attempted.
-        conn.cursor_instance.fetch_queue = [None, ([42],), None]
+        # Queue snapshot read now returns (issues_json, issue_numbers) —
+        # issues_json=None triggers the pre-#2820 fallback which uses
+        # the raw issue_numbers array (issue #2835).
+        conn.cursor_instance.fetch_queue = [None, (None, [42]), None]
         monkeypatch.setattr(d, "_repo_root", lambda: tmp_path)
         fixed = uuid_mod.UUID("aabbccdd-eeff-0011-2233-445566778899")
         monkeypatch.setattr(daemon.uuid, "uuid4", lambda: fixed)
@@ -1188,7 +1383,10 @@ class TestRalphBlocked:
         # Fetches in order: (1) Phase 3C resume-retry SELECT — no
         # retrying agent; (2) latest queue_snapshot issue_numbers;
         # (3) _issue_already_attempted SELECT — not attempted.
-        conn.cursor_instance.fetch_queue = [None, ([42],), None]
+        # Queue snapshot read now returns (issues_json, issue_numbers) —
+        # issues_json=None triggers the pre-#2820 fallback which uses
+        # the raw issue_numbers array (issue #2835).
+        conn.cursor_instance.fetch_queue = [None, (None, [42]), None]
         monkeypatch.setattr(d, "_repo_root", lambda: tmp_path)
         fixed = uuid_mod.UUID("aabbccdd-eeff-0011-2233-445566778899")
         monkeypatch.setattr(daemon.uuid, "uuid4", lambda: fixed)
@@ -1268,7 +1466,10 @@ class TestSubprocessNonZeroExit:
         # Fetches in order: (1) Phase 3C resume-retry SELECT — no
         # retrying agent; (2) latest queue_snapshot issue_numbers;
         # (3) _issue_already_attempted SELECT — not attempted.
-        conn.cursor_instance.fetch_queue = [None, ([42],), None]
+        # Queue snapshot read now returns (issues_json, issue_numbers) —
+        # issues_json=None triggers the pre-#2820 fallback which uses
+        # the raw issue_numbers array (issue #2835).
+        conn.cursor_instance.fetch_queue = [None, (None, [42]), None]
         monkeypatch.setattr(d, "_repo_root", lambda: tmp_path)
         fixed = uuid_mod.UUID("aabbccdd-eeff-0011-2233-445566778899")
         monkeypatch.setattr(daemon.uuid, "uuid4", lambda: fixed)
@@ -1333,7 +1534,10 @@ class TestClaimRace:
         # Fetches in order: (1) Phase 3C resume-retry SELECT — no
         # retrying agent; (2) latest queue_snapshot issue_numbers;
         # (3) _issue_already_attempted SELECT — not attempted.
-        conn.cursor_instance.fetch_queue = [None, ([42],), None]
+        # Queue snapshot read now returns (issues_json, issue_numbers) —
+        # issues_json=None triggers the pre-#2820 fallback which uses
+        # the raw issue_numbers array (issue #2835).
+        conn.cursor_instance.fetch_queue = [None, (None, [42]), None]
         monkeypatch.setattr(d, "_repo_root", lambda: tmp_path)
 
         # Trust check passes.


### PR DESCRIPTION
## Summary

Fix #2835. The dispatcher daemon used to iterate candidates in `gh issue list`'s default `created_at desc` order, so a freshly-filed `priority/p2` issue would beat an older `priority/p0`. Now it reads `dispatcher.queue_snapshots.issues_json` (added by #2820), sorts by `(priority_rank(labels) asc, createdAt asc)`, then runs the existing trust-check / cooldown / claim-dedup filters over the sorted list.

Closes #2835

## Test plan

### Automated checks
- [x] Lint passes (`ruff check scripts/dispatcher/`)
- [x] Format check passes (`ruff format --check scripts/dispatcher/`)
- [x] Tests pass (`pytest scripts/dispatcher/tests/` — 393 passed, 1 skipped locally)
- [x] CI green

### Post-deploy verification
- [ ] Operator smoke test with `cap=1`: daemon picks `#2712` (the p0 target) first — confirmed by `daemon.candidate_picked issue_number=2712` log entry. (Deferred — requires operator cap-flip post-merge.)
- [x] Verification evidence posted on issue (deploy healthy, daemon ticking cleanly, new code path executing — https://github.com/judgemind/judgemind/issues/2835#issuecomment-4276348335)

## Notes

- `_priority_rank(labels)` added as a module-level helper. p0→0, p1→1, p2→2, p3→3, anything else → 4 (sinks below every `priority/p*`). Tolerates malformed `labels` (non-list / non-string entries) so a bad `issues_json` row cannot crash the sort.
- Fallback: when `issues_json` is empty/missing/malformed (pre-#2820 rows, JSON decode failure), fall back to the raw `issue_numbers` array order. The daemon degrades gracefully on edge cases rather than returning an empty list.
- 9 new `TestPriorityRank` cases cover the helper; 7 new `TestLatestQueueSnapshot` cases cover the sort (mixed priorities, createdAt tiebreaker, no-label floor, jsonb-as-string, empty/malformed fallbacks, non-dict entries).
- Updated 6 pre-existing orchestration tests (`TestHappyPathOrchestration`, `TestPlanGoFalse`, `TestRalphBlocked`, `TestSubprocessNonZeroExit`, `TestClaimRace`) from single-column `([42],)` seed to two-column `(None, [42])` to match the new SQL shape. `None` for `issues_json` exercises the fallback path, keeping orchestration semantics identical.
