### PR TITLE
fix(dispatcher): don't create retry markers for task-skill rows (#2903)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -3093,6 +3093,40 @@ class DispatcherDaemon:
         )
         return True
 
+    def _lookup_agent_kind(self, agent_id: str) -> str | None:
+        """Return the ``kind`` for a ``dispatcher.agents`` row, or None.
+
+        Used by :meth:`_create_retry_marker` (issue #2903) as a
+        defensive guard so no caller can accidentally enqueue a retry
+        marker for a /task-skill-owned row (which would cause the
+        daemon to re-dispatch an issue while the operator's subagent
+        is still working it). Best-effort — returns None on DB error
+        or missing row so the caller can fall through to its normal
+        path (fail-open — a DB outage should not silently suppress
+        legitimate retries for daemon-owned rows).
+        """
+        assert self._conn is not None, "connect() must run before reading"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT kind FROM dispatcher.agents WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return None
+        if row is None:
+            return None
+        kind = row[0]
+        if not isinstance(kind, str):
+            return None
+        return kind
+
     def _lookup_active_owner_kind(self, issue_number: int) -> str | None:
         """Return the ``kind`` of the current active row for an issue, or None.
 
@@ -8843,10 +8877,19 @@ class DispatcherDaemon:
         config overrides.
 
         Each flagged agent gets a ``dispatcher.failures`` row with
-        ``category='stuck_timeout'``, is flipped to ``status='crashed'``,
-        and enqueues a retry marker so
-        :meth:`_process_retry_markers` can reset it with a fresh
-        worktree.
+        ``category='stuck_timeout'`` and is flipped to
+        ``status='crashed'``. For daemon-owned rows (``kind='task'``)
+        the sweep also enqueues a retry marker so
+        :meth:`_process_retry_markers` can reset the agent with a
+        fresh worktree. **Task-skill rows (``kind='task-skill'``) are
+        explicitly excluded from retry-marker creation** (issue #2903)
+        because the daemon does not own the subprocess for those rows —
+        creating a retry marker would cause the daemon to re-dispatch
+        the same issue while the operator's /task subagent is still
+        running, duplicating work and risking a push collision. The
+        ``_create_retry_marker`` call also double-checks this via a DB
+        lookup on ``dispatcher.agents.kind`` so any future call site
+        inherits the guard.
 
         Returns the number of stuck agents flagged this tick (for
         logging). Exceptions are caught per-agent + logged; one bad
@@ -8859,15 +8902,19 @@ class DispatcherDaemon:
         # so we can consult both the live config override and the
         # module-level defaults without expressing them as SQL.
         #
-        # Fields: agent_id, issue_number, phase, elapsed_seconds.
-        candidates: list[tuple[str, int | None, str | None, float]] = []
+        # Fields: agent_id, issue_number, phase, elapsed_seconds, kind.
+        # ``kind`` is included so the retry-marker skip for
+        # ``task-skill`` rows (issue #2903) is visible at the call
+        # site without a second DB roundtrip.
+        candidates: list[tuple[str, int | None, str | None, float, str | None]] = []
         try:
             with self._conn.cursor() as cur:
                 cur.execute(
                     "SELECT a.agent_id, a.issue_number, a.phase, "
                     "       EXTRACT(EPOCH FROM ("
                     "           now() - COALESCE(pt.last_ts, a.started_at)"
-                    "       )) AS elapsed_seconds "
+                    "       )) AS elapsed_seconds, "
+                    "       a.kind "
                     "FROM dispatcher.agents a "
                     "LEFT JOIN LATERAL ("
                     "    SELECT MAX(ts) AS last_ts "
@@ -8884,6 +8931,7 @@ class DispatcherDaemon:
                             int(row[1]) if row[1] is not None else None,
                             str(row[2]) if row[2] is not None else None,
                             float(row[3]) if row[3] is not None else 0.0,
+                            str(row[4]) if row[4] is not None else None,
                         )
                     )
             self._conn.commit()
@@ -8907,7 +8955,7 @@ class DispatcherDaemon:
         overrides = self._read_stuck_timeout_overrides()
 
         flagged = 0
-        for agent_id, issue_number, phase, elapsed_seconds in candidates:
+        for agent_id, issue_number, phase, elapsed_seconds, kind in candidates:
             threshold = self._stuck_timeout_for_phase(phase, overrides=overrides)
             if elapsed_seconds < threshold:
                 continue
@@ -8921,6 +8969,7 @@ class DispatcherDaemon:
                         "threshold_seconds": threshold,
                         "last_known_phase": phase,
                         "issue_number": issue_number,
+                        "kind": kind,
                     },
                 )
                 self._mark_agent_terminal(
@@ -8940,15 +8989,44 @@ class DispatcherDaemon:
                         "phase": phase,
                         "stuck_seconds": int(elapsed_seconds),
                         "threshold_seconds": threshold,
+                        "kind": kind,
                     },
                 )
-                # Enqueue the tier-1 retry marker. The processor picks
-                # it up on the next supervisor tick once the backoff
-                # window elapses.
-                self._create_retry_marker(
-                    agent_id=agent_id,
-                    reason=FAILURE_CATEGORY_STUCK_TIMEOUT,
-                )
+                # Issue #2903: skip retry-marker creation for
+                # task-skill rows. The daemon does not own the
+                # operator's /task subagent subprocess, so a retry
+                # marker would re-dispatch the same issue while the
+                # subagent is still working and produce a duplicate
+                # PR or a push collision. The failure row + crashed
+                # status flip above are fine — they are daemon-side
+                # observability only. ``_create_retry_marker`` also
+                # re-checks kind defensively, so adding new call
+                # sites does not reintroduce this bug.
+                if kind == TASK_SKILL_KIND:
+                    self._log.info(
+                        "daemon.retry_marker_skipped_task_skill",
+                        extra={
+                            "event": "retry_marker_skipped_task_skill",
+                            "run_id": self._run_id,
+                            "agent_id": agent_id,
+                            "issue_number": issue_number,
+                            "reason": FAILURE_CATEGORY_STUCK_TIMEOUT,
+                            "phase": phase,
+                            "detail": (
+                                "task-skill rows are not owned by the "
+                                "daemon — skipping retry to avoid "
+                                "re-dispatching the same issue"
+                            ),
+                        },
+                    )
+                else:
+                    # Enqueue the tier-1 retry marker. The processor
+                    # picks it up on the next supervisor tick once
+                    # the backoff window elapses.
+                    self._create_retry_marker(
+                        agent_id=agent_id,
+                        reason=FAILURE_CATEGORY_STUCK_TIMEOUT,
+                    )
                 flagged += 1
             except Exception:
                 # Per-agent failure must not stall the whole scan.
@@ -9163,6 +9241,19 @@ class DispatcherDaemon:
         :data:`AUTO_RETRY_CATEGORIES`. Passing a non-retry category
         (e.g. ``subprocess_auth_fail``) is a caller bug; the method
         logs + returns None without writing.
+
+        **Task-skill rows are skipped unconditionally.** Issue #2903.
+        When an operator's /task subagent row (``kind='task-skill'``)
+        is flagged by the supervisor, diagnoser, or subprocess-failure
+        handler, creating a retry marker would cause the daemon to
+        re-dispatch the same issue while the subagent is still
+        running its own pipeline — duplicating work and risking a
+        push collision on the worktree branch. The daemon never owns
+        a task-skill subprocess, so there is no legitimate retry path
+        for one. Callers (``_check_stuck_agents``, etc.) already
+        filter on kind for visibility; this in-function lookup is the
+        defensive belt-and-suspenders guard that protects any future
+        call site from reintroducing the bug.
         """
         assert self._conn is not None, "connect() must run before marker insert"
 
