### PR TITLE
fix(dispatcher): filter infra-preempted outcomes in circuit breaker (#2942)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -10906,10 +10906,24 @@ class DispatcherDaemon:
                 # construction and the breaker query reverts to its
                 # pre-#2866 shape. The ``a.kind = 'task'`` JOIN added
                 # by #2921 is no longer needed.
+                #
+                # #2942: correlate each terminal_outcomes row with the
+                # most-recent dispatcher.failures.category for the same
+                # agent_id so infra-preempted outcomes
+                # (daemon_restart_abandoned, paused_by_killswitch) can
+                # be filtered out before the bad-outcome count. The
+                # correlated subquery mirrors _build_failure_summary's
+                # "freshest failure row per agent" semantics. agent_id
+                # may be NULL on synthetic test rows; the subquery
+                # simply returns NULL → treated as non-infra.
                 cur.execute(
-                    "SELECT status FROM dispatcher.terminal_outcomes "
-                    "WHERE ended_at > now() - make_interval(mins => %s) "
-                    "ORDER BY ended_at DESC "
+                    "SELECT t.status, "
+                    "       (SELECT f.category FROM dispatcher.failures f "
+                    "        WHERE f.agent_id = t.agent_id "
+                    "        ORDER BY f.ts DESC LIMIT 1) AS latest_category "
+                    "FROM dispatcher.terminal_outcomes t "
+                    "WHERE t.ended_at > now() - make_interval(mins => %s) "
+                    "ORDER BY t.ended_at DESC "
                     "LIMIT %s",
                     (window_minutes, window_size),
                 )
@@ -10930,9 +10944,37 @@ class DispatcherDaemon:
                 pass
             return False
 
-        statuses = [str(r[0]) for r in rows if r and r[0] is not None]
+        # #2942: strip infra-preempted rows before counting bad outcomes.
+        # Infra preemption (daemon restart, operator killswitch) is not
+        # an agent-driven failure; a streak of redeploys must not trip
+        # the breaker. Reuse the module-level frozenset — same set as
+        # _process_retry_markers uses for free-retry classification.
+        raw_pairs = [(str(r[0]), r[1]) for r in rows if r and r[0] is not None]
+        filtered = [
+            (s, c) for s, c in raw_pairs if c not in _INFRA_PREEMPTION_CATEGORIES
+        ]
+        skipped_infra_count = len(raw_pairs) - len(filtered)
+        statuses = [s for s, _c in filtered]
         bad_count = sum(1 for s in statuses if self._is_bad_outcome(s))
+        window_total = len(raw_pairs)
+
         if bad_count < threshold:
+            # Emit an INFO event when infra rows were filtered so post-
+            # incident CloudWatch queries can confirm the filter worked
+            # even when the breaker did not trip.
+            if skipped_infra_count > 0:
+                self._log.info(
+                    "daemon.circuit_breaker_eval_skipped_infra",
+                    extra={
+                        "event": "circuit_breaker_eval_skipped_infra",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "skipped_infra_count": skipped_infra_count,
+                        "window_total": window_total,
+                        "bad_count": bad_count,
+                        "threshold": threshold,
+                    },
+                )
             return False
 
         # Threshold met. Flip ``concurrency_cap`` to 0 and stamp
@@ -11019,6 +11061,8 @@ class DispatcherDaemon:
                 "previous_cap": current_cap,
                 "was_already_open": was_already_open,
                 "recent_statuses": statuses,
+                "skipped_infra_count": skipped_infra_count,
+                "window_total": window_total,
             },
         )
 

--- a/scripts/dispatcher/tests/test_daemon_circuit_breaker.py
+++ b/scripts/dispatcher/tests/test_daemon_circuit_breaker.py
@@ -340,16 +340,16 @@ class TestEvaluateCircuitBreaker:
         # fetchall — but _FakeCursor uses fetchall_queue separately.
         conn.cursor_instance.fetchall_queue.append(
             [
-                ("failed",),
-                ("failed",),
-                ("failed",),
-                ("plan_blocked",),
-                ("needs_review",),
-                ("succeeded",),
-                ("succeeded",),
-                ("succeeded",),
-                ("succeeded",),
-                ("succeeded",),
+                ("failed", None),
+                ("failed", None),
+                ("failed", None),
+                ("plan_blocked", None),
+                ("needs_review", None),
+                ("succeeded", None),
+                ("succeeded", None),
+                ("succeeded", None),
+                ("succeeded", None),
+                ("succeeded", None),
             ]
         )
         # ``current_cap = self._cb_config_int("concurrency_cap", -1)``
