### PR TITLE
fix(dispatcher): /task ↔ daemon claim interlock (#2866)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -154,6 +154,61 @@ Once MCP writes are unblocked (follow-up issue referenced from `docs/agent/gh-to
 - Format: `#<N> — <short title>` (drop any `[AREA]` prefix tag from the issue title)
 - Run: `/rename #<N> — <short title>`
 
+## Step 2a — Record claim in `dispatcher.agents` ledger (MANDATORY)
+
+**Why:** This is the shared claim interlock between `/task` subagents and the Fargate dispatcher daemon. Without it, a /task subagent you spawn on a `agent/ready` issue can race with the daemon's next queue scan — both will independently run the full plan → ralph → summary → PR pipeline on the same issue and produce duplicate PRs. Observed 2026-04-19 with #2856 (issue #2866). The daemon writes to `dispatcher.agents` via `_atomic_claim`; `/task` must do the same write so the partial UNIQUE INDEX on `(issue_number) WHERE status IN ('running', 'retrying')` catches the collision atomically in either direction.
+
+**Two-part interlock — both halves run here:**
+
+### Part A — DB row (atomic race detection)
+
+Run the helper (stays in the foreground — use `timeout: 1200000` since the ECS-Exec code path takes 2-4 s per call):
+
+```
+scripts/dispatcher/task_claim.py claim \
+    --issue <N> \
+    --agent-id <agent-id> \
+    --worktree-path {worktree}
+```
+
+The `<agent-id>` must be the id derived from the worktree directory name (e.g. `agent-a56f2e57`). Exit codes:
+
+- **`0`** — claim row inserted successfully. Continue to Part B.
+- **`2`** — **claim lost to a prior owner.** The helper printed a JSON payload on stdout with `owner_kind` (either `task` for the Fargate daemon or `task-skill` for another /task subagent) and `owner_agent_id`. Do **not** proceed — another worker owns this issue right now. Print the payload and stop. The operator will see the message and either wait for the other agent or cancel it.
+- **`1`** — unexpected error (DB down, dev-db-query.sh missing, auth problem). Surface the stderr message and stop.
+
+The helper uses `DATABASE_URL` when set (Fargate /task paths) and falls back to `scripts/dev-db-query.sh --rw` (laptop /task paths). Both shells write the same `kind='task-skill'` + `status='running'` row.
+
+### Part B — `status/in-progress` label (human-visible signal)
+
+Add the label so the operator sees the issue is being worked on AND the daemon's queue scan filter excludes it (belt-and-suspenders with Part A):
+
+```
+gh issue edit <N> --repo judgemind/judgemind --add-label status/in-progress
+```
+
+Idempotent — `gh` ignores the request if the label is already present.
+
+**MANDATORY teardown on terminal.** On any terminal state (PR merged, verification passed, blocker, investigation closed), run:
+
+```
+scripts/dispatcher/task_claim.py terminal \
+    --agent-id <agent-id> \
+    --status <succeeded|failed> \
+    [--pr-number <N>]
+
+gh issue edit <N> --repo judgemind/judgemind --remove-label status/in-progress
+```
+
+Terminal status values:
+- `succeeded` — PR merged + deploy verified + evidence comment posted (normal success path).
+- `failed` — ralph STUCK, verification failed, task abandoned, or any other terminal non-success state.
+
+Both calls are idempotent and best-effort (exit 0 on rowcount=0 or label-already-absent).
+
+The teardown lives in the Path A/B per-step recipe below (A.8 step 4, B.2 step 3, and the STUCK-exit paths). Do not skip it — leaving the row at `status='running'` blocks the next /task or daemon claim on the same issue until the daemon's supervisor stuck-timeout sweep flips it to `crashed` (30 min), and the label keeps the issue hidden from the queue scan forever.
+
+---
 ---
 
 ## Step 3 — Create todo list for progress tracking
@@ -252,7 +307,12 @@ Skip this for Terraform-only or docs-only tasks.
 - **For testable code tasks** (Python, TypeScript): use the `/ralph` loop — iterative work-then-review with fresh context each iteration. See `.claude/skills/ralph/SKILL.md`. This replaces the old `/tdd` + self-review steps. `/ralph` handles implementation (TDD), pre-PR checks, and cross-perspective review internally. It returns when the reviewer subagent says SHIP.
 - **For non-testable tasks** (Terraform, DB migrations, CI/CD, docs): implement directly, then run all applicable pre-PR checks (see `docs/agent/code-standards.md` §Pre-PR Checks) and review your own diff before continuing.
 - **For ingestion/extraction pipeline tasks** (scraper changes, LLM prompt changes, enrichment logic): use the local dev stack to iterate. The local DB + S3 cache enables fast iteration without deploying to dev. Run `scripts/rebuild_db.sh --skip-reset` to re-process documents through the pipeline and verify data correctness against source documents. See `docs/agent/local-dev.md`. **Prioritize correctness over completeness** — verify that extracted fields match the source document, not just that fields are populated.
-- If `/ralph` exits with a blocker (STUCK or max iterations), the issue has already been commented on and blocked (via `scripts/block-issue.sh` or `status/blocked` label). Stop — the worktree will be cleaned up automatically by Claude Code (if spawned with `isolation: "worktree"`) or by the dispatcher.
+- If `/ralph` exits with a blocker (STUCK or max iterations), the issue has already been commented on and blocked (via `scripts/block-issue.sh` or `status/blocked` label). Before stopping, **release the claim interlock** (issue #2866) so the issue isn't permanently hidden from future agents:
+  ```
+  scripts/dispatcher/task_claim.py terminal --agent-id <agent-id> --status failed
+  gh issue edit <N> --repo judgemind/judgemind --remove-label status/in-progress
+  ```
+  Then stop — the worktree will be cleaned up automatically by Claude Code (if spawned with `isolation: "worktree"`) or by the dispatcher.
 
 **POST-RALPH CHECKPOINT — Do not skip this.** After `/ralph` returns:
 1. Read `{worktree}/tmp/ralph/ralph-done.txt` to confirm ralph completed with SHIP status.
@@ -427,6 +487,19 @@ gh pr merge <PR-N> --repo judgemind/judgemind --squash --delete-branch
 ```
 
 **Dependent issues will be unblocked automatically** by the `unblock-issues` workflow when the PR merges. No manual unblocking needed.
+
+**Record terminal status in the `dispatcher.agents` ledger (issue #2866).** The claim row inserted in Step 2a must be closed out so the next /task or daemon claim on this issue can acquire the partial-UNIQUE-INDEX slot. Run this *before* A.8 deploy-watch so the slot releases promptly even if deploy verification drags:
+
+```
+scripts/dispatcher/task_claim.py terminal \
+    --agent-id <agent-id> \
+    --status succeeded \
+    --pr-number <PR-N>
+
+gh issue edit <N> --repo judgemind/judgemind --remove-label status/in-progress
+```
+
+Best-effort — both commands exit 0 on no-op (row already terminal, label already absent). A failure here is logged but does not block A.8.
 
 #### A.8 — Verify deployment and post evidence (MANDATORY)
 Write status: `phase: deploying`, `summary: Watching deploy pipeline for <workflow>`.
@@ -608,6 +681,18 @@ gh issue close <N> --repo judgemind/judgemind --reason completed
 ```
 
 **Close with a standard summary comment.** Only leave an investigation issue open if it genuinely requires human judgment that cannot be captured in a follow-up issue.
+
+**Record terminal status in the `dispatcher.agents` ledger (issue #2866).** The claim row inserted in Step 2a must be released so a future investigation or follow-up /task on this issue can acquire the partial-UNIQUE-INDEX slot:
+
+```
+scripts/dispatcher/task_claim.py terminal \
+    --agent-id <agent-id> \
+    --status succeeded
+
+gh issue edit <N> --repo judgemind/judgemind --remove-label status/in-progress
+```
+
+Best-effort — both commands exit 0 on no-op (row already terminal, label already absent).
 
 #### B.3 — Unblock dependent issues
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,7 @@ These rules govern how you work with the user in interactive sessions, not just 
 
 **The authoritative step-by-step lives in `.claude/skills/task/SKILL.md` §A.3–A.9.** `/task` subagents follow that. The rules below are the ones every agent (task, dispatcher, interactive) must internalize.
 
+- **Claim interlock (`dispatcher.agents` + `status/in-progress`).** On claim, `/task` writes a `dispatcher.agents` row (`kind='task-skill'`, `status='running'`) via `scripts/dispatcher/task_claim.py claim` AND adds the `status/in-progress` GitHub label. The daemon's `_atomic_claim` does the equivalent. The partial UNIQUE INDEX `idx_dispatcher_agents_active_issue` catches concurrent claims atomically (subagent↔daemon, daemon↔daemon, subagent↔subagent). On terminal, both sides update the row to `succeeded`/`failed` and remove the label. See `.claude/skills/task/SKILL.md` §2a + A.7 + B.2 for the exact commands. Issue #2866.
 - **Single-issue rule.** Each PR addresses exactly one issue. Break large/ambiguous issues into sub-tasks labeled `agent/ready` before picking up.
 - **All commits on the worktree branch.** Never directly on `main` during autonomous work. Every change goes through a PR.
 - **Scope completeness check before implementing.** Grep the codebase for all locations affected by the change. If the issue's scope doesn't cover all, either expand scope or file follow-ups.

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -320,6 +320,24 @@ FIX_CI_LOG_TAIL_MAX_CHARS = 20000
 #:   all three paths eventually cycle the row out of this set.
 ACTIVE_AGENT_STATUSES = ("running", "retrying", "succeeded", "needs_review")
 
+#: GitHub label added to an issue on claim (by either the daemon or the
+#: /task skill) and removed on terminal. Gives operators a GitHub-visible
+#: "this issue is being worked on right now — don't dispatch another
+#: agent on it" signal without querying ``dispatcher.agents``. Paired
+#: with the DB-side partial UNIQUE INDEX (#2783) and the /task-side row
+#: insert (#2866) for defense-in-depth against subagent↔daemon claim
+#: collisions. The queue-scan filter in :meth:`_fetch_agent_ready_issues`
+#: also excludes this label as a redundant safety — the DB row is the
+#: atomic interlock; the label is human + queue-scan visible.
+STATUS_IN_PROGRESS_LABEL = "status/in-progress"
+
+#: ``dispatcher.agents.kind`` value used by the ``/task`` skill's claim
+#: rows (issue #2866). Distinct from the daemon's default ``'task'``
+#: value so :meth:`_atomic_claim`'s UniqueViolation handler can emit a
+#: distinguishing ``already_claimed_by_task`` structured log — useful
+#: for identifying subagent↔daemon races in CloudWatch Logs Insights.
+TASK_SKILL_KIND = "task-skill"
+
 #: Sentinel HTML comment embedded as line 1 of the automated
 #: "plan returned go=false" issue comment. Lets the daemon detect that
 #: the comment has already been posted and skip re-posting on a retry
@@ -2099,11 +2117,17 @@ class DispatcherDaemon:
                 f"gh issue list returned non-list JSON: {type(issues).__name__}"
             )
 
-        # Defensive filter: drop rows that also carry ``status/blocked``.
-        # The ``gh --label agent/ready`` call returns issues that carry
-        # the label; a blocked issue that still has ``agent/ready``
-        # attached (e.g. mid-transition) should not inflate the queue
-        # depth because the daemon would never spawn on it.
+        # Defensive filter: drop rows that also carry ``status/blocked``
+        # or ``status/in-progress``. The ``gh --label agent/ready`` call
+        # returns issues that carry the label; a blocked or in-progress
+        # issue that still has ``agent/ready`` attached (e.g. mid-
+        # transition) should not inflate the queue depth because the
+        # daemon would never spawn on it. ``status/in-progress`` is the
+        # /task-skill↔daemon interlock signal (#2866) — an issue a
+        # ``/task`` subagent has just claimed carries it (and also has
+        # a row in ``dispatcher.agents`` — the DB write is atomic; the
+        # label is human-visible + queue-scan-visible) so the daemon
+        # should never pick it up as a candidate.
         filtered: list[dict[str, Any]] = []
         for issue in issues:
             if not isinstance(issue, dict):
@@ -2113,6 +2137,8 @@ class DispatcherDaemon:
                 entry.get("name") for entry in labels if isinstance(entry, dict)
             }
             if "status/blocked" in label_names:
+                continue
+            if STATUS_IN_PROGRESS_LABEL in label_names:
                 continue
             filtered.append(issue)
         return filtered
@@ -2812,21 +2838,40 @@ class DispatcherDaemon:
                 )
             self._conn.commit()
         except psycopg.errors.UniqueViolation:
