### PR TITLE
fix(dispatcher): pass --issue-title on /task skill claim so admin panel shows real titles

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -162,11 +162,12 @@ Once MCP writes are unblocked (follow-up issue referenced from `docs/agent/gh-to
 
 ### Part A — DB row (atomic race detection)
 
-Run the helper (stays in the foreground — use `timeout: 1200000` since the ECS-Exec code path takes 2-4 s per call):
+Run the helper (stays in the foreground — use `timeout: 1200000` since the ECS-Exec code path takes 2-4 s per call). **Pass the issue title** you already fetched from GitHub in Step 1 (the `title` field from `mcp__github__get_issue` / `mcp__github__list_issues`) — without it, the `dispatcher.agents` row is inserted with `issue_title=NULL` and the admin cockpit's Recently Completed panel renders the row as "(title unavailable)" (issue #2898). The daemon's own `_atomic_claim` caller (`scripts/dispatcher/daemon.py`) already supplies `issue_title`; `/task` must match that behavior.
 
 ```
 python3 {worktree}/scripts/dispatcher/task_claim.py claim \
     --issue <N> \
+    --issue-title "<issue-title>" \
     --worktree-path {worktree}
 ```
 


### PR DESCRIPTION
## Summary

The `/task` skill's `task_claim.py claim` invocation in `.claude/skills/task/SKILL.md` omitted `--issue-title`, so every `kind='task-skill'` row written to `dispatcher.agents` was inserted with `issue_title=NULL` and rendered as "(title unavailable)" in the admin cockpit's Recently Completed panel (observed 2026-04-20). This PR adds `--issue-title "<issue-title>"` to that invocation and adds a one-line prose note pointing at the already-fetched title from Step 1 of the skill.

Closes #2898

## Root cause

- `.claude/skills/task/SKILL.md` §Step 2a Part A (around line 168) omitted `--issue-title`.
- **Daemon parity:** `scripts/dispatcher/daemon.py` (`_atomic_claim` caller at line ~4383) *does* pass `issue_title` — see the bundle construction at `daemon.py:4370` and the call at `daemon.py:4384`. So this bug was scoped to the `/task` skill only.
- The helper `scripts/dispatcher/task_claim.py` already accepts `--issue-title` (CLI arg at line 131, INSERT bindings at lines 269 / 333). The Python side needed no change.
- The `/task` skill already fetches the issue JSON (title, body, labels) in Step 1 / A.1 via `mcp__github__get_issue` or `mcp__github__list_issues`, so the title is in hand before the claim call — no extra fetch needed.

## Change

Single-file SKILL.md edit: two-line diff inside §Step 2a Part A adds `--issue-title "<issue-title>"` to the `task_claim.py claim` code block, and prefixes the block with a sentence explaining why the arg is required and pointing at the daemon's matching behavior.

## Scope

- Only one `task_claim.py claim` occurrence in SKILL.md (verified via grep).
- No change to `task_claim.py` (already works), the admin UI (already handles null), or the DB (historical rows manually backfilled in dev).

## Test plan

### Automated checks
- [ ] Lint passes (N/A — markdown-only change)
- [ ] Format check passes (N/A — markdown-only change)
- [ ] Tests pass (N/A — no code change; no tests exercise SKILL.md directly)
- [ ] `markdown-links-check` CI job green (`scripts/check-markdown-links.sh` passed locally on push)
- [ ] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (docs/agent-workflow only). Effect will be visible on the next `/task`-skill claim: the new `dispatcher.agents` row should have a non-NULL `issue_title`. Historical rows have been backfilled manually in dev, so there is no migration to run.
