### PR TITLE
fix(dispatcher): circuit breaker must only count kind='task' outcomes (#2921)

### DIFF
--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -174,8 +174,8 @@ async function querySpawnFrozenUntil(pool: Pool): Promise<string | null> {
  * Read ``dispatcher.config.cap_flipped_by`` — the diagnostic trail for
  * the last `concurrency_cap` flip. Returns the raw string (e.g.
  * `"circuit_breaker"`) or null when the row is unset or contains JSON
- * `null`. Used by the admin cockpit to render the overnight-safety
- * circuit breaker's open banner (#2860).
+ * `null`. Used by the admin cockpit to render the circuit breaker's
+ * open banner (#2860).
  */
 async function queryCapFlippedBy(pool: Pool): Promise<string | null> {
   const { rows } = await pool.query<{ value: unknown }>(
@@ -858,10 +858,9 @@ export const dispatcherResolvers = {
     },
 
     /**
-     * True when the overnight-safety circuit breaker is open
-     * (#2860). Derived from `cap_flipped_by === 'circuit_breaker'` so
-     * the admin cockpit can show a banner without parsing the raw
-     * config value client-side.
+     * True when the circuit breaker is open (#2860). Derived from
+     * `cap_flipped_by === 'circuit_breaker'` so the admin cockpit can
+     * show a banner without parsing the raw config value client-side.
      */
     circuitBreakerOpen: (parent: Record<string, unknown>) => {
       return parent.__capFlippedBy === 'circuit_breaker';

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -311,7 +311,7 @@ export const dispatcherTypeDefs = `#graphql
     config: [DispatcherConfigEntry!]!
     """\`dispatcher.config.value\` for \`spawn_frozen_until\` (§10), or null if not set."""
     spawnFrozenUntil: DateTime
-    """True when the overnight-safety circuit breaker is open
+    """True when the circuit breaker is open
     (\`dispatcher.config.cap_flipped_by\` == \`"circuit_breaker"\`).
     Surfaces the open state in the admin cockpit so the operator sees
     "Circuit open: N recent agents bad, cap held at 0" instead of a

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -320,7 +320,7 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
             Circuit breaker open — dispatcher auto-paused (#2860).
           </div>
           <div className="mt-1">
-            A streak of bad terminal outcomes tripped the overnight-safety rail.
+            A streak of bad terminal outcomes tripped the circuit breaker.
             <code className="mx-1 font-mono">concurrency_cap</code>
             is held at 0. Review recent completions and failures below, then
             raise cap back to ≥1 in the config strip once the underlying

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
@@ -345,7 +345,7 @@ describe('DispatcherDashboard — #2860 circuit-breaker banner', () => {
     expect(banner).toBeInTheDocument();
     expect(banner.textContent).toMatch(/Circuit breaker open/i);
     expect(banner.textContent).toMatch(/concurrency_cap/);
-    // Red by design — overnight-safety rail is a loud signal.
+    // Red by design — the circuit breaker is a loud signal.
     expect(banner.className).toMatch(/bg-red/);
     expect(banner.getAttribute('role')).toBe('alert');
   });

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -227,7 +227,7 @@ export interface DispatcherState {
   recentCompletions: RecentCompletion[];
   config: DispatcherConfigEntry[];
   spawnFrozenUntil: string | null;
-  /** True when the overnight-safety circuit breaker is open (#2860). */
+  /** True when the circuit breaker is open (#2860). */
   circuitBreakerOpen: boolean;
   /** Diagnostic trail for the last `concurrency_cap` flip (#2860). */
   capFlippedBy: string | null;

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -10434,11 +10434,29 @@ class DispatcherDaemon:
 
         try:
             with self._conn.cursor() as cur:
+                # Issue #2921: filter to ``kind='task'`` daemon-owned
+                # rows only. The supervisor's stuck_timeout sweep
+                # writes ``status='crashed'`` terminal outcomes for
+                # ``kind='task-skill'`` rows (operator-spawned /task
+                # subagents whose phase never advances past
+                # ``claiming`` because the skill doesn't write
+                # ``phase_transitions``). Those are operator-side
+                # lifecycle events — they have no predictive power
+                # for daemon pipeline health and must not trip the
+                # breaker. Sibling fixes in #2903 (retry-markers
+                # skipped for task-skill rows) and #2908
+                # (``_has_active_agent`` + boot recovery filtered to
+                # ``kind='task'``) addressed the same
+                # kind-conflation pattern elsewhere in the daemon.
                 cur.execute(
-                    "SELECT status FROM dispatcher.terminal_outcomes "
-                    "WHERE ended_at > now() - make_interval(mins => %s) "
-                    "ORDER BY ended_at DESC "
-                    "LIMIT %s",
+                    "SELECT o.status "
+                    "  FROM dispatcher.terminal_outcomes o "
+                    "  JOIN dispatcher.agents a "
+                    "    ON a.agent_id = o.agent_id "
+                    " WHERE o.ended_at > now() - make_interval(mins => %s) "
+                    "   AND a.kind = 'task' "
+                    " ORDER BY o.ended_at DESC "
+                    " LIMIT %s",
                     (window_minutes, window_size),
                 )
                 rows = cur.fetchall()

--- a/scripts/dispatcher/tests/test_daemon_circuit_breaker.py
+++ b/scripts/dispatcher/tests/test_daemon_circuit_breaker.py
@@ -857,3 +857,152 @@ class TestTelegramMessage:
             statuses=[],
         )
         assert "(none)" in body
+
+
+# --------------------------------------------------------------------------
+# Issue #2921: the candidate SELECT must JOIN dispatcher.agents and
+# filter ``kind='task'`` so the supervisor's stuck_timeout sweeps on
+# ``kind='task-skill'`` rows (operator-spawned /task subagents whose
+# phase never advances past ``claiming``) do not trip the breaker.
+#
+# Before the fix: 5 task-skill stuck_timeout sweeps in 30 min → breaker
+# opens, cap=0, daemon paused, running pipeline killed by the
+# killswitch. Observed 2026-04-20 16:48:26 UTC with
+# ``recent_statuses=['crashed','crashed','crashed','crashed','crashed']``
+# all sourced from task-skill rows.
+#
+# The DB-level filter is the canonical gate: ``_FakeCursor`` in these
+# tests doesn't enforce the JOIN semantics (it returns whatever rows
+# the test queued), so we assert the filter by inspecting the executed
+# SQL string. An integration test against a real Postgres would
+# additionally exercise the JOIN semantics end-to-end; those live in
+# the dispatcher-integration-tests job and are out of scope here.
+# --------------------------------------------------------------------------
+
+
+class TestCircuitBreakerKindFilter:
+    """Issue #2921 — SELECT must filter to ``kind='task'`` rows."""
+
+    def _stub_config_reads(
+        self,
+        conn: _FakeConnection,
+        *,
+        enabled: Any = True,
+        window_minutes: Any = 30,
+        window_size: Any = 10,
+        threshold: Any = 5,
+    ) -> None:
+        conn.cursor_instance.fetch_queue.extend(
+            [
+                (enabled,),
+                (window_minutes,),
+                (window_size,),
+                (threshold,),
+            ]
+        )
+
+    def test_scan_query_joins_dispatcher_agents_on_kind_task(
+        self, tmp_path: Path
+    ) -> None:
+        """The candidate SELECT must JOIN ``dispatcher.agents`` and filter ``kind='task'``.
+
+        Regression for #2921: the pre-fix query read from
+        ``dispatcher.terminal_outcomes`` alone, with no ``kind``
+        filter. That let supervisor stuck_timeout sweeps on
+        ``kind='task-skill'`` rows count toward the breaker. The
+        post-fix query joins against ``dispatcher.agents`` on
+        ``agent_id`` and filters ``a.kind = 'task'`` so only
+        daemon-owned outcomes influence the breaker.
+        """
+        d, conn, _h = _make_daemon(tmp_path)
+        self._stub_config_reads(conn)
+        # Empty scan result — we only care about the SQL string here.
+        conn.cursor_instance.fetchall_queue.append([])
+
+        d._evaluate_circuit_breaker("agent-x")
+
+        scans = [
+            e
+            for e in conn.cursor_instance.executed
+            if "dispatcher.terminal_outcomes" in e[0]
+        ]
+        assert len(scans) == 1, (
+            f"expected exactly one scan SELECT, got {len(scans)}: {scans!r}"
+        )
+        sql = scans[0][0]
+        # The JOIN on dispatcher.agents is the structural filter.
+        assert "JOIN dispatcher.agents" in sql, (
+            f"scan SQL missing JOIN on dispatcher.agents: {sql!r}"
+        )
+        # And the kind='task' predicate is the filter itself.
+        assert "a.kind = 'task'" in sql, (
+            f"scan SQL missing kind='task' predicate: {sql!r}"
+        )
+
+    def test_five_task_skill_crashed_rows_do_not_trip_breaker(
+        self, tmp_path: Path
+    ) -> None:
+        """AC: 5 ``kind='task-skill'`` crashed rows in 30 min → breaker stays closed.
+
+        The DB-level JOIN filter excludes task-skill rows before they
+        reach Python, so the scan's ``fetchall`` returns zero rows
+        when the only terminal outcomes in the window are task-skill
+        stuck_timeout sweeps. With zero bad rows observed, the
+        breaker cannot trip regardless of threshold. This mirrors
+        the 2026-04-20 16:48:26 UTC incident's real-world shape
+        (``recent_statuses=['crashed','crashed','crashed','crashed','crashed']``
+        all from task-skill rows) — with the fix the scan returns
+        ``[]`` and the breaker stays closed.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        self._stub_config_reads(conn)
+        # Post-fix the JOIN excludes task-skill rows at the DB layer,
+        # so the scan sees an empty window for this workload.
+        conn.cursor_instance.fetchall_queue.append([])
+
+        tripped = d._evaluate_circuit_breaker("daemon-task-agent")
+
+        assert tripped is False, (
+            "breaker tripped on an empty scan result — the kind='task' "
+            "filter is the only thing keeping task-skill stuck_timeouts "
+            "from polluting the breaker signal"
+        )
+        # No cap flip UPDATE fired.
+        cap_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0] and "concurrency_cap" in e[0]
+        ]
+        assert cap_updates == []
+        assert handler.events("circuit_breaker_opened") == []
+
+    def test_five_task_crashed_rows_still_trip_breaker(self, tmp_path: Path) -> None:
+        """Regression: 5 genuine ``kind='task'`` crashed rows still trip.
+
+        Mirror of the AC scenario but with daemon-owned crashed
+        rows — the breaker must still fire as before. The fake
+        cursor represents the post-JOIN result set (task-kind rows
+        only), so the five ``crashed`` entries here stand for five
+        daemon-pipeline crashes that survived the kind filter. The
+        breaker must open and flip cap.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        self._stub_config_reads(conn)
+        conn.cursor_instance.fetchall_queue.append([("crashed",)] * 5)
+        # ``current_cap`` read after the scan / threshold check.
+        conn.cursor_instance.fetch_queue.append((1,))
+
+        tripped = d._evaluate_circuit_breaker("daemon-task-agent")
+
+        assert tripped is True
+        cap_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0]
+            and "concurrency_cap" in e[0]
+            and e[1] == ("circuit_breaker",)
+        ]
+        assert len(cap_updates) == 1
+        opened = handler.events("circuit_breaker_opened")
+        assert len(opened) == 1
+        assert opened[0].bad_count == 5  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Filter the circuit breaker's candidate SELECT to `kind='task'` so supervisor stuck_timeout sweeps on operator-spawned /task subagent rows (`kind='task-skill'`) no longer spuriously trip the breaker. Also refreshes the breaker banner copy in the admin dashboard from "overnight-safety rail" to "circuit breaker" since the breaker fires any time of day (today's incident was 16:48 UTC / midday PT).

Third sibling of #2903 / #2908 — closes the last known kind-conflation in the daemon.

Closes #2921

## Test plan

### Automated checks
- [x] Lint passes (ruff, eslint)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (674 passed, 1 skipped in dispatcher; 1280 passed in web; 411 passed in api)
- [x] CI green

### Post-deploy verification
- [x] CloudWatch: `daemon.circuit_breaker_opened` events fired 0 times in the 18-minute post-deploy smoke window (17:22-17:40 UTC); dispatcher ran healthy with normal scheduler activity
- [x] Deployed Vercel JS bundle contains the new "tripped the circuit breaker" copy; the old "overnight-safety rail" string is absent
- [x] Verification evidence posted on issue (see [#2921 comment](https://github.com/judgemind/judgemind/issues/2921#issuecomment-4282996674))