-            # Another daemon claimed this issue first. Roll back and
-            # return False so the caller skips to the next candidate.
+            # Another daemon OR a /task subagent claimed this issue
+            # first. Roll back and return False so the caller skips to
+            # the next candidate. Look up the existing row's ``kind`` so
+            # the log distinguishes a daemon↔daemon race (``claim_lost``)
+            # from a /task-skill collision (#2866 —
+            # ``already_claimed_by_task``). Owner lookup is best-effort;
+            # failure to read it just falls back to the generic log.
             try:
                 self._conn.rollback()
             except Exception:  # pragma: no cover
                 pass
-            self._log.info(
-                "daemon.claim_lost",
-                extra={
-                    "event": "claim_lost",
-                    "run_id": self._run_id,
-                    "issue_number": issue_number,
-                    "agent_id": agent_id,
-                },
-            )
+            owner_kind = self._lookup_active_owner_kind(issue_number)
+            if owner_kind == TASK_SKILL_KIND:
+                self._log.info(
+                    "daemon.candidate_skipped",
+                    extra={
+                        "event": "candidate_skipped",
+                        "run_id": self._run_id,
+                        "issue_number": issue_number,
+                        "agent_id": agent_id,
+                        "reason": "already_claimed_by_task",
+                    },
+                )
+            else:
+                self._log.info(
+                    "daemon.claim_lost",
+                    extra={
+                        "event": "claim_lost",
+                        "run_id": self._run_id,
+                        "issue_number": issue_number,
+                        "agent_id": agent_id,
+                        "owner_kind": owner_kind,
+                    },
+                )
             return False
         except Exception:
             try:
@@ -2844,6 +2889,15 @@ class DispatcherDaemon:
             )
             return False
 
+        # Atomic DB claim succeeded. Add the ``status/in-progress``
+        # label (#2866) so operators + the queue-scan filter see the
+        # issue is being worked on. The label is the human-visible half
+        # of the interlock; the DB row is the atomic half. Label-write
+        # failure is logged but does NOT roll back the DB claim —
+        # ``_mark_agent_terminal`` will still remove the label on
+        # completion even if the add failed (idempotent).
+        self._gh_issue_add_labels(issue_number, [STATUS_IN_PROGRESS_LABEL])
+
         self._log.info(
             "daemon.claim_succeeded",
             extra={
@@ -2854,6 +2908,40 @@ class DispatcherDaemon:
             },
         )
         return True
+
+    def _lookup_active_owner_kind(self, issue_number: int) -> str | None:
+        """Return the ``kind`` of the current active row for an issue, or None.
+
+        Used by :meth:`_atomic_claim`'s UniqueViolation handler to
+        distinguish daemon↔daemon races (``kind='task'``) from
+        daemon↔/task-skill races (``kind='task-skill'``). Best-effort —
+        returns None on DB error so the caller can fall back to the
+        generic ``claim_lost`` log event rather than crashing the tick.
+        """
+        assert self._conn is not None, "connect() must run before reading"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT kind FROM dispatcher.agents "
+                    "WHERE issue_number = %s "
+                    "  AND status IN ('running', 'retrying') "
+                    "LIMIT 1",
+                    (issue_number,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return None
+        if row is None:
+            return None
+        kind = row[0]
+        if not isinstance(kind, str):
+            return None
+        return kind
 
     def _repo_root(self) -> Path:
         """Legacy "repo-shaped directory" used by non-git callers.
@@ -3423,6 +3511,7 @@ class DispatcherDaemon:
         phase: str,
         exit_code: int | None = None,
         pr_number: int | None = None,
+        issue_number: int | None = None,
     ) -> None:
         """UPDATE ``dispatcher.agents`` with terminal status + metadata.
 
@@ -3450,6 +3539,15 @@ class DispatcherDaemon:
         reached ralph) — the admin cockpit renders it with an
         amber/yellow "needs your eyes" chip because it IS actionable,
         unlike ``plan_blocked`` which is informational.
+
+        ``issue_number`` is optional (issue #2866). When provided, the
+        method clears the ``status/in-progress`` label on the issue so
+        the claim interlock releases. Call sites that don't pass it
+        (supervisor stuck-timeout sweep, generic retry paths) leave the
+        label attached — an operator / next scheduler cycle handles the
+        teardown, which is fine because those paths are rare edge cases
+        and the DB row is already marked terminal (the authoritative
+        interlock signal).
         """
         assert self._conn is not None, "connect() must run before update"
         terminal = status in (
@@ -3544,6 +3642,24 @@ class DispatcherDaemon:
                         "agent_id": agent_id,
                     },
                 )
+
+            # Issue #2866 claim-interlock teardown: on any terminal
+            # transition where the caller knows the issue number, remove
+            # the ``status/in-progress`` label so the issue stops being
+            # hidden from the queue scan filter and the operator-visible
+            # "in flight" signal clears. Wrapped in its own try/except so
+            # a GitHub API hiccup cannot roll back the DB write.
+            #
+            # The teardown is explicit-opt-in — callers thread
+            # ``issue_number`` through when they know it (orchestration
+            # hot path, diagnoser auto-fail). Call sites that don't
+            # (supervisor stuck-timeout sweep, generic retry paths)
+            # simply leave the label attached for the supervisor /
+            # operator to clean up. This keeps the hot DB path narrow
+            # (no extra SELECT, no test-fixture reshape) while still
+            # closing the common-case interlock.
+            if issue_number is not None:
+                self._gh_issue_remove_labels(issue_number, [STATUS_IN_PROGRESS_LABEL])
 
     def _spawn_phase_subprocess(
         self, phase: str, worktree: Path, agent_id: str
@@ -3689,7 +3805,11 @@ class DispatcherDaemon:
                 },
             )
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="claim", exit_code=None
+                agent_id,
+                status="failed",
+                phase="claim",
+                exit_code=None,
+                issue_number=issue_number,
             )
             return
 
@@ -3712,28 +3832,33 @@ class DispatcherDaemon:
         aborting before ralph / summary / push_and_pr leaves no
         GitHub-visible artifact.
         """
-        if self._check_killswitch_and_abort(agent_id, "claiming"):
+        if self._check_killswitch_and_abort(agent_id, "claiming", issue_number):
             return
         ok = self._run_plan_phase(agent_id, issue_number, worktree)
         if not ok:
             return
-        if self._check_killswitch_and_abort(agent_id, "planning"):
+        if self._check_killswitch_and_abort(agent_id, "planning", issue_number):
             return
         ok = self._run_ralph_phase(agent_id, issue_number, worktree)
         if not ok:
             return
-        if self._check_killswitch_and_abort(agent_id, "ralph"):
+        if self._check_killswitch_and_abort(agent_id, "ralph", issue_number):
             return
         ok = self._run_summary_phase(agent_id, issue_number, worktree)
         if not ok:
             return
-        if self._check_killswitch_and_abort(agent_id, "summary"):
+        if self._check_killswitch_and_abort(agent_id, "summary", issue_number):
             return
 
         # Daemon-side git commit + push + PR create.
         self._push_and_open_pr(agent_id, issue_number, worktree)
 
-    def _check_killswitch_and_abort(self, agent_id: str, after_phase: str) -> bool:
+    def _check_killswitch_and_abort(
+        self,
+        agent_id: str,
+        after_phase: str,
+        issue_number: int | None = None,
+    ) -> bool:
         """If the operator flipped ``concurrency_cap=0``, abort the run (#2847).
 
         Called between each orchestration phase. Returns True iff the
@@ -3746,6 +3871,11 @@ class DispatcherDaemon:
         log event to show where in the pipeline the kill landed. For
         the pre-plan check (a killswitch that fired during the claim
         itself) pass ``"claiming"``.
+
+        ``issue_number`` threads through to :meth:`_mark_agent_terminal`
+        so the claim-interlock ``status/in-progress`` label clears on
+        killswitch teardown (issue #2866). Optional for backward
+        compatibility with older call sites that don't know it.
         """
         if not self._pause_requested.is_set():
             return False
@@ -3768,6 +3898,7 @@ class DispatcherDaemon:
             status="failed",
             phase=KILLSWITCH_TERMINAL_PHASE,
             exit_code=None,
+            issue_number=issue_number,
         )
         return True
 
