### PR TITLE
feat(dispatcher): failure_summary on agents row + tooltip on outcome glyph (#2900)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -11,11 +11,11 @@ Diagnoser for the dispatcher v2 tier-2/3 failure flow (`docs/specs/dispatcher-v2
 
 **Prerequisites:** The daemon has already (a) written a `dispatcher.diagnoses` row with `status='pending'` and a serialized context bundle, (b) spawned this skill with the `diagnosis_id` as the argument.
 
-**Goal:** Update `dispatcher.diagnoses.recommendation` (JSONB) with `{action, reasoning, hint?, new_scope?}` and set `status='completed'`, `completed_at=now()`. The daemon's next supervisor tick consumes the recommendation.
+**Goal:** Update `dispatcher.diagnoses.recommendation` (JSONB) with `{action, reasoning, hint?, new_scope?}` and set `status='completed'`, `completed_at=now()`. Additionally, UPDATE `dispatcher.agents.failure_summary` with the first 1-3 sentences of the recommendation's `reasoning` (truncated to 240 chars) so the admin cockpit's "Recently completed" panel shows an LLM-authored summary on hover instead of the daemon's terminal-time template (issue #2900). The daemon's next supervisor tick consumes the recommendation.
 
 **IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation. This subprocess is already a dispatcher-spawned background task.
 
-**IMPORTANT — No side effects on GitHub or the filesystem.** This skill does NOT comment on issues, edit labels, close issues, edit PRs, or modify the worktree. The daemon owns all of those operations — the skill's only write is the UPDATE on `dispatcher.diagnoses`. The skill MAY read from GitHub (`gh issue view`, `gh pr view`, `gh run view --log-failed`) and from local files in the failed agent's worktree when the context bundle references them.
+**IMPORTANT — No side effects on GitHub or the filesystem.** This skill does NOT comment on issues, edit labels, close issues, edit PRs, or modify the worktree. The daemon owns all of those operations — the skill's only writes are the UPDATE on `dispatcher.diagnoses` and the UPDATE on `dispatcher.agents.failure_summary`. The skill MAY read from GitHub (`gh issue view`, `gh pr view`, `gh run view --log-failed`) and from local files in the failed agent's worktree when the context bundle references them.
 
 **IMPORTANT — 5-minute wall-clock budget.** The daemon kills this subprocess after 5 minutes. Aim for the simplest viable recommendation within that budget; default to `escalate` when genuinely uncertain — a human can always re-classify. Do not chase rabbit holes.
 
@@ -52,7 +52,7 @@ You may also shell out with `scripts/dev-db-query.sh` for quick SELECTs. Either 
 
 The `context` JSONB contains (schema stable — the daemon serializes this):
 
-- `agent_id` (str) — the failing agent's UUID.
+- `agent_id` (str) — the failing agent's UUID. **Required for the `failure_summary` upgrade write (#2900).**
 - `failure_id` (int) — `dispatcher.failures.failure_id` for the triggering failure.
 - `failure_category` (str) — one of `subprocess_turn_limit`, `stuck_timeout`, `gh_rate_exhausted`, `subprocess_crash`, `ci_red_after_retries`, or any other §8 category the daemon has routed here.
 - `tier` (int) — `2` or `3`.
@@ -72,21 +72,43 @@ The `context` JSONB contains (schema stable — the daemon serializes this):
 
 ## Output contract
 
-Update the `dispatcher.diagnoses` row. Use a second tiny helper:
+Update the `dispatcher.diagnoses` row AND upgrade `dispatcher.agents.failure_summary` (issue #2900) in a single transaction. Use a second tiny helper:
 
 ```bash
-python3 {worktree}/tmp/dispatcher-diagnoser/write_recommendation.py <diagnosis_id> <recommendation_json_file>
+python3 {worktree}/tmp/dispatcher-diagnoser/write_recommendation.py <diagnosis_id> <agent_id> <recommendation_json_file>
 ```
 
 where the helper runs:
 
 ```python
-import json, os, sys
+import json, os, re, sys
 import psycopg
 
 diagnosis_id = int(sys.argv[1])
-with open(sys.argv[2], "r", encoding="utf-8") as f:
+agent_id = sys.argv[2]  # UUID string from context.agent_id
+with open(sys.argv[3], "r", encoding="utf-8") as f:
     recommendation = json.load(f)
+
+# Issue #2900: upgrade dispatcher.agents.failure_summary with the first
+# 1-3 sentences of recommendation.reasoning, truncated to 240 chars.
+# The daemon wrote a templated fallback at terminal-time; this upgrade
+# replaces it with LLM-authored prose for tier-2/3 failures where we
+# already paid for the analysis. Best-effort — a write failure here
+# must not block the diagnosis row write.
+def _summary_from_reasoning(reasoning: str, cap: int = 240) -> str:
+    text = (reasoning or "").strip()
+    if not text:
+        return ""
+    # Take the first 1-3 sentences. Split on sentence terminators (.!?)
+    # followed by whitespace or end-of-string. Rejoin up to 3.
+    sentences = re.split(r"(?<=[.!?])\s+", text)
+    head = " ".join(sentences[:3]).strip()
+    if len(head) > cap:
+        head = head[: cap - 1].rstrip() + "\u2026"
+    return head
+
+summary = _summary_from_reasoning(recommendation.get("reasoning", ""))
+
 with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
     with conn.cursor() as cur:
         cur.execute(
@@ -97,6 +119,12 @@ with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
             "WHERE diagnosis_id = %s",
             (json.dumps(recommendation), diagnosis_id),
         )
+        if summary:
+            cur.execute(
+                "UPDATE dispatcher.agents "
+                "SET failure_summary = %s WHERE agent_id = %s",
+                (summary, agent_id),
+            )
     conn.commit()
 ```
 
@@ -114,7 +142,7 @@ The recommendation JSON has this shape:
 Field rules:
 
 - `action` (required) — exactly one of the five strings above.
-- `reasoning` (required) — a single paragraph (≤500 chars) explaining the choice in plain English. This gets surfaced in operator dashboards and the §8 weekly report.
+- `reasoning` (required) — a single paragraph (≤500 chars) explaining the choice in plain English. This gets surfaced in operator dashboards and the §8 weekly report. The first 1-3 sentences are also written to `dispatcher.agents.failure_summary` (issue #2900) so the admin cockpit can show an LLM-authored tooltip on hover over the outcome glyph — keep the opening sentences self-contained ("what happened + why this action"), not mid-argument.
 - `hint` (conditional) — required when `action='retry_with_hint'`; the daemon posts it verbatim as an issue comment before enqueueing the retry marker. Ignored for other actions.
 - `new_scope` (conditional) — required when `action='reissue'`; the daemon replaces the issue body with this string. Should be a full, well-formed issue body with acceptance criteria — not a diff.
 
@@ -172,7 +200,7 @@ The context bundle should usually be enough. Shell out sparingly:
 
 3. **Decide.** Walk the decision tree above. Do not fetch anything you don't need — context bundle first, GitHub reads only when a specific question remains.
 
-4. **Write recommendation.** Serialize the recommendation dict to `{worktree}/tmp/dispatcher-diagnoser/recommendation.json`, then run the writer helper with the `diagnosis_id` and the JSON file path.
+4. **Write recommendation.** Serialize the recommendation dict to `{worktree}/tmp/dispatcher-diagnoser/recommendation.json`, then run the writer helper with the `diagnosis_id`, the `agent_id` (from `context.agent_id`), and the JSON file path. The helper writes both the diagnosis row AND the `dispatcher.agents.failure_summary` upgrade in one transaction — issue #2900.
 
 5. **Exit 0.** Done. The daemon picks up the recommendation on the next supervisor tick.
 

--- a/packages/api/migrations/33_dispatcher-agents-failure-summary.sql
+++ b/packages/api/migrations/33_dispatcher-agents-failure-summary.sql
@@ -1,0 +1,52 @@
+-- Up Migration
+--
+-- Dispatcher v2 — add ``failure_summary TEXT`` column to
+-- ``dispatcher.agents`` so the admin "Recently completed" panel can
+-- surface a one-line "what happened" string on hover over the outcome
+-- glyph for failed / crashed / plan_blocked rows (#2900).
+--
+-- Context
+-- -------
+-- Today the diagnostic signal for a terminal failure is scattered
+-- across three tables: ``dispatcher.failures.category`` (enum, coarse),
+-- ``dispatcher.failures.details`` (per-category JSONB), and
+-- ``dispatcher.diagnoses.recommendation.reasoning`` (LLM prose, ONLY
+-- populated for tier-2/3 failures that triggered ``/diagnose-failure``).
+-- There is no single place on the agents row the admin panel can read
+-- to render "ralph crashed at iteration 3 (subprocess_turn_limit):
+-- reviewer exceeded max turns" without a cross-table join.
+--
+-- The daemon's ``_mark_agent_terminal`` will populate this column at
+-- two points (issue #2900 fix):
+--   1. Deterministically at terminal-time with a template built from
+--      ``failures.category + details`` + ``phase_outputs.phase + log_text``.
+--   2. When ``/diagnose-failure`` completes, UPDATE with the first 1-3
+--      sentences of ``diagnoses.recommendation.reasoning`` so tier-2/3
+--      failures upgrade to an LLM-authored summary.
+--
+-- Design notes
+-- ------------
+-- - ``TEXT`` (not ``varchar(N)``) matching the repo convention — the
+--   daemon caps at 240 chars at write-time; a DB cap would turn an
+--   operational cap into a hard failure the daemon has to handle.
+-- - Nullable with no default — historical rows stay NULL (the UI
+--   renders the glyph unchanged), succeeded rows also stay NULL
+--   (there is nothing to summarize), failed/crashed/plan_blocked rows
+--   get populated at terminal-time going forward.
+-- - No CHECK constraint — the template may evolve; tightening the
+--   column to a regex would couple schema to daemon code.
+-- - No index — reads are always keyed by agent_id/ended_at which are
+--   covered elsewhere; the column is a read-through, never searched.
+-- - ``ADD COLUMN IF NOT EXISTS`` so the migration is idempotent and
+--   can re-run safely. This matches the issue's verify line ("Migration
+--   is idempotent (uses IF NOT EXISTS) so it can re-run").
+
+ALTER TABLE dispatcher.agents
+    ADD COLUMN IF NOT EXISTS failure_summary TEXT;
+
+COMMENT ON COLUMN dispatcher.agents.failure_summary IS
+    'One-line "what happened" string for failed / crashed / plan_blocked terminals. Populated by _mark_agent_terminal at terminal-time from failures.category + phase + exit_code + stderr tail (<=240 chars), then optionally upgraded by /diagnose-failure to the first 1-3 sentences of recommendation.reasoning. NULL for succeeded / needs_review rows and historical pre-#2900 rows. Rendered as a tooltip on the outcome glyph in the /admin/dispatcher Recently completed panel. Issue #2900.';
+
+
+-- Down Migration
+ALTER TABLE dispatcher.agents DROP COLUMN IF EXISTS failure_summary;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 32 migrations.
+-- Generated from 33 migrations.
 
 
 
@@ -327,7 +327,8 @@ CREATE TABLE dispatcher.agents (
     pid integer,
     runner_override jsonb,
     model_override jsonb,
-    issue_title text
+    issue_title text,
+    failure_summary text
 );
 
 
@@ -341,6 +342,9 @@ COMMENT ON COLUMN dispatcher.agents.model_override IS 'Per-agent override of dis
 
 
 COMMENT ON COLUMN dispatcher.agents.issue_title IS 'Issue title captured at claim time from the queue-snapshot enrichment. Lets the /admin/dispatcher recent-completions panel render a title without re-fetching from GitHub after the agent has completed and the issue may have left the active queue. Nullable — historical rows pre-dating issue #2820 have NULL and are not backfilled.';
+
+
+COMMENT ON COLUMN dispatcher.agents.failure_summary IS 'One-line "what happened" string for failed / crashed / plan_blocked terminals. Populated by _mark_agent_terminal at terminal-time from failures.category + phase + exit_code + stderr tail (<=240 chars), then optionally upgraded by /diagnose-failure to the first 1-3 sentences of recommendation.reasoning. NULL for succeeded / needs_review rows and historical pre-#2900 rows. Rendered as a tooltip on the outcome glyph in the /admin/dispatcher Recently completed panel. Issue #2900.';
 
 
 CREATE TABLE dispatcher.blocked_snapshots (

--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -287,6 +287,11 @@ async function queryRecentCompletions(pool: Pool, limit: number): Promise<Row[]>
   // predate migration 31 have NULL metering columns, so SUM returns
   // NULL (not 0), which the UI renders as "no cost data" rather than a
   // misleading "$0.00".
+  // #2900: select `a.failure_summary` so the admin cockpit can render
+  // a one-line "what happened" tooltip on hover over the outcome glyph
+  // for failure terminals. Always nullable — succeeded / needs_review
+  // rows don't populate it, nor do historical rows from before
+  // migration 33.
   const { rows } = await pool.query<Row>(
     `SELECT a.agent_id,
             a.issue_number,
@@ -294,6 +299,7 @@ async function queryRecentCompletions(pool: Pool, limit: number): Promise<Row[]>
             a.status,
             a.ended_at,
             a.pr_number,
+            a.failure_summary,
             po.total_tokens,
             po.total_cost_usd
        FROM dispatcher.agents a
@@ -442,6 +448,16 @@ function recentCompletionsToGraphQL(
       typeof row.issue_title === 'string' && row.issue_title.length > 0
         ? row.issue_title
         : null;
+    // #2900: failure_summary is TEXT nullable — any non-string or empty
+    // value collapses to null so the UI renders the outcome glyph
+    // exactly as it did pre-#2900 (no tooltip layering over the
+    // built-in status label). Trimming matches the daemon's write-time
+    // convention and handles the edge case where a migration-era empty
+    // string sneaks through.
+    const failureSummary =
+      typeof row.failure_summary === 'string' && row.failure_summary.trim()
+        ? row.failure_summary.trim()
+        : null;
     return {
       agentId: row.agent_id,
       issueNumber: number,
@@ -459,6 +475,11 @@ function recentCompletionsToGraphQL(
       // null so the UI renders "no data" instead of "$0.00".
       totalTokens: coerceNullableNumber(row.total_tokens),
       totalCostUsd: coerceNullableNumber(row.total_cost_usd),
+      // #2900: one-line "what happened" string for failure terminals,
+      // rendered as a tooltip in the admin cockpit's Recently
+      // completed panel. Null for succeeded / needs_review / historical
+      // rows — the UI falls back to the default status-label tooltip.
+      failureSummary,
     };
   });
 }

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -225,6 +225,15 @@ export const dispatcherTypeDefs = `#graphql
     WARNING: list-price estimate, NOT Max plan-adjusted. See
     \`DispatcherAgent.totalCostUsd\`."""
     totalCostUsd: Float
+    """Short "what happened" string for failure terminals (\`failed\`,
+    \`crashed\`, \`plan_blocked\`). Populated at terminal-time by the
+    daemon from \`failures.category\` + \`phase\` + stderr tail, then
+    optionally upgraded by \`/diagnose-failure\` to a richer LLM-
+    authored sentence. Capped at 240 chars. NULL for \`succeeded\` /
+    \`needs_review\` rows and for historical rows that pre-date
+    migration 33. Rendered as a tooltip on the outcome glyph in the
+    admin cockpit's \`Recently completed\` panel. Issue #2900."""
+    failureSummary: String
   }
 
   """One key/value entry from \`dispatcher.config\` (#2805 §1.6)."""

--- a/packages/api/tests/dispatcher-enrichment.unit.test.ts
+++ b/packages/api/tests/dispatcher-enrichment.unit.test.ts
@@ -192,8 +192,88 @@ describe('recentCompletionsToGraphQL', () => {
         prNumber: 2824,
         totalTokens: 12345,
         totalCostUsd: 0.042,
+        // #2900: succeeded rows stay NULL on failure_summary — the
+        // column only populates on failure terminals.
+        failureSummary: null,
       },
     ]);
+  });
+
+  // #2900: failure_summary passthrough + trimming/empty handling.
+  it('passes ``failure_summary`` through for failure rows', () => {
+    const rows = [
+      {
+        agent_id: 'uuid-fail',
+        issue_number: 2900,
+        issue_title: 'Test failure summary',
+        status: 'failed',
+        ended_at: '2026-04-20T10:00:00Z',
+        pr_number: null,
+        failure_summary:
+          'ralph crashed at ralph-reviewer iteration 3 (subprocess_turn_limit): reviewer exceeded max turns',
+      },
+    ];
+    const result = recentCompletionsToGraphQL(rows);
+    expect(result[0].failureSummary).toBe(
+      'ralph crashed at ralph-reviewer iteration 3 (subprocess_turn_limit): reviewer exceeded max turns',
+    );
+  });
+
+  it('emits ``failureSummary=null`` for NULL / empty values (pre-migration-33 rows)', () => {
+    const rows = [
+      // Historical row — column didn't exist at write-time.
+      {
+        agent_id: 'uuid-old',
+        issue_number: 999,
+        issue_title: 'Old row',
+        status: 'failed',
+        ended_at: '2026-03-01T00:00:00Z',
+        pr_number: null,
+        failure_summary: null,
+      },
+      // Edge: empty string sneaks through.
+      {
+        agent_id: 'uuid-empty',
+        issue_number: 998,
+        issue_title: 'Empty summary',
+        status: 'failed',
+        ended_at: '2026-03-01T00:00:00Z',
+        pr_number: null,
+        failure_summary: '',
+      },
+      // Whitespace-only also collapses to null.
+      {
+        agent_id: 'uuid-ws',
+        issue_number: 997,
+        issue_title: 'Whitespace summary',
+        status: 'failed',
+        ended_at: '2026-03-01T00:00:00Z',
+        pr_number: null,
+        failure_summary: '   ',
+      },
+    ];
+    const result = recentCompletionsToGraphQL(rows);
+    expect(result[0].failureSummary).toBeNull();
+    expect(result[1].failureSummary).toBeNull();
+    expect(result[2].failureSummary).toBeNull();
+  });
+
+  it('trims surrounding whitespace on ``failure_summary``', () => {
+    const rows = [
+      {
+        agent_id: 'uuid-wsp',
+        issue_number: 111,
+        issue_title: 'Padded',
+        status: 'crashed',
+        ended_at: '2026-04-20T10:00:00Z',
+        pr_number: null,
+        failure_summary: '  ralph crashed (stuck_timeout): no log tail  ',
+      },
+    ];
+    const result = recentCompletionsToGraphQL(rows);
+    expect(result[0].failureSummary).toBe(
+      'ralph crashed (stuck_timeout): no log tail',
+    );
   });
 
   it('emits totalTokens=null and totalCostUsd=null for pre-migration-31 rows', () => {

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -77,7 +77,14 @@ function RecentCompletionRow({ completion }: { completion: RecentCompletion }) {
   return (
     <li className="flex items-start gap-3 py-2 text-sm hover:bg-muted/50">
       <span className="flex-shrink-0 pt-0.5">
-        <OutcomePill status={completion.status} />
+        {/* #2900: pass failureSummary through as hover tooltip for
+            failure terminals. Null on succeeded / needs_review /
+            pre-#2900 rows, in which case the pill falls back to its
+            built-in status-label tooltip (prior behaviour). */}
+        <OutcomePill
+          status={completion.status}
+          failureSummary={completion.failureSummary}
+        />
       </span>
       <span className="flex-shrink-0 pt-0.5">
         <IssueLink number={completion.issueNumber} />

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
@@ -19,6 +19,7 @@ function completion(overrides: Partial<RecentCompletion>): RecentCompletion {
     prNumber: 2811,
     totalTokens: null,
     totalCostUsd: null,
+    failureSummary: null,
     ...overrides,
   };
 }
@@ -101,6 +102,56 @@ describe('RecentCompletionsPanel', () => {
     render(<RecentCompletionsPanel completions={items} nowMs={now} />);
     // No footnote rendered — distinguishes "no data" from "$0.00".
     expect(screen.queryByTestId('completion-row-cost')).not.toBeInTheDocument();
+  });
+
+  // --- #2900 — failure_summary tooltip on the outcome glyph.
+  //
+  // The panel keeps its density-first layout (#2818) — no always-
+  // visible second line. The summary surfaces on hover via the
+  // OutcomePill's `title` attribute, so operators can triage failures
+  // without opening the agent detail page.
+  it('#2900: wires failure_summary into the OutcomePill tooltip for failure rows', () => {
+    const summary =
+      'ralph crashed at ralph-reviewer iteration 3 (subprocess_turn_limit): reviewer exceeded max turns';
+    const items = [
+      completion({
+        agentId: 'agent-fail',
+        issueNumber: 2900,
+        status: 'crashed',
+        prNumber: null,
+        failureSummary: summary,
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    const pill = screen.getByTestId('outcome-pill-crashed');
+    expect(pill.getAttribute('title')).toBe(summary);
+  });
+
+  it('#2900: leaves the default status-label tooltip for succeeded rows (no summary)', () => {
+    const items = [completion({ agentId: 'agent-ok', failureSummary: null })];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    const pill = screen.getByTestId('outcome-pill-succeeded');
+    // Default tooltip is the human status label ("succeeded").
+    expect(pill.getAttribute('title')).toBe('succeeded');
+  });
+
+  it('#2900: does NOT render the summary as a second visible line on the row', () => {
+    const summary =
+      'ralph crashed at ralph-reviewer iteration 3 (subprocess_turn_limit): reviewer exceeded max turns';
+    const items = [
+      completion({
+        agentId: 'agent-hidden',
+        issueNumber: 2900,
+        status: 'crashed',
+        prNumber: null,
+        failureSummary: summary,
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    // The summary must not appear as visible text on the row — the
+    // density-first constraint (#2818) is that the panel keeps its
+    // one-line-per-row layout. The tooltip is the *only* surface.
+    expect(screen.queryByText(summary)).not.toBeInTheDocument();
   });
 
   it('#2869: renders only the available half when the other metering field is null', () => {

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
@@ -143,4 +143,85 @@ describe('OutcomePill', () => {
     render(<OutcomePill status="bogus" />);
     expect(screen.getByText('?')).toBeInTheDocument();
   });
+
+  // #2900: failureSummary prop drives the hover tooltip for failure
+  // terminals so operators can triage without opening the agent detail
+  // page. Null / undefined / whitespace falls back to the built-in
+  // status-label tooltip to preserve the existing UX for succeeded /
+  // needs_review / pre-migration-33 rows.
+  describe('failureSummary prop (#2900)', () => {
+    it('uses failureSummary as the title tooltip when present', () => {
+      const summary =
+        'ralph crashed at ralph-reviewer iteration 3 (subprocess_turn_limit): reviewer exceeded max turns';
+      render(<OutcomePill status="crashed" failureSummary={summary} />);
+      const pill = screen.getByTestId('outcome-pill-crashed');
+      expect(pill.getAttribute('title')).toBe(summary);
+      // aria-label stays on the short status string so screen readers
+      // announce "crashed" without reading the full summary mid-row.
+      expect(pill.getAttribute('aria-label')).toBe('crashed');
+    });
+
+    it('falls back to the status label when failureSummary is null', () => {
+      render(<OutcomePill status="failed" failureSummary={null} />);
+      const pill = screen.getByTestId('outcome-pill-failed');
+      expect(pill.getAttribute('title')).toBe('failed');
+    });
+
+    it('falls back to the status label when failureSummary is undefined', () => {
+      render(<OutcomePill status="failed" />);
+      const pill = screen.getByTestId('outcome-pill-failed');
+      expect(pill.getAttribute('title')).toBe('failed');
+    });
+
+    it('falls back to the status label when failureSummary is an empty string', () => {
+      render(<OutcomePill status="failed" failureSummary="" />);
+      const pill = screen.getByTestId('outcome-pill-failed');
+      expect(pill.getAttribute('title')).toBe('failed');
+    });
+
+    it('falls back to the status label when failureSummary is whitespace-only', () => {
+      render(<OutcomePill status="failed" failureSummary="   " />);
+      const pill = screen.getByTestId('outcome-pill-failed');
+      expect(pill.getAttribute('title')).toBe('failed');
+    });
+
+    it('trims surrounding whitespace in the rendered tooltip', () => {
+      render(
+        <OutcomePill
+          status="failed"
+          failureSummary="  plan phase returned go=false: scope is ambiguous  "
+        />,
+      );
+      const pill = screen.getByTestId('outcome-pill-failed');
+      expect(pill.getAttribute('title')).toBe(
+        'plan phase returned go=false: scope is ambiguous',
+      );
+    });
+
+    it('respects the plan_blocked failure-summary path', () => {
+      // plan_blocked is a correct-outcome terminal but still gets a
+      // failure_summary (the block_reason). Verify the pill shows the
+      // summary on hover without losing its neutral chip styling.
+      const summary = 'plan phase returned go=false: acceptance criteria missing';
+      render(
+        <OutcomePill status="plan_blocked" failureSummary={summary} />,
+      );
+      const pill = screen.getByTestId('outcome-pill-plan_blocked');
+      expect(pill.getAttribute('title')).toBe(summary);
+      expect(pill.className).toContain('bg-muted');
+    });
+
+    it('applies the tooltip to the unknown-status fallback chip', () => {
+      render(
+        <OutcomePill
+          status="something-new"
+          failureSummary="future terminal we haven't seen yet"
+        />,
+      );
+      const pill = screen.getByText('?');
+      expect(pill.getAttribute('title')).toBe(
+        "future terminal we haven't seen yet",
+      );
+    });
+  });
 });

--- a/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
@@ -159,19 +159,53 @@ const OUTCOME_STYLES: Record<
   },
 };
 
-export function OutcomePill({ status }: { status: string }) {
+export function OutcomePill({
+  status,
+  failureSummary,
+}: {
+  status: string;
+  /**
+   * Optional one-line "what happened" string. When present (failure
+   * terminals: `failed` / `crashed` / `plan_blocked`), overrides the
+   * default status-label tooltip so operators can scan the cause on
+   * hover without opening the agent detail page. Null / undefined
+   * falls back to the default status label — preserves the existing
+   * UX for `succeeded` / `needs_review` rows and historical rows from
+   * before migration 33. Issue #2900.
+   *
+   * We deliberately do NOT render an always-visible second line — the
+   * "Recently completed" panel's density-first design (#2818) is the
+   * constraint. Tooltip-only.
+   */
+  failureSummary?: string | null;
+}) {
   const info = OUTCOME_STYLES[status as OutcomeStatus];
   if (!info) {
     return (
-      <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[10px] text-muted-foreground">
+      <span
+        className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[10px] text-muted-foreground"
+        title={
+          failureSummary && failureSummary.trim()
+            ? failureSummary.trim()
+            : undefined
+        }
+      >
         ?
       </span>
     );
   }
+  // #2900: prefer the failure_summary for the hover tooltip when
+  // present. The aria-label stays on the short status label so screen
+  // readers announce the category without reading the (possibly long)
+  // summary text mid-row. Sighted operators get the full narrative on
+  // hover; assistive-tech users hear "failed" / "crashed" and can
+  // navigate to the agent detail page from there.
+  const tooltip =
+    failureSummary && failureSummary.trim() ? failureSummary.trim() : info.label;
   return (
     <span
       aria-label={info.label}
-      title={info.label}
+      title={tooltip}
       className={`inline-flex h-5 w-5 items-center justify-center rounded-full text-xs ${info.className}`}
       data-testid={`outcome-pill-${status}`}
     >

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -72,6 +72,7 @@ export const DISPATCHER_STATE_QUERY = gql`
         prNumber
         totalTokens
         totalCostUsd
+        failureSummary
       }
       config {
         key
@@ -176,6 +177,16 @@ export interface RecentCompletion {
    *
    * WARNING: list-price estimate, NOT Max plan-adjusted. */
   totalCostUsd: number | null;
+  /** One-line "what happened" string for failure terminals (`failed`,
+   * `crashed`, `plan_blocked`). Populated at terminal-time by the
+   * daemon from `failures.category` + `phase` + stderr tail, then
+   * optionally upgraded by `/diagnose-failure`. Capped at 240 chars.
+   *
+   * Null for `succeeded` / `needs_review` rows and for historical rows
+   * that pre-date migration 33. Rendered as a tooltip on the outcome
+   * glyph in the `Recently completed` panel — no always-visible second
+   * line. Issue #2900. */
+  failureSummary: string | null;
 }
 
 export interface DispatcherConfigEntry {

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -3962,6 +3962,235 @@ class DispatcherDaemon:
             except Exception:  # pragma: no cover
                 pass
 
+    # ── failure_summary builder (issue #2900) ──────────────────────────
+
+    #: Statuses that get a ``dispatcher.agents.failure_summary``
+    #: populated at terminal-time. Genuine failures + the plan-blocked
+    #: correct-outcome terminal (operators still want "why did plan
+    #: decline") qualify; ``succeeded`` and ``needs_review`` do not —
+    #: the draft PR IS the signal for needs_review and success needs
+    #: no narrative.
+    _FAILURE_SUMMARY_STATUSES = frozenset({"failed", "crashed", "plan_blocked"})
+
+    #: Hard cap matching the admin cockpit tooltip's visual budget and
+    #: the Postgres column comment in migration 33. Enforced at
+    #: write-time; anything longer is truncated with an ellipsis.
+    _FAILURE_SUMMARY_MAX_CHARS = 240
+
+    @staticmethod
+    def _humanize_phase(phase: str) -> str:
+        """Turn ``"ralph-reviewer (3)"`` into ``"ralph-reviewer iteration 3"``.
+
+        Other shapes pass through unchanged — ``"plan"`` stays ``"plan"``,
+        ``"push_and_pr"`` stays ``"push_and_pr"``, ``"ralph (1)"``
+        becomes ``"ralph iteration 1"``. The iteration suffix is the
+        ralph loop's attempt counter; surfacing it inline makes the
+        tooltip self-describing without the operator having to know the
+        phase-naming convention.
+        """
+        import re  # noqa: PLC0415 — lazy; only fires on terminal path
+
+        m = re.match(r"^(.*)\s*\((\d+)\)\s*$", phase or "")
+        if m:
+            prefix = m.group(1).strip()
+            n = m.group(2)
+            return f"{prefix} iteration {n}" if prefix else f"iteration {n}"
+        return phase or "unknown"
+
+    @staticmethod
+    def _extract_stderr_tail(log_text: str | None) -> str:
+        """Pull the last non-empty line out of a ``phase_outputs.log_text``.
+
+        ``log_text`` is the composed stdout+stderr blob from
+        :meth:`_compose_phase_log` — begins with ``=== stderr ===`` when
+        both streams had content. We search from the end for the first
+        non-blank, non-separator line. Empty string when the log has no
+        usable tail.
+        """
+        if not log_text:
+            return ""
+        lines = [line.strip() for line in log_text.splitlines()]
+        for line in reversed(lines):
+            if not line:
+                continue
+            if line.startswith("===") and line.endswith("==="):
+                continue
+            return line
+        return ""
+
+    @staticmethod
+    def _extract_details_message(details: Any) -> str:
+        """Pull a short human message out of a ``failures.details`` JSONB.
+
+        The ``details`` column is per-category schema — different keys
+        for ``stuck_timeout`` (``stuck_seconds``), ``plan_go_false``
+        (``block_reason``), ``ci_red_after_retries`` (``detail``), etc.
+        Try the most-often-present keys in priority order; fall back to
+        an empty string so the caller can still emit a summary using
+        just phase + category.
+        """
+        if not isinstance(details, dict):
+            return ""
+        for key in (
+            "stderr_tail",
+            "block_reason",
+            "detail",
+            "reason",
+            "message",
+            "error",
+        ):
+            value = details.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
+
+    def _build_failure_summary(
+        self,
+        *,
+        agent_id: str,
+        status: str,
+        phase: str,
+        exit_code: int | None,
+    ) -> str | None:
+        """Build the templated one-liner for ``agents.failure_summary``.
+
+        Issue #2900. Reads the latest ``dispatcher.failures`` row
+        (category + details) and the latest ``dispatcher.phase_outputs``
+        ``log_text`` (last stderr line) for the agent, then composes:
+
+            "{phase-group} {verb} at {phase-humanized} ({category}): {detail}"
+
+        For ``plan_blocked`` the verb phrase becomes
+        ``"plan phase returned go=false"`` to match the issue's example
+        list and keep the correct-outcome terminal visually distinct
+        from a genuine crash.
+
+        Returns ``None`` for:
+
+        - Statuses outside :attr:`_FAILURE_SUMMARY_STATUSES` (succeeded,
+          needs_review, running) — caller skips the column write.
+        - Any DB error during the SELECTs — caller writes NULL to the
+          column, matching the "best-effort" contract. The column is a
+          nice-to-have; never blocking the terminal path.
+
+        Truncates to :attr:`_FAILURE_SUMMARY_MAX_CHARS` with a single
+        trailing ellipsis so the admin tooltip stays visually bounded.
+        """
+        if status not in self._FAILURE_SUMMARY_STATUSES:
+            return None
+        if self._conn is None:
+            return None
+
+        category: str | None = None
+        details: Any = None
+        log_text: str | None = None
+        try:
+            with self._conn.cursor() as cur:
+                # Latest failure row for this agent. ``ts DESC LIMIT 1``
+                # — a multi-retry agent may have several failure rows,
+                # the freshest one is the one that caused the current
+                # terminal transition.
+                cur.execute(
+                    "SELECT category, details "
+                    "FROM dispatcher.failures "
+                    "WHERE agent_id = %s "
+                    "ORDER BY ts DESC "
+                    "LIMIT 1",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+                if row is not None:
+                    category = row[0]
+                    details = row[1]
+
+                # Latest phase_outputs log_text — the composed
+                # stdout+stderr blob from the most-recent phase (which
+                # is typically the failing one).
+                cur.execute(
+                    "SELECT log_text "
+                    "FROM dispatcher.phase_outputs "
+                    "WHERE agent_id = %s "
+                    "ORDER BY ts DESC "
+                    "LIMIT 1",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+                if row is not None:
+                    log_text = row[0]
+            self._conn.commit()
+        except Exception:
+            self._log.warning(
+                "daemon.failure_summary_read_failed",
+                extra={
+                    "event": "failure_summary_read_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — defensive
+                pass
+            return None
+
+        phase_humanized = self._humanize_phase(phase)
+        # Phase-group = first token before a dash or space. ``ralph-reviewer``
+        # → ``ralph``; ``push_and_pr`` → ``push_and_pr`` (no dash).
+        phase_group = (phase or "unknown").split("-", 1)[0].split(" ", 1)[0]
+
+        # Detail message: prefer the failure-row details dict (has
+        # category-specific rich data), fall back to the stderr tail
+        # from phase_outputs (raw subprocess output), fall back to the
+        # exit_code.
+        detail = self._extract_details_message(details)
+        if not detail:
+            detail = self._extract_stderr_tail(log_text)
+        if not detail and exit_code is not None:
+            detail = f"exit_code={exit_code}"
+
+        # Verb phrase — ``plan_blocked`` is its own thing per the issue
+        # examples; other failure statuses are "crashed" / "failed".
+        if status == "plan_blocked":
+            verb_phrase = "plan phase returned go=false"
+        elif status == "crashed":
+            verb_phrase = f"{phase_group} crashed at {phase_humanized}"
+        else:  # status == "failed"
+            verb_phrase = f"{phase_group} failed at {phase_humanized}"
+
+        # Compose. Category is parenthesized; detail trails a colon so
+        # a scanner can pattern-match on either end of the string.
+        parts: list[str] = [verb_phrase]
+        if category:
+            parts[-1] = f"{parts[-1]} ({category})"
+        if detail:
+            summary = f"{parts[-1]}: {detail}"
+        else:
+            summary = parts[-1]
+
+        # Truncate to the column's visual budget. Leave room for the
+        # trailing ellipsis so we don't cut a UTF-8 sequence in half.
+        cap = self._FAILURE_SUMMARY_MAX_CHARS
+        if len(summary) > cap:
+            summary = summary[: cap - 1].rstrip() + "\u2026"
+        return summary
+
+    def _write_failure_summary(self, agent_id: str, summary: str) -> None:
+        """UPDATE ``dispatcher.agents.failure_summary`` for one agent.
+
+        Issue #2900. Called by :meth:`_mark_agent_terminal` on genuine-
+        failure terminals and by the ``/diagnose-failure`` upgrade path
+        (written to the same column with richer LLM-authored prose).
+        Best-effort — a write failure logs + rolls back but must not
+        propagate; the terminal status was already committed.
+        """
+        assert self._conn is not None, "connect() must run before update"
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "UPDATE dispatcher.agents SET failure_summary = %s WHERE agent_id = %s",
+                (summary, agent_id),
+            )
+        self._conn.commit()
+
     def _mark_agent_terminal(
         self,
         agent_id: str,
@@ -4071,6 +4300,38 @@ class DispatcherDaemon:
                         "status": status,
                     },
                 )
+
+            # Issue #2900: write a templated one-liner to
+            # ``dispatcher.agents.failure_summary`` for genuine-failure
+            # + plan_blocked terminals so the admin cockpit can surface
+            # "what happened" on hover over the outcome glyph without a
+            # cross-table join. Best-effort — a failure here cannot roll
+            # back the terminal-status update above. The builder returns
+            # None for non-failure statuses (succeeded, needs_review);
+            # we skip the UPDATE entirely in that case.
+            try:
+                summary = self._build_failure_summary(
+                    agent_id=agent_id,
+                    status=status,
+                    phase=phase,
+                    exit_code=exit_code,
+                )
+                if summary:
+                    self._write_failure_summary(agent_id, summary)
+            except Exception:
+                self._log.exception(
+                    "daemon.failure_summary_write_failed",
+                    extra={
+                        "event": "failure_summary_write_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "status": status,
+                    },
+                )
+                try:
+                    self._conn.rollback()
+                except Exception:  # pragma: no cover — defensive
+                    pass
 
             # Overnight-safety circuit breaker (#2860): append the outcome
             # to ``dispatcher.terminal_outcomes`` and evaluate the

--- a/scripts/dispatcher/tests/test_daemon_failure_summary.py
+++ b/scripts/dispatcher/tests/test_daemon_failure_summary.py
@@ -1,0 +1,477 @@
+"""Unit tests for ``_build_failure_summary`` + ``_mark_agent_terminal``'s
+``dispatcher.agents.failure_summary`` write-path (issue #2900).
+
+The daemon populates ``failure_summary`` at terminal-time for rows where
+``status IN ('failed', 'crashed', 'plan_blocked')``. The template pulls
+from ``dispatcher.failures`` (category + details) and
+``dispatcher.phase_outputs`` (phase, log_text), joined by agent_id.
+Summary is ≤240 chars.
+
+This test file is the ONLY consumer of ``_build_failure_summary`` —
+other call sites use the higher-level ``_mark_agent_terminal`` wrapper
+which calls the helper internally. We test the template function
+directly so the AC verify-line ("unit test asserts that a failed agent
+with category='subprocess_turn_limit', phase='ralph-reviewer (3)',
+exit_code=124 produces a summary like …") passes on a pure function
+without threading fetch mocks through the full terminal path.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Provide a stub ``psycopg`` module before importing the daemon — same
+# pattern as test_daemon_phase3a/3b/3c/3d/3e.py.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — same shape as test_daemon_phase3e.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.failure_summary.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# _build_failure_summary — template function (pure-ish — reads one row)
+# --------------------------------------------------------------------------
+
+
+class TestBuildFailureSummary:
+    """The AC verify-line test ("category='subprocess_turn_limit',
+    phase='ralph-reviewer (3)', exit_code=124 → 'ralph crashed at
+    ralph-reviewer iteration 3 (subprocess_turn_limit): reviewer
+    exceeded max turns'") anchors this test class."""
+
+    def test_ac_verify_line_subprocess_turn_limit(self, tmp_path: Path) -> None:
+        """Reproduces the issue #2900 AC verify-line exactly."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        # The helper SELECTs the latest failure + latest phase_outputs log_text.
+        # Return the failure row first (category, details), then the
+        # log_text row for the same agent.
+        conn.cursor_instance.fetch_queue = [
+            # First SELECT: (category, details_json)
+            ("subprocess_turn_limit", {"stderr_tail": "reviewer exceeded max turns"}),
+            # Second SELECT: (log_text,)
+            ("=== stderr ===\nsome noise\nreviewer exceeded max turns\n",),
+        ]
+        summary = d._build_failure_summary(
+            agent_id="agent-xyz",
+            status="crashed",
+            phase="ralph-reviewer (3)",
+            exit_code=124,
+        )
+        assert summary is not None
+        # Shape: "ralph crashed at ralph-reviewer iteration 3 (subprocess_turn_limit): reviewer exceeded max turns"
+        assert "ralph crashed at ralph-reviewer iteration 3" in summary
+        assert "(subprocess_turn_limit)" in summary
+        assert "reviewer exceeded max turns" in summary
+        assert len(summary) <= 240
+
+    def test_caps_at_240_chars(self, tmp_path: Path) -> None:
+        """Long stderr tails are truncated to fit the column."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        long_tail = "x" * 500
+        conn.cursor_instance.fetch_queue = [
+            ("subprocess_crash", {}),
+            (f"=== stderr ===\n{long_tail}\n",),
+        ]
+        summary = d._build_failure_summary(
+            agent_id="agent-long",
+            status="failed",
+            phase="ralph-worker (1)",
+            exit_code=1,
+        )
+        assert summary is not None
+        assert len(summary) <= 240
+
+    def test_plan_blocked_phrasing(self, tmp_path: Path) -> None:
+        """``status='plan_blocked'`` gets a distinct verb phrase — the
+        plan correctly declined to proceed, not a genuine crash."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            (
+                "plan_go_false",
+                {"block_reason": "scope is ambiguous — missing data model"},
+            ),
+            (None,),  # no phase_outputs log_text
+        ]
+        summary = d._build_failure_summary(
+            agent_id="agent-pb",
+            status="plan_blocked",
+            phase="plan",
+            exit_code=0,
+        )
+        assert summary is not None
+        # Distinct from "crashed" — "plan phase returned go=false" is the
+        # expected prefix per the issue's examples list.
+        assert "plan" in summary.lower()
+        assert "go=false" in summary or "plan_blocked" in summary
+        # The block_reason from details is surfaced.
+        assert "scope is ambiguous" in summary
+        assert len(summary) <= 240
+
+    def test_ci_red_after_retries(self, tmp_path: Path) -> None:
+        """``ci_red_after_retries`` is a distinct category; the
+        phase-group ``push_and_pr`` is the verb phrase source.
+
+        Matches issue example:
+          "push_and_pr failed (ci_red_after_retries): pre-push test regression in packages/scraper-framework/tests/"
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            (
+                "ci_red_after_retries",
+                {
+                    "detail": (
+                        "pre-push test regression in packages/scraper-framework/tests/"
+                    )
+                },
+            ),
+            (None,),
+        ]
+        summary = d._build_failure_summary(
+            agent_id="agent-ci",
+            status="failed",
+            phase="push_and_pr",
+            exit_code=1,
+        )
+        assert summary is not None
+        assert "push_and_pr" in summary
+        assert "ci_red_after_retries" in summary
+        # Detail text surfaces.
+        assert "pre-push" in summary
+
+    def test_missing_failure_row_builds_from_phase_alone(self, tmp_path: Path) -> None:
+        """When no ``dispatcher.failures`` row exists for the agent (rare
+        — e.g. plan_blocked without a failure row), the summary falls
+        back to phase + status + exit_code without the category clause."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            None,  # no failure row
+            None,  # no phase_outputs row
+        ]
+        summary = d._build_failure_summary(
+            agent_id="agent-none",
+            status="failed",
+            phase="unknown",
+            exit_code=137,
+        )
+        # A best-effort summary is still produced — the column exists to
+        # carry SOMETHING for every failed/crashed/plan_blocked row.
+        assert summary is not None
+        # At minimum the phase + exit_code surface so triage has a toehold.
+        assert "unknown" in summary or "137" in summary
+        assert len(summary) <= 240
+
+    def test_db_error_returns_none(self, tmp_path: Path) -> None:
+        """A fetch failure must not break the terminal path — helper
+        returns None and the caller writes NULL to the column."""
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        def boom(_sql: str, _params: Any = None) -> None:
+            raise RuntimeError("db lost")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+        summary = d._build_failure_summary(
+            agent_id="agent-db-down",
+            status="failed",
+            phase="ralph",
+            exit_code=1,
+        )
+        assert summary is None
+
+    def test_succeeded_status_returns_none(self, tmp_path: Path) -> None:
+        """Non-terminal-failure statuses don't produce summaries — the
+        column stays NULL for succeeded rows."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        summary = d._build_failure_summary(
+            agent_id="agent-ok",
+            status="succeeded",
+            phase="done",
+            exit_code=0,
+        )
+        assert summary is None
+
+    def test_needs_review_returns_none(self, tmp_path: Path) -> None:
+        """``needs_review`` is a correct-outcome terminal — the draft
+        PR IS the summary signal, not a failure string."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        summary = d._build_failure_summary(
+            agent_id="agent-nr",
+            status="needs_review",
+            phase="needs_review",
+            exit_code=None,
+        )
+        assert summary is None
+
+
+# --------------------------------------------------------------------------
+# _mark_agent_terminal integration — writes failure_summary on failure
+# terminals and leaves it NULL on success terminals
+# --------------------------------------------------------------------------
+
+
+class TestMarkAgentTerminalWritesFailureSummary:
+    def test_failed_terminal_writes_failure_summary(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        # Pre-seed the fetch_queue for the _build_failure_summary helper.
+        conn.cursor_instance.fetch_queue = [
+            ("subprocess_turn_limit", {"stderr_tail": "reviewer exceeded max turns"}),
+            ("=== stderr ===\nreviewer exceeded max turns\n",),
+        ]
+        conn.cursor_instance.rowcount = 1
+
+        d._mark_agent_terminal(
+            "agent-failed",
+            status="failed",
+            phase="ralph-reviewer (3)",
+            exit_code=124,
+        )
+
+        # Search for the failure_summary UPDATE — distinct from the
+        # initial terminal UPDATE which sets status/phase/ended_at.
+        summary_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0] and "failure_summary" in e[0]
+        ]
+        assert summary_updates, (
+            f"Expected failure_summary UPDATE, got executes: "
+            f"{[e[0][:100] for e in conn.cursor_instance.executed]}"
+        )
+        sql, params = summary_updates[0]
+        # params: (summary_text, agent_id)
+        assert params[1] == "agent-failed"
+        summary_text = params[0]
+        assert isinstance(summary_text, str)
+        assert "subprocess_turn_limit" in summary_text
+        assert len(summary_text) <= 240
+
+    def test_crashed_terminal_writes_failure_summary(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            ("stuck_timeout", {"stuck_seconds": 5400}),
+            (None,),
+        ]
+        conn.cursor_instance.rowcount = 1
+
+        d._mark_agent_terminal(
+            "agent-crashed",
+            status="crashed",
+            phase="ralph-worker (2)",
+            exit_code=None,
+        )
+
+        summary_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0] and "failure_summary" in e[0]
+        ]
+        assert summary_updates
+        assert "stuck_timeout" in summary_updates[0][1][0]
+
+    def test_plan_blocked_terminal_writes_failure_summary(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            ("plan_go_false", {"block_reason": "scope is ambiguous"}),
+            (None,),
+        ]
+        conn.cursor_instance.rowcount = 1
+
+        d._mark_agent_terminal(
+            "agent-pb", status="plan_blocked", phase="plan", exit_code=0
+        )
+
+        summary_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0] and "failure_summary" in e[0]
+        ]
+        assert summary_updates
+        assert "scope is ambiguous" in summary_updates[0][1][0]
+
+    def test_succeeded_terminal_skips_failure_summary_write(
+        self, tmp_path: Path
+    ) -> None:
+        """Successful agents leave ``failure_summary`` NULL — the helper
+        returns None and the caller skips the UPDATE entirely."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.rowcount = 1
+
+        d._mark_agent_terminal(
+            "agent-ok", status="succeeded", phase="cleanup_done", exit_code=0
+        )
+
+        summary_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0] and "failure_summary" in e[0]
+        ]
+        assert not summary_updates
+
+    def test_needs_review_terminal_skips_failure_summary_write(
+        self, tmp_path: Path
+    ) -> None:
+        """``needs_review`` is a correct-outcome terminal — no summary."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.rowcount = 1
+
+        d._mark_agent_terminal(
+            "agent-nr",
+            status="needs_review",
+            phase="needs_review",
+            exit_code=None,
+            pr_number=9001,
+        )
+
+        summary_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0] and "failure_summary" in e[0]
+        ]
+        assert not summary_updates
+
+    def test_failure_summary_write_failure_does_not_roll_back_terminal(
+        self, tmp_path: Path
+    ) -> None:
+        """A DB hiccup writing failure_summary must not roll back the
+        authoritative terminal-status update. Mirrors the diagnoser
+        write-back's best-effort contract in the same method."""
+        d, conn, handler = _make_daemon(tmp_path)
+        # Feed enough fetch results so _build_failure_summary can at least try.
+        conn.cursor_instance.fetch_queue = [
+            ("subprocess_crash", {}),
+            (None,),
+        ]
+
+        original_execute = conn.cursor_instance.execute
+
+        def patched(sql: str, params: Any = None) -> None:
+            if "UPDATE dispatcher.agents" in sql and "failure_summary" in sql:
+                raise RuntimeError("db lost mid-summary-write")
+            original_execute(sql, params)
+
+        conn.cursor_instance.execute = patched  # type: ignore[method-assign]
+        conn.cursor_instance.rowcount = 1
+
+        # Must not raise.
+        d._mark_agent_terminal(
+            "agent-hiccup",
+            status="failed",
+            phase="ralph-reviewer (1)",
+            exit_code=1,
+        )
+        # The terminal UPDATE still ran.
+        terminal_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0] and "ended_at = now()" in e[0]
+        ]
+        assert terminal_updates, "Terminal UPDATE must have committed"
+        # Failure event logged.
+        assert handler.events("failure_summary_write_failed")


### PR DESCRIPTION
## Summary

Adds `dispatcher.agents.failure_summary TEXT` (nullable) via migration 33 — a one-line "what happened" string populated at terminal-time for failure terminals (`failed` / `crashed` / `plan_blocked`). Upgrades the column from `/diagnose-failure` with the first 1-3 sentences of the LLM's `recommendation.reasoning` (≤240 chars). Plumbs `RecentCompletion.failureSummary` through GraphQL and renders it as a hover tooltip on the admin cockpit's `OutcomePill` outcome glyph — tooltip-only, no always-visible second line (preserves the #2818 density layout).

Closes #2900

## Test plan

### Automated checks
- [x] Lint passes (`npm --prefix packages/api run lint`, `npm --prefix packages/web run lint`)
- [x] Format check passes (`scripts/dispatcher/.venv/bin/ruff format --check scripts/dispatcher/`)
- [x] Tests pass
  - 648 dispatcher tests (including 14 new in `test_daemon_failure_summary.py`)
  - 410 API tests (including 4 new in `dispatcher-enrichment.unit.test.ts`)
  - 1264 web tests (including 10 new across `ui-primitives.test.tsx` + `RecentCompletionsPanel.test.tsx`)
- [x] CI green

### Post-deploy verification
- [x] Migration 33 applied on dev: `\d dispatcher.agents` shows the `failure_summary` column
- [x] A recent `crashed` agent on dev (#2899) has `failure_summary` populated; historical pre-migration rows correctly stay NULL
- [x] Admin cockpit's "Recently completed" panel shows the tooltip on hover over the real crashed row (Playwright scrape + screenshot overlay captured)
- [x] Verification evidence posted on issue #2900