@@ -390,16 +390,16 @@ class TestEvaluateCircuitBreaker:
         self._stub_config_reads(conn)
         conn.cursor_instance.fetchall_queue.append(
             [
-                ("failed",),
-                ("failed",),
-                ("failed",),
-                ("failed",),
-                ("succeeded",),
-                ("succeeded",),
-                ("succeeded",),
-                ("succeeded",),
-                ("succeeded",),
-                ("succeeded",),
+                ("failed", None),
+                ("failed", None),
+                ("failed", None),
+                ("failed", None),
+                ("succeeded", None),
+                ("succeeded", None),
+                ("succeeded", None),
+                ("succeeded", None),
+                ("succeeded", None),
+                ("succeeded", None),
             ]
         )
 
@@ -419,7 +419,7 @@ class TestEvaluateCircuitBreaker:
         """Regression: all 10 recent successes → circuit stays closed."""
         d, conn, handler = _make_daemon(tmp_path)
         self._stub_config_reads(conn)
-        conn.cursor_instance.fetchall_queue.append([("succeeded",)] * 10)
+        conn.cursor_instance.fetchall_queue.append([("succeeded", None)] * 10)
 
         tripped = d._evaluate_circuit_breaker("agent-x")
 
@@ -479,7 +479,7 @@ class TestIdempotence:
             (0,),  # current_cap already 0 → was_already_open=True
         ]
         conn.cursor_instance.fetchall_queue.append(
-            [("failed",)] * 5 + [("succeeded",)] * 5
+            [("failed", None)] * 5 + [("succeeded", None)] * 5
         )
 
         telegram_calls: list[Any] = []
@@ -646,16 +646,16 @@ class TestAcceptanceCriteria:
         # 25 min window has 10 terminals: 5 bad + 5 good.
         conn.cursor_instance.fetchall_queue.append(
             [
-                ("failed",),
-                ("crashed",),
-                ("failed",),
-                ("plan_blocked",),
-                ("needs_review",),
-                ("succeeded",),
-                ("succeeded",),
-                ("succeeded",),
-                ("succeeded",),
-                ("succeeded",),
+                ("failed", None),
+                ("crashed", None),
+                ("failed", None),
+                ("plan_blocked", None),
+                ("needs_review", None),
+                ("succeeded", None),
+                ("succeeded", None),
+                ("succeeded", None),
+                ("succeeded", None),
+                ("succeeded", None),
             ]
         )
 
@@ -716,7 +716,7 @@ class TestAcceptanceCriteria:
             (5,),
         ]
         conn.cursor_instance.fetchall_queue.append(
-            [("failed",)] * 4 + [("succeeded",)] * 6
+            [("failed", None)] * 4 + [("succeeded", None)] * 6
         )
 
         tripped = d._evaluate_circuit_breaker("agent-y")
@@ -926,6 +926,12 @@ class TestCircuitBreakerQueryShape:
         assert "kind = 'task'" not in sql, (
             f"scan SQL should not carry a kind filter post-#2927: {sql!r}"
         )
+        # #2942: the query now includes a correlated subquery that pulls
+        # the latest failure category for each outcome row.
+        assert "dispatcher.failures" in sql, (
+            f"scan SQL should include correlated subquery against "
+            f"dispatcher.failures post-#2942: {sql!r}"
+        )
 
     def test_five_crashed_rows_trip_breaker(self, tmp_path: Path) -> None:
         """Regression: 5 ``crashed`` rows in the window trip the breaker.
@@ -936,13 +942,212 @@ class TestCircuitBreakerQueryShape:
         """
         d, conn, handler = _make_daemon(tmp_path)
         self._stub_config_reads(conn)
-        conn.cursor_instance.fetchall_queue.append([("crashed",)] * 5)
+        conn.cursor_instance.fetchall_queue.append([("crashed", None)] * 5)
         # ``current_cap`` read after the scan / threshold check.
         conn.cursor_instance.fetch_queue.append((1,))
 
         tripped = d._evaluate_circuit_breaker("daemon-task-agent")
 
         assert tripped is True