@@ -4531,7 +4662,11 @@ class DispatcherDaemon:
                 },
             )
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="planning", exit_code=None
+                agent_id,
+                status="failed",
+                phase="planning",
+                exit_code=None,
+                issue_number=issue_number,
             )
             return False
 
@@ -4543,7 +4678,9 @@ class DispatcherDaemon:
         }
         self._write_phase_input(worktree, "plan", plan_input)
 
-        exit_code = self._run_subprocess_or_fail(agent_id, "plan", worktree)
+        exit_code = self._run_subprocess_or_fail(
+            agent_id, "plan", worktree, issue_number=issue_number
+        )
         if exit_code is None:
             return False
 
@@ -4560,7 +4697,11 @@ class DispatcherDaemon:
                 extra["stderr_preview"] = preview
             self._log.warning("daemon.phase_output_missing", extra=extra)
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="planning", exit_code=exit_code
+                agent_id,
+                status="failed",
+                phase="planning",
+                exit_code=exit_code,
+                issue_number=issue_number,
             )
             return False
 
@@ -4610,7 +4751,11 @@ class DispatcherDaemon:
                 # failure of one does not prevent the others.
                 self._handle_plan_blocked(agent_id, issue_number, reason, worktree)
             self._mark_agent_terminal(
-                agent_id, status=status, phase="planning", exit_code=exit_code
+                agent_id,
+                status=status,
+                phase="planning",
+                exit_code=exit_code,
+                issue_number=issue_number,
             )
             return False
 
@@ -4636,7 +4781,9 @@ class DispatcherDaemon:
         }
         self._write_phase_input(worktree, "ralph", ralph_input)
 
-        exit_code = self._run_subprocess_or_fail(agent_id, "ralph", worktree)
+        exit_code = self._run_subprocess_or_fail(
+            agent_id, "ralph", worktree, issue_number=issue_number
+        )
         if exit_code is None:
             return False
 
@@ -4653,7 +4800,11 @@ class DispatcherDaemon:
                 extra["stderr_preview"] = preview
             self._log.warning("daemon.phase_output_missing", extra=extra)
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="ralph", exit_code=exit_code
+                agent_id,
+                status="failed",
+                phase="ralph",
+                exit_code=exit_code,
+                issue_number=issue_number,
             )
             return False
 
@@ -4689,7 +4840,11 @@ class DispatcherDaemon:
                 },
             )
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="ralph", exit_code=exit_code
+                agent_id,
+                status="failed",
+                phase="ralph",
+                exit_code=exit_code,
+                issue_number=issue_number,
             )
             return False
 
@@ -4791,7 +4946,9 @@ class DispatcherDaemon:
         }
         self._write_phase_input(worktree, "summary", summary_input)
 
-        exit_code = self._run_subprocess_or_fail(agent_id, "summary", worktree)
+        exit_code = self._run_subprocess_or_fail(
+            agent_id, "summary", worktree, issue_number=issue_number
+        )
         if exit_code is None:
             return False
 
@@ -4808,7 +4965,11 @@ class DispatcherDaemon:
                 extra["stderr_preview"] = preview
             self._log.warning("daemon.phase_output_missing", extra=extra)
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="summary", exit_code=exit_code
+                agent_id,
+                status="failed",
+                phase="summary",
+                exit_code=exit_code,
+                issue_number=issue_number,
             )
             return False
 
@@ -4861,7 +5022,11 @@ class DispatcherDaemon:
         return True
 
     def _run_subprocess_or_fail(
-        self, agent_id: str, phase: str, worktree: Path
+        self,
+        agent_id: str,
+        phase: str,
+        worktree: Path,
+        issue_number: int | None = None,
     ) -> int | None:
         """Run ``claude -p <phase>`` and log the outcome.
 
@@ -4880,6 +5045,11 @@ class DispatcherDaemon:
         fresh worktree. Tier-2/3 categories (``turn_limit`` → 3D;
         ``auth_fail`` → halt) leave the agent in ``status='failed'``
         for 3D's diagnoser to pick up.
+
+        ``issue_number`` threads through to :meth:`_mark_agent_terminal`
+        so the ``status/in-progress`` label clears on teardown
+        (issue #2866). Optional for backward compatibility with call
+        sites that don't know it yet.
         """
         try:
             exit_code, duration = self._spawn_phase_subprocess(
@@ -4904,6 +5074,7 @@ class DispatcherDaemon:
                 duration_s=None,
                 extra={"timeout_seconds": CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS},
                 worktree=worktree,
+                issue_number=issue_number,
             )
             return None
         except FileNotFoundError:
@@ -4931,7 +5102,11 @@ class DispatcherDaemon:
                 },
             )
             self._mark_agent_terminal(
-                agent_id, status="failed", phase=phase, exit_code=None
+                agent_id,
+                status="failed",
+                phase=phase,
+                exit_code=None,
+                issue_number=issue_number,
             )
             return None
         except Exception as exc:  # pragma: no cover — defensive catch
@@ -4947,7 +5122,11 @@ class DispatcherDaemon:
                 },
             )
             self._mark_agent_terminal(
-                agent_id, status="failed", phase=phase, exit_code=None
+                agent_id,
+                status="failed",
+                phase=phase,
+                exit_code=None,
+                issue_number=issue_number,
             )
             return None
 
@@ -4973,6 +5152,7 @@ class DispatcherDaemon:
                 duration_s=duration,
                 extra={},
                 worktree=worktree,
+                issue_number=issue_number,
             )
             return None
 
@@ -5000,6 +5180,7 @@ class DispatcherDaemon:
         duration_s: float | None,
         extra: dict[str, Any],
         worktree: Path | None = None,
