### PR TITLE
fix(dispatcher): wire admin command buttons to daemon handlers (#2801)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -866,6 +866,17 @@ class LeaseError(RuntimeError):
     """Another daemon is holding the active-heartbeat lease."""
 
 
+class CommandError(RuntimeError):
+    """A command handler received an invalid or inapplicable payload.
+
+    Raised by ``_handle_*`` methods when the command cannot be applied
+    (e.g. ``retry`` issued for an already-running agent, ``force_kill``
+    missing an ``agentId``). The caller catches this, rolls back, and
+    records a ``dispatcher.failures`` row so the command is left
+    unconsumed for visibility rather than silently discarded.
+    """
+
+
 # --------------------------------------------------------------------------
 # Daemon
 # --------------------------------------------------------------------------
@@ -880,8 +891,9 @@ class DispatcherDaemon:
           within the heartbeat window.
         * INSERT a ``dispatcher.runs`` row on boot.
         * Run the scheduler loop every ``tick_scheduler_seconds``:
-            - consume unconsumed ``dispatcher.commands`` (no-op handler
-              in shadow mode; commands drain so the queue stays small);
+            - consume unconsumed ``dispatcher.commands`` via
+              :meth:`_consume_commands`; each dispatched to its handler
+              with consumed_at set AFTER the handler (#2801);
             - read ``dispatcher.config.concurrency_cap``;
             - enforce the Phase 2 spawn-safety guard (warn if
               ``concurrency_cap != 0``);
@@ -1168,7 +1180,11 @@ class DispatcherDaemon:
         """Run one scheduler tick. Phase 2 = queue scan + spawn-safety guard.
 
         Steps (in order; DB work is one transaction per step for isolation):
-            1. Consume any pending ``dispatcher.commands`` (no-op handler).
+            1. Consume any pending ``dispatcher.commands`` via
+               :meth:`_consume_commands`. Each command is dispatched to
+               its handler; consumed_at is set AFTER the handler so a
+               crash leaves the command unconsumed for next-tick retry
+               (#2801).
             2. Read ``dispatcher.config.concurrency_cap``, record the
                observation, and SET (cap==0) or CLEAR (cap>0) the
                ``_pause_requested`` killswitch event for the worker thread
@@ -1210,20 +1226,14 @@ class DispatcherDaemon:
         """
         assert self._conn is not None, "connect() must run before ticks"
 
-        commands_consumed = 0
+        # 1. Consume any pending commands. Each command is dispatched to
+        # its handler; consumed_at is set AFTER the handler returns so
+        # a mid-handler crash leaves the command unconsumed for retry.
+        commands_consumed = self._consume_commands()
+
         concurrency_cap: int | None = None
 
         with self._conn.cursor() as cur:
-            # 1. Consume any pending commands. Phase 2 = no-op handler;
-            # mark consumed anyway so the queue drains and does not fill
-            # up during shadow mode.
-            cur.execute(
-                "UPDATE dispatcher.commands "
-                "SET consumed_at = now() "
-                "WHERE consumed_at IS NULL",
-            )
-            commands_consumed = cur.rowcount or 0
-
             # 2. Read concurrency_cap (for log observability + spawn guard).
             cur.execute(
                 "SELECT value FROM dispatcher.config WHERE key = %s",
@@ -1349,6 +1359,7 @@ class DispatcherDaemon:
         elif (
             concurrency_cap is not None
             and concurrency_cap > 0
+            and not self._is_paused()
             and not self._has_active_agent()
         ):
             try:
@@ -1396,6 +1407,372 @@ class DispatcherDaemon:
             "orchestration_thread_alive": 1 if orchestration_thread_alive else 0,
             "pause_requested": 1 if pause_requested else 0,
         }
+
+    # ── command consumption (#2801) ────────────────────────────────────
+
+    def _consume_commands(self) -> int:
+        """Drain unconsumed ``dispatcher.commands`` rows.
+
+        SELECTs all rows with ``consumed_at IS NULL`` ordered by
+        ``issued_at ASC``, dispatches each to its per-command handler,
+        and marks ``consumed_at = now()`` AFTER the handler returns so
+        that a mid-handler exception leaves the row unconsumed for
+        next-tick retry.
+
+        Handler exceptions are caught per-row: the transaction is
+        rolled back and a ``dispatcher.failures`` row with
+        ``category='handler_error'`` is inserted (best-effort) before
+        continuing to the next command.
+
+        Returns the number of commands successfully consumed.
+        """
+        assert self._conn is not None, "connect() must run before ticks"
+
+        _HANDLERS = {
+            "start": self._handle_start,
+            "stop": self._handle_stop,
+            "drain": self._handle_drain,
+            "pause": self._handle_pause,
+            "resume": self._handle_resume,
+            "retry": self._handle_retry,
+            "force_kill": self._handle_force_kill,
+        }
+
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT command_id, command, payload "
+                    "FROM dispatcher.commands "
+                    "WHERE consumed_at IS NULL "
+                    "ORDER BY issued_at ASC",
+                )
+                rows = cur.fetchall()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.commands_scan_failed",
+                extra={
+                    "event": "commands_scan_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return 0
+
+        consumed = 0
+        for row in rows:
+            command_id = int(row[0])
+            command = str(row[1])
+            raw_payload = row[2]
+            payload: dict[str, Any] = (
+                raw_payload if isinstance(raw_payload, dict) else {}
+            )
+
+            handler = _HANDLERS.get(command)
+            try:
+                if handler is None:
+                    raise CommandError(
+                        f"unknown command {command!r} — no handler registered"
+                    )
+                with self._conn.cursor() as cur:
+                    handler(cur, payload)
+                    cur.execute(
+                        "UPDATE dispatcher.commands "
+                        "SET consumed_at = now() "
+                        "WHERE command_id = %s",
+                        (command_id,),
+                    )
+                self._conn.commit()
+                self._log.info(
+                    "daemon.command_consumed",
+                    extra={
+                        "event": "command_consumed",
+                        "run_id": self._run_id,
+                        "command_id": command_id,
+                        "command": command,
+                    },
+                )
+                consumed += 1
+            except Exception as exc:
+                self._log.exception(
+                    "daemon.command_handler_failed",
+                    extra={
+                        "event": "command_handler_failed",
+                        "run_id": self._run_id,
+                        "command_id": command_id,
+                        "command": command,
+                        "detail": str(exc),
+                    },
+                )
+                try:
+                    self._conn.rollback()
+                except Exception:  # pragma: no cover — best-effort
+                    pass
+                # Record failure row so operator can see it.
+                category = (
+                    "invalid_command"
+                    if isinstance(exc, CommandError)
+                    else "handler_error"
+                )
+                self._write_failure(
+                    agent_id=None,
+                    category=category,
+                    detected_by="scheduler",
+                    details={
+                        "command_id": command_id,
+                        "command": command,
+                        "detail": str(exc),
+                    },
+                )
+        return consumed
+
+    def _handle_start(self, cur: Any, payload: dict[str, Any]) -> None:
+        """Handle ``start`` command — flip ``concurrency_cap`` from 0 to 1.
+
+        Only applies when the current value is 0 (the killswitch state);
+        if the cap is already > 0 this is a safe no-op (rowcount == 0).
+        """
+        cur.execute(
+            "UPDATE dispatcher.config "
+            "SET value = '1', updated_at = now(), updated_by = 'daemon' "
+            "WHERE key = 'concurrency_cap' AND value::int = 0",
+        )
+        self._log.info(
+            "daemon.command_start_applied",
+            extra={
+                "event": "command_start_applied",
+                "run_id": self._run_id,
+                "rows_updated": cur.rowcount,
+            },
+        )
+
+    def _handle_stop(self, cur: Any, payload: dict[str, Any]) -> None:
+        """Handle ``stop`` command — set ``concurrency_cap`` to 0 (killswitch)."""
+        cur.execute(
+            "UPDATE dispatcher.config "
+            "SET value = '0', updated_at = now(), updated_by = 'daemon' "
+            "WHERE key = 'concurrency_cap'",
+        )
+        self._log.info(
+            "daemon.command_stop_applied",
+            extra={
+                "event": "command_stop_applied",
+                "run_id": self._run_id,
+                "rows_updated": cur.rowcount,
+            },
+        )
+
+    def _handle_drain(self, cur: Any, payload: dict[str, Any]) -> None:
+        """Handle ``drain`` command — same SQL as stop, distinct audit intent."""
+        cur.execute(
+            "UPDATE dispatcher.config "
+            "SET value = '0', updated_at = now(), updated_by = 'daemon' "
+            "WHERE key = 'concurrency_cap'",
+        )
+        self._log.info(
+            "daemon.command_drain_applied",
+            extra={
+                "event": "command_drain_applied",
+                "run_id": self._run_id,
+                "rows_updated": cur.rowcount,
+            },
+        )
+
+    def _handle_pause(self, cur: Any, payload: dict[str, Any]) -> None:
+        """Handle ``pause`` command — UPSERT ``paused=true`` in config.
+
+        Does not change ``concurrency_cap``; the claim gate checks both
+        ``paused`` and ``concurrency_cap > 0``.
+        """
+        cur.execute(
+            "INSERT INTO dispatcher.config (key, value, updated_at, updated_by) "
+            "VALUES ('paused', 'true', now(), 'daemon') "
+            "ON CONFLICT (key) DO UPDATE "
+            "    SET value = 'true', updated_at = now(), updated_by = 'daemon'",
+        )
+        self._log.info(
+            "daemon.command_pause_applied",
+            extra={
+                "event": "command_pause_applied",
+                "run_id": self._run_id,
+            },
+        )
+
+    def _handle_resume(self, cur: Any, payload: dict[str, Any]) -> None:
+        """Handle ``resume`` command — UPSERT ``paused=false`` in config."""
+        cur.execute(
+            "INSERT INTO dispatcher.config (key, value, updated_at, updated_by) "
+            "VALUES ('paused', 'false', now(), 'daemon') "
+            "ON CONFLICT (key) DO UPDATE "
+            "    SET value = 'false', updated_at = now(), updated_by = 'daemon'",
+        )
+        self._log.info(
+            "daemon.command_resume_applied",
+            extra={
+                "event": "command_resume_applied",
+                "run_id": self._run_id,
+            },
+        )
+
+    def _handle_retry(self, cur: Any, payload: dict[str, Any]) -> None:
+        """Handle ``retry`` command — create a retry marker for a failed agent.
+
+        Requires ``payload['agentId']``. Verifies the agent exists with
+        ``status='failed'``; raises ``CommandError`` for any other status
+        (including already-running, already-retrying, or non-existent).
+        Flips the agent to ``status='retrying'`` and inserts a
+        ``dispatcher.retry_markers`` row so ``_process_retry_markers``
+        picks it up on the next supervisor tick.
+        """
+        agent_id = payload.get("agentId")
+        if not agent_id:
+            raise CommandError("retry command missing required payload.agentId")
+
+        cur.execute(
+            "SELECT status, retries_used FROM dispatcher.agents "
+            "WHERE agent_id = %s",
+            (agent_id,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            raise CommandError(
+                f"retry: agent {agent_id!r} not found in dispatcher.agents"
+            )
+        status = str(row[0])
+        retries_used = int(row[1]) if row[1] is not None else 0
+        if status != "failed":
+            raise CommandError(
+                f"retry: agent {agent_id!r} has status {status!r}; "
+                "can only retry agents with status='failed'"
+            )
+
+        cur.execute(
+            "UPDATE dispatcher.agents "
+            "SET status = 'retrying' "
+            "WHERE agent_id = %s",
+            (agent_id,),
+        )
+        cur.execute(
+            "INSERT INTO dispatcher.retry_markers "
+            "    (agent_id, reason, attempt, retry_after_ts) "
+            "VALUES (%s, 'operator_retry', %s, now())",
+            (agent_id, retries_used + 1),
+        )
+        self._log.info(
+            "daemon.command_retry_applied",
+            extra={
+                "event": "command_retry_applied",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "attempt": retries_used + 1,
+            },
+        )
+
+    def _handle_force_kill(self, cur: Any, payload: dict[str, Any]) -> None:
+        """Handle ``force_kill`` command — crash a running agent immediately.
+
+        Requires ``payload['agentId']``. Updates the agent row to
+        ``status='crashed'``, sets ``ended_at = now()``. If the agent's
+        ``pid`` is known and ``os.kill(pid, SIGKILL)`` succeeds on this
+        host, the process is killed; a dead or foreign-host pid is not
+        an error.
+        """
+        agent_id = payload.get("agentId")
+        if not agent_id:
+            raise CommandError("force_kill command missing required payload.agentId")
+
+        cur.execute(
+            "SELECT pid FROM dispatcher.agents WHERE agent_id = %s",
+            (agent_id,),
+        )
+        row = cur.fetchone()
+        if row is None:
+            raise CommandError(
+                f"force_kill: agent {agent_id!r} not found in dispatcher.agents"
+            )
+        pid = int(row[0]) if row[0] is not None else None
+
+        cur.execute(
+            "UPDATE dispatcher.agents "
+            "SET status = 'crashed', ended_at = now() "
+            "WHERE agent_id = %s",
+            (agent_id,),
+        )
+
+        if pid is not None:
+            try:
+                os.kill(pid, signal.SIGKILL)
+                self._log.info(
+                    "daemon.force_kill_signal_sent",
+                    extra={
+                        "event": "force_kill_signal_sent",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "pid": pid,
+                    },
+                )
+            except ProcessLookupError:
+                # Process already gone — not an error.
+                pass
+            except PermissionError:
+                # Foreign host pid — not an error either.
+                pass
+
+        self._log.info(
+            "daemon.command_force_kill_applied",
+            extra={
+                "event": "command_force_kill_applied",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "pid": pid,
+            },
+        )
+
+    def _is_paused(self) -> bool:
+        """Read ``dispatcher.config.paused`` and coerce to bool.
+
+        Returns ``True`` when the ``paused`` key exists and its value
+        is the JSON string ``'true'`` or boolean ``true``. Missing key,
+        ``null``, ``'false'``, or any other value is treated as
+        ``False`` so an absent row never blocks claims.
+
+        Called from the claim gate in :meth:`scheduler_tick` before
+        spawning an orchestration thread.
+        """
+        assert self._conn is not None, "connect() must run before config read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    ("paused",),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return False
+
+        if row is None or row[0] is None:
+            return False
+        raw = row[0]
+        if isinstance(raw, bool):
+            return raw
+        if isinstance(raw, str):
+            try:
+                parsed = json.loads(raw)
+                if isinstance(parsed, bool):
+                    return parsed
+            except json.JSONDecodeError:
+                pass
+            # Handle bare strings 'true'/'false' without JSON quotes.
+            return raw.lower() == "true"
+        return False
 
     # ── orchestration worker thread (#2847) ────────────────────────────
 

--- a/scripts/dispatcher/tests/test_daemon_commands.py
+++ b/scripts/dispatcher/tests/test_daemon_commands.py
@@ -1,0 +1,497 @@
+"""Unit tests for the daemon-side command handlers (issue #2801).
+
+Covers:
+  - _consume_commands: marks consumed_at after handler, leaves unconsumed on error
+  - _handle_start / stop / drain
+  - _handle_pause / resume
+  - _handle_retry (valid + invalid state)
+  - _handle_force_kill (valid + missing agentId)
+  - Claim gate respects dispatcher.config.paused
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Ensure a `psycopg` module exists in sys.modules before importing the daemon.
+if "psycopg" not in sys.modules:  # pragma: no cover — fresh-venv guard
+    sys.modules["psycopg"] = MagicMock()
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes (mirrors test_daemon_phase3c.py shape)
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    """Collect emitted ``LogRecord``s so tests can assert on them."""
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon_with_capture() -> (
+    tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]
+):
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.commands.{id(handler)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake-for-tests",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+def _command_row(
+    command_id: int,
+    command: str,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, str, dict[str, Any]]:
+    """Build a fake row as returned by the commands SELECT."""
+    return (command_id, command, payload or {})
+
+
+# --------------------------------------------------------------------------
+# _handle_start
+# --------------------------------------------------------------------------
+
+
+class TestHandleStart:
+    """_handle_start flips concurrency_cap from 0 to 1."""
+
+    def test_start_flips_cap_when_zero(self) -> None:
+        d, conn, handler = _make_daemon_with_capture()
+        # Stub fetchall to return one 'start' command.
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "start")]
+        ]
+        # concurrency_cap UPDATE: rowcount=1 (was 0, now 1).
+        conn.cursor_instance.rowcount = 1
+
+        count = d._consume_commands()
+
+        assert count == 1
+        updates = [
+            e for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0]
+            and "concurrency_cap" in e[0]
+            and "value = '1'" in e[0]
+        ]
+        assert len(updates) == 1
+        # consumed_at set after handler.
+        consumed_updates = [
+            e for e in conn.cursor_instance.executed
+            if "SET consumed_at = now()" in e[0]
+        ]
+        assert len(consumed_updates) == 1
+
+    def test_start_noop_when_cap_positive(self) -> None:
+        """start when cap > 0 is a safe no-op (rowcount == 0)."""
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "start")]
+        ]
+        conn.cursor_instance.rowcount = 0  # already > 0, no rows updated
+
+        count = d._consume_commands()
+
+        assert count == 1
+        updates = [
+            e for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0]
+            and "value = '1'" in e[0]
+        ]
+        assert len(updates) == 1
+        # Still consumed — a no-op is a valid success.
+        consumed_updates = [
+            e for e in conn.cursor_instance.executed
+            if "SET consumed_at = now()" in e[0]
+        ]
+        assert len(consumed_updates) == 1
+
+
+# --------------------------------------------------------------------------
+# _handle_stop / _handle_drain
+# --------------------------------------------------------------------------
+
+
+class TestHandleStopAndDrain:
+    """stop and drain both set concurrency_cap to 0."""
+
+    def test_stop_sets_cap_zero(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "stop")]
+        ]
+
+        count = d._consume_commands()
+
+        assert count == 1
+        updates = [
+            e for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0]
+            and "value = '0'" in e[0]
+            and "concurrency_cap" in e[0]
+        ]
+        assert len(updates) == 1
+
+    def test_drain_sets_cap_zero(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "drain")]
+        ]
+
+        count = d._consume_commands()
+
+        assert count == 1
+        updates = [
+            e for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0]
+            and "value = '0'" in e[0]
+            and "concurrency_cap" in e[0]
+        ]
+        assert len(updates) == 1
+
+
+# --------------------------------------------------------------------------
+# _handle_pause / _handle_resume
+# --------------------------------------------------------------------------
+
+
+class TestHandlePauseResume:
+    """pause and resume UPSERT the paused config key."""
+
+    def test_pause_upserts_paused_true(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "pause")]
+        ]
+
+        count = d._consume_commands()
+
+        assert count == 1
+        upserts = [
+            e for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.config" in e[0]
+            and "'paused'" in e[0]
+            and "'true'" in e[0]
+        ]
+        assert len(upserts) == 1
+        # ON CONFLICT clause present.
+        assert "ON CONFLICT" in upserts[0][0]
+
+    def test_resume_upserts_paused_false(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "resume")]
+        ]
+
+        count = d._consume_commands()
+
+        assert count == 1
+        upserts = [
+            e for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.config" in e[0]
+            and "'paused'" in e[0]
+            and "'false'" in e[0]
+        ]
+        assert len(upserts) == 1
+        assert "ON CONFLICT" in upserts[0][0]
+
+
+# --------------------------------------------------------------------------
+# _handle_retry
+# --------------------------------------------------------------------------
+
+
+class TestHandleRetry:
+    """retry command creates a retry marker for a failed agent."""
+
+    def test_retry_creates_marker_for_failed_agent(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        agent_id = str(uuid.uuid4())
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "retry", {"agentId": agent_id})]
+        ]
+        # SELECT agents returns (status='failed', retries_used=1).
+        conn.cursor_instance.fetch_queue = [("failed", 1)]
+
+        count = d._consume_commands()
+
+        assert count == 1
+        # Agent flipped to 'retrying'.
+        agent_updates = [
+            e for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and "'retrying'" in e[0]
+        ]
+        assert len(agent_updates) == 1
+        # Retry marker inserted.
+        marker_inserts = [
+            e for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert len(marker_inserts) == 1
+        # Attempt is retries_used + 1 = 2.
+        _sql, params = marker_inserts[0]
+        assert params[1] == 2  # attempt = retries_used + 1
+
+    def test_retry_writes_failure_for_non_failed_agent(self) -> None:
+        """retry for a running agent raises CommandError → failures row."""
+        d, conn, _handler = _make_daemon_with_capture()
+        agent_id = str(uuid.uuid4())
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "retry", {"agentId": agent_id})]
+        ]
+        # Agent is 'running', not 'failed'.
+        conn.cursor_instance.fetch_queue = [("running", 0)]
+
+        count = d._consume_commands()
+
+        # Handler raises CommandError → command stays unconsumed.
+        assert count == 0
+        assert conn.rollbacks >= 1
+        # failures row inserted for invalid_command.
+        failure_inserts = [
+            e for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert len(failure_inserts) == 1
+        _sql, params = failure_inserts[0]
+        assert params[1] == "invalid_command"
+
+
+# --------------------------------------------------------------------------
+# _handle_force_kill
+# --------------------------------------------------------------------------
+
+
+class TestHandleForceKill:
+    """force_kill transitions an agent to crashed."""
+
+    def test_force_kill_transitions_agent_to_crashed(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        agent_id = str(uuid.uuid4())
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "force_kill", {"agentId": agent_id})]
+        ]
+        # SELECT returns pid=None (no live pid to kill).
+        conn.cursor_instance.fetch_queue = [(None,)]
+
+        count = d._consume_commands()
+
+        assert count == 1
+        updates = [
+            e for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and "'crashed'" in e[0]
+        ]
+        assert len(updates) == 1
+
+    def test_force_kill_missing_agent_id_writes_failure(self) -> None:
+        """force_kill with no agentId raises CommandError → failures row."""
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "force_kill", {})]  # no agentId
+        ]
+
+        count = d._consume_commands()
+
+        assert count == 0
+        assert conn.rollbacks >= 1
+        failure_inserts = [
+            e for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert len(failure_inserts) == 1
+        _sql, params = failure_inserts[0]
+        assert params[1] == "invalid_command"
+
+
+# --------------------------------------------------------------------------
+# _consume_commands — lifecycle guarantees
+# --------------------------------------------------------------------------
+
+
+class TestConsumeCommands:
+    """_consume_commands marks consumed_at AFTER handler, leaves unconsumed on error."""
+
+    def test_consume_commands_marks_consumed_after_handler_success(self) -> None:
+        """consumed_at is set in the same transaction as the handler's work."""
+        d, conn, handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "stop")]
+        ]
+
+        count = d._consume_commands()
+
+        assert count == 1
+        executed = conn.cursor_instance.executed
+        # The UPDATE dispatcher.commands SET consumed_at comes after handler.
+        consumed_idx = next(
+            (i for i, e in enumerate(executed) if "SET consumed_at = now()" in e[0]),
+            None,
+        )
+        config_idx = next(
+            (i for i, e in enumerate(executed) if "UPDATE dispatcher.config" in e[0]),
+            None,
+        )
+        assert consumed_idx is not None
+        assert config_idx is not None
+        # Handler work happens before consumed_at update in the same cursor block.
+        assert config_idx < consumed_idx
+
+    def test_consume_commands_leaves_unconsumed_on_handler_exception(self) -> None:
+        """A handler error rolls back and leaves consumed_at NULL (AC6)."""
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "retry", {"agentId": str(uuid.uuid4())})]
+        ]
+        # Agent not found → raises CommandError.
+        conn.cursor_instance.fetch_queue = [None]  # SELECT returns no row
+
+        count = d._consume_commands()
+
+        # Command NOT consumed.
+        assert count == 0
+        # Transaction rolled back.
+        assert conn.rollbacks >= 1
+        # No consumed_at UPDATE.
+        consumed_updates = [
+            e for e in conn.cursor_instance.executed
+            if "SET consumed_at = now()" in e[0]
+        ]
+        assert len(consumed_updates) == 0
+
+    def test_consume_commands_returns_zero_when_no_pending(self) -> None:
+        """Empty commands table returns 0 without errors."""
+        d, conn, _handler = _make_daemon_with_capture()
+        # fetchall_queue empty → fetchall returns []
+
+        count = d._consume_commands()
+
+        assert count == 0
+        assert conn.rollbacks == 0
+
+
+# --------------------------------------------------------------------------
+# Claim gate respects paused config key
+# --------------------------------------------------------------------------
+
+
+class TestClaimGateRespectsPausedKey:
+    """Claim gate blocks orchestration when dispatcher.config.paused = true."""
+
+    def test_claim_gate_respects_paused_key(self) -> None:
+        """When paused=true, orchestration must not fire even if cap > 0."""
+        d, conn, handler = _make_daemon_with_capture()
+        # concurrency_cap = 1 (gate would normally proceed).
+        # _is_paused() SELECT returns ("true",) — JSONB string 'true'.
+        conn.cursor_instance.fetch_queue = [(1,), ("true",)]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            side_effect=AssertionError("must not spawn when paused")
+        )
+        d._consume_commands = lambda: 0  # type: ignore[method-assign]
+
+        summary = d.scheduler_tick()
+
+        # Orchestration was not attempted.
+        assert summary["orchestration_attempted"] == 0
+        assert d._maybe_spawn_orchestration_thread.call_count == 0  # type: ignore[attr-defined]
+
+    def test_claim_gate_allows_spawn_when_not_paused(self) -> None:
+        """When paused key is absent/false, normal spawn proceeds."""
+        d, conn, _handler = _make_daemon_with_capture()
+        # concurrency_cap = 1; paused row absent (None); no active agent.
+        conn.cursor_instance.fetch_queue = [(1,), None, None]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            return_value=False,
+        )
+        d._consume_commands = lambda: 0  # type: ignore[method-assign]
+
+        summary = d.scheduler_tick()
+
+        assert d._maybe_spawn_orchestration_thread.call_count == 1  # type: ignore[attr-defined]

