### PR TITLE
feat(web): add relative-time cell to Recently Completed panel (#2932)

### DIFF
--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -7,10 +7,10 @@ import { IssueLink, OutcomePill, PriorityBadge, PRLink } from './ui-primitives';
 interface RecentCompletionsPanelProps {
   completions: readonly RecentCompletion[];
   /**
-   * Override for deterministic tests. Currently unused after #2818 stripped
-   * the "N min ago" column — kept in the prop signature so callers
-   * (`DispatcherDashboard`) don't need a refactor if we re-introduce a
-   * time-based cell later.
+   * Override for deterministic tests. Used by the relative-time cell
+   * (#2932) to render "Nm ago" / "Nh ago" / "N days ago" against a
+   * fixed `now` in tests. Production callers omit this prop and the
+   * row falls back to `Date.now()` at render time.
    */
   nowMs?: number;
 }
@@ -40,9 +40,16 @@ interface RecentCompletionsPanelProps {
  * when `prNumber` is null — empty space is less noisy than italic copy.
  * The title cell wraps onto a second line rather than ellipsis-truncating
  * so the full text is always readable without hover.
+ *
+ * #2932 re-adds a relative-time cell **after** the cost footnote, with
+ * better formatting than the original ("5m ago" / "4h ago" / "11 days
+ * ago" / "2 months ago"). Native `title` attribute exposes the full
+ * datetime in Pacific time on hover. Operator gets at-a-glance "when
+ * did this happen" without clicking into the agent detail page.
  */
 export function RecentCompletionsPanel({
   completions,
+  nowMs,
 }: RecentCompletionsPanelProps) {
   return (
     <section aria-labelledby="recent-completions-heading">
@@ -61,6 +68,7 @@ export function RecentCompletionsPanel({
             <RecentCompletionRow
               key={completion.agentId}
               completion={completion}
+              nowMs={nowMs}
             />
           ))}
         </ul>
@@ -69,11 +77,28 @@ export function RecentCompletionsPanel({
   );
 }
 
-function RecentCompletionRow({ completion }: { completion: RecentCompletion }) {
+function RecentCompletionRow({
+  completion,
+  nowMs,
+}: {
+  completion: RecentCompletion;
+  nowMs?: number;
+}) {
   const costFootnote = formatCostFootnote(
     completion.totalCostUsd,
     completion.totalTokens,
   );
+  // Resolve `now` at render. Tests pass a fixed `nowMs` to make the
+  // relative-time cell deterministic; production callers omit the
+  // prop so we fall back to `Date.now()`.
+  const effectiveNowMs = nowMs ?? Date.now();
+  const endedMs = Date.parse(completion.endedAt);
+  const relativeTime = Number.isFinite(endedMs)
+    ? formatRelativeTime(endedMs, effectiveNowMs)
+    : null;
+  const pacificTitle = Number.isFinite(endedMs)
+    ? formatPacificDatetime(endedMs)
+    : '';
   return (
     <li className="flex items-start gap-3 py-2 text-sm hover:bg-muted/50">
       <span className="flex-shrink-0 pt-0.5">
@@ -117,6 +142,22 @@ function RecentCompletionRow({ completion }: { completion: RecentCompletion }) {
           </span>
         )}
       </span>
+      {/* #2932 — abbreviated relative-time cell ("5m ago" / "4h ago" /
+          "11 days ago"). Native `title` attribute shows the full datetime
+          in Pacific time on hover, matching the OutcomePill / IssueLink
+          tooltip pattern. Narrow fixed-width cell — abbreviated values
+          are short (≤ ~11 chars).
+          Positioned AFTER the title+cost span so a tall/wrapping title
+          does not push the timestamp off the row. */}
+      {relativeTime !== null && (
+        <span
+          className="flex-shrink-0 pt-0.5 text-xs text-muted-foreground tabular-nums"
+          data-testid="completion-row-relative-time"
+          title={pacificTitle}
+        >
+          {relativeTime}
+        </span>
+      )}
     </li>
   );
 }
@@ -163,7 +204,96 @@ function formatTokenCount(tokens: number): string {
   return `${tokens} tok`;
 }
 
+/** Render an abbreviated, age-scaled "N ago" string from two epoch-ms
+ * values (#2932). Designed for the Recently Completed panel where the
+ * operator wants at-a-glance freshness, not precise duration.
+ *
+ * Ranges (per the issue body):
+ * - `< 60 seconds`: `Just now`
+ *   (`0m ago` reads as "zero minutes", which is confusing — the spec
+ *   allows either phrasing and "Just now" is the clearer one.)
+ * - `< 60 minutes`: `Nm ago` (e.g. `5m ago`, `47m ago`)
+ * - `1–23 hours`: `Nh ago`
+ * - `1 day`: `1 day ago` (singular, no "s")
+ * - `2–29 days`: `N days ago`
+ * - `30–364 days`: `N months ago` (30-day months, singular for N=1)
+ * - `≥ 365 days`: `N years ago` (365-day years, singular for N=1)
+ *
+ * Future timestamps (clock skew, test fixtures) collapse to `Just now`
+ * rather than rendering a nonsensical negative-minutes string.
+ */
+function formatRelativeTime(timestampMs: number, nowMs: number): string {
+  const diffMs = nowMs - timestampMs;
+  // Future or < 1 second → "Just now" (graceful clock-skew handling).
+  if (diffMs < 1000) return 'Just now';
+
+  const seconds = Math.floor(diffMs / 1000);
+  if (seconds < 60) return 'Just now';
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+
+  const days = Math.floor(hours / 24);
+  if (days === 1) return '1 day ago';
+  if (days < 30) return `${days} days ago`;
+
+  // ≥ 30 days — month/year bucketing using fixed 30-day months and
+  // 365-day years. Operators use this for freshness scanning, not
+  // calendar precision; the hover tooltip carries the exact datetime.
+  if (days < 365) {
+    const months = Math.floor(days / 30);
+    return months === 1 ? '1 month ago' : `${months} months ago`;
+  }
+  const years = Math.floor(days / 365);
+  return years === 1 ? '1 year ago' : `${years} years ago`;
+}
+
+/** Format an epoch-ms timestamp as a Pacific-time datetime string
+ * (#2932) like `2026-04-20 15:36:39 PDT`. Used as the native `title`
+ * attribute on the relative-time cell so operators get the exact time
+ * on hover.
+ *
+ * Vanilla `Intl.DateTimeFormat` is used (no dayjs / moment / date-fns
+ * — the web package has none of those and this component is the only
+ * caller). `formatToParts` lets us assemble the YYYY-MM-DD HH:MM:SS
+ * format the spec calls for without relying on a locale that happens
+ * to produce the right shape.
+ */
+function formatPacificDatetime(timestampMs: number): string {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Los_Angeles',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZoneName: 'short',
+  });
+  const parts = formatter.formatToParts(new Date(timestampMs));
+  const lookup: Record<string, string> = {};
+  for (const part of parts) {
+    if (part.type !== 'literal') lookup[part.type] = part.value;
+  }
+  // `hour12: false` can emit "24" for midnight on some engines —
+  // normalize to "00" so the assembled string is unambiguous.
+  const hour = lookup.hour === '24' ? '00' : (lookup.hour ?? '00');
+  return (
+    `${lookup.year}-${lookup.month}-${lookup.day} ` +
+    `${hour}:${lookup.minute}:${lookup.second} ${lookup.timeZoneName}`
+  );
+}
+
 // Exported for unit testing; the helpers stay co-located with the
 // component because they are presentation-only and not reused elsewhere.
 // See ``__tests__/RecentCompletionsPanel.test.tsx``.
-export { formatCostFootnote, formatTokenCount };
+export {
+  formatCostFootnote,
+  formatTokenCount,
+  formatRelativeTime,
+  formatPacificDatetime,
+};

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
@@ -4,6 +4,8 @@ import {
   RecentCompletionsPanel,
   formatCostFootnote,
   formatTokenCount,
+  formatRelativeTime,
+  formatPacificDatetime,
 } from '../RecentCompletionsPanel';
 import type { RecentCompletion } from '@/lib/dispatcher-queries';
 
@@ -59,7 +61,9 @@ describe('RecentCompletionsPanel', () => {
     expect(screen.queryByTestId('pr-link-null')).not.toBeInTheDocument();
   });
 
-  it('#2818: does not render a "N min ago" completion-time column', () => {
+  // #2932 re-introduces the relative-time cell that #2818 stripped,
+  // with a better abbreviated format and a Pacific-time hover tooltip.
+  it('#2932: renders the abbreviated relative-time cell (5m ago) after the cost footnote', () => {
     const items = [
       completion({
         endedAt: '2026-04-18T11:55:00Z', // 5 min ago from the fixed `now`
@@ -67,7 +71,8 @@ describe('RecentCompletionsPanel', () => {
       }),
     ];
     render(<RecentCompletionsPanel completions={items} nowMs={now} />);
-    expect(screen.queryByText(/\bago\b/i)).not.toBeInTheDocument();
+    const cell = screen.getByTestId('completion-row-relative-time');
+    expect(cell.textContent).toBe('5m ago');
   });
 
   it('#2818: still shows the "(title unavailable)" placeholder when issueTitle is null', () => {
@@ -165,6 +170,58 @@ describe('RecentCompletionsPanel', () => {
     expect(screen.queryByText(summary)).not.toBeInTheDocument();
   });
 
+  // --- #2932 — relative-time cell (re-introduced post-#2818 density pass).
+  it('#2932: places the relative-time cell AFTER the cost footnote in DOM order', () => {
+    const items = [
+      completion({
+        agentId: 'agent-order',
+        endedAt: '2026-04-18T11:55:00Z', // 5m ago
+        totalCostUsd: 0.42,
+        totalTokens: 12000,
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    const cost = screen.getByTestId('completion-row-cost');
+    const timestamp = screen.getByTestId('completion-row-relative-time');
+    // `compareDocumentPosition`: 0x04 = DOCUMENT_POSITION_FOLLOWING.
+    expect(
+      cost.compareDocumentPosition(timestamp) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('#2932: sets the native `title` attribute on the cell to a Pacific-time datetime', () => {
+    const items = [
+      completion({
+        agentId: 'agent-pacific',
+        endedAt: '2026-04-18T11:55:00Z',
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    const cell = screen.getByTestId('completion-row-relative-time');
+    const title = cell.getAttribute('title');
+    expect(title).not.toBeNull();
+    // Format: "YYYY-MM-DD HH:MM:SS PDT" or "PST" — Pacific time always
+    // abbreviates to one of these two. April is PDT.
+    expect(title).toMatch(
+      /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} P[DS]T$/,
+    );
+    expect(title).toContain('PDT');
+  });
+
+  it('#2932: falls back to Date.now() when nowMs prop is omitted', () => {
+    // Render without `nowMs`. The cell still renders (with some age
+    // computed against real wall-clock time). We only assert the cell
+    // is present and has the expected testid — the exact text depends
+    // on wall-clock time at test runtime so we don't pin it.
+    const items = [completion({ agentId: 'agent-realtime' })];
+    render(<RecentCompletionsPanel completions={items} />);
+    const cell = screen.getByTestId('completion-row-relative-time');
+    expect(cell).toBeInTheDocument();
+    // Must have a non-empty title attribute (Pacific datetime).
+    expect(cell.getAttribute('title')).toMatch(/P[DS]T$/);
+  });
+
   it('#2869: renders only the available half when the other metering field is null', () => {
     const costOnly = [
       completion({
@@ -232,5 +289,125 @@ describe('formatTokenCount (#2869)', () => {
   it('renders raw count for < 1k so "0k" does not imply zero cost', () => {
     expect(formatTokenCount(500)).toBe('500 tok');
     expect(formatTokenCount(0)).toBe('0 tok');
+  });
+});
+
+describe('formatRelativeTime (#2932)', () => {
+  // Anchor "now" at a fixed instant so the age math is deterministic.
+  const nowMs = Date.parse('2026-04-20T12:00:00Z');
+
+  function at(isoOffset: string): number {
+    return Date.parse(isoOffset);
+  }
+
+  it('renders "Just now" for < 60 seconds (30s case)', () => {
+    const thirtySecondsAgo = nowMs - 30 * 1000;
+    expect(formatRelativeTime(thirtySecondsAgo, nowMs)).toBe('Just now');
+  });
+
+  it('renders "5m ago" for 5 minutes', () => {
+    const fiveMinutesAgo = nowMs - 5 * 60 * 1000;
+    expect(formatRelativeTime(fiveMinutesAgo, nowMs)).toBe('5m ago');
+  });
+
+  it('renders "47m ago" for 47 minutes (edge of the hour bucket)', () => {
+    const fortySevenMinutesAgo = nowMs - 47 * 60 * 1000;
+    expect(formatRelativeTime(fortySevenMinutesAgo, nowMs)).toBe('47m ago');
+  });
+
+  it('renders "1h ago" for exactly 1 hour', () => {
+    const oneHourAgo = nowMs - 60 * 60 * 1000;
+    expect(formatRelativeTime(oneHourAgo, nowMs)).toBe('1h ago');
+  });
+
+  it('renders "23h ago" for 23 hours (edge of the day bucket)', () => {
+    const twentyThreeHoursAgo = nowMs - 23 * 60 * 60 * 1000;
+    expect(formatRelativeTime(twentyThreeHoursAgo, nowMs)).toBe('23h ago');
+  });
+
+  it('renders "1 day ago" (SINGULAR) for exactly 1 day', () => {
+    const oneDayAgo = nowMs - 24 * 60 * 60 * 1000;
+    expect(formatRelativeTime(oneDayAgo, nowMs)).toBe('1 day ago');
+  });
+
+  it('renders "2 days ago" for 2 days', () => {
+    const twoDaysAgo = nowMs - 2 * 24 * 60 * 60 * 1000;
+    expect(formatRelativeTime(twoDaysAgo, nowMs)).toBe('2 days ago');
+  });
+
+  it('renders "11 days ago" for 11 days', () => {
+    const elevenDaysAgo = nowMs - 11 * 24 * 60 * 60 * 1000;
+    expect(formatRelativeTime(elevenDaysAgo, nowMs)).toBe('11 days ago');
+  });
+
+  it('renders "1 month ago" for 40 days (≥ 30-day bucket, singular)', () => {
+    const fortyDaysAgo = nowMs - 40 * 24 * 60 * 60 * 1000;
+    expect(formatRelativeTime(fortyDaysAgo, nowMs)).toBe('1 month ago');
+  });
+
+  it('renders "3 months ago" for 100 days', () => {
+    const hundredDaysAgo = nowMs - 100 * 24 * 60 * 60 * 1000;
+    expect(formatRelativeTime(hundredDaysAgo, nowMs)).toBe('3 months ago');
+  });
+
+  it('renders "1 year ago" for 400 days (singular)', () => {
+    const fourHundredDaysAgo = nowMs - 400 * 24 * 60 * 60 * 1000;
+    expect(formatRelativeTime(fourHundredDaysAgo, nowMs)).toBe('1 year ago');
+  });
+
+  it('renders "N years ago" for multi-year ages', () => {
+    const threeYearsAgo = nowMs - 3 * 365 * 24 * 60 * 60 * 1000;
+    expect(formatRelativeTime(threeYearsAgo, nowMs)).toBe('3 years ago');
+  });
+
+  it('renders "Just now" for future timestamps (clock skew)', () => {
+    const fiveSecondsInTheFuture = nowMs + 5 * 1000;
+    expect(formatRelativeTime(fiveSecondsInTheFuture, nowMs)).toBe('Just now');
+  });
+
+  it('boundary: 59 seconds → "Just now", 60 seconds → "1m ago"', () => {
+    expect(formatRelativeTime(nowMs - 59 * 1000, nowMs)).toBe('Just now');
+    expect(formatRelativeTime(nowMs - 60 * 1000, nowMs)).toBe('1m ago');
+  });
+
+  it('boundary: 59 minutes → "59m ago", 60 minutes → "1h ago"', () => {
+    expect(formatRelativeTime(nowMs - 59 * 60 * 1000, nowMs)).toBe('59m ago');
+    expect(formatRelativeTime(nowMs - 60 * 60 * 1000, nowMs)).toBe('1h ago');
+  });
+
+  it('boundary: 29 days → "29 days ago", 30 days → "1 month ago"', () => {
+    expect(formatRelativeTime(nowMs - 29 * 24 * 60 * 60 * 1000, nowMs)).toBe(
+      '29 days ago',
+    );
+    expect(formatRelativeTime(nowMs - 30 * 24 * 60 * 60 * 1000, nowMs)).toBe(
+      '1 month ago',
+    );
+  });
+
+  // Keep this cheap — `at` is only used when the test needs an
+  // absolute ISO-8601 date rather than an offset.
+  it('works with ISO-parsed endedAt values (smoke test)', () => {
+    expect(formatRelativeTime(at('2026-04-20T11:55:00Z'), nowMs)).toBe('5m ago');
+  });
+});
+
+describe('formatPacificDatetime (#2932)', () => {
+  it('formats an April UTC timestamp as PDT (daylight time)', () => {
+    // 2026-04-20T22:36:39Z is 15:36:39 in Pacific Daylight Time (UTC-7).
+    const ms = Date.parse('2026-04-20T22:36:39Z');
+    expect(formatPacificDatetime(ms)).toBe('2026-04-20 15:36:39 PDT');
+  });
+
+  it('formats a January UTC timestamp as PST (standard time)', () => {
+    // 2026-01-15T18:00:00Z is 10:00:00 in Pacific Standard Time (UTC-8).
+    const ms = Date.parse('2026-01-15T18:00:00Z');
+    expect(formatPacificDatetime(ms)).toBe('2026-01-15 10:00:00 PST');
+  });
+
+  it('emits a consistent YYYY-MM-DD HH:MM:SS ZZZ shape', () => {
+    const ms = Date.parse('2026-04-20T22:36:39Z');
+    expect(formatPacificDatetime(ms)).toMatch(
+      /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} P[DS]T$/,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Re-introduces the "N ago" cell that #2818 stripped, with abbreviated age-scaled formatting (`5m ago` / `4h ago` / `11 days ago` / `2 months ago`) and a native `title` tooltip that shows the full datetime in Pacific time (`2026-04-20 15:36:39 PDT`). Operator gets at-a-glance "when did this happen" on the Recently Completed panel without clicking into each agent's detail page.

No schema change — `RecentCompletion.endedAt` was already in the GraphQL payload. No new dependency — vanilla `Intl.DateTimeFormat.formatToParts` handles the Pacific-time formatting.

Closes #2932

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (43 tests in `RecentCompletionsPanel.test.tsx`, 1303 tests across the full web package)
- [x] CI green

### Post-deploy verification
- [x] Load `/admin/dispatcher` on `dev.judgemind.org` and confirm the relative-time cell renders after the cost footnote on each row
- [x] Hover a row and confirm the tooltip shows a `YYYY-MM-DD HH:MM:SS PDT`-shaped Pacific datetime
- [x] Confirm no regression to other cells (cost footnote, title, priority badge, PR link, outcome pill)
- [x] Verification evidence posted on #2932 (see task skill A.8)
