### PR TITLE
fix(dispatcher): auto-fetch issue title in task_claim.py when --issue-title omitted (#2923)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -172,6 +172,8 @@ python3 {worktree}/scripts/dispatcher/task_claim.py claim \
     --worktree-path {worktree}
 ```
 
+**`--issue-title` is optional — auto-fetched when omitted (issue #2923).** If you omit `--issue-title` (or pass an empty string), the helper shells out to `gh issue view <N> --repo judgemind/judgemind --json title -q .title` and uses the returned value. An ad-hoc operator invocation without `--issue-title` will now land a row with a populated title instead of the "(title unavailable)" cosmetic bug. Passing `--issue-title` in the normal /task flow is still preferred (saves one `gh` round-trip, ~1-2 s), but no longer a correctness requirement — if the fetch fails (gh unavailable, rate-limit, network blip), the claim still succeeds with NULL title and a single warning log line.
+
 The helper **generates a fresh UUID for you** and writes it to `{worktree}/.task-agent-id` (the "sidecar") so the later `terminal` call can recover it without the caller threading state through the rest of the /task flow. The JSON emitted on stdout includes the UUID:
 
 ```

--- a/scripts/dispatcher/task_claim.py
+++ b/scripts/dispatcher/task_claim.py
@@ -119,6 +119,19 @@ VALID_TERMINAL_STATUSES = frozenset({"succeeded", "failed"})
 #: for a slow rollover.
 DEV_DB_QUERY_TIMEOUT_SECONDS = 60
 
+#: Subprocess timeout for the ``gh issue view`` shell-out that populates
+#: ``issue_title`` when the caller omits ``--issue-title``. A slow GitHub
+#: API response shouldn't block the claim for longer than this; if the
+#: call times out we fall back to NULL title (cosmetic, not a
+#: correctness gate — see issue #2923).
+GH_ISSUE_VIEW_TIMEOUT_SECONDS = 15
+
+#: GitHub repository slug used for the ``gh issue view`` fallback fetch.
+#: Matches the hard-coded value in SKILL.md's claim invocation and in
+#: ``scripts/check-issue-author.sh`` — the /task skill is repository-
+#: specific, so we do not plumb this through the CLI.
+GH_REPO_SLUG = "judgemind/judgemind"
+
 #: Relative path to the dev-db-query wrapper, resolved from the repo root.
 DEV_DB_QUERY_SCRIPT = Path("scripts/dev-db-query.sh")
 
@@ -249,6 +262,86 @@ def _dev_db_query_path() -> Path:
     here = Path(__file__).resolve()
     repo_root = _resolve_repo_root(here)
     return repo_root / DEV_DB_QUERY_SCRIPT
+
+
+def _fetch_issue_title_via_gh(issue_number: int) -> str | None:
+    """Fetch the issue title via ``gh issue view`` as a fallback.
+
+    When the caller omits ``--issue-title`` (or passes an empty string),
+    the helper shells out to
+    ``gh issue view <N> --repo judgemind/judgemind --json title -q .title``
+    so the ``dispatcher.agents.issue_title`` column isn't left NULL —
+    which renders as "(title unavailable)" on the admin cockpit. See
+    issue #2923.
+
+    The fetch is best-effort: any failure (``gh`` not on PATH, network
+    blip, rate-limit, non-existent issue, timeout) logs a warning to
+    stderr and returns ``None`` so the claim proceeds with a NULL
+    title. The title is cosmetic, not a correctness gate — never block
+    the claim on this fetch.
+
+    Returns the title string on success, or ``None`` on any failure.
+    """
+    cmd = [
+        "gh",
+        "issue",
+        "view",
+        str(int(issue_number)),
+        "--repo",
+        GH_REPO_SLUG,
+        "--json",
+        "title",
+        "-q",
+        ".title",
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=GH_ISSUE_VIEW_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except FileNotFoundError:
+        sys.stderr.write(
+            "task_claim: gh CLI not on PATH; cannot auto-fetch issue title "
+            f"for #{issue_number}. Claim will proceed with NULL title. "
+            "Pass --issue-title explicitly to populate it (issue #2923).\n"
+        )
+        return None
+    except subprocess.TimeoutExpired:
+        sys.stderr.write(
+            f"task_claim: gh issue view timed out after "
+            f"{GH_ISSUE_VIEW_TIMEOUT_SECONDS}s fetching title for "
+            f"#{issue_number}; claim will proceed with NULL title "
+            "(issue #2923).\n"
+        )
+        return None
+    except OSError as exc:
+        sys.stderr.write(
+            f"task_claim: gh issue view failed for #{issue_number}: {exc}; "
+            "claim will proceed with NULL title (issue #2923).\n"
+        )
+        return None
+
+    if result.returncode != 0:
+        stderr_snippet = (result.stderr or "").strip()[:200]
+        sys.stderr.write(
+            f"task_claim: gh issue view exit={result.returncode} "
+            f"fetching title for #{issue_number}: {stderr_snippet}; "
+            "claim will proceed with NULL title (issue #2923).\n"
+        )
+        return None
+
+    title = (result.stdout or "").strip()
+    if not title:
+        sys.stderr.write(
+            f"task_claim: gh issue view returned empty title for "
+            f"#{issue_number}; claim will proceed with NULL title "
+            "(issue #2923).\n"
+        )
+        return None
+    return title
 
 
 def _run_sql_via_db_query_sh(sql: str) -> dict[str, Any]:
@@ -694,6 +787,15 @@ def do_claim(
             "``str(uuid.uuid4())`` — match that shape. See #2892.\n"
         )
         return 3
+
+    # Fallback-fetch the issue title when the caller omitted it. See
+    # issue #2923: every caller that forgets to pass ``--issue-title``
+    # leaves a NULL-title row that renders as "(title unavailable)" on
+    # the admin cockpit. CLI arg takes precedence — we only fetch when
+    # the caller passed None or an empty/whitespace-only string. Fetch
+    # failure is non-fatal; the claim proceeds with NULL title.
+    if issue_title is None or not issue_title.strip():
+        issue_title = _fetch_issue_title_via_gh(issue_number)
 
     database_url = os.environ.get("DATABASE_URL", "").strip()
     use_psycopg = bool(database_url)

--- a/scripts/dispatcher/tests/test_task_claim.py
+++ b/scripts/dispatcher/tests/test_task_claim.py
@@ -1129,3 +1129,287 @@ class TestMain:
                     "crashed",  # not in VALID_TERMINAL_STATUSES
                 ]
             )
