### PR TITLE
fix(dispatcher): 10× stuck_timeout + max_turns per phase (#2885)

### DIFF
--- a/packages/api/migrations/32_dispatcher-stuck-timeout-10x-bump.sql
+++ b/packages/api/migrations/32_dispatcher-stuck-timeout-10x-bump.sql
@@ -1,0 +1,69 @@
+-- Up Migration
+--
+-- Dispatcher v2 — seed + bump per-phase stuck_timeout overrides in
+-- ``dispatcher.config`` (#2885).
+--
+-- Context
+-- -------
+-- Overnight 2026-04-20 observed a race in the supervisor's stuck-agent
+-- detection: agent ``821e96ee`` on issue #2565 ran ralph for 5834s and
+-- exited cleanly, but at 5419s the supervisor flagged it stuck against
+-- the 5400s (90min) ralph threshold and fired a retry. Ralph finished
+-- 415s later, but the retry had already started — producing
+-- ``phase_output_missing`` and a failed agent despite ralph actually
+-- succeeding. Separately, plan agents hit ``error_max_turns`` at 51/50
+-- on complex scraper issues (#2564, #2565), burning ~$3 of opus with
+-- zero output.
+--
+-- Operator directive (verbatim): "stop being parsimonious on these
+-- limits. Cost is not the constraint; success is."
+--
+-- Design notes
+-- ------------
+-- - This migration writes the ``stuck_timeout_s_by_phase`` JSONB row in
+--   ``dispatcher.config``, which the supervisor reads once per sweep
+--   via ``DispatcherDaemon._read_stuck_timeout_overrides``. Any key
+--   present in the JSONB object wins over the ``STUCK_TIMEOUT_SECONDS_BY_PHASE``
+--   module default (daemon.py). The row did NOT exist before this
+--   migration — fresh installs fell through to module defaults, which
+--   were the pre-#2885 tight windows. Seeding the row here guarantees
+--   a consistent 10× posture across all live environments.
+-- - ``ON CONFLICT (key) DO UPDATE`` is critical: on an install where
+--   an operator had already created the row by hand (e.g. raised
+--   ralph to 10800s to work around the race but never PR'd the
+--   change), this migration bumps the value to 54000s — consistent
+--   with the "bump the already-live rows, not just defaults for fresh
+--   installs" requirement in #2885. Operators who need a LOWER value
+--   than 10× can manually edit the row post-migration via the admin
+--   page; the configuration path still wins over the module default.
+-- - JSONB key names match the daemon's ``STUCK_TIMEOUT_SECONDS_BY_PHASE``
+--   dict keys. ``plan`` and ``planning`` are both populated because
+--   both appear as phase_transitions row labels (legacy alias).
+-- - Non-LLM phases (``claiming``, ``awaiting_ci``, ``awaiting_deploy``,
+--   ``paused_by_killswitch``, ``daemon_restart_abandoned``) are NOT
+--   included: their upper bound is set by external systems
+--   (gh API, GitHub Actions wall-clock, ECS rolling deploy, terminal
+--   sweep loops), so 10× would just delay real stuck-detection.
+-- - ``updated_by='init-2885'`` distinguishes this migration's write
+--   from a manual operator edit. The admin page sets ``updated_by``
+--   to a GitHub login when operators tune the row.
+
+INSERT INTO dispatcher.config (key, value, updated_by) VALUES
+    ('stuck_timeout_s_by_phase',
+     '{"planning":9000,"plan":9000,"ralph":54000,"summary":6000,"verify":3000,"retro":3000,"fix_ci":18000}'::jsonb,
+     'init-2885')
+ON CONFLICT (key) DO UPDATE
+    SET value = EXCLUDED.value,
+        updated_by = EXCLUDED.updated_by,
+        updated_at = NOW();
+
+
+-- Down Migration
+--
+-- Down strategy: remove the row entirely. Reverting reinstates fall-
+-- through to ``STUCK_TIMEOUT_SECONDS_BY_PHASE`` module defaults.
+-- If this migration is run down AFTER the daemon defaults have also
+-- been reverted (via a code revert), the dispatcher returns to its
+-- pre-#2885 posture. We do NOT restore any previous row value here
+-- because the row didn't exist pre-#2885.
+DELETE FROM dispatcher.config WHERE key = 'stuck_timeout_s_by_phase';

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 31 migrations.
+-- Generated from 32 migrations.
 
 
 

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -229,20 +229,34 @@ PHASE_STDERR_PREVIEW_MAX_CHARS = 2000
 #: '<agent_id>'`` returns the pair.
 PHASE_FAILURE_LOG_MAX_CHARS = 10000
 
-#: Per-phase ``--max-turns`` values. Matches the frontmatter on each
-#: ``.claude/skills/task-v2-*/SKILL.md`` file. Sonnet-backed ralph gets
-#: the long tail; plan and summary stay tight. Post-PR phases added
-#: in Phase 3B (#2787) — fix-ci is a targeted patch so 100 turns is
-#: generous; verify is read-mostly so 50 turns fits. Retro added in
-#: Phase 3E (#2798) — a read-only review producing zero-to-many issue
-#: bodies; 30 turns matches the retro skill's frontmatter.
+#: Per-phase ``--max-turns`` values. Issue #2885 bumped every phase by
+#: 10× on the operator directive "stop being parsimonious on these
+#: limits; cost is not the constraint, success is." Two overnight
+#: failure modes forced the bump:
+#:
+#: 1. Plan agents hit ``error_max_turns`` at 51/50 on complex scraper
+#:    issues (#2564, #2565), burning ~$3 of opus with zero output then
+#:    retrying — legitimate exploration on a large codebase just
+#:    doesn't fit in 50 turns.
+#: 2. Ralph's old 500 cap was adequate for typical work but left no
+#:    slack for genuinely hard problems where the worker-reviewer loop
+#:    runs long; on Max-plan billing the extra turns are effectively
+#:    free and a successful ralph iteration beats a failed retry at
+#:    any turn count.
+#:
+#: Original values (#2787 Phase 3B + #2798 Phase 3E) were calibrated
+#: conservatively against observed medians; the new values are 10×
+#: headroom above that calibration. Post-PR phases (fix-ci, verify)
+#: and retro also bumped 10× for consistency; none of them had been
+#: hitting the old cap but the parsimony was left over from when
+#: every turn mattered.
 PHASE_MAX_TURNS = {
-    "plan": 50,
-    "ralph": 500,
-    "summary": 30,
-    "fix-ci": 100,
-    "verify": 50,
-    "retro": 30,
+    "plan": 500,
+    "ralph": 5000,
+    "summary": 300,
+    "fix-ci": 1000,
+    "verify": 500,
+    "retro": 300,
 }
 
 #: Per-phase ``--model`` values. Matches ``dispatcher.config.model_by_phase``
@@ -544,15 +558,32 @@ STUCK_TIMEOUT_SECONDS = 30 * 60
 #: (JSONB object merged into this default at read time — see
 #: :meth:`_stuck_timeout_for_phase`).
 STUCK_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
+    # Issue #2885 bumped every LLM-bearing phase by 10× after an
+    # overnight race: agent ``821e96ee`` ran ralph 5834s and finished
+    # normally, but the supervisor flagged it stuck at 5419s (old 90
+    # min threshold) and fired a retry. Ralph exited cleanly 415s
+    # later, but the retry had already started, producing
+    # ``phase_output_missing`` and a failed agent despite ralph
+    # actually succeeding. Operator directive: "stop being
+    # parsimonious on these limits. Cost is not the constraint;
+    # success is." The new values are effectively "never trip the
+    # timer on a phase that's still running normally" — a truly
+    # stuck agent (subprocess hung, daemon crashed mid-phase) will
+    # still trip eventually. Non-LLM phases (``claiming``,
+    # ``awaiting_ci``, ``awaiting_deploy``, terminal sweeps) keep
+    # their original tight windows because their upper bounds are
+    # set by external systems (gh API, GitHub Actions, ECS rolling
+    # deploy) not by our subprocess runtime.
     "claiming": 5 * 60,  # 5 min — claim is a single gh + psycopg call
-    "planning": 30 * 60,  # 30 min — plan is read-only LLM, typical 2-9 min
-    "plan": 30 * 60,  # alias for phase_transitions "plan" row
-    "ralph": 90 * 60,  # 90 min — ralph iterates, see #2513 107 min outlier
-    "summary": 30 * 60,  # 30 min — summary is single-pass LLM, typical 1-3 min
+    "planning": 9000,  # 2.5 hr (was 30 min) — plan is read-only LLM, issue #2885
+    "plan": 9000,  # alias for phase_transitions "plan" row — issue #2885
+    "ralph": 54000,  # 15 hr (was 90 min) — ralph iterates, issue #2885
+    "summary": 6000,  # 100 min (was 30 min) — summary single-pass LLM, issue #2885
     "awaiting_ci": 120 * 60,  # 2 hr — CI + any flaky retry headroom
     "awaiting_deploy": 45 * 60,  # 45 min — dev deploy rolling wait
-    "fix_ci": 30 * 60,  # 30 min — single /task-v2-fix-ci run
-    "retro": 20 * 60,  # 20 min — single /task-v2-retro run
+    "fix_ci": 18000,  # 5 hr (was 30 min) — single /task-v2-fix-ci, issue #2885
+    "verify": 3000,  # 50 min (was unset, fell back to 30 min global) — issue #2885
+    "retro": 3000,  # 50 min (was 20 min) — single /task-v2-retro, issue #2885
     "paused_by_killswitch": 60,  # 1 min — terminal phase, should be swept quickly
     "daemon_restart_abandoned": 60,  # 1 min — terminal phase from restart recovery
 }

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -1099,7 +1099,7 @@ class TestSpawnPhaseSubprocess:
         assert "--cwd" not in captured["cmd"]
         assert captured["cwd"] == str(tmp_path)
         assert "--max-turns" in captured["cmd"]
-        assert "50" in captured["cmd"]  # plan
+        assert "500" in captured["cmd"]  # plan — 10× bumped in #2885
         assert "--model" in captured["cmd"]
         assert "opus" in captured["cmd"]
         assert captured["timeout"] == 180 * 60
@@ -1107,9 +1107,10 @@ class TestSpawnPhaseSubprocess:
         log_path = tmp_path / "tmp" / "claude-p-plan.log"
         assert log_path.exists()
 
-    def test_ralph_uses_sonnet_and_500_turns(
+    def test_ralph_uses_sonnet_and_5000_turns(
         self, monkeypatch: Any, tmp_path: Path
     ) -> None:
+        """Ralph's max_turns was 10× bumped to 5000 in #2885."""
         d, _conn, _handler = _make_daemon(tmp_path)
         captured: dict[str, Any] = {}
 
@@ -1121,12 +1122,13 @@ class TestSpawnPhaseSubprocess:
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         d._spawn_phase_subprocess("ralph", tmp_path, "agent-uuid")
-        assert "500" in captured["cmd"]
+        assert "5000" in captured["cmd"]
         assert "sonnet" in captured["cmd"]
 
-    def test_summary_uses_haiku_and_30_turns(
+    def test_summary_uses_haiku_and_300_turns(
         self, monkeypatch: Any, tmp_path: Path
     ) -> None:
+        """Summary's max_turns was 10× bumped to 300 in #2885."""
         d, _conn, _handler = _make_daemon(tmp_path)
         captured: dict[str, Any] = {}
 
@@ -1138,7 +1140,7 @@ class TestSpawnPhaseSubprocess:
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         d._spawn_phase_subprocess("summary", tmp_path, "agent-uuid")
-        assert "30" in captured["cmd"]
+        assert "300" in captured["cmd"]
         assert "haiku" in captured["cmd"]
 
 

--- a/scripts/dispatcher/tests/test_daemon_phase3c.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3c.py
@@ -229,12 +229,12 @@ class TestCheckStuckAgents:
     ) -> None:
         d, conn, handler = _make_daemon(tmp_path)
 
-        # Seeded row: one stale ralph agent. Elapsed 6000s = 100 min >
-        # 90 min (ralph default threshold). #2872 — the SELECT now
-        # returns (agent_id, issue_number, phase, elapsed_seconds) and
-        # the Python-side comparison applies the per-phase threshold.
+        # Seeded row: one stale ralph agent. Elapsed 55000s > 54000s
+        # (ralph default threshold bumped 10× in #2885). #2872 — the
+        # SELECT returns (agent_id, issue_number, phase, elapsed_seconds)
+        # and the Python-side comparison applies the per-phase threshold.
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "ralph", 6000.0)],
+            [("agent-1", 42, "ralph", 55000.0)],
         ]
         # Order inside _check_stuck_agents + _create_retry_marker:
         # (1) stuck_timeout_s_by_phase override read (returns None → fall