--- a/scripts/dispatcher/tests/test_daemon_enrichment.py
+++ b/scripts/dispatcher/tests/test_daemon_enrichment.py
@@ -53,6 +53,7 @@ class _FakeCursor:
     def __init__(self) -> None:
         self.executed: list[tuple[str, Any]] = []
         self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
         self.rowcount = 0
 
     def __enter__(self) -> _FakeCursor:
@@ -68,6 +69,11 @@ class _FakeCursor:
         if not self.fetch_queue:
             return None
         return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
 
 
 class _FakeConnection:

--- a/scripts/dispatcher/tests/test_daemon_killswitch.py
+++ b/scripts/dispatcher/tests/test_daemon_killswitch.py
@@ -73,6 +73,7 @@ class _FakeCursor:
     def __init__(self) -> None:
         self.executed: list[tuple[str, Any]] = []
         self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
         self.rowcount = 0
 
     def __enter__(self) -> _FakeCursor:
@@ -88,6 +89,11 @@ class _FakeCursor:
         if not self.fetch_queue:
             return None
         return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
 
 
 class _FakeConnection:
@@ -281,7 +287,10 @@ class TestSchedulerCadenceDecoupling:
     def test_second_tick_while_worker_alive_skips_spawn(self, tmp_path: Path) -> None:
         """While a worker thread is alive, a second tick must not spawn a second."""
         d, conn, handler = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [(1,), None, (1,), None]
