### PR TITLE
fix(dispatcher): daemon-restart retry leaves kind='task' rows stuck in 'retrying' (#2925)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -10022,6 +10022,17 @@ class DispatcherDaemon:
         if not worktree_path:
             return False
 
+        if not Path(worktree_path).exists():
+            self._log.info(
+                "daemon.worktree_already_gone",
+                extra={
+                    "event": "worktree_already_gone",
+                    "run_id": self._run_id,
+                    "worktree_path": worktree_path,
+                },
+            )
+            return True
+
         repo_root = self._repo_root()
         git_parent = self._git_parent_root()
         cleanup_script = repo_root / "scripts" / "cleanup_worktree.sh"
@@ -10134,6 +10145,29 @@ class DispatcherDaemon:
         Returns the number of markers processed this tick. DB errors on
         any single marker are logged + rolled back; the loop continues.
 
+        **Infra-preemption terminal-and-reclaim branch (issue #2925).**
+        When the marker's reason is in :data:`_INFRA_PREEMPTION_CATEGORIES`
+        (``daemon_restart_abandoned``, ``paused_by_killswitch``), the method
+        takes a different path instead of resetting to ``retrying``:
+
+        1. Call :meth:`_mark_agent_terminal` with ``status='failed'``,
+           ``phase=reason`` — sets ``ended_at=now()``, drops the row from
+           the active-issue partial UNIQUE INDEX, and removes
+           ``status/in-progress`` from the issue.
+        2. Add ``agent/ready`` back to the issue so the next
+           ``_scan_queue_and_snapshot`` tick re-discovers it.
+        3. Resolve the marker via ``UPDATE dispatcher.retry_markers
+           SET resolved_at = now()``.
+        4. Skip the ``phase_transitions ('retry_reset')`` insert — the row
+           is terminal, so no future stuck_timeout MAX(ts) reset is needed.
+        5. Emit ``daemon.retry_terminal_and_reclaim`` (distinct from
+           ``retry_processed``) so CloudWatch can separate the two paths.
+
+        For non-infra reasons (``subprocess_crash``, ``stuck_timeout``,
+        ``gh_rate_exhausted``), the existing reset-to-retrying behavior is
+        unchanged — that path is exercised by 3D's diagnoser and the
+        ``_resume_retrying_agent`` handoff in steady state.
+
         The emitted ``daemon.retry_processed`` log event includes a
         ``retry_counted`` boolean so CloudWatch queries can separate
         budgeted retries (``retry_counted=true``) from free infra
@@ -10187,35 +10221,63 @@ class DispatcherDaemon:
             try:
                 self._drop_worktree_best_effort(worktree_path)
 
+                if not retry_counted:
+                    # ── Infra-preemption terminal-and-reclaim (#2925) ──
+                    # Mark the old row terminal so ``idx_dispatcher_agents_active_issue``
+                    # releases its slot and ``status/in-progress`` is removed.
+                    # Then re-add ``agent/ready`` so the scheduler re-discovers
+                    # the issue without a zombie retrying row lingering.
+                    # Skip the ``phase_transitions('retry_reset')`` insert —
+                    # the row is terminal and no future stuck_timeout clock
+                    # reset is needed.
+                    self._mark_agent_terminal(
+                        agent_id,
+                        status="failed",
+                        phase=reason,
+                        exit_code=None,
+                        issue_number=issue_number,
+                    )
+                    if issue_number is not None:
+                        self._gh_issue_add_labels(issue_number, ["agent/ready"])
+                    with self._conn.cursor() as cur:
+                        cur.execute(
+                            "UPDATE dispatcher.retry_markers "
+                            "SET resolved_at = now() "
+                            "WHERE marker_id = %s",
+                            (marker_id,),
+                        )
+                    self._conn.commit()
+                    self._log.info(
+                        "daemon.retry_terminal_and_reclaim",
+                        extra={
+                            "event": "retry_terminal_and_reclaim",
+                            "run_id": self._run_id,
+                            "agent_id": agent_id,
+                            "issue_number": issue_number,
+                            "reason": reason,
+                            "attempt": attempt,
+                            "marker_id": marker_id,
+                        },
+                    )
+                    processed += 1
+                    continue
+
+                # ── Budgeted retry: reset to retrying/claiming ──
                 # Two near-identical UPDATE statements — the difference
                 # is the ``retries_used`` clause. Keeping them as
                 # distinct string literals (rather than a dynamic
                 # join) preserves the grep-ability of SQL statements
                 # in the daemon, which the fakes in
                 # ``test_daemon_phase3c.py`` rely on.
-                if retry_counted:
-                    reset_sql = (
-                        "UPDATE dispatcher.agents "
-                        "SET status = 'retrying', "
-                        "    phase = 'claiming', "
-                        "    retries_used = retries_used + 1, "
-                        "    exit_code = NULL, "
-                        "    ended_at = NULL "
-                        "WHERE agent_id = %s"
-                    )
-                else:
-                    # Preserve ``retries_used`` — infra preemption is
-                    # not an agent-driven failure, so it must not
-                    # consume the retry budget. See
-                    # :data:`_INFRA_PREEMPTION_CATEGORIES`.
-                    reset_sql = (
-                        "UPDATE dispatcher.agents "
-                        "SET status = 'retrying', "
-                        "    phase = 'claiming', "
-                        "    exit_code = NULL, "
-                        "    ended_at = NULL "
-                        "WHERE agent_id = %s"
-                    )
+                reset_sql = (
+                    "UPDATE dispatcher.agents "
+                    "SET status = 'retrying', "
+                    "    phase = 'claiming', "
+                    "    retries_used = retries_used + 1, "
+                    "    exit_code = NULL, "
+                    "    ended_at = NULL "
+                    "WHERE agent_id = %s"
+                )
 
                 with self._conn.cursor() as cur:
                     cur.execute(reset_sql, (agent_id,))

--- a/scripts/dispatcher/tests/test_daemon_phase3c.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3c.py
@@ -728,16 +728,18 @@ class TestProcessRetryMarkers:
     # log event for CloudWatch observability.
     # ------------------------------------------------------------------
 
-    def test_daemon_restart_preserves_prior_attempt(
+    def test_daemon_restart_takes_terminal_and_reclaim_path(
         self, monkeypatch: Any, tmp_path: Path
     ) -> None:
-        """An agent at attempt=2 preempted by daemon restart stays at attempt=2.
+        """After #2925: ``daemon_restart_abandoned`` takes the terminal-and-reclaim path.
 
-        The marker's reason is ``daemon_restart_abandoned`` — classified
-        as infra preemption — so ``_process_retry_markers`` must reset
-        the agent without incrementing ``retries_used``. The
-        ``daemon.retry_processed`` log event records
-        ``retry_counted=false``.
+        Before #2925 this test asserted the old reset-to-retrying behavior.
+        After #2925 infra-preemption markers call ``_mark_agent_terminal``
+        (status='failed', phase=reason) and re-add ``agent/ready`` instead
+        of resetting to ``status='retrying'``. The ``retry_processed`` event
+        is no longer emitted; ``retry_terminal_and_reclaim`` takes its place.
+        The ``retries_used`` column is still not incremented (preservation
+        semantics carry over to the terminal-and-reclaim path).
         """
         d, conn, handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue = [
@@ -753,12 +755,12 @@ class TestProcessRetryMarkers:
             ],
         ]
         monkeypatch.setattr(d, "_drop_worktree_best_effort", lambda _p: True)
+        monkeypatch.setattr(d, "_gh_issue_add_labels", lambda n, l: None)
 
         processed = d._process_retry_markers()
         assert processed == 1
 
-        # The reset UPDATE must NOT include the retries_used++
-        # clause — the agent's prior attempt count is preserved.
+        # retries_used must NOT be incremented.
         incremented = [
             e
             for e in conn.cursor_instance.executed
@@ -766,40 +768,36 @@ class TestProcessRetryMarkers:
             and "retries_used = retries_used + 1" in e[0]
         ]
         assert incremented == [], (
-            "daemon_restart_abandoned retry must not increment retries_used"
+            "daemon_restart_abandoned must not increment retries_used"
         )
 
-        # A reset UPDATE did run — status='retrying', phase='claiming',
-        # and retries_used absent from the SET clause.
-        preserved_resets = [
+        # No reset to status='retrying' — the new path marks the row terminal.
+        retrying_resets = [
             e
             for e in conn.cursor_instance.executed
             if "UPDATE dispatcher.agents" in e[0]
             and "status = 'retrying'" in e[0]
-            and "phase = 'claiming'" in e[0]
-            and "retries_used" not in e[0]
         ]
-        assert preserved_resets, (
-            "infra-preemption retry should still reset agent to retrying/claiming"
+        assert retrying_resets == [], (
+            "infra-preemption path must not emit retrying reset after #2925"
         )
 
-        # retry_processed event with retry_counted=false.
-        events = handler.events("retry_processed")
-        assert len(events) == 1
-        assert events[0].retry_counted is False
-        assert events[0].reason == daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED
-        assert events[0].attempt == 2
+        # retry_terminal_and_reclaim event emitted; NOT retry_processed.
+        reclaim = handler.events("retry_terminal_and_reclaim")
+        assert len(reclaim) == 1
+        assert getattr(reclaim[0], "reason", None) == (
+            daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED
+        )
+        assert handler.events("retry_processed") == []
 
-    def test_killswitch_preserves_prior_attempt(
+    def test_killswitch_takes_terminal_and_reclaim_path(
         self, monkeypatch: Any, tmp_path: Path
     ) -> None:
-        """Killswitch-preempted agent at attempt=2 stays at attempt=2.
+        """After #2925: ``paused_by_killswitch`` takes the terminal-and-reclaim path.
 
-        Parallel to the daemon-restart case. Uses
-        :data:`FAILURE_CATEGORY_PAUSED_BY_KILLSWITCH` (added in this
-        PR) as the marker reason — any future killswitch retry path
-        that tags itself with this constant gets the correct
-        preservation semantics.
+        Parallel to the daemon-restart case. Before #2925 this test
+        asserted reset-to-retrying behavior; after #2925 it asserts
+        the terminal path.
         """
         d, conn, handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue = [
@@ -815,6 +813,7 @@ class TestProcessRetryMarkers:
             ],
         ]
         monkeypatch.setattr(d, "_drop_worktree_best_effort", lambda _p: True)
+        monkeypatch.setattr(d, "_gh_issue_add_labels", lambda n, l: None)
 
         processed = d._process_retry_markers()
         assert processed == 1
@@ -826,13 +825,23 @@ class TestProcessRetryMarkers:
             and "retries_used = retries_used + 1" in e[0]
         ]
         assert incremented == [], (
-            "paused_by_killswitch retry must not increment retries_used"
+            "paused_by_killswitch must not increment retries_used"
         )
 
-        events = handler.events("retry_processed")
-        assert len(events) == 1
-        assert events[0].retry_counted is False
-        assert events[0].reason == daemon.FAILURE_CATEGORY_PAUSED_BY_KILLSWITCH
+        retrying_resets = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and "status = 'retrying'" in e[0]
+        ]
+        assert retrying_resets == []
+
+        reclaim = handler.events("retry_terminal_and_reclaim")
+        assert len(reclaim) == 1
+        assert getattr(reclaim[0], "reason", None) == (
+            daemon.FAILURE_CATEGORY_PAUSED_BY_KILLSWITCH
+        )
+        assert handler.events("retry_processed") == []
 
     def test_subprocess_crash_increments_attempt_at_2(
         self, monkeypatch: Any, tmp_path: Path
@@ -909,6 +918,125 @@ class TestProcessRetryMarkers:
             == daemon.KILLSWITCH_TERMINAL_PHASE
             == "paused_by_killswitch"
         )
