### PR TITLE
test(agent): validate full package test suite in ralph loop before SHIP (#2897)

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -60,6 +60,7 @@ Create the state directory and seed the task file:
 ├── adversarial-feedback.md    # Gemini adversarial detailed findings (testable only)
 ├── iteration.txt              # current iteration number (written before each iteration)
 ├── review-log.jsonl           # structured review log (appended by gemini_review.py and the loop)
+├── touched-packages.txt       # Python packages with code changes (written by worker step 4)
 └── ralph-done.txt             # completion signal for the calling /task workflow
 ```
 
@@ -125,9 +126,16 @@ Spawn a **worker subagent** (using the Agent tool) with this prompt structure:
 > 1. Read the task and feedback files.
 > 2. Examine existing code and test patterns in the relevant packages.
 > 3. If this is iteration 1, write failing tests first, then implement. If this is iteration 2+, focus on addressing the reviewer's feedback — read the existing implementation, apply the requested changes, and re-run tests.
-> 4. Run ALL pre-PR checks for every package you touched:
->    - Python: `.venv/bin/ruff check src/ tests/`, `.venv/bin/ruff format --check src/ tests/`, `.venv/bin/pytest tests/ -v --tb=short`
->    - TypeScript: `npm run lint`, `npm run typecheck`, `npm test`
+> 4. **Derive touched packages and run the full test suite for each.**
+>    - Run `python3 {worktree}/scripts/ralph_touched_packages.py {worktree}` and write the output to `{worktree}/tmp/ralph/touched-packages.txt`.
+>    - Run `python3 {worktree}/scripts/ralph_touched_packages.py --ts {worktree}` to get the list of touched TypeScript packages.
+>    - For each Python package listed in `touched-packages.txt`: if no `.venv` exists, run `{worktree}/scripts/install-package-venv.sh <pkg>` first. Then run the full test suite: `packages/<pkg>/.venv/bin/pytest packages/<pkg>/tests/ -v --tb=short`.
+>    - For each touched TypeScript package: run `npm run lint`, `npm run typecheck`, and `npm test` in that package directory.
+>    - Aggregate test results to `{worktree}/tmp/ralph/pre-push-preview.txt` (one line per package: `PASS packages/<pkg>` or `FAIL packages/<pkg> — <reason>`).
+>    - Any failure → do NOT write COMPLETE. Fix the failures, then re-run.
+>    - **Also run ALL pre-PR checks for every package you touched:**
+>      - Python: `.venv/bin/ruff check src/ tests/`, `.venv/bin/ruff format --check src/ tests/`
+>      - TypeScript: `npm run lint`, `npm run typecheck`, `npm test`
 > 5. Fix any failures. Auto-fix lint with `.venv/bin/ruff check --fix src/ tests/` then `.venv/bin/ruff format src/ tests/`.
 > 6. **Run diff-coverage check for every Python package you touched** (catches CI diff-coverage failures locally):
 >    - Install diff-cover if not already available: `.venv/bin/pip install diff-cover --quiet`
@@ -162,13 +170,17 @@ Spawn a **worker subagent** (using the Agent tool) with this prompt structure:
 > 1. Read the task and feedback files. Focus on the "## Plan (from /task-v2-plan)" section's "What will change" subsection — this is the concrete list of edits to make.
 > 2. Examine the existing structure of the files you will edit. For docs, follow the existing headings and tone. For scripts, follow the existing `# venv:` / `# one-off:` / `# permanent:` header conventions (see `docs/agent/code-standards.md` §Python scripts). For migrations, follow the existing migration file naming and schema patterns.
 > 3. Apply the edits. If this is iteration 2+, focus on addressing the reviewer's feedback from `feedback.md` — read the existing implementation, apply the requested changes.
-> 4. Run the pre-PR checks that apply to the files you actually touched:
->    - Any `.py` file touched → `.venv/bin/ruff check <file>`, `.venv/bin/ruff format --check <file>` in the owning package. (Pytest and diff-coverage are **skipped** — this is a non-testable change.)
->    - Any `.md` file touched → `scripts/check-markdown-links.sh` (reads every `.md` in the push, not just the diff).
->    - Any `.tf` file touched → `terraform fmt -check -recursive` in the touched module.
->    - Any `.yml` / `.yaml` under `.github/workflows/` touched → `scripts/check-ci-job-skipped.sh` (the #2410/#2505 footgun guard).
->    - Any `.sql` migration touched → verify the filename numbering and schema match existing migrations; no runtime check required.
->    - No matching file type → no pre-PR checks needed. Skip to step 5.
+> 4. **Derive touched packages and run pre-PR checks for each.**
+>    - Run `python3 {worktree}/scripts/ralph_touched_packages.py {worktree}` and write the output to `{worktree}/tmp/ralph/touched-packages.txt`.
+>    - Run the pre-PR checks that apply to the files you actually touched:
+>      - Any `.py` file touched → for each package in `touched-packages.txt`: `.venv/bin/ruff check <file>`, `.venv/bin/ruff format --check <file>` in the owning package. (Pytest and diff-coverage are **skipped** — this is a non-testable change.)
+>      - Any `.md` file touched → `scripts/check-markdown-links.sh` (reads every `.md` in the push, not just the diff).
+>      - Any `.tf` file touched → `terraform fmt -check -recursive` in the touched module.
+>      - Any `.yml` / `.yaml` under `.github/workflows/` touched → `scripts/check-ci-job-skipped.sh` (the #2410/#2505 footgun guard).
+>      - Any `.sql` migration touched → verify the filename numbering and schema match existing migrations; no runtime check required.
+>      - No matching file type → no pre-PR checks needed. Skip to step 5.
+>    - Aggregate check results to `{worktree}/tmp/ralph/pre-push-preview.txt` (one line per package or check: `PASS <check>` or `FAIL <check> — <reason>`).
+>    - Any failure → do NOT write COMPLETE. Fix the failures, then re-run.
 > 5. **Self-verify acceptance criteria before completing.** Read `{worktree}/tmp/ralph/task.md` and find every acceptance criterion (the `- [ ]` checkboxes). For EACH criterion, describe how your implementation satisfies it — reference the specific file, section, or edit. If any criterion cannot be verified locally (e.g., requires post-deploy or post-merge observation), note it as "requires post-deploy verification." If any criterion is NOT addressed by your implementation, do NOT write COMPLETE — instead, note the gap and continue implementing.
 > 6. Write your acceptance criteria self-check to `{worktree}/tmp/ralph/acceptance-check.txt` with a table mapping each criterion to its evidence.
 > 7. When all applicable pre-PR checks pass AND all locally-verifiable acceptance criteria are addressed, write "COMPLETE" to `{worktree}/tmp/ralph/work-status.txt`.
@@ -307,11 +319,12 @@ The Claude reviewer prompt applies to both branches:
 >    - If ANY locally-verifiable criterion is **not met**, the review MUST be **REVISE**, regardless of code quality. List the unmet criteria in your feedback.
 > 5. Evaluate against these additional criteria:
 >    - **Correctness**: Does the implementation satisfy the acceptance criteria in task.md?
+>    - **Full-package test coverage (MANDATORY for testable changes):** Read `{worktree}/tmp/ralph/pre-push-preview.txt`. Verify that every package listed in `{worktree}/tmp/ralph/touched-packages.txt` has a `PASS packages/<pkg>` entry in `pre-push-preview.txt`. If `pre-push-preview.txt` is missing, or if any touched package has a `FAIL` entry or is absent from the preview, issue **REVISE** and explain which package's full test suite was not run or did not pass. "I only ran tests for the new file" is not sufficient — the worker must run the full `packages/<pkg>/tests/` suite for every touched package and document the result. Skip this check entirely for non-testable changes (`## Testable: no`).
 >    - **Test coverage** (testable only — skip for non-testable): Are there tests for each acceptance criterion and obvious edge cases? For **non-testable** changes (`## Testable: no`), do **not** flag "no tests added" as a REVISE reason. Tests are not expected on a docs-only or migration-only diff. Verify acceptance criteria against the diff, the plan's "What will change" section, and any updated documentation instead.
 >    - **Scope completeness**: Does the change need to be applied in other locations too? Search the codebase (using Grep) for other files that use, render, or implement the same pattern being changed. If the fix or feature was applied to one file but the same pattern exists elsewhere without the change, flag it as a REVISE reason. For example, if a rendering fix was applied to `ComponentA.tsx`, check whether `ComponentB.tsx` or other components render the same data and need the same fix.
 >    - **Scope creep**: Are there changes unrelated to the issue (extra refactors, unrelated fixes)?
 >    - **Code quality**: Does it follow existing patterns? Any debug code, hardcoded values, or forgotten TODOs?
->    - **Missing pieces**: Are there files that should have been created or modified but weren't?
+>    - **Missing pieces**: Are there files that should have been created or modified but wouldn't?
 >    - **Stale references**: Do comments, imports, or docstrings reference things that changed?
 >    - **Documentation consistency**: If the change modifies behavior, configuration, or interfaces — do related docs (`docs/`, `CLAUDE.md`, `.claude/skills/`, `README.md`, `CONTRIBUTING.md`) need corresponding updates? Flag any docs that reference the old behavior.
 >    - **Performance** (testable only — skip for non-testable): Are there obvious bottlenecks? Sequential I/O that could be parallelized? O(n^2) patterns (e.g. LIMIT/OFFSET pagination, nested loops over large datasets)? Missing connection pooling or batching for network calls (DB, S3, HTTP)?
@@ -332,6 +345,7 @@ The Claude reviewer prompt applies to both branches:
 > - Don't request changes outside the scope of the task.
 > - Don't flag pre-existing patterns not introduced by this diff.
 > - **Unmet acceptance criteria are always REVISE.** Never SHIP if any locally-verifiable acceptance criterion is not satisfied.
+> - **Missing or failed full-package test run is always REVISE (testable only).** If `pre-push-preview.txt` is absent or any touched package's full test suite did not pass, issue REVISE. The worker must document passing results for every touched package.
 > - **Do not REVISE for "no tests added" on non-testable changes.** The `## Testable: no` branch does not require tests; applying a test-coverage standard to a docs-only or migration-only diff is a category error that would deadlock the loop.
 > - If you say REVISE, your feedback must be specific enough that the worker can act on it without guessing.
 > - **Unchecked test plan items are always blockers.** Never approve a PR with unchecked test plan checkboxes.

--- a/scripts/ralph_touched_packages.py
+++ b/scripts/ralph_touched_packages.py
@@ -1,0 +1,146 @@
+"""Helper to derive touched packages from git diff for the /ralph loop.
+
+Given a list of changed file paths, derives which Python or TypeScript
+packages have code changes (src/ or tests/ .py/.ts/.tsx files).
+
+This module is intentionally dependency-free (stdlib only) to avoid requiring
+a venv for the scripts/ directory.
+"""
+# venv: none
+# permanent: true
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def derive_touched_packages(changed_files: list[str]) -> list[str]:
+    """Return sorted list of Python packages with src/ or tests/ .py changes.
+
+    A package is identified by its path under packages/<name>/ that contains
+    a pyproject.toml.  Only files matching
+    ``packages/<name>/src/**/*.py`` or ``packages/<name>/tests/**/*.py``
+    count as code changes — doc, config, and fixture changes are excluded.
+
+    Args:
+        changed_files: List of repo-relative file paths (as returned by
+            ``git diff --name-only``).
+
+    Returns:
+        Sorted list of package *names* (the ``<name>`` component, not the
+        full path).  E.g. ``['nlp-pipeline', 'scraper-framework']``.
+    """
+    packages: set[str] = set()
+    for f in changed_files:
+        parts = f.split("/")
+        # Must be packages/<name>/src/... or packages/<name>/tests/... .py
+        if (
+            len(parts) >= 4
+            and parts[0] == "packages"
+            and parts[2] in ("src", "tests")
+            and f.endswith(".py")
+        ):
+            packages.add(parts[1])
+    return sorted(packages)
+
+
+def derive_touched_ts_packages(changed_files: list[str]) -> list[str]:
+    """Return sorted list of TypeScript packages with src/ or app/ .ts/.tsx changes.
+
+    A package is identified by its path under packages/<name>/ that contains
+    a package.json.  Only files matching
+    ``packages/<name>/src/**/*.{ts,tsx}`` or ``packages/<name>/app/**/*.{ts,tsx}``
+    count as code changes.
+
+    Args:
+        changed_files: List of repo-relative file paths (as returned by
+            ``git diff --name-only``).
+
+    Returns:
+        Sorted list of package *names* (the ``<name>`` component, not the
+        full path).  E.g. ``['web']``.
+    """
+    packages: set[str] = set()
+    for f in changed_files:
+        parts = f.split("/")
+        # Must be packages/<name>/src/... or packages/<name>/app/... .ts/.tsx
+        if (
+            len(parts) >= 4
+            and parts[0] == "packages"
+            and parts[2] in ("src", "app")
+            and (f.endswith(".ts") or f.endswith(".tsx"))
+        ):
+            packages.add(parts[1])
+    return sorted(packages)
+
+
+def git_diff_names(worktree: str | Path, base: str = "origin/main") -> list[str]:
+    """Return list of file paths changed relative to *base*.
+
+    Wraps ``git -C <worktree> diff --name-only <base>...HEAD`` so callers
+    do not need to shell out directly.
+
+    Args:
+        worktree: Absolute path to the worktree.
+        base: The base ref to compare against (default: ``origin/main``).
+
+    Returns:
+        List of repo-relative file paths, one per changed file.  Returns
+        an empty list if git is unavailable or the command fails.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(worktree),
+                "diff",
+                "--name-only",
+                f"{base}...HEAD",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+
+    if result.returncode != 0:
+        return []
+
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def main() -> None:
+    """CLI entry point.
+
+    Prints one package name per line to stdout.  With ``--ts``, prints
+    TypeScript packages; without it, prints Python packages.
+
+    Usage::
+
+        python3 scripts/ralph_touched_packages.py [--ts] [<worktree>]
+
+    If *worktree* is omitted, the current directory is used.
+    """
+    args = sys.argv[1:]
+    ts_mode = "--ts" in args
+    args = [a for a in args if a != "--ts"]
+
+    worktree = Path(args[0]) if args else Path(".")
+
+    changed = git_diff_names(worktree)
+
+    if ts_mode:
+        pkgs = derive_touched_ts_packages(changed)
+    else:
+        pkgs = derive_touched_packages(changed)
+
+    for pkg in pkgs:
+        print(pkg)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_ralph_touched_packages.py
+++ b/scripts/tests/test_ralph_touched_packages.py
@@ -1,0 +1,171 @@
+"""Tests for ralph_touched_packages module."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add scripts directory to path so we can import the module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from ralph_touched_packages import (
+    derive_touched_packages,
+    derive_touched_ts_packages,
+    git_diff_names,
+)
+
+
+class TestDeriveTouchedPackages:
+    """Tests for derive_touched_packages (Python packages)."""
+
+    def test_empty_diff_returns_empty(self) -> None:
+        """Empty changed-files list returns no packages."""
+        assert derive_touched_packages([]) == []
+
+    def test_single_package_src_change(self) -> None:
+        """A .py file under packages/<pkg>/src/ is detected."""
+        files = ["packages/scraper-framework/src/framework/base.py"]
+        assert derive_touched_packages(files) == ["scraper-framework"]
+
+    def test_single_package_tests_change(self) -> None:
+        """A .py file under packages/<pkg>/tests/ is detected."""
+        files = ["packages/nlp-pipeline/tests/test_enrichment.py"]
+        assert derive_touched_packages(files) == ["nlp-pipeline"]
+
+    def test_two_packages_returns_sorted(self) -> None:
+        """Changes to two packages return sorted list of both."""
+        files = [
+            "packages/scraper-framework/src/framework/scraper.py",
+            "packages/nlp-pipeline/tests/test_enrichment.py",
+        ]
+        result = derive_touched_packages(files)
+        assert result == ["nlp-pipeline", "scraper-framework"]
+
+    def test_docs_only_change_returns_empty(self) -> None:
+        """Markdown files are not Python code changes."""
+        files = ["docs/specs/architecture-spec-v1.md", "README.md"]
+        assert derive_touched_packages(files) == []
+
+    def test_non_package_paths_excluded(self) -> None:
+        """Files not under packages/<name>/src/ or tests/ are excluded."""
+        files = [
+            "scripts/some_script.py",
+            "infra/lambda-handler/handler.py",
+            "packages/scraper-framework/pyproject.toml",
+        ]
+        assert derive_touched_packages(files) == []
+
+    def test_package_config_file_excluded(self) -> None:
+        """Config files at the package root level are excluded."""
+        files = [
+            "packages/scraper-framework/pyproject.toml",
+            "packages/scraper-framework/setup.cfg",
+        ]
+        assert derive_touched_packages(files) == []
+
+    def test_duplicate_files_in_same_package_deduplicated(self) -> None:
+        """Multiple changed files in the same package count as one entry."""
+        files = [
+            "packages/scraper-framework/src/framework/base.py",
+            "packages/scraper-framework/src/framework/scraper.py",
+            "packages/scraper-framework/tests/test_base.py",
+        ]
+        result = derive_touched_packages(files)
+        assert result == ["scraper-framework"]
+
+    def test_ts_files_not_in_python_list(self) -> None:
+        """TypeScript files are not returned by the Python helper."""
+        files = [
+            "packages/web/src/app/page.tsx",
+            "packages/web/src/components/Header.ts",
+        ]
+        assert derive_touched_packages(files) == []
+
+    def test_mixed_python_and_non_python(self) -> None:
+        """Only Python packages are returned even when other file types are present."""
+        files = [
+            "packages/scraper-framework/src/framework/base.py",
+            "docs/specs/architecture-spec-v1.md",
+            "scripts/some_script.py",
+            "packages/web/src/app/page.tsx",
+        ]
+        result = derive_touched_packages(files)
+        assert result == ["scraper-framework"]
+
+
+class TestDeriveTouchedTsPackages:
+    """Tests for derive_touched_ts_packages (TypeScript packages)."""
+
+    def test_empty_diff_returns_empty(self) -> None:
+        """Empty changed-files list returns no packages."""
+        assert derive_touched_ts_packages([]) == []
+
+    def test_ts_file_under_src_detected(self) -> None:
+        """A .ts file under packages/<pkg>/src/ is detected."""
+        files = ["packages/web/src/components/Header.ts"]
+        assert derive_touched_ts_packages(files) == ["web"]
+
+    def test_tsx_file_under_src_detected(self) -> None:
+        """A .tsx file under packages/<pkg>/src/ is detected."""
+        files = ["packages/web/src/app/page.tsx"]
+        assert derive_touched_ts_packages(files) == ["web"]
+
+    def test_ts_file_under_app_detected(self) -> None:
+        """A .ts file under packages/<pkg>/app/ is detected."""
+        files = ["packages/web/app/layout.tsx"]
+        assert derive_touched_ts_packages(files) == ["web"]
+
+    def test_py_files_not_in_ts_list(self) -> None:
+        """Python files are not returned by the TypeScript helper."""
+        files = [
+            "packages/scraper-framework/src/framework/base.py",
+            "packages/nlp-pipeline/tests/test_enrichment.py",
+        ]
+        assert derive_touched_ts_packages(files) == []
+
+    def test_two_ts_packages_sorted(self) -> None:
+        """Changes to two TypeScript packages return sorted list."""
+        files = [
+            "packages/web/src/app/page.tsx",
+            "packages/api-client/src/index.ts",
+        ]
+        result = derive_touched_ts_packages(files)
+        assert result == ["api-client", "web"]
+
+    def test_docs_only_excluded(self) -> None:
+        """Markdown docs are excluded from TypeScript packages."""
+        files = ["docs/web-patterns.md", "packages/web/README.md"]
+        assert derive_touched_ts_packages(files) == []
+
+    def test_ts_in_tests_subdir_not_detected(self) -> None:
+        """TypeScript files under packages/<pkg>/tests/ are not detected (only src/ and app/)."""
+        files = ["packages/web/tests/unit.ts"]
+        assert derive_touched_ts_packages(files) == []
+
+    def test_mixed_py_and_ts_returns_ts_only(self) -> None:
+        """With mixed files, only TypeScript packages are returned."""
+        files = [
+            "packages/scraper-framework/src/framework/base.py",
+            "packages/web/src/app/page.tsx",
+        ]
+        result = derive_touched_ts_packages(files)
+        assert result == ["web"]
+
+
+class TestGitDiffNames:
+    """Tests for git_diff_names function."""
+
+    def test_returns_list_for_nonexistent_path(self, tmp_path: Path) -> None:
+        """Returns empty list for a non-git directory."""
+        result = git_diff_names(tmp_path / "nonexistent")
+        assert result == []
+
+    def test_returns_list_type(self, tmp_path: Path) -> None:
+        """Always returns a list (not None or other types)."""
+        result = git_diff_names(tmp_path)
+        assert isinstance(result, list)
+
+    def test_filters_empty_lines(self, tmp_path: Path) -> None:
+        """Result never contains empty strings."""
+        result = git_diff_names(tmp_path)
+        assert all(line.strip() for line in result)


### PR DESCRIPTION
## Summary

Fixed ralph's SHIP→pre-push regression by requiring the worker to run the full test suite for **every touched package** before marking COMPLETE, and requiring the Claude reviewer to verify this evidence before SHIPping. The new `scripts/ralph_touched_packages.py` helper derives touched packages from git diff (mirroring pre-push's detection logic), and updated .claude/skills/ralph/SKILL.md instructs the worker to run `pytest packages/<pkg>/tests/` for each package and the reviewer to enforce pre-push-preview.txt evidence.

Closes #2897

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`) — 22 test cases in scripts/tests/test_ralph_touched_packages.py all passing
- [ ] CI green

### Post-deploy verification

- [ ] Post-merge: run `/task-v2` on an issue touching `packages/scraper-framework/`; confirm ralph iteration log shows `pytest packages/scraper-framework/tests/` invoked; confirm `.githooks/pre-push` passes cleanly. Post task number and log excerpts as comment on #2897.
- [ ] Verification evidence posted on #2897 (see /task-v2-verify output)