+
+
+# --------------------------------------------------------------------------
+# Issue-title auto-fetch — #2923
+# --------------------------------------------------------------------------
+
+
+class TestFetchIssueTitleViaGh:
+    """Unit tests for ``_fetch_issue_title_via_gh`` in isolation."""
+
+    def test_happy_path_returns_stripped_title(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            captured.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = "  Real Title  \n"
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        title = task_claim._fetch_issue_title_via_gh(2923)
+        assert title == "Real Title"
+        # Command shape matches the SKILL.md documentation.
+        assert captured[0][0] == "gh"
+        assert captured[0][1:4] == ["issue", "view", "2923"]
+        assert "--repo" in captured[0]
+        assert task_claim.GH_REPO_SLUG in captured[0]
+        assert "--json" in captured[0]
+        assert "title" in captured[0]
+        assert "-q" in captured[0]
+        assert ".title" in captured[0]
+
+    def test_non_zero_exit_returns_none_and_logs_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        def fake_run(_cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 1
+            r.stdout = ""
+            r.stderr = "GraphQL: Could not resolve to an Issue\n"
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        title = task_claim._fetch_issue_title_via_gh(999999)
+        assert title is None
+        err = capsys.readouterr().err
+        assert "gh issue view" in err.lower()
+        assert "999999" in err
+
+    def test_gh_not_on_path_returns_none(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        def fake_run(_cmd: list[str], **_kwargs: Any) -> Any:
+            raise FileNotFoundError("gh")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        title = task_claim._fetch_issue_title_via_gh(2923)
+        assert title is None
+        err = capsys.readouterr().err
+        assert "gh CLI not on PATH" in err
+
+    def test_timeout_returns_none(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        def fake_run(_cmd: list[str], **_kwargs: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd="gh", timeout=15)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        title = task_claim._fetch_issue_title_via_gh(2923)
+        assert title is None
+        err = capsys.readouterr().err
+        assert "timed out" in err.lower()
+
+    def test_empty_stdout_returns_none(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A zero-exit with empty stdout still means we don't have a title.
+
+        Falls through to NULL so the admin page renders the same
+        "(title unavailable)" as before — but with a warning log that
+        makes it easy to diagnose if it ever happens in practice.
+        """
+
+        def fake_run(_cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = "\n"
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        title = task_claim._fetch_issue_title_via_gh(2923)
+        assert title is None
+        err = capsys.readouterr().err
+        assert "empty title" in err.lower()
+
+
+class TestDoClaimIssueTitleFallback:
+    """``do_claim`` auto-fetches issue_title when the caller omits it — #2923.
+
+    Covers the three AC scenarios from the issue body:
+
+    * ``--issue-title ""`` + ``gh`` returns ``Real Title`` → row stored
+      with ``Real Title``.
+    * ``--issue-title "explicit"`` → row stored with ``explicit``
+      regardless of what ``gh`` would return.
+    * ``--issue-title`` omitted + ``gh`` exits non-zero → row stored with
+      NULL, warning logged, no exception.
+    """
+
+    def test_empty_string_title_triggers_gh_fetch(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+        captured_titles: list[str | None] = []
+
+        def fake_claim(
+            _database_url: str,
+            _issue_number: int,
+            _agent_id: str,
+            _worktree_path: str,
+            issue_title: str | None,
+            _issue_priority: str | None = None,
+        ) -> None:
+            captured_titles.append(issue_title)
+
+        monkeypatch.setattr(task_claim, "_claim_via_psycopg", fake_claim)
+
+        def fake_fetch(_issue_number: int) -> str | None:
+            return "Real Title"
+
+        monkeypatch.setattr(task_claim, "_fetch_issue_title_via_gh", fake_fetch)
+
+        rc = task_claim.do_claim(2923, _VALID_AGENT_ID, str(tmp_path), "", None)
+        assert rc == 0
+        assert captured_titles == ["Real Title"]
+
+    def test_whitespace_only_title_triggers_gh_fetch(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A whitespace-only ``--issue-title "   "`` should be treated
+        the same as empty — otherwise the admin page still renders
+        a blank chip.
+        """
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+        captured_titles: list[str | None] = []
+
+        def fake_claim(
+            _database_url: str,
+            _issue_number: int,
+            _agent_id: str,
+            _worktree_path: str,
+            issue_title: str | None,
+            _issue_priority: str | None = None,
+        ) -> None:
+            captured_titles.append(issue_title)
+
+        monkeypatch.setattr(task_claim, "_claim_via_psycopg", fake_claim)
+        monkeypatch.setattr(
+            task_claim, "_fetch_issue_title_via_gh", lambda _n: "Fetched Title"
+        )
+
+        rc = task_claim.do_claim(2923, _VALID_AGENT_ID, str(tmp_path), "   ", None)
+        assert rc == 0
+        assert captured_titles == ["Fetched Title"]
+
+    def test_none_title_triggers_gh_fetch(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+        captured_titles: list[str | None] = []
+        fetch_calls: list[int] = []
+
+        def fake_claim(
+            _database_url: str,
+            _issue_number: int,
+            _agent_id: str,
+            _worktree_path: str,
+            issue_title: str | None,
+            _issue_priority: str | None = None,
+        ) -> None:
+            captured_titles.append(issue_title)
+
+        def fake_fetch(issue_number: int) -> str | None:
+            fetch_calls.append(issue_number)
+            return "Auto-fetched"
+
+        monkeypatch.setattr(task_claim, "_claim_via_psycopg", fake_claim)
+        monkeypatch.setattr(task_claim, "_fetch_issue_title_via_gh", fake_fetch)
+
+        rc = task_claim.do_claim(2923, _VALID_AGENT_ID, str(tmp_path), None, None)
+        assert rc == 0
+        assert captured_titles == ["Auto-fetched"]
+        assert fetch_calls == [2923]
+
+    def test_explicit_title_wins_over_gh_fetch(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """CLI arg takes precedence — the fetch must NOT run.
+
+        A caller that passes ``--issue-title "explicit"`` gets exactly
+        ``"explicit"`` stored, even if the fetch would return something
+        else. The fetch is a fallback, not an override.
+        """
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+        captured_titles: list[str | None] = []
+
+        def fake_claim(
+            _database_url: str,
+            _issue_number: int,
+            _agent_id: str,
+            _worktree_path: str,
+            issue_title: str | None,
+            _issue_priority: str | None = None,
+        ) -> None:
+            captured_titles.append(issue_title)
+
+        def fake_fetch(_issue_number: int) -> str | None:
+            raise AssertionError(
+                "_fetch_issue_title_via_gh must not run when the caller "
+                "passed an explicit non-empty --issue-title"
+            )
+
+        monkeypatch.setattr(task_claim, "_claim_via_psycopg", fake_claim)
+        monkeypatch.setattr(task_claim, "_fetch_issue_title_via_gh", fake_fetch)
+
+        rc = task_claim.do_claim(2923, _VALID_AGENT_ID, str(tmp_path), "explicit", None)
+        assert rc == 0
+        assert captured_titles == ["explicit"]
+
+    def test_gh_fetch_failure_falls_back_to_null(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """When ``gh`` fails, the claim still succeeds with NULL title.
+
+        The helper logs a warning (covered by ``TestFetchIssueTitleViaGh``
+        above) and returns None; ``do_claim`` forwards that None to the
+        DB path so the row lands with ``issue_title IS NULL``. No
+        exception bubbles up — the claim is never blocked on the fetch.
+        """
+        monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+        captured_titles: list[str | None] = []
+
+        def fake_claim(
+            _database_url: str,
+            _issue_number: int,
+            _agent_id: str,
+            _worktree_path: str,
+            issue_title: str | None,
+            _issue_priority: str | None = None,
+        ) -> None:
+            captured_titles.append(issue_title)
+
+        monkeypatch.setattr(task_claim, "_claim_via_psycopg", fake_claim)
+        # Simulate the fetch returning None (gh exit non-zero, timeout,
+        # gh not on PATH — any failure path).
+        monkeypatch.setattr(task_claim, "_fetch_issue_title_via_gh", lambda _n: None)
+
+        rc = task_claim.do_claim(2923, _VALID_AGENT_ID, str(tmp_path), None, None)
+        # Claim still succeeds (exit 0) with NULL title.
+        assert rc == 0
+        assert captured_titles == [None]


### PR DESCRIPTION
## Summary

`scripts/dispatcher/task_claim.py claim` now auto-fetches the issue title via `gh issue view` when the caller omits `--issue-title` (or passes an empty/whitespace string). Removes the burden of plumbing the title through every caller — ad-hoc operator invocations and future subagents that forget the flag no longer land NULL-title rows that render as "(title unavailable)" on the admin cockpit.

Fallback chain in `do_claim`:
1. CLI `--issue-title "..."` — CLI arg takes precedence (unchanged).
2. `gh issue view <N> --repo judgemind/judgemind --json title -q .title` — new fallback when CLI arg is missing/empty.
3. NULL + single warning log line if `gh` fails (timeout, non-zero exit, not on PATH) — never blocks the claim.

The daemon's `_atomic_claim` path is untouched — it already supplies a real title from its queue snapshot. Only the laptop `/task` path benefits.

Closes #2923

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass (10 new unit tests — 5 for `_fetch_issue_title_via_gh`, 5 for the `do_claim` fallback covering the three AC scenarios)
- [ ] CI green

### Post-deploy verification
- [ ] Run `scripts/dispatcher/task_claim.py claim --issue 2923 --agent-id <uuid> --worktree-path /tmp/test` without `--issue-title` and confirm `SELECT issue_title FROM dispatcher.agents WHERE agent_id = '<uuid>'` returns the real issue title.
- [ ] Verification evidence posted on issue (see A.8).