+
+
+# --------------------------------------------------------------------------
+# Issue #2925 — budgeted retries still use the reset-to-retrying path
+# --------------------------------------------------------------------------
+
+
+class TestProcessRetryMarkersBudgetedRetriesUnchanged:
+    """Regression guard: non-infra retries still reset to retrying/claiming.
+
+    After #2925 added the terminal-and-reclaim branch for infra-preemption,
+    the budgeted paths (``subprocess_crash``, ``stuck_timeout``) must
+    continue to use the original reset-to-retrying flow, including:
+    - ``UPDATE dispatcher.agents SET status='retrying' phase='claiming'
+      retries_used = retries_used + 1``
+    - ``INSERT INTO dispatcher.phase_transitions (retry_reset)``
+    - ``daemon.retry_processed`` log event (not ``retry_terminal_and_reclaim``)
+    """
+
+    def _make_budgeted_row(
+        self,
+        tmp_path: Path,
+        reason: str,
+    ) -> tuple[Any, Any, Any]:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue = [
+            [
+                (
+                    10,  # marker_id
+                    "agent-budgeted",
+                    reason,
+                    1,  # attempt
+                    str(tmp_path / "worktrees" / "agent-budgeted"),
+                    99,  # issue_number
+                ),
+            ],
+        ]
+        return d, conn, handler
+
+    def test_subprocess_crash_still_resets_to_retrying(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """``subprocess_crash`` takes the reset-to-retrying path, not terminal."""
+        d, conn, handler = self._make_budgeted_row(
+            tmp_path, daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH
+        )
+        monkeypatch.setattr(d, "_drop_worktree_best_effort", lambda _p: True)
+
+        processed = d._process_retry_markers()
+        assert processed == 1
+
+        # status='retrying' reset emitted with retries_used++.
+        retrying_resets = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and "status = 'retrying'" in e[0]
+            and "retries_used = retries_used + 1" in e[0]
+        ]
+        assert retrying_resets, (
+            "subprocess_crash must still emit retrying/claiming reset with retries_used++"
+        )
+
+        # retry_reset phase_transition inserted.
+        retry_reset_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_transitions" in e[0]
+            and e[1] is not None
+            and "retry_reset" in str(e[1])
+        ]
+        assert retry_reset_inserts, (
+            "subprocess_crash must insert retry_reset phase_transition"
+        )
+
+        # retry_processed event (not terminal_and_reclaim).
+        assert handler.events("retry_processed"), (
+            "subprocess_crash must emit retry_processed, not terminal_and_reclaim"
+        )
+        assert handler.events("retry_terminal_and_reclaim") == [], (
+            "subprocess_crash must NOT emit retry_terminal_and_reclaim"
+        )
+
+    def test_stuck_timeout_still_resets_to_retrying(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """``stuck_timeout`` takes the reset-to-retrying path, not terminal."""
+        d, conn, handler = self._make_budgeted_row(
+            tmp_path, daemon.FAILURE_CATEGORY_STUCK_TIMEOUT
+        )
+        monkeypatch.setattr(d, "_drop_worktree_best_effort", lambda _p: True)
+
+        processed = d._process_retry_markers()
+        assert processed == 1
+
+        retrying_resets = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and "status = 'retrying'" in e[0]
+            and "retries_used = retries_used + 1" in e[0]
+        ]
+        assert retrying_resets, (
+            "stuck_timeout must still emit retrying/claiming reset with retries_used++"
+        )
+
+        retry_reset_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_transitions" in e[0]
+            and e[1] is not None
+            and "retry_reset" in str(e[1])
+        ]
+        assert retry_reset_inserts, (
+            "stuck_timeout must insert retry_reset phase_transition"
+        )
+
+        assert handler.events("retry_processed")
+        assert handler.events("retry_terminal_and_reclaim") == []
 
 
 # --------------------------------------------------------------------------

