### PR TITLE
feat(dispatcher): pass prior-attempt failure context to retry ralph spawns

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -72,6 +72,7 @@ Write `task.md` with:
 - Which packages are involved and where their venvs/node_modules are
 - Any relevant context from `docs/specs/`
 - A `## Testable` line with `yes` or `no` (see §"Change-type-aware behavior"). `/task-v2-ralph` always writes this line; the legacy `/task` caller may omit it (ralph treats missing as `yes`).
+- A `## Prior attempts (optional)` section if `{worktree}/tmp/dispatcher-output/prior_attempts.md` exists — verbatim content of that file. Omit the section entirely when the file is absent (first-attempt case).
 
 Write `feedback.md` with: `No prior feedback. This is the first iteration.`
 
@@ -122,6 +123,8 @@ Spawn a **worker subagent** (using the Agent tool) with this prompt structure:
 > - `{worktree}/tmp/ralph/task.md`
 > - `{worktree}/tmp/ralph/feedback.md`
 >
+> **If `task.md` contains a `## Prior attempts` section**, read it carefully. It lists failures from previous ralph runs for this same issue — including the failure category, push-time stderr tail, and ralph iteration narrative. Address the listed failures directly rather than re-discovering them. The absence of a `## Prior attempts` section means this is the first attempt.
+>
 > Then implement the task using TDD:
 > 1. Read the task and feedback files.
 > 2. Examine existing code and test patterns in the relevant packages.
@@ -165,6 +168,8 @@ Spawn a **worker subagent** (using the Agent tool) with this prompt structure:
 > Read these files for your task and any prior feedback:
 > - `{worktree}/tmp/ralph/task.md`
 > - `{worktree}/tmp/ralph/feedback.md`
+>
+> **If `task.md` contains a `## Prior attempts` section**, read it carefully. It lists failures from previous ralph runs for this same issue — including the failure category, push-time stderr tail, and ralph iteration narrative. Address the listed failures directly rather than re-discovering them. The absence of a `## Prior attempts` section means this is the first attempt.
 >
 > Then implement the task directly:
 > 1. Read the task and feedback files. Focus on the "## Plan (from /task-v2-plan)" section's "What will change" subsection — this is the concrete list of edits to make.
@@ -299,6 +304,8 @@ The Claude reviewer prompt applies to both branches:
 > You are reviewing a code change in a ralph loop (iteration N of max 5). Your job is to evaluate whether the implementation is ready to ship or needs revision. You are a fresh pair of eyes — you did not write this code.
 >
 > **First, read `{worktree}/tmp/ralph/task.md` and check for `## Testable`.** The line will be `yes`, `no`, or absent. If `no`, this is a **non-testable** change (docs, db_migration, dx_tooling, no_deployed_component); apply the non-testable rules below. Otherwise, apply the testable rules.
+>
+> **Also check `task.md` for a `## Prior attempts` section.** If present, it lists failures from previous ralph runs for this same issue. When reviewing, verify that the current implementation addresses those prior failure causes — flagging the same issue as REVISE that a prior attempt already fixed is a loop deadlock. The absence of a `## Prior attempts` section means this is the first attempt.
 >
 > **Both Gemini reviews either ran (testable) or were skipped (non-testable) before you.** Read their feedback files before starting your own review:
 > - `{worktree}/tmp/ralph/gemini-feedback.md` (Gemini standard review — may say "Skipped: non-testable change type")

--- a/.claude/skills/task-v2-ralph/SKILL.md
+++ b/.claude/skills/task-v2-ralph/SKILL.md
@@ -138,7 +138,18 @@ Before Step 1, verify the `Task` tool is callable. The check is implementation-d
 }
 ```
 
-**If `Task` is available**, continue to Step 1.
+**If `Task` is available**, continue to Step 0.5.
+
+---
+
+## Step 0.5 — Load prior-attempt context (if present)
+
+Before seeding the ralph state directory, check whether the daemon has left a prior-attempts file at `{worktree}/tmp/dispatcher-output/prior_attempts.md`.
+
+- **If the file exists**: read it. Its content will be included in `task.md` under a `## Prior attempts` section (see Step 1) so the inner `/ralph` worker has explicit failure context from previous runs.
+- **If the file does not exist** (first-attempt case): skip this step. Do NOT create the file, do NOT include a `## Prior attempts` section in `task.md`. The worker receives no prior-attempt context — this is the correct zero-cost path for new issues.
+
+Store the file content (or empty string) for use in Step 1.
 
 ---
 
@@ -183,7 +194,13 @@ Create `{worktree}/tmp/ralph/` if it does not exist. Write:
   ## Scope boundary
 
   <any items from plan.scope_check with in_scope=false — so worker does NOT touch them>