@@ -9178,6 +9269,30 @@ class DispatcherDaemon:
                     "agent_id": agent_id,
                     "reason": reason,
                     "detail": "not a tier-1 auto-retry category",
+                },
+            )
+            return None
+
+        # Issue #2903 defensive guard: never create a retry marker for
+        # a task-skill row, regardless of caller. A DB lookup failure
+        # falls through fail-open (treat as daemon-owned) so an
+        # unavailable DB doesn't silently suppress legitimate retries
+        # — the existing retry INSERT path will surface the same DB
+        # error a moment later if it's really down.
+        agent_kind = self._lookup_agent_kind(agent_id)
+        if agent_kind == TASK_SKILL_KIND:
+            self._log.info(
+                "daemon.retry_marker_skipped_task_skill",
+                extra={
+                    "event": "retry_marker_skipped_task_skill",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "reason": reason,
+                    "detail": (
+                        "task-skill rows are not owned by the daemon — "
+                        "skipping retry to avoid re-dispatching the same "
+                        "issue while the subagent is still running"
+                    ),
                 },
             )
             return None

--- a/scripts/dispatcher/tests/test_daemon_phase3c.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3c.py
@@ -231,18 +231,23 @@ class TestCheckStuckAgents:
 
         # Seeded row: one stale ralph agent. Elapsed 55000s > 54000s
         # (ralph default threshold bumped 10× in #2885). #2872 — the
