### PR TITLE
fix(dispatcher): set git committer identity + fix prior-attempts SQL

### DIFF
--- a/Dockerfile.dispatcher
+++ b/Dockerfile.dispatcher
@@ -312,6 +312,29 @@ ARG GIT_SHA=unknown
 ENV GIT_SHA=${GIT_SHA}
 
 # ---------------------------------------------------------------------------
+# Git committer identity
+#
+# The daemon's ``_push_and_open_pr`` runs ``git commit --amend -F
+# <file>`` to rewrite Ralph's placeholder commit with Summary's
+# conventional-commits message. Git refuses to commit (exit 128,
+# "Committer identity unknown") unless ``user.name`` + ``user.email``
+# are set somewhere in the config chain. The non-root dispatcher
+# user has no ``~/.gitconfig`` by default.
+#
+# Observed on agent 44c031ee (#2565) at 2026-04-21 18:14 UTC: Ralph
+# shipped SHIP + Summary completed + daemon hit the amend step and
+# died with "empty ident name". Two hours of Ralph work lost.
+#
+# Set ``--system`` so every process in the image (daemon + spawned
+# subagents) inherits the identity via ``/etc/gitconfig`` without
+# needing per-user setup. Values are cosmetic — GitHub attributes
+# the merged commit to the PR author via the squash-merge flow, not
+# this identity.
+# ---------------------------------------------------------------------------
+RUN git config --system user.email "dispatcher@judgemind.org" \
+    && git config --system user.name "Judgemind Dispatcher"
+
+# ---------------------------------------------------------------------------
 # Drop privileges before the entrypoint.
 #
 # The Claude Code CLI refuses ``--dangerously-skip-permissions`` when UID=0,

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -6700,10 +6700,10 @@ class DispatcherDaemon:
                     "  ON pp.agent_id = a.agent_id AND pp.phase = 'push_and_pr' "
                     "WHERE a.issue_number = %s "
                     "  AND a.status IN ('failed', 'crashed') "
-                    "  AND a.phase NOT IN %s "
+                    "  AND a.phase != ALL(%s) "
                     "ORDER BY a.started_at DESC "
                     "LIMIT 3",
-                    (issue_number, tuple(non_infra_phases)),
+                    (issue_number, non_infra_phases),
                 )
                 rows = cur.fetchall()
             self._conn.commit()

--- a/scripts/dispatcher/tests/test_daemon_prior_attempts.py
+++ b/scripts/dispatcher/tests/test_daemon_prior_attempts.py
@@ -189,15 +189,15 @@ class TestFetchPriorAttempts:
         assert result == []
 
     def test_query_excludes_infra_preempted(self, tmp_path: Path) -> None:
-        """SQL query uses ``phase NOT IN`` to exclude infra-preemption categories."""
+        """SQL query uses ``phase != ALL(%s)`` to exclude infra-preemption categories."""
         d, conn, _handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue.append([])
 
         d._fetch_prior_attempts(42)
 
         executed_sqls = [sql for sql, _ in conn.cursor_instance.executed]
-        assert any("phase NOT IN" in sql for sql in executed_sqls), (
-            "SQL must filter with 'phase NOT IN' to exclude infra-preemption phases"
+        assert any("phase != ALL" in sql for sql in executed_sqls), (
+            "SQL must filter with 'phase != ALL(%s)' to exclude infra-preemption phases"
         )
         assert any(
             "a.status IN ('failed', 'crashed')" in sql for sql in executed_sqls
@@ -276,8 +276,8 @@ class TestMaterializePriorAttempts:
         count = d._materialize_prior_attempts(worktree, 42)
 
         executed_sqls = [sql for sql, _ in conn.cursor_instance.executed]
-        assert any("phase NOT IN" in sql for sql in executed_sqls), (
-            "SQL must use 'phase NOT IN' to exclude infra-preemption categories"
+        assert any("phase != ALL" in sql for sql in executed_sqls), (
+            "SQL must use 'phase != ALL(%s)' to exclude infra-preemption categories"
         )
         assert count == 0
 


### PR DESCRIPTION
## Summary

Two acute dispatcher bugs surfaced in a single run at 2026-04-21 18:14 UTC.

**1. `git commit --amend` fails in the container.** Non-root dispatcher user (PR #2988) has no `~/.gitconfig`, and `git commit --amend` refuses without `user.email` + `user.name`. Agent `44c031ee` (#2565) lost 2h of ralph work when Summary's amend step died with "empty ident name". This is a blocker for **every** ralph success going forward.

Fix: set `user.email` + `user.name` at `--system` level in `Dockerfile.dispatcher` so every process in the image inherits via `/etc/gitconfig`. Values are cosmetic; GitHub attributes the merged commit via the squash-merge flow.

**2. `_fetch_prior_attempts` SQL syntax error.** `a.phase NOT IN %s` with a tuple parameter is invalid in psycopg3. Observed on agent `20677baf` (#3001) plan→ralph transition: `prior_attempts_query_failed` with `syntax error at or near "$2"`. Falls back to empty prior-attempts list, so ralph runs without retry context — not fatal, but breaks the cross-attempt-feedback feature from PR #2992.

Fix: rewrite to `a.phase != ALL(%s)` with a list parameter. Idiomatic psycopg3 array-exclusion form.

## Deploy impact

This touches `Dockerfile.dispatcher` and `scripts/dispatcher/**`, so the `deploy-dispatcher` workflow fires on merge and rolls a new task. The currently-running #3001 agent gets abandoned via `daemon_restart_abandoned` (standard recovery), and its retry will use the fixed SQL.

## Test plan

- [x] Dockerfile change is additive; pre-existing `USER dispatcher` stays at the bottom.
- [x] SQL change is a one-character operator swap (`NOT IN %s` → `!= ALL(%s)`) plus tuple→list on the parameter.
- [ ] CI green.
- [ ] Post-deploy: next agent's `_fetch_prior_attempts` does not log `prior_attempts_query_failed`.
- [ ] Post-deploy: next agent that reaches push_and_pr amends successfully (no "Committer identity unknown").
