### PR TITLE
fix(dispatcher): bump git push timeout from 120s to 600s (#2882)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -429,6 +429,19 @@ BASELINE_FETCH_TIMEOUT_SECONDS = 120
 #: finish in milliseconds.
 GH_AUTH_SETUP_GIT_TIMEOUT_SECONDS = 10
 
+#: Hard wall-clock timeout on the daemon-side ``git push`` subprocess
+#: calls (post-summary push in ``_advance_awaiting_summary`` and the
+#: fix-ci retry push in ``_advance_awaiting_ci``). 120s was too tight:
+#: the pre-push hook runs each touched package's full test suite,
+#: which for multi-package changes (e.g. scraper-framework + nlp-
+#: pipeline) regularly exceeds 3 minutes before the actual git push
+#: even starts. Two confirmed overnight failures on 2026-04-19 lost
+#: ralph's entire output when the 120s ceiling tripped mid-hook (issue
+#: #2882). 600s (10 min) is a comfortable ceiling for the slowest
+#: realistic package test run + git push + network, while still
+#: preventing a genuinely-stuck process from burning indefinitely.
+GIT_PUSH_TIMEOUT_SECONDS = 600
+
 #: Per-issue cooldown — skip an issue from candidate selection if its
 #: most recent ``dispatcher.agents`` row (any status) was created
 #: within this many seconds. Prevents a systemically-broken issue from
@@ -6123,9 +6136,28 @@ class DispatcherDaemon:
                 ],
                 capture_output=True,
                 text=True,
-                timeout=120,
+                timeout=GIT_PUSH_TIMEOUT_SECONDS,
                 check=False,
             )
+        except subprocess.TimeoutExpired as exc:
+            self._log.exception(
+                "daemon.git_push_timeout",
+                extra={
+                    "event": "git_push_timeout",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "timeout_seconds": GIT_PUSH_TIMEOUT_SECONDS,
+                    "detail": str(exc),
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id,
+                status="failed",
+                phase="push_and_pr",
+                exit_code=None,
+                issue_number=issue_number,
+            )
+            return
         except Exception as exc:
             self._log.exception(
                 "daemon.git_push_failed",
@@ -7154,9 +7186,24 @@ class DispatcherDaemon:
                 ],
                 capture_output=True,
                 text=True,
-                timeout=120,
+                timeout=GIT_PUSH_TIMEOUT_SECONDS,
                 check=False,
             )
