### PR TITLE
fix(dispatcher): close 6-bug restart cascade (#2872)

### DIFF
--- a/packages/api/migrations/30_dispatcher-phase-outputs-retry.sql
+++ b/packages/api/migrations/30_dispatcher-phase-outputs-retry.sql
@@ -1,0 +1,88 @@
+-- Up Migration
+--
+-- Dispatcher v2 — phase_outputs retry-capable schema. Fix for the
+-- ``idx_dispatcher_phase_outputs_agent_phase`` unique-constraint
+-- collision that silently dropped second-run phase output on the
+-- 2026-04-19 restart-cascade (#2872 Bug E).
+--
+-- Context
+-- -------
+-- Before this migration, ``dispatcher.phase_outputs`` carried a unique
+-- index on ``(agent_id, phase)`` — one output row per phase per agent.
+-- That invariant was correct when retries always used a fresh
+-- ``agent_id`` (the pre-3C model). But Phase 3C's retry path reuses the
+-- original ``agent_id`` when a tier-1 mechanical retry fires, so a
+-- second plan/ralph/summary run on the same agent hit the unique
+-- constraint and the second run's output was silently rolled back by
+-- ``_persist_phase_output``'s best-effort ``except Exception`` (#2872
+-- 20:05:12 ``persist_phase_output_failed`` log).
+--
+-- The cascade this enabled
+-- ------------------------
+-- On daemon restart mid-ralph, the agent re-appeared as ``status=
+-- 'running'`` to the new daemon. The supervisor's 30m
+-- ``stuck_timeout`` fired on the stale ``phase_transitions.MAX(ts)``
+-- from the pre-restart plan phase. ``_process_retry_markers`` reset the
+-- agent to ``status='retrying'``, ``_resume_retrying_agent`` flipped
+-- back to ``status='running'``, and the re-run produced a duplicate
+-- ``(agent_id, 'plan')`` INSERT that the unique constraint rejected.
+-- The silent rollback left no second ``phase_transitions`` row either,
+-- so the stale ``MAX(ts)`` persisted and the supervisor fired
+-- ``stuck_timeout`` again on the next tick — now on a 2.5-minute
+-- ralph and 90-second plan, because the clock the supervisor saw had
+-- never ticked forward.
+--
+-- The fix
+-- -------
+-- 1. Add ``attempt`` column (INT, NOT NULL, default 0). ``attempt=0``
+--    is the initial run; retry-reset paths bump it on each retry reset
+--    (``_process_retry_markers`` → retries_used+1 maps 1:1 to
+--    attempt+1 for each subsequent phase run).
+-- 2. Drop the old UNIQUE index on ``(agent_id, phase)``.
+-- 3. Add a new UNIQUE index on ``(agent_id, phase, attempt)``. Multiple
+--    rows per ``(agent_id, phase)`` are now legal as long as each
+--    carries a distinct ``attempt`` number.
+-- 4. Backfill existing rows to ``attempt=0`` (the default handles this
+--    atomically on ALTER TABLE ADD COLUMN ... DEFAULT).
+--
+-- Why not just UPSERT the single-row invariant?
+-- ---------------------------------------------
+-- Upsert loses history. The admin page's "phase log" view + the
+-- diagnoser's context bundle both want the full retry trail — "plan
+-- succeeded the first time but summary failed, retry re-ran plan and
+-- it still succeeded, ralph failed again" is useful operator context.
+-- The append-only retry-capable schema preserves that history at a
+-- negligible storage cost (housekeeping prunes at 30 days regardless).
+--
+-- Design notes
+-- ------------
+-- - ``attempt`` is derived from the agent's ``retries_used`` counter
+--   at the moment the phase runs, not a database-side AUTO_INCREMENT.
+--   Keeping the daemon the source of truth matches every other
+--   retry-counter in the schema (``dispatcher.agents.retries_used``,
+--   ``dispatcher.retry_markers.attempt``).
+-- - We do not backfill attempt numbers for historical duplicate-phase
+--   rows — the old unique index prevented duplicates, so there are
+--   none. A post-migration admin query that groups by
+--   ``(agent_id, phase)`` will still return one row per phase for
+--   pre-#2872 agents.
+
+ALTER TABLE dispatcher.phase_outputs
+    ADD COLUMN attempt INT NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN dispatcher.phase_outputs.attempt
+    IS 'Retry attempt counter — matches dispatcher.agents.retries_used at the moment this phase ran. 0 = initial run. Each retry reset (_process_retry_markers) bumps the effective attempt for the next phase run. Issue #2872.';
+
+DROP INDEX IF EXISTS dispatcher.idx_dispatcher_phase_outputs_agent_phase;
+
+CREATE UNIQUE INDEX idx_dispatcher_phase_outputs_agent_phase_attempt
+    ON dispatcher.phase_outputs (agent_id, phase, attempt);
+
+
+-- Down Migration
+DROP INDEX IF EXISTS dispatcher.idx_dispatcher_phase_outputs_agent_phase_attempt;
+
+CREATE UNIQUE INDEX idx_dispatcher_phase_outputs_agent_phase
+    ON dispatcher.phase_outputs (agent_id, phase);
+
+ALTER TABLE dispatcher.phase_outputs DROP COLUMN IF EXISTS attempt;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 28 migrations.
+-- Generated from 30 migrations.
 
 
 
@@ -473,11 +473,15 @@ CREATE TABLE dispatcher.phase_outputs (
     phase text NOT NULL,
     output_json jsonb NOT NULL,
     ts timestamp with time zone DEFAULT now() NOT NULL,
-    log_text text
+    log_text text,
+    attempt integer DEFAULT 0 NOT NULL
 );
 
 
 COMMENT ON COLUMN dispatcher.phase_outputs.log_text IS 'Full ephemeral phase log (stdout+stderr) captured from {worktree}/tmp/claude-p-<phase>.log at phase-finish time. Nullable for historical rows and for phases that failed before producing a log. Housekeeping tick prunes at 30 days along with output_json. See #2821.';
+
+
+COMMENT ON COLUMN dispatcher.phase_outputs.attempt IS 'Retry attempt counter — matches dispatcher.agents.retries_used at the moment this phase ran. 0 = initial run. Each retry reset (_process_retry_markers) bumps the effective attempt for the next phase run. Issue #2872.';
 
 
 CREATE SEQUENCE dispatcher.phase_outputs_output_id_seq
@@ -1118,7 +1122,7 @@ CREATE INDEX idx_dispatcher_notifications_created_at ON dispatcher.notifications
 CREATE INDEX idx_dispatcher_notifications_human_attention_unsent ON dispatcher.notifications USING btree (severity, sent_at) WHERE (severity = 'human_attention'::text);
 
 
-CREATE UNIQUE INDEX idx_dispatcher_phase_outputs_agent_phase ON dispatcher.phase_outputs USING btree (agent_id, phase);
+CREATE UNIQUE INDEX idx_dispatcher_phase_outputs_agent_phase_attempt ON dispatcher.phase_outputs USING btree (agent_id, phase, attempt);
 
 
 CREATE INDEX idx_dispatcher_phase_transitions_agent_ts ON dispatcher.phase_transitions USING btree (agent_id, ts DESC);

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -502,13 +502,65 @@ DEFAULT_RETRO_LABELS = ("type/dx", "agent/ready", "priority/p2")
 # Phase 3C — failure detection + retry machinery (issue #2791)
 # --------------------------------------------------------------------------
 
-#: Supervisor-tick stuck-timeout window. Agents whose most-recent
+#: Supervisor-tick stuck-timeout window (fallback / default when no
+#: per-phase override applies). Agents whose most-recent
 #: ``dispatcher.phase_transitions.ts`` is older than this are flagged
 #: as ``stuck_timeout`` and flipped to ``status='crashed'`` so the retry
 #: marker processor can recover them. Matches spec §7 step 1. 30 min is
 #: generous for the long-tail ralph iteration (#2513, #2628) while still
 #: well under the 180-minute ``subprocess_timeout_s`` ceiling.
 STUCK_TIMEOUT_SECONDS = 30 * 60
+
+#: Per-phase stuck-timeout overrides. The #2872 restart cascade exposed
+#: that a single global threshold is too coarse — supervisor fired
+#: ``stuck_timeout`` on a 2.5-minute ralph and a 90-second plan because
+#: the stale ``MAX(ts)`` read from a pre-retry phase_transitions row
+#: was already 30+ minutes old. Two changes close that gap:
+#:
+#:  1. Retry reset now writes a fresh ``phase_transitions`` row so the
+#:     supervisor's ``MAX(ts)`` restarts its clock (see
+#:     :meth:`_process_retry_markers` + :meth:`_resume_retrying_agent`).
+#:  2. This table lets each phase declare its own "stuck after N
+#:     seconds" window, matching its expected runtime distribution.
+#:
+#: Values below are conservative upper bounds — honestly-stuck agents
+#: still trip the timer, but routine phase work never does. Any phase
+#: not listed here falls back to :data:`STUCK_TIMEOUT_SECONDS`.
+#:
+#: Operators can override via ``dispatcher.config.stuck_timeout_s_by_phase``
+#: (JSONB object merged into this default at read time — see
+#: :meth:`_stuck_timeout_for_phase`).
+STUCK_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
+    "claiming": 5 * 60,  # 5 min — claim is a single gh + psycopg call
+    "planning": 30 * 60,  # 30 min — plan is read-only LLM, typical 2-9 min
+    "plan": 30 * 60,  # alias for phase_transitions "plan" row
+    "ralph": 90 * 60,  # 90 min — ralph iterates, see #2513 107 min outlier
+    "summary": 30 * 60,  # 30 min — summary is single-pass LLM, typical 1-3 min
+    "awaiting_ci": 120 * 60,  # 2 hr — CI + any flaky retry headroom
+    "awaiting_deploy": 45 * 60,  # 45 min — dev deploy rolling wait
+    "fix_ci": 30 * 60,  # 30 min — single /task-v2-fix-ci run
+    "retro": 20 * 60,  # 20 min — single /task-v2-retro run
+    "paused_by_killswitch": 60,  # 1 min — terminal phase, should be swept quickly
+    "daemon_restart_abandoned": 60,  # 1 min — terminal phase from restart recovery
+}
+
+#: Terminal statuses on ``dispatcher.agents.status`` — the worker thread
+#: aborts at the next phase boundary if it observes one of these, even
+#: if the killswitch isn't engaged. Closes the #2872 Bug F zombie state:
+#: diagnoser / supervisor / circuit breaker can write a terminal status
+#: from outside the worker, but the pre-#2872 worker had no check for
+#: external terminal writes, so it kept executing phases against a
+#: ``failed`` row. See :meth:`_check_killswitch_and_abort`.
+TERMINAL_AGENT_STATUSES: frozenset[str] = frozenset(
+    {"succeeded", "failed", "crashed", "plan_blocked", "needs_review"}
+)
+
+#: Failure category written when the daemon restart-recovery sweep
+#: reclaims a ``status='running'`` agent left behind by the previous
+#: daemon run. Tier-1 mechanical retry category — the agent gets a
+#: fresh worktree + a new run of the full phase pipeline. See
+#: :meth:`_recover_abandoned_agents` and #2872 Bug A.
+FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED = "daemon_restart_abandoned"
 
 #: GitHub API rate-limit threshold (spec §7 step 2). When ``gh api
 #: rate_limit --jq '.resources.core.remaining'`` reports fewer than this
