### PR TITLE
fix(dispatcher): bump git push timeout from 600s to 1800s

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -470,10 +470,14 @@ GH_AUTH_SETUP_GIT_TIMEOUT_SECONDS = 10
 #: pipeline) regularly exceeds 3 minutes before the actual git push
 #: even starts. Two confirmed overnight failures on 2026-04-19 lost
 #: ralph's entire output when the 120s ceiling tripped mid-hook (issue
-#: #2882). 600s (10 min) is a comfortable ceiling for the slowest
-#: realistic package test run + git push + network, while still
-#: preventing a genuinely-stuck process from burning indefinitely.
-GIT_PUSH_TIMEOUT_SECONDS = 600
+#: #2882). 600s wasn't enough either: on 2026-04-21 agent c3a69458
+#: (#2564) timed out at 600s with the hook still running the scraper-
+#: framework suite — 7200 tests via ``pytest -n auto`` on 4 vCPU
+#: Fargate exceeded 10 min on a cold-cache first-pre-push. 1800s
+#: (30 min) covers the worst-case full suite while still catching a
+#: genuinely-stuck push; it aligns with the ``push_and_pr`` stuck
+#: timeout fallback of 30 min in :data:`STUCK_TIMEOUT_SECONDS`.
+GIT_PUSH_TIMEOUT_SECONDS = 1800
 
 #: Per-issue cooldown — skip an issue from candidate selection if its
 #: most recent ``dispatcher.agents`` row (any status) was created

--- a/scripts/dispatcher/tests/test_daemon_git_push_timeout.py
+++ b/scripts/dispatcher/tests/test_daemon_git_push_timeout.py
@@ -9,9 +9,13 @@ The dispatcher daemon fires ``git push`` in two places:
 
 Both previously used ``timeout=120``, which was not enough to cover
 the pre-push hook's package test runs. On 2026-04-19 two overnight
-agents lost ralph's work when the 120s ceiling tripped mid-hook. The
-fix (this change) extracts the timeout to a module-level
-``GIT_PUSH_TIMEOUT_SECONDS`` constant set to 600s.
+agents lost ralph's work when the 120s ceiling tripped mid-hook.
+600s was still too tight: on 2026-04-21 agent c3a69458 (#2564) timed
+out at 600s with the hook still running the 7200-test scraper-
+framework suite on 4 vCPU Fargate. The fix (this change) extracts
+the timeout to a module-level ``GIT_PUSH_TIMEOUT_SECONDS`` constant
+set to 1800s (30 min), aligned with the ``push_and_pr`` stuck-
+timeout fallback.
 
 These tests guard against regressing back to a hardcoded value by
 walking the daemon module's AST and asserting every ``git push``
@@ -40,19 +44,19 @@ from dispatcher import daemon  # noqa: E402  — sys.path mutation above
 _DAEMON_PATH = Path(daemon.__file__)
 
 
-def test_git_push_timeout_constant_is_600_seconds() -> None:
-    """The module-level ``GIT_PUSH_TIMEOUT_SECONDS`` constant is 600s.
+def test_git_push_timeout_constant_is_1800_seconds() -> None:
+    """The module-level ``GIT_PUSH_TIMEOUT_SECONDS`` constant is 1800s.
 
     Guards against a well-meaning "tighten this back down" edit that
-    would reintroduce the original 120s failure mode. If you need to
+    would reintroduce the 120s or 600s failure modes. If you need to
     change this value, update the call-site tests below AND the
     docstring explaining the rationale.
     """
     assert hasattr(daemon, "GIT_PUSH_TIMEOUT_SECONDS"), (
         "daemon module must define GIT_PUSH_TIMEOUT_SECONDS (#2882)"
     )
-    assert daemon.GIT_PUSH_TIMEOUT_SECONDS == 600, (
-        f"GIT_PUSH_TIMEOUT_SECONDS must be 600; got {daemon.GIT_PUSH_TIMEOUT_SECONDS}"
+    assert daemon.GIT_PUSH_TIMEOUT_SECONDS == 1800, (
+        f"GIT_PUSH_TIMEOUT_SECONDS must be 1800; got {daemon.GIT_PUSH_TIMEOUT_SECONDS}"
     )
 
 


### PR DESCRIPTION
## Summary

- Bumps `GIT_PUSH_TIMEOUT_SECONDS` from 600s → 1800s (30 min).
- Agent `c3a69458` on #2564 just timed out at 600s mid-pre-push — 7200 scraper-framework tests via `pytest -n auto` on 4 vCPU Fargate exceeded 10 min on a cold-cache first-pre-push. Ralph lost ~90 min of work.
- 30 min aligns with the `push_and_pr` stuck-timeout fallback (`STUCK_TIMEOUT_SECONDS = 30 * 60`), covers the worst-case full suite, and still catches a genuinely-stuck push.

## Context

The daemon's `_push_and_open_pr` runs `git push`, which fires `.githooks/pre-push`, which runs each touched package's full test suite. For scraper-framework changes (like #2564's Riverside multi-case extraction), that's the full 7200-test suite.

Testmon (#2998) was just merged, but this is a cold-cache push — no `.testmondata` yet in the worktree's venv (which was created before testmon was in dev deps). So pre-push runs everything from scratch.

The dispatcher's auto-deploy will kick in on merge (the change is under `scripts/dispatcher/**`), which will restart the daemon and abandon the current #2564 attempt via the daemon-restart-abandoned path.

## Test plan

- [x] Code change is a single-line constant bump + docstring.
- [ ] CI green.
- [ ] Post-merge: deploy-dispatcher workflow rolls new task def.
- [ ] Next scraper-framework-touching agent's daemon-side push completes within 30 min.