+
+  ## Prior attempts (optional — omit this section if no prior_attempts.md exists)
+
+  <verbatim content of {worktree}/tmp/dispatcher-output/prior_attempts.md if present>
   ```
+
+  Include the `## Prior attempts` section only when `{worktree}/tmp/dispatcher-output/prior_attempts.md` exists (i.e. when Step 0.5 found the file). When the file is absent, omit the section entirely — the worker should not see an empty or placeholder section.
 
 - `feedback.md` — `No prior feedback. This is the first iteration.`
 
@@ -296,6 +313,14 @@ Capture `changed_files` from `git -C {worktree} diff --name-only origin/main...H
 Compose `summary` as 1-3 sentences describing what was implemented. Pull from the worker's final status report or the Claude reviewer's SHIP justification.
 
 ## Step 4 — Write output JSON and exit
+
+**Before writing the JSON**, run the iteration-feedback helper to capture any multi-iteration feedback into the result field:
+
+```
+python3 {worktree}/scripts/dispatcher/iteration_feedback.py {worktree}/tmp/ralph/feedback.md
+```
+
+Capture stdout. If the output is non-empty it is the `## Iteration feedback` section (starting with `---\n## Iteration feedback (from feedback.md)\n\n...`). Append this verbatim to the `summary` field or to a separate `iteration_feedback` key in the output JSON — either way the daemon's `_read_full_phase_log` captures the full terminal text (stdout + structured logs) into `phase_outputs.log_text`, so downstream retry spawns can query that column for the iteration narrative.
 
 Use the Write tool to emit `{worktree}/tmp/dispatcher-output/ralph.json` with the fields above. Exit 0.
 

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -6658,6 +6658,153 @@ class DispatcherDaemon:
         output_path = output_dir / "plan.json"
         output_path.write_text(json.dumps(plan_output, indent=2, default=str))
 
+    def _fetch_prior_attempts(self, issue_number: int) -> list[dict[str, Any]]:
+        """Return up to 3 prior non-infra-preempted failed agents for *issue_number*.
+
+        Queries ``dispatcher.agents`` LEFT JOIN ``dispatcher.phase_outputs``
+        (twice — once for the ``ralph`` phase log, once for the
+        ``push_and_pr`` phase log) and returns rows for agents whose terminal
+        phase is NOT in :data:`_INFRA_PREEMPTION_CATEGORIES` (i.e. real
+        budgeted retries: ``subprocess_crash``, ``stuck_timeout``,
+        ``gh_rate_exhausted``, ``operator_retry``).
+
+        Returns an empty list on any DB error (fail-open — the spawn
+        continues without prior context).
+
+        Each returned dict has keys:
+
+        * ``failure_summary`` — ``a.failure_summary`` (may be ``None``).
+        * ``ralph_log_text``  — ``po.log_text`` for the ralph phase (may be ``None``).
+        * ``push_log_text``   — ``pp.log_text`` for the push_and_pr phase (may be ``None``).
+        * ``started_at``      — ``a.started_at`` as a string (ISO-8601).
+        """
+        assert self._conn is not None, "connect() must run before prior-attempts query"
+
+        non_infra_phases = list(_INFRA_PREEMPTION_CATEGORIES)
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT "
+                    "  a.failure_summary, "
+                    "  po.log_text, "
+                    "  pp.log_text, "
+                    "  a.started_at "
+                    "FROM dispatcher.agents a "
+                    "LEFT JOIN dispatcher.phase_outputs po "
+                    "  ON po.agent_id = a.agent_id AND po.phase = 'ralph' "
+                    "LEFT JOIN dispatcher.phase_outputs pp "
+                    "  ON pp.agent_id = a.agent_id AND pp.phase = 'push_and_pr' "
+                    "WHERE a.issue_number = %s "
+                    "  AND a.status IN ('failed', 'crashed') "
+                    "  AND a.phase NOT IN %s "
+                    "ORDER BY a.started_at DESC "
+                    "LIMIT 3",
+                    (issue_number, tuple(non_infra_phases)),
+                )
+                rows = cur.fetchall()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.prior_attempts_query_failed",
+                extra={
+                    "event": "prior_attempts_query_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return []
+
+        results: list[dict[str, Any]] = []
+        for row in rows:
+            failure_summary, ralph_log, push_log, started_at = row
+            started_at_str = (
+                started_at.isoformat()
+                if hasattr(started_at, "isoformat")
+                else str(started_at or "")
+            )
+            results.append(
+                {
+                    "failure_summary": failure_summary,
+                    "ralph_log_text": ralph_log,
+                    "push_log_text": push_log,
+                    "started_at": started_at_str,
+                }
+            )
+        return results
+
+    def _materialize_prior_attempts(self, worktree: Path, issue_number: int) -> int:
+        """Write ``prior_attempts.md`` to the worktree and return the attempt count.
+
+        Fetches up to 3 prior non-infra-preempted failures via
+        :meth:`_fetch_prior_attempts` and formats them into a markdown file at
+        ``{worktree}/tmp/dispatcher-output/prior_attempts.md`` so the ralph
+        skill can surface them to fresh workers.
+
+        **When the count is 0 the file is NOT written** — the first-attempt
+        path must not receive a stale or empty ``prior_attempts.md`` that could
+        confuse the worker.
+
+        The markdown shape for each attempt::
+
+            ## Prior attempt N (started <ISO-ts>)
+
+            **Category:** <failure_summary or "unknown">
+
+            **Pre-push failure tail:**
+
+            <last ~2000 chars of push_and_pr log, or "(none)">
+
+            **Ralph iteration narrative:**
+
+            <## Iteration feedback section extracted from ralph log, or "(none)">
+
+        Returns the number of attempts written (0 if none).
+        """
+        attempts = self._fetch_prior_attempts(issue_number)
+        if not attempts:
+            return 0
+
+        sections: list[str] = []
+        for i, attempt in enumerate(attempts, start=1):
+            failure_summary = attempt.get("failure_summary") or "unknown"
+            started_at = attempt.get("started_at") or "unknown"
+
+            # Push-and-pr log tail (~2000 chars).
+            push_log = attempt.get("push_log_text") or ""
+            if push_log:
+                push_tail = push_log[-2000:] if len(push_log) > 2000 else push_log
+            else:
+                push_tail = "(none)"
+
+            # Extract the ## Iteration feedback section from the ralph log.
+            ralph_log = attempt.get("ralph_log_text") or ""
+            ralph_narrative = "(none)"
+            if ralph_log:
+                marker = "## Iteration feedback"
+                idx = ralph_log.find(marker)
+                if idx != -1:
+                    ralph_narrative = ralph_log[idx:]
+
+            section = (
+                f"## Prior attempt {i} (started {started_at})\n\n"
+                f"**Category:** {failure_summary}\n\n"
+                f"**Pre-push failure tail:**\n\n"
+                f"{push_tail}\n\n"
+                f"**Ralph iteration narrative:**\n\n"
+                f"{ralph_narrative}"
+            )
+            sections.append(section)
+
+        content = "\n\n---\n\n".join(sections)
+        output_dir = worktree / "tmp" / "dispatcher-output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "prior_attempts.md").write_text(content, encoding="utf-8")
+        return len(attempts)
+
     def _run_plan_phase(self, agent_id: str, issue_number: int, worktree: Path) -> bool:
         """Run ``/task-v2-plan``. Returns True to continue, False to stop."""
         self._update_agent_phase(agent_id, "planning")
@@ -6816,6 +6963,24 @@ class DispatcherDaemon:
     ) -> bool:
         """Run ``/task-v2-ralph``. Returns True to continue, False to stop."""
         self._update_agent_phase(agent_id, "ralph")