@@ -307,12 +307,13 @@ class TestCheckStuckAgents:
 
     def test_multiple_stuck_agents_all_flagged(self, tmp_path: Path) -> None:
         d, conn, handler = _make_daemon(tmp_path)
-        # Two stuck agents: ralph exceeds 90min threshold at 6000s,
+        # Two stuck agents: ralph exceeds 54000s threshold at 55000s,
         # claiming exceeds 5min threshold at 600s. (#2872 per-phase
-        # thresholds replace the single 30min global.)
+        # thresholds replace the single 30min global; #2885 bumped
+        # ralph 10× from 90min to 15hr.)
         conn.cursor_instance.fetchall_queue = [
             [
-                ("agent-1", 1, "ralph", 6000.0),
+                ("agent-1", 1, "ralph", 55000.0),
                 ("agent-2", 2, "claiming", 600.0),
             ],
         ]

--- a/scripts/dispatcher/tests/test_daemon_phase3e.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3e.py
@@ -184,7 +184,8 @@ class TestPhase3EPhaseConstants:
 
     def test_retro_phase_in_max_turns(self) -> None:
         assert "retro" in daemon.PHASE_MAX_TURNS
-        assert daemon.PHASE_MAX_TURNS["retro"] == 30
+        # 10× bumped in #2885 (was 30).
+        assert daemon.PHASE_MAX_TURNS["retro"] == 300
 
     def test_retro_phase_in_models(self) -> None:
         assert "retro" in daemon.PHASE_MODELS

