### PR TITLE
fix(dispatcher): git_push_failed must write a failures row + capture full stderr (#2902)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -219,6 +219,14 @@ CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS = 180 * 60
 #: ``dispatcher.phase_outputs.log_text``.
 PHASE_STDERR_TAIL_MAX_CHARS = 2000
 
+#: Character cap on the ``stderr_tail`` field attached to structured-log
+#: events that fire on the **rare error path** — e.g. ``git_push_failed``.
+#: Larger than :data:`PHASE_STDERR_TAIL_MAX_CHARS` because these events
+#: are emitted at most once per failure and the extra context is worth
+#: the CloudWatch log-volume cost when the failure is unusual (network
+#: hiccup, pre-push hook output, transient auth errors). Issue #2902.
+STRUCTURED_LOG_STDERR_MAX = 4000
+
 #: Character cap on the ``stderr_preview`` field attached to
 #: ``daemon.phase_output_missing`` and retro-failure structured events.
 #: Previously 200; raised to 2000 (#2821) for the same rationale as
@@ -676,18 +684,32 @@ FAILURE_CATEGORY_SUBPROCESS_AUTH_FAIL = "subprocess_auth_fail"
 #: fixes "the CI-fixing skill couldn't fix CI three times in a row".
 FAILURE_CATEGORY_CI_RED_AFTER_RETRIES = "ci_red_after_retries"
 
+#: Git-push failure categories for the ``push_and_pr`` phase (issue #2902).
+#: ``push_failed`` is the generic catch-all; the two sub-kinds are
+#: classifier-derived from stderr content via ``_classify_push_failure``.
+#: All three are tier-1 auto-retry — a transient network or pre-push hook
+#: failure on the first attempt is commonly self-healing.
+FAILURE_CATEGORY_PUSH_FAILED = "push_failed"
+FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED = "pre_push_hook_rejected"
+FAILURE_CATEGORY_GIT_PUSH_NETWORK = "git_push_network"
+
 #: Which failure categories auto-create a retry marker (tier 1 per
 #: spec §8 table). ``subprocess_turn_limit`` (tier 2) and
 #: ``subprocess_auth_fail`` (halt — no retry) are intentionally
 #: excluded; 3D's diagnoser owns the escalation path for both.
 #: ``stuck_timeout``, ``gh_rate_exhausted``, and ``subprocess_crash``
-#: are the three that retry mechanically.
+#: are the three that retry mechanically. The three push-failure
+#: sub-kinds (#2902) are also tier-1 — transient network and pre-push
+#: hook failures are self-healing on a fresh retry.
 AUTO_RETRY_CATEGORIES = frozenset(
     {
         FAILURE_CATEGORY_STUCK_TIMEOUT,
         FAILURE_CATEGORY_GH_RATE_EXHAUSTED,
         FAILURE_CATEGORY_SUBPROCESS_CRASH,
         FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED,
+        FAILURE_CATEGORY_PUSH_FAILED,
+        FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED,
+        FAILURE_CATEGORY_GIT_PUSH_NETWORK,
     }
 )
 
@@ -737,6 +759,61 @@ _SUBPROCESS_STDERR_PATTERNS: tuple[tuple[str, str], ...] = (
     (r"401\s+Unauthorized", FAILURE_CATEGORY_SUBPROCESS_AUTH_FAIL),
     (r"Reached max turns", FAILURE_CATEGORY_SUBPROCESS_TURN_LIMIT),
 )
+
+
+def _stderr_tail(stderr: str | bytes | None) -> str:
+    """Return the trailing :data:`STRUCTURED_LOG_STDERR_MAX` chars of *stderr*.
+
+    Handles ``bytes`` input (subprocess ``capture_output=True`` with
+    ``text=False``), ``None``, and empty strings uniformly. No ellipsis
+    marker is added — callers embed the tail verbatim in structured-log
+    ``extra`` dicts where the truncation point is understood by convention.
+
+    .. note::
+        This helper is for **structured-log event fields** (rare, error-path
+        only).  The per-phase ``stderr_tail`` fields in the normal subprocess
+        flow use the named cap constants
+        (:data:`PHASE_STDERR_TAIL_MAX_CHARS`, etc.) directly — do **not**
+        replace those with this helper.
+
+    Issue #2902.
+    """
+    if stderr is None:
+        return ""
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode(errors="replace")
+    stderr = stderr.strip()
+    if len(stderr) <= STRUCTURED_LOG_STDERR_MAX:
+        return stderr
+    return stderr[-STRUCTURED_LOG_STDERR_MAX:]
+
+
+def _classify_push_failure(stderr: str) -> str:
+    """Classify a ``git push`` non-zero exit by inspecting stderr.
+
+    Returns one of the ``FAILURE_CATEGORY_PUSH_*`` constants:
+
+    * ``pre_push_hook_rejected`` — ``pre-push:`` hook output in stderr
+      (e.g. ``.githooks/pre-push`` reporting a lint or test failure).
+    * ``git_push_network`` — network-layer error: DNS, connection refused,
+      or a 4xx/5xx from the remote (GitHub outage, auth).
+    * ``push_failed`` — catch-all for any other non-zero exit.
+
+    Modelled on :meth:`DispatcherDaemon._classify_subprocess_failure`.
+    Issue #2902.
+    """
+    import re  # noqa: PLC0415 — lazy import; called only on error path
+
+    tail = stderr or ""
+    if re.search(r"pre-push:", tail, re.IGNORECASE):
+        return FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED
+    if re.search(
+        r"could not resolve host|connection refused|The requested URL returned error",
+        tail,
+        re.IGNORECASE,
+    ):
+        return FAILURE_CATEGORY_GIT_PUSH_NETWORK
+    return FAILURE_CATEGORY_PUSH_FAILED
 
 
 # --------------------------------------------------------------------------
@@ -3106,7 +3183,7 @@ class DispatcherDaemon:
                 "run_id": self._run_id,
                 "issue_number": issue_number,
                 "exit_code": result.returncode,
-                "detail": (result.stdout or result.stderr or "").strip()[:200],
+                "detail": _stderr_tail(result.stdout or result.stderr),
             },
         )
         return False