+
+        # ── Prior-attempt context (#2984) ──────────────────────────────────
+        # Before seeding the ralph input bundle, materialize prior failed
+        # attempts (non-infra-preempted) into prior_attempts.md so the
+        # /task-v2-ralph skill can surface them to fresh workers.  The call
+        # is a no-op (returns 0, writes no file) on first-attempt spawns.
+        prior_attempts_count = self._materialize_prior_attempts(worktree, issue_number)
+        self._log.info(
+            "daemon.ralph_spawn",
+            extra={
+                "event": "ralph_spawn",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "prior_attempts_count": prior_attempts_count,
+            },
+        )
+        # ── end prior-attempt context ──────────────────────────────────────
 
         plan_output = self._agent_plan_output or {}
         ralph_input = {

--- a/scripts/dispatcher/iteration_feedback.py
+++ b/scripts/dispatcher/iteration_feedback.py
@@ -1,0 +1,80 @@
+"""Helper: extract the iteration-feedback section from ``feedback.md``.
+
+Callable both as a library module (imported by daemon.py) and as a
+stand-alone script:
+
+    python3 scripts/dispatcher/iteration_feedback.py {worktree}/tmp/ralph/feedback.md
+
+When run as a script the function's return value is printed to stdout so
+the calling skill can embed it in its terminal output.
+
+Stdlib-only — no third-party dependencies.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+#: Sentinel written by ``/task-v2-ralph`` Step 1 for the first iteration.
+#: When feedback.md holds only this text (possibly with whitespace) there is
+#: no real feedback to surface; the function returns an empty string.
+_SEED_SENTINEL = "No prior feedback. This is the first iteration."
+
+
+def build_iteration_feedback_section(feedback_md_path: str | Path) -> str:
+    """Return a markdown section quoting ``feedback.md``, or ``""`` when empty.
+
+    Returns a non-empty string only when the file:
+
+    * exists, AND
+    * contains something other than the seed sentinel
+      (``"No prior feedback. This is the first iteration."``).
+
+    The returned string has the form::
+
+        ---
+        ## Iteration feedback (from feedback.md)
+
+        <verbatim content of feedback.md>
+
+    This string is meant to be appended to the ``result`` field that
+    ``/task-v2-ralph`` emits in its terminal JSON output so the daemon's
+    ``_read_full_phase_log`` captures it into ``phase_outputs.log_text``.
+    Downstream retry spawns can then query that column to surface prior
+    failure context to fresh ralph workers.
+
+    Parameters
+    ----------
+    feedback_md_path:
+        Absolute or relative path to ``{worktree}/tmp/ralph/feedback.md``.
+
+    Returns
+    -------
+    str
+        Non-empty markdown section string, or ``""`` when there is nothing
+        meaningful to surface (missing file or first-iteration sentinel).
+    """
+    path = Path(feedback_md_path)
+    if not path.exists():
+        return ""
+
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+    stripped = content.strip()
+    if not stripped or stripped == _SEED_SENTINEL.strip():
+        return ""
+
+    return f"---\n## Iteration feedback (from feedback.md)\n\n{content}"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    if len(sys.argv) != 2:
+        sys.stderr.write(f"Usage: {sys.argv[0]} <path-to-feedback.md>\n")
+        sys.exit(1)
+    result = build_iteration_feedback_section(sys.argv[1])
+    if result:
+        sys.stdout.write(result)

--- a/scripts/dispatcher/tests/test_daemon_prior_attempts.py
+++ b/scripts/dispatcher/tests/test_daemon_prior_attempts.py
@@ -1,0 +1,401 @@
+"""Unit tests for prior-attempt context in retry ralph spawns (#2984).
+
+Covers:
+
+* :meth:`daemon.DispatcherDaemon._fetch_prior_attempts` — DB-query helper:
+  empty list when no rows, correct row shape when rows exist.
+* :meth:`daemon.DispatcherDaemon._materialize_prior_attempts` — writes
+  ``{worktree}/tmp/dispatcher-output/prior_attempts.md`` when count > 0
+  (AC b.1), does NOT write the file when count == 0 (AC b.2).
+* SQL filter: query uses ``phase NOT IN`` + the full
+  ``_INFRA_PREEMPTION_CATEGORIES`` list so infra-preempted agents are
+  excluded (AC b.2 variant).
+* :meth:`daemon.DispatcherDaemon._run_ralph_phase` — ``daemon.ralph_spawn``
+  log event carries ``prior_attempts_count`` (observability AC).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+# Install a psycopg stub whose ``errors.UniqueViolation`` is a real
+# Exception subclass — matches the pattern in test_daemon_plan_reuse.py.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes (mirrors test_daemon_plan_reuse.py)
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.prior_attempts.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+_TS1 = datetime(2026, 4, 20, 10, 0, 0, tzinfo=UTC)
+_TS2 = datetime(2026, 4, 19, 8, 0, 0, tzinfo=UTC)
+
+
+# --------------------------------------------------------------------------
+# _fetch_prior_attempts — unit tests
+# --------------------------------------------------------------------------
+
+
+class TestFetchPriorAttempts:
+    def test_fetch_empty(self, tmp_path: Path) -> None:
+        """Returns empty list when no failed agents exist for the issue."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        # fetchall_queue is empty → fetchall returns []
+
+        result = d._fetch_prior_attempts(42)
+
+        assert result == []
+
+    def test_fetch_two_rows(self, tmp_path: Path) -> None:
+        """Returns two dicts when two rows exist."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue.append(
+            [
+                ("subprocess_crash", "ralph log one", "push log one", _TS1),
+                ("stuck_timeout", None, "push log two", _TS2),
+            ]
+        )
+
+        result = d._fetch_prior_attempts(42)
+
+        assert len(result) == 2
+        assert result[0]["failure_summary"] == "subprocess_crash"
+        assert result[0]["ralph_log_text"] == "ralph log one"
+        assert result[0]["push_log_text"] == "push log one"
+        assert "2026-04-20" in result[0]["started_at"]
+        assert result[1]["failure_summary"] == "stuck_timeout"
+        assert result[1]["ralph_log_text"] is None
+
+    def test_fetch_returns_empty_on_db_exception(self, tmp_path: Path) -> None:
+        """DB errors are caught and return empty list (fail-open)."""
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        def _raising_cursor() -> _FakeCursor:
+            raise RuntimeError("DB is down")
+
+        conn.cursor = _raising_cursor  # type: ignore[method-assign]
+
+        result = d._fetch_prior_attempts(42)
+
+        assert result == []
+
+    def test_query_excludes_infra_preempted(self, tmp_path: Path) -> None:
+        """SQL query uses ``phase NOT IN`` to exclude infra-preemption categories."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue.append([])
+
+        d._fetch_prior_attempts(42)
+
+        executed_sqls = [sql for sql, _ in conn.cursor_instance.executed]
+        assert any("phase NOT IN" in sql for sql in executed_sqls), (
+            "SQL must filter with 'phase NOT IN' to exclude infra-preemption phases"
+        )
+        assert any(
+            "a.status IN ('failed', 'crashed')" in sql for sql in executed_sqls
+        ), "SQL must filter terminal agents"
+
+
+# --------------------------------------------------------------------------
+# _materialize_prior_attempts — writes the file
+# --------------------------------------------------------------------------
+
+
+class TestMaterializePriorAttempts:
+    def test_materialize_writes_two_attempts(self, tmp_path: Path) -> None:
+        """Writes prior_attempts.md with both attempts' content (AC b.1)."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        conn.cursor_instance.fetchall_queue.append(
+            [
+                (
+                    "subprocess_crash",
+                    "ralph log with ## Iteration feedback\n\nSome feedback text",
+                    "push stderr tail here",
+                    _TS1,
+                ),
+                (
+                    "stuck_timeout",
+                    None,
+                    "another push log",
+                    _TS2,
+                ),
+            ]
+        )
+
+        count = d._materialize_prior_attempts(worktree, 42)
+
+        assert count == 2
+        out_file = worktree / "tmp" / "dispatcher-output" / "prior_attempts.md"
+        assert out_file.exists(), "prior_attempts.md must be written when count > 0"
+        content = out_file.read_text(encoding="utf-8")
+        # Both attempts must appear.
+        assert "Prior attempt 1" in content
+        assert "Prior attempt 2" in content
+        # Categories.
+        assert "subprocess_crash" in content
+        assert "stuck_timeout" in content
+        # Ralph narrative extracted.
+        assert "## Iteration feedback" in content
+        assert "Some feedback text" in content
+        # Push tail.
+        assert "push stderr tail here" in content
+
+    def test_materialize_first_attempt_no_file(self, tmp_path: Path) -> None:
+        """Does NOT write file when count == 0 (AC b.2, first-attempt no-regression)."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        # fetchall returns empty list → 0 attempts.
+
+        count = d._materialize_prior_attempts(worktree, 42)
+
+        assert count == 0
+        out_file = worktree / "tmp" / "dispatcher-output" / "prior_attempts.md"
+        assert not out_file.exists(), (
+            "prior_attempts.md must NOT be written when count == 0"
+        )
+
+    def test_materialize_excludes_infra_preempted(self, tmp_path: Path) -> None:
+        """SQL filter excludes infra-preempted phases (implicit via _fetch_prior_attempts)."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        # Return empty — simulates the filter excluding infra rows.
+
+        count = d._materialize_prior_attempts(worktree, 42)
+
+        executed_sqls = [sql for sql, _ in conn.cursor_instance.executed]
+        assert any("phase NOT IN" in sql for sql in executed_sqls), (
+            "SQL must use 'phase NOT IN' to exclude infra-preemption categories"
+        )
+        assert count == 0
+
+    def test_materialize_creates_parent_dirs(self, tmp_path: Path) -> None:
+        """Creates the dispatcher-output/ directory if it doesn't exist."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "new-worktree"
+        # Do NOT mkdir — _materialize_prior_attempts must create dirs.
+
+        conn.cursor_instance.fetchall_queue.append(
+            [
+                ("subprocess_crash", None, None, _TS1),
+            ]
+        )
+
+        count = d._materialize_prior_attempts(worktree, 42)
+
+        assert count == 1
+        out_file = worktree / "tmp" / "dispatcher-output" / "prior_attempts.md"
+        assert out_file.exists()
+
+    def test_materialize_push_log_tail_truncated(self, tmp_path: Path) -> None:
+        """Push log is truncated to the last ~2000 chars."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        long_push_log = "X" * 5000 + "LAST_2000"
+        conn.cursor_instance.fetchall_queue.append(
+            [("subprocess_crash", None, long_push_log, _TS1)]
+        )
+
+        d._materialize_prior_attempts(worktree, 42)
+
+        content = (
+            worktree / "tmp" / "dispatcher-output" / "prior_attempts.md"
+        ).read_text(encoding="utf-8")
+        assert "LAST_2000" in content
+        assert "X" * 5000 not in content  # The leading Xs were truncated.
+
+
+# --------------------------------------------------------------------------
+# _run_ralph_phase — observability: daemon.ralph_spawn event
+# --------------------------------------------------------------------------
+
+
+class TestRunRalphPhaseLogs:
+    def test_run_ralph_phase_logs_prior_attempts_count(self, tmp_path: Path) -> None:
+        """``daemon.ralph_spawn`` log event carries ``prior_attempts_count=2``."""
+        d, conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        # Patch helpers so the test doesn't need real subprocesses or DB.
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._materialize_prior_attempts = MagicMock(  # type: ignore[method-assign]
+            return_value=2
+        )
+        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+
+        good_ralph_output = {
+            "verdict": "SHIP",
+            "iterations_used": 1,
+            "block_reason": None,
+            "changed_files": [],
+            "summary": "done",
+        }
+        d._read_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value=good_ralph_output
+        )
+        d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+        d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+
+        ok = d._run_ralph_phase("agent-test", 42, worktree)
+
+        assert ok is True
+
+        spawn_events = handler.events("ralph_spawn")
+        assert spawn_events, "daemon.ralph_spawn must be logged"
+        record = spawn_events[0]
+        assert getattr(record, "prior_attempts_count", None) == 2, (
+            "prior_attempts_count must be 2 in the ralph_spawn event"
+        )
+        assert getattr(record, "agent_id", None) == "agent-test"
+        assert getattr(record, "issue_number", None) == 42
+
+    def test_run_ralph_phase_logs_zero_for_first_attempt(self, tmp_path: Path) -> None:
+        """``daemon.ralph_spawn`` logs ``prior_attempts_count=0`` for first attempts."""
+        d, conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._materialize_prior_attempts = MagicMock(  # type: ignore[method-assign]
+            return_value=0
+        )
+        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+
+        good_ralph_output = {
+            "verdict": "SHIP",
+            "iterations_used": 1,
+            "block_reason": None,
+            "changed_files": [],
+            "summary": "done",
+        }
+        d._read_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value=good_ralph_output
+        )
+        d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+        d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+
+        ok = d._run_ralph_phase("agent-new", 42, worktree)
+
+        assert ok is True
+        spawn_events = handler.events("ralph_spawn")
+        assert spawn_events
+        assert getattr(spawn_events[0], "prior_attempts_count", None) == 0