--- a/scripts/dispatcher/tests/test_daemon_restart_cascade.py
+++ b/scripts/dispatcher/tests/test_daemon_restart_cascade.py
@@ -312,7 +312,7 @@ class TestPerPhaseStuckTimeout:
         assert d._check_stuck_agents() == 0
 
     def test_plan_below_threshold_not_flagged(self, tmp_path: Path) -> None:
-        """A 90-second plan is not stuck (threshold is 30 min)."""
+        """A 90-second plan is not stuck (threshold is 2.5 hr, #2885)."""
         d, conn, _handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue = [
             [("agent-1", 42, "plan", 90.0)],
@@ -323,10 +323,10 @@ class TestPerPhaseStuckTimeout:
         assert d._check_stuck_agents() == 0
 
     def test_ralph_over_threshold_flagged(self, tmp_path: Path) -> None:
-        """A 100-minute ralph IS stuck (threshold is 90 min)."""
+        """A 16-hour ralph IS stuck (threshold is 15 hr / 54000s, #2885)."""
         d, conn, handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "ralph", 6000.0)],  # 100 min
+            [("agent-1", 42, "ralph", 57600.0)],  # 16 hr
         ]
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
@@ -337,7 +337,7 @@ class TestPerPhaseStuckTimeout:
         detected = handler.events("failure_detected")
         assert detected
         # Structured log includes the per-phase threshold for ops debug.
