### PR TITLE
fix(web/admin): distinct ↺ glyph for infra-preempted outcomes (#2947)

### DIFF
--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -19,9 +19,9 @@ interface RecentCompletionsPanelProps {
  * The "Recently completed" panel (#2805 §1.5). Newest terminal-state
  * agents (succeeded / failed / crashed / plan_blocked / needs_review) in
  * the operator's recent history. Each row links to the issue and, when
- * available, the PR. The two correct-outcome triage terminals render
- * with their own chips to keep them visually separated from genuine
- * failures:
+ * available, the PR. The correct-outcome and infra-preempted terminals
+ * render with their own chips to keep them visually separated from
+ * genuine failures:
  *
  * - `plan_blocked` (#2857) — neutral muted chip (⊘). Operator-
  *   informational; no action expected unless the issue needs reshaping.
@@ -30,6 +30,11 @@ interface RecentCompletionsPanelProps {
  *   summary flagged unmet AC. The yellow is distinct from amber
  *   (`crashed`) so the operator can scan the panel and separate
  *   "review my draft PR" from "something crashed, diagnose this".
+ * - *infra-preempted* (#2947) — amber chip (↺). A `failed` row whose
+ *   `failureSummary` matches one of the canonical infra-preemption
+ *   strings (``"dispatcher restarted"`` / ``"manually stopped"``).
+ *   The dispatcher itself interrupted the agent; it will auto-resume
+ *   on the next tick. NOT an operator action item.
  *
  * Borderless. Lives in the right column below Active agents.
  *

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentFailuresPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentFailuresPanel.tsx
@@ -3,7 +3,12 @@
 import { SECTION_HEADING } from '@/lib/typography';
 import type { DispatcherFailure } from '@/lib/dispatcher-queries';
 import { formatRelativeTime, groupFailuresByCategory } from './format-helpers';
-import { IssueLink } from './ui-primitives';
+import {
+  INFRA_PREEMPTED_CATEGORIES,
+  INFRA_PREEMPTED_CHIP_CLASSES,
+  INFRA_PREEMPTED_GLYPH,
+  IssueLink,
+} from './ui-primitives';
 
 interface RecentFailuresPanelProps {
   failures: readonly DispatcherFailure[];
@@ -11,10 +16,29 @@ interface RecentFailuresPanelProps {
   nowMs?: number;
 }
 
+// #2947: red-✗ chip for non-infra-preempted failure categories. Shares
+// the visual grammar with `OutcomePill`'s `failed` chip so the two
+// panels read as a single outcome vocabulary. Infra-preempted rows
+// (``daemon_restart_abandoned`` / ``paused_by_killswitch``) render the
+// amber ↺ glyph instead (see ``INFRA_PREEMPTED_*`` imports above) —
+// per operator direction, these rows DO still appear in the Recent
+// failures roll-up (useful signal about dispatcher churn) but the
+// different glyph+color makes it obvious at a glance that they aren't
+// real operator action items.
+const FAILURE_GLYPH = '\u2717';
+const FAILURE_CHIP_CLASSES =
+  'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300';
+
 /**
  * Recent failures panel (#2805 §1.7) — same data, borderless. Category
  * renders as a muted pill; most-recent timestamp is a relative string
  * with the raw ISO on hover.
+ *
+ * #2947: adds a leading glyph column that keys off `category`. Infra-
+ * preempted categories (``daemon_restart_abandoned`` /
+ * ``paused_by_killswitch``) render ↺ amber; every other failure
+ * category renders ✗ red. Matches the outcome-pill vocabulary in
+ * ``RecentCompletionsPanel`` so the two panels read together.
  */
 export function RecentFailuresPanel({ failures, nowMs }: RecentFailuresPanelProps) {
   const groups = groupFailuresByCategory(failures);
@@ -34,6 +58,10 @@ export function RecentFailuresPanel({ failures, nowMs }: RecentFailuresPanelProp
         <table className="w-full text-sm">
           <thead>
             <tr className="text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <th scope="col" className="py-2 font-medium">
+                {/* Glyph column — visually narrow, no header text. */}
+                <span className="sr-only">Severity</span>
+              </th>
               <th scope="col" className="py-2 font-medium">Category</th>
               <th scope="col" className="py-2 font-medium">Count</th>
               <th scope="col" className="py-2 font-medium">Most recent</th>
@@ -41,32 +69,53 @@ export function RecentFailuresPanel({ failures, nowMs }: RecentFailuresPanelProp
             </tr>
           </thead>
           <tbody>
-            {groups.map((group) => (
-              <tr
-                key={group.category}
-                className="border-t border-border hover:bg-muted/50"
-              >
-                <td className="py-2">
-                  <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
-                    {group.category}
-                  </span>
-                </td>
-                <td className="py-2 font-mono text-foreground">{group.count}</td>
-                <td
-                  className="py-2 text-xs text-muted-foreground"
-                  title={group.mostRecent.ts}
+            {groups.map((group) => {
+              const infra = INFRA_PREEMPTED_CATEGORIES.has(group.category);
+              const glyph = infra ? INFRA_PREEMPTED_GLYPH : FAILURE_GLYPH;
+              const chipClasses = infra
+                ? INFRA_PREEMPTED_CHIP_CLASSES
+                : FAILURE_CHIP_CLASSES;
+              const label = infra ? 'infra preempted' : 'failed';
+              const testId = infra
+                ? 'failure-glyph-infra_preempted'
+                : 'failure-glyph-failed';
+              return (
+                <tr
+                  key={group.category}
+                  className="border-t border-border hover:bg-muted/50"
                 >
-                  {formatRelativeTime(group.mostRecent.ts, nowMs)}
-                </td>
-                <td className="py-2">
-                  {group.mostRecent.issueNumber !== null ? (
-                    <IssueLink number={group.mostRecent.issueNumber} />
-                  ) : (
-                    <span className="text-muted-foreground">&mdash;</span>
-                  )}
-                </td>
-              </tr>
-            ))}
+                  <td className="py-2 pr-2">
+                    <span
+                      aria-label={label}
+                      title={label}
+                      className={`inline-flex h-5 w-5 items-center justify-center rounded-full text-xs ${chipClasses}`}
+                      data-testid={testId}
+                    >
+                      {glyph}
+                    </span>
+                  </td>
+                  <td className="py-2">
+                    <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+                      {group.category}
+                    </span>
+                  </td>
+                  <td className="py-2 font-mono text-foreground">{group.count}</td>
+                  <td
+                    className="py-2 text-xs text-muted-foreground"
+                    title={group.mostRecent.ts}
+                  >
+                    {formatRelativeTime(group.mostRecent.ts, nowMs)}
+                  </td>
+                  <td className="py-2">
+                    {group.mostRecent.issueNumber !== null ? (
+                      <IssueLink number={group.mostRecent.issueNumber} />
+                    ) : (
+                      <span className="text-muted-foreground">&mdash;</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       )}

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
@@ -170,6 +170,58 @@ describe('RecentCompletionsPanel', () => {
     expect(screen.queryByText(summary)).not.toBeInTheDocument();
   });
 
+  // --- #2947 — infra-preempted override at the panel level.
+  it('#2947: renders ↺ amber for rows with the "dispatcher restarted" summary', () => {
+    const items = [
+      completion({
+        agentId: 'agent-infra-restart',
+        issueNumber: 2947,
+        status: 'failed',
+        prNumber: null,
+        failureSummary: 'dispatcher restarted',
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    // The pill re-skinned to the infra-preempted testid; a red ✗
+    // `outcome-pill-failed` must NOT appear on this row.
+    expect(
+      screen.getByTestId('outcome-pill-infra_preempted'),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('outcome-pill-failed')).not.toBeInTheDocument();
+  });
+
+  it('#2947: renders ↺ amber for rows with the "manually stopped" summary', () => {
+    const items = [
+      completion({
+        agentId: 'agent-infra-killswitch',
+        issueNumber: 2947,
+        status: 'failed',
+        prNumber: null,
+        failureSummary: 'manually stopped',
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    const pill = screen.getByTestId('outcome-pill-infra_preempted');
+    expect(pill.textContent).toBe('\u21BA');
+    expect(pill.className).toContain('bg-amber');
+  });
+
+  it('#2947: leaves the tooltip unchanged — the visual glyph + color is the fix', () => {
+    // Per the issue body: "Tooltip text is unchanged — the visual
+    // glyph + color is the fix." Operators still get the exact
+    // canonical string on hover.
+    const items = [
+      completion({
+        agentId: 'agent-tooltip',
+        status: 'failed',
+        failureSummary: 'dispatcher restarted',
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    const pill = screen.getByTestId('outcome-pill-infra_preempted');
+    expect(pill.getAttribute('title')).toBe('dispatcher restarted');
+  });
+
   // --- #2932 — relative-time cell (re-introduced post-#2818 density pass).
   it('#2932: places the relative-time cell AFTER the cost footnote in DOM order', () => {
     const items = [

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentFailuresPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentFailuresPanel.test.tsx
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { RecentFailuresPanel } from '../RecentFailuresPanel';
+import type { DispatcherFailure } from '@/lib/dispatcher-queries';
+
+// Fixed `nowMs` for deterministic relative-time rendering.
+const NOW_MS = Date.parse('2026-04-20T12:00:00Z');
+
+function makeFailure(overrides: Partial<DispatcherFailure> = {}): DispatcherFailure {
+  return {
+    failureId: '1',
+    agentId: 'agent-1',
+    category: 'subprocess_crash',
+    detectedBy: 'scheduler',
+    details: {},
+    ts: new Date(NOW_MS - 5 * 60 * 1000).toISOString(),
+    issueNumber: 1234,
+    ...overrides,
+  };
+}
+
+describe('RecentFailuresPanel', () => {
+  it('renders the empty state when there are no failures', () => {
+    render(<RecentFailuresPanel failures={[]} nowMs={NOW_MS} />);
+    expect(
+      screen.getByText(/no failures in the last 24 hours/i),
+    ).toBeInTheDocument();
+  });
+
+  // #2947: every failure category gets a leading glyph so operators can
+  // distinguish real failures from infra preemption at a glance.
+  describe('glyph column (#2947)', () => {
+    it('renders red ✗ for ordinary failure categories', () => {
+      render(
+        <RecentFailuresPanel
+          failures={[makeFailure({ category: 'subprocess_crash' })]}
+          nowMs={NOW_MS}
+        />,
+      );
+      const glyph = screen.getByTestId('failure-glyph-failed');
+      expect(glyph.textContent).toBe('\u2717');
+      expect(glyph.className).toContain('bg-red');
+      expect(glyph.className).not.toMatch(/bg-amber/);
+    });
+
+    it('renders amber ↺ for daemon_restart_abandoned', () => {
+      render(
+        <RecentFailuresPanel
+          failures={[makeFailure({ category: 'daemon_restart_abandoned' })]}
+          nowMs={NOW_MS}
+        />,
+      );
+      const glyph = screen.getByTestId('failure-glyph-infra_preempted');
+      expect(glyph.textContent).toBe('\u21BA');
+      expect(glyph.className).toContain('bg-amber');
+      expect(glyph.className).not.toMatch(/bg-red/);
+      // aria-label is a neutral descriptor, not "failed".
+      expect(glyph.getAttribute('aria-label')).toBe('infra preempted');
+    });
+
+    it('renders amber ↺ for paused_by_killswitch', () => {
+      render(
+        <RecentFailuresPanel
+          failures={[makeFailure({ category: 'paused_by_killswitch' })]}
+          nowMs={NOW_MS}
+        />,
+      );
+      const glyph = screen.getByTestId('failure-glyph-infra_preempted');
+      expect(glyph.textContent).toBe('\u21BA');
+      expect(glyph.className).toContain('bg-amber');
+    });
+
+    it('keeps infra-preempted rows IN the table (operator wants the signal)', () => {
+      // Per the #2947 issue body: "Per operator direction, infra-preempted
+      // outcomes should still appear in the Recent Failures (last 24h)
+      // roll-up — they're useful signal about dispatcher churn even if
+      // they don't represent code bugs. Don't filter them out."
+      render(
+        <RecentFailuresPanel
+          failures={[
+            makeFailure({ category: 'daemon_restart_abandoned' }),
+            makeFailure({
+              failureId: '2',
+              category: 'paused_by_killswitch',
+            }),
+            makeFailure({
+              failureId: '3',
+              category: 'subprocess_crash',
+            }),
+          ]}
+          nowMs={NOW_MS}
+        />,
+      );
+      // Both infra categories + the real failure category are rendered.
+      expect(screen.getByText('daemon_restart_abandoned')).toBeInTheDocument();
+      expect(screen.getByText('paused_by_killswitch')).toBeInTheDocument();
+      expect(screen.getByText('subprocess_crash')).toBeInTheDocument();
+
+      // Two amber ↺ glyphs and one red ✗ glyph.
+      expect(screen.getAllByTestId('failure-glyph-infra_preempted')).toHaveLength(
+        2,
+      );
+      expect(screen.getAllByTestId('failure-glyph-failed')).toHaveLength(1);
+    });
+
+    it('groups by category so the count column aggregates per category', () => {
+      render(
+        <RecentFailuresPanel
+          failures={[
+            makeFailure({ failureId: '1', category: 'daemon_restart_abandoned' }),
+            makeFailure({ failureId: '2', category: 'daemon_restart_abandoned' }),
+            makeFailure({ failureId: '3', category: 'daemon_restart_abandoned' }),
+            makeFailure({ failureId: '4', category: 'subprocess_crash' }),
+          ]}
+          nowMs={NOW_MS}
+        />,
+      );
+      // Row for daemon_restart_abandoned shows count=3; grab its row
+      // and assert the count cell within.
+      const daemonRestartRow = screen.getByText('daemon_restart_abandoned')
+        .closest('tr')!;
+      expect(within(daemonRestartRow).getByText('3')).toBeInTheDocument();
+      const subprocessCrashRow = screen.getByText('subprocess_crash')
+        .closest('tr')!;
+      expect(within(subprocessCrashRow).getByText('1')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { IssueLink, OutcomePill, PriorityBadge, PRLink } from '../ui-primitives';
+import {
+  INFRA_PREEMPTED_CATEGORIES,
+  INFRA_PREEMPTED_GLYPH,
+  INFRA_PREEMPTED_SUMMARIES,
+  IssueLink,
+  OutcomePill,
+  PriorityBadge,
+  PRLink,
+} from '../ui-primitives';
 
 describe('IssueLink', () => {
   it('renders an anchor to the github issue that opens in a new tab', () => {
@@ -222,6 +230,107 @@ describe('OutcomePill', () => {
       expect(pill.getAttribute('title')).toBe(
         "future terminal we haven't seen yet",
       );
+    });
+  });
+
+  // #2947: two `dispatcher.failures.category` values represent
+  // infra preemption rather than real failure — `daemon_restart_abandoned`
+  // (dispatcher cycled mid-agent; retry on next tick) and
+  // `paused_by_killswitch` (operator hit the global kill switch). The
+  // daemon writes exactly two canonical `failure_summary` strings for
+  // these — "dispatcher restarted" and "manually stopped" — and the pill
+  // re-skins to amber ↺ to signal "will auto-resume, not an action item".
+  describe('infra-preempted override (#2947)', () => {
+    it('renders ↺ in amber for "dispatcher restarted" (daemon_restart_abandoned)', () => {
+      render(
+        <OutcomePill status="failed" failureSummary="dispatcher restarted" />,
+      );
+      const pill = screen.getByTestId('outcome-pill-infra_preempted');
+      expect(pill.textContent).toBe(INFRA_PREEMPTED_GLYPH);
+      expect(pill.textContent).toBe('\u21BA');
+      expect(pill.className).toContain('bg-amber');
+      expect(pill.className).not.toMatch(/bg-red/);
+      // aria-label is a neutral descriptor; operator-friendly.
+      expect(pill.getAttribute('aria-label')).toBe('infra preempted');
+      expect(pill.getAttribute('title')).toBe('dispatcher restarted');
+    });
+
+    it('renders ↺ in amber for "manually stopped" (paused_by_killswitch)', () => {
+      render(
+        <OutcomePill status="failed" failureSummary="manually stopped" />,
+      );
+      const pill = screen.getByTestId('outcome-pill-infra_preempted');
+      expect(pill.textContent).toBe('\u21BA');
+      expect(pill.className).toContain('bg-amber');
+      expect(pill.className).not.toMatch(/bg-red/);
+      expect(pill.getAttribute('title')).toBe('manually stopped');
+    });
+
+    it('trims whitespace before matching (defensive against upstream drift)', () => {
+      render(
+        <OutcomePill
+          status="failed"
+          failureSummary="  manually stopped  "
+        />,
+      );
+      const pill = screen.getByTestId('outcome-pill-infra_preempted');
+      expect(pill.textContent).toBe('\u21BA');
+      expect(pill.getAttribute('title')).toBe('manually stopped');
+    });
+
+    it('falls back to red ✗ for a non-infra failureSummary', () => {
+      render(
+        <OutcomePill
+          status="failed"
+          failureSummary="subprocess crashed (turn limit)"
+        />,
+      );
+      // Regular failed path — red ✗, not amber ↺.
+      const pill = screen.getByTestId('outcome-pill-failed');
+      expect(pill.textContent).toBe('\u2717');
+      expect(pill.className).toContain('bg-red');
+    });
+
+    it('does not apply the override when failureSummary is null', () => {
+      render(<OutcomePill status="failed" failureSummary={null} />);
+      const pill = screen.getByTestId('outcome-pill-failed');
+      expect(pill.textContent).toBe('\u2717');
+      expect(pill.className).toContain('bg-red');
+    });
+
+    it('overrides crashed → ↺ too, because the category can land on either status', () => {
+      // If a future code path writes `status='crashed'` for an
+      // infra-preempted row (today the daemon uses `failed`, but we
+      // intentionally don't couple to that), the pill should still
+      // re-skin to ↺ amber rather than keep the `⚠ crashed` look.
+      render(
+        <OutcomePill status="crashed" failureSummary="dispatcher restarted" />,
+      );
+      const pill = screen.getByTestId('outcome-pill-infra_preempted');
+      expect(pill.textContent).toBe('\u21BA');
+      expect(pill.className).toContain('bg-amber');
+    });
+
+    it('exports exactly the two canonical summary strings', () => {
+      // Guard rail: the set must stay in lockstep with the daemon's
+      // `_NO_TAIL_CATEGORY_SUMMARIES` (see
+      // `scripts/dispatcher/daemon.py`). Extending this set requires
+      // coordinating with the daemon; shrinking it causes silent
+      // regressions on admin-page rows.
+      expect(INFRA_PREEMPTED_SUMMARIES.size).toBe(2);
+      expect(INFRA_PREEMPTED_SUMMARIES.has('dispatcher restarted')).toBe(true);
+      expect(INFRA_PREEMPTED_SUMMARIES.has('manually stopped')).toBe(true);
+    });
+
+    it('exports exactly the two canonical category strings', () => {
+      // Same guard rail for `dispatcher.failures.category` values,
+      // used by `RecentFailuresPanel` which keys off category
+      // directly.
+      expect(INFRA_PREEMPTED_CATEGORIES.size).toBe(2);
+      expect(INFRA_PREEMPTED_CATEGORIES.has('daemon_restart_abandoned')).toBe(
+        true,
+      );
+      expect(INFRA_PREEMPTED_CATEGORIES.has('paused_by_killswitch')).toBe(true);
     });
   });
 });

--- a/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
@@ -90,7 +90,8 @@ export function PriorityBadge({ priority }: { priority: string | null }) {
 
 // ---------------------------------------------------------------------------
 // Outcome glyph pill — succeeded (✓ green), failed (✗ red), crashed (⚠ amber),
-// plan_blocked (⊘ neutral — #2857), needs_review (◐ yellow — #2856).
+// plan_blocked (⊘ neutral — #2857), needs_review (◐ yellow — #2856),
+// infra-preempted (↺ amber — #2947).
 //
 // Colour assignment intentionally keeps red reserved for genuine failure
 // and amber reserved for the crash-category anomaly. `plan_blocked`
@@ -108,7 +109,64 @@ export function PriorityBadge({ priority }: { priority: string | null }) {
 // separate "review my draft PR" from "something crashed, diagnose
 // this". The glyph ◐ (half-circle) is the semantic anchor: ralph
 // did half the work, you do the other half (review + merge).
+//
+// `infra_preempted` is a *derived* sub-category of `failed` for the two
+// infra-preemption categories in ``scripts/dispatcher/daemon.py``'s
+// ``_INFRA_PREEMPTION_CATEGORIES`` frozenset —
+// ``daemon_restart_abandoned`` and ``paused_by_killswitch``. These
+// agents didn't fail in any code/runtime sense; the dispatcher itself
+// interrupted them (restart recovery, or operator hit the killswitch)
+// and they will resume on the next tick. Rendering them as red ✗
+// misleads operators into treating them as actionable — which is the
+// opposite of the truth. They earn ↺ (counterclockwise arrow) in amber
+// to signal "will auto-resume; not an operator action item".
+//
+// Detection is pattern-based on `failureSummary`. The daemon writes
+// exactly two canonical strings for these categories —
+// ``"dispatcher restarted"`` (daemon_restart_abandoned) and
+// ``"manually stopped"`` (paused_by_killswitch) — from
+// ``_NO_TAIL_CATEGORY_SUMMARIES`` (issues #2924 / #2935). The resolver
+// surfaces these verbatim through ``failureSummary``. Pattern-matching
+// on this closed set is robust because the daemon has no other code
+// path that can produce these exact strings for a failed row. If the
+// daemon ever changes the strings, the pill falls back to the plain
+// red ✗ — a soft regression, not a crash.
 // ---------------------------------------------------------------------------
+
+/**
+ * Canonical failure-summary strings produced by the dispatcher daemon
+ * for rows whose `dispatcher.failures.category` is in
+ * ``_INFRA_PREEMPTION_CATEGORIES``. Mirrors
+ * ``_NO_TAIL_CATEGORY_SUMMARIES`` in ``scripts/dispatcher/daemon.py``.
+ *
+ * Export for re-use by panels that render their own glyph (e.g. the
+ * Recent failures roll-up, which keys off `category` directly and
+ * doesn't go through `OutcomePill`). Issue #2947.
+ */
+export const INFRA_PREEMPTED_SUMMARIES: ReadonlySet<string> = new Set([
+  'dispatcher restarted',
+  'manually stopped',
+]);
+
+/**
+ * Canonical `dispatcher.failures.category` values that are
+ * infra-preempted (will auto-resume; not operator action items).
+ * Mirrors ``_INFRA_PREEMPTION_CATEGORIES`` in
+ * ``scripts/dispatcher/daemon.py``. Used by panels (e.g.
+ * ``RecentFailuresPanel``) that key off `category` directly rather
+ * than matching on `failureSummary`. Issue #2947.
+ */
+export const INFRA_PREEMPTED_CATEGORIES: ReadonlySet<string> = new Set([
+  'daemon_restart_abandoned',
+  'paused_by_killswitch',
+]);
+
+/** Shared amber chip class for the ↺ infra-preempted glyph. Issue #2947. */
+export const INFRA_PREEMPTED_CHIP_CLASSES =
+  'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200';
+
+/** Shared ↺ glyph (U+21BA, ANTICLOCKWISE OPEN CIRCLE ARROW). Issue #2947. */
+export const INFRA_PREEMPTED_GLYPH = '\u21BA';
 
 type OutcomeStatus =
   | 'succeeded'
@@ -176,19 +234,44 @@ export function OutcomePill({
    * We deliberately do NOT render an always-visible second line — the
    * "Recently completed" panel's density-first design (#2818) is the
    * constraint. Tooltip-only.
+   *
+   * Issue #2947: when the summary exactly matches one of
+   * ``INFRA_PREEMPTED_SUMMARIES``, the pill re-skins to amber ↺
+   * (infra-preempted) instead of red ✗ / amber ⚠ — the agent was
+   * preempted by the dispatcher, not an operator action item.
    */
   failureSummary?: string | null;
 }) {
   const info = OUTCOME_STYLES[status as OutcomeStatus];
+  const trimmedSummary =
+    failureSummary && failureSummary.trim() ? failureSummary.trim() : null;
+  // #2947: infra-preemption override. Daemon writes a short canonical
+  // string (``"dispatcher restarted"`` / ``"manually stopped"``) for
+  // the two `_INFRA_PREEMPTION_CATEGORIES` — those rows should render
+  // ↺ amber regardless of the stored `status` (today always `failed`
+  // for these, but we don't want to couple to that invariant).
+  // Pattern-matching on the closed set in ``INFRA_PREEMPTED_SUMMARIES``
+  // avoids plumbing a new `category` field through the GraphQL type
+  // for what is effectively a display override; any drift in the
+  // daemon's canonical strings just collapses back to the default red
+  // ✗ (a soft regression, not a crash).
+  if (trimmedSummary !== null && INFRA_PREEMPTED_SUMMARIES.has(trimmedSummary)) {
+    return (
+      <span
+        aria-label="infra preempted"
+        title={trimmedSummary}
+        className={`inline-flex h-5 w-5 items-center justify-center rounded-full text-xs ${INFRA_PREEMPTED_CHIP_CLASSES}`}
+        data-testid="outcome-pill-infra_preempted"
+      >
+        {INFRA_PREEMPTED_GLYPH}
+      </span>
+    );
+  }
   if (!info) {
     return (
       <span
         className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-muted text-[10px] text-muted-foreground"
-        title={
-          failureSummary && failureSummary.trim()
-            ? failureSummary.trim()
-            : undefined
-        }
+        title={trimmedSummary ?? undefined}
       >
         ?
       </span>
@@ -200,8 +283,7 @@ export function OutcomePill({
   // summary text mid-row. Sighted operators get the full narrative on
   // hover; assistive-tech users hear "failed" / "crashed" and can
   // navigate to the agent detail page from there.
-  const tooltip =
-    failureSummary && failureSummary.trim() ? failureSummary.trim() : info.label;
+  const tooltip = trimmedSummary ?? info.label;
   return (
     <span
       aria-label={info.label}


### PR DESCRIPTION
## Summary

Adds an amber ↺ outcome chip for the two `_INFRA_PREEMPTION_CATEGORIES`
(`daemon_restart_abandoned`, `paused_by_killswitch`) in both admin
dispatcher panels — Recently Completed (via `OutcomePill`) and Recent
Failures (via a new leading glyph column). Operators can now tell at a
glance which rows represent real failures (red ✗) vs. dispatcher churn
that will auto-resume (amber ↺). Tooltip text is unchanged — visual-only
fix.

Closes #2947

## Design notes for reviewer

- **Glyph choice:** stuck with Unicode `↺` (U+21BA) rather than lucide
  `RotateCw`/`RefreshCw`. The existing outcome vocabulary in
  `ui-primitives.tsx` is 100% Unicode glyphs (✓ ✗ ⚠ ⊘ ◐); mixing a
  lucide icon into the set would be visually inconsistent and need a
  different render path.
- **`✗` vs `⊘` consolidation:** the issue asks me to surface `⊘` usage.
  Current state — `✗` is `failed` (red), `⊘` is `plan_blocked`
  (neutral muted per #2857). These are semantically distinct: `⊘` is
  NOT a failure, it means the plan phase correctly declined to proceed.
  I did NOT consolidate. Collapsing `⊘` into `✗` would conflate
  operator-informational with operator-action-item — the opposite of
  the readability fix this PR ships. If the operator wants `⊘`
  removed, that's a follow-up with a different mental model.
- **Detection mechanism:** pattern-match `failureSummary` against the
  two canonical strings from the daemon's `_NO_TAIL_CATEGORY_SUMMARIES`
  (`ui-primitives.tsx`). Avoids a GraphQL schema change / JOIN. Drift
  risk is low (the strings are tested daemon-side, soft-fail to red ✗
  if they change). `RecentFailuresPanel` keys off `category` directly
  because that field is already on `DispatcherFailure`.
- **Shared constants:** `INFRA_PREEMPTED_SUMMARIES` and
  `INFRA_PREEMPTED_CATEGORIES` are exported from `ui-primitives.tsx`
  with set-size guard tests so silent drift with the daemon surfaces
  loudly.

## Test plan

### Automated checks
- [x] Lint passes (`next lint`)
- [x] Format check passes (N/A — no format script in packages/web)
- [x] Typecheck passes (`tsc --noEmit`)
- [x] Tests pass (141 dispatcher tests / 1320 total, all green)
- [x] Build passes (`next build`)
- [x] CI green (ci-passed SUCCESS; 47 SUCCESS, 36 SKIPPED by path
      filters, 1 CANCELLED smoke test that is not a gating check)

### Post-deploy verification
- [x] Screenshot admin dispatcher page on dev after next daemon
      restart; infra-preempted rows render ↺ in amber (not ✗ red) in
      both Recently Completed and Recent Failures panels.
- [x] Tooltip on infra-preempted row reads exactly
      "dispatcher restarted" or "manually stopped" (unchanged from
      today).
- [x] Verification evidence posted on issue (see comment
      https://github.com/judgemind/judgemind/issues/2947#issuecomment-4284895065).
