### PR TITLE
fix(api): sort queueReady resolver by priority, not gh insertion order (#2843)

### DIFF
--- a/packages/api/src/graphql/dispatcher/parse-labels.ts
+++ b/packages/api/src/graphql/dispatcher/parse-labels.ts
@@ -48,3 +48,60 @@ export function extractPriority(
   }
   return null;
 }
+
+/**
+ * Map of `priority/pN` labels to their numeric sort rank. Lower is
+ * more urgent. Mirrors ``_PRIORITY_LABEL_RANKS`` in
+ * ``scripts/dispatcher/daemon.py`` so the admin-page queue display
+ * matches the daemon's pick order (issue #2843 / parallel to #2835).
+ */
+const PRIORITY_LABEL_RANKS: Readonly<Record<string, number>> = {
+  'priority/p0': 0,
+  'priority/p1': 1,
+  'priority/p2': 2,
+  'priority/p3': 3,
+};
+
+/**
+ * Rank assigned to issues that carry no recognised `priority/pN`
+ * label. Sinks below p3 so priority-labelled work always wins a
+ * head-to-head against unlabelled work, but unlabelled issues remain
+ * eligible once the labelled ones are exhausted.
+ */
+export const PRIORITY_RANK_NO_LABEL = 4;
+
+/**
+ * Return the lowest (most-urgent) priority rank implied by `labels`.
+ *
+ * - `priority/p0` → 0
+ * - `priority/p1` → 1
+ * - `priority/p2` → 2
+ * - `priority/p3` → 3
+ * - No priority label (or empty / malformed input) →
+ *   {@link PRIORITY_RANK_NO_LABEL} (4)
+ *
+ * Used as the primary sort key for the admin page's queue display so
+ * the operator sees issues in the same order the daemon picks them
+ * (parallel to `_priority_rank` in `scripts/dispatcher/daemon.py`
+ * from issue #2835).
+ *
+ * When an issue carries more than one priority label (shouldn't
+ * happen, but defensive), the lowest rank wins — picking the most
+ * urgent interpretation matches operator intent.
+ *
+ * Tolerates non-array input (returns the no-label floor) and ignores
+ * non-string entries, so a malformed ``issues_json`` row cannot crash
+ * the sort.
+ */
+export function priorityRank(labels: unknown): number {
+  if (!Array.isArray(labels)) return PRIORITY_RANK_NO_LABEL;
+  let best = PRIORITY_RANK_NO_LABEL;
+  for (const entry of labels) {
+    if (typeof entry !== 'string') continue;
+    const rank = PRIORITY_LABEL_RANKS[entry];
+    if (rank !== undefined && rank < best) {
+      best = rank;
+    }
+  }
+  return best;
+}

--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -16,7 +16,7 @@ import type { Pool } from 'pg';
 import { GraphQLError, GraphQLScalarType, Kind } from 'graphql';
 import type { AuthUser } from '../../auth';
 import { DESTRUCTIVE_COMMANDS, requireDispatcherAdmin } from './auth';