--- a/scripts/dispatcher/tests/test_daemon_phase3c.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3c.py
@@ -1064,7 +1064,9 @@ class TestDropWorktreeBestEffort:
             return r
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        assert d._drop_worktree_best_effort("/some/path") is True
+        worktree_dir = tmp_path / "my_worktree"
+        worktree_dir.mkdir()
+        assert d._drop_worktree_best_effort(str(worktree_dir)) is True
 
     def test_empty_path_returns_false(self, tmp_path: Path) -> None:
         d, _conn, _handler = _make_daemon(tmp_path)
@@ -1089,7 +1091,9 @@ class TestDropWorktreeBestEffort:
             return r
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        assert d._drop_worktree_best_effort("/some/path") is True
+        worktree_dir = tmp_path / "my_worktree"
+        worktree_dir.mkdir()
+        assert d._drop_worktree_best_effort(str(worktree_dir)) is True
 
     def test_git_failure_returns_false(self, monkeypatch: Any, tmp_path: Path) -> None:
         d, _conn, _handler = _make_daemon(tmp_path)
@@ -1103,7 +1107,9 @@ class TestDropWorktreeBestEffort:
             return r
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        assert d._drop_worktree_best_effort("/some/path") is False
+        worktree_dir = tmp_path / "my_worktree"
+        worktree_dir.mkdir()
+        assert d._drop_worktree_best_effort(str(worktree_dir)) is False
 
 
 # --------------------------------------------------------------------------
