### PR TITLE
fix(dispatcher): preserve ralph work on summary_unmet with draft PR + needs_review (#2856)

### DIFF
--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -253,15 +253,17 @@ function normalizeSnapshotJson(raw: unknown): SnapshotIssueRecord[] {
 }
 
 async function queryRecentCompletions(pool: Pool, limit: number): Promise<Row[]> {
-  // Terminal-status filter includes `plan_blocked` (#2857) so the
-  // admin cockpit's "Recently completed" panel surfaces
-  // correct-outcome-triage agents alongside the genuine failures and
-  // successes. Future correct-outcome states (e.g. `needs_review`
-  // from #2856) slot into this IN list.
+  // Terminal-status filter includes the correct-outcome triage states
+  // `plan_blocked` (#2857) and `needs_review` (#2856) so the admin
+  // cockpit's "Recently completed" panel surfaces them alongside the
+  // genuine failures and successes. Additional correct-outcome states
+  // slot into this IN list without a schema migration —
+  // `dispatcher.agents.status` is plain text (migration 25, no CHECK
+  // constraint).
   const { rows } = await pool.query<Row>(
     `SELECT agent_id, issue_number, issue_title, status, ended_at, pr_number
        FROM dispatcher.agents
-      WHERE status IN ('succeeded', 'failed', 'crashed', 'plan_blocked')
+      WHERE status IN ('succeeded', 'failed', 'crashed', 'plan_blocked', 'needs_review')
         AND ended_at IS NOT NULL
       ORDER BY ended_at DESC
       LIMIT $1`,

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -93,14 +93,24 @@ export const dispatcherTypeDefs = `#graphql
     issueNumber: Int!
     worktreePath: String!
     phase: String!
-    """One of running | succeeded | failed | retrying | crashed | plan_blocked.
+    """One of running | succeeded | failed | retrying | crashed | plan_blocked | needs_review.
 
-    \`plan_blocked\` (#2857) is the "plan correctly declined to proceed"
-    terminal — semantically distinct from \`failed\` which is reserved
-    for genuine infrastructure/subprocess failures. Kept as \`String!\`
-    rather than a GraphQL enum so future correct-outcome terminals
-    (e.g. \`needs_review\` from #2856) slot in without a schema
-    migration.
+    Correct-outcome terminals (distinct from \`failed\` which is
+    reserved for genuine infrastructure/subprocess failures):
+
+    - \`plan_blocked\` (#2857) — plan phase correctly declined to proceed
+      (malformed issue, missing info, etc.). Admin cockpit renders with
+      a neutral muted chip — operator-informational, not alarming.
+    - \`needs_review\` (#2856) — ralph completed with verdict=SHIP but
+      the summary phase flagged unmet acceptance criteria. The daemon
+      opened a DRAFT PR preserving ralph's work; operator reviews, marks
+      ready + merges, closes, or iterates. Admin cockpit renders with
+      an amber/yellow chip — actionable, needs operator eyes.
+
+    Kept as \`String!\` rather than a GraphQL enum so future
+    correct-outcome terminals slot in without a schema migration
+    (\`dispatcher.agents.status\` is plain \`text\` in the DB — see
+    migration 25, no CHECK constraint).
     """
     status: String!
     startedAt: DateTime!
@@ -136,8 +146,8 @@ export const dispatcherTypeDefs = `#graphql
 
   """One row in the 'Recently completed' panel (#2805 §1.5). Derived from
   \`dispatcher.agents\` where status IN
-  ('succeeded','failed','crashed','plan_blocked'), newest first. Capped
-  at 10 server-side."""
+  ('succeeded','failed','crashed','plan_blocked','needs_review'), newest
+  first. Capped at 10 server-side."""
   type RecentCompletion {
     """Agent id (UUID)."""
     agentId: ID!
@@ -145,11 +155,13 @@ export const dispatcherTypeDefs = `#graphql
     issueNumber: Int!
     """Issue title (fetched live from GitHub; null if the lookup failed)."""
     issueTitle: String
-    """One of succeeded | failed | crashed | plan_blocked. See
-    \`DispatcherAgent.status\` for the semantics of each value."""
+    """One of succeeded | failed | crashed | plan_blocked | needs_review.
+    See \`DispatcherAgent.status\` for the semantics of each value."""
     status: String!
     endedAt: DateTime!
-    """PR number if the agent produced one; null otherwise."""
+    """PR number if the agent produced one; null otherwise. \`needs_review\`
+    rows (#2856) always have \`prNumber\` populated because the whole
+    point of the terminal is that the daemon opened a draft PR."""
     prNumber: Int
   }
 
@@ -200,8 +212,8 @@ export const dispatcherTypeDefs = `#graphql
     queueBlocked: [QueueItem!]!
     """Top 10 recently-completed agents (#2805 §1.5). Rows from
     \`dispatcher.agents\` where status IN
-    ('succeeded','failed','crashed','plan_blocked') ordered by
-    \`ended_at\` DESC."""
+    ('succeeded','failed','crashed','plan_blocked','needs_review')
+    ordered by \`ended_at\` DESC."""
     recentCompletions: [RecentCompletion!]!
     """All live-editable \`dispatcher.config\` entries (#2805 §1.6)."""
     config: [DispatcherConfigEntry!]!

--- a/packages/api/tests/dispatcher-enrichment.unit.test.ts
+++ b/packages/api/tests/dispatcher-enrichment.unit.test.ts
@@ -249,6 +249,30 @@ describe('recentCompletionsToGraphQL', () => {
     expect(result[0].status).toBe('plan_blocked');
     expect(result[0].agentId).toBe('uuid-planblocked');
   });
+
+  it('passes needs_review status through unchanged (#2856)', () => {
+    // needs_review is the "ralph produced SHIP code but summary
+    // flagged unmet AC" terminal — parallel to plan_blocked but
+    // operator-actionable (amber chip, not neutral). The mapper
+    // must pass it through with its prNumber intact because the
+    // whole point of the terminal is that the daemon opened a draft
+    // PR; dropping prNumber would hide the draft from the cockpit.
+    const rows = [
+      {
+        agent_id: 'uuid-needsreview',
+        issue_number: 2856,
+        issue_title: 'Summary flagged unmet AC',
+        status: 'needs_review',
+        ended_at: '2026-04-19T23:30:00Z',
+        pr_number: 9001,
+      },
+    ];
+    const result = recentCompletionsToGraphQL(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe('needs_review');
+    expect(result[0].agentId).toBe('uuid-needsreview');
+    expect(result[0].prNumber).toBe(9001);
+  });
 });
 
 describe('parse-labels helpers (pure, no fetch)', () => {

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -17,10 +17,19 @@ interface RecentCompletionsPanelProps {
 
 /**
  * The "Recently completed" panel (#2805 §1.5). Newest terminal-state
- * agents (succeeded / failed / crashed / plan_blocked) in the operator's
- * recent history. Each row links to the issue and, when available, the PR.
- * `plan_blocked` (#2857) renders with a distinct neutral chip so
- * correct-outcome triage is visually separated from genuine failures.
+ * agents (succeeded / failed / crashed / plan_blocked / needs_review) in
+ * the operator's recent history. Each row links to the issue and, when
+ * available, the PR. The two correct-outcome triage terminals render
+ * with their own chips to keep them visually separated from genuine
+ * failures:
+ *
+ * - `plan_blocked` (#2857) — neutral muted chip (⊘). Operator-
+ *   informational; no action expected unless the issue needs reshaping.
+ * - `needs_review` (#2856) — yellow chip (◐). DOES need operator action:
+ *   a draft PR is open for review, ralph produced SHIP code but
+ *   summary flagged unmet AC. The yellow is distinct from amber
+ *   (`crashed`) so the operator can scan the panel and separate
+ *   "review my draft PR" from "something crashed, diagnose this".
  *
  * Borderless. Lives in the right column below Active agents.
  *

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
@@ -108,6 +108,37 @@ describe('OutcomePill', () => {
     expect(pill.className).not.toMatch(/bg-amber/);
   });
 
+  // #2856: `needs_review` is the "ralph did real work but summary
+  // flagged unmet AC" terminal — the daemon opened a DRAFT PR for
+  // operator review. Uses a yellow chip (not neutral like
+  // plan_blocked) because it DOES need operator action, and not
+  // amber (reserved for crashed) so the operator can scan the panel
+  // and separate "review my draft PR" from "something crashed".
+  it('renders needs_review with a half-circle glyph', () => {
+    render(<OutcomePill status="needs_review" />);
+    const pill = screen.getByTestId('outcome-pill-needs_review');
+    expect(pill.getAttribute('aria-label')).toBe('needs review');
+    expect(pill.textContent).toBe('\u25D0');
+  });
+
+  it('renders needs_review with a yellow chip (actionable, not alarming)', () => {
+    render(<OutcomePill status="needs_review" />);
+    const pill = screen.getByTestId('outcome-pill-needs_review');
+    // Yellow — distinct from amber (`crashed`) and from the neutral
+    // muted chip (`plan_blocked`). Operator sees it and knows "there
+    // is a draft PR to review" without mistaking it for a crash.
+    expect(pill.className).toContain('bg-yellow');
+    // Must NOT collapse onto the red (failure) palette.
+    expect(pill.className).not.toMatch(/bg-red/);
+    // Must NOT reuse the amber crashed-chip palette — the whole point
+    // of the yellow/amber separation is to keep these two actionable
+    // states visually distinct.
+    expect(pill.className).not.toMatch(/bg-amber/);
+    // Must NOT reuse plan_blocked's neutral muted surface — that chip
+    // is for informational-only outcomes.
+    expect(pill.className).not.toMatch(/bg-muted/);
+  });
+
   it('renders a fallback for unknown status', () => {
     render(<OutcomePill status="bogus" />);
     expect(screen.getByText('?')).toBeInTheDocument();

--- a/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
@@ -90,19 +90,37 @@ export function PriorityBadge({ priority }: { priority: string | null }) {
 
 // ---------------------------------------------------------------------------
 // Outcome glyph pill — succeeded (✓ green), failed (✗ red), crashed (⚠ amber),
-// plan_blocked (⊘ neutral — #2857).
+// plan_blocked (⊘ neutral — #2857), needs_review (◐ yellow — #2856).
 //
-// Colour assignment intentionally keeps red/amber reserved for genuine
-// problems. `plan_blocked` ("plan correctly declined to proceed") is an
-// operator-informational correct-outcome state, so it uses the neutral
-// muted surface — the same treatment `priority/p2` gets above — per
-// BRAND.md §"Minimal accent use". A dashboard full of plan_blocked
-// chips must not look like a house on fire; it should look quiet.
+// Colour assignment intentionally keeps red reserved for genuine failure
+// and amber reserved for the crash-category anomaly. `plan_blocked`
+// ("plan correctly declined to proceed") is operator-informational, so
+// it uses the neutral muted surface — the same treatment `priority/p2`
+// gets above — per BRAND.md §"Minimal accent use". A dashboard full of
+// plan_blocked chips must not look like a house on fire.
+//
+// `needs_review` is the one correct-outcome terminal that DOES need
+// operator action (ralph produced reviewer-approved SHIP code but
+// summary flagged unmet AC; the daemon opened a draft PR that sits
+// for operator triage). It earns yellow — adjacent to amber on the
+// colour wheel but visually distinct from crashed's amber so the
+// operator can scan the "Recently completed" panel and quickly
+// separate "review my draft PR" from "something crashed, diagnose
+// this". The glyph ◐ (half-circle) is the semantic anchor: ralph
+// did half the work, you do the other half (review + merge).
 // ---------------------------------------------------------------------------
 
-type OutcomeStatus = 'succeeded' | 'failed' | 'crashed' | 'plan_blocked';
+type OutcomeStatus =
+  | 'succeeded'
+  | 'failed'
+  | 'crashed'
+  | 'plan_blocked'
+  | 'needs_review';
 
-const OUTCOME_STYLES: Record<OutcomeStatus, { glyph: string; className: string; label: string }> = {
+const OUTCOME_STYLES: Record<
+  OutcomeStatus,
+  { glyph: string; className: string; label: string }
+> = {
   succeeded: {
     glyph: '\u2713',
     className: 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300',
@@ -124,6 +142,20 @@ const OUTCOME_STYLES: Record<OutcomeStatus, { glyph: string; className: string; 
     glyph: '\u2298',
     className: 'bg-muted text-foreground',
     label: 'plan blocked',
+  },
+  needs_review: {
+    // ◐ = "black circle with left half black" — ralph did half the work
+    // (implementation + reviewer SHIP), operator does the other half
+    // (review the draft, mark ready, merge). Deliberately distinct from
+    // ⚠ (crashed) and ⊘ (plan_blocked) at a glance.
+    glyph: '\u25D0',
+    // Yellow, not amber — yellow neighbours amber but is perceptibly
+    // separate so the two actionable-attention chips don't visually
+    // collapse into each other in a scan of the "Recently completed"
+    // panel. Uses the `text-yellow-900` foreground for AA contrast
+    // against the `bg-yellow-100` surface.
+    className: 'bg-yellow-100 text-yellow-900 dark:bg-yellow-900/30 dark:text-yellow-100',
+    label: 'needs review',
   },
 };
 

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -301,11 +301,24 @@ FIX_CI_MAX_FAILING_JOBS = 10
 #: of CI output is typically well under this.
 FIX_CI_LOG_TAIL_MAX_CHARS = 20000
 
-#: Statuses that represent an in-flight claim. Mirrors the partial
-#: UNIQUE INDEX predicate in migration 25. Used by the candidate picker
-#: to skip already-claimed issues client-side (the INSERT also catches
-#: concurrent races via unique-violation).
-ACTIVE_AGENT_STATUSES = ("running", "retrying", "succeeded")
+#: Statuses that represent an in-flight claim or a prior-run row whose
+#: PR is still open / awaiting operator action. Mirrors the partial
+#: UNIQUE INDEX predicate in migration 25 plus two DB-only extensions
+#: (``succeeded``, ``needs_review``) the picker uses to avoid
+#: double-processing an issue whose artifact (PR) has not yet been
+#: merged-and-cleaned.
+#:
+#: * ``running`` / ``retrying`` — uniqueness enforced in DB.
+#: * ``succeeded`` — prior successful run whose PR has not yet been
+#:   merged + cleaned. Added client-side here so we don't re-pick
+#:   during the merge window.
+#: * ``needs_review`` (#2856) — prior run that produced a DRAFT PR
+#:   awaiting operator decision. Same logic: don't re-pick the issue
+#:   while the draft PR is open, or two agent branches collide on the
+#:   same issue. Operator either merges (→ PR close auto-unblocks),
+#:   closes (→ dispatcher housekeeping reclaims), or keeps editing —
+#:   all three paths eventually cycle the row out of this set.
+ACTIVE_AGENT_STATUSES = ("running", "retrying", "succeeded", "needs_review")
 
 #: Sentinel HTML comment embedded as line 1 of the automated
 #: "plan returned go=false" issue comment. Lets the daemon detect that
@@ -320,6 +333,24 @@ PLAN_BLOCKED_COMMENT_SENTINEL = "<!-- dispatcher-plan-blocked -->"
 #: a hung GitHub request can't stall the scheduler tick for multiple
 #: minutes; loose enough that a normal call (<3s) always finishes.
 PLAN_BLOCKED_GH_SUBPROCESS_TIMEOUT_SECONDS = 30
+
+#: Sentinel HTML comment embedded as line 1 of the automated
+#: "summary flagged unmet acceptance criteria" issue comment. Issue
+#: #2856. Lets the daemon detect that the comment has already been
+#: posted and skip re-posting on a retry of the needs_review handler
+#: (idempotence). HTML comments survive GitHub's markdown rendering
+#: pipeline and are visible in ``gh issue view --json comments`` output.
+#: Parallel naming with :data:`PLAN_BLOCKED_COMMENT_SENTINEL` (#2857) —
+#: ``dispatcher.agents.status`` is free-text so the two correct-outcome
+#: terminals live alongside each other without a schema migration.
+NEEDS_REVIEW_COMMENT_SENTINEL = "<!-- dispatcher-needs-review -->"
+
+#: Timeout for the ``gh issue view``/``gh issue comment`` subprocess
+#: calls used by the needs_review handler. Mirrors
+#: :data:`PLAN_BLOCKED_GH_SUBPROCESS_TIMEOUT_SECONDS` — same tradeoffs
+#: (don't stall scheduler ticks on GitHub slowdowns, but don't
+#: false-positive a normal <3s call).
+NEEDS_REVIEW_GH_SUBPROCESS_TIMEOUT_SECONDS = 30
 
 #: Relative path under the repo root where per-agent worktrees land in
 #: the local-dev fallback mode (``baseline_repo_root`` unset). Mirrors
@@ -1016,6 +1047,14 @@ class DispatcherDaemon:
         self._agent_plan_output: dict[str, Any] | None = None
         self._agent_ralph_output: dict[str, Any] | None = None
         self._agent_summary_output: dict[str, Any] | None = None
+        #: Summary-phase ``unmet_criteria`` list. Populated by
+        #: :meth:`_run_summary_phase` when the summary skill flagged
+        #: criteria the ralph diff did not satisfy (#2856). When
+        #: non-empty, :meth:`_push_and_open_pr` opens a DRAFT PR with
+        #: the unmet list in the body and the agent terminates as
+        #: ``status='needs_review'`` rather than ``succeeded``. Reset
+        #: at the start of each orchestration run.
+        self._agent_unmet_criteria: list[str] | None = None
         # Phase 3C: GitHub rate-limit skip window. When set, ``now() <
         # self._gh_rate_skip_until`` → scheduler + supervisor ticks both
         # skip their hot paths. Cleared by
@@ -1646,8 +1685,7 @@ class DispatcherDaemon:
             raise CommandError("retry command missing required payload.agentId")
 
         cur.execute(
-            "SELECT status, retries_used FROM dispatcher.agents "
-            "WHERE agent_id = %s",
+            "SELECT status, retries_used FROM dispatcher.agents WHERE agent_id = %s",
             (agent_id,),
         )
         row = cur.fetchone()
@@ -1664,9 +1702,7 @@ class DispatcherDaemon:
             )
 
         cur.execute(
-            "UPDATE dispatcher.agents "
-            "SET status = 'retrying' "
-            "WHERE agent_id = %s",
+            "UPDATE dispatcher.agents SET status = 'retrying' WHERE agent_id = %s",
             (agent_id,),
         )
         cur.execute(
@@ -3318,22 +3354,38 @@ class DispatcherDaemon:
         """UPDATE ``dispatcher.agents`` with terminal status + metadata.
 
         Used for ``succeeded``, ``failed``, ``crashed``, ``plan_blocked``,
-        and the Phase 3A post-PR hand-off state (``status='running'``,
-        ``phase='awaiting_ci'``). For terminal statuses (``succeeded`` /
-        ``failed`` / ``crashed`` / ``plan_blocked``) also sets
-        ``ended_at`` so the admin page can compute duration AND writes
-        back the resolved outcome to any pending
-        ``dispatcher.diagnoses`` rows for this agent (Phase 3E #2798,
-        spec §8 line 305).
+        ``needs_review``, and the Phase 3A post-PR hand-off state
+        (``status='running'``, ``phase='awaiting_ci'``). For terminal
+        statuses (``succeeded`` / ``failed`` / ``crashed`` /
+        ``plan_blocked`` / ``needs_review``) also sets ``ended_at`` so
+        the admin page can compute duration AND writes back the
+        resolved outcome to any pending ``dispatcher.diagnoses`` rows
+        for this agent (Phase 3E #2798, spec §8 line 305).
 
         ``plan_blocked`` (issue #2857) is the "plan correctly declined
         to proceed" terminal — distinct from ``failed`` (genuine
         infrastructure/subprocess break) so the admin cockpit and
         reporting can separate correct-outcome triage from real
         failures.
+
+        ``needs_review`` (issue #2856) is the "ralph did real work but
+        summary flagged one or more unmet acceptance criteria"
+        terminal. The daemon opened a DRAFT PR preserving ralph's
+        output so the operator can decide whether to mark it ready +
+        merge, close, or iterate. Distinct from ``failed`` (which
+        discarded ralph's work) and from ``plan_blocked`` (which never
+        reached ralph) — the admin cockpit renders it with an
+        amber/yellow "needs your eyes" chip because it IS actionable,
+        unlike ``plan_blocked`` which is informational.
         """
         assert self._conn is not None, "connect() must run before update"
-        terminal = status in ("succeeded", "failed", "crashed", "plan_blocked")
+        terminal = status in (
+            "succeeded",
+            "failed",
+            "crashed",
+            "plan_blocked",
+            "needs_review",
+        )
         try:
             with self._conn.cursor() as cur:
                 if terminal:
@@ -3471,6 +3523,7 @@ class DispatcherDaemon:
         self._agent_plan_output = None
         self._agent_ralph_output = None
         self._agent_summary_output = None
+        self._agent_unmet_criteria = None
 
         # Phase 3C resume-retry path: pick up any retrying agent first.
         # If one exists, re-orchestrate it on a fresh worktree instead
@@ -4055,6 +4108,309 @@ class DispatcherDaemon:
         self._post_plan_blocked_comment(agent_id, issue_number, block_reason, worktree)
         self._swap_plan_blocked_labels(agent_id, issue_number)
 
+    # --------------------------------------------------------------------
+    # #2856: needs_review handlers — summary flagged unmet AC, daemon
+    # opens a DRAFT PR preserving ralph's work + posts an issue comment
+    # linking the draft. Parallel structure to the plan_blocked helpers
+    # above (#2857): shared sentinel pattern for idempotence, shared
+    # timeout constant, independent wrap per side-effect.
+    # --------------------------------------------------------------------
+
+    @staticmethod
+    def _render_unmet_criteria_pr_section(unmet_criteria: list[str]) -> str:
+        """Render the ``⚠️ Unmet acceptance criteria`` PR body section.
+
+        Issue #2856. Appended to the PR body by
+        :meth:`_push_and_open_pr` on the needs_review path so the
+        operator sees the summary-skill concerns inline on the draft
+        PR page without cross-referencing the issue. Each unmet
+        criterion is rendered verbatim as a bullet; multi-line entries
+        (explanations) stay bulleted so the block renders as a flat
+        list rather than a blockquote.
+
+        Format:
+
+            ## \u26a0\ufe0f Unmet acceptance criteria
+
+            The summary phase flagged the following acceptance
+            criteria as not satisfied by this change. Ralph produced
+            reviewer-approved (SHIP) code, but this subset remains
+            for operator review:
+
+            - <criterion 1 text>
+            - <criterion 2 text>
+        """
+        items = [(c or "").strip() for c in unmet_criteria]
+        # Drop any empty entries — skill contract should never emit them
+        # but defense-in-depth keeps the rendered section clean.
+        items = [c for c in items if c]
+        if not items:
+            # Caller only invokes this when non-empty; defensive return
+            # keeps the method total.
+            return "## \u26a0\ufe0f Unmet acceptance criteria\n\n(none recorded)\n"
+        bullets = "\n".join(f"- {c}" for c in items)
+        return (
+            "## \u26a0\ufe0f Unmet acceptance criteria\n"
+            "\n"
+            "The summary phase flagged the following acceptance "
+            "criteria as not satisfied by this change. Ralph produced "
+            "reviewer-approved (SHIP) code, but this subset remains "
+            "for operator review:\n"
+            "\n"
+            f"{bullets}"
+        )
+
+    def _render_needs_review_comment(
+        self,
+        agent_id: str,
+        pr_number: int | None,
+        pr_url: str,
+        unmet_criteria: list[str],
+    ) -> str:
+        """Render the needs_review issue comment body.
+
+        Issue #2856. Shape (sentinel MUST be line 1 — mirrors
+        :meth:`_render_plan_blocked_comment` for the plan_blocked
+        handler):
+
+            <!-- dispatcher-needs-review -->
+            ## Summary flagged unmet acceptance criteria — draft PR opened for review
+
+            Ralph completed with verdict=SHIP, but summary found AC
+            that the diff did not satisfy. Opened <pr_url> as a
+            **draft** so you can review before merge.
+
+            **Unmet acceptance criteria:**
+
+            - <criterion 1>
+            - <criterion 2>
+
+            Agent: `<short_id>`.
+
+        The PR URL is rendered raw (GitHub autolinks it); a
+        ``None``/missing URL falls back to the phrase "the dispatcher
+        draft PR" so the comment still reads if URL parsing fails.
+        """
+        short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
+        items = [(c or "").strip() for c in unmet_criteria]
+        items = [c for c in items if c]
+        if items:
+            bullets = "\n".join(f"- {c}" for c in items)
+        else:
+            bullets = "- (none recorded)"
+        pr_link_phrase = (
+            pr_url.strip() if pr_url and pr_url.strip() else "the dispatcher draft PR"
+        )
+        if (
+            pr_number is not None
+            and pr_number > 0
+            and (not pr_url or not pr_url.strip())
+        ):
+            # Reconstruct a stable link when gh stdout parsing fell
+            # through but we still know the PR number.
+            pr_link_phrase = f"#{pr_number}"
+        return (
+            f"{NEEDS_REVIEW_COMMENT_SENTINEL}\n"
+            f"## Summary flagged unmet acceptance criteria — draft PR "
+            f"opened for review\n"
+            f"\n"
+            f"Ralph completed with `verdict=SHIP` but the summary "
+            f"phase found acceptance criteria the diff did not "
+            f"satisfy. Opened {pr_link_phrase} as a **draft** so you "
+            f"can review before merge, close without merging, or "
+            f"request changes.\n"
+            f"\n"
+            f"**Unmet acceptance criteria:**\n"
+            f"\n"
+            f"{bullets}\n"
+            f"\n"
+            f"Agent: `{short_id}`.\n"
+        )
+
+    def _needs_review_comment_already_posted(self, issue_number: int) -> bool | None:
+        """Return True if the needs_review sentinel is already on the issue.
+
+        Issue #2856. Same fail-open / "unknown → proceed" contract as
+        :meth:`_plan_blocked_comment_already_posted` (#2857): a
+        GitHub outage that hides the sentinel causes at worst one
+        duplicate comment, which is preferable to silently dropping
+        the operator signal. Detection scans every comment body for
+        :data:`NEEDS_REVIEW_COMMENT_SENTINEL`.
+        """
+        cmd = [
+            "gh",
+            "issue",
+            "view",
+            str(issue_number),
+            "--repo",
+            self._cfg.github_repo,
+            "--json",
+            "comments",
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=NEEDS_REVIEW_GH_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            self._log.warning(
+                "daemon.needs_review_sentinel_check_failed",
+                extra={
+                    "event": "needs_review_sentinel_check_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "error": str(exc),
+                },
+            )
+            return None
+
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.needs_review_sentinel_check_failed",
+                extra={
+                    "event": "needs_review_sentinel_check_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "exit_code": result.returncode,
+                    "stderr_preview": (result.stderr or "").strip()[:200],
+                },
+            )
+            return None
+
+        try:
+            payload = json.loads(result.stdout or "{}")
+        except json.JSONDecodeError as exc:
+            self._log.warning(
+                "daemon.needs_review_sentinel_check_failed",
+                extra={
+                    "event": "needs_review_sentinel_check_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "error": f"invalid JSON: {exc}",
+                },
+            )
+            return None
+
+        for comment in payload.get("comments") or []:
+            if not isinstance(comment, dict):
+                continue
+            body = comment.get("body") or ""
+            if NEEDS_REVIEW_COMMENT_SENTINEL in body:
+                return True
+        return False
+
+    def _post_needs_review_comment(
+        self,
+        agent_id: str,
+        issue_number: int,
+        pr_number: int | None,
+        pr_url: str,
+        unmet_criteria: list[str],
+        worktree: Path,
+    ) -> bool:
+        """Post the needs_review issue comment via ``gh issue comment``.
+
+        Issue #2856. Idempotence: skip the post if the sentinel is
+        already present on the issue. Returns True when the comment is
+        present on the issue at return time (whether posted now or
+        found already). Returns False on hard subprocess failure so
+        the caller can log and continue — the DB terminal-status
+        update still runs regardless of this return value (authoritative
+        write rule, same as #2857).
+        """
+        already = self._needs_review_comment_already_posted(issue_number)
+        if already is True:
+            self._log.info(
+                "daemon.needs_review_comment_skipped_idempotent",
+                extra={
+                    "event": "needs_review_comment_skipped_idempotent",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                },
+            )
+            return True
+
+        body = self._render_needs_review_comment(
+            agent_id, pr_number, pr_url, unmet_criteria
+        )
+        body_path = worktree / "tmp" / "needs-review-comment.md"
+        try:
+            body_path.parent.mkdir(parents=True, exist_ok=True)
+            body_path.write_text(body, encoding="utf-8")
+        except OSError as exc:
+            self._log.exception(
+                "daemon.needs_review_comment_failed",
+                extra={
+                    "event": "needs_review_comment_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "error": f"write body file: {exc}",
+                },
+            )
+            return False
+
+        cmd = [
+            "gh",
+            "issue",
+            "comment",
+            str(issue_number),
+            "--repo",
+            self._cfg.github_repo,
+            "--body-file",
+            str(body_path),
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=NEEDS_REVIEW_GH_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            self._log.exception(
+                "daemon.needs_review_comment_failed",
+                extra={
+                    "event": "needs_review_comment_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "error": str(exc),
+                },
+            )
+            return False
+
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.needs_review_comment_failed",
+                extra={
+                    "event": "needs_review_comment_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "exit_code": result.returncode,
+                    "stderr_preview": (result.stderr or "").strip()[:200],
+                },
+            )
+            return False
+
+        self._log.info(
+            "daemon.needs_review_comment_posted",
+            extra={
+                "event": "needs_review_comment_posted",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "pr_number": pr_number,
+            },
+        )
+        return True
+
     def _run_plan_phase(self, agent_id: str, issue_number: int, worktree: Path) -> bool:
         """Run ``/task-v2-plan``. Returns True to continue, False to stop."""
         self._update_agent_phase(agent_id, "planning")
@@ -4373,6 +4729,17 @@ class DispatcherDaemon:
 
         unmet = summary_output.get("unmet_criteria") or []
         if unmet:
+            # #2856: previously this path hard-failed and discarded all
+            # of ralph's work, even when ralph produced reviewer-approved
+            # (verdict=SHIP) code. Now we stash the unmet list and
+            # proceed to _push_and_open_pr which opens the PR as a
+            # DRAFT, appends an "Unmet acceptance criteria" section to
+            # the body, posts an issue comment linking the draft, and
+            # terminates the agent as ``status='needs_review'``
+            # (distinct from ``failed``). The draft PR sits for
+            # operator triage — auto-merge does NOT touch drafts, and
+            # ``needs_review`` is NOT in ``_list_advanceable_agents``'s
+            # SELECT so the supervisor tick leaves it alone.
             self._log.info(
                 "daemon.summary_unmet_criteria",
                 extra={
@@ -4380,12 +4747,13 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "unmet_criteria": unmet,
+                    "terminal_status": "needs_review",
                 },
             )
-            self._mark_agent_terminal(
-                agent_id, status="failed", phase="summary", exit_code=exit_code
-            )
-            return False
+            # Coerce to list[str] so downstream rendering is total on
+            # malformed skill output (non-string entries get stringified
+            # rather than crashing the orchestration).
+            self._agent_unmet_criteria = [str(u) for u in unmet]
 
         self._agent_summary_output = summary_output
         return True
@@ -4727,15 +5095,42 @@ class DispatcherDaemon:
         """Run the final mechanical steps: commit, push, open PR.
 
         On failure at any step, the agent is marked ``failed``. On
-        success, ``phase='awaiting_ci'`` so Phase 3B knows where to
-        pick up, and ``status`` stays ``running``.
+        success (criteria all met), ``phase='awaiting_ci'`` so Phase 3B
+        knows where to pick up, and ``status`` stays ``running``.
+
+        **needs_review branch (#2856):** when
+        :attr:`_agent_unmet_criteria` is non-empty (set by
+        :meth:`_run_summary_phase`), the PR is opened as a DRAFT with
+        an ``⚠️ Unmet acceptance criteria`` section appended to the
+        body, an issue comment is posted linking the draft + listing
+        the unmet criteria, and the agent terminates as
+        ``status='needs_review', phase='needs_review'`` with
+        ``ended_at`` set. The draft PR is NOT picked up by Phase 3B
+        (``needs_review`` is outside the ``_list_advanceable_agents``
+        SELECT), so auto-merge cannot touch it — the operator reviews,
+        marks ready + merges, or closes.
         """
         self._update_agent_phase(agent_id, "push_and_pr")
+
+        unmet_criteria = self._agent_unmet_criteria or []
+        is_needs_review = bool(unmet_criteria)
 
         summary_output = self._agent_summary_output or {}
         commit_message = summary_output.get("commit_message") or ""
         pr_title = summary_output.get("pr_title") or ""
         pr_body_md = summary_output.get("pr_body_md") or ""
+        if is_needs_review:
+            # Append the unmet-criteria section so the operator sees the
+            # concerns inline on the draft PR page without opening the
+            # issue. Render once and reuse the rendered block for the
+            # issue comment (same content, different wrapper) to keep
+            # the two views in sync.
+            pr_body_md = (
+                pr_body_md.rstrip()
+                + "\n\n"
+                + self._render_unmet_criteria_pr_section(unmet_criteria)
+                + "\n"
+            )
 
         if not commit_message or not pr_title or not pr_body_md:
             self._log.warning(
@@ -4894,26 +5289,31 @@ class DispatcherDaemon:
             return
 
         # gh pr create with --body-file pointing to a scratch file in
-        # the worktree's tmp/.
+        # the worktree's tmp/. ``--draft`` is added on the needs_review
+        # path (#2856) so auto-merge cannot touch the PR until the
+        # operator marks it ready.
         pr_body_path = worktree / "tmp" / "pr_body.md"
         pr_body_path.write_text(pr_body_md)
+        pr_create_cmd = [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            self._cfg.github_repo,
+            "--title",
+            pr_title,
+            "--body-file",
+            str(pr_body_path),
+            "--base",
+            "main",
+            "--head",
+            branch,
+        ]
+        if is_needs_review:
+            pr_create_cmd.append("--draft")
         try:
             pr_result = subprocess.run(
-                [
-                    "gh",
-                    "pr",
-                    "create",
-                    "--repo",
-                    self._cfg.github_repo,
-                    "--title",
-                    pr_title,
-                    "--body-file",
-                    str(pr_body_path),
-                    "--base",
-                    "main",
-                    "--head",
-                    branch,
-                ],
+                pr_create_cmd,
                 capture_output=True,
                 text=True,
                 timeout=120,
@@ -4964,8 +5364,33 @@ class DispatcherDaemon:
                 "issue_number": issue_number,
                 "pr_number": pr_number,
                 "pr_url": pr_url,
+                "is_draft": is_needs_review,
             },
         )
+
+        if is_needs_review:
+            # #2856: side-effect — post an issue comment linking the
+            # draft PR + listing the unmet criteria. Runs BEFORE the DB
+            # terminal-status update so a DB crash can't lose the
+            # operator-visible signal. Failure of the comment does NOT
+            # block the terminal transition; the DB update is the
+            # authoritative write.
+            self._post_needs_review_comment(
+                agent_id=agent_id,
+                issue_number=issue_number,
+                pr_number=pr_number,
+                pr_url=pr_url,
+                unmet_criteria=unmet_criteria,
+                worktree=worktree,
+            )
+            self._mark_agent_terminal(
+                agent_id,
+                status="needs_review",
+                phase="needs_review",
+                exit_code=None,
+                pr_number=pr_number,
+            )
+            return
 
         # Final state: keep status=running so Phase 3B picks it up.
         self._mark_agent_terminal(
@@ -7117,12 +7542,17 @@ class DispatcherDaemon:
         assert self._conn is not None, "connect() must run before update"
 
         # ``plan_blocked`` (#2857) is the "plan correctly declined" terminal —
-        # operationally a correct outcome, not a failure. Classify it
-        # alongside ``succeeded`` for the retry_outcome enum so diagnoser
-        # effectiveness dashboards don't count correct-triage decisions
-        # against the retry-success rate.
+        # operationally a correct outcome, not a failure. ``needs_review``
+        # (#2856) likewise: ralph produced real reviewer-approved code
+        # and the draft PR + issue comment + label swap is a correct
+        # outcome — it is the operator's call whether to ship. Classify
+        # both alongside ``succeeded`` for the retry_outcome enum so
+        # diagnoser effectiveness dashboards don't count correct-triage
+        # decisions against the retry-success rate.
         retry_outcome = (
-            "succeeded" if final_status in ("succeeded", "plan_blocked") else "failed"
+            "succeeded"
+            if final_status in ("succeeded", "plan_blocked", "needs_review")
+            else "failed"
         )
         outcome = {
             "retry_outcome": retry_outcome,

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -513,6 +513,38 @@ class TestIssueAlreadyAttempted:
         conn.cursor_instance.execute = boom  # type: ignore[method-assign]
         assert d._issue_already_attempted(42) is True
 
+    def test_needs_review_row_blocks_repickup(self, tmp_path: Path) -> None:
+        """#2856: prior ``needs_review`` row keeps the issue out of the pickup loop.
+
+        When summary_unmet_criteria fires, the daemon opens a DRAFT PR
+        and terminates the agent as ``needs_review``. The issue stays
+        labelled ``agent/ready`` (the issue body still describes
+        requested work), so the next scheduler tick would otherwise
+        re-pick it and race two agent branches against the open draft.
+        ``ACTIVE_AGENT_STATUSES`` includes ``needs_review`` for
+        exactly this reason — the picker treats the prior row as
+        "issue has an in-flight artifact" until the operator merges,
+        closes, or edits.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        # Return a non-None row as if a needs_review agent row exists.
+        conn.cursor_instance.fetch_queue = [(1,)]
+        assert d._issue_already_attempted(42) is True
+        # Confirm the SELECT would have matched needs_review — the
+        # query binds ACTIVE_AGENT_STATUSES as the ANY() parameter.
+        select_calls = [
+            e
+            for e in conn.cursor_instance.executed
+            if "SELECT 1 FROM dispatcher.agents" in e[0]
+        ]
+        assert select_calls
+        # ACTIVE_AGENT_STATUSES is passed as the second param of the
+        # bind tuple: (issue_number, list(ACTIVE_AGENT_STATUSES)).
+        params = select_calls[0][1]
+        assert params is not None
+        # params is (issue_number, [statuses...]).
+        assert "needs_review" in params[1]
+
 
 # --------------------------------------------------------------------------
 # _issue_author_trusted (wraps scripts/check-issue-author.sh)
@@ -2172,3 +2204,633 @@ class TestClaimRace:
             if "INSERT INTO dispatcher.phase_outputs" in e[0]
         ]
         assert phase_inserts == []
+
+
+# --------------------------------------------------------------------------
+# #2856: summary_unmet_criteria opens a DRAFT PR + needs_review terminal
+#
+# Previously (pre-#2856) summary_unmet_criteria discarded all ralph work
+# by marking the agent failed with no PR. Now the daemon preserves
+# ralph's reviewer-approved output by opening a DRAFT PR with an
+# "Unmet acceptance criteria" section appended to the body, posts an
+# issue comment linking the draft, and marks the agent
+# ``status='needs_review'`` (a new terminal distinct from ``failed``).
+#
+# Tests cover: helper rendering (AC3: section text + sentinel); orchestration
+# path (AC1: draft flag, AC2: PR body section, AC4: status='needs_review',
+# AC5: issue comment with PR link). Parallel structure to the
+# plan_blocked tests above (#2857).
+# --------------------------------------------------------------------------
+
+
+class TestNeedsReviewHelpers:
+    """Direct tests for the needs_review rendering helpers (#2856)."""
+
+    def test_render_unmet_criteria_pr_section_includes_warning_heading(
+        self, tmp_path: Path
+    ) -> None:
+        """AC2: PR body section must include the ⚠️ Unmet AC heading."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        section = d._render_unmet_criteria_pr_section(["AC1 — foo", "AC2 — bar"])
+        # "\u26a0\ufe0f" is the warning-sign emoji (U+26A0 U+FE0F).
+        assert "\u26a0\ufe0f Unmet acceptance criteria" in section
+        # Each criterion rendered as a bullet verbatim.
+        assert "- AC1 \u2014 foo" in section
+        assert "- AC2 \u2014 bar" in section
+
+    def test_render_unmet_criteria_pr_section_drops_empty_entries(
+        self, tmp_path: Path
+    ) -> None:
+        """Whitespace-only entries are dropped so the rendered list stays clean."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        section = d._render_unmet_criteria_pr_section(["real AC", "   ", ""])
+        assert "- real AC" in section
+        # Blank bullets must not appear.
+        assert "- \n" not in section
+        assert "- \n- " not in section
+
+    def test_render_unmet_criteria_pr_section_handles_all_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """Degenerate list → still renders the heading so the PR body is valid md."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        section = d._render_unmet_criteria_pr_section(["", "   "])
+        # Defensive fallback — should never happen via the normal path
+        # (the caller only invokes on non-empty) but keeps the helper total.
+        assert "\u26a0\ufe0f Unmet acceptance criteria" in section
+        assert "(none recorded)" in section
+
+    def test_render_needs_review_comment_has_sentinel_on_line_one(
+        self, tmp_path: Path
+    ) -> None:
+        """AC2/AC3: sentinel MUST be line 1 so a future dedupe can detect."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        body = d._render_needs_review_comment(
+            "aabbccdd-eeff-0011-2233-445566778899",
+            1234,
+            "https://github.com/judgemind/judgemind/pull/1234",
+            ["AC1 missing"],
+        )
+        first_line = body.splitlines()[0]
+        assert first_line == "<!-- dispatcher-needs-review -->"
+
+    def test_render_needs_review_comment_includes_pr_link(self, tmp_path: Path) -> None:
+        """AC4: the issue comment MUST link the draft PR."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        body = d._render_needs_review_comment(
+            "aabbccdd-eeff-0011-2233-445566778899",
+            1234,
+            "https://github.com/judgemind/judgemind/pull/1234",
+            ["AC1 missing"],
+        )
+        # GitHub autolinks the raw URL.
+        assert "https://github.com/judgemind/judgemind/pull/1234" in body
+
+    def test_render_needs_review_comment_falls_back_to_pr_number_on_missing_url(
+        self, tmp_path: Path
+    ) -> None:
+        """If ``gh pr create`` stdout parsing fails, fall back to #<num>."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        body = d._render_needs_review_comment(
+            "aabbccdd-eeff-0011-2233-445566778899",
+            1234,
+            "",
+            ["AC1 missing"],
+        )
+        assert "#1234" in body
+
+    def test_render_needs_review_comment_includes_unmet_bullets(
+        self, tmp_path: Path
+    ) -> None:
+        """Each unmet criterion rendered as its own bullet in the comment."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        body = d._render_needs_review_comment(
+            "aabbccdd-eeff-0011-2233-445566778899",
+            1234,
+            "https://github.com/judgemind/judgemind/pull/1234",
+            ["AC1 real fixture missing", "AC2 no deploy evidence"],
+        )
+        assert "- AC1 real fixture missing" in body
+        assert "- AC2 no deploy evidence" in body
+
+    def test_render_needs_review_comment_includes_short_agent_id(
+        self, tmp_path: Path
+    ) -> None:
+        """Operators can correlate comment with CloudWatch / DB row."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        body = d._render_needs_review_comment(
+            "aabbccdd-eeff-0011-2233-445566778899",
+            1234,
+            "https://github.com/judgemind/judgemind/pull/1234",
+            ["AC1"],
+        )
+        # First 8 hex chars of the UUID with dashes stripped.
+        assert "`aabbccdd`" in body
+
+
+class TestNeedsReviewCommentHandler:
+    """Direct tests for the needs_review comment-posting helpers (#2856)."""
+
+    def test_post_needs_review_comment_skips_when_sentinel_already_present(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Idempotence: pre-existing sentinel → no comment post, returns True."""
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        gh_comment_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "comments": [
+                            {"body": "<!-- dispatcher-needs-review -->\n## Prior\n"}
+                        ]
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "issue", "comment"]:
+                gh_comment_calls.append(cmd)
+                r.stdout = ""
+                return r
+            r.stdout = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        ok = d._post_needs_review_comment(
+            agent_id="aabbccdd-eeff-0011-2233-445566778899",
+            issue_number=42,
+            pr_number=1234,
+            pr_url="https://github.com/judgemind/judgemind/pull/1234",
+            unmet_criteria=["AC1"],
+            worktree=worktree,
+        )
+
+        assert ok is True
+        assert gh_comment_calls == []
+        assert handler.events("needs_review_comment_skipped_idempotent") != []
+
+    def test_post_needs_review_comment_posts_when_sentinel_absent(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Fresh issue: sentinel absent → comment posted with --body-file."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        gh_comment_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r.stdout = json.dumps({"comments": []})
+                return r
+            if cmd[:3] == ["gh", "issue", "comment"]:
+                gh_comment_calls.append(cmd)
+                r.stdout = ""
+                return r
+            r.stdout = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        ok = d._post_needs_review_comment(
+            agent_id="aabbccdd-eeff-0011-2233-445566778899",
+            issue_number=42,
+            pr_number=1234,
+            pr_url="https://github.com/judgemind/judgemind/pull/1234",
+            unmet_criteria=["AC1 missing"],
+            worktree=worktree,
+        )
+
+        assert ok is True
+        assert len(gh_comment_calls) == 1
+        assert "--body-file" in gh_comment_calls[0]
+        body_idx = gh_comment_calls[0].index("--body-file") + 1
+        body_path = Path(gh_comment_calls[0][body_idx])
+        body = body_path.read_text(encoding="utf-8")
+        # Sentinel on line 1, PR link present, bullet present.
+        assert body.startswith("<!-- dispatcher-needs-review -->")
+        assert "https://github.com/judgemind/judgemind/pull/1234" in body
+        assert "- AC1 missing" in body
+        assert handler.events("needs_review_comment_posted") != []
+
+    def test_post_needs_review_comment_returns_false_on_gh_failure(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """gh issue comment non-zero → returns False, error logged."""
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.stdout = ""
+            r.stderr = "api error"
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r.returncode = 0
+                r.stdout = json.dumps({"comments": []})
+                return r
+            if cmd[:3] == ["gh", "issue", "comment"]:
+                r.returncode = 1
+                return r
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        ok = d._post_needs_review_comment(
+            agent_id="aabbccdd-eeff-0011-2233-445566778899",
+            issue_number=42,
+            pr_number=1234,
+            pr_url="https://github.com/judgemind/judgemind/pull/1234",
+            unmet_criteria=["AC1"],
+            worktree=worktree,
+        )
+        assert ok is False
+        assert handler.events("needs_review_comment_failed") != []
+
+    def test_needs_review_sentinel_check_treats_gh_error_as_unknown(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """``gh issue view`` non-zero → sentinel check returns None (fail-open)."""
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 1
+            r.stdout = ""
+            r.stderr = "api error"
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = d._needs_review_comment_already_posted(42)
+        assert result is None
+        assert handler.events("needs_review_sentinel_check_failed") != []
+
+    def test_needs_review_sentinel_check_treats_timeout_as_unknown(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """subprocess TimeoutExpired on sentinel check → returns None."""
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd, 30)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = d._needs_review_comment_already_posted(42)
+        assert result is None
+        assert handler.events("needs_review_sentinel_check_failed") != []
+
+    def test_needs_review_sentinel_check_treats_malformed_json_as_unknown(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Malformed JSON from ``gh issue view`` → returns None."""
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = "not-json"
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        result = d._needs_review_comment_already_posted(42)
+        assert result is None
+        assert handler.events("needs_review_sentinel_check_failed") != []
+
+    def test_needs_review_sentinel_check_skips_non_dict_comments(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Non-dict entries in the comments array are skipped safely."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = json.dumps(
+                {
+                    "comments": [
+                        "not-a-dict",
+                        42,
+                        None,
+                        {"body": "ordinary comment"},
+                    ]
+                }
+            )
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert d._needs_review_comment_already_posted(42) is False
+
+    def test_post_needs_review_comment_handles_timeout(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """subprocess TimeoutExpired on ``gh issue comment`` → returns False, logs."""
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r = MagicMock()
+                r.returncode = 0
+                r.stdout = json.dumps({"comments": []})
+                r.stderr = ""
+                return r
+            # gh issue comment → timeout
+            raise subprocess.TimeoutExpired(cmd, 30)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        ok = d._post_needs_review_comment(
+            agent_id="aabbccdd-eeff-0011-2233-445566778899",
+            issue_number=42,
+            pr_number=1234,
+            pr_url="https://github.com/judgemind/judgemind/pull/1234",
+            unmet_criteria=["AC1"],
+            worktree=worktree,
+        )
+        assert ok is False
+        assert handler.events("needs_review_comment_failed") != []
+
+    def test_post_needs_review_comment_handles_body_write_failure(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """OSError writing the body file → returns False, logs error."""
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r = MagicMock()
+                r.returncode = 0
+                r.stdout = json.dumps({"comments": []})
+                r.stderr = ""
+                return r
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        # Block the tmp/ directory creation by planting a file at that path.
+        (worktree / "tmp").write_text("not-a-dir")
+
+        ok = d._post_needs_review_comment(
+            agent_id="aabbccdd-eeff-0011-2233-445566778899",
+            issue_number=42,
+            pr_number=1234,
+            pr_url="https://github.com/judgemind/judgemind/pull/1234",
+            unmet_criteria=["AC1"],
+            worktree=worktree,
+        )
+        assert ok is False
+        assert handler.events("needs_review_comment_failed") != []
+
+
+class TestNeedsReviewOrchestration:
+    """End-to-end: summary with ``unmet_criteria`` → draft PR + needs_review (#2856)."""
+
+    def test_summary_unmet_opens_draft_pr_and_marks_needs_review(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """AC1/AC3/AC4: draft flag in gh create, status='needs_review', phase='needs_review'.
+
+        Previously summary_unmet_criteria hard-failed with no PR.
+        This test locks in the new contract: ralph's output is
+        preserved as a draft PR, agent terminates ``needs_review``,
+        and the PR body contains the ⚠️ Unmet AC section.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        # (1) Phase 3C resume — no retrying; (2) queue snapshot; (3) not-attempted.
+        conn.cursor_instance.fetch_queue = [None, (None, [42]), None]
+
+        monkeypatch.setattr(d, "_repo_root", lambda: tmp_path)
+        fixed = uuid_mod.UUID("aabbccdd-eeff-0011-2233-445566778899")
+        monkeypatch.setattr(daemon.uuid, "uuid4", lambda: fixed)
+
+        summary_unmet = dict(_fixture_summary_output())
+        summary_unmet["unmet_criteria"] = [
+            "AC1 — real fixture must be committed",
+            "AC2 — deploy evidence posted",
+        ]
+
+        phase_outputs = {
+            "plan": _fixture_plan_output(),
+            "ralph": _fixture_ralph_output(),
+            "summary": summary_unmet,
+        }
+
+        gh_pr_create_calls: list[list[str]] = []
+        gh_issue_comment_calls: list[list[str]] = []
+        gh_issue_view_count = 0
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            nonlocal gh_issue_view_count
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            if cmd[0].endswith("check-issue-author.sh"):
+                r.stdout = "TRUSTED: ...\n"
+                return r
+            if cmd[:3] == ["gh", "issue", "view"]:
+                gh_issue_view_count += 1
+                # All gh issue view calls (plan bundle + summary bundle +
+                # needs_review sentinel check) return an empty comments
+                # list so the sentinel check falls through to the post.
+                r.stdout = json.dumps(
+                    {
+                        "number": 42,
+                        "title": "Title",
+                        "body": "body",
+                        "labels": [{"name": "priority/p1"}],
+                        "comments": [],
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "pr", "create"]:
+                gh_pr_create_calls.append(cmd)
+                r.stdout = "https://github.com/judgemind/judgemind/pull/9001\n"
+                return r
+            if cmd[:3] == ["gh", "issue", "comment"]:
+                gh_issue_comment_calls.append(cmd)
+                return r
+            if "worktree" in cmd and "add" in cmd:
+                add_idx = cmd.index("add")
+                Path(cmd[add_idx + 1]).mkdir(parents=True, exist_ok=True)
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        def fake_spawn(phase: str, worktree: Path, agent_id: str) -> tuple[int, float]:
+            output_dir = worktree / "tmp" / "dispatcher-output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            (output_dir / f"{phase}.json").write_text(json.dumps(phase_outputs[phase]))
+            return 0, 0.1
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        d._claim_and_orchestrate_one()
+
+        # --- AC1: draft flag present on gh pr create ---
+        assert len(gh_pr_create_calls) == 1
+        assert "--draft" in gh_pr_create_calls[0]
+
+        # --- AC2: PR body section present with unmet criteria ---
+        body_idx = gh_pr_create_calls[0].index("--body-file") + 1
+        body_path = Path(gh_pr_create_calls[0][body_idx])
+        body_text = body_path.read_text(encoding="utf-8")
+        assert "\u26a0\ufe0f Unmet acceptance criteria" in body_text
+        assert "- AC1 \u2014 real fixture must be committed" in body_text
+        assert "- AC2 \u2014 deploy evidence posted" in body_text
+
+        # --- AC5: issue comment posted linking the draft PR + listing unmet ---
+        assert len(gh_issue_comment_calls) == 1
+        assert "--body-file" in gh_issue_comment_calls[0]
+        comment_body_idx = gh_issue_comment_calls[0].index("--body-file") + 1
+        comment_body_path = Path(gh_issue_comment_calls[0][comment_body_idx])
+        comment_body = comment_body_path.read_text(encoding="utf-8")
+        assert "<!-- dispatcher-needs-review -->" in comment_body
+        assert "https://github.com/judgemind/judgemind/pull/9001" in comment_body
+        assert "- AC1 \u2014 real fixture must be committed" in comment_body
+
+        # --- AC4: terminal UPDATE sets status='needs_review' (not 'failed'). ---
+        needs_review_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "needs_review" in e[1]
+        ]
+        assert needs_review_updates, (
+            "expected UPDATE with status='needs_review'; got: "
+            f"{[e[1] for e in conn.cursor_instance.executed if 'UPDATE dispatcher.agents' in e[0]]}"
+        )
+
+        # summary_unmet_criteria event logged.
+        unmet_events = handler.events("summary_unmet_criteria")
+        assert unmet_events != []
+        assert unmet_events[0].terminal_status == "needs_review"
+
+        # pr_opened event carries is_draft=True so CloudWatch can filter.
+        pr_opened = handler.events("pr_opened")
+        assert pr_opened
+        assert pr_opened[0].pr_number == 9001
+
+        # Side-effect: comment posted event logged.
+        assert handler.events("needs_review_comment_posted") != []
+
+        # Ensure the happy-path ``running+awaiting_ci`` transition did
+        # NOT fire — the supervisor tick must not pick this up for
+        # auto-merge.
+        running_awaiting_ci_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "awaiting_ci" in e[1]
+            and "running" in e[1]
+        ]
+        assert running_awaiting_ci_updates == []
+
+    def test_summary_unmet_comment_failure_does_not_block_db_update(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Issue-comment failure must NOT prevent status='needs_review' DB write.
+
+        DB update is the authoritative terminal-status write. A
+        GitHub outage on the issue-comment path must leave the agent
+        as ``needs_review`` (not stuck in ``push_and_pr``) so the
+        supervisor + admin cockpit see it consistently.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None, (None, [42]), None]
+
+        monkeypatch.setattr(d, "_repo_root", lambda: tmp_path)
+        fixed = uuid_mod.UUID("aabbccdd-eeff-0011-2233-445566778899")
+        monkeypatch.setattr(daemon.uuid, "uuid4", lambda: fixed)
+
+        summary_unmet = dict(_fixture_summary_output())
+        summary_unmet["unmet_criteria"] = ["AC1 missing"]
+
+        phase_outputs = {
+            "plan": _fixture_plan_output(),
+            "ralph": _fixture_ralph_output(),
+            "summary": summary_unmet,
+        }
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            if cmd[0].endswith("check-issue-author.sh"):
+                r.stdout = "TRUSTED: ...\n"
+                return r
+            if cmd[:3] == ["gh", "issue", "view"]:
+                r.stdout = json.dumps(
+                    {
+                        "number": 42,
+                        "title": "T",
+                        "body": "",
+                        "labels": [],
+                        "comments": [],
+                    }
+                )
+                return r
+            if cmd[:3] == ["gh", "pr", "create"]:
+                r.stdout = "https://github.com/judgemind/judgemind/pull/9001\n"
+                return r
+            if cmd[:3] == ["gh", "issue", "comment"]:
+                # Comment post fails — DB update must still run.
+                r.returncode = 1
+                r.stderr = "api error"
+                return r
+            if "worktree" in cmd and "add" in cmd:
+                add_idx = cmd.index("add")
+                Path(cmd[add_idx + 1]).mkdir(parents=True, exist_ok=True)
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        def fake_spawn(phase: str, worktree: Path, agent_id: str) -> tuple[int, float]:
+            output_dir = worktree / "tmp" / "dispatcher-output"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            (output_dir / f"{phase}.json").write_text(json.dumps(phase_outputs[phase]))
+            return 0, 0.1
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        d._claim_and_orchestrate_one()
+
+        # DB terminal-status update ran.
+        needs_review_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "needs_review" in e[1]
+        ]
+        assert needs_review_updates
+        # Failure event logged.
+        assert handler.events("needs_review_comment_failed") != []

--- a/scripts/dispatcher/tests/test_daemon_phase3e.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3e.py
@@ -1106,6 +1106,51 @@ class TestDiagnosisOutcomeWriteback:
         # diagnosis_outcome_written event logged.
         assert handler.events("diagnosis_outcome_written")
 
+    def test_needs_review_terminal_writes_succeeded_outcome(
+        self, tmp_path: Path
+    ) -> None:
+        """``needs_review`` (#2856) classifies as a correct-outcome retry.
+
+        Ralph produced reviewer-approved (SHIP) code and the summary
+        phase found unmet AC — the daemon opened a draft PR for
+        operator review. That IS the correct behavior of the pipeline,
+        so the retry_outcome enum records ``succeeded`` for diagnoser
+        effectiveness tracking (distinct from the agent row's own
+        ``status='needs_review'`` which drives the cockpit's distinct
+        chip). Mirrors the #2857 ``plan_blocked`` classification.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.rowcount = 1
+
+        d._mark_agent_terminal(
+            "agent-needs-review",
+            status="needs_review",
+            phase="needs_review",
+            exit_code=None,
+            pr_number=9001,
+        )
+
+        diag_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.diagnoses" in e[0]
+        ]
+        assert diag_updates
+        outcome_dict = json.loads(diag_updates[0][1][0])
+        assert outcome_dict["retry_outcome"] == "succeeded"
+        assert outcome_dict["final_status"] == "needs_review"
+        # Terminal bookkeeping ran: ended_at SET on the agent row.
+        agent_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "needs_review" in e[1]
+        ]
+        assert agent_updates
+        assert "ended_at = now()" in agent_updates[0][0]
+        assert handler.events("diagnosis_outcome_written")
+
     def test_non_terminal_status_skips_outcome_write(self, tmp_path: Path) -> None:
         # When the daemon transitions to e.g. awaiting_ci (non-terminal),
         # no diagnoses outcome write should happen.


### PR DESCRIPTION
## Summary

When `summary_unmet_criteria` fires the daemon now preserves ralph's reviewer-approved output as a DRAFT PR (with unmet-AC section + issue comment + new `needs_review` terminal) instead of discarding the run. Overnight-safe: `needs_review` is outside `_list_advanceable_agents`'s SELECT so the supervisor cannot auto-merge the draft even with auto-merge ON.

Parallel in shape to #2857 (`plan_blocked`): sentinel-HTML-comment dedupe, independently-wrapped side-effects (DB write is authoritative), `String!` GraphQL status so the DB free-text column keeps absorbing correct-outcome terminals without a schema migration.

Scope touches three layers atomically: Python daemon (new helpers + summary-phase stash + `_push_and_open_pr` draft branch + `ACTIVE_AGENT_STATUSES` extension to keep the issue out of the re-pickup queue while the draft is open), API GraphQL (docstrings + `queryRecentCompletions` SQL IN list), and the admin cockpit (`OutcomePill` extended with a yellow `◐` chip distinct from crashed's amber and plan_blocked's neutral).

Closes #2856

## Test plan

### Automated checks
- [x] Dispatcher Python tests pass (`pytest scripts/dispatcher/tests/` — 465 passed, 1 skipped locally; 20 new)
- [x] Ruff lint + format clean on `scripts/dispatcher/daemon.py` + test files
- [x] API lint + typecheck + unit tests pass (`npm --prefix packages/api run lint/typecheck/test:unit` — 213 passed)
- [x] Web lint + typecheck + tests + build pass (`npm --prefix packages/web run lint/typecheck/test` + `build` — 1237 passed)
- [x] `scripts/check-dispatcher-image-deps.sh` — ok (no new imports)
- [x] Pre-push hook passed locally
- [x] CI green (runs 24637653053 + 24637668011, plus Smoke Test 24637665991 — all SUCCESS/SKIPPED, `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`)

### Post-deploy verification
- [x] Dispatcher image redeployed to dev via `deploy-dispatcher.yml` (run 24637764439 — success; rolloutState COMPLETED, new task booted at 19:58:22 UTC with `version_sha: "b1e6de2"`)
- [x] Runtime verification on live dispatcher container — `scripts/ecs-run.sh --service judgemind-dispatcher-dev --container dispatcher --script tmp/verify_needs_review_code.py` confirmed `NEEDS_REVIEW_COMMENT_SENTINEL`, `_render_unmet_criteria_pr_section`, `_render_needs_review_comment`, `_post_needs_review_comment`, `_needs_review_comment_already_posted`, and the extended `ACTIVE_AGENT_STATUSES` all live and correct. See evidence comment on #2856.
- [ ] Data-level verification (next `summary_unmet_criteria` event on dev fires full automation end-to-end — draft PR created, issue comment posted with sentinel, `dispatcher.agents.status='needs_review'`, PR not auto-merged). Awaits next genuine event; historical pre-deploy `failed` rows do not retroactively flip.
- [ ] Admin cockpit screenshot showing a yellow `◐` chip in the Recently Completed panel (awaits first live `needs_review` row)
- [x] Verification evidence posted on #2856

## Design decisions

Full rationale posted as the process-summary issue comment (see #2856). Highlights:

1. **No label swap on the issue.** `plan_blocked` swaps `agent/ready` → `status/triage` because there is no other artifact; for `needs_review` the draft PR IS the artifact. Scheduler re-pickup guarded via `ACTIVE_AGENT_STATUSES` extension (DB-side, more robust than labels).

2. **Yellow, not amber, for the chip.** Amber is reserved for `crashed`. Yellow is adjacent on the colour wheel but perceptibly distinct, so operators can scan the Recently Completed panel and separate "review my draft PR" (actionable, non-alarming) from "something crashed, diagnose" (actionable, urgent). The `◐` glyph (half-circle) is the semantic anchor: ralph did half, operator does the other half.

3. **Diagnoses outcome classification.** `needs_review` → `retry_outcome='succeeded'` for diagnoser effectiveness dashboards. Ralph produced reviewer-approved code and the daemon took the correct action; a failure-category classification would distort the effectiveness rate downward for correct behaviour. Mirrors #2857.

4. **Supervisor cannot auto-merge the draft.** `_list_advanceable_agents` SELECT matches only `status='running' AND phase IN ('awaiting_ci', 'awaiting_deploy')`. `needs_review` rows are terminal with `phase='needs_review'`, so the supervisor never touches them. Locked in by the `running_awaiting_ci_updates == []` assertion in the orchestration test.

5. **Issue-comment failure does NOT block the DB update.** Each side-effect is independently wrapped (same contract as #2857). DB terminal-status write is authoritative — GitHub outages cannot leave the agent stuck in `phase='push_and_pr'`. Covered by `test_summary_unmet_comment_failure_does_not_block_db_update`.
