### PR TITLE
feat(dispatcher): overnight-safety circuit breaker (#2860)

### DIFF
--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -158,6 +158,43 @@ scripts/dev-db-query.sh --rw "UPDATE dispatcher.config SET value = '0', updated_
 
 The daemon stops claiming new candidates on the next scheduler tick (≤ 30 s). Any in-flight agent finishes naturally — supervisor ticks continue advancing it through CI watch / merge / deploy / verify / retro / cleanup until it lands in a terminal phase. If the in-flight agent is stuck, the supervisor's `_check_stuck_agents` (Phase 3C, 30-min window) flips it to `crashed` and the retry-marker processor takes over.
 
+### Overnight-safety circuit breaker (#2860)
+
+The daemon auto-pauses (`concurrency_cap` → 0) when a streak of bad terminal outcomes hits the threshold — currently 5 of the last 10 agent terminals in a rolling 30-minute window. "Bad" is the complement of the `OVERNIGHT_CB_GOOD_OUTCOME_STATUSES` set in `scripts/dispatcher/daemon.py` (only `succeeded` is good today; `failed`, `crashed`, `plan_blocked`, `needs_review`, and unknown future terminals all count as bad).
+
+When the breaker opens:
+
+1. `UPDATE dispatcher.config SET value = '0' WHERE key = 'concurrency_cap'` with `updated_by = 'circuit_breaker'`.
+2. `UPDATE dispatcher.config SET value = '"circuit_breaker"' WHERE key = 'cap_flipped_by'` — diagnostic trail.
+3. Structured CloudWatch event `daemon.circuit_breaker_opened` with the agent list, bad count, threshold, and window.
+4. Telegram alert via `scripts/notify-telegram.sh` (best-effort — a missing secret is a silent no-op).
+5. Admin cockpit renders the red "Circuit breaker open" banner above the two-column deck.
+
+**Recovering from an open breaker.** The breaker does not auto-close. Investigate the underlying cascade first — run `scripts/dev-db-query.sh "SELECT * FROM dispatcher.terminal_outcomes ORDER BY ended_at DESC LIMIT 20"` to see the recent outcomes and `scripts/ecs-logs.sh /ecs/judgemind-dispatcher-dev --lines 200` for the open event context. Common triggers:
+
+- Gemini API rate limit → every ralph review SKIPPED → summary flags unmet → N `needs_review` in a row.
+- Upstream `main` CI red → every PR fails CI → fix-ci retries exhausted → N `failed` in a row.
+- Skill regression on plan-phase → every plan returns go=false → N `plan_blocked` in a row.
+
+After addressing the root cause, flip cap back up from the admin cockpit (preferred) or via SQL:
+
+```
+scripts/dev-db-query.sh --rw "UPDATE dispatcher.config SET value = '1', updated_by = '<your-handle>', updated_at = now() WHERE key = 'concurrency_cap';"
+```
+
+The next scheduler tick observes `cap_flipped_by = 'circuit_breaker' AND concurrency_cap >= 1`, logs `daemon.circuit_breaker_closed`, and clears `cap_flipped_by` back to `null`. New agents start claiming on the following tick.
+
+**Tuning the knobs.** All four thresholds live in `dispatcher.config` and are live-editable:
+
+| Key | Default | Meaning |
+|---|---|---|
+| `circuit_breaker_enabled` | `true` | Kill switch. Flip to `false` only for controlled chaos testing. |
+| `circuit_breaker_window_minutes` | `30` | Rolling window the M-of-N scan considers. |
+| `circuit_breaker_window_size` | `10` | N (how many most-recent terminals). |
+| `circuit_breaker_bad_outcome_threshold` | `5` | M (bad-outcome count needed to trip). |
+
+Nonsensical values (threshold ≤ 0, window_size ≤ 0) are treated as "breaker disabled" so the rail fails-open rather than tripping on an empty window.
+
 ### Per-agent phase enumeration (Phase 3E)
 
 `dispatcher.agents.phase` is free-form `text` per migration 21 — no schema enum to maintain. The daemon-side enumeration (centralised in constants `PHASE_*` in `scripts/dispatcher/daemon.py`):

--- a/packages/api/migrations/29_dispatcher-circuit-breaker.sql
+++ b/packages/api/migrations/29_dispatcher-circuit-breaker.sql
@@ -1,0 +1,106 @@
+-- Up Migration
+--
+-- Dispatcher v2 — overnight safety circuit breaker. Adds the storage
+-- and seeded config knobs for ``_evaluate_circuit_breaker`` in
+-- ``scripts/dispatcher/daemon.py``.
+--
+-- Issue #2860 (Parent: dispatcher v2 overnight safety). Context:
+--
+--   For unattended overnight cap=1 operation, the daemon needs a rail
+--   that auto-pauses (``concurrency_cap=0``) when the last N terminal
+--   agent outcomes are bad (``failed`` / ``crashed`` / ``plan_blocked``
+--   / ``needs_review``). Without this, a cascading failure mode
+--   (Gemini API rate limit → every reviewer SKIPPED → every summary
+--   unmet → N failed runs in a row) burns $ until morning.
+--
+-- Two changes:
+--
+--   1. ``dispatcher.terminal_outcomes`` — append-only ring-buffer
+--      table. One row per terminal agent transition, populated by the
+--      daemon's ``_mark_agent_terminal`` path. Bounded by the rolling
+--      30-minute window the breaker scans + the 30-day housekeeping
+--      prune (see below for the reuse of the existing retention
+--      mechanism — the breaker owns its own retention knob so operators
+--      can tune independently).
+--
+--   2. ``dispatcher.config`` seeds:
+--      - ``circuit_breaker_enabled`` (bool, default ``true``): kill
+--        switch. Operator flips to ``false`` to disable the rail
+--        entirely (e.g. during controlled chaos testing).
+--      - ``circuit_breaker_window_minutes`` (int, default ``30``):
+--        rolling window for the threshold check.
+--      - ``circuit_breaker_window_size`` (int, default ``10``): N in
+--        "M of last N terminal states".
+--      - ``circuit_breaker_bad_outcome_threshold`` (int, default ``5``):
+--        M in "M of last N" — trip the breaker when at least this many
+--        of the last N terminals in the rolling window are bad.
+--      - ``cap_flipped_by`` (text, default ``null``): diagnostic trail
+--        for "who last flipped ``concurrency_cap``". When the breaker
+--        opens, this becomes ``"circuit_breaker"``. When the operator
+--        manually flips cap up to ≥1, the daemon's scheduler tick
+--        observes the mismatch, logs ``daemon.circuit_breaker_closed``,
+--        and resets ``cap_flipped_by`` to ``null``. Also surfaced in
+--        the admin cockpit as "Circuit open: N/M recent agents bad,
+--        cap held at 0".
+--
+-- Design notes
+-- ------------
+-- - ``terminal_outcomes`` is append-only for the same reason
+--   ``phase_transitions`` is: the rolling-window scan (``ended_at >
+--   now() - interval``) wants the newest rows cheaply. A single
+--   ``(ended_at DESC)`` index gives O(window_size) scan cost with no
+--   deletion churn. Pruning is deferred to the housekeeping tick.
+-- - ``status`` is free-form text (not an enum) for the same reason
+--   ``dispatcher.agents.status`` is: future correct-outcome terminals
+--   (``needs_review`` from #2856, or a ``ci_unrecoverable`` variant
+--   from #2860's sibling work) slot in without a schema migration.
+--   The daemon's classifier is the single source of truth for which
+--   statuses count as "bad" — see ``BAD_OUTCOME_STATUSES`` in
+--   ``scripts/dispatcher/daemon.py``.
+-- - ``agent_id`` is NULLABLE to tolerate synthetic test inputs that do
+--   not reference a real ``dispatcher.agents`` row. Production writes
+--   always carry ``agent_id``. Keeping the column non-FK-constrained
+--   avoids a cascade-delete interaction with the existing
+--   ``dispatcher.agents`` retention story.
+-- - ``ON CONFLICT DO NOTHING`` keeps the seed block idempotent: a
+--   re-run over a DB where an operator has already tuned the threshold
+--   to 3 will NOT revert it to 5.
+
+-- ── dispatcher.terminal_outcomes ──────────────────────────────────────
+CREATE TABLE dispatcher.terminal_outcomes (
+    outcome_id    BIGSERIAL   PRIMARY KEY,
+    agent_id      UUID,
+    issue_number  INT,
+    status        TEXT        NOT NULL,
+    ended_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_dispatcher_terminal_outcomes_ended_at
+    ON dispatcher.terminal_outcomes (ended_at DESC);
+
+COMMENT ON TABLE  dispatcher.terminal_outcomes            IS 'Append-only ring buffer of terminal agent outcomes. Scanned by ``_evaluate_circuit_breaker`` over a rolling window to decide whether to auto-pause ``concurrency_cap``. Issue #2860.';
+COMMENT ON COLUMN dispatcher.terminal_outcomes.status     IS 'Free-form text (succeeded | failed | crashed | plan_blocked | needs_review | ...). Classifier in daemon decides which count as bad.';
+COMMENT ON COLUMN dispatcher.terminal_outcomes.agent_id   IS 'Nullable — synthetic test inputs may have no agent row. Production writes always carry this.';
+
+-- ── dispatcher.config seeds ────────────────────────────────────────────
+INSERT INTO dispatcher.config (key, value, updated_by) VALUES
+    ('circuit_breaker_enabled',                 'true', 'init'),
+    ('circuit_breaker_window_minutes',          '30',   'init'),
+    ('circuit_breaker_window_size',             '10',   'init'),
+    ('circuit_breaker_bad_outcome_threshold',   '5',    'init'),
+    ('cap_flipped_by',                          'null', 'init')
+ON CONFLICT (key) DO NOTHING;
+
+
+-- Down Migration
+DELETE FROM dispatcher.config
+WHERE key IN (
+    'circuit_breaker_enabled',
+    'circuit_breaker_window_minutes',
+    'circuit_breaker_window_size',
+    'circuit_breaker_bad_outcome_threshold',
+    'cap_flipped_by'
+);
+
+DROP INDEX IF EXISTS dispatcher.idx_dispatcher_terminal_outcomes_ended_at;
+DROP TABLE IF EXISTS dispatcher.terminal_outcomes;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -558,6 +558,35 @@ CREATE SEQUENCE dispatcher.retry_markers_marker_id_seq
 ALTER SEQUENCE dispatcher.retry_markers_marker_id_seq OWNED BY dispatcher.retry_markers.marker_id;
 
 
+CREATE TABLE dispatcher.terminal_outcomes (
+    outcome_id bigint NOT NULL,
+    agent_id uuid,
+    issue_number integer,
+    status text NOT NULL,
+    ended_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+COMMENT ON TABLE dispatcher.terminal_outcomes IS 'Append-only ring buffer of terminal agent outcomes. Scanned by ``_evaluate_circuit_breaker`` over a rolling window to decide whether to auto-pause ``concurrency_cap``. Issue #2860.';
+
+
+COMMENT ON COLUMN dispatcher.terminal_outcomes.agent_id IS 'Nullable — synthetic test inputs may have no agent row. Production writes always carry this.';
+
+
+COMMENT ON COLUMN dispatcher.terminal_outcomes.status IS 'Free-form text (succeeded | failed | crashed | plan_blocked | needs_review | ...). Classifier in daemon decides which count as bad.';
+
+
+CREATE SEQUENCE dispatcher.terminal_outcomes_outcome_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE dispatcher.terminal_outcomes_outcome_id_seq OWNED BY dispatcher.terminal_outcomes.outcome_id;
+
+
 CREATE TABLE dispatcher.runs (
     run_id uuid DEFAULT gen_random_uuid() NOT NULL,
     started_at timestamp with time zone DEFAULT now() NOT NULL,
@@ -758,6 +787,9 @@ ALTER TABLE ONLY dispatcher.phase_transitions ALTER COLUMN transition_id SET DEF
 ALTER TABLE ONLY dispatcher.retry_markers ALTER COLUMN marker_id SET DEFAULT nextval('dispatcher.retry_markers_marker_id_seq'::regclass);
 
 
+ALTER TABLE ONLY dispatcher.terminal_outcomes ALTER COLUMN outcome_id SET DEFAULT nextval('dispatcher.terminal_outcomes_outcome_id_seq'::regclass);
+
+
 ALTER TABLE ONLY telemetry.data_quality_metrics ALTER COLUMN id SET DEFAULT nextval('telemetry.data_quality_metrics_id_seq'::regclass);
 
 
@@ -883,6 +915,10 @@ ALTER TABLE ONLY dispatcher.queue_snapshots
 
 ALTER TABLE ONLY dispatcher.retry_markers
     ADD CONSTRAINT retry_markers_pkey PRIMARY KEY (marker_id);
+
+
+ALTER TABLE ONLY dispatcher.terminal_outcomes
+    ADD CONSTRAINT terminal_outcomes_pkey PRIMARY KEY (outcome_id);
 
 
 ALTER TABLE ONLY dispatcher.runs
@@ -1092,6 +1128,9 @@ CREATE INDEX idx_dispatcher_queue_snapshots_observed_at ON dispatcher.queue_snap
 
 
 CREATE INDEX idx_dispatcher_retry_markers_pending ON dispatcher.retry_markers USING btree (retry_after_ts) WHERE (resolved_at IS NULL);
+
+
+CREATE INDEX idx_dispatcher_terminal_outcomes_ended_at ON dispatcher.terminal_outcomes USING btree (ended_at DESC);
 
 
 CREATE INDEX idx_alert_events_sub_id ON public.alert_events USING btree (subscription_id);

--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -162,6 +162,26 @@ async function querySpawnFrozenUntil(pool: Pool): Promise<string | null> {
   return null;
 }
 
+/**
+ * Read ``dispatcher.config.cap_flipped_by`` — the diagnostic trail for
+ * the last `concurrency_cap` flip. Returns the raw string (e.g.
+ * `"circuit_breaker"`) or null when the row is unset or contains JSON
+ * `null`. Used by the admin cockpit to render the overnight-safety
+ * circuit breaker's open banner (#2860).
+ */
+async function queryCapFlippedBy(pool: Pool): Promise<string | null> {
+  const { rows } = await pool.query<{ value: unknown }>(
+    `SELECT value FROM dispatcher.config WHERE key = 'cap_flipped_by'`,
+  );
+  if (rows.length === 0) return null;
+  const raw = rows[0].value;
+  if (raw === null || raw === undefined) return null;
+  // pg's jsonb parser unwraps scalars: JSON `"circuit_breaker"` → the
+  // JS string `'circuit_breaker'`; JSON `null` → JS `null`.
+  if (typeof raw === 'string') return raw;
+  return null;
+}
+
 async function queryQueueDepth(pool: Pool): Promise<number> {
   // Phase 2: return the most recent row's `queue_depth` from
   // `dispatcher.queue_snapshots` (written by the daemon on each 30s
@@ -606,14 +626,16 @@ export const dispatcherResolvers = {
       { pool, user }: DispatcherContext,
     ) => {
       requireDispatcherAdmin(user);
-      const [currentRunRow, spawnFrozenUntil] = await Promise.all([
+      const [currentRunRow, spawnFrozenUntil, capFlippedBy] = await Promise.all([
         queryCurrentRun(pool),
         querySpawnFrozenUntil(pool),
+        queryCapFlippedBy(pool),
       ]);
       return {
         // Nested fields defer to DispatcherState field resolvers.
         __currentRun: currentRunRow,
         __spawnFrozenUntil: spawnFrozenUntil,
+        __capFlippedBy: capFlippedBy,
       };
     },
 
@@ -755,6 +777,20 @@ export const dispatcherResolvers = {
 
     spawnFrozenUntil: (parent: Record<string, unknown>) => {
       return (parent.__spawnFrozenUntil as string | null) ?? null;
+    },
+
+    capFlippedBy: (parent: Record<string, unknown>) => {
+      return (parent.__capFlippedBy as string | null) ?? null;
+    },
+
+    /**
+     * True when the overnight-safety circuit breaker is open
+     * (#2860). Derived from `cap_flipped_by === 'circuit_breaker'` so
+     * the admin cockpit can show a banner without parsing the raw
+     * config value client-side.
+     */
+    circuitBreakerOpen: (parent: Record<string, unknown>) => {
+      return parent.__capFlippedBy === 'circuit_breaker';
     },
   },
 

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -219,6 +219,17 @@ export const dispatcherTypeDefs = `#graphql
     config: [DispatcherConfigEntry!]!
     """\`dispatcher.config.value\` for \`spawn_frozen_until\` (§10), or null if not set."""
     spawnFrozenUntil: DateTime
+    """True when the overnight-safety circuit breaker is open
+    (\`dispatcher.config.cap_flipped_by\` == \`"circuit_breaker"\`).
+    Surfaces the open state in the admin cockpit so the operator sees
+    "Circuit open: N recent agents bad, cap held at 0" instead of a
+    silent cap=0. Issue #2860."""
+    circuitBreakerOpen: Boolean!
+    """Diagnostic trail for the last \`concurrency_cap\` flip. One of
+    \`"circuit_breaker"\` | \`"operator"\` | another identifier |
+    \`null\` (never set). Read from \`dispatcher.config.cap_flipped_by\`.
+    Issue #2860."""
+    capFlippedBy: String
   }
 
   # ---------------------------------------------------------------------------

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -311,6 +311,25 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
         />
       </div>
 
+      {state?.circuitBreakerOpen && (
+        <div
+          role="alert"
+          data-testid="circuit-breaker-banner"
+          className="mb-4 rounded border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-700 dark:bg-red-900/40 dark:text-red-200"
+        >
+          <div className="font-semibold">
+            Circuit breaker open — dispatcher auto-paused (#2860).
+          </div>
+          <div className="mt-1">
+            A streak of bad terminal outcomes tripped the overnight-safety rail.
+            <code className="mx-1 font-mono">concurrency_cap</code>
+            is held at 0. Review recent completions and failures below, then
+            raise cap back to ≥1 in the config strip once the underlying
+            pattern is triaged.
+          </div>
+        </div>
+      )}
+
       {commandError && (
         <div
           role="alert"

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
@@ -97,6 +97,8 @@ const BASE_STATE = {
     },
   ],
   spawnFrozenUntil: null,
+  circuitBreakerOpen: false,
+  capFlippedBy: null,
 };
 
 import { DispatcherDashboard } from '../DispatcherDashboard';
@@ -298,5 +300,59 @@ describe('DispatcherDashboard — #2823 state-flow two-column layout', () => {
       'recent-completions-heading',
       'queue-blocked-heading',
     ]);
+  });
+});
+
+describe('DispatcherDashboard — #2860 circuit-breaker banner', () => {
+  beforeEach(() => {
+    mockControlMutate.mockClear();
+    mockSetConfigMutate.mockClear();
+    mockRefetch.mockClear();
+  });
+
+  it('renders the banner when circuitBreakerOpen is true', () => {
+    mockQueryData = {
+      dispatcherState: {
+        ...BASE_STATE,
+        circuitBreakerOpen: true,
+        capFlippedBy: 'circuit_breaker',
+      },
+    };
+    renderDashboard();
+    const banner = screen.getByTestId('circuit-breaker-banner');
+    expect(banner).toBeInTheDocument();
+    expect(banner.textContent).toMatch(/Circuit breaker open/i);
+    expect(banner.textContent).toMatch(/concurrency_cap/);
+    // Red by design — overnight-safety rail is a loud signal.
+    expect(banner.className).toMatch(/bg-red/);
+    expect(banner.getAttribute('role')).toBe('alert');
+  });
+
+  it('does not render the banner when circuitBreakerOpen is false', () => {
+    mockQueryData = {
+      dispatcherState: {
+        ...BASE_STATE,
+        circuitBreakerOpen: false,
+        capFlippedBy: null,
+      },
+    };
+    renderDashboard();
+    expect(screen.queryByTestId('circuit-breaker-banner')).not.toBeInTheDocument();
+  });
+
+  it('does not render the banner when operator-paused (capFlippedBy != "circuit_breaker")', () => {
+    // Operator hit Pause — concurrency_cap is 0, but circuitBreakerOpen is
+    // false because the breaker did not trip it. The banner must stay
+    // hidden so the operator does not see a misleading "circuit open"
+    // signal for their own deliberate pause.
+    mockQueryData = {
+      dispatcherState: {
+        ...BASE_STATE,
+        circuitBreakerOpen: false,
+        capFlippedBy: 'operator',
+      },
+    };
+    renderDashboard();
+    expect(screen.queryByTestId('circuit-breaker-banner')).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -78,6 +78,8 @@ export const DISPATCHER_STATE_QUERY = gql`
         updatedBy
       }
       spawnFrozenUntil
+      circuitBreakerOpen
+      capFlippedBy
     }
   }
 `;
@@ -183,6 +185,10 @@ export interface DispatcherState {
   recentCompletions: RecentCompletion[];
   config: DispatcherConfigEntry[];
   spawnFrozenUntil: string | null;
+  /** True when the overnight-safety circuit breaker is open (#2860). */
+  circuitBreakerOpen: boolean;
+  /** Diagnostic trail for the last `concurrency_cap` flip (#2860). */
+  capFlippedBy: string | null;
 }
 
 export interface DispatcherSetConfigData {

--- a/packages/web/tests/dispatcher-dashboard.test.tsx
+++ b/packages/web/tests/dispatcher-dashboard.test.tsx
@@ -91,6 +91,8 @@ function makeEmptyState() {
         },
       ],
       spawnFrozenUntil: null,
+      circuitBreakerOpen: false,
+      capFlippedBy: null,
     },
   };
 }
@@ -146,6 +148,8 @@ function makeActiveState() {
         },
       ],
       spawnFrozenUntil: null,
+      circuitBreakerOpen: false,
+      capFlippedBy: null,
     },
   };
 }

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -664,6 +664,59 @@ CIRCUIT_BREAKER_WINDOW_SECONDS = 24 * 60 * 60
 #: is missing or malformed. Matches the migration-26 seed ``0.30``.
 DEFAULT_CIRCUIT_BREAKER_THRESHOLD = 0.30
 
+# --------------------------------------------------------------------------
+# Overnight-safety circuit breaker (#2860) — separate from the diagnoser
+# circuit breaker above. This one trips on a streak of bad terminal agent
+# outcomes (failed / crashed / plan_blocked / needs_review) and flips
+# ``concurrency_cap`` to 0 so the dispatcher auto-pauses instead of
+# burning $ all night on a cascading failure mode.
+# --------------------------------------------------------------------------
+
+#: Fallback "window minutes" when ``dispatcher.config.circuit_breaker_window_minutes``
+#: is missing or malformed. Matches the migration-29 seed.
+DEFAULT_OVERNIGHT_CB_WINDOW_MINUTES = 30
+
+#: Fallback "window size" (N in M-of-N) when the config row is missing
+#: or malformed. Matches the migration-29 seed.
+DEFAULT_OVERNIGHT_CB_WINDOW_SIZE = 10
+
+#: Fallback "bad outcome threshold" (M in M-of-N). Matches the migration-29
+#: seed. Trip opens when at least this many of the last ``window_size``
+#: terminal outcomes in the rolling ``window_minutes`` are in
+#: :data:`OVERNIGHT_CB_BAD_OUTCOME_STATUSES`.
+DEFAULT_OVERNIGHT_CB_BAD_OUTCOME_THRESHOLD = 5
+
+#: The classifier. Any terminal agent status NOT in this set counts as
+#: "bad" for the circuit-breaker threshold. ``succeeded`` is the only
+#: status treated as "good". This matches the spec's tolerant-classifier
+#: contract (#2860): if a future correct-outcome terminal ships before
+#: we update this set, it is conservatively counted as bad (better to
+#: open the breaker on an unknown new state than to let a cascading
+#: failure mode go undetected because the classifier didn't know about
+#: its status string).
+OVERNIGHT_CB_GOOD_OUTCOME_STATUSES: frozenset[str] = frozenset({"succeeded"})
+
+#: Sentinel value for ``dispatcher.config.cap_flipped_by`` when the
+#: overnight-safety circuit breaker opens. The scheduler tick's
+#: auto-close path looks for this exact value to decide whether a cap
+#: change back to ≥1 was operator-initiated (the flag gets cleared) vs
+#: the breaker's own flip (no-op — the breaker has already flipped cap).
+CAP_FLIPPED_BY_CIRCUIT_BREAKER = "circuit_breaker"
+
+#: Path to the Telegram notification helper. Invoked as a subprocess
+#: with ``--message-file <tmp>``. The helper exits 0 when Telegram is
+#: unconfigured (no-op), 2 when all sends fail — see
+#: ``scripts/notify-telegram.sh``. The daemon treats any non-zero exit
+#: as a warning, not a failure: the circuit-breaker flip has already
+#: happened regardless of whether the alert reaches the operator.
+NOTIFY_TELEGRAM_SCRIPT_RELPATH = "scripts/notify-telegram.sh"
+
+#: Hard timeout on the ``notify-telegram.sh`` subprocess. Short enough
+#: that a Telegram outage can't stall a terminal transition; long
+#: enough that AWS Secrets Manager + curl to the Bot API always fits
+#: on a healthy network.
+NOTIFY_TELEGRAM_SUBPROCESS_TIMEOUT_SECONDS = 30
+
 
 # --------------------------------------------------------------------------
 # Logging — structured JSON per line to stdout.
@@ -1330,6 +1383,26 @@ class DispatcherDaemon:
                     },
                 )
             self._pause_requested.clear()
+
+        # Overnight-safety circuit breaker auto-close (#2860). When the
+        # breaker previously opened it set ``cap_flipped_by='circuit_breaker'``
+        # and flipped ``concurrency_cap`` to 0. If the operator has
+        # since flipped cap back up to ≥1, log the close event and
+        # clear the flag. Runs only on cap>0 ticks so the common
+        # cap=0 path (Phase 2 steady state, most tests) adds zero
+        # cursor reads. Wrapped in try/except so a failure here cannot
+        # stall the scheduler tick.
+        if concurrency_cap is not None and concurrency_cap >= 1:
+            try:
+                self._check_circuit_breaker_auto_close(concurrency_cap)
+            except Exception:
+                self._log.exception(
+                    "daemon.circuit_breaker_auto_close_error",
+                    extra={
+                        "event": "circuit_breaker_auto_close_error",
+                        "run_id": self._run_id,
+                    },
+                )
 
         # Phase 2 spawn-safety guard: the spawn path does not exist yet,
         # but a future Phase 3 wiring mistake could activate it. Warn if
@@ -3440,6 +3513,35 @@ class DispatcherDaemon:
                         "run_id": self._run_id,
                         "agent_id": agent_id,
                         "status": status,
+                    },
+                )
+
+            # Overnight-safety circuit breaker (#2860): append the outcome
+            # to ``dispatcher.terminal_outcomes`` and evaluate the
+            # M-of-N rolling-window threshold. A breaker failure here
+            # cannot roll back the terminal-status update above — both
+            # side effects are independently wrapped.
+            try:
+                self._write_terminal_outcome(agent_id, status)
+            except Exception:
+                self._log.exception(
+                    "daemon.terminal_outcome_write_failed",
+                    extra={
+                        "event": "terminal_outcome_write_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "status": status,
+                    },
+                )
+            try:
+                self._evaluate_circuit_breaker(agent_id)
+            except Exception:
+                self._log.exception(
+                    "daemon.circuit_breaker_evaluate_failed",
+                    extra={
+                        "event": "circuit_breaker_evaluate_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
                     },
                 )
 
@@ -8522,6 +8624,531 @@ class DispatcherDaemon:
                 "total_diagnoses_24h": total_n,
                 "failed_diagnoses_24h": failed_n,
                 "min_diagnoses": CIRCUIT_BREAKER_MIN_DIAGNOSES,
+            },
+        )
+        return True
+
+    # ── Overnight-safety circuit breaker (#2860) ───────────────────────
+
+    def _cb_config_int(self, key: str, default: int) -> int:
+        """Read a numeric key from ``dispatcher.config`` with a fallback.
+
+        Shared helper for the three overnight-safety knobs
+        (``circuit_breaker_window_minutes``, ``_window_size``,
+        ``_bad_outcome_threshold``). Returns ``default`` on missing row,
+        malformed JSON, non-integer value, or DB error — the breaker
+        must never crash a terminal transition.
+        """
+        assert self._conn is not None, "connect() must run before config read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    (key,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return default
+        if row is None or row[0] is None:
+            return default
+        raw = row[0]
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return default
+        try:
+            n = int(raw)
+        except (TypeError, ValueError):
+            return default
+        if n < 0:
+            return default
+        return n
+
+    def _cb_enabled(self) -> bool:
+        """Read ``dispatcher.config.circuit_breaker_enabled`` as a bool.
+
+        Defaults to ``True`` when the config row is missing or malformed —
+        the overnight-safety rail is the safe default. Operators who want
+        to disable it must explicitly set ``false``.
+        """
+        assert self._conn is not None, "connect() must run before config read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    ("circuit_breaker_enabled",),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return True
+        if row is None or row[0] is None:
+            return True
+        raw = row[0]
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return True
+        if isinstance(raw, bool):
+            return raw
+        return True
+
+    def _read_cap_flipped_by(self) -> str | None:
+        """Read ``dispatcher.config.cap_flipped_by``. ``None`` if unset or error.
+
+        Used by the scheduler tick to detect when the operator has
+        manually flipped ``concurrency_cap`` back up after the breaker
+        opened (diagnostic trail cleared; breaker auto-closes).
+        """
+        assert self._conn is not None, "connect() must run before config read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    ("cap_flipped_by",),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return None
+        if row is None or row[0] is None:
+            return None
+        raw = row[0]
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return None
+        if isinstance(raw, str):
+            return raw
+        return None
+
+    def _write_terminal_outcome(self, agent_id: str, status: str) -> None:
+        """Append a row to ``dispatcher.terminal_outcomes``.
+
+        Called by :meth:`_mark_agent_terminal` for every terminal
+        status. ``issue_number`` is looked up from ``dispatcher.agents``
+        so the outcome row is self-contained (no JOIN needed at scan
+        time). Append-only: the ring-buffer semantics come from the
+        rolling-window scan in :meth:`_evaluate_circuit_breaker`, not
+        from deleting rows on write.
+        """
+        assert self._conn is not None, "connect() must run before outcome write"
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "SELECT issue_number FROM dispatcher.agents WHERE agent_id = %s",
+                (agent_id,),
+            )
+            row = cur.fetchone()
+            issue_number = (
+                int(row[0]) if row is not None and row[0] is not None else None
+            )
+            cur.execute(
+                "INSERT INTO dispatcher.terminal_outcomes "
+                "    (agent_id, issue_number, status, ended_at) "
+                "VALUES (%s, %s, %s, now())",
+                (agent_id, issue_number, status),
+            )
+        self._conn.commit()
+
+    def _is_bad_outcome(self, status: str) -> bool:
+        """Classify a terminal status for the overnight-safety breaker.
+
+        Tolerant classifier — any status not explicitly known to be
+        "good" (i.e. ``succeeded``) counts as bad. This matches the
+        issue #2860 scope note: if #2856 ships ``needs_review`` after
+        this PR merges (or a later PR adds another correct-outcome
+        terminal), that status is conservatively counted as bad until
+        :data:`OVERNIGHT_CB_GOOD_OUTCOME_STATUSES` is updated to
+        include it. Erring on the side of opening the breaker is the
+        safer bias for overnight operation.
+        """
+        return status not in OVERNIGHT_CB_GOOD_OUTCOME_STATUSES
+
+    def _evaluate_circuit_breaker(self, agent_id: str) -> bool:
+        """Trip the overnight-safety circuit breaker if the streak is bad.
+
+        Runs post-terminal-transition (called from
+        :meth:`_mark_agent_terminal`). Scans
+        ``dispatcher.terminal_outcomes`` for the last ``window_size``
+        rows whose ``ended_at`` falls inside the last ``window_minutes``,
+        counts how many are in :data:`OVERNIGHT_CB_GOOD_OUTCOME_STATUSES`-
+        complement via :meth:`_is_bad_outcome`, and flips
+        ``concurrency_cap`` to 0 when the bad count reaches the
+        threshold.
+
+        Idempotent: if ``concurrency_cap`` is already 0 the breaker
+        does nothing (no log spam, no duplicate Telegram alert). The
+        ``cap_flipped_by`` trail is always rewritten to
+        :data:`CAP_FLIPPED_BY_CIRCUIT_BREAKER` when the breaker triggers
+        so the admin cockpit shows the open banner even if the cap
+        happened to already be 0 (e.g. operator paused, then cascade
+        hit threshold).
+
+        Returns True when the breaker opened (or re-asserted an already-
+        open state) this call; False when the threshold was not met or
+        the breaker is disabled via config.
+        """
+        assert self._conn is not None, "connect() must run before breaker eval"
+
+        if not self._cb_enabled():
+            return False
+
+        window_minutes = self._cb_config_int(
+            "circuit_breaker_window_minutes", DEFAULT_OVERNIGHT_CB_WINDOW_MINUTES
+        )
+        window_size = self._cb_config_int(
+            "circuit_breaker_window_size", DEFAULT_OVERNIGHT_CB_WINDOW_SIZE
+        )
+        threshold = self._cb_config_int(
+            "circuit_breaker_bad_outcome_threshold",
+            DEFAULT_OVERNIGHT_CB_BAD_OUTCOME_THRESHOLD,
+        )
+
+        # Defensive: the seed rows should never produce these, but if
+        # an operator sets ``window_size=0`` or
+        # ``threshold=0`` via the config panel, treat the breaker as
+        # disabled rather than tripping on the empty-window edge case.
+        if window_size <= 0 or threshold <= 0:
+            return False
+
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT status FROM dispatcher.terminal_outcomes "
+                    "WHERE ended_at > now() - make_interval(mins => %s) "
+                    "ORDER BY ended_at DESC "
+                    "LIMIT %s",
+                    (window_minutes, window_size),
+                )
+                rows = cur.fetchall()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.circuit_breaker_scan_failed",
+                extra={
+                    "event": "circuit_breaker_scan_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return False
+
+        statuses = [str(r[0]) for r in rows if r and r[0] is not None]
+        bad_count = sum(1 for s in statuses if self._is_bad_outcome(s))
+        if bad_count < threshold:
+            return False
+
+        # Threshold met. Flip ``concurrency_cap`` to 0 and stamp
+        # ``cap_flipped_by``. Use a single UPDATE per config row so a
+        # partial failure (e.g. the ``cap_flipped_by`` write 500s) does
+        # not roll back the cap flip — the cap flip is the safety
+        # action, the flag is the diagnostic trail.
+        current_cap = self._cb_config_int("concurrency_cap", -1)
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.config "
+                    "SET value = '0', "
+                    "    updated_at = now(), "
+                    "    updated_by = %s "
+                    "WHERE key = 'concurrency_cap'",
+                    (CAP_FLIPPED_BY_CIRCUIT_BREAKER,),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.circuit_breaker_flip_failed",
+                extra={
+                    "event": "circuit_breaker_flip_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "bad_count": bad_count,
+                    "window_size": window_size,
+                    "threshold": threshold,
+                    "window_minutes": window_minutes,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return False
+
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.config "
+                    "SET value = %s, "
+                    "    updated_at = now(), "
+                    "    updated_by = %s "
+                    "WHERE key = 'cap_flipped_by'",
+                    (
+                        json.dumps(CAP_FLIPPED_BY_CIRCUIT_BREAKER),
+                        CAP_FLIPPED_BY_CIRCUIT_BREAKER,
+                    ),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.circuit_breaker_flag_failed",
+                extra={
+                    "event": "circuit_breaker_flag_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            # Continue — the cap flip above is the safety action; the
+            # flag is diagnostic. Still log the open event.
+
+        # Idempotence signal: if cap was already 0 we are re-asserting
+        # the same state, not opening fresh. The log level + Telegram
+        # alert branch downstream uses this to avoid notification spam.
+        was_already_open = current_cap == 0
+
+        self._log.warning(
+            "daemon.circuit_breaker_opened",
+            extra={
+                "event": "circuit_breaker_opened",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "bad_count": bad_count,
+                "window_size": window_size,
+                "threshold": threshold,
+                "window_minutes": window_minutes,
+                "previous_cap": current_cap,
+                "was_already_open": was_already_open,
+                "recent_statuses": statuses,
+            },
+        )
+
+        if not was_already_open:
+            # Only alert operator on fresh opens — re-asserting an
+            # already-open state is a no-op from the operator's
+            # perspective.
+            try:
+                self._send_circuit_breaker_telegram_alert(
+                    bad_count=bad_count,
+                    window_size=window_size,
+                    window_minutes=window_minutes,
+                    statuses=statuses,
+                )
+            except Exception:
+                self._log.exception(
+                    "daemon.circuit_breaker_telegram_failed",
+                    extra={
+                        "event": "circuit_breaker_telegram_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                    },
+                )
+        return True
+
+    def _send_circuit_breaker_telegram_alert(
+        self,
+        *,
+        bad_count: int,
+        window_size: int,
+        window_minutes: int,
+        statuses: list[str],
+    ) -> None:
+        """Fire a Telegram alert via ``scripts/notify-telegram.sh``.
+
+        Best-effort — the helper script exits 0 when Telegram is
+        unconfigured (secret missing, no allowed user IDs) so the
+        daemon never depends on Telegram being wired up in a given
+        environment. A non-zero exit is logged as a warning and the
+        breaker is still considered "opened" (the cap flip is the
+        safety action; the alert is operator-UX).
+        """
+        repo_root = self._repo_root_for_notify_script()
+        notify_script = repo_root / NOTIFY_TELEGRAM_SCRIPT_RELPATH
+        if not notify_script.exists():
+            self._log.info(
+                "daemon.circuit_breaker_telegram_skipped_no_script",
+                extra={
+                    "event": "circuit_breaker_telegram_skipped_no_script",
+                    "run_id": self._run_id,
+                    "script_path": str(notify_script),
+                },
+            )
+            return
+
+        # Write the message to a temp file and pass via --message-file
+        # so the daemon does not inline secret-ish content (bad status
+        # strings) into argv where it could leak to ps listings.
+        message = self._render_circuit_breaker_telegram_message(
+            bad_count=bad_count,
+            window_size=window_size,
+            window_minutes=window_minutes,
+            statuses=statuses,
+        )
+        tmp_dir = repo_root / "tmp"
+        tmp_dir.mkdir(parents=True, exist_ok=True)
+        msg_path = tmp_dir / f"circuit-breaker-alert-{self._run_id or 'unknown'}.txt"
+        msg_path.write_text(message, encoding="utf-8")
+
+        try:
+            result = subprocess.run(
+                [str(notify_script), "--message-file", str(msg_path)],
+                capture_output=True,
+                text=True,
+                timeout=NOTIFY_TELEGRAM_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            self._log.warning(
+                "daemon.circuit_breaker_telegram_timeout",
+                extra={
+                    "event": "circuit_breaker_telegram_timeout",
+                    "run_id": self._run_id,
+                    "timeout_s": NOTIFY_TELEGRAM_SUBPROCESS_TIMEOUT_SECONDS,
+                },
+            )
+            return
+
+        if result.returncode == 0:
+            self._log.info(
+                "daemon.circuit_breaker_telegram_sent",
+                extra={
+                    "event": "circuit_breaker_telegram_sent",
+                    "run_id": self._run_id,
+                },
+            )
+        else:
+            self._log.warning(
+                "daemon.circuit_breaker_telegram_nonzero_exit",
+                extra={
+                    "event": "circuit_breaker_telegram_nonzero_exit",
+                    "run_id": self._run_id,
+                    "exit_code": result.returncode,
+                    "stderr_tail": (result.stderr or "")[-500:],
+                },
+            )
+
+    def _render_circuit_breaker_telegram_message(
+        self,
+        *,
+        bad_count: int,
+        window_size: int,
+        window_minutes: int,
+        statuses: list[str],
+    ) -> str:
+        """Render the Telegram alert body.
+
+        Plain text (``notify-telegram.sh`` uses ``parse_mode=HTML`` but
+        HTML entities would leak through as literal characters on a
+        misconfigured client — plain text is safer). The recent-status
+        list is comma-joined newest first so the operator can see the
+        cascade pattern at a glance.
+        """
+        recent = ", ".join(statuses[: min(window_size, 10)]) if statuses else "(none)"
+        return (
+            "Dispatcher circuit breaker OPENED\n"
+            f"{bad_count}/{window_size} of the last terminal outcomes in the "
+            f"last {window_minutes} min were bad.\n"
+            f"concurrency_cap has been set to 0 — the daemon will not spawn "
+            f"new agents.\n"
+            f"Recent statuses (newest first): {recent}\n"
+            "Manually flip cap back to ≥1 in the admin cockpit once you've "
+            "triaged the underlying failure pattern."
+        )
+
+    def _repo_root_for_notify_script(self) -> Path:
+        """Resolve the repo root for ``scripts/notify-telegram.sh``.
+
+        In production the daemon runs inside the Fargate container with
+        the repo at ``/var/lib/dispatcher/repo`` (see
+        :data:`DEFAULT_BASELINE_REPO_ROOT`). Tests inject a different
+        root by setting ``self._cfg.baseline_repo_root``. Fall back to
+        the daemon module's parent (``scripts/dispatcher/`` → two
+        levels up to the repo root) when neither is set.
+        """
+        baseline = getattr(self._cfg, "baseline_repo_root", None)
+        if baseline:
+            return Path(baseline)
+        return Path(__file__).resolve().parents[2]
+
+    def _check_circuit_breaker_auto_close(self, current_cap: int) -> bool:
+        """Auto-close the breaker if the operator manually raised the cap.
+
+        Called by scheduler_tick once the live ``concurrency_cap`` has
+        been read (passed as ``current_cap``). When:
+
+          - ``current_cap >= 1``, AND
+          - ``cap_flipped_by == 'circuit_breaker'``,
+
+        the operator has explicitly re-enabled the dispatcher after
+        the breaker opened — log ``daemon.circuit_breaker_closed`` and
+        clear ``cap_flipped_by`` back to null so subsequent cap flips
+        by the operator don't get mis-attributed to the breaker.
+
+        Returns True when the breaker was auto-closed this tick; False
+        otherwise. The common case (``cap_flipped_by`` null or not the
+        breaker) is a single SELECT + early return.
+        """
+        assert self._conn is not None, "connect() must run before auto-close"
+        if current_cap < 1:
+            return False
+
+        flipped_by = self._read_cap_flipped_by()
+        if flipped_by != CAP_FLIPPED_BY_CIRCUIT_BREAKER:
+            return False
+
+        # Operator manually raised cap — clear the flag.
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.config "
+                    "SET value = 'null', "
+                    "    updated_at = now(), "
+                    "    updated_by = 'circuit_breaker_auto_close' "
+                    "WHERE key = 'cap_flipped_by'",
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.circuit_breaker_auto_close_failed",
+                extra={
+                    "event": "circuit_breaker_auto_close_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return False
+
+        self._log.info(
+            "daemon.circuit_breaker_closed",
+            extra={
+                "event": "circuit_breaker_closed",
+                "run_id": self._run_id,
+                "new_cap": current_cap,
             },
         )
         return True

--- a/scripts/dispatcher/tests/test_daemon_circuit_breaker.py
+++ b/scripts/dispatcher/tests/test_daemon_circuit_breaker.py
@@ -1,0 +1,818 @@
+"""Unit tests for the overnight-safety circuit breaker in ``scripts.dispatcher.daemon``.
+
+Issue #2860. Covers:
+
+* Terminal outcomes are appended to ``dispatcher.terminal_outcomes`` by
+  ``_mark_agent_terminal`` via ``_write_terminal_outcome``.
+* ``_evaluate_circuit_breaker`` counts "bad" outcomes (anything not in
+  :data:`daemon.OVERNIGHT_CB_GOOD_OUTCOME_STATUSES`) in the rolling
+  window and flips ``concurrency_cap`` to 0 when the M-of-N threshold
+  is met.
+* On open: ``cap_flipped_by`` is set to ``"circuit_breaker"``, the
+  ``daemon.circuit_breaker_opened`` event is logged, and
+  ``scripts/notify-telegram.sh`` is invoked.
+* Idempotence: re-running the check against an already-open breaker
+  does not fire a second Telegram alert or bump the open counter.
+* Auto-close: when the operator manually flips cap back to ≥1, the
+  scheduler tick's auto-close path logs
+  ``daemon.circuit_breaker_closed`` and clears ``cap_flipped_by``.
+* Classifier: the good-outcome set currently contains only
+  ``succeeded`` — ``failed``/``crashed``/``plan_blocked``/
+  ``needs_review`` all count as bad.
+
+All external calls — subprocess (``notify-telegram.sh``) and psycopg
+— are mocked. The tests exercise the classifier + SQL scan logic
+directly so they run in milliseconds regardless of DB / Telegram
+availability.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Provide a real-Exception psycopg stub for the daemon's lazy import.
+# Other test files install a pure MagicMock stub whose
+# ``errors.UniqueViolation`` is itself a Mock — that trips Python's
+# "catching classes that do not inherit from BaseException" rule.
+
+
+class _UniqueViolation(Exception):
+    """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+
+_psycopg_stub = MagicMock()
+_psycopg_errors = MagicMock()
+_psycopg_errors.UniqueViolation = _UniqueViolation
+_psycopg_stub.errors = _psycopg_errors
+sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — mirror the pattern used in sibling test files so the
+# fixtures compose the same way under pytest collection.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    """Make a daemon with a fake connection. Matches the phase3a factory."""
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.circuit_breaker.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+        baseline_repo_root=str(tmp_path),
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# Classifier — the good-outcome set is the single source of truth.
+# --------------------------------------------------------------------------
+
+
+class TestIsBadOutcome:
+    """``_is_bad_outcome`` treats anything not in the good set as bad.
+
+    This matches the tolerant-classifier contract from issue #2860:
+    future correct-outcome terminals (``needs_review`` from #2856, or
+    later) are conservatively counted as bad until the good-outcome
+    set is updated — erring toward opening the breaker is safer for
+    overnight operation.
+    """
+
+    def test_succeeded_is_good(self, tmp_path: Path) -> None:
+        d, _c, _h = _make_daemon(tmp_path)
+        assert d._is_bad_outcome("succeeded") is False
+
+    def test_failed_is_bad(self, tmp_path: Path) -> None:
+        d, _c, _h = _make_daemon(tmp_path)
+        assert d._is_bad_outcome("failed") is True
+
+    def test_crashed_is_bad(self, tmp_path: Path) -> None:
+        d, _c, _h = _make_daemon(tmp_path)
+        assert d._is_bad_outcome("crashed") is True
+
+    def test_plan_blocked_is_bad(self, tmp_path: Path) -> None:
+        """#2857's ``plan_blocked`` terminal counts as bad for the breaker."""
+        d, _c, _h = _make_daemon(tmp_path)
+        assert d._is_bad_outcome("plan_blocked") is True
+
+    def test_needs_review_is_bad(self, tmp_path: Path) -> None:
+        """#2856's ``needs_review`` terminal counts as bad for the breaker.
+
+        Even if #2856 ships first and we update the good-outcome set
+        later, today's tolerant classifier correctly treats it as bad.
+        """
+        d, _c, _h = _make_daemon(tmp_path)
+        assert d._is_bad_outcome("needs_review") is True
+
+    def test_future_unknown_terminal_is_bad(self, tmp_path: Path) -> None:
+        """A hypothetical new terminal state defaults to "bad"."""
+        d, _c, _h = _make_daemon(tmp_path)
+        assert d._is_bad_outcome("ci_unrecoverable") is True
+        assert d._is_bad_outcome("some_new_state") is True
+
+
+# --------------------------------------------------------------------------
+# Terminal-outcome write — appended on every terminal transition.
+# --------------------------------------------------------------------------
+
+
+class TestWriteTerminalOutcome:
+    """``_write_terminal_outcome`` appends to ``dispatcher.terminal_outcomes``."""
+
+    def test_writes_row_with_issue_number_lookup(self, tmp_path: Path) -> None:
+        """Row carries the issue_number looked up from ``dispatcher.agents``."""
+        d, conn, _h = _make_daemon(tmp_path)
+        # First fetchone returns the agent's issue_number.
+        conn.cursor_instance.fetch_queue = [(42,)]
+
+        d._write_terminal_outcome("agent-42-uuid", "failed")
+
+        # Last executed statement is the INSERT.
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.terminal_outcomes" in e[0]
+        ]
+        assert len(inserts) == 1
+        params = inserts[0][1]
+        assert params == ("agent-42-uuid", 42, "failed")
+        assert conn.commits >= 1
+
+    def test_writes_row_with_null_issue_number_when_agent_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """Fallback: agent row absent → issue_number is NULL. Still inserts."""
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]  # agent row absent
+
+        d._write_terminal_outcome("orphan-agent", "succeeded")
+
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.terminal_outcomes" in e[0]
+        ]
+        assert len(inserts) == 1
+        params = inserts[0][1]
+        assert params == ("orphan-agent", None, "succeeded")
+
+
+# --------------------------------------------------------------------------
+# Config readers — overnight-CB knobs with safe defaults.
+# --------------------------------------------------------------------------
+
+
+class TestCBConfigReaders:
+    """The ``_cb_config_int``/``_cb_enabled`` helpers fall back to safe defaults."""
+
+    def test_enabled_defaults_to_true_when_row_missing(self, tmp_path: Path) -> None:
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        assert d._cb_enabled() is True
+
+    def test_enabled_reads_bool_from_config(self, tmp_path: Path) -> None:
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(False,)]
+        assert d._cb_enabled() is False
+
+    def test_enabled_parses_json_string(self, tmp_path: Path) -> None:
+        """Stored as JSONB → driver may hand us the string ``"false"``."""
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("false",)]
+        assert d._cb_enabled() is False
+
+    def test_enabled_defaults_to_true_on_malformed_json(self, tmp_path: Path) -> None:
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("not-json{",)]
+        assert d._cb_enabled() is True
+
+    def test_config_int_defaults_when_missing(self, tmp_path: Path) -> None:
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        assert d._cb_config_int("circuit_breaker_window_minutes", 30) == 30
+
+    def test_config_int_reads_raw_int(self, tmp_path: Path) -> None:
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(10,)]
+        assert d._cb_config_int("circuit_breaker_window_size", 10) == 10
+
+    def test_config_int_parses_json_string(self, tmp_path: Path) -> None:
+        """An integer stored as a JSON string ``"5"`` still parses."""
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("5",)]
+        assert d._cb_config_int("circuit_breaker_bad_outcome_threshold", 999) == 5
+
+    def test_config_int_negative_falls_back_to_default(self, tmp_path: Path) -> None:
+        """Negative values are nonsense for count/window knobs."""
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(-7,)]
+        assert d._cb_config_int("circuit_breaker_window_minutes", 30) == 30
+
+
+# --------------------------------------------------------------------------
+# Evaluation — the M-of-N threshold check.
+# --------------------------------------------------------------------------
+
+
+class TestEvaluateCircuitBreaker:
+    """``_evaluate_circuit_breaker`` trips on 5-of-10 bad in 30 min."""
+
+    def _stub_config_reads(
+        self,
+        conn: _FakeConnection,
+        *,
+        enabled: Any = True,
+        window_minutes: Any = 30,
+        window_size: Any = 10,
+        threshold: Any = 5,
+    ) -> None:
+        """Queue up the four config SELECTs in order."""
+        conn.cursor_instance.fetch_queue.extend(
+            [
+                (enabled,),
+                (window_minutes,),
+                (window_size,),
+                (threshold,),
+            ]
+        )
+
+    def test_trips_when_five_of_ten_are_bad(self, tmp_path: Path) -> None:
+        """AC: 5 failures in 25 min → circuit opens, cap set to 0."""
+        d, conn, handler = _make_daemon(tmp_path)
+        self._stub_config_reads(conn)
+        # Scan returns 5 failures + 5 successes. Rows are (status,).
+        conn.cursor_instance.fetch_queue.append(None)  # will be rewritten below
+
+        # Override the scan fetchall AFTER stubbing config so the ORDER
+        # matches daemon.py: 4 fetchones (config), then 1 fetchall (scan),
+        # then 1 fetchone (concurrency_cap read pre-flip).
+        conn.cursor_instance.fetch_queue.pop()  # drop placeholder
+        # Fifth item in the queue (after 4 config reads) is used by the
+        # fetchall — but _FakeCursor uses fetchall_queue separately.
+        conn.cursor_instance.fetchall_queue.append(
+            [
+                ("failed",),
+                ("failed",),
+                ("failed",),
+                ("plan_blocked",),
+                ("needs_review",),
+                ("succeeded",),
+                ("succeeded",),
+                ("succeeded",),
+                ("succeeded",),
+                ("succeeded",),
+            ]
+        )
+        # ``current_cap = self._cb_config_int("concurrency_cap", -1)``
+        # runs inside the fifth config read. Add its row.
+        conn.cursor_instance.fetch_queue.append((1,))  # cap was 1 before flip
+
+        tripped = d._evaluate_circuit_breaker("agent-x")
+
+        assert tripped is True
+        # cap flip UPDATE fired.
+        cap_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0]
+            and "concurrency_cap" in e[0]
+            and e[1] == ("circuit_breaker",)
+        ]
+        assert len(cap_updates) == 1
+        # cap_flipped_by UPDATE fired with JSON-encoded sentinel.
+        flag_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0]
+            and "cap_flipped_by" in e[0]
+            and e[1] == ('"circuit_breaker"', "circuit_breaker")
+        ]
+        assert len(flag_updates) == 1
+        # Structured log event.
+        opened = handler.events("circuit_breaker_opened")
+        assert len(opened) == 1
+        assert opened[0].bad_count == 5  # type: ignore[attr-defined]
+        assert opened[0].window_size == 10  # type: ignore[attr-defined]
+        assert opened[0].threshold == 5  # type: ignore[attr-defined]
+
+    def test_does_not_trip_when_four_of_ten_are_bad(self, tmp_path: Path) -> None:
+        """AC: 4 fails, 6 successes → circuit stays closed."""
+        d, conn, handler = _make_daemon(tmp_path)
+        self._stub_config_reads(conn)
+        conn.cursor_instance.fetchall_queue.append(
+            [
+                ("failed",),
+                ("failed",),
+                ("failed",),
+                ("failed",),
+                ("succeeded",),
+                ("succeeded",),
+                ("succeeded",),
+                ("succeeded",),
+                ("succeeded",),
+                ("succeeded",),
+            ]
+        )
+
+        tripped = d._evaluate_circuit_breaker("agent-x")
+
+        assert tripped is False
+        # No cap flip.
+        cap_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0] and "concurrency_cap" in e[0]
+        ]
+        assert cap_updates == []
+        assert handler.events("circuit_breaker_opened") == []
+
+    def test_happy_path_all_success_never_trips(self, tmp_path: Path) -> None:
+        """Regression: all 10 recent successes → circuit stays closed."""
+        d, conn, handler = _make_daemon(tmp_path)
+        self._stub_config_reads(conn)
+        conn.cursor_instance.fetchall_queue.append([("succeeded",)] * 10)
+
+        tripped = d._evaluate_circuit_breaker("agent-x")
+
+        assert tripped is False
+        assert handler.events("circuit_breaker_opened") == []
+
+    def test_disabled_breaker_never_trips(self, tmp_path: Path) -> None:
+        """``circuit_breaker_enabled=false`` → short-circuit, no scan."""
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(False,)]  # enabled=false
+
+        tripped = d._evaluate_circuit_breaker("agent-x")
+
+        assert tripped is False
+        # No SELECT against terminal_outcomes happened.
+        scans = [
+            e
+            for e in conn.cursor_instance.executed
+            if "dispatcher.terminal_outcomes" in e[0]
+        ]
+        assert scans == []
+        assert handler.events("circuit_breaker_opened") == []
+
+    def test_zero_threshold_treated_as_disabled(self, tmp_path: Path) -> None:
+        """Defensive: operator setting threshold=0 doesn't trip on empty window."""
+        d, conn, handler = _make_daemon(tmp_path)
+        self._stub_config_reads(conn, threshold=0)
+        # No scan should happen — the early-return catches threshold<=0.
+
+        tripped = d._evaluate_circuit_breaker("agent-x")
+
+        assert tripped is False
+        assert handler.events("circuit_breaker_opened") == []
+
+
+# --------------------------------------------------------------------------
+# Idempotence — re-evaluation while already open does not fire a second
+# Telegram alert. The open log is still written (so operators see the
+# re-trip in CloudWatch) but ``was_already_open=True`` suppresses the
+# alert side effect.
+# --------------------------------------------------------------------------
+
+
+class TestIdempotence:
+    def test_already_open_does_not_fire_second_telegram_alert(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Second trip with cap already 0 → no duplicate Telegram send."""
+        d, conn, handler = _make_daemon(tmp_path)
+        # enabled, window_minutes, window_size, threshold, concurrency_cap,
+        # (then fetchall for scan).
+        conn.cursor_instance.fetch_queue = [
+            (True,),
+            (30,),
+            (10,),
+            (5,),
+            (0,),  # current_cap already 0 → was_already_open=True
+        ]
+        conn.cursor_instance.fetchall_queue.append(
+            [("failed",)] * 5 + [("succeeded",)] * 5
+        )
+
+        telegram_calls: list[Any] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            telegram_calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        tripped = d._evaluate_circuit_breaker("agent-x")
+
+        assert tripped is True
+        # Open log still written (forensics want to see the re-trip).
+        opened = handler.events("circuit_breaker_opened")
+        assert len(opened) == 1
+        assert opened[0].was_already_open is True  # type: ignore[attr-defined]
+        # But NO Telegram alert — idempotence suppressed it.
+        assert telegram_calls == []
+
+
+# --------------------------------------------------------------------------
+# Auto-close — operator re-flip clears the flag.
+# --------------------------------------------------------------------------
+
+
+class TestAutoClose:
+    """``_check_circuit_breaker_auto_close`` clears the flag on operator re-flip."""
+
+    def test_does_nothing_when_flag_is_null(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]  # cap_flipped_by = null
+
+        closed = d._check_circuit_breaker_auto_close(current_cap=1)
+
+        assert closed is False
+        assert handler.events("circuit_breaker_closed") == []
+        # No UPDATE.
+        updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0]
+        ]
+        assert updates == []
+
+    def test_does_nothing_when_flag_is_operator_string(self, tmp_path: Path) -> None:
+        """Flag was set by something other than the breaker — don't touch it."""
+        d, conn, _h = _make_daemon(tmp_path)
+        # JSONB-encoded string value as returned from Postgres.
+        conn.cursor_instance.fetch_queue = [('"operator"',)]
+
+        closed = d._check_circuit_breaker_auto_close(current_cap=1)
+
+        assert closed is False
+
+    def test_does_nothing_when_cap_still_zero(self, tmp_path: Path) -> None:
+        """Breaker still open (cap=0) — no auto-close."""
+        d, conn, handler = _make_daemon(tmp_path)
+        # The helper short-circuits before reading cap_flipped_by if
+        # current_cap < 1. No fetchones needed.
+
+        closed = d._check_circuit_breaker_auto_close(current_cap=0)
+
+        assert closed is False
+        assert handler.events("circuit_breaker_closed") == []
+
+    def test_closes_when_flag_is_circuit_breaker_and_cap_raised(
+        self, tmp_path: Path
+    ) -> None:
+        """Operator re-flip: flag=circuit_breaker + cap=1 → log + clear flag."""
+        d, conn, handler = _make_daemon(tmp_path)
+        # JSONB-encoded string value as returned from Postgres.
+        conn.cursor_instance.fetch_queue = [('"circuit_breaker"',)]
+
+        closed = d._check_circuit_breaker_auto_close(current_cap=1)
+
+        assert closed is True
+        # One UPDATE that sets value='null'.
+        flag_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0] and "cap_flipped_by" in e[0]
+        ]
+        assert len(flag_updates) == 1
+        closed_events = handler.events("circuit_breaker_closed")
+        assert len(closed_events) == 1
+        assert closed_events[0].new_cap == 1  # type: ignore[attr-defined]
+
+
+# --------------------------------------------------------------------------
+# End-to-end: the synthetic acceptance-criteria scenarios from #2860.
+# Exercises the full ``_evaluate_circuit_breaker`` flow including the
+# Telegram subprocess call via mocked ``subprocess.run``.
+# --------------------------------------------------------------------------
+
+
+class TestAcceptanceCriteria:
+    """Map the issue's acceptance criteria to synthetic-data assertions."""
+
+    def test_ac_five_failures_in_twenty_five_minutes_opens_circuit(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """AC: feed 5-of-10 bad → circuit opens, cap=0, Telegram fires.
+
+        Single agent runs the helper; the scan fetchall returns the
+        synthetic 10-row window. The cap-flip UPDATE is asserted
+        directly against ``conn.executed`` so the test does not depend
+        on the real DB.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        # Four config reads + current_cap read.
+        conn.cursor_instance.fetch_queue = [
+            (True,),  # enabled
+            (30,),  # window_minutes
+            (10,),  # window_size
+            (5,),  # threshold
+            (1,),  # current_cap before flip
+        ]
+        # 25 min window has 10 terminals: 5 bad + 5 good.
+        conn.cursor_instance.fetchall_queue.append(
+            [
+                ("failed",),
+                ("crashed",),
+                ("failed",),
+                ("plan_blocked",),
+                ("needs_review",),
+                ("succeeded",),
+                ("succeeded",),
+                ("succeeded",),
+                ("succeeded",),
+                ("succeeded",),
+            ]
+        )
+
+        telegram_cmds: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            telegram_cmds.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        # Create the notify-telegram.sh placeholder file so the code
+        # path that exists() the script returns True.
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        (scripts_dir / "notify-telegram.sh").write_text("#!/bin/sh\n")
+
+        tripped = d._evaluate_circuit_breaker("agent-y")
+
+        assert tripped is True
+        # Cap flipped to 0.
+        cap_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0] and "concurrency_cap" in e[0]
+        ]
+        assert cap_updates, "expected UPDATE ... WHERE key='concurrency_cap'"
+        # cap_flipped_by='circuit_breaker'
+        flag_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0] and "cap_flipped_by" in e[0]
+        ]
+        assert flag_updates, "expected UPDATE ... WHERE key='cap_flipped_by'"
+        assert flag_updates[0][1] == (
+            json.dumps("circuit_breaker"),
+            "circuit_breaker",
+        )
+        # Telegram invoked.
+        assert len(telegram_cmds) == 1
+        assert "--message-file" in telegram_cmds[0]
+        # Structured log.
+        opened = handler.events("circuit_breaker_opened")
+        assert len(opened) == 1
+        assert opened[0].bad_count == 5  # type: ignore[attr-defined]
+
+    def test_ac_mixed_sequence_does_not_open_circuit(self, tmp_path: Path) -> None:
+        """AC: 4 fails, 6 successes in 30 min → circuit stays closed."""
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            (True,),
+            (30,),
+            (10,),
+            (5,),
+        ]
+        conn.cursor_instance.fetchall_queue.append(
+            [("failed",)] * 4 + [("succeeded",)] * 6
+        )
+
+        tripped = d._evaluate_circuit_breaker("agent-y")
+
+        assert tripped is False
+        assert handler.events("circuit_breaker_opened") == []
+
+    def test_ac_operator_reflip_closes_circuit(self, tmp_path: Path) -> None:
+        """AC: operator raises cap=1 after open → flag cleared, close logged."""
+        d, conn, handler = _make_daemon(tmp_path)
+        # JSONB-encoded string value as returned from Postgres.
+        conn.cursor_instance.fetch_queue = [('"circuit_breaker"',)]
+
+        closed = d._check_circuit_breaker_auto_close(current_cap=1)
+
+        assert closed is True
+        assert handler.events("circuit_breaker_closed") != []
+
+
+# --------------------------------------------------------------------------
+# Hook integration — ``_mark_agent_terminal`` calls both
+# ``_write_terminal_outcome`` and ``_evaluate_circuit_breaker`` for
+# terminal statuses. Non-terminal statuses skip both (the intermediate
+# ``awaiting_ci`` / ``awaiting_deploy`` handoff states must not populate
+# the circuit breaker's ring buffer).
+# --------------------------------------------------------------------------
+
+
+class TestMarkAgentTerminalHooks:
+    def test_terminal_statuses_trigger_write_and_evaluate(self, tmp_path: Path) -> None:
+        """succeeded / failed / crashed / plan_blocked → both helpers fire."""
+        for status in ("succeeded", "failed", "crashed", "plan_blocked"):
+            d, _conn, _h = _make_daemon(tmp_path)
+            # Stub the inner helpers so we only test the wiring.
+            write_calls: list[tuple[str, str]] = []
+            eval_calls: list[str] = []
+
+            def fake_write(agent_id: str, s: str, _c: list = write_calls) -> None:
+                _c.append((agent_id, s))
+
+            def fake_evaluate(agent_id: str, _c: list = eval_calls) -> bool:
+                _c.append(agent_id)
+                return False
+
+            def fake_diag_outcome(*_args: Any, **_kwargs: Any) -> None:
+                return None
+
+            d._write_terminal_outcome = fake_write  # type: ignore[method-assign]
+            d._evaluate_circuit_breaker = fake_evaluate  # type: ignore[method-assign]
+            d._write_diagnosis_outcome_for_agent = fake_diag_outcome  # type: ignore[method-assign]
+
+            d._mark_agent_terminal("agent-t", status, "some_phase")
+
+            assert write_calls == [("agent-t", status)], (
+                f"status={status!r}: expected one write call, got {write_calls!r}"
+            )
+            assert eval_calls == ["agent-t"], (
+                f"status={status!r}: expected one eval call, got {eval_calls!r}"
+            )
+
+    def test_non_terminal_status_skips_write_and_evaluate(self, tmp_path: Path) -> None:
+        """``running`` (the awaiting_ci/awaiting_deploy handoff) skips both."""
+        d, _conn, _h = _make_daemon(tmp_path)
+        write_calls: list[Any] = []
+        eval_calls: list[Any] = []
+
+        d._write_terminal_outcome = (  # type: ignore[method-assign]
+            lambda *a, **k: write_calls.append((a, k))
+        )
+        d._evaluate_circuit_breaker = (  # type: ignore[method-assign]
+            lambda *a, **k: eval_calls.append((a, k)) or False
+        )
+        d._write_diagnosis_outcome_for_agent = (  # type: ignore[method-assign]
+            lambda *a, **k: None
+        )
+
+        d._mark_agent_terminal("agent-t", "running", "awaiting_ci")
+
+        assert write_calls == []
+        assert eval_calls == []
+
+    def test_write_terminal_outcome_failure_does_not_stop_evaluate(
+        self, tmp_path: Path
+    ) -> None:
+        """Independence: outcome-write exception does not prevent eval."""
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        def raising_write(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("simulated DB failure")
+
+        eval_calls: list[str] = []
+
+        def fake_evaluate(agent_id: str) -> bool:
+            eval_calls.append(agent_id)
+            return False
+
+        d._write_terminal_outcome = raising_write  # type: ignore[method-assign]
+        d._evaluate_circuit_breaker = fake_evaluate  # type: ignore[method-assign]
+        d._write_diagnosis_outcome_for_agent = (  # type: ignore[method-assign]
+            lambda *a, **k: None
+        )
+
+        d._mark_agent_terminal("agent-t", "failed", "some_phase")
+
+        # eval still ran.
+        assert eval_calls == ["agent-t"]
+        # and the error was logged.
+        assert handler.events("terminal_outcome_write_failed") != []
+
+
+# --------------------------------------------------------------------------
+# Telegram message rendering — smoke-test the body content so the
+# operator sees the useful fields.
+# --------------------------------------------------------------------------
+
+
+class TestTelegramMessage:
+    def test_message_contains_bad_count_and_window(self, tmp_path: Path) -> None:
+        d, _c, _h = _make_daemon(tmp_path)
+        body = d._render_circuit_breaker_telegram_message(
+            bad_count=6,
+            window_size=10,
+            window_minutes=30,
+            statuses=["failed", "failed", "crashed"],
+        )
+        assert "OPENED" in body
+        assert "6/10" in body
+        assert "30 min" in body
+        assert "concurrency_cap has been set to 0" in body
+        assert "failed, failed, crashed" in body
+
+    def test_message_handles_empty_status_list(self, tmp_path: Path) -> None:
+        d, _c, _h = _make_daemon(tmp_path)
+        body = d._render_circuit_breaker_telegram_message(
+            bad_count=5,
+            window_size=10,
+            window_minutes=30,
+            statuses=[],
+        )
+        assert "(none)" in body

--- a/scripts/dispatcher/tests/test_daemon_commands.py
+++ b/scripts/dispatcher/tests/test_daemon_commands.py
@@ -99,9 +99,9 @@ class _CapturingLogHandler(logging.Handler):
         return [r for r in self.records if getattr(r, "event", None) == name]
 
 
-def _make_daemon_with_capture() -> (
-    tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]
-):
+def _make_daemon_with_capture() -> tuple[
+    daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler
+]:
     handler = _CapturingLogHandler()
     logger = logging.getLogger(f"dispatcher.test.commands.{id(handler)}")
     logger.handlers = [handler]
@@ -143,9 +143,7 @@ class TestHandleStart:
     def test_start_flips_cap_when_zero(self) -> None:
         d, conn, handler = _make_daemon_with_capture()
         # Stub fetchall to return one 'start' command.
-        conn.cursor_instance.fetchall_queue = [
-            [_command_row(1, "start")]
-        ]
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "start")]]
         # concurrency_cap UPDATE: rowcount=1 (was 0, now 1).
         conn.cursor_instance.rowcount = 1
 
@@ -153,7 +151,8 @@ class TestHandleStart:
 
         assert count == 1
         updates = [
-            e for e in conn.cursor_instance.executed
+            e
+            for e in conn.cursor_instance.executed
             if "UPDATE dispatcher.config" in e[0]
             and "concurrency_cap" in e[0]
             and "value = '1'" in e[0]
@@ -161,7 +160,8 @@ class TestHandleStart:
         assert len(updates) == 1
         # consumed_at set after handler.
         consumed_updates = [
-            e for e in conn.cursor_instance.executed
+            e
+            for e in conn.cursor_instance.executed
             if "SET consumed_at = now()" in e[0]
         ]
         assert len(consumed_updates) == 1
@@ -169,23 +169,22 @@ class TestHandleStart:
     def test_start_noop_when_cap_positive(self) -> None:
         """start when cap > 0 is a safe no-op (rowcount == 0)."""
         d, conn, _handler = _make_daemon_with_capture()
-        conn.cursor_instance.fetchall_queue = [
-            [_command_row(1, "start")]
-        ]
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "start")]]
         conn.cursor_instance.rowcount = 0  # already > 0, no rows updated
 
         count = d._consume_commands()
 
         assert count == 1
         updates = [
-            e for e in conn.cursor_instance.executed
-            if "UPDATE dispatcher.config" in e[0]
-            and "value = '1'" in e[0]
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0] and "value = '1'" in e[0]
         ]
         assert len(updates) == 1
         # Still consumed — a no-op is a valid success.
         consumed_updates = [
-            e for e in conn.cursor_instance.executed
+            e
+            for e in conn.cursor_instance.executed
             if "SET consumed_at = now()" in e[0]
         ]
         assert len(consumed_updates) == 1
@@ -201,15 +200,14 @@ class TestHandleStopAndDrain:
 
     def test_stop_sets_cap_zero(self) -> None:
         d, conn, _handler = _make_daemon_with_capture()
-        conn.cursor_instance.fetchall_queue = [
-            [_command_row(1, "stop")]
-        ]
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "stop")]]
 
         count = d._consume_commands()
 
         assert count == 1
         updates = [
-            e for e in conn.cursor_instance.executed
+            e
+            for e in conn.cursor_instance.executed
             if "UPDATE dispatcher.config" in e[0]
             and "value = '0'" in e[0]
             and "concurrency_cap" in e[0]
@@ -218,15 +216,14 @@ class TestHandleStopAndDrain:
 
     def test_drain_sets_cap_zero(self) -> None:
         d, conn, _handler = _make_daemon_with_capture()
-        conn.cursor_instance.fetchall_queue = [
-            [_command_row(1, "drain")]
-        ]
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "drain")]]
 
         count = d._consume_commands()
 
         assert count == 1
         updates = [
-            e for e in conn.cursor_instance.executed
+            e
+            for e in conn.cursor_instance.executed
             if "UPDATE dispatcher.config" in e[0]
             and "value = '0'" in e[0]
             and "concurrency_cap" in e[0]
@@ -244,15 +241,14 @@ class TestHandlePauseResume:
 
     def test_pause_upserts_paused_true(self) -> None:
         d, conn, _handler = _make_daemon_with_capture()
-        conn.cursor_instance.fetchall_queue = [
-            [_command_row(1, "pause")]
-        ]
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "pause")]]
 
         count = d._consume_commands()
 
         assert count == 1
         upserts = [
-            e for e in conn.cursor_instance.executed
+            e
+            for e in conn.cursor_instance.executed
             if "INSERT INTO dispatcher.config" in e[0]
             and "'paused'" in e[0]
             and "'true'" in e[0]
@@ -263,15 +259,14 @@ class TestHandlePauseResume:
 
     def test_resume_upserts_paused_false(self) -> None:
         d, conn, _handler = _make_daemon_with_capture()
-        conn.cursor_instance.fetchall_queue = [
-            [_command_row(1, "resume")]
-        ]
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "resume")]]
 
         count = d._consume_commands()
 
         assert count == 1
         upserts = [
-            e for e in conn.cursor_instance.executed
+            e
+            for e in conn.cursor_instance.executed
             if "INSERT INTO dispatcher.config" in e[0]
             and "'paused'" in e[0]
             and "'false'" in e[0]
@@ -302,14 +297,15 @@ class TestHandleRetry:
         assert count == 1
         # Agent flipped to 'retrying'.
         agent_updates = [
-            e for e in conn.cursor_instance.executed
-            if "UPDATE dispatcher.agents" in e[0]
-            and "'retrying'" in e[0]
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0] and "'retrying'" in e[0]
         ]
         assert len(agent_updates) == 1
         # Retry marker inserted.
         marker_inserts = [
-            e for e in conn.cursor_instance.executed
+            e
+            for e in conn.cursor_instance.executed
             if "INSERT INTO dispatcher.retry_markers" in e[0]
         ]
         assert len(marker_inserts) == 1
@@ -334,7 +330,8 @@ class TestHandleRetry:
         assert conn.rollbacks >= 1
         # failures row inserted for invalid_command.
         failure_inserts = [
-            e for e in conn.cursor_instance.executed
+            e
+            for e in conn.cursor_instance.executed
             if "INSERT INTO dispatcher.failures" in e[0]
         ]
         assert len(failure_inserts) == 1
@@ -363,9 +360,9 @@ class TestHandleForceKill:
 
         assert count == 1
         updates = [
-            e for e in conn.cursor_instance.executed
-            if "UPDATE dispatcher.agents" in e[0]
-            and "'crashed'" in e[0]
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0] and "'crashed'" in e[0]
         ]
         assert len(updates) == 1
 
@@ -381,7 +378,8 @@ class TestHandleForceKill:
         assert count == 0
         assert conn.rollbacks >= 1
         failure_inserts = [
-            e for e in conn.cursor_instance.executed
+            e
+            for e in conn.cursor_instance.executed
             if "INSERT INTO dispatcher.failures" in e[0]
         ]
         assert len(failure_inserts) == 1
@@ -400,9 +398,7 @@ class TestConsumeCommands:
     def test_consume_commands_marks_consumed_after_handler_success(self) -> None:
         """consumed_at is set in the same transaction as the handler's work."""
         d, conn, handler = _make_daemon_with_capture()
-        conn.cursor_instance.fetchall_queue = [
-            [_command_row(1, "stop")]
-        ]
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "stop")]]
 
         count = d._consume_commands()
 
@@ -439,7 +435,8 @@ class TestConsumeCommands:
         assert conn.rollbacks >= 1
         # No consumed_at UPDATE.
         consumed_updates = [
-            e for e in conn.cursor_instance.executed
+            e
+            for e in conn.cursor_instance.executed
             if "SET consumed_at = now()" in e[0]
         ]
         assert len(consumed_updates) == 0
@@ -466,9 +463,11 @@ class TestClaimGateRespectsPausedKey:
     def test_claim_gate_respects_paused_key(self) -> None:
         """When paused=true, orchestration must not fire even if cap > 0."""
         d, conn, handler = _make_daemon_with_capture()
-        # concurrency_cap = 1 (gate would normally proceed).
-        # _is_paused() SELECT returns ("true",) — JSONB string 'true'.
-        conn.cursor_instance.fetch_queue = [(1,), ("true",)]
+        # SELECTs (in scheduler_tick order, cap>0 branch):
+        #   1. concurrency_cap = 1 (gate would normally proceed)
+        #   2. cap_flipped_by = None (overnight CB auto-close #2860; no-op)
+        #   3. _is_paused() = "true" — JSONB string 'true'
+        conn.cursor_instance.fetch_queue = [(1,), None, ("true",)]
         d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
         d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
             side_effect=AssertionError("must not spawn when paused")
@@ -484,8 +483,12 @@ class TestClaimGateRespectsPausedKey:
     def test_claim_gate_allows_spawn_when_not_paused(self) -> None:
         """When paused key is absent/false, normal spawn proceeds."""
         d, conn, _handler = _make_daemon_with_capture()
-        # concurrency_cap = 1; paused row absent (None); no active agent.
-        conn.cursor_instance.fetch_queue = [(1,), None, None]
+        # SELECTs (in scheduler_tick order, cap>0 branch):
+        #   1. concurrency_cap = 1
+        #   2. cap_flipped_by = None (overnight CB auto-close #2860; no-op)
+        #   3. _is_paused() = None (absent)
+        #   4. _has_active_agent() COUNT = None (no active agent)
+        conn.cursor_instance.fetch_queue = [(1,), None, None, None]
         d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
         d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
             return_value=False,

--- a/scripts/dispatcher/tests/test_daemon_killswitch.py
+++ b/scripts/dispatcher/tests/test_daemon_killswitch.py
@@ -287,10 +287,23 @@ class TestSchedulerCadenceDecoupling:
     def test_second_tick_while_worker_alive_skips_spawn(self, tmp_path: Path) -> None:
         """While a worker thread is alive, a second tick must not spawn a second."""
         d, conn, handler = _make_daemon(tmp_path)
-        # Two scheduler ticks, each with: cap=1, is_paused=None, has_active=None.
+        # Two scheduler ticks, each with:
+        #   1. cap=1
+        #   2. cap_flipped_by=None (overnight CB auto-close #2860; no-op)
+        #   3. is_paused=None
+        #   4. has_active=None
         # The second tick's gate passes but _maybe_spawn_orchestration_thread
         # notices the thread is still alive and skips.
-        conn.cursor_instance.fetch_queue = [(1,), None, None, (1,), None, None]
+        conn.cursor_instance.fetch_queue = [
+            (1,),
+            None,
+            None,
+            None,
+            (1,),
+            None,
+            None,
+            None,
+        ]
 
         worker_blocker = threading.Event()
 
@@ -508,11 +521,15 @@ class TestSyntheticMidClaimCapFlip:
     def test_mid_claim_cap_flip_is_observed_next_tick(self, tmp_path: Path) -> None:
         """Tick sequence: cap=1 → worker starts → cap=0 → next tick sees 0."""
         d, conn, handler = _make_daemon(tmp_path)
-        # Tick 1: cap read = 1 (spawns worker). Tick 2: cap read = 0.
-        # Note: the ``_is_paused`` and ``_has_active_agent`` checks fire after
-        # the cap read on tick 1; on tick 2 cap=0 short-circuits both.
-        # is_paused=None (not paused), has_active_agent=None (no active agent).
-        conn.cursor_instance.fetch_queue = [(1,), None, None, (0,)]
+        # Tick 1: cap=1 (spawns worker). Tick 2: cap=0.
+        # Per-tick SELECTs (cap>0 branch only):
+        #   1. concurrency_cap
+        #   2. cap_flipped_by (overnight CB auto-close #2860; no-op)
+        #   3. _is_paused
+        #   4. _has_active_agent
+        # Tick 2's cap=0 short-circuits both the auto-close gate and
+        # paused/active checks.
+        conn.cursor_instance.fetch_queue = [(1,), None, None, None, (0,)]
 
         worker_blocker = threading.Event()
 
@@ -549,6 +566,7 @@ class TestSyntheticMidClaimCapFlip:
         # even with no worker alive, cap=0 still blocks the spawn.
         conn.cursor_instance.fetch_queue = [
             (1,),
+            None,  # cap_flipped_by on tick 1 (overnight CB auto-close #2860)
             None,  # _is_paused on tick 1
             None,  # _has_active_agent on tick 1
             (0,),  # tick 2


### PR DESCRIPTION
## Summary

Adds an overnight-safety circuit breaker to the dispatcher daemon. When the last 5 of the last 10 terminal agent outcomes in a rolling 30-minute window are "bad" (anything not `succeeded`), the daemon flips `concurrency_cap` to 0, stamps `cap_flipped_by='circuit_breaker'`, logs `daemon.circuit_breaker_opened`, and fires a Telegram alert. The admin cockpit renders a red banner. Recovery is operator-only: manually raising cap back to ≥1 triggers an auto-close on the next scheduler tick.

Closes #2860

## Design decisions

1. **Tolerant classifier.** `OVERNIGHT_CB_GOOD_OUTCOME_STATUSES = {"succeeded"}` — everything else (including unknown future terminals) counts as bad. Post-rebase on #2856's merged PR, `needs_review` lands in `_mark_agent_terminal`'s terminal set and therefore correctly triggers both the terminal-outcome write and the circuit-breaker evaluation. The classifier test `TestIsBadOutcome::test_needs_review_is_bad` continues to assert this even if the good-outcome set is widened in the future — erring toward opening the breaker is the safer bias for overnight unattended operation.

2. **No automatic close.** The breaker stays open until the operator flips cap back to ≥1 manually. Auto-closing after a quiet period would hide the underlying cascade pattern — the operator must look at what caused the bad streak before re-enabling.

3. **Auto-close runs only on cap≥1 ticks.** The additional `cap_flipped_by` SELECT runs only in the `concurrency_cap >= 1` branch of `scheduler_tick`, so the Phase 2 steady state (cap=0) and most existing tests are completely unaffected. Only four existing tests needed a one-line `None` insertion in their `fetch_queue` fixture — each edit includes an updated inline comment.

4. **Hot-path side-effect independence.** `_mark_agent_terminal` wraps `_write_terminal_outcome` and `_evaluate_circuit_breaker` in their own try/except blocks. A write failure cannot prevent evaluation; an evaluation failure cannot roll back the terminal-status update. The cap flip and the `cap_flipped_by` stamp are also wrapped independently — a failure on the flag write does not roll back the cap flip (the cap flip is the safety action; the flag is diagnostic).

5. **Telegram is best-effort.** `scripts/notify-telegram.sh` exits 0 when the secret / allowed-user-IDs are not configured. The daemon treats any non-zero exit as a warning event — the breaker is still considered "opened" regardless of whether the alert reaches the operator.

6. **Idempotence on re-open.** If `_evaluate_circuit_breaker` runs while cap is already 0 (concurrent bad outcomes post-flip), the cap UPDATE is still written (cheap no-op), the structured `circuit_breaker_opened` event is still logged (forensics), but the Telegram alert is suppressed via `was_already_open=True`.

## Test plan

### Automated checks
- [x] Python tests pass — `pytest scripts/dispatcher/tests/` = 500 passed, 1 skipped (was 445 passed before this change)
- [x] 34 new unit tests in `test_daemon_circuit_breaker.py` cover the classifier, evaluation, idempotence, auto-close, hook integration, and Telegram rendering
- [x] Ruff lint + format clean on `scripts/dispatcher/`
- [x] API tests pass — `npm --prefix packages/api run test:unit` = 213 passed
- [x] API typecheck + lint clean
- [x] Web tests pass — `npm --prefix packages/web run test` = 1240 passed (was 1235 before)
- [x] Web typecheck + lint clean
- [x] 3 new `DispatcherDashboard` tests cover the banner (open / closed / operator-paused-but-not-breaker)
- [x] `scripts/check-graphql-queries.sh` — all 29 GraphQL queries validated against the schema
- [x] `scripts/check_schema_drift.sh` — schema.sql matches migrations (ran during pre-push hook)
- [x] `scripts/check-dispatcher-image-deps.sh` — no new external imports
- [x] `scripts/check-markdown-links.sh docs/agent/infrastructure-reference.md` — all internal links resolve
- [x] CI green — 2 runs passed (pre-rebase + post-rebase on #2856's merge)

### Post-deploy verification
- [ ] Dispatcher image redeployed to dev via `deploy-dispatcher.yml` (migration 29 applied via the deploy's migrate step)
- [ ] Migration 29 applied — `scripts/dev-db-query.sh "\d dispatcher.terminal_outcomes"` shows the table
- [ ] Config seeds present — `scripts/dev-db-query.sh "SELECT key, value FROM dispatcher.config WHERE key LIKE 'circuit_breaker_%' OR key = 'cap_flipped_by' ORDER BY key"` shows all 5 rows at defaults
- [ ] Admin cockpit loads without error on `/admin/dispatcher` — GraphQL returns `circuitBreakerOpen: false` + `capFlippedBy: null` at steady state
- [ ] Synthetic live test: `scripts/dev-db-query.sh --rw "UPDATE dispatcher.config SET value = '\"circuit_breaker\"' WHERE key = 'cap_flipped_by'; UPDATE dispatcher.config SET value = '0' WHERE key = 'concurrency_cap';"` and confirm the admin cockpit shows the red banner
- [ ] Reset the synthetic state: `scripts/dev-db-query.sh --rw "UPDATE dispatcher.config SET value = 'null' WHERE key = 'cap_flipped_by'; UPDATE dispatcher.config SET value = '1' WHERE key = 'concurrency_cap';"` → watch for `daemon.circuit_breaker_closed` in CloudWatch
- [ ] Verification evidence posted on issue (see task skill A.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