@@ -3404,7 +3481,7 @@ class DispatcherDaemon:
                 "event": "gh_setup_git_failed",
                 "run_id": self._run_id,
                 "exit_code": result.returncode,
-                "detail": (result.stderr or result.stdout or "").strip()[:200],
+                "detail": _stderr_tail(result.stderr or result.stdout),
             },
         )
 
@@ -3693,7 +3770,7 @@ class DispatcherDaemon:
             ) from exc
 
         if result.returncode != 0:
-            stderr_preview = (result.stderr or "").strip()[:200]
+            stderr_preview = _stderr_tail(result.stderr)
             raise RuntimeError(f"git clone exit={result.returncode}: {stderr_preview}")
 
         self._log.info(
@@ -3734,7 +3811,7 @@ class DispatcherDaemon:
             ) from exc
 
         if result.returncode != 0:
-            stderr_preview = (result.stderr or "").strip()[:200]
+            stderr_preview = _stderr_tail(result.stderr)
             raise RuntimeError(f"git fetch exit={result.returncode}: {stderr_preview}")
 
     def _create_worktree(self, agent_id: str) -> Path:
@@ -3817,7 +3894,7 @@ class DispatcherDaemon:
             raise RuntimeError("git worktree add timed out after 60s") from exc
 
         if result.returncode != 0:
-            stderr_preview = (result.stderr or "").strip()[:200]
+            stderr_preview = _stderr_tail(result.stderr)
             raise RuntimeError(
                 f"git worktree add exit={result.returncode}: {stderr_preview}"
             )
@@ -3864,7 +3941,7 @@ class DispatcherDaemon:
             raise RuntimeError("gh issue view timed out after 30s") from exc
 
         if result.returncode != 0:
-            stderr_preview = (result.stderr or "").strip()[:200]
+            stderr_preview = _stderr_tail(result.stderr)
             raise RuntimeError(
                 f"gh issue view exit={result.returncode}: {stderr_preview}"
             )
@@ -4177,6 +4254,10 @@ class DispatcherDaemon:
         "ci_red_after_retries": "CI failed after retries",
         "gh_rate_exhausted": "GitHub rate limit",
         "stuck_timeout": "timed out",
+        # Push-failure sub-kinds (#2902).
+        "push_failed": "git push failed",
+        "pre_push_hook_rejected": "pre-push hook rejected",
+        "git_push_network": "git push network error",
     }
 
     @staticmethod
@@ -5337,7 +5418,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "issue_number": issue_number,
                     "exit_code": result.returncode,
-                    "stderr_preview": (result.stderr or "").strip()[:200],
+                    "stderr_preview": _stderr_tail(result.stderr),
                 },
             )
             return None
@@ -5493,7 +5574,7 @@ class DispatcherDaemon:
                     "agent_id": agent_id,
                     "issue_number": issue_number,
                     "exit_code": result.returncode,
-                    "stderr_preview": (result.stderr or "").strip()[:200],
+                    "stderr_preview": _stderr_tail(result.stderr),
                 },
             )
             return False
@@ -5560,7 +5641,7 @@ class DispatcherDaemon:
                     "agent_id": agent_id,
                     "issue_number": issue_number,
                     "exit_code": result.returncode,
-                    "stderr_preview": (result.stderr or "").strip()[:200],
+                    "stderr_preview": _stderr_tail(result.stderr),
                 },
             )
             return False
@@ -5775,7 +5856,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "issue_number": issue_number,
                     "exit_code": result.returncode,
-                    "stderr_preview": (result.stderr or "").strip()[:200],
+                    "stderr_preview": _stderr_tail(result.stderr),
                 },
             )
             return None
@@ -5894,7 +5975,7 @@ class DispatcherDaemon:
                     "agent_id": agent_id,
                     "issue_number": issue_number,
                     "exit_code": result.returncode,
-                    "stderr_preview": (result.stderr or "").strip()[:200],
+                    "stderr_preview": _stderr_tail(result.stderr),
                 },
             )
             return False
