### PR TITLE
perf(dispatcher): use pytest-testmon in pre-push to skip unchanged-coverage tests (#2997)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -228,7 +228,22 @@ while read -r local_ref local_sha remote_ref remote_sha; do
             else
                 xdist_flag=""
             fi
-            if ! run_check "$pkg" "pytest" "$pkg_dir/.venv/bin/pytest" $xdist_flag "$pkg_dir/tests/" -x -q --tb=line; then
+            # Use pytest-testmon when available to skip tests whose
+            # covered source lines haven't changed since the last run
+            # (#2997). State is kept in $pkg_dir/.testmondata (gitignored,
+            # per-worktree). First run is a full suite; subsequent runs
+            # within the same worktree (e.g. ralph iteration 2+) re-run
+            # only the tests whose coverage map intersects the diff.
+            # Flag order matters: testmon filters the test list, xdist
+            # parallelizes whatever testmon selects. Defensive check
+            # mirrors the xdist pattern above so pre-push still works
+            # on venvs built before pytest-testmon was added to dev deps.
+            if "$pkg_dir/.venv/bin/python" -c "import testmon" 2>/dev/null; then
+                testmon_flag="--testmon"
+            else
+                testmon_flag=""
+            fi
+            if ! run_check "$pkg" "pytest" "$pkg_dir/.venv/bin/pytest" $testmon_flag $xdist_flag "$pkg_dir/tests/" -x -q --tb=line; then
                 echo "  Run: $pkg_dir/.venv/bin/pytest $pkg_dir/tests/ -v --tb=short" >&2
                 failures=$((failures + 1))
             fi

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ htmlcov/
 coverage.xml
 lcov.info
 .pytest_cache/
+.testmondata
+.testmondata-journal
 
 # Docker
 docker-compose.override.yml

--- a/packages/judgemind-config/pyproject.toml
+++ b/packages/judgemind-config/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = []
 dev = [
     "pytest>=8.0",
     "pytest-cov>=4.1",
+    "pytest-testmon>=2.1",
     "pytest-xdist>=3.5",
     "ruff>=0.3",
 ]

--- a/packages/nlp-pipeline/pyproject.toml
+++ b/packages/nlp-pipeline/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-cov>=4.1",
+    "pytest-testmon>=2.1",
     "pytest-xdist>=3.5",
     "ruff>=0.3",
 ]

--- a/packages/scraper-framework/pyproject.toml
+++ b/packages/scraper-framework/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-cov>=4.1",
+    "pytest-testmon>=2.1",
     "pytest-xdist>=3.5",
     "ruff>=0.3",
     "respx>=0.21",       # httpx mocking


### PR DESCRIPTION
## Summary

Add `pytest-testmon>=2.1` to dev deps in all 3 Python packages (scraper-framework, nlp-pipeline, judgemind-config) and wire up `.githooks/pre-push` to pass `--testmon` when available. testmon skips tests whose covered source lines haven't changed since the last run in the same worktree — collapsing ralph's 2nd+ pre-push iterations from full-suite (~2-5 min) down to the affected subset (~10-30s for narrow diffs).

Closes #2997

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component. Changes are to dev-dep pyproject.toml entries, the `.githooks/pre-push` script, and `.gitignore`. The dispatcher picks up the changes via baseline git pull (`ensure_baseline_clone` fetches origin/main on boot and before each worktree creation); no ECS redeploy required.
- [x] Verification evidence posted on issue (smoke test results).

## Implementation notes

- Flag order in pre-push: `--testmon -n auto` — testmon filters the test list, xdist parallelizes whatever testmon selects. Confirmed composition via unit smoke test on `judgemind-config`.
- Defensive `import testmon` check mirrors the existing xdist pattern at lines 226-230 so pre-push still works on venvs built before this PR.
- `.testmondata` and `.testmondata-journal` are gitignored per-worktree; no shared-baseline complexity per the issue's scope boundaries.
- CI is unchanged — it still runs the full shard matrix. testmon is pre-push/local only.

## Smoke test results (judgemind-config, 8 tests)

| Run | Scenario | Tests executed | Wall-clock |
|-----|----------|---------------|------------|
| 1 | First run, no `.testmondata` | 8/8 | 1.53s |
| 2 | Second run, no diff | 0/8 | 0.99s |
| 3 | After `touch` (no content change) | 0/8 | 0.90s |
| 4 | After semantic change to `models.py` | 8/8 (all tests cover this constant) | 1.00s |

Confirms: content-hash-based selection (not mtime), composes with `-n auto`, correctly re-selects affected tests.

Full scraper-framework suite smoke test not run locally (would require ~20 min venv install for a 6-line config change) — will be exercised by the first real ralph session on that package.