-import { extractPriority, parseBlockedBy } from './parse-labels';
+import { extractPriority, parseBlockedBy, priorityRank } from './parse-labels';
 
 /**
  * Shape of a single entry in the enrichment JSON the daemon writes
@@ -307,9 +307,48 @@ async function queryQueueReady(
 ): Promise<Array<Record<string, unknown>>> {
   const issues = await queryLatestQueueSnapshotIssuesJson(pool);
   if (issues.length === 0) return [];
-  return issues
-    .slice(0, limit)
-    .map((issue) => queueItemFromSnapshot(issue, /* includeBlockedBy */ false));
+  return sortAndSliceQueueReady(issues, limit).map((issue) =>
+    queueItemFromSnapshot(issue, /* includeBlockedBy */ false),
+  );
+}
+
+/**
+ * Sort the enriched `issues` snapshot by `(priorityRank, createdAt ASC)`
+ * and return the first `limit` entries. Extracted so unit tests can
+ * exercise the ordering directly without a DB fixture (issue #2843).
+ *
+ * The daemon's queue-scan stores issues in gh CREATED_AT DESC order,
+ * which does NOT match the order the daemon actually picks them in
+ * (post-#2835 the daemon sorts by priority). The admin page's "top 10"
+ * must match the daemon's pick order so the operator sees what's
+ * coming up next — otherwise a p0 sitting at position 23-by-createdAt
+ * never appears, even though it's the next pick.
+ *
+ * Uses a copied array + stable-by-construction comparator — we do not
+ * mutate the input. Within a priority bucket the secondary key is
+ * `createdAt` ASC (older first), matching the Python daemon's
+ * ``key=(_priority_rank(labels), createdAt or "")`` at
+ * ``scripts/dispatcher/daemon.py:1708-1713``.
+ */
+function sortAndSliceQueueReady(
+  issues: readonly SnapshotIssueRecord[],
+  limit: number,
+): SnapshotIssueRecord[] {
+  const copy = issues.slice();
+  copy.sort((a, b) => {
+    const ra = priorityRank(a.labels);
+    const rb = priorityRank(b.labels);
+    if (ra !== rb) return ra - rb;
+    // Secondary key: createdAt ASC. Empty/missing createdAt sorts last
+    // within its priority bucket (same convention as the daemon).
+    const ca = a.createdAt || '';
+    const cb = b.createdAt || '';
+    if (ca === cb) return 0;
+    if (ca === '') return 1;
+    if (cb === '') return -1;
+    return ca < cb ? -1 : 1;
+  });
+  return copy.slice(0, limit);
 }
 
 /**
@@ -818,6 +857,7 @@ export {
   queueItemFromSnapshot,
   recentCompletionsToGraphQL,
   runRowToGraphQL,
+  sortAndSliceQueueReady,
   transitionRowToGraphQL,
   updateConfigEntry,
 };

--- a/packages/api/tests/dispatcher-enrichment.unit.test.ts
+++ b/packages/api/tests/dispatcher-enrichment.unit.test.ts
@@ -21,11 +21,14 @@ import {
   normalizeSnapshotJson,
   queueItemFromSnapshot,
   recentCompletionsToGraphQL,
+  sortAndSliceQueueReady,
   type SnapshotIssueRecord,
 } from '../src/graphql/dispatcher/resolvers';
 import {
   extractPriority,
   parseBlockedBy,
+  priorityRank,
+  PRIORITY_RANK_NO_LABEL,
 } from '../src/graphql/dispatcher/parse-labels';
 
 describe('normalizeSnapshotJson', () => {
@@ -259,5 +262,206 @@ describe('parse-labels helpers (pure, no fetch)', () => {
 
   it('parseBlockedBy ignores "Parent:" lines (distinct mechanic)', () => {
     expect(parseBlockedBy('Parent: #1\n')).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// priorityRank + sortAndSliceQueueReady (issue #2843 — parallel to #2835)
+// ---------------------------------------------------------------------------
+
+describe('priorityRank', () => {
+  it('maps priority labels to their rank (p0..p3 → 0..3)', () => {
+    expect(priorityRank(['priority/p0'])).toBe(0);
+    expect(priorityRank(['priority/p1'])).toBe(1);
+    expect(priorityRank(['priority/p2'])).toBe(2);
+    expect(priorityRank(['priority/p3'])).toBe(3);
+  });
+
+  it('returns the no-label floor (4) when no priority label is present', () => {
+    expect(priorityRank(['area/api', 'type/bug'])).toBe(PRIORITY_RANK_NO_LABEL);
+    expect(priorityRank([])).toBe(PRIORITY_RANK_NO_LABEL);
+    expect(PRIORITY_RANK_NO_LABEL).toBe(4);
+  });
+
+  it('returns the no-label floor for null / undefined / non-array input', () => {
+    expect(priorityRank(null)).toBe(PRIORITY_RANK_NO_LABEL);
+    expect(priorityRank(undefined)).toBe(PRIORITY_RANK_NO_LABEL);
+    expect(priorityRank('priority/p0')).toBe(PRIORITY_RANK_NO_LABEL);
+    expect(priorityRank({ 'priority/p0': 1 })).toBe(PRIORITY_RANK_NO_LABEL);
+    expect(priorityRank(42)).toBe(PRIORITY_RANK_NO_LABEL);
+  });
+
+  it('ignores non-string entries in the label array', () => {
+    // Every entry is non-string → floor
+    expect(priorityRank([{ name: 'priority/p0' }, 42, null])).toBe(
+      PRIORITY_RANK_NO_LABEL,
+    );
+    // Mixed — valid string wins despite noise
+    expect(priorityRank([null, 'priority/p1', { obj: true }])).toBe(1);
+  });
+
+  it('picks the lowest rank when multiple priority labels are present', () => {
+    expect(priorityRank(['priority/p2', 'priority/p0'])).toBe(0);
+    expect(priorityRank(['priority/p3', 'priority/p1'])).toBe(1);
+    expect(priorityRank(['priority/p2', 'priority/p3'])).toBe(2);
+  });
+
+  it('rejects malformed priority labels (priority/p9, priority/high, etc.)', () => {
+    expect(priorityRank(['priority/p9'])).toBe(PRIORITY_RANK_NO_LABEL);
+    expect(priorityRank(['priority/high'])).toBe(PRIORITY_RANK_NO_LABEL);
+    expect(priorityRank(['priority/p0 '])).toBe(PRIORITY_RANK_NO_LABEL);
+  });
+
+  it('documents the end-to-end rank ordering (p0 < p1 < p2 < p3 < floor)', () => {
+    const ranks = [
+      priorityRank(['priority/p0']),
+      priorityRank(['priority/p1']),
+      priorityRank(['priority/p2']),
+      priorityRank(['priority/p3']),
+      priorityRank([]),
+    ];
+    expect(ranks).toEqual([0, 1, 2, 3, PRIORITY_RANK_NO_LABEL]);
+    expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
+  });
+});
+
+describe('sortAndSliceQueueReady', () => {
+  /** Small helper — build a SnapshotIssueRecord with sensible defaults. */
+  function issue(
+    number: number,
+    labels: string[],
+    createdAt: string,
+  ): SnapshotIssueRecord {
+    return { number, title: `Issue ${number}`, labels, createdAt };
+  }
+
+  it('surfaces the p0 at row 1 even when it is the 23rd newest (#2712 scenario)', () => {
+    // Mirrors the real-world case from the issue body: 22 p1/p2 issues
+    // filed AFTER the single p0, stored in gh CREATED_AT DESC order.
+    // With the buggy slice-only behaviour the p0 is invisible; the
+    // fixed resolver must surface it at row 1.
+    const newerP1P2: SnapshotIssueRecord[] = [];
+    for (let i = 0; i < 22; i += 1) {
+      // createdAt strictly newer than the p0 below. Alternate p1/p2.
+      const day = String(20 - (i % 20)).padStart(2, '0');
+      const createdAt = `2026-05-${day}T12:00:00Z`;
+      const prio = i % 2 === 0 ? 'priority/p1' : 'priority/p2';
+      newerP1P2.push(issue(3000 + i, [prio, 'agent/ready'], createdAt));
+    }
+    const p0 = issue(
+      2712,
+      ['priority/p0', 'agent/ready'],
+      '2026-03-01T00:00:00Z',
+    );
+    // Storage order is CREATED_AT DESC — the 22 newer ones first, then the p0.
+    const storedOrder = [...newerP1P2, p0];
+    // Sanity — p0 is at the 23rd position by default.
+    expect(storedOrder[22].number).toBe(2712);
+    // The buggy path would drop the p0 from slice(0, 10) entirely.
+    expect(storedOrder.slice(0, 10).some((i) => i.number === 2712)).toBe(false);
+
+    const result = sortAndSliceQueueReady(storedOrder, 10);
+
+    expect(result).toHaveLength(10);
+    expect(result[0].number).toBe(2712);
+    expect(priorityRank(result[0].labels)).toBe(0);
+    // Every other row in top 10 is p1 (p1 beats p2 in the sort).
+    for (let i = 1; i < result.length; i += 1) {
+      expect(result[i].labels).toContain('priority/p1');
+    }
+  });
+
+  it('sorts unlabelled issues last among open issues', () => {
+    const unlabelled = issue(900, ['area/api'], '2026-01-01T00:00:00Z');
+    const p3 = issue(901, ['priority/p3'], '2026-04-19T00:00:00Z');
+    const p0 = issue(902, ['priority/p0'], '2026-04-19T00:00:00Z');
+    const input = [unlabelled, p0, p3];
+
+    const result = sortAndSliceQueueReady(input, 10);
+
+    expect(result.map((r) => r.number)).toEqual([902, 901, 900]);
+    // Specifically: the oldest-by-createdAt `unlabelled` still sorts last
+    // because its rank (4) beats every priority-labelled issue.
+    expect(result[result.length - 1].number).toBe(900);
+  });
+
+  it('breaks ties within a priority bucket by createdAt ASC (older first)', () => {
+    // Three p1 issues, stored in createdAt DESC order (newest first).
+    const newer = issue(100, ['priority/p1'], '2026-04-19T12:00:00Z');
+    const middle = issue(101, ['priority/p1'], '2026-04-18T12:00:00Z');
+    const older = issue(102, ['priority/p1'], '2026-04-17T12:00:00Z');
+
+    const result = sortAndSliceQueueReady([newer, middle, older], 10);
+
+    expect(result.map((r) => r.number)).toEqual([102, 101, 100]);
+  });
+
+  it('respects both keys: priority first, then createdAt ASC', () => {
+    // Mixed priorities + mixed createdAts. Expected order:
+    //   p0 (any createdAt wins), then p1 by createdAt ASC, then p2.
+    const p0New = issue(1, ['priority/p0'], '2026-04-19T00:00:00Z');
+    const p1Old = issue(2, ['priority/p1'], '2026-01-01T00:00:00Z');
+    const p1New = issue(3, ['priority/p1'], '2026-04-19T00:00:00Z');
+    const p2 = issue(4, ['priority/p2'], '2025-12-01T00:00:00Z');
+
+    const result = sortAndSliceQueueReady([p2, p1New, p0New, p1Old], 10);
+
+    expect(result.map((r) => r.number)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('slices to `limit` after sorting, not before', () => {
+    // Deliberately order the input so a naive `input.slice(0, limit)`
+    // would drop the p0, exactly as the old queryQueueReady bug did.
+    const input: SnapshotIssueRecord[] = [];
+    for (let i = 0; i < 15; i += 1) {
+      input.push(
+        issue(2000 + i, ['priority/p2'], `2026-04-${String(19 - i).padStart(2, '0')}T00:00:00Z`),
+      );
+    }
+    const p0 = issue(1, ['priority/p0'], '2025-01-01T00:00:00Z');
+    input.push(p0); // p0 at position 15 (past the slice boundary)
+
+    const result = sortAndSliceQueueReady(input, 10);
+
+    expect(result).toHaveLength(10);
+    expect(result[0].number).toBe(1);
+  });
+
+  it('returns an empty array for an empty input', () => {
+    expect(sortAndSliceQueueReady([], 10)).toEqual([]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input: SnapshotIssueRecord[] = [
+      issue(1, ['priority/p2'], '2026-04-19T00:00:00Z'),
+      issue(2, ['priority/p0'], '2026-04-18T00:00:00Z'),
+    ];
+    const inputCopy = input.slice();
+
+    sortAndSliceQueueReady(input, 10);
+
+    expect(input).toEqual(inputCopy);
+    expect(input[0].number).toBe(1);
+  });
+
+  it('handles missing / empty createdAt by sorting them last within their bucket', () => {
+    const withTs = issue(1, ['priority/p1'], '2026-04-19T00:00:00Z');
+    const withoutTs = issue(2, ['priority/p1'], '');
+
+    const result = sortAndSliceQueueReady([withoutTs, withTs], 10);
+
+    expect(result.map((r) => r.number)).toEqual([1, 2]);
+  });
+
+  it('handles a limit larger than the input length without padding', () => {
+    const input: SnapshotIssueRecord[] = [
+      issue(1, ['priority/p0'], '2026-04-19T00:00:00Z'),
+      issue(2, ['priority/p1'], '2026-04-19T00:00:00Z'),
+    ];
+
+    const result = sortAndSliceQueueReady(input, 10);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.number)).toEqual([1, 2]);
   });
 });