@@ -1624,7 +1630,9 @@ class TestDropWorktreeBestEffortGitParent:
         monkeypatch.setattr(subprocess, "run", fake_run)
 
         # No cleanup_worktree.sh at the repo_root — forces git fallback.
-        assert d._drop_worktree_best_effort("/some/worktree") is True
+        worktree_dir = tmp_path / "my_worktree"
+        worktree_dir.mkdir()
+        assert d._drop_worktree_best_effort(str(worktree_dir)) is True
 
         # Only one call (the fallback), anchored to the baseline via -C.
         git_remove = [c for c in captured if "worktree" in c and "remove" in c]
@@ -1663,7 +1671,9 @@ class TestDropWorktreeBestEffortGitParent:
             return r
 
         monkeypatch.setattr(subprocess, "run", fake_run)
-        assert d._drop_worktree_best_effort("/some/worktree") is True
+        worktree_dir = tmp_path / "my_worktree"
+        worktree_dir.mkdir()
+        assert d._drop_worktree_best_effort(str(worktree_dir)) is True
 
         git_remove = [c for c in captured if "worktree" in c and "remove" in c]
         assert git_remove

--- a/scripts/dispatcher/tests/test_daemon_restart_cascade.py
+++ b/scripts/dispatcher/tests/test_daemon_restart_cascade.py
@@ -840,3 +840,260 @@ class TestAutoRetryCategoriesIncludesRestartAbandoned:
             daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED
             in daemon.AUTO_RETRY_CATEGORIES
         )
