### PR TITLE
fix(dispatcher): failure_summary skips JSON envelope tail + dedups phase echo (#2924)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -4133,6 +4133,25 @@ class DispatcherDaemon:
     #: write-time; anything longer is truncated with an ellipsis.
     _FAILURE_SUMMARY_MAX_CHARS = 240
 
+    #: Failure categories where the log tail is meaningless — the
+    #: terminal was not caused by a subprocess crash or stderr-emitting
+    #: error, so the tail of ``phase_outputs.log_text`` is just the
+    #: Anthropic JSON success envelope from the last phase that did run.
+    #: For these categories we emit a short human-readable summary with
+    #: no tail segment. Issue #2924.
+    _NO_TAIL_CATEGORIES = frozenset(
+        {"paused_by_killswitch", "daemon_restart_abandoned"}
+    )
+
+    #: Human-readable summaries for the no-tail categories. Keyed by
+    #: category; the value is the complete ``failure_summary`` string
+    #: (no phase/status/category parens — those would repeat the same
+    #: word). Issue #2924.
+    _NO_TAIL_CATEGORY_SUMMARIES = {
+        "paused_by_killswitch": "paused by killswitch",
+        "daemon_restart_abandoned": "daemon restart abandoned",
+    }
+
     @staticmethod
     def _humanize_phase(phase: str) -> str:
         """Turn ``"ralph-reviewer (3)"`` into ``"ralph-reviewer iteration 3"``.
@@ -4155,13 +4174,21 @@ class DispatcherDaemon:
 
     @staticmethod
     def _extract_stderr_tail(log_text: str | None) -> str:
-        """Pull the last non-empty line out of a ``phase_outputs.log_text``.
+        """Pull the last non-empty, non-JSON line out of a ``log_text``.
 
         ``log_text`` is the composed stdout+stderr blob from
         :meth:`_compose_phase_log` — begins with ``=== stderr ===`` when
         both streams had content. We search from the end for the first
-        non-blank, non-separator line. Empty string when the log has no
-        usable tail.
+        non-blank, non-separator, non-JSON-envelope line. Empty string
+        when the log has no usable tail.
+
+        Issue #2924: the admin cockpit tooltip was rendering the raw
+        ``claude -p`` JSON result envelope (``{"type":"result",...}``)
+        as the failure summary tail. A completed phase writes its
+        success envelope as stdout, which ends up as the last line of
+        ``log_text`` — useless as a "what went wrong" tail. We skip
+        lines that parse as JSON objects so the tail falls back to the
+        nearest real stderr line.
         """
         if not log_text:
             return ""
@@ -4171,8 +4198,37 @@ class DispatcherDaemon:
                 continue
             if line.startswith("===") and line.endswith("==="):
                 continue
+            if DispatcherDaemon._looks_like_json_envelope(line):
+                continue
             return line
         return ""
+
+    @staticmethod
+    def _looks_like_json_envelope(line: str) -> bool:
+        """True if ``line`` parses as a JSON object/array (envelope).
+
+        Used by :meth:`_extract_stderr_tail` to skip past the Anthropic
+        ``claude -p`` success envelope that lives in stdout. We only
+        treat objects/arrays as envelopes — a bare JSON scalar
+        (``"foo"`` or ``42``) could plausibly be a real stderr token
+        and we want to preserve it. Non-JSON lines fail the ``json.loads``
+        call and return False immediately. Issue #2924.
+        """
+        if not line:
+            return False
+        # Quick structural filter — only object/array-shaped lines can be
+        # the multi-line JSON envelope we want to skip. Avoids a parse
+        # attempt for every log line (cheap but not free).
+        first = line[0]
+        if first not in "{[":
+            return False
+        import json  # noqa: PLC0415 — lazy; only on terminal path
+
+        try:
+            json.loads(line)
+        except (ValueError, TypeError):
+            return False
+        return True
 
     @staticmethod
     def _extract_details_message(details: Any) -> str:
@@ -4289,6 +4345,14 @@ class DispatcherDaemon:
                 pass
             return None
 
+        # Issue #2924: for killswitch / restart-abandoned categories
+        # there IS no meaningful stderr tail — the agent did not crash,
+        # it was administratively terminated. Emit a short neutral
+        # summary instead of dumping the raw JSON success envelope from
+        # the last phase that did complete.
+        if category in self._NO_TAIL_CATEGORIES:
+            return self._NO_TAIL_CATEGORY_SUMMARIES[category]
+
         phase_humanized = self._humanize_phase(phase)
         # Phase-group = first token before a dash or space. ``ralph-reviewer``
         # → ``ralph``; ``push_and_pr`` → ``push_and_pr`` (no dash).
@@ -4306,12 +4370,29 @@ class DispatcherDaemon:
 
         # Verb phrase — ``plan_blocked`` is its own thing per the issue
         # examples; other failure statuses are "crashed" / "failed".
+        #
+        # Issue #2924: collapse the ``<phase-group> <verb> at
+        # <phase-humanized>`` form to just ``<phase> <verb>`` when the
+        # two positions resolve to the same string. Sibling #2914
+        # already flagged the tautological case — e.g.
+        # ``"daemon_restart_abandoned crashed at daemon_restart_abandoned"``
+        # just reads as the same word twice. Short-phase rows (``plan``,
+        # ``push_and_pr``, ``daemon_restart_abandoned``) hit this every
+        # time; only multi-iteration phases like ``ralph-reviewer (3)``
+        # preserve the ``at …`` clause because the humanized version
+        # adds new information (``ralph`` vs ``ralph-reviewer iteration 3``).
         if status == "plan_blocked":
             verb_phrase = "plan phase returned go=false"
         elif status == "crashed":
-            verb_phrase = f"{phase_group} crashed at {phase_humanized}"
+            if phase_group == phase_humanized:
+                verb_phrase = f"{phase_humanized} crashed"
+            else:
+                verb_phrase = f"{phase_group} crashed at {phase_humanized}"
         else:  # status == "failed"
-            verb_phrase = f"{phase_group} failed at {phase_humanized}"
+            if phase_group == phase_humanized:
+                verb_phrase = f"{phase_humanized} failed"
+            else:
+                verb_phrase = f"{phase_group} failed at {phase_humanized}"
 
         # Compose. Category is parenthesized; detail trails a colon so
         # a scanner can pattern-match on either end of the string.

--- a/scripts/dispatcher/tests/test_daemon_failure_summary.py
+++ b/scripts/dispatcher/tests/test_daemon_failure_summary.py
@@ -309,6 +309,245 @@ class TestBuildFailureSummary:
         )
         assert summary is None
 
