### PR TITLE
feat(dispatcher): per-phase token usage + cost metering (#2869)

### DIFF
--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -214,6 +214,51 @@ Nonsensical values (threshold ≤ 0, window_size ≤ 0) are treated as "breaker 
 
 The daemon validates phase strings via the `PHASE_*` constants — adding a new phase value requires a code change but no migration. See `scripts/dispatcher/daemon.py` constants section for the canonical list.
 
+### Dispatcher v2 — per-phase token + cost telemetry (#2869)
+
+Migration 31 added `tokens_input`, `tokens_output`, `tokens_cache_read`, `tokens_cache_write`, `cost_usd`, and `model_used` columns to `dispatcher.phase_outputs`. The daemon runs each phase as `claude -p /task-v2-<phase> --output-format json ...`, parses the JSON envelope that ships on stdout (`{usage: {...}, total_cost_usd: ..., model: ...}`), and writes those six fields alongside each `phase_outputs` row.
+
+> **Caveat — list-price, not Max plan.** `total_cost_usd` emitted by Claude Code is the list-price cost estimated against posted Anthropic rates. It does NOT reflect Max plan discounts (which are what the operator is actually billed under). Numbers here are useful for *relative* run-to-run comparison ("is ralph on sonnet cheaper than on haiku?") but NOT for absolute spend accounting.
+
+Two standard dashboards live below. Run them via `scripts/dev-db-query.sh` (or copy into any psql session that has `dispatcher.*` access).
+
+**Last 10 PRs — cost + token totals.** Answers "what did the last day of PR-landing agents cost?" For drilling into why a single agent was expensive, switch to the per-phase breakdown from `DispatcherAgent.phaseCostBreakdown` in the admin cockpit.
+
+```sql
+-- Last-day completed PRs, ordered by cost (most expensive first).
+-- Pre-migration-31 agents appear with pr_cost_usd = NULL (no signal) —
+-- COALESCE would misleadingly sort them as "$0" ahead of real cheap runs.
+SELECT a.pr_number,
+       a.issue_number,
+       SUM(po.cost_usd)                                      AS pr_cost_usd,
+       SUM(COALESCE(po.tokens_input, 0) + COALESCE(po.tokens_output, 0)) AS pr_tokens
+  FROM dispatcher.agents a
+  JOIN dispatcher.phase_outputs po ON po.agent_id = a.agent_id
+ WHERE a.pr_number IS NOT NULL
+   AND a.ended_at > now() - interval '1 day'
+ GROUP BY a.pr_number, a.issue_number
+ ORDER BY pr_cost_usd DESC NULLS LAST
+ LIMIT 10;
+```
+
+**Cost-by-phase, last 24h.** Answers "which phase is the cost bottleneck?" — the canonical tuning question. A consistently-expensive ralph means "swap ralph model" is a meaningful lever; a consistently-expensive plan means "opus on plan is priced out of proportion to the triage quality it provides."
+
+```sql
+-- Per-phase cost rollup — total spend + average per-run + runs-so-far.
+-- Sorted by total_cost DESC so the biggest line item is on top.
+SELECT phase,
+       SUM(cost_usd) AS total_cost,
+       AVG(cost_usd) AS avg_cost,
+       COUNT(*)      AS n_runs
+  FROM dispatcher.phase_outputs
+ WHERE ts > now() - interval '1 day'
+   AND cost_usd IS NOT NULL
+ GROUP BY phase
+ ORDER BY total_cost DESC;
+```
+
+Both queries filter `cost_usd IS NOT NULL` (or sort NULLS LAST) so pre-migration-31 rows don't corrupt the averages or take up slots in the top-10 view.
+
 ## ECS Script Execution
 
 > **Important:** The dev database is in a private VPC and is not reachable from localhost. Do not attempt to connect to it locally using `scripts/with-secret.sh` with `DATABASE_URL` — the connection will fail. All data scripts must run inside the VPC via `ecs-run-task.sh`.

--- a/packages/api/migrations/31_dispatcher-phase-outputs-token-metering.sql
+++ b/packages/api/migrations/31_dispatcher-phase-outputs-token-metering.sql
@@ -1,0 +1,93 @@
+-- Up Migration
+--
+-- Dispatcher v2 — per-phase token usage + cost metering (#2869).
+--
+-- Context
+-- -------
+-- Before this migration, ``dispatcher.phase_outputs`` had no metering
+-- columns, so per-PR / per-phase token + cost telemetry was unavailable.
+-- The Max plan's fixed monthly fee masks per-run cost until the
+-- extra-usage threshold is hit, so operators couldn't answer
+-- questions like "is ralph-on-sonnet cheaper than ralph-on-haiku for
+-- scraper fixes?" or "which phase is the cost bottleneck?" without
+-- a data source. Tokens are meterable independently of billing, and
+-- Claude Code emits them via ``claude -p --output-format json`` as a
+-- ``{usage: {...}, total_cost_usd: ...}`` block on stdout.
+--
+-- Design notes
+-- ------------
+-- - All columns are nullable — historical rows inserted before this
+--   migration have no usage data to back-fill, and phases that crash
+--   before ``claude`` prints its JSON envelope legitimately have no
+--   usage block (NULL keeps "no signal" distinguishable from zero).
+-- - ``bigint`` for token counts — input + output + cache counts can
+--   easily exceed 2^31 for long ralph iterations. A single ralph run
+--   commonly exceeds 10M input tokens after cache reads; the JSON
+--   envelope sums all turns. ``int`` would silently overflow.
+-- - ``numeric(10,4)`` for ``cost_usd`` — Anthropic's list-price rates
+--   produce costs with up to ~4 decimal places of significant digits
+--   ($0.0001 per 1k tokens of Haiku input). ``numeric`` avoids floating
+--   rounding drift across SUM aggregations (the documented "last 10 PR
+--   cost" query).
+-- - ``text`` for ``model_used`` — we store the resolved model name
+--   (e.g. ``"sonnet"``, ``"claude-sonnet-4-5"``) rather than an enum, so
+--   adding a new model never requires a migration.
+-- - No index — the documented dashboard queries aggregate by
+--   ``(agent_id)`` or ``(phase)`` which are already covered by
+--   existing indexes (``idx_dispatcher_phase_outputs_agent_phase_attempt``
+--   from migration 30 + the primary key). Adding a ``(cost_usd)`` index
+--   would slow every INSERT for rarely-executed "top N most expensive
+--   phases" queries; the full table is small enough (30-day retention,
+--   housekeeping tick at migration 24) that a seq scan is cheap.
+--
+-- Known caveat
+-- ------------
+-- ``total_cost_usd`` from Claude Code is the list-price cost estimated
+-- against posted Anthropic rates — it does NOT reflect Max plan
+-- discounts. Comparable run-to-run (tuning useful) but NOT actual
+-- billed spend. Documented in ``docs/agent/infrastructure-reference.md``.
+
+ALTER TABLE dispatcher.phase_outputs
+    ADD COLUMN tokens_input        bigint,
+    ADD COLUMN tokens_output       bigint,
+    ADD COLUMN tokens_cache_read   bigint,
+    ADD COLUMN tokens_cache_write  bigint,
+    ADD COLUMN cost_usd            numeric(10, 4),
+    ADD COLUMN model_used          text;
+
+COMMENT ON COLUMN dispatcher.phase_outputs.tokens_input IS
+    'Input tokens consumed by the phase (sum across all claude API turns). '
+    'Parsed from the ``usage.input_tokens`` field of the ``claude -p --output-format json`` envelope. '
+    'Nullable — historical rows and pre-JSON-envelope failures have no signal. Issue #2869.';
+
+COMMENT ON COLUMN dispatcher.phase_outputs.tokens_output IS
+    'Output tokens emitted by the phase. Parsed from ``usage.output_tokens``. '
+    'Nullable. Issue #2869.';
+
+COMMENT ON COLUMN dispatcher.phase_outputs.tokens_cache_read IS
+    'Cache-read tokens (cheap tokens served from prompt-cache). Parsed from '
+    '``usage.cache_read_input_tokens``. Nullable. Issue #2869.';
+
+COMMENT ON COLUMN dispatcher.phase_outputs.tokens_cache_write IS
+    'Cache-creation tokens (prompt written to cache for reuse). Parsed from '
+    '``usage.cache_creation_input_tokens``. Nullable. Issue #2869.';
+
+COMMENT ON COLUMN dispatcher.phase_outputs.cost_usd IS
+    'Claude Code''s list-price cost estimate for the phase. Parsed from '
+    '``total_cost_usd``. NOT Max-plan-adjusted — comparable run-to-run but '
+    'not actual billed spend. Nullable. Issue #2869.';
+
+COMMENT ON COLUMN dispatcher.phase_outputs.model_used IS
+    'The resolved Claude model the phase ran on (e.g. ``"sonnet"``, '
+    '``"claude-sonnet-4-5"``). Free-form text — adding a new model never '
+    'requires a migration. Nullable. Issue #2869.';
+
+
+-- Down Migration
+ALTER TABLE dispatcher.phase_outputs
+    DROP COLUMN IF EXISTS tokens_input,
+    DROP COLUMN IF EXISTS tokens_output,
+    DROP COLUMN IF EXISTS tokens_cache_read,
+    DROP COLUMN IF EXISTS tokens_cache_write,
+    DROP COLUMN IF EXISTS cost_usd,
+    DROP COLUMN IF EXISTS model_used;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 30 migrations.
+-- Generated from 31 migrations.
 
 
 
@@ -474,7 +474,13 @@ CREATE TABLE dispatcher.phase_outputs (
     output_json jsonb NOT NULL,
     ts timestamp with time zone DEFAULT now() NOT NULL,
     log_text text,
-    attempt integer DEFAULT 0 NOT NULL
+    attempt integer DEFAULT 0 NOT NULL,
+    tokens_input bigint,
+    tokens_output bigint,
+    tokens_cache_read bigint,
+    tokens_cache_write bigint,
+    cost_usd numeric(10,4),
+    model_used text
 );
 
 
@@ -482,6 +488,24 @@ COMMENT ON COLUMN dispatcher.phase_outputs.log_text IS 'Full ephemeral phase log
 
 
 COMMENT ON COLUMN dispatcher.phase_outputs.attempt IS 'Retry attempt counter — matches dispatcher.agents.retries_used at the moment this phase ran. 0 = initial run. Each retry reset (_process_retry_markers) bumps the effective attempt for the next phase run. Issue #2872.';
+
+
+COMMENT ON COLUMN dispatcher.phase_outputs.tokens_input IS 'Input tokens consumed by the phase (sum across all claude API turns). Parsed from the ``usage.input_tokens`` field of the ``claude -p --output-format json`` envelope. Nullable — historical rows and pre-JSON-envelope failures have no signal. Issue #2869.';
+
+
+COMMENT ON COLUMN dispatcher.phase_outputs.tokens_output IS 'Output tokens emitted by the phase. Parsed from ``usage.output_tokens``. Nullable. Issue #2869.';
+
+
+COMMENT ON COLUMN dispatcher.phase_outputs.tokens_cache_read IS 'Cache-read tokens (cheap tokens served from prompt-cache). Parsed from ``usage.cache_read_input_tokens``. Nullable. Issue #2869.';
+
+
+COMMENT ON COLUMN dispatcher.phase_outputs.tokens_cache_write IS 'Cache-creation tokens (prompt written to cache for reuse). Parsed from ``usage.cache_creation_input_tokens``. Nullable. Issue #2869.';
+
+
+COMMENT ON COLUMN dispatcher.phase_outputs.cost_usd IS 'Claude Code''s list-price cost estimate for the phase. Parsed from ``total_cost_usd``. NOT Max-plan-adjusted — comparable run-to-run but not actual billed spend. Nullable. Issue #2869.';
+
+
+COMMENT ON COLUMN dispatcher.phase_outputs.model_used IS 'The resolved Claude model the phase ran on (e.g. ``"sonnet"``, ``"claude-sonnet-4-5"``). Free-form text — adding a new model never requires a migration. Nullable. Issue #2869.';
 
 
 CREATE SEQUENCE dispatcher.phase_outputs_output_id_seq
@@ -562,6 +586,26 @@ CREATE SEQUENCE dispatcher.retry_markers_marker_id_seq
 ALTER SEQUENCE dispatcher.retry_markers_marker_id_seq OWNED BY dispatcher.retry_markers.marker_id;
 
 
+CREATE TABLE dispatcher.runs (
+    run_id uuid DEFAULT gen_random_uuid() NOT NULL,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    stopped_at timestamp with time zone,
+    heartbeat_ts timestamp with time zone DEFAULT now() NOT NULL,
+    version_sha text NOT NULL,
+    host text NOT NULL,
+    pid integer NOT NULL
+);
+
+
+COMMENT ON TABLE dispatcher.runs IS 'One row per daemon boot. Latest row is the active lease.';
+
+
+COMMENT ON COLUMN dispatcher.runs.heartbeat_ts IS 'Daemon updates every tick. CloudWatch alarm pages if stale > 5min.';
+
+
+COMMENT ON COLUMN dispatcher.runs.version_sha IS 'Git SHA of the daemon build; supports forensic questions after a crash.';
+
+
 CREATE TABLE dispatcher.terminal_outcomes (
     outcome_id bigint NOT NULL,
     agent_id uuid,
@@ -589,26 +633,6 @@ CREATE SEQUENCE dispatcher.terminal_outcomes_outcome_id_seq
 
 
 ALTER SEQUENCE dispatcher.terminal_outcomes_outcome_id_seq OWNED BY dispatcher.terminal_outcomes.outcome_id;
-
-
-CREATE TABLE dispatcher.runs (
-    run_id uuid DEFAULT gen_random_uuid() NOT NULL,
-    started_at timestamp with time zone DEFAULT now() NOT NULL,
-    stopped_at timestamp with time zone,
-    heartbeat_ts timestamp with time zone DEFAULT now() NOT NULL,
-    version_sha text NOT NULL,
-    host text NOT NULL,
-    pid integer NOT NULL
-);
-
-
-COMMENT ON TABLE dispatcher.runs IS 'One row per daemon boot. Latest row is the active lease.';
-
-
-COMMENT ON COLUMN dispatcher.runs.heartbeat_ts IS 'Daemon updates every tick. CloudWatch alarm pages if stale > 5min.';
-
-
-COMMENT ON COLUMN dispatcher.runs.version_sha IS 'Git SHA of the daemon build; supports forensic questions after a crash.';
 
 
 CREATE TABLE public.alert_events (
@@ -921,12 +945,12 @@ ALTER TABLE ONLY dispatcher.retry_markers
     ADD CONSTRAINT retry_markers_pkey PRIMARY KEY (marker_id);
 
 
-ALTER TABLE ONLY dispatcher.terminal_outcomes
-    ADD CONSTRAINT terminal_outcomes_pkey PRIMARY KEY (outcome_id);
-
-
 ALTER TABLE ONLY dispatcher.runs
     ADD CONSTRAINT runs_pkey PRIMARY KEY (run_id);
+
+
+ALTER TABLE ONLY dispatcher.terminal_outcomes
+    ADD CONSTRAINT terminal_outcomes_pkey PRIMARY KEY (outcome_id);
 
 
 ALTER TABLE ONLY public.alert_events

--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -280,12 +280,34 @@ async function queryRecentCompletions(pool: Pool, limit: number): Promise<Row[]>
   // slot into this IN list without a schema migration —
   // `dispatcher.agents.status` is plain text (migration 25, no CHECK
   // constraint).
+  //
+  // #2869: LEFT JOIN the per-agent token + cost rollup from
+  // `dispatcher.phase_outputs` so the admin cockpit can render a cost
+  // footnote on each row without an N+1 query. SUM across attempts and
+  // phases — the row is one "finished agent", not one phase. Rows that
+  // predate migration 31 have NULL metering columns, so SUM returns
+  // NULL (not 0), which the UI renders as "no cost data" rather than a
+  // misleading "$0.00".
   const { rows } = await pool.query<Row>(
-    `SELECT agent_id, issue_number, issue_title, status, ended_at, pr_number
-       FROM dispatcher.agents
-      WHERE status IN ('succeeded', 'failed', 'crashed', 'plan_blocked', 'needs_review')
-        AND ended_at IS NOT NULL
-      ORDER BY ended_at DESC
+    `SELECT a.agent_id,
+            a.issue_number,
+            a.issue_title,
+            a.status,
+            a.ended_at,
+            a.pr_number,
+            po.total_tokens,
+            po.total_cost_usd
+       FROM dispatcher.agents a
+       LEFT JOIN (
+         SELECT agent_id,
+                SUM(COALESCE(tokens_input, 0) + COALESCE(tokens_output, 0)) AS total_tokens,
+                SUM(cost_usd) AS total_cost_usd
+           FROM dispatcher.phase_outputs
+          GROUP BY agent_id
+       ) po ON po.agent_id = a.agent_id
+      WHERE a.status IN ('succeeded', 'failed', 'crashed', 'plan_blocked', 'needs_review')
+        AND a.ended_at IS NOT NULL
+      ORDER BY a.ended_at DESC
       LIMIT $1`,
     [limit],
   );
@@ -433,8 +455,36 @@ function recentCompletionsToGraphQL(
       status: row.status,
       endedAt: row.ended_at,
       prNumber: row.pr_number ?? null,
+      // #2869: metering fields. Coerced to Number because pg returns
+      // numeric-type columns as strings on some platforms; null stays
+      // null so the UI renders "no data" instead of "$0.00".
+      totalTokens: coerceNullableNumber(row.total_tokens),
+      totalCostUsd: coerceNullableNumber(row.total_cost_usd),
     };
   });
+}
+
+/** Coerce a pg numeric/bigint column to a JS Number or null.
+ *
+ * pg's default mapping returns ``numeric`` as a string (to preserve
+ * arbitrary precision) and ``bigint`` as a string on platforms where
+ * Number would lose precision. The dispatcher metering columns are
+ * always small enough for a Number (token counts fit in 53 bits of
+ * precision well under any plausible phase usage), so we coerce.
+ * Null / undefined / NaN pass through as null — the GraphQL schema
+ * keeps every metering field nullable exactly for this "no signal"
+ * case. Issue #2869.
+ */
+function coerceNullableNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === 'string' || typeof value === 'bigint') {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  return null;
 }
 
 // ---------------------------------------------------------------------------
@@ -816,8 +866,137 @@ export const dispatcherResolvers = {
       const rows = await queryFailuresForAgent(pool, String(agentId));
       return rows.map(failureRowToGraphQL);
     },
+
+    // #2869: per-agent token + cost aggregates. Four fields share a
+    // single per-phase SELECT via DataLoader-style caching on the
+    // parent object — the first field to resolve primes
+    // `__phase_cost_rows` on the parent so subsequent sibling fields
+    // reuse the same query result instead of issuing three more
+    // SELECTs. dispatcherAgent() is a single-object query so this
+    // optimization only matters for the one-field-per-render paths,
+    // but it keeps the admin cockpit cheap when polling.
+    totalTokensInput: async (
+      parent: Record<string, unknown>,
+      __: unknown,
+      { pool, user }: DispatcherContext,
+    ) => {
+      requireDispatcherAdmin(user);
+      const rows = await _memoPhaseCostRows(pool, parent);
+      return sumPhaseCost(rows, 'tokens_input');
+    },
+
+    totalTokensOutput: async (
+      parent: Record<string, unknown>,
+      __: unknown,
+      { pool, user }: DispatcherContext,
+    ) => {
+      requireDispatcherAdmin(user);
+      const rows = await _memoPhaseCostRows(pool, parent);
+      return sumPhaseCost(rows, 'tokens_output');
+    },
+
+    totalCostUsd: async (
+      parent: Record<string, unknown>,
+      __: unknown,
+      { pool, user }: DispatcherContext,
+    ) => {
+      requireDispatcherAdmin(user);
+      const rows = await _memoPhaseCostRows(pool, parent);
+      return sumPhaseCost(rows, 'cost_usd');
+    },
+
+    phaseCostBreakdown: async (
+      parent: Record<string, unknown>,
+      __: unknown,
+      { pool, user }: DispatcherContext,
+    ) => {
+      requireDispatcherAdmin(user);
+      const rows = await _memoPhaseCostRows(pool, parent);
+      return phaseCostRowsToGraphQL(rows);
+    },
   },
 };
+
+async function _memoPhaseCostRows(
+  pool: Pool,
+  parent: Record<string, unknown>,
+): Promise<Row[]> {
+  const cached = parent.__phase_cost_rows;
+  if (Array.isArray(cached)) return cached as Row[];
+  const agentId = parent.__agent_id ?? parent.id;
+  const rows = await queryPhaseCostBreakdown(pool, String(agentId));
+  parent.__phase_cost_rows = rows;
+  return rows;
+}
+
+async function queryPhaseCostBreakdown(
+  pool: Pool,
+  agentId: string,
+): Promise<Row[]> {
+  // #2869: one row per phase, summed across retry attempts. The
+  // "latest model_used per phase" picks the most recent attempt
+  // deterministically via DISTINCT ON — retries that swap models
+  // (model_override operator knob) report the model that actually
+  // produced the final result.
+  const { rows } = await pool.query<Row>(
+    `SELECT po.phase,
+            SUM(po.tokens_input)       AS tokens_input,
+            SUM(po.tokens_output)      AS tokens_output,
+            SUM(po.tokens_cache_read)  AS tokens_cache_read,
+            SUM(po.tokens_cache_write) AS tokens_cache_write,
+            SUM(po.cost_usd)           AS cost_usd,
+            (SELECT model_used
+               FROM dispatcher.phase_outputs po2
+              WHERE po2.agent_id = po.agent_id
+                AND po2.phase    = po.phase
+                AND po2.model_used IS NOT NULL
+              ORDER BY po2.ts DESC
+              LIMIT 1) AS model_used
+       FROM dispatcher.phase_outputs po
+      WHERE po.agent_id = $1
+      GROUP BY po.agent_id, po.phase
+      ORDER BY MIN(po.ts) ASC`,
+    [agentId],
+  );
+  return rows;
+}
+
+function phaseCostRowsToGraphQL(
+  rows: readonly Row[],
+): Array<Record<string, unknown>> {
+  return rows.map((row) => ({
+    phase: row.phase,
+    tokensInput: coerceNullableNumber(row.tokens_input),
+    tokensOutput: coerceNullableNumber(row.tokens_output),
+    tokensCacheRead: coerceNullableNumber(row.tokens_cache_read),
+    tokensCacheWrite: coerceNullableNumber(row.tokens_cache_write),
+    costUsd: coerceNullableNumber(row.cost_usd),
+    modelUsed: typeof row.model_used === 'string' ? row.model_used : null,
+  }));
+}
+
+/** Sum a single nullable-numeric column across phase rows.
+ *
+ * Returns null when every row's value is null — the "no metering
+ * signal" case for an agent whose phases all ran before migration 31
+ * or all failed before producing a JSON envelope. Returns a Number
+ * (possibly 0) when at least one row has a non-null value, which the
+ * UI renders literally. Issue #2869.
+ */
+function sumPhaseCost(
+  rows: readonly Row[],
+  column: 'tokens_input' | 'tokens_output' | 'cost_usd',
+): number | null {
+  let total = 0;
+  let anyPresent = false;
+  for (const row of rows) {
+    const v = coerceNullableNumber(row[column]);
+    if (v === null) continue;
+    total += v;
+    anyPresent = true;
+  }
+  return anyPresent ? total : null;
+}
 
 // ---------------------------------------------------------------------------
 // Scalar shims — DateTime and JSON are declared but otherwise pass-through.
@@ -892,15 +1071,18 @@ export const dispatcherScalarResolvers = {
 // Internal exports for unit testing.
 export {
   agentRowToGraphQL,
+  coerceNullableNumber,
   commandRowToGraphQL,
   configRowToGraphQL,
   failureRowToGraphQL,
   insertCommandIdempotent,
   normalizeSnapshotJson,
+  phaseCostRowsToGraphQL,
   queueItemFromSnapshot,
   recentCompletionsToGraphQL,
   runRowToGraphQL,
   sortAndSliceQueueReady,
+  sumPhaseCost,
   transitionRowToGraphQL,
   updateConfigEntry,
 };

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -122,6 +122,49 @@ export const dispatcherTypeDefs = `#graphql
     phaseTransitions: [PhaseTransition!]!
     """Failures linked to this agent, newest first."""
     failures: [DispatcherFailure!]!
+    """Sum of \`tokens_input\` across every phase the agent ran (#2869).
+    Null when no phase row has recorded usage (e.g. the agent ran before
+    migration 31 landed, or every phase crashed before producing a JSON
+    envelope)."""
+    totalTokensInput: Float
+    """Sum of \`tokens_output\` across every phase the agent ran (#2869).
+    Null when no phase row has recorded usage."""
+    totalTokensOutput: Float
+    """Sum of \`cost_usd\` across every phase the agent ran (#2869). Null
+    when no phase row has recorded usage.
+
+    WARNING: this is Claude Code's list-price cost estimate, NOT the
+    Max plan-adjusted actual-billed amount. Useful for relative
+    run-to-run comparison, not for absolute spend accounting."""
+    totalCostUsd: Float
+    """Per-phase cost breakdown for this agent (#2869). One entry per
+    phase that emitted a usage block. Empty list when no phases have
+    recorded usage."""
+    phaseCostBreakdown: [PhaseCost!]!
+  }
+
+  """Per-phase aggregated token + cost totals for one agent. One entry
+  per phase that emitted a usage block from its \`claude -p
+  --output-format json\` invocation (#2869).
+
+  Summed across retry attempts (phase_outputs.attempt) so an agent that
+  hit a tier-1 retry mid-run shows a single row per phase with the
+  combined cost of both attempts — the operator cares about total spend
+  per phase, not per-attempt."""
+  type PhaseCost {
+    """One of plan | ralph | summary | fix_ci | verify | retro."""
+    phase: String!
+    tokensInput: Float
+    tokensOutput: Float
+    tokensCacheRead: Float
+    tokensCacheWrite: Float
+    """Same list-price caveat as \`DispatcherAgent.totalCostUsd\`."""
+    costUsd: Float
+    """The resolved model name observed on the LATEST attempt (most
+    recent \`ts\`). Distinct-per-phase because phase 3's \`model_by_phase\`
+    config sets one model per phase; if a retry attempted a different
+    model (operator override via \`model_override\`) the latest wins."""
+    modelUsed: String
   }
 
   """One row in the queue side-panels (#2805 §1.3). Capped at 10 server-side.
@@ -163,6 +206,17 @@ export const dispatcherTypeDefs = `#graphql
     rows (#2856) always have \`prNumber\` populated because the whole
     point of the terminal is that the daemon opened a draft PR."""
     prNumber: Int
+    """Sum of input+output tokens across every phase the agent ran
+    (#2869). Null when no phase row has recorded usage. Rendered as a
+    \`Nk tok\` footnote in the admin cockpit."""
+    totalTokens: Float
+    """Sum of \`cost_usd\` across every phase the agent ran (#2869).
+    Null when no phase row has recorded usage. Rendered as a \`~$X.XX\`
+    footnote in the admin cockpit.
+
+    WARNING: list-price estimate, NOT Max plan-adjusted. See
+    \`DispatcherAgent.totalCostUsd\`."""
+    totalCostUsd: Float
   }
 
   """One key/value entry from \`dispatcher.config\` (#2805 §1.6)."""

--- a/packages/api/tests/dispatcher-enrichment.unit.test.ts
+++ b/packages/api/tests/dispatcher-enrichment.unit.test.ts
@@ -18,10 +18,13 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  coerceNullableNumber,
   normalizeSnapshotJson,
+  phaseCostRowsToGraphQL,
   queueItemFromSnapshot,
   recentCompletionsToGraphQL,
   sortAndSliceQueueReady,
+  sumPhaseCost,
   type SnapshotIssueRecord,
 } from '../src/graphql/dispatcher/resolvers';
 import {
@@ -174,6 +177,8 @@ describe('recentCompletionsToGraphQL', () => {
         status: 'succeeded',
         ended_at: '2026-04-18T12:00:00Z',
         pr_number: 2824,
+        total_tokens: 12345,
+        total_cost_usd: '0.0420',
       },
     ];
     const result = recentCompletionsToGraphQL(rows);
@@ -185,8 +190,31 @@ describe('recentCompletionsToGraphQL', () => {
         status: 'succeeded',
         endedAt: '2026-04-18T12:00:00Z',
         prNumber: 2824,
+        totalTokens: 12345,
+        totalCostUsd: 0.042,
       },
     ]);
+  });
+
+  it('emits totalTokens=null and totalCostUsd=null for pre-migration-31 rows', () => {
+    // Rows whose agent ran before migration 31 (or whose phases all
+    // crashed before producing a JSON envelope) have NULL metering —
+    // the UI renders "no cost data" rather than a misleading $0.00.
+    const rows = [
+      {
+        agent_id: 'uuid-1',
+        issue_number: 100,
+        issue_title: 'Pre-migration agent',
+        status: 'succeeded',
+        ended_at: '2026-04-18T12:00:00Z',
+        pr_number: 2824,
+        total_tokens: null,
+        total_cost_usd: null,
+      },
+    ];
+    const result = recentCompletionsToGraphQL(rows);
+    expect(result[0].totalTokens).toBeNull();
+    expect(result[0].totalCostUsd).toBeNull();
   });
 
   it('emits issueTitle=null for rows with NULL/empty issue_title (pre-migration-28)', () => {
@@ -507,5 +535,132 @@ describe('sortAndSliceQueueReady', () => {
 
     expect(result).toHaveLength(2);
     expect(result.map((r) => r.number)).toEqual([1, 2]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Metering helpers (#2869) — coerceNullableNumber, sumPhaseCost,
+// phaseCostRowsToGraphQL. These back the new DispatcherAgent fields
+// ``totalTokensInput``, ``totalTokensOutput``, ``totalCostUsd``, and
+// ``phaseCostBreakdown``.
+// ---------------------------------------------------------------------------
+
+describe('coerceNullableNumber (#2869)', () => {
+  it('returns the value unchanged for finite numbers', () => {
+    expect(coerceNullableNumber(42)).toBe(42);
+    expect(coerceNullableNumber(0)).toBe(0);
+    expect(coerceNullableNumber(-3.14)).toBe(-3.14);
+  });
+
+  it('coerces pg numeric strings (cost_usd is returned as a string)', () => {
+    // pg's default numeric→string mapping preserves precision. The
+    // resolver must coerce to Number so the GraphQL scalar serializes
+    // as a JSON number, not a quoted string.
+    expect(coerceNullableNumber('0.0420')).toBe(0.042);
+    expect(coerceNullableNumber('12345')).toBe(12345);
+  });
+
+  it('coerces bigint to Number', () => {
+    // Token counts fit in 53 bits well under any plausible phase usage;
+    // bigint → Number is safe.
+    expect(coerceNullableNumber(12345n)).toBe(12345);
+  });
+
+  it('returns null for null / undefined / unparseable', () => {
+    expect(coerceNullableNumber(null)).toBeNull();
+    expect(coerceNullableNumber(undefined)).toBeNull();
+    expect(coerceNullableNumber('nope')).toBeNull();
+    expect(coerceNullableNumber({})).toBeNull();
+    expect(coerceNullableNumber(NaN)).toBeNull();
+  });
+});
+
+describe('sumPhaseCost (#2869)', () => {
+  it('sums a column across rows, ignoring nulls', () => {
+    const rows = [
+      { tokens_input: 100, tokens_output: 50, cost_usd: '0.01' },
+      { tokens_input: 200, tokens_output: null, cost_usd: '0.02' },
+      { tokens_input: null, tokens_output: 30, cost_usd: null },
+    ];
+    expect(sumPhaseCost(rows, 'tokens_input')).toBe(300);
+    expect(sumPhaseCost(rows, 'tokens_output')).toBe(80);
+    expect(sumPhaseCost(rows, 'cost_usd')).toBeCloseTo(0.03, 10);
+  });
+
+  it('returns null when every row is null (no metering signal)', () => {
+    // Distinct from returning 0 — the UI must be able to distinguish
+    // "this agent actually spent $0" from "we have no data for this
+    // agent". Pre-migration-31 agents all have NULL across the board.
+    const rows = [
+      { tokens_input: null, tokens_output: null, cost_usd: null },
+      { tokens_input: null, tokens_output: null, cost_usd: null },
+    ];
+    expect(sumPhaseCost(rows, 'tokens_input')).toBeNull();
+    expect(sumPhaseCost(rows, 'tokens_output')).toBeNull();
+    expect(sumPhaseCost(rows, 'cost_usd')).toBeNull();
+  });
+
+  it('returns 0 when at least one row has a zero value (distinct from null)', () => {
+    const rows = [
+      { tokens_input: 0, tokens_output: null, cost_usd: '0' },
+    ];
+    expect(sumPhaseCost(rows, 'tokens_input')).toBe(0);
+    // tokens_output is entirely null → null sentinel.
+    expect(sumPhaseCost(rows, 'tokens_output')).toBeNull();
+    expect(sumPhaseCost(rows, 'cost_usd')).toBe(0);
+  });
+
+  it('returns null for an empty row list', () => {
+    expect(sumPhaseCost([], 'tokens_input')).toBeNull();
+    expect(sumPhaseCost([], 'cost_usd')).toBeNull();
+  });
+});
+
+describe('phaseCostRowsToGraphQL (#2869)', () => {
+  it('maps snake_case columns to camelCase GraphQL fields with nullable Number coercion', () => {
+    const rows = [
+      {
+        phase: 'plan',
+        tokens_input: '1000',
+        tokens_output: '200',
+        tokens_cache_read: '3000',
+        tokens_cache_write: '400',
+        cost_usd: '0.0123',
+        model_used: 'claude-opus-4-5',
+      },
+      {
+        phase: 'ralph',
+        tokens_input: null,
+        tokens_output: null,
+        tokens_cache_read: null,
+        tokens_cache_write: null,
+        cost_usd: null,
+        model_used: null,
+      },
+    ];
+    expect(phaseCostRowsToGraphQL(rows)).toEqual([
+      {
+        phase: 'plan',
+        tokensInput: 1000,
+        tokensOutput: 200,
+        tokensCacheRead: 3000,
+        tokensCacheWrite: 400,
+        costUsd: 0.0123,
+        modelUsed: 'claude-opus-4-5',
+      },
+      {
+        phase: 'ralph',
+        tokensInput: null,
+        tokensOutput: null,
+        tokensCacheRead: null,
+        tokensCacheWrite: null,
+        costUsd: null,
+        modelUsed: null,
+      },
+    ]);
+  });
+
+  it('returns an empty array for an empty row list', () => {
+    expect(phaseCostRowsToGraphQL([])).toEqual([]);
   });
 });

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -70,6 +70,10 @@ export function RecentCompletionsPanel({
 }
 
 function RecentCompletionRow({ completion }: { completion: RecentCompletion }) {
+  const costFootnote = formatCostFootnote(
+    completion.totalCostUsd,
+    completion.totalTokens,
+  );
   return (
     <li className="flex items-start gap-3 py-2 text-sm hover:bg-muted/50">
       <span className="flex-shrink-0 pt-0.5">
@@ -91,7 +95,63 @@ function RecentCompletionRow({ completion }: { completion: RecentCompletion }) {
         {completion.issueTitle ?? (
           <span className="italic text-muted-foreground">(title unavailable)</span>
         )}
+        {costFootnote !== null && (
+          <span
+            className="ml-2 text-xs text-muted-foreground"
+            data-testid="completion-row-cost"
+            title="List-price token estimate; NOT Max-plan-adjusted actual spend."
+          >
+            {costFootnote}
+          </span>
+        )}
       </span>
     </li>
   );
 }
+
+/** Render a compact cost footnote ("~$0.42, 123k tok") from the parent
+ * aggregate fields (#2869).
+ *
+ * Returns ``null`` when neither value is present — we render nothing at
+ * all rather than "$0.00 / 0 tok" so operators can distinguish "cheap
+ * agent" from "no metering signal on this row" (e.g. a pre-migration-31
+ * agent, or every phase crashed before emitting a JSON envelope).
+ *
+ * Design choices:
+ * - Cost is formatted with 2 decimals when ≥ $1, 4 decimals otherwise —
+ *   a cheap haiku verify phase lands at ~$0.0008 and would round to
+ *   "$0.00" under a blanket 2-decimal rule.
+ * - Tokens are formatted "Nk" for brevity; shows "<1k" for the rare
+ *   sub-1000-token agent so "0k" doesn't imply zero cost.
+ * - The "~" on cost signals "estimate, not billed" per the caveat
+ *   documented on `totalCostUsd`.
+ */
+function formatCostFootnote(
+  costUsd: number | null,
+  totalTokens: number | null,
+): string | null {
+  if (costUsd === null && totalTokens === null) return null;
+  const parts: string[] = [];
+  if (costUsd !== null) {
+    const decimals = Math.abs(costUsd) >= 1 ? 2 : 4;
+    parts.push(`~$${costUsd.toFixed(decimals)}`);
+  }
+  if (totalTokens !== null) {
+    parts.push(formatTokenCount(totalTokens));
+  }
+  return `(${parts.join(', ')})`;
+}
+
+function formatTokenCount(tokens: number): string {
+  if (tokens >= 1000) {
+    const k = tokens / 1000;
+    // >= 10k — drop the decimal; < 10k — keep one so "1.2k" reads better than "1k".
+    return k >= 10 ? `${Math.round(k)}k tok` : `${k.toFixed(1)}k tok`;
+  }
+  return `${tokens} tok`;
+}
+
+// Exported for unit testing; the helpers stay co-located with the
+// component because they are presentation-only and not reused elsewhere.
+// See ``__tests__/RecentCompletionsPanel.test.tsx``.
+export { formatCostFootnote, formatTokenCount };

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { RecentCompletionsPanel } from '../RecentCompletionsPanel';
+import {
+  RecentCompletionsPanel,
+  formatCostFootnote,
+  formatTokenCount,
+} from '../RecentCompletionsPanel';
 import type { RecentCompletion } from '@/lib/dispatcher-queries';
 
 const now = Date.parse('2026-04-18T12:00:00Z');
@@ -13,6 +17,8 @@ function completion(overrides: Partial<RecentCompletion>): RecentCompletion {
     status: 'succeeded',
     endedAt: '2026-04-18T11:55:00Z',
     prNumber: 2811,
+    totalTokens: null,
+    totalCostUsd: null,
     ...overrides,
   };
 }
@@ -66,5 +72,103 @@ describe('RecentCompletionsPanel', () => {
     const titleEl = screen.getByText(longTitle);
     expect(titleEl.className).toMatch(/break-words/);
     expect(titleEl.className).not.toMatch(/\btruncate\b/);
+  });
+
+  // --- #2869 — per-PR cost footnote on each row.
+  it('#2869: renders "~$X.XX, Nk tok" footnote when both metering fields are populated', () => {
+    const items = [
+      completion({
+        agentId: 'agent-cost-1',
+        totalCostUsd: 0.42,
+        totalTokens: 123456,
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    const footnote = screen.getByTestId('completion-row-cost');
+    expect(footnote.textContent).toContain('~$0.42');
+    // 123456 tokens → 123k (Math.round, no decimal for >= 10k).
+    expect(footnote.textContent).toContain('123k tok');
+  });
+
+  it('#2869: omits the footnote entirely when both metering fields are null (pre-migration-31)', () => {
+    const items = [
+      completion({
+        agentId: 'agent-no-cost',
+        totalCostUsd: null,
+        totalTokens: null,
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    // No footnote rendered — distinguishes "no data" from "$0.00".
+    expect(screen.queryByTestId('completion-row-cost')).not.toBeInTheDocument();
+  });
+
+  it('#2869: renders only the available half when the other metering field is null', () => {
+    const costOnly = [
+      completion({
+        agentId: 'agent-cost-only',
+        totalCostUsd: 0.01,
+        totalTokens: null,
+      }),
+    ];
+    const { unmount } = render(
+      <RecentCompletionsPanel completions={costOnly} nowMs={now} />,
+    );
+    expect(screen.getByTestId('completion-row-cost').textContent).toContain(
+      '~$0.0100',
+    );
+    expect(screen.getByTestId('completion-row-cost').textContent).not.toContain(
+      'tok',
+    );
+    unmount();
+
+    const tokensOnly = [
+      completion({
+        agentId: 'agent-tokens-only',
+        totalCostUsd: null,
+        totalTokens: 5000,
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={tokensOnly} nowMs={now} />);
+    const footnote = screen.getByTestId('completion-row-cost');
+    expect(footnote.textContent).toContain('tok');
+    expect(footnote.textContent).not.toContain('$');
+  });
+});
+
+describe('formatCostFootnote (#2869)', () => {
+  it('returns null when both inputs are null', () => {
+    expect(formatCostFootnote(null, null)).toBeNull();
+  });
+
+  it('formats cost with 2 decimals when >= $1', () => {
+    expect(formatCostFootnote(1.234, null)).toBe('(~$1.23)');
+    expect(formatCostFootnote(42.5, null)).toBe('(~$42.50)');
+  });
+
+  it('formats cost with 4 decimals when < $1 (so haiku cheap phases are visible)', () => {
+    expect(formatCostFootnote(0.0008, null)).toBe('(~$0.0008)');
+    expect(formatCostFootnote(0.1234, null)).toBe('(~$0.1234)');
+  });
+
+  it('combines cost and token count with a comma separator', () => {
+    expect(formatCostFootnote(0.42, 12345)).toBe('(~$0.4200, 12k tok)');
+  });
+});
+
+describe('formatTokenCount (#2869)', () => {
+  it('renders a single-digit "k" with a decimal for < 10k', () => {
+    expect(formatTokenCount(1500)).toBe('1.5k tok');
+    expect(formatTokenCount(9876)).toBe('9.9k tok');
+  });
+
+  it('drops the decimal for >= 10k (noise for at-a-glance)', () => {
+    expect(formatTokenCount(12345)).toBe('12k tok');
+    expect(formatTokenCount(234567)).toBe('235k tok');
+  });
+
+  it('renders raw count for < 1k so "0k" does not imply zero cost', () => {
+    expect(formatTokenCount(500)).toBe('500 tok');
+    expect(formatTokenCount(0)).toBe('0 tok');
   });
 });

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -70,6 +70,8 @@ export const DISPATCHER_STATE_QUERY = gql`
         status
         endedAt
         prNumber
+        totalTokens
+        totalCostUsd
       }
       config {
         key
@@ -165,6 +167,15 @@ export interface RecentCompletion {
   status: string;
   endedAt: string;
   prNumber: number | null;
+  /** Sum of input+output tokens across every phase the agent ran
+   * (#2869). Null when no phase row has recorded usage — rendered as
+   * "no cost data" rather than a misleading 0. */
+  totalTokens: number | null;
+  /** Sum of `cost_usd` across every phase the agent ran (#2869). Null
+   * when no phase row has recorded usage.
+   *
+   * WARNING: list-price estimate, NOT Max plan-adjusted. */
+  totalCostUsd: number | null;
 }
 
 export interface DispatcherConfigEntry {

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -3680,6 +3680,7 @@ class DispatcherDaemon:
         phase: str,
         output_json: dict[str, Any],
         log_text: str | None = None,
+        usage: dict[str, Any] | None = None,
     ) -> None:
         """INSERT the phase's output into ``dispatcher.phase_outputs``
         and append a row to ``dispatcher.phase_transitions``.
@@ -3703,25 +3704,48 @@ class DispatcherDaemon:
         single-attempt callers saw the INSERT rolled back silently; now
         every retry's output is preserved and the admin-page phase log
         shows the full retry trail.
+
+        ``usage`` (added #2869, migration 31) is the parsed
+        ``{tokens_input, tokens_output, tokens_cache_read,
+        tokens_cache_write, cost_usd, model_used}`` dict produced by
+        :meth:`_parse_phase_usage`. All six fields are nullable. When
+        ``usage`` is ``None`` (no metering signal — phase crashed before
+        claude emitted its JSON envelope, or the envelope was malformed)
+        every metering column is set to NULL and the INSERT still runs.
         """
         assert self._conn is not None, "connect() must run before persisting"
         attempt = self._current_attempt_for(agent_id)
+        u = usage or {}
         try:
             with self._conn.cursor() as cur:
                 cur.execute(
                     "INSERT INTO dispatcher.phase_outputs "
-                    "    (agent_id, phase, output_json, log_text, attempt) "
-                    "VALUES (%s, %s, %s, %s, %s) "
+                    "    (agent_id, phase, output_json, log_text, attempt, "
+                    "     tokens_input, tokens_output, tokens_cache_read, "
+                    "     tokens_cache_write, cost_usd, model_used) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
                     "ON CONFLICT (agent_id, phase, attempt) DO UPDATE SET "
-                    "    output_json = EXCLUDED.output_json, "
-                    "    log_text    = EXCLUDED.log_text, "
-                    "    ts          = now()",
+                    "    output_json         = EXCLUDED.output_json, "
+                    "    log_text            = EXCLUDED.log_text, "
+                    "    tokens_input        = EXCLUDED.tokens_input, "
+                    "    tokens_output       = EXCLUDED.tokens_output, "
+                    "    tokens_cache_read   = EXCLUDED.tokens_cache_read, "
+                    "    tokens_cache_write  = EXCLUDED.tokens_cache_write, "
+                    "    cost_usd            = EXCLUDED.cost_usd, "
+                    "    model_used          = EXCLUDED.model_used, "
+                    "    ts                  = now()",
                     (
                         agent_id,
                         phase,
                         json.dumps(output_json, default=str),
                         log_text,
                         attempt,
+                        u.get("tokens_input"),
+                        u.get("tokens_output"),
+                        u.get("tokens_cache_read"),
+                        u.get("tokens_cache_write"),
+                        u.get("cost_usd"),
+                        u.get("model_used"),
                     ),
                 )
                 cur.execute(
@@ -3967,13 +3991,29 @@ class DispatcherDaemon:
     def _spawn_phase_subprocess(
         self, phase: str, worktree: Path, agent_id: str
     ) -> tuple[int, float]:
-        """Run ``claude -p '/task-v2-<phase> <agent_id>'`` synchronously.
+        """Run ``claude -p '/task-v2-<phase> <agent_id>' --output-format json``.
 
-        Captures stdout + stderr to ``{worktree}/tmp/claude-p-<phase>.log``.
         Returns ``(exit_code, duration_seconds)``. Raises
         :class:`subprocess.TimeoutExpired` on wall-clock timeout so the
         caller can mark the agent failed. Other subprocess errors bubble
         up as their native exception types.
+
+        **Output capture layout (#2869).** ``--output-format json`` makes
+        stdout a single JSON envelope with ``{result, usage,
+        total_cost_usd, ...}``; if stderr merged into it the JSON would
+        be corrupted and unparseable. We split:
+
+        - stdout → ``{worktree}/tmp/claude-p-<phase>.stdout.json`` (pure
+          JSON, parsed by :meth:`_parse_phase_usage` for metering).
+        - stderr → ``{worktree}/tmp/claude-p-<phase>.stderr.log`` (normal
+          text, preserved for triage).
+        - After the subprocess exits we also write a combined view to
+          ``{worktree}/tmp/claude-p-<phase>.log`` (stderr first, then a
+          separator, then stdout). This preserves the pre-#2869 filename
+          invariant so triage helpers (:meth:`_log_tail`,
+          :meth:`_read_full_phase_log`, :meth:`_emit_phase_failure_log_event`)
+          keep working unchanged, and operators can still ``cat``,
+          ``tail``, or ``grep`` a single file during incident triage.
 
         The worktree is passed as the subprocess's CWD via
         ``subprocess.run(..., cwd=...)`` — NOT as a ``--cwd`` flag. The
@@ -3985,6 +4025,8 @@ class DispatcherDaemon:
         max_turns = PHASE_MAX_TURNS[phase]
         model = PHASE_MODELS[phase]
         log_path = worktree / "tmp" / f"claude-p-{phase}.log"
+        stdout_path = worktree / "tmp" / f"claude-p-{phase}.stdout.json"
+        stderr_path = worktree / "tmp" / f"claude-p-{phase}.stderr.log"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
         cmd = [
@@ -3995,6 +4037,8 @@ class DispatcherDaemon:
             str(max_turns),
             "--model",
             model,
+            "--output-format",
+            "json",
         ]
 
         start = time.monotonic()
@@ -4007,21 +4051,141 @@ class DispatcherDaemon:
                 "phase": phase,
                 "model": model,
                 "max_turns": max_turns,
+                "output_format": "json",
             },
         )
 
-        with log_path.open("w", encoding="utf-8") as log_file:
-            result = subprocess.run(
-                cmd,
-                stdout=log_file,
-                stderr=subprocess.STDOUT,
-                text=True,
-                timeout=CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-                cwd=str(worktree),
+        try:
+            with (
+                stdout_path.open("w", encoding="utf-8") as stdout_file,
+                stderr_path.open("w", encoding="utf-8") as stderr_file,
+            ):
+                result = subprocess.run(
+                    cmd,
+                    stdout=stdout_file,
+                    stderr=stderr_file,
+                    text=True,
+                    timeout=CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS,
+                    check=False,
+                    cwd=str(worktree),
+                )
+            duration = time.monotonic() - start
+        finally:
+            # Always compose the combined ``.log`` view, even on timeout /
+            # non-zero exit — triage helpers read it. Whatever partial
+            # content the two streams produced before the fault is useful.
+            self._compose_phase_log(
+                log_path=log_path,
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
             )
-        duration = time.monotonic() - start
         return result.returncode, duration
+
+    @staticmethod
+    def _compose_phase_log(
+        log_path: Path, stdout_path: Path, stderr_path: Path
+    ) -> None:
+        """Concatenate stderr + stdout files into the combined ``.log`` file.
+
+        Written after every ``_spawn_phase_subprocess`` exit so the
+        legacy single-file triage path (``claude-p-<phase>.log``)
+        continues to surface both streams to operators. stderr comes
+        first because the rare content there (claude CLI crash messages,
+        boot errors) is almost always what operators want at the head of
+        the triage file; stdout (which is the JSON envelope post-#2869)
+        follows behind a thin separator so it's still grep-able but not
+        mistaken for stderr.
+        """
+        parts: list[str] = []
+        try:
+            if stderr_path.exists():
+                stderr_text = stderr_path.read_text(encoding="utf-8", errors="replace")
+                if stderr_text:
+                    parts.append("=== stderr ===\n")
+                    parts.append(stderr_text)
+                    if not stderr_text.endswith("\n"):
+                        parts.append("\n")
+            if stdout_path.exists():
+                stdout_text = stdout_path.read_text(encoding="utf-8", errors="replace")
+                if stdout_text:
+                    parts.append("=== stdout (JSON envelope) ===\n")
+                    parts.append(stdout_text)
+                    if not stdout_text.endswith("\n"):
+                        parts.append("\n")
+        except Exception:  # pragma: no cover — defensive
+            # Never let log composition break the phase. The phase's
+            # structured output path is separate; this is triage-only.
+            return
+        try:
+            log_path.write_text("".join(parts), encoding="utf-8")
+        except Exception:  # pragma: no cover — defensive
+            return
+
+    def _parse_phase_usage(self, worktree: Path, phase: str) -> dict[str, Any] | None:
+        """Parse the ``claude -p --output-format json`` usage envelope.
+
+        Reads ``{worktree}/tmp/claude-p-<phase>.stdout.json`` — the
+        single JSON object Claude Code writes to stdout when
+        ``--output-format json`` is passed. Extracts the fields we
+        persist on ``dispatcher.phase_outputs``:
+
+        - ``tokens_input`` ← ``usage.input_tokens``
+        - ``tokens_output`` ← ``usage.output_tokens``
+        - ``tokens_cache_read`` ← ``usage.cache_read_input_tokens``
+        - ``tokens_cache_write`` ← ``usage.cache_creation_input_tokens``
+        - ``cost_usd`` ← ``total_cost_usd``
+        - ``model_used`` ← ``model`` (falls back to ``PHASE_MODELS[phase]``)
+
+        Returns ``None`` on any error — the stdout file is missing,
+        empty, not JSON, or the envelope has no ``usage`` block. The
+        caller treats ``None`` the same as "no metering signal": the
+        new columns stay NULL, the row still inserts. Issue #2869.
+        """
+        stdout_path = worktree / "tmp" / f"claude-p-{phase}.stdout.json"
+        if not stdout_path.exists():
+            return None
+        try:
+            raw = stdout_path.read_text(encoding="utf-8", errors="replace").strip()
+        except Exception:  # pragma: no cover — defensive
+            return None
+        if not raw:
+            return None
+        try:
+            envelope = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(envelope, dict):
+            return None
+        usage = envelope.get("usage")
+        if not isinstance(usage, dict):
+            # Some Claude Code versions emit a usage-less envelope for
+            # errors; persist nothing rather than guessing.
+            return None
+        cost_raw = envelope.get("total_cost_usd")
+        try:
+            cost_usd: float | None = float(cost_raw) if cost_raw is not None else None
+        except (TypeError, ValueError):
+            cost_usd = None
+        model_used = envelope.get("model")
+        if not isinstance(model_used, str) or not model_used:
+            model_used = PHASE_MODELS.get(phase)
+
+        def _int_or_none(v: Any) -> int | None:
+            try:
+                return int(v) if v is not None else None
+            except (TypeError, ValueError):
+                return None
+
+        return {
+            "tokens_input": _int_or_none(usage.get("input_tokens")),
+            "tokens_output": _int_or_none(usage.get("output_tokens")),
+            "tokens_cache_read": _int_or_none(usage.get("cache_read_input_tokens")),
+            "tokens_cache_write": _int_or_none(
+                usage.get("cache_creation_input_tokens")
+            ),
+            "cost_usd": cost_usd,
+            "model_used": model_used,
+        }
 
     def _claim_and_orchestrate_one(self) -> None:
         """Claim one issue and run the plan → ralph → summary → PR flow.
@@ -5107,6 +5271,7 @@ class DispatcherDaemon:
             "plan",
             plan_output,
             log_text=self._read_full_phase_log(worktree, "plan") or None,
+            usage=self._parse_phase_usage(worktree, "plan"),
         )
         self._log.info(
             "daemon.phase_succeeded",
@@ -5210,6 +5375,7 @@ class DispatcherDaemon:
             "ralph",
             ralph_output,
             log_text=self._read_full_phase_log(worktree, "ralph") or None,
+            usage=self._parse_phase_usage(worktree, "ralph"),
         )
         verdict = ralph_output.get("verdict", "")
         self._log.info(
@@ -5375,6 +5541,7 @@ class DispatcherDaemon:
             "summary",
             summary_output,
             log_text=self._read_full_phase_log(worktree, "summary") or None,
+            usage=self._parse_phase_usage(worktree, "summary"),
         )
         self._log.info(
             "daemon.phase_succeeded",
@@ -6750,6 +6917,7 @@ class DispatcherDaemon:
             "fix-ci",
             fix_ci_output,
             log_text=self._read_full_phase_log(worktree, "fix-ci") or None,
+            usage=self._parse_phase_usage(worktree, "fix-ci"),
         )
         verdict = str(fix_ci_output.get("verdict") or "").upper()
 
@@ -7319,6 +7487,7 @@ class DispatcherDaemon:
             "verify",
             verify_output,
             log_text=self._read_full_phase_log(worktree, "verify") or None,
+            usage=self._parse_phase_usage(worktree, "verify"),
         )
 
         evidence_md = str(verify_output.get("evidence_md") or "").strip()
@@ -7676,6 +7845,7 @@ class DispatcherDaemon:
             "retro",
             retro_output,
             log_text=self._read_full_phase_log(worktree, "retro") or None,
+            usage=self._parse_phase_usage(worktree, "retro"),
         )
 
         # File the retro issues. Each entry becomes a separate

--- a/scripts/dispatcher/tests/test_daemon_token_metering.py
+++ b/scripts/dispatcher/tests/test_daemon_token_metering.py
@@ -1,0 +1,462 @@
+"""Unit tests for per-phase token + cost metering (#2869).
+
+Covers the full read/write loop for the ``dispatcher.phase_outputs``
+metering columns introduced by migration 31:
+
+* :meth:`daemon.DispatcherDaemon._spawn_phase_subprocess` — adds the
+  ``--output-format json`` flag, splits stdout / stderr to their own
+  files, and composes the legacy combined ``.log`` triage view.
+* :meth:`daemon.DispatcherDaemon._parse_phase_usage` — reads the
+  stdout JSON envelope and normalizes the usage block.
+* :meth:`daemon.DispatcherDaemon._persist_phase_output` — threads the
+  parsed usage dict into the six new DB columns (``tokens_input``,
+  ``tokens_output``, ``tokens_cache_read``, ``tokens_cache_write``,
+  ``cost_usd``, ``model_used``), and keeps every column ``NULL`` when
+  ``usage=None`` (the "no metering signal" case).
+
+Same mocking strategy as :mod:`test_daemon_phase3a` — ``psycopg`` is
+stubbed before the daemon import so the test runner never needs a real
+DB or the ``psycopg`` wheel. No ``claude`` / ``gh`` / ``git``
+subprocesses run.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+class _UniqueViolation(Exception):
+    """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+
+_psycopg_stub = MagicMock()
+_psycopg_errors = MagicMock()
+_psycopg_errors.UniqueViolation = _UniqueViolation
+_psycopg_stub.errors = _psycopg_errors
+sys.modules.setdefault("psycopg", _psycopg_stub)
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — mirror test_daemon_phase3a's lightweight DB doubles.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.metering.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# _spawn_phase_subprocess — new flag + split stdout/stderr files
+# --------------------------------------------------------------------------
+
+
+class TestSpawnAddsOutputFormatJsonFlag:
+    """``_spawn_phase_subprocess`` must add ``--output-format json`` so the
+    stdout stream is a parseable JSON envelope. Without the flag the usage
+    block is not emitted and metering is silent (#2869)."""
+
+    def test_command_includes_output_format_json(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        captured: dict[str, Any] = {}
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            captured["cmd"] = cmd
+            r = MagicMock()
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d._spawn_phase_subprocess("plan", tmp_path, "agent-uuid")
+
+        cmd = captured["cmd"]
+        assert "--output-format" in cmd, cmd
+        # "json" must follow the flag, not some other token.
+        i = cmd.index("--output-format")
+        assert cmd[i + 1] == "json"
+
+    def test_stdout_and_stderr_written_to_separate_files(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """``--output-format json`` would corrupt the JSON envelope if stderr
+        merged into stdout. The spawn helper must split the streams so
+        :meth:`_parse_phase_usage` can ``json.loads`` the stdout file
+        directly."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            # Simulate claude writing to the two provided file handles —
+            # the stdlib's subprocess.run threads them through directly.
+            kwargs["stdout"].write('{"usage":{"input_tokens":1}}')
+            kwargs["stderr"].write("boot-log line\n")
+            r = MagicMock()
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d._spawn_phase_subprocess("plan", tmp_path, "agent-uuid")
+
+        stdout_path = tmp_path / "tmp" / "claude-p-plan.stdout.json"
+        stderr_path = tmp_path / "tmp" / "claude-p-plan.stderr.log"
+        assert stdout_path.exists()
+        assert stderr_path.exists()
+        assert '{"usage":{"input_tokens":1}}' in stdout_path.read_text()
+        assert "boot-log line" in stderr_path.read_text()
+
+    def test_combined_log_file_still_written_for_backward_compat(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Pre-#2869 triage helpers (``_log_tail``, ``_read_full_phase_log``,
+        ``_emit_phase_failure_log_event``) key on
+        ``claude-p-<phase>.log``. The combined file must still be written so
+        those helpers keep working unchanged, and operators still have a
+        single ``cat``-able triage target."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            kwargs["stdout"].write('{"result":"ok"}')
+            kwargs["stderr"].write("stderr content")
+            r = MagicMock()
+            r.returncode = 0
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d._spawn_phase_subprocess("plan", tmp_path, "agent-uuid")
+
+        combined = tmp_path / "tmp" / "claude-p-plan.log"
+        assert combined.exists()
+        body = combined.read_text()
+        # Both streams present, with a visible separator.
+        assert "stderr content" in body
+        assert '{"result":"ok"}' in body
+        assert "=== stderr ===" in body
+        assert "=== stdout (JSON envelope) ===" in body
+
+    def test_combined_log_written_even_on_nonzero_exit(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Triage matters most when the subprocess failed. The combined log
+        composition runs in a ``finally`` block so it is produced even when
+        claude -p exits non-zero — operators still see whatever partial
+        output the streams captured before the fault."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            kwargs["stderr"].write("crash-trace here")
+            r = MagicMock()
+            r.returncode = 1
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        exit_code, _duration = d._spawn_phase_subprocess("plan", tmp_path, "agent-uuid")
+        assert exit_code == 1
+        combined = tmp_path / "tmp" / "claude-p-plan.log"
+        assert combined.exists()
+        assert "crash-trace here" in combined.read_text()
+
+
+# --------------------------------------------------------------------------
+# _parse_phase_usage
+# --------------------------------------------------------------------------
+
+
+class TestParsePhaseUsage:
+    """``_parse_phase_usage`` reads the stdout JSON envelope and returns a
+    normalized ``{tokens_input, tokens_output, tokens_cache_read,
+    tokens_cache_write, cost_usd, model_used}`` dict — or ``None`` when any
+    of the graceful-degradation conditions fires."""
+
+    def _write_stdout(self, tmp_path: Path, phase: str, payload: str) -> None:
+        path = tmp_path / "tmp" / f"claude-p-{phase}.stdout.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(payload)
+
+    def test_parses_full_usage_envelope(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        envelope = {
+            "result": "...",
+            "usage": {
+                "input_tokens": 1234,
+                "output_tokens": 567,
+                "cache_creation_input_tokens": 8901,
+                "cache_read_input_tokens": 23456,
+            },
+            "total_cost_usd": 0.1234,
+            "model": "claude-sonnet-4-5-20250929",
+        }
+        self._write_stdout(tmp_path, "plan", json.dumps(envelope))
+
+        usage = d._parse_phase_usage(tmp_path, "plan")
+        assert usage is not None
+        assert usage["tokens_input"] == 1234
+        assert usage["tokens_output"] == 567
+        assert usage["tokens_cache_write"] == 8901
+        assert usage["tokens_cache_read"] == 23456
+        assert usage["cost_usd"] == 0.1234
+        assert usage["model_used"] == "claude-sonnet-4-5-20250929"
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        assert d._parse_phase_usage(tmp_path, "plan") is None
+
+    def test_empty_file_returns_none(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        self._write_stdout(tmp_path, "plan", "")
+        assert d._parse_phase_usage(tmp_path, "plan") is None
+
+    def test_malformed_json_returns_none(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        self._write_stdout(tmp_path, "plan", "not json at all")
+        assert d._parse_phase_usage(tmp_path, "plan") is None
+
+    def test_envelope_without_usage_block_returns_none(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        self._write_stdout(tmp_path, "plan", json.dumps({"result": "hi"}))
+        assert d._parse_phase_usage(tmp_path, "plan") is None
+
+    def test_missing_individual_fields_produce_none_values(
+        self, tmp_path: Path
+    ) -> None:
+        """A partial usage block (e.g. only input_tokens present) should
+        still surface — the columns are independently nullable so a
+        partial signal is better than no signal at all."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        envelope = {
+            "usage": {"input_tokens": 100},
+            "total_cost_usd": None,
+        }
+        self._write_stdout(tmp_path, "plan", json.dumps(envelope))
+
+        usage = d._parse_phase_usage(tmp_path, "plan")
+        assert usage is not None
+        assert usage["tokens_input"] == 100
+        assert usage["tokens_output"] is None
+        assert usage["tokens_cache_read"] is None
+        assert usage["tokens_cache_write"] is None
+        assert usage["cost_usd"] is None
+        # Model falls back to PHASE_MODELS default.
+        assert usage["model_used"] == daemon.PHASE_MODELS["plan"]
+
+    def test_falls_back_to_phase_model_when_envelope_omits_it(
+        self, tmp_path: Path
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        envelope = {"usage": {"input_tokens": 1}, "total_cost_usd": 0.01}
+        self._write_stdout(tmp_path, "ralph", json.dumps(envelope))
+
+        usage = d._parse_phase_usage(tmp_path, "ralph")
+        assert usage is not None
+        assert usage["model_used"] == daemon.PHASE_MODELS["ralph"]
+
+    def test_non_dict_envelope_returns_none(self, tmp_path: Path) -> None:
+        """A top-level JSON array or string is not a usage envelope."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        self._write_stdout(tmp_path, "plan", '["not", "an", "envelope"]')
+        assert d._parse_phase_usage(tmp_path, "plan") is None
+
+    def test_non_numeric_token_values_coerce_to_none(self, tmp_path: Path) -> None:
+        """The helper must not crash on a string value — fall back to
+        None so the column stays NULL and the INSERT still runs."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        envelope = {
+            "usage": {
+                "input_tokens": "not an int",
+                "output_tokens": 42,
+            },
+            "total_cost_usd": "nope",
+        }
+        self._write_stdout(tmp_path, "plan", json.dumps(envelope))
+
+        usage = d._parse_phase_usage(tmp_path, "plan")
+        assert usage is not None
+        assert usage["tokens_input"] is None
+        assert usage["tokens_output"] == 42
+        assert usage["cost_usd"] is None
+
+
+# --------------------------------------------------------------------------
+# _persist_phase_output — threads usage into the INSERT
+# --------------------------------------------------------------------------
+
+
+class TestPersistPhaseOutputWritesUsage:
+    def test_usage_dict_lands_in_insert_params(self, tmp_path: Path) -> None:
+        """Every metering column must be written in the correct position.
+        The INSERT binds parameters in the order
+        ``(agent_id, phase, output_json, log_text, attempt,
+           tokens_input, tokens_output, tokens_cache_read,
+           tokens_cache_write, cost_usd, model_used)``."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        # Migration-30 contract: persist reads retries_used first.
+        conn.cursor_instance.fetch_queue = [(0,)]
+
+        usage = {
+            "tokens_input": 100,
+            "tokens_output": 50,
+            "tokens_cache_read": 200,
+            "tokens_cache_write": 300,
+            "cost_usd": 0.0042,
+            "model_used": "claude-sonnet-4-5",
+        }
+        d._persist_phase_output(
+            "agent-a", "plan", {"go": True}, log_text="log-body", usage=usage
+        )
+
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_outputs" in e[0]
+        ]
+        assert len(inserts) == 1
+        sql, params = inserts[0]
+        # 11 bind params: 5 original + 6 metering.
+        assert len(params) == 11
+        # Token metering columns (positions 5-8 are tokens_* in our binding
+        # order, 9 is cost_usd, 10 is model_used).
+        assert params[5] == 100  # tokens_input
+        assert params[6] == 50  # tokens_output
+        assert params[7] == 200  # tokens_cache_read
+        assert params[8] == 300  # tokens_cache_write
+        assert params[9] == 0.0042  # cost_usd
+        assert params[10] == "claude-sonnet-4-5"  # model_used
+        # The SQL statement references every new column name — guards
+        # against a position-only pass with a stale SQL string.
+        assert "tokens_input" in sql
+        assert "tokens_output" in sql
+        assert "tokens_cache_read" in sql
+        assert "tokens_cache_write" in sql
+        assert "cost_usd" in sql
+        assert "model_used" in sql
+
+    def test_no_usage_signal_writes_nulls_but_still_inserts(
+        self, tmp_path: Path
+    ) -> None:
+        """The ``usage=None`` path is the "no metering signal" case — the
+        row must still insert, with every new column as ``NULL``. Without
+        this, a malformed JSON envelope from claude would silently drop
+        the whole phase output (same failure mode migration 30 fixed for
+        attempt collisions)."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+
+        d._persist_phase_output(
+            "agent-a", "plan", {"go": True}, log_text="log", usage=None
+        )
+
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_outputs" in e[0]
+        ]
+        assert len(inserts) == 1
+        _sql, params = inserts[0]
+        # tokens_input..model_used all None.
+        for idx in range(5, 11):
+            assert params[idx] is None, f"param idx={idx} should be None"
+
+    def test_backward_compat_call_without_usage_kwarg(self, tmp_path: Path) -> None:
+        """Callers that predate #2869 (don't pass ``usage=``) must keep
+        working — the new columns default to NULL."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+
+        d._persist_phase_output("agent-a", "plan", {"go": True})
+
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_outputs" in e[0]
+        ]
+        assert len(inserts) == 1
+        _sql, params = inserts[0]
+        for idx in range(5, 11):
+            assert params[idx] is None


### PR DESCRIPTION
## Summary

Per-phase token usage + cost metering for dispatcher v2: each phase subprocess now runs with `claude -p --output-format json`, the daemon parses the usage envelope, and the data lands on `dispatcher.phase_outputs` (six new columns, migration 31). Surfaced through GraphQL (`DispatcherAgent.{totalTokensInput, totalTokensOutput, totalCostUsd, phaseCostBreakdown}`, `RecentCompletion.{totalTokens, totalCostUsd}`) and a compact admin cockpit footnote, plus two standard SQL dashboards in `infrastructure-reference.md`.

Caveat documented everywhere the numbers surface: `total_cost_usd` is Claude Code's list-price estimate, NOT Max plan-adjusted — useful for relative comparison, not absolute spend.

Closes #2869

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`, `eslint`)
- [x] Format check passes (`ruff format --check`, prettier via CI)
- [x] Tests pass (dispatcher 582 ✓, api 406 ✓, web 1250 ✓)
- [x] CI green

### Post-deploy verification
- [x] After the dispatcher redeploys, the next cap=1 agent's `dispatcher.phase_outputs` rows have non-null `tokens_input`, `tokens_output`, `cache_{read,write}`, `cost_usd`, `model_used` — verified: agent `88a65a9b-460a-4b79-88b5-0f3964a8c845` plan row shows `tokens_input=34`, `tokens_output=18455`, `cache_read=2164822`, `cache_write=97422`, `cost_usd=$2.1528`, `model_used=opus`
- [x] "Cost by phase last day" SQL from `infrastructure-reference.md` returns real $ values — confirmed
- [x] Admin cockpit cost footnote code deployed via Vercel — will render as soon as the current in-flight agent completes (wire-up + unit tests green)
- [x] Verification evidence posted on issue (see A.8)
