### PR TITLE
polish(web/admin): extend category rephrase to Recent Failures table (#2948)

### DIFF
--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -86,12 +86,66 @@ function runRowToGraphQL(row: Row): Record<string, unknown> {
   };
 }
 
+/**
+ * Operator-friendly rephrasing of the machine-readable category tokens
+ * stored in ``dispatcher.failures.category``. Mirrors two Python maps in
+ * ``scripts/dispatcher/daemon.py`` so the admin cockpit renders a single
+ * consistent string whether the category surfaces as a Recently
+ * Completed tooltip (``failure_summary`` — server-rendered in Python)
+ * or as a Recent Failures table cell (``displayCategory`` — rendered
+ * here and returned by the GraphQL surface).
+ *
+ * - ``DispatcherDaemon._CATEGORY_DISPLAY_NAMES`` — daemon.py:4173
+ * - ``DispatcherDaemon._NO_TAIL_CATEGORY_SUMMARIES`` — daemon.py:4156
+ *   (these are short-circuits used inline by ``_build_failure_summary``
+ *   in Python; their LHS tokens also want operator-friendly phrasing
+ *   when rendered in the Recent Failures table)
+ *
+ * Drift risk: this map lives in TypeScript because the GraphQL layer is
+ * TypeScript, so there are two copies of the dictionary — one per
+ * language. Precedent: ``FAILURE_SUMMARY_STATUSES`` above already
+ * mirrors ``_FAILURE_SUMMARY_STATUSES`` from Python. A new token only
+ * needs a rephrase on one side (the operator cares about the rendered
+ * string, not the stored token); if this map goes stale the UI just
+ * falls through to the raw token until it's updated. The Python side is
+ * guarded by ``test_category_display_names_map_contents`` in
+ * ``scripts/dispatcher/tests/test_daemon_failure_summary.py``; the
+ * TypeScript side is guarded by
+ * ``packages/api/tests/dispatcher-enrichment.unit.test.ts``.
+ *
+ * Issue #2948.
+ */
+const CATEGORY_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  // From _CATEGORY_DISPLAY_NAMES (daemon.py:4173):
+  subprocess_turn_limit: 'turn limit reached',
+  subprocess_crash: 'subprocess crashed',
+  subprocess_auth_fail: 'auth failed',
+  ci_red_after_retries: 'CI failed after retries',
+  gh_rate_exhausted: 'GitHub rate limit',
+  stuck_timeout: 'timed out',
+  // From _NO_TAIL_CATEGORY_SUMMARIES (daemon.py:4156) — these are the
+  // "display-only alias" categories that bypass Python's tail-appending
+  // logic. Their LHS tokens still show up in dispatcher.failures.category
+  // rows, so we rephrase them here too for the Recent Failures table:
+  paused_by_killswitch: 'manually stopped',
+  daemon_restart_abandoned: 'dispatcher restarted',
+};
+
+/** Rephrase a raw category token for display. Unknown tokens fall
+ * through verbatim so the operator always sees *something* (and the
+ * cell's `title` attribute preserves the raw token for debugging). */
+function displayCategoryFor(category: string): string {
+  return CATEGORY_DISPLAY_NAMES[category] ?? category;
+}
+
 /** Convert a `dispatcher.failures` row into the GraphQL `DispatcherFailure` shape. */
 function failureRowToGraphQL(row: Row): Record<string, unknown> {
+  const category = typeof row.category === 'string' ? row.category : '';
   return {
     failureId: row.failure_id,
     agentId: row.agent_id,
-    category: row.category,
+    category,
+    displayCategory: displayCategoryFor(category),
     detectedBy: row.detected_by,
     details: row.details ?? {},
     ts: row.ts,
@@ -1195,9 +1249,11 @@ export const dispatcherScalarResolvers = {
 // Internal exports for unit testing.
 export {
   agentRowToGraphQL,
+  CATEGORY_DISPLAY_NAMES,
   coerceNullableNumber,
   commandRowToGraphQL,
   configRowToGraphQL,
+  displayCategoryFor,
   failureRowToGraphQL,
   insertCommandIdempotent,
   normalizeSnapshotJson,

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -85,7 +85,23 @@ export const dispatcherTypeDefs = `#graphql
   type DispatcherFailure {
     failureId: ID!
     agentId: ID
+    """Stored machine-readable category token (e.g.
+    \`subprocess_turn_limit\`, \`daemon_restart_abandoned\`). Used by
+    CloudWatch queries, SQL filters, and retry classification — keep
+    this field available for operator tooling even when surfacing
+    \`displayCategory\` in the UI."""
     category: String!
+    """Operator-friendly rephrasing of \`category\` (e.g.
+    \`subprocess_turn_limit\` → \`turn limit reached\`). Computed
+    server-side from the display-name map in
+    packages/api/src/graphql/dispatcher/resolvers.ts (which mirrors
+    DispatcherDaemon._CATEGORY_DISPLAY_NAMES and
+    _NO_TAIL_CATEGORY_SUMMARIES in scripts/dispatcher/daemon.py).
+    Categories not in the map fall through to the raw token
+    verbatim. Issue #2948 — keeps the admin cockpit's Recent
+    Failures table consistent with the Recently Completed tooltips
+    introduced in #2935/#2939."""
+    displayCategory: String!
     detectedBy: String!
     """Opaque category-specific JSON payload."""
     details: JSON!

--- a/packages/api/tests/dispatcher-enrichment.unit.test.ts
+++ b/packages/api/tests/dispatcher-enrichment.unit.test.ts
@@ -18,7 +18,10 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  CATEGORY_DISPLAY_NAMES,
   coerceNullableNumber,
+  displayCategoryFor,
+  failureRowToGraphQL,
   normalizeSnapshotJson,
   phaseCostRowsToGraphQL,
   queueItemFromSnapshot,
@@ -1112,5 +1115,139 @@ describe('phaseCostRowsToGraphQL (#2869)', () => {
 
   it('returns an empty array for an empty row list', () => {
     expect(phaseCostRowsToGraphQL([])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Category display-name rephrasing (issue #2948)
+// ---------------------------------------------------------------------------
+
+describe('CATEGORY_DISPLAY_NAMES (#2948 — Recent Failures table rephrase)', () => {
+  it('locks the full map so a typo or accidental deletion fails the test', () => {
+    // Must stay in sync with DispatcherDaemon._CATEGORY_DISPLAY_NAMES
+    // and DispatcherDaemon._NO_TAIL_CATEGORY_SUMMARIES in
+    // scripts/dispatcher/daemon.py. If a new category is added on the
+    // Python side, adding its LHS here (and updating this assertion) is
+    // part of the rephrase. If the Python map changes but this one
+    // doesn't, the Recent Failures table falls back to the raw token
+    // for the new category — acceptable degradation, but the mismatch
+    // is surfaced by the Python side's
+    // ``test_category_display_names_map_contents`` test.
+    expect(CATEGORY_DISPLAY_NAMES).toEqual({
+      subprocess_turn_limit: 'turn limit reached',
+      subprocess_crash: 'subprocess crashed',
+      subprocess_auth_fail: 'auth failed',
+      ci_red_after_retries: 'CI failed after retries',
+      gh_rate_exhausted: 'GitHub rate limit',
+      stuck_timeout: 'timed out',
+      paused_by_killswitch: 'manually stopped',
+      daemon_restart_abandoned: 'dispatcher restarted',
+    });
+  });
+
+  it('displayCategoryFor rephrases known tokens', () => {
+    expect(displayCategoryFor('subprocess_turn_limit')).toBe('turn limit reached');
+    expect(displayCategoryFor('daemon_restart_abandoned')).toBe('dispatcher restarted');
+    expect(displayCategoryFor('paused_by_killswitch')).toBe('manually stopped');
+    expect(displayCategoryFor('ci_red_after_retries')).toBe('CI failed after retries');
+  });
+
+  it('displayCategoryFor falls through to the raw token for unknown categories', () => {
+    // Acceptance criterion #3: unknown category (future additions not
+    // yet in the map) falls through to the raw token as today.
+    expect(displayCategoryFor('some_new_category')).toBe('some_new_category');
+    expect(displayCategoryFor('')).toBe('');
+  });
+});
+
+describe('failureRowToGraphQL (#2948 — displayCategory field)', () => {
+  it('exposes displayCategory alongside the raw category token', () => {
+    const row = {
+      failure_id: 'failure-1',
+      agent_id: 'agent-1',
+      category: 'subprocess_turn_limit',
+      detected_by: 'supervisor:turn_limit',
+      details: { note: 'ran out of turns' },
+      ts: '2026-04-20T12:00:00Z',
+      issue_number: 2948,
+    };
+    expect(failureRowToGraphQL(row)).toEqual({
+      failureId: 'failure-1',
+      agentId: 'agent-1',
+      category: 'subprocess_turn_limit',
+      displayCategory: 'turn limit reached',
+      detectedBy: 'supervisor:turn_limit',
+      details: { note: 'ran out of turns' },
+      ts: '2026-04-20T12:00:00Z',
+      issueNumber: 2948,
+    });
+  });
+
+  it('passes unknown categories through to displayCategory verbatim', () => {
+    const row = {
+      failure_id: 'failure-2',
+      agent_id: null,
+      category: 'some_future_category',
+      detected_by: 'hook:unknown',
+      details: null,
+      ts: '2026-04-20T12:00:00Z',
+      issue_number: null,
+    };
+    const out = failureRowToGraphQL(row);
+    expect(out.category).toBe('some_future_category');
+    expect(out.displayCategory).toBe('some_future_category');
+    // null details round-trips to an empty object (consistent with
+    // pre-#2948 behavior — `details: JSON!` is non-nullable on the
+    // schema).
+    expect(out.details).toEqual({});
+    expect(out.issueNumber).toBeNull();
+  });
+
+  it('rephrases the display-only alias categories (_NO_TAIL_CATEGORY_SUMMARIES)', () => {
+    // paused_by_killswitch and daemon_restart_abandoned come from
+    // Python's _NO_TAIL_CATEGORY_SUMMARIES map, not the main
+    // _CATEGORY_DISPLAY_NAMES map — but they still appear as raw
+    // category tokens in dispatcher.failures rows, so the Recent
+    // Failures table needs to rephrase them too (issue #2948).
+    expect(
+      failureRowToGraphQL({
+        failure_id: 'f1',
+        agent_id: 'a1',
+        category: 'paused_by_killswitch',
+        detected_by: 'supervisor:killswitch',
+        details: {},
+        ts: '2026-04-20T12:00:00Z',
+        issue_number: null,
+      }).displayCategory,
+    ).toBe('manually stopped');
+
+    expect(
+      failureRowToGraphQL({
+        failure_id: 'f2',
+        agent_id: 'a2',
+        category: 'daemon_restart_abandoned',
+        detected_by: 'supervisor:daemon_restart',
+        details: {},
+        ts: '2026-04-20T12:00:00Z',
+        issue_number: null,
+      }).displayCategory,
+    ).toBe('dispatcher restarted');
+  });
+
+  it('coerces a non-string category to empty + empty displayCategory', () => {
+    // Defensive — the resolver type-guards category before passing it
+    // through. A malformed row (null category, which should never
+    // happen under the NOT NULL constraint) should collapse cleanly.
+    const out = failureRowToGraphQL({
+      failure_id: 'f3',
+      agent_id: null,
+      category: null as unknown as string,
+      detected_by: 'hook',
+      details: {},
+      ts: '2026-04-20T12:00:00Z',
+      issue_number: null,
+    });
+    expect(out.category).toBe('');
+    expect(out.displayCategory).toBe('');
   });
 });

--- a/packages/api/tests/dispatcher.integration.test.ts
+++ b/packages/api/tests/dispatcher.integration.test.ts
@@ -373,7 +373,7 @@ describe('dispatcherState — admin', () => {
       details: { hook: 'subagentstop', note: MARKER },
     });
     const body = await gql(
-      `{ dispatcherState { recentFailures(sinceHours: 1) { failureId category detectedBy agentId details } } }`,
+      `{ dispatcherState { recentFailures(sinceHours: 1) { failureId category displayCategory detectedBy agentId details } } }`,
       undefined,
       adminToken,
     );
@@ -384,6 +384,9 @@ describe('dispatcherState — admin', () => {
     const ours = failures.find((f) => (f.agentId as string) === agentId);
     expect(ours).toBeDefined();
     expect(ours!.category).toBe('hook_failure');
+    // #2948: unknown categories (like the test's synthetic
+    // `hook_failure`) fall through to the raw token as `displayCategory`.
+    expect(ours!.displayCategory).toBe('hook_failure');
     expect(ours!.detectedBy).toBe('hook:subagentstop');
     // details round-trips as JSON
     expect((ours!.details as Record<string, unknown>).note).toBe(MARKER);

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentFailuresPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentFailuresPanel.tsx
@@ -39,6 +39,17 @@ const FAILURE_CHIP_CLASSES =
  * ``paused_by_killswitch``) render ↺ amber; every other failure
  * category renders ✗ red. Matches the outcome-pill vocabulary in
  * ``RecentCompletionsPanel`` so the two panels read together.
+ *
+ * #2948: the Category column renders the operator-friendly
+ * `displayCategory` string (e.g. "turn limit reached") instead of the
+ * raw token (`subprocess_turn_limit`), matching the Recently Completed
+ * tooltip rephrasing from #2935/#2939. The raw token is preserved on
+ * the cell's `title` attribute and as a `data-category` attribute so
+ * operators can still grab the exact string they need for CloudWatch
+ * queries / SQL filters. Unknown categories (not in the server-side
+ * display map) fall through to the raw token — the backend returns
+ * `category` verbatim as `displayCategory` in that case, so the UI
+ * doesn't need a fallback.
  */
 export function RecentFailuresPanel({ failures, nowMs }: RecentFailuresPanelProps) {
   const groups = groupFailuresByCategory(failures);
@@ -95,8 +106,18 @@ export function RecentFailuresPanel({ failures, nowMs }: RecentFailuresPanelProp
                     </span>
                   </td>
                   <td className="py-2">
-                    <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
-                      {group.category}
+                    <span
+                      // #2948: title + data-category preserve the raw
+                      // machine-readable token for operator debugging
+                      // (CloudWatch queries, SQL filters, copy-paste)
+                      // while the visible pill text shows the
+                      // operator-friendly `displayCategory` string.
+                      className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground"
+                      title={group.category}
+                      data-category={group.category}
+                      data-testid={`failure-category-pill-${group.category}`}
+                    >
+                      {group.mostRecent.displayCategory}
                     </span>
                   </td>
                   <td className="py-2 font-mono text-foreground">{group.count}</td>

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentFailuresPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentFailuresPanel.test.tsx
@@ -6,11 +6,20 @@ import type { DispatcherFailure } from '@/lib/dispatcher-queries';
 // Fixed `nowMs` for deterministic relative-time rendering.
 const NOW_MS = Date.parse('2026-04-20T12:00:00Z');
 
+/**
+ * Build a fixture DispatcherFailure. When `displayCategory` is not
+ * supplied we default it to the raw `category` — matching the backend
+ * contract (#2948): unknown categories fall through to the raw token.
+ * Tests that exercise the #2948 rephrase explicitly set
+ * `displayCategory` to the operator-friendly string.
+ */
 function makeFailure(overrides: Partial<DispatcherFailure> = {}): DispatcherFailure {
+  const category = overrides.category ?? 'subprocess_crash';
   return {
     failureId: '1',
     agentId: 'agent-1',
-    category: 'subprocess_crash',
+    category,
+    displayCategory: overrides.displayCategory ?? category,
     detectedBy: 'scheduler',
     details: {},
     ts: new Date(NOW_MS - 5 * 60 * 1000).toISOString(),
@@ -78,23 +87,30 @@ describe('RecentFailuresPanel', () => {
       render(
         <RecentFailuresPanel
           failures={[
-            makeFailure({ category: 'daemon_restart_abandoned' }),
+            makeFailure({
+              category: 'daemon_restart_abandoned',
+              displayCategory: 'dispatcher restarted',
+            }),
             makeFailure({
               failureId: '2',
               category: 'paused_by_killswitch',
+              displayCategory: 'manually stopped',
             }),
             makeFailure({
               failureId: '3',
               category: 'subprocess_crash',
+              displayCategory: 'subprocess crashed',
             }),
           ]}
           nowMs={NOW_MS}
         />,
       );
-      // Both infra categories + the real failure category are rendered.
-      expect(screen.getByText('daemon_restart_abandoned')).toBeInTheDocument();
-      expect(screen.getByText('paused_by_killswitch')).toBeInTheDocument();
-      expect(screen.getByText('subprocess_crash')).toBeInTheDocument();
+      // All three category rows render their operator-friendly
+      // displayCategory (#2948). The raw tokens are available via the
+      // pill's data-category attribute for debugging.
+      expect(screen.getByText('dispatcher restarted')).toBeInTheDocument();
+      expect(screen.getByText('manually stopped')).toBeInTheDocument();
+      expect(screen.getByText('subprocess crashed')).toBeInTheDocument();
 
       // Two amber ↺ glyphs and one red ✗ glyph.
       expect(screen.getAllByTestId('failure-glyph-infra_preempted')).toHaveLength(
@@ -107,22 +123,152 @@ describe('RecentFailuresPanel', () => {
       render(
         <RecentFailuresPanel
           failures={[
-            makeFailure({ failureId: '1', category: 'daemon_restart_abandoned' }),
-            makeFailure({ failureId: '2', category: 'daemon_restart_abandoned' }),
-            makeFailure({ failureId: '3', category: 'daemon_restart_abandoned' }),
-            makeFailure({ failureId: '4', category: 'subprocess_crash' }),
+            makeFailure({
+              failureId: '1',
+              category: 'daemon_restart_abandoned',
+              displayCategory: 'dispatcher restarted',
+            }),
+            makeFailure({
+              failureId: '2',
+              category: 'daemon_restart_abandoned',
+              displayCategory: 'dispatcher restarted',
+            }),
+            makeFailure({
+              failureId: '3',
+              category: 'daemon_restart_abandoned',
+              displayCategory: 'dispatcher restarted',
+            }),
+            makeFailure({
+              failureId: '4',
+              category: 'subprocess_crash',
+              displayCategory: 'subprocess crashed',
+            }),
           ]}
           nowMs={NOW_MS}
         />,
       );
       // Row for daemon_restart_abandoned shows count=3; grab its row
-      // and assert the count cell within.
-      const daemonRestartRow = screen.getByText('daemon_restart_abandoned')
-        .closest('tr')!;
+      // via the pill's data-category attribute (the raw token is still
+      // available for querying even though the visible text is the
+      // rephrased string).
+      const daemonRestartPill = screen.getByTestId(
+        'failure-category-pill-daemon_restart_abandoned',
+      );
+      const daemonRestartRow = daemonRestartPill.closest('tr')!;
       expect(within(daemonRestartRow).getByText('3')).toBeInTheDocument();
-      const subprocessCrashRow = screen.getByText('subprocess_crash')
-        .closest('tr')!;
+
+      const subprocessCrashPill = screen.getByTestId(
+        'failure-category-pill-subprocess_crash',
+      );
+      const subprocessCrashRow = subprocessCrashPill.closest('tr')!;
       expect(within(subprocessCrashRow).getByText('1')).toBeInTheDocument();
+    });
+  });
+
+  // #2948: the Category column renders the operator-friendly
+  // `displayCategory` string instead of the raw category token,
+  // matching the Recently Completed tooltip rephrasing from #2935.
+  describe('category rephrase (#2948)', () => {
+    it('renders the rephrased display category, not the raw token', () => {
+      // Acceptance criterion #1: Recent Failures table's category
+      // column renders the display names, not raw tokens.
+      render(
+        <RecentFailuresPanel
+          failures={[
+            makeFailure({
+              category: 'subprocess_turn_limit',
+              displayCategory: 'turn limit reached',
+            }),
+          ]}
+          nowMs={NOW_MS}
+        />,
+      );
+      expect(screen.getByText('turn limit reached')).toBeInTheDocument();
+      // The raw token is absent from the visible text (the pill
+      // renders the rephrased string in place of the token).
+      expect(
+        screen.queryByText('subprocess_turn_limit'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('preserves the raw category token on the cell title for debugging', () => {
+      // Acceptance criterion #2: the raw category string is still
+      // accessible for debugging — either as a tooltip on the cell or
+      // as a data attribute. Both are present.
+      render(
+        <RecentFailuresPanel
+          failures={[
+            makeFailure({
+              category: 'daemon_restart_abandoned',
+              displayCategory: 'dispatcher restarted',
+            }),
+          ]}
+          nowMs={NOW_MS}
+        />,
+      );
+      const pill = screen.getByTestId(
+        'failure-category-pill-daemon_restart_abandoned',
+      );
+      expect(pill).toHaveAttribute('title', 'daemon_restart_abandoned');
+      expect(pill).toHaveAttribute(
+        'data-category',
+        'daemon_restart_abandoned',
+      );
+      expect(pill).toHaveTextContent('dispatcher restarted');
+    });
+
+    it('rephrases multiple well-known categories consistently', () => {
+      // Sanity-check the happy-path rephrases called out in the issue
+      // body: daemon_restart_abandoned, paused_by_killswitch,
+      // ci_red_after_retries.
+      const failures: DispatcherFailure[] = [
+        makeFailure({
+          failureId: 'f1',
+          category: 'daemon_restart_abandoned',
+          displayCategory: 'dispatcher restarted',
+          ts: new Date(NOW_MS - 5 * 60 * 1000).toISOString(),
+        }),
+        makeFailure({
+          failureId: 'f2',
+          category: 'paused_by_killswitch',
+          displayCategory: 'manually stopped',
+          ts: new Date(NOW_MS - 6 * 60 * 1000).toISOString(),
+        }),
+        makeFailure({
+          failureId: 'f3',
+          category: 'ci_red_after_retries',
+          displayCategory: 'CI failed after retries',
+          ts: new Date(NOW_MS - 7 * 60 * 1000).toISOString(),
+        }),
+      ];
+      render(<RecentFailuresPanel failures={failures} nowMs={NOW_MS} />);
+      expect(screen.getByText('dispatcher restarted')).toBeInTheDocument();
+      expect(screen.getByText('manually stopped')).toBeInTheDocument();
+      expect(screen.getByText('CI failed after retries')).toBeInTheDocument();
+    });
+
+    it('falls through to the raw token when displayCategory === category (unknown category)', () => {
+      // Acceptance criterion #3: unknown category (future additions
+      // not yet in the map) falls through to the raw token as today.
+      // The backend returns `category` verbatim as `displayCategory`
+      // when the token isn't in the display-name map, so the UI just
+      // renders whatever `displayCategory` contains.
+      render(
+        <RecentFailuresPanel
+          failures={[
+            makeFailure({
+              category: 'some_new_category',
+              displayCategory: 'some_new_category',
+            }),
+          ]}
+          nowMs={NOW_MS}
+        />,
+      );
+      expect(screen.getByText('some_new_category')).toBeInTheDocument();
+      const pill = screen.getByTestId(
+        'failure-category-pill-some_new_category',
+      );
+      expect(pill).toHaveAttribute('title', 'some_new_category');
     });
   });
 });

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -42,6 +42,7 @@ export const DISPATCHER_STATE_QUERY = gql`
         failureId
         agentId
         category
+        displayCategory
         detectedBy
         details
         ts
@@ -159,7 +160,20 @@ export interface DispatcherAgent {
 export interface DispatcherFailure {
   failureId: string;
   agentId: string | null;
+  /** Stored machine-readable category token (e.g.
+   * `subprocess_turn_limit`, `daemon_restart_abandoned`). Used by
+   * CloudWatch queries, SQL filters, and retry classification. The
+   * admin cockpit surfaces this via the table cell's `title` tooltip
+   * so operators can still copy-paste the raw token for debugging
+   * even when the cell renders `displayCategory`. */
   category: string;
+  /** Operator-friendly rephrasing of `category` computed server-side
+   * from the display-name map in the API resolver, which mirrors
+   * `_CATEGORY_DISPLAY_NAMES` in `scripts/dispatcher/daemon.py`.
+   * Categories not in the map fall through to the raw token. Issue
+   * #2948 — keeps Recent Failures table labels consistent with the
+   * Recently Completed tooltips introduced in #2935. */
+  displayCategory: string;
   detectedBy: string;
   details: Record<string, unknown>;
   ts: string;


### PR DESCRIPTION
## Summary

Extend the `_CATEGORY_DISPLAY_NAMES` category rephrase introduced in
#2939/#2935 (Recently Completed tooltips) to the admin cockpit's Recent
Failures (last 24h) table. The table now shows "turn limit reached",
"dispatcher restarted", "CI failed after retries" etc. instead of the
raw tokens `subprocess_turn_limit`, `daemon_restart_abandoned`,
`ci_red_after_retries`.

Followed **Option A** from the issue body: backend surfaces a new
`displayCategory: String!` field on the GraphQL `DispatcherFailure`
type; the map lives in the TS resolver
(`packages/api/src/graphql/dispatcher/resolvers.ts`) as a mirror of the
Python `_CATEGORY_DISPLAY_NAMES` + `_NO_TAIL_CATEGORY_SUMMARIES` in
`scripts/dispatcher/daemon.py`. Same precedent + drift-management as
the existing `FAILURE_SUMMARY_STATUSES` TS mirror that shipped with
#2913. Both sides have a lock-the-map test; raw token is preserved on
the GraphQL surface (and on the cell's `title` + `data-category`
attributes) for operator debugging. Unknown categories fall through to
the raw token verbatim.

Also rebased on main to integrate #2951's (#2947) glyph column — the
two features compose cleanly: infra-preempted rows render amber ↺ with
"dispatcher restarted" / "manually stopped" text; genuine failures
render red ✗ with their rephrased category.

Closes #2948

## Test plan

### Automated checks
- [x] Lint passes (API + web)
- [x] Format check passes
- [x] Tests pass — 414/414 API, 1328/1328 web, 10 RecentFailuresPanel
      tests (5 glyph + 4 rephrase + 1 empty-state) covering all four
      acceptance criteria
- [x] CI green

### Post-deploy verification
- [x] API deploy verified — `displayCategory` field confirmed live on
      the dev GraphQL schema via probe; ECS service on task def :116
      steady-state
- [ ] Frontend deploy STALLED (Vercel `NOT_FOUND` affecting multiple
      recent merges — tracked in #2957). Will re-verify once Vercel
      picks up the commit; screenshot the admin page and confirm
      rephrased labels render.
- [x] Verification evidence posted on issue #2948