-        # SELECT returns (agent_id, issue_number, phase, elapsed_seconds)
+        # SELECT returns (agent_id, issue_number, phase, elapsed_seconds, kind)
         # and the Python-side comparison applies the per-phase threshold.
+        # Issue #2903: ``kind`` is now included so the retry-marker skip
+        # for task-skill rows is visible at the call site.
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "ralph", 55000.0)],
+            [("agent-1", 42, "ralph", 55000.0, "task")],
         ]
         # Order inside _check_stuck_agents + _create_retry_marker:
         # (1) stuck_timeout_s_by_phase override read (returns None → fall
         # through to module defaults),
-        # (2) COUNT prior markers in _create_retry_marker,
-        # (3) read backoff_seconds config.
+        # (2) _lookup_agent_kind in _create_retry_marker (issue #2903
+        # defensive guard) — returns the row's kind,
+        # (3) COUNT prior markers in _create_retry_marker,
+        # (4) read backoff_seconds config.
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            ("task",),  # _lookup_agent_kind — daemon-owned row
             (0,),  # prior retry marker count
             ("[60,300,900]",),  # backoff schedule
         ]
@@ -290,6 +295,118 @@ class TestCheckStuckAgents:
         assert marker_params[1] == daemon.FAILURE_CATEGORY_STUCK_TIMEOUT
         assert marker_params[2] == 1  # first attempt
 
+    def test_task_skill_row_flagged_but_no_retry_marker(self, tmp_path: Path) -> None:
+        """Issue #2903: task-skill rows get the failure + crash flip but NO retry marker.
+
+        The daemon does not own the operator's /task subagent
+        subprocess, so creating a retry marker would cause the daemon
+        to re-dispatch the same issue while the subagent is still
+        running — producing duplicate PRs or a push collision.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # Task-skill row stuck in ``claiming`` past the 5-minute
+        # default threshold. 600s > 300s.
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-task-skill-1", 99, "claiming", 600.0, "task-skill")],
+        ]
+        # Only ONE fetch queued: the stuck_timeout override lookup.
+        # _create_retry_marker is not called for task-skill rows, so
+        # neither the _lookup_agent_kind query nor the COUNT/backoff
+        # queries fire.
+        conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase override — unset
+        ]
+
+        flagged = d._check_stuck_agents()
+        assert flagged == 1
+
+        # Failure row still inserted — issue #2903 explicitly scopes
+        # the failure row and the crashed flip as acceptable.
+        failure_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert len(failure_inserts) == 1
+        assert failure_inserts[0][1][0] == "agent-task-skill-1"
+
+        # Crashed flip still happens.
+        crashed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "crashed" in e[1]
+        ]
+        assert crashed_updates
+
+        # The critical assertion: NO retry marker inserted.
+        marker_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert marker_inserts == []
+
+        # Explicit skip event is logged so operators can trace the
+        # decision in CloudWatch.
+        skipped_events = handler.events("retry_marker_skipped_task_skill")
+        assert len(skipped_events) == 1
+        assert skipped_events[0].agent_id == "agent-task-skill-1"
+        assert skipped_events[0].reason == daemon.FAILURE_CATEGORY_STUCK_TIMEOUT
+
+        # Structured failure_detected event still fires (includes kind).
+        detected = handler.events("failure_detected")
+        assert len(detected) == 1
+        assert getattr(detected[0], "kind", None) == "task-skill"
+
+    def test_mixed_kinds_only_task_kind_gets_retry_marker(self, tmp_path: Path) -> None:
+        """Issue #2903: with mixed kinds in one sweep, only kind='task' gets retry.
+
+        Regression guard against the #2866 interlock collision
+        scenario where two task-skill rows and one daemon-owned row
+        are all stuck in the same sweep. The daemon-owned row should
+        still be recovered (retry marker created), but the two
+        task-skill rows must not.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        conn.cursor_instance.fetchall_queue = [
+            [
+                ("agent-task-1", 1, "claiming", 600.0, "task-skill"),
+                ("agent-daemon-1", 2, "ralph", 55000.0, "task"),
+                ("agent-task-2", 3, "claiming", 700.0, "task-skill"),
+            ],
+        ]
+        # Queue: (1) stuck_timeout override,
+        # then the daemon-owned agent goes through _create_retry_marker:
+        # (2) _lookup_agent_kind, (3) prior count, (4) backoff.
+        # The two task-skill rows skip the retry path entirely, so no
+        # additional queue entries are needed for them.
+        conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase
+            ("task",),  # _lookup_agent_kind for agent-daemon-1
+            (0,),  # prior marker count
+            ("[60,300,900]",),  # backoff
+        ]
+
+        assert d._check_stuck_agents() == 3
+
+        marker_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        # Exactly one retry marker — for agent-daemon-1 only.
+        assert len(marker_inserts) == 1
+        assert marker_inserts[0][1][0] == "agent-daemon-1"
+
+        # Two skip events (one per task-skill row) from the call-site guard.
+        skipped_events = handler.events("retry_marker_skipped_task_skill")
+        skipped_agents = {e.agent_id for e in skipped_events}
+        assert skipped_agents == {"agent-task-1", "agent-task-2"}
+
     def test_no_stuck_agents_returns_zero(self, tmp_path: Path) -> None:
         d, conn, _handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue = [[]]