@@ -6742,7 +6823,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "exit_code": add_result.returncode,
-                    "stderr_tail": (add_result.stderr or "")[:200],
+                    "stderr_tail": _stderr_tail(add_result.stderr),
                 },
             )
             self._mark_agent_terminal(
@@ -6801,7 +6882,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "exit_code": commit_result.returncode,
-                    "stderr_tail": (commit_result.stderr or "")[:200],
+                    "stderr_tail": _stderr_tail(commit_result.stderr),
                 },
             )
             self._mark_agent_terminal(
@@ -6833,6 +6914,7 @@ class DispatcherDaemon:
                 check=False,
             )
         except subprocess.TimeoutExpired as exc:
+            tail = _stderr_tail(getattr(exc, "stderr", None))
             self._log.exception(
                 "daemon.git_push_timeout",
                 extra={
@@ -6840,8 +6922,27 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "timeout_seconds": GIT_PUSH_TIMEOUT_SECONDS,
+                    "stderr_tail": tail,
                     "detail": str(exc),
                 },
+            )
+            self._write_failure(
+                agent_id=agent_id,
+                category=FAILURE_CATEGORY_GIT_PUSH_NETWORK,
+                detected_by="scheduler",
+                details={
+                    "phase": "push_and_pr",
+                    "branch": branch,
+                    "stderr_tail": tail,
+                    "exit_code": None,
+                    "reason": "timeout",
+                },
+            )
+            self._persist_phase_output(
+                agent_id,
+                phase="push_and_pr",
+                output_json={"event": "git_push_timeout", "branch": branch},
+                log_text=tail,
             )
             self._mark_agent_terminal(
                 agent_id,
@@ -6861,6 +6962,23 @@ class DispatcherDaemon:
                     "detail": str(exc),
                 },
             )
+            self._write_failure(
+                agent_id=agent_id,
+                category=FAILURE_CATEGORY_PUSH_FAILED,
+                detected_by="scheduler",
+                details={
+                    "phase": "push_and_pr",
+                    "branch": branch,
+                    "stderr_tail": str(exc),
+                    "exit_code": None,
+                },
+            )
+            self._persist_phase_output(
+                agent_id,
+                phase="push_and_pr",
+                output_json={"event": "git_push_failed", "branch": branch},
+                log_text=str(exc),
+            )
             self._mark_agent_terminal(
                 agent_id,
                 status="failed",
@@ -6870,6 +6988,8 @@ class DispatcherDaemon:
             )
             return
         if push_result.returncode != 0:
+            tail = _stderr_tail(push_result.stderr)
+            category = _classify_push_failure(tail)
             self._log.warning(
                 "daemon.git_push_failed",
                 extra={
@@ -6877,8 +6997,31 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "exit_code": push_result.returncode,
-                    "stderr_tail": (push_result.stderr or "")[:200],
+                    "stderr_tail": tail,
+                    "category": category,
+                    "branch": branch,
                 },
+            )
+            self._write_failure(
+                agent_id=agent_id,
+                category=category,
+                detected_by="scheduler",
+                details={
+                    "phase": "push_and_pr",
+                    "branch": branch,
+                    "stderr_tail": tail,
+                    "exit_code": push_result.returncode,
+                },
+            )
+            self._persist_phase_output(
+                agent_id,
+                phase="push_and_pr",
+                output_json={
+                    "event": "git_push_failed",
+                    "exit_code": push_result.returncode,
+                    "branch": branch,
+                },
+                log_text=(push_result.stderr or ""),
             )
             self._mark_agent_terminal(
                 agent_id,
@@ -6946,7 +7089,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "exit_code": pr_result.returncode,
-                    "stderr_tail": (pr_result.stderr or "")[:200],
+                    "stderr_tail": _stderr_tail(pr_result.stderr),
                 },
             )
             self._mark_agent_terminal(
@@ -7338,7 +7481,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "pr_number": pr_number,
                     "exit_code": result.returncode,
-                    "stderr_tail": (result.stderr or "").strip()[:200],
+                    "stderr_tail": _stderr_tail(result.stderr),
                 },
             )
             return None
@@ -7492,7 +7635,7 @@ class DispatcherDaemon:
                     "agent_id": agent_id,
                     "pr_number": pr_number,
                     "exit_code": result.returncode,
-                    "stderr_tail": (result.stderr or "").strip()[:200],
+                    "stderr_tail": _stderr_tail(result.stderr),
                 },
             )
             return
@@ -7810,7 +7953,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "exit_code": add_result.returncode,
-                    "stderr_tail": (add_result.stderr or "")[:200],
+                    "stderr_tail": _stderr_tail(add_result.stderr),
                 },
             )
             self._mark_agent_terminal(
@@ -7862,7 +8005,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "exit_code": commit_result.returncode,
-                    "stderr_tail": (commit_result.stderr or "")[:200],
+                    "stderr_tail": _stderr_tail(commit_result.stderr),
                 },
             )
             self._mark_agent_terminal(
@@ -7922,7 +8065,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "exit_code": push_result.returncode,
-                    "stderr_tail": (push_result.stderr or "")[:200],
+                    "stderr_tail": _stderr_tail(push_result.stderr),
                 },
             )
             self._mark_agent_terminal(
@@ -8089,7 +8232,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "merge_sha": merge_sha,
                     "exit_code": result.returncode,
-                    "stderr_tail": (result.stderr or "")[:200],
+                    "stderr_tail": _stderr_tail(result.stderr),
                 },
             )
             return []