--- a/scripts/dispatcher/tests/test_iteration_feedback.py
+++ b/scripts/dispatcher/tests/test_iteration_feedback.py
@@ -1,0 +1,171 @@
+"""Tests for :func:`iteration_feedback.build_iteration_feedback_section`.
+
+Covers:
+
+* ``test_build_section_with_real_feedback`` — multi-iteration session with real
+  feedback returns a non-empty markdown section (AC a.1 unit half).
+* ``test_build_section_seed_returns_empty`` — file holds only the first-iteration
+  sentinel → returns empty string.
+* ``test_build_section_missing_returns_empty`` — file does not exist → returns
+  empty string.
+* ``test_build_section_contains_feedback_verbatim`` — returned string includes the
+  full feedback.md content verbatim.
+* ``test_build_section_heading_format`` — returned string uses the expected
+  ``## Iteration feedback (from feedback.md)`` heading.
+* ``test_script_main_prints_output`` — running the module as a script prints the
+  section to stdout when feedback is real.
+* ``test_script_main_empty_output_on_seed`` — running as a script produces no
+  output on the seed sentinel.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from dispatcher.iteration_feedback import (  # noqa: E402
+    _SEED_SENTINEL,
+    build_iteration_feedback_section,
+)
+
+_REAL_FEEDBACK = """\
+## Pre-push hook failure (local gate — Step 2.5)
+
+ruff check failed on scripts/dispatcher/daemon.py:
+  Line 42: E501 line too long (102 > 100 characters)
+
+## Reviewer feedback (iteration 2)
+
+The `_fetch_prior_attempts` method does not guard against empty `non_infra_phases`.
+Use `IN %s` with a tuple guard or fall back gracefully when the frozenset is empty.
+"""
+
+
+class TestBuildIterationFeedbackSection:
+    def test_build_section_with_real_feedback(self, tmp_path: Path) -> None:
+        """Real feedback → non-empty markdown section (AC a.1 unit half)."""
+        feedback_file = tmp_path / "feedback.md"
+        feedback_file.write_text(_REAL_FEEDBACK, encoding="utf-8")
+
+        result = build_iteration_feedback_section(feedback_file)
+
+        assert result, "Expected non-empty section for real feedback"
+
+    def test_build_section_seed_returns_empty(self, tmp_path: Path) -> None:
+        """First-iteration sentinel → empty string."""
+        feedback_file = tmp_path / "feedback.md"
+        feedback_file.write_text(_SEED_SENTINEL, encoding="utf-8")
+
+        result = build_iteration_feedback_section(feedback_file)
+
+        assert result == "", f"Expected empty string for seed sentinel, got: {result!r}"
+
+    def test_build_section_missing_returns_empty(self, tmp_path: Path) -> None:
+        """Missing file → empty string."""
+        missing = tmp_path / "does_not_exist.md"
+
+        result = build_iteration_feedback_section(missing)
+
+        assert result == "", f"Expected empty string for missing file, got: {result!r}"
+
+    def test_build_section_contains_feedback_verbatim(self, tmp_path: Path) -> None:
+        """The section must include the feedback.md content verbatim."""
+        feedback_file = tmp_path / "feedback.md"
+        feedback_file.write_text(_REAL_FEEDBACK, encoding="utf-8")
+
+        result = build_iteration_feedback_section(feedback_file)
+
+        assert _REAL_FEEDBACK in result, (
+            "Returned section must include the feedback.md content verbatim"
+        )
+
+    def test_build_section_heading_format(self, tmp_path: Path) -> None:
+        """Heading must use the expected ``## Iteration feedback`` format."""
+        feedback_file = tmp_path / "feedback.md"
+        feedback_file.write_text(_REAL_FEEDBACK, encoding="utf-8")
+
+        result = build_iteration_feedback_section(feedback_file)
+
+        assert "## Iteration feedback (from feedback.md)" in result
+
+    def test_build_section_seed_with_whitespace_returns_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """Sentinel with surrounding whitespace still returns empty."""
+        feedback_file = tmp_path / "feedback.md"
+        feedback_file.write_text(f"\n  {_SEED_SENTINEL}  \n", encoding="utf-8")
+
+        result = build_iteration_feedback_section(feedback_file)
+
+        assert result == ""
+
+    def test_build_section_empty_file_returns_empty(self, tmp_path: Path) -> None:
+        """Completely empty file returns empty string."""
+        feedback_file = tmp_path / "feedback.md"
+        feedback_file.write_text("", encoding="utf-8")
+
+        result = build_iteration_feedback_section(feedback_file)
+
+        assert result == ""
+
+    def test_accepts_string_path(self, tmp_path: Path) -> None:
+        """Function accepts str path in addition to Path objects."""
+        feedback_file = tmp_path / "feedback.md"
+        feedback_file.write_text(_REAL_FEEDBACK, encoding="utf-8")
+
+        result = build_iteration_feedback_section(str(feedback_file))
+
+        assert result, "Expected non-empty section when path passed as str"
+
+
+class TestScriptMain:
+    """Test the module's ``__main__`` entry point."""
+
+    def test_script_main_prints_output(self, tmp_path: Path) -> None:
+        """Running as a script prints section to stdout for real feedback."""
+        feedback_file = tmp_path / "feedback.md"
+        feedback_file.write_text(_REAL_FEEDBACK, encoding="utf-8")
+        script = _SCRIPTS / "dispatcher" / "iteration_feedback.py"
+
+        proc = subprocess.run(
+            [sys.executable, str(script), str(feedback_file)],
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode == 0
+        assert "## Iteration feedback" in proc.stdout
+        assert _REAL_FEEDBACK in proc.stdout
+
+    def test_script_main_empty_output_on_seed(self, tmp_path: Path) -> None:
+        """Running as a script produces no stdout output for the seed sentinel."""
+        feedback_file = tmp_path / "feedback.md"
+        feedback_file.write_text(_SEED_SENTINEL, encoding="utf-8")
+        script = _SCRIPTS / "dispatcher" / "iteration_feedback.py"
+
+        proc = subprocess.run(
+            [sys.executable, str(script), str(feedback_file)],
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode == 0
+        assert proc.stdout == ""
+
+    def test_script_main_missing_arg_exits_nonzero(self) -> None:
+        """Running without argument exits with non-zero code."""
+        script = _SCRIPTS / "dispatcher" / "iteration_feedback.py"
+
+        proc = subprocess.run(
+            [sys.executable, str(script)],
+            capture_output=True,
+            text=True,
+        )
+
+        assert proc.returncode != 0

--- a/scripts/dispatcher/tests/test_skill_md_contracts.py
+++ b/scripts/dispatcher/tests/test_skill_md_contracts.py
@@ -1,0 +1,108 @@
+"""Contract tests verifying expected text patterns in skill SKILL.md files.
+
+These tests assert that:
+
+* ``prior_attempts.md`` is referenced in ``task-v2-ralph/SKILL.md`` Step 0.5
+  and the worker-context handoff (AC b.3).
+* ``## Prior attempts`` is referenced in ``ralph/SKILL.md`` worker prompt AND
+  Claude-reviewer prompt (AC b.4).
+* ``iteration_feedback.py`` and ``## Iteration feedback`` appear in
+  ``task-v2-ralph/SKILL.md`` Step 4 (AC a.1 grep half).
+
+These are grep-style assertions against the literal SKILL.md text — they catch
+regressions where an edit removes or renames a required marker.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]  # worktree root
+
+_TASK_V2_RALPH_SKILL = _REPO_ROOT / ".claude" / "skills" / "task-v2-ralph" / "SKILL.md"
+_RALPH_SKILL = _REPO_ROOT / ".claude" / "skills" / "ralph" / "SKILL.md"
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"SKILL.md not found: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+class TestTaskV2RalphSkillContracts:
+    """Contracts for ``.claude/skills/task-v2-ralph/SKILL.md``."""
+
+    def test_prior_attempts_md_in_step_0_5(self) -> None:
+        """Step 0.5 must reference ``prior_attempts.md`` (AC b.3)."""
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "prior_attempts.md" in content, (
+            "task-v2-ralph/SKILL.md must reference prior_attempts.md (AC b.3)"
+        )
+
+    def test_step_0_5_heading_present(self) -> None:
+        """The Step 0.5 heading must be present."""
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "Step 0.5" in content, (
+            "task-v2-ralph/SKILL.md must have a Step 0.5 section for prior_attempts context"
+        )
+
+    def test_prior_attempts_section_in_task_md_format(self) -> None:
+        """The task.md format in Step 1 must include ``## Prior attempts`` (AC b.3)."""
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "## Prior attempts" in content, (
+            "task-v2-ralph/SKILL.md Step 1 must include ## Prior attempts "
+            "in the task.md format (AC b.3)"
+        )
+
+    def test_iteration_feedback_py_in_step_4(self) -> None:
+        """Step 4 must reference ``iteration_feedback.py`` (AC a.1 grep half)."""
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "iteration_feedback.py" in content, (
+            "task-v2-ralph/SKILL.md Step 4 must reference iteration_feedback.py (AC a.1)"
+        )
+
+    def test_iteration_feedback_heading_in_step_4(self) -> None:
+        """Step 4 must reference ``## Iteration feedback`` output (AC a.1 grep half)."""
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "## Iteration feedback" in content, (
+            "task-v2-ralph/SKILL.md must reference ## Iteration feedback (AC a.1)"
+        )
+
+
+class TestRalphSkillContracts:
+    """Contracts for ``.claude/skills/ralph/SKILL.md``."""
+
+    def test_prior_attempts_in_worker_prompt(self) -> None:
+        """Worker prompt must reference ``## Prior attempts`` (AC b.4)."""
+        content = _read(_RALPH_SKILL)
+        assert "## Prior attempts" in content, (
+            "ralph/SKILL.md must reference ## Prior attempts in worker prompt (AC b.4)"
+        )
+
+    def test_prior_attempts_in_claude_reviewer_prompt(self) -> None:
+        """Claude reviewer prompt must reference prior attempts context (AC b.4)."""
+        content = _read(_RALPH_SKILL)
+        # The reviewer prompt section starts at "Claude reviewer prompt".
+        reviewer_idx = content.find("Claude reviewer prompt")
+        assert reviewer_idx != -1, (
+            "ralph/SKILL.md must have a Claude reviewer prompt section"
+        )
+        reviewer_section = content[reviewer_idx:]
+        assert (
+            "Prior attempts" in reviewer_section or "prior attempts" in reviewer_section
+        ), (
+            "ralph/SKILL.md Claude reviewer prompt must reference prior attempts (AC b.4)"
+        )
+
+    def test_prior_attempts_in_task_md_section_list(self) -> None:
+        """Step 0 task.md section list must mention ``## Prior attempts (optional)``."""
+        content = _read(_RALPH_SKILL)
+        assert "## Prior attempts (optional)" in content, (
+            "ralph/SKILL.md Step 0 must list ## Prior attempts (optional) in task.md sections"
+        )
+
+    def test_prior_attempts_file_path_referenced(self) -> None:
+        """ralph/SKILL.md must reference the file path ``prior_attempts.md``."""
+        content = _read(_RALPH_SKILL)
+        assert "prior_attempts.md" in content, (
+            "ralph/SKILL.md must reference prior_attempts.md so workers know where to look"
+        )


### PR DESCRIPTION
## Summary

When a ralph attempt fails and the daemon spawns a retry, the new ralph subagent now receives explicit context about the prior attempt's failure: the failure category, the push-time stderr tail (~2000 chars), and the full iteration-by-iteration feedback narrative from the prior ralph run. This prevents re-discovery of the same failure mode across retries, preserving retry budget for real problem-solving work.

Implementation adds: (1) new `iteration_feedback.py` stdlib helper to extract and format feedback.md content into phase logs; (2) new daemon helpers to query prior failed agents and materialize a digest file before spawning ralph; (3) updated SKILL.md files in both `/task-v2-ralph` and `/ralph` to read and pass prior-attempt context; (4) comprehensive unit and contract tests.

Closes #2984

## Test plan

### Automated checks

- [ ] Lint passes (`ruff check` / `npm run lint`)
- [ ] Format check passes (`ruff format --check` / prettier)
- [ ] Tests pass (`pytest`)
- [ ] CI green

### Local verification

- [ ] `scripts/dispatcher/tests/test_daemon_prior_attempts.py` — all unit tests for `_fetch_prior_attempts`, `_materialize_prior_attempts`, and `_run_ralph_phase` logging pass.
- [ ] `scripts/dispatcher/tests/test_iteration_feedback.py` — all unit and script-main tests for `build_iteration_feedback_section` pass.
- [ ] `scripts/dispatcher/tests/test_skill_md_contracts.py` — all contract assertions for SKILL.md references pass (grep-based validation).

### Post-deploy verification

- [ ] CloudWatch query over N post-deploy ralph runs: assert `phase_outputs.log_text` for multi-iteration runs is longer than pre-deploy baseline (iteration feedback appended).
- [ ] Force a synthetic ralph retry on a test issue: confirm the retried ralph's worker prompt contains prior-attempt context including iteration narrative excerpts and failure category.
- [ ] Observability: `ralph_spawn` log event carries `prior_attempts_count` field (0 for first attempts, ≥1 for retries with context).
- [ ] Verification evidence posted on #2984 (see /task-v2-verify output)
