### PR TITLE
chore(ci): detect cross-PR migration-number collisions (#2916)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,9 +110,17 @@ jobs:
               - '.github/playwright-browser-check/**'
             migrations:
               - 'packages/api/migrations/**'
+              # Include ci.yml so that edits to the migration-* jobs below
+              # (migration-files-check, migration-collision-check,
+              # schema-drift-check, migration-notice) are actually exercised
+              # on the PR that introduces them. Without this, the paths
+              # filter would make those jobs SKIP on their own PR — the
+              # #2410 / #2505 footgun. See scripts/check-ci-job-skipped.py.
+              - '.github/workflows/ci.yml'
             schema:
               - 'packages/api/migrations/**'
               - 'packages/api/src/data-access/schema.sql'
+              - '.github/workflows/ci.yml'
             hooks:
               - '.claude/hooks/**'
               # Also trigger when the preflight-hook-test job itself changes,
@@ -935,6 +943,33 @@ jobs:
         run: scripts/check-migration-files.sh
 
   # ---------------------------------------------------------------
+  # Cross-PR migration number guard: detect when two open PRs both
+  # claim the same migration number (see #2916). `migration-files-check`
+  # only sees the current PR's diff; this job compares against every
+  # other open PR via `gh pr list --json number,title,files`.
+  # ---------------------------------------------------------------
+  migration-collision-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.migrations == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Need history for `git merge-base HEAD origin/main` to find the
+          # diff base; fetch-depth: 0 pulls full history.
+          fetch-depth: 0
+      - name: Fetch origin/main for diff base
+        run: git fetch origin main --depth=50
+      - name: Check cross-PR migration number claims
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REF: ${{ github.ref }}
+        run: scripts/check-migration-number-collision.sh --base origin/main
+
+  # ---------------------------------------------------------------
   # ECS oneshot import guard: prevent scripts/ from importing siblings
   # ---------------------------------------------------------------
   oneshot-imports-check:
@@ -1243,7 +1278,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-migration-number-collision.py
+++ b/scripts/check-migration-number-collision.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""
+check-migration-number-collision.py — Detect migration-number conflicts
+across open pull requests.
+
+Motivation (#2916): Two open PRs can independently claim the same
+migration number because `migration-files-check` only inspects the PR's
+own diff. Example (2026-04-20): #2899 and #2900 both picked migration
+33 in parallel.
+
+This check:
+  1. Reads migration numbers added or modified in the current PR's diff
+     vs a base ref (default: `origin/main`).
+  2. For each number, queries `gh pr list --state open --json
+     number,title,files` and grep-detects any OTHER open PR that
+     touches `packages/api/migrations/N_*.sql` with the same N.
+  3. Exits non-zero with a clear message naming the conflicting PRs if
+     a collision is found.
+  4. Bonus: emits a WARNING (no failure) if a migration number in the
+     current PR is `<= the latest migration number already on `base`,
+     which signals a stale branch that will conflict on rebase.
+
+The check is pure-ish: the I/O layer is small (git diff, gh pr list,
+ls packages/api/migrations on base). Core detection is a function
+`find_collisions(my_numbers, other_prs, current_pr_number)` that unit
+tests can exercise against canned inputs.
+
+Usage:
+    scripts/check-migration-number-collision.py
+    scripts/check-migration-number-collision.py --base main
+    scripts/check-migration-number-collision.py --current-pr 1234
+    scripts/check-migration-number-collision.py \\
+        --gh-pr-list-file pr_list.json --diff-file diff.txt
+    scripts/check-migration-number-collision.py --help
+
+Exit codes:
+    0 — No collisions detected (warnings may still be printed).
+    1 — Collision detected with another open PR.
+    2 — Script error (cannot parse inputs, cannot run git/gh, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+MIGRATIONS_DIR = "packages/api/migrations"
+_MIGRATION_FILE_RE = re.compile(r"^packages/api/migrations/(\d+)_.+\.sql$")
+
+
+# -----------------------------------------------------------------------------
+# Data model
+# -----------------------------------------------------------------------------
+
+
+@dataclass
+class OtherPR:
+    """A single open PR to compare against.
+
+    Fields mirror the output of `gh pr list --json number,title,files`.
+    """
+
+    number: int
+    title: str
+    migration_numbers: list[int]
+
+
+@dataclass
+class Collision:
+    """A single collision: `my_number` appears in `other_pr.migration_numbers`."""
+
+    my_number: int
+    other_pr: OtherPR
+
+
+# -----------------------------------------------------------------------------
+# Parsing helpers (pure — easy to unit-test)
+# -----------------------------------------------------------------------------
+
+
+def extract_migration_number(path: str) -> int | None:
+    """Return the migration number for a given repo-relative path, or None.
+
+    A path qualifies only if it sits directly under packages/api/migrations/
+    and begins with a digit-prefix followed by an underscore and `.sql`:
+
+        packages/api/migrations/33_dispatcher-thing.sql -> 33
+        packages/api/migrations/README.md              -> None
+        packages/api/migrations/sub/1_inner.sql        -> None
+    """
+    m = _MIGRATION_FILE_RE.match(path.strip())
+    if not m:
+        return None
+    return int(m.group(1))
+
+
+def parse_added_migration_numbers_from_diff(diff_text: str) -> list[int]:
+    """From a unified `git diff` over the PR, return migration numbers added
+    or modified.
+
+    We care about `diff --git a/<path> b/<path>` headers where the b-side
+    path matches our migration pattern. This covers:
+      - Added migration files (new side present, old side absent)
+      - Modified migration files (should still flag; better safe)
+      - Renamed migration files landing on a new number
+    and ignores:
+      - Deleted migration files (we don't collide with a deletion)
+      - Unrelated files
+
+    Returns a de-duplicated, sorted-ascending list.
+    """
+    numbers: set[int] = set()
+    for line in diff_text.splitlines():
+        if not line.startswith("diff --git "):
+            continue
+        # `diff --git a/path b/path`
+        parts = line.split(" ")
+        if len(parts) < 4:
+            continue
+        new_token = parts[-1]
+        if not new_token.startswith("b/"):
+            continue
+        new_path = new_token[2:]
+        n = extract_migration_number(new_path)
+        if n is not None:
+            numbers.add(n)
+    return sorted(numbers)
+
+
+def parse_gh_pr_list(
+    pr_list_json_text: str,
+) -> list[OtherPR]:
+    """Parse the output of `gh pr list --state open --json number,title,files`.
+
+    Each element has shape:
+        {"number": 2899, "title": "...", "files": [{"path": "...", ...}, ...]}
+
+    We extract migration numbers from each PR's file list so the collision
+    test has a compact structure to work with. Returns a list sorted by PR
+    number ascending.
+    """
+    try:
+        data = json.loads(pr_list_json_text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON from gh pr list: {exc}") from exc
+    if not isinstance(data, list):
+        raise ValueError("expected a JSON array from gh pr list")
+
+    prs: list[OtherPR] = []
+    for entry in data:
+        if not isinstance(entry, dict):
+            continue
+        number = entry.get("number")
+        title = entry.get("title") or ""
+        files = entry.get("files") or []
+        if not isinstance(number, int):
+            continue
+        mig_numbers: set[int] = set()
+        for f in files:
+            if not isinstance(f, dict):
+                continue
+            path = f.get("path")
+            if not isinstance(path, str):
+                continue
+            n = extract_migration_number(path)
+            if n is not None:
+                mig_numbers.add(n)
+        prs.append(
+            OtherPR(
+                number=number,
+                title=title,
+                migration_numbers=sorted(mig_numbers),
+            )
+        )
+    prs.sort(key=lambda p: p.number)
+    return prs
+
+
+# -----------------------------------------------------------------------------
+# Core detection (pure — unit-tested)
+# -----------------------------------------------------------------------------
+
+
+def find_collisions(
+    my_numbers: list[int],
+    other_prs: list[OtherPR],
+    current_pr_number: int | None,
+) -> list[Collision]:
+    """Return every (my_number, other_pr) where the other PR also claims
+    that migration number.
+
+    `current_pr_number` identifies the PR whose diff supplied `my_numbers`
+    — it is excluded from `other_prs` so a PR never reports a collision
+    with itself.
+
+    Ordering: collisions are returned sorted by `(my_number, other_pr.number)`
+    so CLI output is deterministic.
+    """
+    if not my_numbers:
+        return []
+    my_set = set(my_numbers)
+    collisions: list[Collision] = []
+    for pr in other_prs:
+        if current_pr_number is not None and pr.number == current_pr_number:
+            continue
+        for n in pr.migration_numbers:
+            if n in my_set:
+                collisions.append(Collision(my_number=n, other_pr=pr))
+    collisions.sort(key=lambda c: (c.my_number, c.other_pr.number))
+    return collisions
+
+
+def find_stale_numbers(
+    my_numbers: list[int],
+    latest_on_base: int | None,
+) -> list[int]:
+    """Bonus check — return migration numbers in `my_numbers` that are
+    already <= the latest applied migration on `base`.
+
+    This catches a stale long-lived branch whose migration number has
+    been "used up" on main since the branch forked. Purely advisory —
+    the caller warns but does not fail.
+    """
+    if latest_on_base is None:
+        return []
+    return sorted(n for n in my_numbers if n <= latest_on_base)
+
+
+# -----------------------------------------------------------------------------
+# I/O: git / gh / filesystem
+# -----------------------------------------------------------------------------
+
+
+def get_diff_from_git(base_ref: str, repo_root: Path) -> str:
+    """Run `git diff <merge-base>...HEAD` and return the unified diff text."""
+    mb = subprocess.run(
+        ["git", "-C", str(repo_root), "merge-base", "HEAD", base_ref],
+        capture_output=True,
+        text=True,
+    )
+    base = mb.stdout.strip() if (mb.returncode == 0 and mb.stdout.strip()) else base_ref
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), "diff", f"{base}...HEAD", "--unified=0"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git diff failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def get_latest_migration_number_on_base(base_ref: str, repo_root: Path) -> int | None:
+    """List `packages/api/migrations/` on the base ref and return the
+    highest migration number. Returns None if the listing is empty or on
+    error."""
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "ls-tree",
+            "--name-only",
+            f"{base_ref}:{MIGRATIONS_DIR}",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    nums: list[int] = []
+    for name in result.stdout.splitlines():
+        m = re.match(r"^(\d+)_.+\.sql$", name.strip())
+        if m:
+            nums.append(int(m.group(1)))
+    if not nums:
+        return None
+    return max(nums)
+
+
+def get_open_prs_via_gh(repo: str | None) -> str:
+    """Invoke `gh pr list --state open --json number,title,files`.
+
+    Returns the raw JSON text. Raises RuntimeError on failure.
+    """
+    cmd = [
+        "gh",
+        "pr",
+        "list",
+        "--state",
+        "open",
+        "--json",
+        "number,title,files",
+        "--limit",
+        "200",
+    ]
+    if repo:
+        cmd += ["--repo", repo]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh pr list failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def detect_current_pr_number(repo_root: Path) -> int | None:
+    """Best-effort: if this commit is part of an open PR, return its number.
+
+    In GitHub Actions' `pull_request` context the PR number is available
+    via `GITHUB_REF` (`refs/pull/<N>/merge`). Otherwise we fall back to
+    asking `gh` to resolve the current branch's PR. Returns None if no
+    PR is associated with HEAD.
+    """
+    # GitHub Actions sets GITHUB_REF like refs/pull/1234/merge on PR runs.
+    ref = os.environ.get("GITHUB_REF", "")
+    m = re.match(r"^refs/pull/(\d+)/(merge|head)$", ref)
+    if m:
+        return int(m.group(1))
+
+    # Fall back to `gh pr view --json number` — matches HEAD's branch to a PR.
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", "--json", "number"],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+        )
+    except FileNotFoundError:
+        return None
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    n = data.get("number") if isinstance(data, dict) else None
+    return n if isinstance(n, int) else None
+
+
+# -----------------------------------------------------------------------------
+# CLI
+# -----------------------------------------------------------------------------
+
+
+def format_collision(c: Collision) -> str:
+    pr_url_hint = f"https://github.com/<owner>/<repo>/pull/{c.other_pr.number}"
+    return (
+        f"ERROR: migration number {c.my_number} is also claimed by PR #{c.other_pr.number}\n"
+        f"  Title: {c.other_pr.title}\n"
+        f"  Link:  {pr_url_hint}\n"
+        f"\n"
+        f"Remediation:\n"
+        f"  1. git fetch origin main\n"
+        f"  2. git rebase origin/main\n"
+        f"  3. Inspect the latest migration number actually on main:\n"
+        f"       ls packages/api/migrations/ | sort | tail -5\n"
+        f"  4. Rename your migration file to the next available number.\n"
+        f"  5. git add packages/api/migrations/ && git commit --amend\n"
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Detect migration-number collisions between the current PR and "
+            "other open PRs on the same repository."
+        )
+    )
+    ap.add_argument(
+        "--base",
+        default="origin/main",
+        help="Base ref to diff against (default: origin/main).",
+    )
+    ap.add_argument(
+        "--repo",
+        default=None,
+        help="owner/repo passed to `gh pr list`; default: gh's inferred repo.",
+    )
+    ap.add_argument(
+        "--current-pr",
+        type=int,
+        default=None,
+        help=(
+            "Current PR number (excluded from the open-PR comparison). Default: "
+            "auto-detected from GITHUB_REF or `gh pr view`."
+        ),
+    )
+    ap.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repo root (default: auto-detect from git rev-parse --show-toplevel).",
+    )
+    ap.add_argument(
+        "--diff-file",
+        default=None,
+        help="Read unified diff from a file instead of invoking git (for tests).",
+    )
+    ap.add_argument(
+        "--gh-pr-list-file",
+        default=None,
+        help="Read gh pr list JSON from a file instead of invoking gh (for tests).",
+    )
+    ap.add_argument(
+        "--latest-base-migration",
+        type=int,
+        default=None,
+        help=(
+            "Override the latest-migration-on-base number used for the stale "
+            "branch warning (for tests)."
+        ),
+    )
+    args = ap.parse_args()
+
+    # -------- Resolve repo root --------
+    if args.repo_root:
+        repo_root = Path(args.repo_root).resolve()
+    else:
+        try:
+            r = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            repo_root = Path(r.stdout.strip())
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            print(f"ERROR: cannot determine repo root: {exc}", file=sys.stderr)
+            return 2
+
+    # -------- Read diff --------
+    if args.diff_file:
+        try:
+            diff_text = Path(args.diff_file).read_text()
+        except OSError as exc:
+            print(f"ERROR: cannot read diff file: {exc}", file=sys.stderr)
+            return 2
+    else:
+        try:
+            diff_text = get_diff_from_git(args.base, repo_root)
+        except RuntimeError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+    my_numbers = parse_added_migration_numbers_from_diff(diff_text)
+
+    if not my_numbers:
+        print(
+            "check-migration-number-collision: no migration files touched in diff — OK."
+        )
+        return 0
+
+    print(
+        f"check-migration-number-collision: PR touches migration numbers: "
+        f"{', '.join(str(n) for n in my_numbers)}"
+    )
+
+    # -------- Read open PRs --------
+    if args.gh_pr_list_file:
+        try:
+            pr_list_text = Path(args.gh_pr_list_file).read_text()
+        except OSError as exc:
+            print(f"ERROR: cannot read gh pr list file: {exc}", file=sys.stderr)
+            return 2
+    else:
+        try:
+            pr_list_text = get_open_prs_via_gh(args.repo)
+        except RuntimeError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+        except FileNotFoundError:
+            print(
+                "ERROR: `gh` CLI not found in PATH — cannot query open PRs.",
+                file=sys.stderr,
+            )
+            return 2
+
+    try:
+        other_prs = parse_gh_pr_list(pr_list_text)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    current_pr = args.current_pr
+    if current_pr is None:
+        current_pr = detect_current_pr_number(repo_root)
+
+    collisions = find_collisions(my_numbers, other_prs, current_pr)
+
+    # -------- Stale-branch warning (advisory only) --------
+    if args.latest_base_migration is not None:
+        latest_on_base = args.latest_base_migration
+    else:
+        latest_on_base = get_latest_migration_number_on_base(args.base, repo_root)
+
+    stale = find_stale_numbers(my_numbers, latest_on_base)
+    if stale:
+        print(
+            f"WARNING: migration number(s) {', '.join(str(n) for n in stale)} are "
+            f"<= the latest migration on `{args.base}` ({latest_on_base}). This "
+            f"branch may be stale — rebase and renumber.",
+            file=sys.stderr,
+        )
+
+    if not collisions:
+        print("check-migration-number-collision: no collisions with open PRs.")
+        return 0
+
+    print("", file=sys.stderr)
+    for c in collisions:
+        print(format_collision(c), file=sys.stderr)
+    print(
+        "See https://github.com/judgemind/judgemind/issues/2916 for background.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-migration-number-collision.sh
+++ b/scripts/check-migration-number-collision.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# check-migration-number-collision.sh — Thin wrapper for
+# check-migration-number-collision.py.
+#
+# Runs the Python checker against the current diff vs origin/main, using
+# `gh pr list --state open --json number,title,files` to enumerate other
+# open PRs. Used by the CI `migration-collision-check` job and
+# manually reproducible locally.
+#
+# Passes all args through to the Python script — see that file for flags
+# and exit codes (#2916).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/check-migration-number-collision.py" "$@"

--- a/scripts/tests/test_check_migration_number_collision.py
+++ b/scripts/tests/test_check_migration_number_collision.py
@@ -1,0 +1,336 @@
+"""Tests for check-migration-number-collision.py — migration-number
+collision detection across open PRs."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+# Import the module despite its dash-containing filename.
+# Register it in sys.modules BEFORE exec_module so `@dataclass` can find
+# its own module by name (it calls sys.modules[cls.__module__]).
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent / "check-migration-number-collision.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "check_migration_number_collision", _SCRIPT_PATH
+)
+assert _spec is not None
+assert _spec.loader is not None
+mod = importlib.util.module_from_spec(_spec)
+sys.modules["check_migration_number_collision"] = mod
+_spec.loader.exec_module(mod)
+
+extract_migration_number = mod.extract_migration_number
+parse_added_migration_numbers_from_diff = mod.parse_added_migration_numbers_from_diff
+parse_gh_pr_list = mod.parse_gh_pr_list
+find_collisions = mod.find_collisions
+find_stale_numbers = mod.find_stale_numbers
+OtherPR = mod.OtherPR
+
+
+# ---------------------------------------------------------------------------
+# extract_migration_number
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMigrationNumber:
+    def test_standard_path(self) -> None:
+        assert (
+            extract_migration_number(
+                "packages/api/migrations/33_dispatcher-agents-failure-summary.sql"
+            )
+            == 33
+        )
+
+    def test_single_digit(self) -> None:
+        assert (
+            extract_migration_number("packages/api/migrations/1_initial-schema.sql")
+            == 1
+        )
+
+    def test_two_digits(self) -> None:
+        assert extract_migration_number("packages/api/migrations/42_whatever.sql") == 42
+
+    def test_readme_ignored(self) -> None:
+        assert extract_migration_number("packages/api/migrations/README.md") is None
+
+    def test_other_dir_ignored(self) -> None:
+        assert (
+            extract_migration_number("packages/api/src/data-access/schema.sql") is None
+        )
+
+    def test_nested_subdir_ignored(self) -> None:
+        # The regex anchors to direct children of migrations/.
+        assert (
+            extract_migration_number("packages/api/migrations/sub/1_nested.sql") is None
+        )
+
+    def test_no_number_prefix_ignored(self) -> None:
+        assert (
+            extract_migration_number("packages/api/migrations/initial-schema.sql")
+            is None
+        )
+
+    def test_trailing_whitespace_stripped(self) -> None:
+        assert (
+            extract_migration_number(
+                "packages/api/migrations/7_case-parties-unique-constraint.sql   "
+            )
+            == 7
+        )
+
+
+# ---------------------------------------------------------------------------
+# parse_added_migration_numbers_from_diff
+# ---------------------------------------------------------------------------
+
+
+class TestParseAddedMigrationNumbersFromDiff:
+    def test_single_added_migration(self) -> None:
+        diff = (
+            "diff --git a/packages/api/migrations/33_foo.sql "
+            "b/packages/api/migrations/33_foo.sql\n"
+            "new file mode 100644\n"
+            "index 0000000..abc1234\n"
+            "--- /dev/null\n"
+            "+++ b/packages/api/migrations/33_foo.sql\n"
+            "@@ -0,0 +1,1 @@\n"
+            "+ALTER TABLE x ADD COLUMN y TEXT;\n"
+        )
+        assert parse_added_migration_numbers_from_diff(diff) == [33]
+
+    def test_multiple_added_migrations(self) -> None:
+        diff = (
+            "diff --git a/packages/api/migrations/33_foo.sql "
+            "b/packages/api/migrations/33_foo.sql\n"
+            "new file mode 100644\n"
+            "+++ b/packages/api/migrations/33_foo.sql\n"
+            "diff --git a/packages/api/migrations/34_bar.sql "
+            "b/packages/api/migrations/34_bar.sql\n"
+            "new file mode 100644\n"
+            "+++ b/packages/api/migrations/34_bar.sql\n"
+        )
+        assert parse_added_migration_numbers_from_diff(diff) == [33, 34]
+
+    def test_ignores_non_migration_diffs(self) -> None:
+        diff = (
+            "diff --git a/scripts/foo.sh b/scripts/foo.sh\n"
+            "+++ b/scripts/foo.sh\n"
+            "diff --git a/packages/api/src/routes/index.ts "
+            "b/packages/api/src/routes/index.ts\n"
+            "+++ b/packages/api/src/routes/index.ts\n"
+        )
+        assert parse_added_migration_numbers_from_diff(diff) == []
+
+    def test_empty_diff(self) -> None:
+        assert parse_added_migration_numbers_from_diff("") == []
+
+    def test_mixed_diff(self) -> None:
+        diff = (
+            "diff --git a/scripts/foo.sh b/scripts/foo.sh\n"
+            "+++ b/scripts/foo.sh\n"
+            "diff --git a/packages/api/migrations/5_bar.sql "
+            "b/packages/api/migrations/5_bar.sql\n"
+            "+++ b/packages/api/migrations/5_bar.sql\n"
+            "diff --git a/README.md b/README.md\n"
+            "+++ b/README.md\n"
+        )
+        assert parse_added_migration_numbers_from_diff(diff) == [5]
+
+    def test_duplicate_numbers_deduplicated(self) -> None:
+        # A rare scenario — e.g. a rename that creates two diff entries for
+        # the same migration number. We still return a unique list.
+        diff = (
+            "diff --git a/packages/api/migrations/7_old.sql "
+            "b/packages/api/migrations/7_old.sql\n"
+            "+++ b/packages/api/migrations/7_old.sql\n"
+            "diff --git a/packages/api/migrations/7_also-old.sql "
+            "b/packages/api/migrations/7_also-old.sql\n"
+            "+++ b/packages/api/migrations/7_also-old.sql\n"
+        )
+        assert parse_added_migration_numbers_from_diff(diff) == [7]
+
+    def test_sorted_ascending(self) -> None:
+        diff = (
+            "diff --git a/packages/api/migrations/5_five.sql "
+            "b/packages/api/migrations/5_five.sql\n"
+            "+++ b/packages/api/migrations/5_five.sql\n"
+            "diff --git a/packages/api/migrations/3_three.sql "
+            "b/packages/api/migrations/3_three.sql\n"
+            "+++ b/packages/api/migrations/3_three.sql\n"
+        )
+        assert parse_added_migration_numbers_from_diff(diff) == [3, 5]
+
+
+# ---------------------------------------------------------------------------
+# parse_gh_pr_list
+# ---------------------------------------------------------------------------
+
+
+class TestParseGhPrList:
+    def test_empty_list(self) -> None:
+        assert parse_gh_pr_list("[]") == []
+
+    def test_single_pr_with_migration(self) -> None:
+        payload = json.dumps(
+            [
+                {
+                    "number": 2899,
+                    "title": "admin table unify",
+                    "files": [
+                        {"path": "packages/api/migrations/33_foo.sql"},
+                        {"path": "packages/api/src/routes/admin.ts"},
+                    ],
+                }
+            ]
+        )
+        prs = parse_gh_pr_list(payload)
+        assert len(prs) == 1
+        assert prs[0].number == 2899
+        assert prs[0].title == "admin table unify"
+        assert prs[0].migration_numbers == [33]
+
+    def test_pr_without_migration(self) -> None:
+        payload = json.dumps(
+            [
+                {
+                    "number": 2800,
+                    "title": "docs: update readme",
+                    "files": [{"path": "README.md"}],
+                }
+            ]
+        )
+        prs = parse_gh_pr_list(payload)
+        assert len(prs) == 1
+        assert prs[0].migration_numbers == []
+
+    def test_multiple_prs_sorted_by_number(self) -> None:
+        payload = json.dumps(
+            [
+                {
+                    "number": 3000,
+                    "title": "b",
+                    "files": [{"path": "packages/api/migrations/34_b.sql"}],
+                },
+                {
+                    "number": 2500,
+                    "title": "a",
+                    "files": [{"path": "packages/api/migrations/33_a.sql"}],
+                },
+            ]
+        )
+        prs = parse_gh_pr_list(payload)
+        assert [p.number for p in prs] == [2500, 3000]
+
+    def test_invalid_json_raises(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError):
+            parse_gh_pr_list("not json")
+
+    def test_non_array_raises(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError):
+            parse_gh_pr_list('{"foo": "bar"}')
+
+    def test_skips_malformed_entries(self) -> None:
+        # Non-dict entries, missing-number entries — skipped silently.
+        payload = json.dumps(
+            [
+                "not a dict",
+                {"title": "no number", "files": []},
+                {
+                    "number": 42,
+                    "title": "real one",
+                    "files": [{"path": "packages/api/migrations/5_real.sql"}],
+                },
+            ]
+        )
+        prs = parse_gh_pr_list(payload)
+        assert len(prs) == 1
+        assert prs[0].number == 42
+        assert prs[0].migration_numbers == [5]
+
+
+# ---------------------------------------------------------------------------
+# find_collisions — core logic
+# ---------------------------------------------------------------------------
+
+
+class TestFindCollisions:
+    def test_no_migration_numbers_no_collisions(self) -> None:
+        assert find_collisions([], [], current_pr_number=None) == []
+
+    def test_no_other_prs_no_collisions(self) -> None:
+        assert find_collisions([33], [], current_pr_number=1) == []
+
+    def test_single_collision(self) -> None:
+        other = OtherPR(number=2899, title="other", migration_numbers=[33])
+        cols = find_collisions([33], [other], current_pr_number=2900)
+        assert len(cols) == 1
+        assert cols[0].my_number == 33
+        assert cols[0].other_pr.number == 2899
+
+    def test_self_excluded(self) -> None:
+        # If the "other" PR IS me, no collision should be reported.
+        me = OtherPR(number=2900, title="me", migration_numbers=[33])
+        cols = find_collisions([33], [me], current_pr_number=2900)
+        assert cols == []
+
+    def test_no_collision_when_numbers_differ(self) -> None:
+        other = OtherPR(number=2899, title="other", migration_numbers=[32])
+        cols = find_collisions([33], [other], current_pr_number=2900)
+        assert cols == []
+
+    def test_multiple_other_prs_multiple_collisions(self) -> None:
+        other_a = OtherPR(number=2899, title="a", migration_numbers=[33])
+        other_b = OtherPR(number=2901, title="b", migration_numbers=[33, 34])
+        cols = find_collisions([33, 34], [other_a, other_b], current_pr_number=2900)
+        # Expect three collisions: (33, 2899), (33, 2901), (34, 2901)
+        assert len(cols) == 3
+        tuples = [(c.my_number, c.other_pr.number) for c in cols]
+        assert tuples == [(33, 2899), (33, 2901), (34, 2901)]
+
+    def test_collisions_sorted_deterministically(self) -> None:
+        other_a = OtherPR(number=3000, title="a", migration_numbers=[50])
+        other_b = OtherPR(number=2000, title="b", migration_numbers=[50])
+        cols = find_collisions([50], [other_a, other_b], current_pr_number=1234)
+        tuples = [(c.my_number, c.other_pr.number) for c in cols]
+        assert tuples == [(50, 2000), (50, 3000)]
+
+    def test_current_pr_number_none_excludes_nothing(self) -> None:
+        # No current_pr_number → no self-exclusion. Every match counts.
+        other = OtherPR(number=99, title="x", migration_numbers=[10])
+        cols = find_collisions([10], [other], current_pr_number=None)
+        assert len(cols) == 1
+
+
+# ---------------------------------------------------------------------------
+# find_stale_numbers — bonus stale-branch warning
+# ---------------------------------------------------------------------------
+
+
+class TestFindStaleNumbers:
+    def test_none_latest_returns_empty(self) -> None:
+        assert find_stale_numbers([33, 34], None) == []
+
+    def test_no_my_numbers_returns_empty(self) -> None:
+        assert find_stale_numbers([], 30) == []
+
+    def test_all_above_latest_returns_empty(self) -> None:
+        assert find_stale_numbers([34, 35], 33) == []
+
+    def test_all_below_or_equal_latest(self) -> None:
+        # latest_on_base = 33 means migration 33 is already applied.
+        # Numbers <= 33 are stale.
+        assert find_stale_numbers([33, 32], 33) == [32, 33]
+
+    def test_mixed_some_stale_some_fine(self) -> None:
+        assert find_stale_numbers([32, 33, 34], 33) == [32, 33]
+
+    def test_result_sorted_ascending(self) -> None:
+        assert find_stale_numbers([34, 30, 31], 33) == [30, 31]


### PR DESCRIPTION
## Summary

Adds a new CI job `migration-collision-check` that detects when the current PR's added migration numbers are also claimed by any other open PR, closing the cross-PR coordination gap that `migration-files-check` doesn't cover. Observed 2026-04-20 when subagents for #2899 and #2900 independently claimed migration 33 — the only safety net today is "the second PR hits rebase conflicts and figures it out," which wastes a ralph cycle.

The check lives in `scripts/check-migration-number-collision.{py,sh}` with 36 unit tests. Bonus: emits a non-failing WARNING when a migration number is `<= latest on origin/main` (stale-branch signal).

Closes #2916

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest scripts/tests/test_check_migration_number_collision.py` — 36 passed locally; scripts-tests CI job passed)
- [x] `scripts/check-ci-job-skipped.sh` passes (`ci-job-skipped-check` CI job passed)
- [x] `shellcheck scripts/check-migration-number-collision.sh` passes
- [x] CI green (62 SUCCESS, `migration-collision-check` passed in 5s on this PR's own run)

### Post-deploy verification
- [x] N/A — no deployed component (CI/tooling only)
- [x] Verification evidence posted on issue (see A.8 in task skill)

## Notes for reviewers

- **Job gating.** The new `migration-collision-check` job is gated on `needs.detect-changes.outputs.migrations == 'true'`, same as `migration-files-check`. The script also early-exits with "no migration files touched in diff" if the diff has no migration paths, so accidental invocations are inert.
- **ci-job-skipped footgun.** Added `.github/workflows/ci.yml` to both `migrations` and `schema` paths filters so edits to any of the migration-* jobs are exercised on the PR that introduces them (#2410/#2505 pattern). This PR's own `migration-collision-check` run fired on its own CI run — proving the gate works.
- **Hygiene-check self-match footgun.** This isn't a `check-no-*` / `check-forbidden-*` guard, but the step name "Check cross-PR migration number claims" deliberately avoids any literal the script scans for (the script matches paths under `packages/api/migrations/`, not arbitrary strings).
- **Self-check evidence.** See the adoption-note comment on #2916 for collision / no-collision / stale-branch local self-check output and exit codes.