+
+
+# --------------------------------------------------------------------------
+# Issue #2925 — terminal-and-reclaim for infra-preemption retry markers
+# --------------------------------------------------------------------------
+
+
+class TestProcessRetryMarkersInfraPreemption:
+    """Infra-preemption markers take the terminal-and-reclaim path.
+
+    Before #2925, ``_process_retry_markers`` reset infra-preemption markers
+    to ``status='retrying' phase='claiming'`` — leaving a zombie row in
+    ``dispatcher.agents`` with ``ended_at=NULL`` that blocked the partial
+    UNIQUE INDEX and prevented fresh claims. The fix instead marks the old
+    row terminal (``status='failed'``, ``phase=reason``, ``ended_at=now()``)
+    and adds ``agent/ready`` back to the issue so the scheduler re-discovers
+    it.
+    """
+
+    def _make_infra_marker_row(
+        self,
+        tmp_path: Path,
+        reason: str,
+        issue_number: int = 42,
+    ) -> tuple[Any, _FakeConnection, _CapturingLogHandler]:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue = [
+            [
+                (
+                    1,  # marker_id
+                    "agent-infra-preempted",
+                    reason,
+                    1,  # attempt
+                    str(tmp_path / "worktrees" / "agent-infra"),  # worktree_path
+                    issue_number,
+                ),
+            ],
+        ]
+        return d, conn, handler
+
+    def test_restart_abandoned_terminates_old_and_unblocks_claim(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """``daemon_restart_abandoned`` marks the row failed + adds agent/ready.
+
+        Verifies:
+        - ``_mark_agent_terminal`` called with ``status='failed'``,
+          ``phase='daemon_restart_abandoned'``, ``issue_number=42``.
+        - ``agent/ready`` label added via ``_gh_issue_add_labels``.
+        - Marker resolved via ``UPDATE dispatcher.retry_markers SET resolved_at``.
+        - No ``status='retrying'`` UPDATE emitted.
+        - No ``phase_transitions ('retry_reset')`` INSERT emitted.
+        - ``daemon.retry_terminal_and_reclaim`` log event emitted.
+        """
+        d, conn, handler = self._make_infra_marker_row(
+            tmp_path, daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED
+        )
+        monkeypatch.setattr(d, "_drop_worktree_best_effort", lambda _p: True)
+
+        gh_calls: list[tuple[int, list[str]]] = []
+
+        def fake_gh_add(issue_num: int, labels: list[str]) -> None:
+            gh_calls.append((issue_num, labels))
+
+        monkeypatch.setattr(d, "_gh_issue_add_labels", fake_gh_add)
+
+        processed = d._process_retry_markers()
+        assert processed == 1
+
+        # agent/ready added.
+        assert gh_calls == [(42, ["agent/ready"])], (
+            f"expected [(42, ['agent/ready'])], got {gh_calls}"
+        )
+
+        # No retrying-reset UPDATE.
+        retrying_resets = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and "status = 'retrying'" in e[0]
+        ]
+        assert retrying_resets == [], (
+            f"infra-preemption path must not emit retrying reset; got {retrying_resets}"
+        )
+
+        # No retry_reset phase_transition.
+        retry_reset_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_transitions" in e[0]
+            and e[1] is not None
+            and "retry_reset" in str(e[1])
+        ]
+        assert retry_reset_inserts == [], (
+            f"infra-preemption path must not insert retry_reset transition; got {retry_reset_inserts}"
+        )
+
+        # Marker resolved.
+        resolves = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.retry_markers" in e[0]
+            and "resolved_at" in e[0]
+        ]
+        assert resolves, "retry marker must be resolved"
+
+        # Terminal-and-reclaim log event emitted.
+        reclaim_events = handler.events("retry_terminal_and_reclaim")
+        assert len(reclaim_events) == 1
+        assert getattr(reclaim_events[0], "reason", None) == (
+            daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED
+        )
+
+        # No retry_processed event (that's for the budgeted path).
+        assert handler.events("retry_processed") == []
+
+    def test_paused_by_killswitch_takes_same_terminal_path(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """``paused_by_killswitch`` follows the same terminal-and-reclaim flow."""
+        d, conn, handler = self._make_infra_marker_row(
+            tmp_path, daemon.FAILURE_CATEGORY_PAUSED_BY_KILLSWITCH
+        )
+        monkeypatch.setattr(d, "_drop_worktree_best_effort", lambda _p: True)
+
+        gh_calls: list[tuple[int, list[str]]] = []
+        monkeypatch.setattr(d, "_gh_issue_add_labels", lambda n, l: gh_calls.append((n, l)))
+
+        processed = d._process_retry_markers()
+        assert processed == 1
+
+        assert gh_calls == [(42, ["agent/ready"])]
+
+        retrying_resets = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and "status = 'retrying'" in e[0]
+        ]
+        assert retrying_resets == []
+
+        reclaim_events = handler.events("retry_terminal_and_reclaim")
+        assert len(reclaim_events) == 1
+        assert getattr(reclaim_events[0], "reason", None) == (
+            daemon.FAILURE_CATEGORY_PAUSED_BY_KILLSWITCH
+        )
+
+    def test_mark_agent_terminal_called_with_correct_args(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """``_mark_agent_terminal`` receives status='failed', phase=reason, issue_number.
+
+        Integration-style: verify the _mark_agent_terminal call shape
+        mirrors the ``recover_abandoned_agents`` precedent (line 3660).
+        """
+        d, conn, handler = self._make_infra_marker_row(
+            tmp_path,
+            daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED,
+            issue_number=2925,
+        )
+        monkeypatch.setattr(d, "_drop_worktree_best_effort", lambda _p: True)
+        monkeypatch.setattr(d, "_gh_issue_add_labels", lambda n, l: None)
+
+        terminal_calls: list[dict[str, Any]] = []
+
+        original_mark = d._mark_agent_terminal
+
+        def capturing_mark(
+            agent_id: str,
+            status: str,
+            phase: str,
+            exit_code: int | None = None,
+            pr_number: int | None = None,
+            issue_number: int | None = None,
+        ) -> None:
+            terminal_calls.append(
+                {
+                    "agent_id": agent_id,
+                    "status": status,
+                    "phase": phase,
+                    "exit_code": exit_code,
+                    "issue_number": issue_number,
+                }
+            )
+            original_mark(
+                agent_id,
+                status=status,
+                phase=phase,
+                exit_code=exit_code,
+                issue_number=issue_number,
+            )
+
+        monkeypatch.setattr(d, "_mark_agent_terminal", capturing_mark)
+
+        d._process_retry_markers()
+
+        assert len(terminal_calls) == 1
+        call = terminal_calls[0]
+        assert call["status"] == "failed"
+        assert call["phase"] == daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED
+        assert call["exit_code"] is None
+        assert call["issue_number"] == 2925
+
+
+# --------------------------------------------------------------------------
+# Issue #2925 — _drop_worktree_best_effort missing path guard
+# --------------------------------------------------------------------------
+
+
+class TestDropWorktreeBestEffortMissingPath:
+    """When the worktree path doesn't exist, no subprocess fires.
+
+    Before #2925, ``_drop_worktree_best_effort`` always tried
+    ``cleanup_worktree.sh`` and/or ``git worktree remove`` even when the
+    path was already gone — emitting the noisy ``worktree_remove_nonzero``
+    WARNING on every daemon restart. The fix returns True immediately
+    when ``Path(worktree_path).exists()`` is False and logs a lighter
+    ``worktree_already_gone`` INFO event.
+    """
+
+    def test_missing_path_logs_already_gone_no_subprocess(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        subprocess_calls: list[Any] = []
+
+        def fake_run(cmd: Any, **_kwargs: Any) -> Any:
+            subprocess_calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        # Stub Path.exists to return False for any path.
+        monkeypatch.setattr(
+            "dispatcher.daemon.Path",
+            lambda p: type("_FakePath", (), {"exists": lambda self: False})(),
+        )
+
+        result = d._drop_worktree_best_effort("/nonexistent/worktree/agent-abc")
+
+        assert result is True, "should return True (path already gone = success)"
+        assert subprocess_calls == [], (
+            f"no subprocess should fire when path is missing; got {subprocess_calls}"
+        )
+
+        events = handler.events("worktree_already_gone")
+        assert len(events) == 1
+        assert getattr(events[0], "worktree_path", None) == (
+            "/nonexistent/worktree/agent-abc"
+        )
+        # INFO level, not WARNING.
+        assert events[0].levelno == logging.INFO, (
+            f"expected INFO, got {logging.getLevelName(events[0].levelno)}"
+        )


### PR DESCRIPTION
## Summary

When the dispatcher daemon restarts mid-pipeline, infra-preempted agent rows (e.g., `kind='task'` agents interrupted by a deploy) were reset to `status='retrying'` forever, holding the partial unique index `idx_dispatcher_agents_active_issue` and blocking re-claim. This fix makes `_process_retry_markers` take a different path for infra-preemption markers: mark the old row `failed` and restore `agent/ready` to the issue so the scheduler re-discovers it without a zombie row lingering.

Closes #2925

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
  - `TestProcessRetryMarkersInfraPreemption` (3 tests) — terminal-and-reclaim path for `daemon_restart_abandoned` and `paused_by_killswitch`
  - `TestDropWorktreeBestEffortMissingPath` (1 test) — path-existence guard prevents noisy subprocess calls
  - `TestProcessRetryMarkersBudgetedRetriesUnchanged` (2 tests) — regression: non-infra retries (`subprocess_crash`, `stuck_timeout`) still reset-to-retrying
  - Updated 2 existing tests in `TestProcessRetryMarkers` to assert terminal-and-reclaim behavior
- [x] CI green

### Post-deploy verification

- [ ] Monitor CloudWatch Logs Insights for `worktree_already_gone` INFO events on next daemon restart (replaces `worktree_remove_nonzero` WARNINGs)
- [ ] Verify no `status='retrying'` rows with `ended_at=NULL` lingering after daemon deploy
- [ ] Trigger a daemon redeploy while a task is in-flight; confirm old agent row marked `failed` and new agent row spawned for same issue within ~60s
- [ ] Query #2565 agent row post-deploy (before/after state, manual cleanup SQL evidence)
- [ ] Verification evidence posted on #2925