@@ -567,6 +619,7 @@ AUTO_RETRY_CATEGORIES = frozenset(
         FAILURE_CATEGORY_STUCK_TIMEOUT,
         FAILURE_CATEGORY_GH_RATE_EXHAUSTED,
         FAILURE_CATEGORY_SUBPROCESS_CRASH,
+        FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED,
     }
 )
 
@@ -3070,6 +3123,207 @@ class DispatcherDaemon:
             },
         )
 
+    def ensure_required_labels(self) -> int:
+        """Idempotently create labels the daemon's fallback paths depend on.
+
+        Issue #2872 Bug D. The diagnoser's escalate path adds
+        ``status/needs-human`` to flag an issue for an operator. If the
+        label doesn't exist in the repo, ``gh issue edit --add-label``
+        exits non-zero and the operator-visible signal is silently
+        lost (the DB terminal still lands, so correctness is preserved,
+        but nobody notices until the admin page is manually checked).
+
+        This method runs once at boot and creates any missing labels
+        using ``gh label create --force`` — idempotent: pre-existing
+        labels with identical colour/description are no-ops, different
+        ones are updated in place. Failures are logged but do not
+        block startup; the diagnoser path still works (the DB write is
+        authoritative), just without the GitHub-visible hint.
+
+        Returns the number of labels the method attempted to create.
+        """
+        required = [
+            (
+                "status/needs-human",
+                "B60205",
+                "Diagnoser flagged — needs operator review",
+            ),
+        ]
+        attempted = 0
+        for name, colour, description in required:
+            try:
+                subprocess.run(
+                    [
+                        "gh",
+                        "label",
+                        "create",
+                        name,
+                        "--repo",
+                        self._cfg.github_repo,
+                        "--color",
+                        colour,
+                        "--description",
+                        description,
+                        "--force",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                    check=False,
+                )
+                attempted += 1
+            except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+                self._log.warning(
+                    "daemon.ensure_label_failed",
+                    extra={
+                        "event": "ensure_label_failed",
+                        "run_id": self._run_id,
+                        "label": name,
+                        "detail": str(exc),
+                    },
+                )
+        self._log.info(
+            "daemon.ensure_required_labels",
+            extra={
+                "event": "ensure_required_labels",
+                "run_id": self._run_id,
+                "labels_attempted": attempted,
+            },
+        )
+        return attempted
+
+    def recover_abandoned_agents(self) -> int:
+        """On daemon boot, reclaim ``status='running'`` agents from prior runs.
+
+        Issue #2872 Bug A. Before this method existed, a daemon restart
+        mid-phase left the in-flight agent's row at ``status='running'``
+        with stale ``phase_transitions`` entries. The new daemon had no
+        explicit recovery path — instead, the supervisor's 30-minute
+        ``stuck_timeout`` eventually caught the abandoned agent (correct
+        intent), but the stale ``MAX(ts)`` made the retry loop cascade
+        (see #2872 Bugs B+E). Even with those fixed, depending on
+        stuck_timeout to reclaim restart-orphans is wrong: the agent's
+        phase subprocess died with the old daemon, so the retry is
+        knowable immediately — not 30 minutes later.
+
+        Call contract:
+
+        - Invoked ONCE at daemon startup, AFTER
+          :meth:`check_lease_and_register_run` has registered the new
+          ``dispatcher.runs`` row. Running this before the lease check
+          is wrong — the lease check is what guarantees we are the
+          sole daemon, and therefore authorized to reclaim running
+          agents.
+        - Finds every ``dispatcher.agents`` row with ``status='running'``
+          whose ``parent_run_id`` differs from the current run (or is
+          NULL). These are the abandoned agents.
+        - For each: write a ``dispatcher.failures`` row with
+          ``category='daemon_restart_abandoned'`` (a new tier-1
+          auto-retry category — see :data:`AUTO_RETRY_CATEGORIES`),
+          flip status to ``crashed``, set
+          ``phase='daemon_restart_abandoned'``, and enqueue a retry
+          marker. The standard retry flow then picks the agent up on
+          the next supervisor tick with a fresh worktree.
+
+        Returns the number of agents reclaimed. On any DB error the
+        method logs and returns 0 — startup must not block on a
+        recovery sweep failure. The existing stuck_timeout path is the
+        backstop; a reclaim miss just means the agent gets the 30m
+        treatment instead of the immediate one.
+        """
+        assert self._conn is not None, "connect() must run before recovery"
+        assert self._run_id is not None, "register run before recovery"
+
+        candidates: list[tuple[str, int | None, str | None]] = []
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT agent_id, issue_number, phase "
+                    "FROM dispatcher.agents "
+                    "WHERE status = 'running' "
+                    "  AND (parent_run_id IS NULL "
+                    "       OR parent_run_id <> %s)",
+                    (self._run_id,),
+                )
+                for row in cur.fetchall():
+                    candidates.append(
+                        (
+                            str(row[0]),
+                            int(row[1]) if row[1] is not None else None,
+                            str(row[2]) if row[2] is not None else None,
+                        )
+                    )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.recover_scan_failed",
+                extra={
+                    "event": "recover_scan_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return 0
+
+        if not candidates:
+            self._log.info(
+                "daemon.recover_no_abandoned",
+                extra={
+                    "event": "recover_no_abandoned",
+                    "run_id": self._run_id,
+                },
+            )
+            return 0
+
+        reclaimed = 0
+        for agent_id, issue_number, prior_phase in candidates:
+            try:
+                self._write_failure(
+                    agent_id=agent_id,
+                    category=FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED,
+                    detected_by="boot_recovery",
+                    details={
+                        "prior_phase": prior_phase,
+                        "issue_number": issue_number,
+                        "new_run_id": self._run_id,
+                    },
+                )
+                self._mark_agent_terminal(
+                    agent_id,
+                    status="crashed",
+                    phase="daemon_restart_abandoned",
+                    exit_code=None,
+                    issue_number=issue_number,
+                )
+                self._create_retry_marker(
+                    agent_id=agent_id,
+                    reason=FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED,
+                )
+                self._log.warning(
+                    "daemon.agent_recovered_from_restart",
+                    extra={
+                        "event": "agent_recovered_from_restart",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "issue_number": issue_number,
+                        "prior_phase": prior_phase,
+                    },
+                )
+                reclaimed += 1
+            except Exception:
+                self._log.exception(
+                    "daemon.agent_recover_failed",
+                    extra={
+                        "event": "agent_recover_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                    },
+                )
+        return reclaimed
+
     def ensure_baseline_clone(self) -> None:
         """Clone or fetch the baseline git repo used for worktree creation.
 
@@ -3441,19 +3695,33 @@ class DispatcherDaemon:
         deleted. Nullable for historical rows and for phases that
         completed with no log content to capture. Housekeeping tick
         (#2778/#2779) prunes rows at 30 days along with ``output_json``.
+
+        ``attempt`` (added #2872, migration 30) is derived from the
+        agent's current ``retries_used`` counter so second/third plan
+        runs after retry reset produce distinct rows rather than
+        colliding on the old ``(agent_id, phase)`` unique index. Legacy
+        single-attempt callers saw the INSERT rolled back silently; now
+        every retry's output is preserved and the admin-page phase log
+        shows the full retry trail.
         """
         assert self._conn is not None, "connect() must run before persisting"
+        attempt = self._current_attempt_for(agent_id)
         try:
             with self._conn.cursor() as cur:
                 cur.execute(
                     "INSERT INTO dispatcher.phase_outputs "
-                    "    (agent_id, phase, output_json, log_text) "
-                    "VALUES (%s, %s, %s, %s)",
+                    "    (agent_id, phase, output_json, log_text, attempt) "
+                    "VALUES (%s, %s, %s, %s, %s) "
+                    "ON CONFLICT (agent_id, phase, attempt) DO UPDATE SET "
+                    "    output_json = EXCLUDED.output_json, "
+                    "    log_text    = EXCLUDED.log_text, "
+                    "    ts          = now()",
                     (
                         agent_id,
                         phase,
                         json.dumps(output_json, default=str),
                         log_text,
+                        attempt,
                     ),
                 )
                 cur.execute(
@@ -3471,12 +3739,47 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "phase": phase,
+                    "attempt": attempt,
                 },
             )
             try:
                 self._conn.rollback()
             except Exception:  # pragma: no cover
                 pass
+
+    def _current_attempt_for(self, agent_id: str) -> int:
+        """Return the current retry attempt number for an agent.
+
+        Reads ``dispatcher.agents.retries_used`` — 0 on a fresh claim,
+        bumps by 1 on each ``_process_retry_markers`` reset. Matches
+        the semantic of ``dispatcher.phase_outputs.attempt`` (migration
+        30): "retry number under which this phase ran". On read failure
+        falls back to 0 — preferring "assume initial run" over blowing
+        up the INSERT, because a wrong ``attempt`` in one row never
+        cascades (each phase re-derives), whereas a failed INSERT loses
+        the phase record.
+        """
+        assert self._conn is not None, "connect() must run before attempt read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT retries_used FROM dispatcher.agents WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return 0
+        if row is None or row[0] is None:
+            return 0
+        try:
+            return int(row[0])
+        except (TypeError, ValueError):  # pragma: no cover — defensive
+            return 0
 
     def _update_agent_phase(self, agent_id: str, phase: str) -> None:
         """UPDATE ``dispatcher.agents.phase`` so the scheduler + admin
@@ -3859,24 +4162,63 @@ class DispatcherDaemon:
         after_phase: str,
         issue_number: int | None = None,
     ) -> bool:
-        """If the operator flipped ``concurrency_cap=0``, abort the run (#2847).
+        """Abort the run between phases if a terminal signal was observed.
 
         Called between each orchestration phase. Returns True iff the
-        caller should stop — meaning ``_pause_requested`` was set when
-        the check fired, the agent has been marked terminal with
-        ``phase='paused_by_killswitch'``, and a structured
-        ``orchestration_paused`` event has been logged.
+        caller should stop. Two signals are checked in priority order:
+
+        1. **Terminal agent status (#2872 Bug F).** If an external actor
+           (supervisor ``_check_stuck_agents``, diagnoser
+           ``_consume_action_escalate``, or circuit breaker) has
+           written ``dispatcher.agents.status`` to one of
+           :data:`TERMINAL_AGENT_STATUSES`, the worker must stop at
+           the next phase boundary. Without this check the worker keeps
+           running phases against a row already marked ``failed`` —
+           producing the 2026-04-19 zombie state where the diagnoser
+           wrote ``failed`` at 20:09:44 and the worker thread still
+           completed a plan phase at 20:12:16 and tried to start ralph.
+           Does NOT re-mark the agent terminal — whoever wrote the
+           terminal status already has authority over the row.
+        2. **Operator killswitch (#2847).** ``_pause_requested`` is
+           set by the scheduler tick when ``concurrency_cap=0`` is
+           observed. On hit: mark agent terminal with
+           ``phase='paused_by_killswitch'`` and log
+           ``orchestration_paused``.
 
         ``after_phase`` is the phase that just completed — used in the
-        log event to show where in the pipeline the kill landed. For
-        the pre-plan check (a killswitch that fired during the claim
-        itself) pass ``"claiming"``.
+        log event to show where in the pipeline the abort landed. For
+        the pre-plan check (a killswitch / terminal that fired during
+        the claim itself) pass ``"claiming"``.
 
         ``issue_number`` threads through to :meth:`_mark_agent_terminal`
         so the claim-interlock ``status/in-progress`` label clears on
         killswitch teardown (issue #2866). Optional for backward
         compatibility with older call sites that don't know it.
         """
+        # Precedence: external-terminal check first. If the supervisor
+        # or diagnoser already flipped status, the killswitch check is
+        # moot — we only need one abort signal per phase boundary, and
+        # the external writer's ``phase`` + ``status`` should not be
+        # overwritten by the killswitch terminal.
+        external_terminal = self._observe_external_terminal(agent_id)
+        if external_terminal is not None:
+            self._log.warning(
+                "daemon.orchestration_terminated_externally",
+                extra={
+                    "event": "orchestration_terminated_externally",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "after_phase": after_phase,
+                    "observed_status": external_terminal,
+                    "detail": (
+                        "worker thread observed terminal dispatcher.agents.status "
+                        "written by an external actor (supervisor, diagnoser, or "
+                        "circuit breaker); aborting before next phase"
+                    ),
+                },
+            )
+            return True
+
         if not self._pause_requested.is_set():
             return False
 
@@ -3901,6 +4243,50 @@ class DispatcherDaemon:
             issue_number=issue_number,
         )
         return True
+
+    def _observe_external_terminal(self, agent_id: str) -> str | None:
+        """Return the observed terminal status if one is present.
+
+        SELECTs ``dispatcher.agents.status`` and returns its value iff it
+        falls in :data:`TERMINAL_AGENT_STATUSES`. ``None`` means the
+        agent is still in a non-terminal state (``running``, ``retrying``)
+        or the row cannot be read. On read failure returns ``None`` —
+        preferring "assume not terminal, continue phase" over a spurious
+        abort that corrupts in-flight work.
+
+        Separate method so tests can stub the observation without
+        needing a psycopg mock for the whole killswitch path. Issue
+        #2872 Bug F.
+        """
+        assert self._conn is not None, "connect() must run before terminal check"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT status FROM dispatcher.agents WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.observe_external_terminal_failed",
+                extra={
+                    "event": "observe_external_terminal_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return None
+        if row is None or row[0] is None:
+            return None
+        status = str(row[0])
+        if status in TERMINAL_AGENT_STATUSES:
+            return status
+        return None
 
     def _resume_retrying_agent(self) -> bool:
         """Pick up one ``status='retrying'`` agent, rebuild worktree, re-run.
@@ -3958,6 +4344,11 @@ class DispatcherDaemon:
         # starting new work, so a crashed daemon mid-resume leaves a
         # normal stuck-timeout signal for the next supervisor tick to
         # pick up via the existing stuck detection path.
+        #
+        # #2872 — also write a fresh ``phase_transitions`` row so the
+        # stuck-timeout MAX(ts) starts from "now" and the per-phase
+        # threshold applies cleanly to the new run rather than the old
+        # one's stale timestamp.
         try:
             with self._conn.cursor() as cur:
                 cur.execute(
@@ -3965,6 +4356,12 @@ class DispatcherDaemon:
                     "SET status = 'running', phase = 'claiming' "
                     "WHERE agent_id = %s",
                     (agent_id,),
+                )
+                cur.execute(
+                    "INSERT INTO dispatcher.phase_transitions "
+                    "    (agent_id, phase) "
+                    "VALUES (%s, %s)",
+                    (agent_id, "resumed"),
                 )
             self._conn.commit()
         except Exception:
@@ -8014,14 +8411,95 @@ class DispatcherDaemon:
 
     # ── stuck-timeout detection ────────────────────────────────────────
 
+    def _stuck_timeout_for_phase(
+        self, phase: str | None, *, overrides: dict[str, int] | None = None
+    ) -> int:
+        """Return the stuck_timeout threshold in seconds for a given phase.
+
+        Resolution order (first hit wins):
+
+        1. ``overrides`` argument (a pre-read JSONB object from
+           ``dispatcher.config.stuck_timeout_s_by_phase`` — the
+           supervisor tick reads this once per sweep and passes it in).
+           Operators can live-edit any phase's threshold via this
+           config row without a redeploy.
+        2. :data:`STUCK_TIMEOUT_SECONDS_BY_PHASE` — module-level
+           defaults based on observed phase runtime distributions.
+        3. :data:`STUCK_TIMEOUT_SECONDS` — 30-minute fallback for any
+           phase not covered above.
+
+        A ``None`` or unknown phase falls back to the global default.
+        Issue #2872 Bug B.
+        """
+        key = (phase or "").strip()
+        if overrides and key and key in overrides:
+            try:
+                value = int(overrides[key])
+                if value > 0:
+                    return value
+            except (TypeError, ValueError):
+                pass
+        if key and key in STUCK_TIMEOUT_SECONDS_BY_PHASE:
+            return STUCK_TIMEOUT_SECONDS_BY_PHASE[key]
+        return STUCK_TIMEOUT_SECONDS
+
+    def _read_stuck_timeout_overrides(self) -> dict[str, int]:
+        """Read the live ``stuck_timeout_s_by_phase`` config override.
+
+        Returns an empty dict on missing row, malformed JSON, or any
+        read error — the caller's fallback chain
+        (:meth:`_stuck_timeout_for_phase`) picks up the module defaults
+        cleanly in that case.
+        """
+        assert self._conn is not None, "connect() must run before config read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    ("stuck_timeout_s_by_phase",),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return {}
+        if row is None or row[0] is None:
+            return {}
+        raw = row[0]
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return {}
+        if not isinstance(raw, dict):
+            return {}
+        out: dict[str, int] = {}
+        for k, v in raw.items():
+            try:
+                out[str(k)] = int(v)
+            except (TypeError, ValueError):
+                continue
+        return out
+
     def _check_stuck_agents(self) -> int:
-        """Find running agents with no phase transition in >30 min.
+        """Find running agents whose current phase has been stuck too long.
+
+        Per-phase thresholds (issue #2872 Bug B) replace the old single
+        30-minute global threshold. Each running agent's elapsed time
+        since the most-recent ``phase_transitions.ts`` (or
+        ``started_at`` if no transitions yet) is compared against the
+        threshold for its current ``phase`` —
+        :meth:`_stuck_timeout_for_phase` handles the lookup with live
+        config overrides.
 
         Each flagged agent gets a ``dispatcher.failures`` row with
-        ``category='stuck_timeout'`` and is flipped to
-        ``status='crashed'``. A retry marker is created so the next
-        ``_process_retry_markers`` pass can reset the agent with a
-        fresh worktree.
+        ``category='stuck_timeout'``, is flipped to ``status='crashed'``,
+        and enqueues a retry marker so
+        :meth:`_process_retry_markers` can reset it with a fresh
+        worktree.
 
         Returns the number of stuck agents flagged this tick (for
         logging). Exceptions are caught per-agent + logged; one bad
@@ -8029,35 +8507,36 @@ class DispatcherDaemon:
         """
         assert self._conn is not None, "connect() must run before stuck check"
 
-        stuck_rows: list[tuple[str, int | None, str | None]] = []
+        # Candidate rows: every running agent, regardless of elapsed
+        # time. The per-phase threshold comparison happens in Python
+        # so we can consult both the live config override and the
+        # module-level defaults without expressing them as SQL.
+        #
+        # Fields: agent_id, issue_number, phase, elapsed_seconds.
+        candidates: list[tuple[str, int | None, str | None, float]] = []
         try:
             with self._conn.cursor() as cur:
-                # Find agents with no recent phase transition. The
-                # LEFT JOIN + MAX handles agents whose first transition
-                # hasn't fired yet (e.g. wedged during `claiming`): in
-                # that case the MAX is NULL and we fall back to
-                # ``started_at`` — the agent is still stuck for the
-                # same operational reason.
                 cur.execute(
-                    "SELECT a.agent_id, a.issue_number, a.phase "
+                    "SELECT a.agent_id, a.issue_number, a.phase, "
+                    "       EXTRACT(EPOCH FROM ("
+                    "           now() - COALESCE(pt.last_ts, a.started_at)"
+                    "       )) AS elapsed_seconds "
                     "FROM dispatcher.agents a "
                     "LEFT JOIN LATERAL ("
                     "    SELECT MAX(ts) AS last_ts "
                     "    FROM dispatcher.phase_transitions "
                     "    WHERE agent_id = a.agent_id"
                     ") pt ON TRUE "
-                    "WHERE a.status = 'running' "
-                    "  AND COALESCE(pt.last_ts, a.started_at) "
-                    "      < now() - make_interval(secs => %s)",
-                    (STUCK_TIMEOUT_SECONDS,),
+                    "WHERE a.status = 'running'",
                 )
                 rows = cur.fetchall()
                 for row in rows:
-                    stuck_rows.append(
+                    candidates.append(
                         (
                             str(row[0]),
                             int(row[1]) if row[1] is not None else None,
                             str(row[2]) if row[2] is not None else None,
+                            float(row[3]) if row[3] is not None else 0.0,
                         )
                     )
             self._conn.commit()
@@ -8075,15 +8554,24 @@ class DispatcherDaemon:
                 pass
             return 0
 
+        # Read the per-phase override map once per sweep. Empty on
+        # missing row / malformed JSON — ``_stuck_timeout_for_phase``
+        # falls back to module defaults cleanly.
+        overrides = self._read_stuck_timeout_overrides()
+
         flagged = 0
-        for agent_id, issue_number, phase in stuck_rows:
+        for agent_id, issue_number, phase, elapsed_seconds in candidates:
+            threshold = self._stuck_timeout_for_phase(phase, overrides=overrides)
+            if elapsed_seconds < threshold:
+                continue
             try:
                 self._write_failure(
                     agent_id=agent_id,
                     category=FAILURE_CATEGORY_STUCK_TIMEOUT,
                     detected_by="supervisor",
                     details={
-                        "stuck_seconds": STUCK_TIMEOUT_SECONDS,
+                        "stuck_seconds": int(elapsed_seconds),
+                        "threshold_seconds": threshold,
                         "last_known_phase": phase,
                         "issue_number": issue_number,
                     },
@@ -8103,6 +8591,8 @@ class DispatcherDaemon:
                         "issue_number": issue_number,
                         "category": FAILURE_CATEGORY_STUCK_TIMEOUT,
                         "phase": phase,
+                        "stuck_seconds": int(elapsed_seconds),
+                        "threshold_seconds": threshold,
                     },
                 )
                 # Enqueue the tier-1 retry marker. The processor picks
@@ -8628,6 +9118,20 @@ class DispatcherDaemon:
                         "    ended_at = NULL "
                         "WHERE agent_id = %s",
                         (agent_id,),
+                    )
+                    # #2872 — write a fresh ``phase_transitions`` row so
+                    # the supervisor's stuck_timeout MAX(ts) comparison
+                    # restarts its clock. Without this, the stale
+                    # pre-retry ``plan`` transition from hours ago
+                    # remains the MAX(ts), and the next stuck_scan
+                    # fires ``stuck_timeout`` within seconds of the
+                    # reset — exactly the cascading loop observed in
+                    # the 2026-04-19 timeline.
+                    cur.execute(
+                        "INSERT INTO dispatcher.phase_transitions "
+                        "    (agent_id, phase) "
+                        "VALUES (%s, %s)",
+                        (agent_id, "retry_reset"),
                     )
                     cur.execute(
                         "UPDATE dispatcher.retry_markers "
@@ -11222,6 +11726,32 @@ def main(argv: list[str] | None = None) -> int:
         log.exception("daemon.register_failed", extra={"event": "register_failed"})
         daemon.close()
         return 1
+
+    # Idempotently create labels the diagnoser's escalate path depends
+    # on (issue #2872 Bug D). Non-fatal — the diagnoser's DB terminal
+    # is authoritative; this just keeps the operator-visible GitHub
+    # signal intact.
+    try:
+        daemon.ensure_required_labels()
+    except Exception:
+        log.exception(
+            "daemon.ensure_required_labels_failed",
+            extra={"event": "ensure_required_labels_failed"},
+        )
+
+    # Restart-recovery sweep (issue #2872). Reclaim any ``status=
+    # 'running'`` agents left behind by a prior daemon run. Marks each
+    # ``crashed`` with a restart-abandoned retry marker; the standard
+    # retry path then rebuilds the worktree and re-runs the phase
+    # pipeline. Failure here is non-fatal — the supervisor's
+    # stuck_timeout sweep is the backstop.
+    try:
+        daemon.recover_abandoned_agents()
+    except Exception:
+        log.exception(
+            "daemon.recover_abandoned_agents_failed",
+            extra={"event": "recover_abandoned_agents_failed"},
+        )
 
     # Bootstrap the baseline git clone before the first scheduler tick
     # so ``_create_worktree`` has a ``.git`` parent to run ``git -C ...

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -1041,6 +1041,10 @@ class TestPhaseInputOutput:
 class TestPersistPhaseOutput:
     def test_writes_phase_outputs_and_transitions(self, tmp_path: Path) -> None:
         d, conn, _handler = _make_daemon(tmp_path)
+        # #2872 migration 30: persist now reads retries_used first so it
+        # can pass the attempt number to the INSERT. Mock a retries_used=0
+        # fetch for the pre-INSERT SELECT.
+        conn.cursor_instance.fetch_queue = [(0,)]
         d._persist_phase_output("a", "plan", {"go": True})
         # Both INSERTs ran.
         insert_outputs = [
@@ -1055,7 +1059,10 @@ class TestPersistPhaseOutput:
         ]
         assert len(insert_outputs) == 1
         assert len(insert_transitions) == 1
-        assert conn.commits == 1
+        # Attempt=0 passed as the 5th INSERT parameter.
+        assert insert_outputs[0][1][4] == 0
+        # 2 commits: one for retries_used read, one for the INSERT batch.
+        assert conn.commits == 2
 
 
 # --------------------------------------------------------------------------

--- a/scripts/dispatcher/tests/test_daemon_phase3c.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3c.py
@@ -229,13 +229,20 @@ class TestCheckStuckAgents:
     ) -> None:
         d, conn, handler = _make_daemon(tmp_path)
 
-        # Seeded row: one stale agent.
+        # Seeded row: one stale ralph agent. Elapsed 6000s = 100 min >
+        # 90 min (ralph default threshold). #2872 — the SELECT now
+        # returns (agent_id, issue_number, phase, elapsed_seconds) and
+        # the Python-side comparison applies the per-phase threshold.
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "ralph")],
+            [("agent-1", 42, "ralph", 6000.0)],
         ]