@@ -8433,7 +8576,7 @@ class DispatcherDaemon:
                     "agent_id": agent_id,
                     "issue_number": issue_number,
                     "exit_code": result.returncode,
-                    "stderr_tail": (result.stderr or "")[:200],
+                    "stderr_tail": _stderr_tail(result.stderr),
                 },
             )
             return
@@ -9008,7 +9151,7 @@ class DispatcherDaemon:
                     "agent_id": agent_id,
                     "title": title,
                     "exit_code": result.returncode,
-                    "stderr_tail": (result.stderr or "")[:200],
+                    "stderr_tail": _stderr_tail(result.stderr),
                 },
             )
             return None
@@ -9145,8 +9288,8 @@ class DispatcherDaemon:
                 "agent_id": agent_id,
                 "worktree_path": worktree_path,
                 "exit_code": result.returncode,
-                "stderr_tail": (result.stderr or "").strip()[:200],
-                "stdout_tail": (result.stdout or "").strip()[:200],
+                "stderr_tail": _stderr_tail(result.stderr),
+                "stdout_tail": _stderr_tail(result.stdout),
             },
         )
 
@@ -9611,7 +9754,7 @@ class DispatcherDaemon:
                     "event": "gh_rate_probe_failed",
                     "run_id": self._run_id,
                     "exit_code": result.returncode,
-                    "stderr_tail": (result.stderr or "").strip()[:200],
+                    "stderr_tail": _stderr_tail(result.stderr),
                 },
             )
             return None
@@ -9901,7 +10044,7 @@ class DispatcherDaemon:
                         "run_id": self._run_id,
                         "worktree_path": worktree_path,
                         "exit_code": result.returncode,
-                        "stderr_tail": (result.stderr or "").strip()[:200],
+                        "stderr_tail": _stderr_tail(result.stderr),
                     },
                 )
             except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
@@ -9958,7 +10101,7 @@ class DispatcherDaemon:
                 "run_id": self._run_id,
                 "worktree_path": worktree_path,
                 "exit_code": result.returncode,
-                "stderr_tail": (result.stderr or "").strip()[:200],
+                "stderr_tail": _stderr_tail(result.stderr),
             },
         )
         return False
@@ -11648,7 +11791,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "issue_number": issue_number,
                     "exit_code": result.returncode,
-                    "stderr_tail": (result.stderr or "").strip()[:200],
+                    "stderr_tail": _stderr_tail(result.stderr),
                 },
             )
 
@@ -11693,7 +11836,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "issue_number": issue_number,
                     "exit_code": result.returncode,
-                    "stderr_tail": (result.stderr or "").strip()[:200],
+                    "stderr_tail": _stderr_tail(result.stderr),
                 },
             )
 
@@ -11742,7 +11885,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "issue_number": issue_number,
                     "exit_code": result.returncode,
-                    "stderr_tail": (result.stderr or "").strip()[:200],
+                    "stderr_tail": _stderr_tail(result.stderr),
                 },
             )
 
@@ -11794,7 +11937,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "issue_number": issue_number,
                     "exit_code": result.returncode,
-                    "stderr_tail": (result.stderr or "").strip()[:200],
+                    "stderr_tail": _stderr_tail(result.stderr),
                 },
             )
 
@@ -11841,7 +11984,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "issue_number": issue_number,
                     "exit_code": result.returncode,
-                    "stderr_tail": (result.stderr or "").strip()[:200],
+                    "stderr_tail": _stderr_tail(result.stderr),
                 },
             )
 

--- a/scripts/dispatcher/tests/test_daemon_failure_summary.py
+++ b/scripts/dispatcher/tests/test_daemon_failure_summary.py
@@ -640,7 +640,8 @@ class TestCategoryDisplayNames:
 
     def test_category_display_names_map_contents(self) -> None:
         """Lock the full ``_CATEGORY_DISPLAY_NAMES`` map contents so a
-        typo or accidental deletion on any row surfaces immediately."""
+        typo or accidental deletion on any row surfaces immediately.
+        Issue #2902 added three push-failure sub-kinds."""
         assert daemon.DispatcherDaemon._CATEGORY_DISPLAY_NAMES == {
             "subprocess_turn_limit": "turn limit reached",
             "subprocess_crash": "subprocess crashed",
@@ -648,7 +649,29 @@ class TestCategoryDisplayNames:
             "ci_red_after_retries": "CI failed after retries",
             "gh_rate_exhausted": "GitHub rate limit",
             "stuck_timeout": "timed out",
+            # Push-failure sub-kinds (#2902).
+            "push_failed": "git push failed",
+            "pre_push_hook_rejected": "pre-push hook rejected",
+            "git_push_network": "git push network error",
         }