+        except subprocess.TimeoutExpired as exc:
+            self._log.exception(
+                "daemon.fix_ci_git_push_timeout",
+                extra={
+                    "event": "fix_ci_git_push_timeout",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "timeout_seconds": GIT_PUSH_TIMEOUT_SECONDS,
+                    "detail": str(exc),
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            )
+            return
         except Exception:
             self._log.exception(
                 "daemon.fix_ci_git_push_failed",

--- a/scripts/dispatcher/tests/test_daemon_git_push_timeout.py
+++ b/scripts/dispatcher/tests/test_daemon_git_push_timeout.py
@@ -1,0 +1,160 @@
+"""Unit tests for the daemon-side ``git push`` subprocess timeout (#2882).
+
+The dispatcher daemon fires ``git push`` in two places:
+
+1. ``_advance_awaiting_summary`` — the post-ralph/post-summary push
+   that lands the agent's branch before ``gh pr create``.
+2. ``_advance_awaiting_ci`` — the fix-ci retry push after the ``fix-ci``
+   phase rewrites files in response to a red CI run.
+
+Both previously used ``timeout=120``, which was not enough to cover
+the pre-push hook's package test runs. On 2026-04-19 two overnight
+agents lost ralph's work when the 120s ceiling tripped mid-hook. The
+fix (this change) extracts the timeout to a module-level
+``GIT_PUSH_TIMEOUT_SECONDS`` constant set to 600s.
+
+These tests guard against regressing back to a hardcoded value by
+walking the daemon module's AST and asserting every ``git push``
+subprocess invocation passes the named constant as its ``timeout``
+keyword argument.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+if "psycopg" not in sys.modules:  # pragma: no cover — fresh-venv only
+    sys.modules["psycopg"] = MagicMock()
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+_DAEMON_PATH = Path(daemon.__file__)
+
+
+def test_git_push_timeout_constant_is_600_seconds() -> None:
+    """The module-level ``GIT_PUSH_TIMEOUT_SECONDS`` constant is 600s.
+
+    Guards against a well-meaning "tighten this back down" edit that
+    would reintroduce the original 120s failure mode. If you need to
+    change this value, update the call-site tests below AND the
+    docstring explaining the rationale.
+    """
+    assert hasattr(daemon, "GIT_PUSH_TIMEOUT_SECONDS"), (
+        "daemon module must define GIT_PUSH_TIMEOUT_SECONDS (#2882)"
+    )
+    assert daemon.GIT_PUSH_TIMEOUT_SECONDS == 600, (
+        f"GIT_PUSH_TIMEOUT_SECONDS must be 600; got {daemon.GIT_PUSH_TIMEOUT_SECONDS}"
+    )
+
+
+def _collect_subprocess_run_push_calls() -> list[ast.Call]:
+    """Return every ``subprocess.run(...)`` call in daemon.py whose
+    first positional arg starts with ``['git', '-C', ..., 'push', ...]``.
+    """
+    tree = ast.parse(_DAEMON_PATH.read_text())
+    out: list[ast.Call] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        # Match ``subprocess.run(...)``.
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and func.attr == "run"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "subprocess"
+        ):
+            continue
+        if not node.args:
+            continue
+        cmd_arg = node.args[0]
+        if not isinstance(cmd_arg, ast.List):
+            continue
+        # Extract string literals so we can detect ``"git" ... "push"``.
+        literals: list[str] = []
+        for elt in cmd_arg.elts:
+            if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                literals.append(elt.value)
+            else:
+                # Non-literal elements (e.g. ``str(worktree)``, branch
+                # variables) don't carry the command shape we care about
+                # — skip them for detection purposes.
+                literals.append("")
+        if not literals or literals[0] != "git":
+            continue
+        if "push" not in literals:
+            continue
+        out.append(node)
+    return out
+
+
+def _timeout_kwarg(call: ast.Call) -> ast.expr | None:
+    for kw in call.keywords:
+        if kw.arg == "timeout":
+            return kw.value
+    return None
+
+
+def test_git_push_call_sites_use_the_constant() -> None:
+    """Both ``git push`` subprocess.run sites use GIT_PUSH_TIMEOUT_SECONDS.
+
+    Scans daemon.py's AST for every ``subprocess.run([... 'git' ... 'push' ...])``
+    call and asserts the ``timeout`` kwarg is the ``Name``
+    ``GIT_PUSH_TIMEOUT_SECONDS`` — not a hardcoded integer. Regression
+    guard for #2882: the old 120s ceiling tripped pre-push hooks on
+    multi-package changes and lost ralph's work entirely.
+    """
+    push_calls = _collect_subprocess_run_push_calls()
+    assert len(push_calls) >= 2, (
+        f"expected at least 2 git-push subprocess.run sites in daemon.py, "
+        f"found {len(push_calls)} — have the call sites moved? Update this "
+        f"test alongside any legitimate refactor."
+    )
+    for call in push_calls:
+        timeout_node = _timeout_kwarg(call)
+        assert timeout_node is not None, (
+            f"git push subprocess.run at line {call.lineno} is missing a "
+            f"``timeout=`` kwarg — every daemon subprocess must have one."
+        )
+        assert isinstance(timeout_node, ast.Name), (
+            f"git push subprocess.run at line {call.lineno} passes a "
+            f"non-name timeout ({ast.dump(timeout_node)}); must use the "
+            f"module-level GIT_PUSH_TIMEOUT_SECONDS constant so future "
+            f"tuning is a 1-line change (#2882)."
+        )
+        assert timeout_node.id == "GIT_PUSH_TIMEOUT_SECONDS", (
+            f"git push subprocess.run at line {call.lineno} passes "
+            f"timeout={timeout_node.id}; must be GIT_PUSH_TIMEOUT_SECONDS "
+            f"(#2882)."
+        )
+
+
+def test_daemon_logs_git_push_timeout_event_distinctly() -> None:
+    """Timeout is logged as ``git_push_timeout`` / ``fix_ci_git_push_timeout``.
+
+    Separating the timeout event name from the generic push_failed event
+    gives operators immediate signal on what went wrong (agent ran too
+    long vs git rejected the push) without grepping stderr tails. Guard
+    against a future refactor that folds the ``except
+    subprocess.TimeoutExpired`` branch back into the generic handler.
+    """
+    source = _DAEMON_PATH.read_text()
+    assert '"event": "git_push_timeout"' in source, (
+        "post-summary git push handler must log a distinct "
+        "``git_push_timeout`` structured event when subprocess.TimeoutExpired "
+        "is raised (#2882)."
+    )
+    assert '"event": "fix_ci_git_push_timeout"' in source, (
+        "fix-ci git push handler must log a distinct "
+        "``fix_ci_git_push_timeout`` structured event when "
+        "subprocess.TimeoutExpired is raised (#2882)."
+    )


### PR DESCRIPTION
## Summary

Bumps the daemon-side `git push` subprocess timeout from `120s` to `600s` via a new `GIT_PUSH_TIMEOUT_SECONDS` module-level constant. The 120s ceiling was too tight to cover multi-package pre-push hook runs and cost two overnight agents their ralph output on 2026-04-19. Also logs `git_push_timeout` / `fix_ci_git_push_timeout` structured events distinctly from the generic `push_failed` event so operators get immediate signal on what went wrong.

Closes #2882

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component. Dispatcher daemon changes deploy via terraform/ECS redeploy on the next dispatcher release; the new timeout takes effect for the next `_advance_awaiting_summary` / `_advance_awaiting_ci` invocation with no migration or config change. The change is exercised by the new AST-driven unit tests (`tests/test_daemon_git_push_timeout.py`), and real-world validation is implicit: if the next overnight agent lands a multi-package PR without timing out on push, the fix worked.
- [x] Verification evidence posted on issue (see A.8)