@@ -313,16 +430,19 @@ class TestCheckStuckAgents:
         # ralph 10× from 90min to 15hr.)
         conn.cursor_instance.fetchall_queue = [
             [
-                ("agent-1", 1, "ralph", 55000.0),
-                ("agent-2", 2, "claiming", 600.0),
+                ("agent-1", 1, "ralph", 55000.0, "task"),
+                ("agent-2", 2, "claiming", 600.0, "task"),
             ],
         ]
         # Queue: (1) stuck_timeout_s_by_phase override (unset),
-        # then for each agent (1) prior count (2) backoff config.
+        # then for each agent (1) _lookup_agent_kind (2) prior count
+        # (3) backoff config.
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase — unset
+            ("task",),  # _lookup_agent_kind for agent-1
             (0,),
             ("[60,300,900]",),
+            ("task",),  # _lookup_agent_kind for agent-2
             (0,),
             ("[60,300,900]",),
         ]
@@ -465,8 +585,10 @@ class TestGhRateSkipActive:
 class TestCreateRetryMarker:
     def test_first_attempt_inserts_marker(self, tmp_path: Path) -> None:
         d, conn, handler = _make_daemon(tmp_path)
-        # Order: (1) COUNT prior markers, (2) read backoff_seconds.
+        # Order (issue #2903 adds the kind lookup):
+        # (1) _lookup_agent_kind, (2) COUNT prior markers, (3) backoff.
         conn.cursor_instance.fetch_queue = [
+            ("task",),  # _lookup_agent_kind — daemon-owned
             (0,),  # prior count = 0
             ("[60,300,900]",),  # backoff read
         ]
@@ -492,6 +614,7 @@ class TestCreateRetryMarker:
     def test_third_attempt_still_inserts(self, tmp_path: Path) -> None:
         d, conn, _handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetch_queue = [
+            ("task",),  # _lookup_agent_kind (#2903)
             (2,),  # prior attempts 1 and 2 already exist
             ("[60,300,900]",),
         ]
@@ -510,8 +633,9 @@ class TestCreateRetryMarker:
 
     def test_fourth_attempt_blocked_and_agent_failed(self, tmp_path: Path) -> None:
         d, conn, handler = _make_daemon(tmp_path)
