### PR TITLE
fix(web/admin): preserve dispatcher dashboard on transient poll errors (#2842)

### DIFF
--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -265,14 +265,21 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
     return <SkeletonShell />;
   }
 
-  // GraphQL errors — the server returns NOT_FOUND for non-admins; that
-  // path is already handled by the admin check above, so any error here
-  // is an actual infrastructure problem.
-  if (error) {
+  const state = data?.dispatcherState;
+
+  // GraphQL errors — hard-fail only when we have no cached state to show.
+  // Apollo's polling contract is that `data` and `error` can both be
+  // populated simultaneously: `data` holds the last successful result and
+  // `error` holds the latest failure. If a transient polling refetch
+  // fails after we already rendered the page, we keep showing the cached
+  // state and surface a small "stale" indicator so the operator knows
+  // the latest poll failed — tearing down the entire page on every
+  // sub-2s blip is exactly the wrong behaviour during active agent
+  // phases (#2842).
+  if (error && !state) {
     return <ErrorBanner message="Failed to load dispatcher state." onRetry={() => void refetch()} />;
   }
 
-  const state = data?.dispatcherState;
   const showInitialLoad = loading && !state;
 
   return (
@@ -281,6 +288,21 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
         <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
           <h1 className={PAGE_TITLE}>Dispatcher</h1>
           <DispatcherHeader currentRun={state?.currentRun ?? null} />
+          {error && state && (
+            <span
+              data-testid="dispatcher-stale-indicator"
+              role="status"
+              aria-label="Last poll failed — showing cached state"
+              title="Last poll failed — showing cached state"
+              className="inline-flex items-center gap-1.5 font-mono text-xs text-yellow-700 dark:text-yellow-300"
+            >
+              <span
+                aria-hidden="true"
+                className="inline-block h-2 w-2 animate-pulse rounded-full bg-yellow-500 motion-reduce:animate-none"
+              />
+              stale
+            </span>
+          )}
         </div>
         <DispatcherControls
           currentRun={state?.currentRun ?? null}

--- a/packages/web/tests/dispatcher-dashboard.test.tsx
+++ b/packages/web/tests/dispatcher-dashboard.test.tsx
@@ -292,5 +292,41 @@ describe('DispatcherDashboard', () => {
     mockQueryResult.error = new Error('network');
     render(<DispatcherDashboard />);
     expect(screen.getByText(/Failed to load dispatcher state/i)).toBeInTheDocument();
+    // Stale indicator is only shown when we have cached state — on
+    // initial-load failure the full error banner takes over instead
+    // (#2842).
+    expect(screen.queryByTestId('dispatcher-stale-indicator')).not.toBeInTheDocument();
+  });
+
+  it('keeps rendering the dashboard with a stale indicator when a polling refetch fails (#2842)', () => {
+    // Simulate Apollo's polling contract: `data` from the last successful
+    // fetch stays populated while `error` reflects the latest failure.
+    mockQueryResult.data = makeActiveState();
+    mockQueryResult.loading = false;
+    mockQueryResult.error = new Error('network blip');
+    render(<DispatcherDashboard />);
+    // Dashboard is still rendered — no ErrorBanner takeover.
+    expect(screen.getByRole('heading', { level: 1, name: /Dispatcher/i })).toBeInTheDocument();
+    expect(screen.queryByText(/Failed to load dispatcher state/i)).not.toBeInTheDocument();
+    // Cached content is still visible (active agents row from makeActiveState).
+    expect(screen.getByText(/Active agents \(1\)/)).toBeInTheDocument();
+    // Stale indicator is visible so the operator knows the latest poll failed.
+    expect(screen.getByTestId('dispatcher-stale-indicator')).toBeInTheDocument();
+  });
+
+  it('clears the stale indicator when the next poll succeeds (#2842)', () => {
+    // First render: transient poll failure after a successful load.
+    mockQueryResult.data = makeActiveState();
+    mockQueryResult.loading = false;
+    mockQueryResult.error = new Error('network blip');
+    const { rerender } = render(<DispatcherDashboard />);
+    expect(screen.getByTestId('dispatcher-stale-indicator')).toBeInTheDocument();
+    // Second render: the next poll succeeds, so `error` clears while
+    // `data` stays populated.
+    mockQueryResult.error = undefined;
+    rerender(<DispatcherDashboard />);
+    expect(screen.queryByTestId('dispatcher-stale-indicator')).not.toBeInTheDocument();
+    // Dashboard is still rendered and there was no retry click.
+    expect(screen.getByRole('heading', { level: 1, name: /Dispatcher/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

A single transient `dispatcherState` poll failure was replacing the whole `/admin/dispatcher` page with an ErrorBanner, even though Apollo still held cached `data` from the previous successful fetch. Guard the hard-fail on `!state` so only initial-load failures tear down the page; transient polling failures keep the cockpit and surface a small, accessible "stale" indicator alongside the header. When the next poll succeeds, `error` clears and the indicator is removed from the DOM — no Retry click required.

Closes #2842

## Test plan

### Automated checks
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (1,233 tests across 82 files; 3 dispatcher-dashboard tests — initial-load failure, transient-failure, recovery)
- [x] `npm run build` passes (`/admin/dispatcher` route compiles at 10.4 kB)
- [x] CI green

### Post-deploy verification
- [x] On dev `/admin/dispatcher`, verified the new code is live — bundle grep at `/_next/static/chunks/app/(main)/admin/dispatcher/page-df9a40ceb5d43a7e.js` finds both `dispatcher-stale-indicator` and "Last poll failed" strings from this PR. Page returns HTTP 200. Transient-failure fault injection is not practical as a post-deploy smoke check; the three new tests in `packages/web/tests/dispatcher-dashboard.test.tsx` cover initial-load failure, transient-failure, and recovery scenarios and pass in CI.
- [x] Verification evidence posted on issue (see [#2842 comment](https://github.com/judgemind/judgemind/issues/2842#issuecomment-4276422460))
