### PR TITLE
refactor(dx): shrink CLAUDE.md by 47% (#2991)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,48 +4,43 @@
 
 ## Critical Rules — Read First
 
-These are the most frequently violated rules. **A PreToolUse hook enforces the shell rules automatically**, but you must internalize all of them. See `docs/preflight-checklist.md` for the complete machine-readable checklist.
+**A PreToolUse hook enforces the shell rules automatically.** See `docs/preflight-checklist.md` for the complete machine-readable checklist.
 
 ### NEVER — Shell Commands
-- **NEVER** use `$()` command substitution in any Bash command. Run the inner command as a separate tool call and use the literal result. For secrets, use `scripts/with-secret.sh`.
-- **NEVER** use heredocs (`<<EOF`) in Bash commands. Write content to a file with the Write tool, then pass via `--body-file` or `-F`.
-- **NEVER** use `python3 -c "..."` for inline scripts. Write to `{worktree}/tmp/script.py` and run the file.
-- **NEVER** combine quoted strings with `&&` or `;`. Split into separate tool calls.
-- **NEVER** prefix scripts with `bash` — run `scripts/cleanup_worktree.sh`, not `bash scripts/cleanup_worktree.sh`.
-- **NEVER** use shell `&`, `nohup`, `disown`, or multicommand tricks to background a process. Use the Bash tool's `run_in_background: true` parameter instead. Shell backgrounding requires compound commands that cannot be allowlisted and always trigger permission prompts.
-- **NEVER** use Edit or Write tools on files inside `.claude/`. The CLI blocks these operations. Write content to `{worktree}/tmp/` first, then copy it into place with `scripts/write-claude-file.sh {worktree}/tmp/file.md {worktree}/.claude/target/file.md`.
-- **NEVER** run bare `git stash pop` or `git stash apply` — `.git/refs/stash` is shared across every worktree in the clone, so a bare pop can silently apply another agent's or another worktree's stash (reverting your edits and dumping their WIP into your worktree; observed in #2749). Always pop by explicit ref: run `git stash list` first, confirm `stash@{0}`'s subject contains your current branch, then `git stash pop stash@{0}`. Better yet, avoid stash entirely — use a throwaway commit (`git commit -am "WIP"`, do the thing, `git reset --soft HEAD~1`) which has no shared global state. The preflight hook blocks bare pop/apply.
+
+Shell-interactive prompt-prevention rules (`$()`, heredocs, inline `python -c`, quoted + `&&`/`;`, `bash scripts/`, bare `stash pop`, `.claude/` writes) are hook-enforced on operator laptops and inert on Fargate — see `docs/agent/interactive-shell-rules.md` for the full list with rationale.
+
+- Never use shell `&`, `nohup`, `disown`, or multicommand tricks to background a process. Use the Bash tool's `run_in_background: true` parameter instead.
+- Never run bare `git stash pop` or `git stash apply` (#2749). Pop by explicit ref after `git stash list`, or use a throwaway commit instead.
 
 ### NEVER — Workflow
-- **NEVER** use `run_in_background` in any subagent (`/task`, `/ralph`, `/tdd`, or any Agent-spawned worker/reviewer). Subagents are already running as background tasks — further backgrounding causes completion notifications to surface in the wrong context (the parent agent), leading to confusion and lost results. All commands inside subagents run synchronously.
-- **NEVER** commit directly to `main` during autonomous task work. All `/task` work happens on worktree branches via PRs. (The user may direct you to commit to `main` during interactive sessions — that's fine.)
-- **You MAY merge your own PRs** if the PR has passed the `/ralph` review loop (§4.3) and CI is green. Use `gh pr merge <N> --repo judgemind/judgemind --squash --delete-branch`.
-- **NEVER** exit or stop after `/ralph` completes without finishing the full `/task` workflow (steps 4.4 through 4.11 in this document; A.3 through A.9 in the task skill). Ralph completing means the code is ready — but uncommitted, unpushed, and unmerged. The task is only halfway done. See #721.
-- **NEVER** deploy to production. Production deploys are human-only.
-- **NEVER** set `priority/p0` on issues unless explicitly told to by a human. `p0` is human-only.
-- **NEVER** skip pre-PR checks. Run lint, format, AND tests locally before pushing.
-- **NEVER** share venvs between worktrees. Each worktree gets its own `.venv`.
-- **NEVER** create additional worktrees from inside a worktree via `git worktree add`. Subagents must work in their assigned worktree only. If the worktree gets into a bad state, fix it (e.g., `git checkout -- .`, `git clean -fd`) rather than creating a new one. Child worktrees become orphaned — `cleanup_worktree.sh` cannot track them, and the dispatcher does not know about them.
-- **NEVER** close a task or remove a worktree without posting a verification evidence comment on the issue. Every task completion requires concrete evidence that the change works (deployed services) or an explicit skip reason (docs/CI/tooling). See §4.10 Step 3.
-- **NEVER** merge user-visible affordances that haven't been exercised end-to-end. A button, menu item, form, API endpoint, config flag, or schema field only lands in `main` when someone has actually used it and observed the downstream effect — clicked the stop button and confirmed the task was killed, hit the endpoint and verified the DB row changed, toggled the flag and saw the behavior switch. "The page renders" / "the service returns 200" is not evidence that a control works. If a feature can't be exercised today, it is feature-flagged off, kept out of the UI, or not merged. Half-built behind a flag is fine; half-built and reachable by users is the bug. The verification evidence comment (§4.10 Step 3, task skill A.8) must show the affordance being *exercised*, not just rendered.
-- **NEVER** bypass a safety check (e.g. `cleanup_worktree.sh`, preflight hooks, `.githooks/pre-push`) with `--force` or a manual workaround. When a check blocks you, trust it: skip and retry later, or investigate the root cause. The check is usually right and you are usually wrong about what is happening.
-- **NEVER** run `gh auth switch` or change the active GitHub CLI account without an explicit user instruction. If `gh` fails on auth, report the problem — don't swap accounts as a workaround. A subagent doing this once caused a ghost-PR incident that derailed an agent for multiple iterations.
+- Never use `run_in_background` in any subagent (`/task`, `/ralph`, `/tdd`, or Agent-spawned workers). All commands inside subagents run synchronously.
+- Never commit directly to `main` during autonomous task work.
+- **You MAY merge your own PRs** after `/ralph` and CI are green: `gh pr merge <N> --repo judgemind/judgemind --squash --delete-branch`.
+- Never exit or stop after `/ralph` completes without finishing the full `/task` workflow (steps 4.4–4.11; A.3–A.9 in the task skill). Ralph completing means code is ready — not committed, not pushed, not merged. See #721.
+- Never deploy to production. Production deploys are human-only.
+- Never set `priority/p0` on issues unless explicitly told to by a human.
+- Never skip pre-PR checks. Run lint, format, AND tests locally before pushing.
+- Never share venvs between worktrees. Each worktree gets its own `.venv`.
+- Never create additional worktrees from inside a worktree via `git worktree add`. Fix bad state with `git checkout -- .` / `git clean -fd` rather than creating a new worktree.
+- Never close a task or remove a worktree without posting a verification evidence comment on the issue. See §4.10 Step 3.
+- Never merge user-visible affordances that haven't been exercised end-to-end. "The page renders" / "the service returns 200" is not evidence. Half-built behind a flag is fine; half-built and reachable by users is the bug.
+- Never bypass a safety check with `--force` or a manual workaround. When a check blocks you, trust it.
+- Never run `gh auth switch` without an explicit user instruction.
 
 ### ALWAYS — Before Acting
-- **ALWAYS** Read a file before Writing to it (the Write tool fails on existing files you haven't read).
-- **ALWAYS** pull latest code (run `git fetch origin main` then `git rebase origin/main` as separate tool calls) before analyzing or modifying files.
-- **ALWAYS** use `{worktree}/tmp/` for temp files, never `/tmp/`.
-- **ALWAYS** use dedicated tools (Read, Glob, Grep) instead of Bash for file operations.
-- **ALWAYS** watch CI to completion (`gh run watch`) before doing anything else after pushing.
-- **ALWAYS** create a PR immediately after your first push to a branch.
-- **ALWAYS** re-fetch GitHub issue or PR state before acting on it if more than a few minutes have elapsed since you last fetched it. Other agents may have closed, merged, or modified issues in the interim — acting on stale state causes incorrect cross-references, duplicate filings, and wasted work.
-- **ALWAYS** set `timeout: 1200000` (20 minutes) on Bash commands that may take longer than 2 minutes. The default 2-minute timeout causes the platform to auto-background the command, which violates the no-background rule for subagents and causes lost results. Commands that need this: `pytest`, `gh run watch`, `terraform apply`, `pip install`, `npm install`, `npm run build`, `ruff check` on large codebases, and any script that processes data.
+- Read a file before Writing to it (the Write tool fails on existing files you haven't read).
+- Pull latest code: `git fetch origin main` then `git rebase origin/main` as separate tool calls before modifying files.
+- Use `{worktree}/tmp/` for temp files, never `/tmp/`.
+- Use dedicated tools (Read, Glob, Grep) instead of Bash for file operations.
+- Watch CI to completion (`gh run watch`) before doing anything else after pushing.
+- Create a PR immediately after your first push to a branch.
+- Re-fetch GitHub issue or PR state before acting on it if more than a few minutes have elapsed.
+- Set `timeout: 1200000` (20 minutes) on Bash commands that may take longer than 2 minutes: `pytest`, `gh run watch`, `terraform apply`, `pip install`, `npm install`, `npm run build`, `ruff check` on large codebases, any data-processing script.
 
 ## Enforced Rules — Automated Checks
 
-The PreToolUse hook (`.claude/hooks/preflight-bash.sh`) and `scripts/preflight.sh` automatically enforce the Critical Rules above. The hook blocks `$(`, `<<EOF`, `python -c`, `git push` to main, `git worktree add` inside worktrees, cross-worktree writes via Bash (cp/mv/tar/redirection into the main repo checkout from a worktree subagent — see #2455), and bare `git stash pop` / `git stash apply` (see #2749 — the stash list is per-clone, not per-worktree, so bare pops can apply another worktree's stash). A separate PreToolUse hook (`.claude/hooks/agent-worktree-guard.sh`) blocks Agent tool calls with `isolation: "worktree"` when cwd has drifted into an existing worktree, preventing nested worktree creation. Another PreToolUse hook (`.claude/hooks/worktree-write-guard.sh`) blocks Edit/Write on paths inside the main repo checkout when the agent is running inside a worktree, preventing silent writes to the main repo that bypass the PR workflow (#2440). Runtime checks:
-
-**Operator-interactive vs. Fargate dispatcher scope.** The rules above all apply in **operator-interactive sessions** (developer laptops). Most of them exist to prevent the interactive Claude CLI from stalling on permission prompts — a problem that does not exist in the non-interactive Fargate dispatcher container, where subagents run with `--dangerously-skip-permissions` and there are no prompts. Inside the Fargate image (`Dockerfile.dispatcher`) the preflight hook is file-swapped at worktree creation time to a narrowed variant (`scripts/preflight-bash-fargate.sh`) that only enforces the 4 safety-critical rules: `git push` to main, `git worktree add` inside a worktree, cross-worktree writes into the main repo, and bare `git stash pop` / `git stash apply`. The 6 interactive-prompt-prevention rules (`$(...)`, heredocs, inline `python -c`, quoted strings + `&&`/`;`, `bash script/` prefix, empty-quotes bypass) are allowed in-container because they are safe there. Operator laptops keep the full ruleset — this change is scoped to the Fargate image via `DISPATCHER_FARGATE_HOOKS_DIR` + per-worktree `git update-index --skip-worktree`. See issue #2982.
+The PreToolUse hook (`.claude/hooks/preflight-bash.sh`) and `scripts/preflight.sh` enforce the Critical Rules above. See `docs/agent/interactive-shell-rules.md` for the full operator-laptop vs. Fargate-runtime scope split.
 
 ```bash
 source scripts/preflight.sh
@@ -61,9 +56,9 @@ preflight_rate_budget       # Warn if GitHub API rate budget < 100 remaining
 
 Judgemind is a free, open-source legal research platform replacing Trellis.law. Read the specs in `docs/specs/` for full context. The key things to know:
 
-- **Capture to S3 is the most critical step.** Tentative rulings disappear from court websites within days. If the scraper is down when a ruling is posted, the raw is lost forever — scraper reliability is the top priority. Once captured to S3, the raw is durable.
+- **Capture to S3 is the most critical step.** Tentative rulings disappear from court websites within days. If the scraper is down when a ruling is posted, the raw is lost forever — scraper reliability is the top priority.
 - **Data is tiered; the schema encodes the tiers.** S3 is the source of truth. PostgreSQL is split by schema namespace:
-  - `derived.*` (documents, rulings, cases, judges, attorneys, parties, court_directory_snapshots, aliases) — fully rebuildable from S3 via `rebuild_db.py`. **For cleanup or corrupted state, prefer rebuild over surgical deletion/patch scripts.** Surgical one-offs are prone to their own bugs (wrong filter, missed edge case, partial mutation) and frequently create more problems than they solve. They also only touch existing rows — they don't validate the ingestion or enrichment pipeline, so inbound data can keep arriving with the same root-cause bug. Rebuild exercises the real pipeline end-to-end: the same fix validates existing and future rows in one step.
+  - `derived.*` (documents, rulings, cases, judges, attorneys, parties, court_directory_snapshots, aliases) — fully rebuildable from S3 via `rebuild_db.py`. For cleanup or corrupted state, prefer rebuild over surgical deletion/patch scripts.
   - `public.*` (users, refresh_tokens, alert_subscriptions, alert_events) — authoritative accumulated state. Never drop without explicit justification; not rebuildable.
   - `staging.*` (captures, ruled_items) — transient pipeline state. Drain, don't rebuild.
   - `telemetry.*` (scraper_runs, validation_results, data_quality_metrics) — accumulated observability. Low-stakes but not rebuildable from S3.
@@ -90,6 +85,7 @@ Consult these docs before making changes in their domain:
 | `docs/agent/infrastructure-reference.md` | ECS script execution, Terraform apply, secrets, Vercel, Reingest vs Rebuild |
 | `docs/agent/local-dev.md` | Docker Compose, local DB rebuild, S3 cache, local env vars |
 | `docs/agent/unattended-patterns.md` | Permission-prompt workarounds for git, curl, secrets, `.claude/` writes |
+| `docs/agent/interactive-shell-rules.md` | Hook-enforced shell NEVERs, operator-laptop vs. Fargate scope |
 | `docs/agent/github-api-access.md` | When to use the GitHub MCP server vs the `gh` CLI — MCP-first for reads, `gh` for writes and gaps |
 | `docs/agent/gh-to-mcp-migration.md` | Full tool-by-tool `gh` → `mcp__github__*` mapping, including the known gaps |
 | `docs/agent/aws-api-access.md` | When to use the AWS MCP servers vs the `aws` CLI vs `scripts/ecs-*.sh` — MCP-first for ECS/CloudWatch reads, scripts for launch-and-stream, CLI for writes/S3/secrets |
@@ -97,7 +93,7 @@ Consult these docs before making changes in their domain:
 
 ### Writing Specs and Long-Lived Design Docs
 
-Every architecture or product spec separates **Today** (what exists and is running in production) from **Direction** (aspirational, planned, or not yet built). Readers of a spec must never have to guess whether a component, API, schema, or feature actually exists — because past conflation has repeatedly caused agents and humans to build on foundations that weren't there (Qdrant vector DB, federal court scrapers that weren't wired up, judge analytics before the data was trustworthy).
+Every architecture or product spec separates **Today** (implemented and running) from **Direction** (aspirational, not yet built). Readers must never have to guess whether a component, API, schema, or feature actually exists.
 
 Structure every new spec as:
 
@@ -111,11 +107,11 @@ Structure every new spec as:
 ```
 
 Rules:
-- **Don't mix.** A Today section describes only what exists. A Direction section describes only what doesn't. No "partially implemented" hedge prose sprinkled inside Today — if it's partial, name the shipped part in Today and the unbuilt part in Direction.
-- **Speculative ideas** ("we'll probably want X") go in Direction or a separate roadmap doc. Never in Today.
-- **Principles and cross-cutting constraints** (cost-awareness, archive-first, security) stay in §1 — they apply regardless of which items are shipped.
+- **Don't mix.** A Today section describes only what exists. A Direction section describes only what doesn't. No "partially implemented" hedge prose — if it's partial, name the shipped part in Today and the unbuilt part in Direction.
+- **Speculative ideas** go in Direction or a separate roadmap doc. Never in Today.
+- **Principles and cross-cutting constraints** stay in §1.
 
-`docs/specs/architecture-spec-v1.md` and `docs/data-flow.md` are the reference patterns. When adding a new spec or materially editing an existing one, follow their structure.
+`docs/specs/architecture-spec-v1.md` and `docs/data-flow.md` are the reference patterns.
 
 ## Starting a New Session
 
@@ -148,7 +144,7 @@ Each worktree gets its own `.venv` per package. Use `scripts/install-package-ven
 scripts/install-package-venv.sh <pkg>     # e.g. scraper-framework, nlp-pipeline
 ```
 
-The raw equivalent (what the helper does): `python3.12 -m venv packages/<pkg>/.venv`, install `packages/judgemind-config` into it first if `<pkg>` depends on it, then `pip install -e "packages/<pkg>[dev]"`. Plain `pip install -e ".[dev]"` **fails** for `scraper-framework` and `nlp-pipeline` because `judgemind-config` is an unpublished local sibling (see #2491).
+The raw equivalent: `python3.12 -m venv packages/<pkg>/.venv`, install `packages/judgemind-config` first if `<pkg>` depends on it, then `pip install -e "packages/<pkg>[dev]"`. Plain `pip install -e ".[dev]"` **fails** for `scraper-framework` and `nlp-pipeline` because `judgemind-config` is an unpublished local sibling (see #2491).
 
 ### Step 3 — Pick up a task
 
@@ -156,61 +152,54 @@ Use `/task` to claim and work on an issue: `/task`, `/task #42`, or `/task scrap
 
 ### Issue author trust check (security gate)
 
-**This is a public repository.** Before working on any issue, the dispatcher and `/task` skill verify the issue author is a trusted collaborator using `scripts/check-issue-author.sh <N>`. Issues filed by non-collaborators (NONE, FIRST_TIMER, FIRST_TIME_CONTRIBUTOR, CONTRIBUTOR without write access) are rejected and moved to `status/triage` for maintainer review. This prevents external users from crafting issues that instruct agents to execute arbitrary code. Three layers enforce this:
+**This is a public repository.** Before working on any issue, the dispatcher and `/task` skill verify the issue author is a trusted collaborator using `scripts/check-issue-author.sh <N>`. Issues filed by non-collaborators are rejected and moved to `status/triage`. Three layers enforce this:
 
-1. **Issue template** — the Task template uses `status/triage` (not `agent/ready`), so new issues require manual labeling.
+1. **Issue template** — the Task template uses `status/triage`, so new issues require manual labeling.
 2. **GitHub Action** (`issue-triage.yml`) — strips `agent/ready` from issues filed by non-collaborators.
 3. **Runtime check** — dispatcher and `/task` call `scripts/check-issue-author.sh` before spawning work (fail-closed).
 
 ## Collaboration & Judgment
 
-These rules govern how you work with the user in interactive sessions, not just the mechanics of a task.
-
-- **Wait for confirmation before acting on proposals.** When you present an approach, options, or questions, end the turn and wait. Don't file issues, don't start implementing, don't spawn agents until the user responds with something like "yes", "go", "file it", or "looks good". Premature action skips the collaborative refinement step and produces issues/PRs that often need to be edited or closed.
-- **Evidence-Based Answers.** When making factual claims about code, PRs, issues, deploy state, CI status, or any other verifiable fact, verify first before answering. Use `gh issue view` / `gh pr view`, Read, Grep, `git log`, or the relevant status/timing file rather than guessing from context. Soft-hedging words ("likely", "probably", "I think") are fine in exploratory discussion but never as a stand-in for verification the agent could have performed in the same turn. If a verification would take more than one or two quick tool calls, state that explicitly and ask the user whether to proceed — don't paper over uncertainty with confident prose.
-- **Zoom out before planning: root cause vs. symptom.** Before generating a plan or filing a batch of issues, ask: do these share a root cause? Have we fixed similar things before — and if so, why did it recur? Would a structural fix prevent the entire class of problem? Group by cause, not symptom. Present the reasoning to the user, not just the conclusion. Sometimes the honest answer is "this is just iteration on a sound approach" — that's fine — but if we keep re-treading the same ground, question the approach before adding more patches.
-- **Root Cause Over Symptoms (triage, spotcheck, investigation).** The rule above applies generally; this one is its triage/spotcheck/investigation specialization. Before filing a symptom-level ticket in those contexts, look one level deeper for the shared cause. If three sampled rulings from different counties all have the same wrong field, the bug is probably in shared enrichment code, not in three separate scrapers — file one root-cause issue, not three symptom issues. Do not propose soak periods, validation delays, or "let's observe for a week" unless the user asks for them — they add calendar time without adding information when the cause is knowable from the data already in hand.
+- **Wait for confirmation before acting on proposals.** End the turn after presenting options and wait. Don't file issues, don't start implementing, don't spawn agents until the user responds.
+- **Evidence-Based Answers.** Verify before answering factual claims about code, PRs, deploy state, CI status. Use `gh issue view` / `gh pr view`, Read, Grep, `git log`. Soft hedges are fine in exploratory discussion but not as a substitute for verification.
+- **Zoom out before planning: root cause vs. symptom.** Before generating a plan or filing issues, ask: do these share a root cause? Would a structural fix prevent the entire class of problem?
+- **Root Cause Over Symptoms** (triage, spotcheck, investigation). Before filing a symptom-level ticket, look one level deeper. File one root-cause issue, not three symptom issues.
 
 ## PR Workflow
 
-**The authoritative step-by-step lives in `.claude/skills/task/SKILL.md` §A.3–A.9.** `/task` subagents follow that. The rules below are the ones every agent (task, dispatcher, interactive) must internalize.
+**The authoritative step-by-step lives in `.claude/skills/task/SKILL.md` §A.3–A.9.**
 
-- **Claim interlock (`status/in-progress` label, label-only).** On claim, `/task` adds the `status/in-progress` GitHub label **before** removing `agent/ready` so a racing daemon tick sees the new label during the ~100ms propagation window. The daemon's queue-scan filter drops any issue carrying `status/in-progress`, and the daemon's `_atomic_claim` re-reads the label set at claim time as a final fence. On terminal (PR merged, verification passed, blocker, investigation closed, STUCK exit), `/task` removes the label. The daemon still writes its own `dispatcher.agents` row for daemon↔daemon atomic collision detection via the partial UNIQUE INDEX `idx_dispatcher_agents_active_issue`, but `/task` subagents no longer touch that table. The residual race window — both operator-add and daemon-scan completing within the same ~100ms — is accepted (worst case: two PRs on the same issue, a human notices and closes one). Issue #2927 replaced the prior DB-row + label interlock (#2866) with this label-only flow. See `.claude/skills/task/SKILL.md` §2a + A.7 + B.2 for the exact commands.
-- **Single-issue rule.** Each PR addresses exactly one issue. Break large/ambiguous issues into sub-tasks labeled `agent/ready` before picking up.
-- **All commits on the worktree branch.** Never directly on `main` during autonomous work. Every change goes through a PR.
-- **Scope completeness check before implementing.** Grep the codebase for all locations affected by the change. If the issue's scope doesn't cover all, either expand scope or file follow-ups.
-- **Ralph for testable code only** (Python, TypeScript). Non-testable tasks (Terraform, migrations, CI/CD, docs) implement directly, then run pre-PR checks and self-review the diff.
-- **Check for duplicate PRs before creating one** — `scripts/check-duplicate-pr.sh <N>`. Adopt an existing PR rather than filing a second.
+- **Claim interlock (`status/in-progress` label, label-only).** On claim, `/task` adds `status/in-progress` before removing `agent/ready`; removes it on terminal. Issue #2927 replaced the prior DB-row + label interlock (#2866) with this label-only flow.
+- **Single-issue rule.** Each PR addresses exactly one issue.
+- **All commits on the worktree branch.** Every change goes through a PR.
+- **Scope completeness check before implementing.** Grep for all locations affected by the change.
+- **Ralph for testable code only** (Python, TypeScript). Non-testable tasks implement directly, then run pre-PR checks and self-review the diff.
+- **Check for duplicate PRs** — `scripts/check-duplicate-pr.sh <N>`.
 - **CI watch is non-negotiable.** `gh run watch <id> --interval 60 --exit-status --compact`. Fix and re-push until CI is green.
 - **Verify `mergeable: MERGEABLE` and `statusCheckRollup` all SUCCESS/SKIPPED before merging.**
-- **Verification evidence comment is MANDATORY on every task completion** — deployed or not. For deployed services, include concrete evidence (curl / DB query / log lines / screenshot). For docs/CI/tooling, state the skip reason explicitly. See task skill A.8 Step 3 for the evidence format and the change-type → verification mapping.
-- **For new user-visible affordances, the evidence must be the affordance exercised** — not "the page loads" or "the service returns 200." A stop button requires log lines showing the process was killed AND a DB/state snapshot showing the task transitioned to stopped. A new endpoint requires the request-response pair AND the state change it caused. A new config flag requires toggling it and observing both branches of the behavior. Rendering is not evidence. See task skill A.8 Step 2 verification table.
-- **Deploy before cleanup.** A task is done when the change is deployed, functionally verified, AND evidence posted — not when the PR merges. Worktree stays alive until verification passes.
+- **Verification evidence comment is MANDATORY on every task completion.** For deployed services: curl / DB query / log lines / screenshot. For docs/CI/tooling: state the skip reason.
+- **For new user-visible affordances, the evidence must be the affordance exercised** — not "the page loads." A stop button requires log lines showing the kill AND a DB/state snapshot. Rendering is not evidence.
+- **Deploy before cleanup.** A task is done when the change is deployed, verified, AND evidence posted.
 - **Never ask for user confirmation during the substeps.** Just execute.
 
 ## Tool Use Rules
 
 - **Use dedicated tools for file operations** — never use Bash for `cat`, `ls`, `grep`, `find`. Use Read, Glob, and Grep instead.
 - **Always Read before Write** — the Write tool requires this for existing files.
-- **Prefer Edit over Write for existing files.** Edit sends only the diff (old_string/new_string). Write sends the entire file content as output tokens — a 60KB file is ~20K output tokens, and a single large Write can trigger autocompact mid-task. Reserve Write for new files or genuine full rewrites. For a targeted change to a large file, always use Edit.
-- **Don't re-Read a file you already Read in full.** Keep the initial content in working memory. Re-reading different offsets of the same unmodified file to "double-check" burns ~5K cached tokens per call and adds nothing.
+- **Prefer Edit over Write for existing files.** Edit sends only the diff. Write sends the entire file content — a 60KB file is ~20K output tokens. Reserve Write for new files or full rewrites.
+- **Don't re-Read a file you already Read in full.**
 - **Use Bash only for shell-only operations** — git, gh CLI, running tests, pip install, terraform, etc.
-- **GitHub reads: MCP for single objects, `gh --json` for lists and wide rollups.** `mcp__github__get_issue` / `get_pull_request` / `get_file_contents` return typed objects with no jq or shell quoting — cleaner for one-shot lookups. But MCP returns the full server payload, which loses to a narrow `gh --json <tight field list>` on lists and wide rollups. A busy `agent/ready` queue is ~150K chars via `list_issues` vs ~50K via `gh issue list --json number,title,labels,assignees,createdAt` — sometimes the MCP response exceeds the token ceiling outright. `get_pull_request_status` only covers legacy commit statuses, not Actions check runs; for the full rollup use `gh pr view <N> --json statusCheckRollup,mergeable,mergeStateStatus`. Tools are deferred; load with `ToolSearch query="select:mcp__github__get_issue,..."` before first use. See `docs/agent/github-api-access.md` for the decision table and `docs/agent/gh-to-mcp-migration.md` for the full mapping.
-- **GitHub writes: `gh` CLI.** Writes — `gh issue create`, `gh issue comment`, `gh issue edit`, `gh issue close --reason`, `gh pr create`, `gh pr merge --squash --delete-branch`, `gh pr edit`, `gh pr review` — stay on `gh` until the MCP server has a `GITHUB_PERSONAL_ACCESS_TOKEN` (see `docs/agent/gh-to-mcp-migration.md` §Write-path status). Reads without an MCP equivalent also stay on `gh`: `gh run watch`, `gh run list --workflow`, `gh run view`, `gh pr diff`, `gh api rate_limit`, `gh auth status`. Do not invent MCP calls that do not exist.
-- **MCP-first for AWS reads (ECS + CloudWatch).** Prefer `mcp__awslabs_ecs-mcp-server__ecs_resource_management` for ECS reads (`DescribeServices`, `DescribeTasks`, `ListTasks`) and `mcp__awslabs_cloudwatch-mcp-server__*` for log discovery (`describe_log_groups`) and Logs Insights (`execute_log_insights_query`, `get_logs_insight_query_results`). MCP returns parsed JSON in one call — no `--query`/`-o json` shell juggling, no millisecond-epoch math. Tools are deferred; load via `ToolSearch query="select:mcp__awslabs_ecs-mcp-server__ecs_resource_management,mcp__awslabs_cloudwatch-mcp-server__execute_log_insights_query"` before first use. **Note the hyphenated server segment** (`awslabs_ecs-mcp-server`, `awslabs_cloudwatch-mcp-server`) — not underscores. See `docs/agent/aws-api-access.md` for the decision table and `docs/agent/aws-to-mcp-migration.md` for the full mapping.
-- **`scripts/ecs-*.sh` wrappers stay** for launch-and-stream-logs workflows (`scripts/ecs-run-task.sh` for oneshot Fargate tasks, `scripts/ecs-redeploy.sh` for service redeploys with rollout-wait, `scripts/ecs-logs.sh --follow` for live log tailing). The MCP `RunTask` is gated behind Phase B (`ALLOW_WRITE` IAM scoping) and would not include the stream-logs convenience even when unlocked.
-- **`aws` CLI for the rest:** writes (until Phase B), `aws s3 cp`/`ls`/`sync` for S3 (no MCP equivalent), `aws ecs execute-command` for interactive Exec via `scripts/dev-db-query.sh` and `scripts/ecs-run.sh` (interactive SSM streams are not MCP-replicable), and `aws sts`/`aws configure` for auth-state checks. Never call `aws secretsmanager get-secret-value` directly — use `scripts/with-secret.sh`.
-- **Parallelize independent Bash calls** — when multiple Bash commands have no dependencies between them (e.g., fetching multiple issue details, running lint + format check), make all calls in a single message rather than sequentially. This significantly reduces wall-clock time for multi-step workflows.
+- **GitHub reads: MCP for single objects, `gh --json` for lists and wide rollups.** See `docs/agent/github-api-access.md`. Tools are deferred; load with `ToolSearch` before first use.
+- **GitHub writes: `gh` CLI** (`gh issue create`, `gh pr create`, `gh pr merge --squash --delete-branch`, etc.). See `docs/agent/gh-to-mcp-migration.md`.
+- **AWS reads: MCP-first for ECS + CloudWatch.** See `docs/agent/aws-api-access.md`. `scripts/ecs-*.sh` wrappers stay for launch-and-stream-logs. `aws` CLI for writes, S3, and interactive Exec. Never call `aws secretsmanager get-secret-value` directly — use `scripts/with-secret.sh`.
+- **Parallelize independent Bash calls** to reduce wall-clock time.
 - `sudo` and `rm` always prompt; split commands to avoid triggering prompts.
 
 For detailed patterns to avoid permission prompts, see `docs/agent/unattended-patterns.md`.
 
 ### GitHub API Rate Limit Awareness
 
-GitHub allows 5,000 API requests per hour. With multiple concurrent agents, this budget is shared and can be exhausted quickly.
-
-- **Always use `--interval 60` with `gh run watch`.** The default poll interval is 3 seconds, which burns through API budget fast. Use `gh run watch <id> --repo judgemind/judgemind --interval 60 --exit-status --compact` as the standard CI/deploy watch command.
-- **Never retry 403 errors in a tight loop.** Always check the rate limit reset time and wait for it.
+GitHub allows 5,000 API requests per hour. Always use `--interval 60` with `gh run watch`. Never retry 403 errors in a tight loop.
 
 ## Accounts & Infrastructure
 
@@ -220,20 +209,20 @@ For detailed infrastructure reference (Vercel, Terraform state, ECS, secrets), s
 
 ## Code Standards & Pre-PR Checks
 
-See **`docs/agent/code-standards.md`** for the full reference (Python/TypeScript/Terraform style, one-off script conventions, pre-PR commands, coverage gates). Highlights every agent must internalize:
+See **`docs/agent/code-standards.md`** for the full reference. Highlights:
 
-- **Python:** 3.12+, `.venv` per package, ruff + pytest. Scripts in `scripts/` need a `# venv:` header, plus exactly one of `# one-off: true` or `# permanent: true` (see `docs/agent/code-standards.md` §Python scripts). ECS oneshot scripts cannot import from other `scripts/*.py` files.
+- **Python:** 3.12+, `.venv` per package, ruff + pytest. Scripts in `scripts/` need a `# venv:` header plus exactly one of `# one-off: true` or `# permanent: true`. ECS oneshot scripts cannot import from other `scripts/*.py` files.
 - **TypeScript:** strict mode, Node 20+. In `packages/web/`, use `@/` path aliases; any new GraphQL type without `id` needs a `keyFields` entry in `apollo-client.ts`.
-- **General:** all code has tests. Never hardcode secrets. When removing/renaming exports, grep every import site across `src/` and `tests/` before committing.
+- **General:** all code has tests. Never hardcode secrets. Grep every import site before removing/renaming exports.
 - **Perf:** watch for sequential I/O, `LIMIT/OFFSET` pagination, unbatched DB writes, missing connection reuse.
-- **Pre-PR (MANDATORY, `.githooks/pre-push` enforces):** from each touched package, run `ruff check`, `ruff format --check`, and `pytest` (Python) or `lint`/`typecheck`/`test` + `build` for `packages/web/` (TS). Diff coverage ≥ 90% on changed lines; package floor ratchet in `coverage-baselines.json`. Subagents run the same checks; never push on red.
-- **Docs / Markdown:** when any `.md` file changes, run `scripts/check-markdown-links.sh` to verify internal markdown pointers (both Markdown-link and backtick-ref styles) resolve. CI runs this in the `markdown-links-check` job; `.githooks/pre-push` runs it on any `.md` file being pushed so failures are caught before CI.
-- **CI workflow edits:** when `.github/workflows/ci.yml` changes, `scripts/check-ci-job-skipped.sh` runs automatically to detect the #2410 / #2505 footgun — modifying a job whose paths-filter gate doesn't match anything in the diff, so the job is SKIPPED on that PR's own CI run and your edits are never exercised. CI runs the same check in the `ci-job-skipped-check` job; pre-push runs it whenever ci.yml is in the push. If it fails, either add `.github/workflows/ci.yml` to the offending filter or modify a file that already matches the filter.
-- **Hygiene-check CI steps:** when wiring a `scripts/check-no-*.sh`, `scripts/check-forbidden-*.sh`, or `scripts/check-deprecated-*.sh` guard into `.github/workflows/ci.yml`, do not quote the forbidden string in the step's `name:` field — the quoted pattern itself will trip the guard on the next CI run (see #2541/#2542 for the specific incident). Describe what the check *does* instead of repeating what it *forbids* (e.g. name it after the replacement tool or the category of misuse, not the literal string). The peer guard tests under `scripts/tests/test_check_*.sh` include a self-match assertion (see `scripts/tests/_guard_self_match_helpers.sh`) that catches this at test time. When adding a new string-forbidding guard, add an `assert_no_self_match_on_ci_step_name` call to its test.
+- **Pre-PR (MANDATORY, `.githooks/pre-push` enforces):** from each touched package, run `ruff check`, `ruff format --check`, and `pytest` (Python) or `lint`/`typecheck`/`test` + `build` for `packages/web/` (TS). Diff coverage ≥ 90%; package floor ratchet in `coverage-baselines.json`.
+- **Docs / Markdown:** run `scripts/check-markdown-links.sh` when any `.md` file changes.
+- **CI workflow edits:** run `scripts/check-ci-job-skipped.sh` when `.github/workflows/ci.yml` changes.
+- **Hygiene-check CI steps:** when wiring a `scripts/check-no-*.sh` / `check-forbidden-*.sh` / `check-deprecated-*.sh` guard into CI, do not quote the forbidden string in the step's `name:` field. See `docs/agent/code-standards.md` §Hygiene-check CI steps.
 
 ### Subagent Responsibilities
 
-**Spawn `/task` agents with `isolation: "worktree"` on the Agent tool.** Claude Code creates a unique worktree at `.claude/worktrees/agent-<id>/` automatically — no locking, no number contention, no races. The `/task` agent detects it is already in a worktree and skips manual worktree setup. For non-`/task` subagents needing branch isolation (rare), create a worktree manually. **Never run `git checkout` or `git switch` in the parent's working directory from a subagent.**
+**Spawn `/task` agents with `isolation: "worktree"` on the Agent tool.** Claude Code creates a unique worktree at `.claude/worktrees/agent-<id>/` automatically. **Never run `git checkout` or `git switch` in the parent's working directory from a subagent.**
 
 ## Git Workflow
 
@@ -243,41 +232,18 @@ See **`docs/agent/code-standards.md`** for the full reference (Python/TypeScript
 
 ## Task Dependencies, Sub-Tasks, Investigations
 
-See **`docs/agent/task-dependencies.md`** and **`docs/agent/issue-authoring.md`** for the full mechanics. Core rules every agent must follow:
+See **`docs/agent/task-dependencies.md`** and **`docs/agent/issue-authoring.md`** for the full mechanics. Core rules:
 
-- **Blocking:** use `scripts/block-issue.sh <issue> <blocker>`. Both the `status/blocked` label AND a `Blocked by #N` line in the issue body are required — the `unblock-issues` CI workflow searches the body for `Blocked by #N`. Label-only blocks never auto-unblock. `Parent: #N` is hierarchy, not a dependency.
+- **Blocking:** use `scripts/block-issue.sh <issue> <blocker>`. Both the `status/blocked` label AND a `Blocked by #N` line in the issue body are required. Label-only blocks never auto-unblock. `Parent: #N` is hierarchy, not a dependency.
 - **Unblocking:** PR merges auto-unblock via `Closes #N`. For non-PR completions, run `scripts/unblock-dependents.sh <your-issue>`.
 - **Sub-tasks:** reference the parent as `Parent: #N`; each sub-task should be independently pickup-able.
-- **Acceptance criteria:** concrete and machine-checkable. Each criterion has at least one `Verify:` line (SQL query, curl response, URL/screenshot, etc.). External-integration issues need a one-line HTTP feasibility note before `agent/ready` (see #1979). **Data cleanup on `derived.*` defaults to `rebuild_db.py --county <name>`** — surgical delete/patch scripts are a last resort and must be justified in the issue body.
-- **Investigation tasks:** produce documentation (issue body or `docs/investigations/`) and file follow-up issues for every actionable finding, then close.
-- **Priority:** classify by urgency + workflow impact, not user-visibility. p1 = time-sensitive or workflow accelerators (scraper failures, data quality, DX, process improvements). p2 = most user-facing bugs, backfills, refactoring, docs. p3 = large slow work (features, redesigns). p0 is human-only. See `docs/agent/issue-authoring.md` §Priority Framework for the full table.
+- **Acceptance criteria:** concrete and machine-checkable. Each criterion has at least one `Verify:` line. **Data cleanup on `derived.*` defaults to `rebuild_db.py --county <name>`** — surgical scripts are a last resort.
+- **Investigation tasks:** produce documentation and file follow-up issues for every actionable finding, then close.
+- **Priority:** p1 = time-sensitive or workflow accelerators. p2 = most user-facing bugs, backfills, refactoring. p3 = large slow work. p0 is human-only.
 
-## Ingestion Pipeline — Separation of Concerns
+## Ingestion Pipeline & Scraper Development
 
-The ingestion pipeline has three stages. **Each stage does one job. Do not mix responsibilities.**
-
-| Stage | Responsibility | Does NOT do |
-|---|---|---|
-| **Capture** (scraper) | Fetch raw content, extract metadata from website structure (link text, HTML headers, URL params), archive to S3 | Parse PDF content, extract fields from unstructured text |
-| **Transcription** | Convert raw content to clean text per case, split multi-case documents, mark cross-page continuations | Extract structured fields (case_number, outcome, etc.) |
-| **Enrichment** | Extract structured fields from text using two-tier strategy (scraper metadata > LLM) | Fetch content, parse PDFs |
-
-**Transcription** varies by format:
-- **HTML** (e.g., LA): BeautifulSoup parsing, no LLM needed.
-- **PDF** (e.g., OC, Riverside): multimodal LLM sees page images, returns `ruling_text` per case + `continued` markers. One page per LLM call, join results across pages. Does NOT extract case_number, case_title, outcome, etc. — that's enrichment.
-
-See `docs/specs/architecture-spec-v1.md` Section 5.2 for the full specification.
-
-## Scraper Development Rules
-
-Key paths: framework in `packages/scraper-framework/src/framework/`, California courts in `packages/scraper-framework/src/courts/ca/`.
-
-- **Never run production scraping from dev.** Fetching pages to create real test fixtures is fine.
-- Every scraper must implement the base `Scraper` class, report health metrics, and use SHA-256 content hashing.
-- Raw content is always archived to object storage before processing.
-- Scraper configurations (URLs, selectors, schedules) are separate from scraper logic.
-- **Scrapers extract metadata from website structure only** — judge name from link text, department from URL parameters, etc. They do NOT parse PDF content or extract fields from unstructured text. Field extraction from document content happens downstream in enrichment.
-- **Data correctness is the #1 priority. Completeness is secondary.** A missing field is acceptable; a wrong field is a bug. When evaluating data quality, always verify correctness first (is the extracted value accurate compared to the source document?), then completeness (is the field populated?). Completeness metrics are useful as a signal toward correctness problems — a sudden drop in judge match rate suggests a bug — but high completeness with low correctness is worse than low completeness with high correctness. Required fields: **judge name, motion type, case title, hearing date, outcome, parties**. Write regression tests against real fixtures for every field.
+See **`docs/specs/architecture-spec-v1.md` §3.3** for the full ingestion pipeline (three-stage: Capture → Transcription → Enrichment) and §3.3.3 for scraper development constraints (archive-first, SHA-256 hashing, data correctness > completeness, required fields, regression tests). Key paths: framework in `packages/scraper-framework/src/framework/`, California courts in `packages/scraper-framework/src/courts/ca/`.
 
 ## Infrastructure & Data Scripts
 
@@ -286,39 +252,26 @@ Key paths: framework in `packages/scraper-framework/src/framework/`, California 
 - Terraform for all AWS resources. Every resource must be in a module.
 - **Do NOT add `tags` blocks to individual resources** — the AWS provider's `default_tags` handles this.
 - Never commit AWS credentials or state files.
-- **Always run `terraform init` with `-lockfile=readonly`** for agent-side validation — without this, `init` will silently prune provider hashes the current environment doesn't reference (e.g. `hashicorp/archive` in `environments/dev/`), causing unrelated `.terraform.lock.hcl` churn in `git status` that either pollutes the PR diff or breaks other environments' hashes. Only omit the flag when you are intentionally adding or upgrading a provider alongside a `main.tf` / `terraform.tf` change. See `docs/agent/code-standards.md` §Terraform for full details (#2582).
-- **Dev terraform apply is automated.** After a PR that touches `infra/terraform/` merges to main, the dispatcher automatically runs `terraform apply` for the dev environment. Production applies remain human-only. See `.claude/skills/dispatcher/SKILL.md` and `docs/agent/infrastructure-reference.md` for the full procedure.
+- **Always run `terraform init` with `-lockfile=readonly`** for agent-side validation (#2582). See `docs/agent/code-standards.md` §Terraform.
+- **Dev terraform apply is automated.** After a PR that touches `infra/terraform/` merges, the dispatcher runs `terraform apply` for dev. Production applies remain human-only.
 
 ### Running Data Scripts on Dev
 
-The dev database is in a private VPC — **not reachable from localhost**. Never use `scripts/with-secret.sh` with `DATABASE_URL` to run data scripts locally; the connection will fail. Use:
+The dev database is in a private VPC — **not reachable from localhost**. Use:
 
-- `scripts/ecs-run-task.sh` for **all data scripts** (backfills, migrations, audits, one-offs) — standalone Fargate task with CloudWatch log streaming, most reliable.
-- `scripts/dev-db-query.sh` for **quick SQL queries** (SELECT, EXPLAIN) — uses ECS Exec internally.
-- `scripts/ecs-run.sh` for **interactive debugging only** (e.g. `bash`) — SSM sessions drop; never use for scripts.
+- `scripts/ecs-run-task.sh` for **all data scripts** (backfills, migrations, audits, one-offs).
+- `scripts/dev-db-query.sh` for **quick SQL queries** (SELECT, EXPLAIN).
+- `scripts/ecs-run.sh` for **interactive debugging only** — SSM sessions drop; never use for scripts.
 
-See `docs/agent/infrastructure-reference.md` §ECS Script Execution for full patterns, flag reference, and CPU/memory overrides.
-
-**Reingest vs Rebuild — choosing the right script:**
-
-| Scenario | Script | Why |
-|---|---|---|
-| Cleanup orphaned/corrupted `derived.*` state (failed run, bad IDs, partial mutation) | `rebuild_db.py --county <name>` | `derived.*` is fully rebuildable from S3. Rebuild is idempotent, validates the real ingestion/enrichment path (fixing inbound data, not just existing rows), and handles edge cases surgical scripts miss. Surgical one-offs often introduce bugs of their own — only write one if rebuild cost is prohibitive at the affected scale. |
-| Re-process existing records after extraction logic changes | `reingest_from_s3.py --county <name>` | Queries the `documents` table — only works when records already exist |
-| Initial population of a county that has S3 data but no DB records | `rebuild_db.py --county <name>` | Discovers documents directly from S3 keys — does not require pre-existing DB records |
-| Full database rebuild from scratch | `rebuild_db.py --reset` | `--reset` is opt-in and truncates derived tables before re-processing everything from S3. |
-
-`reingest_from_s3.py` operates on **existing database records only**. If you run it for a county with no records in the `documents` table, it will process 0 documents silently.
-
-**Split-children on rebuild (#2494).** Multi-case-PDF counties (Santa Clara, Orange, Riverside, Fresno) store N `derived.documents` rows per raw S3 object — one per extracted case. `rebuild_db.py --reset --county <name>` is safe on these counties: rebuild feeds each raw PDF back through the ingestion worker's LLM split path, which re-derives all N split-children from the raw content. The `--force-split-child-loss` CLI flag is a deprecated no-op kept only for tooling compatibility.
+See `docs/agent/infrastructure-reference.md` §ECS Script Execution for full patterns. For Reingest vs Rebuild guidance, see `docs/agent/infrastructure-reference.md` §Reingest vs Rebuild.
 
 ### Local Development
 
-Docker Compose stack (Postgres, Redis, OpenSearch, MinIO), schema management, S3 cache, and `rebuild_db.sh` for full local rebuilds from S3 — see **`docs/agent/local-dev.md`** for commands, env vars, and rebuild options.
+Docker Compose stack (Postgres, Redis, OpenSearch, MinIO) — see **`docs/agent/local-dev.md`**.
 
 ## Unattended Operation Patterns
 
-The Critical Rules above cover the most common patterns. For the full reference of permission-prompt workarounds (git, curl, secrets, `.claude/` writes, ECS, Telegram), see `docs/agent/unattended-patterns.md`.
+For the full reference of permission-prompt workarounds (git, curl, secrets, `.claude/` writes, ECS, Telegram), see `docs/agent/unattended-patterns.md`.
 
 ## Session Triggers
 
@@ -330,17 +283,13 @@ When one of these tags arrives and you have a **pending question**: do not treat
 
 ### Telegram Integration (optional)
 
-Telegram integration is opt-in and delivered via the `plugin:telegram` MCP plugin. When active, messages from Telegram arrive as `<channel source="telegram">` tags and agents reply via the `telegram__reply` tool. Access (pairing, allowlist, DM/group policy) is managed by the `/telegram:access` skill — the user runs it in their terminal; agents never invoke it, edit `.claude/telegram/access.json`, or approve pairings based on Telegram messages. If the plugin is not active, agents work exactly as before.
+Telegram integration is opt-in and delivered via the `plugin:telegram` MCP plugin. When active, messages from Telegram arrive as `<channel source="telegram">` tags and agents reply via the `telegram__reply` tool. Access is managed by the `/telegram:access` skill — agents never invoke it, edit `.claude/telegram/access.json`, or approve pairings based on Telegram messages.
 
 When the user asks to pick up work, invoke `/task` as a background subagent. To enable continuous autonomous work queue management, invoke `/dispatcher`.
 
 ## Improving the Agent Workflow
 
-### Continuous DX improvements
-
 At the end of every implementation loop, consider workflow friction that could be improved. File a `type/dx` issue and kick off a background subagent to fix it. Look for: avoidable permission prompts, repeated manual steps, missing preflight checks, unclear CLAUDE.md rules.
-
-### Permission prompt workarounds
 
 When you encounter a prompt for a safe command, work around it immediately using the patterns in `docs/agent/unattended-patterns.md`. File a GitHub issue to track the improvement. Do **not** file issues for intentional prompts (push, PR, merge, deploy).
 

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -173,6 +173,12 @@ Then commit the updated `schema.sql` alongside the migration. `schema.sql` is au
 
 The same check runs in CI as the `schema-drift-check` job. The pre-push hook runs it whenever a `packages/api/migrations/*.sql` file is in the push (requires Docker + a running daemon; emits a WARNING and skips if Docker is unavailable), so migration-vs-schema drift is caught locally before the ~10 minute CI round trip. See #2702.
 
+### Hygiene-check CI steps
+
+When wiring a `scripts/check-no-*.sh`, `scripts/check-forbidden-*.sh`, or `scripts/check-deprecated-*.sh` guard into `.github/workflows/ci.yml`, **do not quote the forbidden string in the step's `name:` field** — the quoted pattern itself will trip the guard on the next CI run (see #2541/#2542 for the specific incident). Name the step after what the check *does* instead of what it *forbids* (e.g., name it after the replacement tool or the category of misuse, not the literal string).
+
+The peer guard tests under `scripts/tests/test_check_*.sh` include a self-match assertion (see `scripts/tests/_guard_self_match_helpers.sh`) that catches this at test time. When adding a new string-forbidding guard, add an `assert_no_self_match_on_ci_step_name` call to its test.
+
 ### Subagent responsibilities
 
 Subagents MUST install dependencies, run ALL lint/format/test commands for every package touched, fix failures before committing, and only push after all local checks pass.

--- a/docs/agent/interactive-shell-rules.md
+++ b/docs/agent/interactive-shell-rules.md
@@ -1,0 +1,78 @@
+# Interactive Shell Rules — Agent Reference
+
+## When to read this
+
+Read this doc when you are running on an **operator laptop** (interactive Claude CLI session) and need to know which shell patterns the PreToolUse hook will block. These rules exist to prevent the CLI from stalling on permission prompts — a problem that does not exist in the Fargate dispatcher container.
+
+If you are on Fargate (inside `Dockerfile.dispatcher`), only the four safety-critical rules in §Fargate scope below apply. The six interactive-prompt-prevention rules in §Shell NEVERs are inert in-container.
+
+Cross-reference: `docs/agent/unattended-patterns.md` covers the broader set of permission-prompt workarounds (git, curl, secrets, `.claude/` writes, ECS, Telegram). This doc is the canonical home for the hook-enforced shell NEVERs.
+
+---
+
+## Shell NEVERs (operator laptops — hook-enforced)
+
+The PreToolUse hook (`.claude/hooks/preflight-bash.sh`) blocks all of the following on operator laptops.
+
+### Never use `$()` command substitution
+
+`$()` in any Bash command triggers a permission prompt. Run the inner command as a separate Bash tool call and use the literal result in the next command. For secrets, use `scripts/with-secret.sh` — never `$(aws secretsmanager get-secret-value ...)`.
+
+### Never use heredocs (`<<EOF`)
+
+Write content to a file using the Write tool, then reference it with `--body-file` or `-F`. For commits: `git commit -F {worktree}/tmp/commit_msg.txt`. For PR bodies: `gh pr create --body-file {worktree}/tmp/body.txt`.
+
+### Never use `python3 -c "..."` inline scripts
+
+Write the script to `{worktree}/tmp/script.py` first, then run it as a file. Even a single-line script with semicolons counts. Inline scripts trigger a prompt and are hard to debug.
+
+### Never combine quoted strings with `&&` or `;`
+
+A hook rejects commands that contain quoted characters combined with `&&` or `;`. Split into separate tool calls.
+
+### Never prefix scripts with `bash`
+
+Run `scripts/cleanup_worktree.sh`, not `bash scripts/cleanup_worktree.sh`. The `Bash(scripts/*)` permission pattern only matches commands that start with `scripts/`; prepending `bash` breaks the match and triggers a prompt.
+
+### Never use shell `&`, `nohup`, `disown`, or multicommand backgrounding tricks
+
+These require compound commands that cannot be allowlisted and always trigger prompts. Use the Bash tool's `run_in_background: true` parameter instead — it runs the command as a background task natively, with no shell tricks needed.
+
+### Never use Edit or Write tools on files inside `.claude/`
+
+The CLI platform blocks Edit and Write operations on any path under `.claude/`. To modify files there:
+
+1. Write the content to `{worktree}/tmp/` using the Write tool.
+2. Copy into place: `scripts/write-claude-file.sh {worktree}/tmp/file.md {worktree}/.claude/target/file.md`
+
+The script uses Python's `shutil.copy2()` internally, which bypasses the platform restriction. Do not use `cp` directly — it may also be blocked. This applies to skill definitions (`SKILL.md`), hook scripts, and any other file under `.claude/`. (Incident: #2440 — silent writes to the main repo bypassing PR workflow.)
+
+### Never run bare `git stash pop` or `git stash apply`
+
+`git stash` stores refs in `$GIT_DIR/refs/stash`, which is a single per-clone stack shared across every worktree. A bare `git stash pop` in worktree A can silently apply a stash created by worktree B — your edits get overwritten and another agent's WIP lands in your diff. (Incident: #2749.)
+
+Always pop by explicit ref: run `git stash list` first, confirm `stash@{0}`'s subject contains your current branch, then `git stash pop stash@{0}`. Better yet, avoid stash entirely — use a throwaway commit (`git commit -am "WIP"`, do the thing, `git reset --soft HEAD~1`), which has no shared global state. The preflight hook blocks bare `pop` and `apply`.
+
+---
+
+## Fargate scope
+
+**Four safety-critical rules remain enforced** in the Fargate dispatcher container (`Dockerfile.dispatcher`):
+
+1. `git push` to `main` — never allowed anywhere.
+2. `git worktree add` inside an existing worktree — creates orphaned child worktrees `cleanup_worktree.sh` cannot track (#2455).
+3. Cross-worktree writes — `cp`/`mv`/`tar`/shell redirection from a worktree subagent into the main repo checkout (#2455, #2440).
+4. Bare `git stash pop` / `git stash apply` — the stash list is per-clone, not per-worktree (#2749).
+
+**Six interactive-prompt-prevention rules are inert in-container** (Fargate runs `--dangerously-skip-permissions`, no prompts):
+
+- `$()` command substitution
+- heredocs (`<<EOF`)
+- inline `python3 -c "..."`
+- quoted strings + `&&`/`;`
+- `bash scripts/` prefix
+- empty-quotes bypass
+
+The Fargate image swaps the preflight hook at worktree-creation time to `scripts/preflight-bash-fargate.sh`, which enforces only the four safety-critical rules. This swap is scoped to the Fargate image via `DISPATCHER_FARGATE_HOOKS_DIR` + per-worktree `git update-index --skip-worktree`. Operator laptops keep the full ruleset. See issue #2982.
+
+**Claim interlock note.** The `status/in-progress` label-only claim interlock (#2927, replacing the prior DB-row + label interlock #2866) is a workflow rule, not a shell rule — it applies in both environments.

--- a/docs/specs/architecture-spec-v1.md
+++ b/docs/specs/architecture-spec-v1.md
@@ -229,6 +229,24 @@ The transcription LLM prompt describes **visual structure, not text heuristics**
 
 **Reingestion.** Historical documents already in S3 can be reprocessed through the full pipeline using `scripts/reingest_from_s3.py`. Operates on **existing database records only** — it queries `documents` to find S3 keys to reprocess. For initial population of a county that has S3 data but no DB records, use `scripts/rebuild_db.py --county <name>`, which discovers documents directly from S3 keys.
 
+### 3.3.3 Scraper Development Constraints
+
+Rules every scraper author and reviewer must follow. These apply to new scrapers and changes to existing ones.
+
+**Never run production scraping from dev.** Fetching court pages to create local test fixtures is fine. Automated runs that post to the production capture pipeline, write to the production S3 bucket, or emit `document.captured` events on production Redis Streams are not. Dev and production share no scraper execution paths.
+
+**Archive before anything else.** Every captured document must be written to S3 before any extraction or transformation begins. If a downstream step fails, the raw content is preserved and can be reprocessed. This is the archive-first principle applied specifically to scrapers.
+
+**SHA-256 content hashing on every document.** Content hashes drive deduplication (skip if hash matches), upsert logic (new version if hash differs), and the content-addressed S3 key scheme. Every scraper must compute and emit a `sha256(content)` hash for every captured document.
+
+**Data correctness over completeness.** A missing field is acceptable; a wrong field is a bug. When evaluating scraper output quality, verify correctness first (is the extracted value accurate against the source?) then completeness (is the field populated?). High completeness with low correctness is worse than low completeness with high correctness. A sudden drop in completeness metrics is a signal to investigate correctness — not just a completeness problem.
+
+**Required fields.** A scraper is not shippable until it correctly extracts all of the following from source data present at development time: **judge name, motion type, case title, hearing date, outcome, parties**. Fields the court website does not provide may be left blank; fields the court website does provide must be extracted. Do not ship scrapers that leave extractable fields empty and rely on post-hoc backfills.
+
+**Regression tests against real fixtures.** Every scraper must ship with tests against archived real court pages covering typical rulings, edge cases, and known formatting variations. Each test must assert the value of every required field. "The scraper runs without error" is not a test.
+
+Key paths: framework in `packages/scraper-framework/src/framework/`, California courts in `packages/scraper-framework/src/courts/ca/`.
+
 ## 3.4 Application Layer
 
 ### 3.4.1 Dual API — GraphQL + Minimal REST


### PR DESCRIPTION
## Summary

Reduces CLAUDE.md from 44,908 to 23,975 bytes (47% reduction, ~11.2K to ~6K tokens) by moving interactive-only shell rules and decision tables to on-demand docs, tightening prose throughout, and removing redundant emphasis prefixes. CLAUDE.md is loaded on every agent invocation across the entire system; this shrink compounds across every dispatcher tick, every ralph iteration, every subagent spawn.

Closes #2991

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green
- [x] `scripts/check-markdown-links.sh` passes (confirmed in ralph_summary: "All 10 AC verification checks pass including scripts/check-markdown-links.sh")

### Post-deploy verification

- [ ] Dispatcher + /task + /ralph smoke test: run one /task end-to-end on dev dispatcher. All hooks fire correctly; no subagent reports missing guidance; verification evidence comment posted on #2991.
