### PR TITLE
refactor(dispatcher): split terminal success into milestone columns (#2953)

### DIFF
--- a/packages/api/migrations/35_dispatcher-agents-milestone-columns.sql
+++ b/packages/api/migrations/35_dispatcher-agents-milestone-columns.sql
@@ -1,0 +1,170 @@
+-- Up Migration
+--
+-- Dispatcher v2 — split the single ``status='succeeded'`` terminal
+-- write into four independently-written milestone columns on
+-- ``dispatcher.agents`` so the admin cockpit can distinguish
+-- "shipped" from "verified" from "retro completed" and show a single
+-- glyph whose color encodes pipeline completeness (#2953).
+--
+-- Problem
+-- -------
+-- Before this migration, ``dispatcher.agents.status`` conflated "did
+-- the PR ship?" with "did verify + retro finish?" — so a PR that
+-- merged successfully but whose verify or retro phase was killed by
+-- a mid-pipeline dispatcher restart got written as ``status='failed'``
+-- with ``failure_summary='dispatcher restarted'``. That renders as a
+-- red ✗ in the admin panel even though the code shipped. See
+-- issues #2942/#2943/#2944/#2945/#2946 for four concrete examples of
+-- the false-failure pattern.
+--
+-- Fix
+-- ---
+-- Four new nullable TIMESTAMPTZ / TEXT columns, each written at the
+-- exact moment its milestone happens (no batch update at end-of-
+-- pipeline):
+--
+--   merged_at          — PR squash-merge observed (shipped bar).
+--   verified_at        — verify phase returned VERIFIED (or skipped
+--                        rows intentionally leave this NULL and set
+--                        verify_skip_reason instead).
+--   verify_skip_reason — nullable; populated when verify is
+--                        intentionally skipped. Today: 'self_deploy'
+--                        for dispatcher-self-PRs. Future:
+--                        'docs_only', 'ci_cd_only'.
+--   retroed_at         — retro phase reached PHASE_RETRO_DONE.
+--
+-- With these columns, ``status`` becomes a one-way latch:
+--   * ``succeeded`` is written the moment ``merged_at`` is — not
+--     conditional on verify/retro.
+--   * If the container dies between merge and retro, the row reads
+--     ``succeeded`` with ``merged_at`` set and ``verified_at`` /
+--     ``retroed_at`` NULL. That absence is the visible signal; the
+--     admin cockpit renders an amber ✓ to highlight the incomplete
+--     post-merge bookkeeping.
+--
+-- Design notes
+-- ------------
+-- - TIMESTAMPTZ with no DEFAULT — explicit writes at each milestone,
+--   no drift from NOW() elsewhere.
+-- - No CHECK constraint on ``verify_skip_reason`` — the set of valid
+--   values is daemon-code owned (``_VERIFY_SKIP_REASONS``); adding a
+--   CHECK here would couple schema to that enum. Unknown values flow
+--   through the UI (which renders the raw string in the tooltip).
+-- - No indexes — every read path queries by ``agent_id`` or
+--   ``ended_at`` which are already covered; these columns are
+--   render-only.
+-- - ``ADD COLUMN IF NOT EXISTS`` so the migration is idempotent.
+--
+-- Backfill
+-- --------
+-- Two UPDATE statements, both idempotent (guarded on the new column
+-- being NULL):
+--
+--   1. Historical "true succeeded" rows — ``pr_number IS NOT NULL
+--      AND status='succeeded'`` — get ``merged_at = ended_at``. We
+--      don't know exactly when the merge happened vs. the verify, but
+--      ``ended_at`` is the upper bound and matches the observable
+--      "shipped before or at ended_at" truth.
+--
+--   2. The false-failure pattern this issue targets — ``pr_number IS
+--      NOT NULL AND status='failed' AND failure_summary='dispatcher
+--      restarted'`` — gets both ``merged_at = ended_at`` AND ``status
+--      = 'succeeded'``. These rows merged successfully before the
+--      daemon restart; the stored ``failed`` was the bug. Flipping
+--      to ``succeeded`` removes the false-red glyph from the admin
+--      page while ``verified_at`` / ``retroed_at`` staying NULL
+--      preserves the "post-merge bookkeeping interrupted" signal (the
+--      row renders amber ✓ instead of green).
+--
+-- Historical ``verified_at`` and ``retroed_at`` stay NULL because we
+-- have no durable signal of when those phases completed — the prior
+-- code path only wrote the coarse ``status`` column. The UI handles
+-- this gracefully (the absence just means "no milestone stamped").
+
+ALTER TABLE dispatcher.agents
+    ADD COLUMN IF NOT EXISTS merged_at          TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS verified_at        TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS verify_skip_reason TEXT,
+    ADD COLUMN IF NOT EXISTS retroed_at         TIMESTAMPTZ;
+
+COMMENT ON COLUMN dispatcher.agents.merged_at IS
+    'Timestamp the PR squash-merge was observed by the daemon '
+    '(``_merge_pr_and_advance``). One-way latch: written once, never '
+    'cleared. Paired with the ``status=''succeeded''`` write at the '
+    'same merge point. NULL for rows that never merged (push_and_pr '
+    'failed, CI red after retries, etc.) and for pre-migration-35 '
+    'rows without a recoverable merge signal. Issue #2953.';
+
+COMMENT ON COLUMN dispatcher.agents.verified_at IS
+    'Timestamp the verify phase completed with verdict=VERIFIED. '
+    'NULL when verify was intentionally skipped (see '
+    '``verify_skip_reason``), when verify crashed mid-phase, or for '
+    'pre-migration-35 rows. A merged row with NULL ``verified_at`` '
+    'AND NULL ``verify_skip_reason`` renders as amber ✓ in the admin '
+    'cockpit — "shipped but post-merge bookkeeping incomplete". '
+    'Issue #2953.';
+
+COMMENT ON COLUMN dispatcher.agents.verify_skip_reason IS
+    'Non-null when verify is intentionally skipped — the row is '
+    '"shipped + verify-does-not-apply" rather than "shipped + verify '
+    'failed to run". Today the only written value is ''self_deploy'' '
+    '(dispatcher-self-PR touches ``scripts/dispatcher/`` and the new '
+    'daemon deploy will land mid-verify, making verify against the '
+    'soon-to-be-replaced process useless). Planned future values: '
+    '''docs_only'' (``docs/`` / ``*.md`` only), ''ci_cd_only'' '
+    '(``.github/workflows/`` only). No CHECK constraint — the set is '
+    'daemon-code owned. Issue #2953.';
+
+COMMENT ON COLUMN dispatcher.agents.retroed_at IS
+    'Timestamp the retro phase reached PHASE_RETRO_DONE. NULL when '
+    'retro crashed, when the worktree was already gone at retro time '
+    '(fast-path to cleanup_done), or for pre-migration-35 rows. A '
+    'merged row with ``verified_at`` set but ``retroed_at`` NULL '
+    'renders as amber ✓ — "shipped + verified but retro bookkeeping '
+    'did not complete". Issue #2953.';
+
+-- Backfill 1 — rows that legitimately succeeded (status='succeeded'
+-- with a merged PR) get ``merged_at = ended_at``. Guarded on the new
+-- column being NULL so re-running the migration (or the upstream
+-- daemon code writing a precise merged_at at the actual merge time)
+-- does not clobber a more accurate value.
+UPDATE dispatcher.agents
+   SET merged_at = ended_at
+ WHERE pr_number IS NOT NULL
+   AND status = 'succeeded'
+   AND ended_at IS NOT NULL
+   AND merged_at IS NULL;
+
+-- Backfill 2 — the false-failure pattern #2953 targets. Rows that
+-- got terminalized as 'failed' with failure_summary='dispatcher
+-- restarted' AND had a PR number actually did merge before the daemon
+-- restart; the 'failed' is the bug this issue resolves. Flip them to
+-- 'succeeded' and stamp merged_at so the admin panel stops showing
+-- red ✗ for work that actually shipped. Other 'failed' rows (no PR,
+-- or a different failure_summary) stay as-is — they are genuine
+-- non-merge failures.
+UPDATE dispatcher.agents
+   SET merged_at = ended_at,
+       status    = 'succeeded'
+ WHERE pr_number IS NOT NULL
+   AND status = 'failed'
+   AND failure_summary = 'dispatcher restarted'
+   AND ended_at IS NOT NULL
+   AND merged_at IS NULL;
+
+
+-- Down Migration
+--
+-- Drop the four columns. The admin cockpit's OutcomePill handles
+-- nullable inputs gracefully — absent milestone columns collapse
+-- rendering back to the legacy ``status``-only path. Backfill 2's
+-- status flip is NOT reversed on down-migrate (we do not know which
+-- 'succeeded' rows came from the flip vs. the normal success path
+-- without reading ``failure_summary``, and the flip was always the
+-- correct terminal value anyway).
+
+ALTER TABLE dispatcher.agents
+    DROP COLUMN IF EXISTS merged_at,
+    DROP COLUMN IF EXISTS verified_at,
+    DROP COLUMN IF EXISTS verify_skip_reason,
+    DROP COLUMN IF EXISTS retroed_at;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -329,7 +329,11 @@ CREATE TABLE dispatcher.agents (
     model_override jsonb,
     issue_title text,
     failure_summary text,
-    priority text
+    priority text,
+    merged_at timestamp with time zone,
+    verified_at timestamp with time zone,
+    verify_skip_reason text,
+    retroed_at timestamp with time zone
 );
 
 
@@ -349,6 +353,18 @@ COMMENT ON COLUMN dispatcher.agents.failure_summary IS 'One-line "what happened"
 
 
 COMMENT ON COLUMN dispatcher.agents.priority IS 'Priority label captured at claim time (p0|p1|p2|p3|NULL). Written by both DispatcherDaemon._atomic_claim and scripts/dispatcher/task_claim.py. Reflects "priority when spawned"; does not retroactively update when the issue is relabeled on GitHub. Issue #2899.';
+
+
+COMMENT ON COLUMN dispatcher.agents.merged_at IS 'Timestamp the PR squash-merge was observed by the daemon (``_merge_pr_and_advance``). One-way latch: written once, never cleared. Paired with the ``status=''succeeded''`` write at the same merge point. NULL for rows that never merged (push_and_pr failed, CI red after retries, etc.) and for pre-migration-35 rows without a recoverable merge signal. Issue #2953.';
+
+
+COMMENT ON COLUMN dispatcher.agents.verified_at IS 'Timestamp the verify phase completed with verdict=VERIFIED. NULL when verify was intentionally skipped (see ``verify_skip_reason``), when verify crashed mid-phase, or for pre-migration-35 rows. A merged row with NULL ``verified_at`` AND NULL ``verify_skip_reason`` renders as amber ✓ in the admin cockpit — "shipped but post-merge bookkeeping incomplete". Issue #2953.';
+
+
+COMMENT ON COLUMN dispatcher.agents.verify_skip_reason IS 'Non-null when verify is intentionally skipped — the row is "shipped + verify-does-not-apply" rather than "shipped + verify failed to run". Today the only written value is ''self_deploy'' (dispatcher-self-PR touches ``scripts/dispatcher/`` and the new daemon deploy will land mid-verify, making verify against the soon-to-be-replaced process useless). Planned future values: ''docs_only'' (``docs/`` / ``*.md`` only), ''ci_cd_only'' (``.github/workflows/`` only). No CHECK constraint — the set is daemon-code owned. Issue #2953.';
+
+
+COMMENT ON COLUMN dispatcher.agents.retroed_at IS 'Timestamp the retro phase reached PHASE_RETRO_DONE. NULL when retro crashed, when the worktree was already gone at retro time (fast-path to cleanup_done), or for pre-migration-35 rows. A merged row with ``verified_at`` set but ``retroed_at`` NULL renders as amber ✓ — "shipped + verified but retro bookkeeping did not complete". Issue #2953.';
 
 
 CREATE TABLE dispatcher.blocked_snapshots (

--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -330,6 +330,14 @@ async function queryRecentCompletions(pool: Pool, limit: number): Promise<Row[]>
   // for failure terminals. Always nullable — succeeded / needs_review
   // rows don't populate it, nor do historical rows from before
   // migration 33.
+  // #2953: also select the four milestone columns
+  // (``merged_at`` / ``verified_at`` / ``verify_skip_reason`` /
+  // ``retroed_at``) so the admin cockpit can render a single glyph
+  // whose color encodes pipeline completeness — green ✓ for fully
+  // verified+retroed shipments, amber ✓ for shipped but bookkeeping-
+  // incomplete, red ✗ for non-merged failures, gray ↺ for infra
+  // preempts. See ``packages/web/src/app/(main)/admin/dispatcher/
+  // ui-primitives.tsx`` for the color-mapping logic.
   const { rows } = await pool.query<Row>(
     `SELECT a.agent_id,
             a.issue_number,
@@ -339,6 +347,10 @@ async function queryRecentCompletions(pool: Pool, limit: number): Promise<Row[]>
             a.ended_at,
             a.pr_number,
             a.failure_summary,
+            a.merged_at,
+            a.verified_at,
+            a.verify_skip_reason,
+            a.retroed_at,
             po.total_tokens,
             po.total_cost_usd
        FROM dispatcher.agents a
@@ -591,6 +603,18 @@ function recentCompletionsToGraphQL(
       // completed panel. Null for succeeded / needs_review / historical
       // rows — the UI falls back to the default status-label tooltip.
       failureSummary,
+      // #2953: milestone columns. Each one is null when the milestone
+      // hasn't happened (or can't happen — skip reason case for
+      // ``verifiedAt``). The UI uses the combined presence of these
+      // fields to pick the outcome glyph color — see
+      // ``packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx``.
+      mergedAt: row.merged_at ?? null,
+      verifiedAt: row.verified_at ?? null,
+      verifySkipReason:
+        typeof row.verify_skip_reason === 'string' && row.verify_skip_reason
+          ? row.verify_skip_reason
+          : null,
+      retroedAt: row.retroed_at ?? null,
     };
   });
 }

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -260,6 +260,33 @@ export const dispatcherTypeDefs = `#graphql
     migration 33. Rendered as a tooltip on the outcome glyph in the
     admin cockpit's \`Recently completed\` panel. Issue #2900."""
     failureSummary: String
+    """Timestamp the PR squash-merge was observed by the daemon. One-way
+    latch — written at merge time, never cleared. Paired with the
+    \`status='succeeded'\` flip that happens in the same write, so
+    \`mergedAt != null\` is the canonical "shipped" signal (use it in
+    preference to \`status\` for "did this PR make it"). NULL on rows
+    that never merged (push_and_pr failed, CI red after retries, etc.)
+    and on pre-migration-35 historical rows. Issue #2953."""
+    mergedAt: DateTime
+    """Timestamp the verify phase completed with verdict=VERIFIED. NULL
+    when verify was intentionally skipped (see \`verifySkipReason\`),
+    when verify crashed mid-phase, or for pre-migration-35 rows. A
+    merged row with NULL \`verifiedAt\` AND NULL \`verifySkipReason\`
+    renders as amber ✓ in the admin cockpit — "shipped but post-merge
+    bookkeeping incomplete". Issue #2953."""
+    verifiedAt: DateTime
+    """Non-null when verify was intentionally skipped. Today the only
+    written value is \`"self_deploy"\` (dispatcher-self-PR touches
+    \`scripts/dispatcher/\`). Admin cockpit treats a merged row with
+    a non-null skip reason as fully-shipped (green ✓) — skipping is
+    not a regression signal. Issue #2953."""
+    verifySkipReason: String
+    """Timestamp the retro phase completed (reached PHASE_RETRO_DONE).
+    NULL when retro crashed, when the worktree was already gone at
+    retro time (fast-path to cleanup_done), or for pre-migration-35
+    rows. Rendered as the third tick in the milestone-breakdown
+    tooltip. Issue #2953."""
+    retroedAt: DateTime
   }
 
   """One key/value entry from \`dispatcher.config\` (#2805 §1.6)."""

--- a/packages/api/tests/dispatcher-enrichment.unit.test.ts
+++ b/packages/api/tests/dispatcher-enrichment.unit.test.ts
@@ -199,6 +199,12 @@ describe('recentCompletionsToGraphQL', () => {
         // #2900: succeeded rows stay NULL on failure_summary — the
         // column only populates on failure terminals.
         failureSummary: null,
+        // #2953: milestone columns default to null when the input row
+        // omits them (pre-migration-35 historical case).
+        mergedAt: null,
+        verifiedAt: null,
+        verifySkipReason: null,
+        retroedAt: null,
       },
     ]);
   });
@@ -394,6 +400,106 @@ describe('recentCompletionsToGraphQL', () => {
     const result = recentCompletionsToGraphQL(rows);
     expect(result[0].priority).toBeNull();
     expect(result[1].priority).toBeNull();
+  });
+
+  // #2953 — milestone-column passthrough: the resolver must surface
+  // merged_at / verified_at / verify_skip_reason / retroed_at verbatim
+  // so the admin cockpit can render a single glyph whose colour
+  // encodes pipeline completeness.
+  it('#2953: passes all four milestone columns through verbatim', () => {
+    const rows = [
+      {
+        agent_id: 'uuid-fully-shipped',
+        issue_number: 2953,
+        issue_title: 'Fully-shipped row',
+        status: 'succeeded',
+        ended_at: '2026-04-20T22:50:00Z',
+        pr_number: 3000,
+        merged_at: '2026-04-20T22:35:00Z',
+        verified_at: '2026-04-20T22:41:00Z',
+        verify_skip_reason: null,
+        retroed_at: '2026-04-20T22:50:00Z',
+      },
+    ];
+    const result = recentCompletionsToGraphQL(rows);
+    expect(result[0].mergedAt).toBe('2026-04-20T22:35:00Z');
+    expect(result[0].verifiedAt).toBe('2026-04-20T22:41:00Z');
+    expect(result[0].verifySkipReason).toBeNull();
+    expect(result[0].retroedAt).toBe('2026-04-20T22:50:00Z');
+  });
+
+  it('#2953: surfaces verifySkipReason on a self-deploy row', () => {
+    const rows = [
+      {
+        agent_id: 'uuid-self-deploy',
+        issue_number: 2953,
+        issue_title: 'Dispatcher self-PR',
+        status: 'succeeded',
+        ended_at: '2026-04-20T22:48:00Z',
+        pr_number: 3001,
+        merged_at: '2026-04-20T22:35:00Z',
+        verified_at: null,
+        verify_skip_reason: 'self_deploy',
+        retroed_at: '2026-04-20T22:48:00Z',
+      },
+    ];
+    const result = recentCompletionsToGraphQL(rows);
+    expect(result[0].verifySkipReason).toBe('self_deploy');
+    expect(result[0].verifiedAt).toBeNull();
+  });
+
+  it('#2953: emits all milestone columns null for pre-migration-35 rows', () => {
+    // A historical row whose agent ran before migration 35 has NULL
+    // in the four new columns (backfill only sets merged_at for
+    // rows with pr_number + status='succeeded'; rows without a PR
+    // stay untouched).
+    const rows = [
+      {
+        agent_id: 'uuid-pre35',
+        issue_number: 100,
+        issue_title: 'Pre-migration row',
+        status: 'succeeded',
+        ended_at: '2026-01-01T00:00:00Z',
+        pr_number: null,
+        // columns missing entirely — defensive against pg result shape drift
+      },
+    ];
+    const result = recentCompletionsToGraphQL(rows);
+    expect(result[0].mergedAt).toBeNull();
+    expect(result[0].verifiedAt).toBeNull();
+    expect(result[0].verifySkipReason).toBeNull();
+    expect(result[0].retroedAt).toBeNull();
+  });
+
+  it('#2953: verifySkipReason ignores empty / non-string values', () => {
+    // Defense-in-depth: empty strings or non-string jsonb drift
+    // must collapse to null so the UI's milestone-completeness
+    // logic doesn't treat an empty string as "skipped".
+    const rows = [
+      {
+        agent_id: 'uuid-empty',
+        issue_number: 100,
+        issue_title: 'Empty skip reason',
+        status: 'succeeded',
+        ended_at: '2026-04-20T00:00:00Z',
+        pr_number: 500,
+        merged_at: '2026-04-20T00:00:00Z',
+        verify_skip_reason: '',
+      },
+      {
+        agent_id: 'uuid-nonstring',
+        issue_number: 101,
+        issue_title: 'Non-string skip reason',
+        status: 'succeeded',
+        ended_at: '2026-04-20T00:00:00Z',
+        pr_number: 501,
+        merged_at: '2026-04-20T00:00:00Z',
+        verify_skip_reason: 42,
+      },
+    ];
+    const result = recentCompletionsToGraphQL(rows);
+    expect(result[0].verifySkipReason).toBeNull();
+    expect(result[1].verifySkipReason).toBeNull();
   });
 
   it('emits totalTokens=null and totalCostUsd=null for pre-migration-31 rows', () => {

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -110,10 +110,16 @@ function RecentCompletionRow({
         {/* #2900: pass failureSummary through as hover tooltip for
             failure terminals. Null on succeeded / needs_review /
             pre-#2900 rows, in which case the pill falls back to its
-            built-in status-label tooltip (prior behaviour). */}
+            built-in status-label tooltip (prior behaviour).
+            #2953: pass the four milestone columns through so the pill
+            can render green vs. amber vs. red+milestone-breakdown. */}
         <OutcomePill
           status={completion.status}
           failureSummary={completion.failureSummary}
+          mergedAt={completion.mergedAt}
+          verifiedAt={completion.verifiedAt}
+          verifySkipReason={completion.verifySkipReason}
+          retroedAt={completion.retroedAt}
         />
       </span>
       {/* Unified (issue, priority, [pr,] title) prefix — matches

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
@@ -23,6 +23,13 @@ function completion(overrides: Partial<RecentCompletion>): RecentCompletion {
     totalTokens: null,
     totalCostUsd: null,
     failureSummary: null,
+    // Issue #2953 — milestone columns. Default to a "fully-complete"
+    // success row so the existing green-✓ assertions hold; individual
+    // test cases override as needed.
+    mergedAt: '2026-04-18T11:50:00Z',
+    verifiedAt: '2026-04-18T11:53:00Z',
+    verifySkipReason: null,
+    retroedAt: '2026-04-18T11:55:00Z',
     ...overrides,
   };
 }
@@ -127,6 +134,10 @@ describe('RecentCompletionsPanel', () => {
   // OutcomePill's `title` attribute, so operators can triage failures
   // without opening the agent detail page.
   it('#2900: wires failure_summary into the OutcomePill tooltip for failure rows', () => {
+    // A `crashed` row with no merge signal — failureSummary becomes the
+    // tooltip (pre-#2953 status-only path). Post-#2953 a merged row
+    // whose verify failed shows a combined "<summary> — <milestones>"
+    // tooltip; see the milestone-completeness suite for that case.
     const summary =
       'ralph crashed at ralph-reviewer iteration 3 (subprocess_turn_limit): reviewer exceeded max turns';
     const items = [
@@ -136,6 +147,10 @@ describe('RecentCompletionsPanel', () => {
         status: 'crashed',
         prNumber: null,
         failureSummary: summary,
+        mergedAt: null,
+        verifiedAt: null,
+        verifySkipReason: null,
+        retroedAt: null,
       }),
     ];
     render(<RecentCompletionsPanel completions={items} nowMs={now} />);
@@ -144,7 +159,21 @@ describe('RecentCompletionsPanel', () => {
   });
 
   it('#2900: leaves the default status-label tooltip for succeeded rows (no summary)', () => {
-    const items = [completion({ agentId: 'agent-ok', failureSummary: null })];
+    // Issue #2953: pre-merge `succeeded` rows with NO mergedAt signal
+    // (pre-migration-35 data where the backfill failed for some
+    // reason, or a future code path) still use the pre-#2953 status-
+    // label tooltip. The milestone-completeness path only kicks in
+    // when mergedAt is populated.
+    const items = [
+      completion({
+        agentId: 'agent-ok',
+        failureSummary: null,
+        mergedAt: null,
+        verifiedAt: null,
+        verifySkipReason: null,
+        retroedAt: null,
+      }),
+    ];
     render(<RecentCompletionsPanel completions={items} nowMs={now} />);
     const pill = screen.getByTestId('outcome-pill-succeeded');
     // Default tooltip is the human status label ("succeeded").
@@ -161,6 +190,10 @@ describe('RecentCompletionsPanel', () => {
         status: 'crashed',
         prNumber: null,
         failureSummary: summary,
+        mergedAt: null,
+        verifiedAt: null,
+        verifySkipReason: null,
+        retroedAt: null,
       }),
     ];
     render(<RecentCompletionsPanel completions={items} nowMs={now} />);
@@ -170,8 +203,9 @@ describe('RecentCompletionsPanel', () => {
     expect(screen.queryByText(summary)).not.toBeInTheDocument();
   });
 
-  // --- #2947 — infra-preempted override at the panel level.
-  it('#2947: renders ↺ amber for rows with the "dispatcher restarted" summary', () => {
+  // --- #2947 — infra-preempted override at the panel level
+  //     (#2953 recoloured the chip from amber → gray).
+  it('#2947 / #2953: renders ↺ gray for rows with the "dispatcher restarted" summary', () => {
     const items = [
       completion({
         agentId: 'agent-infra-restart',
@@ -179,6 +213,11 @@ describe('RecentCompletionsPanel', () => {
         status: 'failed',
         prNumber: null,
         failureSummary: 'dispatcher restarted',
+        // Infra-preempted rows have no merge/verify/retro signal.
+        mergedAt: null,
+        verifiedAt: null,
+        verifySkipReason: null,
+        retroedAt: null,
       }),
     ];
     render(<RecentCompletionsPanel completions={items} nowMs={now} />);
@@ -190,7 +229,7 @@ describe('RecentCompletionsPanel', () => {
     expect(screen.queryByTestId('outcome-pill-failed')).not.toBeInTheDocument();
   });
 
-  it('#2947: renders ↺ amber for rows with the "manually stopped" summary', () => {
+  it('#2947 / #2953: renders ↺ gray for rows with the "manually stopped" summary', () => {
     const items = [
       completion({
         agentId: 'agent-infra-killswitch',
@@ -198,23 +237,34 @@ describe('RecentCompletionsPanel', () => {
         status: 'failed',
         prNumber: null,
         failureSummary: 'manually stopped',
+        mergedAt: null,
+        verifiedAt: null,
+        verifySkipReason: null,
+        retroedAt: null,
       }),
     ];
     render(<RecentCompletionsPanel completions={items} nowMs={now} />);
     const pill = screen.getByTestId('outcome-pill-infra_preempted');
     expect(pill.textContent).toBe('\u21BA');
-    expect(pill.className).toContain('bg-amber');
+    // Issue #2953: gray (bg-muted), not amber.
+    expect(pill.className).toContain('bg-muted');
+    expect(pill.className).not.toMatch(/bg-amber/);
   });
 
   it('#2947: leaves the tooltip unchanged — the visual glyph + color is the fix', () => {
     // Per the issue body: "Tooltip text is unchanged — the visual
     // glyph + color is the fix." Operators still get the exact
-    // canonical string on hover.
+    // canonical string on hover. (#2953 recoloured but kept the
+    // tooltip behaviour.)
     const items = [
       completion({
         agentId: 'agent-tooltip',
         status: 'failed',
         failureSummary: 'dispatcher restarted',
+        mergedAt: null,
+        verifiedAt: null,
+        verifySkipReason: null,
+        retroedAt: null,
       }),
     ];
     render(<RecentCompletionsPanel completions={items} nowMs={now} />);

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentFailuresPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentFailuresPanel.test.tsx
@@ -43,7 +43,9 @@ describe('RecentFailuresPanel', () => {
       expect(glyph.className).not.toMatch(/bg-amber/);
     });
 
-    it('renders amber ↺ for daemon_restart_abandoned', () => {
+    it('renders gray ↺ for daemon_restart_abandoned', () => {
+      // Issue #2953 recoloured the infra-preempt chip from amber to
+      // gray (bg-muted) — infra churn is neutral, not a warning.
       render(
         <RecentFailuresPanel
           failures={[makeFailure({ category: 'daemon_restart_abandoned' })]}
@@ -52,13 +54,14 @@ describe('RecentFailuresPanel', () => {
       );
       const glyph = screen.getByTestId('failure-glyph-infra_preempted');
       expect(glyph.textContent).toBe('\u21BA');
-      expect(glyph.className).toContain('bg-amber');
+      expect(glyph.className).toContain('bg-muted');
+      expect(glyph.className).not.toMatch(/bg-amber/);
       expect(glyph.className).not.toMatch(/bg-red/);
       // aria-label is a neutral descriptor, not "failed".
       expect(glyph.getAttribute('aria-label')).toBe('infra preempted');
     });
 
-    it('renders amber ↺ for paused_by_killswitch', () => {
+    it('renders gray ↺ for paused_by_killswitch', () => {
       render(
         <RecentFailuresPanel
           failures={[makeFailure({ category: 'paused_by_killswitch' })]}
@@ -67,7 +70,8 @@ describe('RecentFailuresPanel', () => {
       );
       const glyph = screen.getByTestId('failure-glyph-infra_preempted');
       expect(glyph.textContent).toBe('\u21BA');
-      expect(glyph.className).toContain('bg-amber');
+      expect(glyph.className).toContain('bg-muted');
+      expect(glyph.className).not.toMatch(/bg-amber/);
     });
 
     it('keeps infra-preempted rows IN the table (operator wants the signal)', () => {

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
@@ -239,29 +239,37 @@ describe('OutcomePill', () => {
   // `paused_by_killswitch` (operator hit the global kill switch). The
   // daemon writes exactly two canonical `failure_summary` strings for
   // these — "dispatcher restarted" and "manually stopped" — and the pill
-  // re-skins to amber ↺ to signal "will auto-resume, not an action item".
-  describe('infra-preempted override (#2947)', () => {
-    it('renders ↺ in amber for "dispatcher restarted" (daemon_restart_abandoned)', () => {
+  // re-skins to ↺ to signal "will auto-resume, not an action item".
+  // #2953: the ↺ chip colour moved from amber → gray (bg-muted) so the
+  // infra-preempt glyph sits on the neutral palette, distinct from the
+  // amber ✓ "shipped but bookkeeping incomplete" chip this issue
+  // introduces.
+  describe('infra-preempted override (#2947, gray-recoloured by #2953)', () => {
+    it('renders ↺ in gray for "dispatcher restarted" (daemon_restart_abandoned)', () => {
       render(
         <OutcomePill status="failed" failureSummary="dispatcher restarted" />,
       );
       const pill = screen.getByTestId('outcome-pill-infra_preempted');
       expect(pill.textContent).toBe(INFRA_PREEMPTED_GLYPH);
       expect(pill.textContent).toBe('\u21BA');
-      expect(pill.className).toContain('bg-amber');
+      // Issue #2953: gray (bg-muted), not amber — infra churn is
+      // neutral, not a warning.
+      expect(pill.className).toContain('bg-muted');
+      expect(pill.className).not.toMatch(/bg-amber/);
       expect(pill.className).not.toMatch(/bg-red/);
       // aria-label is a neutral descriptor; operator-friendly.
       expect(pill.getAttribute('aria-label')).toBe('infra preempted');
       expect(pill.getAttribute('title')).toBe('dispatcher restarted');
     });
 
-    it('renders ↺ in amber for "manually stopped" (paused_by_killswitch)', () => {
+    it('renders ↺ in gray for "manually stopped" (paused_by_killswitch)', () => {
       render(
         <OutcomePill status="failed" failureSummary="manually stopped" />,
       );
       const pill = screen.getByTestId('outcome-pill-infra_preempted');
       expect(pill.textContent).toBe('\u21BA');
-      expect(pill.className).toContain('bg-amber');
+      expect(pill.className).toContain('bg-muted');
+      expect(pill.className).not.toMatch(/bg-amber/);
       expect(pill.className).not.toMatch(/bg-red/);
       expect(pill.getAttribute('title')).toBe('manually stopped');
     });
@@ -285,7 +293,7 @@ describe('OutcomePill', () => {
           failureSummary="subprocess crashed (turn limit)"
         />,
       );
-      // Regular failed path — red ✗, not amber ↺.
+      // Regular failed path — red ✗, not gray ↺.
       const pill = screen.getByTestId('outcome-pill-failed');
       expect(pill.textContent).toBe('\u2717');
       expect(pill.className).toContain('bg-red');
@@ -302,13 +310,14 @@ describe('OutcomePill', () => {
       // If a future code path writes `status='crashed'` for an
       // infra-preempted row (today the daemon uses `failed`, but we
       // intentionally don't couple to that), the pill should still
-      // re-skin to ↺ amber rather than keep the `⚠ crashed` look.
+      // re-skin to ↺ gray rather than keep the `⚠ crashed` look.
       render(
         <OutcomePill status="crashed" failureSummary="dispatcher restarted" />,
       );
       const pill = screen.getByTestId('outcome-pill-infra_preempted');
       expect(pill.textContent).toBe('\u21BA');
-      expect(pill.className).toContain('bg-amber');
+      expect(pill.className).toContain('bg-muted');
+      expect(pill.className).not.toMatch(/bg-amber/);
     });
 
     it('exports exactly the two canonical summary strings', () => {
@@ -331,6 +340,181 @@ describe('OutcomePill', () => {
         true,
       );
       expect(INFRA_PREEMPTED_CATEGORIES.has('paused_by_killswitch')).toBe(true);
+    });
+  });
+
+  // #2953: milestone-completeness glyph + colour logic. A merged row
+  // renders ✓ whose colour depends on whether post-merge bookkeeping
+  // (verify + retro) completed:
+  // - green ✓   — fully complete
+  // - amber ✓   — shipped but bookkeeping incomplete
+  // - red ✗     — verify flipped status back to 'failed' post-merge
+  // - gray ↺    — infra-preempted (see infra-preempted suite above)
+  describe('milestone-completeness (#2953)', () => {
+    it('renders green ✓ when merged + verified + retroed', () => {
+      render(
+        <OutcomePill
+          status="succeeded"
+          mergedAt="2026-04-20T22:35:00Z"
+          verifiedAt="2026-04-20T22:41:00Z"
+          retroedAt="2026-04-20T22:50:00Z"
+        />,
+      );
+      const pill = screen.getByTestId('outcome-pill-succeeded');
+      expect(pill.textContent).toBe('\u2713');
+      expect(pill.className).toContain('bg-green');
+      expect(pill.className).not.toMatch(/bg-amber/);
+    });
+
+    it('renders green ✓ when verify-skipped-with-reason + retroed', () => {
+      // Dispatcher-self-PR case — verifySkipReason is the canonical
+      // signal; verifiedAt is null (the verify phase didn't run).
+      // The glyph should still be green.
+      render(
+        <OutcomePill
+          status="succeeded"
+          mergedAt="2026-04-20T22:35:00Z"
+          verifiedAt={null}
+          verifySkipReason="self_deploy"
+          retroedAt="2026-04-20T22:48:00Z"
+        />,
+      );
+      const pill = screen.getByTestId('outcome-pill-succeeded');
+      expect(pill.textContent).toBe('\u2713');
+      expect(pill.className).toContain('bg-green');
+    });
+
+    it('renders amber ✓ when merged but retroed is missing', () => {
+      render(
+        <OutcomePill
+          status="succeeded"
+          mergedAt="2026-04-20T22:35:00Z"
+          verifiedAt="2026-04-20T22:41:00Z"
+          retroedAt={null}
+        />,
+      );
+      // Data-testid differs so tests can distinguish the two success
+      // variants without relying on class-string matching.
+      const pill = screen.getByTestId('outcome-pill-succeeded-incomplete');
+      expect(pill.textContent).toBe('\u2713');
+      expect(pill.className).toContain('bg-amber');
+      expect(pill.className).not.toMatch(/bg-green/);
+    });
+
+    it('renders amber ✓ when merged but verifiedAt is missing with no skip reason', () => {
+      // Historical (pre-migration-35) succeeded row has mergedAt set
+      // from the backfill but verifiedAt NULL and no skip reason —
+      // we genuinely don't know whether verify ran, so the amber ✓
+      // ("incomplete bookkeeping") is the honest signal.
+      render(
+        <OutcomePill
+          status="succeeded"
+          mergedAt="2026-04-19T10:00:00Z"
+          verifiedAt={null}
+          retroedAt={null}
+        />,
+      );
+      const pill = screen.getByTestId('outcome-pill-succeeded-incomplete');
+      expect(pill.textContent).toBe('\u2713');
+      expect(pill.className).toContain('bg-amber');
+    });
+
+    it('renders red ✗ for a post-merge verify failure', () => {
+      // verify returned FAILED → daemon flipped status back to 'failed'
+      // (real regression signal — the deployed code didn't behave as
+      // expected). mergedAt stays set so the tooltip can still show
+      // the shipment, but the glyph colour is red.
+      render(
+        <OutcomePill
+          status="failed"
+          mergedAt="2026-04-20T22:35:00Z"
+          verifiedAt={null}
+          retroedAt={null}
+          failureSummary="verify FAILED: API returned 500"
+        />,
+      );
+      const pill = screen.getByTestId('outcome-pill-failed');
+      expect(pill.textContent).toBe('\u2717');
+      expect(pill.className).toContain('bg-red');
+    });
+
+    it('falls back to the pre-#2953 status-only path when mergedAt is null', () => {
+      // A row that never merged (push_and_pr failed, CI red after
+      // retries) has mergedAt null — the milestone-completeness
+      // branch does not apply. The pill renders red ✗ with the
+      // standard failure tooltip.
+      render(
+        <OutcomePill
+          status="failed"
+          mergedAt={null}
+          failureSummary="git push failed"
+        />,
+      );
+      const pill = screen.getByTestId('outcome-pill-failed');
+      expect(pill.textContent).toBe('\u2717');
+      expect(pill.className).toContain('bg-red');
+      expect(pill.getAttribute('title')).toBe('git push failed');
+    });
+
+    it('milestone-breakdown tooltip shows merged / verified / retro times', () => {
+      render(
+        <OutcomePill
+          status="succeeded"
+          mergedAt="2026-04-20T22:35:00Z"
+          verifiedAt="2026-04-20T22:41:00Z"
+          retroedAt="2026-04-20T22:50:00Z"
+        />,
+      );
+      const pill = screen.getByTestId('outcome-pill-succeeded');
+      const tooltip = pill.getAttribute('title') ?? '';
+      expect(tooltip).toMatch(/merged \d{2}:\d{2}/);
+      expect(tooltip).toMatch(/verified \d{2}:\d{2}/);
+      expect(tooltip).toMatch(/retro \d{2}:\d{2}/);
+      expect(tooltip).toContain('\u00B7'); // middle-dot separator
+    });
+
+    it('tooltip shows skip reason when verifySkipReason is set', () => {
+      render(
+        <OutcomePill
+          status="succeeded"
+          mergedAt="2026-04-20T22:35:00Z"
+          verifiedAt={null}
+          verifySkipReason="self_deploy"
+          retroedAt="2026-04-20T22:48:00Z"
+        />,
+      );
+      const pill = screen.getByTestId('outcome-pill-succeeded');
+      const tooltip = pill.getAttribute('title') ?? '';
+      expect(tooltip).toContain('verify skipped (self-deploy)');
+    });
+
+    it('tooltip flags post-merge bookkeeping incompleteness', () => {
+      render(
+        <OutcomePill
+          status="succeeded"
+          mergedAt="2026-04-19T10:00:00Z"
+          verifiedAt={null}
+          retroedAt={null}
+        />,
+      );
+      const pill = screen.getByTestId('outcome-pill-succeeded-incomplete');
+      const tooltip = pill.getAttribute('title') ?? '';
+      expect(tooltip).toContain('post-merge bookkeeping incomplete');
+    });
+
+    it('tooltip em-dashes missing milestones in the fully-incomplete case', () => {
+      render(
+        <OutcomePill
+          status="succeeded"
+          mergedAt="2026-04-19T10:00:00Z"
+          verifiedAt={null}
+          retroedAt={null}
+        />,
+      );
+      const pill = screen.getByTestId('outcome-pill-succeeded-incomplete');
+      const tooltip = pill.getAttribute('title') ?? '';
+      expect(tooltip).toContain('verified \u2014');
+      expect(tooltip).toContain('retro \u2014');
     });
   });
 });

--- a/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
@@ -89,48 +89,47 @@ export function PriorityBadge({ priority }: { priority: string | null }) {
 }
 
 // ---------------------------------------------------------------------------
-// Outcome glyph pill — succeeded (✓ green), failed (✗ red), crashed (⚠ amber),
-// plan_blocked (⊘ neutral — #2857), needs_review (◐ yellow — #2856),
-// infra-preempted (↺ amber — #2947).
+// Outcome glyph pill — the single visual summary of an agent's terminal
+// state. One glyph per row; colour encodes pipeline completeness.
 //
-// Colour assignment intentionally keeps red reserved for genuine failure
-// and amber reserved for the crash-category anomaly. `plan_blocked`
-// ("plan correctly declined to proceed") is operator-informational, so
-// it uses the neutral muted surface — the same treatment `priority/p2`
-// gets above — per BRAND.md §"Minimal accent use". A dashboard full of
-// plan_blocked chips must not look like a house on fire.
+// Colour vocabulary (issue #2953):
+// * green  ✓ — shipped + post-merge bookkeeping complete (merged +
+//              verified OR verify-skipped-with-reason + retroed)
+// * amber  ✓ — shipped but post-merge bookkeeping incomplete (merged
+//              but missing verifiedAt AND no skip reason, OR missing
+//              retroedAt). Operator signal: "this PR landed, but
+//              verify/retro didn't finish — investigate why before
+//              trusting the shipment."
+// * red    ✗ — genuine failure (didn't merge).
+// * gray   ↺ — infra-preempted (dispatcher restart / killswitch). Not
+//              an operator action item; will auto-resume. Issue #2953
+//              changes the colour from amber (#2947) to gray to sit
+//              the glyph on the neutral palette — infra churn is not
+//              a warning, it's routine resumption.
+// * yellow ◐ — needs_review (#2856): ralph produced reviewer-approved
+//              SHIP code but summary flagged unmet AC; daemon opened a
+//              draft PR for operator triage.
+// * neutral⊘ — plan_blocked (#2857): plan correctly declined to
+//              proceed. Operator-informational, not alarming.
+// * fallback? — unknown status.
 //
-// `needs_review` is the one correct-outcome terminal that DOES need
-// operator action (ralph produced reviewer-approved SHIP code but
-// summary flagged unmet AC; the daemon opened a draft PR that sits
-// for operator triage). It earns yellow — adjacent to amber on the
-// colour wheel but visually distinct from crashed's amber so the
-// operator can scan the "Recently completed" panel and quickly
-// separate "review my draft PR" from "something crashed, diagnose
-// this". The glyph ◐ (half-circle) is the semantic anchor: ralph
-// did half the work, you do the other half (review + merge).
+// Tooltip:
+// For a merged row, the tooltip renders a milestone breakdown —
+// `merged 22:35 · verified 22:41 · retro 22:50` or
+// `merged 22:35 · verify skipped (self-deploy) · retro 22:48` or
+// `merged 22:35 · verified — · retro — (container restarted before retry)` —
+// so the operator can at-a-glance see where the pipeline stopped.
+// Non-merged rows keep the pre-#2953 tooltip behaviour (failureSummary
+// or status-label fallback).
 //
-// `infra_preempted` is a *derived* sub-category of `failed` for the two
-// infra-preemption categories in ``scripts/dispatcher/daemon.py``'s
-// ``_INFRA_PREEMPTION_CATEGORIES`` frozenset —
-// ``daemon_restart_abandoned`` and ``paused_by_killswitch``. These
-// agents didn't fail in any code/runtime sense; the dispatcher itself
-// interrupted them (restart recovery, or operator hit the killswitch)
-// and they will resume on the next tick. Rendering them as red ✗
-// misleads operators into treating them as actionable — which is the
-// opposite of the truth. They earn ↺ (counterclockwise arrow) in amber
-// to signal "will auto-resume; not an operator action item".
-//
-// Detection is pattern-based on `failureSummary`. The daemon writes
-// exactly two canonical strings for these categories —
-// ``"dispatcher restarted"`` (daemon_restart_abandoned) and
-// ``"manually stopped"`` (paused_by_killswitch) — from
-// ``_NO_TAIL_CATEGORY_SUMMARIES`` (issues #2924 / #2935). The resolver
-// surfaces these verbatim through ``failureSummary``. Pattern-matching
-// on this closed set is robust because the daemon has no other code
-// path that can produce these exact strings for a failed row. If the
-// daemon ever changes the strings, the pill falls back to the plain
-// red ✗ — a soft regression, not a crash.
+// `infra_preempted` is detected from `failureSummary` matching one of
+// the canonical strings produced by the daemon's
+// `_NO_TAIL_CATEGORY_SUMMARIES` map — `"dispatcher restarted"` (from
+// `daemon_restart_abandoned`) and `"manually stopped"` (from
+// `paused_by_killswitch`). This avoids plumbing a new `category`
+// field through GraphQL for what is effectively a display override;
+// any drift in the daemon strings just collapses back to the default
+// chip (soft regression, not a crash).
 // ---------------------------------------------------------------------------
 
 /**
@@ -161,9 +160,18 @@ export const INFRA_PREEMPTED_CATEGORIES: ReadonlySet<string> = new Set([
   'paused_by_killswitch',
 ]);
 
-/** Shared amber chip class for the ↺ infra-preempted glyph. Issue #2947. */
+/** Shared gray chip class for the ↺ infra-preempted glyph.
+ *
+ * Issue #2953: recoloured from amber (#2947) to gray. An infra-
+ * preempt is not a warning — it's a neutral resumption event
+ * (dispatcher restarted, operator hit killswitch, etc.). Amber
+ * inappropriately visually groups it with the amber ✓ "shipped but
+ * bookkeeping incomplete" state introduced by this issue; gray keeps
+ * the two clearly distinct. Uses `bg-muted` / `text-muted-foreground`
+ * so the chip inherits the shadcn neutral palette — same treatment as
+ * `plan_blocked` (⊘), with no accent weight. */
 export const INFRA_PREEMPTED_CHIP_CLASSES =
-  'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200';
+  'bg-muted text-muted-foreground';
 
 /** Shared ↺ glyph (U+21BA, ANTICLOCKWISE OPEN CIRCLE ARROW). Issue #2947. */
 export const INFRA_PREEMPTED_GLYPH = '\u21BA';
@@ -174,6 +182,18 @@ type OutcomeStatus =
   | 'crashed'
   | 'plan_blocked'
   | 'needs_review';
+
+/** Amber ✓ chip — shipped but post-merge bookkeeping incomplete.
+ *
+ * Issue #2953. Written when a row is ``status='succeeded'`` with a
+ * ``mergedAt`` timestamp (so it genuinely shipped) but either
+ * ``verifiedAt`` is missing with no skip reason, or ``retroedAt``
+ * is missing. The amber colour is distinct from the green ✓
+ * (``bg-green-100``), yellow ◐ (``bg-yellow-100``), and gray ↺
+ * (``bg-muted``) so the operator can scan the panel and separate
+ * the four "shipped" sub-states at a glance. */
+const INCOMPLETE_SUCCESS_CLASSES =
+  'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200';
 
 const OUTCOME_STYLES: Record<
   OutcomeStatus,
@@ -217,9 +237,93 @@ const OUTCOME_STYLES: Record<
   },
 };
 
+/** Format a milestone timestamp for the tooltip. Returns `HH:MM` in
+ * the viewer's local time (no date — the panel already scopes to
+ * recently-completed rows, full datetime is on the relative-time
+ * hover). Returns an em-dash for null / undefined / unparseable
+ * inputs so the tooltip format is stable. Issue #2953. */
+function formatMilestoneTime(ts: string | null | undefined): string {
+  if (!ts) return '\u2014';
+  const parsed = Date.parse(ts);
+  if (!Number.isFinite(parsed)) return '\u2014';
+  const d = new Date(parsed);
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+/** Render the milestone-breakdown tooltip for a row. Issue #2953.
+ *
+ * Format:
+ *   `merged HH:MM · verified HH:MM · retro HH:MM`
+ *   `merged HH:MM · verify skipped (<reason>) · retro HH:MM`
+ *   `merged HH:MM · verified — · retro — (post-merge bookkeeping incomplete)`
+ *
+ * Rendered inside the native `title` attribute — plain text, no HTML.
+ * Reuses the same em-dash placeholder the milestone-time formatter
+ * produces so the tooltip shape is stable regardless of which
+ * milestones landed. */
+export function formatMilestoneTooltip(args: {
+  mergedAt: string | null;
+  verifiedAt: string | null;
+  verifySkipReason: string | null;
+  retroedAt: string | null;
+}): string {
+  const parts: string[] = [];
+  parts.push(`merged ${formatMilestoneTime(args.mergedAt)}`);
+  if (args.verifySkipReason) {
+    // Render the skip reason with underscores → spaces so
+    // ``self_deploy`` reads as ``self-deploy``. Keep the parens so
+    // the tooltip is scannable.
+    const pretty = args.verifySkipReason.replace(/_/g, '-');
+    parts.push(`verify skipped (${pretty})`);
+  } else {
+    parts.push(`verified ${formatMilestoneTime(args.verifiedAt)}`);
+  }
+  parts.push(`retro ${formatMilestoneTime(args.retroedAt)}`);
+
+  // If the row merged but any post-merge milestone is missing with no
+  // skip reason, append a short trailing hint so the operator can
+  // spot the incomplete-bookkeeping case at a glance.
+  const incomplete =
+    !!args.mergedAt &&
+    ((!args.verifiedAt && !args.verifySkipReason) || !args.retroedAt);
+  if (incomplete) {
+    parts.push('post-merge bookkeeping incomplete');
+  }
+  return parts.join(' \u00B7 ');
+}
+
+/** Return the pipeline-completeness category for a row. Issue #2953.
+ *
+ * - ``fully_complete`` — merged + (verified OR skipped with reason) +
+ *   retroed.
+ * - ``shipped_incomplete`` — merged, but verify and/or retro bookkeeping
+ *   did not complete (no skip reason to explain verify, or retro is
+ *   missing).
+ * - ``not_merged`` — no ``mergedAt`` signal; the base ``status`` drives
+ *   the glyph (failed / crashed / plan_blocked / needs_review).
+ *
+ * Pure-functional for testability. */
+export function classifyPipelineCompleteness(args: {
+  mergedAt: string | null;
+  verifiedAt: string | null;
+  verifySkipReason: string | null;
+  retroedAt: string | null;
+}): 'fully_complete' | 'shipped_incomplete' | 'not_merged' {
+  if (!args.mergedAt) return 'not_merged';
+  const verifyDone = !!args.verifiedAt || !!args.verifySkipReason;
+  const retroDone = !!args.retroedAt;
+  return verifyDone && retroDone ? 'fully_complete' : 'shipped_incomplete';
+}
+
 export function OutcomePill({
   status,
   failureSummary,
+  mergedAt = null,
+  verifiedAt = null,
+  verifySkipReason = null,
+  retroedAt = null,
 }: {
   status: string;
   /**
@@ -227,34 +331,45 @@ export function OutcomePill({
    * terminals: `failed` / `crashed` / `plan_blocked`), overrides the
    * default status-label tooltip so operators can scan the cause on
    * hover without opening the agent detail page. Null / undefined
-   * falls back to the default status label — preserves the existing
-   * UX for `succeeded` / `needs_review` rows and historical rows from
-   * before migration 33. Issue #2900.
-   *
-   * We deliberately do NOT render an always-visible second line — the
-   * "Recently completed" panel's density-first design (#2818) is the
-   * constraint. Tooltip-only.
+   * falls back to the default status label. Issue #2900.
    *
    * Issue #2947: when the summary exactly matches one of
-   * ``INFRA_PREEMPTED_SUMMARIES``, the pill re-skins to amber ↺
-   * (infra-preempted) instead of red ✗ / amber ⚠ — the agent was
-   * preempted by the dispatcher, not an operator action item.
+   * ``INFRA_PREEMPTED_SUMMARIES``, the pill re-skins to ↺ gray
+   * (infra-preempted) instead of red ✗ / amber ⚠. Issue #2953 moves
+   * the infra-preempt colour from amber → gray — see
+   * ``INFRA_PREEMPTED_CHIP_CLASSES``.
    */
   failureSummary?: string | null;
+  /** Issue #2953 — PR-merge timestamp. When present the pill uses the
+   * milestone-completeness rules (green ✓ vs. amber ✓) instead of the
+   * base status mapping. When null the pill falls back to the pre-
+   * #2953 status-only path. */
+  mergedAt?: string | null;
+  /** Issue #2953 — verify phase timestamp. */
+  verifiedAt?: string | null;
+  /** Issue #2953 — ``dispatcher.agents.verify_skip_reason``. Non-null
+   * means verify was intentionally skipped (today: ``self_deploy``).
+   * A merged row with a skip reason counts as fully-verified for the
+   * glyph colour — the skip was intentional, not a regression. */
+  verifySkipReason?: string | null;
+  /** Issue #2953 — retro phase timestamp. */
+  retroedAt?: string | null;
 }) {
   const info = OUTCOME_STYLES[status as OutcomeStatus];
   const trimmedSummary =
     failureSummary && failureSummary.trim() ? failureSummary.trim() : null;
-  // #2947: infra-preemption override. Daemon writes a short canonical
-  // string (``"dispatcher restarted"`` / ``"manually stopped"``) for
-  // the two `_INFRA_PREEMPTION_CATEGORIES` — those rows should render
-  // ↺ amber regardless of the stored `status` (today always `failed`
-  // for these, but we don't want to couple to that invariant).
-  // Pattern-matching on the closed set in ``INFRA_PREEMPTED_SUMMARIES``
-  // avoids plumbing a new `category` field through the GraphQL type
-  // for what is effectively a display override; any drift in the
-  // daemon's canonical strings just collapses back to the default red
-  // ✗ (a soft regression, not a crash).
+
+  // #2947 / #2953: infra-preemption override. Daemon writes a short
+  // canonical string (``"dispatcher restarted"`` / ``"manually
+  // stopped"``) for the two `_INFRA_PREEMPTION_CATEGORIES` — those
+  // rows render ↺ gray (was amber in #2947; #2953 recoloured to gray
+  // to keep infra churn on the neutral palette, distinct from the
+  // amber ✓ "shipped but bookkeeping incomplete" chip introduced by
+  // #2953). Pattern-matching on the closed set in
+  // ``INFRA_PREEMPTED_SUMMARIES`` avoids plumbing a new `category`
+  // field through GraphQL; any drift in the daemon strings just
+  // collapses back to the default red ✗ (soft regression, not a
+  // crash).
   if (trimmedSummary !== null && INFRA_PREEMPTED_SUMMARIES.has(trimmedSummary)) {
     return (
       <span
@@ -267,6 +382,81 @@ export function OutcomePill({
       </span>
     );
   }
+
+  // #2953: milestone-completeness path. When the row has a
+  // ``mergedAt`` stamp, it genuinely shipped — the glyph is always ✓,
+  // and the colour encodes whether the post-merge bookkeeping (verify
+  // + retro) completed. The milestone-breakdown tooltip replaces the
+  // status-label / failure-summary tooltips for merged rows so the
+  // operator can scan "where did this land in the pipeline" on hover
+  // without opening the agent detail page.
+  //
+  // Only applied when ``status`` resolves to 'succeeded' OR the row
+  // has a mergedAt (defensive — a row flipped back to 'failed' after
+  // a post-merge verify failure stays in the failure path, but we
+  // still want the tooltip to surface that it did merge).
+  if (mergedAt) {
+    const completeness = classifyPipelineCompleteness({
+      mergedAt,
+      verifiedAt,
+      verifySkipReason,
+      retroedAt,
+    });
+    const milestoneTooltip = formatMilestoneTooltip({
+      mergedAt,
+      verifiedAt,
+      verifySkipReason,
+      retroedAt,
+    });
+
+    // Genuine post-merge failure (verify FAILED → status flipped to
+    // 'failed' by _run_verify_and_complete). We keep the red ✗ glyph
+    // but the tooltip surfaces the milestone breakdown so the
+    // operator sees that the PR *did* ship before verify rejected it.
+    if (status === 'failed' || status === 'crashed') {
+      const failureInfo = info ?? OUTCOME_STYLES.failed;
+      const combinedTooltip = trimmedSummary
+        ? `${trimmedSummary} — ${milestoneTooltip}`
+        : milestoneTooltip;
+      return (
+        <span
+          aria-label={failureInfo.label}
+          title={combinedTooltip}
+          className={`inline-flex h-5 w-5 items-center justify-center rounded-full text-xs ${failureInfo.className}`}
+          data-testid={`outcome-pill-${status}`}
+        >
+          {failureInfo.glyph}
+        </span>
+      );
+    }
+
+    // The succeeded / merged branch — green ✓ when fully complete,
+    // amber ✓ when shipped but bookkeeping incomplete.
+    const className =
+      completeness === 'fully_complete'
+        ? OUTCOME_STYLES.succeeded.className
+        : INCOMPLETE_SUCCESS_CLASSES;
+    const label =
+      completeness === 'fully_complete'
+        ? 'succeeded'
+        : 'shipped, post-merge bookkeeping incomplete';
+    const testId =
+      completeness === 'fully_complete'
+        ? 'outcome-pill-succeeded'
+        : 'outcome-pill-succeeded-incomplete';
+    return (
+      <span
+        aria-label={label}
+        title={milestoneTooltip}
+        className={`inline-flex h-5 w-5 items-center justify-center rounded-full text-xs ${className}`}
+        data-testid={testId}
+      >
+        {OUTCOME_STYLES.succeeded.glyph}
+      </span>
+    );
+  }
+
+  // No mergedAt — fall back to the pre-#2953 status-only path.
   if (!info) {
     return (
       <span

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -76,6 +76,10 @@ export const DISPATCHER_STATE_QUERY = gql`
         totalTokens
         totalCostUsd
         failureSummary
+        mergedAt
+        verifiedAt
+        verifySkipReason
+        retroedAt
       }
       config {
         key
@@ -206,6 +210,27 @@ export interface RecentCompletion {
    * glyph in the `Recently completed` panel — no always-visible second
    * line. Issue #2900. */
   failureSummary: string | null;
+  /** Timestamp the PR squash-merge was observed by the daemon. Paired
+   * with the `status='succeeded'` flip at merge time — `mergedAt != null`
+   * is the canonical "shipped" signal. Null on rows that never merged
+   * (push failed, CI red after retries, etc.) and on pre-migration-35
+   * historical rows. Issue #2953. */
+  mergedAt: string | null;
+  /** Timestamp the verify phase completed with verdict=VERIFIED. Null
+   * when verify was intentionally skipped (see `verifySkipReason`),
+   * when verify crashed mid-phase, or for pre-migration-35 rows.
+   * Issue #2953. */
+  verifiedAt: string | null;
+  /** Non-null when verify was intentionally skipped. Today the only
+   * written value is `"self_deploy"` (dispatcher-self-PR touches
+   * `scripts/dispatcher/`). A merged row with a non-null skip reason
+   * counts as fully-shipped (green ✓) — skipping is not a regression.
+   * Issue #2953. */
+  verifySkipReason: string | null;
+  /** Timestamp the retro phase completed (reached PHASE_RETRO_DONE).
+   * Null when retro crashed, when the worktree was already gone at
+   * retro time, or for pre-migration-35 rows. Issue #2953. */
+  retroedAt: string | null;
 }
 
 export interface DispatcherConfigEntry {

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -618,6 +618,30 @@ TERMINAL_AGENT_STATUSES: frozenset[str] = frozenset(
     {"succeeded", "failed", "crashed", "plan_blocked", "needs_review"}
 )
 
+# --------------------------------------------------------------------------
+# Milestone columns on ``dispatcher.agents`` — split the single
+# ``status='succeeded'`` terminal write into four independently-stamped
+# milestones so the admin cockpit can distinguish "shipped" from
+# "verified" from "retro completed" (issue #2953, migration 35).
+# --------------------------------------------------------------------------
+
+#: Verify-skip reason written to ``dispatcher.agents.verify_skip_reason``
+#: when a dispatcher-self-PR (touches ``scripts/dispatcher/``) is
+#: detected in push_and_pr. Verify cannot meaningfully run against a
+#: process that is about to be replaced by its own deploy, so the
+#: verify phase no-ops and the admin cockpit renders the row as
+#: shipped-without-verify (not as an incomplete-verify warning).
+#: Issue #2953.
+VERIFY_SKIP_REASON_SELF_DEPLOY = "self_deploy"
+
+#: Path prefixes whose presence in a PR's file list triggers
+#: ``verify_skip_reason=self_deploy``. Today: dispatcher source only.
+#: Future candidates (``docs/`` → ``docs_only``, ``.github/workflows/``
+#: → ``ci_cd_only``) are not yet written — the migration column allows
+#: them but the daemon code path doesn't emit them until a follow-up
+#: issue lands.
+_SELF_DEPLOY_PATH_PREFIXES: tuple[str, ...] = ("scripts/dispatcher/",)
+
 #: Failure category written when the daemon restart-recovery sweep
 #: reclaims a ``status='running'`` agent left behind by the previous
 #: daemon run. Tier-1 mechanical retry category — the agent gets a
@@ -4206,6 +4230,299 @@ class DispatcherDaemon:
             except Exception:  # pragma: no cover
                 pass
 
+    # ── milestone column writers (issue #2953, migration 35) ───────────
+    #
+    # Each helper stamps one of the four milestone columns on
+    # ``dispatcher.agents``. All are best-effort — a DB error logs,
+    # rolls back, and returns without re-raising, matching the
+    # ``_update_agent_phase`` / ``_write_failure_summary`` pattern so a
+    # transient DB hiccup cannot unwind the caller's control flow (the
+    # daemon is already past the decision point the milestone records).
+
+    def _write_merged_at(
+        self,
+        agent_id: str,
+        *,
+        pr_number: int | None = None,
+        issue_number: int | None = None,
+    ) -> None:
+        """Stamp ``merged_at = now()`` + flip ``status='succeeded'`` on merge.
+
+        Issue #2953. Called by ``_merge_pr_and_advance`` at the moment
+        the ``gh pr merge`` call returns successfully — not at end of
+        retro. One-way latch: status becomes ``succeeded`` the instant
+        the PR ships, so a container kill between merge and retro no
+        longer renders as a red ✗.
+
+        Mirrors the terminal-time side-effects of ``_mark_agent_terminal``
+        for the ``succeeded`` branch (``ended_at``, ``failure_summary``
+        cleanup, diagnosis outcome write-back, terminal-outcome circuit
+        breaker feed) in one UPDATE so the admin row transitions atomically.
+        """
+        assert self._conn is not None, "connect() must run before update"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.agents "
+                    "SET status = 'succeeded', "
+                    "    merged_at = now(), "
+                    "    ended_at = COALESCE(ended_at, now()), "
+                    "    exit_code = COALESCE(exit_code, 0), "
+                    "    pr_number = COALESCE(%s, pr_number), "
+                    "    failure_summary = NULL "
+                    "WHERE agent_id = %s",
+                    (pr_number, agent_id),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.write_merged_at_failed",
+                extra={
+                    "event": "write_merged_at_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "pr_number": pr_number,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — defensive
+                pass
+            return
+
+        # Mirror the best-effort side-effects that ``_mark_agent_terminal``
+        # runs for terminal statuses so the merge-time flip lands the
+        # same downstream signals (diagnosis outcome write-back,
+        # terminal-outcome circuit-breaker feed, issue-label teardown,
+        # circuit-breaker evaluation). Each one is independently
+        # wrapped — a failure here cannot roll back the status flip
+        # above (which was already committed).
+        try:
+            self._write_diagnosis_outcome_for_agent(agent_id, "succeeded")
+        except Exception:
+            self._log.exception(
+                "daemon.diagnosis_outcome_write_failed",
+                extra={
+                    "event": "diagnosis_outcome_write_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "status": "succeeded",
+                    "origin": "merged_at",
+                },
+            )
+        try:
+            self._write_terminal_outcome(agent_id, "succeeded")
+        except Exception:
+            self._log.exception(
+                "daemon.terminal_outcome_write_failed",
+                extra={
+                    "event": "terminal_outcome_write_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "status": "succeeded",
+                    "origin": "merged_at",
+                },
+            )
+        try:
+            self._evaluate_circuit_breaker(agent_id)
+        except Exception:
+            self._log.exception(
+                "daemon.circuit_breaker_evaluate_failed",
+                extra={
+                    "event": "circuit_breaker_evaluate_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "origin": "merged_at",
+                },
+            )
+        if issue_number is not None:
+            # Release ``status/in-progress`` label — the agent logically
+            # succeeded the moment the PR shipped. Best-effort; matches
+            # the ``_mark_agent_terminal`` teardown path (#2866).
+            self._gh_issue_remove_labels(issue_number, [STATUS_IN_PROGRESS_LABEL])
+
+    def _write_verified_at(self, agent_id: str) -> None:
+        """Stamp ``verified_at = now()`` when the verify phase succeeds.
+
+        Issue #2953. Does NOT touch ``status`` — ``merged_at`` already
+        flipped it to ``succeeded`` at merge. The admin cockpit reads
+        both columns and renders the pill color from their combined
+        presence.
+        """
+        assert self._conn is not None, "connect() must run before update"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.agents SET verified_at = now() "
+                    "WHERE agent_id = %s",
+                    (agent_id,),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.write_verified_at_failed",
+                extra={
+                    "event": "write_verified_at_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — defensive
+                pass
+
+    def _write_verify_skip_reason(self, agent_id: str, reason: str) -> None:
+        """Stamp ``verify_skip_reason`` pre-push when verify is skipped.
+
+        Issue #2953. Written by ``_push_and_open_pr`` before the push
+        when the PR touches ``scripts/dispatcher/`` (self-deploy case).
+        The verify phase later reads this column and no-ops if it's
+        non-null, so the admin cockpit can distinguish "shipped + verify
+        does not apply" from "shipped + verify failed to run".
+        """
+        assert self._conn is not None, "connect() must run before update"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.agents SET verify_skip_reason = %s "
+                    "WHERE agent_id = %s",
+                    (reason, agent_id),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.write_verify_skip_reason_failed",
+                extra={
+                    "event": "write_verify_skip_reason_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "reason": reason,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — defensive
+                pass
+
+    def _read_verify_skip_reason(self, agent_id: str) -> str | None:
+        """Return the current ``verify_skip_reason`` for an agent, or None."""
+        assert self._conn is not None, "connect() must run before read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT verify_skip_reason FROM dispatcher.agents "
+                    "WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.read_verify_skip_reason_failed",
+                extra={
+                    "event": "read_verify_skip_reason_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — defensive
+                pass
+            return None
+        if row is None:
+            return None
+        value = row[0]
+        return str(value) if isinstance(value, str) and value else None
+
+    def _write_retroed_at(self, agent_id: str) -> None:
+        """Stamp ``retroed_at = now()`` when retro reaches PHASE_RETRO_DONE.
+
+        Issue #2953. Does NOT touch ``status`` or ``phase`` — those are
+        handled by the existing ``_update_agent_phase(PHASE_RETRO_DONE)``
+        call. Best-effort; a DB error here cannot unwind the retro work.
+        """
+        assert self._conn is not None, "connect() must run before update"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.agents SET retroed_at = now() "
+                    "WHERE agent_id = %s",
+                    (agent_id,),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.write_retroed_at_failed",
+                extra={
+                    "event": "write_retroed_at_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — defensive
+                pass
+
+    @staticmethod
+    def _detect_verify_skip_reason(
+        touched_paths: list[str],
+    ) -> str | None:
+        """Return a ``verify_skip_reason`` for a PR's touched file list, or None.
+
+        Issue #2953 dispatcher-self-PR detection. Called in
+        ``_push_and_open_pr`` after ``git commit`` and before ``git
+        push``. Any file whose path starts with a prefix in
+        :data:`_SELF_DEPLOY_PATH_PREFIXES` triggers
+        :data:`VERIFY_SKIP_REASON_SELF_DEPLOY`.
+
+        The check is "any file matches" — a PR that touches both
+        dispatcher source AND something else still skips verify,
+        because the daemon deploy will land mid-verify regardless of
+        what else the PR did. Pure-functional for testability.
+        """
+        for path in touched_paths:
+            for prefix in _SELF_DEPLOY_PATH_PREFIXES:
+                if path.startswith(prefix):
+                    return VERIFY_SKIP_REASON_SELF_DEPLOY
+        return None
+
+    def _list_committed_files_at_head(self, worktree: Path) -> list[str]:
+        """Return the file list of the most recent commit on ``worktree``.
+
+        Issue #2953. Uses ``git show --name-only --pretty=format:``
+        which emits one path per line after the commit's empty-message
+        preamble. Returns an empty list on subprocess failure — the
+        caller treats that as "no skip reason detectable" and verify
+        runs normally. Swallowing the error is safe because the
+        admin-cockpit UX gracefully handles a verify that ran and
+        wrote ``verified_at`` (the normal path).
+        """
+        cmd = [
+            "git",
+            "-C",
+            str(worktree),
+            "show",
+            "--name-only",
+            "--pretty=format:",
+            "HEAD",
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            return []
+        if result.returncode != 0:
+            return []
+        return [line for line in (result.stdout or "").splitlines() if line.strip()]
+
     # ── failure_summary builder (issue #2900) ──────────────────────────
 
     #: Statuses that get a ``dispatcher.agents.failure_summary``
@@ -7061,6 +7378,46 @@ class DispatcherDaemon:
             )
             return
 
+        # Issue #2953: dispatcher-self-PR detection. If the just-made
+        # commit touches any file under ``scripts/dispatcher/``, stamp
+        # ``verify_skip_reason='self_deploy'`` NOW — before the push —
+        # so the downstream verify phase reads the signal and no-ops.
+        # Rationale: the daemon that would run verify post-merge is
+        # about to be replaced by the deploy of this very PR, and
+        # verifying against a soon-dead container produces false-failure
+        # noise during the drain window. Inspecting HEAD's file list
+        # is a pure read against the local worktree — no network, no
+        # DB beyond the single UPDATE.
+        try:
+            touched_paths = self._list_committed_files_at_head(worktree)
+            skip_reason = self._detect_verify_skip_reason(touched_paths)
+            if skip_reason:
+                self._write_verify_skip_reason(agent_id, skip_reason)
+                self._log.info(
+                    "daemon.verify_skip_reason_written",
+                    extra={
+                        "event": "verify_skip_reason_written",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "issue_number": issue_number,
+                        "skip_reason": skip_reason,
+                        "touched_paths": touched_paths[:20],
+                    },
+                )
+        except Exception:
+            # Non-critical path — a failure to detect skip reason
+            # just means verify runs normally. The worst case is
+            # false-failure noise on the admin page during a self-
+            # deploy window, which was the pre-#2953 status quo.
+            self._log.exception(
+                "daemon.verify_skip_detection_failed",
+                extra={
+                    "event": "verify_skip_detection_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+
         # git push -u origin <branch>
         short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
         branch = f"agent/{short_id}"
@@ -7400,6 +7757,17 @@ class DispatcherDaemon:
                 # ``dispatcher.agents``, so every row here is
                 # daemon-owned by construction — no ``kind`` filter
                 # needed.
+                # Issue #2953: post-merge rows now carry
+                # ``status='succeeded'`` from merge-detection onward
+                # (instead of only after retro). The filter picks up
+                # both pre-merge ``status='running'`` agents (awaiting_ci,
+                # awaiting_deploy) AND post-merge ``status='succeeded'``
+                # agents that still need verify / retro / cleanup
+                # (awaiting_deploy, done, retro_done, retro_failed).
+                # The awaiting_deploy phase appears in both branches
+                # because the transition merge→awaiting_deploy flips
+                # status without changing phase — the next tick sees
+                # the succeeded branch.
                 cur.execute(
                     "SELECT agent_id, issue_number, phase, pr_number, "
                     "       worktree_path, retries_used, status "
@@ -7407,7 +7775,8 @@ class DispatcherDaemon:
                     "WHERE (status = 'running' "
                     "       AND phase IN ('awaiting_ci', 'awaiting_deploy')) "
                     "   OR (status = 'succeeded' "
-                    "       AND phase IN ('done', 'retro_done', 'retro_failed')) "
+                    "       AND phase IN ('awaiting_deploy', 'done', "
+                    "                     'retro_done', 'retro_failed')) "
                     "ORDER BY started_at ASC",
                 )
                 for row in cur.fetchall():
@@ -7466,6 +7835,13 @@ class DispatcherDaemon:
                 if phase == "awaiting_ci":
                     self._advance_awaiting_ci(agent)
                 elif phase == "awaiting_deploy":
+                    # Issue #2953: post-merge rows have flipped to
+                    # ``status='succeeded'`` at merge time; pre-merge
+                    # rows (merge path not yet reached) are still
+                    # ``status='running'``. Both need the deploy
+                    # handler — status differentiates only the "is the
+                    # crash recoverable" policy in the exception
+                    # handler below.
                     self._advance_awaiting_deploy(agent)
                 elif phase == "done" and status == "succeeded":
                     # Phase 3E (#2798): post-success retro phase.
@@ -7508,11 +7884,26 @@ class DispatcherDaemon:
                 )
                 if status == "succeeded":
                     # Mark the post-success phase failed without
-                    # touching the success status. retro phase failure
-                    # → flip to retro_failed so cleanup still runs;
-                    # cleanup phase failure → flip to cleanup_blocked
-                    # so an operator can investigate.
-                    if phase == "done":
+                    # touching the success status. The agent logically
+                    # succeeded at merge time (#2953) — subsequent
+                    # deploy-watch / verify / retro / cleanup are
+                    # bookkeeping that can leave milestone columns
+                    # NULL without retroactively changing the success
+                    # status:
+                    #   awaiting_deploy  → deploy-watch/verify exception
+                    #                      advances straight to
+                    #                      PHASE_RETRO_FAILED so retro
+                    #                      runs bookkeeping anyway.
+                    #                      ``verified_at`` stays NULL
+                    #                      — admin shows amber ✓.
+                    #   done             → retro exception → retro_failed
+                    #                      so cleanup still runs.
+                    #   retro_done /
+                    #   retro_failed     → cleanup exception →
+                    #                      cleanup_blocked.
+                    if phase == "awaiting_deploy":
+                        self._update_agent_phase(agent_id, PHASE_RETRO_FAILED)
+                    elif phase == "done":
                         self._update_agent_phase(agent_id, PHASE_RETRO_FAILED)
                     elif phase in (PHASE_RETRO_DONE, PHASE_RETRO_FAILED):
                         self._update_agent_phase(agent_id, PHASE_CLEANUP_BLOCKED)
@@ -7815,6 +8206,24 @@ class DispatcherDaemon:
             if refreshed is not None:
                 merge_sha = self._extract_merge_sha(refreshed)
 
+        # Issue #2953: flip ``status='succeeded'`` + stamp ``merged_at``
+        # the moment the PR squash-merge lands — not at end of retro.
+        # The row now reads "shipped" durably even if the container
+        # dies mid-verify / mid-retro. ``phase`` advances to
+        # ``awaiting_deploy`` so the scheduler's next tick picks it up
+        # and drives the remaining post-merge bookkeeping. Order
+        # matters: stamp milestone + flip status FIRST, then advance
+        # phase — a crash between the two writes leaves a
+        # ``status='succeeded' AND phase='awaiting_ci'`` row (still
+        # recoverable by the next tick's advanceable-agents scan
+        # because the expanded filter picks up
+        # ``status='succeeded' AND phase IN (...)``).
+        issue_number = agent.get("issue_number")
+        self._write_merged_at(
+            agent_id,
+            pr_number=pr_number,
+            issue_number=int(issue_number) if issue_number is not None else None,
+        )
         self._update_agent_phase(agent_id, "awaiting_deploy")
         self._log.info(
             "daemon.pr_merged",
@@ -8459,11 +8868,57 @@ class DispatcherDaemon:
         merge_sha: str,
         deploy_runs: list[dict[str, Any]],
     ) -> None:
-        """Spawn ``/task-v2-verify``, post evidence comment, mark succeeded."""
+        """Spawn ``/task-v2-verify``, post evidence comment, advance to done.
+
+        Issue #2953: ``status='succeeded'`` was already written at merge
+        time by ``_write_merged_at`` — this method no longer flips the
+        status. Its remaining responsibilities are (a) short-circuit
+        when ``verify_skip_reason`` is set (dispatcher-self-PR case),
+        (b) run the verify subprocess, (c) stamp ``verified_at`` on
+        VERIFIED/SKIPPED verdict, and (d) advance ``phase`` to ``done``
+        so the retro phase picks it up on the next tick.
+
+        A FAILED verdict flips status back to ``failed`` via
+        ``_mark_agent_terminal`` — verify failing post-merge is a real
+        problem (the deployed code didn't behave as expected) and the
+        admin cockpit should surface it in red even though the PR
+        technically shipped. The row still has ``merged_at`` populated
+        so the milestone breakdown tooltip can show "merged X · verify
+        failed" on operator hover.
+        """
         agent_id = agent["agent_id"]
         issue_number = agent["issue_number"]
         pr_number = agent["pr_number"]
         worktree = Path(agent["worktree_path"])
+
+        # Issue #2953: short-circuit when this PR was detected as a
+        # dispatcher-self-PR during push_and_pr. The daemon process
+        # running verify here is about to be replaced by its own
+        # deploy, so verifying against a soon-dead container adds
+        # noise (false-failure race during the drain window) without
+        # validating anything. Advance straight to ``done`` — the
+        # retro phase still runs (bookkeeping fits in the drain
+        # window) and the admin row renders as shipped-without-verify
+        # (green ✓) per the skip-reason semantic.
+        skip_reason = self._read_verify_skip_reason(agent_id)
+        if skip_reason:
+            self._log.info(
+                "daemon.verify_skipped",
+                extra={
+                    "event": "verify_skipped",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "pr_number": pr_number,
+                    "skip_reason": skip_reason,
+                },
+            )
+            # Advance phase so retro picks it up. Do NOT stamp
+            # ``verified_at`` — the skip reason is the canonical
+            # signal; a stamped timestamp would conflate "verify ran
+            # and passed" with "verify intentionally did not run".
+            self._update_agent_phase(agent_id, "done")
+            return
 
         # Fetch the issue bundle for acceptance criteria. Best-effort —
         # the verify skill tolerates an empty AC list with a failure row.
@@ -8570,15 +9025,23 @@ class DispatcherDaemon:
                     "failure_reason": verify_output.get("failure_reason"),
                 },
             )
+            # Issue #2953: verify failed post-merge is a genuine
+            # regression signal — the deployed code didn't behave as
+            # expected. Flip status back to ``failed`` so the admin
+            # cockpit renders red. ``merged_at`` stays populated so the
+            # tooltip can read "merged X · verify failed" instead of
+            # hiding the shipment entirely.
             self._mark_agent_terminal(
                 agent_id, status="failed", phase="done", exit_code=exit_code
             )
             return
 
-        # VERIFIED or SKIPPED — either is a success for the daemon.
-        self._mark_agent_terminal(
-            agent_id, status="succeeded", phase="done", exit_code=0
-        )
+        # VERIFIED or SKIPPED — stamp ``verified_at`` and advance phase
+        # so the retro phase picks up the row next tick. ``status`` is
+        # already ``succeeded`` from merge-time; no re-flip needed
+        # (issue #2953).
+        self._write_verified_at(agent_id)
+        self._update_agent_phase(agent_id, "done")
         self._log.info(
             "daemon.agent_completed",
             extra={
@@ -8929,6 +9392,13 @@ class DispatcherDaemon:
             if new_issue is not None:
                 filed += 1
 
+        # Issue #2953: stamp ``retroed_at`` BEFORE advancing phase so a
+        # crash between the two writes leaves the milestone column set
+        # — the admin cockpit can render the "retro completed" signal
+        # even if the phase advance failed. Paired reads of
+        # ``phase=retro_done`` and ``retroed_at IS NOT NULL`` are both
+        # authoritative (post this fix).
+        self._write_retroed_at(agent_id)
         self._update_agent_phase(agent_id, PHASE_RETRO_DONE)
         self._log.info(
             "daemon.retro_done",

--- a/scripts/dispatcher/tests/test_daemon_milestone_columns.py
+++ b/scripts/dispatcher/tests/test_daemon_milestone_columns.py
@@ -1,0 +1,774 @@
+"""Unit tests for the milestone-column split on ``dispatcher.agents``.
+
+Issue #2953, migration 35. Covers the new write paths the daemon
+gained when ``status='succeeded'`` was moved from end-of-retro to
+merge-detection and three independent milestone columns
+(``merged_at``, ``verified_at``, ``verify_skip_reason``,
+``retroed_at``) were stamped in place:
+
+* ``_write_merged_at`` — flips status → succeeded + stamps merged_at
+  atomically at merge time; mirrors ``_mark_agent_terminal``
+  best-effort side-effects.
+* ``_write_verified_at`` — stamps verified_at without touching status.
+* ``_write_verify_skip_reason`` + ``_read_verify_skip_reason`` — round-
+  trip the skip reason column.
+* ``_write_retroed_at`` — stamps retroed_at.
+* ``_detect_verify_skip_reason`` — pure-functional file-list classifier.
+* ``_push_and_open_pr`` — end-to-end: a dispatcher-touching commit gets
+  ``verify_skip_reason='self_deploy'`` written pre-push.
+* ``_merge_pr_and_advance`` — writes ``merged_at`` + flips status.
+* ``_run_verify_and_complete`` — short-circuits on skip reason; on
+  VERIFIED/SKIPPED stamps verified_at without re-flipping status.
+* ``_run_retro_phase`` — stamps retroed_at on success.
+* ``_list_advanceable_agents`` — filter picks up both
+  ``status='running'`` AND ``status='succeeded'`` rows across phases.
+
+All external calls (``gh``, ``git``, ``claude -p``, psycopg) are mocked.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.milestone.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# _detect_verify_skip_reason — pure-functional file-list classifier
+# --------------------------------------------------------------------------
+
+
+class TestDetectVerifySkipReason:
+    def test_self_deploy_detected_for_dispatcher_path(self) -> None:
+        touched = ["scripts/dispatcher/daemon.py"]
+        assert (
+            daemon.DispatcherDaemon._detect_verify_skip_reason(touched)
+            == daemon.VERIFY_SKIP_REASON_SELF_DEPLOY
+        )
+
+    def test_self_deploy_detected_for_dispatcher_subpath(self) -> None:
+        touched = ["scripts/dispatcher/tests/test_daemon_phase3b.py"]
+        assert (
+            daemon.DispatcherDaemon._detect_verify_skip_reason(touched)
+            == daemon.VERIFY_SKIP_REASON_SELF_DEPLOY
+        )
+
+    def test_no_skip_when_only_non_dispatcher_files_touched(self) -> None:
+        touched = [
+            "packages/web/src/app/(main)/admin/page.tsx",
+            "docs/agent/code-standards.md",
+        ]
+        assert daemon.DispatcherDaemon._detect_verify_skip_reason(touched) is None
+
+    def test_self_deploy_detected_when_any_file_matches(self) -> None:
+        """A PR touching both dispatcher AND unrelated code still skips verify."""
+        touched = [
+            "packages/api/src/graphql/schema.ts",
+            "scripts/dispatcher/daemon.py",
+            "docs/README.md",
+        ]
+        assert (
+            daemon.DispatcherDaemon._detect_verify_skip_reason(touched)
+            == daemon.VERIFY_SKIP_REASON_SELF_DEPLOY
+        )
+
+    def test_empty_file_list_returns_none(self) -> None:
+        assert daemon.DispatcherDaemon._detect_verify_skip_reason([]) is None
+
+    def test_similarly_named_path_does_not_false_positive(self) -> None:
+        """``scripts/dispatcher_audit.sh`` (no trailing slash) does NOT match."""
+        touched = ["scripts/dispatcher_audit.sh"]
+        assert daemon.DispatcherDaemon._detect_verify_skip_reason(touched) is None
+
+
+# --------------------------------------------------------------------------
+# _write_merged_at — flips status='succeeded', stamps merged_at
+# --------------------------------------------------------------------------
+
+
+class TestWriteMergedAt:
+    def test_writes_status_succeeded_and_merged_at_in_one_update(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        # Best-effort side-effect paths are stubbed — we assert the
+        # primary UPDATE here; sibling tests cover the side effects.
+        d._write_diagnosis_outcome_for_agent = MagicMock()  # type: ignore[method-assign]
+        d._write_terminal_outcome = MagicMock()  # type: ignore[method-assign]
+        d._evaluate_circuit_breaker = MagicMock()  # type: ignore[method-assign]
+        d._gh_issue_remove_labels = MagicMock()  # type: ignore[method-assign]
+
+        d._write_merged_at("aaaa-bbbb", pr_number=123, issue_number=42)
+
+        primary_updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in sql and "merged_at" in sql
+        ]
+        assert primary_updates
+        sql, params = primary_updates[0]
+        assert "status = 'succeeded'" in sql
+        assert "merged_at = now()" in sql
+        # Ensure the COALESCE guards don't clobber existing ended_at /
+        # exit_code values — the SQL uses COALESCE, not assignment.
+        assert "COALESCE(ended_at" in sql
+        assert "COALESCE(exit_code" in sql
+        # failure_summary is cleared in the same statement (matches
+        # the existing ``_mark_agent_terminal`` succeeded path for
+        # the #2913 fix).
+        assert "failure_summary = NULL" in sql
+        assert params == (123, "aaaa-bbbb")
+
+    def test_runs_best_effort_side_effects_on_success(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        d._write_diagnosis_outcome_for_agent = MagicMock()  # type: ignore[method-assign]
+        d._write_terminal_outcome = MagicMock()  # type: ignore[method-assign]
+        d._evaluate_circuit_breaker = MagicMock()  # type: ignore[method-assign]
+        d._gh_issue_remove_labels = MagicMock()  # type: ignore[method-assign]
+
+        d._write_merged_at("aaaa-bbbb", pr_number=99, issue_number=17)
+
+        d._write_diagnosis_outcome_for_agent.assert_called_once_with(
+            "aaaa-bbbb", "succeeded"
+        )
+        d._write_terminal_outcome.assert_called_once_with("aaaa-bbbb", "succeeded")
+        d._evaluate_circuit_breaker.assert_called_once_with("aaaa-bbbb")
+        d._gh_issue_remove_labels.assert_called_once_with(
+            17, [daemon.STATUS_IN_PROGRESS_LABEL]
+        )
+
+    def test_does_not_remove_label_when_issue_number_is_none(
+        self, tmp_path: Path
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        d._write_diagnosis_outcome_for_agent = MagicMock()  # type: ignore[method-assign]
+        d._write_terminal_outcome = MagicMock()  # type: ignore[method-assign]
+        d._evaluate_circuit_breaker = MagicMock()  # type: ignore[method-assign]
+        d._gh_issue_remove_labels = MagicMock()  # type: ignore[method-assign]
+
+        d._write_merged_at("aaaa-bbbb", pr_number=99)
+
+        d._gh_issue_remove_labels.assert_not_called()
+
+    def test_side_effect_failure_does_not_propagate(self, tmp_path: Path) -> None:
+        """A failure in a best-effort side-effect must not unwind the flip."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        d._write_diagnosis_outcome_for_agent = MagicMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("diagnoses table not yet migrated")
+        )
+        d._write_terminal_outcome = MagicMock()  # type: ignore[method-assign]
+        d._evaluate_circuit_breaker = MagicMock()  # type: ignore[method-assign]
+        d._gh_issue_remove_labels = MagicMock()  # type: ignore[method-assign]
+
+        # Does not raise.
+        d._write_merged_at("aaaa-bbbb", pr_number=99, issue_number=17)
+
+        # The subsequent side-effects still run because each one is
+        # wrapped in its own try/except.
+        d._write_terminal_outcome.assert_called_once()
+        d._evaluate_circuit_breaker.assert_called_once()
+        # And the diagnosis-outcome failure was logged.
+        failures = handler.events("diagnosis_outcome_write_failed")
+        assert failures
+        assert failures[0].origin == "merged_at"
+
+
+# --------------------------------------------------------------------------
+# _write_verified_at / _write_retroed_at — simple milestone stamps
+# --------------------------------------------------------------------------
+
+
+class TestWriteMilestoneStamps:
+    def test_write_verified_at_sets_only_that_column(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        d._write_verified_at("aaaa-bbbb")
+        updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in sql
+        ]
+        assert len(updates) == 1
+        sql, params = updates[0]
+        assert "verified_at = now()" in sql
+        # Must not touch status / phase / ended_at.
+        assert "status" not in sql
+        assert "phase" not in sql
+        assert "ended_at" not in sql
+        assert params == ("aaaa-bbbb",)
+        assert conn.commits == 1
+
+    def test_write_retroed_at_sets_only_that_column(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        d._write_retroed_at("aaaa-bbbb")
+        updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in sql
+        ]
+        assert len(updates) == 1
+        sql, params = updates[0]
+        assert "retroed_at = now()" in sql
+        assert "status" not in sql
+        assert "phase" not in sql
+        assert params == ("aaaa-bbbb",)
+
+
+# --------------------------------------------------------------------------
+# _write_verify_skip_reason / _read_verify_skip_reason
+# --------------------------------------------------------------------------
+
+
+class TestVerifySkipReasonRoundTrip:
+    def test_write_then_read_round_trip(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        d._write_verify_skip_reason("aaaa-bbbb", "self_deploy")
+        write_updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in sql and "verify_skip_reason" in sql
+        ]
+        assert write_updates
+        _sql, params = write_updates[0]
+        assert params == ("self_deploy", "aaaa-bbbb")
+
+    def test_read_returns_string_when_present(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [("self_deploy",)]
+        result = d._read_verify_skip_reason("aaaa-bbbb")
+        assert result == "self_deploy"
+
+    def test_read_returns_none_for_empty_row(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(None,)]
+        assert d._read_verify_skip_reason("aaaa-bbbb") is None
+
+    def test_read_returns_none_when_no_row(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        # fetch_queue is empty → fetchone returns None.
+        assert d._read_verify_skip_reason("aaaa-bbbb") is None
+
+
+# --------------------------------------------------------------------------
+# _push_and_open_pr — self-deploy detection writes verify_skip_reason pre-push
+# --------------------------------------------------------------------------
+
+
+class TestSelfDeployDetectionPrePush:
+    def test_dispatcher_touching_commit_writes_self_deploy_skip_reason(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        agent_id = "aaaabbbb-0000-0000-0000-000000000001"
+
+        # Stub DB phase updates so we don't need to care about them.
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
+
+        d._agent_summary_output = {  # type: ignore[attr-defined]
+            "commit_message": "feat(dispatcher): split terminal success (#2953)",
+            "pr_title": "feat(dispatcher): split terminal success",
+            "pr_body_md": "body",
+        }
+        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        add_ok = subprocess.CompletedProcess(
+            args=["git", "add"], returncode=0, stdout="", stderr=""
+        )
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit"], returncode=0, stdout="", stderr=""
+        )
+        # git show --name-only HEAD returns a list of files where the
+        # first one is in ``scripts/dispatcher/`` — should trigger
+        # self_deploy skip reason.
+        git_show = subprocess.CompletedProcess(
+            args=["git", "show"],
+            returncode=0,
+            stdout=(
+                "scripts/dispatcher/daemon.py\n"
+                "packages/api/migrations/35_dispatcher-agents-milestone-columns.sql\n"
+            ),
+            stderr="",
+        )
+        push_ok = subprocess.CompletedProcess(
+            args=["git", "push"], returncode=0, stdout="", stderr=""
+        )
+        pr_create_ok = subprocess.CompletedProcess(
+            args=["gh", "pr", "create"],
+            returncode=0,
+            stdout="https://github.com/x/y/pull/2953\n",
+            stderr="",
+        )
+
+        from unittest.mock import patch
+
+        with patch(
+            "subprocess.run",
+            side_effect=[add_ok, commit_ok, git_show, push_ok, pr_create_ok],
+        ):
+            d._push_and_open_pr(agent_id=agent_id, issue_number=2953, worktree=worktree)
+
+        # verify_skip_reason UPDATE was written before push.
+        skip_updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in sql and "verify_skip_reason" in sql
+        ]
+        assert skip_updates, (
+            "Expected UPDATE writing verify_skip_reason; "
+            f"got: {conn.cursor_instance.executed}"
+        )
+        _sql, params = skip_updates[0]
+        assert params == ("self_deploy", agent_id)
+
+        # Structured log event.
+        events = handler.events("verify_skip_reason_written")
+        assert events
+        assert events[0].skip_reason == "self_deploy"
+        assert events[0].issue_number == 2953
+
+    def test_non_dispatcher_commit_does_not_write_skip_reason(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        agent_id = "aaaabbbb-0000-0000-0000-000000000002"
+
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
+
+        d._agent_summary_output = {  # type: ignore[attr-defined]
+            "commit_message": "feat(web): new feature",
+            "pr_title": "feat(web): new feature",
+            "pr_body_md": "body",
+        }
+        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        add_ok = subprocess.CompletedProcess(
+            args=["git", "add"], returncode=0, stdout="", stderr=""
+        )
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit"], returncode=0, stdout="", stderr=""
+        )
+        git_show = subprocess.CompletedProcess(
+            args=["git", "show"],
+            returncode=0,
+            stdout="packages/web/src/app/page.tsx\n",
+            stderr="",
+        )
+        push_ok = subprocess.CompletedProcess(
+            args=["git", "push"], returncode=0, stdout="", stderr=""
+        )
+        pr_create_ok = subprocess.CompletedProcess(
+            args=["gh", "pr", "create"],
+            returncode=0,
+            stdout="https://github.com/x/y/pull/42\n",
+            stderr="",
+        )
+
+        from unittest.mock import patch
+
+        with patch(
+            "subprocess.run",
+            side_effect=[add_ok, commit_ok, git_show, push_ok, pr_create_ok],
+        ):
+            d._push_and_open_pr(agent_id=agent_id, issue_number=42, worktree=worktree)
+
+        skip_updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in sql and "verify_skip_reason" in sql
+        ]
+        assert skip_updates == []
+
+    def test_git_show_failure_does_not_block_push(self, tmp_path: Path) -> None:
+        """A ``git show`` error is swallowed so the push proceeds."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        agent_id = "aaaabbbb-0000-0000-0000-000000000003"
+
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
+
+        d._agent_summary_output = {  # type: ignore[attr-defined]
+            "commit_message": "x",
+            "pr_title": "x",
+            "pr_body_md": "x",
+        }
+        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        add_ok = subprocess.CompletedProcess(
+            args=["git", "add"], returncode=0, stdout="", stderr=""
+        )
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit"], returncode=0, stdout="", stderr=""
+        )
+        # git show returns non-zero → _list_committed_files_at_head
+        # returns [] → no skip reason detected.
+        git_show_fail = subprocess.CompletedProcess(
+            args=["git", "show"],
+            returncode=128,
+            stdout="",
+            stderr="fatal: bad object HEAD",
+        )
+        push_ok = subprocess.CompletedProcess(
+            args=["git", "push"], returncode=0, stdout="", stderr=""
+        )
+        pr_create_ok = subprocess.CompletedProcess(
+            args=["gh", "pr", "create"],
+            returncode=0,
+            stdout="https://github.com/x/y/pull/50\n",
+            stderr="",
+        )
+
+        from unittest.mock import patch
+
+        with patch(
+            "subprocess.run",
+            side_effect=[add_ok, commit_ok, git_show_fail, push_ok, pr_create_ok],
+        ):
+            d._push_and_open_pr(agent_id=agent_id, issue_number=50, worktree=worktree)
+
+        # No skip reason written; push went through.
+        skip_updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in sql and "verify_skip_reason" in sql
+        ]
+        assert skip_updates == []
+
+
+# --------------------------------------------------------------------------
+# _merge_pr_and_advance — now stamps merged_at + flips status='succeeded'
+# --------------------------------------------------------------------------
+
+
+class TestMergePrAndAdvanceMilestone:
+    def test_merge_writes_merged_at_and_flips_status(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # Stub the side-effects — we assert the primary UPDATE.
+        d._write_diagnosis_outcome_for_agent = MagicMock()  # type: ignore[method-assign]
+        d._write_terminal_outcome = MagicMock()  # type: ignore[method-assign]
+        d._evaluate_circuit_breaker = MagicMock()  # type: ignore[method-assign]
+        d._gh_issue_remove_labels = MagicMock()  # type: ignore[method-assign]
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            if cmd[:3] == ["gh", "pr", "merge"]:
+                r.stdout = ""
+                return r
+            if cmd[:3] == ["gh", "pr", "view"]:
+                r.stdout = json.dumps({"mergeCommit": {"oid": "merge-sha"}})
+                return r
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        agent = {
+            "agent_id": "a1",
+            "issue_number": 2953,
+            "phase": "awaiting_ci",
+            "pr_number": 101,
+            "worktree_path": str(tmp_path),
+            "retries_used": 0,
+        }
+        pr_status = {
+            "mergeCommit": {"oid": "merge-sha"},
+            "headRefOid": "head",
+        }
+        d._merge_pr_and_advance(agent, pr_status)
+
+        # merged_at + status='succeeded' in one UPDATE (from
+        # _write_merged_at).
+        merged_updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in sql and "merged_at = now()" in sql
+        ]
+        assert merged_updates
+        sql, _params = merged_updates[0]
+        assert "status = 'succeeded'" in sql
+
+        # Phase advanced to awaiting_deploy.
+        phase_updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in sql
+            and "SET phase" in sql
+            and params is not None
+            and "awaiting_deploy" in params
+        ]
+        assert phase_updates
+
+        # pr_merged event fired with merge_sha.
+        events = handler.events("pr_merged")
+        assert events
+        assert events[0].merge_sha == "merge-sha"
+
+
+# --------------------------------------------------------------------------
+# _run_verify_and_complete — skip reason short-circuit
+# --------------------------------------------------------------------------
+
+
+class TestVerifySkipReasonShortCircuit:
+    def test_skip_reason_short_circuits_without_spawning_verify(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        # _read_verify_skip_reason returns 'self_deploy'.
+        conn.cursor_instance.fetch_queue = [("self_deploy",)]
+
+        # Spawn should NOT be called if skip reason is set.
+        d._spawn_phase_subprocess = MagicMock(  # type: ignore[method-assign]
+            side_effect=AssertionError("verify subprocess should not spawn on skip")
+        )
+
+        agent = {
+            "agent_id": "a1",
+            "issue_number": 2953,
+            "phase": "awaiting_deploy",
+            "pr_number": 101,
+            "worktree_path": str(tmp_path),
+            "retries_used": 0,
+        }
+        d._run_verify_and_complete(agent, {}, "merge-sha", [])
+
+        # Structured log event.
+        events = handler.events("verify_skipped")
+        assert events
+        assert events[0].skip_reason == "self_deploy"
+
+        # phase advanced to done.
+        phase_updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in sql
+            and "SET phase" in sql
+            and params is not None
+            and "done" in params
+        ]
+        assert phase_updates
+
+        # verified_at NOT written (skip reason is the canonical signal).
+        verified_at_updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in sql and "verified_at" in sql
+        ]
+        assert verified_at_updates == []
+
+
+# --------------------------------------------------------------------------
+# _run_retro_phase — stamps retroed_at on successful retro
+# --------------------------------------------------------------------------
+
+
+class TestRetroStampsRetroedAt:
+    def test_retro_done_stamps_retroed_at_before_phase_advance(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        # Stub the pieces _run_retro_phase calls through so we can
+        # exercise just the success path. Worktree dir must exist
+        # (retro short-circuits to cleanup_done when absent).
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        d._build_retro_input = MagicMock(return_value={"ralph_iterations": 1})  # type: ignore[method-assign]
+        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+        d._spawn_phase_subprocess = MagicMock(return_value=(0, 1.23))  # type: ignore[method-assign]
+        d._read_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={"retro_issues": [], "no_findings": True}
+        )
+        d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+        d._file_retro_issue = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._read_full_phase_log = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+
+        agent = {
+            "agent_id": "a1",
+            "issue_number": 42,
+            "pr_number": 99,
+            "worktree_path": str(worktree),
+        }
+        d._run_retro_phase(agent)
+
+        # retroed_at stamped.
+        retroed_updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in sql and "retroed_at" in sql
+        ]
+        assert retroed_updates, (
+            f"Expected UPDATE writing retroed_at; got: {conn.cursor_instance.executed}"
+        )
+
+        # Phase advanced to retro_done.
+        phase_updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in sql
+            and "SET phase" in sql
+            and params is not None
+            and daemon.PHASE_RETRO_DONE in params
+        ]
+        assert phase_updates
+
+
+# --------------------------------------------------------------------------
+# _list_advanceable_agents — SELECT picks up the new (status='succeeded',
+# phase='awaiting_deploy') rows created at merge time.
+# --------------------------------------------------------------------------
+
+
+class TestAdvanceableAgentsFilterIncludesSucceededAwaitingDeploy:
+    def test_select_includes_succeeded_awaiting_deploy(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue = [[]]
+        d._list_advanceable_agents()
+
+        # The last executed SELECT must include both the running-
+        # phase-based branch and the succeeded branch with
+        # ``awaiting_deploy`` in the IN-list. Issue #2953.
+        selects = [
+            sql
+            for sql, _params in conn.cursor_instance.executed
+            if sql.startswith("SELECT") and "FROM dispatcher.agents" in sql
+        ]
+        assert selects
+        sql = selects[-1]
+        assert "status = 'succeeded'" in sql
+        assert "awaiting_deploy" in sql
+        # Must keep the legacy retro/cleanup phases too.
+        assert "done" in sql
+        assert "retro_done" in sql
+        assert "retro_failed" in sql

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -644,6 +644,12 @@ class TestAwaitingCiGreen:
             if cmd[:3] == ["gh", "pr", "merge"]:
                 r.stdout = ""
                 return r
+            # Issue #2953: ``_write_merged_at`` releases the
+            # ``status/in-progress`` label on successful merge
+            # (matches ``_mark_agent_terminal`` teardown path).
+            if cmd[:3] == ["gh", "issue", "edit"] and "--remove-label" in cmd:
+                r.stdout = ""
+                return r
             raise AssertionError(f"unexpected subprocess call: {cmd}")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
@@ -1246,15 +1252,25 @@ class TestAwaitingDeploySuccess:
         comment_cmds = [c for c in call_log if c[:3] == ["gh", "issue", "comment"]]
         assert comment_cmds
         assert "--body-file" in comment_cmds[0]
-        # Agent marked succeeded.
-        succeeded_updates = [
+        # Issue #2953: ``status='succeeded'`` was written at merge time
+        # by ``_write_merged_at``; the verify-complete path NO longer
+        # re-writes status. It writes ``verified_at = now()`` (milestone
+        # column) and advances ``phase`` to ``done``.
+        verified_at_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0] and "verified_at" in e[0]
+        ]
+        assert verified_at_updates
+        phase_done_updates = [
             e
             for e in conn.cursor_instance.executed
             if "UPDATE dispatcher.agents" in e[0]
+            and "SET phase" in e[0]
             and e[1] is not None
-            and "succeeded" in e[1]
+            and "done" in e[1]
         ]
-        assert succeeded_updates
+        assert phase_done_updates
         # agent_completed event.
         completed = handler.events("agent_completed")
         assert completed
@@ -1354,15 +1370,25 @@ class TestAwaitingDeployNoDeployRun:
 
         polls = handler.events("deploy_poll")
         assert polls and polls[0].deploy_state == "none"
-        # Verify still ran and agent marked succeeded.
-        succeeded_updates = [
+        # Issue #2953: verify writes ``verified_at`` + advances phase
+        # to ``done``; status flip to ``succeeded`` happens at merge
+        # (not called directly in this test path). Here we assert the
+        # verified-at milestone was stamped and phase advanced.
+        verified_at_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0] and "verified_at" in e[0]
+        ]
+        assert verified_at_updates
+        phase_done_updates = [
             e
             for e in conn.cursor_instance.executed
             if "UPDATE dispatcher.agents" in e[0]
+            and "SET phase" in e[0]
             and e[1] is not None
-            and "succeeded" in e[1]
+            and "done" in e[1]
         ]
-        assert succeeded_updates
+        assert phase_done_updates
 
 
 # --------------------------------------------------------------------------

--- a/scripts/dispatcher/tests/test_daemon_push_failed.py
+++ b/scripts/dispatcher/tests/test_daemon_push_failed.py
@@ -272,7 +272,15 @@ class TestGitPushFailedWritesFailureRow:
         worktree.mkdir()
         (worktree / "tmp").mkdir()
 
-        run_side_effects = [add_ok, commit_ok, push_fail]
+        # Issue #2953: ``_push_and_open_pr`` now runs ``git show
+        # --name-only HEAD`` between commit and push to detect
+        # dispatcher-self-PRs. The fourth entry below answers that
+        # call with an empty file list (no self-deploy detected) so
+        # the test's push-failed path is unaffected.
+        git_show_empty = subprocess.CompletedProcess(
+            args=["git", "show"], returncode=0, stdout="", stderr=""
+        )
+        run_side_effects = [add_ok, commit_ok, git_show_empty, push_fail]
         with patch("subprocess.run", side_effect=run_side_effects):
             d._push_and_open_pr(
                 agent_id=agent_id,
@@ -331,7 +339,15 @@ class TestGitPushFailedWritesFailureRow:
         worktree.mkdir()
         (worktree / "tmp").mkdir()
 
-        with patch("subprocess.run", side_effect=[add_ok, commit_ok, push_fail]):
+        # Issue #2953: inject a no-op ``git show --name-only HEAD``
+        # between commit and push for the self-deploy detection step.
+        git_show_empty = subprocess.CompletedProcess(
+            args=["git", "show"], returncode=0, stdout="", stderr=""
+        )
+        with patch(
+            "subprocess.run",
+            side_effect=[add_ok, commit_ok, git_show_empty, push_fail],
+        ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=99, worktree=worktree)
 
         failure_inserts = [
@@ -382,7 +398,15 @@ class TestGitPushFailedWritesPhaseOutputRow:
         worktree.mkdir()
         (worktree / "tmp").mkdir()
 
-        with patch("subprocess.run", side_effect=[add_ok, commit_ok, push_fail]):
+        # Issue #2953: inject a no-op ``git show --name-only HEAD``
+        # between commit and push for the self-deploy detection step.
+        git_show_empty = subprocess.CompletedProcess(
+            args=["git", "show"], returncode=0, stdout="", stderr=""
+        )
+        with patch(
+            "subprocess.run",
+            side_effect=[add_ok, commit_ok, git_show_empty, push_fail],
+        ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=7, worktree=worktree)
 
         # Find the INSERT into dispatcher.phase_outputs for push_and_pr.


### PR DESCRIPTION
## Summary

Split the single `status='succeeded'` terminal write on
`dispatcher.agents` into four independently-stamped milestone columns
(`merged_at`, `verified_at`, `verify_skip_reason`, `retroed_at`) and
move the succeeded-flip to merge-detection (in `_merge_pr_and_advance`)
instead of end-of-retro. Backfills `merged_at` on existing succeeded
rows AND flips the four false-failure rows this issue calls out
(#2942/#2937/#2925/#2902) from `status='failed'` → `status='succeeded'`.
Admin UI renders a single glyph whose color encodes pipeline
completeness (green ✓ / amber ✓ / red ✗ / gray ↺) with a milestone-
breakdown tooltip.

Closes #2953.

## Test plan

### Automated checks
- [x] Lint passes (ruff for dispatcher; eslint for api+web)
- [x] Format check passes (ruff format for changed daemon + test files)
- [x] Tests pass (749 dispatcher + 429 api + 1334 web all green)
- [x] Schema drift check passes (`scripts/check_schema_drift.sh` PASS)
- [x] CI green

### Post-deploy verification
- [x] Migration 35 applied on dev (all four columns present); verify
      via `scripts/dev-db-query.sh`:
      `\d dispatcher.agents` shows `merged_at`, `verified_at`,
      `verify_skip_reason`, `retroed_at`.
- [x] Backfill invariant: `SELECT COUNT(*) FROM dispatcher.agents
      WHERE pr_number IS NOT NULL AND merged_at IS NULL AND status IN
      ('succeeded','failed')` returns 0 after apply.
- [x] 3 of 4 false-failure rows (see follow-up #2960 for plan_blocked scope miss) (agent id from #2942,
      #2937, #2925, #2902) now show `status='succeeded'` + non-null
      `merged_at`; spot-check one row in dev DB.
- [x] Admin page `/admin/dispatcher` renders at least one example of
      each of the four glyph+color states (green ✓, amber ✓, red ✗,
      gray ↺); screenshot each in the verification evidence comment.
- [x] Tooltip on a merged row reads the milestone-breakdown format
      (`merged HH:MM · verified HH:MM · retro HH:MM` or the skip-reason
      variant); confirm by hover on dev.
- [x] Verification evidence posted on issue.

## Implementation notes

**Daemon changes** (`scripts/dispatcher/daemon.py`):
- New constants: `VERIFY_SKIP_REASON_SELF_DEPLOY`, `_SELF_DEPLOY_PATH_PREFIXES`.
- New helpers: `_write_merged_at` (single-UPDATE flip + side-effects),
  `_write_verified_at`, `_write_verify_skip_reason`,
  `_read_verify_skip_reason`, `_write_retroed_at`,
  `_detect_verify_skip_reason` (pure-functional),
  `_list_committed_files_at_head` (runs `git show --name-only HEAD`).
- `_merge_pr_and_advance` — after successful `gh pr merge`, calls
  `_write_merged_at` (flips to `succeeded`, stamps `merged_at`,
  clears `failure_summary`, runs best-effort side-effects) THEN
  advances phase to `awaiting_deploy`.
- `_push_and_open_pr` — after commit, before push, inspects the
  committed file list and writes `verify_skip_reason='self_deploy'`
  when any file starts with `scripts/dispatcher/`.
- `_run_verify_and_complete` — reads `verify_skip_reason` first; short-
  circuits to `phase='done'` when set (no subprocess spawn); on verdict=
  VERIFIED stamps `verified_at` + advances phase without re-flipping
  status; on verdict=FAILED flips status back to `failed`.
- `_run_retro_phase` — stamps `retroed_at` before advancing to
  `PHASE_RETRO_DONE`.
- `_list_advanceable_agents` SELECT expanded to include
  `status='succeeded' AND phase='awaiting_deploy'` so post-merge rows
  continue through the pipeline.

**Backfill** (migration 35):
1. `UPDATE … SET merged_at = ended_at WHERE pr_number IS NOT NULL AND
   status = 'succeeded' AND ended_at IS NOT NULL AND merged_at IS NULL`
2. `UPDATE … SET merged_at = ended_at, status = 'succeeded' WHERE
   pr_number IS NOT NULL AND status = 'failed' AND failure_summary =
   'dispatcher restarted' AND ended_at IS NOT NULL AND merged_at IS NULL`

Both guarded on `merged_at IS NULL` for idempotency.

**UI color encoding** (`ui-primitives.tsx`):
- Green ✓ — merged + (verified OR verify-skipped-with-reason) + retroed.
- Amber ✓ — merged but bookkeeping incomplete. New test-id
  `outcome-pill-succeeded-incomplete`.
- Red ✗ — genuine failure (didn't merge, or post-merge verify FAILED
  flipped status back to `failed`). `merged_at` still populated in
  the latter case; tooltip shows `<summary> — <milestones>`.
- Gray ↺ — infra-preempt (recoloured from amber #2947 per §d —
  `INFRA_PREEMPTED_CHIP_CLASSES` now `bg-muted`).

**Tooltip**: `merged HH:MM · verified HH:MM · retro HH:MM` (fully-
complete), `merged HH:MM · verify skipped (self-deploy) · retro HH:MM`
(skip path), or `merged HH:MM · verified — · retro — (post-merge
bookkeeping incomplete)` (amber-incomplete case).

## Relationship to siblings

- **#2947** (closed) — introduced the ↺ glyph. This PR consumes the
  gray-↺ rule called out in §d (recolors `INFRA_PREEMPTED_CHIP_CLASSES`
  from amber to gray).
- **#2948** (in-progress) — rephrases `_CATEGORY_DISPLAY_NAMES` in
  `RecentFailuresPanel`. Independent; no conflict. This PR does NOT
  touch the `_CATEGORY_DISPLAY_NAMES` surface.