-        # Cap reached — only the prior-count read runs; no backoff read.
+        # Cap reached — kind lookup + prior-count read; no backoff read.
         conn.cursor_instance.fetch_queue = [
+            ("task",),  # _lookup_agent_kind (#2903)
             (3,),
         ]
         attempt = d._create_retry_marker(
@@ -561,11 +685,69 @@ class TestCreateRetryMarker:
         assert attempt is None
         assert handler.events("retry_marker_skipped")
 
+    def test_task_skill_kind_blocks_retry_marker(self, tmp_path: Path) -> None:
+        """Issue #2903: _create_retry_marker must bail when kind='task-skill'.
+
+        Defensive in-function guard that protects every call site —
+        even if a future caller forgets to check kind itself, the
+        daemon cannot enqueue a retry marker for an operator's /task
+        subagent row. The guard runs before the AUTO_RETRY_CATEGORIES
+        check in practice only for legitimate retry categories; here
+        we exercise a tier-1 category so we know the kind check is
+        what blocked the write.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            ("task-skill",),  # _lookup_agent_kind returns task-skill
+        ]
+        attempt = d._create_retry_marker(
+            agent_id="a-task-skill-1",
+            reason=daemon.FAILURE_CATEGORY_STUCK_TIMEOUT,
+        )
+        assert attempt is None
+        # No retry marker row written.
+        marker_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert marker_inserts == []
+        # Structured skip log for CloudWatch visibility.
+        skipped = handler.events("retry_marker_skipped_task_skill")
+        assert len(skipped) == 1
+        assert skipped[0].agent_id == "a-task-skill-1"
+        assert skipped[0].reason == daemon.FAILURE_CATEGORY_STUCK_TIMEOUT
+
+    def test_db_error_on_kind_lookup_fails_open(self, tmp_path: Path) -> None:
+        """Issue #2903: DB error during _lookup_agent_kind falls through to retry path.
+
+        A broken DB lookup must NOT silently suppress retries for
+        daemon-owned rows — the downstream retry INSERT will hit the
+        same DB error a moment later if the DB is really unavailable,
+        but a transient kind-lookup blip should not cause a missed
+        retry.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        # _lookup_agent_kind: no row for agent_id (fetchone returns
+        # None) — helper returns None, create_retry_marker proceeds.
+        # Then the usual COUNT + backoff reads.
+        conn.cursor_instance.fetch_queue = [
+            None,  # _lookup_agent_kind → None (missing row)
+            (0,),  # prior count
+            ("[60,300,900]",),  # backoff
+        ]
+        attempt = d._create_retry_marker(
+            agent_id="unknown",
+            reason=daemon.FAILURE_CATEGORY_STUCK_TIMEOUT,
+        )
+        assert attempt == 1  # retry proceeded normally
+
     def test_malformed_backoff_config_falls_back_to_default(
         self, tmp_path: Path
     ) -> None:
         d, conn, handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetch_queue = [
+            ("task",),  # _lookup_agent_kind (#2903)
             (0,),  # prior count
             ("not valid json",),  # bad backoff config → falls back
         ]
@@ -791,6 +973,7 @@ class TestHandleSubprocessFailure:
     def test_crash_writes_failure_and_enqueues_retry(self, tmp_path: Path) -> None:
         d, conn, handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetch_queue = [
+            ("task",),  # _lookup_agent_kind (#2903)
             (0,),  # prior count
             ("[60,300,900]",),  # backoff
         ]

--- a/scripts/dispatcher/tests/test_daemon_phase3d.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3d.py
@@ -628,16 +628,22 @@ class TestConsumeDiagnosis:
         conn: _FakeConnection,
         recommendation: dict[str, Any] | None,
         retry_marker_count: int = 0,
+        agent_kind: str = "task",
     ) -> None:
         """Seed the fetch queue in the order the consumer issues reads.
 
         Order for the common retry path:
           1. read_recommendation → (rec,)
-          2. create_retry_marker COUNT → (retry_marker_count,)
-          3. _backoff_seconds → ("[60,300,900]",)
+          2. _lookup_agent_kind in _create_retry_marker → (kind,)  (#2903)
+          3. create_retry_marker COUNT → (retry_marker_count,)
+          4. _backoff_seconds → ("[60,300,900]",)
+
+        ``agent_kind`` defaults to ``"task"`` (daemon-owned) so the
+        existing tests continue exercising the retry-marker path.
         """
         conn.cursor_instance.fetch_queue = [
             (recommendation,) if recommendation is not None else None,
+            (agent_kind,),
             (retry_marker_count,),
             ("[60,300,900]",),
         ]

--- a/scripts/dispatcher/tests/test_daemon_restart_cascade.py
+++ b/scripts/dispatcher/tests/test_daemon_restart_cascade.py
@@ -186,8 +186,10 @@ class TestRecoverAbandonedAgents:
         ]
         # _write_failure → _mark_agent_terminal → _create_retry_marker
         # reads nothing via fetchone in the write path except
-        # _create_retry_marker's COUNT query + backoff_seconds config.
+        # _create_retry_marker's _lookup_agent_kind (#2903) +
+        # COUNT query + backoff_seconds config.
         conn.cursor_instance.fetch_queue = [
+            ("task",),  # _lookup_agent_kind (#2903) — daemon-owned row
             (0,),  # prior retry marker count
             ("[60,300,900]",),  # backoff schedule
         ]
