### PR TITLE
fix(dispatcher): handle psycopg3 jsonb unwrap in _read_cap_flipped_by (#2860)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -8710,6 +8710,17 @@ class DispatcherDaemon:
         Used by the scheduler tick to detect when the operator has
         manually flipped ``concurrency_cap`` back up after the breaker
         opened (diagnostic trail cleared; breaker auto-closes).
+
+        **JSONB handling.** psycopg3 natively decodes jsonb → Python
+        values — a JSONB string like ``"circuit_breaker"`` comes back
+        as the Python string ``"circuit_breaker"`` (quotes unwrapped);
+        JSONB ``null`` comes back as Python ``None``; JSONB number /
+        bool / array / object come back as their Python equivalents.
+        Test fixtures sometimes feed us the raw JSONB bytes (e.g.
+        ``'"circuit_breaker"'`` — JSON-encoded with quotes) via the
+        fake cursor, so we try ``json.loads`` first on strings and
+        fall back to the raw string if that fails. Either shape
+        resolves to the same Python string.
         """
         assert self._conn is not None, "connect() must run before config read"
         try:
@@ -8730,12 +8741,19 @@ class DispatcherDaemon:
             return None
         raw = row[0]
         if isinstance(raw, str):
+            # Try to JSON-decode first. If the string is a JSON-encoded
+            # string literal (fake-cursor test path) ``json.loads``
+            # gives us the unwrapped value. If it is already the
+            # unwrapped Python string (psycopg3 production path) the
+            # decode fails with ``JSONDecodeError`` and we use the raw
+            # string directly.
             try:
-                raw = json.loads(raw)
+                decoded = json.loads(raw)
             except json.JSONDecodeError:
-                return None
-        if isinstance(raw, str):
-            return raw
+                return raw
+            if isinstance(decoded, str):
+                return decoded
+            return None
         return None
 
     def _write_terminal_outcome(self, agent_id: str, status: str) -> None:

--- a/scripts/dispatcher/tests/test_daemon_circuit_breaker.py
+++ b/scripts/dispatcher/tests/test_daemon_circuit_breaker.py
@@ -510,6 +510,47 @@ class TestIdempotence:
 # --------------------------------------------------------------------------
 
 
+class TestReadCapFlippedBy:
+    """``_read_cap_flipped_by`` handles both psycopg3 and fake-cursor JSONB shapes.
+
+    psycopg3 unwraps jsonb scalars to their Python equivalents: a JSONB
+    string ``"circuit_breaker"`` (9 bytes in Postgres) becomes the
+    Python string ``"circuit_breaker"`` (no quotes). Test fake cursors
+    may pass the pre-decode shape ``'"circuit_breaker"'``. Both must
+    resolve identically.
+    """
+
+    def test_returns_none_when_row_absent(self, tmp_path: Path) -> None:
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        assert d._read_cap_flipped_by() is None
+
+    def test_returns_none_when_json_null(self, tmp_path: Path) -> None:
+        """JSONB null → psycopg3 → Python None."""
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(None,)]
+        assert d._read_cap_flipped_by() is None
+
+    def test_returns_unwrapped_string_production_shape(self, tmp_path: Path) -> None:
+        """psycopg3 production shape: JSONB string → Python string (no quotes)."""
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("circuit_breaker",)]
+        assert d._read_cap_flipped_by() == "circuit_breaker"
+
+    def test_returns_unwrapped_string_fake_cursor_shape(self, tmp_path: Path) -> None:
+        """Test fixtures may pass JSON-encoded bytes — accepted equivalently."""
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [('"circuit_breaker"',)]
+        assert d._read_cap_flipped_by() == "circuit_breaker"
+
+    def test_returns_none_for_non_string_value(self, tmp_path: Path) -> None:
+        """A JSON number / bool / null where we expected a string is a
+        malformed row — return None."""
+        d, conn, _h = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(42,)]
+        assert d._read_cap_flipped_by() is None
+
+
 class TestAutoClose:
     """``_check_circuit_breaker_auto_close`` clears the flag on operator re-flip."""
 
@@ -532,8 +573,8 @@ class TestAutoClose:
     def test_does_nothing_when_flag_is_operator_string(self, tmp_path: Path) -> None:
         """Flag was set by something other than the breaker — don't touch it."""
         d, conn, _h = _make_daemon(tmp_path)
-        # JSONB-encoded string value as returned from Postgres.
-        conn.cursor_instance.fetch_queue = [('"operator"',)]
+        # psycopg3 unwraps JSONB scalar strings to Python str in production.
+        conn.cursor_instance.fetch_queue = [("operator",)]
 
         closed = d._check_circuit_breaker_auto_close(current_cap=1)
 
@@ -555,8 +596,8 @@ class TestAutoClose:
     ) -> None:
         """Operator re-flip: flag=circuit_breaker + cap=1 → log + clear flag."""
         d, conn, handler = _make_daemon(tmp_path)