### PR DESCRIPTION
## Summary

Mirrors the Python priority-sort fix from #2835 / PR #2841 in the TypeScript admin resolver. `queryQueueReady` was returning `issues.slice(0, 10)` from `dispatcher.queue_snapshots.issues_json` — which is stored in gh CREATED_AT DESC order — so a single p0 sitting at position 23 (e.g. #2712) never appeared in the admin page's "Queue: Agent-ready" panel even though it was the daemon's next pick.

Adds a `priorityRank(labels)` helper in `parse-labels.ts` next to `extractPriority` (p0→0, p1→1, p2→2, p3→3, unlabelled→4, tolerant of malformed input), extracts sort+slice into `sortAndSliceQueueReady(issues, limit)`, and adds 17 unit tests including a fixture that reproduces the exact #2712 scenario.

Closes #2843

## Test plan

### Automated checks
- [x] Lint passes (`npm run lint` — clean)
- [x] TypeScript typecheck passes (`npm run typecheck` — clean)
- [x] Tests pass (`npm test` — 30 files, 393 tests)
- [x] Build passes (`npm run build` — clean)
- [x] CI green

### Post-deploy verification
- [x] On `dev.judgemind.org/admin/dispatcher`, the Queue: Agent-ready panel shows #2712 (p0) as row 1. Screenshot attached to the verification-evidence comment on #2843.
- [x] Verification evidence posted on #2843.
