### PR TITLE
fix(ci): run migrations before deploy-dev in deploy-api (#2915)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -87,7 +87,7 @@ jobs:
 
   deploy-dev:
     name: Deploy to Dev
-    needs: build-and-push
+    needs: [build-and-push, run-migrations]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 
@@ -146,7 +146,7 @@ jobs:
 
   run-migrations:
     name: Run Database Migrations (Dev)
-    needs: [build-and-push, deploy-dev]
+    needs: build-and-push
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
 

--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -259,6 +259,29 @@ SELECT phase,
 
 Both queries filter `cost_usd IS NOT NULL` (or sort NULLS LAST) so pre-migration-31 rows don't corrupt the averages or take up slots in the top-10 view.
 
+## Deploy Pipeline Invariants
+
+### Migrations always run before code (#2915)
+
+The API deploy pipeline (`.github/workflows/deploy-api.yml`) enforces a strict ordering: **dev database migrations complete before the new API image is rolled onto the `judgemind-api-dev` service.** The job graph is:
+
+```
+build-and-push
+  ├─> run-migrations     (needs: build-and-push)                  <-- apply first
+  └─> deploy-dev         (needs: [build-and-push, run-migrations]) <-- then ship code
+post-deploy-health-check (needs: [deploy-dev, run-migrations])
+```
+
+This closes the race window observed in PR #2907 where a new resolver shipped onto dev before its backing migration applied, leaving `/admin/dispatcher` briefly serving `UndefinedColumn` errors. The enforcement is the `needs:` dependency on `deploy-dev` — if migrations fail, the deploy is cancelled and the old image keeps serving traffic.
+
+**Scope.** This covers forward-compatible migrations (add nullable column, add table, add index) — the overwhelming majority of Judgemind schema changes. Migrations-first plus rolling deploy is safe for those regardless of whether the old or new code is running when the new column appears.
+
+**Out of scope (backward-incompatible migrations).** Renames, drops, and type changes are still unsafe under a single-phase rolling deploy and require an explicit two-phase cadence (ship tolerant code → migrate → ship code that uses the new shape). Not enforced by this workflow — plan those PRs manually.
+
+**Other deploy workflows.**
+- `deploy-dispatcher.yml` — no migration step. The dispatcher image does not run `scripts/seed-and-migrate.mjs`; the API image owns schema. Nothing to enforce here.
+- `deploy-scraper.yml`, `deploy-production.yml` — no migration step. Same reason.
+
 ## ECS Script Execution
 
 > **Important:** The dev database is in a private VPC and is not reachable from localhost. Do not attempt to connect to it locally using `scripts/with-secret.sh` with `DATABASE_URL` — the connection will fail. All data scripts must run inside the VPC via `ecs-run-task.sh`.


### PR DESCRIPTION
## Summary

Flip the job dependency graph in `.github/workflows/deploy-api.yml` so `run-migrations` runs **before** `deploy-dev` instead of after it. Closes the race window observed on 2026-04-20 with PR #2907 where a new resolver shipped onto dev before its backing migration applied (`/admin/dispatcher` briefly returned `UndefinedColumn: failure_summary`). Also added a "Deploy Pipeline Invariants" section to `docs/agent/infrastructure-reference.md` documenting the invariant.

Closes #2915

## Job graph

Before:

```
build-and-push
  ├─> deploy-dev         (needs: build-and-push)           <-- code ships first
  └─> run-migrations     (needs: [build-and-push, deploy-dev])
post-deploy-health-check (needs: [deploy-dev, run-migrations])
```

After:

```
build-and-push
  ├─> run-migrations     (needs: build-and-push)                  <-- apply first
  └─> deploy-dev         (needs: [build-and-push, run-migrations]) <-- then ship code
post-deploy-health-check (needs: [deploy-dev, run-migrations])    (unchanged)
```

## Other deploy workflows (verified)

- `deploy-dispatcher.yml` — no migration step (grep for `migrat` returns no matches). The dispatcher image does not run `scripts/seed-and-migrate.mjs`; schema is owned by the API image.
- `deploy-scraper.yml` — no migration step.
- `deploy-production.yml` — no migration step.

No changes needed in those workflows.

## Scope

- **Covers forward-compatible migrations** (add nullable column, add table, add index). These are the overwhelming majority of Judgemind schema changes and are safe under migrations-first + rolling deploy regardless of whether old or new code is running when the new column appears.
- **Does NOT cover backward-incompatible migrations** (rename, drop, type change). Those still require an explicit two-phase cadence (ship tolerant code → migrate → ship code that uses the new shape). Flagged as out of scope in the new doc section and in the issue body.

## Test plan

### Automated checks
- [x] Lint passes (actionlint validated deploy-api.yml locally)
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Observe this PR's own deploy-api run on merge — since the PR modifies `.github/workflows/deploy-api.yml`, the workflow's paths filter triggers and the updated graph runs against itself. Confirm `run-migrations` completes before `deploy-dev` starts. (Run [`24678340012`](https://github.com/judgemind/judgemind/actions/runs/24678340012): migrations completed 16:37:54Z, deploy-dev started 16:37:56Z — 2s serial gap confirms the `needs:` dependency is enforced.)
- [ ] On the NEXT real schema-changing PR, confirm the migrations-succeed → deploy-dev sequence on a real schema change (natural integration test).
- [x] Verification evidence posted on issue (see task skill A.8).