+
+    def test_push_failed_renders_as_git_push_failed(self, tmp_path: Path) -> None:
+        """``push_failed`` → ``"git push failed"``. Issue #2902."""
+        summary = self._build_for_category(tmp_path, "push_failed")
+        assert "(git push failed)" in summary
+        assert "push_failed" not in summary
+
+    def test_pre_push_hook_rejected_renders_humanized(self, tmp_path: Path) -> None:
+        """``pre_push_hook_rejected`` → ``"pre-push hook rejected"``. Issue #2902."""
+        summary = self._build_for_category(tmp_path, "pre_push_hook_rejected")
+        assert "(pre-push hook rejected)" in summary
+        assert "pre_push_hook_rejected" not in summary
+
+    def test_git_push_network_renders_humanized(self, tmp_path: Path) -> None:
+        """``git_push_network`` → ``"git push network error"``. Issue #2902."""
+        summary = self._build_for_category(tmp_path, "git_push_network")
+        assert "(git push network error)" in summary
+        assert "git_push_network" not in summary
 
 
 # --------------------------------------------------------------------------

--- a/scripts/dispatcher/tests/test_daemon_push_failed.py
+++ b/scripts/dispatcher/tests/test_daemon_push_failed.py
@@ -1,0 +1,484 @@
+"""Unit tests for the ``git_push_failed`` path improvements (issue #2902).
+
+Acceptance criteria covered:
+- AC#2 — ``git_push_failed`` writes a ``dispatcher.failures`` row with a
+  meaningful, classifier-derived category.
+- AC#3 — ``git_push_failed`` writes a ``push_and_pr`` phase_outputs row
+  with ``log_text`` = full stderr (no length cap).
+- AC#4 — ``_build_failure_summary`` produces an informative tooltip for
+  push_and_pr failures that includes category-in-parens and a colon-separated
+  detail.
+
+The classifier tests cover ``_classify_push_failure`` directly; the
+failure-row and phase-output tests exercise the non-zero-returncode branch
+of ``_push_and_open_pr`` by patching ``subprocess.run`` and asserting on the
+cursor's executed SQL.
+
+Fakes + psycopg MagicMock stub follow the pattern from
+``test_daemon_failure_summary.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Provide a stub ``psycopg`` module before importing the daemon — same
+# pattern as test_daemon_failure_summary.py.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+from dispatcher.daemon import (  # noqa: E402
+    AUTO_RETRY_CATEGORIES,
+    FAILURE_CATEGORY_GIT_PUSH_NETWORK,
+    FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED,
+    FAILURE_CATEGORY_PUSH_FAILED,
+    _classify_push_failure,
+)
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — same shape as test_daemon_failure_summary.py
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.push_failed.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# _classify_push_failure
+# --------------------------------------------------------------------------
+
+
+class TestClassifyPushFailure:
+    """AC#2 — classifier returns correct category for each stderr shape."""
+
+    def test_classify_push_failure_pre_push_hook(self) -> None:
+        """stderr with 'pre-push:' → pre_push_hook_rejected."""
+        stderr = (
+            "remote: Permission to foo/bar.git denied.\n"
+            "pre-push: ruff check failed — 2 errors\n"
+            "error: failed to push some refs"
+        )
+        assert _classify_push_failure(stderr) == FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED
+
+    def test_classify_push_failure_network_could_not_resolve(self) -> None:
+        """'could not resolve host' → git_push_network."""
+        stderr = "fatal: unable to access 'https://github.com/': Could not resolve host: github.com"
+        assert _classify_push_failure(stderr) == FAILURE_CATEGORY_GIT_PUSH_NETWORK
+
+    def test_classify_push_failure_network_connection_refused(self) -> None:
+        """'connection refused' → git_push_network."""
+        stderr = "fatal: Connection refused to remote"
+        assert _classify_push_failure(stderr) == FAILURE_CATEGORY_GIT_PUSH_NETWORK
+
+    def test_classify_push_failure_network_url_error(self) -> None:
+        """'The requested URL returned error' → git_push_network."""
+        stderr = "error: The requested URL returned error: 503"
+        assert _classify_push_failure(stderr) == FAILURE_CATEGORY_GIT_PUSH_NETWORK
+
+    def test_classify_push_failure_fallback(self) -> None:
+        """Unrecognised stderr → push_failed (catch-all)."""
+        stderr = "error: remote rejected (branch protection is active)"
+        assert _classify_push_failure(stderr) == FAILURE_CATEGORY_PUSH_FAILED
+
+    def test_classify_push_failure_empty_stderr(self) -> None:
+        """Empty stderr → push_failed (catch-all)."""
+        assert _classify_push_failure("") == FAILURE_CATEGORY_PUSH_FAILED
+
+    def test_classify_push_failure_case_insensitive(self) -> None:
+        """Pattern matching is case-insensitive (e.g. 'PRE-PUSH:')."""
+        assert (
+            _classify_push_failure("PRE-PUSH: hook returned 1")
+            == FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED
+        )
+
+
+# --------------------------------------------------------------------------
+# AUTO_RETRY_CATEGORIES includes push failure kinds
+# --------------------------------------------------------------------------
+
+
+class TestAutoRetryCategories:
+    """AC#2 — all three push failure categories are in AUTO_RETRY_CATEGORIES."""
+
+    def test_auto_retry_categories_include_push_failed(self) -> None:
+        assert FAILURE_CATEGORY_PUSH_FAILED in AUTO_RETRY_CATEGORIES
+
+    def test_auto_retry_categories_include_pre_push_hook_rejected(self) -> None:
+        assert FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED in AUTO_RETRY_CATEGORIES
+
+    def test_auto_retry_categories_include_git_push_network(self) -> None:
+        assert FAILURE_CATEGORY_GIT_PUSH_NETWORK in AUTO_RETRY_CATEGORIES
+
+
+# --------------------------------------------------------------------------
+# _push_and_open_pr — non-zero returncode branch
+# --------------------------------------------------------------------------
+
+
+def _make_push_result(
+    returncode: int,
+    stderr: str = "",
+    stdout: str = "",
+) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+    return subprocess.CompletedProcess(
+        args=["git", "push"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+class TestGitPushFailedWritesFailureRow:
+    """AC#2 — a ``dispatcher.failures`` row is written on push failure."""
+
+    def test_git_push_failed_writes_failure_row(self, tmp_path: Path) -> None:
+        """Non-zero ``git push`` exit writes a failures row with a classified
+        category."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        agent_id = "aaaabbbb-0000-0000-0000-000000000001"
+
+        # Stub the git add / commit steps to succeed; fail on push.
+        add_ok = subprocess.CompletedProcess(
+            args=["git", "add"], returncode=0, stdout="", stderr=""
+        )
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit"], returncode=0, stdout="", stderr=""
+        )
+        push_fail = _make_push_result(
+            returncode=1,
+            stderr="pre-push: ruff check failed — 1 error",
+        )
+
+        # _push_and_open_pr reads _agent_summary_output and _agent_unmet_criteria.
+        d._agent_summary_output = {  # type: ignore[attr-defined]
+            "commit_message": "feat: test commit",
+            "pr_title": "Test PR",
+            "pr_body_md": "body",
+        }
+        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+
+        # _update_agent_phase and _mark_agent_terminal do DB writes we don't
+        # need to actually run in this test — stub them out.
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
+
+        # Create a real worktree dir so the git add command path resolves.
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        run_side_effects = [add_ok, commit_ok, push_fail]
+        with patch("subprocess.run", side_effect=run_side_effects):
+            d._push_and_open_pr(
+                agent_id=agent_id,
+                issue_number=42,
+                worktree=worktree,
+            )
+
+        # Find the INSERT into dispatcher.failures.
+        failure_inserts = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "dispatcher.failures" in sql and "INSERT" in sql
+        ]
+        assert len(failure_inserts) >= 1, (
+            "Expected at least one INSERT into dispatcher.failures; "
+            f"executed: {conn.cursor_instance.executed}"
+        )
+        _sql, params = failure_inserts[0]
+        # params: (agent_id, category, detected_by, details_json)
+        assert params[0] == agent_id
+        # Category must be the classifier-derived value, not a generic stub.
+        assert params[1] == FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED, (
+            f"Expected pre_push_hook_rejected from classifier; got {params[1]!r}"
+        )
+        details = json.loads(params[3])
+        assert details["phase"] == "push_and_pr"
+        assert "pre-push" in details["stderr_tail"]
+
+    def test_git_push_failed_category_for_network_error(self, tmp_path: Path) -> None:
+        """Network-layer push failure is classified as git_push_network."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        agent_id = "aaaabbbb-0000-0000-0000-000000000002"
+
+        add_ok = subprocess.CompletedProcess(
+            args=["git", "add"], returncode=0, stdout="", stderr=""
+        )
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit"], returncode=0, stdout="", stderr=""
+        )
+        push_fail = _make_push_result(
+            returncode=128,
+            stderr="fatal: unable to access 'https://github.com/': Could not resolve host: github.com",
+        )
+
+        d._agent_summary_output = {
+            "commit_message": "c",
+            "pr_title": "t",
+            "pr_body_md": "b",
+        }  # type: ignore[attr-defined]
+        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
+
+        worktree = tmp_path / "worktree2"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        with patch("subprocess.run", side_effect=[add_ok, commit_ok, push_fail]):
+            d._push_and_open_pr(agent_id=agent_id, issue_number=99, worktree=worktree)
+
+        failure_inserts = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "dispatcher.failures" in sql and "INSERT" in sql
+        ]
+        assert failure_inserts, "Expected INSERT into dispatcher.failures"
+        _sql, params = failure_inserts[0]
+        assert params[1] == FAILURE_CATEGORY_GIT_PUSH_NETWORK
+
+
+# --------------------------------------------------------------------------
+# _push_and_open_pr — phase_outputs row
+# --------------------------------------------------------------------------
+
+
+class TestGitPushFailedWritesPhaseOutputRow:
+    """AC#3 — a ``dispatcher.phase_outputs`` row is written with full stderr
+    as ``log_text`` (no length cap) on push failure."""
+
+    def test_git_push_failed_writes_phase_output_row(self, tmp_path: Path) -> None:
+        """After a push failure, phase_outputs row exists for push_and_pr."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        agent_id = "aaaabbbb-0000-0000-0000-000000000003"
+        # Use a long stderr to verify it is NOT truncated.
+        long_stderr = "pre-push: " + "x" * 5000
+
+        add_ok = subprocess.CompletedProcess(
+            args=["git", "add"], returncode=0, stdout="", stderr=""
+        )
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit"], returncode=0, stdout="", stderr=""
+        )
+        push_fail = _make_push_result(returncode=1, stderr=long_stderr)
+
+        d._agent_summary_output = {
+            "commit_message": "c",
+            "pr_title": "t",
+            "pr_body_md": "b",
+        }  # type: ignore[attr-defined]
+        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
+
+        worktree = tmp_path / "worktree3"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        with patch("subprocess.run", side_effect=[add_ok, commit_ok, push_fail]):
+            d._push_and_open_pr(agent_id=agent_id, issue_number=7, worktree=worktree)
+
+        # Find the INSERT into dispatcher.phase_outputs for push_and_pr.
+        phase_inserts = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "dispatcher.phase_outputs" in sql and "INSERT" in sql
+        ]
+        assert phase_inserts, (
+            "Expected INSERT into dispatcher.phase_outputs; "
+            f"executed: {conn.cursor_instance.executed}"
+        )
+        # Params order: (agent_id, phase, output_json, log_text, attempt, ...)
+        _sql, params = phase_inserts[0]
+        assert params[0] == agent_id
+        assert params[1] == "push_and_pr"
+        # log_text must be the full stderr — not truncated to 200 or 4000 chars.
+        log_text = params[3]
+        assert log_text is not None
+        assert len(log_text) == len(long_stderr), (
+            f"log_text truncated: got {len(log_text)} chars, expected {len(long_stderr)}"
+        )
+        assert log_text == long_stderr
+
+
+# --------------------------------------------------------------------------
+# _build_failure_summary — push_and_pr tooltip shape (AC#4)
+# --------------------------------------------------------------------------
+
+
+class TestGitPushFailedSummaryTooltip:
+    """AC#4 — tooltip for push_and_pr failures includes category and detail."""
+
+    def test_git_push_failed_summary_contains_category_and_detail(
+        self, tmp_path: Path
+    ) -> None:
+        """``_build_failure_summary`` with a push_failed category + stderr
+        produces a summary that contains category-in-parens AND colon-separated
+        detail. No bare 'push_and_pr failed' with no detail.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            # First SELECT: (category, details_json)
+            (
+                "pre_push_hook_rejected",
+                {
+                    "stderr_tail": (
+                        "pre-push: ruff check failed — 1 error\n"
+                        "error: failed to push some refs to 'origin'"
+                    )
+                },
+            ),
+            # Second SELECT: (log_text,)
+            (
+                "pre-push: ruff check failed — 1 error\n"
+                "error: failed to push some refs to 'origin'\n",
+            ),
+        ]
+        summary = d._build_failure_summary(
+            agent_id="agent-push-fail",
+            status="failed",
+            phase="push_and_pr",
+            exit_code=1,
+        )
+        assert summary is not None, (
+            "Expected a non-None summary for push_and_pr failure"
+        )
+        # Must include parenthesised category (human-friendly display name).
+        assert "(pre-push hook rejected)" in summary, (
+            f"Summary missing category paren: {summary!r}"
+        )
+        # Must include some detail from stderr — not just the bare phase name.
+        assert (
+            "pre-push" in summary or "ruff" in summary or "push" in summary.lower()
+        ), f"Summary has no detail from stderr: {summary!r}"
+        assert len(summary) <= 240, f"Summary exceeds 240-char limit: {len(summary)}"
+
+    def test_push_failed_renders_humanized(self, tmp_path: Path) -> None:
+        """``push_failed`` category maps to 'git push failed' display name."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            (
+                "push_failed",
+                {"stderr_tail": "remote: Repository not found."},
+            ),
+            ("remote: Repository not found.\n",),
+        ]
+        summary = d._build_failure_summary(
+            agent_id="agent-push-failed",
+            status="failed",
+            phase="push_and_pr",
+            exit_code=128,
+        )
+        assert summary is not None
+        # Display name must appear, not the raw token.
+        assert "(git push failed)" in summary, f"Unexpected summary: {summary!r}"
+        assert "push_failed" not in summary, (
+            f"Raw category token leaked into summary: {summary!r}"
+        )