+        # Two scheduler ticks, each with: cap=1, is_paused=None, has_active=None.
+        # The second tick's gate passes but _maybe_spawn_orchestration_thread
+        # notices the thread is still alive and skips.
+        conn.cursor_instance.fetch_queue = [(1,), None, None, (1,), None, None]
 
         worker_blocker = threading.Event()
 
@@ -500,9 +509,10 @@ class TestSyntheticMidClaimCapFlip:
         """Tick sequence: cap=1 → worker starts → cap=0 → next tick sees 0."""
         d, conn, handler = _make_daemon(tmp_path)
         # Tick 1: cap read = 1 (spawns worker). Tick 2: cap read = 0.
-        # Note: the ``_has_active_agent`` check fires after the cap read
-        # on tick 1; on tick 2 cap=0 short-circuits that check.
-        conn.cursor_instance.fetch_queue = [(1,), None, (0,)]
+        # Note: the ``_is_paused`` and ``_has_active_agent`` checks fire after
+        # the cap read on tick 1; on tick 2 cap=0 short-circuits both.
+        # is_paused=None (not paused), has_active_agent=None (no active agent).
+        conn.cursor_instance.fetch_queue = [(1,), None, None, (0,)]
 
         worker_blocker = threading.Event()
 
@@ -539,6 +549,7 @@ class TestSyntheticMidClaimCapFlip:
         # even with no worker alive, cap=0 still blocks the spawn.
         conn.cursor_instance.fetch_queue = [
             (1,),
+            None,  # _is_paused on tick 1
             None,  # _has_active_agent on tick 1
             (0,),  # tick 2
             (0,),  # tick 3

--- a/scripts/dispatcher/tests/test_daemon_phase2.py
+++ b/scripts/dispatcher/tests/test_daemon_phase2.py
@@ -51,6 +51,7 @@ class _FakeCursor:
     def __init__(self) -> None:
         self.executed: list[tuple[str, Any]] = []
         self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
         self.rowcount = 0
 
     def __enter__(self) -> _FakeCursor:
@@ -66,6 +67,11 @@ class _FakeCursor:
         if not self.fetch_queue:
             return None
         return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
 
 
 class _FakeConnection:

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -79,6 +79,7 @@ class _FakeCursor:
     def __init__(self) -> None:
         self.executed: list[tuple[str, Any]] = []
         self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
         self.rowcount = 0
 
     def __enter__(self) -> _FakeCursor:
@@ -94,6 +95,11 @@ class _FakeCursor:
         if not self.fetch_queue:
             return None
         return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
 
 
 class _FakeConnection:
@@ -250,8 +256,9 @@ class TestSchedulerGate:
 
     def test_claims_when_cap_nonzero_and_no_active_agent(self, tmp_path: Path) -> None:
         d, conn, handler = _make_daemon(tmp_path)
-        # 1) config read returns 1; 2) _has_active_agent SELECT returns None.
-        conn.cursor_instance.fetch_queue = [(1,), None]
+        # 1) config read returns 1; 2) _is_paused SELECT returns None (not paused);
+        # 3) _has_active_agent SELECT returns None (no active agent).
+        conn.cursor_instance.fetch_queue = [(1,), None, None]
         d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
         d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
             return_value=True,
@@ -262,8 +269,9 @@ class TestSchedulerGate:
 
     def test_does_not_claim_when_active_agent_exists(self, tmp_path: Path) -> None:
         d, conn, _handler = _make_daemon(tmp_path)
-        # config=1 then _has_active_agent returns (1,) meaning active row exists.
-        conn.cursor_instance.fetch_queue = [(1,), (1,)]
+        # config=1; _is_paused returns None (not paused); _has_active_agent
+        # returns (1,) meaning active row exists.
+        conn.cursor_instance.fetch_queue = [(1,), None, (1,)]
         d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
         d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
             side_effect=AssertionError("must not be called when agent active")
@@ -283,7 +291,9 @@ class TestSchedulerGate:
         :class:`TestOrchestrationWorkerThread`.
         """
         d, conn, handler = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [(1,), None]
+        # config=1; _is_paused returns None (not paused); _has_active_agent
+        # returns None (no active agent) — spawn path fires but throws.
+        conn.cursor_instance.fetch_queue = [(1,), None, None]
         d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
         # Make the spawn path itself raise — covers the
         # ``orchestration_spawn_failed`` branch in the tick.

--- a/scripts/dispatcher/tests/test_daemon_skeleton.py
+++ b/scripts/dispatcher/tests/test_daemon_skeleton.py
@@ -62,6 +62,7 @@ class _FakeCursor:
     def __init__(self) -> None:
         self.executed: list[tuple[str, Any]] = []
         self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
         self.rowcount = 0
 
     def __enter__(self) -> _FakeCursor:
@@ -77,6 +78,11 @@ class _FakeCursor:
         if not self.fetch_queue:
             return None
         return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
 
 
 class _FakeConnection:
@@ -184,10 +190,9 @@ class TestSchedulerTick:
 
     def test_consumes_commands_and_reads_config(self) -> None:
         fake_conn = _FakeConnection()
-        # UPDATE returns rowcount=3; SELECT config returns concurrency_cap=0
-        # (the Phase 2 safe value — keeps the Phase 3A orchestration gate
-        # closed so this skeleton test isolates the command-drain + config-
-        # read path).
+        # SELECT config returns concurrency_cap=0 (the Phase 2 safe value —
+        # keeps the Phase 3A orchestration gate closed so this skeleton test
+        # isolates the command-drain + config-read path).
         fake_conn.cursor_instance.fetch_queue = [(0,)]
 
         d = _make_daemon(fake_conn=fake_conn)
@@ -195,34 +200,23 @@ class TestSchedulerTick:
         # not try to shell out to ``gh`` in this skeleton test.
         d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
         d._fetch_blocked_issues = lambda: []  # type: ignore[method-assign]
-        # Set rowcount via a wrapper: execute() sets it before fetchone.
-        # _FakeCursor doesn't auto-populate rowcount, so set it directly
-        # between execute calls — the daemon calls execute then reads
-        # self._conn.cursor().rowcount, which is a single attribute, so
-        # we set rowcount on the cursor after the UPDATE by patching.
-
-        original_execute = fake_conn.cursor_instance.execute
-
-        def execute_with_rowcount(sql: str, params: Any = None) -> None:
-            original_execute(sql, params)
-            if sql.startswith("UPDATE dispatcher.commands"):
-                fake_conn.cursor_instance.rowcount = 3
-
-        fake_conn.cursor_instance.execute = execute_with_rowcount  # type: ignore[method-assign]
+        # Stub _consume_commands so this skeleton test stays focused on the
+        # config-read path. The full handler dispatch is tested in
+        # test_daemon_commands.py (#2801).
+        d._consume_commands = lambda: 3  # type: ignore[method-assign]
 
         summary = d.scheduler_tick()
         assert summary["commands_consumed"] == 3
         assert summary["concurrency_cap"] == 0
         # Three commits on the first tick:
-        #   1. command-consumption + config read,
+        #   1. config read (command consumption is now its own transaction
+        #      managed by _consume_commands, which is stubbed here),
         #   2. queue_snapshots INSERT (Phase 2 addition, #2768),
         #   3. blocked_snapshots INSERT (#2820) — always runs on the
         #      first tick so the admin page has a populated blocked
         #      panel immediately after daemon boot.
-        # Each scan is isolated in its own transaction so a snapshot
-        # failure does not roll back a successful command drain. Phase
-        # 3A gate stays closed at ``concurrency_cap=0`` so no
-        # additional reads/commits happen.
+        # Each scan is isolated in its own transaction. Phase 3A gate stays
+        # closed at ``concurrency_cap=0`` so no additional reads/commits.
         assert fake_conn.commits == 3
         # Tick counter incremented.
         assert d._scheduler_ticks == 1


### PR DESCRIPTION
## Summary

Wired all 7 admin-page command buttons (`start`, `stop`, `drain`, `pause`, `resume`, `retry`, `force_kill`) to daemon-side handlers. Previously, clicking any button would mark the command consumed and do nothing else — a silent stub that looked functional but was a no-op. Now each command executes its documented action: cap flips, pause state toggles, failed agents retry, running agents force-killed.

Closes #2801

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest scripts/dispatcher/tests/test_daemon_commands.py`)
- [x] CI green

### Post-deploy verification

- [ ] Admin clicks "Start" on `/admin/dispatcher` → within 30s `dispatcher.config.concurrency_cap` flips to 1 → within 90s `daemon.candidate_picked` event appears in CloudWatch (orchestration begins claiming agents)
- [ ] Admin clicks "Pause" → daemon stops claiming new agents on next tick (in-flight agents continue) → pool drains naturally → click "Resume" → daemon resumes claiming
- [ ] Admin clicks "Stop (drain)" → `concurrency_cap` flips to 0 → no new agents claimed → existing agents finish naturally
- [ ] Click "Retry" on a failed agent → agent transitions to `status='retrying'` → retry marker row created → 3C processor picks up and re-runs
- [ ] Verification evidence posted on #2801 (see /task-v2-verify output)
