### PR TITLE
fix(dispatcher): auto-triage on plan go=false with plan_blocked terminal (#2857)

### DIFF
--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -253,10 +253,15 @@ function normalizeSnapshotJson(raw: unknown): SnapshotIssueRecord[] {
 }
 
 async function queryRecentCompletions(pool: Pool, limit: number): Promise<Row[]> {
+  // Terminal-status filter includes `plan_blocked` (#2857) so the
+  // admin cockpit's "Recently completed" panel surfaces
+  // correct-outcome-triage agents alongside the genuine failures and
+  // successes. Future correct-outcome states (e.g. `needs_review`
+  // from #2856) slot into this IN list.
   const { rows } = await pool.query<Row>(
     `SELECT agent_id, issue_number, issue_title, status, ended_at, pr_number
        FROM dispatcher.agents
-      WHERE status IN ('succeeded', 'failed', 'crashed')
+      WHERE status IN ('succeeded', 'failed', 'crashed', 'plan_blocked')
         AND ended_at IS NOT NULL
       ORDER BY ended_at DESC
       LIMIT $1`,

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -93,7 +93,15 @@ export const dispatcherTypeDefs = `#graphql
     issueNumber: Int!
     worktreePath: String!
     phase: String!
-    """One of running | succeeded | failed | retrying | crashed."""
+    """One of running | succeeded | failed | retrying | crashed | plan_blocked.
+
+    \`plan_blocked\` (#2857) is the "plan correctly declined to proceed"
+    terminal — semantically distinct from \`failed\` which is reserved
+    for genuine infrastructure/subprocess failures. Kept as \`String!\`
+    rather than a GraphQL enum so future correct-outcome terminals
+    (e.g. \`needs_review\` from #2856) slot in without a schema
+    migration.
+    """
     status: String!
     startedAt: DateTime!
     endedAt: DateTime
@@ -127,8 +135,9 @@ export const dispatcherTypeDefs = `#graphql
   }
 
   """One row in the 'Recently completed' panel (#2805 §1.5). Derived from
-  \`dispatcher.agents\` where status IN ('succeeded','failed','crashed'),
-  newest first. Capped at 10 server-side."""
+  \`dispatcher.agents\` where status IN
+  ('succeeded','failed','crashed','plan_blocked'), newest first. Capped
+  at 10 server-side."""
   type RecentCompletion {
     """Agent id (UUID)."""
     agentId: ID!
@@ -136,7 +145,8 @@ export const dispatcherTypeDefs = `#graphql
     issueNumber: Int!
     """Issue title (fetched live from GitHub; null if the lookup failed)."""
     issueTitle: String
-    """One of succeeded | failed | crashed."""
+    """One of succeeded | failed | crashed | plan_blocked. See
+    \`DispatcherAgent.status\` for the semantics of each value."""
     status: String!
     endedAt: DateTime!
     """PR number if the agent produced one; null otherwise."""
@@ -189,8 +199,9 @@ export const dispatcherTypeDefs = `#graphql
     when nothing is blocked."""
     queueBlocked: [QueueItem!]!
     """Top 10 recently-completed agents (#2805 §1.5). Rows from
-    \`dispatcher.agents\` where status IN ('succeeded','failed','crashed')
-    ordered by \`ended_at\` DESC."""
+    \`dispatcher.agents\` where status IN
+    ('succeeded','failed','crashed','plan_blocked') ordered by
+    \`ended_at\` DESC."""
     recentCompletions: [RecentCompletion!]!
     """All live-editable \`dispatcher.config\` entries (#2805 §1.6)."""
     config: [DispatcherConfigEntry!]!

--- a/packages/api/tests/dispatcher-enrichment.unit.test.ts
+++ b/packages/api/tests/dispatcher-enrichment.unit.test.ts
@@ -229,6 +229,26 @@ describe('recentCompletionsToGraphQL', () => {
     // Synchronous return — not a Promise.
     expect(Array.isArray(result)).toBe(true);
   });
+
+  it('passes plan_blocked status through unchanged (#2857)', () => {
+    // plan_blocked is a new terminal status parallel to failed/crashed;
+    // the mapper must pass it through so the admin cockpit's
+    // OutcomePill can render it with its distinct chip/colour.
+    const rows = [
+      {
+        agent_id: 'uuid-planblocked',
+        issue_number: 2857,
+        issue_title: 'Plan correctly declined',
+        status: 'plan_blocked',
+        ended_at: '2026-04-19T20:00:00Z',
+        pr_number: null,
+      },
+    ];
+    const result = recentCompletionsToGraphQL(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe('plan_blocked');
+    expect(result[0].agentId).toBe('uuid-planblocked');
+  });
 });
 
 describe('parse-labels helpers (pure, no fetch)', () => {

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -17,8 +17,10 @@ interface RecentCompletionsPanelProps {
 
 /**
  * The "Recently completed" panel (#2805 §1.5). Newest terminal-state
- * agents (succeeded / failed / crashed) in the operator's recent history.
- * Each row links to the issue and, when available, the PR.
+ * agents (succeeded / failed / crashed / plan_blocked) in the operator's
+ * recent history. Each row links to the issue and, when available, the PR.
+ * `plan_blocked` (#2857) renders with a distinct neutral chip so
+ * correct-outcome triage is visually separated from genuine failures.
  *
  * Borderless. Lives in the right column below Active agents.
  *

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
@@ -87,6 +87,27 @@ describe('OutcomePill', () => {
     expect(pill.textContent).toBe('\u26A0');
   });
 
+  // #2857: `plan_blocked` is the "plan correctly declined" terminal —
+  // distinct from `failed` (real infrastructure break). Uses a muted
+  // neutral chip (not red/amber) because it is operator-informational,
+  // not alarming.
+  it('renders plan_blocked with a circled-division-slash glyph', () => {
+    render(<OutcomePill status="plan_blocked" />);
+    const pill = screen.getByTestId('outcome-pill-plan_blocked');
+    expect(pill.getAttribute('aria-label')).toBe('plan blocked');
+    expect(pill.textContent).toBe('\u2298');
+  });
+
+  it('renders plan_blocked with the neutral muted chip (not red/amber)', () => {
+    render(<OutcomePill status="plan_blocked" />);
+    const pill = screen.getByTestId('outcome-pill-plan_blocked');
+    // Neutral stone treatment — signals "informational, not alarming".
+    expect(pill.className).toContain('bg-muted');
+    // Must NOT use the failure/warning colour tokens.
+    expect(pill.className).not.toMatch(/bg-red/);
+    expect(pill.className).not.toMatch(/bg-amber/);
+  });
+
   it('renders a fallback for unknown status', () => {
     render(<OutcomePill status="bogus" />);
     expect(screen.getByText('?')).toBeInTheDocument();

--- a/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
@@ -89,10 +89,18 @@ export function PriorityBadge({ priority }: { priority: string | null }) {
 }
 
 // ---------------------------------------------------------------------------
-// Outcome glyph pill — succeeded (✓ green), failed (✗ red), crashed (⚠ amber).
+// Outcome glyph pill — succeeded (✓ green), failed (✗ red), crashed (⚠ amber),
+// plan_blocked (⊘ neutral — #2857).
+//
+// Colour assignment intentionally keeps red/amber reserved for genuine
+// problems. `plan_blocked` ("plan correctly declined to proceed") is an
+// operator-informational correct-outcome state, so it uses the neutral
+// muted surface — the same treatment `priority/p2` gets above — per
+// BRAND.md §"Minimal accent use". A dashboard full of plan_blocked
+// chips must not look like a house on fire; it should look quiet.
 // ---------------------------------------------------------------------------
 
-type OutcomeStatus = 'succeeded' | 'failed' | 'crashed';
+type OutcomeStatus = 'succeeded' | 'failed' | 'crashed' | 'plan_blocked';
 
 const OUTCOME_STYLES: Record<OutcomeStatus, { glyph: string; className: string; label: string }> = {
   succeeded: {
@@ -109,6 +117,13 @@ const OUTCOME_STYLES: Record<OutcomeStatus, { glyph: string; className: string; 
     glyph: '\u26A0',
     className: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200',
     label: 'crashed',
+  },
+  plan_blocked: {
+    // ⊘ = "circled division slash" — signals "declined to proceed"
+    // without overlapping the ✗/⚠ iconography reserved for failures.
+    glyph: '\u2298',
+    className: 'bg-muted text-foreground',
+    label: 'plan blocked',
   },
 };
 

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -307,6 +307,20 @@ FIX_CI_LOG_TAIL_MAX_CHARS = 20000
 #: concurrent races via unique-violation).
 ACTIVE_AGENT_STATUSES = ("running", "retrying", "succeeded")
 
+#: Sentinel HTML comment embedded as line 1 of the automated
+#: "plan returned go=false" issue comment. Lets the daemon detect that
+#: the comment has already been posted and skip re-posting on a retry
+#: of the plan_blocked handler (idempotence — see issue #2857).
+#: HTML comments survive GitHub's markdown rendering pipeline and are
+#: visible in ``gh issue view --json comments`` output.
+PLAN_BLOCKED_COMMENT_SENTINEL = "<!-- dispatcher-plan-blocked -->"
+
+#: Timeout for the ``gh issue view``/``gh issue comment``/``gh issue edit``
+#: subprocess calls used by the plan_blocked handler. Tight enough that
+#: a hung GitHub request can't stall the scheduler tick for multiple
+#: minutes; loose enough that a normal call (<3s) always finishes.
+PLAN_BLOCKED_GH_SUBPROCESS_TIMEOUT_SECONDS = 30
+
 #: Relative path under the repo root where per-agent worktrees land in
 #: the local-dev fallback mode (``baseline_repo_root`` unset). Mirrors
 #: the laptop-dispatcher convention from ``.claude/skills/task/SKILL.md``
@@ -2926,16 +2940,23 @@ class DispatcherDaemon:
     ) -> None:
         """UPDATE ``dispatcher.agents`` with terminal status + metadata.
 
-        Used for ``succeeded``, ``failed``, ``crashed``, and the
-        Phase 3A post-PR hand-off state (``status='running'``,
+        Used for ``succeeded``, ``failed``, ``crashed``, ``plan_blocked``,
+        and the Phase 3A post-PR hand-off state (``status='running'``,
         ``phase='awaiting_ci'``). For terminal statuses (``succeeded`` /
-        ``failed`` / ``crashed``) also sets ``ended_at`` so the admin
-        page can compute duration AND writes back the resolved outcome
-        to any pending ``dispatcher.diagnoses`` rows for this agent
-        (Phase 3E #2798, spec §8 line 305).
+        ``failed`` / ``crashed`` / ``plan_blocked``) also sets
+        ``ended_at`` so the admin page can compute duration AND writes
+        back the resolved outcome to any pending
+        ``dispatcher.diagnoses`` rows for this agent (Phase 3E #2798,
+        spec §8 line 305).
+
+        ``plan_blocked`` (issue #2857) is the "plan correctly declined
+        to proceed" terminal — distinct from ``failed`` (genuine
+        infrastructure/subprocess break) so the admin cockpit and
+        reporting can separate correct-outcome triage from real
+        failures.
         """
         assert self._conn is not None, "connect() must run before update"
-        terminal = status in ("succeeded", "failed", "crashed")
+        terminal = status in ("succeeded", "failed", "crashed", "plan_blocked")
         try:
             with self._conn.cursor() as cur:
                 if terminal:
@@ -3333,6 +3354,330 @@ class DispatcherDaemon:
         self._run_orchestration_phases(agent_id, issue_number, worktree)
         return True
 
+    def _plan_blocked_comment_already_posted(self, issue_number: int) -> bool | None:
+        """Return True if the plan-blocked sentinel comment is already on the issue.
+
+        Used by :meth:`_handle_plan_blocked` for idempotence — if a
+        prior invocation successfully posted the comment but failed
+        mid-sequence (label swap crashed, DB update crashed), the next
+        run would otherwise double-post. Detects by scanning the body
+        of every comment on the issue for
+        :data:`PLAN_BLOCKED_COMMENT_SENTINEL`.
+
+        Returns ``None`` on subprocess failure — the caller treats that
+        as "unknown" and proceeds with the post attempt (the cost of a
+        duplicate comment on a GitHub outage is lower than the cost of
+        silently dropping the operator signal).
+        """
+        cmd = [
+            "gh",
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            self._cfg.github_repo,
+            "--json",
+            "comments",
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=PLAN_BLOCKED_GH_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            self._log.warning(
+                "daemon.plan_blocked_sentinel_check_failed",
+                extra={
+                    "event": "plan_blocked_sentinel_check_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "error": str(exc),
+                },
+            )
+            return None
+
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.plan_blocked_sentinel_check_failed",
+                extra={
+                    "event": "plan_blocked_sentinel_check_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "exit_code": result.returncode,
+                    "stderr_preview": (result.stderr or "").strip()[:200],
+                },
+            )
+            return None
+
+        try:
+            payload = json.loads(result.stdout or "{}")
+        except json.JSONDecodeError as exc:
+            self._log.warning(
+                "daemon.plan_blocked_sentinel_check_failed",
+                extra={
+                    "event": "plan_blocked_sentinel_check_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "error": f"invalid JSON: {exc}",
+                },
+            )
+            return None
+
+        for comment in payload.get("comments") or []:
+            if not isinstance(comment, dict):
+                continue
+            body = comment.get("body") or ""
+            if PLAN_BLOCKED_COMMENT_SENTINEL in body:
+                return True
+        return False
+
+    def _render_plan_blocked_comment(self, agent_id: str, block_reason: str) -> str:
+        """Render the plan-blocked issue comment body.
+
+        Shape (sentinel MUST be line 1 — see issue #2857 AC2):
+
+            <!-- dispatcher-plan-blocked -->
+            ## Plan phase output — `go=false` (autonomous dispatcher run <ISO-8601>)
+
+            The dispatcher picked this up and plan returned `go=false`. Block reason:
+
+            > <block_reason, each line prefixed with `> `>
+
+            Moving this out of `agent/ready` pending operator triage. Agent: `<short>`.
+
+        The block_reason is rendered as a markdown blockquote. Each
+        line is prefixed with ``> `` so multi-line reasons stay valid
+        blockquote markup. Empty lines inside the reason become ``>`` to
+        keep the blockquote from breaking at the first blank line.
+        """
+        short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
+        now_iso = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        quoted_lines: list[str] = []
+        for line in (block_reason or "").splitlines() or [""]:
+            if line == "":
+                quoted_lines.append(">")
+            else:
+                quoted_lines.append(f"> {line}")
+        quoted_reason = "\n".join(quoted_lines)
+        return (
+            f"{PLAN_BLOCKED_COMMENT_SENTINEL}\n"
+            f"## Plan phase output — `go=false` "
+            f"(autonomous dispatcher run {now_iso})\n"
+            f"\n"
+            f"The dispatcher picked this up and plan returned "
+            f"`go=false`. Block reason:\n"
+            f"\n"
+            f"{quoted_reason}\n"
+            f"\n"
+            f"Moving this out of `agent/ready` pending operator triage. "
+            f"Agent: `{short_id}`.\n"
+        )
+
+    def _post_plan_blocked_comment(
+        self,
+        agent_id: str,
+        issue_number: int,
+        block_reason: str,
+        worktree: Path,
+    ) -> bool:
+        """Post the plan-blocked issue comment via ``gh issue comment``.
+
+        Skips the post if the sentinel is already present on the issue
+        (idempotence). Returns True when the comment is present on the
+        issue at return time (whether we posted it now or found it
+        already there). Returns False on a hard subprocess failure so
+        the caller can log and continue — label swap and DB update
+        still run regardless of this return value.
+        """
+        already = self._plan_blocked_comment_already_posted(issue_number)
+        if already is True:
+            self._log.info(
+                "daemon.plan_blocked_comment_skipped_idempotent",
+                extra={
+                    "event": "plan_blocked_comment_skipped_idempotent",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                },
+            )
+            return True
+
+        body = self._render_plan_blocked_comment(agent_id, block_reason)
+        body_path = worktree / "tmp" / "plan-blocked-comment.md"
+        try:
+            body_path.parent.mkdir(parents=True, exist_ok=True)
+            body_path.write_text(body, encoding="utf-8")
+        except OSError as exc:
+            self._log.exception(
+                "daemon.plan_blocked_comment_failed",
+                extra={
+                    "event": "plan_blocked_comment_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "error": f"write body file: {exc}",
+                },
+            )
+            return False
+
+        cmd = [
+            "gh",
+            "issue",
+            "comment",
+            str(issue_number),
+            "--repo",
+            self._cfg.github_repo,
+            "--body-file",
+            str(body_path),
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=PLAN_BLOCKED_GH_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            self._log.exception(
+                "daemon.plan_blocked_comment_failed",
+                extra={
+                    "event": "plan_blocked_comment_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "error": str(exc),
+                },
+            )
+            return False
+
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.plan_blocked_comment_failed",
+                extra={
+                    "event": "plan_blocked_comment_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "exit_code": result.returncode,
+                    "stderr_preview": (result.stderr or "").strip()[:200],
+                },
+            )
+            return False
+
+        self._log.info(
+            "daemon.plan_blocked_comment_posted",
+            extra={
+                "event": "plan_blocked_comment_posted",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+            },
+        )
+        return True
+
+    def _swap_plan_blocked_labels(self, agent_id: str, issue_number: int) -> bool:
+        """Remove ``agent/ready`` and add ``status/triage`` via ``gh issue edit``.
+
+        Idempotent by construction — ``gh issue edit --remove-label`` is
+        a no-op when the label is already absent and ``--add-label`` is
+        a no-op when the label is already present. Returns True on
+        subprocess success; False on failure. Failure is logged and
+        does NOT block the caller's DB update.
+        """
+        cmd = [
+            "gh",
+            "issue",
+            "edit",
+            str(issue_number),
+            "--repo",
+            self._cfg.github_repo,
+            "--remove-label",
+            "agent/ready",
+            "--add-label",
+            "status/triage",
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=PLAN_BLOCKED_GH_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            self._log.exception(
+                "daemon.plan_blocked_labels_failed",
+                extra={
+                    "event": "plan_blocked_labels_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "error": str(exc),
+                },
+            )
+            return False
+
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.plan_blocked_labels_failed",
+                extra={
+                    "event": "plan_blocked_labels_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "exit_code": result.returncode,
+                    "stderr_preview": (result.stderr or "").strip()[:200],
+                },
+            )
+            return False
+
+        self._log.info(
+            "daemon.plan_blocked_labels_swapped",
+            extra={
+                "event": "plan_blocked_labels_swapped",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+            },
+        )
+        return True
+
+    def _handle_plan_blocked(
+        self,
+        agent_id: str,
+        issue_number: int,
+        block_reason: str,
+        worktree: Path,
+    ) -> None:
+        """Automation for ``plan_go_false`` with a populated ``block_reason``.
+
+        Issue #2857. Performs three side effects in sequence; each is
+        independently wrapped so a failure of one does not prevent the
+        others:
+
+        1. **Comment.** Post the standard plan-blocked comment (with the
+           ``<!-- dispatcher-plan-blocked -->`` sentinel as line 1) so
+           the operator can see why plan declined without opening the
+           admin cockpit or CloudWatch. Idempotent: if the sentinel is
+           already present, skip the post.
+        2. **Labels.** Remove ``agent/ready``, add ``status/triage`` so
+           the cooldown-expiry re-pickup loop stops claiming the issue.
+        3. **(caller handles DB update.)** The ``_mark_agent_terminal``
+           call with ``status='plan_blocked'`` runs in the caller so
+           this method can remain side-effect-only and the DB write
+           survives comment/label failures.
+
+        All failures are logged with structured events; none raise. The
+        contract is "fire-and-forget for the three external effects —
+        the DB update is the authoritative terminal-status write".
+        """
+        self._post_plan_blocked_comment(agent_id, issue_number, block_reason, worktree)
+        self._swap_plan_blocked_labels(agent_id, issue_number)
+
     def _run_plan_phase(self, agent_id: str, issue_number: int, worktree: Path) -> bool:
         """Run ``/task-v2-plan``. Returns True to continue, False to stop."""
         self._update_agent_phase(agent_id, "planning")
@@ -3406,9 +3751,13 @@ class DispatcherDaemon:
         if not plan_output.get("go"):
             reason = plan_output.get("block_reason") or ""
             # A missing block_reason means "no work needed" —
-            # succeed. A populated block_reason indicates a hard
-            # problem — fail so operators see it.
-            status = "failed" if reason else "succeeded"
+            # succeed. A populated block_reason indicates plan
+            # correctly declined to proceed ("plan_blocked" — #2857).
+            # Distinct from ``failed`` which is reserved for real
+            # infrastructure / subprocess failures so the admin
+            # cockpit and reporting can separate correct-outcome
+            # triage from genuine breakage.
+            status = "plan_blocked" if reason else "succeeded"
             self._log.info(
                 "daemon.plan_go_false",
                 extra={
@@ -3419,6 +3768,12 @@ class DispatcherDaemon:
                     "terminal_status": status,
                 },
             )
+            if status == "plan_blocked":
+                # Side-effects: comment + label swap. Run BEFORE the DB
+                # update so a DB crash can't lose the operator-visible
+                # work. Each side-effect is individually wrapped so a
+                # failure of one does not prevent the others.
+                self._handle_plan_blocked(agent_id, issue_number, reason, worktree)
             self._mark_agent_terminal(
                 agent_id, status=status, phase="planning", exit_code=exit_code
             )
@@ -6384,7 +6739,14 @@ class DispatcherDaemon:
         """
         assert self._conn is not None, "connect() must run before update"
 
-        retry_outcome = "succeeded" if final_status == "succeeded" else "failed"
+        # ``plan_blocked`` (#2857) is the "plan correctly declined" terminal —
+        # operationally a correct outcome, not a failure. Classify it
+        # alongside ``succeeded`` for the retry_outcome enum so diagnoser
+        # effectiveness dashboards don't count correct-triage decisions
+        # against the retry-success rate.
+        retry_outcome = (
+            "succeeded" if final_status in ("succeeded", "plan_blocked") else "failed"
+        )
         outcome = {
             "retry_outcome": retry_outcome,
             "final_status": final_status,

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -1255,9 +1255,16 @@ class TestHappyPathOrchestration:
 
 
 class TestPlanGoFalse:
-    def test_plan_go_false_with_block_reason_marks_failed(
+    def test_plan_go_false_with_block_reason_marks_plan_blocked(
         self, monkeypatch: Any, tmp_path: Path
     ) -> None:
+        """plan.go=false + populated block_reason → status='plan_blocked' (#2857).
+
+        Previously this path set status='failed'. #2857 introduced the
+        distinct terminal ``plan_blocked`` state for "plan correctly
+        declined to proceed" — reserved ``failed`` for real
+        infrastructure/subprocess failures.
+        """
         d, conn, handler = _make_daemon(tmp_path)
         # Fetches in order: (1) Phase 3C resume-retry SELECT — no
         # retrying agent; (2) latest queue_snapshot issue_numbers;
@@ -1316,20 +1323,33 @@ class TestPlanGoFalse:
         # Plan executed; ralph/summary did NOT.
         phases_succeeded = [r.phase for r in handler.events("phase_succeeded")]
         assert phases_succeeded == ["plan"]
-        assert handler.events("plan_go_false") != []
-        # Final UPDATE sets status='failed' with phase='planning'.
-        failed_updates = [
+        plan_go_false_events = handler.events("plan_go_false")
+        assert plan_go_false_events != []
+        assert plan_go_false_events[0].terminal_status == "plan_blocked"
+        # Final UPDATE sets status='plan_blocked' with phase='planning'.
+        plan_blocked_updates = [
             e
             for e in conn.cursor_instance.executed
             if "UPDATE dispatcher.agents" in e[0]
             and e[1] is not None
-            and "failed" in e[1]
+            and "plan_blocked" in e[1]
         ]
-        assert failed_updates
+        assert plan_blocked_updates
+        # Side effects: comment posted, labels swapped.
+        assert handler.events("plan_blocked_comment_posted") != []
+        assert handler.events("plan_blocked_labels_swapped") != []
 
     def test_plan_go_false_no_block_reason_marks_succeeded(
         self, monkeypatch: Any, tmp_path: Path
     ) -> None:
+        """plan.go=false with empty block_reason → 'no work needed' = succeeded.
+
+        Preserves the pre-#2857 no-work path: when plan returns
+        go=false WITHOUT a block_reason, the interpretation is "there
+        is no work for this issue" (e.g. already fixed, duplicate), and
+        the agent terminates as ``succeeded``. No comment is posted
+        and no labels are swapped — the agent simply exits cleanly.
+        """
         d, conn, handler = _make_daemon(tmp_path)
         # Fetches in order: (1) Phase 3C resume-retry SELECT — no
         # retrying agent; (2) latest queue_snapshot issue_numbers;
@@ -1345,6 +1365,9 @@ class TestPlanGoFalse:
         plan_nowork = dict(_fixture_plan_output())
         plan_nowork["go"] = False
         plan_nowork["block_reason"] = None  # no work needed
+
+        gh_comment_calls: list[list[str]] = []
+        gh_edit_calls: list[list[str]] = []
 
         def fake_run(cmd: list[str], **kwargs: Any) -> Any:
             r = MagicMock()
@@ -1364,6 +1387,12 @@ class TestPlanGoFalse:
                         "comments": [],
                     }
                 )
+                return r
+            if cmd[:3] == ["gh", "issue", "comment"]:
+                gh_comment_calls.append(cmd)
+                return r
+            if cmd[:3] == ["gh", "issue", "edit"]:
+                gh_edit_calls.append(cmd)
                 return r
             if "worktree" in cmd and "add" in cmd:
                 add_idx = cmd.index("add")
@@ -1393,6 +1422,539 @@ class TestPlanGoFalse:
             and "succeeded" in e[1]
         ]
         assert succeeded_updates
+        # No plan_blocked side effects on the no-work path.
+        assert gh_comment_calls == []
+        assert gh_edit_calls == []
+        assert handler.events("plan_blocked_comment_posted") == []
+        assert handler.events("plan_blocked_labels_swapped") == []
+
+
+# --------------------------------------------------------------------------
+# #2857: plan_blocked side effects (comment + label swap) —
+# direct tests of the helper methods, independent of the full orchestrator
+# path. Exercises the comment body template, idempotence via sentinel,
+# and the "each side effect wrapped independently" contract.
+# --------------------------------------------------------------------------
+
+
+class TestPlanBlockedHandler:
+    """Direct tests for ``_handle_plan_blocked`` + its subordinate helpers.
+
+    The orchestrator-level ``TestPlanGoFalse`` above exercises the
+    wiring through ``_claim_and_orchestrate_one``. These tests focus on
+    the helper methods in isolation so each side effect (comment post,
+    label swap) can be asserted cleanly without dragging in the whole
+    queue-snapshot / worktree-add / phase-spawn machinery.
+    """
+
+    def _make_handler_daemon(
+        self, tmp_path: Path
+    ) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+        """Make a daemon with the .tmp directory layout _post_plan_blocked_comment expects."""
+        return _make_daemon(tmp_path)
+
+    def test_render_plan_blocked_comment_has_sentinel_on_line_one(
+        self, tmp_path: Path
+    ) -> None:
+        """AC2: sentinel MUST be line 1 so a future operator tool can dedupe."""
+        d, _conn, _handler = self._make_handler_daemon(tmp_path)
+        body = d._render_plan_blocked_comment(
+            "aabbccdd-eeff-0011-2233-445566778899", "reason"
+        )
+        first_line = body.splitlines()[0]
+        assert first_line == "<!-- dispatcher-plan-blocked -->"
+
+    def test_render_plan_blocked_comment_includes_block_reason_as_blockquote(
+        self, tmp_path: Path
+    ) -> None:
+        """Multi-line block_reason rendered as a valid markdown blockquote."""
+        d, _conn, _handler = self._make_handler_daemon(tmp_path)
+        reason = "Issue bundles three distinct tracks.\n\nEach needs its own issue."
+        body = d._render_plan_blocked_comment("abcdef0012345678", reason)
+        # First line of the reason gets "> " prefix, blank line becomes ">"
+        # (keeps blockquote valid across blank lines).
+        assert "> Issue bundles three distinct tracks." in body
+        assert ">\n" in body
+        assert "> Each needs its own issue." in body
+
+    def test_render_plan_blocked_comment_includes_short_agent_id(
+        self, tmp_path: Path
+    ) -> None:
+        """Operators can correlate the comment with a CloudWatch / DB row."""
+        d, _conn, _handler = self._make_handler_daemon(tmp_path)
+        body = d._render_plan_blocked_comment(
+            "aabbccdd-eeff-0011-2233-445566778899", "reason"
+        )
+        # Short id is first 8 chars of the UUID with dashes removed.
+        assert "`aabbccdd`" in body
+
+    def test_post_plan_blocked_comment_skips_when_sentinel_already_present(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Idempotence: pre-existing sentinel → no comment post, returns True."""
+        d, _conn, handler = self._make_handler_daemon(tmp_path)
+
+        gh_comment_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "comments": [
+                            {"body": "<!-- dispatcher-plan-blocked -->\n## Prior\n"}
+                        ]
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "issue", "comment"]:
+                gh_comment_calls.append(cmd)
+                r.stdout = ""
+                return r
+            r.stdout = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        ok = d._post_plan_blocked_comment(
+            "aabbccdd-eeff-0011-2233-445566778899", 42, "reason", worktree
+        )
+
+        assert ok is True
+        assert gh_comment_calls == []
+        assert handler.events("plan_blocked_comment_skipped_idempotent") != []
+
+    def test_post_plan_blocked_comment_posts_when_sentinel_absent(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Fresh issue: sentinel absent → comment posted with --body-file."""
+        d, _conn, handler = self._make_handler_daemon(tmp_path)
+
+        gh_comment_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r.stdout = json.dumps({"comments": []})
+                return r
+            if cmd[:3] == ["gh", "issue", "comment"]:
+                gh_comment_calls.append(cmd)
+                r.stdout = ""
+                return r
+            r.stdout = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        ok = d._post_plan_blocked_comment(
+            "aabbccdd-eeff-0011-2233-445566778899", 42, "block_reason", worktree
+        )
+
+        assert ok is True
+        assert len(gh_comment_calls) == 1
+        assert "--body-file" in gh_comment_calls[0]
+        # Body file is written and contains the sentinel.
+        body_idx = gh_comment_calls[0].index("--body-file") + 1
+        body_path = Path(gh_comment_calls[0][body_idx])
+        body = body_path.read_text(encoding="utf-8")
+        assert body.startswith("<!-- dispatcher-plan-blocked -->")
+        assert "> block_reason" in body
+        assert handler.events("plan_blocked_comment_posted") != []
+
+    def test_post_plan_blocked_comment_returns_false_on_gh_failure(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """gh issue comment non-zero → returns False, error logged."""
+        d, _conn, handler = self._make_handler_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.stdout = ""
+            r.stderr = "api error"
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r.returncode = 0
+                r.stdout = json.dumps({"comments": []})
+                return r
+            if cmd[:3] == ["gh", "issue", "comment"]:
+                r.returncode = 1
+                return r
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        ok = d._post_plan_blocked_comment(
+            "aabbccdd-eeff-0011-2233-445566778899", 42, "reason", worktree
+        )
+        assert ok is False
+        assert handler.events("plan_blocked_comment_failed") != []
+
+    def test_swap_plan_blocked_labels_calls_gh_issue_edit(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Happy path: gh issue edit --remove-label agent/ready --add-label status/triage."""
+        d, _conn, handler = self._make_handler_daemon(tmp_path)
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            if cmd[:3] == ["gh", "issue", "edit"]:
+                calls.append(cmd)
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        ok = d._swap_plan_blocked_labels("aabbccdd-eeff-0011-2233-445566778899", 42)
+
+        assert ok is True
+        assert len(calls) == 1
+        assert "--remove-label" in calls[0]
+        assert "agent/ready" in calls[0]
+        assert "--add-label" in calls[0]
+        assert "status/triage" in calls[0]
+        assert handler.events("plan_blocked_labels_swapped") != []
+
+    def test_swap_plan_blocked_labels_returns_false_on_gh_failure(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """gh issue edit non-zero → False, error logged."""
+        d, _conn, handler = self._make_handler_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 1
+            r.stdout = ""
+            r.stderr = "api error"
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        ok = d._swap_plan_blocked_labels("aabbccdd-eeff-0011-2233-445566778899", 42)
+        assert ok is False
+        assert handler.events("plan_blocked_labels_failed") != []
+
+    def test_plan_blocked_sentinel_check_treats_gh_error_as_unknown(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """``gh issue view`` non-zero → sentinel check returns None.
+
+        Fail-open: on a GitHub outage the cost of a duplicate comment
+        is lower than the cost of silently dropping the operator
+        signal. The caller proceeds with the post attempt.
+        """
+        d, _conn, handler = self._make_handler_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.stdout = ""
+            r.stderr = "api error"
+            r.returncode = 1
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = d._plan_blocked_comment_already_posted(42)
+        assert result is None
+        assert handler.events("plan_blocked_sentinel_check_failed") != []
+
+    def test_plan_blocked_sentinel_check_treats_timeout_as_unknown(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """subprocess TimeoutExpired on sentinel check → returns None."""
+        d, _conn, handler = self._make_handler_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd, 30)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = d._plan_blocked_comment_already_posted(42)
+        assert result is None
+        assert handler.events("plan_blocked_sentinel_check_failed") != []
+
+    def test_plan_blocked_sentinel_check_treats_malformed_json_as_unknown(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Malformed JSON from ``gh issue view`` → returns None."""
+        d, _conn, handler = self._make_handler_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = "not-json"
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = d._plan_blocked_comment_already_posted(42)
+        assert result is None
+        assert handler.events("plan_blocked_sentinel_check_failed") != []
+
+    def test_plan_blocked_sentinel_check_skips_non_dict_comments(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Non-dict entries in the ``comments`` array are skipped safely."""
+        d, _conn, _handler = self._make_handler_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = json.dumps(
+                {
+                    "comments": [
+                        "not-a-dict",
+                        42,
+                        None,
+                        {"body": "ordinary comment"},
+                    ]
+                }
+            )
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        # Sentinel not present among the valid dict entry → False.
+        result = d._plan_blocked_comment_already_posted(42)
+        assert result is False
+
+    def test_post_plan_blocked_comment_handles_timeout(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """subprocess TimeoutExpired on ``gh issue comment`` → returns False, logs."""
+        d, _conn, handler = self._make_handler_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r = MagicMock()
+                r.returncode = 0
+                r.stdout = json.dumps({"comments": []})
+                r.stderr = ""
+                return r
+            # gh issue comment → timeout
+            raise subprocess.TimeoutExpired(cmd, 30)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        ok = d._post_plan_blocked_comment(
+            "aabbccdd-eeff-0011-2233-445566778899", 42, "reason", worktree
+        )
+        assert ok is False
+        assert handler.events("plan_blocked_comment_failed") != []
+
+    def test_swap_plan_blocked_labels_handles_timeout(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """subprocess TimeoutExpired on ``gh issue edit`` → False, logs."""
+        d, _conn, handler = self._make_handler_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd, 30)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        ok = d._swap_plan_blocked_labels("aabbccdd-eeff-0011-2233-445566778899", 42)
+        assert ok is False
+        assert handler.events("plan_blocked_labels_failed") != []
+
+    def test_render_plan_blocked_comment_handles_empty_reason(
+        self, tmp_path: Path
+    ) -> None:
+        """Edge case: empty block_reason still produces valid markdown.
+
+        The orchestrator path never calls this with an empty reason
+        (that branch routes to ``succeeded``), but defensive tests
+        prevent the helper from regressing into crash-on-empty.
+        """
+        d, _conn, _handler = self._make_handler_daemon(tmp_path)
+        body = d._render_plan_blocked_comment("aabbccdd" + "0" * 24, "")
+        # Sentinel still on line 1, blockquote still present.
+        assert body.startswith("<!-- dispatcher-plan-blocked -->")
+        assert "`aabbccdd`" in body
+
+    def test_post_plan_blocked_comment_handles_body_write_failure(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """OSError writing the body file → returns False, logs the error.
+
+        Exercises the mkdir/write_text error-handling arm so
+        filesystem-level failures (disk full, permission denied) don't
+        crash the orchestration.
+        """
+        d, _conn, handler = self._make_handler_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            # Sentinel check returns "not present".
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r = MagicMock()
+                r.returncode = 0
+                r.stdout = json.dumps({"comments": []})
+                r.stderr = ""
+                return r
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        # Pass a worktree whose ``tmp`` path already exists as a file —
+        # ``mkdir(parents=True, exist_ok=True)`` raises NotADirectoryError
+        # (an OSError subclass) because it cannot create a directory
+        # whose parent is a non-directory file.
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        # Create a regular file where the ``tmp`` directory would be.
+        (worktree / "tmp").write_text("not-a-dir")
+
+        ok = d._post_plan_blocked_comment(
+            "aabbccdd-eeff-0011-2233-445566778899", 42, "reason", worktree
+        )
+        assert ok is False
+        assert handler.events("plan_blocked_comment_failed") != []
+
+    def test_handle_plan_blocked_comment_failure_does_not_block_label_swap(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Each side effect is independently wrapped: comment fail → labels still run."""
+        d, _conn, handler = self._make_handler_daemon(tmp_path)
+        label_edit_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.stdout = ""
+            r.stderr = ""
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r.returncode = 0
+                r.stdout = json.dumps({"comments": []})
+                return r
+            if cmd[:3] == ["gh", "issue", "comment"]:
+                r.returncode = 1
+                return r
+            if cmd[:3] == ["gh", "issue", "edit"]:
+                r.returncode = 0
+                label_edit_calls.append(cmd)
+                return r
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        # Handler returns None, does not raise.
+        result = d._handle_plan_blocked(
+            "aabbccdd-eeff-0011-2233-445566778899", 42, "reason", worktree
+        )
+        assert result is None
+        # Even though the comment failed, the label swap still ran.
+        assert len(label_edit_calls) == 1
+        assert handler.events("plan_blocked_comment_failed") != []
+        assert handler.events("plan_blocked_labels_swapped") != []
+
+    def test_plan_go_false_label_swap_fails_but_status_still_runs(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Orchestrator path: label swap fails → DB still writes plan_blocked.
+
+        The DB update is the authoritative terminal-status write. A
+        label-swap failure (e.g. GitHub outage, token expired) must not
+        prevent ``dispatcher.agents.status='plan_blocked'`` — otherwise
+        the agent row would be stuck in ``phase=planning`` forever and
+        the cooldown loop would not trip the stale-agent cleaner.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None, (None, [42]), None]
+
+        monkeypatch.setattr(d, "_repo_root", lambda: tmp_path)
+        fixed = uuid_mod.UUID("aabbccdd-eeff-0011-2233-445566778899")
+        monkeypatch.setattr(daemon.uuid, "uuid4", lambda: fixed)
+
+        plan_blocked = dict(_fixture_plan_output())
+        plan_blocked["go"] = False
+        plan_blocked["block_reason"] = "reason"
+
+        issue_view_call_count = 0
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            nonlocal issue_view_call_count
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            if cmd[0].endswith("check-issue-author.sh"):
+                r.stdout = "TRUSTED: ...\n"
+                return r
+            if cmd[:3] == ["gh", "issue", "view"]:
+                # First call is the issue-bundle fetch (plan input);
+                # subsequent calls are the sentinel check. Both return
+                # empty comments.
+                issue_view_call_count += 1
+                r.stdout = json.dumps(
+                    {
+                        "number": 42,
+                        "title": "T",
+                        "body": "",
+                        "labels": [],
+                        "comments": [],
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "issue", "edit"]:
+                # Label swap: fail.
+                r.returncode = 1
+                r.stderr = "api error"
+                return r
+            if "worktree" in cmd and "add" in cmd:
+                add_idx = cmd.index("add")
+                Path(cmd[add_idx + 1]).mkdir(parents=True, exist_ok=True)
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        def fake_spawn(phase: str, worktree: Path, agent_id: str) -> tuple[int, float]:
+            (worktree / "tmp" / "dispatcher-output").mkdir(parents=True, exist_ok=True)
+            (worktree / "tmp" / "dispatcher-output" / f"{phase}.json").write_text(
+                json.dumps(plan_blocked)
+            )
+            return 0, 0.1
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        d._claim_and_orchestrate_one()
+
+        # DB still got the terminal-status update.
+        plan_blocked_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "plan_blocked" in e[1]
+        ]
+        assert plan_blocked_updates
+        # Label swap failure was logged.
+        assert handler.events("plan_blocked_labels_failed") != []
+        # Comment still got posted.
+        assert handler.events("plan_blocked_comment_posted") != []
 
 
 # --------------------------------------------------------------------------

--- a/scripts/dispatcher/tests/test_daemon_phase3e.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3e.py
@@ -1060,6 +1060,52 @@ class TestDiagnosisOutcomeWriteback:
         assert outcome_dict["retry_outcome"] == "failed"
         assert outcome_dict["final_status"] == "crashed"
 
+    def test_plan_blocked_terminal_writes_succeeded_outcome(
+        self, tmp_path: Path
+    ) -> None:
+        """``plan_blocked`` (#2857) is a terminal status that classifies as a
+        correct-outcome retry (not a failure) for diagnoser effectiveness
+        tracking.
+
+        The agent row's ``status`` is ``plan_blocked`` (visible in the
+        admin cockpit as a distinct chip), but the retry-outcome
+        classification for dashboards/reporting is ``succeeded`` —
+        declining to proceed on a malformed issue is the correct thing
+        for the diagnoser to have surfaced.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.rowcount = 1
+
+        d._mark_agent_terminal(
+            "agent-plan-blocked",
+            status="plan_blocked",
+            phase="planning",
+            exit_code=0,
+        )
+
+        diag_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.diagnoses" in e[0]
+        ]
+        assert diag_updates
+        outcome_dict = json.loads(diag_updates[0][1][0])
+        assert outcome_dict["retry_outcome"] == "succeeded"
+        assert outcome_dict["final_status"] == "plan_blocked"
+        # Terminal bookkeeping ran: ended_at SET on the agent row.
+        agent_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "plan_blocked" in e[1]
+        ]
+        assert agent_updates
+        # The SET clause of the terminal update writes ended_at.
+        assert "ended_at = now()" in agent_updates[0][0]
+        # diagnosis_outcome_written event logged.
+        assert handler.events("diagnosis_outcome_written")
+
     def test_non_terminal_status_skips_outcome_write(self, tmp_path: Path) -> None:
         # When the daemon transitions to e.g. awaiting_ci (non-terminal),
         # no diagnoses outcome write should happen.


### PR DESCRIPTION
## Summary

On `plan_go_false` with a populated `block_reason`, the dispatcher now automatically posts a standardised issue comment, swaps labels (`agent/ready` → `status/triage`), and records the agent as a new `status='plan_blocked'` terminal — distinct from `failed` which is reserved for genuine infrastructure failures. This removes a per-incident operator burden that scales linearly with dispatcher throughput and gives operators a semantically honest "plan correctly declined" signal.

Scope touches three layers atomically: Python daemon (side-effect orchestration + helpers + sentinel-based idempotence), API GraphQL (docstring + recent-completions SQL filter), and the admin cockpit (`OutcomePill` extended with a neutral `⊘` chip).

Closes #2857

## Test plan

### Automated checks
- [x] Python tests pass (`pytest scripts/dispatcher/tests/` — 430 passed, 1 skipped)
- [x] Python diff coverage 100% on `daemon.py`, 94% overall
- [x] Ruff lint + format clean on `scripts/dispatcher/`
- [x] API lint + typecheck + unit tests pass (`npm --prefix packages/api run lint`/`typecheck`/`test:unit` — 212 passed)
- [x] Web lint + typecheck + tests pass (`npm --prefix packages/web` — 1235 passed)
- [x] `scripts/check-dispatcher-image-deps.sh` — ok (no new imports)
- [x] CI green

### Post-deploy verification
- [x] Dispatcher image redeployed to dev via `deploy-dispatcher.yml` (run `24636965265`, rollout COMPLETED, task-def `:7`)
- [x] Runtime verification on live dispatcher container — `scripts/ecs-run.sh --service judgemind-dispatcher-dev --container dispatcher --script verify_plan_blocked_code.py` confirmed `PLAN_BLOCKED_COMMENT_SENTINEL`, `_render_plan_blocked_comment`, and comment template all live and correct. See evidence comment on #2857.
- [ ] Data-level verification (next `plan_go_false` event on dev fires full automation end-to-end — comment posted, labels swapped, `dispatcher.agents.status='plan_blocked'`). Awaits next genuine event; historical `failed` rows pre-deploy are frozen and will not retroactively flip. Sentinel to revisit on the next dispatcher cycle.
- [ ] Admin cockpit screenshot (awaits first live `plan_blocked` row).
- [x] Verification evidence posted on #2857

## Design decisions

Full rationale posted as issue comments on #2857 before implementation:

1. **Comment sentinel** — `<!-- dispatcher-plan-blocked -->` on line 1 for dedupe/idempotence detection. HTML comments survive GitHub's markdown pipeline.
2. **No DB migration** — `dispatcher.agents.status` is plain `text` with no CHECK constraint (verified in `packages/api/src/data-access/schema.sql` and every migration 18-28).
3. **Chip colour is neutral (`bg-muted`), not red/amber** — `plan_blocked` is operator-informational, not alarming, per BRAND.md §"Minimal accent use".
4. **GraphQL `status` stays `String!`** (not hard enum) so #2856's future `needs_review` state slots in without a schema migration.
5. **Three side effects are independently wrapped** — a failure of one (comment / label / DB) does not prevent the others. The DB update is the authoritative terminal-status write; operator-visible side effects are best-effort with structured failure logs.
