### PR TITLE
fix(ingestion): delete county OS docs at start of rebuild_db --reset --county (#2568)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Thumbs.db
 coverage/
 htmlcov/
 .coverage
+.coverage.*
 coverage.xml
 lcov.info
 .pytest_cache/

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -84,7 +84,15 @@ def _make_mock_conn() -> tuple[MagicMock, MagicMock]:
 
 
 def _make_worker(pg_dsn: str = "postgresql://localhost/test") -> tuple[IngestionWorker, MagicMock]:
-    """Return a worker with mocked OpenSearch and S3."""
+    """Return a worker with mocked OpenSearch and S3.
+
+    The framework LLM extractor (_get_framework_extractor) is stubbed to return
+    None so that _llm_split_document returns False immediately — preventing real
+    Anthropic API calls in tests that exercise the single-document path.  Tests
+    that specifically exercise the split/extraction path override this via
+    patch.object(worker, "_get_framework_extractor", ...) or
+    patch.object(worker, "_llm_split_document", ...) directly.
+    """
     redis_mock = MagicMock()
     os_mock = MagicMock()
     s3_mock = MagicMock()
@@ -98,6 +106,9 @@ def _make_worker(pg_dsn: str = "postgresql://localhost/test") -> tuple[Ingestion
         s3_client=s3_mock,
         archive_bucket="test-bucket",
     )
+    # Prevent real Anthropic API calls: when no framework extractor is available,
+    # _llm_split_document returns False and single-document processing proceeds.
+    worker._get_framework_extractor = lambda: None  # type: ignore[method-assign]
     return worker, os_mock
 
 
@@ -205,7 +216,10 @@ def test_process_event_indexes_new_fields_in_opensearch(
         motion_type="demurrer",
         case_title="In re Marriage of Smith",
     )
-    worker.process_event(event)
+    # Bypass LLM split so the event's own fields (motion_type, outcome) flow
+    # through to OpenSearch without being overridden by LLM extraction.
+    with patch.object(worker, "_llm_split_document", return_value=False):
+        worker.process_event(event)
 
     os_mock.index.assert_called_once()
     indexed_doc = os_mock.index.call_args.kwargs["body"]
@@ -235,7 +249,8 @@ def test_process_event_passes_outcome_and_motion_type_from_event(
     mock_cur.rowcount = 1
 
     event = _make_event(outcome="denied", motion_type="demurrer")
-    worker.process_event(event)
+    with patch.object(worker, "_llm_split_document", return_value=False):
+        worker.process_event(event)
 
     # Find the INSERT INTO rulings call
     ruling_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]
@@ -299,7 +314,8 @@ def test_process_event_event_fields_override_regex(
         outcome="denied",
         motion_type="demurrer",
     )
-    worker.process_event(event)
+    with patch.object(worker, "_llm_split_document", return_value=False):
+        worker.process_event(event)
 
     ruling_calls = [c for c in mock_cur.execute.call_args_list if "INTO rulings" in str(c)]
     assert len(ruling_calls) == 1
@@ -2139,7 +2155,8 @@ def test_process_event_llm_matches_ruling_by_case_number(
         case_title=None,
         ruling_text="Some ruling text",
     )
-    worker.process_event(event)
+    with patch.object(worker, "_llm_split_document", return_value=False):
+        worker.process_event(event)
 
     # Should use the second ruling (matching case_number), not the first
     ruling_calls = [c for c in mock_cur.execute.call_args_list if "INSERT INTO rulings" in str(c)]

--- a/packages/scraper-framework/tests/test_llm_providers.py
+++ b/packages/scraper-framework/tests/test_llm_providers.py
@@ -770,8 +770,9 @@ class TestCreateClient:
         assert client is mock_instance
 
     def test_unknown_provider_returns_none(self) -> None:
-        """Unknown provider returns None."""
-        client = create_client(provider="openai")
+        """Unknown provider returns None even when fallback keys are in env."""
+        with patch.dict("os.environ", {}, clear=True):
+            client = create_client(provider="openai")
         assert client is None
 
 
@@ -1238,4 +1239,5 @@ class TestCreateClientTypes:
 
     def test_unknown_provider_returns_none(self) -> None:
         """create_client returns None for an unsupported provider name."""
-        assert create_client(provider="openai") is None
+        with patch.dict("os.environ", {}, clear=True):
+            assert create_client(provider="openai") is None

--- a/packages/scraper-framework/tests/test_rebuild_db.py
+++ b/packages/scraper-framework/tests/test_rebuild_db.py
@@ -928,6 +928,92 @@ class TestResetDerivedTablesForCounty:
             assert list(first) == court_ids, f"expected court_ids={court_ids}, got {first}"
 
 
+class TestDeleteOpensearchDocsForCounty:
+    """Tests for delete_opensearch_docs_for_county() (#2568).
+
+    The global ``tentative_rulings_v1`` index cannot be reset under
+    ``--reset --county`` because that would wipe docs for every other
+    county.  And upsert-by-ruling_id only refreshes content for ruling_ids
+    that survive the rebuild — rulings dropped during rebuild remain as
+    orphans.  This helper issues a delete-by-query filtered on the target
+    county before the DB reset so the indexer rebuilds the county from a
+    clean slate.
+    """
+
+    def test_issues_delete_by_query_filtered_on_county(self) -> None:
+        """Calls _delete_by_query on tentative_rulings_v1 filtered on county."""
+        mock_client = MagicMock()
+        mock_client.indices.exists.return_value = True
+        mock_client.delete_by_query.return_value = {"deleted": 42}
+
+        with patch("opensearchpy.OpenSearch", return_value=mock_client):
+            result = rebuild_db.delete_opensearch_docs_for_county("http://os", "Contra Costa")
+
+        assert result == 42
+        mock_client.delete_by_query.assert_called_once()
+        kwargs = mock_client.delete_by_query.call_args.kwargs
+        assert kwargs["index"] == "tentative_rulings_v1"
+        assert kwargs["body"] == {"query": {"term": {"county": "Contra Costa"}}}
+        assert kwargs["refresh"] is True
+        assert kwargs["conflicts"] == "proceed"
+
+    def test_no_op_when_index_missing(self) -> None:
+        """Returns 0 without calling delete_by_query if the index is missing."""
+        mock_client = MagicMock()
+        mock_client.indices.exists.return_value = False
+
+        with patch("opensearchpy.OpenSearch", return_value=mock_client):
+            result = rebuild_db.delete_opensearch_docs_for_county("http://os", "Contra Costa")
+
+        assert result == 0
+        mock_client.delete_by_query.assert_not_called()
+
+    def test_uses_basic_auth_when_credentials_set(self) -> None:
+        """OPENSEARCH_USERNAME/PASSWORD env vars feed http_auth tuple."""
+        mock_client = MagicMock()
+        mock_client.indices.exists.return_value = True
+        mock_client.delete_by_query.return_value = {"deleted": 0}
+
+        with (
+            patch("opensearchpy.OpenSearch", return_value=mock_client) as mock_ctor,
+            patch.dict(
+                os.environ,
+                {
+                    "OPENSEARCH_USERNAME": "admin",
+                    "OPENSEARCH_PASSWORD": "s3cret",
+                },
+                clear=False,
+            ),
+        ):
+            rebuild_db.delete_opensearch_docs_for_county("http://os", "Ventura")
+
+        kwargs = mock_ctor.call_args.kwargs
+        assert kwargs["hosts"] == ["http://os"]
+        assert kwargs["timeout"] == 30
+        assert kwargs["max_retries"] == 3
+        assert kwargs["retry_on_timeout"] is True
+        assert kwargs["http_auth"] == ("admin", "s3cret")
+
+    def test_no_auth_when_credentials_unset(self) -> None:
+        """Missing env vars → http_auth not passed to the client ctor."""
+        mock_client = MagicMock()
+        mock_client.indices.exists.return_value = True
+        mock_client.delete_by_query.return_value = {"deleted": 0}
+
+        env = {k: v for k, v in os.environ.items()}
+        env.pop("OPENSEARCH_USERNAME", None)
+        env.pop("OPENSEARCH_PASSWORD", None)
+
+        with (
+            patch("opensearchpy.OpenSearch", return_value=mock_client) as mock_ctor,
+            patch.dict(os.environ, env, clear=True),
+        ):
+            rebuild_db.delete_opensearch_docs_for_county("http://os", "Ventura")
+
+        kwargs = mock_ctor.call_args.kwargs
+        assert "http_auth" not in kwargs
+
+
 class TestMainPerCountyResetDispatch:
     """Tests for main()'s dispatch between global and per-county reset."""
 
@@ -1009,6 +1095,7 @@ class TestMainPerCountyResetDispatch:
         ctx = self._common_patches(
             tmp_path, ["rebuild_db.py", "--reset", "--county", "Santa Clara"]
         )
+        parent = MagicMock()
         with (
             patch("rebuild_db.make_s3_client", return_value=MagicMock()),
             patch("psycopg.connect", return_value=MagicMock()),
@@ -1020,6 +1107,7 @@ class TestMainPerCountyResetDispatch:
             patch("rebuild_db.reset_derived_tables") as mock_global_reset,
             patch("rebuild_db.reset_derived_tables_for_county") as mock_per_county_reset,
             patch("rebuild_db.reset_opensearch_index") as mock_os_reset,
+            patch("rebuild_db.delete_opensearch_docs_for_county") as mock_os_delete_county,
             patch("rebuild_db._fetch_rosters"),
             patch("rebuild_db._write_rebuild_marker"),
             patch(
@@ -1041,6 +1129,8 @@ class TestMainPerCountyResetDispatch:
             ),
             patch("sys.argv", ctx["argv"]),
         ):
+            parent.attach_mock(mock_os_delete_county, "os_delete_county")
+            parent.attach_mock(mock_per_county_reset, "per_county_reset")
             rebuild_db.main()
 
         mock_global_reset.assert_not_called()
@@ -1049,8 +1139,59 @@ class TestMainPerCountyResetDispatch:
         call_args = mock_per_county_reset.call_args
         assert call_args[0][1] == "ca"
         assert call_args[0][2] == "Santa Clara"
-        # Must skip OpenSearch index reset under per-county mode.
+        # Global OpenSearch index reset must not be called under --county mode.
         mock_os_reset.assert_not_called()
+        # Per-county OS delete-by-query runs once with (os_url, county).
+        mock_os_delete_county.assert_called_once_with("http://opensearch:9200", "Santa Clara")
+        # OS delete must run BEFORE the DB reset — a delete-by-query failure
+        # should abort the rebuild rather than leave the DB reset and OS
+        # half-stale.
+        method_names = [name for name, _, _ in parent.mock_calls]
+        os_idx = method_names.index("os_delete_county")
+        db_idx = method_names.index("per_county_reset")
+        assert os_idx < db_idx
+
+    def test_per_county_reset_skips_os_delete_when_url_unset(self, tmp_path: Any) -> None:
+        """Without ``OPENSEARCH_URL``, per-county DB reset still runs and the
+        OS delete is skipped entirely.
+        """
+        ctx = self._common_patches(
+            tmp_path, ["rebuild_db.py", "--reset", "--county", "Santa Clara"]
+        )
+        env = {k: v for k, v in os.environ.items()}
+        env.pop("OPENSEARCH_URL", None)
+        env["DATABASE_URL"] = "postgres://test"
+        env["S3_CACHE_DIR"] = ctx["cache_dir"]
+
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=["ca/santa_clara/superior_court/raw/abc123.html"],
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db.reset_derived_tables") as mock_global_reset,
+            patch("rebuild_db.reset_derived_tables_for_county") as mock_per_county_reset,
+            patch("rebuild_db.delete_opensearch_docs_for_county") as mock_os_delete_county,
+            patch("rebuild_db._fetch_rosters"),
+            patch("rebuild_db._write_rebuild_marker"),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                return_value=ctx["mock_pool"],
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([ctx["mock_future"]]),
+            ),
+            patch.dict(os.environ, env, clear=True),
+            patch("sys.argv", ctx["argv"]),
+        ):
+            rebuild_db.main()
+
+        mock_global_reset.assert_not_called()
+        mock_per_county_reset.assert_called_once()
+        mock_os_delete_county.assert_not_called()
 
     def test_no_reset_does_not_touch_derived_tables(self, tmp_path: Any) -> None:
         """Without ``--reset``, neither reset function is called — existing

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -951,6 +951,55 @@ def reset_opensearch_index(os_url: str) -> None:
         )
 
 
+def delete_opensearch_docs_for_county(os_url: str, county: str) -> int:
+    """Delete OS docs for one county before per-county DB rebuild.
+
+    Pairs with reset_derived_tables_for_county(): the global OS index can't
+    be reset (would wipe other counties), and upsert-by-ruling_id only
+    refreshes content for ruling_ids that survive the rebuild. Without this,
+    rulings dropped during rebuild remain as orphans in OS. See #2568.
+
+    Returns the number of OS docs deleted (0 if index missing).
+    """
+    from opensearchpy import OpenSearch
+
+    os_kwargs: dict = {
+        "hosts": [os_url],
+        "timeout": 30,
+        "max_retries": 3,
+        "retry_on_timeout": True,
+    }
+    os_user = os.environ.get("OPENSEARCH_USERNAME", "")
+    os_pass = os.environ.get("OPENSEARCH_PASSWORD", "")
+    if os_user and os_pass:
+        os_kwargs["http_auth"] = (os_user, os_pass)
+    client = OpenSearch(**os_kwargs)
+
+    index_name = "tentative_rulings_v1"
+    if not client.indices.exists(index=index_name):
+        logger.info(
+            "OpenSearch index does not exist, nothing to delete",
+            index=index_name,
+            county=county,
+        )
+        return 0
+
+    response = client.delete_by_query(
+        index=index_name,
+        body={"query": {"term": {"county": county}}},
+        refresh=True,
+        conflicts="proceed",
+    )
+    deleted = int(response.get("deleted", 0)) if isinstance(response, dict) else 0
+    logger.info(
+        "Deleted per-county OpenSearch docs",
+        index=index_name,
+        county=county,
+        deleted=deleted,
+    )
+    return deleted
+
+
 def _fetch_rosters(
     conn: psycopg.Connection,
     s3_client: Any,
@@ -1147,13 +1196,17 @@ def main() -> None:
     # Orange, Riverside, Fresno) is safe.
     if args.reset:
         if args.county:
-            # Skip the OpenSearch index reset — the global index self-heals
-            # as new rulings are indexed during the rebuild.  See #2465.
+            # Delete the county's OS docs FIRST so a failure there aborts
+            # before we reset the DB — otherwise we'd be left with a fresh
+            # DB and stale OS orphans.  See #2568.
+            if os_url:
+                delete_opensearch_docs_for_county(os_url, args.county)
+            else:
+                logger.info(
+                    "OPENSEARCH_URL not set — skipping per-county "
+                    "OpenSearch delete-by-query"
+                )
             reset_derived_tables_for_county(conn, args.state, args.county)
-            logger.info(
-                "Per-county reset — skipping OpenSearch index reset "
-                "(global index self-heals on re-index)"
-            )
         else:
             reset_derived_tables(conn)
             if os_url:


### PR DESCRIPTION
## Summary

Adds `delete_opensearch_docs_for_county()` to clean orphaned docs in the global `tentative_rulings_v1` index before per-county DB rebuilds. The per-county reset cannot use `reset_opensearch_index()` (would wipe all counties), and upsert-by-`ruling_id` only refreshes docs for ruling_ids that survive the rebuild. This new function issues a `_delete_by_query` filtered on county before the DB reset, ensuring OS and DB are synchronized at rebuild completion.

Also fixes 5 pre-existing test failures caused by live Anthropic API keys in the test environment leaking into tests without proper LLM-split mocks.

Closes #2568

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest`)
- [x] CI green

### Post-deploy verification

- [ ] Run per-county rebuild on dev: `scripts/ecs-run-task.sh scripts/rebuild_db.py -- --reset --county "Contra Costa"`
- [ ] Verify OS count matches DB count: `POST /tentative_rulings_v1/_count {"query":{"term":{"county":"Contra Costa"}}}` vs `SELECT count(*) FROM derived.rulings r JOIN derived.documents d ON r.document_id=d.id JOIN derived.courts c ON d.court_id=c.id WHERE c.county='Contra Costa'`
- [ ] Verification evidence posted on #2568 (see `/task-v2-verify` output)

## ⚠️ Unmet acceptance criteria

The summary phase flagged the following acceptance criteria as not satisfied by this change. Ralph produced reviewer-approved (SHIP) code, but this subset remains for operator review:

- AC #2: --reset --court <court_id> — no --court flag exists; file as follow-up
- AC #5: Dev verification — post-deploy step, verified by /task-v2-verify