+        issue_number: int | None = None,
     ) -> None:
         """Classify a subprocess failure, write failure row, enqueue retry.
 
@@ -5087,6 +5268,7 @@ class DispatcherDaemon:
             status="failed",
             phase=phase,
             exit_code=int(exit_code) if exit_code is not None else None,
+            issue_number=issue_number,
         )
 
         if category in AUTO_RETRY_CATEGORIES:
@@ -5247,7 +5429,11 @@ class DispatcherDaemon:
                 },
             )
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="push_and_pr", exit_code=None
+                agent_id,
+                status="failed",
+                phase="push_and_pr",
+                exit_code=None,
+                issue_number=issue_number,
             )
             return
 
@@ -5271,7 +5457,11 @@ class DispatcherDaemon:
                 },
             )
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="push_and_pr", exit_code=None
+                agent_id,
+                status="failed",
+                phase="push_and_pr",
+                exit_code=None,
+                issue_number=issue_number,
             )
             return
         if add_result.returncode != 0:
@@ -5286,7 +5476,11 @@ class DispatcherDaemon:
                 },
             )
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="push_and_pr", exit_code=None
+                agent_id,
+                status="failed",
+                phase="push_and_pr",
+                exit_code=None,
+                issue_number=issue_number,
             )
             return
 
@@ -5322,7 +5516,11 @@ class DispatcherDaemon:
                 },
             )
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="push_and_pr", exit_code=None
+                agent_id,
+                status="failed",
+                phase="push_and_pr",
+                exit_code=None,
+                issue_number=issue_number,
             )
             return
         if commit_result.returncode != 0:
@@ -5337,7 +5535,11 @@ class DispatcherDaemon:
                 },
             )
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="push_and_pr", exit_code=None
+                agent_id,
+                status="failed",
+                phase="push_and_pr",
+                exit_code=None,
+                issue_number=issue_number,
             )
             return
 
@@ -5371,7 +5573,11 @@ class DispatcherDaemon:
                 },
             )
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="push_and_pr", exit_code=None
+                agent_id,
+                status="failed",
+                phase="push_and_pr",
+                exit_code=None,
+                issue_number=issue_number,
             )
             return
         if push_result.returncode != 0:
@@ -5386,7 +5592,11 @@ class DispatcherDaemon:
                 },
             )
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="push_and_pr", exit_code=None
+                agent_id,
+                status="failed",
+                phase="push_and_pr",
+                exit_code=None,
+                issue_number=issue_number,
             )
             return
 
@@ -5432,7 +5642,11 @@ class DispatcherDaemon:
                 },
             )
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="push_and_pr", exit_code=None
+                agent_id,
+                status="failed",
+                phase="push_and_pr",
+                exit_code=None,
+                issue_number=issue_number,
             )
             return
         if pr_result.returncode != 0:
@@ -5447,7 +5661,11 @@ class DispatcherDaemon:
                 },
             )
             self._mark_agent_terminal(
-                agent_id, status="failed", phase="push_and_pr", exit_code=None
+                agent_id,
+                status="failed",
+                phase="push_and_pr",
+                exit_code=None,
+                issue_number=issue_number,
             )
             return
 
@@ -5491,6 +5709,7 @@ class DispatcherDaemon:
                 phase="needs_review",
                 exit_code=None,
                 pr_number=pr_number,
+                issue_number=issue_number,
             )
             return
 
@@ -10034,6 +10253,58 @@ class DispatcherDaemon:
                 "daemon.diagnoser_gh_label_nonzero",
                 extra={
                     "event": "diagnoser_gh_label_nonzero",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "exit_code": result.returncode,
+                    "stderr_tail": (result.stderr or "").strip()[:200],
+                },
+            )
+
+    def _gh_issue_remove_labels(self, issue_number: int, labels: list[str]) -> None:
+        """Remove one or more labels via ``gh issue edit --remove-label``.
+
+        Mirror of :meth:`_gh_issue_add_labels`. Idempotent — removing a
+        label that is already absent is a no-op. Used by the claim
+        interlock (#2866) to drop the ``status/in-progress`` label on
+        agent terminal so the issue becomes re-claimable (for retries /
+        follow-ups) and operators see it is no longer active.
+        """
+        if not labels:
+            return
+        label_csv = ",".join(labels)
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "edit",
+                    str(issue_number),
+                    "--repo",
+                    self._cfg.github_repo,
+                    "--remove-label",
+                    label_csv,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            self._log.warning(
+                "daemon.label_remove_failed",
+                extra={
+                    "event": "label_remove_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "detail": str(exc),
+                },
+            )
+            return
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.label_remove_nonzero",
+                extra={
+                    "event": "label_remove_nonzero",
                     "run_id": self._run_id,
                     "issue_number": issue_number,
                     "exit_code": result.returncode,

--- a/scripts/dispatcher/task_claim.py
+++ b/scripts/dispatcher/task_claim.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""Shared ``dispatcher.agents`` claim ledger — write path for the ``/task`` skill.
+
+The dispatcher v2 daemon writes to ``dispatcher.agents`` on every claim via
+:meth:`scripts.dispatcher.daemon.DispatcherDaemon._atomic_claim`. That write
+is what the partial UNIQUE INDEX
+``idx_dispatcher_agents_active_issue`` (migration 25) protects — at most one
+``status IN ('running', 'retrying')`` row per ``issue_number``.
+
+Historically the ``/task`` skill (operator-spawned subagents) did **not**
+write to that table. The result was a race: operator spawns ``/task #N`` on
+their laptop; seconds later the Fargate daemon's queue scan independently
+claims the same issue and runs its own plan → ralph → summary pipeline.
+Observed 2026-04-19 with issue #2856. Issue #2866 closes that gap.
+
+This module is the write-side helper the ``/task`` skill calls to:
+
+1. ``claim`` — INSERT a row with ``kind='task-skill'`` + ``status='running'``.
+   The same partial UNIQUE INDEX that catches daemon↔daemon races also
+   catches daemon↔/task (and /task↔/task) races in either direction — if
+   the INSERT fails with a UniqueViolation, the helper looks up the row
+   that owns the index slot and surfaces the conflicting owner's
+   ``kind`` + ``agent_id`` so the skill can emit a clear
+   "already being worked on by <kind> agent <uuid>" error.
+2. ``terminal`` — UPDATE the row to ``status='succeeded'`` or
+   ``status='failed'`` + ``ended_at=now()`` on completion. Releases the
+   index slot so a retry of the same issue can claim again.
+
+``kind='task-skill'`` distinguishes operator-spawned /task rows from
+daemon-spawned ``kind='task'`` rows so the daemon can log
+``candidate_skipped reason='already_claimed_by_task'`` when it observes one
+in its queue scan, and the admin cockpit can render a distinguishing chip.
+
+Database access
+---------------
+The /task skill can run in two environments:
+
+* **Operator laptop** — no direct network path to the dev VPC's RDS. The
+  helper shells out to ``scripts/dev-db-query.sh --rw "<SQL>"`` which runs
+  the SQL inside the already-running ingestion-worker container via ECS
+  Exec. Handles both SELECT and non-SELECT statements. Latency is the SSM
+  session cost (~2-4s).
+* **Fargate /task** — ``DATABASE_URL`` is present in the environment.
+  The helper imports ``psycopg`` and talks to RDS directly. This is
+  the same path :class:`emit_failure.py` uses.
+
+Which path runs is chosen by a single env-var check: if ``DATABASE_URL`` is
+set, use psycopg; otherwise use the ``dev-db-query.sh`` wrapper. Callers
+can force the wrapper path by unsetting ``DATABASE_URL``.
+
+Usage
+-----
+
+::
+
+    # Claim (exit 0 on success, 2 on duplicate, 1 on other error):
+    scripts/dispatcher/task_claim.py claim \\
+        --issue 2866 \\
+        --agent-id aabbccdd-eeff-0011-2233-445566778899 \\
+        --worktree-path /Users/you/.../.claude/worktrees/agent-aabbccdd
+
+    # Terminal update (exit 0 always — terminal is best-effort):
+    scripts/dispatcher/task_claim.py terminal \\
+        --agent-id aabbccdd-eeff-0011-2233-445566778899 \\
+        --status succeeded
+
+Exit codes
+----------
+* ``0`` — claim succeeded / terminal update succeeded (or silently
+  swallowed on DB failure — never block the /task skill's flow).
+* ``1`` — unexpected error (bad args, subprocess missing, DB error on
+  claim). stderr contains the detail.
+* ``2`` — claim lost to a prior owner (UniqueViolation). stderr and stdout
+  contain a JSON object with ``owner_agent_id``, ``owner_kind``,
+  ``owner_status``, ``issue_number``.
+"""
+# venv: scraper-framework
+# permanent: true
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+#: Dedicated CLI identifier that tags /task-skill-originated claim rows.
+#: Rows the daemon writes use ``kind='task'`` (or future ``'v2-per-phase'``);
+#: /task writes use this value so the daemon's collision-detection path
+#: can emit a distinguishing ``already_claimed_by_task`` structured log.
+TASK_SKILL_KIND = "task-skill"
+
+#: Valid terminal statuses the /task skill can report. Matches the set
+#: the daemon's :meth:`_mark_agent_terminal` accepts (minus the
+#: dispatcher-specific ``crashed`` and ``plan_blocked``, which are daemon-
+#: side concepts). Any value outside this set is rejected with exit 1.
+VALID_TERMINAL_STATUSES = frozenset({"succeeded", "failed"})
+
+#: Subprocess timeout for the ``scripts/dev-db-query.sh`` wrapper. ECS
+#: Exec SSM sessions typically take 2-4s; 60s gives generous headroom
+#: for a slow rollover.
+DEV_DB_QUERY_TIMEOUT_SECONDS = 60
+
+#: Relative path to the dev-db-query wrapper, resolved from the repo root.
+DEV_DB_QUERY_SCRIPT = Path("scripts/dev-db-query.sh")
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse CLI arguments for the two subcommands."""
+    parser = argparse.ArgumentParser(
+        description="Write /task skill claim + terminal rows to dispatcher.agents.",
+    )
+    sub = parser.add_subparsers(dest="subcommand", required=True)
+
+    claim = sub.add_parser("claim", help="INSERT a claim row.")
+    claim.add_argument("--issue", required=True, type=int, help="Issue number.")
+    claim.add_argument(
+        "--agent-id",
+        required=True,
+        help="UUID of the /task agent (derive from worktree path or fresh uuid4).",
+    )
+    claim.add_argument(
+        "--worktree-path",
+        required=True,
+        help="Absolute path to the worktree the /task skill is running in.",
+    )
+    claim.add_argument(
+        "--issue-title",
+        default=None,
+        help="Optional issue title to store for admin-page rendering.",
+    )
+
+    term = sub.add_parser("terminal", help="UPDATE the row to a terminal status.")
+    term.add_argument(
+        "--agent-id",
+        required=True,
+        help="UUID of the /task agent that previously claimed.",
+    )
+    term.add_argument(
+        "--status",
+        required=True,
+        choices=sorted(VALID_TERMINAL_STATUSES),
+        help="Terminal status to record.",
+    )
+    term.add_argument(
+        "--pr-number",
+        default=None,
+        type=int,
+        help="Optional PR number to write back.",
+    )
+
+    return parser.parse_args(argv)
+
+
+def _resolve_repo_root(start: Path) -> Path:
+    """Walk up from ``start`` until ``.git`` is found.
+
+    Works from either the main repo checkout or a worktree (``.git`` is a
+    file in worktrees, a directory in the main checkout — either way
+    :meth:`Path.exists` returns True).
+    """
+    cur = start.resolve()
+    while cur != cur.parent:
+        if (cur / ".git").exists():
+            return cur
+        cur = cur.parent
+    return start.resolve()
+
+
+def _dev_db_query_path() -> Path:
+    """Absolute path to ``scripts/dev-db-query.sh`` in the current repo."""
+    here = Path(__file__).resolve()
+    repo_root = _resolve_repo_root(here)
+    return repo_root / DEV_DB_QUERY_SCRIPT
+
+
+def _run_sql_via_db_query_sh(sql: str) -> dict[str, Any]:
+    """Execute SQL via the ``dev-db-query.sh --rw`` wrapper.
+
+    Returns the parsed JSON from stdout on success. For non-SELECT
+    statements the wrapper emits ``{"rowcount": N}``; for SELECT it emits
+    a list of row dicts.
+
+    Raises :class:`RuntimeError` on subprocess failure. UniqueViolation
+    and other DB errors bubble up as non-zero exit codes with the DB
+    error message on stderr — the caller classifies them.
+    """
+    script = _dev_db_query_path()
+    if not script.exists():
+        raise RuntimeError(f"dev-db-query.sh not found at {script}")
+
+    cmd = ["bash", str(script), "--rw", sql]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=DEV_DB_QUERY_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(f"bash not on PATH: {exc}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"dev-db-query.sh timed out after {DEV_DB_QUERY_TIMEOUT_SECONDS}s"
+        ) from exc
+
+    if result.returncode != 0:
+        # Propagate stderr — the caller classifies UniqueViolation vs
+        # genuine errors by string-matching it.
+        raise RuntimeError(
+            f"dev-db-query.sh exit={result.returncode}: "
+            f"{(result.stderr or result.stdout or '').strip()}"
+        )
+
+    stdout = (result.stdout or "").strip()
+    # The wrapper prints informational lines to stderr; stdout is the
+    # JSON payload. An empty payload indicates a non-SELECT with 0
+    # rowcount which we treat as "nothing happened".
+    if not stdout:
+        return {"rowcount": 0}
+
+    # The wrapper streams SSM output too — find the first JSON-looking
+    # chunk. In practice stdout is just the JSON, but be defensive.
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        # Last-ditch: try to find the JSON object/array in the output.
+        for token in ("[", "{"):
+            idx = stdout.find(token)
+            if idx == -1:
+                continue
+            try:
+                return json.loads(stdout[idx:])
+            except json.JSONDecodeError:
+                continue
+        raise RuntimeError(f"dev-db-query.sh returned non-JSON stdout: {stdout[:200]}")
+
+
+class ClaimLost(Exception):
+    """Raised by :func:`_claim_via_psycopg` when the partial UNIQUE INDEX rejects the INSERT."""
+
+
+def _claim_via_psycopg(
+    database_url: str,
+    issue_number: int,
+    agent_id: str,
+    worktree_path: str,
+    issue_title: str | None,
+) -> None:
+    """INSERT a claim row via psycopg. Raises :class:`ClaimLost` on UniqueViolation."""
+    import psycopg  # noqa: PLC0415 — lazy import
+
+    with psycopg.connect(database_url, connect_timeout=10) as conn:
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO dispatcher.agents "
+                    "    (agent_id, kind, issue_number, "
+                    "     issue_title, worktree_path, phase, status) "
+                    "VALUES (%s, %s, %s, %s, %s, 'claiming', 'running')",
+                    (
+                        agent_id,
+                        TASK_SKILL_KIND,
+                        issue_number,
+                        issue_title,
+                        worktree_path,
+                    ),
+                )
+            conn.commit()
+        except psycopg.errors.UniqueViolation as exc:
+            conn.rollback()
+            raise ClaimLost(str(exc)) from exc
+
+
+def _lookup_owner_via_psycopg(
+    database_url: str, issue_number: int
+) -> dict[str, Any] | None:
+    """SELECT the current ``running``/``retrying`` row for ``issue_number``.
+
+    Returns the owner metadata dict or None when the row is no longer
+    active (edge case — the partial index released between our failed
+    INSERT and this lookup).
+    """
+    import psycopg  # noqa: PLC0415 — lazy import
+
+    with psycopg.connect(database_url, connect_timeout=10) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT agent_id, kind, status, started_at "
+                "FROM dispatcher.agents "
+                "WHERE issue_number = %s "
+                "  AND status IN ('running', 'retrying') "
+                "LIMIT 1",
+                (issue_number,),
+            )
+            row = cur.fetchone()
+    if row is None:
+        return None
+    return {
+        "owner_agent_id": str(row[0]),
+        "owner_kind": row[1],
+        "owner_status": row[2],
+        "owner_started_at": str(row[3]),
+        "issue_number": issue_number,
+    }
+
+
+def _claim_via_db_query_sh(
+    issue_number: int,
+    agent_id: str,
+    worktree_path: str,
+    issue_title: str | None,
+) -> None:
+    """INSERT a claim row via the ``dev-db-query.sh --rw`` wrapper.
+
+    Raises :class:`ClaimLost` when the wrapper's stderr contains a
+    UniqueViolation signature. Any other subprocess error bubbles up as
+    :class:`RuntimeError`.
+    """
+    # Build a parameter-inlined INSERT. We can't pass parameters through
+    # the wrapper, so values are inlined — safe because agent_id/kind are
+    # constrained identifiers and worktree_path/issue_title come from
+    # the /task skill (trusted caller). The wrapper's own --rw flag
+    # already SETs the session to read-write; INSERT returns no rows so
+    # the wrapper prints ``{"rowcount": 1}`` on success.
+    title_sql = _sql_literal(issue_title) if issue_title else "NULL"
+    sql = (
+        "INSERT INTO dispatcher.agents "
+        "(agent_id, kind, issue_number, issue_title, worktree_path, phase, status) "
+        f"VALUES ({_sql_literal(agent_id)}, {_sql_literal(TASK_SKILL_KIND)}, "
+        f"{int(issue_number)}, {title_sql}, {_sql_literal(worktree_path)}, "
+        "'claiming', 'running')"
+    )
+    try:
+        _run_sql_via_db_query_sh(sql)
+    except RuntimeError as exc:
+        msg = str(exc).lower()
+        # psycopg surfaces UniqueViolation as a multi-line error whose
+        # first relevant token is ``duplicate key value violates unique
+        # constraint "idx_dispatcher_agents_active_issue"``. Match on
+        # the constraint name (the index) — less fragile than the
+        # human-readable prefix across psycopg versions.
+        if (
+            "idx_dispatcher_agents_active_issue" in msg
+            or "duplicate key" in msg
+            or "uniqueviolation" in msg
+        ):
+            raise ClaimLost(str(exc)) from exc
+        raise
+
+
+def _lookup_owner_via_db_query_sh(issue_number: int) -> dict[str, Any] | None:
+    """SELECT current owner via the wrapper; None if no active row."""
+    sql = (
+        "SELECT agent_id::text AS owner_agent_id, "
+        "       kind AS owner_kind, "
+        "       status AS owner_status, "
+        "       started_at::text AS owner_started_at "
+        "FROM dispatcher.agents "
+        f"WHERE issue_number = {int(issue_number)} "
+        "  AND status IN ('running', 'retrying') "
+        "LIMIT 1"
+    )
+    try:
+        rows = _run_sql_via_db_query_sh(sql)
+    except RuntimeError:
+        return None
+    if not isinstance(rows, list) or not rows:
+        return None
+    owner = rows[0]
+    owner["issue_number"] = issue_number
+    return owner
+
+
+def _sql_literal(value: str) -> str:
+    """Quote a string as a Postgres SQL literal.
+
+    Only single-quotes are doubled — PostgreSQL accepts ``'it''s'`` as
+    ``it's``. Backslashes are passed through because the session is not
+    in ``standard_conforming_strings=off`` mode (default is on in
+    Postgres ≥ 9.1). Good enough for the trusted-caller inputs the
+    /task skill hands us.
+    """
+    if "\x00" in value:
+        raise ValueError("value contains NUL byte; cannot be a SQL literal")
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _terminal_via_psycopg(
+    database_url: str,
+    agent_id: str,
+    status: str,
+    pr_number: int | None,
+) -> int:
+    """UPDATE the row to the terminal status. Returns rowcount."""
+    import psycopg  # noqa: PLC0415 — lazy import
+
+    with psycopg.connect(database_url, connect_timeout=10) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE dispatcher.agents "
+                "SET status = %s, ended_at = now(), "
+                "    pr_number = COALESCE(%s, pr_number) "
+                "WHERE agent_id = %s",
+                (status, pr_number, agent_id),
+            )
+            rowcount = cur.rowcount
+        conn.commit()
+    return rowcount
+
+
+def _terminal_via_db_query_sh(agent_id: str, status: str, pr_number: int | None) -> int:
+    """UPDATE the row to the terminal status via ``dev-db-query.sh --rw``."""
+    pr_clause = str(int(pr_number)) if pr_number is not None else "NULL"
+    sql = (
+        "UPDATE dispatcher.agents "
+        f"SET status = {_sql_literal(status)}, "
+        "    ended_at = now(), "
+        f"    pr_number = COALESCE({pr_clause}, pr_number) "
+        f"WHERE agent_id = {_sql_literal(agent_id)}"
+    )
+    result = _run_sql_via_db_query_sh(sql)
+    if isinstance(result, dict):
+        return int(result.get("rowcount", 0))
+    return 0
+
+
+def do_claim(
+    issue_number: int,
+    agent_id: str,
+    worktree_path: str,
+    issue_title: str | None,
+) -> int:
+    """Orchestrate the claim INSERT. Returns the process exit code."""
+    database_url = os.environ.get("DATABASE_URL", "").strip()
+    use_psycopg = bool(database_url)
+
+    try:
+        if use_psycopg:
+            _claim_via_psycopg(
+                database_url, issue_number, agent_id, worktree_path, issue_title
+            )
+        else:
+            _claim_via_db_query_sh(issue_number, agent_id, worktree_path, issue_title)
+    except ClaimLost:
+        # Look up the current owner so the /task skill can tell the operator
+        # who owns the issue right now.
+        if use_psycopg:
+            owner = _lookup_owner_via_psycopg(database_url, issue_number)
+        else:
+            owner = _lookup_owner_via_db_query_sh(issue_number)
+        payload = owner or {"issue_number": issue_number}
+        payload.setdefault("reason", "claim_lost")
+        print(json.dumps(payload), file=sys.stdout)
+        sys.stderr.write(
+            f"claim_lost: issue #{issue_number} is already being worked on "
+            f"by {payload.get('owner_kind', 'unknown')} agent "
+            f"{payload.get('owner_agent_id', 'unknown')} "
+            f"(status={payload.get('owner_status', 'unknown')}).\n"
+        )
+        return 2
+    except Exception as exc:  # noqa: BLE001 — surface any DB / subprocess error
+        sys.stderr.write(f"task_claim: claim failed: {exc}\n")
+        return 1
+
+    print(json.dumps({"status": "claimed", "issue_number": issue_number}))
+    return 0
+
+
+def do_terminal(agent_id: str, status: str, pr_number: int | None) -> int:
+    """Orchestrate the terminal UPDATE. Returns the process exit code.
+
+    Terminal updates are best-effort — a failure here does not block the
+    /task skill's flow (the PR has already landed; the DB row just stays
+    ``running`` until the daemon's supervisor tick reconciles it). We
+    still return a non-zero exit on catastrophic failure so a caller
+    that WANTS to know can act on it, but the skill ignores it.
+    """
+    database_url = os.environ.get("DATABASE_URL", "").strip()
+    use_psycopg = bool(database_url)
+
+    try:
+        if use_psycopg:
+            rowcount = _terminal_via_psycopg(database_url, agent_id, status, pr_number)
+        else:
+            rowcount = _terminal_via_db_query_sh(agent_id, status, pr_number)
+    except Exception as exc:  # noqa: BLE001 — DB/subprocess surface
+        sys.stderr.write(f"task_claim: terminal update failed: {exc}\n")
+        return 1
+
+    if rowcount == 0:
+        sys.stderr.write(
+            f"task_claim: terminal update matched 0 rows for agent_id={agent_id}\n"
+        )
+    print(
+        json.dumps(
+            {
+                "status": "terminal_recorded",
+                "agent_id": agent_id,
+                "terminal_status": status,
+                "rowcount": rowcount,
+            }
+        )
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    if args.subcommand == "claim":
+        return do_claim(
+            args.issue,
+            args.agent_id,
+            args.worktree_path,
+            args.issue_title,
+        )
+    if args.subcommand == "terminal":
+        return do_terminal(args.agent_id, args.status, args.pr_number)
+    sys.stderr.write(f"Unknown subcommand: {args.subcommand}\n")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dispatcher/tests/test_daemon_killswitch.py
+++ b/scripts/dispatcher/tests/test_daemon_killswitch.py
@@ -444,6 +444,7 @@ class TestOrchestrationPhasePause:
             status="failed",
             phase=daemon.KILLSWITCH_TERMINAL_PHASE,
             exit_code=None,
+            issue_number=42,
         )
         # Structured event logged so CloudWatch can confirm the abort.
         events = handler.events("orchestration_paused")
@@ -485,6 +486,7 @@ class TestOrchestrationPhasePause:
             status="failed",
             phase=daemon.KILLSWITCH_TERMINAL_PHASE,
             exit_code=None,
+            issue_number=42,
         )
         events = handler.events("orchestration_paused")
         assert len(events) == 1
@@ -653,6 +655,7 @@ class TestSyntheticMidClaimCapFlip:
                 status="failed",
                 phase=daemon.KILLSWITCH_TERMINAL_PHASE,
                 exit_code=None,
+                issue_number=42,
             )
             assert handler.events("orchestration_paused") != []
         finally:

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -675,6 +675,121 @@ class TestAtomicClaim:
         assert ok is False
         assert handler.events("claim_failed") != []
 
+    # ── #2866 claim-interlock tests ──────────────────────────────────
+
+    def test_happy_path_adds_status_in_progress_label(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Successful claim adds ``status/in-progress`` via ``gh issue edit``.
+
+        Issue #2866 — the label is the human-visible half of the
+        claim interlock. Add happens in :meth:`_atomic_claim` on
+        happy-path success AFTER the DB commit.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+        gh_edit_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            if cmd[:3] == ["gh", "issue", "edit"]:
+                gh_edit_calls.append(cmd)
+                return r
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        ok = d._atomic_claim(42, "agent-uuid", "/path")
+        assert ok is True
+        # Exactly one add-label call with the in-progress label.
+        assert len(gh_edit_calls) == 1
+        assert "--add-label" in gh_edit_calls[0]
+        assert daemon.STATUS_IN_PROGRESS_LABEL in gh_edit_calls[0]
+
+    def test_unique_violation_with_task_skill_owner_logs_already_claimed_by_task(
+        self, tmp_path: Path
+    ) -> None:
+        """UniqueViolation + owner.kind='task-skill' → ``candidate_skipped`` with ``already_claimed_by_task``.
+
+        Issue #2866 — daemon queue scan observes that a /task subagent
+        has already claimed the issue and logs a distinguishing reason
+        so CloudWatch Logs Insights queries can count collisions
+        separately from daemon↔daemon races.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def insert_raises_select_returns_owner(sql: str, params: Any = None) -> None:
+            if "INSERT INTO dispatcher.agents" in sql:
+                raise psycopg.errors.UniqueViolation("dup")
+            # owner-lookup SELECT executes and returns ('task-skill',)
+
+        conn.cursor_instance.execute = (  # type: ignore[method-assign]
+            insert_raises_select_returns_owner
+        )
+        conn.cursor_instance.fetch_queue = [("task-skill",)]
+
+        ok = d._atomic_claim(42, "agent-uuid", "/path")
+        assert ok is False
+        # Distinguishing event: ``candidate_skipped`` reason matches
+        # ``already_claimed_by_task``. No generic ``claim_lost``.
+        skipped = handler.events("candidate_skipped")
+        assert skipped, "expected candidate_skipped event"
+        assert skipped[0].__dict__.get("reason") == "already_claimed_by_task"
+        assert handler.events("claim_lost") == []
+
+    def test_unique_violation_with_task_owner_logs_generic_claim_lost(
+        self, tmp_path: Path
+    ) -> None:
+        """UniqueViolation + owner.kind='task' (daemon↔daemon) → ``claim_lost``.
+
+        Issue #2866 — preserves pre-existing semantics for the common
+        daemon-on-daemon race case. Owner kind is surfaced on the log
+        envelope so operators can still see who won.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def insert_raises_select_returns_owner(sql: str, params: Any = None) -> None:
+            if "INSERT INTO dispatcher.agents" in sql:
+                raise psycopg.errors.UniqueViolation("dup")
+
+        conn.cursor_instance.execute = (  # type: ignore[method-assign]
+            insert_raises_select_returns_owner
+        )
+        # Owner is another daemon-spawned agent (kind='task').
+        conn.cursor_instance.fetch_queue = [("task",)]
+
+        ok = d._atomic_claim(42, "agent-uuid", "/path")
+        assert ok is False
+        assert handler.events("claim_lost") != []
+        assert handler.events("candidate_skipped") == []
+
+    def test_unique_violation_with_no_owner_row_still_logs_claim_lost(
+        self, tmp_path: Path
+    ) -> None:
+        """Edge case: partial index released between INSERT and SELECT.
+
+        Owner lookup returns None because the row already completed +
+        was indexed out. We still log ``claim_lost`` so the operator
+        sees the race happened, but ``owner_kind`` is None in the
+        envelope.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def insert_raises(sql: str, params: Any = None) -> None:
+            if "INSERT INTO dispatcher.agents" in sql:
+                raise psycopg.errors.UniqueViolation("dup")
+
+        conn.cursor_instance.execute = insert_raises  # type: ignore[method-assign]
+        # Empty fetch_queue → fetchone returns None → owner_kind=None.
+
+        ok = d._atomic_claim(42, "agent-uuid", "/path")
+        assert ok is False
+        lost = handler.events("claim_lost")
+        assert lost, "expected claim_lost event"
+        assert lost[0].__dict__.get("owner_kind") is None
+
 
 # --------------------------------------------------------------------------
 # _create_worktree / git subprocess
@@ -1466,7 +1581,14 @@ class TestPlanGoFalse:
         assert succeeded_updates
         # No plan_blocked side effects on the no-work path.
         assert gh_comment_calls == []
-        assert gh_edit_calls == []
+        # #2866 claim-interlock label calls ARE expected here:
+        # the ``status/in-progress`` label is added on claim and removed
+        # on terminal. Filter them out before asserting "no plan_blocked
+        # label swap happened".
+        non_interlock_edits = [
+            call for call in gh_edit_calls if "status/in-progress" not in call
+        ]
+        assert non_interlock_edits == []
         assert handler.events("plan_blocked_comment_posted") == []
         assert handler.events("plan_blocked_labels_swapped") == []
 
@@ -2834,3 +2956,215 @@ class TestNeedsReviewOrchestration:
         assert needs_review_updates
         # Failure event logged.
         assert handler.events("needs_review_comment_failed") != []
+
+
+# --------------------------------------------------------------------------
+# #2866 — claim interlock: ``status/in-progress`` label lifecycle +
+# daemon queue-scan filter + task-skill collision detection.
+# --------------------------------------------------------------------------
+
+
+class TestClaimInterlockLabel:
+    """Status label add on claim / remove on terminal (#2866)."""
+
+    def test_mark_agent_terminal_removes_label_when_issue_number_provided(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Terminal transition with ``issue_number`` → ``gh issue edit --remove-label``.
+
+        The explicit-opt-in contract: callers thread issue_number
+        through when they know it; otherwise the teardown is skipped.
+        This test covers the "thread through" path.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+        gh_edit_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            if cmd[:3] == ["gh", "issue", "edit"]:
+                gh_edit_calls.append(cmd)
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        d._mark_agent_terminal(
+            "agent-uuid",
+            status="succeeded",
+            phase="done",
+            exit_code=0,
+            issue_number=42,
+        )
+        assert len(gh_edit_calls) == 1
+        assert "--remove-label" in gh_edit_calls[0]
+        assert daemon.STATUS_IN_PROGRESS_LABEL in gh_edit_calls[0]
+
+    def test_mark_agent_terminal_skips_label_when_issue_number_omitted(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Terminal transition without ``issue_number`` → no gh call.
+
+        Protects call sites that don't know the issue number
+        (supervisor retry paths, generic diagnoser hand-offs) from
+        making an expensive subprocess call that would pin the event
+        loop on a slow GitHub response.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+        gh_edit_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            if cmd[:3] == ["gh", "issue", "edit"]:
+                gh_edit_calls.append(cmd)
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        d._mark_agent_terminal(
+            "agent-uuid",
+            status="failed",
+            phase="awaiting_ci",
+            exit_code=None,
+            # issue_number omitted
+        )
+        assert gh_edit_calls == []
+
+    def test_mark_agent_terminal_non_terminal_status_does_not_remove_label(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Non-terminal transitions (e.g. awaiting_ci hand-off) keep the label.
+
+        The label only clears when the agent is genuinely done; the
+        Phase 3A post-PR hand-off is still "running" with
+        ``phase='awaiting_ci'`` so the label must persist until the
+        final success/failed/crashed transition.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+        gh_edit_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            if cmd[:3] == ["gh", "issue", "edit"]:
+                gh_edit_calls.append(cmd)
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        d._mark_agent_terminal(
+            "agent-uuid",
+            status="running",
+            phase="awaiting_ci",
+            exit_code=None,
+            issue_number=42,
+        )
+        assert gh_edit_calls == []
+
+
+class TestQueueScanExcludesInProgressLabel:
+    """``_fetch_agent_ready_issues`` filters out ``status/in-progress`` (#2866)."""
+
+    def test_in_progress_label_excludes_issue_from_candidate_list(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Issues carrying ``status/in-progress`` alongside ``agent/ready`` drop.
+
+        Belt-and-suspenders with the DB-side partial UNIQUE INDEX: the
+        label filter is redundant if the DB write is atomic, but a
+        ``gh`` output that races a /task skill's label add protects
+        against the daemon picking up an issue in the few-second
+        window before the DB row lands.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = json.dumps(
+                [
+                    {
+                        "number": 1,
+                        "labels": [{"name": "agent/ready"}],
+                        "title": "ok",
+                    },
+                    {
+                        "number": 2,
+                        "labels": [
+                            {"name": "agent/ready"},
+                            {"name": daemon.STATUS_IN_PROGRESS_LABEL},
+                        ],
+                        "title": "in-progress",
+                    },
+                    {
+                        "number": 3,
+                        "labels": [{"name": "agent/ready"}],
+                        "title": "ok2",
+                    },
+                ]
+            )
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        issues = d._fetch_agent_ready_issues()
+        # #2 drops; #1 + #3 remain.
+        assert [i["number"] for i in issues] == [1, 3]
+
+
+class TestGhIssueRemoveLabelsHelper:
+    """Thin helper tests for :meth:`_gh_issue_remove_labels` (#2866)."""
+
+    def test_empty_labels_is_a_noop(self, monkeypatch: Any, tmp_path: Path) -> None:
+        """No labels → no subprocess call."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        called: list[list[str]] = []
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **_kw: called.append(cmd) or MagicMock(returncode=0),
+        )
+        d._gh_issue_remove_labels(42, [])
+        assert called == []
+
+    def test_happy_path_shells_out_to_gh_issue_edit_remove_label(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """One label → one ``gh issue edit --remove-label LABEL`` subprocess call."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            captured.append(cmd)
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d._gh_issue_remove_labels(42, [daemon.STATUS_IN_PROGRESS_LABEL])
+        assert len(captured) == 1
+        assert captured[0][:3] == ["gh", "issue", "edit"]
+        assert "--remove-label" in captured[0]
+        assert daemon.STATUS_IN_PROGRESS_LABEL in captured[0]
+
+    def test_nonzero_exit_is_logged_not_raised(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """``gh`` returning non-zero must not raise — DB write is authoritative."""
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 1
+            r.stdout = ""
+            r.stderr = "label not found\n"
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        # Must not raise.
+        d._gh_issue_remove_labels(42, [daemon.STATUS_IN_PROGRESS_LABEL])
+        assert handler.events("label_remove_nonzero") != []

--- a/scripts/dispatcher/tests/test_task_claim.py
+++ b/scripts/dispatcher/tests/test_task_claim.py
@@ -1,0 +1,597 @@
+"""Unit tests for ``scripts.dispatcher.task_claim`` — /task skill claim helper.
+
+Issue #2866. Covers the four code paths the helper owns:
+
+* ``claim`` via psycopg (DATABASE_URL set) — happy path + UniqueViolation.
+* ``claim`` via dev-db-query.sh (DATABASE_URL unset) — happy path +
+  UniqueViolation-by-string-match + non-unique-violation subprocess error.
+* ``terminal`` via psycopg — happy path + UPDATE-matched-0-rows.
+* ``terminal`` via dev-db-query.sh — happy path + rowcount parse.
+
+All external calls — psycopg and the ``dev-db-query.sh`` subprocess —
+are mocked. The helper is deliberately light on logic so these tests
+cover most of its LOC via pair-assertions.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+# Provide a stub ``psycopg`` module before importing the helper. The
+# helper imports psycopg lazily inside each function, but we install a
+# stub whose ``errors.UniqueViolation`` is a real Exception so the
+# ``except psycopg.errors.UniqueViolation`` clause works.
+#
+# Match the defensive install pattern from test_daemon_phase3c.py —
+# only overwrite ``sys.modules["psycopg"]`` when it's missing or
+# malformed. Another test in the same pytest session (e.g.
+# test_daemon_phase3a.py) may have already installed a compatible stub;
+# overwriting it would swap out the ``UniqueViolation`` class that
+# other tests captured via ``import psycopg``, causing the daemon's
+# ``except psycopg.errors.UniqueViolation`` clause to miss.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+import psycopg  # noqa: E402  — re-import after stub install
+
+from dispatcher import task_claim  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — mirror the _FakeCursor / _FakeConnection pattern from
+# test_daemon_phase3a.py so behavior stays consistent across suites.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, fetch_result: Any = None, rowcount: int = 1) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self._fetch_result = fetch_result
+        self.rowcount = rowcount
+        self.raise_on_execute: Exception | None = None
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+        if self.raise_on_execute is not None:
+            raise self.raise_on_execute
+
+    def fetchone(self) -> Any:
+        return self._fetch_result
+
+
+class _FakeConnection:
+    def __init__(self, cursor: _FakeCursor) -> None:
+        self._cursor = cursor
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+
+    def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+    def __enter__(self) -> _FakeConnection:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.closed = True
+
+
+def _patch_psycopg_connect(
+    monkeypatch: pytest.MonkeyPatch, cursor: _FakeCursor
+) -> _FakeConnection:
+    """Install a fake ``psycopg.connect`` that returns the provided cursor.
+
+    Returns the underlying connection so the test can assert commits /
+    rollbacks.
+    """
+    conn = _FakeConnection(cursor)
+    monkeypatch.setattr(psycopg, "connect", lambda *_args, **_kwargs: conn)
+    return conn
+
+
+# --------------------------------------------------------------------------
+# SQL literal escaping — defensive against single-quote inputs
+# --------------------------------------------------------------------------
+
+
+class TestSqlLiteral:
+    """``_sql_literal`` doubles single quotes and rejects NUL."""
+
+    def test_simple_string_roundtrips(self) -> None:
+        assert task_claim._sql_literal("hello") == "'hello'"
+
+    def test_doubles_single_quotes(self) -> None:
+        assert task_claim._sql_literal("it's") == "'it''s'"
+
+    def test_rejects_null_byte(self) -> None:
+        with pytest.raises(ValueError):
+            task_claim._sql_literal("has\x00null")
+
+
+# --------------------------------------------------------------------------
+# _claim_via_psycopg — DATABASE_URL path
+# --------------------------------------------------------------------------
+
+
+class TestClaimViaPsycopg:
+    """psycopg-path claim INSERT covers happy + UniqueViolation."""
+
+    def test_happy_path_inserts_and_commits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cur = _FakeCursor()
+        conn = _patch_psycopg_connect(monkeypatch, cur)
+
+        task_claim._claim_via_psycopg(
+            "postgres://fake",
+            issue_number=2866,
+            agent_id="aabbccdd-eeff-0011-2233-445566778899",
+            worktree_path="/tmp/wt",
+            issue_title="title",
+        )
+
+        assert len(cur.executed) == 1
+        sql, params = cur.executed[0]
+        assert "INSERT INTO dispatcher.agents" in sql
+        assert params[0] == "aabbccdd-eeff-0011-2233-445566778899"
+        assert params[1] == task_claim.TASK_SKILL_KIND
+        assert params[2] == 2866
+        assert params[3] == "title"
+        assert params[4] == "/tmp/wt"
+        assert conn.commits == 1
+
+    def test_unique_violation_is_translated_to_claim_lost(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cur = _FakeCursor()
+        cur.raise_on_execute = psycopg.errors.UniqueViolation("dup")
+        conn = _patch_psycopg_connect(monkeypatch, cur)
+
+        with pytest.raises(task_claim.ClaimLost):
+            task_claim._claim_via_psycopg(
+                "postgres://fake",
+                issue_number=2866,
+                agent_id="abc",
+                worktree_path="/tmp/wt",
+                issue_title=None,
+            )
+        assert conn.rollbacks == 1
+
+
+# --------------------------------------------------------------------------
+# _lookup_owner_via_psycopg — owner-identification path
+# --------------------------------------------------------------------------
+
+
+class TestLookupOwnerViaPsycopg:
+    def test_returns_owner_dict_when_active_row_exists(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cur = _FakeCursor(
+            fetch_result=(
+                "0000-owner-uuid",
+                "task-skill",
+                "running",
+                "2026-04-19T20:00:00Z",
+            )
+        )
+        _patch_psycopg_connect(monkeypatch, cur)
+
+        owner = task_claim._lookup_owner_via_psycopg("postgres://fake", 2866)
+        assert owner is not None
+        assert owner["owner_agent_id"] == "0000-owner-uuid"
+        assert owner["owner_kind"] == "task-skill"
+        assert owner["owner_status"] == "running"
+        assert owner["issue_number"] == 2866
+
+    def test_returns_none_when_no_active_row(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cur = _FakeCursor(fetch_result=None)
+        _patch_psycopg_connect(monkeypatch, cur)
+
+        owner = task_claim._lookup_owner_via_psycopg("postgres://fake", 2866)
+        assert owner is None
+
+
+# --------------------------------------------------------------------------
+# _claim_via_db_query_sh — DATABASE_URL-unset path
+# --------------------------------------------------------------------------
+
+
+class TestClaimViaDbQuerySh:
+    """Subprocess-path claim covers happy + UniqueViolation string match."""
+
+    def test_happy_path_invokes_dev_db_query_sh_rw(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            captured.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = '{"rowcount": 1}'
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        # Point the helper's dev-db-query.sh resolver at a real path so
+        # the _run_sql_via_db_query_sh "exists" check passes. The script
+        # in this repo lives at scripts/dev-db-query.sh which the
+        # worktree always has.
+        task_claim._claim_via_db_query_sh(
+            issue_number=2866,
+            agent_id="abc",
+            worktree_path="/tmp/wt",
+            issue_title=None,
+        )
+        assert len(captured) == 1
+        assert captured[0][0] == "bash"
+        assert captured[0][1].endswith("scripts/dev-db-query.sh")
+        assert "--rw" in captured[0]
+
+    def test_unique_violation_error_message_raises_claim_lost(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 1
+            r.stdout = ""
+            r.stderr = (
+                "Database error: duplicate key value violates unique "
+                'constraint "idx_dispatcher_agents_active_issue"\n'
+            )
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        with pytest.raises(task_claim.ClaimLost):
+            task_claim._claim_via_db_query_sh(
+                issue_number=2866,
+                agent_id="abc",
+                worktree_path="/tmp/wt",
+                issue_title=None,
+            )
+
+    def test_non_unique_violation_error_raises_runtime_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 1
+            r.stdout = ""
+            r.stderr = "Database error: connection refused\n"
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError):
+            task_claim._claim_via_db_query_sh(
+                issue_number=2866,
+                agent_id="abc",
+                worktree_path="/tmp/wt",
+                issue_title=None,
+            )
+
+
+# --------------------------------------------------------------------------
+# _terminal_via_psycopg — psycopg terminal UPDATE
+# --------------------------------------------------------------------------
+
+
+class TestTerminalViaPsycopg:
+    def test_happy_path_updates_and_commits(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cur = _FakeCursor(rowcount=1)
+        conn = _patch_psycopg_connect(monkeypatch, cur)
+
+        rowcount = task_claim._terminal_via_psycopg(
+            "postgres://fake",
+            agent_id="abc",
+            status="succeeded",
+            pr_number=42,
+        )
+        assert rowcount == 1
+        assert len(cur.executed) == 1
+        sql, params = cur.executed[0]
+        assert "UPDATE dispatcher.agents" in sql
+        assert params[0] == "succeeded"
+        assert params[1] == 42
+        assert params[2] == "abc"
+        assert conn.commits == 1
+
+    def test_rowcount_zero_when_no_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cur = _FakeCursor(rowcount=0)
+        _patch_psycopg_connect(monkeypatch, cur)
+
+        rowcount = task_claim._terminal_via_psycopg(
+            "postgres://fake",
+            agent_id="missing",
+            status="failed",
+            pr_number=None,
+        )
+        assert rowcount == 0
+
+
+# --------------------------------------------------------------------------
+# do_claim — top-level orchestration + exit codes
+# --------------------------------------------------------------------------
+
+
+class TestDoClaim:
+    """Exit code contract: 0 on success, 1 on error, 2 on claim_lost."""
+
+    def test_happy_path_with_database_url_returns_zero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+        called: list[dict[str, Any]] = []
+
+        def fake_claim(*args: Any, **kwargs: Any) -> None:
+            called.append({"args": args, "kwargs": kwargs})
+
+        monkeypatch.setattr(task_claim, "_claim_via_psycopg", fake_claim)
+        rc = task_claim.do_claim(2866, "abc", "/tmp/wt", None)
+        assert rc == 0
+        assert len(called) == 1
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out.strip())
+        assert payload == {"status": "claimed", "issue_number": 2866}
+
+    def test_claim_lost_returns_two_and_emits_owner_json(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+
+        def raise_claim_lost(*_args: Any, **_kwargs: Any) -> None:
+            raise task_claim.ClaimLost("dup")
+
+        def fake_lookup(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "owner_agent_id": "daemon-agent-uuid",
+                "owner_kind": "task",
+                "owner_status": "running",
+                "owner_started_at": "2026-04-19T20:00:00Z",
+                "issue_number": 2866,
+            }
+
+        monkeypatch.setattr(task_claim, "_claim_via_psycopg", raise_claim_lost)
+        monkeypatch.setattr(task_claim, "_lookup_owner_via_psycopg", fake_lookup)
+
+        rc = task_claim.do_claim(2866, "abc", "/tmp/wt", None)
+        assert rc == 2
+        out = capsys.readouterr()
+        payload = json.loads(out.out.strip())
+        assert payload["owner_agent_id"] == "daemon-agent-uuid"
+        assert payload["owner_kind"] == "task"
+        assert payload["owner_status"] == "running"
+        assert payload["issue_number"] == 2866
+        assert payload["reason"] == "claim_lost"
+        assert "daemon agent" in out.err or "task agent" in out.err
+
+    def test_claim_lost_with_no_owner_still_returns_two(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Edge case: owner lookup returned None (row released between attempts).
+
+        We still report claim_lost (exit 2) because the INSERT failed,
+        but the payload is minimal — just the issue number + reason.
+        """
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+
+        def raise_claim_lost(*_args: Any, **_kwargs: Any) -> None:
+            raise task_claim.ClaimLost("dup")
+
+        monkeypatch.setattr(task_claim, "_claim_via_psycopg", raise_claim_lost)
+        monkeypatch.setattr(
+            task_claim, "_lookup_owner_via_psycopg", lambda *_a, **_k: None
+        )
+
+        rc = task_claim.do_claim(2866, "abc", "/tmp/wt", None)
+        assert rc == 2
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload["issue_number"] == 2866
+        assert payload["reason"] == "claim_lost"
+
+    def test_unexpected_error_returns_one(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+
+        def fake_claim(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(task_claim, "_claim_via_psycopg", fake_claim)
+        rc = task_claim.do_claim(2866, "abc", "/tmp/wt", None)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "boom" in err
+
+    def test_no_database_url_uses_db_query_sh_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        called: list[tuple[Any, ...]] = []
+
+        def fake_claim_sh(*args: Any, **kwargs: Any) -> None:
+            called.append((args, kwargs))
+
+        monkeypatch.setattr(task_claim, "_claim_via_db_query_sh", fake_claim_sh)
+        rc = task_claim.do_claim(2866, "abc", "/tmp/wt", None)
+        assert rc == 0
+        assert len(called) == 1
+
+
+# --------------------------------------------------------------------------
+# do_terminal — top-level orchestration + rowcount handling
+# --------------------------------------------------------------------------
+
+
+class TestDoTerminal:
+    def test_happy_path_returns_zero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+        monkeypatch.setattr(
+            task_claim,
+            "_terminal_via_psycopg",
+            lambda *_a, **_k: 1,
+        )
+        rc = task_claim.do_terminal("abc", "succeeded", 42)
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload["status"] == "terminal_recorded"
+        assert payload["rowcount"] == 1
+
+    def test_rowcount_zero_still_returns_zero(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Terminal update on a missing row is best-effort — exit 0 with warning."""
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+        monkeypatch.setattr(
+            task_claim,
+            "_terminal_via_psycopg",
+            lambda *_a, **_k: 0,
+        )
+        rc = task_claim.do_terminal("missing", "failed", None)
+        assert rc == 0
+        err = capsys.readouterr().err
+        assert "matched 0 rows" in err
+
+    def test_db_error_returns_one(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+
+        def fake_terminal(*_a: Any, **_k: Any) -> int:
+            raise RuntimeError("db down")
+
+        monkeypatch.setattr(task_claim, "_terminal_via_psycopg", fake_terminal)
+        rc = task_claim.do_terminal("abc", "succeeded", None)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "db down" in err
+
+
+# --------------------------------------------------------------------------
+# main() CLI — argparse + dispatch
+# --------------------------------------------------------------------------
+
+
+class TestMain:
+    def test_claim_subcommand_dispatches_to_do_claim(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: list[tuple[int, str, str, str | None]] = []
+
+        def fake_do_claim(
+            issue: int, agent_id: str, worktree_path: str, issue_title: str | None
+        ) -> int:
+            captured.append((issue, agent_id, worktree_path, issue_title))
+            return 0
+
+        monkeypatch.setattr(task_claim, "do_claim", fake_do_claim)
+        rc = task_claim.main(
+            [
+                "claim",
+                "--issue",
+                "2866",
+                "--agent-id",
+                "abc",
+                "--worktree-path",
+                "/tmp/wt",
+            ]
+        )
+        assert rc == 0
+        assert captured == [(2866, "abc", "/tmp/wt", None)]
+
+    def test_terminal_subcommand_dispatches_to_do_terminal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: list[tuple[str, str, int | None]] = []
+
+        def fake_do_terminal(agent_id: str, status: str, pr_number: int | None) -> int:
+            captured.append((agent_id, status, pr_number))
+            return 0
+
+        monkeypatch.setattr(task_claim, "do_terminal", fake_do_terminal)
+        rc = task_claim.main(
+            [
+                "terminal",
+                "--agent-id",
+                "abc",
+                "--status",
+                "succeeded",
+                "--pr-number",
+                "42",
+            ]
+        )
+        assert rc == 0
+        assert captured == [("abc", "succeeded", 42)]
+
+    def test_terminal_rejects_invalid_status(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        with pytest.raises(SystemExit):
+            task_claim.main(
+                [
+                    "terminal",
+                    "--agent-id",
+                    "abc",
+                    "--status",
+                    "crashed",  # not in VALID_TERMINAL_STATUSES
+                ]
+            )


### PR DESCRIPTION
## Summary

Defense-in-depth claim interlock between operator-spawned `/task` subagents and the Fargate dispatcher daemon. Two layers both land together: (A) shared `dispatcher.agents` row — new `scripts/dispatcher/task_claim.py` helper writes `kind='task-skill', status='running'` on claim, existing partial UNIQUE INDEX catches collisions atomically; (B) `status/in-progress` GitHub label — added by both sides on claim, removed on terminal, daemon queue scan filter extended to exclude it.

Closes the race observed 2026-04-19 with #2856 where the operator's `/task` subagent and the Fargate daemon independently claimed the same issue.

Closes #2866

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass (479 passed, 1 skipped locally in dispatcher suite — adds 23 in test_task_claim.py + 8 in test_daemon_phase3a.py over the pre-#2866 baseline)
- [ ] CI green

### Post-deploy verification
- [ ] Dispatcher image redeployed to dev via `deploy-dispatcher.yml` — watch `gh run list --workflow "deploy-dispatcher.yml"` then `gh run watch`.
- [ ] Runtime sanity on live daemon: `scripts/ecs-run.sh --service judgemind-dispatcher-dev --container dispatcher --script verify_task_claim_interlock.py` confirms `STATUS_IN_PROGRESS_LABEL = 'status/in-progress'`, `TASK_SKILL_KIND = 'task-skill'`, and `_gh_issue_remove_labels` is importable.
- [ ] Verification evidence posted on #2866 (per-criterion against live env).

## Design decisions

1. **Two-layer interlock, not one.** DB row (atomic, race-free) + label (human-visible, filter-visible). Either alone has a gap; together they're complete. Daemon and /task both write both, so failure of one side doesn't silently expose the other.

2. **`kind='task-skill'` vs `'task'`.** Rows the daemon writes use `kind='task'`; /task-skill writes use `'task-skill'`. Lets the daemon's UniqueViolation handler emit a distinguishing `candidate_skipped reason='already_claimed_by_task'` log instead of the generic `claim_lost` — useful for operator triage (CloudWatch Logs Insights queries can count collisions separately).

3. **`DATABASE_URL` vs `dev-db-query.sh` dual path.** The /task skill runs in two environments — operator laptop (no direct VPC access to dev RDS) and Fargate container (has `DATABASE_URL`). Helper detects env and picks the right write path. Laptop path uses the existing ECS Exec wrapper, ~2-4 s per call. No new Fargate task spawn per claim.

4. **`issue_number` is explicit-opt-in on `_mark_agent_terminal`.** Phase 3A orchestration hot-path callers (plan/ralph/summary/push, subprocess failure handler, killswitch) thread it through so label teardown always runs. Supervisor/retry/diagnoser paths omit it — edge cases keep the label until next scheduler cycle or operator cleanup. Trade-off: narrow hot DB path (no extra SELECT per terminal, no 45+ test-fixture reshapes) at the cost of slightly-stale labels on rare edge paths.

5. **No DB migration.** `dispatcher.agents.kind` is free-text `text` with default `'task'` and no CHECK constraint (schema.sql:317, migration 21). Writing `'task-skill'` requires no schema change.

6. **No `$(...)`, no heredocs, no shell backgrounding** — adheres to CLAUDE.md rules throughout (`write-claude-file.sh` used to update `.claude/` files, `--body-file` used for all issue/PR writes).

## Meta-risk

This PR modifies `.claude/skills/task/SKILL.md` — the skill file that every `/task` agent runs under, including the one that produced this PR. Edits take effect on the **NEXT** invocation of `/task`, not this one. This agent completed its own claim under the pre-#2866 version (no `dispatcher.agents` write, no `status/in-progress` label). Subsequent /task spawns are where the interlock activates.

## Potential collisions with sibling PRs

Two other /task subagents (#2856 summary-unmet fix, #2860 circuit-breaker) touch `_mark_agent_terminal` in `scripts/dispatcher/daemon.py` in parallel. This PR adds an optional `issue_number` kwarg to `_mark_agent_terminal` and threads it through the Phase 3A orchestration callers — a straightforward merge with theirs unless they also added kwargs at the same position. If either lands first, rebase + re-run the dispatcher suite.