+        cap_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0]
+            and "concurrency_cap" in e[0]
+            and e[1] == ("circuit_breaker",)
+        ]
+        assert len(cap_updates) == 1
+        opened = handler.events("circuit_breaker_opened")
+        assert len(opened) == 1
+        assert opened[0].bad_count == 5  # type: ignore[attr-defined]
+
+
+# --------------------------------------------------------------------------
+# Infra-preemption filter — issue #2942.
+# The circuit breaker must skip daemon_restart_abandoned and
+# paused_by_killswitch outcomes when counting bad terminals so a
+# stretch of dispatcher redeploys does not falsely trip the breaker.
+# --------------------------------------------------------------------------
+
+
+class TestInfraPreemptionFilter:
+    """#2942: infra-preempted outcomes are filtered before the bad-count check."""
+
+    def _stub_config_reads(
+        self,
+        conn: _FakeConnection,
+        *,
+        enabled: Any = True,
+        window_minutes: Any = 30,
+        window_size: Any = 10,
+        threshold: Any = 5,
+    ) -> None:
+        """Queue up the four config SELECTs in order."""
+        conn.cursor_instance.fetch_queue.extend(
+            [
+                (enabled,),
+                (window_minutes,),
+                (window_size,),
+                (threshold,),
+            ]
+        )
+
+    def test_breaker_skips_infra_preempted_outcomes(self, tmp_path: Path) -> None:
+        """AC1: 4 daemon_restart_abandoned + 2 subprocess_crash — only 2 count.
+
+        threshold=5, bad_count after filter=2 → breaker does NOT flip.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        self._stub_config_reads(conn, threshold=5)
+        # 4 infra rows (daemon_restart_abandoned) + 2 genuine (subprocess_crash).
+        conn.cursor_instance.fetchall_queue.append(
+            [
+                ("crashed", daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED),
+                ("crashed", daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED),
+                ("crashed", daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED),
+                ("crashed", daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED),
+                ("crashed", daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH),
+                ("crashed", daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH),
+            ]
+        )
+
+        tripped = d._evaluate_circuit_breaker("agent-infra")
+
+        assert tripped is False, (
+            "infra-preempted outcomes must not count toward the bad-outcome budget"
+        )
+        # No cap flip.
+        cap_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0] and "concurrency_cap" in e[0]
+        ]
+        assert cap_updates == [], "cap_flip must not fire when only 2 genuine bad rows"
+        assert handler.events("circuit_breaker_opened") == []
+
+    def test_breaker_skips_paused_by_killswitch_outcomes(self, tmp_path: Path) -> None:
+        """AC1: paused_by_killswitch is symmetric to daemon_restart_abandoned.
+
+        4 killswitch + 2 subprocess_crash; threshold=5 → only 2 genuine
+        rows after filter; breaker stays closed.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        self._stub_config_reads(conn, threshold=5)
+        conn.cursor_instance.fetchall_queue.append(
+            [
+                ("failed", daemon.FAILURE_CATEGORY_PAUSED_BY_KILLSWITCH),
+                ("failed", daemon.FAILURE_CATEGORY_PAUSED_BY_KILLSWITCH),
+                ("failed", daemon.FAILURE_CATEGORY_PAUSED_BY_KILLSWITCH),
+                ("failed", daemon.FAILURE_CATEGORY_PAUSED_BY_KILLSWITCH),
+                ("crashed", daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH),
+                ("crashed", daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH),
+            ]
+        )
+
+        tripped = d._evaluate_circuit_breaker("agent-killswitch")
+
+        assert tripped is False, (
+            "paused_by_killswitch outcomes must not count toward the bad-outcome budget"
+        )
+        cap_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.config" in e[0] and "concurrency_cap" in e[0]
+        ]
+        assert cap_updates == []
+        assert handler.events("circuit_breaker_opened") == []
+
+    def test_breaker_eval_logs_skipped_infra_count_when_not_tripping(
+        self, tmp_path: Path
+    ) -> None:
+        """AC3: skipped_infra_count observability — INFO event emitted when not tripping.
+
+        3 infra + 1 genuine; bad_count=1 < threshold=5 → no flip, but
+        circuit_breaker_eval_skipped_infra is logged with skipped_infra_count=3.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        self._stub_config_reads(conn, threshold=5)
+        conn.cursor_instance.fetchall_queue.append(
+            [
+                ("crashed", daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED),
+                ("crashed", daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED),
+                ("failed", daemon.FAILURE_CATEGORY_PAUSED_BY_KILLSWITCH),
+                ("crashed", daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH),
+            ]
+        )
+
+        tripped = d._evaluate_circuit_breaker("agent-obs")
+
+        assert tripped is False
+        skipped_events = handler.events("circuit_breaker_eval_skipped_infra")
+        assert len(skipped_events) == 1, (
+            "expected circuit_breaker_eval_skipped_infra event when infra rows skipped"
+        )
+        ev = skipped_events[0]
+        assert ev.skipped_infra_count == 3  # type: ignore[attr-defined]
+        assert ev.window_total == 4  # type: ignore[attr-defined]
+        assert ev.bad_count == 1  # type: ignore[attr-defined]
+        assert ev.threshold == 5  # type: ignore[attr-defined]
+
+    def test_breaker_opened_log_includes_skipped_infra_count(
+        self, tmp_path: Path
+    ) -> None:
+        """AC3: circuit_breaker_opened extras carry skipped_infra_count + window_total.
+
+        2 infra + 5 genuine (threshold=5) → breaker trips. The opened
+        log event must include skipped_infra_count=2 and window_total=7.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        self._stub_config_reads(conn, threshold=5)
+        conn.cursor_instance.fetchall_queue.append(
+            [
+                ("crashed", daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED),
+                ("crashed", daemon.FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED),
+                ("crashed", daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH),
+                ("crashed", daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH),
+                ("failed", None),
+                ("failed", None),
+                ("crashed", None),
+            ]
+        )
+        # current_cap read after threshold met.
+        conn.cursor_instance.fetch_queue.append((1,))
+
+        tripped = d._evaluate_circuit_breaker("agent-obs2")
+
+        assert tripped is True
+        opened = handler.events("circuit_breaker_opened")
+        assert len(opened) == 1
+        ev = opened[0]
+        assert ev.bad_count == 5  # type: ignore[attr-defined]
+        assert ev.skipped_infra_count == 2  # type: ignore[attr-defined]
+        assert ev.window_total == 7  # type: ignore[attr-defined]
+
+    def test_breaker_still_trips_on_pure_genuine_streak(self, tmp_path: Path) -> None:
+        """AC2: regression guard — genuine failure streak still trips the breaker.
+
+        5 subprocess_crash rows with no infra category → all 5 count;
+        bad_count=5 == threshold=5 → breaker opens.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        self._stub_config_reads(conn, threshold=5)
+        conn.cursor_instance.fetchall_queue.append(
+            [
+                ("crashed", daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH),
+                ("crashed", daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH),
+                ("crashed", daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH),
+                ("failed", daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH),
+                ("failed", daemon.FAILURE_CATEGORY_SUBPROCESS_CRASH),
+            ]
+        )
+        # current_cap read after threshold met.
+        conn.cursor_instance.fetch_queue.append((1,))
+
+        tripped = d._evaluate_circuit_breaker("agent-genuine")
+
+        assert tripped is True, (
+            "a genuine failure streak must still trip the breaker after the infra filter"
+        )
         cap_updates = [
             e
             for e in conn.cursor_instance.executed


### PR DESCRIPTION
## Summary

The circuit breaker was counting dispatcher restarts (daemon_restart_abandoned) and operator killswitches (paused_by_killswitch) toward its bad-terminal-streak threshold. A tight cadence of dispatcher deploys in rapid succession could trip the breaker even though each "failure" was infrastructure preemption, not an agent-driven failure.

This fix reuses the `_INFRA_PREEMPTION_CATEGORIES` constant (introduced in #2936 for retry-budget filtering) to filter infra-preempted rows before counting toward the circuit breaker. A correlated subquery joins each terminal outcome with its agent's most-recent failure category; outcomes in the preemption set are excluded from the bad-count calculation.

Closes #2942

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest`) — 726 tests pass, including 5 new tests in TestInfraPreemptionFilter
- [x] CI green

### Post-deploy verification

- [ ] Force a deploy storm on dev (merge 3+ dispatcher PRs in quick succession)
- [ ] Confirm `dispatcher.config.concurrency_cap` stays at 1 (not flipped to 0)
- [ ] Confirm `cap_flipped_by` stays null (no circuit_breaker entry)
- [ ] Verify CloudWatch Logs Insights query finds `circuit_breaker_eval_skipped_infra` events with correct `skipped_infra_count` and `window_total` fields
- [ ] Verification evidence posted on #2942 (see /task-v2-verify output)