@@ -303,8 +305,10 @@ class TestPerPhaseStuckTimeout:
     def test_ralph_below_threshold_not_flagged(self, tmp_path: Path) -> None:
         """A 2.5-minute ralph is not stuck (threshold is 90 min)."""
         d, conn, _handler = _make_daemon(tmp_path)
+        # SELECT returns (agent_id, issue_number, phase, elapsed, kind).
+        # Issue #2903 added the ``kind`` column.
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "ralph", 150.0)],  # 2.5 min elapsed
+            [("agent-1", 42, "ralph", 150.0, "task")],  # 2.5 min elapsed
         ]
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
@@ -315,7 +319,7 @@ class TestPerPhaseStuckTimeout:
         """A 90-second plan is not stuck (threshold is 2.5 hr, #2885)."""
         d, conn, _handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "plan", 90.0)],
+            [("agent-1", 42, "plan", 90.0, "task")],
         ]
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
@@ -326,10 +330,11 @@ class TestPerPhaseStuckTimeout:
         """A 16-hour ralph IS stuck (threshold is 15 hr / 54000s, #2885)."""
         d, conn, handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "ralph", 57600.0)],  # 16 hr
+            [("agent-1", 42, "ralph", 57600.0, "task")],  # 16 hr
         ]
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            ("task",),  # _lookup_agent_kind in _create_retry_marker (#2903)
             (0,),  # prior retry marker count
             ("[60,300,900]",),  # backoff
         ]
@@ -345,10 +350,11 @@ class TestPerPhaseStuckTimeout:
         # Elapsed 400s — under the default 5min claiming threshold, but
         # operator set claiming override to 300s. Should fire.
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "claiming", 400.0)],
+            [("agent-1", 42, "claiming", 400.0, "task")],
         ]
         conn.cursor_instance.fetch_queue = [
             ('{"claiming": 300}',),  # operator override
+            ("task",),  # _lookup_agent_kind (#2903)
             (0,),
             ("[60,300,900]",),
         ]
@@ -359,10 +365,11 @@ class TestPerPhaseStuckTimeout:
         d, conn, _handler = _make_daemon(tmp_path)
         # Novel phase, elapsed 31 min — over the 30 min default fallback.
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "novel_phase", 31 * 60.0)],
+            [("agent-1", 42, "novel_phase", 31 * 60.0, "task")],
         ]
         conn.cursor_instance.fetch_queue = [
             None,  # no override
+            ("task",),  # _lookup_agent_kind (#2903)
             (0,),
             ("[60,300,900]",),
         ]
@@ -477,7 +484,7 @@ class TestIssue2885TenTimesBump:
         """
         d, conn, _handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue = [
-            [("agent-821e96ee", 2565, "ralph", 5419.0)],
+            [("agent-821e96ee", 2565, "ralph", 5419.0, "task")],
         ]
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset


### PR DESCRIPTION
## Summary

Close the #2866 /task↔daemon interlock's last remaining collision vector: when the dispatcher-v2 supervisor sweeps a `kind='task-skill'` row as stuck, it no longer enqueues a retry marker. The daemon does not own the operator's /task subagent subprocess, so a retry marker would re-dispatch the same issue while the subagent is still working — duplicating work and risking a push collision on the worktree branch. The failure row + `status='crashed'` flip remain (per #2903 scope — those are daemon-side observability only).

Two-part defense: (1) `_check_stuck_agents` now fetches `a.kind` in its candidate SELECT and skips the retry call at the call site for readability; (2) `_create_retry_marker` has a defensive in-function guard via a new `_lookup_agent_kind(agent_id)` helper that protects every current and future caller (sweep, boot recovery, subprocess-failure handler, all three diagnoser consume-action paths) with one piece of code.

Closes #2903

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (638 dispatcher tests — 3 new task-skill tests + updates to 9 existing tests for the added `kind` column / extra `_lookup_agent_kind` fetch)
- [x] CI green

### Post-deploy verification
- [x] Revert `dispatcher.config.stuck_timeout_s_by_phase.claiming=86400` override (done via `scripts/dev-db-query.sh --rw`; post-revert SELECT shows no `claiming` key).
- [x] CloudWatch Insights smoke window against `/ecs/judgemind-dispatcher-dev`: `filter @message like /retry_marker_created/ and @message like /task-skill/` returned zero results since `version_sha: cea9ae7` started at 16:18:37 UTC.
- [x] Verification evidence posted on #2903 (issuecomment-4282507822).
