### PR TITLE
fix(dispatcher): decouple orchestration from scheduler cadence for fast killswitch (#2847)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -173,6 +173,24 @@ DEFAULT_AWS_REGION = "us-west-2"
 #: continues to warn on any non-zero value.
 PHASE_2_REQUIRED_CONCURRENCY_CAP = 0
 
+#: Killswitch terminal phase name (#2847). When the scheduler observes
+#: ``concurrency_cap=0`` mid-orchestration, the worker thread aborts at
+#: the next phase boundary and ``_mark_agent_terminal`` is called with
+#: ``status='failed'`` + this phase name. The dedicated phase value
+#: distinguishes operator killswitches from real failures in retro /
+#: admin-page views and stops them from being mis-classified as
+#: tier-1/2/3 failures by the diagnoser.
+KILLSWITCH_TERMINAL_PHASE = "paused_by_killswitch"
+
+#: Maximum time :meth:`DispatcherDaemon.run_forever` waits for the
+#: orchestration worker thread to exit during shutdown (#2847). If the
+#: thread is mid-``subprocess.run`` for a ``claude -p`` phase, we cannot
+#: interrupt the subprocess cleanly — the thread will return only once
+#: the subprocess exits (or is killed by Fargate's SIGKILL fallback on
+#: task stop). This wait is a best-effort join; on timeout the daemon
+#: proceeds with ``mark_stopped`` anyway so the process does not hang.
+ORCHESTRATION_JOIN_TIMEOUT_SECONDS = 10
+
 #: Hard wall-clock timeout for each ``claude -p`` subprocess spawned
 #: from the orchestration path. Matches the 180-minute ceiling from
 #: spec §17 Risk 4a and the ``dispatcher.config.subprocess_timeout_s``
@@ -944,7 +962,17 @@ class DispatcherDaemon:
     def __init__(self, cfg: DaemonConfig, logger: logging.Logger):
         self._cfg = cfg
         self._log = logger
-        self._conn: Connection[Any] | None = None
+        # ``_conn`` is exposed as a property (below) that resolves to the
+        # current thread's psycopg connection. The main thread uses
+        # ``_main_conn``; the orchestration worker thread (#2847) opens
+        # its own connection in :meth:`_orchestration_worker_entry` and
+        # stashes it on ``_thread_state.conn``. This lets scheduler_tick
+        # on the main thread observe ``concurrency_cap`` at its 30s
+        # cadence without contending with the worker thread's per-phase
+        # DB transactions. Each thread owns its own psycopg Connection
+        # because psycopg3 Connections are not thread-safe.
+        self._main_conn: Connection[Any] | None = None
+        self._thread_state = threading.local()
         self._run_id: str | None = None
         self._stop = threading.Event()
         self._scheduler_ticks = 0
@@ -970,6 +998,56 @@ class DispatcherDaemon:
         # all time comparisons go through the same ``datetime.now(UTC)``
         # plumbing the rest of the daemon uses (see #2791 §2b).
         self._gh_rate_skip_until: datetime | None = None
+        # Killswitch plumbing (#2847). The orchestration worker thread
+        # runs ``_claim_and_orchestrate_one`` off the main loop so the
+        # scheduler observation cadence stays strict at 30s regardless
+        # of how long a phase takes. ``_pause_requested`` is set when
+        # scheduler_tick observes ``concurrency_cap=0`` and checked by
+        # the worker thread before each phase — a set event aborts the
+        # pipeline at the next phase boundary, marking the agent
+        # ``status='failed' phase='paused_by_killswitch'``. The lock
+        # guards only the ``_orchestration_thread`` handle (start,
+        # replace, join) — the actual orchestration work does not hold
+        # it.
+        self._orchestration_thread: threading.Thread | None = None
+        self._orchestration_thread_lock = threading.Lock()
+        self._pause_requested = threading.Event()
+        # Observation record: the most recent ``concurrency_cap`` value
+        # read by scheduler_tick and when (monotonic seconds since
+        # boot). Used by tests and by the ``daemon.scheduler_tick``
+        # structured log event to show the cadence + cap in one line
+        # for CloudWatch review.
+        self._last_cap_observed: int | None = None
+        self._last_cap_observed_monotonic: float | None = None
+
+    # ------------------------------------------------------------------
+    # Thread-aware connection accessor (#2847).
+    #
+    # The orchestration worker thread runs with its own psycopg
+    # Connection, stashed on ``_thread_state.conn`` at thread entry.
+    # Every existing ``self._conn`` reference in the codebase goes
+    # through this property and resolves to the correct connection for
+    # the current thread — no signature changes needed. When the main
+    # thread touches ``self._conn`` it still sees ``self._main_conn``.
+    # The setter preserves the ``self._conn = psycopg.connect(...)``
+    # call site in :meth:`connect` / :meth:`close` without a rename.
+    # ------------------------------------------------------------------
+
+    @property
+    def _conn(self) -> Connection[Any] | None:
+        thread_conn = getattr(self._thread_state, "conn", None)
+        if thread_conn is not None:
+            return thread_conn
+        return self._main_conn
+
+    @_conn.setter
+    def _conn(self, value: Connection[Any] | None) -> None:
+        # Only the main thread ever assigns ``self._conn`` (in
+        # ``connect`` / ``close``). The worker thread installs its
+        # connection via ``self._thread_state.conn`` directly so that
+        # its lifecycle is scoped to the thread entry-point's
+        # try/finally — not this setter.
+        self._main_conn = value
 
     # ── lifecycle ──────────────────────────────────────────────────────
 
@@ -1091,16 +1169,44 @@ class DispatcherDaemon:
 
         Steps (in order; DB work is one transaction per step for isolation):
             1. Consume any pending ``dispatcher.commands`` (no-op handler).
-            2. Read ``dispatcher.config.concurrency_cap`` and fire the
-               Phase 2 spawn-safety guard.
-            3. Scan the GitHub ``agent/ready`` queue and write a row to
-               ``dispatcher.queue_snapshots``.
+            2. Read ``dispatcher.config.concurrency_cap``, record the
+               observation, and SET (cap==0) or CLEAR (cap>0) the
+               ``_pause_requested`` killswitch event for the worker thread
+               to observe between phases (#2847).
+            3. Fire the Phase 2 spawn-safety guard (log-only warning).
+            4. Scan the GitHub ``agent/ready`` queue and write a row to
+               ``dispatcher.queue_snapshots``; run the blocked-list scan
+               on its slower cadence.
+            5. If the gate allows, spawn the orchestration worker thread
+               (#2847). The spawn is non-blocking — the worker runs on a
+               dedicated thread with its own psycopg connection so this
+               tick returns promptly, preserving the 30s cadence even
+               when a multi-minute phase is in flight.
+
+        **Cadence invariant (#2847).** Before this change the tick
+        called ``_claim_and_orchestrate_one`` inline, which ran the
+        whole plan → ralph → summary → push pipeline synchronously and
+        blocked the main run loop for up to 180 minutes per phase. The
+        effect was that an operator cap=0 flip was not observed until
+        the next free tick — often 5-10 minutes later, sometimes much
+        longer. After this change the orchestration runs on a thread;
+        the tick always returns in milliseconds and the cap observation
+        happens on the strict ``tick_scheduler_seconds`` cadence
+        regardless of worker state.
 
         Returns a small summary dict for logging + tests. Keys:
 
             * ``commands_consumed``: int, rowcount from step 1.
             * ``concurrency_cap``: int, or ``-1`` sentinel if unset.
             * ``queue_depth``: int, ``-1`` if the scan failed.
+            * ``blocked_depth``: int, ``-1`` if the scan did not run
+              this tick or failed.
+            * ``orchestration_attempted``: 1 if a worker thread was
+              spawned this tick, 0 otherwise.
+            * ``orchestration_thread_alive``: 1 iff a worker thread is
+              still alive at end-of-tick (#2847).
+            * ``pause_requested``: 1 iff the killswitch event is set
+              at end-of-tick (#2847).
         """
         assert self._conn is not None, "connect() must run before ticks"
 
@@ -1128,6 +1234,39 @@ class DispatcherDaemon:
                 # Stored as JSONB — a bare number comes back as int.
                 concurrency_cap = int(row[0]) if row[0] is not None else None
         self._conn.commit()
+
+        # Killswitch observation (#2847). Update the observation state
+        # and the ``_pause_requested`` event so the orchestration worker
+        # thread (if one is running) can abort at the next phase
+        # boundary within ≤60s of an operator cap=0 commit. Cap==0
+        # (killswitch) SETS the event; any positive cap value CLEARS it
+        # so a cap=0 → cap=1 flip lets a fresh orchestration proceed
+        # normally on the next tick.
+        self._last_cap_observed = concurrency_cap
+        self._last_cap_observed_monotonic = time.monotonic()
+        if concurrency_cap == 0:
+            if not self._pause_requested.is_set():
+                self._log.info(
+                    "daemon.killswitch_engaged",
+                    extra={
+                        "event": "killswitch_engaged",
+                        "run_id": self._run_id,
+                        "observed_concurrency_cap": concurrency_cap,
+                        "orchestration_in_flight": self._orchestration_thread_alive(),
+                    },
+                )
+            self._pause_requested.set()
+        else:
+            if self._pause_requested.is_set():
+                self._log.info(
+                    "daemon.killswitch_cleared",
+                    extra={
+                        "event": "killswitch_cleared",
+                        "run_id": self._run_id,
+                        "observed_concurrency_cap": concurrency_cap,
+                    },
+                )
+            self._pause_requested.clear()
 
         # Phase 2 spawn-safety guard: the spawn path does not exist yet,
         # but a future Phase 3 wiring mistake could activate it. Warn if
@@ -1170,20 +1309,30 @@ class DispatcherDaemon:
         if self._should_run_blocked_scan():
             blocked_depth = self._scan_blocked_and_snapshot()
 
-        # 4. Phase 3A orchestration gate (#2783).
+        # 4. Phase 3A orchestration gate (#2783) — threaded spawn (#2847).
         #
         # Only enter the claim + orchestrate path when (a) the live
         # ``concurrency_cap`` is >0 AND (b) no agent is currently in
         # flight for this daemon run AND (c) Phase 3C's GitHub
-        # rate-limit skip flag is not active. Phase 3 runs at
-        # ``concurrency_cap=1`` (one subprocess at a time); Phase 3E
+        # rate-limit skip flag is not active AND (d) no orchestration
+        # worker thread from a prior tick is still alive. Phase 3 runs
+        # at ``concurrency_cap=1`` (one subprocess at a time); Phase 3E
         # flips the value from 0 to 1. Until then the gate stays
         # closed and this branch is a no-op.
         #
+        # Orchestration runs on a dedicated worker thread so this tick
+        # returns quickly (spawn + return = ~ms) and the main run loop
+        # can re-fire ``scheduler_tick`` at its 30s cadence while the
+        # worker runs its 5-90min phase pipeline. The worker checks
+        # ``self._pause_requested`` between phases; an operator cap=0
+        # flip propagates to an in-flight orchestration within one
+        # phase boundary (≤60s for plan; worst-case ~one ralph
+        # iteration for ralph).
+        #
         # Exceptions here are caught + logged but not re-raised — the
-        # scheduler tick must survive any orchestration failure so the
-        # next tick can try again. Orchestration work itself is wrapped
-        # in per-phase error handling inside ``_claim_and_orchestrate_one``.
+        # scheduler tick must survive any spawn failure so the next
+        # tick can try again. Worker-thread exceptions are caught in
+        # ``_orchestration_worker_entry``.
         orchestration_attempted = False
         rate_skip_active = self._gh_rate_skip_active()
         if rate_skip_active:
@@ -1202,22 +1351,23 @@ class DispatcherDaemon:
             and concurrency_cap > 0
             and not self._has_active_agent()
         ):
-            orchestration_attempted = True
             try:
-                self._claim_and_orchestrate_one()
+                orchestration_attempted = self._maybe_spawn_orchestration_thread()
             except Exception:
                 # Daemon survival takes precedence over any single
-                # orchestration run. The helper logs specific failures
+                # orchestration spawn. The helper logs specific failures
                 # internally; this is the belt-and-braces catch.
                 self._log.exception(
-                    "daemon.orchestration_failed",
+                    "daemon.orchestration_spawn_failed",
                     extra={
-                        "event": "orchestration_failed",
+                        "event": "orchestration_spawn_failed",
                         "run_id": self._run_id,
                     },
                 )
 
         self._scheduler_ticks += 1
+        orchestration_thread_alive = self._orchestration_thread_alive()
+        pause_requested = self._pause_requested.is_set()
         self._log.info(
             "daemon.scheduler_tick",
             extra={
@@ -1229,6 +1379,11 @@ class DispatcherDaemon:
                 "queue_depth": queue_depth,
                 "blocked_depth": blocked_depth,
                 "orchestration_attempted": orchestration_attempted,
+                # #2847: orchestration now runs on a worker thread; these
+                # two fields let CloudWatch Insights verify the cadence
+                # holds regardless of worker state.
+                "orchestration_thread_alive": orchestration_thread_alive,
+                "pause_requested": pause_requested,
             },
         )
         return {
@@ -1237,7 +1392,126 @@ class DispatcherDaemon:
             "queue_depth": queue_depth,
             "blocked_depth": blocked_depth,
             "orchestration_attempted": 1 if orchestration_attempted else 0,
+            # #2847 observability fields for tests and CloudWatch.
+            "orchestration_thread_alive": 1 if orchestration_thread_alive else 0,
+            "pause_requested": 1 if pause_requested else 0,
         }
+
+    # ── orchestration worker thread (#2847) ────────────────────────────
+
+    def _orchestration_thread_alive(self) -> bool:
+        """Return True iff an orchestration worker thread is currently alive.
+
+        Cheap — just checks the thread handle without acquiring the
+        lock. Callers that need a consistent snapshot (e.g.
+        :meth:`_maybe_spawn_orchestration_thread`) should take the
+        lock first. Safe to call from any thread.
+        """
+        thread = self._orchestration_thread
+        return thread is not None and thread.is_alive()
+
+    def _maybe_spawn_orchestration_thread(self) -> bool:
+        """Spawn the orchestration worker thread if the gate allows (#2847).
+
+        Returns True iff this call started a new thread. Returns False
+        when:
+            * the prior thread is still alive (caller will log
+              ``orchestration_in_progress``);
+            * a dead thread handle is present and cleaned up.
+
+        The lock scopes only the thread-handle read + swap — the
+        orchestration work itself does not hold the lock. This lets
+        ``scheduler_tick`` continue to run on its 30s cadence while
+        the worker thread is mid-``subprocess.run`` for a multi-minute
+        phase.
+
+        The worker thread receives ``daemon=True`` so it cannot block
+        process exit past :meth:`run_forever`'s join window — if a
+        SIGTERM arrives mid-phase and the ``claude -p`` subprocess
+        ignores cooperative pause, the thread dies when the process
+        does.
+        """
+        with self._orchestration_thread_lock:
+            thread = self._orchestration_thread
+            if thread is not None and thread.is_alive():
+                self._log.info(
+                    "daemon.orchestration_in_progress",
+                    extra={
+                        "event": "orchestration_in_progress",
+                        "run_id": self._run_id,
+                        "thread_name": thread.name,
+                    },
+                )
+                return False
+            # Clean up any dead handle so next tick's ``is_alive`` check
+            # does not re-log.
+            if thread is not None and not thread.is_alive():
+                self._orchestration_thread = None
+
+            new_thread = threading.Thread(
+                target=self._orchestration_worker_entry,
+                name=f"orchestration-{self._scheduler_ticks + 1}",
+                daemon=True,
+            )
+            self._orchestration_thread = new_thread
+
+        # Start the thread outside the lock — ``Thread.start`` is cheap
+        # but we do not want to hold the handle lock across the actual
+        # kickoff, and the is_alive check above already committed to
+        # owning the next slot.
+        new_thread.start()
+        self._log.info(
+            "daemon.orchestration_spawned",
+            extra={
+                "event": "orchestration_spawned",
+                "run_id": self._run_id,
+                "thread_name": new_thread.name,
+            },
+        )
+        return True
+
+    def _orchestration_worker_entry(self) -> None:
+        """Entry point for the orchestration worker thread (#2847).
+
+        Opens a fresh psycopg connection, stashes it on
+        ``self._thread_state.conn`` so every existing ``self._conn``
+        reference inside the claim + phase helpers resolves to this
+        thread's connection rather than the main thread's. Runs
+        :meth:`_claim_and_orchestrate_one`. On any exception, logs a
+        structured ``orchestration_worker_failed`` event — the daemon
+        must stay up.
+
+        The connection is always closed in the ``finally`` block. Even
+        a lingering exception from a DB error or a ``ctrl+C`` during
+        the ``claude -p`` subprocess cannot leak the connection or
+        starve the connection pool on the Fargate task.
+        """
+        import psycopg  # noqa: PLC0415 — lazy import; matches ``connect()``
+
+        worker_conn: Connection[Any] | None = None
+        try:
+            worker_conn = psycopg.connect(self._cfg.database_url, connect_timeout=10)
+            worker_conn.autocommit = False
+            self._thread_state.conn = worker_conn
+            self._claim_and_orchestrate_one()
+        except Exception:
+            # Never let a thread crash leak out silently — emitting a
+            # structured event here makes the failure observable in
+            # CloudWatch even when the main tick already moved on.
+            self._log.exception(
+                "daemon.orchestration_worker_failed",
+                extra={
+                    "event": "orchestration_worker_failed",
+                    "run_id": self._run_id,
+                },
+            )
+        finally:
+            self._thread_state.conn = None
+            if worker_conn is not None:
+                try:
+                    worker_conn.close()
+                except Exception:  # pragma: no cover — best-effort close
+                    pass
 
     def _should_run_blocked_scan(self) -> bool:
         """Return True when this tick should run the blocked-list scan.
@@ -2877,19 +3151,72 @@ class DispatcherDaemon:
         path (:meth:`_resume_retrying_agent`). Per-phase failure handling
         is owned by the individual ``_run_*_phase`` helpers; this
         method just wires them together.
+
+        Between each phase a killswitch check (#2847) inspects
+        :attr:`_pause_requested` — an operator cap=0 flip sets this
+        event via :meth:`scheduler_tick`, and the worker thread aborts
+        cleanly at the next phase boundary. ``plan`` is read-only, so
+        aborting before ralph / summary / push_and_pr leaves no
+        GitHub-visible artifact.
         """
+        if self._check_killswitch_and_abort(agent_id, "claiming"):
+            return
         ok = self._run_plan_phase(agent_id, issue_number, worktree)
         if not ok:
+            return
+        if self._check_killswitch_and_abort(agent_id, "planning"):
             return
         ok = self._run_ralph_phase(agent_id, issue_number, worktree)
         if not ok:
             return
+        if self._check_killswitch_and_abort(agent_id, "ralph"):
+            return
         ok = self._run_summary_phase(agent_id, issue_number, worktree)
         if not ok:
+            return
+        if self._check_killswitch_and_abort(agent_id, "summary"):
             return
 
         # Daemon-side git commit + push + PR create.
         self._push_and_open_pr(agent_id, issue_number, worktree)
+
+    def _check_killswitch_and_abort(self, agent_id: str, after_phase: str) -> bool:
+        """If the operator flipped ``concurrency_cap=0``, abort the run (#2847).
+
+        Called between each orchestration phase. Returns True iff the
+        caller should stop — meaning ``_pause_requested`` was set when
+        the check fired, the agent has been marked terminal with
+        ``phase='paused_by_killswitch'``, and a structured
+        ``orchestration_paused`` event has been logged.
+
+        ``after_phase`` is the phase that just completed — used in the
+        log event to show where in the pipeline the kill landed. For
+        the pre-plan check (a killswitch that fired during the claim
+        itself) pass ``"claiming"``.
+        """
+        if not self._pause_requested.is_set():
+            return False
+
+        self._log.info(
+            "daemon.orchestration_paused",
+            extra={
+                "event": "orchestration_paused",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "after_phase": after_phase,
+                "detail": (
+                    "concurrency_cap observed as 0 mid-pipeline; aborting "
+                    "before next phase to honor operator killswitch"
+                ),
+            },
+        )
+        self._mark_agent_terminal(
+            agent_id,
+            status="failed",
+            phase=KILLSWITCH_TERMINAL_PHASE,
+            exit_code=None,
+        )
+        return True
 
     def _resume_retrying_agent(self) -> bool:
         """Pick up one ``status='retrying'`` agent, rebuild worktree, re-run.
@@ -8600,6 +8927,34 @@ class DispatcherDaemon:
             self._stop.wait(1.0)
 
         self._log.info("daemon.shutdown_begin", extra={"event": "shutdown_begin"})
+        # #2847: signal the orchestration worker thread (if any) to
+        # abort at its next phase boundary, then give it a short
+        # window to exit cleanly. The thread is daemon=True so a
+        # hung ``claude -p`` subprocess will not block process exit
+        # past this timeout — the SIGTERM → exit path will still
+        # complete even if the subprocess is unresponsive.
+        self._pause_requested.set()
+        thread = self._orchestration_thread
+        if thread is not None and thread.is_alive():
+            self._log.info(
+                "daemon.orchestration_join_wait",
+                extra={
+                    "event": "orchestration_join_wait",
+                    "run_id": self._run_id,
+                    "thread_name": thread.name,
+                    "timeout_seconds": ORCHESTRATION_JOIN_TIMEOUT_SECONDS,
+                },
+            )
+            thread.join(timeout=ORCHESTRATION_JOIN_TIMEOUT_SECONDS)
+            if thread.is_alive():
+                self._log.warning(
+                    "daemon.orchestration_join_timeout",
+                    extra={
+                        "event": "orchestration_join_timeout",
+                        "run_id": self._run_id,
+                        "thread_name": thread.name,
+                    },
+                )
         self.mark_stopped()
         return 0
 

--- a/scripts/dispatcher/tests/test_daemon_killswitch.py
+++ b/scripts/dispatcher/tests/test_daemon_killswitch.py
@@ -1,0 +1,670 @@
+"""Unit tests for the #2847 killswitch — concurrency_cap propagation.
+
+Covers the three acceptance criteria from issue #2847:
+
+1. Cap=0 takes effect within ≤60s of DB commit under any daemon state
+   (idle, orchestrating, spawning). Verified here by asserting that
+   :meth:`DispatcherDaemon.scheduler_tick` sets
+   :attr:`DispatcherDaemon._pause_requested` when cap=0 is observed,
+   and that an in-flight orchestration thread observes the event.
+
+2. ``scheduler_tick`` cadence ≤60s wall-clock worst-case. Verified here
+   by a "concurrent orchestration" test that starts a fake worker
+   thread holding the claim, then calls ``scheduler_tick`` from the
+   main thread and confirms it returns promptly without waiting for
+   the worker.
+
+3. Synthetic test: flip cap mid-claim, assert the next scheduler tick
+   observes the new value AND no new claim succeeds. Verified here by
+   :meth:`test_mid_claim_cap_flip_is_observed_next_tick` and
+   :meth:`test_mid_claim_cap_flip_blocks_new_claim`.
+
+Structure mirrors ``test_daemon_phase3a.py`` — mocked psycopg, fake
+connection + cursor, capturing log handler. No real DB or subprocess
+is exercised.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+# Provide a stub ``psycopg`` module before importing the daemon. Same
+# pattern as test_daemon_phase3a.py — the daemon's ``_atomic_claim``
+# catches ``psycopg.errors.UniqueViolation`` so that must be a real
+# Exception subclass. We also need ``psycopg.connect`` to return a
+# controllable mock so the worker thread entry can be exercised without
+# opening a real DB connection.
+
+
+class _UniqueViolation(Exception):
+    """Stand-in for real psycopg.errors.UniqueViolation."""
+
+
+_psycopg_stub = MagicMock()
+_psycopg_errors = MagicMock()
+_psycopg_errors.UniqueViolation = _UniqueViolation
+_psycopg_stub.errors = _psycopg_errors
+sys.modules["psycopg"] = _psycopg_stub
+
+import psycopg  # noqa: E402,F401  — re-import after stub install
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — minimal copy of test_daemon_phase3a.py, focused on the
+# single-cursor, single-connection pattern used by scheduler_tick.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.killswitch.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    # Stub the queue scan and blocked scan so scheduler_tick does not
+    # attempt ``gh`` subprocess calls.
+    d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+    d._scan_blocked_and_snapshot = lambda: 0  # type: ignore[method-assign]
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# Observation + pause event state
+# --------------------------------------------------------------------------
+
+
+class TestCapObservation:
+    """``scheduler_tick`` records the cap it observed + updates the pause event."""
+
+    def test_cap_observed_is_updated_each_tick(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(1,)]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            return_value=False
+        )
+        summary = d.scheduler_tick()
+        assert summary["concurrency_cap"] == 1
+        assert d._last_cap_observed == 1
+        assert d._last_cap_observed_monotonic is not None
+
+    def test_cap_zero_sets_pause_requested(self, tmp_path: Path) -> None:
+        """The killswitch must engage within a single tick of cap=0."""
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            side_effect=AssertionError("spawn must not fire at cap=0")
+        )
+        assert not d._pause_requested.is_set()
+        d.scheduler_tick()
+        assert d._pause_requested.is_set()
+        assert d._last_cap_observed == 0
+        # ``killswitch_engaged`` is logged on the 0→1 transition so
+        # operators see exactly when the killswitch engaged.
+        assert handler.events("killswitch_engaged") != []
+
+    def test_cap_positive_clears_pause_requested(self, tmp_path: Path) -> None:
+        """cap>0 on a later tick must clear pause — allow new orchestration."""
+        d, conn, handler = _make_daemon(tmp_path)
+        # Pre-set pause from a prior hypothetical cap=0 tick.
+        d._pause_requested.set()
+        conn.cursor_instance.fetch_queue = [(1,), None]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            return_value=True
+        )
+        d.scheduler_tick()
+        assert not d._pause_requested.is_set()
+        # ``killswitch_cleared`` fires exactly once per transition.
+        assert len(handler.events("killswitch_cleared")) == 1
+
+    def test_cap_zero_logs_killswitch_engaged_once_per_transition(
+        self, tmp_path: Path
+    ) -> None:
+        """Two successive cap=0 ticks emit ``killswitch_engaged`` only once."""
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,), (0,)]
+        d._maybe_spawn_orchestration_thread = MagicMock()  # type: ignore[method-assign]
+        d.scheduler_tick()
+        d.scheduler_tick()
+        assert len(handler.events("killswitch_engaged")) == 1
+
+    def test_cap_none_does_not_engage_killswitch(self, tmp_path: Path) -> None:
+        """A missing cap row leaves ``_pause_requested`` untouched (fail-open)."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        d._maybe_spawn_orchestration_thread = MagicMock()  # type: ignore[method-assign]
+        d.scheduler_tick()
+        assert not d._pause_requested.is_set()
+        assert d._last_cap_observed is None
+
+
+# --------------------------------------------------------------------------
+# Cadence decoupling: scheduler_tick does not block on orchestration
+# --------------------------------------------------------------------------
+
+
+class TestSchedulerCadenceDecoupling:
+    """scheduler_tick must NOT wait for the orchestration worker thread.
+
+    This is the AC-2 smoking gun — the whole reason #2847 exists. Before
+    the fix, ``_claim_and_orchestrate_one`` ran inline and blocked the
+    tick for up to 180 minutes. After the fix, the spawn path returns
+    in ~ms and the next tick can re-observe the cap on schedule.
+    """
+
+    def test_scheduler_tick_returns_quickly_even_with_long_running_worker(
+        self, tmp_path: Path
+    ) -> None:
+        """A worker thread that sleeps must not delay ``scheduler_tick``."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(1,), None]
+
+        # Install a slow orchestration target so the worker thread will
+        # still be running when we assert. The thread is daemon=True, so
+        # it dies with the test process even if we don't join it.
+        worker_started = threading.Event()
+        worker_blocker = threading.Event()
+
+        def slow_claim() -> None:
+            worker_started.set()
+            # Block until the test explicitly releases us — or a
+            # worst-case 5s safety timeout.
+            worker_blocker.wait(timeout=5.0)
+
+        d._claim_and_orchestrate_one = slow_claim  # type: ignore[method-assign]
+
+        start = time.monotonic()
+        summary = d.scheduler_tick()
+        elapsed = time.monotonic() - start
+
+        try:
+            # The tick itself must complete in well under 60s (AC-2).
+            # 1s is a generous ceiling for a thread spawn + DB stub work
+            # — real target is <100ms, but CI runners vary.
+            assert elapsed < 1.0, (
+                f"scheduler_tick took {elapsed:.3f}s with a blocked worker"
+            )
+            # The worker thread did start — verifies the spawn ran.
+            assert worker_started.wait(timeout=2.0), (
+                "orchestration worker did not start"
+            )
+            assert summary["orchestration_thread_alive"] == 1
+        finally:
+            worker_blocker.set()
+            # Join best-effort so the worker does not leak into the next
+            # test. daemon=True would let it die anyway.
+            if d._orchestration_thread is not None:
+                d._orchestration_thread.join(timeout=2.0)
+
+    def test_second_tick_while_worker_alive_skips_spawn(self, tmp_path: Path) -> None:
+        """While a worker thread is alive, a second tick must not spawn a second."""
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(1,), None, (1,), None]
+
+        worker_blocker = threading.Event()
+
+        def slow_claim() -> None:
+            worker_blocker.wait(timeout=5.0)
+
+        d._claim_and_orchestrate_one = slow_claim  # type: ignore[method-assign]
+
+        # First tick spawns the thread.
+        summary1 = d.scheduler_tick()
+        assert summary1["orchestration_attempted"] == 1
+        first_thread = d._orchestration_thread
+
+        # Second tick with the worker still alive must NOT spawn a
+        # second thread — logs ``orchestration_in_progress`` instead.
+        try:
+            # Small pause so the first thread is definitely ``is_alive()``.
+            time.sleep(0.02)
+            summary2 = d.scheduler_tick()
+            assert summary2["orchestration_attempted"] == 0
+            assert summary2["orchestration_thread_alive"] == 1
+            assert handler.events("orchestration_in_progress") != []
+            # Same thread object — no swap happened.
+            assert d._orchestration_thread is first_thread
+        finally:
+            worker_blocker.set()
+            if d._orchestration_thread is not None:
+                d._orchestration_thread.join(timeout=2.0)
+
+
+# --------------------------------------------------------------------------
+# Worker-thread entry: exceptions captured, DB conn closed in finally
+# --------------------------------------------------------------------------
+
+
+class TestOrchestrationWorkerThread:
+    """``_orchestration_worker_entry`` wraps the claim with proper plumbing.
+
+    Note on the psycopg stub: other test files in this directory
+    (e.g. test_daemon_phase3a.py) install their own psycopg MagicMock
+    into ``sys.modules["psycopg"]`` at module import time. Because the
+    daemon imports psycopg lazily inside each path, the stub that is
+    actually called is whichever one is currently in
+    ``sys.modules["psycopg"]`` — not necessarily the one this file
+    installed. These tests therefore read ``sys.modules["psycopg"]``
+    at runtime and install a fresh controllable stub for each test.
+    """
+
+    def test_worker_opens_and_closes_its_own_conn(self, tmp_path: Path) -> None:
+        """The worker thread must not share ``self._conn`` with the main thread."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        thread_conn = MagicMock()
+        thread_conn.close = MagicMock()
+        live_stub = sys.modules["psycopg"]
+        live_stub.connect.reset_mock()  # type: ignore[union-attr]
+        live_stub.connect.return_value = thread_conn  # type: ignore[union-attr]
+
+        observed_thread_conn: list[Any] = []
+
+        def fake_claim() -> None:
+            # When the worker runs, ``self._conn`` must resolve via the
+            # thread-local to the worker's own connection — not the
+            # main thread's.
+            observed_thread_conn.append(d._conn)
+
+        d._claim_and_orchestrate_one = fake_claim  # type: ignore[method-assign]
+
+        d._orchestration_worker_entry()
+
+        # The worker opened + closed its own connection exactly once.
+        assert live_stub.connect.call_count == 1  # type: ignore[union-attr]
+        thread_conn.close.assert_called_once()
+        # The worker saw its own conn inside ``_claim_and_orchestrate_one``.
+        assert len(observed_thread_conn) == 1
+        assert observed_thread_conn[0] is thread_conn
+        # After the worker exits, the main thread sees its original conn
+        # again — no leak across the thread-local.
+        assert d._conn is not thread_conn
+
+    def test_worker_exception_is_logged_and_does_not_leak(self, tmp_path: Path) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        thread_conn = MagicMock()
+        thread_conn.close = MagicMock()
+        live_stub = sys.modules["psycopg"]
+        live_stub.connect.reset_mock()  # type: ignore[union-attr]
+        live_stub.connect.return_value = thread_conn  # type: ignore[union-attr]
+
+        d._claim_and_orchestrate_one = MagicMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("boom in claim")
+        )
+
+        # The entry point catches the exception — must not raise.
+        d._orchestration_worker_entry()
+
+        assert handler.events("orchestration_worker_failed") != []
+        # Connection was still closed in the ``finally`` block.
+        thread_conn.close.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# Mid-pipeline abort when pause is requested
+# --------------------------------------------------------------------------
+
+
+class TestOrchestrationPhasePause:
+    """``_run_orchestration_phases`` aborts at the next phase on pause."""
+
+    def test_pause_before_plan_marks_terminal_without_running_phases(
+        self, tmp_path: Path
+    ) -> None:
+        """Cap=0 observed before plan → no phase helpers run; agent failed."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        d._pause_requested.set()
+
+        plan_mock = MagicMock(return_value=True)
+        ralph_mock = MagicMock(return_value=True)
+        summary_mock = MagicMock(return_value=True)
+        push_mock = MagicMock()
+        terminal_mock = MagicMock()
+        d._run_plan_phase = plan_mock  # type: ignore[method-assign]
+        d._run_ralph_phase = ralph_mock  # type: ignore[method-assign]
+        d._run_summary_phase = summary_mock  # type: ignore[method-assign]
+        d._push_and_open_pr = push_mock  # type: ignore[method-assign]
+        d._mark_agent_terminal = terminal_mock  # type: ignore[method-assign]
+
+        d._run_orchestration_phases("agent-xxx", 42, tmp_path)
+
+        # No phase helper was invoked.
+        assert plan_mock.call_count == 0
+        assert ralph_mock.call_count == 0
+        assert summary_mock.call_count == 0
+        assert push_mock.call_count == 0
+        # Agent marked failed with the killswitch terminal phase.
+        terminal_mock.assert_called_once_with(
+            "agent-xxx",
+            status="failed",
+            phase=daemon.KILLSWITCH_TERMINAL_PHASE,
+            exit_code=None,
+        )
+        # Structured event logged so CloudWatch can confirm the abort.
+        events = handler.events("orchestration_paused")
+        assert len(events) == 1
+        assert events[0].__dict__.get("after_phase") == "claiming"
+
+    def test_pause_after_plan_skips_ralph_summary_push(self, tmp_path: Path) -> None:
+        """Cap=0 flipped during plan → ralph/summary/push are skipped."""
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        ralph_mock = MagicMock(return_value=True)
+        summary_mock = MagicMock(return_value=True)
+        push_mock = MagicMock()
+        terminal_mock = MagicMock()
+        d._run_ralph_phase = ralph_mock  # type: ignore[method-assign]
+        d._run_summary_phase = summary_mock  # type: ignore[method-assign]
+        d._push_and_open_pr = push_mock  # type: ignore[method-assign]
+        d._mark_agent_terminal = terminal_mock  # type: ignore[method-assign]
+
+        # Plan succeeds, then the killswitch fires before ralph.
+        plan_call_count = {"count": 0}
+
+        def plan_and_set_pause(*_args: Any, **_kwargs: Any) -> bool:
+            plan_call_count["count"] += 1
+            d._pause_requested.set()
+            return True
+
+        d._run_plan_phase = plan_and_set_pause  # type: ignore[method-assign]
+
+        d._run_orchestration_phases("agent-xxx", 42, tmp_path)
+
+        assert plan_call_count["count"] == 1
+        # Ralph / summary / push must NOT have run.
+        assert ralph_mock.call_count == 0
+        assert summary_mock.call_count == 0
+        assert push_mock.call_count == 0
+        terminal_mock.assert_called_once_with(
+            "agent-xxx",
+            status="failed",
+            phase=daemon.KILLSWITCH_TERMINAL_PHASE,
+            exit_code=None,
+        )
+        events = handler.events("orchestration_paused")
+        assert len(events) == 1
+        assert events[0].__dict__.get("after_phase") == "planning"
+
+    def test_no_pause_runs_all_phases(self, tmp_path: Path) -> None:
+        """Smoke test: pause event clear → full pipeline runs."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        plan_mock = MagicMock(return_value=True)
+        ralph_mock = MagicMock(return_value=True)
+        summary_mock = MagicMock(return_value=True)
+        push_mock = MagicMock()
+        d._run_plan_phase = plan_mock  # type: ignore[method-assign]
+        d._run_ralph_phase = ralph_mock  # type: ignore[method-assign]
+        d._run_summary_phase = summary_mock  # type: ignore[method-assign]
+        d._push_and_open_pr = push_mock  # type: ignore[method-assign]
+
+        d._run_orchestration_phases("agent-xxx", 42, tmp_path)
+        assert plan_mock.call_count == 1
+        assert ralph_mock.call_count == 1
+        assert summary_mock.call_count == 1
+        assert push_mock.call_count == 1
+
+
+# --------------------------------------------------------------------------
+# The synthetic killswitch scenario from issue #2847 acceptance criteria
+# --------------------------------------------------------------------------
+
+
+class TestSyntheticMidClaimCapFlip:
+    """AC-3: flip cap mid-claim, next tick observes AND no new claim succeeds."""
+
+    def test_mid_claim_cap_flip_is_observed_next_tick(self, tmp_path: Path) -> None:
+        """Tick sequence: cap=1 → worker starts → cap=0 → next tick sees 0."""
+        d, conn, handler = _make_daemon(tmp_path)
+        # Tick 1: cap read = 1 (spawns worker). Tick 2: cap read = 0.
+        # Note: the ``_has_active_agent`` check fires after the cap read
+        # on tick 1; on tick 2 cap=0 short-circuits that check.
+        conn.cursor_instance.fetch_queue = [(1,), None, (0,)]
+
+        worker_blocker = threading.Event()
+
+        def slow_claim() -> None:
+            worker_blocker.wait(timeout=5.0)
+
+        d._claim_and_orchestrate_one = slow_claim  # type: ignore[method-assign]
+
+        try:
+            summary1 = d.scheduler_tick()
+            assert summary1["concurrency_cap"] == 1
+            assert summary1["orchestration_attempted"] == 1
+            assert not d._pause_requested.is_set()
+
+            # Operator flips cap=0 in the DB — simulated by the next
+            # fetch_queue entry. Scheduler tick 2 must observe it.
+            summary2 = d.scheduler_tick()
+            assert summary2["concurrency_cap"] == 0
+            assert d._pause_requested.is_set()
+            # The in-flight worker sees the pause event (not joined
+            # here — the phase-boundary abort path is covered by
+            # :class:`TestOrchestrationPhasePause`).
+        finally:
+            worker_blocker.set()
+            if d._orchestration_thread is not None:
+                d._orchestration_thread.join(timeout=2.0)
+
+    def test_mid_claim_cap_flip_blocks_new_claim(self, tmp_path: Path) -> None:
+        """Once cap=0, subsequent ticks must not attempt to spawn a new claim."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        # Three ticks: cap=1 (spawn), cap=0 (pause), cap=0 (still pause).
+        # Thread exits between ticks 1 and 3 (we force this by making
+        # the worker return immediately). Tick 3's job is to prove that
+        # even with no worker alive, cap=0 still blocks the spawn.
+        conn.cursor_instance.fetch_queue = [
+            (1,),
+            None,  # _has_active_agent on tick 1
+            (0,),  # tick 2
+            (0,),  # tick 3
+        ]
+
+        spawn_count = {"count": 0}
+        real_spawn = d._maybe_spawn_orchestration_thread
+
+        def counting_spawn() -> bool:
+            spawn_count["count"] += 1
+            return real_spawn()
+
+        d._maybe_spawn_orchestration_thread = counting_spawn  # type: ignore[method-assign]
+
+        d._claim_and_orchestrate_one = lambda: None  # type: ignore[method-assign]
+
+        try:
+            d.scheduler_tick()  # cap=1 → spawn #1
+            # Let the trivial worker finish.
+            if d._orchestration_thread is not None:
+                d._orchestration_thread.join(timeout=2.0)
+
+            d.scheduler_tick()  # cap=0 → must NOT spawn
+            d.scheduler_tick()  # cap=0 → must NOT spawn
+        finally:
+            if d._orchestration_thread is not None:
+                d._orchestration_thread.join(timeout=2.0)
+
+        # Exactly one spawn attempt total — the cap=1 tick.
+        assert spawn_count["count"] == 1
+
+    def test_worker_aborts_at_next_phase_when_pause_set_mid_run(
+        self, tmp_path: Path
+    ) -> None:
+        """Full integration: spawn worker → flip cap → worker aborts cleanly."""
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        # Scenario: the worker finishes plan successfully, then the
+        # scheduler on the main thread sets ``_pause_requested`` (the
+        # effect of a cap=0 tick). Ralph/summary/push must be skipped.
+        plan_ran = threading.Event()
+        plan_release = threading.Event()
+
+        def slow_plan(*_args: Any, **_kwargs: Any) -> bool:
+            plan_ran.set()
+            # Wait for the "cap flip" signal before returning from plan.
+            plan_release.wait(timeout=5.0)
+            return True
+
+        ralph_mock = MagicMock(return_value=True)
+        summary_mock = MagicMock(return_value=True)
+        push_mock = MagicMock()
+        terminal_mock = MagicMock()
+
+        d._run_plan_phase = slow_plan  # type: ignore[method-assign]
+        d._run_ralph_phase = ralph_mock  # type: ignore[method-assign]
+        d._run_summary_phase = summary_mock  # type: ignore[method-assign]
+        d._push_and_open_pr = push_mock  # type: ignore[method-assign]
+        d._mark_agent_terminal = terminal_mock  # type: ignore[method-assign]
+
+        worker = threading.Thread(
+            target=d._run_orchestration_phases,
+            args=("agent-xxx", 42, tmp_path),
+        )
+        worker.start()
+        try:
+            assert plan_ran.wait(timeout=2.0), "plan did not start"
+            # Simulate the scheduler observing cap=0 on the main thread.
+            d._pause_requested.set()
+            # Release plan so the worker advances to the post-plan
+            # killswitch check.
+            plan_release.set()
+            worker.join(timeout=5.0)
+            assert not worker.is_alive(), "worker did not exit after pause"
+
+            # Ralph / summary / push skipped.
+            assert ralph_mock.call_count == 0
+            assert summary_mock.call_count == 0
+            assert push_mock.call_count == 0
+            # Agent marked terminal.
+            terminal_mock.assert_called_once_with(
+                "agent-xxx",
+                status="failed",
+                phase=daemon.KILLSWITCH_TERMINAL_PHASE,
+                exit_code=None,
+            )
+            assert handler.events("orchestration_paused") != []
+        finally:
+            plan_release.set()
+            worker.join(timeout=2.0)
+
+
+# --------------------------------------------------------------------------
+# Thread-aware self._conn property
+# --------------------------------------------------------------------------
+
+
+class TestThreadLocalConnProperty:
+    """The ``_conn`` property resolves to the thread-local conn when set."""
+
+    def test_main_thread_sees_main_conn(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        assert d._conn is conn
+
+    def test_worker_thread_sees_its_own_conn(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        worker_conn = MagicMock(name="worker_conn")
+        observed: dict[str, Any] = {}
+
+        def worker() -> None:
+            d._thread_state.conn = worker_conn
+            observed["thread_conn"] = d._conn
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join(timeout=2.0)
+        # Worker saw its thread-local conn.
+        assert observed["thread_conn"] is worker_conn
+        # Main thread still sees the main conn — no bleed.
+        assert d._conn is conn
+
+    def test_setter_assigns_to_main_conn_only(self, tmp_path: Path) -> None:
+        """``d._conn = x`` always targets the main thread's slot."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        new_conn = MagicMock()
+        d._conn = new_conn  # type: ignore[assignment]
+        assert d._main_conn is new_conn
+        # Thread-local untouched.
+        assert getattr(d._thread_state, "conn", None) is None

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -219,59 +219,82 @@ class TestPriorityRank:
 
 
 class TestSchedulerGate:
-    """``_claim_and_orchestrate_one`` runs only when the gate allows."""
+    """``_maybe_spawn_orchestration_thread`` runs only when the gate allows.
+
+    After #2847 the actual orchestration work runs on a background
+    thread spawned by :meth:`DispatcherDaemon._maybe_spawn_orchestration_thread`.
+    These tests cover the gate logic on the scheduler tick itself —
+    cap=0 / cap-missing / active-agent / orchestration-in-flight — by
+    mocking the spawn helper directly. The thread-side behavior is
+    covered by :class:`TestOrchestrationWorkerThread` in this file.
+    """
 
     def test_does_not_claim_when_concurrency_cap_zero(self, tmp_path: Path) -> None:
         d, conn, _handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetch_queue = [(0,)]
         d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
-        d._claim_and_orchestrate_one = MagicMock(  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
             side_effect=AssertionError("must not be called with cap=0")
         )
         summary = d.scheduler_tick()
         assert summary["orchestration_attempted"] == 0
-        assert d._claim_and_orchestrate_one.call_count == 0  # type: ignore[attr-defined]
+        assert d._maybe_spawn_orchestration_thread.call_count == 0  # type: ignore[attr-defined]
 
     def test_does_not_claim_when_concurrency_cap_missing(self, tmp_path: Path) -> None:
         d, conn, _handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetch_queue = [None]
         d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
-        d._claim_and_orchestrate_one = MagicMock()  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock()  # type: ignore[method-assign]
         d.scheduler_tick()
-        assert d._claim_and_orchestrate_one.call_count == 0  # type: ignore[attr-defined]
+        assert d._maybe_spawn_orchestration_thread.call_count == 0  # type: ignore[attr-defined]
 
     def test_claims_when_cap_nonzero_and_no_active_agent(self, tmp_path: Path) -> None:
         d, conn, handler = _make_daemon(tmp_path)
         # 1) config read returns 1; 2) _has_active_agent SELECT returns None.
         conn.cursor_instance.fetch_queue = [(1,), None]
         d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
-        d._claim_and_orchestrate_one = MagicMock()  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            return_value=True,
+        )
         summary = d.scheduler_tick()
         assert summary["orchestration_attempted"] == 1
-        assert d._claim_and_orchestrate_one.call_count == 1  # type: ignore[attr-defined]
+        assert d._maybe_spawn_orchestration_thread.call_count == 1  # type: ignore[attr-defined]
 
     def test_does_not_claim_when_active_agent_exists(self, tmp_path: Path) -> None:
         d, conn, _handler = _make_daemon(tmp_path)
         # config=1 then _has_active_agent returns (1,) meaning active row exists.
         conn.cursor_instance.fetch_queue = [(1,), (1,)]
         d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
-        d._claim_and_orchestrate_one = MagicMock(  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
             side_effect=AssertionError("must not be called when agent active")
         )
         summary = d.scheduler_tick()
         assert summary["orchestration_attempted"] == 0
 
     def test_orchestration_exception_does_not_crash_tick(self, tmp_path: Path) -> None:
+        """A spawn-path exception must not crash ``scheduler_tick`` (#2847).
+
+        After #2847 the orchestration work runs on a worker thread, so
+        an exception raised inside :meth:`_claim_and_orchestrate_one`
+        surfaces as ``orchestration_worker_failed`` from the thread
+        (not ``orchestration_failed`` from the main tick). This test
+        asserts the spawn path itself does not raise — the actual
+        thread-side failure is covered by
+        :class:`TestOrchestrationWorkerThread`.
+        """
         d, conn, handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetch_queue = [(1,), None]
         d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
-        d._claim_and_orchestrate_one = MagicMock(  # type: ignore[method-assign]
+        # Make the spawn path itself raise — covers the
+        # ``orchestration_spawn_failed`` branch in the tick.
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
             side_effect=RuntimeError("boom")
         )
         # The tick must still return a summary, not raise.
         summary = d.scheduler_tick()
-        assert summary["orchestration_attempted"] == 1
-        assert handler.events("orchestration_failed") != []
+        assert handler.events("orchestration_spawn_failed") != []
+        # Spawn failed → no thread was actually started.
+        assert summary["orchestration_attempted"] == 0
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Decouples `scheduler_tick` from the orchestration pipeline so an operator `concurrency_cap=0` flip propagates to the daemon within one tick (≤30s cadence) regardless of whether a phase is in flight. Adds a between-phases killswitch check so an in-flight orchestration aborts cleanly at the next phase boundary instead of running the full `plan → ralph → summary → push` pipeline to completion.

Closes #2847

## Root cause

`run_forever` is a single synchronous loop. Before this change, `scheduler_tick` called `_claim_and_orchestrate_one` inline, which ran every phase via `subprocess.run(..., timeout=CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS=10800s)`. While orchestration ran, the main loop could not re-enter the tick — so the cap re-read could not happen. Observed 2026-04-19: 4m43s gap between `tick_n=12` and `tick_n=13` on dev matched the plan-phase duration of #2712 and the operator's cap=0 flip was not observed until ~7 min after the DB commit.

## Architecture

- **Worker thread.** `_maybe_spawn_orchestration_thread` launches a `threading.Thread` running `_orchestration_worker_entry`, which opens its own psycopg connection, stashes it on `_thread_state.conn`, runs `_claim_and_orchestrate_one`, and closes the conn in `finally`. The thread is `daemon=True` so SIGTERM does not hang on an unresponsive `claude -p`.
- **Thread-aware `_conn`.** `_conn` becomes a `@property` that returns the thread-local conn if set, else the main conn. The setter targets `_main_conn` so `connect()` / `close()` work unchanged. All 184 existing `self._conn` sites route through the property with no further changes.
- **Killswitch event.** `scheduler_tick` SETs `_pause_requested: threading.Event` on `cap==0` and CLEARs on `cap>0`. `_run_orchestration_phases` now calls `_check_killswitch_and_abort` before each of plan / ralph / summary / push_and_pr. On pause: agent is marked `status='failed' phase='paused_by_killswitch'` (new `KILLSWITCH_TERMINAL_PHASE` constant) and `daemon.orchestration_paused` is logged.
- **Shutdown.** `run_forever` sets the pause event and joins the worker thread with a 10s timeout before `mark_stopped`, so clean shutdown also honors the killswitch.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (411 passed, 1 skipped — 18 new in test_daemon_killswitch.py)
- [x] CI green

### Post-deploy verification
- [x] CloudWatch Insights query on `/ecs/judgemind-dispatcher-dev` confirms `scheduler_tick` fires on ≤60s cadence. Observed four consecutive ticks @ ~31s intervals (17:31:19 → 17:31:50 → 17:32:21 → 17:32:52).
- [x] Synthetic cap-flip test against dev: daemon boot with cap=0 in DB emits `daemon.killswitch_engaged` at 17:31:17.578 and every subsequent `scheduler_tick` shows `pause_requested: true`. The mid-claim variant (cap=1 running orchestration → cap=0 flip → next tick observes + sets pause event + worker aborts at next phase boundary with `phase='paused_by_killswitch'`) is proven by `TestSyntheticMidClaimCapFlip.test_worker_aborts_at_next_phase_when_pause_set_mid_run` — a production cap=1 session is not currently active.
- [x] Verification evidence posted on issue #2847 (comment 4276444813).

## Meta-note

No file overlap with #2845 (ralph short-circuit fix — lives in `.claude/skills/task-v2-ralph/**`).
