### PR TITLE
feat(ralph): run pre-push hook locally before signaling done (#2962)

### DIFF
--- a/.claude/skills/task-v2-ralph/SKILL.md
+++ b/.claude/skills/task-v2-ralph/SKILL.md
@@ -39,7 +39,7 @@ This is the harness-limitation path surfaced by the Phase 1 gate smoke test (iss
 
 **IMPORTANT — Subagent isolation.** The context-budget analysis in spike 0.3 (`docs/investigations/dispatcher-v2-spike-0.3.md`) shows `/task-v2-ralph` stays inside the 200k-token window ONLY if each worker + each reviewer runs as a fresh-context subagent (Task tool). Inline workers break this guarantee. Do not inline.
 
-**Implementation choice (per issue #2732):** This skill invokes the existing `/ralph` skill as its inner loop. `/ralph` already implements the worker + three-reviewer cycle with fresh-context Task-tool subagents and per-iteration state files under `{worktree}/tmp/ralph/`. `/task-v2-ralph` is the thin outer wrapper that (a) seeds `task.md` from `plan.json`, (b) invokes `/ralph`, (c) parses `{worktree}/tmp/ralph/ralph-done.txt` into the output JSON. Keeps the implementation in one place and ensures parity with the current `/task` workflow's ralph behavior.
+**Implementation choice (per issue #2732):** This skill invokes the existing `/ralph` skill as its inner loop. `/ralph` already implements the worker + three-reviewer cycle with fresh-context Task-tool subagents and per-iteration state files under `{worktree}/tmp/ralph/`. `/task-v2-ralph` is the thin outer wrapper that (a) seeds `task.md` from `plan.json`, (b) invokes `/ralph`, (c) runs the local pre-push gate (Step 2.5), (d) parses `{worktree}/tmp/ralph/ralph-done.txt` into the output JSON. Keeps the implementation in one place and ensures parity with the current `/task` workflow's ralph behavior.
 
 ---
 
@@ -110,7 +110,7 @@ Always exit 0. BLOCKED is not a subprocess error — the daemon reads verdict fr
 
 `ralph_done_path` and `review_log_path` are non-null whenever the ralph loop ran (every SHIP path). They are `null` only when Step 0's Task-tool availability check fails and the skill exits BLOCKED without spawning a worker.
 
-On SHIP: the worktree working tree contains the implementation diff (or is clean, if the change was trivially a no-op — unusual). It may be staged or unstaged. The daemon stages + commits + pushes in the `summary` and `push_and_pr` phases.
+On SHIP: the worktree working tree contains the implementation diff (or is clean, if the change was trivially a no-op — unusual), AND the local `.githooks/pre-push` hook passed on the current branch (Step 2.5). It may be staged or unstaged. The daemon stages + commits + pushes in the `summary` and `push_and_pr` phases.
 
 On BLOCKED: the working tree may contain partial work. The daemon decides whether to retry (fresh worktree) or diagnose (`§8` Tier 2/3 flow).
 
@@ -218,6 +218,47 @@ Spawn the `/ralph` skill as a Task-tool subagent (so its own internal worker+rev
 
 Wait synchronously for the subagent to complete. Do not time out from the outer skill — the dispatcher owns the subprocess-wide timeout.
 
+## Step 2.5 — Local pre-push gate (MANDATORY before SHIP)
+
+**Ralph is not done until `.githooks/pre-push` passes locally.** This step is the final convergence criterion — a local pre-flight that shifts the pre-push feedback earlier so the `push_and_pr` phase does not reject ralph's output after the daemon commits. The daemon's `git push` still runs the same hook authoritatively; this step just catches it in-session rather than after subprocess exit.
+
+**Skip condition.** If Step 2 read `ralph-done.txt` as `BLOCKED` or `REVISE` (i.e. the inner `/ralph` did not reach SHIP), skip this step entirely and continue to Step 3 with the existing verdict. The pre-push gate only runs on the SHIP path.
+
+### 2.5a — Run the hook
+
+The pre-push hook reads its ref range from stdin, with one line per ref in the form `<local_ref> <local_sha> <remote_ref> <remote_sha>`. On the SHIP path, ralph's inner loop has produced an uncommitted diff in the worktree — there are no new commits to push yet. To exercise the full hook against the would-be push, stage the current diff into a throwaway commit, run the hook, then reset back to uncommitted state:
+
+1. Capture the current branch name: `git -C {worktree} rev-parse --abbrev-ref HEAD`. Store as `<branch>`.
+2. Capture the current `HEAD` SHA (the pre-push "remote_sha" baseline — the commit the daemon will push against): `git -C {worktree} rev-parse HEAD`. Store as `<base_sha>`.
+3. Stage and commit everything in the working tree to a throwaway commit so the hook sees the would-be-pushed contents:
+   - `git -C {worktree} add -A`
+   - `git -C {worktree} commit -m "pre-push gate snapshot"` (use `-F {worktree}/tmp/ralph/prepush_commit_msg.txt` to avoid quoted-string-and-`;` violations if needed)
+4. Capture the new commit SHA as `<local_sha>`: `git -C {worktree} rev-parse HEAD`.
+5. Run the hook with the stdin ref line written to a file first (no heredocs — see CLAUDE.md Critical Rules). Write `refs/heads/<branch> <local_sha> refs/heads/<branch> <base_sha>` to `{worktree}/tmp/ralph/prepush_stdin.txt`, then:
+   - `bash {worktree}/.githooks/pre-push origin https://github.com/judgemind/judgemind.git < {worktree}/tmp/ralph/prepush_stdin.txt 2> {worktree}/tmp/ralph/prepush_stderr.txt`
+   - Capture the exit code.
+6. **Always undo the throwaway commit** so the daemon's `summary` + `push_and_pr` phases see the original uncommitted diff:
+   - `git -C {worktree} reset --soft <base_sha>` (un-commits but keeps the staged diff)
+   - `git -C {worktree} reset HEAD` (un-stages so the working tree matches ralph's original output)
+
+The `reset --soft` + `reset HEAD` pair is deliberate: it returns the worktree to the exact state ralph left it in (unstaged diff), regardless of whether the hook passed or failed.
+
+### 2.5b — Handle the result
+
+- **Exit 0 (hook passed):** the local pre-push gate is green. Continue to Step 3 with the existing SHIP verdict.
+
+- **Exit non-zero (hook failed):** treat the captured stderr as new reviewer feedback and iterate:
+  1. Read `{worktree}/tmp/ralph/prepush_stderr.txt`. Append it to `{worktree}/tmp/ralph/feedback.md` under a new heading `## Pre-push hook failure (local gate — Step 2.5)`, preserving the full stderr so the next worker iteration has exact error messages (ruff lines, pytest tracebacks, markdown-link failures, schema-drift diffs).
+  2. Bump `iteration.txt` by one.
+  3. **If the new iteration count exceeds `max_iterations`**, stop iterating. Emit `verdict=BLOCKED` with `block_reason="pre-push hook failed on iteration N; max_iterations reached — see {worktree}/tmp/ralph/prepush_stderr.txt"`. Continue to Step 3 (Step 3 maps BLOCKED correctly).
+  4. **Otherwise**, re-invoke `/ralph` via the Task tool (same call as Step 2). The inner loop re-runs the worker with the new feedback, converges again, and writes a new `ralph-done.txt`. After `/ralph` returns, loop back to Step 2.5a — run the hook again. Repeat until the hook passes or `max_iterations` is exhausted.
+
+This is intentionally identical to how the Claude reviewer's REVISE feedback is iterated on — the pre-push hook is just another reviewer whose verdict must be SHIP before the outer skill emits SHIP. A pre-push failure is not a dispatcher escalation; it is a signal that ralph's inner checks missed something the push-time hook catches (cross-package hygiene, schema drift, markdown links, CI-job-skipped footgun, dispatcher-image deps). The failure modes cited in issue #2962 (`push_and_pr failed (pre-push hook rejected): FAILED: tests for scraper-framework`, `FAILED: npm run lint for api`, schema drift) all converge by re-running the worker with the concrete stderr.
+
+### 2.5c — No-op guardrail
+
+If `git -C {worktree} status --porcelain` returns empty (no diff to commit), skip Steps 2.5a and 2.5b entirely — there is nothing to pre-push-check. This happens on trivially no-op changes and on BLOCKED paths. Log "pre-push gate skipped — working tree clean" and continue to Step 3.
+
 ## Step 3 — Parse ralph output
 
 Read `{worktree}/tmp/ralph/ralph-done.txt` and `{worktree}/tmp/ralph/review-log.jsonl` (optional, structured, may be empty).
@@ -233,9 +274,11 @@ Map to output `verdict`:
 | `REVISE` | `BLOCKED` | `max_iterations reached without SHIP` |
 | `BLOCKED` | `BLOCKED` | `"<text from ralph-done.txt body>"` |
 
-Count iterations from `{worktree}/tmp/ralph/iteration.txt`.
+If Step 2.5 overrode the verdict to BLOCKED (pre-push hook failed and max_iterations was reached on the re-invocation path), use the Step 2.5 `block_reason` instead of the table above.
 
-Capture `changed_files` from `git -C {worktree} diff --name-only HEAD`. Do NOT commit — daemon owns that.
+Count iterations from `{worktree}/tmp/ralph/iteration.txt`. Include the Step 2.5 re-invocations — each pre-push retry counts as an iteration because each one re-ran `/ralph` with new feedback.
+
+Capture `changed_files` from `git -C {worktree} diff --name-only HEAD`. Do NOT commit — daemon owns that. (Step 2.5's throwaway commit has already been reset, so this yields ralph's original uncommitted diff.)
 
 Compose `summary` as 1-3 sentences describing what was implemented. Pull from the worker's final status report or the Claude reviewer's SHIP justification.
 
@@ -259,17 +302,19 @@ For non-testable change types, the budget is tighter: worker runs without TDD an
 
 The Task-tool availability check (Step 0) is cheap: a single tool-registry probe, no subprocess.
 
+The Step 2.5 pre-push gate is cheap on the green path — the hook takes ~5-30s wall clock for a typical single-package diff (ruff + pytest + format). On the red path it re-invokes `/ralph`, which spends another iteration's worth of tokens; the re-invocation is bounded by `max_iterations` (same budget as the inner loop), so the worst case adds one iteration's tokens, not unbounded retry cost.
+
 ## What this skill does NOT do
 
 - **Does not install dependencies.** Daemon already did that in the `setup` phase.
-- **Does not commit, push, or open a PR.** Daemon owns git + GitHub.
+- **Does not commit, push, or open a PR.** Daemon owns git + GitHub. (Step 2.5's throwaway commit is local-only and always reset before Step 3.)
 - **Does not post issue comments.** `/task-v2-summary` owns the pre-PR comment.
 - **Does not watch CI or merge.** Daemon's `ci_watch` and `merge` phases handle that; if CI fails, the daemon spawns `/task-v2-fix-ci`.
 - **Does not run deploy verification.** `/task-v2-verify` owns that post-deploy.
 
 ## Worked example — testable change, 1-iteration SHIP
 
-Input `plan.json` has `change_type=scraper` — a one-file scraper fix. Step 0 confirms the Task tool is available, Step 1 seeds state (with `## Testable: yes`), Step 2 invokes `/ralph`, worker applies the one-line fix + regression test, all three reviewers agree SHIP on iteration 1. Ralph writes `ralph-done.txt` = `SHIP` at iteration 1, exit.
+Input `plan.json` has `change_type=scraper` — a one-file scraper fix. Step 0 confirms the Task tool is available, Step 1 seeds state (with `## Testable: yes`), Step 2 invokes `/ralph`, worker applies the one-line fix + regression test, all three reviewers agree SHIP on iteration 1. Ralph writes `ralph-done.txt` = `SHIP` at iteration 1. Step 2.5 runs `.githooks/pre-push` against the staged diff — the hook's per-package ruff, pytest, and diff-coverage checks pass (the inner worker already ran them per-package in iteration 1). Step 3 parses `ralph-done.txt` = `SHIP`, emits output.
 
 Output `ralph.json`:
 
@@ -292,7 +337,7 @@ Output `ralph.json`:
 
 ## Worked example — non-testable change (docs), 1-iteration SHIP
 
-Input `plan.json` has `change_type=docs`. Step 0 confirms the Task tool is available, Step 1 seeds state (with `## Testable: no`), Step 2 invokes `/ralph`. The worker reads `## Testable: no`, skips TDD, implements the plan's "What will change" section (e.g. edits `docs/agent/unattended-patterns.md`), runs `scripts/check-markdown-links.sh` on any touched markdown files, and writes `COMPLETE`. Only the Claude reviewer runs — verifies acceptance criteria against the diff, confirms no stale references remain, writes `SHIP` to `review-result.txt`. Ralph writes `ralph-done.txt` = `SHIP` at iteration 1, exit.
+Input `plan.json` has `change_type=docs`. Step 0 confirms the Task tool is available, Step 1 seeds state (with `## Testable: no`), Step 2 invokes `/ralph`. The worker reads `## Testable: no`, skips TDD, implements the plan's "What will change" section (e.g. edits `docs/agent/unattended-patterns.md`), runs `scripts/check-markdown-links.sh` on any touched markdown files, and writes `COMPLETE`. Only the Claude reviewer runs — verifies acceptance criteria against the diff, confirms no stale references remain, writes `SHIP` to `review-result.txt`. Ralph writes `ralph-done.txt` = `SHIP` at iteration 1. Step 2.5 runs `.githooks/pre-push` against the staged diff — the hook re-runs `check-markdown-links.sh`, which passes. Step 3 emits SHIP.
 
 Output `ralph.json`:
 
@@ -314,9 +359,15 @@ Output `ralph.json`:
 
 Notice `iterations_used=1` (not 0) and `changed_files` is non-empty — the #2845 fix guarantees both properties for any non-BLOCKED verdict.
 
+## Worked example — pre-push gate catches a cross-package hygiene failure (Step 2.5 re-iteration)
+
+Input `plan.json` has `change_type=api` — an API change that also touches a docs file. Step 2's inner `/ralph` loop converges on iteration 2 with SHIP (worker ran ruff + pytest + diff-coverage per-package, Claude reviewer approved). Step 2.5 stages the diff and runs `.githooks/pre-push`, which executes `scripts/check-markdown-links.sh` across the whole push — a markdown pointer in the touched docs file is broken. Exit non-zero, stderr captures the broken-link line. Step 2.5b appends the stderr to `feedback.md`, bumps `iteration.txt` to 3, and re-invokes `/ralph`. The new worker reads the feedback, fixes the markdown link, re-runs the worker's internal pre-PR checks, and reviewers SHIP again. Step 2.5 re-runs the hook — this time it passes. Step 3 emits SHIP with `iterations_used=3`.
+
+This is the failure mode cited in issue #2962 (push-time hygiene rejections like `FAILED: scripts/check-markdown-links.sh`, `FAILED: tests for scraper-framework` across packages the inner loop didn't spot-check, schema drift, CI-job-skipped footgun). Moving the check into Step 2.5 converts an expensive across-subprocess retry (daemon re-spawns the whole ralph phase in a fresh worktree) into a cheap in-session iteration.
+
 ## Worked example — BLOCKED on max iterations
 
-Ralph runs 5 iterations, reviewers keep bouncing between SHIP and REVISE (fix-flipping). Ralph writes `ralph-done.txt` = `REVISE` + detail about the last iteration's feedback.
+Ralph runs 5 iterations, reviewers keep bouncing between SHIP and REVISE (fix-flipping). Ralph writes `ralph-done.txt` = `REVISE` + detail about the last iteration's feedback. Step 2.5 is skipped because the verdict is not SHIP.
 
 Output `ralph.json`:
 
@@ -353,8 +404,9 @@ Elapsed time: under a second. The operator re-runs the smoke test via `claude -p
 
 ## Reminders
 
-- No `$()`, no heredocs, no `python -c`. See `CLAUDE.md` Critical Rules.
+- No `$()`, no heredocs, no `python -c`. See `CLAUDE.md` Critical Rules. Step 2.5's stdin-ref line goes through a temp file, not a heredoc.
 - All temp files go in `{worktree}/tmp/`, never `/tmp/`.
 - Reviewers run synchronously via Task-tool subagents — no `run_in_background`.
-- Pre-PR checks (ruff, pytest, lint/typecheck/build for testable types; markdown-link check, ruff on any touched `.py` scripts for non-testable types) run INSIDE ralph's worker or final verification step — the daemon does NOT re-run them before `git push`, but `.githooks/pre-push` will bail if anything is red. If your worker skipped pre-PR checks, ralph must run them at the end of the final iteration.
+- Pre-PR checks (ruff, pytest, lint/typecheck/build for testable types; markdown-link check, ruff on any touched `.py` scripts for non-testable types) run INSIDE ralph's worker or final verification step. **Step 2.5 then runs the full `.githooks/pre-push` hook as a final in-session gate before SHIP** — it catches the cross-package hygiene checks (markdown-links, schema-drift, ci-job-skipped, dispatcher-image-deps, filename-separator collisions) that the per-package worker checks don't cover. The daemon's `git push` still runs the same hook authoritatively; Step 2.5 just shifts the failure detection earlier so a fix iterates in-session instead of triggering a whole-phase retry. Issue #2962.
+- Step 2.5's throwaway commit is always reset (both `--soft` and `reset HEAD`) before Step 3, regardless of whether the hook passed or failed. The daemon's `summary` + `push_and_pr` phases expect ralph's original uncommitted diff.
 - `/ralph` writes status updates to `{repo_root}/tmp/agent-status/<agent-id>.txt` per its convention. `/task-v2-ralph` may read this file for monitoring but should not write to it — the dispatcher daemon owns agent status via `dispatcher.phase_transitions` rows.


### PR DESCRIPTION
## Summary

Adds **Step 2.5 — Local pre-push gate (MANDATORY before SHIP)** to
`.claude/skills/task-v2-ralph/SKILL.md`. After the inner `/ralph`
loop returns SHIP but before task-v2-ralph emits its SHIP verdict
to the dispatcher, the skill now stages the uncommitted diff into
a throwaway commit, runs `.githooks/pre-push` against it, and
iterates on any failure — appending the hook's stderr to
`feedback.md` and re-invoking `/ralph` via the Task tool. The
throwaway commit is always reset (`--soft` + `reset HEAD`) before
Step 3 so the daemon's `summary` + `push_and_pr` phases see
ralph's original uncommitted diff unchanged. Bounded by the same
`max_iterations` as the inner loop; on exhaustion the verdict
becomes BLOCKED with pre-push stderr as the reason.

The motivation is the real failure class observed on 2026-04-20:
multiple dispatcher-v2 sessions (#2564 attempt 3, #2568, #2609,
#2960) rejected at `push_and_pr` for cross-package hygiene the
inner worker doesn't spot-check — full pytest across affected
packages, markdown-links, schema-drift, CI-job-skipped footgun,
dispatcher-image-deps drift. Shifting the pre-push hook into an
in-session gate converts an expensive across-subprocess retry
(daemon re-spawns the whole ralph phase in a fresh worktree)
into a cheap in-session iteration with the concrete hook stderr
as feedback.

Closes #2962.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green
- [x] `scripts/check-markdown-links.sh` passes (ran locally, clean)

### Post-deploy verification
- [ ] Merged and ralph/task-v2-ralph skill picked up by the
      dispatcher on the next session.
- [ ] Spot-check on a small-diff dispatcher-v2 run post-merge:
      `phase_failures.category` no longer shows
      `push_and_pr failed (pre-push hook rejected)` for the
      inner-worker-catchable failure modes over a window of
      N sessions (where N ≥ the baseline 2026-04-20 window of 4+
      rejections in a single day).
- [ ] No regression: clean runs take at most ~30s extra wall
      clock (the pre-push hook's green-path cost on a typical
      single-package diff, documented in the updated
      Context-budget note).
- [ ] Verification evidence posted on issue #2962 (see §A.8).

## Notes

- **Scope-confined**: only `.claude/skills/task-v2-ralph/SKILL.md`
  is edited. No daemon-side changes, no new phases, no
  fast/slow pre-push tiering. Issue #2962 lists those as separate
  follow-ups if SKILL.md alone turns out to be insufficient.
- **Not-a-test-suite change**: this is a prompt-level skill edit
  (change-type: `agent_skill` / `dx_tooling`). No unit tests
  were added; acceptance-criterion #4 ("no regression on already-
  passing ralph sessions") is verified post-deploy by the
  dispatcher.phase_failures CloudWatch aggregation, not by a
  local test. Open to adding a contract test on follow-up if the
  dispatcher team wants a guard against accidental deletion of
  Step 2.5.