--- a/scripts/dispatcher/tests/test_daemon_stderr_tail.py
+++ b/scripts/dispatcher/tests/test_daemon_stderr_tail.py
@@ -1,0 +1,117 @@
+"""Unit tests for ``_stderr_tail`` helper and the STRUCTURED_LOG_STDERR_MAX
+constant (issue #2902).
+
+Acceptance criteria covered:
+- AC#1 — tail returns trailing 4000 chars for >4000 inputs (no ellipsis).
+- AC#5 — zero inline [:200] truncations remain in daemon.py.
+- AC#6 — STRUCTURED_LOG_STDERR_MAX == 4000 and _stderr_tail uses it.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from dispatcher.daemon import STRUCTURED_LOG_STDERR_MAX, _stderr_tail  # noqa: E402
+
+
+class TestStructuredLogStderrMaxConstant:
+    """AC#6 — constant value and usage."""
+
+    def test_structured_log_stderr_max_constant_is_4000(self) -> None:
+        """AC#6: STRUCTURED_LOG_STDERR_MAX must be exactly 4000."""
+        assert STRUCTURED_LOG_STDERR_MAX == 4000
+
+    def test_constant_larger_than_phase_stderr_tail_max(self) -> None:
+        """Structured-log events get more context than the normal phase cap."""
+        from dispatcher.daemon import PHASE_STDERR_TAIL_MAX_CHARS
+
+        assert STRUCTURED_LOG_STDERR_MAX > PHASE_STDERR_TAIL_MAX_CHARS
+
+
+class TestStderrTail:
+    """AC#1, AC#6 — _stderr_tail helper behaviour."""
+
+    def test_stderr_tail_returns_full_when_under_cap(self) -> None:
+        """Short inputs are returned unchanged."""
+        text = "short stderr line"
+        assert _stderr_tail(text) == text
+
+    def test_stderr_tail_keeps_trailing_4000_when_over_cap(self) -> None:
+        """AC#1: 6000-char input returns the last 4000 chars, no ellipsis."""
+        text = "a" * 2000 + "b" * 4000
+        result = _stderr_tail(text)
+        assert len(result) == 4000
+        assert result == "b" * 4000
+        assert "…" not in result
+        assert "..." not in result
+
+    def test_stderr_tail_exactly_at_cap_returns_full(self) -> None:
+        """At exactly the cap boundary the full string is returned."""
+        text = "x" * STRUCTURED_LOG_STDERR_MAX
+        result = _stderr_tail(text)
+        assert result == text
+
+    def test_stderr_tail_decodes_bytes(self) -> None:
+        """bytes input is decoded via utf-8 (replace on error)."""
+        raw = b"git push failed\n"
+        result = _stderr_tail(raw)
+        assert isinstance(result, str)
+        assert "git push failed" in result
+
+    def test_stderr_tail_decodes_bytes_with_invalid_utf8(self) -> None:
+        """Invalid UTF-8 bytes are replaced rather than raising."""
+        raw = b"ok\xff\xfebad bytes"
+        result = _stderr_tail(raw)
+        assert isinstance(result, str)
+        assert "ok" in result
+
+    def test_stderr_tail_handles_none(self) -> None:
+        """None returns an empty string — safe for use with subprocess.stderr."""
+        assert _stderr_tail(None) == ""
+
+    def test_stderr_tail_handles_empty_string(self) -> None:
+        """Empty string returns empty string."""
+        assert _stderr_tail("") == ""
+
+    def test_stderr_tail_strips_surrounding_whitespace(self) -> None:
+        """Leading/trailing whitespace is stripped."""
+        result = _stderr_tail("  hello world  ")
+        assert result == "hello world"
+
+    def test_stderr_tail_trailing_bias(self) -> None:
+        """For long inputs the tail (not the head) is returned."""
+        head = "HEAD: " + "h" * 3000
+        tail = "TAIL: " + "t" * 3000
+        long_text = head + "\n" + tail
+        result = _stderr_tail(long_text)
+        assert "TAIL:" in result
+        assert "HEAD:" not in result
+
+
+class TestNoInline200CharTruncations:
+    """AC#5 — no inline [:200] slice on stderr/stdout remains in daemon.py."""
+
+    def test_no_inline_200char_truncations_remain_in_daemon_py(self) -> None:
+        """Source-grep assertion: grep for the [:200] pattern must return no matches."""
+        daemon_path = Path(__file__).resolve().parents[1] / "daemon.py"
+        assert daemon_path.exists(), f"daemon.py not found at {daemon_path}"
+        source = daemon_path.read_text(encoding="utf-8")
+        # Match stderr/stdout tail slices — the pattern we eliminated.
+        matches = re.findall(r"\[:200\]", source)
+        assert matches == [], (
+            f"Found {len(matches)} inline [:200] truncation(s) in daemon.py — "
+            "all call sites should use _stderr_tail() instead. "
+            f"Lines:\n"
+            + "\n".join(
+                f"  {i + 1}: {line.strip()}"
+                for i, line in enumerate(source.splitlines())
+                if "[:200]" in line
+            )
+        )


### PR DESCRIPTION
## Summary

Fixed two critical gaps in the `push_and_pr` failure path:

1. **Stderr truncation** — `daemon.git_push_failed` captured only 200 chars, chopping off the actual error message. Now captures trailing 4000 chars (via new `_stderr_tail()` helper).
2. **Opacity** — no `dispatcher.failures` row was written, leaving the admin cockpit tooltip showing only `"push_and_pr failed"` with no category or detail. Now writes a classified failure row + uncapped `phase_outputs` row.

Also refactored all 33 inline `[:200]` truncations across daemon.py to use the shared helper, and extended auto-retry categories to include the three new push-failure kinds (pre_push_hook_rejected, git_push_network, push_failed).

Closes #2902

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `ruff format --check`)
- [x] Tests pass (`pytest scripts/dispatcher/tests/`) — 696 tests
- [x] CI green

### Post-deploy verification

- [ ] Backfill a dev agent row (e.g., #2565 if still relevant) with a realistic retroactive `failure_summary` via UPDATE SQL, then snapshot the admin cockpit to verify the tooltip now includes category-in-parens and detail.
- [ ] Verification evidence posted on #2902 (see /task-v2-verify output).