+    # ----------------------------------------------------------------
+    # Issue #2924 — no-tail categories + JSON-envelope filter + phase
+    # echo dedup
+    # ----------------------------------------------------------------
+
+    def test_paused_by_killswitch_skips_tail(self, tmp_path: Path) -> None:
+        """``category='paused_by_killswitch'`` yields a short neutral
+        string with no JSON dump, no phase echo, no category paren.
+
+        Regression for issue #2924. Observed on dev 2026-04-20 for agent
+        ``de44c316-...`` (issue #2564): the admin tooltip rendered the
+        raw ``claude -p`` JSON result envelope because ``phase_outputs
+        .log_text`` contained the stdout success blob (the agent was
+        paused mid-run, not crashed)."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        # Feed a log_text that contains the raw JSON envelope — the
+        # exact shape observed in the #2564 tooltip. If the fix regresses
+        # the envelope will leak through and the assertion fails.
+        conn.cursor_instance.fetch_queue = [
+            ("paused_by_killswitch", {}),
+            (
+                "=== stdout ===\n"
+                '{"type":"result","subtype":"success","is_error":false,'
+                '"duration_ms":212725,"num_turns":38,"result":"Plan written"}\n',
+            ),
+        ]
+        summary = d._build_failure_summary(
+            agent_id="agent-killswitch",
+            status="failed",
+            phase="paused_by_killswitch",
+            exit_code=0,
+        )
+        assert summary == "paused by killswitch"
+        # Belt-and-suspenders — no JSON in the output.
+        assert "{" not in summary
+        assert "result" not in summary
+        # No phase echo — the word "paused_by_killswitch" must not appear
+        # twice or show up parenthesized as a category.
+        assert summary.count("killswitch") == 1
+
+    def test_daemon_restart_abandoned_skips_tail(self, tmp_path: Path) -> None:
+        """``category='daemon_restart_abandoned'`` same as killswitch:
+        short neutral string, no JSON, no phase echo.
+
+        Regression for the ``7c28b8e1-...`` pattern (issue #2899) — the
+        tooltip read ``"daemon_restart_abandoned crashed at
+        daemon_restart_abandoned (daemon_restart_abandoned)"`` because
+        every template slot resolved to the same word."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            ("daemon_restart_abandoned", {}),
+            ("=== stdout ===\nprior log blob\n",),
+        ]
+        summary = d._build_failure_summary(
+            agent_id="agent-restart",
+            status="crashed",
+            phase="daemon_restart_abandoned",
+            exit_code=None,
+        )
+        assert summary == "daemon restart abandoned"
+        assert "{" not in summary
+        # Phase word appears exactly once — no tautological repetition.
+        # (Count the underscored form since the summary uses the
+        # humanized spaced form.)
+        assert "daemon_restart_abandoned" not in summary
+
+    def test_subprocess_turn_limit_tail_skips_json_envelope(
+        self, tmp_path: Path
+    ) -> None:
+        """For normal subprocess-crash categories, the tail still comes
+        from ``log_text`` — but JSON-envelope lines are skipped so the
+        tail falls back to the nearest real stderr line.
+
+        Issue #2924 AC verify-line: "synthesize a row with a log_text
+        containing mixed JSON-envelope lines and one stderr-style line;
+        assert the summary ends with the stderr line, not the JSON."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        mixed_log = (
+            "=== stderr ===\n"
+            "Traceback (most recent call last):\n"
+            "RuntimeError: subprocess exceeded turn budget\n"
+            "=== stdout ===\n"
+            '{"type":"result","subtype":"error","is_error":true,'
+            '"api_error_status":"overloaded","duration_ms":600000}\n'
+        )
+        conn.cursor_instance.fetch_queue = [
+            # Failure row has no stderr_tail in details — forces the
+            # template down the log_text path.
+            ("subprocess_turn_limit", {}),
+            (mixed_log,),
+        ]
+        summary = d._build_failure_summary(
+            agent_id="agent-mixed",
+            status="crashed",
+            phase="ralph-reviewer (3)",
+            exit_code=124,
+        )
+        assert summary is not None
+        # Tail ends with the stderr line, NOT the JSON envelope.
+        assert summary.endswith("RuntimeError: subprocess exceeded turn budget")
+        # No raw JSON envelope leaked through.
+        assert '{"type"' not in summary
+        assert "api_error_status" not in summary
+        assert len(summary) <= 240
+
+    def test_subprocess_crash_tail_omitted_when_only_json(self, tmp_path: Path) -> None:
+        """When ``log_text`` contains ONLY JSON-envelope lines (no real
+        stderr), the tail falls back to ``exit_code=<N>`` instead of
+        leaking the envelope."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        json_only = (
+            '{"type":"result","subtype":"success","is_error":false}\n'
+            '{"type":"message_stop","num_turns":10}\n'
+        )
+        conn.cursor_instance.fetch_queue = [
+            ("subprocess_crash", {}),
+            (json_only,),
+        ]
+        summary = d._build_failure_summary(
+            agent_id="agent-json-only",
+            status="crashed",
+            phase="ralph-worker (1)",
+            exit_code=1,
+        )
+        assert summary is not None
+        # Should fall back to exit_code, not leak the envelope.
+        assert "exit_code=1" in summary
+        assert '{"type"' not in summary
+
+    def test_phase_echo_dedup_collapses_tautology(self, tmp_path: Path) -> None:
+        """Phase echo collapse — when ``phase_group`` and
+        ``phase_humanized`` would resolve to the same string, the
+        template emits ``<phase> <status>`` once, not twice.
+
+        Synthesize a ``phase='daemon_restart_abandoned'`` row without
+        the no-tail short-circuit (use a non-tautology-triggering
+        category so only the phase-echo fix applies). The summary must
+        NOT contain the phase word twice."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            # Use a non-no-tail category so the phase-echo path fires.
+            ("subprocess_crash", {"detail": "something went wrong"}),
+            (None,),
+        ]
+        summary = d._build_failure_summary(
+            agent_id="agent-echo",
+            status="crashed",
+            phase="daemon_restart_abandoned",
+            exit_code=1,
+        )
+        assert summary is not None
+        # The phase word appears exactly once — no ``<phase> crashed at
+        # <phase>`` tautology.
+        assert summary.count("daemon_restart_abandoned") == 1
+        # Full expected shape: "daemon_restart_abandoned crashed
+        # (subprocess_crash): something went wrong".
+        assert summary.startswith("daemon_restart_abandoned crashed")
+        assert " at daemon_restart_abandoned" not in summary
+
+    def test_phase_echo_preserved_for_multi_iteration_phases(
+        self, tmp_path: Path
+    ) -> None:
+        """Phase echo collapse ONLY fires when the two positions resolve
+        to the same string. ``ralph-reviewer (3)`` humanizes to
+        ``ralph-reviewer iteration 3`` while its phase-group is just
+        ``ralph`` — those differ, so the ``at …`` clause is preserved
+        because it adds information (the iteration count)."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            ("subprocess_turn_limit", {"stderr_tail": "turns exceeded"}),
+            (None,),
+        ]
+        summary = d._build_failure_summary(
+            agent_id="agent-ralph",
+            status="crashed",
+            phase="ralph-reviewer (3)",
+            exit_code=124,
+        )
+        assert summary is not None
+        # ``ralph crashed at ralph-reviewer iteration 3`` — both
+        # positions present because they differ.
+        assert "ralph crashed at ralph-reviewer iteration 3" in summary
+
+
+# --------------------------------------------------------------------------
+# _extract_stderr_tail — JSON-envelope filter
+# --------------------------------------------------------------------------
+
+
+class TestExtractStderrTailJsonFilter:
+    """Issue #2924 — the tail extractor must skip lines that parse as
+    JSON objects/arrays. The ``claude -p`` success envelope is emitted
+    as a one-line JSON object on stdout; before this fix it was being
+    surfaced as the failure-summary tail for paused/restarted agents."""
+
+    def test_skips_json_object_line(self) -> None:
+        """A JSON object on the last line is skipped."""
+        log = (
+            "=== stderr ===\n"
+            "runtime error: something broke\n"
+            "=== stdout ===\n"
+            '{"type":"result","subtype":"success"}\n'
+        )
+        tail = daemon.DispatcherDaemon._extract_stderr_tail(log)
+        assert tail == "runtime error: something broke"
+
+    def test_skips_json_array_line(self) -> None:
+        """A JSON array on the last line is also skipped."""
+        log = "previous error\n[1, 2, 3]\n"
+        tail = daemon.DispatcherDaemon._extract_stderr_tail(log)
+        assert tail == "previous error"
+
+    def test_preserves_bare_scalar_lines(self) -> None:
+        """Bare scalars (``42``, ``"foo"``) are NOT treated as
+        envelopes — a real stderr line could plausibly contain a bare
+        token. Only object/array shapes are filtered."""
+        log = "something went wrong\n42\n"
+        tail = daemon.DispatcherDaemon._extract_stderr_tail(log)
+        # ``42`` is a real (if unusual) stderr line — it is NOT an
+        # envelope, so it surfaces as the tail.
+        assert tail == "42"
+
+    def test_preserves_json_like_prose(self) -> None:
+        """A line that starts with a ``{`` but isn't valid JSON is
+        kept — we only filter what actually parses."""
+        log = "error: invalid config {foo=bar}\n"
+        tail = daemon.DispatcherDaemon._extract_stderr_tail(log)
+        assert tail == "error: invalid config {foo=bar}"
+
+    def test_empty_log_returns_empty_string(self) -> None:
+        assert daemon.DispatcherDaemon._extract_stderr_tail(None) == ""
+        assert daemon.DispatcherDaemon._extract_stderr_tail("") == ""
+
+    def test_all_json_returns_empty(self) -> None:
+        """When every line is a JSON envelope, the tail falls back to
+        an empty string so the caller can use ``exit_code`` instead."""
+        log = '{"type":"result","subtype":"success"}\n{"type":"message_stop"}\n'
+        assert daemon.DispatcherDaemon._extract_stderr_tail(log) == ""
+
 
 # --------------------------------------------------------------------------
 # _mark_agent_terminal integration — writes failure_summary on failure