-        assert getattr(detected[0], "threshold_seconds", None) == 90 * 60
+        assert getattr(detected[0], "threshold_seconds", None) == 54000
 
     def test_config_override_wins_over_default(self, tmp_path: Path) -> None:
         """Operator override in ``stuck_timeout_s_by_phase`` takes precedence."""
@@ -369,13 +369,121 @@ class TestPerPhaseStuckTimeout:
         assert d._check_stuck_agents() == 1
 
     def test_stuck_timeout_for_phase_table_values(self) -> None:
-        """Module-level defaults match the documented spec (#2872)."""
-        assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["ralph"] == 90 * 60
-        assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["plan"] == 30 * 60
+        """Module-level defaults match the documented spec (#2872 + #2885 10× bump)."""
+        assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["ralph"] == 54000  # 15 hr
+        assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["plan"] == 9000  # 2.5 hr
+        assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["summary"] == 6000
+        assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["verify"] == 3000
+        assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["retro"] == 3000
+        assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["fix_ci"] == 18000
+        # Non-LLM phases keep original tight windows — external-system-bound.
         assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["claiming"] == 5 * 60
         # Restart-recovery "terminal" phases have a tight window so a
         # daemon that crashes mid-reclaim is picked up quickly.
         assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["daemon_restart_abandoned"] == 60
