### PR TITLE
fix(dispatcher): bump Fargate memory to 8 GiB so ralph pre-push can run pytest

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -229,6 +229,16 @@ module "dispatcher_daemon" {
   # singleton and overlapping instances would double-spawn agents.
   desired_count = 1
 
+  # Memory sized for ralph's in-container pre-push gate (#2962).
+  # The spec §14 default (2 GiB) covers the daemon itself but not the
+  # per-agent ralph subprocess that runs `pytest packages/<pkg>/tests/`
+  # over the full 7200-test scraper-framework suite — pytest was
+  # SIGKILL'd by the kernel OOM reaper on #2568 after loading ~3% of
+  # tests. Bump to 8 GiB (Fargate 1 vCPU max; larger requires bumping
+  # CPU too) to give the pre-push gate headroom. Cost delta is minimal
+  # (~$0.04/hr extra for a singleton dev dispatcher).
+  task_memory = 8192
+
   # Secret ARNs — populated incrementally as their owning issues land.
   # #2700 wires `github_token_secret_arn` (this ARN is the scoped PAT from
   # spike 0.7, provisioned in Secrets Manager by the operator and pinned


### PR DESCRIPTION
## Summary

Bump dev dispatcher Fargate task memory from 2 GiB → 8 GiB.

## Why

Ralph's Step 2.5 pre-push gate (from PR #2963) invokes the full package `pytest` suite via `.githooks/pre-push`. On #2568 the scraper-framework test suite (~7200 tests) was **SIGKILL'd by the kernel OOM reaper at ~3%** of collection:

> "The pre-push gate failed not due to a code bug but due to OOM: pytest was SIGKILL'd at ~3% of the scraper-framework's ~7200-test suite in the Fargate container. All visible test output was passing dots." — agent `67dddab7` BLOCKED verdict, 2026-04-21 06:59 UTC

Ralph correctly diagnosed (code was correct, reviewer SHIPped) but the gate can't return a real pass/fail signal under 2 GiB. The next scraper agent (#2609 currently in ralph, #2613 queued) would hit the same wall.

Dispatcher spec §14 sized task memory for the daemon alone, not for per-agent pytest execution. 8 GiB is the max at the 1-vCPU tier; larger needs CPU escalation which is out of scope here.

Cost delta on a singleton dev dispatcher: roughly $0.04/hr, ~$30/month.

## Test plan

- [ ] CI green
- [ ] Post-merge: dev terraform apply (automated per CLAUDE.md) updates the ECS task definition
- [ ] New dispatcher task launches with 8 GiB (verify via `aws ecs describe-task-definition` or `describe-tasks`)
- [ ] Unpause daemon (flip `concurrency_cap` 0 → 1)
- [ ] #2568 retry (or fresh scraper-framework agent) reaches push_and_pr with pre-push test run completing — either pass or real test failure, not OOM SIGKILL