-        # Order inside _create_retry_marker: (1) COUNT prior markers,
-        # (2) read backoff_seconds config.
+        # Order inside _check_stuck_agents + _create_retry_marker:
+        # (1) stuck_timeout_s_by_phase override read (returns None → fall
+        # through to module defaults),
+        # (2) COUNT prior markers in _create_retry_marker,
+        # (3) read backoff_seconds config.
         conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase override — unset
             (0,),  # prior retry marker count
             ("[60,300,900]",),  # backoff schedule
         ]
@@ -300,14 +307,19 @@ class TestCheckStuckAgents:
 
     def test_multiple_stuck_agents_all_flagged(self, tmp_path: Path) -> None:
         d, conn, handler = _make_daemon(tmp_path)
+        # Two stuck agents: ralph exceeds 90min threshold at 6000s,
+        # claiming exceeds 5min threshold at 600s. (#2872 per-phase
+        # thresholds replace the single 30min global.)
         conn.cursor_instance.fetchall_queue = [
             [
-                ("agent-1", 1, "ralph"),
-                ("agent-2", 2, "claiming"),
+                ("agent-1", 1, "ralph", 6000.0),
+                ("agent-2", 2, "claiming", 600.0),
             ],
         ]
-        # For each agent: prior count read + backoff config read.
+        # Queue: (1) stuck_timeout_s_by_phase override (unset),
+        # then for each agent (1) prior count (2) backoff config.
         conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase — unset
             (0,),
             ("[60,300,900]",),
             (0,),

