### PR TITLE
fix(dispatcher): kill MFA gate + simplify commands to start/stop/force_stop (#2884)

### DIFF
--- a/docs/specs/dispatcher-v2-spec.md
+++ b/docs/specs/dispatcher-v2-spec.md
@@ -350,7 +350,7 @@ No subscriptions. Admin page uses Apollo `pollInterval: 2000` (2s). Dispatcher e
 **UI sections:**
 
 - **Header:** daemon status pill (running / paused / stopped / unhealthy), uptime, version SHA.
-- **Controls:** Start, Stop (drain), Force-stop, Pause, Resume buttons. Each posts a confirmation modal (stop/kill are destructive).
+- **Controls (#2884 simplified):** three buttons — **Start**, **Stop**, **Force Stop**. `start` flips `concurrency_cap` back to 1; `stop` is graceful (blocks new spawns, lets any in-flight agent finish its current phase pipeline); `force_stop` is immediate (sets `_pause_requested` so the in-flight worker aborts at the next phase boundary). Only `force_stop` posts a confirmation modal — the whole point of the simplification is that stopping dev work must not be friction-heavy for the operator. The former Pause / Resume / Stop (drain) / Force-stop cluster and the MFA re-auth gate were removed per #2884.
 - **Active agents table:** agent_id (short), issue #, phase, elapsed, worktree (link to CloudWatch logs), actions (retry, kill).
 - **Queue:** upcoming `agent/ready` issues, blocked-by count.
 - **Recent failures (last 24h):** grouped by category, with count and most recent example.
@@ -506,7 +506,7 @@ Rollback plan: any phase can revert by scaling ECS to 0 and invoking laptop `/di
 
 5. **GitHub Actions runner queue depth.** If CI is backed up (common on busy days), PRs pile up waiting for checks. Daemon merges based on check rollup; if checks don't start for 20min, "recently merged" signal (for idle-mode `/audit`) fires incorrectly. **Mitigation:** treat `pending` as neutral, not green; only count SUCCESS for idle triggers.
 
-6. **Admin page auth compromise.** Controls include force-kill and drain. Anyone with admin access can stop the daemon. **Mitigation:** require fresh re-auth (MFA-style) for destructive actions. Audit log in `dispatcher.commands.issued_by`.
+6. **Admin page auth compromise.** Controls include force-stop (global and per-agent). Anyone with admin access can stop the daemon. **Original mitigation (superseded by #2884):** require fresh re-auth (MFA-style) for destructive actions. **Current mitigation:** admin role on the session is the only gate. The prior placeholder MFA check accepted any non-empty `X-MFA-Token` header — zero real safety, pure friction — and during a 2026-04-20 incident it actively prevented the operator from stopping a runaway pipeline for ~2 hours. Since admin-session auth is already required for any dispatcher control, adding a per-request friction layer without a real second factor was net-negative. Audit log in `dispatcher.commands.issued_by` remains the trail of record. If a real MFA second factor is ever implemented, apply it to login (every admin action) rather than per-control-button (which is the friction pattern that failed in 2026-04-20).
 
 7. **Schema evolution.** Adding a new phase name requires a migration. **Mitigation:** `dispatcher.phase_transitions.phase` is a free-form string, not an enum. Validation is daemon-side, not DB-side.
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -95,17 +95,9 @@ export async function buildApp(db?: Pool, os?: Client): Promise<FastifyInstance>
           const ip = req.ip ?? req.headers['x-forwarded-for'] ?? 'unknown';
           const cookieHeader =
             typeof req.headers.cookie === 'string' ? req.headers.cookie : '';
-          // X-MFA-Token propagates the admin re-auth challenge token for
-          // destructive dispatcherControl commands (§17 Risk 6). Phase 1
-          // placeholder — any non-empty value is accepted; sub-task E wires
-          // the real MFA challenge flow.
-          const mfaTokenHeader = req.headers['x-mfa-token'];
-          const mfaToken =
-            typeof mfaTokenHeader === 'string'
-              ? mfaTokenHeader
-              : Array.isArray(mfaTokenHeader)
-                ? mfaTokenHeader[0]
-                : null;
+          // #2884: X-MFA-Token parsing removed with the MFA re-auth gate.
+          // Admin surfaces rely on `user.role === 'admin'` alone; audit
+          // trail lives in `dispatcher.commands.issued_by`.
           return {
             pool,
             loaders: createLoaders(pool),
@@ -114,7 +106,6 @@ export async function buildApp(db?: Pool, os?: Client): Promise<FastifyInstance>
             reply,
             cookieHeader,
             opensearch,
-            mfaToken,
           };
         },
       });

--- a/packages/api/src/graphql/dispatcher/auth.ts
+++ b/packages/api/src/graphql/dispatcher/auth.ts
@@ -12,6 +12,11 @@
  * is the response shape: this gate returns a generic NOT_FOUND so the
  * dispatcher schema is not enumerable by non-admins, whereas data-quality
  * returns an explicit FORBIDDEN.
+ *
+ * #2884: the placeholder MFA re-auth gate (`DESTRUCTIVE_COMMANDS` +
+ * `X-MFA-Token`) was removed — it accepted any non-empty header string
+ * and added pure friction with zero real safety. Admin session auth is
+ * sufficient; audit trail lives in `dispatcher.commands.issued_by`.
  */
 
 import { GraphQLError } from 'graphql';
@@ -43,11 +48,3 @@ export function requireDispatcherAdmin(user: AuthUser | null): AuthUser {
   }
   return user;
 }
-
-/**
- * Destructive commands that require a fresh re-auth (MFA) step before
- * execution per §17 Risk 6. In Phase 1 the check is a placeholder — any
- * non-empty `X-MFA-Token` header is accepted. Sub-task E or a follow-up
- * will wire the real MFA challenge flow (see TODO in resolvers.ts).
- */
-export const DESTRUCTIVE_COMMANDS = new Set(['stop', 'drain', 'force_kill']);

--- a/packages/api/src/graphql/dispatcher/index.ts
+++ b/packages/api/src/graphql/dispatcher/index.ts
@@ -20,4 +20,4 @@ export {
   runRowToGraphQL,
   transitionRowToGraphQL,
 } from './resolvers';
-export { requireDispatcherAdmin, notFound, DESTRUCTIVE_COMMANDS } from './auth';
+export { requireDispatcherAdmin, notFound } from './auth';

--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -15,7 +15,7 @@
 import type { Pool } from 'pg';
 import { GraphQLError, GraphQLScalarType, Kind } from 'graphql';
 import type { AuthUser } from '../../auth';
-import { DESTRUCTIVE_COMMANDS, requireDispatcherAdmin } from './auth';
+import { requireDispatcherAdmin } from './auth';
 import { extractPriority, parseBlockedBy, priorityRank } from './parse-labels';
 
 /**
@@ -38,7 +38,6 @@ interface SnapshotIssueRecord {
 interface DispatcherContext {
   pool: Pool;
   user: AuthUser | null;
-  mfaToken: string | null;
 }
 
 type Row = Record<string, unknown>;
@@ -707,22 +706,15 @@ export const dispatcherResolvers = {
         command,
         payload,
       }: { command: string; payload?: Record<string, unknown> | null },
-      { pool, user, mfaToken }: DispatcherContext,
+      { pool, user }: DispatcherContext,
     ) => {
       const admin = requireDispatcherAdmin(user);
 
-      // Destructive commands require a fresh re-auth token per §17 Risk 6.
-      // TODO(#2730 follow-up): Phase 1 placeholder — accept any non-empty
-      // X-MFA-Token header. Sub-task E or a follow-up wires the real MFA
-      // challenge flow (short-lived token issued by a dedicated
-      // challenge-verify mutation).
-      if (DESTRUCTIVE_COMMANDS.has(command)) {
-        if (!mfaToken || mfaToken.trim().length === 0) {
-          throw new GraphQLError('MFA re-auth required for destructive commands', {
-            extensions: { code: 'MFA_REQUIRED' },
-          });
-        }
-      }
+      // #2884: the MFA re-auth placeholder was removed — admin session
+      // auth is sufficient, and the "destructive vs not" gate added pure
+      // friction with zero real safety (any non-empty X-MFA-Token
+      // header was accepted). Audit trail lives in
+      // `dispatcher.commands.issued_by`.
 
       const effectivePayload = payload ?? {};
       const { row, created } = await insertCommandIdempotent(
@@ -737,17 +729,13 @@ export const dispatcherResolvers = {
     dispatcherSetConfig: async (
       _: unknown,
       { key, value }: { key: string; value: string },
-      { pool, user, mfaToken }: DispatcherContext,
+      { pool, user }: DispatcherContext,
     ) => {
       const admin = requireDispatcherAdmin(user);
 
-      // Config edits materially change daemon behaviour — require the
-      // same MFA placeholder gate as destructive commands (§17 Risk 6).
-      if (!mfaToken || mfaToken.trim().length === 0) {
-        throw new GraphQLError('MFA re-auth required for config updates', {
-          extensions: { code: 'MFA_REQUIRED' },
-        });
-      }
+      // #2884: MFA re-auth placeholder removed (see dispatcherControl
+      // above). Config edits still go through `requireDispatcherAdmin`
+      // and `validateConfigValue`.
 
       let parsed: unknown;
       try {

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -24,30 +24,38 @@ export const dispatcherTypeDefs = `#graphql
   scalar JSON
 
   # ---------------------------------------------------------------------------
-  # Enum — admin control commands
+  # Enum — admin control commands (#2884 simplified taxonomy)
   # ---------------------------------------------------------------------------
 
   """Control commands the admin page can issue to the daemon.
   Consumed via \`dispatcher.commands\` row insert.
 
-  Destructive commands (\`stop\`, \`drain\`, \`force_kill\`) require fresh
-  re-auth (MFA-style) per §17 Risk 6 — see \`dispatcherControl\`.
+  Four commands: three global daemon-state transitions
+  (\`start\` / \`stop\` / \`force_stop\`) and one per-agent action
+  (\`retry\`). Previously the surface included \`pause\`, \`resume\`,
+  \`drain\`, and a separate \`force_kill\` — all removed per #2884.
+  Stopping development work is not destructive, so no MFA gate.
   """
   enum DispatcherCommand {
-    """Resume scheduler + supervisor ticks after a pause/stop."""
+    """Resume claiming; sets \`concurrency_cap\` from 0 back to 1."""
     start
-    """Block new spawns; let in-flight agents finish (destructive)."""
+    """Graceful stop: blocks new spawns and lets any in-flight agent
+    finish its current phase pipeline. Sets \`concurrency_cap\` to 0
+    without engaging the killswitch — the in-flight worker keeps
+    running. Replaces the former \`drain\` command (same SQL, clearer
+    semantic boundary vs. \`force_stop\`)."""
     stop
-    """Block new spawns with aggressive timeout on in-flight agents (destructive)."""
-    drain
-    """Suspend both scheduler and supervisor until \`resume\`."""
-    pause
-    """Resume after \`pause\`."""
-    resume
-    """Queue a manual retry for a specific agent (payload.agentId required)."""
+    """Immediate stop. Sets \`concurrency_cap\` to 0 AND engages the
+    killswitch so the in-flight worker aborts at the next phase
+    boundary via \`_check_killswitch_and_abort\`.
+
+    When \`payload.agentId\` is supplied, scope narrows to that single
+    agent: kill its subprocess (SIGKILL if the pid is local) and mark
+    it \`status='crashed'\` without changing the global
+    \`concurrency_cap\`. Replaces the former \`force_kill\` command."""
+    force_stop
+    """Queue a manual retry for a specific agent. \`payload.agentId\` required."""
     retry
-    """Kill a specific agent's subprocess without waiting (destructive; payload.agentId required)."""
-    force_kill
   }
 
   # ---------------------------------------------------------------------------
@@ -310,25 +318,26 @@ export const dispatcherTypeDefs = `#graphql
     written in the last 10 seconds and is still unconsumed, return that row
     and set \`created=false\` instead of inserting a duplicate.
 
-    Destructive commands (\`stop\`, \`drain\`, \`force_kill\`) require fresh
-    re-auth per §17 Risk 6. In Phase 1 this is enforced via the
-    \`X-MFA-Token\` HTTP header — any non-empty value is accepted as a
-    placeholder. Sub-task E or a follow-up wires the real MFA prompt.
+    #2884: the MFA re-auth placeholder was removed. Admin session auth
+    is sufficient; audit trail lives in \`dispatcher.commands.issued_by\`.
 
     Admin-only; non-admins receive "not found".
     """
     dispatcherControl(
       command: DispatcherCommand!
-      """Command-specific JSON payload. For \`retry\` / \`force_kill\` this must
-      include \`agentId\`. For others, \`{}\` is fine."""
+      """Command-specific JSON payload. For \`retry\` this must include
+      \`agentId\`. For \`force_stop\`, \`agentId\` is optional — when
+      present the command is scoped to that agent; when absent it is a
+      global immediate stop. For \`start\` and \`stop\`, \`{}\` is fine."""
       payload: JSON
     ): DispatcherCommandResult!
 
     """Update a single \`dispatcher.config\` entry (#2805 §1.6). Writes the
     new value as JSONB, stamps \`updated_at\`, and records the admin's email
-    in \`updated_by\` for audit. Like \`dispatcherControl\`, this requires a
-    non-empty \`X-MFA-Token\` header — config edits can materially change
-    daemon behaviour (e.g. lowering \`concurrency_cap\` mid-flight).
+    in \`updated_by\` for audit.
+
+    #2884: the MFA re-auth placeholder was removed — admin session auth
+    is the gate.
 
     Admin-only; non-admins receive "not found".
     """

--- a/packages/api/src/graphql/resolvers.ts
+++ b/packages/api/src/graphql/resolvers.ts
@@ -19,12 +19,6 @@ interface Context {
   reply: FastifyReply;
   cookieHeader: string;
   opensearch: Client;
-  /**
-   * `X-MFA-Token` header value, propagated per request. Consumed by the
-   * dispatcher admin surface for destructive-command re-auth. Null when
-   * the header is absent.
-   */
-  mfaToken: string | null;
 }
 
 type Row = Record<string, unknown>;

--- a/packages/api/tests/dispatcher.integration.test.ts
+++ b/packages/api/tests/dispatcher.integration.test.ts
@@ -10,7 +10,8 @@
  *   - dispatcherControl: writes a row visible in the next dispatcherState call.
  *   - dispatcherControl: idempotency — repeating the same command inside
  *     the idempotency window returns the existing row (created=false).
- *   - dispatcherControl: destructive commands require X-MFA-Token header.
+ *   - dispatcherControl: admin role is the only gate (#2884 removed the
+ *     MFA re-auth placeholder — admin session auth is sufficient).
  *
  * DATA ISOLATION: this file uses `dispatcher` in the test-counties registry.
  * It writes only to `public.users` (emails prefixed with the run timestamp)
@@ -245,7 +246,7 @@ describe('dispatcher — auth gate', () => {
 
   it('non-admin: dispatcherControl returns "not found"', async () => {
     const body = await gql(
-      `mutation { dispatcherControl(command: pause) { commandId } }`,
+      `mutation { dispatcherControl(command: start) { commandId } }`,
       undefined,
       userToken,
     );
@@ -422,13 +423,13 @@ describe('dispatcherAgent — admin', () => {
 });
 
 // ---------------------------------------------------------------------------
-// dispatcherControl — write path, idempotency, MFA
+// dispatcherControl — write path, idempotency, #2884 no-MFA regression
 // ---------------------------------------------------------------------------
 
 describe('dispatcherControl — admin', () => {
-  it('PAUSE writes a row in dispatcher.commands and returns it', async () => {
+  it('start writes a row in dispatcher.commands and returns it', async () => {
     const body = await gql(
-      `mutation { dispatcherControl(command: pause) {
+      `mutation { dispatcherControl(command: start) {
          commandId command issuedBy payload created
        } }`,
       undefined,
@@ -436,7 +437,7 @@ describe('dispatcherControl — admin', () => {
     );
     expect(body.errors).toBeUndefined();
     const result = body.data?.dispatcherControl as Record<string, unknown>;
-    expect(result.command).toBe('pause');
+    expect(result.command).toBe('start');
     expect(result.issuedBy).toBe(`${MARKER}-admin@test.com`);
     expect(result.created).toBe(true);
 
@@ -446,7 +447,7 @@ describe('dispatcherControl — admin', () => {
       [result.commandId],
     );
     expect(rows).toHaveLength(1);
-    expect(rows[0].command).toBe('pause');
+    expect(rows[0].command).toBe('start');
     expect(rows[0].issued_by).toBe(`${MARKER}-admin@test.com`);
   });
 
@@ -458,7 +459,7 @@ describe('dispatcherControl — admin', () => {
 
     // Issue #1
     const first = await gql(
-      `mutation($p: JSON) { dispatcherControl(command: pause, payload: $p) { commandId created } }`,
+      `mutation($p: JSON) { dispatcherControl(command: start, payload: $p) { commandId created } }`,
       { p: markerPayload },
       adminToken,
     );
@@ -468,7 +469,7 @@ describe('dispatcherControl — admin', () => {
 
     // Issue #2 — identical command, identical issuer, identical payload.
     const second = await gql(
-      `mutation($p: JSON) { dispatcherControl(command: pause, payload: $p) { commandId created } }`,
+      `mutation($p: JSON) { dispatcherControl(command: start, payload: $p) { commandId created } }`,
       { p: markerPayload },
       adminToken,
     );
@@ -494,26 +495,44 @@ describe('dispatcherControl — admin', () => {
     expect(payload.reason).toBe('flake');
   });
 
-  it('destructive command (stop) without X-MFA-Token returns MFA_REQUIRED', async () => {
-    const body = await gql(
-      `mutation { dispatcherControl(command: stop) { commandId } }`,
-      undefined,
-      adminToken,
-    );
-    expect(body.errors).toBeDefined();
-    expect(body.errors![0].extensions?.code).toBe('MFA_REQUIRED');
-  });
-
-  it('destructive command (stop) with non-empty X-MFA-Token succeeds', async () => {
+  it('stop command succeeds without any MFA header (#2884 removed the gate)', async () => {
+    // Regression guard: the placeholder X-MFA-Token gate was removed;
+    // admin session auth is sufficient. Stopping dev work is not
+    // destructive — the operator needs an immediate stop button.
     const body = await gql(
       `mutation { dispatcherControl(command: stop) { commandId command created } }`,
       undefined,
       adminToken,
-      { 'x-mfa-token': 'placeholder-token-accepted-in-phase-1' },
     );
     expect(body.errors).toBeUndefined();
     const result = body.data?.dispatcherControl as Record<string, unknown>;
     expect(result.command).toBe('stop');
+  });
+
+  it('force_stop command succeeds without any MFA header (#2884)', async () => {
+    const body = await gql(
+      `mutation { dispatcherControl(command: force_stop) { commandId command created } }`,
+      undefined,
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const result = body.data?.dispatcherControl as Record<string, unknown>;
+    expect(result.command).toBe('force_stop');
+  });
+
+  it('dispatcherSetConfig succeeds without any MFA header (#2884)', async () => {
+    // Same rationale as the control mutations — admin session auth is
+    // the gate; the placeholder MFA header was removed.
+    const body = await gql(
+      `mutation($k: String!, $v: String!) {
+         dispatcherSetConfig(key: $k, value: $v) { key value updatedBy }
+       }`,
+      { k: 'concurrency_cap', v: '1' },
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const result = body.data?.dispatcherSetConfig as Record<string, unknown>;
+    expect(result.key).toBe('concurrency_cap');
   });
 
   it('state reflects a newly-issued command on the next read', async () => {
@@ -521,7 +540,7 @@ describe('dispatcherControl — admin', () => {
     // dispatcher.commands, which this test verifies directly (admin surface
     // doesn't expose the commands queue in dispatcherState for Phase 1).
     const issue = await gql(
-      `mutation { dispatcherControl(command: resume) { commandId } }`,
+      `mutation { dispatcherControl(command: start) { commandId } }`,
       undefined,
       adminToken,
     );
@@ -531,6 +550,6 @@ describe('dispatcherControl — admin', () => {
       [commandId],
     );
     expect(rows).toHaveLength(1);
-    expect(rows[0].command).toBe('resume');
+    expect(rows[0].command).toBe('start');
   });
 });

--- a/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
@@ -9,7 +9,7 @@ import { IssueLink } from './ui-primitives';
 interface ActiveAgentsTableProps {
   agents: readonly DispatcherAgent[];
   disabled?: boolean;
-  onAgentAction: (command: 'retry' | 'force_kill', agentId: string) => void;
+  onAgentAction: (command: 'retry' | 'force_stop', agentId: string) => void;
   /** Override for deterministic tests. */
   nowMs?: number;
 }
@@ -60,7 +60,7 @@ function ActiveAgentRow({
 }: {
   agent: DispatcherAgent;
   disabled?: boolean;
-  onAction: (command: 'retry' | 'force_kill', agentId: string) => void;
+  onAction: (command: 'retry' | 'force_stop', agentId: string) => void;
   nowMs?: number;
 }) {
   const logsHref = worktreeLogsUrl(agent.worktreePath);
@@ -116,7 +116,7 @@ function ActiveAgentRow({
           variant="destructive"
           size="xs"
           disabled={disabled}
-          onClick={() => onAction('force_kill', agent.id)}
+          onClick={() => onAction('force_stop', agent.id)}
         >
           Kill
         </Button>

--- a/packages/web/src/app/(main)/admin/dispatcher/ConfigPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ConfigPanel.tsx
@@ -19,7 +19,7 @@ interface ConfigPanelProps {
    * or surface the error via `errorMessage`.
    */
   onCommitEdit: (key: string, value: string) => Promise<void>;
-  /** Transient error surfaced by the parent (e.g. MFA_REQUIRED). */
+  /** Transient error surfaced by the parent (e.g. validation failure). */
   errorMessage?: string | null;
   /** Transient busy indicator for the last-edited key. */
   busyKey?: string | null;

--- a/packages/web/src/app/(main)/admin/dispatcher/ConfirmDialog.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ConfirmDialog.tsx
@@ -12,9 +12,13 @@ import { Button } from '@/components/ui/button';
 import type { DispatcherCommand } from '@/lib/dispatcher-queries';
 
 /**
- * Commands that can open the ConfirmDialog. Includes all
- * `DESTRUCTIVE_COMMANDS` plus the synthetic `'lower_cap'` sentinel used
- * by the config strip when the operator reduces `concurrency_cap`
+ * Commands that can open the ConfirmDialog. After #2884's command-
+ * surface simplification, only `force_stop` needs the modal — `stop`
+ * is graceful and doesn't kill in-flight work, so it fires without
+ * confirmation.
+ *
+ * Also includes the synthetic `'lower_cap'` sentinel used by the
+ * config strip when the operator reduces `concurrency_cap`
  * (#2805 §1.6; spec §17 Risk 6 Option A).
  */
 export type ConfirmableCommand = DispatcherCommand | 'lower_cap';
@@ -32,17 +36,9 @@ interface ConfirmDialogProps {
 }
 
 const DESCRIPTIONS: Partial<Record<DispatcherCommand, { title: string; body: string }>> = {
-  stop: {
+  force_stop: {
     title: 'Force-stop daemon?',
-    body: 'This blocks new spawns and does not wait for in-flight agents to finish. In-flight agents may be killed abruptly, leaking worktrees. Prefer Stop (drain) unless the daemon is unresponsive.',
-  },
-  drain: {
-    title: 'Stop (drain) daemon?',
-    body: 'This blocks new spawns but lets in-flight agents finish their current /task iteration. Safer than Force-stop but may take several minutes.',
-  },
-  force_kill: {
-    title: 'Force-kill agent?',
-    body: 'Terminates the agent subprocess without waiting for a clean exit. Leaves the worktree in place for manual inspection. This cannot be undone.',
+    body: 'This blocks new spawns AND aborts any in-flight agent at the next phase boundary. In-flight work is lost. Prefer Stop (graceful) unless the daemon is unresponsive or you need to halt immediately.',
   },
 };
 

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherControls.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherControls.tsx
@@ -10,21 +10,23 @@ interface DispatcherControlsProps {
 }
 
 /**
- * Five control buttons matching spec §11: Start · Pause · Resume ·
- * Stop (drain) · Force-stop.
+ * Three control buttons — Start, Stop, Force Stop — matching the
+ * simplified command taxonomy from #2884. Replaces the prior
+ * Start / Pause / Resume / Stop (drain) / Force-stop cluster:
+ *
+ *   - **Start** — set `concurrency_cap` back to 1 (resume claiming).
+ *   - **Stop** — graceful: block new spawns, let any in-flight agent
+ *     finish its current phase. Previously spelled "Stop (drain)".
+ *     No confirmation modal — stopping dev work is not destructive,
+ *     and the operator needs an immediate stop button (not a friction
+ *     path) when something goes sideways.
+ *   - **Force Stop** — immediate: block new spawns AND abort any
+ *     in-flight agent at the next phase boundary. Confirms via
+ *     `ConfirmDialog` because it kills work in progress.
  *
  * Rendered as a flat inline cluster — no card wrapper, no explanatory
- * paragraph — per #2805 §1.1. Same size/variant/enabled rules as the
- * previous implementation so behaviour is unchanged.
- *
- * The implementation-trivia footnote ("commands written to
- * dispatcher.commands") is intentionally removed — the operator has
- * internalized it and the page is about visibility, not tutorials.
- *
- * Daemon-side command handlers are tracked in #2801 — until that lands
- * some click handlers write a `dispatcher.commands` row but produce no
- * observable daemon behaviour change. This UI ships the correct writes
- * today.
+ * paragraph. The MFA re-auth gate was also removed (#2884) — admin
+ * session auth is sufficient.
  */
 export function DispatcherControls({
   currentRun,
@@ -49,36 +51,18 @@ export function DispatcherControls({
         variant="outline"
         size="sm"
         disabled={disabled || !daemonActive}
-        onClick={() => onControlClick('pause')}
+        onClick={() => onControlClick('stop')}
       >
-        Pause
-      </Button>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        disabled={disabled}
-        onClick={() => onControlClick('resume')}
-      >
-        Resume
-      </Button>
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        disabled={disabled || !daemonActive}
-        onClick={() => onControlClick('drain')}
-      >
-        Stop (drain)
+        Stop
       </Button>
       <Button
         type="button"
         variant="destructive"
         size="sm"
         disabled={disabled || !daemonActive}
-        onClick={() => onControlClick('stop')}
+        onClick={() => onControlClick('force_stop')}
       >
-        Force-stop
+        Force Stop
       </Button>
     </div>
   );

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -7,7 +7,6 @@ import { useAuth } from '@/providers/AuthProvider';
 import { ErrorBanner } from '@/components/ErrorBanner';
 import { PAGE_TITLE } from '@/lib/typography';
 import {
-  DESTRUCTIVE_COMMANDS,
   DISPATCHER_CONTROL_MUTATION,
   DISPATCHER_SET_CONFIG_MUTATION,
   DISPATCHER_STATE_QUERY,
@@ -130,17 +129,11 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
     async (command: DispatcherCommand, payload: Record<string, unknown> = {}) => {
       setCommandError(null);
       try {
+        // #2884: the X-MFA-Token placeholder was removed — admin
+        // session auth is the only gate. No per-command context
+        // headers needed.
         await dispatcherControl({
           variables: { command, payload },
-          // Destructive commands require a non-empty X-MFA-Token header per
-          // the Phase 1 placeholder in `dispatcher/auth.ts`. We always send
-          // it so the destructive flow succeeds; a follow-up wires the real
-          // MFA challenge flow (#2761). Non-destructive paths omit the
-          // header to avoid any confusion if/when the backend starts
-          // distinguishing admin-with-MFA from admin.
-          context: DESTRUCTIVE_COMMANDS.has(command)
-            ? { headers: { 'X-MFA-Token': 'phase1-placeholder' } }
-            : undefined,
         });
         // Kick an immediate refetch so the page doesn't wait up to 2s for
         // the next poll to reflect the newly-written command row.
@@ -156,7 +149,13 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
   const handleControlClick = useCallback(
     (command: DispatcherCommand) => {
       setCommandError(null);
-      if (DESTRUCTIVE_COMMANDS.has(command)) {
+      // #2884: `force_stop` is the only control command that confirms
+      // via modal — it aborts in-flight work. `stop` is graceful
+      // (in-flight agent finishes its current phase) and `start` is
+      // safe, so both fire without a confirmation prompt. The whole
+      // point of the simplification is that stopping dev work should
+      // NOT be friction-heavy for the operator.
+      if (command === 'force_stop') {
         setPendingCommand(command);
         return;
       }
@@ -166,10 +165,10 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
   );
 
   /**
-   * Internal helper that actually calls `dispatcherSetConfig` with the
-   * MFA placeholder header + JSON-encoded value. Not exposed directly to
-   * `ConfigPanel` — see `handleConfigEdit` below, which interposes the
-   * "lower cap" confirm dialog.
+   * Internal helper that actually calls `dispatcherSetConfig` with a
+   * JSON-encoded value. Not exposed directly to `ConfigPanel` — see
+   * `handleConfigEdit` below, which interposes the "lower cap"
+   * confirm dialog. #2884: the MFA placeholder header was removed.
    */
   const commitConfigEdit = useCallback(
     async (key: string, value: string): Promise<void> => {
@@ -178,9 +177,6 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
       try {
         await dispatcherSetConfig({
           variables: { key, value },
-          context: {
-            headers: { 'X-MFA-Token': 'phase1-placeholder' },
-          },
         });
         await refetch();
       } catch (err) {
@@ -216,11 +212,14 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
   }, []);
 
   const handleAgentAction = useCallback(
-    (command: 'retry' | 'force_kill', agentId: string) => {
+    (command: 'retry' | 'force_stop', agentId: string) => {
       setCommandError(null);
-      if (DESTRUCTIVE_COMMANDS.has(command)) {
+      // Per-agent `force_stop` (formerly `force_kill`) still confirms —
+      // it crashes a running agent without a clean exit. `retry` is
+      // safe and fires immediately.
+      if (command === 'force_stop') {
         const confirmed = window.confirm(
-          `Force-kill agent ${agentId.slice(0, 8)}? This cannot be undone.`,
+          `Force-stop agent ${agentId.slice(0, 8)}? This cannot be undone.`,
         );
         if (!confirmed) return;
       }

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
@@ -2,9 +2,11 @@
  * Tests for the dispatcher admin dashboard (#2805).
  *
  * Focus areas:
- *   - Destructive control mutations always inject `X-MFA-Token` in the
- *     Apollo `context.headers` (#2805 §1.1 / #2803 Option A).
- *   - Config-edit mutations always inject `X-MFA-Token`.
+ *   - #2884: the three-button control surface — Start, Stop, Force
+ *     Stop. Stop is graceful (no confirm modal, fires immediately);
+ *     Force Stop pops the ConfirmDialog.
+ *   - #2884: control and config-edit mutations do NOT inject any
+ *     `X-MFA-Token` header — the MFA re-auth placeholder was removed.
  *   - Lowering `concurrency_cap` pops the ConfirmDialog before committing.
  *   - Raising `concurrency_cap` commits immediately without dialog.
  *   - State-flow two-column layout (#2823): Active → Queue-ready (left),
@@ -107,7 +109,7 @@ function renderDashboard() {
   return render(<DispatcherDashboard />);
 }
 
-describe('DispatcherDashboard — MFA header plumbing', () => {
+describe('DispatcherDashboard — #2884 simplified command surface', () => {
   beforeEach(() => {
     mockControlMutate.mockClear();
     mockSetConfigMutate.mockClear();
@@ -115,20 +117,33 @@ describe('DispatcherDashboard — MFA header plumbing', () => {
     mockQueryData = { dispatcherState: { ...BASE_STATE } };
   });
 
-  it('non-destructive commands (Pause) do NOT send X-MFA-Token', async () => {
+  it('Start fires immediately and does NOT send any context headers', async () => {
     renderDashboard();
-    fireEvent.click(screen.getByRole('button', { name: /^pause$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^start$/i }));
     await waitFor(() => {
       expect(mockControlMutate).toHaveBeenCalled();
     });
     const call = mockControlMutate.mock.calls[0][0];
-    expect(call.variables).toEqual({ command: 'pause', payload: {} });
+    expect(call.variables).toEqual({ command: 'start', payload: {} });
+    // #2884: no X-MFA-Token header — the MFA re-auth placeholder was removed.
     expect(call.context).toBeUndefined();
   });
 
-  it('destructive Stop requires confirm + sends X-MFA-Token on confirm', async () => {
+  it('Stop is graceful — fires immediately without a confirm modal (#2884)', async () => {
     renderDashboard();
-    fireEvent.click(screen.getByRole('button', { name: /force-stop/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^stop$/i }));
+    await waitFor(() => {
+      expect(mockControlMutate).toHaveBeenCalled();
+    });
+    const call = mockControlMutate.mock.calls[0][0];
+    expect(call.variables).toEqual({ command: 'stop', payload: {} });
+    // No confirm dialog and no X-MFA-Token header.
+    expect(call.context).toBeUndefined();
+  });
+
+  it('Force Stop requires confirm and fires without X-MFA-Token (#2884)', async () => {
+    renderDashboard();
+    fireEvent.click(screen.getByRole('button', { name: /force stop/i }));
     // ConfirmDialog appears — the mutation has NOT fired yet.
     expect(mockControlMutate).not.toHaveBeenCalled();
     const confirm = await screen.findByTestId('confirm-dialog-confirm');
@@ -137,21 +152,25 @@ describe('DispatcherDashboard — MFA header plumbing', () => {
       expect(mockControlMutate).toHaveBeenCalled();
     });
     const call = mockControlMutate.mock.calls[0][0];
-    expect(call.variables.command).toBe('stop');
-    expect(call.context?.headers).toEqual({ 'X-MFA-Token': 'phase1-placeholder' });
+    expect(call.variables.command).toBe('force_stop');
+    expect(call.context).toBeUndefined();
   });
 
-  it('destructive Drain (stop drain) sends X-MFA-Token on confirm', async () => {
+  it('Pause/Resume/Drain buttons no longer exist (#2884 removed)', () => {
     renderDashboard();
-    fireEvent.click(screen.getByRole('button', { name: /stop \(drain\)/i }));
-    const confirm = await screen.findByTestId('confirm-dialog-confirm');
-    fireEvent.click(confirm);
-    await waitFor(() => {
-      expect(mockControlMutate).toHaveBeenCalled();
-    });
-    const call = mockControlMutate.mock.calls[0][0];
-    expect(call.variables.command).toBe('drain');
-    expect(call.context?.headers).toEqual({ 'X-MFA-Token': 'phase1-placeholder' });
+    expect(screen.queryByRole('button', { name: /^pause$/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^resume$/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /stop \(drain\)/i })).toBeNull();
+  });
+
+  it('dispatcher-controls has exactly three buttons: Start, Stop, Force Stop (#2884 AC2)', () => {
+    renderDashboard();
+    const controls = screen.getByTestId('dispatcher-controls');
+    const buttons = controls.querySelectorAll('button');
+    expect(buttons.length).toBe(3);
+    expect(buttons[0].textContent).toMatch(/^start$/i);
+    expect(buttons[1].textContent).toMatch(/^stop$/i);
+    expect(buttons[2].textContent).toMatch(/^force stop$/i);
   });
 });
 
@@ -163,7 +182,7 @@ describe('DispatcherDashboard — config edit lifecycle', () => {
     mockQueryData = { dispatcherState: { ...BASE_STATE } };
   });
 
-  it('raising concurrency_cap commits immediately with MFA header', async () => {
+  it('raising concurrency_cap commits immediately without any context headers (#2884)', async () => {
     renderDashboard();
     const capButton = screen.getByTestId('config-value-concurrency_cap');
     fireEvent.click(capButton);
@@ -175,10 +194,11 @@ describe('DispatcherDashboard — config edit lifecycle', () => {
     });
     const call = mockSetConfigMutate.mock.calls[0][0];
     expect(call.variables).toEqual({ key: 'concurrency_cap', value: '4' });
-    expect(call.context?.headers).toEqual({ 'X-MFA-Token': 'phase1-placeholder' });
+    // #2884: no X-MFA-Token header — admin session auth is the gate.
+    expect(call.context).toBeUndefined();
   });
 
-  it('lowering concurrency_cap pops confirm dialog before committing', async () => {
+  it('lowering concurrency_cap pops confirm dialog before committing (no MFA header)', async () => {
     renderDashboard();
     const capButton = screen.getByTestId('config-value-concurrency_cap');
     fireEvent.click(capButton);
@@ -197,7 +217,8 @@ describe('DispatcherDashboard — config edit lifecycle', () => {
     });
     const call = mockSetConfigMutate.mock.calls[0][0];
     expect(call.variables).toEqual({ key: 'concurrency_cap', value: '1' });
-    expect(call.context?.headers).toEqual({ 'X-MFA-Token': 'phase1-placeholder' });
+    // #2884: no X-MFA-Token header.
+    expect(call.context).toBeUndefined();
   });
 
   it('Escape cancels an in-progress cap edit without firing the mutation', async () => {
@@ -212,7 +233,7 @@ describe('DispatcherDashboard — config edit lifecycle', () => {
     expect(mockSetConfigMutate).not.toHaveBeenCalled();
   });
 
-  it('backoff edit commits with MFA header + preserves higher attempts in array', async () => {
+  it('backoff edit commits without MFA header + preserves higher attempts in array (#2884)', async () => {
     renderDashboard();
     const backoffButton = screen.getByTestId('config-value-backoff_seconds');
     fireEvent.click(backoffButton);
@@ -226,7 +247,8 @@ describe('DispatcherDashboard — config edit lifecycle', () => {
     expect(call.variables.key).toBe('backoff_seconds');
     // First slot updated; subsequent retry delays preserved.
     expect(JSON.parse(call.variables.value)).toEqual([120, 300, 900]);
-    expect(call.context?.headers).toEqual({ 'X-MFA-Token': 'phase1-placeholder' });
+    // #2884: no X-MFA-Token header.
+    expect(call.context).toBeUndefined();
   });
 });
 

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -210,29 +210,21 @@ export interface DispatcherStateData {
   dispatcherState: DispatcherState;
 }
 
-/** Control commands accepted by `dispatcherControl`.
+/** Control commands accepted by `dispatcherControl` (#2884 simplified).
  *
- * Mirrors the `DispatcherCommand` enum in the API schema. The subset marked
- * "destructive" in the server's `DESTRUCTIVE_COMMANDS` set triggers a
- * confirmation modal in the UI before invoking the mutation.
+ * Mirrors the `DispatcherCommand` enum in the API schema. Three global
+ * commands (`start` / `stop` / `force_stop`) plus one per-agent command
+ * (`retry`). The former `pause`, `resume`, `drain`, and `force_kill`
+ * commands were removed — `stop` now carries the former `drain`
+ * semantic (graceful) and `force_stop` replaces both the former `stop`
+ * (immediate) and the per-agent `force_kill` (when `payload.agentId`
+ * is supplied).
+ *
+ * `force_stop` is the only command the admin page confirms via modal
+ * (immediate abort is destructive). `stop` is graceful — in-flight
+ * agents finish their current phase — so no confirmation is needed.
  */
-export type DispatcherCommand =
-  | 'start'
-  | 'stop'
-  | 'drain'
-  | 'pause'
-  | 'resume'
-  | 'retry'
-  | 'force_kill';
-
-/** Commands that mutate in-flight agent state. Matches the server-side
- * `DESTRUCTIVE_COMMANDS` set in `packages/api/src/graphql/dispatcher/auth.ts`.
- * The admin page always raises a confirmation modal for these. */
-export const DESTRUCTIVE_COMMANDS: ReadonlySet<DispatcherCommand> = new Set([
-  'stop',
-  'drain',
-  'force_kill',
-]);
+export type DispatcherCommand = 'start' | 'stop' | 'force_stop' | 'retry';
 
 export interface DispatcherCommandResult {
   commandId: string;

--- a/packages/web/tests/dispatcher-dashboard.test.tsx
+++ b/packages/web/tests/dispatcher-dashboard.test.tsx
@@ -255,26 +255,33 @@ describe('DispatcherDashboard', () => {
     }
   });
 
-  it('invokes dispatcherControl with "pause" when the Pause button is clicked', () => {
+  it('invokes dispatcherControl with "stop" when the Stop button is clicked (#2884 graceful)', () => {
     mockQueryResult.data = makeActiveState();
     mockQueryResult.loading = false;
     render(<DispatcherDashboard />);
-    const pauseButton = screen.getByRole('button', { name: /Pause/i });
-    fireEvent.click(pauseButton);
+    // #2884: Stop is graceful — no confirm modal, fires immediately.
+    // This is the whole point of the simplification: stopping dev
+    // work should not be friction-heavy.
+    const stopButton = screen.getByRole('button', { name: /^stop$/i });
+    fireEvent.click(stopButton);
     expect(mockMutationFn).toHaveBeenCalledTimes(1);
     expect(mockMutationFn).toHaveBeenCalledWith(
       expect.objectContaining({
-        variables: { command: 'pause', payload: {} },
+        variables: { command: 'stop', payload: {} },
       }),
     );
+    // #2884: no X-MFA-Token header — the MFA re-auth placeholder was
+    // removed. Admin session auth is the only gate.
+    const call = mockMutationFn.mock.calls[0][0];
+    expect(call.context).toBeUndefined();
   });
 
-  it('requires confirmation for destructive commands', () => {
+  it('requires confirmation for Force Stop (immediate abort, destructive)', () => {
     mockQueryResult.data = makeActiveState();
     mockQueryResult.loading = false;
     render(<DispatcherDashboard />);
-    const drainButton = screen.getByRole('button', { name: /Stop \(drain\)/i });
-    fireEvent.click(drainButton);
+    const forceStopButton = screen.getByRole('button', { name: /force stop/i });
+    fireEvent.click(forceStopButton);
     // Mutation NOT yet invoked — waiting on confirm modal.
     expect(mockMutationFn).not.toHaveBeenCalled();
     // Confirm dialog should have appeared.
@@ -282,12 +289,30 @@ describe('DispatcherDashboard', () => {
     fireEvent.click(confirmButton);
     expect(mockMutationFn).toHaveBeenCalledWith(
       expect.objectContaining({
-        variables: { command: 'drain', payload: {} },
-        context: expect.objectContaining({
-          headers: expect.objectContaining({ 'X-MFA-Token': expect.any(String) }),
-        }),
+        variables: { command: 'force_stop', payload: {} },
       }),
     );
+    // #2884: no X-MFA-Token header — even for the destructive
+    // variant. Admin session auth is sufficient; the confirm modal
+    // provides the "are you sure" friction.
+    const call = mockMutationFn.mock.calls[0][0];
+    expect(call.context).toBeUndefined();
+  });
+
+  it('renders exactly three control buttons (#2884): Start, Stop, Force Stop', () => {
+    mockQueryResult.data = makeActiveState();
+    mockQueryResult.loading = false;
+    render(<DispatcherDashboard />);
+    const controls = screen.getByTestId('dispatcher-controls');
+    const buttons = controls.querySelectorAll('button');
+    expect(buttons.length).toBe(3);
+    expect(buttons[0]).toHaveTextContent(/^start$/i);
+    expect(buttons[1]).toHaveTextContent(/^stop$/i);
+    expect(buttons[2]).toHaveTextContent(/^force stop$/i);
+    // Pause/Resume/Drain must be gone.
+    expect(screen.queryByRole('button', { name: /^pause$/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^resume$/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /stop \(drain\)/i })).toBeNull();
   });
 
   it('renders an error banner when the query errors', () => {

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -174,13 +174,23 @@ DEFAULT_AWS_REGION = "us-west-2"
 PHASE_2_REQUIRED_CONCURRENCY_CAP = 0
 
 #: Killswitch terminal phase name (#2847). When the scheduler observes
-#: ``concurrency_cap=0`` mid-orchestration, the worker thread aborts at
-#: the next phase boundary and ``_mark_agent_terminal`` is called with
+#: ``concurrency_cap=0`` mid-orchestration and the killswitch engages
+#: (not a #2884 graceful ``stop``), the worker thread aborts at the
+#: next phase boundary and ``_mark_agent_terminal`` is called with
 #: ``status='failed'`` + this phase name. The dedicated phase value
 #: distinguishes operator killswitches from real failures in retro /
 #: admin-page views and stops them from being mis-classified as
 #: tier-1/2/3 failures by the diagnoser.
 KILLSWITCH_TERMINAL_PHASE = "paused_by_killswitch"
+
+#: #2884 terminal phase name for explicit operator ``force_stop``
+#: commands. Distinct from ``paused_by_killswitch`` (which covers
+#: cap=0 observed for any reason, including a direct config edit) so
+#: the admin cockpit / retro can tell "operator fired the emergency
+#: kill button" apart from "cap observed as 0 for some other reason".
+#: Used by :meth:`DispatcherDaemon._check_killswitch_and_abort` when
+#: :attr:`DispatcherDaemon._force_stop_requested` is set.
+FORCE_STOP_TERMINAL_PHASE = "force_stopped"
 
 #: Maximum time :meth:`DispatcherDaemon.run_forever` waits for the
 #: orchestration worker thread to exit during shutdown (#2847). If the
@@ -554,6 +564,7 @@ STUCK_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
     "fix_ci": 30 * 60,  # 30 min — single /task-v2-fix-ci run
     "retro": 20 * 60,  # 20 min — single /task-v2-retro run
     "paused_by_killswitch": 60,  # 1 min — terminal phase, should be swept quickly
+    "force_stopped": 60,  # 1 min — #2884 operator force_stop terminal phase
     "daemon_restart_abandoned": 60,  # 1 min — terminal phase from restart recovery
 }
 
@@ -1052,10 +1063,11 @@ class CommandError(RuntimeError):
     """A command handler received an invalid or inapplicable payload.
 
     Raised by ``_handle_*`` methods when the command cannot be applied
-    (e.g. ``retry`` issued for an already-running agent, ``force_kill``
-    missing an ``agentId``). The caller catches this, rolls back, and
-    records a ``dispatcher.failures`` row so the command is left
-    unconsumed for visibility rather than silently discarded.
+    (e.g. ``retry`` issued for an already-running agent, a per-agent
+    ``force_stop`` naming an unknown ``agentId``). The caller catches
+    this, rolls back, and records a ``dispatcher.failures`` row so the
+    command is left unconsumed for visibility rather than silently
+    discarded.
     """
 
 
@@ -1214,6 +1226,30 @@ class DispatcherDaemon:
         self._orchestration_thread: threading.Thread | None = None
         self._orchestration_thread_lock = threading.Lock()
         self._pause_requested = threading.Event()
+        # #2884 command-taxonomy flags. In-memory only — a daemon
+        # restart loses them, which is acceptable: on restart the
+        # in-flight worker thread doesn't exist yet, so there's
+        # nothing to abort-vs-let-finish. Both flags read by
+        # ``scheduler_tick`` (to decide whether cap=0 engages the
+        # killswitch) and by ``_check_killswitch_and_abort`` (to
+        # pick the terminal phase name — ``paused_by_killswitch`` vs
+        # ``force_stopped``).
+        #
+        # ``_graceful_stop_requested`` — set by the ``stop`` handler.
+        # Tells ``scheduler_tick`` to NOT auto-set ``_pause_requested``
+        # when it observes cap==0. The in-flight worker keeps running
+        # through its current phase pipeline; new spawns are still
+        # blocked (cap=0). Cleared by the ``start`` handler and by the
+        # ``force_stop`` handler.
+        #
+        # ``_force_stop_requested`` — set by the ``force_stop``
+        # handler (global variant — no ``agentId`` in payload). Tells
+        # ``_check_killswitch_and_abort`` to mark the aborting agent
+        # with ``phase='force_stopped'`` instead of the default
+        # ``phase='paused_by_killswitch'``. Cleared by the ``start``
+        # handler.
+        self._graceful_stop_requested: bool = False
+        self._force_stop_requested: bool = False
         # Observation record: the most recent ``concurrency_cap`` value
         # read by scheduler_tick and when (monotonic seconds since
         # boot). Used by tests and by the ``daemon.scheduler_tick``
@@ -1435,27 +1471,54 @@ class DispatcherDaemon:
                 concurrency_cap = int(row[0]) if row[0] is not None else None
         self._conn.commit()
 
-        # Killswitch observation (#2847). Update the observation state
-        # and the ``_pause_requested`` event so the orchestration worker
-        # thread (if one is running) can abort at the next phase
-        # boundary within ≤60s of an operator cap=0 commit. Cap==0
-        # (killswitch) SETS the event; any positive cap value CLEARS it
-        # so a cap=0 → cap=1 flip lets a fresh orchestration proceed
+        # Killswitch observation (#2847, amended #2884). Update the
+        # observation state and the ``_pause_requested`` event so the
+        # orchestration worker thread (if one is running) can abort at
+        # the next phase boundary within ≤60s of an operator cap=0
+        # commit.
+        #
+        # #2884 amendment: when the operator issued a graceful ``stop``
+        # command (``_graceful_stop_requested`` flag set), cap==0 is
+        # observed but ``_pause_requested`` is NOT set — the in-flight
+        # worker is allowed to finish its current phase pipeline.
+        # ``force_stop`` (or any other path that sets cap=0 — e.g. a
+        # direct config edit, the circuit breaker) continues to engage
+        # the killswitch as before.
+        #
+        # Any positive cap value CLEARS ``_pause_requested`` (and the
+        # #2884 graceful-stop / force-stop flags as belt-and-braces) so
+        # a cap=0 → cap=1 flip lets a fresh orchestration proceed
         # normally on the next tick.
         self._last_cap_observed = concurrency_cap
         self._last_cap_observed_monotonic = time.monotonic()
         if concurrency_cap == 0:
-            if not self._pause_requested.is_set():
+            if self._graceful_stop_requested:
+                # Graceful stop: observe cap=0, do NOT engage the
+                # killswitch. Log a distinct event so CloudWatch can
+                # distinguish "operator asked for graceful stop" from
+                # "cap=0 engaged killswitch". Idempotent on repeated
+                # ticks — this is informational, not state.
                 self._log.info(
-                    "daemon.killswitch_engaged",
+                    "daemon.graceful_stop_in_progress",
                     extra={
-                        "event": "killswitch_engaged",
+                        "event": "graceful_stop_in_progress",
                         "run_id": self._run_id,
                         "observed_concurrency_cap": concurrency_cap,
                         "orchestration_in_flight": self._orchestration_thread_alive(),
                     },
                 )
-            self._pause_requested.set()
+            else:
+                if not self._pause_requested.is_set():
+                    self._log.info(
+                        "daemon.killswitch_engaged",
+                        extra={
+                            "event": "killswitch_engaged",
+                            "run_id": self._run_id,
+                            "observed_concurrency_cap": concurrency_cap,
+                            "orchestration_in_flight": self._orchestration_thread_alive(),
+                        },
+                    )
+                self._pause_requested.set()
         else:
             if self._pause_requested.is_set():
                 self._log.info(
@@ -1467,6 +1530,14 @@ class DispatcherDaemon:
                     },
                 )
             self._pause_requested.clear()
+            # #2884: positive cap also clears the stop-intent flags so
+            # a stale ``stop`` / ``force_stop`` from a prior cycle
+            # doesn't leak into the next one. The ``start`` handler
+            # already clears these, but an operator who sets cap back
+            # to ≥1 via a direct config edit (bypassing the ``start``
+            # command) must also get a clean slate.
+            self._graceful_stop_requested = False
+            self._force_stop_requested = False
 
         # Overnight-safety circuit breaker auto-close (#2860). When the
         # breaker previously opened it set ``cap_flipped_by='circuit_breaker'``
@@ -1638,14 +1709,14 @@ class DispatcherDaemon:
         """
         assert self._conn is not None, "connect() must run before ticks"
 
+        # #2884 simplified taxonomy: three global commands + retry.
+        # Removed: drain, pause/resume, force_kill (per-agent variant
+        # now lives as force_stop with an agentId payload).
         _HANDLERS = {
             "start": self._handle_start,
             "stop": self._handle_stop,
-            "drain": self._handle_drain,
-            "pause": self._handle_pause,
-            "resume": self._handle_resume,
+            "force_stop": self._handle_force_stop,
             "retry": self._handle_retry,
-            "force_kill": self._handle_force_kill,
         }
 
         try:
@@ -1744,12 +1815,20 @@ class DispatcherDaemon:
 
         Only applies when the current value is 0 (the killswitch state);
         if the cap is already > 0 this is a safe no-op (rowcount == 0).
+        Also clears the in-memory ``_graceful_stop_requested`` and
+        ``_force_stop_requested`` flags so a prior ``stop`` / ``force_stop``
+        does not leak into the new cycle (#2884).
         """
         cur.execute(
             "UPDATE dispatcher.config "
             "SET value = '1', updated_at = now(), updated_by = 'daemon' "
             "WHERE key = 'concurrency_cap' AND value::int = 0",
         )
+        # Clear #2884 stop-intent flags. scheduler_tick will also clear
+        # _pause_requested on the next cap>0 observation via the
+        # existing #2847 machinery — doing it here is belt-and-braces.
+        self._graceful_stop_requested = False
+        self._force_stop_requested = False
         self._log.info(
             "daemon.command_start_applied",
             extra={
@@ -1760,7 +1839,28 @@ class DispatcherDaemon:
         )
 
     def _handle_stop(self, cur: Any, payload: dict[str, Any]) -> None:
-        """Handle ``stop`` command — set ``concurrency_cap`` to 0 (killswitch)."""
+        """Handle ``stop`` command — graceful stop (#2884).
+
+        Sets ``concurrency_cap`` to 0 so no new agents spawn, and marks
+        the in-memory ``_graceful_stop_requested`` flag so the next
+        ``scheduler_tick`` does NOT engage the killswitch
+        (``_pause_requested``) on its cap=0 observation. Any in-flight
+        orchestration worker thread therefore keeps running through
+        its current phase pipeline and completes normally — graceful
+        stop = block new work but don't yank the rug from under
+        existing work.
+
+        Replaces the former ``drain`` command (same SQL, clearer
+        semantic boundary vs. ``force_stop``). Replaces the former
+        ``stop`` command (which mapped to the immediate-abort
+        semantic — that role now belongs to ``force_stop``).
+        """
+        # Set the flag BEFORE the UPDATE so there is no brief window
+        # where scheduler_tick could observe cap=0 without seeing the
+        # graceful-stop intent. Worst case: an extra scheduler_tick
+        # observes cap=0 with the flag already set, which is harmless.
+        self._graceful_stop_requested = True
+        self._force_stop_requested = False
         cur.execute(
             "UPDATE dispatcher.config "
             "SET value = '0', updated_at = now(), updated_by = 'daemon' "
@@ -1772,58 +1872,105 @@ class DispatcherDaemon:
                 "event": "command_stop_applied",
                 "run_id": self._run_id,
                 "rows_updated": cur.rowcount,
+                "mode": "graceful",
             },
         )
 
-    def _handle_drain(self, cur: Any, payload: dict[str, Any]) -> None:
-        """Handle ``drain`` command — same SQL as stop, distinct audit intent."""
+    def _handle_force_stop(self, cur: Any, payload: dict[str, Any]) -> None:
+        """Handle ``force_stop`` command (#2884).
+
+        Unified command with two behaviours, selected by payload:
+
+        - **Global (no ``agentId``)** — set ``concurrency_cap`` to 0
+          AND immediately set ``_pause_requested`` so the worker
+          thread aborts at the next phase boundary via
+          ``_check_killswitch_and_abort``. Also set
+          ``_force_stop_requested = True`` so the terminal phase is
+          marked ``force_stopped`` (distinct from the generic
+          ``paused_by_killswitch`` used when cap=0 is observed by
+          any other means, e.g. a direct config edit).
+
+        - **Per-agent (``payload['agentId']`` present)** — kill just
+          that agent: update its ``status`` to ``crashed``, set
+          ``ended_at`` to now(), and SIGKILL the pid if it is local.
+          Does NOT touch ``concurrency_cap`` or any global flag —
+          other in-flight agents and new claims are unaffected.
+          Replaces the former ``force_kill`` command.
+        """
+        agent_id = payload.get("agentId")
+
+        if agent_id:
+            # Per-agent force_stop — narrow scope, no global effects.
+            cur.execute(
+                "SELECT pid FROM dispatcher.agents WHERE agent_id = %s",
+                (agent_id,),
+            )
+            row = cur.fetchone()
+            if row is None:
+                raise CommandError(
+                    f"force_stop: agent {agent_id!r} not found in dispatcher.agents"
+                )
+            pid = int(row[0]) if row[0] is not None else None
+
+            cur.execute(
+                "UPDATE dispatcher.agents "
+                "SET status = 'crashed', ended_at = now() "
+                "WHERE agent_id = %s",
+                (agent_id,),
+            )
+
+            if pid is not None:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                    self._log.info(
+                        "daemon.force_stop_signal_sent",
+                        extra={
+                            "event": "force_stop_signal_sent",
+                            "run_id": self._run_id,
+                            "agent_id": agent_id,
+                            "pid": pid,
+                        },
+                    )
+                except ProcessLookupError:
+                    # Process already gone — not an error.
+                    pass
+                except PermissionError:
+                    # Foreign host pid — not an error either.
+                    pass
+
+            self._log.info(
+                "daemon.command_force_stop_agent_applied",
+                extra={
+                    "event": "command_force_stop_agent_applied",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "pid": pid,
+                },
+            )
+            return
+
+        # Global force_stop — cap=0 + engage killswitch immediately.
+        # Clear the graceful flag so a pending graceful stop doesn't
+        # override the force-stop intent.
+        self._graceful_stop_requested = False
+        self._force_stop_requested = True
         cur.execute(
             "UPDATE dispatcher.config "
             "SET value = '0', updated_at = now(), updated_by = 'daemon' "
             "WHERE key = 'concurrency_cap'",
         )
+        # Engage the killswitch immediately — don't wait for the next
+        # scheduler_tick to observe cap=0. The orchestration worker
+        # checks this event before each phase and aborts; see
+        # :meth:`_check_killswitch_and_abort`.
+        self._pause_requested.set()
         self._log.info(
-            "daemon.command_drain_applied",
+            "daemon.command_force_stop_applied",
             extra={
-                "event": "command_drain_applied",
+                "event": "command_force_stop_applied",
                 "run_id": self._run_id,
                 "rows_updated": cur.rowcount,
-            },
-        )
-
-    def _handle_pause(self, cur: Any, payload: dict[str, Any]) -> None:
-        """Handle ``pause`` command — UPSERT ``paused=true`` in config.
-
-        Does not change ``concurrency_cap``; the claim gate checks both
-        ``paused`` and ``concurrency_cap > 0``.
-        """
-        cur.execute(
-            "INSERT INTO dispatcher.config (key, value, updated_at, updated_by) "
-            "VALUES ('paused', 'true', now(), 'daemon') "
-            "ON CONFLICT (key) DO UPDATE "
-            "    SET value = 'true', updated_at = now(), updated_by = 'daemon'",
-        )
-        self._log.info(
-            "daemon.command_pause_applied",
-            extra={
-                "event": "command_pause_applied",
-                "run_id": self._run_id,
-            },
-        )
-
-    def _handle_resume(self, cur: Any, payload: dict[str, Any]) -> None:
-        """Handle ``resume`` command — UPSERT ``paused=false`` in config."""
-        cur.execute(
-            "INSERT INTO dispatcher.config (key, value, updated_at, updated_by) "
-            "VALUES ('paused', 'false', now(), 'daemon') "
-            "ON CONFLICT (key) DO UPDATE "
-            "    SET value = 'false', updated_at = now(), updated_by = 'daemon'",
-        )
-        self._log.info(
-            "daemon.command_resume_applied",
-            extra={
-                "event": "command_resume_applied",
-                "run_id": self._run_id,
+                "mode": "global",
             },
         )
 
@@ -1875,66 +2022,6 @@ class DispatcherDaemon:
                 "run_id": self._run_id,
                 "agent_id": agent_id,
                 "attempt": retries_used + 1,
-            },
-        )
-
-    def _handle_force_kill(self, cur: Any, payload: dict[str, Any]) -> None:
-        """Handle ``force_kill`` command — crash a running agent immediately.
-
-        Requires ``payload['agentId']``. Updates the agent row to
-        ``status='crashed'``, sets ``ended_at = now()``. If the agent's
-        ``pid`` is known and ``os.kill(pid, SIGKILL)`` succeeds on this
-        host, the process is killed; a dead or foreign-host pid is not
-        an error.
-        """
-        agent_id = payload.get("agentId")
-        if not agent_id:
-            raise CommandError("force_kill command missing required payload.agentId")
-
-        cur.execute(
-            "SELECT pid FROM dispatcher.agents WHERE agent_id = %s",
-            (agent_id,),
-        )
-        row = cur.fetchone()
-        if row is None:
-            raise CommandError(
-                f"force_kill: agent {agent_id!r} not found in dispatcher.agents"
-            )
-        pid = int(row[0]) if row[0] is not None else None
-
-        cur.execute(
-            "UPDATE dispatcher.agents "
-            "SET status = 'crashed', ended_at = now() "
-            "WHERE agent_id = %s",
-            (agent_id,),
-        )
-
-        if pid is not None:
-            try:
-                os.kill(pid, signal.SIGKILL)
-                self._log.info(
-                    "daemon.force_kill_signal_sent",
-                    extra={
-                        "event": "force_kill_signal_sent",
-                        "run_id": self._run_id,
-                        "agent_id": agent_id,
-                        "pid": pid,
-                    },
-                )
-            except ProcessLookupError:
-                # Process already gone — not an error.
-                pass
-            except PermissionError:
-                # Foreign host pid — not an error either.
-                pass
-
-        self._log.info(
-            "daemon.command_force_kill_applied",
-            extra={
-                "event": "command_force_kill_applied",
-                "run_id": self._run_id,
-                "agent_id": agent_id,
-                "pid": pid,
             },
         )
 
@@ -4399,6 +4486,17 @@ class DispatcherDaemon:
         if not self._pause_requested.is_set():
             return False
 
+        # #2884: pick the terminal phase name based on how the
+        # killswitch was engaged. An explicit ``force_stop`` command
+        # marks the agent ``phase='force_stopped'`` so the admin
+        # cockpit / retro can distinguish it from a generic cap=0
+        # observation (config edit, circuit breaker, etc.) which
+        # marks the agent ``phase='paused_by_killswitch'``.
+        terminal_phase = (
+            FORCE_STOP_TERMINAL_PHASE
+            if self._force_stop_requested
+            else KILLSWITCH_TERMINAL_PHASE
+        )
         self._log.info(
             "daemon.orchestration_paused",
             extra={
@@ -4406,6 +4504,7 @@ class DispatcherDaemon:
                 "run_id": self._run_id,
                 "agent_id": agent_id,
                 "after_phase": after_phase,
+                "terminal_phase": terminal_phase,
                 "detail": (
                     "concurrency_cap observed as 0 mid-pipeline; aborting "
                     "before next phase to honor operator killswitch"
@@ -4415,7 +4514,7 @@ class DispatcherDaemon:
         self._mark_agent_terminal(
             agent_id,
             status="failed",
-            phase=KILLSWITCH_TERMINAL_PHASE,
+            phase=terminal_phase,
             exit_code=None,
             issue_number=issue_number,
         )

--- a/scripts/dispatcher/tests/test_daemon_commands.py
+++ b/scripts/dispatcher/tests/test_daemon_commands.py
@@ -1,12 +1,22 @@
-"""Unit tests for the daemon-side command handlers (issue #2801).
+"""Unit tests for the daemon-side command handlers.
+
+Originally landed with issue #2801 covering six commands
+(start/stop/drain/pause/resume/retry/force_kill); revised for issue
+#2884 which simplified the command surface to four
+(start/stop/force_stop/retry) and removed the MFA re-auth gate.
 
 Covers:
   - _consume_commands: marks consumed_at after handler, leaves unconsumed on error
-  - _handle_start / stop / drain
-  - _handle_pause / resume
+  - _handle_start — flips cap 0→1, clears #2884 stop-intent flags
+  - _handle_stop — graceful: sets flag, UPDATEs cap=0, does NOT engage killswitch
+  - _handle_force_stop — global: cap=0 + _pause_requested.set() + phase=force_stopped
+  - _handle_force_stop — per-agent (payload.agentId): kill agent, no global side-effects
   - _handle_retry (valid + invalid state)
-  - _handle_force_kill (valid + missing agentId)
-  - Claim gate respects dispatcher.config.paused
+  - scheduler_tick respects _graceful_stop_requested (does NOT set _pause_requested)
+  - scheduler_tick cap>0 clears both stop-intent flags
+  - _check_killswitch_and_abort picks force_stopped vs paused_by_killswitch terminal phase
+  - Claim gate still respects dispatcher.config.paused (legacy _is_paused, not written
+    by any handler any more; kept as a manual escape hatch for operators)
 """
 
 from __future__ import annotations
@@ -138,7 +148,7 @@ def _command_row(
 
 
 class TestHandleStart:
-    """_handle_start flips concurrency_cap from 0 to 1."""
+    """_handle_start flips concurrency_cap from 0 to 1 and clears stop-intent flags."""
 
     def test_start_flips_cap_when_zero(self) -> None:
         d, conn, handler = _make_daemon_with_capture()
@@ -189,14 +199,26 @@ class TestHandleStart:
         ]
         assert len(consumed_updates) == 1
 
+    def test_start_clears_graceful_and_force_stop_flags(self) -> None:
+        """#2884: start clears any prior stop-intent flags."""
+        d, conn, _handler = _make_daemon_with_capture()
+        d._graceful_stop_requested = True
+        d._force_stop_requested = True
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "start")]]
+
+        d._consume_commands()
+
+        assert d._graceful_stop_requested is False
+        assert d._force_stop_requested is False
+
 
 # --------------------------------------------------------------------------
-# _handle_stop / _handle_drain
+# _handle_stop — #2884 graceful semantic
 # --------------------------------------------------------------------------
 
 
-class TestHandleStopAndDrain:
-    """stop and drain both set concurrency_cap to 0."""
+class TestHandleStop:
+    """stop is graceful: cap=0, set flag, do NOT engage killswitch."""
 
     def test_stop_sets_cap_zero(self) -> None:
         d, conn, _handler = _make_daemon_with_capture()
@@ -214,9 +236,56 @@ class TestHandleStopAndDrain:
         ]
         assert len(updates) == 1
 
-    def test_drain_sets_cap_zero(self) -> None:
+    def test_stop_sets_graceful_flag(self) -> None:
+        """#2884 AC3: stop lets in-flight finish — scheduler_tick will not
+        engage the killswitch because _graceful_stop_requested is True."""
         d, conn, _handler = _make_daemon_with_capture()
-        conn.cursor_instance.fetchall_queue = [[_command_row(1, "drain")]]
+        assert d._graceful_stop_requested is False
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "stop")]]
+
+        d._consume_commands()
+
+        assert d._graceful_stop_requested is True
+        # And stop does NOT set _pause_requested directly; scheduler_tick
+        # is the only place that touches it.
+        assert d._pause_requested.is_set() is False
+
+    def test_stop_clears_force_stop_flag(self) -> None:
+        """If a prior force_stop left _force_stop_requested set and the
+        operator now re-issues a graceful stop, clear it so the aborting
+        agent does not get mis-tagged as force_stopped on the next phase
+        boundary."""
+        d, conn, _handler = _make_daemon_with_capture()
+        d._force_stop_requested = True
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "stop")]]
+
+        d._consume_commands()
+
+        assert d._force_stop_requested is False
+
+    def test_stop_logs_mode_graceful(self) -> None:
+        """Log event contains ``mode=graceful`` for CloudWatch filtering."""
+        d, conn, handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "stop")]]
+
+        d._consume_commands()
+
+        events = handler.events("command_stop_applied")
+        assert len(events) == 1
+        assert getattr(events[0], "mode", None) == "graceful"
+
+
+# --------------------------------------------------------------------------
+# _handle_force_stop — #2884 global variant (no agentId)
+# --------------------------------------------------------------------------
+
+
+class TestHandleForceStopGlobal:
+    """force_stop with no agentId: cap=0 + engage killswitch immediately."""
+
+    def test_force_stop_sets_cap_zero(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "force_stop")]]
 
         count = d._consume_commands()
 
@@ -230,49 +299,175 @@ class TestHandleStopAndDrain:
         ]
         assert len(updates) == 1
 
-
-# --------------------------------------------------------------------------
-# _handle_pause / _handle_resume
-# --------------------------------------------------------------------------
-
-
-class TestHandlePauseResume:
-    """pause and resume UPSERT the paused config key."""
-
-    def test_pause_upserts_paused_true(self) -> None:
+    def test_force_stop_engages_killswitch_immediately(self) -> None:
+        """#2884 AC4: force_stop aborts in-flight at next phase boundary.
+        The handler must set _pause_requested itself rather than waiting
+        for the next scheduler_tick — the worker thread may check the
+        event at any time."""
         d, conn, _handler = _make_daemon_with_capture()
-        conn.cursor_instance.fetchall_queue = [[_command_row(1, "pause")]]
+        assert d._pause_requested.is_set() is False
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "force_stop")]]
+
+        d._consume_commands()
+
+        assert d._pause_requested.is_set() is True
+
+    def test_force_stop_sets_force_stop_flag(self) -> None:
+        """_force_stop_requested True tells _check_killswitch_and_abort
+        to use the force_stopped terminal phase name."""
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "force_stop")]]
+
+        d._consume_commands()
+
+        assert d._force_stop_requested is True
+
+    def test_force_stop_clears_graceful_flag(self) -> None:
+        """A pending graceful stop is overridden by force_stop."""
+        d, conn, _handler = _make_daemon_with_capture()
+        d._graceful_stop_requested = True
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "force_stop")]]
+
+        d._consume_commands()
+
+        assert d._graceful_stop_requested is False
+
+    def test_force_stop_logs_mode_global(self) -> None:
+        d, conn, handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, "force_stop")]]
+
+        d._consume_commands()
+
+        events = handler.events("command_force_stop_applied")
+        assert len(events) == 1
+        assert getattr(events[0], "mode", None) == "global"
+
+
+# --------------------------------------------------------------------------
+# _handle_force_stop — #2884 per-agent variant (payload.agentId)
+# --------------------------------------------------------------------------
+
+
+class TestHandleForceStopPerAgent:
+    """force_stop with agentId: kill that agent, no global side-effects."""
+
+    def test_force_stop_agent_transitions_to_crashed(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        agent_id = str(uuid.uuid4())
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "force_stop", {"agentId": agent_id})]
+        ]
+        # SELECT returns pid=None (no live pid to kill).
+        conn.cursor_instance.fetch_queue = [(None,)]
 
         count = d._consume_commands()
 
         assert count == 1
-        upserts = [
+        updates = [
             e
             for e in conn.cursor_instance.executed
-            if "INSERT INTO dispatcher.config" in e[0]
-            and "'paused'" in e[0]
-            and "'true'" in e[0]
+            if "UPDATE dispatcher.agents" in e[0] and "'crashed'" in e[0]
         ]
-        assert len(upserts) == 1
-        # ON CONFLICT clause present.
-        assert "ON CONFLICT" in upserts[0][0]
+        assert len(updates) == 1
 
-    def test_resume_upserts_paused_false(self) -> None:
+    def test_force_stop_agent_does_not_touch_concurrency_cap(self) -> None:
+        """Per-agent kill has narrow scope — other in-flight agents and
+        new claims are unaffected."""
         d, conn, _handler = _make_daemon_with_capture()
-        conn.cursor_instance.fetchall_queue = [[_command_row(1, "resume")]]
+        agent_id = str(uuid.uuid4())
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "force_stop", {"agentId": agent_id})]
+        ]
+        conn.cursor_instance.fetch_queue = [(None,)]
+
+        d._consume_commands()
+
+        cap_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0] and "concurrency_cap" in e[0]
+        ]
+        assert cap_updates == []
+
+    def test_force_stop_agent_does_not_engage_global_killswitch(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        agent_id = str(uuid.uuid4())
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "force_stop", {"agentId": agent_id})]
+        ]
+        conn.cursor_instance.fetch_queue = [(None,)]
+
+        d._consume_commands()
+
+        assert d._pause_requested.is_set() is False
+        assert d._force_stop_requested is False
+
+    def test_force_stop_agent_missing_in_db_writes_failure(self) -> None:
+        """Unknown agentId → CommandError → failures row, command stays unconsumed."""
+        d, conn, _handler = _make_daemon_with_capture()
+        agent_id = str(uuid.uuid4())
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "force_stop", {"agentId": agent_id})]
+        ]
+        conn.cursor_instance.fetch_queue = [None]  # SELECT returns no row
 
         count = d._consume_commands()
 
-        assert count == 1
-        upserts = [
+        assert count == 0
+        assert conn.rollbacks >= 1
+        failure_inserts = [
             e
             for e in conn.cursor_instance.executed
-            if "INSERT INTO dispatcher.config" in e[0]
-            and "'paused'" in e[0]
-            and "'false'" in e[0]
+            if "INSERT INTO dispatcher.failures" in e[0]
         ]
-        assert len(upserts) == 1
-        assert "ON CONFLICT" in upserts[0][0]
+        assert len(failure_inserts) == 1
+        _sql, params = failure_inserts[0]
+        assert params[1] == "invalid_command"
+
+    def test_force_stop_agent_logs_per_agent_event(self) -> None:
+        """Per-agent and global variants emit distinct log events so
+        CloudWatch filtering can distinguish them."""
+        d, conn, handler = _make_daemon_with_capture()
+        agent_id = str(uuid.uuid4())
+        conn.cursor_instance.fetchall_queue = [
+            [_command_row(1, "force_stop", {"agentId": agent_id})]
+        ]
+        conn.cursor_instance.fetch_queue = [(None,)]
+
+        d._consume_commands()
+
+        assert handler.events("command_force_stop_agent_applied") != []
+        assert handler.events("command_force_stop_applied") == []
+
+
+# --------------------------------------------------------------------------
+# Removed handlers — regression guard (#2884)
+# --------------------------------------------------------------------------
+
+
+class TestRemovedCommandsRaiseInvalidCommand:
+    """Old command names are no longer registered; _consume_commands
+    raises CommandError → failures row with category='invalid_command'."""
+
+    @pytest.mark.parametrize(
+        "removed_command", ["drain", "pause", "resume", "force_kill"]
+    )
+    def test_removed_command_produces_failure(self, removed_command: str) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        conn.cursor_instance.fetchall_queue = [[_command_row(1, removed_command)]]
+
+        count = d._consume_commands()
+
+        # Not consumed — CommandError rolled back.
+        assert count == 0
+        failure_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert len(failure_inserts) == 1
+        _sql, params = failure_inserts[0]
+        assert params[1] == "invalid_command"
 
 
 # --------------------------------------------------------------------------
@@ -329,54 +524,6 @@ class TestHandleRetry:
         assert count == 0
         assert conn.rollbacks >= 1
         # failures row inserted for invalid_command.
-        failure_inserts = [
-            e
-            for e in conn.cursor_instance.executed
-            if "INSERT INTO dispatcher.failures" in e[0]
-        ]
-        assert len(failure_inserts) == 1
-        _sql, params = failure_inserts[0]
-        assert params[1] == "invalid_command"
-
-
-# --------------------------------------------------------------------------
-# _handle_force_kill
-# --------------------------------------------------------------------------
-
-
-class TestHandleForceKill:
-    """force_kill transitions an agent to crashed."""
-
-    def test_force_kill_transitions_agent_to_crashed(self) -> None:
-        d, conn, _handler = _make_daemon_with_capture()
-        agent_id = str(uuid.uuid4())
-        conn.cursor_instance.fetchall_queue = [
-            [_command_row(1, "force_kill", {"agentId": agent_id})]
-        ]
-        # SELECT returns pid=None (no live pid to kill).
-        conn.cursor_instance.fetch_queue = [(None,)]
-
-        count = d._consume_commands()
-
-        assert count == 1
-        updates = [
-            e
-            for e in conn.cursor_instance.executed
-            if "UPDATE dispatcher.agents" in e[0] and "'crashed'" in e[0]
-        ]
-        assert len(updates) == 1
-
-    def test_force_kill_missing_agent_id_writes_failure(self) -> None:
-        """force_kill with no agentId raises CommandError → failures row."""
-        d, conn, _handler = _make_daemon_with_capture()
-        conn.cursor_instance.fetchall_queue = [
-            [_command_row(1, "force_kill", {})]  # no agentId
-        ]
-
-        count = d._consume_commands()
-
-        assert count == 0
-        assert conn.rollbacks >= 1
         failure_inserts = [
             e
             for e in conn.cursor_instance.executed
@@ -453,15 +600,141 @@ class TestConsumeCommands:
 
 
 # --------------------------------------------------------------------------
-# Claim gate respects paused config key
+# scheduler_tick graceful-stop behaviour (#2884)
 # --------------------------------------------------------------------------
 
 
-class TestClaimGateRespectsPausedKey:
-    """Claim gate blocks orchestration when dispatcher.config.paused = true."""
+class TestSchedulerTickGracefulStop:
+    """scheduler_tick observes cap=0 but respects _graceful_stop_requested."""
+
+    def test_graceful_stop_cap_zero_does_not_engage_killswitch(self) -> None:
+        """AC3: stop finishes in-flight agent then sets cap=0.
+        The flag (set by _handle_stop) tells scheduler_tick to NOT set
+        _pause_requested, so the in-flight worker keeps running."""
+        d, conn, handler = _make_daemon_with_capture()
+        d._graceful_stop_requested = True
+        # SELECTs in scheduler_tick cap==0 branch:
+        #   1. concurrency_cap = 0
+        conn.cursor_instance.fetch_queue = [(0,)]
+        d._consume_commands = lambda: 0  # type: ignore[method-assign]
+
+        d.scheduler_tick()
+
+        assert d._pause_requested.is_set() is False
+        # Distinct log event so CloudWatch can see graceful-stop ticks.
+        assert handler.events("graceful_stop_in_progress") != []
+        assert handler.events("killswitch_engaged") == []
+
+    def test_force_stop_path_engages_killswitch(self) -> None:
+        """When NOT in graceful-stop mode, cap=0 still engages the
+        killswitch — this is the default #2847 behaviour for config
+        edits / circuit-breaker / force_stop."""
+        d, conn, handler = _make_daemon_with_capture()
+        assert d._graceful_stop_requested is False
+        conn.cursor_instance.fetch_queue = [(0,)]
+        d._consume_commands = lambda: 0  # type: ignore[method-assign]
+
+        d.scheduler_tick()
+
+        assert d._pause_requested.is_set() is True
+        assert handler.events("killswitch_engaged") != []
+        assert handler.events("graceful_stop_in_progress") == []
+
+    def test_cap_positive_clears_stop_intent_flags(self) -> None:
+        """An operator who sets cap back to ≥1 via a direct config
+        edit (bypassing the start command) still gets a clean slate."""
+        d, conn, _handler = _make_daemon_with_capture()
+        d._graceful_stop_requested = True
+        d._force_stop_requested = True
+        d._pause_requested.set()
+        # SELECTs (scheduler_tick cap>0 branch):
+        #   1. concurrency_cap = 1
+        #   2. cap_flipped_by = None (overnight CB auto-close; no-op)
+        #   3. _is_paused = None (not paused)
+        #   4. _has_active_agent COUNT = None
+        conn.cursor_instance.fetch_queue = [(1,), None, None, None]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            return_value=False,
+        )
+        d._consume_commands = lambda: 0  # type: ignore[method-assign]
+
+        d.scheduler_tick()
+
+        assert d._graceful_stop_requested is False
+        assert d._force_stop_requested is False
+        assert d._pause_requested.is_set() is False
+
+
+# --------------------------------------------------------------------------
+# _check_killswitch_and_abort picks the terminal phase name (#2884)
+# --------------------------------------------------------------------------
+
+
+class TestCheckKillswitchTerminalPhase:
+    """_check_killswitch_and_abort distinguishes force_stopped vs
+    paused_by_killswitch based on _force_stop_requested."""
+
+    def test_default_terminal_phase_is_paused_by_killswitch(self) -> None:
+        d, conn, handler = _make_daemon_with_capture()
+        d._pause_requested.set()
+        assert d._force_stop_requested is False
+        # _observe_external_terminal → SELECT returns None (no terminal)
+        conn.cursor_instance.fetch_queue = [None]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+
+        aborted = d._check_killswitch_and_abort("agent-xyz", "plan")
+
+        assert aborted is True
+        d._mark_agent_terminal.assert_called_once()  # type: ignore[attr-defined]
+        _args, kwargs = d._mark_agent_terminal.call_args  # type: ignore[attr-defined]
+        assert kwargs["phase"] == daemon.KILLSWITCH_TERMINAL_PHASE
+        assert kwargs["phase"] == "paused_by_killswitch"
+
+    def test_force_stop_terminal_phase_is_force_stopped(self) -> None:
+        """#2884 AC4: force_stop marks aborting agent phase=force_stopped."""
+        d, conn, handler = _make_daemon_with_capture()
+        d._pause_requested.set()
+        d._force_stop_requested = True
+        # _observe_external_terminal → SELECT returns None (no external terminal)
+        conn.cursor_instance.fetch_queue = [None]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+
+        aborted = d._check_killswitch_and_abort("agent-xyz", "plan")
+
+        assert aborted is True
+        d._mark_agent_terminal.assert_called_once()  # type: ignore[attr-defined]
+        _args, kwargs = d._mark_agent_terminal.call_args  # type: ignore[attr-defined]
+        assert kwargs["phase"] == daemon.FORCE_STOP_TERMINAL_PHASE
+        assert kwargs["phase"] == "force_stopped"
+
+    def test_no_killswitch_no_abort(self) -> None:
+        d, conn, _handler = _make_daemon_with_capture()
+        assert d._pause_requested.is_set() is False
+        # _observe_external_terminal → SELECT returns None (no terminal)
+        conn.cursor_instance.fetch_queue = [None]
+
+        aborted = d._check_killswitch_and_abort("agent-xyz", "plan")
+
+        assert aborted is False
+
+
+# --------------------------------------------------------------------------
+# Claim gate legacy paused key (kept as manual escape hatch — #2884)
+# --------------------------------------------------------------------------
+
+
+class TestClaimGateLegacyPausedKey:
+    """The ``dispatcher.config.paused`` key is no longer written by any
+    command handler (pause/resume were removed in #2884), but
+    ``_is_paused()`` is retained as a manual operator escape hatch —
+    a direct ``INSERT INTO dispatcher.config ('paused', 'true', ...)``
+    from dev-db-query still blocks new claims. These tests verify that
+    escape hatch still works."""
 
     def test_claim_gate_respects_paused_key(self) -> None:
-        """When paused=true, orchestration must not fire even if cap > 0."""
+        """When paused=true (manually inserted), orchestration must not
+        fire even if cap > 0."""
         d, conn, handler = _make_daemon_with_capture()
         # SELECTs (in scheduler_tick order, cap>0 branch):
         #   1. concurrency_cap = 1 (gate would normally proceed)
@@ -495,6 +768,6 @@ class TestClaimGateRespectsPausedKey:
         )
         d._consume_commands = lambda: 0  # type: ignore[method-assign]
 
-        summary = d.scheduler_tick()
+        d.scheduler_tick()
 
         assert d._maybe_spawn_orchestration_thread.call_count == 1  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Two coupled admin-UX fixes shipped together. Removes the placeholder MFA
re-auth gate entirely (it accepted any non-empty `X-MFA-Token` header —
zero real safety, pure friction) and simplifies the dispatcher command
surface from six to three global commands: `start` / `stop` /
`force_stop`. `stop` is now graceful (in-flight agent finishes its
current phase pipeline); `force_stop` is immediate; per-agent kill
folds into `force_stop` with a `payload.agentId`.

Closes #2884

## Background

During a 2026-04-20 incident the operator tried to stop a runaway
pipeline, hit the placeholder reauth prompt, and the reauth failed —
the pipeline kept burning cost for another ~2 hours before `pause`
(non-destructive, no reauth) finally halted it. The operator's words:

> "the spec is dumb and incorrect here. it's not actually destructive
> to stop doing dev work" + "get rid of pause/resume. start and two
> flavors of stop is enough."

## What changed

### API
- `auth.ts` — deleted `DESTRUCTIVE_COMMANDS`.
- `resolvers.ts` — removed `mfaToken` from context and both
  `MFA_REQUIRED` throws. `requireDispatcherAdmin(user)` remains.
- `schema.ts` — `DispatcherCommand` enum reduced to four values:
  `start | stop | force_stop | retry`. Enum member docstrings + both
  mutation docstrings rewritten.
- `app.ts` — deleted `x-mfa-token` header parsing.
- Global `Context` interface — deleted `mfaToken: string | null`.
- `dispatcher.integration.test.ts` — replaced MFA-specific tests with
  three regression guards ("X succeeds without any MFA header").

### Web
- `dispatcher-queries.ts` — deleted `DESTRUCTIVE_COMMANDS`; narrowed
  `DispatcherCommand` union.
- `DispatcherControls.tsx` — exactly three buttons (Start, Stop, Force
  Stop). Stop fires immediately with no confirm modal; Force Stop
  confirms via `ConfirmDialog`.
- `DispatcherDashboard.tsx` — stopped sending `X-MFA-Token` context on
  any mutation. Confirm-dialog gate is now the narrow
  `command === 'force_stop'`, not a set-membership check.
- `ConfirmDialog.tsx` — DESCRIPTIONS map narrowed to `force_stop` only.
- `ActiveAgentsTable.tsx` — per-agent kill button writes `force_stop`
  with `agentId` payload instead of `force_kill`.
- `ConfigPanel.tsx` — updated docstring (no more `MFA_REQUIRED` mention).
- Two test files updated with new regression guards.

### Daemon (scripts/dispatcher/daemon.py)
- `_HANDLERS` dict: removed `drain`, `pause`, `resume`, `force_kill`;
  added `force_stop`.
- Deleted `_handle_drain`, `_handle_pause`, `_handle_resume`,
  `_handle_force_kill`.
- New `_handle_stop` — graceful: sets
  `self._graceful_stop_requested = True` then `UPDATE cap=0`. Does NOT
  touch `_pause_requested`.
- New `_handle_force_stop` — global variant (no agentId): `cap=0` +
  `_pause_requested.set()` + `_force_stop_requested = True`. Per-agent
  variant (agentId present): kill that agent's pid, no global side
  effects (fold-in of former `force_kill`).
- `_handle_start` — also clears both stop-intent flags.
- `scheduler_tick`'s cap==0 branch now respects
  `_graceful_stop_requested` (emits a new `graceful_stop_in_progress`
  log event instead of engaging the killswitch).
- `_check_killswitch_and_abort` — picks `FORCE_STOP_TERMINAL_PHASE =
  "force_stopped"` when `_force_stop_requested` is set, falling back
  to existing `KILLSWITCH_TERMINAL_PHASE = "paused_by_killswitch"` for
  generic cap=0 observations (config edits / circuit breaker).
- Added `force_stopped` to `STUCK_TIMEOUT_SECONDS_BY_PHASE`.

### Tests
- `test_daemon_commands.py` — full rewrite; 34 tests cover the new
  handler suite plus a parametrized regression guard for the removed
  command names (`drain | pause | resume | force_kill` all produce
  `invalid_command` failure rows).

### Docs
- `dispatcher-v2-spec.md` §11 Controls rewritten (three buttons); §17
  Risk 6 marked superseded with rationale.

## Scope notes

- **`_is_paused()` retained as dead-code-adjacent escape hatch.** The
  `pause` / `resume` commands that wrote `dispatcher.config.paused` are
  gone, but removing `_is_paused()` would require updating fetch_queue
  stubs in 3+ unrelated test files (phase3a, killswitch, commands).
  It's a no-op in production now; an operator can still manually
  `INSERT INTO dispatcher.config ('paused', 'true', ...)` via
  `dev-db-query` as a last-ditch manual halt.
- **No DB migration.** `dispatcher.commands.command` is plain text; old
  rows have `consumed_at` set and won't replay. Edge-case manual
  insertion of an old name produces an `invalid_command` failure row.
- **No backward-compat aliases** — we control the only writer (admin
  page) and ship both changes together.

## Test plan

### Automated checks
- [x] Lint passes — `npm --prefix packages/api run lint` (ESLint clean),
      `npm --prefix packages/web run lint` (no warnings).
- [x] Format check — no repo-level format script; `ruff format --check`
      on `scripts/dispatcher/` passes.
- [x] Tests pass locally — 604 Python tests (full dispatcher suite,
      including killswitch / restart_cascade / phase3a regressions);
      407 API tests (including dispatcher integration); 1253 web tests.
- [x] Typecheck — `tsc --noEmit` clean on both api and web.
- [x] Build — `tsc` + `next build` both succeed.
- [x] CI green (53 SUCCESS / 28 SKIPPED / 0 FAILED; mergeable=CLEAN)

### Post-deploy verification
- [ ] Click each admin button on `dev.judgemind.org/admin/dispatcher`
      (Start, Stop, Force Stop); confirm three buttons only. Screenshot
      attached to verification comment. **Awaits human operator —
      autonomous agent cannot simulate an admin browser session.**
- [ ] `scripts/dev-db-query.sh` against
      `SELECT command, issued_by, issued_at FROM dispatcher.commands
      ORDER BY issued_at DESC LIMIT 10;` shows the expected `start` /
      `stop` / `force_stop` rows with the admin email as `issued_by`.
      **Awaits human operator button clicks.**
- [ ] CloudWatch Insights query against
      `/ecs/judgemind-dispatcher-dev` shows
      `command_start_applied` / `command_stop_applied` /
      `command_force_stop_applied` events matching the clicks.
      **Awaits human operator button clicks.**
- [x] Deploy-health verification (CloudWatch scheduler_tick cadence,
      ECS rollout-complete on new task-def, dev page returns 200,
      `dispatcher.commands` table intact).
- [x] Verification evidence posted on issue (A.8 contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
