### PR TITLE
fix(dispatcher): _has_active_agent must filter kind='task' (#2908)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -2592,17 +2592,32 @@ class DispatcherDaemon:
     # ``{worktree}/tmp/claude-p-<phase>.log``.
 
     def _has_active_agent(self) -> bool:
-        """Return True when an agent row is already ``running`` for this run.
+        """Return True when a daemon-owned agent row is already ``running``.
 
         Phase 3 concurrency cap is 1 per daemon: no new claim while any
         existing agent is still in flight. Uses the
-        ``idx_dispatcher_agents_running`` partial index.
+        ``idx_dispatcher_agents_running`` partial index; the extra
+        ``kind = 'task'`` predicate is a cheap post-filter on top.
+
+        The ``kind = 'task'`` filter is the key scope discipline (#2908):
+        the scheduler gate must only count daemon-owned agents. A laptop
+        /task subagent writes a ``kind='task-skill'`` row at
+        ``status='running'`` (see ``scripts/dispatcher/task_claim.py``);
+        that row represents a separate OS process on the operator's
+        machine and has no bearing on the daemon's subprocess-slot
+        budget. Counting task-skill rows here caused the daemon to go
+        idle with a full queue whenever any subagent was running.
+        Interlock paths (``_lookup_active_owner_kind``,
+        ``_atomic_claim`` UniqueViolation handling) legitimately need to
+        see task-skill rows and MUST NOT use this filter.
         """
         assert self._conn is not None, "connect() must run before checking"
         try:
             with self._conn.cursor() as cur:
                 cur.execute(
-                    "SELECT 1 FROM dispatcher.agents WHERE status = 'running' LIMIT 1",
+                    "SELECT 1 FROM dispatcher.agents "
+                    "WHERE status = 'running' AND kind = 'task' "
+                    "LIMIT 1",
                 )
                 row = cur.fetchone()
             self._conn.commit()
@@ -3368,10 +3383,19 @@ class DispatcherDaemon:
         candidates: list[tuple[str, int | None, str | None]] = []
         try:
             with self._conn.cursor() as cur:
+                # ``kind = 'task'`` filter (#2908): only reclaim
+                # daemon-owned agents from prior runs. Laptop /task
+                # subagents (``kind='task-skill'``) write their own
+                # ``dispatcher.agents`` row but their subprocess lives
+                # on the operator's machine — the daemon cannot reclaim
+                # or retry them, and enqueuing a restart-abandoned retry
+                # marker would phantom-dispatch work that is still
+                # running elsewhere.
                 cur.execute(
                     "SELECT agent_id, issue_number, phase "
                     "FROM dispatcher.agents "
                     "WHERE status = 'running' "
+                    "  AND kind = 'task' "
                     "  AND (parent_run_id IS NULL "
                     "       OR parent_run_id <> %s)",
                     (self._run_id,),
@@ -6523,14 +6547,23 @@ class DispatcherDaemon:
         agents: list[dict[str, Any]] = []
         try:
             with self._conn.cursor() as cur:
+                # ``kind = 'task'`` filter (#2908): the advance loop is
+                # scoped to daemon-owned agents. Laptop /task subagents
+                # (``kind='task-skill'``) never reach
+                # ``awaiting_ci``/``awaiting_deploy``/``retro_*`` in
+                # practice, but filtering defensively documents the
+                # scope and prevents a future phase-label collision
+                # from silently driving the advance loop against rows
+                # the daemon does not own.
                 cur.execute(
                     "SELECT agent_id, issue_number, phase, pr_number, "
                     "       worktree_path, retries_used, status "
                     "FROM dispatcher.agents "
-                    "WHERE (status = 'running' "
-                    "       AND phase IN ('awaiting_ci', 'awaiting_deploy')) "
-                    "   OR (status = 'succeeded' "
-                    "       AND phase IN ('done', 'retro_done', 'retro_failed')) "
+                    "WHERE kind = 'task' "
+                    "  AND ((status = 'running' "
+                    "        AND phase IN ('awaiting_ci', 'awaiting_deploy')) "
+                    "    OR (status = 'succeeded' "
+                    "        AND phase IN ('done', 'retro_done', 'retro_failed'))) "
                     "ORDER BY started_at ASC",
                 )
                 for row in cur.fetchall():

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -334,6 +334,52 @@ class TestHasActiveAgent:
         assert d._has_active_agent() is True
         assert conn.rollbacks >= 1
 
+    def test_query_filters_on_kind_task(self, tmp_path: Path) -> None:
+        """Regression for #2908.
+
+        The scheduler concurrency gate must only consider daemon-owned
+        (``kind='task'``) agents. A laptop ``/task`` subagent's
+        ``kind='task-skill'`` row at ``status='running'`` is operator-
+        owned and has no bearing on the daemon's subprocess-slot
+        accounting — counting it starves the daemon's scheduler.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        d._has_active_agent()
+
+        selects = [
+            e
+            for e in conn.cursor_instance.executed
+            if "SELECT 1 FROM dispatcher.agents" in e[0]
+        ]
+        assert selects, "expected _has_active_agent to issue the SELECT"
+        sql, _params = selects[0]
+        assert "status = 'running'" in sql
+        assert "kind = 'task'" in sql, (
+            "_has_active_agent must filter kind='task' so task-skill rows "
+            "do not starve the scheduler (see #2908). Actual SQL: " + sql
+        )
+
+    def test_task_skill_row_is_not_counted_as_active(self, tmp_path: Path) -> None:
+        """End-to-end behavior: with a live ``kind='task-skill'`` row as
+        the only ``status='running'`` row in the database, the scheduler
+        gate must treat the slot as FREE.
+
+        We simulate this by seeding the fake cursor's ``fetch_queue``
+        with ``None`` — i.e. the kind-filtered SELECT returns zero rows.
+        This only holds if the SQL actually includes the ``kind='task'``
+        predicate; without it, the pre-fix query would return a row and
+        the fake would have to be primed with ``(1,)`` instead.
+        The assertion on the SQL text in
+        ``test_query_filters_on_kind_task`` is the structural guarantee;
+        this test documents the behavioral contract alongside.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        # After the kind filter, a lone task-skill row produces zero
+        # matches.
+        conn.cursor_instance.fetch_queue = [None]
+        assert d._has_active_agent() is False
+
 
 # --------------------------------------------------------------------------
 # _latest_queue_snapshot_issues

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -431,6 +431,35 @@ class TestListAdvanceableAgents:
         assert rows == []
         assert conn.rollbacks >= 1
 
+    def test_select_filters_on_kind_task(self, tmp_path: Path) -> None:
+        """Regression for #2908.
+
+        ``_list_advanceable_agents`` drives the daemon's Phase 3B/3E
+        advance loop (CI watch, deploy watch, retro, cleanup). It should
+        only advance ``kind='task'`` rows — task-skill rows never reach
+        ``awaiting_ci``/``awaiting_deploy``/``retro_*`` in practice
+        (their lifecycle ends with the operator's /task pipeline), but
+        filtering defensively documents the scope and prevents a future
+        phase-label collision from starving the advance loop.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue = [[]]
+        d._list_advanceable_agents()
+
+        selects = [
+            e
+            for e in conn.cursor_instance.executed
+            if "SELECT agent_id" in e[0] and "dispatcher.agents" in e[0]
+        ]
+        assert selects, "expected _list_advanceable_agents to issue the SELECT"
+        sql, _params = selects[0]
+        assert "status = 'running'" in sql
+        assert "kind = 'task'" in sql, (
+            "_list_advanceable_agents must filter kind='task' so the "
+            "advance loop is scoped to daemon-owned agents (see #2908). "
+            "Actual SQL: " + sql
+        )
+
 
 # --------------------------------------------------------------------------
 # _advance_running_agents — dispatch + crash isolation

--- a/scripts/dispatcher/tests/test_daemon_restart_cascade.py
+++ b/scripts/dispatcher/tests/test_daemon_restart_cascade.py
@@ -282,6 +282,36 @@ class TestRecoverAbandonedAgents:
         assert d.recover_abandoned_agents() == 0
         assert conn.rollbacks >= 1
 
+    def test_select_filters_on_kind_task(self, tmp_path: Path) -> None:
+        """Regression for #2908.
+
+        ``recover_abandoned_agents`` is a daemon-supervisor decision —
+        it reclaims ``status='running'`` agents from PRIOR daemon runs
+        and enqueues retry markers. ``kind='task-skill'`` rows are
+        operator-owned laptop subagents, not daemon-reclaimable; if the
+        daemon "reclaimed" one it would create a phantom retry of work
+        that is still running in a separate OS process on the operator's
+        laptop. The SELECT must filter ``kind='task'``.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue = [[]]
+        d.recover_abandoned_agents()
+
+        selects = [
+            e
+            for e in conn.cursor_instance.executed
+            if "SELECT agent_id, issue_number, phase" in e[0]
+            and "dispatcher.agents" in e[0]
+        ]
+        assert selects, "expected recover_abandoned_agents to issue the SELECT"
+        sql, _params = selects[0]
+        assert "status = 'running'" in sql
+        assert "kind = 'task'" in sql, (
+            "recover_abandoned_agents must filter kind='task' so laptop "
+            "/task subagents are not reclaimed at daemon boot (see #2908). "
+            "Actual SQL: " + sql
+        )
+
 
 # --------------------------------------------------------------------------
 # Bug B — per-phase stuck_timeout thresholds


### PR DESCRIPTION
## Summary

Fix Phase 3A scheduler concurrency gate to only count daemon-owned
(`kind='task'`) agents. `_has_active_agent`, `recover_abandoned_agents`,
and `_list_advanceable_agents` now filter `AND kind = 'task'` so laptop
/task subagents (`kind='task-skill'`) don't starve the daemon's
scheduler or get phantom-reclaimed at boot.

Closes #2908

Parent: #2866. Sibling: #2903 (covers `_check_stuck_agents` via option
(b) — different function, merges cleanly).

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] CloudWatch Insights query over a post-deploy window shows
      `scheduler_tick tick_n=1` with `orchestration_attempted: true`,
      `queue_depth: 90`, `concurrency_cap: 1` on merge commit e0c8154.
- [x] Verification evidence posted on issue:
      https://github.com/judgemind/judgemind/issues/2908#issuecomment-4282547535

## Notes

- Audit of all `status = 'running'` queries in `scripts/dispatcher/daemon.py`
  posted as a comment on the issue:
  https://github.com/judgemind/judgemind/issues/2908#issuecomment-4282483361
- Process summary with per-AC mapping:
  https://github.com/judgemind/judgemind/issues/2908#issuecomment-4282486309
- `_check_stuck_agents` (line 8877) is intentionally left alone —
  #2903 owns it via option (b), guarding `_create_retry_marker`
  rather than filtering the SELECT.