-        # JSONB-encoded string value as returned from Postgres.
-        conn.cursor_instance.fetch_queue = [('"circuit_breaker"',)]
+        # psycopg3 unwraps JSONB scalar strings to Python str in production.
+        conn.cursor_instance.fetch_queue = [("circuit_breaker",)]
 
         closed = d._check_circuit_breaker_auto_close(current_cap=1)
 
@@ -686,8 +727,8 @@ class TestAcceptanceCriteria:
     def test_ac_operator_reflip_closes_circuit(self, tmp_path: Path) -> None:
         """AC: operator raises cap=1 after open → flag cleared, close logged."""
         d, conn, handler = _make_daemon(tmp_path)
-        # JSONB-encoded string value as returned from Postgres.
-        conn.cursor_instance.fetch_queue = [('"circuit_breaker"',)]
+        # psycopg3 unwraps JSONB scalar strings to Python str in production.
+        conn.cursor_instance.fetch_queue = [("circuit_breaker",)]
 
         closed = d._check_circuit_breaker_auto_close(current_cap=1)
 


### PR DESCRIPTION
## Summary

Follow-up to just-merged #2868 / #2860. Fixes a production-only bug in `_read_cap_flipped_by`: psycopg3 natively unwraps JSONB scalars, so a stored JSONB string `"circuit_breaker"` comes back from `fetchone` as the raw Python string `"circuit_breaker"` — not the JSON-encoded bytes `'"circuit_breaker"'`. The original helper called `json.loads` on the string, which raised `JSONDecodeError` and caused the helper to return `None`. The circuit-breaker auto-close path then always short-circuited, leaving the flag stuck open.

Closes #2860 (post-deploy verification that exposed this).

## Evidence that the bug was real

Synthetic verification on dev after PR #2868 deployed (task-def bumped to `circuit_breaker` release):

```
scripts/dev-db-query.sh --rw "UPDATE dispatcher.config SET value = '\"circuit_breaker\"' WHERE key = 'cap_flipped_by'"
# cap is already 1 from today's overnight run
```

Then CloudWatch logs over the next ~8 minutes: 5 `scheduler_tick` events with `concurrency_cap=1`, zero `daemon.circuit_breaker_closed` events. DB flag remained `"circuit_breaker"` — the auto-close never fired.

## The fix

```python
# Before (broken):
if isinstance(raw, str):
    try:
        raw = json.loads(raw)       # "circuit_breaker" → JSONDecodeError
    except json.JSONDecodeError:
        return None                 # production path always lands here

# After:
if isinstance(raw, str):
    try:
        decoded = json.loads(raw)
    except json.JSONDecodeError:
        return raw                  # production path — raw IS the value
    if isinstance(decoded, str):
        return decoded              # fake-cursor path — unwrap JSON bytes
    return None
```

Both the production psycopg3 shape (already-unwrapped string) and the fake-cursor test-fixture shape (JSON-encoded bytes) resolve to the same Python string. 5 new `TestReadCapFlippedBy` tests pin both shapes + null + malformed (non-string) values.

## Test plan

### Automated checks
- [x] Dispatcher tests pass — `pytest scripts/dispatcher/tests/` = 505 passed, 1 skipped (was 500 passed before this fix)
- [x] 5 new `TestReadCapFlippedBy` tests: null absent, json null, production unwrapped string, fake-cursor JSON-encoded string, malformed non-string
- [x] 3 existing `TestAutoClose` fixtures updated to use the production-shape unwrapped string (consistent with what psycopg3 actually hands the helper in prod)
- [x] Ruff lint + format clean
- [ ] CI green

### Post-deploy verification
- [ ] Dispatcher redeployed via `deploy-dispatcher.yml`
- [ ] Synthetic re-test on dev: with `cap_flipped_by = 'circuit_breaker'` and cap=1, next scheduler tick should log `daemon.circuit_breaker_closed` and the flag should clear to `null`.
- [ ] Verification evidence posted on #2860

🤖 Generated with [Claude Code](https://claude.com/claude-code)