+
+
+# --------------------------------------------------------------------------
+# Issue #2885 — 10× stuck_timeout + max_turns bump.
+# --------------------------------------------------------------------------
+
+
+class TestIssue2885TenTimesBump:
+    """Regressions for the #2885 10× bump.
+
+    Overnight 2026-04-20 observed two distinct failure modes:
+
+    1. Ralph race. Agent ``821e96ee`` on #2565 ran ralph 5834s. The
+       supervisor flagged it stuck at 5419s (old 90 min threshold, 19s
+       of slack), fired a retry. Ralph exited cleanly 415s later but
+       the retry had already taken over — ``phase_output_missing`` +
+       failed agent despite ralph actually succeeding.
+    2. Plan ``error_max_turns``. Plan agents hit 51/50 turns on complex
+       scraper issues (#2564, #2565), burning ~$3 of opus with zero
+       output. Two agents tripped this within 5 min 24s on 2026-04-20.
+
+    Operator directive: "stop being parsimonious on these limits.
+    Cost is not the constraint; success is." Every LLM-bearing phase
+    gets a 10× headroom bump so a normally-progressing subprocess
+    never races against the supervisor's stuck-declaration.
+    """
+
+    def test_max_turns_all_bumped_to_ten_times(self) -> None:
+        """Every phase in PHASE_MAX_TURNS is at least 10× the original calibration."""
+        # Original values from #2787 Phase 3B + #2798 Phase 3E.
+        original = {
+            "plan": 50,
+            "ralph": 500,
+            "summary": 30,
+            "fix-ci": 100,
+            "verify": 50,
+            "retro": 30,
+        }
+        for phase, old in original.items():
+            assert phase in daemon.PHASE_MAX_TURNS, (
+                f"phase {phase!r} missing from PHASE_MAX_TURNS"
+            )
+            assert daemon.PHASE_MAX_TURNS[phase] >= old * 10, (
+                f"phase {phase!r} max_turns not 10×-bumped: got "
+                f"{daemon.PHASE_MAX_TURNS[phase]}, expected >= {old * 10}"
+            )
+
+    def test_max_turns_exact_issue_values(self) -> None:
+        """Exact values called out in #2885."""
+        assert daemon.PHASE_MAX_TURNS["plan"] == 500
+        assert daemon.PHASE_MAX_TURNS["ralph"] == 5000
+        assert daemon.PHASE_MAX_TURNS["summary"] == 300
+        assert daemon.PHASE_MAX_TURNS["verify"] == 500
+        assert daemon.PHASE_MAX_TURNS["retro"] == 300
+        # fix-ci's old value was 100 (not 50 as misremembered in the
+        # issue body); 10× is 1000.
+        assert daemon.PHASE_MAX_TURNS["fix-ci"] == 1000
+
+    def test_stuck_timeout_llm_phases_match_issue_targets(self) -> None:
+        """Every LLM-bearing phase matches the explicit target values in #2885.
+
+        The issue calls out exact target values rather than a blanket
+        10× formula (because the pre-#2885 ralph threshold of 5400s
+        was already under the rest of the module defaults — the table
+        was inconsistent). These values are what #2885 explicitly
+        requested; treating them as the authoritative spec here
+        guards against "fix the parsimony, lose the parsimony, fix
+        again" drift.
+        """
+        issue_targets = {
+            "planning": 9000,
+            "plan": 9000,
+            "ralph": 54000,
+            "summary": 6000,
+            "verify": 3000,
+            "fix_ci": 18000,
+            "retro": 3000,
+        }
+        for phase, target in issue_targets.items():
+            assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE[phase] == target, (
+                f"phase {phase!r} stuck_timeout not at issue #2885 target: "
+                f"got {daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE[phase]}, "
+                f"expected {target}"
+            )
+
+    def test_ralph_race_regression(self, tmp_path: Path) -> None:
+        """Agent ``821e96ee`` at 5419s would NOT be flagged under the new threshold.
+
+        Concrete reproduction of the overnight race. Pre-#2885 ralph
+        threshold was 5400s, so 5419s tripped the supervisor even
+        though the subprocess was 15s from clean exit. The new 54000s
+        threshold gives ~15 hr of headroom — enough that a
+        normally-progressing ralph can NEVER race against the timer.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-821e96ee", 2565, "ralph", 5419.0)],
+        ]
+        conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase override — unset
+        ]
+        # Pre-fix: 1. Post-fix: 0.
+        assert d._check_stuck_agents() == 0
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

10× bump on dispatcher v2 supervisor thresholds — `PHASE_MAX_TURNS`
and `STUCK_TIMEOUT_SECONDS_BY_PHASE` — to eliminate two distinct
overnight failure modes where parsimony on limits was racing against
legitimate subprocess runtime. Migration 32 seeds the
`dispatcher.config.stuck_timeout_s_by_phase` row via `ON CONFLICT DO
UPDATE` so existing deploys get the bump, not just fresh installs.

Closes #2885

## Test plan

### Automated checks
- [x] Lint passes (`ruff check` on `scripts/dispatcher/**` clean)
- [x] Format check passes (`ruff format --check` clean)
- [x] Tests pass (589 dispatcher tests + 521 scripts tests passing
      locally; includes new `TestIssue2885TenTimesBump` with
      reproduction of the 5419s ralph race)
- [x] Schema drift check passes (`scripts/check_schema_drift.sh --ci`)
- [x] Migration file validation passes (sequential 1..32)
- [x] CI green

### Post-deploy verification
- [x] Migration 32 applied on dev (config row present with
      `updated_by: init-2885` and correct JSONB values —
      `{plan: 9000, ralph: 54000, retro: 3000, fix_ci: 18000,
      verify: 3000, summary: 6000, planning: 9000}`).
- [x] Dispatcher daemon redeployed on new code (version_sha=6a0e4dc,
      new run_id `6e48ddda-...` healthy from 06:20:39 UTC).
- [x] No regressions: zero `stuck_flagged` / `failure_detected`
      events since the new run started.
- [x] Verification evidence posted on issue #2885.
