### PR TITLE
refactor(dispatcher): ralph commits; daemon amends with summary msg (#2971)

### DIFF
--- a/.claude/skills/task-v2-ralph/SKILL.md
+++ b/.claude/skills/task-v2-ralph/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Ralph phase for the per-phase /task-v2 pipeline. Iterative worker + reviewer loop, returns SHIP verdict plus uncommitted implementation diff in the worktree. Long-tail phase (~45-90 min internally).
+description: Ralph phase for the per-phase /task-v2 pipeline. Iterative worker + reviewer loop, returns SHIP verdict plus a committed implementation diff on the worktree branch. Long-tail phase (~45-90 min internally).
 argument-hint: "<agent-id>"
 maxTurns: 500
 model: sonnet
@@ -33,7 +33,7 @@ This is the harness-limitation path surfaced by the Phase 1 gate smoke test (iss
 
 **Prerequisites:** The dispatcher daemon has already (a) installed dependencies per `dependencies_to_install` from the plan output, (b) written the input bundle to `{worktree}/tmp/dispatcher-input/ralph.json`.
 
-**Goal:** Produce committed-ready code in the worktree's working tree (staged or unstaged — daemon stages + commits + pushes), plus `{worktree}/tmp/dispatcher-output/ralph.json` with a SHIP/BLOCKED verdict.
+**Goal:** Produce a committed implementation diff on the worktree branch (ralph commits directly — see Step 2.5), plus `{worktree}/tmp/dispatcher-output/ralph.json` with a SHIP/BLOCKED verdict.
 
 **IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, any Task tool call, or any other operation. `/task-v2-ralph` is already a dispatcher-spawned background subprocess — further backgrounding causes completion notifications to surface in the wrong context and loses results.
 
@@ -110,9 +110,9 @@ Always exit 0. BLOCKED is not a subprocess error — the daemon reads verdict fr
 
 `ralph_done_path` and `review_log_path` are non-null whenever the ralph loop ran (every SHIP path). They are `null` only when Step 0's Task-tool availability check fails and the skill exits BLOCKED without spawning a worker.
 
-On SHIP: the worktree working tree contains the implementation diff (or is clean, if the change was trivially a no-op — unusual), AND the local `.githooks/pre-push` hook passed on the current branch (Step 2.5). It may be staged or unstaged. The daemon stages + commits + pushes in the `summary` and `push_and_pr` phases.
+On SHIP: ralph has committed the implementation diff to the worktree branch with the placeholder message `"WIP: ralph output"` (see Step 2.5), AND the local `.githooks/pre-push` hook passed against that commit. The daemon's `summary` phase reads the diff via `git diff origin/main...HEAD`; the daemon's `push_and_pr` phase amends ralph's commit with summary's conventional-commits message (`git commit --amend -F <file>`) and pushes. Issue #2971.
 
-On BLOCKED: the working tree may contain partial work. The daemon decides whether to retry (fresh worktree) or diagnose (`§8` Tier 2/3 flow).
+On BLOCKED: the working tree may contain partial work (committed or uncommitted). The daemon decides whether to retry (fresh worktree) or diagnose (`§8` Tier 2/3 flow).
 
 ---
 
@@ -218,46 +218,59 @@ Spawn the `/ralph` skill as a Task-tool subagent (so its own internal worker+rev
 
 Wait synchronously for the subagent to complete. Do not time out from the outer skill — the dispatcher owns the subprocess-wide timeout.
 
-## Step 2.5 — Local pre-push gate (MANDATORY before SHIP)
+## Step 2.5 — Commit ralph's work and run local pre-push gate (MANDATORY before SHIP)
 
-**Ralph is not done until `.githooks/pre-push` passes locally.** This step is the final convergence criterion — a local pre-flight that shifts the pre-push feedback earlier so the `push_and_pr` phase does not reject ralph's output after the daemon commits. The daemon's `git push` still runs the same hook authoritatively; this step just catches it in-session rather than after subprocess exit.
+**Ralph is not done until (a) ralph's work is committed to the worktree branch, AND (b) `.githooks/pre-push` passes against that commit.**
 
-**Skip condition.** If Step 2 read `ralph-done.txt` as `BLOCKED` or `REVISE` (i.e. the inner `/ralph` did not reach SHIP), skip this step entirely and continue to Step 3 with the existing verdict. The pre-push gate only runs on the SHIP path.
+The commit is the load-bearing change from issue #2971. Ralph commits directly with a placeholder message (`"WIP: ralph output"`); the daemon's `push_and_pr` phase later amends that commit with summary's conventional-commits message via `git commit --amend -F <file>`. Committing in place eliminates the pre-#2971 "stage + throwaway commit + hook + reset --soft + reset HEAD" juggling, which had a latent failure mode: an incomplete undo silently swallowed ralph's diff and produced `git_commit_failed exit_code=1 stderr_tail=""` on the daemon side (observed 2026-04-21 02:59 UTC on agent `cc6c5a07`, issue #2565).
 
-### 2.5a — Run the hook
+**Skip condition.** If Step 2 read `ralph-done.txt` as `BLOCKED` or `REVISE` (i.e. the inner `/ralph` did not reach SHIP), skip this step entirely and continue to Step 3 with the existing verdict. The commit + pre-push gate only runs on the SHIP path.
 
-The pre-push hook reads its ref range from stdin, with one line per ref in the form `<local_ref> <local_sha> <remote_ref> <remote_sha>`. On the SHIP path, ralph's inner loop has produced an uncommitted diff in the worktree — there are no new commits to push yet. To exercise the full hook against the would-be push, stage the current diff into a throwaway commit, run the hook, then reset back to uncommitted state:
+### 2.5a — Commit ralph's work with the placeholder message
 
 1. Capture the current branch name: `git -C {worktree} rev-parse --abbrev-ref HEAD`. Store as `<branch>`.
 2. Capture the current `HEAD` SHA (the pre-push "remote_sha" baseline — the commit the daemon will push against): `git -C {worktree} rev-parse HEAD`. Store as `<base_sha>`.
-3. Stage and commit everything in the working tree to a throwaway commit so the hook sees the would-be-pushed contents:
+3. Stage and commit everything in the working tree with the placeholder message. Write the placeholder message to a file first (no heredocs / quoted `;` — see CLAUDE.md Critical Rules):
+   - Write `WIP: ralph output` to `{worktree}/tmp/ralph/prepush_commit_msg.txt`.
    - `git -C {worktree} add -A`
-   - `git -C {worktree} commit -m "pre-push gate snapshot"` (use `-F {worktree}/tmp/ralph/prepush_commit_msg.txt` to avoid quoted-string-and-`;` violations if needed)
+   - `git -C {worktree} commit -F {worktree}/tmp/ralph/prepush_commit_msg.txt`
 4. Capture the new commit SHA as `<local_sha>`: `git -C {worktree} rev-parse HEAD`.
-5. Run the hook with the stdin ref line written to a file first (no heredocs — see CLAUDE.md Critical Rules). Write `refs/heads/<branch> <local_sha> refs/heads/<branch> <base_sha>` to `{worktree}/tmp/ralph/prepush_stdin.txt`, then:
-   - `bash {worktree}/.githooks/pre-push origin https://github.com/judgemind/judgemind.git < {worktree}/tmp/ralph/prepush_stdin.txt 2> {worktree}/tmp/ralph/prepush_stderr.txt`
-   - Capture the exit code.
-6. **Always undo the throwaway commit** so the daemon's `summary` + `push_and_pr` phases see the original uncommitted diff:
-   - `git -C {worktree} reset --soft <base_sha>` (un-commits but keeps the staged diff)
-   - `git -C {worktree} reset HEAD` (un-stages so the working tree matches ralph's original output)
 
-The `reset --soft` + `reset HEAD` pair is deliberate: it returns the worktree to the exact state ralph left it in (unstaged diff), regardless of whether the hook passed or failed.
+There is **no undo step**. The commit stays on the branch. The daemon's `push_and_pr` phase amends it in place (`git commit --amend -F <summary-message-file>`) — see `scripts/dispatcher/daemon.py::_push_and_open_pr` and issue #2971.
 
-### 2.5b — Handle the result
+### 2.5b — Run the pre-push hook against the committed state
 
-- **Exit 0 (hook passed):** the local pre-push gate is green. Continue to Step 3 with the existing SHIP verdict.
+The pre-push hook reads its ref range from stdin, with one line per ref in the form `<local_ref> <local_sha> <remote_ref> <remote_sha>`. Run it against the committed SHAs captured in 2.5a:
+
+- Write `refs/heads/<branch> <local_sha> refs/heads/<branch> <base_sha>` to `{worktree}/tmp/ralph/prepush_stdin.txt`.
+- `bash {worktree}/.githooks/pre-push origin https://github.com/judgemind/judgemind.git < {worktree}/tmp/ralph/prepush_stdin.txt 2> {worktree}/tmp/ralph/prepush_stderr.txt`
+- Capture the exit code.
+
+### 2.5c — Handle the hook result
+
+- **Exit 0 (hook passed):** the local pre-push gate is green. Ralph's commit stays in place; continue to Step 3 with the existing SHIP verdict.
 
 - **Exit non-zero (hook failed):** treat the captured stderr as new reviewer feedback and iterate:
   1. Read `{worktree}/tmp/ralph/prepush_stderr.txt`. Append it to `{worktree}/tmp/ralph/feedback.md` under a new heading `## Pre-push hook failure (local gate — Step 2.5)`, preserving the full stderr so the next worker iteration has exact error messages (ruff lines, pytest tracebacks, markdown-link failures, schema-drift diffs).
   2. Bump `iteration.txt` by one.
-  3. **If the new iteration count exceeds `max_iterations`**, stop iterating. Emit `verdict=BLOCKED` with `block_reason="pre-push hook failed on iteration N; max_iterations reached — see {worktree}/tmp/ralph/prepush_stderr.txt"`. Continue to Step 3 (Step 3 maps BLOCKED correctly).
-  4. **Otherwise**, re-invoke `/ralph` via the Task tool (same call as Step 2). The inner loop re-runs the worker with the new feedback, converges again, and writes a new `ralph-done.txt`. After `/ralph` returns, loop back to Step 2.5a — run the hook again. Repeat until the hook passes or `max_iterations` is exhausted.
+  3. **If the new iteration count exceeds `max_iterations`**, stop iterating. Emit `verdict=BLOCKED` with `block_reason="pre-push hook failed on iteration N; max_iterations reached — see {worktree}/tmp/ralph/prepush_stderr.txt"`. Continue to Step 3 (Step 3 maps BLOCKED correctly). The ralph commit stays on the branch; the daemon does not advance past `push_and_pr` on BLOCKED so the commit does not reach main.
+  4. **Otherwise**, re-invoke `/ralph` via the Task tool (same call as Step 2). The inner loop re-runs the worker with the new feedback, converges again, and writes a new `ralph-done.txt`. After `/ralph` returns, **collapse the new worker's changes into ralph's existing commit via amend**:
+     - `git -C {worktree} add -A`
+     - `git -C {worktree} commit --amend --no-edit`
+  
+     The `--no-edit` keeps the placeholder message intact (the daemon will rewrite it later). The `-a` is absorbed by the explicit `add -A` + `--amend`. The net effect is a single commit on the branch reflecting the latest iteration's work, ready for the next pre-push hook run. Then loop back to 2.5b — run the hook again. Repeat until the hook passes or `max_iterations` is exhausted.
 
 This is intentionally identical to how the Claude reviewer's REVISE feedback is iterated on — the pre-push hook is just another reviewer whose verdict must be SHIP before the outer skill emits SHIP. A pre-push failure is not a dispatcher escalation; it is a signal that ralph's inner checks missed something the push-time hook catches (cross-package hygiene, schema drift, markdown links, CI-job-skipped footgun, dispatcher-image deps). The failure modes cited in issue #2962 (`push_and_pr failed (pre-push hook rejected): FAILED: tests for scraper-framework`, `FAILED: npm run lint for api`, schema drift) all converge by re-running the worker with the concrete stderr.
 
-### 2.5c — No-op guardrail
+### 2.5d — No-op guardrail
 
-If `git -C {worktree} status --porcelain` returns empty (no diff to commit), skip Steps 2.5a and 2.5b entirely — there is nothing to pre-push-check. This happens on trivially no-op changes and on BLOCKED paths. Log "pre-push gate skipped — working tree clean" and continue to Step 3.
+If the inner `/ralph` produced no diff (e.g. trivially-no-op change, or a non-testable path that converged without touching any file), `git -C {worktree} status --porcelain` returns empty at the top of 2.5a. In that case:
+
+- Skip the commit step in 2.5a (there is nothing to commit; `git commit` would fail with "nothing to commit, working tree clean").
+- Skip 2.5b (no commit to push-check).
+- Log "pre-push gate skipped — working tree clean; no commit created" and continue to Step 3 with the existing SHIP verdict.
+
+A truly no-op SHIP is unusual; the daemon handles this case by emitting a no-op PR or escalating depending on the change type.
 
 ## Step 3 — Parse ralph output
 
@@ -278,7 +291,7 @@ If Step 2.5 overrode the verdict to BLOCKED (pre-push hook failed and max_iterat
 
 Count iterations from `{worktree}/tmp/ralph/iteration.txt`. Include the Step 2.5 re-invocations — each pre-push retry counts as an iteration because each one re-ran `/ralph` with new feedback.
 
-Capture `changed_files` from `git -C {worktree} diff --name-only HEAD`. Do NOT commit — daemon owns that. (Step 2.5's throwaway commit has already been reset, so this yields ralph's original uncommitted diff.)
+Capture `changed_files` from `git -C {worktree} diff --name-only origin/main...HEAD` — compares the committed state (ralph's commit) to origin/main. On the no-op guardrail path (2.5d) the range is empty and `changed_files` is `[]`.
 
 Compose `summary` as 1-3 sentences describing what was implemented. Pull from the worker's final status report or the Claude reviewer's SHIP justification.
 
@@ -302,19 +315,19 @@ For non-testable change types, the budget is tighter: worker runs without TDD an
 
 The Task-tool availability check (Step 0) is cheap: a single tool-registry probe, no subprocess.
 
-The Step 2.5 pre-push gate is cheap on the green path — the hook takes ~5-30s wall clock for a typical single-package diff (ruff + pytest + format). On the red path it re-invokes `/ralph`, which spends another iteration's worth of tokens; the re-invocation is bounded by `max_iterations` (same budget as the inner loop), so the worst case adds one iteration's tokens, not unbounded retry cost.
+The Step 2.5 commit + pre-push gate is cheap on the green path — the commit is a single `git add -A && git commit -F` (sub-second), and the hook takes ~5-30s wall clock for a typical single-package diff (ruff + pytest + format). On the red path it re-invokes `/ralph`, which spends another iteration's worth of tokens; the re-invocation is bounded by `max_iterations` (same budget as the inner loop), so the worst case adds one iteration's tokens, not unbounded retry cost.
 
 ## What this skill does NOT do
 
 - **Does not install dependencies.** Daemon already did that in the `setup` phase.
-- **Does not commit, push, or open a PR.** Daemon owns git + GitHub. (Step 2.5's throwaway commit is local-only and always reset before Step 3.)
+- **Does not push or open a PR.** Daemon owns remote git + GitHub. Ralph's local commit stays in the worktree until the daemon's `push_and_pr` phase amends + pushes it.
 - **Does not post issue comments.** `/task-v2-summary` owns the pre-PR comment.
 - **Does not watch CI or merge.** Daemon's `ci_watch` and `merge` phases handle that; if CI fails, the daemon spawns `/task-v2-fix-ci`.
 - **Does not run deploy verification.** `/task-v2-verify` owns that post-deploy.
 
 ## Worked example — testable change, 1-iteration SHIP
 
-Input `plan.json` has `change_type=scraper` — a one-file scraper fix. Step 0 confirms the Task tool is available, Step 1 seeds state (with `## Testable: yes`), Step 2 invokes `/ralph`, worker applies the one-line fix + regression test, all three reviewers agree SHIP on iteration 1. Ralph writes `ralph-done.txt` = `SHIP` at iteration 1. Step 2.5 runs `.githooks/pre-push` against the staged diff — the hook's per-package ruff, pytest, and diff-coverage checks pass (the inner worker already ran them per-package in iteration 1). Step 3 parses `ralph-done.txt` = `SHIP`, emits output.
+Input `plan.json` has `change_type=scraper` — a one-file scraper fix. Step 0 confirms the Task tool is available, Step 1 seeds state (with `## Testable: yes`), Step 2 invokes `/ralph`, worker applies the one-line fix + regression test, all three reviewers agree SHIP on iteration 1. Ralph writes `ralph-done.txt` = `SHIP` at iteration 1. Step 2.5a commits the diff with message `"WIP: ralph output"`. Step 2.5b runs `.githooks/pre-push` against the committed state — the hook's per-package ruff, pytest, and diff-coverage checks pass (the inner worker already ran them per-package in iteration 1). Step 3 parses `ralph-done.txt` = `SHIP`, captures `changed_files` via `git diff --name-only origin/main...HEAD`, emits output. The ralph commit stays in place; the daemon's `push_and_pr` phase amends it with summary's conventional-commits message.
 
 Output `ralph.json`:
 
@@ -337,7 +350,7 @@ Output `ralph.json`:
 
 ## Worked example — non-testable change (docs), 1-iteration SHIP
 
-Input `plan.json` has `change_type=docs`. Step 0 confirms the Task tool is available, Step 1 seeds state (with `## Testable: no`), Step 2 invokes `/ralph`. The worker reads `## Testable: no`, skips TDD, implements the plan's "What will change" section (e.g. edits `docs/agent/unattended-patterns.md`), runs `scripts/check-markdown-links.sh` on any touched markdown files, and writes `COMPLETE`. Only the Claude reviewer runs — verifies acceptance criteria against the diff, confirms no stale references remain, writes `SHIP` to `review-result.txt`. Ralph writes `ralph-done.txt` = `SHIP` at iteration 1. Step 2.5 runs `.githooks/pre-push` against the staged diff — the hook re-runs `check-markdown-links.sh`, which passes. Step 3 emits SHIP.
+Input `plan.json` has `change_type=docs`. Step 0 confirms the Task tool is available, Step 1 seeds state (with `## Testable: no`), Step 2 invokes `/ralph`. The worker reads `## Testable: no`, skips TDD, implements the plan's "What will change" section (e.g. edits `docs/agent/unattended-patterns.md`), runs `scripts/check-markdown-links.sh` on any touched markdown files, and writes `COMPLETE`. Only the Claude reviewer runs — verifies acceptance criteria against the diff, confirms no stale references remain, writes `SHIP` to `review-result.txt`. Ralph writes `ralph-done.txt` = `SHIP` at iteration 1. Step 2.5a commits with placeholder message. Step 2.5b runs `.githooks/pre-push` against the committed state — the hook re-runs `check-markdown-links.sh`, which passes. Step 3 emits SHIP.
 
 Output `ralph.json`:
 
@@ -361,7 +374,7 @@ Notice `iterations_used=1` (not 0) and `changed_files` is non-empty — the #284
 
 ## Worked example — pre-push gate catches a cross-package hygiene failure (Step 2.5 re-iteration)
 
-Input `plan.json` has `change_type=api` — an API change that also touches a docs file. Step 2's inner `/ralph` loop converges on iteration 2 with SHIP (worker ran ruff + pytest + diff-coverage per-package, Claude reviewer approved). Step 2.5 stages the diff and runs `.githooks/pre-push`, which executes `scripts/check-markdown-links.sh` across the whole push — a markdown pointer in the touched docs file is broken. Exit non-zero, stderr captures the broken-link line. Step 2.5b appends the stderr to `feedback.md`, bumps `iteration.txt` to 3, and re-invokes `/ralph`. The new worker reads the feedback, fixes the markdown link, re-runs the worker's internal pre-PR checks, and reviewers SHIP again. Step 2.5 re-runs the hook — this time it passes. Step 3 emits SHIP with `iterations_used=3`.
+Input `plan.json` has `change_type=api` — an API change that also touches a docs file. Step 2's inner `/ralph` loop converges on iteration 2 with SHIP (worker ran ruff + pytest + diff-coverage per-package, Claude reviewer approved). Step 2.5a commits with placeholder. Step 2.5b runs `.githooks/pre-push`, which executes `scripts/check-markdown-links.sh` across the whole push — a markdown pointer in the touched docs file is broken. Exit non-zero, stderr captures the broken-link line. Step 2.5c appends the stderr to `feedback.md`, bumps `iteration.txt` to 3, and re-invokes `/ralph`. The new worker reads the feedback, fixes the markdown link, re-runs the worker's internal pre-PR checks, and reviewers SHIP again. Back in 2.5c step 4, the new changes are folded into the existing commit via `git add -A && git commit --amend --no-edit`, and control returns to 2.5b. The hook runs again — this time it passes. Step 3 emits SHIP with `iterations_used=3`. The branch still has exactly one commit (the amended ralph commit); the daemon's `push_and_pr` phase will amend it one more time to replace the placeholder message with summary's conventional-commits text.
 
 This is the failure mode cited in issue #2962 (push-time hygiene rejections like `FAILED: scripts/check-markdown-links.sh`, `FAILED: tests for scraper-framework` across packages the inner loop didn't spot-check, schema drift, CI-job-skipped footgun). Moving the check into Step 2.5 converts an expensive across-subprocess retry (daemon re-spawns the whole ralph phase in a fresh worktree) into a cheap in-session iteration.
 
@@ -404,9 +417,9 @@ Elapsed time: under a second. The operator re-runs the smoke test via `claude -p
 
 ## Reminders
 
-- No `$()`, no heredocs, no `python -c`. See `CLAUDE.md` Critical Rules. Step 2.5's stdin-ref line goes through a temp file, not a heredoc.
+- No `$()`, no heredocs, no `python -c`. See `CLAUDE.md` Critical Rules. Step 2.5's stdin-ref line and the commit message both go through temp files, not heredocs.
 - All temp files go in `{worktree}/tmp/`, never `/tmp/`.
 - Reviewers run synchronously via Task-tool subagents — no `run_in_background`.
-- Pre-PR checks (ruff, pytest, lint/typecheck/build for testable types; markdown-link check, ruff on any touched `.py` scripts for non-testable types) run INSIDE ralph's worker or final verification step. **Step 2.5 then runs the full `.githooks/pre-push` hook as a final in-session gate before SHIP** — it catches the cross-package hygiene checks (markdown-links, schema-drift, ci-job-skipped, dispatcher-image-deps, filename-separator collisions) that the per-package worker checks don't cover. The daemon's `git push` still runs the same hook authoritatively; Step 2.5 just shifts the failure detection earlier so a fix iterates in-session instead of triggering a whole-phase retry. Issue #2962.
-- Step 2.5's throwaway commit is always reset (both `--soft` and `reset HEAD`) before Step 3, regardless of whether the hook passed or failed. The daemon's `summary` + `push_and_pr` phases expect ralph's original uncommitted diff.
+- Pre-PR checks (ruff, pytest, lint/typecheck/build for testable types; markdown-link check, ruff on any touched `.py` scripts for non-testable types) run INSIDE ralph's worker or final verification step. **Step 2.5 then commits ralph's work and runs the full `.githooks/pre-push` hook as a final in-session gate before SHIP** — it catches the cross-package hygiene checks (markdown-links, schema-drift, ci-job-skipped, dispatcher-image-deps, filename-separator collisions) that the per-package worker checks don't cover. The daemon's `git push` still runs the same hook authoritatively; Step 2.5 just shifts the failure detection earlier so a fix iterates in-session instead of triggering a whole-phase retry. Issues #2962, #2971.
+- Step 2.5 commits in place with the placeholder message `"WIP: ralph output"` and **does not undo the commit**. The daemon's `push_and_pr` phase amends it with summary's conventional-commits message (`git commit --amend -F <file>`) — never pattern-match or parse the placeholder elsewhere; it is purely a stopgap label that the daemon rewrites.
 - `/ralph` writes status updates to `{repo_root}/tmp/agent-status/<agent-id>.txt` per its convention. `/task-v2-ralph` may read this file for monitoring but should not write to it — the dispatcher daemon owns agent status via `dispatcher.phase_transitions` rows.

--- a/.claude/skills/task-v2-summary/SKILL.md
+++ b/.claude/skills/task-v2-summary/SKILL.md
@@ -30,7 +30,7 @@ Read `{worktree}/tmp/dispatcher-input/summary.json`. Required fields:
 - `issue_comments` (list of `{author, date, body}` — non-bots only).
 - `ralph_summary` (str) — the 1-3 sentence summary from ralph output.
 - `changed_files` (list of path).
-- `git_diff` (str) — full unified diff from `git diff origin/main...HEAD` (or `git diff HEAD` if commits not yet made).
+- `git_diff` (str) — full unified diff from `git diff origin/main...HEAD`. Post-#2971, ralph's Step 2.5 always commits its work before returning, so the range resolves against a committed HEAD and the diff is non-empty for every non-no-op SHIP. No working-tree-vs-committed-state branching is required on the summary side.
 - `worktree_path` (str).
 - `repo_root` (str).
 - `branch` (str) — worktree branch name.
@@ -157,6 +157,8 @@ Set `pr_title` equal to the subject line only (no body — GitHub uses the title
 
 Set `commit_message` to the subject plus an optional body (separated by a blank line). Include `Closes #<N>` in the body if applicable.
 
+**How the commit message reaches main.** The daemon's `push_and_pr` phase runs `git commit --amend -F <message-file>` to rewrite ralph's placeholder commit (`"WIP: ralph output"`) with the `commit_message` from this skill's output. When the PR is squash-merged, GitHub uses the **PR title** for the merged-main commit subject (not the constituent commit messages). So `pr_title` is the on-main authoritative subject; the amended `commit_message` is what maintainers see on the PR's commits tab and in `git log` on the feature branch. Keeping the two in sync (pr_title == subject line of commit_message) is intentional.
+
 ## Step 5 — Write the PR body
 
 Use this template for `pr_body_md`:
@@ -206,7 +208,7 @@ Emit `{worktree}/tmp/dispatcher-output/summary.json` with all fields above. Exit
 
 - **Does not open the PR.** Daemon does that after consuming this output.
 - **Does not post comments.** Daemon posts `process_summary_md` on the issue.
-- **Does not commit or push.** Daemon handles git operations.
+- **Does not commit or push.** Daemon handles git operations. (The daemon's `push_and_pr` runs `git commit --amend -F` to rewrite ralph's placeholder commit with this skill's `commit_message` output — see #2971.)
 - **Does not read GitHub directly.** All issue + comment + diff data comes through the input JSON.
 - **Does not run tests.** Any pre-PR check reruns happen in ralph's final iteration or the daemon's pre-push hook.
 

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -7278,7 +7278,18 @@ class DispatcherDaemon:
     def _push_and_open_pr(
         self, agent_id: str, issue_number: int, worktree: Path
     ) -> None:
-        """Run the final mechanical steps: commit, push, open PR.
+        """Run the final mechanical steps: amend commit, push, open PR.
+
+        **Commit model (issue #2971).** Ralph's Step 2.5 commits its
+        work to a placeholder commit ("WIP: ralph output") and leaves
+        it in place on SHIP. This method amends that commit with
+        summary's conventional-commits message via ``git commit
+        --amend -F <file>``, then pushes. The pre-#2971 model (Ralph
+        resets to uncommitted, daemon runs ``git add -A && git commit
+        -m <msg>``) was removed because an incomplete reset silently
+        swallowed ralph's diff and produced ``git_commit_failed
+        exit_code=1 stderr_tail=""`` ("nothing to commit" goes to
+        stdout, not stderr).
 
         On failure at any step, the agent is marked ``failed``. On
         success (criteria all met), ``phase='awaiting_ci'`` so Phase 3B
@@ -7339,55 +7350,30 @@ class DispatcherDaemon:
             )
             return
 
-        # git add -A
-        try:
-            add_result = subprocess.run(
-                ["git", "-C", str(worktree), "add", "-A"],
-                capture_output=True,
-                text=True,
-                timeout=60,
-                check=False,
-            )
-        except Exception as exc:
-            self._log.exception(
-                "daemon.git_add_failed",
-                extra={
-                    "event": "git_add_failed",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "detail": str(exc),
-                },
-            )
-            self._mark_agent_terminal(
-                agent_id,
-                status="failed",
-                phase="push_and_pr",
-                exit_code=None,
-                issue_number=issue_number,
-            )
-            return
-        if add_result.returncode != 0:
-            self._log.warning(
-                "daemon.git_add_failed",
-                extra={
-                    "event": "git_add_failed",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "exit_code": add_result.returncode,
-                    "stderr_tail": _stderr_tail(add_result.stderr),
-                },
-            )
-            self._mark_agent_terminal(
-                agent_id,
-                status="failed",
-                phase="push_and_pr",
-                exit_code=None,
-                issue_number=issue_number,
-            )
-            return
-
-        # git commit -F <file>. Write the message to a file in the
-        # worktree's tmp/ so we don't rely on shell quoting.
+        # git commit --amend -F <file>. Issue #2971: Ralph's Step 2.5
+        # commits its work directly (placeholder message "WIP: ralph
+        # output") and leaves the commit in place. We amend that commit
+        # with summary's conventional-commits message here, instead of
+        # the pre-#2971 ``git add -A && git commit -m <msg>`` pair that
+        # assumed ralph produced an uncommitted diff.
+        #
+        # Why amend instead of stage+commit: the old flow required Step
+        # 2.5 to undo its throwaway commit before returning, so the
+        # daemon could re-stage and commit fresh. An incomplete undo
+        # (observed 2026-04-21 02:59 UTC on agent cc6c5a07) produced a
+        # "nothing to commit" failure (``exit_code=1, stderr_tail=""``)
+        # because the working tree was already clean — the diff was
+        # trapped in the throwaway commit. Amending eliminates the
+        # juggling: ralph's commit is always in place, we just rewrite
+        # the message.
+        #
+        # Squash-merge compatibility: GitHub's squash-merge uses the PR
+        # title for the merged-main commit subject, so the number of
+        # commits on the PR branch is irrelevant to the merged history.
+        # Whether this call amends a single ralph commit or ralph
+        # landed multiple iteration commits (`--amend --no-edit -a` in
+        # Step 2.5's retry loop collapses iterations to one), the
+        # result on main is identical.
         commit_msg_path = worktree / "tmp" / "commit_msg.txt"
         commit_msg_path.parent.mkdir(parents=True, exist_ok=True)
         commit_msg_path.write_text(commit_message)
@@ -7399,6 +7385,7 @@ class DispatcherDaemon:
                     "-C",
                     str(worktree),
                     "commit",
+                    "--amend",
                     "-F",
                     str(commit_msg_path),
                 ],

--- a/scripts/dispatcher/tests/test_daemon_amend_commit.py
+++ b/scripts/dispatcher/tests/test_daemon_amend_commit.py
@@ -1,0 +1,456 @@
+"""Unit + integration tests for the ``git commit --amend`` flow (#2971).
+
+The dispatcher v2 pipeline flipped its commit model:
+
+* **Pre-#2971:** Ralph's Step 2.5 created a throwaway commit, undid
+  it before SHIP (``git reset --soft HEAD~1`` + ``git reset HEAD``),
+  and the daemon's ``_push_and_open_pr`` staged the resulting
+  uncommitted diff via ``git add -A`` and committed fresh with
+  summary's message. An incomplete undo (observed 2026-04-21 02:59 UTC
+  on agent cc6c5a07, issue #2565) silently swallowed ralph's diff and
+  produced ``git_commit_failed exit_code=1 stderr_tail=""`` — "nothing
+  to commit" goes to stdout, not stderr.
+
+* **Post-#2971:** Ralph commits its work directly with the placeholder
+  message ``"WIP: ralph output"`` and leaves the commit in place on
+  SHIP. The daemon amends that commit with summary's conventional-
+  commits message via ``git commit --amend -F <message-file>``. There
+  is no undo to misfire, no ``git add -A`` to swallow.
+
+These tests cover both the unit view (mocked ``subprocess.run``
+records the amend call with the right arguments) and the integration
+view (a real git repo exercises ralph-commits → daemon-amends end to
+end, verifying the final HEAD commit message matches summary's
+output).
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Provide a stub ``psycopg`` module before importing the daemon — same
+# pattern as test_daemon_failure_summary.py.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — same shape as test_daemon_failure_summary.py +
+# test_daemon_push_failed.py
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _make_daemon(tmp_path: Path) -> tuple[daemon.DispatcherDaemon, _FakeConnection]:
+    logger = logging.getLogger(f"dispatcher.test.amend.{id(tmp_path)}")
+    logger.handlers = []
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn
+
+
+def _prep_daemon_for_push(d: daemon.DispatcherDaemon) -> None:
+    """Stub the DB methods ``_push_and_open_pr`` calls into no-ops."""
+    d._agent_summary_output = {  # type: ignore[attr-defined]
+        "commit_message": "feat(dispatcher): ralph-commits-daemon-amends (#2971)",
+        "pr_title": "feat(dispatcher): ralph-commits-daemon-amends (#2971)",
+        "pr_body_md": "body",
+    }
+    d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+    d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+    d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+    d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
+
+
+# --------------------------------------------------------------------------
+# Unit view — the amend call passes --amend and -F <path>
+# --------------------------------------------------------------------------
+
+
+class TestPushAndOpenPrUsesAmend:
+    """#2971 AC — daemon's commit step uses ``git commit --amend -F <file>``
+    and never runs ``git add -A``."""
+
+    def test_commit_step_uses_amend_with_message_file(self, tmp_path: Path) -> None:
+        """The first subprocess call is ``git commit --amend -F <tmp/commit_msg.txt>``."""
+        d, _conn = _make_daemon(tmp_path)
+        _prep_daemon_for_push(d)
+
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
+        )
+        git_show_empty = subprocess.CompletedProcess(
+            args=["git", "show"], returncode=0, stdout="", stderr=""
+        )
+        push_ok = subprocess.CompletedProcess(
+            args=["git", "push"], returncode=0, stdout="", stderr=""
+        )
+        pr_create_ok = subprocess.CompletedProcess(
+            args=["gh", "pr", "create"],
+            returncode=0,
+            stdout="https://github.com/x/y/pull/2971\n",
+            stderr="",
+        )
+
+        with patch(
+            "subprocess.run",
+            side_effect=[commit_ok, git_show_empty, push_ok, pr_create_ok],
+        ) as run_mock:
+            d._push_and_open_pr(
+                agent_id="amend-test-0000-0000-0000-000000000001",
+                issue_number=2971,
+                worktree=worktree,
+            )
+
+        # Inspect every subprocess.run argv.
+        calls = [call.args[0] for call in run_mock.call_args_list]
+
+        # AC: the commit step uses ``commit --amend``, not ``commit -m`` or
+        # ``commit -F`` without ``--amend``.
+        commit_calls = [
+            argv
+            for argv in calls
+            if len(argv) >= 4 and argv[0] == "git" and "commit" in argv
+        ]
+        assert commit_calls, f"Expected a commit call; got: {calls}"
+        commit_argv = commit_calls[0]
+        assert "--amend" in commit_argv, (
+            f"Expected --amend in commit argv; got {commit_argv}"
+        )
+        assert "-F" in commit_argv, f"Expected -F in commit argv; got {commit_argv}"
+        # The -F argument must point to the commit message file in
+        # tmp/commit_msg.txt inside the worktree.
+        dash_f_index = commit_argv.index("-F")
+        msg_path = Path(commit_argv[dash_f_index + 1])
+        assert msg_path.name == "commit_msg.txt", (
+            f"Expected -F argument to point at commit_msg.txt; got {msg_path}"
+        )
+        assert msg_path.parent == worktree / "tmp", (
+            f"Expected -F argument under {worktree}/tmp; got {msg_path}"
+        )
+
+    def test_daemon_does_not_run_git_add(self, tmp_path: Path) -> None:
+        """AC — ``_push_and_open_pr`` does NOT run ``git add -A`` after #2971.
+
+        Ralph's Step 2.5 committed its work before returning; there is
+        nothing to stage on the daemon side. Preserving ``git add -A``
+        would be a no-op but the point of the refactor is to make the
+        flow self-documenting: the absence of ``add`` is a deliberate
+        contract, and a regression that added it back would be
+        dangerous (it could silently stage arbitrary untracked files
+        the daemon did not intend to ship).
+        """
+        d, _conn = _make_daemon(tmp_path)
+        _prep_daemon_for_push(d)
+
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
+        )
+        git_show_empty = subprocess.CompletedProcess(
+            args=["git", "show"], returncode=0, stdout="", stderr=""
+        )
+        push_ok = subprocess.CompletedProcess(
+            args=["git", "push"], returncode=0, stdout="", stderr=""
+        )
+        pr_create_ok = subprocess.CompletedProcess(
+            args=["gh", "pr", "create"],
+            returncode=0,
+            stdout="https://github.com/x/y/pull/2971\n",
+            stderr="",
+        )
+
+        with patch(
+            "subprocess.run",
+            side_effect=[commit_ok, git_show_empty, push_ok, pr_create_ok],
+        ) as run_mock:
+            d._push_and_open_pr(
+                agent_id="amend-test-0000-0000-0000-000000000002",
+                issue_number=2971,
+                worktree=worktree,
+            )
+
+        calls = [call.args[0] for call in run_mock.call_args_list]
+        add_calls = [
+            argv
+            for argv in calls
+            if len(argv) >= 4 and argv[0] == "git" and argv[3] == "add"
+        ]
+        assert add_calls == [], (
+            f"Expected zero ``git add`` calls after #2971; got {add_calls!r}"
+        )
+
+    def test_commit_message_file_contains_summary_output(self, tmp_path: Path) -> None:
+        """AC — the -F argument points to a file whose contents equal the
+        summary's ``commit_message`` output. This is what the amend will
+        write to the rewritten commit."""
+        d, _conn = _make_daemon(tmp_path)
+        _prep_daemon_for_push(d)
+        expected_msg = d._agent_summary_output["commit_message"]  # type: ignore[index]
+
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
+        )
+        git_show_empty = subprocess.CompletedProcess(
+            args=["git", "show"], returncode=0, stdout="", stderr=""
+        )
+        push_ok = subprocess.CompletedProcess(
+            args=["git", "push"], returncode=0, stdout="", stderr=""
+        )
+        pr_create_ok = subprocess.CompletedProcess(
+            args=["gh", "pr", "create"],
+            returncode=0,
+            stdout="https://github.com/x/y/pull/2971\n",
+            stderr="",
+        )
+
+        with patch(
+            "subprocess.run",
+            side_effect=[commit_ok, git_show_empty, push_ok, pr_create_ok],
+        ):
+            d._push_and_open_pr(
+                agent_id="amend-test-0000-0000-0000-000000000003",
+                issue_number=2971,
+                worktree=worktree,
+            )
+
+        msg_file = worktree / "tmp" / "commit_msg.txt"
+        assert msg_file.exists(), f"Expected commit_msg.txt at {msg_file}"
+        assert msg_file.read_text() == expected_msg
+
+
+# --------------------------------------------------------------------------
+# Integration view — a real git repo exercises ralph-commits → daemon-amends
+# --------------------------------------------------------------------------
+
+
+def _git(worktree: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    """Run ``git -C <worktree> <args>`` with minimal env so the test is
+    hermetic (no user name/email lookup, no signing hook, no global
+    config interference)."""
+    env = {
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "HOME": str(worktree.parent),
+        "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+    }
+    return subprocess.run(
+        ["git", "-C", str(worktree), *args],
+        capture_output=True,
+        text=True,
+        check=check,
+        env=env,
+    )
+
+
+class TestAmendFlowIntegration:
+    """End-to-end: a real git repo where ralph committed a placeholder
+    message, the daemon's amend step rewrites the message, and the
+    final HEAD commit carries summary's conventional-commits text.
+
+    This is the happy-path AC #5 from issue #2971:
+
+    > Integration test covering the happy path: ralph commits,
+    > summary writes message file, daemon amends + pushes. Verify:
+    > test asserts final HEAD commit message matches summary's output.
+
+    We stop short of the push + PR-create steps (they require network
+    + a remote). The amend is the refactor's load-bearing change; once
+    HEAD carries summary's message, the subsequent push is unchanged
+    from the pre-#2971 flow.
+    """
+
+    def test_ralph_commits_daemon_amends_final_message_matches_summary(
+        self, tmp_path: Path
+    ) -> None:
+        """Real-git integration: ralph commit is rewritten by the daemon's
+        amend and the final HEAD message is summary's output verbatim.
+        """
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        # Seed a local-only repo (no remote needed for amend semantics).
+        _git(worktree, "init", "-b", "main", "--quiet")
+        _git(worktree, "config", "commit.gpgsign", "false")
+        (worktree / "README.md").write_text("# test\n")
+        _git(worktree, "add", "README.md")
+        _git(worktree, "commit", "-m", "initial", "--quiet")
+
+        # Switch to a work branch to mirror the dispatcher's
+        # ``agent/<short-id>`` branch from _create_worktree.
+        _git(worktree, "checkout", "-b", "agent/amendflow", "--quiet")
+
+        # Simulate ralph's Step 2.5 (post-#2971 model): commit the
+        # work with a placeholder message and leave it in place.
+        (worktree / "src.py").write_text("def ralph_output():\n    return 42\n")
+        _git(worktree, "add", "src.py")
+        _git(worktree, "commit", "-m", "WIP: ralph output", "--quiet")
+        ralph_sha = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+
+        # Now run the daemon's amend step. We don't need to run
+        # _push_and_open_pr end-to-end (it would try to push + open a
+        # PR), but we can exercise the exact same git invocation the
+        # daemon does.
+        (worktree / "tmp").mkdir()
+        commit_msg_path = worktree / "tmp" / "commit_msg.txt"
+        summary_message = (
+            "feat(dispatcher): ralph-commits-daemon-amends (#2971)\n"
+            "\n"
+            "Flip the commit model so ralph commits directly and the\n"
+            "daemon amends with summary's message. Eliminates the\n"
+            "throwaway-undo juggling.\n"
+            "\n"
+            "Closes #2971\n"
+        )
+        commit_msg_path.write_text(summary_message)
+
+        result = _git(
+            worktree,
+            "commit",
+            "--amend",
+            "-F",
+            str(commit_msg_path),
+        )
+        assert result.returncode == 0, (
+            f"Expected amend to succeed; stderr: {result.stderr}"
+        )
+
+        # Assertions matching issue #2971 AC#5:
+        # 1. HEAD commit is a single commit past main (amend rewrites,
+        #    does not create a new commit).
+        commit_count = _git(
+            worktree, "rev-list", "--count", "main..HEAD"
+        ).stdout.strip()
+        assert commit_count == "1", (
+            f"Expected exactly one commit on the branch; got {commit_count}"
+        )
+
+        # 2. HEAD SHA is DIFFERENT from ralph's commit (amend rewrites
+        #    history and produces a new SHA).
+        amended_sha = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+        assert amended_sha != ralph_sha, (
+            "Expected amend to produce a new SHA; got the same as ralph's commit"
+        )
+
+        # 3. HEAD commit message is summary's message verbatim — NOT
+        #    "WIP: ralph output". This is the load-bearing assertion
+        #    for issue #2971 AC#4 (the PR spot-check criterion).
+        head_message = _git(worktree, "log", "-1", "--format=%B", "HEAD").stdout
+        # ``git log --format=%B`` adds a trailing newline on top of the
+        # commit's own trailing newline, so compare stripped forms.
+        assert head_message.strip() == summary_message.strip(), (
+            f"Expected HEAD message to equal summary's; got:\n{head_message!r}"
+        )
+        assert "WIP: ralph output" not in head_message, (
+            "Placeholder 'WIP: ralph output' leaked into final commit message"
+        )
+        # Subject line assertion — the conventional-commits subject
+        # is what GitHub's squash-merge uses for the merged-main
+        # commit when the PR has exactly one commit.
+        subject = head_message.splitlines()[0]
+        assert subject == ("feat(dispatcher): ralph-commits-daemon-amends (#2971)"), (
+            f"Subject mismatch: {subject!r}"
+        )
+
+        # 4. The diff content is preserved across the amend — the
+        #    refactor only changes the message, not the files.
+        ls = _git(worktree, "ls-tree", "HEAD", "--name-only").stdout
+        assert "src.py" in ls
+        assert "README.md" in ls

--- a/scripts/dispatcher/tests/test_daemon_milestone_columns.py
+++ b/scripts/dispatcher/tests/test_daemon_milestone_columns.py
@@ -385,11 +385,12 @@ class TestSelfDeployDetectionPrePush:
         worktree.mkdir()
         (worktree / "tmp").mkdir()
 
-        add_ok = subprocess.CompletedProcess(
-            args=["git", "add"], returncode=0, stdout="", stderr=""
-        )
+        # Issue #2971: subprocess sequence is now
+        # [commit_amend, git_show, push, pr_create]. The amend rewrites
+        # ralph's "WIP: ralph output" placeholder commit with summary's
+        # conventional-commits message; no separate ``git add -A`` runs.
         commit_ok = subprocess.CompletedProcess(
-            args=["git", "commit"], returncode=0, stdout="", stderr=""
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
         )
         # git show --name-only HEAD returns a list of files where the
         # first one is in ``scripts/dispatcher/`` — should trigger
@@ -417,7 +418,7 @@ class TestSelfDeployDetectionPrePush:
 
         with patch(
             "subprocess.run",
-            side_effect=[add_ok, commit_ok, git_show, push_ok, pr_create_ok],
+            side_effect=[commit_ok, git_show, push_ok, pr_create_ok],
         ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=2953, worktree=worktree)
 
@@ -461,11 +462,11 @@ class TestSelfDeployDetectionPrePush:
         worktree.mkdir()
         (worktree / "tmp").mkdir()
 
-        add_ok = subprocess.CompletedProcess(
-            args=["git", "add"], returncode=0, stdout="", stderr=""
-        )
+        # Issue #2971: subprocess sequence is [commit_amend, git_show,
+        # push, pr_create] — the amend rewrites ralph's placeholder
+        # commit with summary's message.
         commit_ok = subprocess.CompletedProcess(
-            args=["git", "commit"], returncode=0, stdout="", stderr=""
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
         )
         git_show = subprocess.CompletedProcess(
             args=["git", "show"],
@@ -487,7 +488,7 @@ class TestSelfDeployDetectionPrePush:
 
         with patch(
             "subprocess.run",
-            side_effect=[add_ok, commit_ok, git_show, push_ok, pr_create_ok],
+            side_effect=[commit_ok, git_show, push_ok, pr_create_ok],
         ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=42, worktree=worktree)
 
@@ -518,11 +519,10 @@ class TestSelfDeployDetectionPrePush:
         worktree.mkdir()
         (worktree / "tmp").mkdir()
 
-        add_ok = subprocess.CompletedProcess(
-            args=["git", "add"], returncode=0, stdout="", stderr=""
-        )
+        # Issue #2971: subprocess sequence is [commit_amend, git_show,
+        # push, pr_create].
         commit_ok = subprocess.CompletedProcess(
-            args=["git", "commit"], returncode=0, stdout="", stderr=""
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
         )
         # git show returns non-zero → _list_committed_files_at_head
         # returns [] → no skip reason detected.
@@ -546,7 +546,7 @@ class TestSelfDeployDetectionPrePush:
 
         with patch(
             "subprocess.run",
-            side_effect=[add_ok, commit_ok, git_show_fail, push_ok, pr_create_ok],
+            side_effect=[commit_ok, git_show_fail, push_ok, pr_create_ok],
         ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=50, worktree=worktree)
 

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -1512,15 +1512,27 @@ class TestHappyPathOrchestration:
             f"got: {[e[1] for e in conn.cursor_instance.executed if 'UPDATE dispatcher.agents' in e[0]]}"
         )
 
-        # git commands: worktree add, add -A, commit, push. All use
+        # git commands: worktree add, commit --amend, push. All use
         # ``git -C <repo-or-worktree> <verb>`` shape, so just check the
         # verb appears anywhere in each command.
+        #
+        # Issue #2971: the happy-path sequence no longer runs ``git add
+        # -A``. Ralph's Step 2.5 committed its work with the placeholder
+        # message; the daemon's commit step is ``git commit --amend -F
+        # <file>`` which rewrites the message without touching the index.
         git_cmds = [c for c in call_log if c and c[0] == "git"]
         flat = [" ".join(c) for c in git_cmds]
         assert any("worktree add" in s for s in flat)
-        assert any("add -A" in s for s in flat)
-        assert any(" commit" in s for s in flat)
+        assert any("commit --amend" in s for s in flat), (
+            f"Expected ``git commit --amend`` after #2971; got: {flat}"
+        )
         assert any(" push " in s for s in flat)
+        # Guard: no stray ``git add -A`` call (would be a regression
+        # toward the pre-#2971 flow that swallowed ralph's diff on an
+        # incomplete undo).
+        assert not any("add -A" in s for s in flat), (
+            f"Unexpected ``git add -A`` call after #2971; got: {flat}"
+        )
 
 
 # --------------------------------------------------------------------------

--- a/scripts/dispatcher/tests/test_daemon_push_failed.py
+++ b/scripts/dispatcher/tests/test_daemon_push_failed.py
@@ -241,12 +241,12 @@ class TestGitPushFailedWritesFailureRow:
         d, conn, _handler = _make_daemon(tmp_path)
         agent_id = "aaaabbbb-0000-0000-0000-000000000001"
 
-        # Stub the git add / commit steps to succeed; fail on push.
-        add_ok = subprocess.CompletedProcess(
-            args=["git", "add"], returncode=0, stdout="", stderr=""
-        )
+        # Stub the git commit --amend step to succeed; fail on push.
+        # Issue #2971: daemon now amends ralph's placeholder commit
+        # instead of running ``git add -A && git commit -m <msg>``,
+        # so the subprocess sequence is [commit_amend, git_show, push].
         commit_ok = subprocess.CompletedProcess(
-            args=["git", "commit"], returncode=0, stdout="", stderr=""
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
         )
         push_fail = _make_push_result(
             returncode=1,
@@ -267,20 +267,20 @@ class TestGitPushFailedWritesFailureRow:
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
 
-        # Create a real worktree dir so the git add command path resolves.
+        # Create a real worktree dir so the git amend command path resolves.
         worktree = tmp_path / "worktree"
         worktree.mkdir()
         (worktree / "tmp").mkdir()
 
-        # Issue #2953: ``_push_and_open_pr`` now runs ``git show
+        # Issue #2953: ``_push_and_open_pr`` runs ``git show
         # --name-only HEAD`` between commit and push to detect
-        # dispatcher-self-PRs. The fourth entry below answers that
+        # dispatcher-self-PRs. The third entry below answers that
         # call with an empty file list (no self-deploy detected) so
         # the test's push-failed path is unaffected.
         git_show_empty = subprocess.CompletedProcess(
             args=["git", "show"], returncode=0, stdout="", stderr=""
         )
-        run_side_effects = [add_ok, commit_ok, git_show_empty, push_fail]
+        run_side_effects = [commit_ok, git_show_empty, push_fail]
         with patch("subprocess.run", side_effect=run_side_effects):
             d._push_and_open_pr(
                 agent_id=agent_id,
@@ -314,11 +314,10 @@ class TestGitPushFailedWritesFailureRow:
         d, conn, _handler = _make_daemon(tmp_path)
         agent_id = "aaaabbbb-0000-0000-0000-000000000002"
 
-        add_ok = subprocess.CompletedProcess(
-            args=["git", "add"], returncode=0, stdout="", stderr=""
-        )
+        # Issue #2971: subprocess sequence is now
+        # [commit_amend, git_show, push] (no separate ``git add -A``).
         commit_ok = subprocess.CompletedProcess(
-            args=["git", "commit"], returncode=0, stdout="", stderr=""
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
         )
         push_fail = _make_push_result(
             returncode=128,
@@ -346,7 +345,7 @@ class TestGitPushFailedWritesFailureRow:
         )
         with patch(
             "subprocess.run",
-            side_effect=[add_ok, commit_ok, git_show_empty, push_fail],
+            side_effect=[commit_ok, git_show_empty, push_fail],
         ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=99, worktree=worktree)
 
@@ -376,11 +375,10 @@ class TestGitPushFailedWritesPhaseOutputRow:
         # Use a long stderr to verify it is NOT truncated.
         long_stderr = "pre-push: " + "x" * 5000
 
-        add_ok = subprocess.CompletedProcess(
-            args=["git", "add"], returncode=0, stdout="", stderr=""
-        )
+        # Issue #2971: subprocess sequence is now
+        # [commit_amend, git_show, push] (no separate ``git add -A``).
         commit_ok = subprocess.CompletedProcess(
-            args=["git", "commit"], returncode=0, stdout="", stderr=""
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
         )
         push_fail = _make_push_result(returncode=1, stderr=long_stderr)
 
@@ -405,7 +403,7 @@ class TestGitPushFailedWritesPhaseOutputRow:
         )
         with patch(
             "subprocess.run",
-            side_effect=[add_ok, commit_ok, git_show_empty, push_fail],
+            side_effect=[commit_ok, git_show_empty, push_fail],
         ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=7, worktree=worktree)
 


### PR DESCRIPTION
## Summary

Flip the ralph → summary → push_and_pr commit model so ralph commits its work directly (placeholder message `"WIP: ralph output"`) and the daemon amends with summary's conventional-commits message via `git commit --amend -F <file>`. Removes the pre-#2971 throwaway-commit / `reset --soft` / `reset HEAD` juggling in Step 2.5 that caused `git_commit_failed exit_code=1 stderr_tail=""` on an incomplete undo (observed 2026-04-21 02:59 UTC on agent `cc6c5a07`, issue #2565 — "nothing to commit" goes to stdout, not stderr, which is why the stderr_tail was empty).

The underlying design fix: eliminate the state juggling. With ralph committing in place, there is nothing to undo, nothing to swallow, and the daemon's commit step is a single `--amend` that only rewrites the message.

Closes #2971

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest scripts/dispatcher/tests/`) — 766 passed, 1 skipped locally
- [x] CI green

### Post-deploy verification
- [x] Dispatcher deploy succeeded (`version_sha: 8514976` in startup log at 2026-04-21T03:36:46Z)
- [x] Service healthy: `runningCount=1`, `rolloutState: COMPLETED`
- [x] No `git_commit_failed` events in the 20-minute post-deploy window (longer 48h soak will confirm the trend)
- [x] Verification evidence posted on #2971

## What changed

- `scripts/dispatcher/daemon.py::_push_and_open_pr` — commit step is now `git commit --amend -F <msg-file>`. No `git add -A`. Updated docstring calling out the pre-#2971 failure mode and the amend rationale.
- `.claude/skills/task-v2-ralph/SKILL.md` Step 2.5 — rewritten to commit in place with the placeholder message `"WIP: ralph output"`, run the pre-push hook against the committed state, and iterate via `git add -A && git commit --amend --no-edit` on failure. No `git reset --soft HEAD~1` anywhere. Updated worked examples.
- `.claude/skills/task-v2-summary/SKILL.md` — doc clarification that `git diff origin/main...HEAD` now always resolves against a committed HEAD (post-#2971). No behavioral change on the summary side; the daemon passes the same `git_diff` string it always did.
- `scripts/dispatcher/tests/test_daemon_amend_commit.py` (new) — 3 unit tests (amend argv shape, no `git add -A` regression guard, commit message file contents) + 1 real-git integration test that simulates ralph's WIP commit, runs the daemon's amend, and asserts the final HEAD message matches summary's verbatim (issue AC#5).
- `scripts/dispatcher/tests/test_daemon_push_failed.py`, `test_daemon_milestone_columns.py`, `test_daemon_phase3a.py` — adjusted for the new subprocess sequence `[commit_amend, git_show, push, pr_create]` (removed the `add_ok` entries).

## Squash-merge note

GitHub's squash-merge uses the PR title for the merged-main commit subject. So whether the PR branch has one commit (ralph-amend) or many, the merged history is identical. The daemon's `--amend` collapses iterations on the branch; squash-merge further collapses to one commit on main. Both ends of the pipeline converge on the same commit shape.
