### PR TITLE
feat(web): unify dispatcher admin tables with (issue, priority, title) + phase tooltip (#2899)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -162,12 +162,13 @@ Once MCP writes are unblocked (follow-up issue referenced from `docs/agent/gh-to
 
 ### Part A — DB row (atomic race detection)
 
-Run the helper (stays in the foreground — use `timeout: 1200000` since the ECS-Exec code path takes 2-4 s per call). **Pass the issue title** you already fetched from GitHub in Step 1 (the `title` field from `mcp__github__get_issue` / `mcp__github__list_issues`) — without it, the `dispatcher.agents` row is inserted with `issue_title=NULL` and the admin cockpit's Recently Completed panel renders the row as "(title unavailable)" (issue #2898). The daemon's own `_atomic_claim` caller (`scripts/dispatcher/daemon.py`) already supplies `issue_title`; `/task` must match that behavior.
+Run the helper (stays in the foreground — use `timeout: 1200000` since the ECS-Exec code path takes 2-4 s per call). **Pass the issue title** you already fetched from GitHub in Step 1 (the `title` field from `mcp__github__get_issue` / `mcp__github__list_issues`) — without it, the `dispatcher.agents` row is inserted with `issue_title=NULL` and the admin cockpit's Recently Completed panel renders the row as "(title unavailable)" (issue #2898). **Also pass the priority** derived from the issue's `priority/pN` label (`--issue-priority p0|p1|p2|p3`) — without it, the admin cockpit's Active-agents and Recently-completed panels render the priority badge as an em-dash instead of the actual p0/p1/p2/p3 chip (issue #2899). Omit `--issue-priority` only when the issue carries no priority label at all. The daemon's own `_atomic_claim` caller (`scripts/dispatcher/daemon.py`) already supplies both; `/task` must match that behavior.
 
 ```
 python3 {worktree}/scripts/dispatcher/task_claim.py claim \
     --issue <N> \
     --issue-title "<issue-title>" \
+    --issue-priority <p0|p1|p2|p3> \
     --worktree-path {worktree}
 ```
 

--- a/packages/api/migrations/34_dispatcher-agents-priority.sql
+++ b/packages/api/migrations/34_dispatcher-agents-priority.sql
@@ -1,0 +1,63 @@
+-- Up Migration
+--
+-- Dispatcher v2 — add a nullable ``priority`` text column to
+-- ``dispatcher.agents`` so the admin cockpit's Active agents and
+-- Recently completed panels can render a priority badge without a
+-- GraphQL-layer JOIN to GitHub (#2899).
+--
+-- Context
+-- -------
+-- Issue #2899 unifies the three dispatcher-admin tables on a shared
+-- ``(issue, priority, title)`` prefix. The queue panels already have
+-- priority because queue rows are derived from the ``dispatcher.queue_snapshots``
+-- JSON (which carries per-issue labels). Active agents and Recently
+-- completed rows come from ``dispatcher.agents`` directly, which had
+-- ``issue_number`` + ``issue_title`` but no priority — so adding the
+-- column here mirrors the ``issue_title`` denormalization that migration
+-- 28 (#2820) landed for the same reason.
+--
+-- Design notes
+-- ------------
+-- - **Nullable TEXT.** Values are ``'p0'`` | ``'p1'`` | ``'p2'`` | ``'p3'``
+--   | NULL (no priority label at claim time, or a pre-migration row).
+--   No CHECK constraint because ``dispatcher.agents.status`` is also
+--   plain text for the same reason (future labels slot in without a
+--   schema migration). The admin cockpit's ``<PriorityBadge>`` is the
+--   single render point — it already handles null and unknown values.
+-- - **Written at claim time.** Both the daemon (``_atomic_claim``) and
+--   the /task skill (``scripts/dispatcher/task_claim.py claim
+--   --issue-priority``) populate this column when inserting. The value
+--   is parsed from the issue's label set at the moment of the claim —
+--   it intentionally reflects "priority when spawned", not "priority
+--   now", so a relabel on GitHub post-claim does not retroactively
+--   rewrite the admin row. This mirrors the existing
+--   ``dispatcher.agents.issue_title`` pattern.
+-- - **No backfill.** Historical rows keep ``priority=NULL`` — the UI
+--   renders an em-dash placeholder. Backfilling would require hitting
+--   GitHub for thousands of closed issues, which is exactly the kind of
+--   GitHub-PAT-budget burn the operator constraint bans (see the
+--   ``parse-labels.ts`` docstring in the API package).
+-- - **No index.** We never filter or sort ``dispatcher.agents`` by
+--   priority — it's strictly a render-time column for the admin table.
+--   The existing ``idx_dispatcher_agents_running`` and
+--   ``idx_dispatcher_agents_issue_number`` indexes already cover all
+--   read paths.
+
+ALTER TABLE dispatcher.agents
+    ADD COLUMN priority TEXT;
+
+COMMENT ON COLUMN dispatcher.agents.priority IS
+    'Priority label captured at claim time (p0|p1|p2|p3|NULL). '
+    'Written by both DispatcherDaemon._atomic_claim and '
+    'scripts/dispatcher/task_claim.py. Reflects "priority when spawned"; '
+    'does not retroactively update when the issue is relabeled on GitHub. '
+    'Issue #2899.';
+
+
+-- Down Migration
+--
+-- Drop the column. The UI gracefully degrades — ``<PriorityBadge
+-- priority={null} />`` renders the em-dash placeholder, which is the
+-- same behaviour operators see for pre-migration rows.
+ALTER TABLE dispatcher.agents
+    DROP COLUMN IF EXISTS priority;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -328,7 +328,8 @@ CREATE TABLE dispatcher.agents (
     runner_override jsonb,
     model_override jsonb,
     issue_title text,
-    failure_summary text
+    failure_summary text,
+    priority text
 );
 
 
@@ -345,6 +346,9 @@ COMMENT ON COLUMN dispatcher.agents.issue_title IS 'Issue title captured at clai
 
 
 COMMENT ON COLUMN dispatcher.agents.failure_summary IS 'One-line "what happened" string for failed / crashed / plan_blocked terminals. Populated by _mark_agent_terminal at terminal-time from failures.category + phase + exit_code + stderr tail (<=240 chars), then optionally upgraded by /diagnose-failure to the first 1-3 sentences of recommendation.reasoning. NULL for succeeded / needs_review rows and historical pre-#2900 rows. Rendered as a tooltip on the outcome glyph in the /admin/dispatcher Recently completed panel. Issue #2900.';
+
+
+COMMENT ON COLUMN dispatcher.agents.priority IS 'Priority label captured at claim time (p0|p1|p2|p3|NULL). Written by both DispatcherDaemon._atomic_claim and scripts/dispatcher/task_claim.py. Reflects "priority when spawned"; does not retroactively update when the issue is relabeled on GitHub. Issue #2899.';
 
 
 CREATE TABLE dispatcher.blocked_snapshots (

--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -52,6 +52,15 @@ function agentRowToGraphQL(row: Row): Record<string, unknown> {
     id: row.agent_id,
     kind: row.kind,
     issueNumber: row.issue_number,
+    // Issue title captured at claim time (#2820). Pre-migration-28 rows
+    // have NULL which the UI renders as a fallback to `#<number>`.
+    issueTitle:
+      typeof row.issue_title === 'string' && row.issue_title.length > 0
+        ? row.issue_title
+        : null,
+    // Priority was added in migration 33 (#2899). Pre-migration rows
+    // return null from pg, which the UI renders as an em-dash.
+    priority: typeof row.priority === 'string' ? row.priority : null,
     worktreePath: row.worktree_path,
     phase: row.phase,
     status: row.status,
@@ -296,6 +305,7 @@ async function queryRecentCompletions(pool: Pool, limit: number): Promise<Row[]>
     `SELECT a.agent_id,
             a.issue_number,
             a.issue_title,
+            a.priority,
             a.status,
             a.ended_at,
             a.pr_number,
@@ -461,6 +471,11 @@ function recentCompletionsToGraphQL(
     return {
       agentId: row.agent_id,
       issueNumber: number,
+      // Priority pulled from ``dispatcher.agents.priority`` (populated
+      // by the daemon at claim time from the queue-snapshot labels;
+      // issue #2899). Pre-migration-33 rows return null, which the UI
+      // renders as an em-dash placeholder.
+      priority: typeof row.priority === 'string' ? row.priority : null,
       // Pulled from ``dispatcher.agents.issue_title`` (populated by the
       // daemon at claim time from the queue-snapshot enrichment; issue
       // #2820). Agents that claimed before migration 28 will have

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -99,6 +99,22 @@ export const dispatcherTypeDefs = `#graphql
     id: ID!
     kind: String!
     issueNumber: Int!
+    """Issue title captured at claim time. Populated by the daemon
+    (\`_atomic_claim\`) + /task skill (\`task_claim.py claim --issue-title ...\`)
+    from the queue-snapshot enrichment, issue #2820. Null when the issue
+    is not in the snapshot or the row predates migration 28 — the admin
+    cockpit falls back to \`#<number>\`. Exposed on the active-agents
+    query so the unified table can render title alongside issue+priority
+    without a separate GitHub round-trip. Issue #2899."""
+    issueTitle: String
+    """Priority label captured at claim time — one of p0 | p1 | p2 | p3 | null.
+    Written by both the daemon's \`_atomic_claim\` and the /task skill's
+    \`task_claim.py claim --issue-priority ...\`. Reflects "priority when
+    spawned"; does NOT retroactively update when the issue is relabeled
+    on GitHub after the claim. Pre-migration-33 rows return null —
+    the admin cockpit renders those as an em-dash placeholder.
+    Issue #2899."""
+    priority: String
     worktreePath: String!
     phase: String!
     """One of running | succeeded | failed | retrying | crashed | plan_blocked | needs_review.
@@ -204,6 +220,11 @@ export const dispatcherTypeDefs = `#graphql
     agentId: ID!
     """Issue the agent was working on."""
     issueNumber: Int!
+    """Priority label captured at claim time — one of p0 | p1 | p2 | p3 | null.
+    Same semantics as \`DispatcherAgent.priority\`: reflects "priority
+    when spawned". Pre-migration-33 rows return null (em-dash in the
+    admin cockpit). Issue #2899."""
+    priority: String
     """Issue title (fetched live from GitHub; null if the lookup failed)."""
     issueTitle: String
     """One of succeeded | failed | crashed | plan_blocked | needs_review.

--- a/packages/api/tests/dispatcher-enrichment.unit.test.ts
+++ b/packages/api/tests/dispatcher-enrichment.unit.test.ts
@@ -168,12 +168,14 @@ describe('queueItemFromSnapshot', () => {
 });
 
 describe('recentCompletionsToGraphQL', () => {
-  it('passes ``issue_title`` through from the agents row', () => {
+  it('passes ``issue_title`` and ``priority`` through from the agents row', () => {
     const rows = [
       {
         agent_id: 'uuid-1',
         issue_number: 100,
         issue_title: 'Fix the thing',
+        // #2899 — priority is captured at claim time.
+        priority: 'p2',
         status: 'succeeded',
         ended_at: '2026-04-18T12:00:00Z',
         pr_number: 2824,
@@ -187,6 +189,7 @@ describe('recentCompletionsToGraphQL', () => {
         agentId: 'uuid-1',
         issueNumber: 100,
         issueTitle: 'Fix the thing',
+        priority: 'p2',
         status: 'succeeded',
         endedAt: '2026-04-18T12:00:00Z',
         prNumber: 2824,
@@ -274,6 +277,34 @@ describe('recentCompletionsToGraphQL', () => {
     expect(result[0].failureSummary).toBe(
       'ralph crashed (stuck_timeout): no log tail',
     );
+  });
+
+  it('emits priority=null for pre-migration-33 rows (#2899)', () => {
+    // Rows whose claim predates migration 34 (the one #2899 adds) have
+    // ``priority`` = NULL from pg; the UI renders an em-dash placeholder.
+    const rows = [
+      {
+        agent_id: 'uuid-1',
+        issue_number: 100,
+        issue_title: 'Legacy agent',
+        priority: null,
+        status: 'succeeded',
+        ended_at: '2026-04-18T12:00:00Z',
+        pr_number: null,
+      },
+      {
+        agent_id: 'uuid-2',
+        issue_number: 101,
+        issue_title: 'Agent on unlabelled issue',
+        // column missing entirely (defensive — pg result shape drift)
+        status: 'succeeded',
+        ended_at: '2026-04-18T13:00:00Z',
+        pr_number: null,
+      },
+    ];
+    const result = recentCompletionsToGraphQL(rows);
+    expect(result[0].priority).toBeNull();
+    expect(result[1].priority).toBeNull();
   });
 
   it('emits totalTokens=null and totalCostUsd=null for pre-migration-31 rows', () => {

--- a/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
@@ -3,8 +3,9 @@
 import { Button } from '@/components/ui/button';
 import { SECTION_HEADING } from '@/lib/typography';
 import type { DispatcherAgent } from '@/lib/dispatcher-queries';
+import { tooltipText } from '@/lib/dispatcher-phase-flow';
 import { formatUptime, shortAgentId, worktreeLogsUrl } from './format-helpers';
-import { IssueLink } from './ui-primitives';
+import { IssueLink, PriorityBadge } from './ui-primitives';
 
 interface ActiveAgentsTableProps {
   agents: readonly DispatcherAgent[];
@@ -65,6 +66,9 @@ function ActiveAgentRow({
 }) {
   const logsHref = worktreeLogsUrl(agent.worktreePath);
   const elapsed = formatUptime(agent.startedAt, nowMs);
+  // Build the phase tooltip from the shared canonical constant so
+  // future phase additions propagate automatically (#2899).
+  const phaseTooltip = tooltipText(agent.phase);
   return (
     <li className="flex flex-wrap items-center gap-x-3 gap-y-1 py-2 text-sm hover:bg-muted/50">
       <span
@@ -73,10 +77,30 @@ function ActiveAgentRow({
       >
         {shortAgentId(agent.id)}
       </span>
+      {/* Unified (issue, priority, title) prefix — matches QueuePanel
+          and RecentCompletionsPanel (#2899). */}
       <span className="flex-shrink-0">
         <IssueLink number={agent.issueNumber} />
       </span>
-      <span className="min-w-0 flex-1 font-mono text-xs text-muted-foreground">
+      <span className="flex-shrink-0">
+        <PriorityBadge priority={agent.priority} />
+      </span>
+      <span
+        className="min-w-0 flex-1 truncate text-foreground"
+        data-testid="active-agent-title"
+        title={agent.issueTitle ?? undefined}
+      >
+        {agent.issueTitle ?? (
+          <span className="italic text-muted-foreground">
+            (title unavailable)
+          </span>
+        )}
+      </span>
+      <span
+        className="flex-shrink-0 cursor-help rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground"
+        data-testid={`active-agent-phase-${agent.id}`}
+        title={phaseTooltip}
+      >
         {agent.phase}
       </span>
       <span className="w-16 flex-shrink-0 text-right font-mono text-xs text-muted-foreground">

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -2,7 +2,7 @@
 
 import { SECTION_HEADING } from '@/lib/typography';
 import type { RecentCompletion } from '@/lib/dispatcher-queries';
-import { IssueLink, OutcomePill, PRLink } from './ui-primitives';
+import { IssueLink, OutcomePill, PriorityBadge, PRLink } from './ui-primitives';
 
 interface RecentCompletionsPanelProps {
   completions: readonly RecentCompletion[];
@@ -86,8 +86,13 @@ function RecentCompletionRow({ completion }: { completion: RecentCompletion }) {
           failureSummary={completion.failureSummary}
         />
       </span>
+      {/* Unified (issue, priority, [pr,] title) prefix — matches
+          ActiveAgentsTable and QueuePanel (#2899). */}
       <span className="flex-shrink-0 pt-0.5">
         <IssueLink number={completion.issueNumber} />
+      </span>
+      <span className="flex-shrink-0 pt-0.5">
+        <PriorityBadge priority={completion.priority} />
       </span>
       {completion.prNumber !== null && (
         <span className="flex-shrink-0 pt-0.5">

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ActiveAgentsTable.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ActiveAgentsTable.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import type { DispatcherAgent } from '@/lib/dispatcher-queries';
+import { ActiveAgentsTable } from '../ActiveAgentsTable';
+
+/**
+ * Tests for the ActiveAgentsTable's shared `(issue, priority, title)`
+ * prefix and the phase tooltip (#2899). The row layout predates these
+ * tests, but the prefix + tooltip are new — covering just them
+ * exercises the issue's AC without re-testing unchanged behaviour.
+ */
+
+function makeAgent(overrides: Partial<DispatcherAgent> = {}): DispatcherAgent {
+  return {
+    id: 'aabbccdd-eeff-0011-2233-445566778899',
+    kind: 'task',
+    issueNumber: 2899,
+    issueTitle: 'feat(web): unify dispatcher admin tables',
+    priority: 'p2',
+    worktreePath: '/Users/x/.claude/worktrees/agent-aabbccdd',
+    phase: 'ralph',
+    status: 'running',
+    startedAt: '2026-04-20T15:00:00Z',
+    endedAt: null,
+    exitCode: null,
+    prNumber: null,
+    retriesUsed: 0,
+    ...overrides,
+  };
+}
+
+describe('ActiveAgentsTable — unified (issue, priority, title) prefix', () => {
+  it('renders the issue link, priority badge, and title for each row', () => {
+    const agent = makeAgent();
+    render(
+      <ActiveAgentsTable agents={[agent]} onAgentAction={vi.fn()} />,
+    );
+    expect(screen.getByTestId('issue-link-2899')).toBeInTheDocument();
+    expect(screen.getByTestId('priority-badge-p2')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('active-agent-title').textContent,
+    ).toContain('unify dispatcher admin tables');
+  });
+
+  it('renders an em-dash placeholder when priority is null', () => {
+    const agent = makeAgent({ priority: null });
+    render(
+      <ActiveAgentsTable agents={[agent]} onAgentAction={vi.fn()} />,
+    );
+    // PriorityBadge renders the em-dash glyph for null priority.
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('renders a placeholder when the title is null (pre-#2820 agent)', () => {
+    const agent = makeAgent({ issueTitle: null });
+    render(
+      <ActiveAgentsTable agents={[agent]} onAgentAction={vi.fn()} />,
+    );
+    expect(screen.getByText('(title unavailable)')).toBeInTheDocument();
+  });
+});
+
+describe('ActiveAgentsTable — phase tooltip', () => {
+  it('renders the phase chip with a native title tooltip including the flow', () => {
+    const agent = makeAgent({ phase: 'ralph' });
+    render(
+      <ActiveAgentsTable agents={[agent]} onAgentAction={vi.fn()} />,
+    );
+    const chip = screen.getByTestId(`active-agent-phase-${agent.id}`);
+    const tooltip = chip.getAttribute('title');
+    expect(tooltip).not.toBeNull();
+    // Both the "Currently in X" preamble and the Flow line must be present.
+    expect(tooltip).toContain('Currently in ralph phase.');
+    expect(tooltip).toContain('Flow: ');
+    // Full forward flow is present (happy-path phases + conditional marker).
+    expect(tooltip).toContain('claiming');
+    expect(tooltip).toContain('planning');
+    expect(tooltip).toContain('setup');
+    expect(tooltip).toContain('ralph');
+    expect(tooltip).toContain('summary');
+    expect(tooltip).toContain('fix_ci*');
+    expect(tooltip).toContain('merge');
+    expect(tooltip).toContain('verify');
+    expect(tooltip).toContain('retro');
+    // Current phase is bracketed so the operator can locate their position.
+    expect(tooltip).toContain('[ralph]');
+  });
+
+  it('rebuilds the tooltip for each phase — different phases get different highlights', () => {
+    const agent = makeAgent({ phase: 'summary' });
+    render(
+      <ActiveAgentsTable agents={[agent]} onAgentAction={vi.fn()} />,
+    );
+    const chip = screen.getByTestId(`active-agent-phase-${agent.id}`);
+    expect(chip.getAttribute('title')).toContain('[summary]');
+    expect(chip.getAttribute('title')).toContain('Currently in summary phase.');
+  });
+});
+
+describe('ActiveAgentsTable — empty state', () => {
+  it('renders an empty message when no agents are active', () => {
+    render(<ActiveAgentsTable agents={[]} onAgentAction={vi.fn()} />);
+    expect(screen.getByText('No active agents.')).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
@@ -14,6 +14,7 @@ function completion(overrides: Partial<RecentCompletion>): RecentCompletion {
     agentId: 'agent-1',
     issueNumber: 2805,
     issueTitle: 'wire dispatcher admin dashboard',
+    priority: 'p2',
     status: 'succeeded',
     endedAt: '2026-04-18T11:55:00Z',
     prNumber: 2811,
@@ -30,13 +31,23 @@ describe('RecentCompletionsPanel', () => {
     expect(screen.getByText(/no completed agents yet/i)).toBeInTheDocument();
   });
 
-  it('renders outcome glyph + issue link + PR link + title', () => {
+  it('renders outcome glyph + issue link + priority badge + PR link + title', () => {
     const items = [completion({})];
     render(<RecentCompletionsPanel completions={items} nowMs={now} />);
     expect(screen.getByTestId('outcome-pill-succeeded')).toBeInTheDocument();
     expect(screen.getByTestId('issue-link-2805')).toBeInTheDocument();
+    // #2899: unified `(issue, priority, [pr,] title)` prefix — priority
+    // badge sits between the issue link and the PR link.
+    expect(screen.getByTestId('priority-badge-p2')).toBeInTheDocument();
     expect(screen.getByTestId('pr-link-2811')).toBeInTheDocument();
     expect(screen.getByText('wire dispatcher admin dashboard')).toBeInTheDocument();
+  });
+
+  it('#2899: renders the em-dash priority placeholder when priority is null', () => {
+    const items = [completion({ priority: null, agentId: 'agent-pnull' })];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    // PriorityBadge's em-dash placeholder.
+    expect(screen.getByText('—')).toBeInTheDocument();
   });
 
   // --- #2818 — density pass: "(no PR)" filler and "N min ago" column removed.

--- a/packages/web/src/lib/__tests__/dispatcher-phase-flow.test.ts
+++ b/packages/web/src/lib/__tests__/dispatcher-phase-flow.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for the dispatcher phase-flow tooltip helpers (#2899) plus a
+ * parity check against `scripts/dispatcher/phases.py`.
+ *
+ * Why the parity check
+ * --------------------
+ * The admin cockpit's phase tooltip reads from the TS constant in
+ * `../dispatcher-phase-flow.ts`, but the canonical sequence lives in
+ * `scripts/dispatcher/phases.py` (the daemon is the source of truth
+ * for what phases the state machine actually advances through). Without
+ * a parity check the two could drift — e.g. a future PR adds a new
+ * phase to the daemon's Python side but forgets the TS mirror, and
+ * operators see an incomplete flow string in the tooltip even though
+ * the agent is in the new phase.
+ *
+ * The parity check reads the Python source file as text, extracts the
+ * `PHASE_FLOW_FORWARD` tuple via a simple line-based parse (no Python
+ * interpreter needed — the JS test runner already has file I/O), and
+ * asserts the TS `PHASE_FLOW_FORWARD` array matches element-for-element.
+ * A mismatch fails CI with a diff-friendly error message.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  CONDITIONAL_PHASES,
+  PHASE_FLOW_FORWARD,
+  buildFlowString,
+  tooltipText,
+} from '../dispatcher-phase-flow';
+
+// ---------------------------------------------------------------------------
+// Parity test — TS constant MUST match the Python source
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `PHASE_FLOW_FORWARD` out of the Python source by reading until
+ * the closing `)` after the tuple opens. We do NOT try to be a full
+ * Python parser — the file is our own, and we control its format. If
+ * the shape changes (say, someone rewrites it as a list), update this
+ * regex alongside the source.
+ */
+function extractPythonPhaseFlow(pythonSource: string): string[] {
+  // Find the assignment, not the docstring mention. The tuple literal
+  // always starts with `PHASE_FLOW_FORWARD: tuple[str, ...] = (`.
+  const assignMatch = pythonSource.match(
+    /^PHASE_FLOW_FORWARD\s*:\s*tuple\[str,\s*\.\.\.\]\s*=\s*\(/m,
+  );
+  if (!assignMatch || assignMatch.index === undefined) {
+    throw new Error(
+      'phases.py is missing the `PHASE_FLOW_FORWARD: tuple[str, ...] = (` ' +
+        'assignment — the parity test parser expects that exact shape.',
+    );
+  }
+  const openParen =
+    assignMatch.index + assignMatch[0].length - 1; // position of the `(`
+  const closeParen = pythonSource.indexOf(')', openParen);
+  if (closeParen === -1) {
+    throw new Error(
+      'phases.py PHASE_FLOW_FORWARD tuple has no closing `)` — ' +
+        'the parity test parser expects a simple tuple, not a multi-line ' +
+        'computed value.',
+    );
+  }
+  const tupleBody = pythonSource.slice(openParen + 1, closeParen);
+  // Match each "quoted string" entry — Python uses either "..." or
+  // '...'. Keep regex tolerant of whitespace and trailing commas.
+  const matches = tupleBody.match(/["']([a-zA-Z0-9_]+)["']/g);
+  if (!matches) return [];
+  return matches.map((m) => m.slice(1, -1));
+}
+
+describe('dispatcher-phase-flow parity with scripts/dispatcher/phases.py', () => {
+  it('TS PHASE_FLOW_FORWARD matches the Python PHASE_FLOW_FORWARD', () => {
+    // Resolve repo root by climbing from this test file. Four levels:
+    // __tests__ → lib → src → packages/web → repo root.
+    const repoRoot = join(__dirname, '..', '..', '..', '..', '..');
+    const pythonPath = join(repoRoot, 'scripts', 'dispatcher', 'phases.py');
+    const pythonSource = readFileSync(pythonPath, 'utf8');
+
+    const pythonFlow = extractPythonPhaseFlow(pythonSource);
+    const tsFlow = [...PHASE_FLOW_FORWARD];
+
+    expect(tsFlow).toEqual(pythonFlow);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFlowString — decoration + conditional marker
+// ---------------------------------------------------------------------------
+
+describe('buildFlowString', () => {
+  it('renders every forward phase separated by a Unicode arrow', () => {
+    const flow = buildFlowString();
+    for (const phase of PHASE_FLOW_FORWARD) {
+      expect(flow).toContain(phase);
+    }
+    expect(flow).toContain('\u2192'); // U+2192 RIGHTWARDS ARROW
+  });
+
+  it('inserts the conditional fix_ci* marker between ci_watch and merge', () => {
+    const flow = buildFlowString();
+    const ciWatchIdx = flow.indexOf('ci_watch');
+    const fixCiIdx = flow.indexOf('fix_ci*');
+    const mergeIdx = flow.indexOf('merge');
+    expect(ciWatchIdx).toBeGreaterThan(-1);
+    expect(fixCiIdx).toBeGreaterThan(ciWatchIdx);
+    expect(mergeIdx).toBeGreaterThan(fixCiIdx);
+  });
+
+  it('brackets the current phase so the operator can spot their position', () => {
+    const flow = buildFlowString('ralph');
+    expect(flow).toContain('[ralph]');
+    // Other phases stay unbracketed.
+    expect(flow).toMatch(/(^|[^[])planning([^\]]|$)/);
+  });
+
+  it('brackets the current phase even when the input uses hyphens (fix-ci)', () => {
+    const flow = buildFlowString('fix-ci');
+    expect(flow).toContain('[fix_ci*]');
+  });
+
+  it('leaves the output unbracketed when the current phase is unknown', () => {
+    const flow = buildFlowString('bogus_phase');
+    expect(flow).not.toContain('[');
+  });
+
+  it('exposes fix_ci in CONDITIONAL_PHASES so future phases can mirror the pattern', () => {
+    expect(CONDITIONAL_PHASES.has('fix_ci')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tooltipText — two-line format
+// ---------------------------------------------------------------------------
+
+describe('tooltipText', () => {
+  it('renders the two-line "Currently in <phase>" + "Flow: ..." format', () => {
+    const text = tooltipText('ralph');
+    const lines = text.split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe('Currently in ralph phase.');
+    expect(lines[1]).toMatch(/^Flow: /);
+  });
+
+  it('preserves the full flow string including the conditional fix_ci* marker', () => {
+    const text = tooltipText('planning');
+    expect(text).toContain('fix_ci*');
+    expect(text).toContain('[planning]');
+  });
+});

--- a/packages/web/src/lib/dispatcher-phase-flow.ts
+++ b/packages/web/src/lib/dispatcher-phase-flow.ts
@@ -1,0 +1,105 @@
+/**
+ * Canonical dispatcher phase names and the forward flow string for the
+ * admin cockpit's phase tooltip (#2899).
+ *
+ * This is a TS mirror of `scripts/dispatcher/phases.py`. A parity test
+ * in `__tests__/dispatcher-phase-flow.test.ts` reads the Python source
+ * and asserts the two lists stay in sync — when a phase is added or
+ * removed, update both files in the same PR. CI catches drift.
+ *
+ * Why two copies instead of a GraphQL field?
+ * ------------------------------------------
+ * Phase names almost never change. Plumbing them through the
+ * GraphQL schema would add a server round-trip on every admin-page
+ * render for data that would be identical 99.9% of the time; the
+ * parity test gives us the "single source of truth" guarantee at
+ * build time at zero runtime cost.
+ *
+ * ASCII-only
+ * ----------
+ * The rendered string is injected into the native `title` attribute
+ * of the phase chip, which does not parse HTML. Unicode arrow
+ * (U+2192) is safe because `title` renders the Unicode code point
+ * directly. No markup.
+ */
+
+/**
+ * Happy-path phase sequence in daemon execution order. Matches
+ * `docs/specs/dispatcher-v2-spec.md` §6 and the per-agent state
+ * machine in `scripts/dispatcher/daemon.py`. Every phase listed is
+ * something the `ActiveAgents` row can display as its current
+ * `phase` value; the mechanical phases (claiming, setup,
+ * push_and_pr, ci_watch, merge, deploy_watch) are included so
+ * operators see the full pipeline.
+ */
+export const PHASE_FLOW_FORWARD: readonly string[] = [
+  'claiming',
+  'planning',
+  'setup',
+  'ralph',
+  'summary',
+  'push_and_pr',
+  'ci_watch',
+  'merge',
+  'deploy_watch',
+  'verify',
+  'retro',
+] as const;
+
+/**
+ * Phases that only appear on the unhappy branch. The tooltip
+ * decorates these with a trailing `*` to signal they are conditional.
+ */
+export const CONDITIONAL_PHASES: ReadonlySet<string> = new Set(['fix_ci']);
+
+/**
+ * Canonical-form match for the admin tooltip's current-phase
+ * highlighting. The daemon sometimes writes phase names with hyphens
+ * (legacy alias — `fix-ci` vs `fix_ci`), so both sides normalize
+ * before comparison. The conditional marker `fix_ci*` also matches
+ * `fix_ci`.
+ */
+function matchesCurrent(flowEntry: string, currentPhase: string): boolean {
+  const canonicalEntry = flowEntry.replace(/\*$/, '').replace(/-/g, '_');
+  const canonicalCurrent = currentPhase.replace(/-/g, '_');
+  return canonicalEntry === canonicalCurrent;
+}
+
+/**
+ * Render the forward flow as an arrow-separated string. When
+ * `currentPhase` is provided and matches a phase in the flow, that
+ * phase is surrounded by square brackets so the operator's eye can
+ * land on their current position.
+ *
+ * The single conditional marker `fix_ci*` is inserted between
+ * `ci_watch` and `merge` so the tooltip communicates that the red-CI
+ * branch exists without forcing the operator to read a diagram.
+ */
+export function buildFlowString(currentPhase: string | null = null): string {
+  const assembled: string[] = [];
+  for (const name of PHASE_FLOW_FORWARD) {
+    assembled.push(name);
+    if (name === 'ci_watch') {
+      // fix_ci* lives on the red-CI branch between ci_watch and merge.
+      assembled.push('fix_ci*');
+    }
+  }
+  const decorated = currentPhase
+    ? assembled.map((name) =>
+        matchesCurrent(name, currentPhase) ? `[${name}]` : name,
+      )
+    : assembled;
+  return decorated.join(' \u2192 ');
+}
+
+/**
+ * Two-line admin-tooltip text for a given phase. Matches the format
+ * in issue #2899:
+ *
+ *     Currently in <phase> phase.
+ *     Flow: <phase1> \u2192 <phase2> \u2192 ...
+ */
+export function tooltipText(currentPhase: string): string {
+  const flow = buildFlowString(currentPhase);
+  return `Currently in ${currentPhase} phase.\nFlow: ${flow}`;
+}

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -28,6 +28,8 @@ export const DISPATCHER_STATE_QUERY = gql`
         id
         kind
         issueNumber
+        issueTitle
+        priority
         worktreePath
         phase
         status
@@ -67,6 +69,7 @@ export const DISPATCHER_STATE_QUERY = gql`
         agentId
         issueNumber
         issueTitle
+        priority
         status
         endedAt
         prNumber
@@ -131,6 +134,19 @@ export interface DispatcherAgent {
   id: string;
   kind: string;
   issueNumber: number;
+  /** Issue title captured at claim time from the queue-snapshot
+   * enrichment (#2820). Null for pre-migration-28 rows or when the
+   * issue was not in the snapshot at claim time — the UI renders
+   * `#<number>` alone in that case. Exposed here so the active-agents
+   * table can render a shared `(issue, priority, title)` prefix
+   * matching the queue and recent-completions panels (#2899). */
+  issueTitle: string | null;
+  /** Priority label captured at claim time — `p0` | `p1` | `p2` | `p3`
+   * | null. Null for pre-migration-33 rows or issues with no
+   * `priority/pN` label at claim time; the UI renders an em-dash
+   * placeholder. Reflects "priority when spawned", not "priority now".
+   * Issue #2899. */
+  priority: string | null;
   worktreePath: string;
   phase: string;
   status: string;
@@ -164,6 +180,10 @@ export interface RecentCompletion {
   agentId: string;
   issueNumber: number;
   issueTitle: string | null;
+  /** Priority label captured at claim time — `p0` | `p1` | `p2` | `p3`
+   * | null. Same semantics as `DispatcherAgent.priority`; pre-migration-33
+   * rows return null (em-dash in the UI). Issue #2899. */
+  priority: string | null;
   /** One of `succeeded | failed | crashed`. */
   status: string;
   endedAt: string;

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -994,6 +994,35 @@ _PRIORITY_LABEL_RANKS: dict[str, int] = {
 _PRIORITY_RANK_NO_LABEL: int = 4
 
 
+def _extract_priority(labels: Any) -> str | None:
+    """Extract the priority label value (``'p0'`` | ``'p1'`` | ``'p2'`` | ``'p3'``).
+
+    Issue #2899. Used at claim time to populate
+    ``dispatcher.agents.priority`` from the per-issue ``labels`` array
+    stored in ``dispatcher.queue_snapshots.issues_json``.
+
+    When an issue carries more than one priority label (shouldn't
+    happen, but defensive), the most urgent (lowest-numbered) wins —
+    the same convention as :func:`_priority_rank`.
+
+    Tolerates non-list input (returns None) so a malformed
+    ``issues_json`` row cannot crash the claim path.
+    """
+    if not isinstance(labels, list):
+        return None
+    best: str | None = None
+    best_rank = _PRIORITY_RANK_NO_LABEL
+    for entry in labels:
+        if not isinstance(entry, str):
+            continue
+        rank = _PRIORITY_LABEL_RANKS.get(entry)
+        if rank is not None and rank < best_rank:
+            best_rank = rank
+            # The label is ``priority/pN``; the stored value is ``pN``.
+            best = entry.split("/", 1)[1] if "/" in entry else None
+    return best
+
+
 def _priority_rank(labels: list[str] | Any) -> int:
     """Return the lowest (highest-priority) rank implied by ``labels``.
 
@@ -2787,6 +2816,65 @@ class DispatcherDaemon:
                 return None
         return None
 
+    def _latest_queue_snapshot_priority_for(self, issue_number: int) -> str | None:
+        """Return the priority label for ``issue_number`` from the latest snapshot.
+
+        Reads the same ``dispatcher.queue_snapshots.issues_json`` blob
+        as :meth:`_latest_queue_snapshot_title_for` and picks the
+        priority label out of the per-issue ``labels`` array. Returns
+        ``'p0'`` | ``'p1'`` | ``'p2'`` | ``'p3'`` or None when the
+        issue carries no ``priority/pN`` label, is absent from the
+        snapshot, or the read fails.
+
+        Written for the admin cockpit's table-unification pass (#2899).
+        Keeping the read separate from :meth:`_latest_queue_snapshot_title_for`
+        is deliberate: each call is one lightweight cursor round-trip
+        (~1 ms against RDS), the two lookups happen once per claim, and
+        a combined helper would force every future caller that only
+        needs one field to fetch both.
+        """
+        assert self._conn is not None, "connect() must run before reading"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT issues_json FROM dispatcher.queue_snapshots "
+                    "ORDER BY observed_at DESC "
+                    "LIMIT 1",
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.latest_snapshot_priority_lookup_failed",
+                extra={
+                    "event": "latest_snapshot_priority_lookup_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return None
+        if row is None:
+            return None
+        issues = row[0]
+        if isinstance(issues, str):
+            try:
+                issues = json.loads(issues)
+            except json.JSONDecodeError:
+                return None
+        if not isinstance(issues, list):
+            return None
+        for entry in issues:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("number") == issue_number:
+                labels = entry.get("labels")
+                return _extract_priority(labels)
+        return None
+
     def _pick_candidate_issue(self, candidates: list[int]) -> int | None:
         """Pick the first candidate that is trusted and not already claimed.
 
@@ -2996,6 +3084,7 @@ class DispatcherDaemon:
         agent_id: str,
         worktree_path: str,
         issue_title: str | None = None,
+        priority: str | None = None,
     ) -> bool:
         """INSERT a new agent row; return True on success, False on race.
 
@@ -3012,6 +3101,13 @@ class DispatcherDaemon:
         ``dispatcher.queue_snapshots.issues_json`` so the admin-page
         recent-completions panel can render a title after the agent has
         finished without a GitHub round-trip.
+
+        ``priority`` is optional (nullable in the schema — migration
+        33, #2899). Values are ``'p0'`` | ``'p1'`` | ``'p2'`` | ``'p3'``
+        | None, parsed from the issue's label set at claim time. The
+        admin cockpit's Active-agents and Recently-completed panels
+        render this as a coloured badge; pre-migration-33 rows render
+        an em-dash placeholder.
         """
         assert self._conn is not None, "connect() must run before claiming"
 
@@ -3024,15 +3120,17 @@ class DispatcherDaemon:
                 cur.execute(
                     "INSERT INTO dispatcher.agents "
                     "    (agent_id, parent_run_id, kind, issue_number, "
-                    "     issue_title, worktree_path, phase, status) "
+                    "     issue_title, worktree_path, phase, status, "
+                    "     priority) "
                     "VALUES (%s, %s, 'task', %s, %s, %s, 'claiming', "
-                    "        'running')",
+                    "        'running', %s)",
                     (
                         agent_id,
                         self._run_id,
                         issue_number,
                         issue_title,
                         worktree_path,
+                        priority,
                     ),
                 )
             self._conn.commit()
@@ -4687,6 +4785,11 @@ class DispatcherDaemon:
         # recent-completions row renders with issue_title=NULL and the
         # UI falls back to "#N" — not a blocker for the claim.
         issue_title = self._latest_queue_snapshot_title_for(issue_number)
+        # Best-effort priority lookup from the same snapshot (#2899).
+        # A None result renders an em-dash placeholder — identical to
+        # the pre-migration-33 fallback — so a missing snapshot never
+        # blocks the claim.
+        issue_priority = self._latest_queue_snapshot_priority_for(issue_number)
 
         self._log.info(
             "daemon.candidate_picked",
@@ -4696,11 +4799,16 @@ class DispatcherDaemon:
                 "agent_id": agent_id,
                 "issue_number": issue_number,
                 "issue_title_captured": issue_title is not None,
+                "issue_priority": issue_priority,
             },
         )
 
         if not self._atomic_claim(
-            issue_number, agent_id, str(worktree_path), issue_title=issue_title
+            issue_number,
+            agent_id,
+            str(worktree_path),
+            issue_title=issue_title,
+            priority=issue_priority,
         ):
             # Race lost. Don't try the next candidate on this tick —
             # the next tick will re-scan the queue.

--- a/scripts/dispatcher/phases.py
+++ b/scripts/dispatcher/phases.py
@@ -1,0 +1,147 @@
+"""Canonical dispatcher phase names and the forward flow string.
+
+Single source of truth for the per-phase pipeline (#2899). The daemon's
+scheduler loop (see ``docs/specs/dispatcher-v2-spec.md`` §6) drives an
+agent through a fixed sequence of phases, and the admin cockpit's phase
+tooltip surfaces that sequence to operators so they can answer "what
+comes next?" without reading the daemon code.
+
+Before #2899 the sequence was re-derived implicitly: Python code had
+``PHASE_SEQUENCE = ("plan", "ralph", "summary")`` (the three LLM phases
+3A orchestrates) but no end-to-end list including mechanical phases,
+and the ``phase`` cell in the admin table was opaque. The tooltip
+strings that serve the admin UI now derive from
+:data:`PHASE_FLOW_FORWARD` here, and a parallel TS constant in
+``packages/web/src/lib/dispatcher-phase-flow.ts`` mirrors it — a
+parity test (``packages/web/src/lib/__tests__/dispatcher-phase-flow.test.ts``)
+reads this module's source and asserts the two lists stay in sync.
+
+Why a flat list instead of a graph
+----------------------------------
+The actual phase map in the daemon has one conditional branch
+(``ci_watch → ci_fix`` on red CI, otherwise ``ci_watch → merge``) plus
+retry loops — not a strict linear sequence. For an operator tooltip we
+want a single human-readable string, not a diagram. The convention is:
+
+- :data:`PHASE_FLOW_FORWARD` is the HAPPY path through the pipeline
+  (CI green, deploy OK, verify OK). Every phase listed is a phase the
+  admin table will ever display as the current ``phase`` value.
+- :data:`CONDITIONAL_PHASES` names the phases that only appear on the
+  unhappy branch (``ci_fix`` today). The tooltip renders them with a
+  trailing ``*`` to signal "conditional".
+
+Adding a new phase
+------------------
+1. Add the name here in :data:`PHASE_FLOW_FORWARD` at the correct
+   position.
+2. Add the matching entry to ``packages/web/src/lib/dispatcher-phase-flow.ts``.
+3. The parity test fails on mismatch — CI catches drift.
+"""
+# venv: scraper-framework
+# permanent: true
+
+from __future__ import annotations
+
+#: Happy-path phase sequence in daemon execution order. Matches
+#: ``docs/specs/dispatcher-v2-spec.md`` §6 ("Scheduler Loop") and the
+#: per-agent state machine in ``scripts/dispatcher/daemon.py``. The
+#: mechanical phases (``claiming``, ``setup``, ``push_and_pr``, etc.)
+#: are included because the admin table can display any of them as the
+#: current ``phase`` value — an operator seeing ``push_and_pr`` in the
+#: tooltip should see that phase in the flow and understand what comes
+#: after.
+#:
+#: Order is deliberate: every entry is either the exit label of the
+#: previous entry (e.g. ``planning`` → ``setup``) or the canonical
+#: label for the phase that runs next. See the phase map in daemon.py
+#: ``advance_per_agent_state_machine`` comment block.
+PHASE_FLOW_FORWARD: tuple[str, ...] = (
+    "claiming",
+    "planning",
+    "setup",
+    "ralph",
+    "summary",
+    "push_and_pr",
+    "ci_watch",
+    "merge",
+    "deploy_watch",
+    "verify",
+    "retro",
+)
+
+#: Phases that only appear on the unhappy branch. The tooltip
+#: decorates these with a trailing ``*`` to signal they are conditional
+#: — e.g. ``fix_ci*`` appears between ``ci_watch`` and ``merge`` when
+#: CI fails, but is skipped on green CI.
+CONDITIONAL_PHASES: frozenset[str] = frozenset({"fix_ci"})
+
+
+def build_flow_string(current_phase: str | None = None) -> str:
+    """Render the forward flow as a human-readable arrow-separated string.
+
+    Used by the admin cockpit's phase tooltip. The string always
+    includes every happy-path phase in order, plus the conditional
+    ``fix_ci*`` marker between ``ci_watch`` and ``merge`` so operators
+    can see that one failure branch exists. When ``current_phase`` is
+    provided and matches a phase in the flow, that phase is surrounded
+    by square brackets (``[current]``) so the operator's eye can land
+    on "where am I now" at a glance.
+
+    The returned string deliberately stays plain ASCII / unicode
+    arrows — no HTML — because it is injected into the native
+    ``title`` attribute (which does not parse markup).
+    """
+    # Assemble the full sequence including the single conditional
+    # marker between ci_watch and merge.
+    assembled: list[str] = []
+    for name in PHASE_FLOW_FORWARD:
+        assembled.append(name)
+        if name == "ci_watch":
+            # fix_ci* sits between ci_watch and merge on the red branch.
+            assembled.append("fix_ci*")
+
+    if current_phase:
+        assembled = [
+            f"[{name}]" if _matches_current(name, current_phase) else name
+            for name in assembled
+        ]
+
+    return " \u2192 ".join(assembled)
+
+
+def _matches_current(flow_entry: str, current_phase: str) -> bool:
+    """Return True when ``flow_entry`` names the agent's current phase.
+
+    The daemon sometimes writes phase names with hyphens instead of
+    underscores (legacy alias — ``fix-ci`` vs ``fix_ci``), so the
+    comparison normalizes both sides to a canonical form before
+    matching. The conditional marker ``fix_ci*`` matches ``fix_ci``
+    (or ``fix-ci``) as well.
+    """
+    canonical_entry = flow_entry.rstrip("*").replace("-", "_")
+    canonical_current = current_phase.replace("-", "_")
+    return canonical_entry == canonical_current
+
+
+def tooltip_text(current_phase: str) -> str:
+    """Return the two-line admin-tooltip text for a given phase.
+
+    Matches the format in issue #2899::
+
+        Currently in <phase> phase.
+        Flow: <phase1> \u2192 <phase2> \u2192 ...
+
+    The current phase is rendered both in the first line and
+    highlighted in-line in the flow string so operators can locate
+    their position without cross-referencing.
+    """
+    flow = build_flow_string(current_phase)
+    return f"Currently in {current_phase} phase.\nFlow: {flow}"
+
+
+__all__ = [
+    "CONDITIONAL_PHASES",
+    "PHASE_FLOW_FORWARD",
+    "build_flow_string",
+    "tooltip_text",
+]

--- a/scripts/dispatcher/task_claim.py
+++ b/scripts/dispatcher/task_claim.py
@@ -182,6 +182,16 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         default=None,
         help="Optional issue title to store for admin-page rendering.",
     )
+    claim.add_argument(
+        "--issue-priority",
+        default=None,
+        choices=["p0", "p1", "p2", "p3"],
+        help=(
+            "Optional priority label (p0|p1|p2|p3) to store in "
+            "dispatcher.agents.priority for admin-page rendering (#2899). "
+            "Omit when the issue carries no priority/pN label."
+        ),
+    )
 
     term = sub.add_parser("terminal", help="UPDATE the row to a terminal status.")
     term.add_argument(
@@ -315,6 +325,7 @@ def _claim_via_psycopg(
     agent_id: str,
     worktree_path: str,
     issue_title: str | None,
+    issue_priority: str | None = None,
 ) -> None:
     """INSERT a claim row via psycopg. Raises :class:`ClaimLost` on UniqueViolation."""
     import psycopg  # noqa: PLC0415 — lazy import
@@ -325,14 +336,16 @@ def _claim_via_psycopg(
                 cur.execute(
                     "INSERT INTO dispatcher.agents "
                     "    (agent_id, kind, issue_number, "
-                    "     issue_title, worktree_path, phase, status) "
-                    "VALUES (%s, %s, %s, %s, %s, 'claiming', 'running')",
+                    "     issue_title, worktree_path, phase, status, "
+                    "     priority) "
+                    "VALUES (%s, %s, %s, %s, %s, 'claiming', 'running', %s)",
                     (
                         agent_id,
                         TASK_SKILL_KIND,
                         issue_number,
                         issue_title,
                         worktree_path,
+                        issue_priority,
                     ),
                 )
             conn.commit()
@@ -385,6 +398,7 @@ def _claim_via_db_query_sh(
     agent_id: str,
     worktree_path: str,
     issue_title: str | None,
+    issue_priority: str | None = None,
 ) -> None:
     """INSERT a claim row via the ``dev-db-query.sh --rw`` wrapper.
 
@@ -399,12 +413,14 @@ def _claim_via_db_query_sh(
     # already SETs the session to read-write; INSERT returns no rows so
     # the wrapper prints ``{"rowcount": 1}`` on success.
     title_sql = _sql_literal(issue_title) if issue_title else "NULL"
+    priority_sql = _sql_literal(issue_priority) if issue_priority else "NULL"
     sql = (
         "INSERT INTO dispatcher.agents "
-        "(agent_id, kind, issue_number, issue_title, worktree_path, phase, status) "
+        "(agent_id, kind, issue_number, issue_title, worktree_path, phase, "
+        "status, priority) "
         f"VALUES ({_sql_literal(agent_id)}, {_sql_literal(TASK_SKILL_KIND)}, "
         f"{int(issue_number)}, {title_sql}, {_sql_literal(worktree_path)}, "
-        "'claiming', 'running')"
+        f"'claiming', 'running', {priority_sql})"
     )
     try:
         _run_sql_via_db_query_sh(sql)
@@ -651,6 +667,7 @@ def do_claim(
     agent_id: str | None,
     worktree_path: str,
     issue_title: str | None,
+    issue_priority: str | None = None,
 ) -> int:
     """Orchestrate the claim INSERT. Returns the process exit code.
 
@@ -660,6 +677,10 @@ def do_claim(
     supplied, we validate it's a UUID before issuing the INSERT so a
     bad caller argument produces a clear error rather than surfacing
     as ``invalid input syntax for type uuid`` (issue #2892).
+
+    ``issue_priority`` is stored in ``dispatcher.agents.priority``
+    (migration 33, #2899). Values are ``'p0'`` | ``'p1'`` | ``'p2'`` |
+    ``'p3'`` | None; the admin-page renders this as a coloured badge.
     """
     # Generate or validate agent_id up front so an obviously-broken
     # caller gets a clear error before we round-trip to the DB.
@@ -680,10 +701,21 @@ def do_claim(
     try:
         if use_psycopg:
             _claim_via_psycopg(
-                database_url, issue_number, agent_id, worktree_path, issue_title
+                database_url,
+                issue_number,
+                agent_id,
+                worktree_path,
+                issue_title,
+                issue_priority,
             )
         else:
-            _claim_via_db_query_sh(issue_number, agent_id, worktree_path, issue_title)
+            _claim_via_db_query_sh(
+                issue_number,
+                agent_id,
+                worktree_path,
+                issue_title,
+                issue_priority,
+            )
     except ClaimLost:
         # Look up the current owner so the /task skill can tell the operator
         # who owns the issue right now.
@@ -805,6 +837,7 @@ def main(argv: list[str] | None = None) -> int:
             args.agent_id,
             args.worktree_path,
             args.issue_title,
+            args.issue_priority,
         )
     if args.subcommand == "terminal":
         return do_terminal(

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -220,6 +220,52 @@ class TestPriorityRank:
 
 
 # --------------------------------------------------------------------------
+# _extract_priority (issue #2899)
+# --------------------------------------------------------------------------
+
+
+class TestExtractPriority:
+    """``_extract_priority`` maps label lists to the stored priority value.
+
+    Mirrors :class:`TestPriorityRank` but returns the string value
+    (``'p0'`` | ... | None) instead of a numeric sort rank. Used at
+    claim time to populate ``dispatcher.agents.priority``.
+    """
+
+    def test_p0_returns_p0(self) -> None:
+        assert daemon._extract_priority(["priority/p0"]) == "p0"
+
+    def test_p1_returns_p1(self) -> None:
+        assert daemon._extract_priority(["priority/p1"]) == "p1"
+
+    def test_p2_returns_p2(self) -> None:
+        assert daemon._extract_priority(["priority/p2"]) == "p2"
+
+    def test_p3_returns_p3(self) -> None:
+        assert daemon._extract_priority(["priority/p3"]) == "p3"
+
+    def test_no_priority_label_returns_none(self) -> None:
+        assert daemon._extract_priority(["area/devops", "type/bug"]) is None
+
+    def test_empty_labels_returns_none(self) -> None:
+        assert daemon._extract_priority([]) is None
+
+    def test_non_list_returns_none(self) -> None:
+        assert daemon._extract_priority(None) is None
+        assert daemon._extract_priority("priority/p0") is None
+        assert daemon._extract_priority({"priority/p0": 1}) is None
+
+    def test_multiple_priority_labels_picks_most_urgent(self) -> None:
+        """Matches ``_priority_rank`` — p0 wins over p2, p1 over p3, etc."""
+        assert daemon._extract_priority(["priority/p2", "priority/p0"]) == "p0"
+        assert daemon._extract_priority(["priority/p3", "priority/p1"]) == "p1"
+
+    def test_non_string_entries_are_ignored(self) -> None:
+        """Defensive: malformed JSONB rows cannot crash the claim path."""
+        assert daemon._extract_priority([{"name": "priority/p0"}, 42, None]) is None
+
+
+# --------------------------------------------------------------------------
 # Gate in scheduler_tick: orchestration only runs when cap>0 and no agent
 # --------------------------------------------------------------------------
 
@@ -694,8 +740,43 @@ class TestAtomicClaim:
             if "INSERT INTO dispatcher.agents" in e[0]
         ]
         assert len(inserts) == 1
+        # #2899 — priority column is now part of every INSERT.
+        insert_sql = inserts[0][0]
+        assert "priority" in insert_sql
         assert conn.commits == 1
         assert handler.events("claim_succeeded") != []
+
+    def test_priority_parameter_is_passed_to_insert(self, tmp_path: Path) -> None:
+        """Issue #2899 — the daemon pipes the priority through to the
+        INSERT so the admin cockpit can render the priority badge in
+        the active-agents and recently-completed panels.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        ok = d._atomic_claim(42, "agent-uuid", "/path", priority="p0")
+        assert ok is True
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.agents" in e[0]
+        ]
+        # Last bound parameter is the priority value.
+        _sql, params = inserts[0]
+        assert params[-1] == "p0"
+
+    def test_priority_default_none_passes_null(self, tmp_path: Path) -> None:
+        """Priority is optional; omitting it stores NULL (pre-migration-33
+        fallback behaviour).
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        ok = d._atomic_claim(42, "agent-uuid", "/path")
+        assert ok is True
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.agents" in e[0]
+        ]
+        _sql, params = inserts[0]
+        assert params[-1] is None
 
     def test_unique_violation_returns_false(self, tmp_path: Path) -> None:
         d, conn, handler = _make_daemon(tmp_path)

--- a/scripts/dispatcher/tests/test_task_claim.py
+++ b/scripts/dispatcher/tests/test_task_claim.py
@@ -173,17 +173,42 @@ class TestClaimViaPsycopg:
             agent_id="aabbccdd-eeff-0011-2233-445566778899",
             worktree_path="/tmp/wt",
             issue_title="title",
+            issue_priority="p1",
         )
 
         assert len(cur.executed) == 1
         sql, params = cur.executed[0]
         assert "INSERT INTO dispatcher.agents" in sql
+        assert "priority" in sql
         assert params[0] == "aabbccdd-eeff-0011-2233-445566778899"
         assert params[1] == task_claim.TASK_SKILL_KIND
         assert params[2] == 2866
         assert params[3] == "title"
         assert params[4] == "/tmp/wt"
+        # New in #2899 — priority lands as the last positional param.
+        assert params[5] == "p1"
         assert conn.commits == 1
+
+    def test_happy_path_with_null_priority(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Issue #2899 — priority is nullable. Pre-migration-33 rows and
+        issues with no priority/pN label both land here.
+        """
+        cur = _FakeCursor()
+        _patch_psycopg_connect(monkeypatch, cur)
+
+        task_claim._claim_via_psycopg(
+            "postgres://fake",
+            issue_number=2866,
+            agent_id="aabbccdd-eeff-0011-2233-445566778899",
+            worktree_path="/tmp/wt",
+            issue_title="title",
+            issue_priority=None,
+        )
+
+        sql, params = cur.executed[0]
+        assert params[5] is None
 
     def test_unique_violation_is_translated_to_claim_lost(
         self, monkeypatch: pytest.MonkeyPatch
@@ -199,6 +224,7 @@ class TestClaimViaPsycopg:
                 agent_id="abc",
                 worktree_path="/tmp/wt",
                 issue_title=None,
+                issue_priority=None,
             )
         assert conn.rollbacks == 1
 
@@ -270,8 +296,14 @@ class TestClaimViaDbQuerySh:
             agent_id="abc",
             worktree_path="/tmp/wt",
             issue_title=None,
+            issue_priority="p1",
         )
         assert len(captured) == 1
+        # #2899 — the INSERT SQL includes a ``priority`` column and the
+        # literal value is rendered inline (wrapped in single quotes).
+        sql_blob = captured[0][-1]
+        assert "priority" in sql_blob
+        assert "'p1'" in sql_blob
         assert captured[0][0] == "bash"
         assert captured[0][1].endswith("scripts/dev-db-query.sh")
         assert "--rw" in captured[0]
@@ -296,6 +328,7 @@ class TestClaimViaDbQuerySh:
                 agent_id="abc",
                 worktree_path="/tmp/wt",
                 issue_title=None,
+                issue_priority=None,
             )
 
     def test_non_unique_violation_error_raises_runtime_error(
@@ -315,7 +348,44 @@ class TestClaimViaDbQuerySh:
                 agent_id="abc",
                 worktree_path="/tmp/wt",
                 issue_title=None,
+                issue_priority=None,
             )
+
+    def test_null_priority_renders_sql_NULL_not_quoted_string(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Issue #2899 — priority is nullable.
+
+        When the /task skill doesn't know the priority (no priority/pN
+        label on the issue, or a pre-migration-33 call path), the
+        INSERT must render a bare ``NULL`` literal, not the string
+        ``'NULL'`` (which would be accepted by PostgreSQL as a valid
+        non-null TEXT value).
+        """
+
+        captured: list[str] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            captured.append(cmd[-1])
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = '{"rowcount": 1}'
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        task_claim._claim_via_db_query_sh(
+            issue_number=2866,
+            agent_id="abc",
+            worktree_path="/tmp/wt",
+            issue_title=None,
+            issue_priority=None,
+        )
+        sql = captured[0]
+        # The priority clause renders as the bare SQL literal NULL.
+        assert ", NULL)" in sql
+        # It is NOT a quoted string ``'NULL'``.
+        assert ", 'NULL')" not in sql
 
     def test_invalid_uuid_error_raises_configuration_error(
         self, monkeypatch: pytest.MonkeyPatch
@@ -351,6 +421,7 @@ class TestClaimViaDbQuerySh:
                 agent_id="agent-a5d7e546",
                 worktree_path="/tmp/wt",
                 issue_title=None,
+                issue_priority=None,
             )
 
     def test_json_parser_strips_ecs_exec_trailer(
@@ -521,18 +592,24 @@ class TestDoClaimUuidGeneration:
         monkeypatch.setenv("DATABASE_URL", "postgres://fake")
         captured_agent_ids: list[str] = []
 
+        captured_priorities: list[str | None] = []
+
         def fake_claim(
             database_url: str,
             issue_number: int,
             agent_id: str,
             worktree_path: str,
             issue_title: str | None,
+            issue_priority: str | None,
         ) -> None:
             captured_agent_ids.append(agent_id)
+            captured_priorities.append(issue_priority)
 
         monkeypatch.setattr(task_claim, "_claim_via_psycopg", fake_claim)
-        rc = task_claim.do_claim(2866, None, str(tmp_path), None)
+        rc = task_claim.do_claim(2866, None, str(tmp_path), None, "p1")
         assert rc == 0
+        # #2899 — do_claim forwards issue_priority through to the DB call.
+        assert captured_priorities == ["p1"]
         assert len(captured_agent_ids) == 1
         generated = captured_agent_ids[0]
         assert task_claim._is_uuid(generated)
@@ -553,7 +630,7 @@ class TestDoClaimUuidGeneration:
         """Regression test: ``agent-a5d7e546`` (the exact shape #2892
         documents in SKILL.md) must fail fast at the validator, not
         round-trip to the DB."""
-        rc = task_claim.do_claim(2892, "agent-a5d7e546", "/tmp/wt", None)
+        rc = task_claim.do_claim(2892, "agent-a5d7e546", "/tmp/wt", None, None)
         assert rc == 3
         err = capsys.readouterr().err
         assert "agent-a5d7e546" in err
@@ -574,7 +651,7 @@ class TestDoClaimUuidGeneration:
             raise task_claim.ClaimConfigurationError("invalid input syntax")
 
         monkeypatch.setattr(task_claim, "_claim_via_psycopg", raise_cfg)
-        rc = task_claim.do_claim(2866, _VALID_AGENT_ID, "/tmp/wt", None)
+        rc = task_claim.do_claim(2866, _VALID_AGENT_ID, "/tmp/wt", None, None)
         assert rc == 3
         err = capsys.readouterr().err
         assert "configuration error" in err.lower()
@@ -898,12 +975,53 @@ class TestMain:
     def test_claim_subcommand_dispatches_to_do_claim(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        captured: list[tuple[int, str, str, str | None]] = []
+        captured: list[tuple[int, str, str, str | None, str | None]] = []
 
         def fake_do_claim(
-            issue: int, agent_id: str, worktree_path: str, issue_title: str | None
+            issue: int,
+            agent_id: str,
+            worktree_path: str,
+            issue_title: str | None,
+            issue_priority: str | None,
         ) -> int:
-            captured.append((issue, agent_id, worktree_path, issue_title))
+            captured.append(
+                (issue, agent_id, worktree_path, issue_title, issue_priority)
+            )
+            return 0
+
+        monkeypatch.setattr(task_claim, "do_claim", fake_do_claim)
+        rc = task_claim.main(
+            [
+                "claim",
+                "--issue",
+                "2866",
+                "--agent-id",
+                "abc",
+                "--worktree-path",
+                "/tmp/wt",
+                "--issue-priority",
+                "p1",
+            ]
+        )
+        assert rc == 0
+        assert captured == [(2866, "abc", "/tmp/wt", None, "p1")]
+
+    def test_claim_subcommand_without_issue_priority_passes_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#2899 — ``--issue-priority`` is optional. Omitting it should
+        result in ``do_claim`` receiving ``issue_priority=None``.
+        """
+        captured: list[str | None] = []
+
+        def fake_do_claim(
+            issue: int,
+            agent_id: str,
+            worktree_path: str,
+            issue_title: str | None,
+            issue_priority: str | None,
+        ) -> int:
+            captured.append(issue_priority)
             return 0
 
         monkeypatch.setattr(task_claim, "do_claim", fake_do_claim)
@@ -919,7 +1037,22 @@ class TestMain:
             ]
         )
         assert rc == 0
-        assert captured == [(2866, "abc", "/tmp/wt", None)]
+        assert captured == [None]
+
+    def test_claim_subcommand_rejects_invalid_priority(self) -> None:
+        """#2899 — ``--issue-priority`` must be one of p0|p1|p2|p3."""
+        with pytest.raises(SystemExit):
+            task_claim.main(
+                [
+                    "claim",
+                    "--issue",
+                    "2866",
+                    "--worktree-path",
+                    "/tmp/wt",
+                    "--issue-priority",
+                    "urgent",  # not a valid priority label
+                ]
+            )
 
     def test_terminal_subcommand_dispatches_to_do_terminal(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

Unifies the three dispatcher admin tables on a shared `(issue, priority, title)` prefix and adds a hoverable phase tooltip to the Active-agents chip. Priority is persisted on `dispatcher.agents` at claim time (new migration 34) by both the daemon and the `/task` skill, exposed through GraphQL on `DispatcherAgent` and `RecentCompletion`, and rendered through the existing shared `<PriorityBadge>` in all three panels. The tooltip derives its flow string from a new `scripts/dispatcher/phases.py` canonical module; `packages/web/src/lib/dispatcher-phase-flow.ts` is the TS mirror with a parity test that reads the Python source.

Closes #2899

## Test plan

### Automated checks
- [x] Lint passes (web + api: clean)
- [x] Format check passes (ruff: clean)
- [x] Tests pass (web: 1280; api: 411; scraper-framework: 6410; dispatcher unit+integration: 671)
- [x] CI green (#2918 run `24678610714`)

### Post-deploy verification
- [x] Migration 34 applied on dev (verified via `scripts/dev-db-query.sh` — column exists as nullable text)
- [x] Admin cockpit renders priority chip on Active agents + Recently completed rows (verified with a test insert: `#289999 P1 …` on Recently completed, `#289998 P2 …` on Active agents)
- [x] Active-agents phase chip `title` attribute contains the full tooltip flow string (`Currently in ralph phase.\nFlow: claiming → planning → setup → [ralph] → summary → push_and_pr → ci_watch → fix_ci* → merge → deploy_watch → verify → retro`) — verified live via Playwright inspection
- [x] Verification evidence posted on issue #2899
