### PR TITLE
dx: surface pre-push tool output on failure (#2973)

### DIFF
--- a/.claude/skills/task-v2-ralph/SKILL.md
+++ b/.claude/skills/task-v2-ralph/SKILL.md
@@ -243,17 +243,17 @@ There is **no undo step**. The commit stays on the branch. The daemon's `push_an
 The pre-push hook reads its ref range from stdin, with one line per ref in the form `<local_ref> <local_sha> <remote_ref> <remote_sha>`. Run it against the committed SHAs captured in 2.5a:
 
 - Write `refs/heads/<branch> <local_sha> refs/heads/<branch> <base_sha>` to `{worktree}/tmp/ralph/prepush_stdin.txt`.
-- `bash {worktree}/.githooks/pre-push origin https://github.com/judgemind/judgemind.git < {worktree}/tmp/ralph/prepush_stdin.txt 2> {worktree}/tmp/ralph/prepush_stderr.txt`
+- `bash {worktree}/.githooks/pre-push origin https://github.com/judgemind/judgemind.git < {worktree}/tmp/ralph/prepush_stdin.txt &> {worktree}/tmp/ralph/prepush-failure.txt`
 - Capture the exit code.
 
 ### 2.5c — Handle the hook result
 
 - **Exit 0 (hook passed):** the local pre-push gate is green. Ralph's commit stays in place; continue to Step 3 with the existing SHIP verdict.
 
-- **Exit non-zero (hook failed):** treat the captured stderr as new reviewer feedback and iterate:
-  1. Read `{worktree}/tmp/ralph/prepush_stderr.txt`. Append it to `{worktree}/tmp/ralph/feedback.md` under a new heading `## Pre-push hook failure (local gate — Step 2.5)`, preserving the full stderr so the next worker iteration has exact error messages (ruff lines, pytest tracebacks, markdown-link failures, schema-drift diffs).
+- **Exit non-zero (hook failed):** treat the captured output as new reviewer feedback and iterate:
+  1. Read `{worktree}/tmp/ralph/prepush-failure.txt`. Append it to `{worktree}/tmp/ralph/feedback.md` under a new heading `## Pre-push hook failure (local gate — Step 2.5)`, preserving the full output so the next worker iteration has exact error messages (ruff lines, pytest tracebacks, markdown-link failures, schema-drift diffs).
   2. Bump `iteration.txt` by one.
-  3. **If the new iteration count exceeds `max_iterations`**, stop iterating. Emit `verdict=BLOCKED` with `block_reason="pre-push hook failed on iteration N; max_iterations reached — see {worktree}/tmp/ralph/prepush_stderr.txt"`. Continue to Step 3 (Step 3 maps BLOCKED correctly). The ralph commit stays on the branch; the daemon does not advance past `push_and_pr` on BLOCKED so the commit does not reach main.
+  3. **If the new iteration count exceeds `max_iterations`**, stop iterating. Emit `verdict=BLOCKED` with `block_reason="pre-push hook failed on iteration N; max_iterations reached — see {worktree}/tmp/ralph/prepush-failure.txt"`. Continue to Step 3 (Step 3 maps BLOCKED correctly). The ralph commit stays on the branch; the daemon does not advance past `push_and_pr` on BLOCKED so the commit does not reach main.
   4. **Otherwise**, re-invoke `/ralph` via the Task tool (same call as Step 2). The inner loop re-runs the worker with the new feedback, converges again, and writes a new `ralph-done.txt`. After `/ralph` returns, **collapse the new worker's changes into ralph's existing commit via amend**:
      - `git -C {worktree} add -A`
      - `git -C {worktree} commit --amend --no-edit`

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -14,6 +14,38 @@
 set -uo pipefail
 
 # -------------------------------------------------------------------
+# run_check <pkg> <check-name> <cmd> [args...]
+#
+# Runs the given command, teeing combined stdout+stderr into a log file
+# at /tmp/prepush-<pkg_sanitized>-<check_sanitized>.log.
+# On non-zero exit, prints the last 20 lines of the log plus the log path
+# to stderr, then returns the command's exit code so the caller can
+# increment failures.
+# -------------------------------------------------------------------
+run_check() {
+    local pkg="$1"
+    local check_name="$2"
+    shift 2
+    local pkg_safe check_safe log_file
+    pkg_safe="${pkg//\//_}"
+    check_safe="${check_name//\//_}"
+    check_safe="${check_safe// /-}"
+    log_file="/tmp/prepush-${pkg_safe}-${check_safe}.log"
+
+    local rc=0
+    "$@" > "$log_file" 2>&1 || rc=$?
+
+    if [ "$rc" -ne 0 ]; then
+        echo "" >&2
+        echo "  FAILED: $check_name for $pkg" >&2
+        echo "  Last 20 lines of output:" >&2
+        tail -n 20 "$log_file" | sed 's/^/    /' >&2
+        echo "  Full log: $log_file" >&2
+    fi
+    return "$rc"
+}
+
+# -------------------------------------------------------------------
 # Determine the range of commits being pushed
 # -------------------------------------------------------------------
 # Git passes the remote name and URL as positional args.
@@ -162,17 +194,13 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         fi
 
         # ruff check (lint)
-        if ! $ruff_cmd check $check_dirs 2>&1; then
-            echo "" >&2
-            echo "  FAILED: ruff check for $pkg" >&2
+        if ! run_check "$pkg" "ruff check" $ruff_cmd check $check_dirs; then
             echo "  Fix with: $ruff_cmd check --fix $check_dirs && $ruff_cmd format $check_dirs" >&2
             failures=$((failures + 1))
         fi
 
         # ruff format --check
-        if ! $ruff_cmd format --check $check_dirs 2>&1; then
-            echo "" >&2
-            echo "  FAILED: ruff format for $pkg" >&2
+        if ! run_check "$pkg" "ruff format" $ruff_cmd format --check $check_dirs; then
             echo "  Fix with: $ruff_cmd format $check_dirs" >&2
             failures=$((failures + 1))
         fi
@@ -190,9 +218,7 @@ while read -r local_ref local_sha remote_ref remote_sha; do
 
         if [ -x "$pkg_dir/.venv/bin/pytest" ]; then
             echo "pre-push: running tests for Python package '$pkg'..." >&2
-            if ! "$pkg_dir/.venv/bin/pytest" "$pkg_dir/tests/" -x -q --tb=line 2>&1; then
-                echo "" >&2
-                echo "  FAILED: tests for $pkg" >&2
+            if ! run_check "$pkg" "pytest" "$pkg_dir/.venv/bin/pytest" "$pkg_dir/tests/" -x -q --tb=line; then
                 echo "  Run: $pkg_dir/.venv/bin/pytest $pkg_dir/tests/ -v --tb=short" >&2
                 failures=$((failures + 1))
             fi
@@ -218,13 +244,11 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         baselines_file="coverage-baselines.json"
         if [ -f "$cov_file" ] && [ -f "$baselines_file" ] && [ -f "scripts/update-coverage-baselines.py" ]; then
             echo "pre-push: checking coverage floor for '$pkg'..." >&2
-            if ! python3 scripts/update-coverage-baselines.py \
+            if ! run_check "$pkg" "coverage floor" python3 scripts/update-coverage-baselines.py \
                     --package "$pkg_key" \
                     --coverage-file "$cov_file" \
                     --baselines-file "$baselines_file" \
-                    --dry-run 2>&1; then
-                echo "" >&2
-                echo "  FAILED: coverage floor check for $pkg" >&2
+                    --dry-run; then
                 echo "  Coverage has dropped below the baseline in coverage-baselines.json." >&2
                 echo "  Add tests to restore coverage before pushing." >&2
                 failures=$((failures + 1))
@@ -246,12 +270,10 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         diff_cover_cmd="$pkg_dir/.venv/bin/diff-cover"
         if [ -f "$cov_file" ] && [ -x "$diff_cover_cmd" ]; then
             echo "pre-push: checking diff coverage for '$pkg'..." >&2
-            if ! "$diff_cover_cmd" "$cov_file" \
+            if ! run_check "$pkg" "diff coverage" "$diff_cover_cmd" "$cov_file" \
                     --compare-branch=origin/main \
                     --fail-under=90 \
-                    --diff-range-notation='..' 2>&1; then
-                echo "" >&2
-                echo "  FAILED: diff coverage for $pkg" >&2
+                    --diff-range-notation='..'; then
                 echo "  New/changed lines have < 90% test coverage." >&2
                 echo "  Run: scripts/check-diff-coverage.sh $pkg --skip-tests" >&2
                 echo "  to see exactly which lines need tests." >&2
@@ -275,9 +297,7 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         if (cd "$pkg_dir" && npm run lint --if-present 2>&1) | grep -q "Missing script"; then
             echo "  No lint script found for $pkg — skipping" >&2
         else
-            if ! (cd "$pkg_dir" && npm run lint 2>&1); then
-                echo "" >&2
-                echo "  FAILED: npm run lint for $pkg" >&2
+            if ! run_check "$pkg" "npm run lint" bash -c "cd $(printf '%q' "$pkg_dir") && npm run lint"; then
                 echo "  Fix lint issues in $pkg_dir before pushing." >&2
                 failures=$((failures + 1))
             fi
@@ -301,9 +321,7 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         fi
 
         echo "pre-push: running tests for TypeScript package '$pkg'..." >&2
-        if ! (cd "$pkg_dir" && npm test 2>&1); then
-            echo "" >&2
-            echo "  FAILED: tests for $pkg" >&2
+        if ! run_check "$pkg" "npm test" bash -c "cd $(printf '%q' "$pkg_dir") && npm test"; then
             echo "  Run: cd $pkg_dir && npm test" >&2
             failures=$((failures + 1))
         fi
@@ -318,13 +336,11 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         baselines_file="coverage-baselines.json"
         if [ -f "$cov_file" ] && [ -f "$baselines_file" ] && [ -f "scripts/update-coverage-baselines.py" ]; then
             echo "pre-push: checking coverage floor for '$pkg'..." >&2
-            if ! python3 scripts/update-coverage-baselines.py \
+            if ! run_check "$pkg" "coverage floor" python3 scripts/update-coverage-baselines.py \
                     --package "packages/$pkg" \
                     --coverage-file "$cov_file" \
                     --baselines-file "$baselines_file" \
-                    --dry-run 2>&1; then
-                echo "" >&2
-                echo "  FAILED: coverage floor check for $pkg" >&2
+                    --dry-run; then
                 echo "  Coverage has dropped below the baseline in coverage-baselines.json." >&2
                 echo "  Add tests to restore coverage before pushing." >&2
                 failures=$((failures + 1))
@@ -352,12 +368,10 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         fi
         if [ -f "$cov_file" ] && [ -n "$diff_cover_cmd" ]; then
             echo "pre-push: checking diff coverage for '$pkg'..." >&2
-            if ! "$diff_cover_cmd" "$cov_file" \
+            if ! run_check "$pkg" "diff coverage" "$diff_cover_cmd" "$cov_file" \
                     --compare-branch=origin/main \
                     --fail-under=90 \
-                    --diff-range-notation='..' 2>&1; then
-                echo "" >&2
-                echo "  FAILED: diff coverage for $pkg" >&2
+                    --diff-range-notation='..'; then
                 echo "  New/changed lines have < 90% test coverage." >&2
                 echo "  Run: scripts/check-diff-coverage.sh $pkg --skip-tests" >&2
                 echo "  to see exactly which lines need tests." >&2
@@ -373,9 +387,7 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         echo "pre-push: checking Terraform formatting..." >&2
 
         if command -v terraform &>/dev/null; then
-            if ! terraform fmt -check -recursive infra/terraform/ 2>&1; then
-                echo "" >&2
-                echo "  FAILED: terraform fmt" >&2
+            if ! run_check "terraform" "terraform fmt" terraform fmt -check -recursive infra/terraform/; then
                 echo "  Fix with: terraform fmt -recursive infra/terraform/" >&2
                 failures=$((failures + 1))
             fi
@@ -393,9 +405,7 @@ changed_workflows=$(echo "$changed_files" | grep '^\.github/workflows/' || true)
 if [ -n "$changed_workflows" ]; then
     echo "pre-push: checking GitHub Actions workflow files..." >&2
     if command -v actionlint &>/dev/null; then
-        if ! actionlint -ignore 'SC2086' $changed_workflows 2>&1; then
-            echo "" >&2
-            echo "  FAILED: actionlint" >&2
+        if ! run_check "_" "actionlint" actionlint -ignore 'SC2086' $changed_workflows; then
             echo "  Fix workflow syntax errors before pushing." >&2
             failures=$((failures + 1))
         fi
@@ -416,9 +426,7 @@ changed_ci_yml=$(echo "$changed_files" | grep -E '^\.github/workflows/ci\.yml$' 
 if [ -n "$changed_ci_yml" ]; then
     echo "pre-push: checking for modified-but-skipped CI jobs..." >&2
     if [ -x scripts/check-ci-job-skipped.sh ]; then
-        if ! scripts/check-ci-job-skipped.sh 2>&1; then
-            echo "" >&2
-            echo "  FAILED: scripts/check-ci-job-skipped.sh" >&2
+        if ! run_check "_" "scripts/check-ci-job-skipped.sh" scripts/check-ci-job-skipped.sh; then
             echo "  A job body in ci.yml was modified but its paths-filter" >&2
             echo "  gate doesn't match anything in the diff — the job will" >&2
             echo "  be SKIPPED on this PR's CI run and the change won't be" >&2
@@ -439,9 +447,7 @@ changed_markdown=$(echo "$changed_files" | grep -E '\.md$' || true)
 if [ -n "$changed_markdown" ]; then
     echo "pre-push: checking markdown links..." >&2
     if [ -x scripts/check-markdown-links.sh ]; then
-        if ! scripts/check-markdown-links.sh 2>&1; then
-            echo "" >&2
-            echo "  FAILED: scripts/check-markdown-links.sh" >&2
+        if ! run_check "_" "scripts/check-markdown-links.sh" scripts/check-markdown-links.sh; then
             echo "  Broken internal markdown pointer detected." >&2
             echo "  Fix the pointer, create the target, or drop the backticks" >&2
             echo "  if the token is illustrative prose rather than a real path." >&2
@@ -476,9 +482,7 @@ if [ -n "$changed_migrations" ]; then
         # Use --ci mode so the check spins up its own ephemeral postgres
         # container rather than relying on the docker-compose stack being
         # up. ~15s when postgres image is already cached; ~30-60s cold.
-        if ! scripts/check_schema_drift.sh --ci 2>&1; then
-            echo "" >&2
-            echo "  FAILED: scripts/check_schema_drift.sh" >&2
+        if ! run_check "_" "scripts/check_schema_drift.sh" scripts/check_schema_drift.sh --ci; then
             echo "  packages/api/src/data-access/schema.sql is out of sync with the" >&2
             echo "  migrations in packages/api/migrations/." >&2
             echo "" >&2
@@ -507,9 +511,7 @@ changed_dispatcher_deps=$(echo "$changed_files" \
 if [ -n "$changed_dispatcher_deps" ]; then
     echo "pre-push: checking dispatcher image dependency drift..." >&2
     if [ -x scripts/check-dispatcher-image-deps.sh ]; then
-        if ! scripts/check-dispatcher-image-deps.sh 2>&1; then
-            echo "" >&2
-            echo "  FAILED: scripts/check-dispatcher-image-deps.sh" >&2
+        if ! run_check "_" "scripts/check-dispatcher-image-deps.sh" scripts/check-dispatcher-image-deps.sh; then
             echo "  A Python import under scripts/dispatcher/ is not installed" >&2
             echo "  in Dockerfile.dispatcher. The dispatcher daemon will fail" >&2
             echo "  at runtime with ModuleNotFoundError in production." >&2
@@ -535,9 +537,7 @@ fi
 # than behind a path filter.
 if [ -x scripts/check-hyphen-underscore-collision.sh ]; then
     echo "pre-push: checking for filename separator collisions..." >&2
-    if ! scripts/check-hyphen-underscore-collision.sh 2>&1; then
-        echo "" >&2
-        echo "  FAILED: scripts/check-hyphen-underscore-collision.sh" >&2
+    if ! run_check "_" "scripts/check-hyphen-underscore-collision.sh" scripts/check-hyphen-underscore-collision.sh; then
         echo "  Two files in the same directory differ only by '-' vs '_'" >&2
         echo "  — rename one or delete the stale sibling. See #2751/#2754." >&2
         failures=$((failures + 1))
@@ -556,9 +556,7 @@ changed_scripts_py=$(echo "$changed_files" | grep -E '^scripts/[^/]+\.py$' || tr
 if [ -n "$changed_scripts_py" ]; then
     echo "pre-push: checking one-off/permanent markers on scripts/*.py..." >&2
     if [ -x scripts/check-script-headers.sh ]; then
-        if ! scripts/check-script-headers.sh 2>&1; then
-            echo "" >&2
-            echo "  FAILED: scripts/check-script-headers.sh" >&2
+        if ! run_check "_" "scripts/check-script-headers.sh" scripts/check-script-headers.sh; then
             echo "  A top-level one-off-pattern script is missing its marker." >&2
             echo "  Add '# one-off: true' or '# permanent: true' within the" >&2
             echo "  first 50 lines of the file. See docs/agent/code-standards.md" >&2

--- a/scripts/tests/test_pre_push.sh
+++ b/scripts/tests/test_pre_push.sh
@@ -28,6 +28,7 @@
 #   6. Missing ruff -> WARNING only       no failure, WARNING in output
 #   7. Missing actionlint on workflow     WARNING only, exit 0
 #   8. Missing terraform on infra change  WARNING only, exit 0
+#  11. run_check helper surfaces ruff error tail + Full log path (#2973 AC1)
 #
 # Run:
 #   scripts/tests/test_pre_push.sh
@@ -465,6 +466,65 @@ elif ! echo "$hook_out" | grep -q "FAILED: scripts/check_schema_drift.sh"; then
     report_fail "expected 'FAILED: scripts/check_schema_drift.sh' in output" "$hook_out"
 else
     report_pass "hook rejects drift and names regenerate_schema.sh in the fix message"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
+# Scenario 11: run_check helper surfaces ruff output tail + Full log path
+# ───────────────────────────────────────────────────────────────────────
+# Seeds testpkg with a clean src/good.py AND a syntactically-broken
+# src/bad.py, stubs a ruff binary in the package .venv so the hook uses
+# it, runs the hook, and asserts:
+#   - exit != 0
+#   - output contains "FAILED: ruff check for testpkg"
+#   - output contains "E999" or "SyntaxError" (ruff's syntax-error signal)
+#   - output contains "Full log: /tmp/prepush-testpkg-ruff-check.log"
+# This directly exercises AC1 (run_check tees combined output to a log and
+# prints the last 20 lines + log path on failure) without needing a real
+# ruff installation or pytest.
+echo "[scenario 11] run_check helper surfaces ruff error tail + Full log path"
+init_workspace
+git -C "$WORK" checkout --quiet -b feature-syntax-error
+seed_testpkg
+
+# Add a syntactically broken Python file that ruff will reject with E999.
+cat > "$WORK/packages/testpkg/src/bad.py" <<'PY'
+def greet( -> str:
+    return "hello"
+PY
+
+# Stub a ruff binary in the package .venv so the hook uses it (the hook
+# prefers $pkg_dir/.venv/bin/ruff over the global ruff). The stub:
+#   - exits 0 for "ruff format --check ..." (format passes)
+#   - exits 1 for "ruff check ..." and prints an E999 error
+mkdir -p "$WORK/packages/testpkg/.venv/bin"
+cat > "$WORK/packages/testpkg/.venv/bin/ruff" <<'RUFF'
+#!/usr/bin/env bash
+# Stub ruff: fail on "ruff check", pass on "ruff format --check"
+if [ "${1:-}" = "format" ]; then
+    exit 0
+fi
+# "ruff check" path — emit a fake E999 syntax error and exit 1
+echo "packages/testpkg/src/bad.py:1:16: E999 SyntaxError: invalid syntax"
+exit 1
+RUFF
+chmod +x "$WORK/packages/testpkg/.venv/bin/ruff"
+
+git -C "$WORK" add packages/testpkg
+git -C "$WORK" commit --quiet -m "feat: add testpkg with syntax error"
+feat_sha="$(git -C "$WORK" rev-parse HEAD)"
+
+run_hook "refs/heads/feature-syntax-error $feat_sha refs/heads/feature-syntax-error $ZERO_SHA"
+
+if [ "$hook_rc" -eq 0 ]; then
+    report_fail "expected hook to exit non-zero on ruff syntax error, got 0" "$hook_out"
+elif ! echo "$hook_out" | grep -q "FAILED: ruff check for testpkg"; then
+    report_fail "expected 'FAILED: ruff check for testpkg' in output (#2973 AC1)" "$hook_out"
+elif ! echo "$hook_out" | grep -qE "E999|SyntaxError"; then
+    report_fail "expected E999 or SyntaxError in output tail (#2973 AC1)" "$hook_out"
+elif ! echo "$hook_out" | grep -q "Full log: /tmp/prepush-testpkg-ruff-check.log"; then
+    report_fail "expected 'Full log: /tmp/prepush-testpkg-ruff-check.log' in output (#2973 AC1)" "$hook_out"
+else
+    report_pass "run_check helper surfaces ruff error tail and Full log path (#2973 AC1)"
 fi
 
 # ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Added `run_check` helper to `.githooks/pre-push` that tees combined stdout+stderr to log files and prints the last 20 lines plus a "Full log:" path on failure. Replaced all 17 per-package check invocations. Updated `.claude/skills/task-v2-ralph/SKILL.md` §2.5 to capture both streams via `&>` (not just `2>`) so ralph's error loop can surface actual tool output to the next worker iteration, eliminating the opacity that has caused environment bugs to be misdiagnosed as ralph bugs (#2564, #2568, #2609, #2968).

Closes #2973

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`scripts/tests/test_pre_push.sh` — all 11 scenarios pass, including new scenario 11 verifying E999/SyntaxError appears in hook output tail)
- [x] CI green

### Post-deploy verification

- [ ] Intentionally introduce a syntax error in a scratch package, run `git push`, confirm hook prints last 20 lines of output showing SyntaxError and prints "Full log: /tmp/prepush-<pkg>-<check>.log"
- [ ] Induce a pre-push failure in a `/ralph` iteration and confirm the next worker iteration shows the actual tool output (not just "FAILED: tests for <package>") in the worker's feedback context
- [ ] Time a successful pre-push on `main` before and after the change; verify delta < 100ms (tee + tail overhead should be negligible)
- [ ] Verification evidence posted on #2973 (see `/task-v2-verify` output)
