### PR TITLE
fix(dispatcher): task_claim UUID mismatch + ECS-trailer parse (#2892)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -165,16 +165,24 @@ Once MCP writes are unblocked (follow-up issue referenced from `docs/agent/gh-to
 Run the helper (stays in the foreground — use `timeout: 1200000` since the ECS-Exec code path takes 2-4 s per call):
 
 ```
-scripts/dispatcher/task_claim.py claim \
+python3 {worktree}/scripts/dispatcher/task_claim.py claim \
     --issue <N> \
-    --agent-id <agent-id> \
     --worktree-path {worktree}
 ```
 
-The `<agent-id>` must be the id derived from the worktree directory name (e.g. `agent-a56f2e57`). Exit codes:
+The helper **generates a fresh UUID for you** and writes it to `{worktree}/.task-agent-id` (the "sidecar") so the later `terminal` call can recover it without the caller threading state through the rest of the /task flow. The JSON emitted on stdout includes the UUID:
+
+```
+{"status": "claimed", "issue_number": 2866, "agent_id": "aabbccdd-eeff-..."}
+```
+
+**Do NOT pass `--agent-id` with the short worktree suffix** (e.g. `agent-a56f2e57`). The DB column is `uuid` — non-UUID values fail the INSERT with `invalid input syntax for type uuid`. Issue #2892 was the bug. The helper's own `uuid4()` is the right shape; let it do the work.
+
+Exit codes:
 
 - **`0`** — claim row inserted successfully. Continue to Part B.
 - **`2`** — **claim lost to a prior owner.** The helper printed a JSON payload on stdout with `owner_kind` (either `task` for the Fargate daemon or `task-skill` for another /task subagent) and `owner_agent_id`. Do **not** proceed — another worker owns this issue right now. Print the payload and stop. The operator will see the message and either wait for the other agent or cancel it.
+- **`3`** — **configuration error.** The caller handed the helper something the DB rejected at the column-type level (e.g. a non-UUID explicit `--agent-id`). This is a bug in the /task skill or an override the operator supplied by hand. Surface the stderr and stop — retrying with the same args will fail again.
 - **`1`** — unexpected error (DB down, dev-db-query.sh missing, auth problem). Surface the stderr message and stop.
 
 The helper uses `DATABASE_URL` when set (Fargate /task paths) and falls back to `scripts/dev-db-query.sh --rw` (laptop /task paths). Both shells write the same `kind='task-skill'` + `status='running'` row.
@@ -192,13 +200,15 @@ Idempotent — `gh` ignores the request if the label is already present.
 **MANDATORY teardown on terminal.** On any terminal state (PR merged, verification passed, blocker, investigation closed), run:
 
 ```
-scripts/dispatcher/task_claim.py terminal \
-    --agent-id <agent-id> \
+python3 {worktree}/scripts/dispatcher/task_claim.py terminal \
+    --worktree-path {worktree} \
     --status <succeeded|failed> \
     [--pr-number <N>]
 
 gh issue edit <N> --repo judgemind/judgemind --remove-label status/in-progress
 ```
+
+The helper reads the agent's UUID from `{worktree}/.task-agent-id` (written by `claim`), so you don't need to remember or pass it. If the sidecar is missing you can still pass `--agent-id <uuid>` explicitly — but in the normal /task flow, `--worktree-path` is all you need.
 
 Terminal status values:
 - `succeeded` — PR merged + deploy verified + evidence comment posted (normal success path).
@@ -309,10 +319,10 @@ Skip this for Terraform-only or docs-only tasks.
 - **For ingestion/extraction pipeline tasks** (scraper changes, LLM prompt changes, enrichment logic): use the local dev stack to iterate. The local DB + S3 cache enables fast iteration without deploying to dev. Run `scripts/rebuild_db.sh --skip-reset` to re-process documents through the pipeline and verify data correctness against source documents. See `docs/agent/local-dev.md`. **Prioritize correctness over completeness** — verify that extracted fields match the source document, not just that fields are populated.
 - If `/ralph` exits with a blocker (STUCK or max iterations), the issue has already been commented on and blocked (via `scripts/block-issue.sh` or `status/blocked` label). Before stopping, **release the claim interlock** (issue #2866) so the issue isn't permanently hidden from future agents:
   ```
-  scripts/dispatcher/task_claim.py terminal --agent-id <agent-id> --status failed
+  python3 {worktree}/scripts/dispatcher/task_claim.py terminal --worktree-path {worktree} --status failed
   gh issue edit <N> --repo judgemind/judgemind --remove-label status/in-progress
   ```
-  Then stop — the worktree will be cleaned up automatically by Claude Code (if spawned with `isolation: "worktree"`) or by the dispatcher.
+  The helper reads the agent's UUID from `{worktree}/.task-agent-id` (written by `claim` in Step 2a). Then stop — the worktree will be cleaned up automatically by Claude Code (if spawned with `isolation: "worktree"`) or by the dispatcher.
 
 **POST-RALPH CHECKPOINT — Do not skip this.** After `/ralph` returns:
 1. Read `{worktree}/tmp/ralph/ralph-done.txt` to confirm ralph completed with SHIP status.
@@ -491,15 +501,15 @@ gh pr merge <PR-N> --repo judgemind/judgemind --squash --delete-branch
 **Record terminal status in the `dispatcher.agents` ledger (issue #2866).** The claim row inserted in Step 2a must be closed out so the next /task or daemon claim on this issue can acquire the partial-UNIQUE-INDEX slot. Run this *before* A.8 deploy-watch so the slot releases promptly even if deploy verification drags:
 
 ```
-scripts/dispatcher/task_claim.py terminal \
-    --agent-id <agent-id> \
+python3 {worktree}/scripts/dispatcher/task_claim.py terminal \
+    --worktree-path {worktree} \
     --status succeeded \
     --pr-number <PR-N>
 
 gh issue edit <N> --repo judgemind/judgemind --remove-label status/in-progress
 ```
 
-Best-effort — both commands exit 0 on no-op (row already terminal, label already absent). A failure here is logged but does not block A.8.
+The helper reads the agent's UUID from `{worktree}/.task-agent-id` (written by `claim` in Step 2a). Best-effort — both commands exit 0 on no-op (row already terminal, label already absent). A failure here is logged but does not block A.8.
 
 #### A.8 — Verify deployment and post evidence (MANDATORY)
 Write status: `phase: deploying`, `summary: Watching deploy pipeline for <workflow>`.
@@ -688,14 +698,14 @@ gh issue close <N> --repo judgemind/judgemind --reason completed
 **Record terminal status in the `dispatcher.agents` ledger (issue #2866).** The claim row inserted in Step 2a must be released so a future investigation or follow-up /task on this issue can acquire the partial-UNIQUE-INDEX slot:
 
 ```
-scripts/dispatcher/task_claim.py terminal \
-    --agent-id <agent-id> \
+python3 {worktree}/scripts/dispatcher/task_claim.py terminal \
+    --worktree-path {worktree} \
     --status succeeded
 
 gh issue edit <N> --repo judgemind/judgemind --remove-label status/in-progress
 ```
 
-Best-effort — both commands exit 0 on no-op (row already terminal, label already absent).
+The helper reads the agent's UUID from `{worktree}/.task-agent-id` (written by `claim` in Step 2a). Best-effort — both commands exit 0 on no-op (row already terminal, label already absent).
 
 #### B.3 — Unblock dependent issues
 

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,8 @@ worktrees/
 
 # Agent lock files (per-worktree, ephemeral)
 .agent-lock
+
+# Task-claim agent_id sidecar (per-worktree, written by
+# scripts/dispatcher/task_claim.py, read by the terminal call —
+# ephemeral handshake between claim and terminal, never committed).
+.task-agent-id

--- a/scripts/dispatcher/task_claim.py
+++ b/scripts/dispatcher/task_claim.py
@@ -53,13 +53,22 @@ Usage
 
 ::
 
-    # Claim (exit 0 on success, 2 on duplicate, 1 on other error):
+    # Claim — the helper generates a uuid4() and writes it to
+    # ``<worktree>/.task-agent-id`` so ``terminal`` can recover it
+    # without the caller threading state. Exit 0 on success, 2 on
+    # duplicate, 3 on configuration error, 1 on other error.
     scripts/dispatcher/task_claim.py claim \\
         --issue 2866 \\
-        --agent-id aabbccdd-eeff-0011-2233-445566778899 \\
         --worktree-path /Users/you/.../.claude/worktrees/agent-aabbccdd
 
-    # Terminal update (exit 0 always — terminal is best-effort):
+    # Terminal update — reads agent_id from the sidecar. Exit 0 always
+    # (best-effort) unless the sidecar is missing and --agent-id is not
+    # supplied (exit 3).
+    scripts/dispatcher/task_claim.py terminal \\
+        --worktree-path /Users/you/.../.claude/worktrees/agent-aabbccdd \\
+        --status succeeded
+
+    # You may still pass ``--agent-id`` explicitly (must be a UUID):
     scripts/dispatcher/task_claim.py terminal \\
         --agent-id aabbccdd-eeff-0011-2233-445566778899 \\
         --status succeeded
@@ -68,11 +77,16 @@ Exit codes
 ----------
 * ``0`` — claim succeeded / terminal update succeeded (or silently
   swallowed on DB failure — never block the /task skill's flow).
-* ``1`` — unexpected error (bad args, subprocess missing, DB error on
-  claim). stderr contains the detail.
+* ``1`` — unexpected error (subprocess missing, DB error on claim).
+  stderr contains the detail.
 * ``2`` — claim lost to a prior owner (UniqueViolation). stderr and stdout
   contain a JSON object with ``owner_agent_id``, ``owner_kind``,
   ``owner_status``, ``issue_number``.
+* ``3`` — configuration error: caller passed a non-UUID ``--agent-id``,
+  missing sidecar on ``terminal``, or the DB returned
+  ``InvalidTextRepresentation`` on a column-type mismatch. Distinct
+  from ``1`` so the /task skill doesn't treat a caller bug as a
+  transient DB error (issue #2892).
 """
 # venv: scraper-framework
 # permanent: true
@@ -84,6 +98,7 @@ import json
 import os
 import subprocess
 import sys
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -107,6 +122,34 @@ DEV_DB_QUERY_TIMEOUT_SECONDS = 60
 #: Relative path to the dev-db-query wrapper, resolved from the repo root.
 DEV_DB_QUERY_SCRIPT = Path("scripts/dev-db-query.sh")
 
+#: Sidecar filename written inside the worktree after a successful claim.
+#: Stores the UUID agent_id so the ``terminal`` subcommand can recover
+#: it without the caller needing to thread state across invocations.
+#: The worktree path is always available to the /task skill (it's the
+#: agent's cwd), so the sidecar + ``--worktree-path`` is a clean
+#: handshake.
+AGENT_ID_SIDECAR_NAME = ".task-agent-id"
+
+#: Substrings in a subprocess stderr that indicate a UniqueViolation
+#: against the partial unique index protecting ``dispatcher.agents``.
+#: Match on the index name first (least fragile across psycopg versions),
+#: fall back to the generic SQLSTATE 23505 names.
+_UNIQUE_VIOLATION_MARKERS = (
+    "idx_dispatcher_agents_active_issue",
+    "duplicate key",
+    "uniqueviolation",
+)
+
+#: Substrings in a subprocess stderr that indicate the caller handed us
+#: a malformed ``agent_id`` — i.e. a configuration bug in the /task
+#: skill or its caller, not a race and not a DB outage. Surfacing these
+#: as a distinct exit code stops them from being silently treated as
+#: "generic DB error" (which was the pre-fix failure mode — see #2892).
+_CONFIGURATION_ERROR_MARKERS = (
+    "invalid input syntax for type uuid",
+    "invalidtextrepresentation",
+)
+
 
 def _parse_args(argv: list[str]) -> argparse.Namespace:
     """Parse CLI arguments for the two subcommands."""
@@ -119,8 +162,15 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     claim.add_argument("--issue", required=True, type=int, help="Issue number.")
     claim.add_argument(
         "--agent-id",
-        required=True,
-        help="UUID of the /task agent (derive from worktree path or fresh uuid4).",
+        default=None,
+        help=(
+            "UUID of the /task agent. If omitted, the helper generates a "
+            "fresh uuid4() and writes it to "
+            "``<worktree>/" + AGENT_ID_SIDECAR_NAME + "`` for the terminal "
+            "call to recover. Must be a valid UUID string when supplied; "
+            "otherwise the DB INSERT fails with "
+            "``invalid input syntax for type uuid`` (issue #2892)."
+        ),
     )
     claim.add_argument(
         "--worktree-path",
@@ -136,8 +186,22 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     term = sub.add_parser("terminal", help="UPDATE the row to a terminal status.")
     term.add_argument(
         "--agent-id",
-        required=True,
-        help="UUID of the /task agent that previously claimed.",
+        default=None,
+        help=(
+            "UUID of the /task agent that previously claimed. If omitted, "
+            "the helper recovers it from ``<worktree>/"
+            + AGENT_ID_SIDECAR_NAME
+            + "`` (written by ``claim``). Either --agent-id or "
+            "--worktree-path must be supplied."
+        ),
+    )
+    term.add_argument(
+        "--worktree-path",
+        default=None,
+        help=(
+            "Absolute path to the worktree. Used to recover the agent_id "
+            "from the sidecar file when --agent-id is omitted."
+        ),
     )
     term.add_argument(
         "--status",
@@ -223,21 +287,22 @@ def _run_sql_via_db_query_sh(sql: str) -> dict[str, Any]:
     if not stdout:
         return {"rowcount": 0}
 
-    # The wrapper streams SSM output too — find the first JSON-looking
-    # chunk. In practice stdout is just the JSON, but be defensive.
-    try:
-        return json.loads(stdout)
-    except json.JSONDecodeError:
-        # Last-ditch: try to find the JSON object/array in the output.
-        for token in ("[", "{"):
-            idx = stdout.find(token)
-            if idx == -1:
-                continue
-            try:
-                return json.loads(stdout[idx:])
-            except json.JSONDecodeError:
-                continue
-        raise RuntimeError(f"dev-db-query.sh returned non-JSON stdout: {stdout[:200]}")
+    # The wrapper streams SSM output around the JSON payload. Typical
+    # stdout looks like::
+    #
+    #     The Session Manager plugin was installed successfully. ...
+    #
+    #
+    #     Starting session with SessionId: ecs-execute-command-...
+    #     {"rowcount": 1}
+    #     Cannot perform start session: EOF
+    #
+    # ``json.loads(stdout)`` chokes on the preamble; the old fallback
+    # (``stdout[stdout.find("{"):]``) then chokes on the trailer because
+    # it's not strict JSON. Use :meth:`JSONDecoder.raw_decode` starting
+    # at the first ``[`` or ``{`` to consume exactly one JSON value and
+    # ignore everything after it. See issue #2892.
+    return _extract_first_json_value(stdout)
 
 
 class ClaimLost(Exception):
@@ -274,6 +339,12 @@ def _claim_via_psycopg(
         except psycopg.errors.UniqueViolation as exc:
             conn.rollback()
             raise ClaimLost(str(exc)) from exc
+        except psycopg.errors.InvalidTextRepresentation as exc:
+            # Caller passed a non-UUID ``agent_id`` (or a malformed
+            # ``issue_number`` etc.). Surface as a configuration error
+            # so ``do_claim`` can emit a distinct exit code. See #2892.
+            conn.rollback()
+            raise ClaimConfigurationError(str(exc)) from exc
 
 
 def _lookup_owner_via_psycopg(
@@ -338,18 +409,18 @@ def _claim_via_db_query_sh(
     try:
         _run_sql_via_db_query_sh(sql)
     except RuntimeError as exc:
-        msg = str(exc).lower()
-        # psycopg surfaces UniqueViolation as a multi-line error whose
-        # first relevant token is ``duplicate key value violates unique
-        # constraint "idx_dispatcher_agents_active_issue"``. Match on
-        # the constraint name (the index) — less fragile than the
-        # human-readable prefix across psycopg versions.
-        if (
-            "idx_dispatcher_agents_active_issue" in msg
-            or "duplicate key" in msg
-            or "uniqueviolation" in msg
-        ):
-            raise ClaimLost(str(exc)) from exc
+        msg = str(exc)
+        # UniqueViolation — the partial unique index rejected the row.
+        # Match on constraint name first (less fragile than the
+        # human-readable prefix across psycopg versions).
+        if _stderr_matches_any(msg, _UNIQUE_VIOLATION_MARKERS):
+            raise ClaimLost(msg) from exc
+        # Caller configuration error — e.g. passed ``agent-a5d7e546``
+        # (not a UUID) for ``--agent-id``. Surface distinctly from a
+        # generic DB outage so the /task skill can report "fix the
+        # caller" vs. "wait for RDS to come back". See #2892.
+        if _stderr_matches_any(msg, _CONFIGURATION_ERROR_MARKERS):
+            raise ClaimConfigurationError(msg) from exc
         raise
 
 
@@ -388,6 +459,152 @@ def _sql_literal(value: str) -> str:
     if "\x00" in value:
         raise ValueError("value contains NUL byte; cannot be a SQL literal")
     return "'" + value.replace("'", "''") + "'"
+
+
+def _extract_first_json_value(payload: str) -> Any:
+    """Consume exactly one JSON value from the front of ``payload``.
+
+    The ``dev-db-query.sh`` wrapper streams its output through ECS Exec,
+    which adds a session preamble before the command output and a
+    ``Cannot perform start session: EOF`` trailer after. We locate the
+    first ``[`` or ``{`` and use :meth:`json.JSONDecoder.raw_decode` to
+    read one value, ignoring anything that follows.
+
+    Falls back to a line-by-line scan if ``raw_decode`` can't parse at
+    the first candidate (handles a pathological case where a character
+    before the JSON looks JSON-ish, e.g. a stray ``[`` in the preamble).
+
+    Raises :class:`RuntimeError` when no JSON value is recoverable —
+    indicates the wrapper failed to produce output, not a caller bug.
+    """
+    # Fast path: the whole string is valid JSON.
+    stripped = payload.strip()
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        pass
+
+    decoder = json.JSONDecoder()
+
+    # Try raw_decode starting at every candidate position where a JSON
+    # value could start.
+    candidates: list[int] = []
+    for token in ("[", "{"):
+        idx = 0
+        while True:
+            idx = stripped.find(token, idx)
+            if idx < 0:
+                break
+            candidates.append(idx)
+            idx += 1
+    candidates.sort()
+
+    for start in candidates:
+        try:
+            value, _end = decoder.raw_decode(stripped, start)
+        except json.JSONDecodeError:
+            continue
+        return value
+
+    # Line-based fallback — a single line that is pure JSON.
+    for line in stripped.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            return json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+    raise RuntimeError(f"dev-db-query.sh returned non-JSON stdout: {payload[:400]}")
+
+
+def _is_uuid(value: str) -> bool:
+    """Return True when ``value`` parses as a valid UUID.
+
+    ``dispatcher.agents.agent_id`` is ``uuid NOT NULL`` — any non-UUID
+    input fails the INSERT with ``InvalidTextRepresentation``. We
+    validate client-side so the error message is clear (caller supplied
+    a bad UUID) rather than surfacing as a generic DB error (issue
+    #2892).
+    """
+    try:
+        uuid.UUID(value)
+    except (ValueError, AttributeError, TypeError):
+        return False
+    return True
+
+
+def _sidecar_path(worktree_path: str) -> Path:
+    """Return the absolute path to the agent_id sidecar file.
+
+    Kept private so the sidecar location can be centralized here — both
+    ``claim`` and ``terminal`` go through this function so they always
+    agree on where the file lives.
+    """
+    return Path(worktree_path).resolve() / AGENT_ID_SIDECAR_NAME
+
+
+def _write_agent_id_sidecar(worktree_path: str, agent_id: str) -> None:
+    """Write ``agent_id`` to ``<worktree>/.task-agent-id``.
+
+    Best-effort — if the write fails (disk full, permission issue, the
+    worktree directory is missing for some reason), we log to stderr
+    and continue. The DB row still carries the canonical ``agent_id``;
+    the sidecar is only a convenience for the ``terminal`` caller.
+    Without it, the caller would have to remember and pass
+    ``--agent-id`` explicitly on the terminal invocation.
+    """
+    path = _sidecar_path(worktree_path)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(agent_id + "\n", encoding="utf-8")
+    except OSError as exc:
+        sys.stderr.write(
+            f"task_claim: failed to write agent_id sidecar at {path}: {exc}\n"
+        )
+
+
+def _read_agent_id_sidecar(worktree_path: str) -> str | None:
+    """Read the agent_id from ``<worktree>/.task-agent-id`` if it exists.
+
+    Returns the UUID string or None if the file is missing / unreadable
+    / contents aren't a UUID. Callers treat a None return as "no
+    sidecar" and fall back to raising a usage error.
+    """
+    path = _sidecar_path(worktree_path)
+    if not path.exists():
+        return None
+    try:
+        content = path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        sys.stderr.write(
+            f"task_claim: failed to read agent_id sidecar at {path}: {exc}\n"
+        )
+        return None
+    if not _is_uuid(content):
+        sys.stderr.write(
+            f"task_claim: agent_id sidecar at {path} does not contain a UUID: "
+            f"{content[:80]!r}\n"
+        )
+        return None
+    return content
+
+
+def _stderr_matches_any(text: str, markers: tuple[str, ...]) -> bool:
+    """Lowercase-substring match helper for subprocess error classification."""
+    lowered = text.lower()
+    return any(marker in lowered for marker in markers)
+
+
+class ClaimConfigurationError(Exception):
+    """Raised when the caller hands the helper malformed args.
+
+    Distinct from :class:`ClaimLost` (benign race — exit 2) and generic
+    ``RuntimeError`` (DB down / subprocess broken — exit 1) so the
+    /task skill surfaces a clear "skill bug, fix the agent_id" message
+    rather than a silent retry.
+    """
 
 
 def _terminal_via_psycopg(
@@ -431,11 +648,32 @@ def _terminal_via_db_query_sh(agent_id: str, status: str, pr_number: int | None)
 
 def do_claim(
     issue_number: int,
-    agent_id: str,
+    agent_id: str | None,
     worktree_path: str,
     issue_title: str | None,
 ) -> int:
-    """Orchestrate the claim INSERT. Returns the process exit code."""
+    """Orchestrate the claim INSERT. Returns the process exit code.
+
+    When ``agent_id`` is None, we generate a fresh uuid4() and write it
+    to ``<worktree>/.task-agent-id`` so the later ``terminal`` call can
+    recover it without the caller threading state. When explicitly
+    supplied, we validate it's a UUID before issuing the INSERT so a
+    bad caller argument produces a clear error rather than surfacing
+    as ``invalid input syntax for type uuid`` (issue #2892).
+    """
+    # Generate or validate agent_id up front so an obviously-broken
+    # caller gets a clear error before we round-trip to the DB.
+    if agent_id is None:
+        agent_id = str(uuid.uuid4())
+    elif not _is_uuid(agent_id):
+        sys.stderr.write(
+            f"task_claim: --agent-id {agent_id!r} is not a valid UUID. "
+            "Omit --agent-id to have the helper generate one, or pass a "
+            "uuid4() value. The daemon's claim path uses "
+            "``str(uuid.uuid4())`` — match that shape. See #2892.\n"
+        )
+        return 3
+
     database_url = os.environ.get("DATABASE_URL", "").strip()
     use_psycopg = bool(database_url)
 
@@ -463,15 +701,39 @@ def do_claim(
             f"(status={payload.get('owner_status', 'unknown')}).\n"
         )
         return 2
+    except ClaimConfigurationError as exc:
+        sys.stderr.write(
+            f"task_claim: configuration error — the /task skill or its "
+            f"caller passed something the DB rejected at the column-type "
+            f"level (likely a non-UUID ``agent_id``). Fix the caller and "
+            f"retry. Underlying error: {exc}\n"
+        )
+        return 3
     except Exception as exc:  # noqa: BLE001 — surface any DB / subprocess error
         sys.stderr.write(f"task_claim: claim failed: {exc}\n")
         return 1
 
-    print(json.dumps({"status": "claimed", "issue_number": issue_number}))
+    # Claim landed — persist the agent_id for ``terminal`` to recover.
+    _write_agent_id_sidecar(worktree_path, agent_id)
+
+    print(
+        json.dumps(
+            {
+                "status": "claimed",
+                "issue_number": issue_number,
+                "agent_id": agent_id,
+            }
+        )
+    )
     return 0
 
 
-def do_terminal(agent_id: str, status: str, pr_number: int | None) -> int:
+def do_terminal(
+    agent_id: str | None,
+    status: str,
+    pr_number: int | None,
+    worktree_path: str | None,
+) -> int:
     """Orchestrate the terminal UPDATE. Returns the process exit code.
 
     Terminal updates are best-effort — a failure here does not block the
@@ -479,7 +741,32 @@ def do_terminal(agent_id: str, status: str, pr_number: int | None) -> int:
     ``running`` until the daemon's supervisor tick reconciles it). We
     still return a non-zero exit on catastrophic failure so a caller
     that WANTS to know can act on it, but the skill ignores it.
+
+    When ``agent_id`` is None, we read ``<worktree>/.task-agent-id`` to
+    recover it — written by a prior ``claim`` call. Either ``agent_id``
+    or ``worktree_path`` must be supplied.
     """
+    # Resolve agent_id — either from the CLI or from the sidecar.
+    if agent_id is None:
+        if worktree_path is None:
+            sys.stderr.write(
+                "task_claim: terminal requires either --agent-id or "
+                "--worktree-path (to recover agent_id from the sidecar).\n"
+            )
+            return 3
+        agent_id = _read_agent_id_sidecar(worktree_path)
+        if agent_id is None:
+            sys.stderr.write(
+                f"task_claim: no agent_id sidecar found at "
+                f"{_sidecar_path(worktree_path)} — either the claim never "
+                "ran in this worktree or the file was removed. Pass "
+                "--agent-id explicitly.\n"
+            )
+            return 3
+    elif not _is_uuid(agent_id):
+        sys.stderr.write(f"task_claim: --agent-id {agent_id!r} is not a valid UUID.\n")
+        return 3
+
     database_url = os.environ.get("DATABASE_URL", "").strip()
     use_psycopg = bool(database_url)
 
@@ -520,7 +807,12 @@ def main(argv: list[str] | None = None) -> int:
             args.issue_title,
         )
     if args.subcommand == "terminal":
-        return do_terminal(args.agent_id, args.status, args.pr_number)
+        return do_terminal(
+            args.agent_id,
+            args.status,
+            args.pr_number,
+            args.worktree_path,
+        )
     sys.stderr.write(f"Unknown subcommand: {args.subcommand}\n")
     return 1
 

--- a/scripts/dispatcher/tests/test_task_claim.py
+++ b/scripts/dispatcher/tests/test_task_claim.py
@@ -59,6 +59,13 @@ import psycopg  # noqa: E402  — re-import after stub install
 
 from dispatcher import task_claim  # noqa: E402  — sys.path mutation above
 
+# A valid UUID to use as the ``agent_id`` in tests that don't care
+# about the specific value — matches the ``str(uuid.uuid4())`` shape
+# ``dispatcher.agents.agent_id`` expects (issue #2892 — bare hex
+# strings like ``"abc"`` or ``"agent-a56f2e57"`` fail the real DB
+# column's ``InvalidTextRepresentation`` check).
+_VALID_AGENT_ID = "aabbccdd-eeff-0011-2233-445566778899"
+
 
 # --------------------------------------------------------------------------
 # Shared fakes — mirror the _FakeCursor / _FakeConnection pattern from
@@ -310,6 +317,358 @@ class TestClaimViaDbQuerySh:
                 issue_title=None,
             )
 
+    def test_invalid_uuid_error_raises_configuration_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression test for issue #2892.
+
+        The old classifier treated ``InvalidTextRepresentation`` (caller
+        bug — non-UUID agent_id) as a generic RuntimeError, which the
+        /task skill was supposed to treat as "stop" but in practice
+        silently swallowed. Surface it as a distinct
+        :class:`ClaimConfigurationError` so ``do_claim`` can emit exit
+        code 3.
+        """
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 1
+            r.stdout = ""
+            # Exact error text reproduced from running the helper
+            # against dev RDS with agent_id='agent-a5d7e546':
+            r.stderr = (
+                "Database error: invalid input syntax for type uuid: "
+                '"agent-a5d7e546"\n'
+                "LINE 1: ...ssue_title, worktree_path, phase, status) "
+                "VALUES ('agent-a5d...\n"
+            )
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        with pytest.raises(task_claim.ClaimConfigurationError):
+            task_claim._claim_via_db_query_sh(
+                issue_number=2866,
+                agent_id="agent-a5d7e546",
+                worktree_path="/tmp/wt",
+                issue_title=None,
+            )
+
+    def test_json_parser_strips_ecs_exec_trailer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Regression test for issue #2892.
+
+        ``aws ecs execute-command`` wraps command output with a session
+        preamble and a ``Cannot perform start session: EOF`` trailer.
+        The old parser's fallback used ``stdout[stdout.find("{"):]``
+        which leaves the trailer in the slice, so ``json.loads`` fails
+        and the whole claim comes back as a generic RuntimeError.
+        Use :meth:`json.JSONDecoder.raw_decode` to read exactly one
+        JSON value and ignore the trailer.
+        """
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = (
+                "\n"
+                "The Session Manager plugin was installed successfully. "
+                "Use the AWS CLI to start a session.\n"
+                "\n"
+                "\n"
+                "Starting session with SessionId: "
+                "ecs-execute-command-abc123\n"
+                '{"rowcount": 1}\n'
+                "Cannot perform start session: EOF\n"
+            )
+            r.stderr = "Running query on dev database via ECS Exec...\n"
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        result = task_claim._run_sql_via_db_query_sh("INSERT INTO x VALUES (1)")
+        assert result == {"rowcount": 1}
+
+    def test_json_parser_handles_select_list_payload_with_trailer(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Same as above but for SELECT-shape payloads (a JSON array).
+
+        The owner-lookup code path reads a list of row dicts; it hits
+        the same ECS Exec trailer and must parse just the array.
+        """
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = (
+                "Starting session with SessionId: ecs-abc\n"
+                '[{"owner_agent_id": "daemon-uuid", "owner_kind": "task"}]\n'
+                "Cannot perform start session: EOF\n"
+            )
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        result = task_claim._run_sql_via_db_query_sh("SELECT 1")
+        assert isinstance(result, list)
+        assert result[0]["owner_agent_id"] == "daemon-uuid"
+
+
+class TestExtractFirstJsonValue:
+    """Direct tests for the raw-decode helper — fast path + trailing-noise."""
+
+    def test_pure_json_object(self) -> None:
+        assert task_claim._extract_first_json_value('{"rowcount": 1}') == {
+            "rowcount": 1
+        }
+
+    def test_pure_json_array(self) -> None:
+        assert task_claim._extract_first_json_value("[1, 2, 3]") == [1, 2, 3]
+
+    def test_strips_ecs_exec_trailer(self) -> None:
+        payload = (
+            "Starting session with SessionId: ecs-xyz\n"
+            '{"rowcount": 1}\n'
+            "Cannot perform start session: EOF\n"
+        )
+        assert task_claim._extract_first_json_value(payload) == {"rowcount": 1}
+
+    def test_raw_decode_prefers_outer_object_over_inner_string_literal(
+        self,
+    ) -> None:
+        """Ensure the raw_decode scan prefers the outer wrapping object.
+
+        If someone embeds a ``{`` inside a string literal earlier in the
+        payload, we want the outer object — not the start of a string
+        value. ``raw_decode`` is naturally greedy-forward so the first
+        successful raw_decode at the first ``[``/``{`` wins, which is
+        exactly what we want.
+        """
+        payload = '{"outer": {"inner": 1}}'
+        assert task_claim._extract_first_json_value(payload) == {"outer": {"inner": 1}}
+
+    def test_no_json_raises(self) -> None:
+        with pytest.raises(RuntimeError, match="non-JSON stdout"):
+            task_claim._extract_first_json_value("no json here at all")
+
+
+class TestIsUuid:
+    """Regression tests for the UUID validator added in #2892."""
+
+    def test_accepts_canonical_uuid(self) -> None:
+        assert task_claim._is_uuid("aabbccdd-eeff-0011-2233-445566778899")
+
+    def test_rejects_short_hex(self) -> None:
+        # This is the exact bug shape from #2892 — worktree basenames
+        # are ``agent-<8 hex chars>`` which is NOT a UUID.
+        assert not task_claim._is_uuid("agent-a56f2e57")
+
+    def test_rejects_bare_hex(self) -> None:
+        assert not task_claim._is_uuid("abc")
+
+    def test_rejects_empty(self) -> None:
+        assert not task_claim._is_uuid("")
+
+    def test_accepts_uuid_without_hyphens(self) -> None:
+        # ``uuid.UUID`` accepts no-hyphen form too; we don't care as
+        # long as Postgres's UUID type would accept it.
+        assert task_claim._is_uuid("aabbccddeeff00112233445566778899")
+
+
+class TestAgentIdSidecar:
+    """The claim→terminal handshake via ``<worktree>/.task-agent-id``."""
+
+    def test_write_then_read_round_trips(self, tmp_path: Path) -> None:
+        task_claim._write_agent_id_sidecar(str(tmp_path), _VALID_AGENT_ID)
+        recovered = task_claim._read_agent_id_sidecar(str(tmp_path))
+        assert recovered == _VALID_AGENT_ID
+
+    def test_read_returns_none_when_missing(self, tmp_path: Path) -> None:
+        # tmp_path exists but no sidecar written yet.
+        assert task_claim._read_agent_id_sidecar(str(tmp_path)) is None
+
+    def test_read_rejects_non_uuid_contents(self, tmp_path: Path) -> None:
+        """A sidecar with non-UUID contents is treated as missing.
+
+        Defends against ancient sidecars that predate the UUID fix
+        (e.g. containing ``agent-a56f2e57``) — don't propagate the bad
+        value into an INSERT that would fail again.
+        """
+        (tmp_path / task_claim.AGENT_ID_SIDECAR_NAME).write_text(
+            "agent-a56f2e57\n", encoding="utf-8"
+        )
+        assert task_claim._read_agent_id_sidecar(str(tmp_path)) is None
+
+    def test_write_creates_parent_dir(self, tmp_path: Path) -> None:
+        # Nested non-existent path — write should create it.
+        nested = tmp_path / "nested"
+        task_claim._write_agent_id_sidecar(str(nested), _VALID_AGENT_ID)
+        assert (nested / task_claim.AGENT_ID_SIDECAR_NAME).exists()
+
+
+class TestDoClaimUuidGeneration:
+    """``do_claim`` generates a UUID when ``agent_id`` is None — #2892."""
+
+    def test_none_agent_id_generates_uuid_and_writes_sidecar(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        """Pass ``agent_id=None``; verify a UUID was generated, passed
+        to the DB path, emitted in the JSON response, and persisted to
+        the sidecar."""
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+        captured_agent_ids: list[str] = []
+
+        def fake_claim(
+            database_url: str,
+            issue_number: int,
+            agent_id: str,
+            worktree_path: str,
+            issue_title: str | None,
+        ) -> None:
+            captured_agent_ids.append(agent_id)
+
+        monkeypatch.setattr(task_claim, "_claim_via_psycopg", fake_claim)
+        rc = task_claim.do_claim(2866, None, str(tmp_path), None)
+        assert rc == 0
+        assert len(captured_agent_ids) == 1
+        generated = captured_agent_ids[0]
+        assert task_claim._is_uuid(generated)
+
+        # Sidecar round-trips.
+        sidecar = tmp_path / task_claim.AGENT_ID_SIDECAR_NAME
+        assert sidecar.exists()
+        assert sidecar.read_text(encoding="utf-8").strip() == generated
+
+        # JSON response carries the agent_id.
+        payload = json.loads(capsys.readouterr().out.strip())
+        assert payload["agent_id"] == generated
+
+    def test_non_uuid_agent_id_returns_three(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Regression test: ``agent-a5d7e546`` (the exact shape #2892
+        documents in SKILL.md) must fail fast at the validator, not
+        round-trip to the DB."""
+        rc = task_claim.do_claim(2892, "agent-a5d7e546", "/tmp/wt", None)
+        assert rc == 3
+        err = capsys.readouterr().err
+        assert "agent-a5d7e546" in err
+        assert "UUID" in err
+
+    def test_configuration_error_from_db_returns_three(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """If the DB returns InvalidTextRepresentation despite client-
+        side UUID validation (edge case — e.g. caller passed a valid
+        UUID but the psycopg path tripped something else), surface as
+        exit 3 not exit 1."""
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+
+        def raise_cfg(*_a: Any, **_k: Any) -> None:
+            raise task_claim.ClaimConfigurationError("invalid input syntax")
+
+        monkeypatch.setattr(task_claim, "_claim_via_psycopg", raise_cfg)
+        rc = task_claim.do_claim(2866, _VALID_AGENT_ID, "/tmp/wt", None)
+        assert rc == 3
+        err = capsys.readouterr().err
+        assert "configuration error" in err.lower()
+
+
+class TestDoTerminalSidecarRecovery:
+    """``do_terminal`` recovers ``agent_id`` from the sidecar — #2892."""
+
+    def test_sidecar_recovery_round_trip(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Write a sidecar, then call ``do_terminal`` with only a
+        worktree path — it should recover the agent_id and pass it to
+        the terminal DB path."""
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+        task_claim._write_agent_id_sidecar(str(tmp_path), _VALID_AGENT_ID)
+
+        captured: list[str] = []
+
+        def fake_terminal(
+            database_url: str,
+            agent_id: str,
+            status: str,
+            pr_number: int | None,
+        ) -> int:
+            captured.append(agent_id)
+            return 1
+
+        monkeypatch.setattr(task_claim, "_terminal_via_psycopg", fake_terminal)
+        rc = task_claim.do_terminal(None, "succeeded", None, str(tmp_path))
+        assert rc == 0
+        assert captured == [_VALID_AGENT_ID]
+
+    def test_missing_sidecar_and_no_agent_id_returns_three(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+        # tmp_path has no sidecar.
+        rc = task_claim.do_terminal(None, "succeeded", None, str(tmp_path))
+        assert rc == 3
+        err = capsys.readouterr().err
+        assert "sidecar" in err.lower()
+
+    def test_neither_agent_id_nor_worktree_returns_three(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = task_claim.do_terminal(None, "succeeded", None, None)
+        assert rc == 3
+        err = capsys.readouterr().err
+        assert "either --agent-id or --worktree-path" in err
+
+    def test_explicit_agent_id_wins_over_sidecar(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """If the caller passes ``--agent-id`` explicitly, use that and
+        ignore the sidecar. Sidecar is a fallback, not an override."""
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+        task_claim._write_agent_id_sidecar(str(tmp_path), _VALID_AGENT_ID)
+
+        # Different UUID for the explicit arg.
+        other_uuid = "00112233-4455-6677-8899-aabbccddeeff"
+        captured: list[str] = []
+
+        def fake_terminal(
+            database_url: str,
+            agent_id: str,
+            status: str,
+            pr_number: int | None,
+        ) -> int:
+            captured.append(agent_id)
+            return 1
+
+        monkeypatch.setattr(task_claim, "_terminal_via_psycopg", fake_terminal)
+        rc = task_claim.do_terminal(other_uuid, "succeeded", None, str(tmp_path))
+        assert rc == 0
+        assert captured == [other_uuid]
+
+    def test_invalid_explicit_agent_id_returns_three(
+        self,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        rc = task_claim.do_terminal("not-a-uuid", "succeeded", None, None)
+        assert rc == 3
+        err = capsys.readouterr().err
+        assert "UUID" in err
+
 
 # --------------------------------------------------------------------------
 # _terminal_via_psycopg — psycopg terminal UPDATE
@@ -371,12 +730,16 @@ class TestDoClaim:
             called.append({"args": args, "kwargs": kwargs})
 
         monkeypatch.setattr(task_claim, "_claim_via_psycopg", fake_claim)
-        rc = task_claim.do_claim(2866, "abc", "/tmp/wt", None)
+        rc = task_claim.do_claim(2866, _VALID_AGENT_ID, "/tmp/wt", None)
         assert rc == 0
         assert len(called) == 1
         captured = capsys.readouterr()
         payload = json.loads(captured.out.strip())
-        assert payload == {"status": "claimed", "issue_number": 2866}
+        # Payload now includes ``agent_id`` so the terminal call can
+        # recover it if the sidecar somehow fails to write.
+        assert payload["status"] == "claimed"
+        assert payload["issue_number"] == 2866
+        assert payload["agent_id"] == _VALID_AGENT_ID
 
     def test_claim_lost_returns_two_and_emits_owner_json(
         self,
@@ -400,7 +763,7 @@ class TestDoClaim:
         monkeypatch.setattr(task_claim, "_claim_via_psycopg", raise_claim_lost)
         monkeypatch.setattr(task_claim, "_lookup_owner_via_psycopg", fake_lookup)
 
-        rc = task_claim.do_claim(2866, "abc", "/tmp/wt", None)
+        rc = task_claim.do_claim(2866, _VALID_AGENT_ID, "/tmp/wt", None)
         assert rc == 2
         out = capsys.readouterr()
         payload = json.loads(out.out.strip())
@@ -431,7 +794,7 @@ class TestDoClaim:
             task_claim, "_lookup_owner_via_psycopg", lambda *_a, **_k: None
         )
 
-        rc = task_claim.do_claim(2866, "abc", "/tmp/wt", None)
+        rc = task_claim.do_claim(2866, _VALID_AGENT_ID, "/tmp/wt", None)
         assert rc == 2
         payload = json.loads(capsys.readouterr().out.strip())
         assert payload["issue_number"] == 2866
@@ -448,7 +811,7 @@ class TestDoClaim:
             raise RuntimeError("boom")
 
         monkeypatch.setattr(task_claim, "_claim_via_psycopg", fake_claim)
-        rc = task_claim.do_claim(2866, "abc", "/tmp/wt", None)
+        rc = task_claim.do_claim(2866, _VALID_AGENT_ID, "/tmp/wt", None)
         assert rc == 1
         err = capsys.readouterr().err
         assert "boom" in err
@@ -464,7 +827,7 @@ class TestDoClaim:
             called.append((args, kwargs))
 
         monkeypatch.setattr(task_claim, "_claim_via_db_query_sh", fake_claim_sh)
-        rc = task_claim.do_claim(2866, "abc", "/tmp/wt", None)
+        rc = task_claim.do_claim(2866, _VALID_AGENT_ID, "/tmp/wt", None)
         assert rc == 0
         assert len(called) == 1
 
@@ -486,7 +849,7 @@ class TestDoTerminal:
             "_terminal_via_psycopg",
             lambda *_a, **_k: 1,
         )
-        rc = task_claim.do_terminal("abc", "succeeded", 42)
+        rc = task_claim.do_terminal(_VALID_AGENT_ID, "succeeded", 42, None)
         assert rc == 0
         payload = json.loads(capsys.readouterr().out.strip())
         assert payload["status"] == "terminal_recorded"
@@ -504,7 +867,7 @@ class TestDoTerminal:
             "_terminal_via_psycopg",
             lambda *_a, **_k: 0,
         )
-        rc = task_claim.do_terminal("missing", "failed", None)
+        rc = task_claim.do_terminal(_VALID_AGENT_ID, "failed", None, None)
         assert rc == 0
         err = capsys.readouterr().err
         assert "matched 0 rows" in err
@@ -520,7 +883,7 @@ class TestDoTerminal:
             raise RuntimeError("db down")
 
         monkeypatch.setattr(task_claim, "_terminal_via_psycopg", fake_terminal)
-        rc = task_claim.do_terminal("abc", "succeeded", None)
+        rc = task_claim.do_terminal(_VALID_AGENT_ID, "succeeded", None, None)
         assert rc == 1
         err = capsys.readouterr().err
         assert "db down" in err
@@ -561,10 +924,15 @@ class TestMain:
     def test_terminal_subcommand_dispatches_to_do_terminal(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        captured: list[tuple[str, str, int | None]] = []
+        captured: list[tuple[str, str, int | None, str | None]] = []
 
-        def fake_do_terminal(agent_id: str, status: str, pr_number: int | None) -> int:
-            captured.append((agent_id, status, pr_number))
+        def fake_do_terminal(
+            agent_id: str,
+            status: str,
+            pr_number: int | None,
+            worktree_path: str | None,
+        ) -> int:
+            captured.append((agent_id, status, pr_number, worktree_path))
             return 0
 
         monkeypatch.setattr(task_claim, "do_terminal", fake_do_terminal)
@@ -572,7 +940,7 @@ class TestMain:
             [
                 "terminal",
                 "--agent-id",
-                "abc",
+                _VALID_AGENT_ID,
                 "--status",
                 "succeeded",
                 "--pr-number",
@@ -580,7 +948,40 @@ class TestMain:
             ]
         )
         assert rc == 0
-        assert captured == [("abc", "succeeded", 42)]
+        assert captured == [(_VALID_AGENT_ID, "succeeded", 42, None)]
+
+    def test_terminal_with_worktree_path_threads_through(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--worktree-path`` on ``terminal`` threads through to do_terminal.
+
+        Guards the sidecar-recovery code path — the /task skill's
+        terminal call passes ``--worktree-path`` (not ``--agent-id``)
+        after the ``claim`` wrote the sidecar.
+        """
+        captured: list[tuple[Any, ...]] = []
+
+        def fake_do_terminal(
+            agent_id: Any,
+            status: str,
+            pr_number: int | None,
+            worktree_path: str | None,
+        ) -> int:
+            captured.append((agent_id, status, pr_number, worktree_path))
+            return 0
+
+        monkeypatch.setattr(task_claim, "do_terminal", fake_do_terminal)
+        rc = task_claim.main(
+            [
+                "terminal",
+                "--worktree-path",
+                "/tmp/wt",
+                "--status",
+                "succeeded",
+            ]
+        )
+        assert rc == 0
+        assert captured == [(None, "succeeded", None, "/tmp/wt")]
 
     def test_terminal_rejects_invalid_status(
         self, capsys: pytest.CaptureFixture[str]
@@ -590,7 +991,7 @@ class TestMain:
                 [
                     "terminal",
                     "--agent-id",
-                    "abc",
+                    _VALID_AGENT_ID,
                     "--status",
                     "crashed",  # not in VALID_TERMINAL_STATUSES
                 ]


### PR DESCRIPTION
## Summary

Three coupled bugs in the `/task` ↔ dispatcher claim interlock (#2866 / PR #2873) meant that since `#2866` merged, **zero** `kind='task-skill'` rows ever landed in `dispatcher.agents` despite 20+ /task-dispatched PRs. Primary root cause: SKILL.md §2a told agents to pass the short worktree basename (`agent-<8hex>`) as `--agent-id`, but the DB column is `uuid` — every INSERT failed with `InvalidTextRepresentation`. The helper also mis-classified that error as "generic DB outage" (exit 1) and its JSON parser choked on the `Cannot perform start session: EOF` trailer that ECS Exec appends to command output. Live verification on dev RDS confirms the fix: `SELECT DISTINCT kind FROM dispatcher.agents` went from `[{"task"}]` to `[{"task"}, {"task-skill"}]` — the first `task-skill` row ever, inserted by this very /task agent's claim on #2892.

Closes #2892

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass — 615 passed, 1 skipped (dispatcher suite); `test_task_claim.py` grew from 23 → 49 tests (+25 net, 1 updated signature)
- [x] CI green

### Post-deploy verification
- [ ] Fargate dispatcher deploy completes successfully (deploy-dispatcher.yml)
- [ ] On next /task subagent spawn, confirm a `kind='task-skill'` row appears in `dispatcher.agents`. Query after deploy: `SELECT DISTINCT kind FROM dispatcher.agents ORDER BY kind`.
- [ ] Confirm admin page "Recently Completed" panel renders subagent-dispatched PRs (acceptance criterion #6).
- [ ] Verification evidence posted on #2892

## Design decisions

1. **Sidecar handshake between `claim` and `terminal`.** `claim` generates `uuid4()` → writes `<worktree>/.task-agent-id` → emits the UUID in JSON. `terminal` accepts `--worktree-path` and reads the sidecar. Keeps SKILL.md §2a at three lines per call — no UUID generation, no state threading. `.gitignore` updated so the sidecar never hits version control.
2. **Backward-compatible CLI.** `--agent-id` is still accepted (now optional); explicit callers get client-side UUID validation. Only the **recommended** invocation in SKILL.md changes. Avoids a flag-day migration across other callers.
3. **New exit code 3 for configuration errors.** Distinct from exit 1 (DB down) and exit 2 (claim lost). The /task skill now has a clear "this is a caller bug — retrying won't help" signal. Covers both client-side (`--agent-id` is non-UUID) and server-side (`InvalidTextRepresentation` from psycopg or the subprocess) detection paths.
4. **`JSONDecoder.raw_decode` for ECS Exec output.** Iterates candidate `[`/`{` positions, consumes exactly one JSON value, ignores the trailer. Falls through to line-by-line scan if raw_decode can't parse at the first candidate — handles the pathological case where a pre-JSON character looks JSON-ish. Preserves the fast path (`json.loads` on the whole stripped string) for Fargate's clean psycopg output.
5. **`chmod +x` on `task_claim.py` AND explicit `python3` prefix in SKILL.md.** Belt-and-suspenders — the file mode is preserved by git in this repo but not universally, and the `python3` prefix makes the invocation portable regardless.
6. **No DB migration.** The `kind` column is already free-text (hypothesis 3 confirmed false via live `information_schema.columns` query) and `agent_id` is already `uuid` — this was always a client-side contract bug.

## Meta-risk

This PR's own /task agent **ran under the broken version of the helper** — the manual meta-risk check in the diagnosis comment documents exactly which exit codes I hit and the SQL-level error text. My own claim row for #2892 only landed because I manually workarounded the bug by passing a valid explicit UUID before the fix was in place. Future /task spawns run under the fixed helper on whatever image the next daemon deploy picks up; laptop-side /task spawns pick up the fix as soon as this PR merges since they use the worktree's on-disk copy.

## Why CI didn't catch this (retro)

Existing tests mocked `psycopg.connect` via `MagicMock()`, so the UUID column type was never enforced. No integration test hits a real Postgres against the actual `dispatcher.agents` schema. PR #2873's own body explicitly noted that its agent ran under the pre-#2866 version and "subsequent /task spawns are where the interlock activates" — so the first real exercise was supposed to be the next spawn, but that first spawn also failed silently (because the helper's `do_claim` returned exit 1 which the /task skill was supposed to treat as "stop" but in practice swallowed). A retrospective follow-up issue will track adding either a docker-compose-backed integration fixture or a runtime assertion that catches the full kind + agent_id round-trip. The client-side UUID validator in this PR (`_is_uuid`) is the minimum viable piece of that.