### PR DESCRIPTION
## Summary

Clean up `dispatcher.agents.failure_summary` tooltip rendering on killswitch / restart terminals and on subprocess crashes whose `phase_outputs.log_text` ends with the Anthropic `claude -p` JSON success envelope. Adds a no-tail short-circuit for `paused_by_killswitch` / `daemon_restart_abandoned`, a JSON-envelope filter on the stderr-tail extractor, and a phase-echo dedup for short single-word phases. Closes the cosmetic half of #2914 in the same PR.

Closes #2924

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`pytest scripts/dispatcher/tests/` — 26 in `test_daemon_failure_summary.py`, 12 new; 686 total)
- [x] CI green

### Post-deploy verification
- [x] Backfilled 2 remaining bad rows (the other 2 were already cleared by #2913's retry-recovery path): `de44c316-...` (#2564) → `"paused by killswitch"`, `3001696a-...` (#2565) → `"daemon restart abandoned"`.
- [x] Admin-page tooltip scrape on `dev.judgemind.org/admin/dispatcher` shows clean wording — no JSON, no tautology — for both backfilled rows AND for row `44df06a4-...` generated by the redeployed daemon on its normal terminal path.
- [x] Verification evidence posted on issue (see §A.8) — https://github.com/judgemind/judgemind/issues/2924#issuecomment-4283228452

## Observed patterns (from dev 2026-04-20)

Bug shape 1 — JSON dump + phase echo in one row:

```
"paused_by_killswitch failed at paused_by_killswitch (daemon_restart_abandoned):
 {\"type\":\"result\",\"subtype\":\"success\",\"is_error\":false,
  \"duration_ms\":212725,\"num_turns\":38,\"result\":\"Plan writt..."
```

Bug shape 2 — pure tautology:

```
"daemon_restart_abandoned crashed at daemon_restart_abandoned (daemon_restart_abandoned)"
```

After this PR those render as `"paused by killswitch"` and `"daemon restart abandoned"` respectively.