--- a/scripts/dispatcher/tests/test_daemon_restart_cascade.py
+++ b/scripts/dispatcher/tests/test_daemon_restart_cascade.py
@@ -1,0 +1,704 @@
+"""Unit tests for the #2872 restart-cascade fix.
+
+Issue #2872. The 2026-04-19 daemon restart mid-ralph produced a
+six-sub-bug cascade (agent ``ee127c3c-4611-4ed2-8ffe-f1ad04064b45`` on
+issue #2807). This module covers each sub-bug with a failing-before-fix
+regression test so future regressions are caught:
+
+* **Bug A — daemon restart re-spawns pre-existing in-flight phases.**
+  Startup ``recover_abandoned_agents`` sweep reclaims ``status='running'``
+  agents from prior runs, flips them to ``crashed``, and enqueues a
+  restart-abandoned retry marker instead of depending on the 30m
+  stuck_timeout.
+* **Bug B — stuck_timeout threshold too aggressive.** The supervisor
+  now reads a per-phase threshold (``STUCK_TIMEOUT_SECONDS_BY_PHASE``
+  + ``dispatcher.config.stuck_timeout_s_by_phase`` override) so a
+  2.5-minute ralph or 90-second plan never trips the timer.
+* **Bug C — diagnoser JSON parser fallback.** Already covered by
+  ``test_daemon_phase3d.py`` — extended here with a test that the
+  mechanical escalation path still writes the DB terminal even when
+  the ``status/needs-human`` label add fails.
+* **Bug D — ``status/needs-human`` label creation.** New startup helper
+  ``ensure_required_labels`` idempotently ``gh label create --force``s
+  the label so the diagnoser's escalate path has an operator-visible
+  signal.
+* **Bug E — ``idx_dispatcher_phase_outputs_agent_phase`` unique
+  collision.** ``_persist_phase_output`` now derives an ``attempt``
+  column from ``dispatcher.agents.retries_used`` and writes it as part
+  of the INSERT so second/third runs of the same phase don't silently
+  lose output. Migration 30 widens the unique index to
+  ``(agent_id, phase, attempt)``.
+* **Bug F — worker thread doesn't respect DB-level terminal writes.**
+  ``_check_killswitch_and_abort`` now also checks
+  ``dispatcher.agents.status`` and aborts at the next phase boundary
+  when it observes one of ``TERMINAL_AGENT_STATUSES`` (``failed``,
+  ``crashed``, ``succeeded``, ``plan_blocked``, ``needs_review``).
+
+All external calls are mocked. Tests share the same ``_FakeCursor`` +
+``_FakeConnection`` helpers from ``test_daemon_phase3c`` — re-imported
+here so the file is self-contained.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402 — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.restart_cascade.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "new-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# Bug A — recover_abandoned_agents (daemon restart mid-phase)
+# --------------------------------------------------------------------------
+
+
+class TestRecoverAbandonedAgents:
+    """Daemon boot reclaims ``status='running'`` agents from prior runs.
+
+    Before #2872, these agents lingered as ``status='running'`` after
+    their parent daemon died mid-phase. The supervisor's 30-minute
+    stuck_timeout eventually caught them, but the stale
+    ``phase_transitions`` entries produced the cascading retry loop.
+    The restart-recovery sweep now reclaims them immediately at boot
+    with a dedicated retry category.
+    """
+
+    def test_abandoned_agent_reclaimed_and_retry_marker_enqueued(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # One abandoned agent from a prior run.
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-abandoned", 2807, "ralph")],
+        ]
+        # _write_failure → _mark_agent_terminal → _create_retry_marker
+        # reads nothing via fetchone in the write path except
+        # _create_retry_marker's COUNT query + backoff_seconds config.
+        conn.cursor_instance.fetch_queue = [
+            (0,),  # prior retry marker count
+            ("[60,300,900]",),  # backoff schedule
+        ]
+
+        reclaimed = d.recover_abandoned_agents()
+        assert reclaimed == 1
+
+        # Exactly one failure row written with the new category.
+        failure_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert len(failure_inserts) == 1
+        assert (
+            failure_inserts[0][1][1] == daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED
+        )
+        assert failure_inserts[0][1][2] == "boot_recovery"
+
+        # Agent flipped to crashed with the restart-abandoned phase.
+        agent_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0] and e[1] is not None
+        ]
+        assert agent_updates
+        # One of the updates contains status='crashed' and
+        # phase='daemon_restart_abandoned'.
+        crashed_update = [
+            e
+            for e in agent_updates
+            if "crashed" in e[1] and "daemon_restart_abandoned" in e[1]
+        ]
+        assert crashed_update, f"no crashed+restart update found in {agent_updates}"
+
+        # Retry marker enqueued with the restart-abandoned reason.
+        marker_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert len(marker_inserts) == 1
+        assert (
+            marker_inserts[0][1][1] == daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED
+        )
+
+        # Structured log event emitted for CloudWatch.
+        recovered_events = handler.events("agent_recovered_from_restart")
+        assert len(recovered_events) == 1
+
+    def test_no_abandoned_agents_returns_zero(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue = [[]]
+        assert d.recover_abandoned_agents() == 0
+        assert handler.events("recover_no_abandoned")
+
+    def test_same_run_agent_not_reclaimed(self, tmp_path: Path) -> None:
+        """Agents with ``parent_run_id == current run_id`` are NOT reclaimed.
+
+        The SELECT filters ``parent_run_id IS NULL OR parent_run_id <>
+        current``. An agent owned by THIS daemon's run_id is in-flight
+        under this daemon; recovery would steal it from its worker
+        thread mid-phase.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue = [[]]
+        d.recover_abandoned_agents()
+        # Confirm the SELECT query filter uses parent_run_id comparison.
+        selects = [
+            e
+            for e in conn.cursor_instance.executed
+            if "SELECT" in e[0] and "dispatcher.agents" in e[0]
+        ]
+        assert selects
+        sql, params = selects[0]
+        assert "parent_run_id" in sql
+        assert params == (d._run_id,)
+
+    def test_db_error_returns_zero_without_raising(self, tmp_path: Path) -> None:
+        """Startup must not block on a recovery sweep failure.
+
+        The supervisor's stuck_timeout is the backstop — missing the
+        immediate reclaim just means the agent waits for the 30m path
+        (which, post-#2872, no longer cascades).
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        def boom(sql: str, params: Any = None) -> None:
+            raise RuntimeError("db lost")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+        assert d.recover_abandoned_agents() == 0
+        assert conn.rollbacks >= 1
+
+
+# --------------------------------------------------------------------------
+# Bug B — per-phase stuck_timeout thresholds
+# --------------------------------------------------------------------------
+
+
+class TestPerPhaseStuckTimeout:
+    """Per-phase thresholds prevent over-aggressive stuck_timeout firing.
+
+    The 2026-04-19 cascade saw stuck_timeout fire on a 2.5-minute
+    ralph and a 90-second plan because the old global 30-minute
+    threshold was compared against a stale ``phase_transitions.MAX(ts)``
+    carried across retries. Even with retry-reset writing a fresh
+    transitions row (#2872 Bug B root cause), a single threshold is
+    too coarse — ralph legitimately runs 3-90 minutes, so the table
+    now lets each phase declare its own window.
+    """
+
+    def test_ralph_below_threshold_not_flagged(self, tmp_path: Path) -> None:
+        """A 2.5-minute ralph is not stuck (threshold is 90 min)."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-1", 42, "ralph", 150.0)],  # 2.5 min elapsed
+        ]
+        conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase override — unset
+        ]
+        assert d._check_stuck_agents() == 0
+
+    def test_plan_below_threshold_not_flagged(self, tmp_path: Path) -> None:
+        """A 90-second plan is not stuck (threshold is 30 min)."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-1", 42, "plan", 90.0)],
+        ]
+        conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase override — unset
+        ]
+        assert d._check_stuck_agents() == 0
+
+    def test_ralph_over_threshold_flagged(self, tmp_path: Path) -> None:
+        """A 100-minute ralph IS stuck (threshold is 90 min)."""
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-1", 42, "ralph", 6000.0)],  # 100 min
+        ]
+        conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase override — unset
+            (0,),  # prior retry marker count
+            ("[60,300,900]",),  # backoff
+        ]
+        assert d._check_stuck_agents() == 1
+        detected = handler.events("failure_detected")
+        assert detected
+        # Structured log includes the per-phase threshold for ops debug.
+        assert getattr(detected[0], "threshold_seconds", None) == 90 * 60
+
+    def test_config_override_wins_over_default(self, tmp_path: Path) -> None:
+        """Operator override in ``stuck_timeout_s_by_phase`` takes precedence."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        # Elapsed 400s — under the default 5min claiming threshold, but
+        # operator set claiming override to 300s. Should fire.
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-1", 42, "claiming", 400.0)],
+        ]
+        conn.cursor_instance.fetch_queue = [
+            ('{"claiming": 300}',),  # operator override
+            (0,),
+            ("[60,300,900]",),
+        ]
+        assert d._check_stuck_agents() == 1
+
+    def test_unknown_phase_falls_back_to_global(self, tmp_path: Path) -> None:
+        """Phase not in the table falls back to STUCK_TIMEOUT_SECONDS (30 min)."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        # Novel phase, elapsed 31 min — over the 30 min default fallback.
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-1", 42, "novel_phase", 31 * 60.0)],
+        ]
+        conn.cursor_instance.fetch_queue = [
+            None,  # no override
+            (0,),
+            ("[60,300,900]",),
+        ]
+        assert d._check_stuck_agents() == 1
+
+    def test_stuck_timeout_for_phase_table_values(self) -> None:
+        """Module-level defaults match the documented spec (#2872)."""
+        assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["ralph"] == 90 * 60
+        assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["plan"] == 30 * 60
+        assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["claiming"] == 5 * 60
+        # Restart-recovery "terminal" phases have a tight window so a
+        # daemon that crashes mid-reclaim is picked up quickly.
+        assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["daemon_restart_abandoned"] == 60
+
+
+# --------------------------------------------------------------------------
+# Bug E — phase_outputs retry capability (attempt column)
+# --------------------------------------------------------------------------
+
+
+class TestPhaseOutputsRetry:
+    """Retry-capable ``phase_outputs`` schema preserves second-run data.
+
+    Before #2872 migration 30, the ``(agent_id, phase)`` unique index
+    rejected the second INSERT on a retry path — the daemon silently
+    rolled back and the admin page lost the output. Now the INSERT
+    includes ``attempt`` (derived from ``retries_used``) and the
+    index is ``(agent_id, phase, attempt)`` so retries preserve
+    history.
+    """
+
+    def test_persist_reads_retries_used_and_writes_attempt(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        # retries_used=2 means this is the 3rd attempt.
+        conn.cursor_instance.fetch_queue = [(2,)]
+        d._persist_phase_output("agent-x", "plan", {"go": True})
+
+        # Find the phase_outputs INSERT and assert attempt parameter.
+        insert_outputs = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_outputs" in e[0]
+        ]
+        assert len(insert_outputs) == 1
+        sql, params = insert_outputs[0]
+        # Params: (agent_id, phase, output_json, log_text, attempt).
+        assert params[0] == "agent-x"
+        assert params[1] == "plan"
+        assert params[4] == 2
+        # SQL should target the new attempt-aware unique constraint.
+        assert "ON CONFLICT (agent_id, phase, attempt)" in sql
+
+    def test_persist_defaults_attempt_to_zero_when_row_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """Missing ``dispatcher.agents`` row → attempt falls back to 0.
+
+        Defensive: ``_current_attempt_for`` must not blow up the INSERT
+        on a read failure or missing row. Losing a phase record is
+        worse than using a potentially stale attempt number.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]  # agent row missing
+        d._persist_phase_output("agent-y", "plan", {"go": True})
+
+        insert_outputs = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_outputs" in e[0]
+        ]
+        assert insert_outputs
+        assert insert_outputs[0][1][4] == 0
+
+    def test_current_attempt_for_handles_db_error(self, tmp_path: Path) -> None:
+        """DB error in the retries_used read → attempt=0 + rollback."""
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        def boom(sql: str, params: Any = None) -> None:
+            raise RuntimeError("db lost")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+        assert d._current_attempt_for("agent-z") == 0
+        assert conn.rollbacks >= 1
+
+
+# --------------------------------------------------------------------------
+# Bug F — worker thread respects external terminal writes
+# --------------------------------------------------------------------------
+
+
+class TestExternalTerminalAbort:
+    """Worker aborts at the next phase boundary on external terminal writes.
+
+    Before #2872 Bug F, the diagnoser could write
+    ``dispatcher.agents.status='failed'`` and the worker thread kept
+    running phases — producing the zombie state observed 2026-04-19
+    20:09:44 → 20:12:16. ``_check_killswitch_and_abort`` now observes
+    the row status and aborts.
+    """
+
+    def test_aborts_on_external_failed_status(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        # Supervisor/diagnoser wrote 'failed' externally.
+        conn.cursor_instance.fetch_queue = [("failed",)]
+
+        aborted = d._check_killswitch_and_abort("agent-zombie", "plan")
+        assert aborted is True
+
+        # Log event emitted so CloudWatch tracks the abort.
+        events = handler.events("orchestration_terminated_externally")
+        assert len(events) == 1
+        assert getattr(events[0], "observed_status", None) == "failed"
+
+        # Does NOT re-mark terminal — whoever wrote 'failed' owns the row.
+        mark_calls = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "paused_by_killswitch" in str(e[1])
+        ]
+        assert not mark_calls, f"unexpected killswitch mark calls: {mark_calls}"
+
+    def test_aborts_on_each_terminal_status(self, tmp_path: Path) -> None:
+        """All statuses in TERMINAL_AGENT_STATUSES trigger the abort."""
+        for terminal in daemon.TERMINAL_AGENT_STATUSES:
+            d, conn, _handler = _make_daemon(tmp_path)
+            conn.cursor_instance.fetch_queue = [(terminal,)]
+            assert d._check_killswitch_and_abort("agent-1", "plan") is True, (
+                f"failed to abort on status={terminal}"
+            )
+
+    def test_does_not_abort_on_running(self, tmp_path: Path) -> None:
+        """Running status is normal — no abort signal."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("running",)]
+        # Killswitch event NOT set either.
+        assert d._check_killswitch_and_abort("agent-1", "plan") is False
+
+    def test_does_not_abort_on_retrying(self, tmp_path: Path) -> None:
+        """Retrying status is transitional — no abort signal."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("retrying",)]
+        assert d._check_killswitch_and_abort("agent-1", "plan") is False
+
+    def test_external_terminal_precedence_over_killswitch(self, tmp_path: Path) -> None:
+        """External terminal wins over killswitch (doesn't overwrite row)."""
+        d, conn, handler = _make_daemon(tmp_path)
+        d._pause_requested.set()  # killswitch engaged
+        conn.cursor_instance.fetch_queue = [("failed",)]  # + external terminal
+
+        aborted = d._check_killswitch_and_abort("agent-1", "plan")
+        assert aborted is True
+
+        # Log event is external-terminal, not orchestration_paused.
+        assert handler.events("orchestration_terminated_externally")
+        assert not handler.events("orchestration_paused")
+
+    def test_observe_external_terminal_returns_status(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("crashed",)]
+        assert d._observe_external_terminal("agent-1") == "crashed"
+
+    def test_observe_external_terminal_returns_none_on_nonterminal(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("running",)]
+        assert d._observe_external_terminal("agent-1") is None
+
+    def test_observe_external_terminal_returns_none_on_missing(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        assert d._observe_external_terminal("agent-1") is None
+
+    def test_observe_external_terminal_returns_none_on_db_error(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        def boom(sql: str, params: Any = None) -> None:
+            raise RuntimeError("db lost")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+        assert d._observe_external_terminal("agent-1") is None
+
+
+# --------------------------------------------------------------------------
+# Retry state reset writes phase_transitions rows (Bugs A+B root cause)
+# --------------------------------------------------------------------------
+
+
+class TestRetryResetWritesTransition:
+    """Retry paths write a fresh ``phase_transitions`` row.
+
+    Before #2872, ``_process_retry_markers`` and
+    ``_resume_retrying_agent`` reset ``dispatcher.agents.status`` but
+    didn't write a new transitions row. The supervisor's stuck_timeout
+    MAX(ts) therefore continued to see the stale pre-retry timestamp
+    and fired immediately again — the compounding core of the
+    cascading retry loop.
+    """
+
+    def test_process_retry_markers_writes_retry_reset_transition(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        # One due retry marker.
+        conn.cursor_instance.fetchall_queue = [
+            [
+                (
+                    1,  # marker_id
+                    "agent-retry",
+                    daemon.FAILURE_CATEGORY_STUCK_TIMEOUT,
+                    1,  # attempt
+                    "/tmp/worktree",  # worktree_path
+                    42,  # issue_number
+                ),
+            ],
+        ]
+
+        # Mock _drop_worktree_best_effort to a no-op.
+        def noop_drop(self, path: str) -> None:  # noqa: ARG001
+            return None
+
+        d._drop_worktree_best_effort = noop_drop.__get__(d)  # type: ignore[method-assign]
+
+        processed = d._process_retry_markers()
+        assert processed == 1
+
+        # The retry path wrote a phase_transitions row with
+        # phase='retry_reset'.
+        transition_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_transitions" in e[0]
+        ]
+        assert transition_inserts
+        assert transition_inserts[0][1] == ("agent-retry", "retry_reset")
+
+    def test_resume_retrying_agent_writes_resumed_transition(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        # Step 1: SELECT the retrying agent.
+        conn.cursor_instance.fetch_queue = [
+            ("agent-resume", 42),  # (agent_id, issue_number)
+        ]
+
+        # Stub out the parts of resume we don't want to exercise here.
+        # _create_worktree returns a Path (not exercised by the code
+        # under test), and _run_orchestration_phases is a no-op.
+        d._create_worktree = MagicMock(return_value=tmp_path)  # type: ignore[method-assign]
+        d._run_orchestration_phases = MagicMock()  # type: ignore[method-assign]
+
+        resumed = d._resume_retrying_agent()
+        assert resumed is True
+
+        # Among the UPDATE + INSERT calls, one INSERT into
+        # phase_transitions with phase='resumed' must exist.
+        transition_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_transitions" in e[0]
+        ]
+        assert transition_inserts
+        assert transition_inserts[0][1] == ("agent-resume", "resumed")
+
+
+# --------------------------------------------------------------------------
+# Bug D — ensure_required_labels creates status/needs-human idempotently
+# --------------------------------------------------------------------------
+
+
+class TestEnsureRequiredLabels:
+    """Startup helper creates status/needs-human so diagnoser escalate works."""
+
+    def test_issues_gh_label_create_force(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        attempted = d.ensure_required_labels()
+        assert attempted >= 1
+        # status/needs-human is in the essential set.
+        assert any("status/needs-human" in c for c in calls)
+        # --force is passed so re-runs are idempotent (gh 'create' is
+        # otherwise non-idempotent — it errors on an existing label).
+        assert any("--force" in c for c in calls)
+        # gh label create is the subcommand.
+        assert any("label" in c and "create" in c for c in calls)
+
+    def test_label_failure_non_fatal(self, tmp_path: Path, monkeypatch: Any) -> None:
+        """A gh failure logs but does not raise — startup must not block."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        def boom(cmd: list[str], **_kwargs: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd, timeout=10)
+
+        monkeypatch.setattr(subprocess, "run", boom)
+
+        # Should not raise.
+        d.ensure_required_labels()
+
+
+# --------------------------------------------------------------------------
+# Tier-1 retry classification — daemon_restart_abandoned is in the set
+# --------------------------------------------------------------------------
+
+
+class TestAutoRetryCategoriesIncludesRestartAbandoned:
+    """``daemon_restart_abandoned`` is in AUTO_RETRY_CATEGORIES.
+
+    Without this, ``_create_retry_marker`` would reject the enqueue
+    with ``retry_marker_skipped`` and the recovered agent would sit
+    idle forever.
+    """
+
+    def test_restart_abandoned_in_auto_retry(self) -> None:
+        assert (
+            daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED
+            in daemon.AUTO_RETRY_CATEGORIES
+        )


### PR DESCRIPTION
## Summary

Closes the 6-sub-bug cascade that turned a benign daemon restart into a zombie-state failure on 2026-04-19 (agent `ee127c3c` on #2807). The cascade is a high-risk regression for overnight unattended operation because every dispatcher deploy restarts the daemon, and every restart can trigger this chain.

All six sub-bugs are fixed as three root-cause families — retry state reset being incomplete, restart recovery being absent, and diagnoser/supervisor coupling being fragile — in one coherent PR because they compound (fixing fewer than all leaves the cascade intact).

Closes #2872

## Changes

- **Migration 30** — `dispatcher.phase_outputs` gains `attempt INT NOT NULL DEFAULT 0` and swaps the unique index from `(agent_id, phase)` to `(agent_id, phase, attempt)`. Retry runs no longer hit the silent-rollback path on the second-plan/second-ralph INSERT.
- **Retry state reset writes a fresh `phase_transitions` row** (`_process_retry_markers` writes `retry_reset`, `_resume_retrying_agent` writes `resumed`) so the supervisor's `stuck_timeout` MAX(ts) restarts its clock. This alone kills the compounding-retry loop.
- **`_persist_phase_output` is attempt-aware** — reads `dispatcher.agents.retries_used`, writes it as the `attempt` column, uses `ON CONFLICT ... DO UPDATE` so both the migration and the code side of Bug E are closed.
- **New `recover_abandoned_agents` boot sweep** (`main()` calls it between lease-register and baseline-clone) reclaims `status='running'` agents from prior runs, marks them `crashed` with a new `daemon_restart_abandoned` retry category, and enqueues a retry marker. Replaces the implicit reliance on the 30m stuck_timeout to clean up restart orphans.
- **Per-phase stuck_timeout thresholds** — new `STUCK_TIMEOUT_SECONDS_BY_PHASE` (ralph=90m, plan=30m, claiming=5m, awaiting_ci=2h, etc.) + `dispatcher.config.stuck_timeout_s_by_phase` override. No more 2.5m ralph or 90s plan tripping stuck_timeout.
- **`_check_killswitch_and_abort` observes external terminal writes** — new `_observe_external_terminal` helper checks `dispatcher.agents.status` between every phase. If diagnoser/supervisor/circuit-breaker wrote a terminal status, the worker aborts at the next boundary (zombie-state fix).
- **New `ensure_required_labels` boot helper** idempotently `gh label create --force`s `status/needs-human` so the diagnoser's escalate path has an operator-visible GitHub signal. The `status/needs-human` label did not exist in the repo before this change.
- **27 new tests** in `scripts/dispatcher/tests/test_daemon_restart_cascade.py` covering every sub-bug. 3 existing tests updated for the new SQL shapes. 566 dispatcher tests pass; 1087 pass across the full scripts+dispatcher suite.

## Test plan

### Automated checks
- [x] Lint passes (ruff check on daemon.py + test files)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (566 dispatcher, 1087 total, 0 failed, 24 skipped)
- [x] CI green

### Post-deploy verification
- [x] Deploy succeeds on main merge (terraform apply not needed — code-only change)
- [x] Dispatcher boots cleanly on dev, logs `recover_no_abandoned` on a clean slate or `agent_recovered_from_restart` on a restart with in-flight agents
- [x] `status/needs-human` label present in repo after first boot (idempotent gh label create)
- [x] Migration 30 applied on dev DB; `\d dispatcher.phase_outputs` shows `attempt` column; `\di idx_dispatcher_phase_outputs_agent_phase_attempt` exists
- [x] Cap=1 smoke test on dev (or organically from agent/ready queue) — no cascading failures on a routine deploy-triggered restart
- [x] Verification evidence posted on #2872 with per-criterion proof
