### PR TITLE
feat(dispatcher): AC_INFEASIBLE (ralph+summary) + deferred-to-verify classifier (#3010)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -144,7 +144,7 @@ Field rules:
 - `action` (required) — exactly one of the five strings above.
 - `reasoning` (required) — a single paragraph (≤500 chars) explaining the choice in plain English. This gets surfaced in operator dashboards and the §8 weekly report. The first 1-3 sentences are also written to `dispatcher.agents.failure_summary` (issue #2900) so the admin cockpit can show an LLM-authored tooltip on hover over the outcome glyph — keep the opening sentences self-contained ("what happened + why this action"), not mid-argument.
 - `hint` (conditional) — required when `action='retry_with_hint'`; the daemon posts it verbatim as an issue comment before enqueueing the retry marker. Ignored for other actions.
-- `new_scope` (conditional) — required when `action='reissue'`; the daemon replaces the issue body with this string. Should be a full, well-formed issue body with acceptance criteria — not a diff.
+- `new_scope` (conditional) — required when `action='reissue'`. **The daemon replaces the issue body wholesale** via `gh issue edit --body-file` (no splicing, no patching — Python writes the string to a file and `gh` edits the body). MUST be a complete, well-formed issue body with `## Goal`, `## Scope`, `## Acceptance criteria`, `## Priority`, `## References` sections and any `Parent: #N` / `Blocked by #N` lines. A diff, patch, or partial body will truncate the issue. Issue #3010.
 
 Exit 0 regardless of recommendation. If the recommendation cannot be written (DB down, malformed JSON, subprocess error), exit non-zero so the daemon marks the diagnosis `status='failed'` and falls back to the fixed mechanical escalation policy.
 
@@ -172,6 +172,48 @@ Work through these questions in order. The first "yes" determines the action.
    - → **`close`**. The daemon will close with `status/invalid` and post the reasoning as the close comment.
 
 **When uncertain, prefer `escalate` over a wrong guess.** A human re-classification is cheap; a wrong `close` or `reissue` can destroy context.
+
+---
+
+## Per-category guidance — AC-infeasibility categories (issue #3010)
+
+Two categories land in this skill via the post-exit parse path added for #3010:
+
+### `ralph_ac_infeasible` — ralph surfaced infeasibility
+
+**Context bundle extras.** In addition to the shared bundle shape, the daemon populates:
+
+- `infeasible_acs` (list of `{index, evidence}`) — the full array ralph emitted. `index` is 1-based into the issue body's acceptance-criteria list. `evidence` is a paragraph with the citable reason (grep output, file path, conflicting AC index).
+- `issue_acceptance_criteria` (list of str, 1-based-addressable) — the issue body's AC list extracted by the daemon so you can correlate `index` → criterion text without re-fetching.
+
+**Default action selection:**
+
+| Situation | Action | Why |
+|---|---|---|
+| One or two ACs cite a non-existent symbol, but the issue's core intent is clear and the AC can be rewritten | `reissue` | Author wrote ACs against an older codebase state; rewrite the offending AC(s) and let a fresh plan→ralph run satisfy the corrected list. `new_scope` MUST be the full rewritten issue body (wholesale replace — see §Output contract). |
+| The whole issue's premise is broken (e.g. it asks to remove a feature that was already removed, or to add a column that already exists) | `close` | The issue is invalid. The reasoning becomes the close comment. |
+| One AC is out-of-scope work (depends on a sibling open issue), but the rest of the issue is well-formed | `reissue` | Drop the blocking AC from the rewritten body and add `Blocked by #<sibling>` if appropriate. |
+| You cannot tell whether the AC is infeasible or just tricky, and the evidence paragraphs are hand-wavy | `escalate` | Prefer a human re-read over a wrong `reissue`. A human can re-label or rewrite; a wrong `reissue` destroys context. |
+
+**Do not pick `retry` or `retry_with_hint` for this category.** Ralph already evaluated the AC and found it structurally impossible — a second attempt with the same AC will hit the same wall. If the AC text is fine but ralph misread it, prefer `reissue` with a clarified `new_scope` over `retry_with_hint`.
+
+### `summary_ac_infeasible` — summary surfaced infeasibility
+
+**Context bundle extras.** Same as `ralph_ac_infeasible`, plus:
+
+- `ralph_diff` (str) — the full committed diff from ralph's SHIP run (ralph shipped, summary caught the structural impossibility downstream). Useful for aligning the `reissue` rewrite with what ralph already built.
+- `summary_ac_mapping` (list) — summary's `ac_mapping` array with `{index, criterion, status, evidence}` for every AC. Lets you see which ACs summary marked deferred / met / unmet_shape_mismatch / infeasible without re-running the classifier.
+- `deferred_acs` (list) — the `deferred_acs` list summary emitted (so you can distinguish deferred ACs from infeasible ones when reasoning about scope).
+
+**Default action selection:** same table as `ralph_ac_infeasible` with one addition:
+
+| Situation | Action | Why |
+|---|---|---|
+| The AC is fine as written; ralph shipped code that matches a different but valid reading of it | `reissue` | Rewrite the AC to match ralph's reading. Because `ralph_diff` is available, the `new_scope` body can explicitly reference "the implementation in commit `<sha>` satisfies this AC" and keep the PR alive via a downstream retry. This is the specific win `summary_ac_infeasible` enables: salvage ralph's work. |
+| Ralph shipped something out of scope AND summary correctly flagged the AC as infeasible | `reissue` or `close` — judgment call. `reissue` if the corrected AC is a small rewrite and ralph's diff is mostly reusable; `close` if the corrected AC would require a fundamentally different implementation. | Wasting ralph's diff is OK when the AC is structurally wrong; salvaging is OK when the AC is close to the right one. |
+| Summary flagged AC_INFEASIBLE on a single AC out of five, and the other four are met + deferred | `reissue` with a tightened AC | Same salvage path — ralph's diff covers the other four, so the rewritten body keeps the successful work intact and only rewrites the offending AC. |
+
+**`new_scope` semantics — applies to both categories.** `new_scope` is **always the complete rewritten issue body**. The daemon runs `gh issue edit --body-file <path>` with zero parsing or splicing — your output is the full body verbatim. Preserve the structure: `## Goal`, `## Scope`, `## Acceptance criteria`, `## Priority`, `## References`, plus any `Parent: #N` / `Blocked by #N` lines. Do NOT emit a diff, a patch, a list of "changes", or a partial body — the body-file path is authoritative and partial content will truncate the issue.
 
 ---
 

--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -34,6 +34,39 @@ Ralph reads `## Testable` from `{worktree}/tmp/ralph/task.md` (seeded by the cal
 
 When `## Testable: no`, the reviewer MUST NOT issue a REVISE for "no tests added" or "diff-coverage gate not satisfied" — those checks do not apply to the non-testable branch. Reviewer still verifies acceptance criteria, correctness, scope, stale references, and docs consistency.
 
+### AC_INFEASIBLE emit rules — when the worker + reviewer should raise this verdict
+
+The inner `/ralph` loop normally returns `SHIP` (reviewers approved) or `REVISE`/`BLOCKED` (max iterations / worker stuck). Starting with issue #3010, both the worker and the Claude reviewer may also surface `AC_INFEASIBLE` when one or more acceptance criteria cannot be satisfied as written — see [spec §6a `^ralph-ac-infeasible` footnote](../../../docs/specs/dispatcher-v2-spec.md). This is distinct from "hard to implement" (that stays a SHIP-after-iterations outcome) and from "max iterations reached" (that stays `ralph_max_iterations`).
+
+**Positive triggers — any one is sufficient to raise the verdict:**
+
+1. **Non-existent symbol.** The AC references a CLI flag, function, module, environment variable, file path, config key, or AWS resource that does NOT exist in the current codebase AND is NOT introduced by this PR's diff. Example: an AC reads `Verify: scripts/rebuild_db.py --court oc-riverside flushes the staging table` but `grep -n "\-\-court" scripts/rebuild_db.py` returns nothing and the PR doesn't add it. Cite the grep/find output as evidence.
+2. **Self-contradiction between ACs.** Two ACs in the same issue demand mutually exclusive outcomes. Example: AC #2 says "extracted judge names must preserve middle initials" and AC #5 says "normalize judge names to `Last, First` form without initials". Cite both AC indices.
+3. **Out-of-scope dependency.** The AC depends on work another not-yet-merged issue owns, AND the blocking relationship is not listed in the issue body's `Blocked by` section. Example: an AC depends on a new DB column `derived.rulings.enrichment_v2_confidence` that is owned by a sibling open issue; attempting to implement it here would duplicate schema changes. Cite the sibling issue number.
+
+**Negative guardrails — do NOT raise `AC_INFEASIBLE` for any of these:**
+
+- **"Hard to implement."** If the AC is legitimate but the implementation is tricky, keep iterating. Partial progress + clearer reviewer feedback is the right path; the verdict is `SHIP` (when done) or `ralph_max_iterations` (when budget is out), not `AC_INFEASIBLE`.
+- **Max iterations exhausted.** Hitting `max_iterations` is its own failure mode (`ralph_max_iterations` → BLOCKED with that reason). An iteration-budget exhaustion is not structural impossibility — the remedy is a retry with narrower scope, not a diagnoser reissue.
+- **Ambiguous wording.** If an AC's wording is ambiguous but reasonable implementations exist, pick the most defensible one and note the ambiguity in the PR body. Reserve `AC_INFEASIBLE` for ACs where NO implementation satisfies the literal text.
+- **Missing test fixture that the worker can create.** If the AC requires a fixture file, the worker should create it. A "fixture doesn't exist yet" situation is worker scope, not structural impossibility.
+
+**Emit mechanics.** Both the worker and the Claude reviewer may surface infeasibility. The worker signals it by writing:
+
+- `AC_INFEASIBLE` to `{worktree}/tmp/ralph/work-status.txt` (in place of `COMPLETE` / `STUCK`), AND
+- a JSON array of `{"index": <1-based>, "evidence": "<paragraph>"}` objects to `{worktree}/tmp/ralph/infeasible-acs.json`.
+
+The Claude reviewer signals it by writing:
+
+- `AC_INFEASIBLE` to `{worktree}/tmp/ralph/review-result.txt` (in place of `SHIP` / `REVISE`), AND
+- the same JSON array shape to `{worktree}/tmp/ralph/infeasible-acs.json` (append or merge with the worker's entries — dedupe by `index`).
+
+When either path writes the verdict, the outer loop (§2e) terminates with `ralph-done.txt` = `AC_INFEASIBLE` and the outer `/task-v2-ralph` wrapper reads `infeasible-acs.json` to populate its `infeasible_acs` output field. The daemon then routes to the diagnoser per spec §8.
+
+**Evidence is load-bearing.** Every `infeasible_acs` entry MUST cite concrete evidence (grep result, file path, conflicting AC index) so the diagnoser can recommend `reissue` vs. `escalate` vs. `close` without re-running the investigation. Paragraphs like "this feels wrong" or "I don't think this is right" are not evidence.
+
+---
+
 ### Status file
 
 The `/task` skill sets up a status file at `{repo_root}/tmp/agent-status/{agent-id}.txt`. The `/ralph` skill writes status updates to this file at each worker/reviewer phase transition using the Write tool. The format is defined in `/task` Step 0. Derive the status file path from the worktree path (e.g. `.claude/worktrees/agent-ab4722a2` -> `{repo_root}/tmp/agent-status/agent-ab4722a2.txt`, or `worktrees/worker-2` -> `{repo_root}/tmp/agent-status/worker-2.txt`).
@@ -61,6 +94,7 @@ Create the state directory and seed the task file:
 ├── iteration.txt              # current iteration number (written before each iteration)
 ├── review-log.jsonl           # structured review log (appended by gemini_review.py and the loop)
 ├── touched-packages.txt       # Python packages with code changes (written by worker step 4)
+├── infeasible-acs.json        # written only on AC_INFEASIBLE verdict (worker / reviewer)
 └── ralph-done.txt             # completion signal for the calling /task workflow
 ```
 
@@ -151,6 +185,7 @@ Spawn a **worker subagent** (using the Agent tool) with this prompt structure:
 > 8. Write your acceptance criteria self-check to `{worktree}/tmp/ralph/acceptance-check.txt` with a table mapping each criterion to its evidence.
 > 9. When all checks pass (including diff-coverage >= 90%) AND all locally-verifiable acceptance criteria are addressed, write "COMPLETE" to `{worktree}/tmp/ralph/work-status.txt`.
 > 10. If you cannot get checks passing after reasonable effort, write "STUCK" to `work-status.txt` and describe what's failing in `{worktree}/tmp/ralph/stuck-reason.txt`.
+> 11. **If during steps 1-8 you determine one or more acceptance criteria are structurally infeasible** per the §"AC_INFEASIBLE emit rules" above (non-existent symbol, self-contradiction, out-of-scope dependency), do NOT keep iterating and do NOT write COMPLETE. Instead, write `AC_INFEASIBLE` to `{worktree}/tmp/ralph/work-status.txt` AND write a JSON array of `{"index": <1-based>, "evidence": "<paragraph citing the grep output / file path / conflicting AC index>"}` entries to `{worktree}/tmp/ralph/infeasible-acs.json`. Apply the negative guardrails — do NOT raise this verdict for "hard to implement", max iterations, ambiguous wording, or missing fixtures you can create yourself.
 >
 > Rules:
 > - All work happens in `{worktree}`. All temp files go in `{worktree}/tmp/`.
@@ -190,6 +225,7 @@ Spawn a **worker subagent** (using the Agent tool) with this prompt structure:
 > 6. Write your acceptance criteria self-check to `{worktree}/tmp/ralph/acceptance-check.txt` with a table mapping each criterion to its evidence.
 > 7. When all applicable pre-PR checks pass AND all locally-verifiable acceptance criteria are addressed, write "COMPLETE" to `{worktree}/tmp/ralph/work-status.txt`.
 > 8. If you cannot get the plan implemented after reasonable effort (e.g. the plan's "What will change" section is unclear, or a required file doesn't exist), write "STUCK" to `work-status.txt` and describe what's failing in `{worktree}/tmp/ralph/stuck-reason.txt`.
+> 9. **If during steps 1-6 you determine one or more acceptance criteria are structurally infeasible** per the §"AC_INFEASIBLE emit rules" above (non-existent symbol, self-contradiction, out-of-scope dependency), do NOT keep iterating and do NOT write COMPLETE. Instead, write `AC_INFEASIBLE` to `{worktree}/tmp/ralph/work-status.txt` AND write a JSON array of `{"index": <1-based>, "evidence": "<paragraph citing the grep output / file path / conflicting AC index>"}` entries to `{worktree}/tmp/ralph/infeasible-acs.json`. Apply the negative guardrails — do NOT raise this verdict for "hard to implement" or ambiguous wording.
 >
 > Rules:
 > - All work happens in `{worktree}`. All temp files go in `{worktree}/tmp/`.
@@ -201,6 +237,7 @@ Spawn a **worker subagent** (using the Agent tool) with this prompt structure:
 After the worker subagent completes, read `{worktree}/tmp/ralph/work-status.txt`.
 
 - If **STUCK**: Stop the loop. Comment on the issue describing the blocker. Block the issue with `scripts/block-issue.sh <issue> <blocker>` (if a specific blocking issue exists) or add `status/blocked` manually. Return to the caller with failure status.
+- If **AC_INFEASIBLE**: Stop the loop. Do NOT comment on the issue (the diagnoser will own the follow-up action — reissue, escalate, or close). Do NOT block the issue. Write `AC_INFEASIBLE` to `{worktree}/tmp/ralph/ralph-done.txt` along with the current iteration count, leaving `{worktree}/tmp/ralph/infeasible-acs.json` in place for the outer `/task-v2-ralph` wrapper to read. Return to the caller — the daemon routes to the diagnoser from here.
 - If **COMPLETE**: Continue to the review phase (2b for testable, 2b' for non-testable).
 
 ### 2b — Sequential review phase (testable branch)
@@ -338,9 +375,10 @@ The Claude reviewer prompt applies to both branches:
 >    - **Unchecked test plan items**: If the PR includes a test plan with checkboxes, any unchecked items are **merge blockers**. An unchecked item means something was not verified — flag it as a REVISE reason. The author must either check the item (verify it) or remove it (not applicable).
 >    - **Diff-coverage gate** (testable only — skip for non-testable): confirm the worker's self-check reports diff-coverage ≥ 90%.
 >    - **Web Interface Guidelines (conditional)**: If any changed files have `.tsx` or `.css` extensions, read `~/.claude/commands/web-interface-guidelines.md` and check those files against its rules. Report violations as REVISE reasons with `file:line` format. Skip this criterion entirely if no `.tsx` or `.css` files appear in the diff.
-> 6. Make a binary decision:
+> 6. Make a decision — **one of three verdicts**:
 >    - **SHIP**: The implementation is correct, well-tested (or, for non-testable changes, implements the plan's "What will change" section faithfully), properly scoped, ALL locally-verifiable acceptance criteria are met, and ready for PR. Write "SHIP" to `{worktree}/tmp/ralph/review-result.txt`.
 >    - **REVISE**: Something needs to change. Write "REVISE" to `{worktree}/tmp/ralph/review-result.txt`. Then write specific, actionable feedback to `{worktree}/tmp/ralph/feedback.md` — describe exactly what needs to change and why. Be concrete: reference specific files, functions, and line numbers. **If any acceptance criterion is unmet, list it first in your feedback.**
+>    - **AC_INFEASIBLE**: One or more acceptance criteria are structurally impossible per the §"AC_INFEASIBLE emit rules" section (non-existent symbol, self-contradiction, out-of-scope dependency) — NOT "hard to implement", not "max iterations", not "ambiguous". Write "AC_INFEASIBLE" to `{worktree}/tmp/ralph/review-result.txt`. Write the JSON array of `{"index": <1-based>, "evidence": "<paragraph>"}` to `{worktree}/tmp/ralph/infeasible-acs.json` (merge with any entries the worker already wrote; dedupe by `index`). Err on the side of REVISE when uncertain — AC_INFEASIBLE requires citable evidence (grep output, file path, conflicting AC index), not a hunch. When you pick AC_INFEASIBLE, do NOT write feedback.md — the diagnoser owns the follow-up action.
 >
 > Scope boundaries:
 > - **Only flag issues introduced or modified by this diff.** Pre-existing code patterns that were not changed in this PR are out of scope — even if they look questionable. The worker is not responsible for fixing code they did not touch.
@@ -405,6 +443,8 @@ Run this script with any available Python 3 interpreter (e.g. a venv python from
 - **Non-testable branch:** Claude alone must SHIP. Both Gemini entries are always **SKIPPED** on this branch, so the same predicate — Claude SHIP AND Gemini standard SHIP-or-SKIPPED AND Gemini adversarial SHIP-or-SKIPPED — reduces to Claude SHIP. The predicate is uniform across branches.
 
 If the predicate is satisfied: the loop is done. Continue to Step 3.
+
+**AC_INFEASIBLE short-circuit.** If the worker wrote `AC_INFEASIBLE` to `work-status.txt` OR the Claude reviewer wrote `AC_INFEASIBLE` to `review-result.txt`, the loop terminates immediately with verdict `AC_INFEASIBLE`. Do NOT run subsequent reviewers. Do NOT run the next iteration. Do NOT invoke the persistent-dissent override (it does not apply to AC_INFEASIBLE). Write `AC_INFEASIBLE` to `{worktree}/tmp/ralph/ralph-done.txt` along with the iteration count, leave `infeasible-acs.json` in place, and return to the caller — the outer `/task-v2-ralph` wrapper will read both files and emit the dispatcher-facing JSON.
 
 - **Persistent-dissent override** (testable branch only): If ANY reviewer says **REVISE**, first check whether this is a persistent solo-dissent pattern. The override logic only applies when multiple reviewers actually ran — on the non-testable branch where only Claude runs, there is no dissent to override. Write and run a small Python script (`{worktree}/tmp/ralph/check_dissent.py`):
 
@@ -481,6 +521,16 @@ iterations: <N>
 next-steps: The /task workflow MUST now continue with: A.2b (process summary), A.3 (stage, commit, push), A.4 (verify no merge conflicts), A.5 (monitor CI), A.6 (update PR test plan), A.7 (merge PR), A.8 (verify deployment, functional health, and acceptance criteria if applicable), A.9 (retrospective). THE TASK IS NOT COMPLETE UNTIL ALL THESE STEPS FINISH.
 ```
 
+**AC_INFEASIBLE completion signal (issue #3010).** When the §2e short-circuit fires, write this content to `ralph-done.txt` instead (again, substituting the actual iteration count):
+
+```
+status: AC_INFEASIBLE
+iterations: <N>
+next-steps: The daemon will read infeasible-acs.json, write a dispatcher.failures(category='ralph_ac_infeasible') row, and route to the diagnoser. No commit, no push, no PR. The outer /task-v2-ralph wrapper propagates the infeasible_acs array to the dispatcher.
+```
+
+Leave `{worktree}/tmp/ralph/infeasible-acs.json` in place so the outer wrapper can pass it through. Do NOT commit, push, or open a PR. Return to the caller.
+
 The code is ready for commit. Return control to the calling workflow (`/task` Path A or `/task-v2-ralph`), which handles process summary, staging, committing, pushing, PR creation, CI monitoring, and cleanup.
 
 **Do not commit, push, or open a PR from this skill.**
@@ -503,6 +553,7 @@ Under dispatcher v2, the calling `/task-v2-ralph` skill parses `ralph-done.txt` 
 - **Unchecked test plan items are merge blockers.** Reviewers must flag unchecked test plan checkboxes as REVISE reasons. A PR with unchecked items is not ready to ship.
 - **Unmet acceptance criteria are always REVISE.** Reviewers must verify every acceptance criterion individually. Code quality alone is not sufficient for SHIP — all locally-verifiable acceptance criteria must be met.
 - **"No tests added" is not a REVISE reason on the non-testable branch.** Applying test-coverage standards to a docs-only or migration-only diff is a category error that deadlocks the loop. The reviewer must distinguish the branches by reading `## Testable` in `task.md`.
+- **AC_INFEASIBLE requires citable evidence (issue #3010).** The worker or Claude reviewer may surface `AC_INFEASIBLE` when an AC references a non-existent symbol, self-contradicts another AC, or depends on out-of-scope work — see §"AC_INFEASIBLE emit rules". "Hard to implement", "max iterations exhausted", and ambiguous wording are NOT triggers. When uncertain, prefer REVISE — the diagnoser cannot reason about a hunch.
 - **Persistent-dissent override** (testable branch only). If one reviewer says REVISE for 2+ consecutive iterations while the other two say SHIP, and the detection function (`detect_persistent_dissent`) confirms the pattern, the loop treats it as SHIP. This prevents a single reviewer from blocking convergence on theoretical grounds that the other reviewers have already evaluated and dismissed. The override is logged to `review-log.jsonl` with type `dissent_override` for audit. This override only applies when exactly one reviewer dissents — if two reviewers REVISE, that is a genuine concern and the override does not trigger. On the non-testable branch, only Claude reviews, so the override is inapplicable and the REVISE path always re-runs the worker.
 - **Do not use `run_in_background` anywhere in the ralph loop.** All commands — test suites, lint, format checks, git commands, reviewer invocations, and worker subagents — must run in the foreground. Subagents are already running as background tasks from the parent's perspective. Further backgrounding causes completion notifications to route to the wrong context, leading to confusion and lost results.
 

--- a/.claude/skills/task-v2-ralph/SKILL.md
+++ b/.claude/skills/task-v2-ralph/SKILL.md
@@ -94,23 +94,28 @@ Write `{worktree}/tmp/dispatcher-output/ralph.json` with these fields, then exit
 {
   "agent_id": "<echo>",
   "issue_number": <int>,
-  "verdict": "SHIP" | "BLOCKED",
+  "verdict": "SHIP" | "AC_INFEASIBLE" | "BLOCKED",
   "iterations_used": <int, 1..max_iterations>,
   "block_reason": null | "<string>",
   "changed_files": ["<path>", ...],
+  "infeasible_acs": [ {"index": <int>, "evidence": "<paragraph>"} ],
   "summary": "<1-3 sentence implementation summary>",
   "ralph_done_path": "<worktree>/tmp/ralph/ralph-done.txt" | null,
   "review_log_path": "<worktree>/tmp/ralph/review-log.jsonl" | null
 }
 ```
 
-Always exit 0. BLOCKED is not a subprocess error — the daemon reads verdict from JSON.
+Always exit 0. BLOCKED and AC_INFEASIBLE are not subprocess errors — the daemon reads `verdict` from JSON.
 
 `iterations_used` is `1..max_iterations` when the ralph loop runs (which is every non-BLOCKED path). The pre-#2845 short-circuit that emitted `iterations_used=0` for non-testable types no longer exists.
 
-`ralph_done_path` and `review_log_path` are non-null whenever the ralph loop ran (every SHIP path). They are `null` only when Step 0's Task-tool availability check fails and the skill exits BLOCKED without spawning a worker.
+`ralph_done_path` and `review_log_path` are non-null whenever the ralph loop ran (every SHIP / AC_INFEASIBLE path). They are `null` only when Step 0's Task-tool availability check fails and the skill exits BLOCKED without spawning a worker.
+
+`infeasible_acs` MUST be present and non-empty when `verdict == "AC_INFEASIBLE"`; absent or `[]` on SHIP/BLOCKED. Each entry is `{"index": <1-based into the issue body's acceptance-criteria list>, "evidence": "<one paragraph naming the missing symbol / contradicting AC / out-of-scope dependency>"}`. An array (not a single object) lets ralph flag multiple ACs in one pass — a single root cause (e.g. two ACs both referencing the same non-existent CLI flag) should not force sequential re-plan cycles. See the inner `/ralph` skill's §"AC_INFEASIBLE emit rules" for the positive triggers and negative guardrails the worker + reviewer apply.
 
 On SHIP: ralph has committed the implementation diff to the worktree branch with the placeholder message `"WIP: ralph output"` (see Step 2.5), AND the local `.githooks/pre-push` hook passed against that commit. The daemon's `summary` phase reads the diff via `git diff origin/main...HEAD`; the daemon's `push_and_pr` phase amends ralph's commit with summary's conventional-commits message (`git commit --amend -F <file>`) and pushes. Issue #2971.
+
+On AC_INFEASIBLE: ralph did not ship a diff. The daemon detects the verdict in post-exit parse, writes a `dispatcher.failures(category='ralph_ac_infeasible', details={infeasible_acs, agent_id, issue_number})` row, and routes the agent to the diagnoser (Tier 3 — spec §8). Summary and push_and_pr are skipped. Whatever partial work landed on the worktree branch is discarded when the daemon drops the worktree on diagnoser handoff.
 
 On BLOCKED: the working tree may contain partial work (committed or uncommitted). The daemon decides whether to retry (fresh worktree) or diagnose (`§8` Tier 2/3 flow).
 
@@ -301,8 +306,11 @@ Map to output `verdict`:
 | ralph-done.txt | output.verdict | block_reason |
 |---|---|---|
 | `SHIP` | `SHIP` | `null` |
+| `AC_INFEASIBLE` | `AC_INFEASIBLE` | `null` (populate `infeasible_acs` instead) |
 | `REVISE` | `BLOCKED` | `max_iterations reached without SHIP` |
 | `BLOCKED` | `BLOCKED` | `"<text from ralph-done.txt body>"` |
+
+When `ralph-done.txt` is `AC_INFEASIBLE`, the inner `/ralph` skill has also written `{worktree}/tmp/ralph/infeasible-acs.json` — a JSON array of `{index, evidence}` objects (see the inner `/ralph` skill's AC_INFEASIBLE emit path). Read that file and pass it through verbatim as the `infeasible_acs` field of the output JSON. On any other verdict the file is absent — emit `"infeasible_acs": []` so downstream consumers can rely on the field's presence.
 
 If Step 2.5 overrode the verdict to BLOCKED (pre-push hook failed and max_iterations was reached on the re-invocation path), use the Step 2.5 `block_reason` instead of the table above.
 

--- a/.claude/skills/task-v2-summary/SKILL.md
+++ b/.claude/skills/task-v2-summary/SKILL.md
@@ -52,18 +52,37 @@ Write `{worktree}/tmp/dispatcher-output/summary.json`:
 {
   "agent_id": "<echo>",
   "issue_number": <int>,
+  "verdict": "OK" | "AC_INFEASIBLE",
   "process_summary_md": "<markdown comment body>",
   "commit_message": "<conventional-commits subject + body>",
   "pr_title": "<subject line, matches commit subject without body>",
   "pr_body_md": "<full PR body markdown with Summary + Test plan>",
+  "deferred_acs": [
+    {"index": <int>, "reason": "marker" | "heuristic",
+     "verify_instruction": "<Verify: line text>"}
+  ],
+  "infeasible_acs": [
+    {"index": <int>, "evidence": "<paragraph>"}
+  ],
   "unmet_criteria": ["<criterion text>", ...],
+  "ac_mapping": [
+    {"index": <int>, "criterion": "<text>",
+     "status": "met" | "deferred" | "unmet_shape_mismatch" | "infeasible" | "not_applicable",
+     "evidence": "<1-3 lines or reason>"}
+  ],
   "pre_pr_check_notes": "<optional notes about lint/tests — prose>"
 }
 ```
 
-`unmet_criteria` signals the daemon: **non-empty means the daemon must NOT open the PR**. Instead it returns the agent to the ralph phase with the list as a hint, or escalates to diagnose if ralph already completed with SHIP.
+`verdict` is `"OK"` on the normal path (summary proceeds to PR) and `"AC_INFEASIBLE"` on the structural-impossibility path (daemon routes to diagnoser — see §"Classifier order" below). When `verdict == "AC_INFEASIBLE"`, `infeasible_acs` MUST be non-empty; on `verdict == "OK"`, `infeasible_acs` is absent or `[]`.
 
-Exit 0 regardless. The output JSON's shape is the contract — empty `unmet_criteria` == proceed.
+`deferred_acs` lists acceptance criteria that summary recognized as post-deploy-only. The daemon persists this alongside the rest of summary's output (`dispatcher.phase_outputs`), and `/task-v2-verify` reads it after deploy to run those ACs against the live dev environment. The list may be non-empty on both `verdict="OK"` and `verdict="AC_INFEASIBLE"` — deferred classification runs before the unmet-AC classification.
+
+`unmet_criteria` stays on the **shape-mismatch** path only: ralph produced a valid implementation that simply doesn't match the AC's expected artifact (inline tests vs. a fixture file, wrong field name, etc.). Non-empty `unmet_criteria` triggers today's `needs_review` flow (draft PR + operator comment). Structural-impossibility unmet ACs go to `infeasible_acs` instead, with `verdict="AC_INFEASIBLE"`.
+
+`ac_mapping` is the full per-AC classification, one entry per acceptance criterion in the issue body. Every AC lands in exactly one bucket via the classifier order below; the `process_summary_md` comment is rendered from this list.
+
+Exit 0 regardless. Empty `unmet_criteria` + empty `infeasible_acs` + `verdict="OK"` == proceed.
 
 ---
 
@@ -73,17 +92,66 @@ Read the issue body and `issue_comments`. Identify all `- [ ]` checkboxes under 
 
 If `plan_acceptance_criteria` is populated, cross-check against your extracted list. If they diverge, prefer the issue body + comments (the source of truth). Note the divergence in `pre_pr_check_notes` so the retro phase can file a follow-up.
 
-## Step 2 — Map each criterion to the diff
+## Step 2 — Classifier order (deferred → validate → classify unmet)
 
-For each criterion, determine from `git_diff` and `changed_files` whether it is:
+For EACH acceptance criterion, run these checks in order. The first match wins — do not fall through once a bucket is assigned. Issue #3010 codifies this ordering so the deferred check always runs BEFORE the validate-against-diff check, preventing post-deploy ACs from being flagged unmet.
 
-- **Met** — describe specifically how: which file, which function/test, which line range. Cite the test name if a criterion has a `Verify:` line that maps to a test.
-- **Not met — post-deploy verification** — criteria that require running against dev (e.g., "GET /api/foo returns 200"). These are legitimately not verifiable pre-deploy; they belong to `/task-v2-verify`.
-- **Not met — scope expansion** — criterion was sharpened mid-flight and the diff does not cover it. Add to `unmet_criteria`.
-- **Not met — blocked** — criterion is blocked by a dependency that was out of scope. Add to `unmet_criteria` with explanation.
-- **Not applicable** — criterion was made obsolete by an earlier PR or the approach shifted. Explain in evidence cell.
+### 2a — Deferred check (runs FIRST, always)
 
-If `unmet_criteria` is non-empty, the daemon will NOT open the PR. Add detail to each entry explaining what's missing so the retry hint is actionable.
+Before validating against the diff, determine whether the criterion can be validated pre-merge at all:
+
+1. **Marker — authoritative.** If the AC's `Verify:` line begins with `(post-deploy)` (exact literal, case-sensitive), mark it deferred with `reason="marker"`. Stop here — do NOT run the validate or unmet steps for this AC.
+2. **Heuristic — for pre-convention issues without the marker.** If the `Verify:` line references a dev/prod artifact, mark it deferred with `reason="heuristic"`. Stop here. Non-exhaustive heuristic tokens (match any of these, case-insensitive):
+   - `scripts/ecs-run-task.sh`, `scripts/ecs-run.sh`, `ecs-logs.sh`
+   - `scripts/dev-db-query.sh`, `dev-db-query.sh`
+   - `curl dev.api.judgemind.org`, `curl https://dev.api.`, `curl https://dev.judgemind.org`
+   - `dev.judgemind.org/` (any path), `dev.api.judgemind.org/` (any path)
+   - `POST /<index>/_count`, `GET /<index>/_search`, `OpenSearch`, `opensearch` (index query)
+   - `rebuild_db.py`, `rebuild_db --reset`, `scripts/rebuild_db.sh`
+   - `gh run watch` on a deploy workflow (`deploy-api.yml`, `deploy-scraper.yml`, `deploy-production.yml`, `terraform.yml`)
+   - `aws logs`, `CloudWatch Insights`, `/ecs/judgemind-` (log group names)
+   - `dispatcher.phase_outputs`, `dispatcher.failures`, `dispatcher.diagnoses` (require a running daemon)
+   - `kubectl`, `helm` (future — deploy-dependent)
+   - `psql $DATABASE_URL`, `psql dev`, anything that runs a SQL query against a deployed database
+
+   The heuristic is deliberately broad to catch the backlog of pre-convention issues. **False-positive heuristic (tagging a code-verifiable AC as deferred) is benign** — verify runs it post-deploy and confirms the pass. **False-negative (missing a post-deploy AC) is today's behavior — no regression.** When uncertain between deferred-heuristic and validate, prefer deferred — the verify phase is the safety net.
+
+3. **No match.** Proceed to 2b.
+
+Add deferred entries to `deferred_acs` with `{"index": <N>, "reason": "marker" | "heuristic", "verify_instruction": "<exact Verify: line text>"}`. Do NOT count deferred ACs as unmet or infeasible.
+
+### 2b — Validate against diff
+
+For each AC NOT marked deferred, determine from `git_diff` and `changed_files` whether the diff satisfies it. If satisfied: record as **met** in `ac_mapping` with a citation (file path, function name, test name, line range as appropriate). Done for this AC.
+
+### 2c — Classify unmet ACs (shape-mismatch vs. structural-impossibility)
+
+When an AC is neither deferred (2a) nor satisfied by the diff (2b), classify it as one of:
+
+- **Shape mismatch** — ralph produced something valid but not the exact artifact the AC describes. Typical causes: AC demands a fixture file but ralph wrote inline tests; AC expects a specific field name but ralph used a similar one; the diff covers the behavior but not the exact Verify line's pattern. → Add the raw criterion text to `unmet_criteria` AND record in `ac_mapping` with `status="unmet_shape_mismatch"` and a one-line reason. The daemon opens a DRAFT PR with the unmet list in the body and terminates the agent as `status='needs_review'` for operator triage. This is today's flow.
+
+- **Structural impossibility** — the AC references a symbol that doesn't exist in the codebase OR the PR diff, self-contradicts another AC, or demands work outside this issue's scope. → Add an entry to `infeasible_acs` with `{"index": <N>, "evidence": "<paragraph citing the grep / file / conflicting AC>"}` AND record in `ac_mapping` with `status="infeasible"`. Set `verdict="AC_INFEASIBLE"` on the overall output. The daemon writes a `dispatcher.failures(category='summary_ac_infeasible', details={infeasible_acs, deferred_acs, ralph_diff, summary_ac_mapping, agent_id, issue_number})` row and routes to the diagnoser; ralph's shipped diff is discarded on this branch.
+
+- **Not applicable** — the AC was made obsolete by an earlier PR or the approach shifted. → Record in `ac_mapping` with `status="not_applicable"` and an explanation. Do NOT add to `unmet_criteria` or `infeasible_acs` — the criterion simply doesn't apply.
+
+**Err toward shape-mismatch when uncertain.** `AC_INFEASIBLE` requires citable evidence (grep result, file path, conflicting AC index), not a hunch. A draft PR + operator review is reversible; a diagnoser-driven `reissue` rewrites the issue body and discards ralph's diff — higher cost on a false positive. When in doubt, pick `unmet_shape_mismatch` and let the operator decide.
+
+### 2d — Output assembly
+
+After every AC is classified, assemble the output JSON:
+
+- `verdict` = `"AC_INFEASIBLE"` if `infeasible_acs` is non-empty, else `"OK"`.
+- `deferred_acs`, `infeasible_acs`, `unmet_criteria`, and `ac_mapping` populate from the per-AC classifications above.
+- Render `process_summary_md` from `ac_mapping` (see Step 3).
+
+**Daemon behavior by verdict:**
+
+| verdict | unmet_criteria | deferred_acs | Daemon next step |
+|---|---|---|---|
+| `OK` | empty | any | push_and_pr (normal flow); verify reads `deferred_acs` post-deploy |
+| `OK` | non-empty | any | `_push_and_open_pr` opens a DRAFT PR with `unmet_criteria` in body, terminates agent as `needs_review` |
+| `AC_INFEASIBLE` | any | any | `dispatcher.failures(category='summary_ac_infeasible')` + route to diagnoser; ralph diff discarded |
+
 
 ## Step 3 — Write the process-summary comment
 
@@ -101,8 +169,10 @@ Use this markdown structure in `process_summary_md`. The daemon posts this comme
 | # | Criterion | Status | Evidence |
 |---|-----------|--------|----------|
 | 1 | <criterion text, truncate at 80 chars with …> | Met | `path/to/file.py::test_or_function` |
-| 2 | <criterion text> | Met | `path/to/other.py` — line range |
-| 3 | <criterion text> | Not met — post-deploy | Will be verified by /task-v2-verify |
+| 2 | <criterion text> | Deferred (marker) | Will be verified post-deploy by /task-v2-verify |
+| 3 | <criterion text> | Deferred (heuristic) | Matches post-deploy artifact pattern; /task-v2-verify will run it |
+| 4 | <criterion text> | Not met — shape mismatch | needs_review: ralph shipped inline tests but AC asks for fixture file |
+| 5 | <criterion text> | Infeasible | Cites `--court` flag not present in `scripts/rebuild_db.py` |
 
 ### Scope decisions
 
@@ -113,7 +183,7 @@ Use this markdown structure in `process_summary_md`. The daemon posts this comme
 <Issues the retro phase will file based on scope_check out-of-scope findings. Leave empty if none.>
 ```
 
-Keep the comment under ~4000 characters. The issue thread gets noisy if summary comments are long.
+Use the `Status` column values: `Met`, `Deferred (marker)`, `Deferred (heuristic)`, `Not met — shape mismatch`, `Infeasible`, `Not applicable`. These map 1:1 to the `ac_mapping[].status` enum. Keep the comment under ~4000 characters. The issue thread gets noisy if summary comments are long. On `verdict="AC_INFEASIBLE"`, the daemon does NOT post this comment on the issue — the diagnoser will post its own comment/reissue body instead; summary's `process_summary_md` is retained for the `dispatcher.phase_outputs` audit trail.
 
 ## Step 4 — Write the commit message and PR title
 

--- a/.claude/skills/task-v2-verify/SKILL.md
+++ b/.claude/skills/task-v2-verify/SKILL.md
@@ -40,6 +40,7 @@ Optional:
 
 - `plan_text` (str) — from plan output; can clarify ambiguous criteria.
 - `scope_check` (list) — for context on what's intentionally out of scope.
+- `deferred_acs` (list) — carried forward from summary's output (`dispatcher.phase_outputs`). Shape: `[{"index": <int>, "reason": "marker" | "heuristic", "verify_instruction": "<Verify: line text>"}]`. When present, this skill runs the deferred ACs FIRST and labels each result as "deferred (marker|heuristic) → pass|fail"; the remaining ACs are labeled as "pre-merge validated, re-confirmed post-deploy". See [spec §6a `^summary-deferred-acs`](../../../docs/specs/dispatcher-v2-spec.md) and issue #3010. Absent or empty on pre-#3010 agents and on no-deploy/docs change types — the skill treats the verification universe as "every AC, no labeling" in that case.
 
 If the file is missing or malformed, exit 0 with verdict=`FAILED, failure_reason="input JSON missing or malformed"`.
 
@@ -92,7 +93,25 @@ If `deploy_status` is `null` or `conclusion != 'success'` and `change_type` is d
 
 ## Step 2 — Per-criterion verification
 
-For each acceptance criterion in `acceptance_criteria`, execute the verification action that the criterion's `Verify:` line names (per `docs/agent/issue-authoring.md`). Capture concrete evidence into `per_criterion_results[].evidence`:
+Order matters: **run the `deferred_acs` first** (they are the ACs summary intentionally skipped pre-merge — verifying them is the point of this phase), then run the non-deferred ACs as a belt. Within each group, execute the verification action that the criterion's `Verify:` line names (per `docs/agent/issue-authoring.md`) and capture concrete evidence into `per_criterion_results[].evidence`.
+
+### 2a — Run deferred ACs first (issue #3010)
+
+If `deferred_acs` is non-empty in the input bundle:
+
+1. For each entry `{index, reason, verify_instruction}`:
+   - Look up the AC text in `acceptance_criteria[index - 1]` (1-based → 0-based index).
+   - Execute the verification using `verify_instruction` as the primary source for the action (summary already extracted the exact `Verify:` line).
+   - Record the result in `per_criterion_results` with a label that surfaces the deferred classification: set `evidence` to begin with `"deferred (marker) → pass:"` or `"deferred (heuristic) → pass:"` followed by the concrete proof. Use `"deferred (marker) → fail: <why>"` when the verification fails.
+2. A `fail` on a deferred AC promotes the overall `verdict` to `FAILED` with a `failure_reason` that calls out the deferred AC by index (e.g. `"deferred AC #5 (post-deploy OpenSearch count) did not match expected after deploy"`).
+
+### 2b — Run non-deferred ACs as a belt
+
+For each AC NOT in `deferred_acs`, re-run the verification against the deployed environment. Summary already validated these against the pre-merge diff; the belt run confirms the deployed code still passes. Prefix each `evidence` with `"pre-merge validated, re-confirmed post-deploy:"` so operators reading the PR trail can see which verifications were time-shifted vs. redundantly re-run.
+
+**Default: 100% coverage.** The post-deploy evidence comment covers every AC. If a non-deferred AC is genuinely impossible to re-verify post-deploy (rare — e.g. a static analysis gate that only runs in CI), record `evidence` as `"pre-merge validated by summary (CI-only check, not re-runnable post-deploy): <summary's original evidence>"` and keep `verified=true`.
+
+### 2c — Per-AC verification rules (applies to 2a and 2b)
 
 - **Frontend criteria** ("Verify: page renders without errors") — screenshot or page-fetch. Evidence = screenshot filepath or first 500 chars of rendered HTML.
 - **Data criteria** ("Verify: SELECT count(*) FROM derived.documents WHERE …") — run the exact SQL via `scripts/dev-db-query.sh`. Evidence = the query + result.
@@ -100,9 +119,7 @@ For each acceptance criterion in `acceptance_criteria`, execute the verification
 - **Behavior criteria** ("Verify: ingestion worker processes a sample fixture without errors") — trigger the scenario (or find a recent occurrence in logs) and capture result.
 - **Log criteria** — MCP CloudWatch Logs Insights query; capture the matching log line(s). Limit to 5-10 lines per criterion to keep the evidence comment readable.
 
-If any criterion fails to verify, record `verified=false` in that row, and set the overall `verdict=FAILED` with `failure_reason` summarizing which criteria failed.
-
-For criteria that are explicitly "post-deploy only" and were marked `unmet` by summary, this phase is the one that resolves them.
+If any criterion fails to verify, record `verified=false` in that row, and set the overall `verdict=FAILED` with `failure_reason` summarizing which criteria failed (deferred or not).
 
 ## Step 3 — Build the evidence comment
 
@@ -124,11 +141,18 @@ For `verdict=VERIFIED`:
 
 | # | Criterion | Verified | Evidence |
 |---|-----------|----------|----------|
-| 1 | <criterion> | Yes | <proof, 1-3 lines> |
-| 2 | <criterion> | Yes | <proof> |
+| 1 | <criterion> | Yes | deferred (marker) → pass: curl dev.api.judgemind.org/... returned 200 |
+| 2 | <criterion> | Yes | deferred (heuristic) → pass: OpenSearch index count matches expected 2,444 |
+| 3 | <criterion> | Yes | pre-merge validated, re-confirmed post-deploy: pytest test_foo still green against merged sha |
 
 **Post-deploy verification: PASSED**
 ```
+
+Each row's `Evidence` column begins with one of three labels so a PR-trail reader can see which verifications were time-shifted from pre-merge (per spec §6a `^verify-deferred-acs`):
+
+- `deferred (marker) → pass:` — AC was tagged `(post-deploy)` by its author; summary skipped it pre-merge; verify ran it now.
+- `deferred (heuristic) → pass:` — AC matched the heuristic pattern; summary skipped it pre-merge; verify ran it now.
+- `pre-merge validated, re-confirmed post-deploy:` — summary validated against the diff, verify re-ran against the deployed environment as a belt.
 
 For `verdict=SKIPPED` (no deployed component):
 

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -713,6 +713,16 @@ FAILURE_CATEGORY_SUBPROCESS_AUTH_FAIL = "subprocess_auth_fail"
 #: fixes "the CI-fixing skill couldn't fix CI three times in a row".
 FAILURE_CATEGORY_CI_RED_AFTER_RETRIES = "ci_red_after_retries"
 
+#: Tier-3 failure categories from spec §8 for AC-infeasibility (issue
+#: #3010). Both are written by post-exit parse of the structured phase
+#: output JSON — ``ralph_ac_infeasible`` when ``ralph.json.verdict ==
+#: "AC_INFEASIBLE"`` and ``summary_ac_infeasible`` when
+#: ``summary.json.verdict == "AC_INFEASIBLE"``. Neither has a mechanical
+#: retry (the AC is structurally wrong, not flaky), so both route
+#: directly to the diagnoser for ``reissue`` / ``escalate`` / ``close``.
+FAILURE_CATEGORY_RALPH_AC_INFEASIBLE = "ralph_ac_infeasible"
+FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE = "summary_ac_infeasible"
+
 #: Git-push failure categories for the ``push_and_pr`` phase (issue #2902).
 #: ``push_failed`` is the generic catch-all; the two sub-kinds are
 #: classifier-derived from stderr content via ``_classify_push_failure``.
@@ -878,13 +888,19 @@ TIER_2_FIRST_OCCURRENCE_CATEGORIES: frozenset[str] = frozenset(
     }
 )
 
-#: Tier-3 categories that diagnose on first occurrence (spec §8). Today
-#: only ``ci_red_after_retries`` qualifies — the 3B fix-CI loop has
-#: already burned its 3 mechanical retries, so there is no reliable
-#: mechanical remedy left.
+#: Tier-3 categories that diagnose on first occurrence (spec §8).
+#: ``ci_red_after_retries`` — the 3B fix-CI loop has already burned its
+#: 3 mechanical retries, so there is no reliable mechanical remedy left.
+#: ``ralph_ac_infeasible`` / ``summary_ac_infeasible`` (issue #3010) —
+#: ralph or summary determined one or more ACs are structurally
+#: impossible (non-existent symbol, self-contradiction, out-of-scope
+#: dependency); no mechanical retry fixes a malformed AC, so the
+#: diagnoser picks ``reissue`` / ``escalate`` / ``close`` immediately.
 TIER_3_CATEGORIES: frozenset[str] = frozenset(
     {
         FAILURE_CATEGORY_CI_RED_AFTER_RETRIES,
+        FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
+        FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
     }
 )
 
@@ -4788,6 +4804,12 @@ class DispatcherDaemon:
         "push_failed": "git push failed",
         "pre_push_hook_rejected": "pre-push hook rejected",
         "git_push_network": "git push network error",
+        # AC-infeasibility (#3010). Tier 3 — routed directly to the
+        # diagnoser. Rendered as "AC infeasible (ralph)" /
+        # "AC infeasible (summary)" so operators see where in the
+        # pipeline the infeasibility was detected.
+        "ralph_ac_infeasible": "AC infeasible (ralph)",
+        "summary_ac_infeasible": "AC infeasible (summary)",
     }
 
     @staticmethod
@@ -7044,6 +7066,61 @@ class DispatcherDaemon:
             },
         )
 
+        if verdict == "AC_INFEASIBLE":
+            # Issue #3010 — ralph surfaced a structurally-impossible AC.
+            # Route to the diagnoser (Tier 3) immediately; no summary,
+            # no push_and_pr, no mechanical retry. Ralph's worktree
+            # diff (if any) is discarded on diagnoser handoff.
+            infeasible_acs = ralph_output.get("infeasible_acs") or []
+            # Normalize to a list of dicts with int-coerced indices so
+            # the diagnoser's context bundle has a clean shape even if
+            # the skill emitted strings or a single dict.
+            normalized_infeasible: list[dict[str, Any]] = []
+            if isinstance(infeasible_acs, list):
+                for entry in infeasible_acs:
+                    if not isinstance(entry, dict):
+                        continue
+                    idx = entry.get("index")
+                    try:
+                        idx_int = int(idx) if idx is not None else None
+                    except (TypeError, ValueError):
+                        idx_int = None
+                    evidence = entry.get("evidence")
+                    normalized_infeasible.append(
+                        {
+                            "index": idx_int,
+                            "evidence": str(evidence) if evidence is not None else "",
+                        }
+                    )
+            self._log.info(
+                "daemon.ralph_ac_infeasible",
+                extra={
+                    "event": "ralph_ac_infeasible",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "infeasible_acs_count": len(normalized_infeasible),
+                },
+            )
+            self._write_failure(
+                agent_id=agent_id,
+                category=FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
+                detected_by="ralph_output_parse",
+                details={
+                    "infeasible_acs": normalized_infeasible,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id,
+                status="failed",
+                phase="ralph",
+                exit_code=exit_code,
+                issue_number=issue_number,
+            )
+            return False
+
         if verdict != "SHIP":
             self._log.info(
                 "daemon.ralph_not_ship",
@@ -7206,6 +7283,64 @@ class DispatcherDaemon:
                 "exit_code": exit_code,
             },
         )
+
+        summary_verdict = str(summary_output.get("verdict") or "").upper()
+        if summary_verdict == "AC_INFEASIBLE":
+            # Issue #3010 — summary found a structurally-impossible AC
+            # after ralph already shipped. Ralph's diff is discarded;
+            # daemon writes a failure row and routes to the diagnoser
+            # (Tier 3). The diagnoser bundle carries ralph's diff +
+            # summary's AC mapping so the reissue rewrite can align
+            # with what ralph already built.
+            infeasible_acs_raw = summary_output.get("infeasible_acs") or []
+            normalized_infeasible: list[dict[str, Any]] = []
+            if isinstance(infeasible_acs_raw, list):
+                for entry in infeasible_acs_raw:
+                    if not isinstance(entry, dict):
+                        continue
+                    idx = entry.get("index")
+                    try:
+                        idx_int = int(idx) if idx is not None else None
+                    except (TypeError, ValueError):
+                        idx_int = None
+                    evidence = entry.get("evidence")
+                    normalized_infeasible.append(
+                        {
+                            "index": idx_int,
+                            "evidence": str(evidence) if evidence is not None else "",
+                        }
+                    )
+            self._log.info(
+                "daemon.summary_ac_infeasible",
+                extra={
+                    "event": "summary_ac_infeasible",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "infeasible_acs_count": len(normalized_infeasible),
+                },
+            )
+            self._write_failure(
+                agent_id=agent_id,
+                category=FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
+                detected_by="summary_output_parse",
+                details={
+                    "infeasible_acs": normalized_infeasible,
+                    "deferred_acs": summary_output.get("deferred_acs") or [],
+                    "ralph_diff": git_diff,
+                    "summary_ac_mapping": summary_output.get("ac_mapping") or [],
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id,
+                status="failed",
+                phase="summary",
+                exit_code=exit_code,
+                issue_number=issue_number,
+            )
+            return False
 
         unmet = summary_output.get("unmet_criteria") or []
         if unmet:
@@ -9313,6 +9448,35 @@ class DispatcherDaemon:
         deploy_status = self._select_deploy_status(deploy_runs)
         change_type = self._infer_change_type(deploy_runs)
 
+        # Issue #3010 — fetch summary's persisted output so we can thread
+        # ``deferred_acs`` through to the verify skill. The verify skill
+        # runs the deferred ACs first (summary skipped them pre-merge)
+        # and labels each as "deferred (marker|heuristic) → pass|fail"
+        # in the evidence comment. Absent/empty on pre-#3010 agents and
+        # on no-deploy types — verify treats the universe as "every AC,
+        # no labeling" in that case (see task-v2-verify SKILL.md).
+        summary_persisted = self._fetch_phase_output(agent_id, "summary") or {}
+        deferred_acs_raw = summary_persisted.get("deferred_acs") or []
+        deferred_acs: list[dict[str, Any]] = []
+        if isinstance(deferred_acs_raw, list):
+            for entry in deferred_acs_raw:
+                if not isinstance(entry, dict):
+                    continue
+                idx = entry.get("index")
+                try:
+                    idx_int = int(idx) if idx is not None else None
+                except (TypeError, ValueError):
+                    idx_int = None
+                reason = str(entry.get("reason") or "")
+                verify_instruction = str(entry.get("verify_instruction") or "")
+                deferred_acs.append(
+                    {
+                        "index": idx_int,
+                        "reason": reason,
+                        "verify_instruction": verify_instruction,
+                    }
+                )
+
         verify_input = {
             "agent_id": agent_id,
             "issue_number": issue_number,
@@ -9324,6 +9488,7 @@ class DispatcherDaemon:
             "merged_commit_sha": merge_sha,
             "worktree_path": str(worktree),
             "repo_root": str(worktree),
+            "deferred_acs": deferred_acs,
         }
         self._write_phase_input(worktree, "verify", verify_input)
 
@@ -12497,7 +12662,40 @@ class DispatcherDaemon:
         if isinstance(details, dict):
             ci_log_url = details.get("ci_log_url") or None
 
-        return {
+        # Issue #3010 — AC-infeasibility context extras. The diagnoser
+        # skill's per-category guidance for ``ralph_ac_infeasible`` and
+        # ``summary_ac_infeasible`` reads these fields; on other
+        # categories they stay absent so the bundle shape is unchanged.
+        infeasible_acs: list[dict[str, Any]] | None = None
+        deferred_acs: list[dict[str, Any]] | None = None
+        ralph_diff: str | None = None
+        summary_ac_mapping: list[dict[str, Any]] | None = None
+        issue_acceptance_criteria: list[str] | None = None
+        if candidate["category"] in (
+            FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
+            FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
+        ):
+            if isinstance(details, dict):
+                raw_inf = details.get("infeasible_acs") or []
+                if isinstance(raw_inf, list):
+                    infeasible_acs = [e for e in raw_inf if isinstance(e, dict)]
+            if issue_body:
+                issue_acceptance_criteria = self._extract_acceptance_criteria(
+                    issue_body
+                )
+            if candidate["category"] == FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE:
+                if isinstance(details, dict):
+                    raw_def = details.get("deferred_acs") or []
+                    if isinstance(raw_def, list):
+                        deferred_acs = [e for e in raw_def if isinstance(e, dict)]
+                    raw_diff = details.get("ralph_diff")
+                    if isinstance(raw_diff, str):
+                        ralph_diff = raw_diff
+                    raw_map = details.get("summary_ac_mapping") or []
+                    if isinstance(raw_map, list):
+                        summary_ac_mapping = [e for e in raw_map if isinstance(e, dict)]
+
+        bundle: dict[str, Any] = {
             "agent_id": agent_id,
             "failure_id": failure_id,
             "failure_category": candidate["category"],
@@ -12514,6 +12712,17 @@ class DispatcherDaemon:
             "prior_mechanical_fix": prior_mechanical_fix,
             "worktree_path": worktree_path,
         }
+        if infeasible_acs is not None:
+            bundle["infeasible_acs"] = infeasible_acs
+        if issue_acceptance_criteria is not None:
+            bundle["issue_acceptance_criteria"] = issue_acceptance_criteria
+        if deferred_acs is not None:
+            bundle["deferred_acs"] = deferred_acs
+        if ralph_diff is not None:
+            bundle["ralph_diff"] = ralph_diff
+        if summary_ac_mapping is not None:
+            bundle["summary_ac_mapping"] = summary_ac_mapping
+        return bundle
 
     def _insert_pending_diagnosis(
         self,

--- a/scripts/dispatcher/tests/test_daemon_failure_summary.py
+++ b/scripts/dispatcher/tests/test_daemon_failure_summary.py
@@ -641,7 +641,8 @@ class TestCategoryDisplayNames:
     def test_category_display_names_map_contents(self) -> None:
         """Lock the full ``_CATEGORY_DISPLAY_NAMES`` map contents so a
         typo or accidental deletion on any row surfaces immediately.
-        Issue #2902 added three push-failure sub-kinds."""
+        Issue #2902 added three push-failure sub-kinds. Issue #3010
+        added two AC-infeasibility categories."""
         assert daemon.DispatcherDaemon._CATEGORY_DISPLAY_NAMES == {
             "subprocess_turn_limit": "turn limit reached",
             "subprocess_crash": "subprocess crashed",
@@ -653,6 +654,9 @@ class TestCategoryDisplayNames:
             "push_failed": "git push failed",
             "pre_push_hook_rejected": "pre-push hook rejected",
             "git_push_network": "git push network error",
+            # AC-infeasibility (#3010).
+            "ralph_ac_infeasible": "AC infeasible (ralph)",
+            "summary_ac_infeasible": "AC infeasible (summary)",
         }
 
     def test_push_failed_renders_as_git_push_failed(self, tmp_path: Path) -> None:

--- a/scripts/dispatcher/tests/test_daemon_ralph_ac_infeasible.py
+++ b/scripts/dispatcher/tests/test_daemon_ralph_ac_infeasible.py
@@ -1,0 +1,478 @@
+"""Unit tests for ralph-originated ``AC_INFEASIBLE`` verdict handling (#3010).
+
+Covers:
+
+* :meth:`daemon.DispatcherDaemon._run_ralph_phase` writes a
+  ``dispatcher.failures(category='ralph_ac_infeasible')`` row with
+  ``details={infeasible_acs, agent_id, issue_number}`` when ralph's
+  ``verdict == 'AC_INFEASIBLE'``.
+* The summary phase is NOT advanced in that case (method returns False).
+* A SHIP verdict still advances to summary (regression guard so the
+  AC_INFEASIBLE branch doesn't accidentally short-circuit the happy
+  path).
+* ``ralph_ac_infeasible`` is in :data:`daemon.TIER_3_CATEGORIES` so the
+  diagnoser candidate scan picks it up on first occurrence with no
+  mechanical retry.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Install a psycopg stub whose ``errors.UniqueViolation`` is a real
+# Exception subclass — matches the pattern in test_daemon_prior_attempts.py.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes (mirrors test_daemon_prior_attempts.py)
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.ralph_ac_infeasible.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+def _patch_ralph_helpers(
+    d: daemon.DispatcherDaemon, *, ralph_output: dict[str, Any]
+) -> None:
+    """Patch the helpers _run_ralph_phase calls so the test doesn't need
+    real subprocesses, DB, or filesystem state."""
+    d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+    d._materialize_prior_attempts = MagicMock(return_value=0)  # type: ignore[method-assign]
+    d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+    d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+    d._read_phase_output = MagicMock(return_value=ralph_output)  # type: ignore[method-assign]
+    d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+    d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
+    d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+    d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+    d._write_failure = MagicMock()  # type: ignore[method-assign]
+
+
+# --------------------------------------------------------------------------
+# Tier-3 registration
+# --------------------------------------------------------------------------
+
+
+class TestTierRegistration:
+    def test_ralph_ac_infeasible_is_tier_3(self) -> None:
+        """``ralph_ac_infeasible`` diagnoses on first occurrence — no retry."""
+        assert daemon.FAILURE_CATEGORY_RALPH_AC_INFEASIBLE in daemon.TIER_3_CATEGORIES
+
+    def test_ralph_ac_infeasible_not_in_auto_retry(self) -> None:
+        """Ralph-AC-infeasible is NOT auto-retried — a mechanical retry
+        will hit the same structural wall. The diagnoser must decide
+        reissue vs. escalate vs. close."""
+        assert (
+            daemon.FAILURE_CATEGORY_RALPH_AC_INFEASIBLE
+            not in daemon.AUTO_RETRY_CATEGORIES
+        )
+
+
+# --------------------------------------------------------------------------
+# _run_ralph_phase behavior on verdict=AC_INFEASIBLE
+# --------------------------------------------------------------------------
+
+
+class TestRunRalphPhaseAcInfeasible:
+    def test_ac_infeasible_writes_failure_row(self, tmp_path: Path) -> None:
+        """ralph's AC_INFEASIBLE verdict writes
+        ``dispatcher.failures(category='ralph_ac_infeasible')`` with
+        the full infeasible_acs list in details."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        _patch_ralph_helpers(
+            d,
+            ralph_output={
+                "verdict": "AC_INFEASIBLE",
+                "iterations_used": 2,
+                "block_reason": None,
+                "changed_files": [],
+                "infeasible_acs": [
+                    {
+                        "index": 1,
+                        "evidence": (
+                            "AC #1 references the `--court` flag on "
+                            "scripts/rebuild_db.py but `grep -n` returns no "
+                            "match and the PR diff does not add it."
+                        ),
+                    },
+                    {
+                        "index": 4,
+                        "evidence": (
+                            "AC #4 expects a `derived.enrichment_v2` table "
+                            "but the schema migration owning that work is "
+                            "sibling open issue #9999."
+                        ),
+                    },
+                ],
+                "summary": "ralph declined to SHIP — 2 ACs structurally infeasible.",
+            },
+        )
+
+        ok = d._run_ralph_phase("agent-ac-inf", 3010, worktree)
+
+        # Ralph short-circuits — summary must not be advanced to.
+        assert ok is False
+        # _write_failure was called with the right category + details.
+        d._write_failure.assert_called_once()  # type: ignore[union-attr]
+        call_kwargs = d._write_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert call_kwargs["agent_id"] == "agent-ac-inf"
+        assert call_kwargs["category"] == daemon.FAILURE_CATEGORY_RALPH_AC_INFEASIBLE
+        assert call_kwargs["detected_by"] == "ralph_output_parse"
+        details = call_kwargs["details"]
+        assert details["agent_id"] == "agent-ac-inf"
+        assert details["issue_number"] == 3010
+        assert len(details["infeasible_acs"]) == 2
+        assert details["infeasible_acs"][0]["index"] == 1
+        assert "rebuild_db" in details["infeasible_acs"][0]["evidence"]
+        assert details["infeasible_acs"][1]["index"] == 4
+        # Agent marked failed at the ralph phase.
+        d._mark_agent_terminal.assert_called_once()  # type: ignore[union-attr]
+        terminal_kwargs = d._mark_agent_terminal.call_args.kwargs  # type: ignore[union-attr]
+        assert terminal_kwargs["status"] == "failed"
+        assert terminal_kwargs["phase"] == "ralph"
+        assert terminal_kwargs["issue_number"] == 3010
+        # Observability — ralph_ac_infeasible event logged.
+        events = handler.events("ralph_ac_infeasible")
+        assert events
+        assert getattr(events[0], "infeasible_acs_count", None) == 2
+
+    def test_ship_verdict_still_advances_to_summary(self, tmp_path: Path) -> None:
+        """Regression guard — the AC_INFEASIBLE branch must not
+        short-circuit the SHIP path. A SHIP verdict advances to summary
+        exactly like today."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        _patch_ralph_helpers(
+            d,
+            ralph_output={
+                "verdict": "SHIP",
+                "iterations_used": 1,
+                "block_reason": None,
+                "changed_files": ["docs/example.md"],
+                "infeasible_acs": [],
+                "summary": "Implemented cleanly.",
+            },
+        )
+
+        ok = d._run_ralph_phase("agent-ship", 3010, worktree)
+
+        assert ok is True
+        # No failure row written, no terminal mark.
+        d._write_failure.assert_not_called()  # type: ignore[union-attr]
+        d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
+        # Ralph output stashed for summary phase.
+        assert d._agent_ralph_output is not None
+        assert d._agent_ralph_output.get("verdict") == "SHIP"
+
+    def test_blocked_verdict_does_not_write_ac_infeasible_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """BLOCKED is a different failure mode — not AC_INFEASIBLE.
+        Existing routing (tier-2/3 via subprocess classifier) owns it.
+        This test locks down that the AC_INFEASIBLE branch doesn't
+        accidentally swallow BLOCKED verdicts."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        _patch_ralph_helpers(
+            d,
+            ralph_output={
+                "verdict": "BLOCKED",
+                "iterations_used": 5,
+                "block_reason": "max_iterations reached without SHIP",
+                "changed_files": [],
+                "summary": "ralph hit max iterations.",
+            },
+        )
+
+        ok = d._run_ralph_phase("agent-blocked", 3010, worktree)
+
+        assert ok is False
+        # BLOCKED path does NOT write a ralph_ac_infeasible failure row.
+        d._write_failure.assert_not_called()  # type: ignore[union-attr]
+        # Agent still marked failed (the not-SHIP path).
+        d._mark_agent_terminal.assert_called_once()  # type: ignore[union-attr]
+
+    def test_malformed_infeasible_acs_list_is_sanitized(self, tmp_path: Path) -> None:
+        """Defensive parsing — a malformed `infeasible_acs` entry (e.g.
+        a plain string instead of a dict) is skipped so the downstream
+        failure row / diagnoser bundle always has a clean shape."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        _patch_ralph_helpers(
+            d,
+            ralph_output={
+                "verdict": "AC_INFEASIBLE",
+                "iterations_used": 1,
+                "block_reason": None,
+                "changed_files": [],
+                "infeasible_acs": [
+                    "a stray string, not a dict",  # malformed
+                    {"index": "not-an-int", "evidence": "bad index shape"},
+                    {"index": 2, "evidence": "genuine entry"},
+                ],
+                "summary": "mixed shape",
+            },
+        )
+
+        ok = d._run_ralph_phase("agent-mix", 3010, worktree)
+
+        assert ok is False
+        call_kwargs = d._write_failure.call_args.kwargs  # type: ignore[union-attr]
+        entries = call_kwargs["details"]["infeasible_acs"]
+        # Stray string dropped; "not-an-int" coerced to None; genuine
+        # entry preserved.
+        assert len(entries) == 2
+        assert entries[0]["index"] is None
+        assert entries[1]["index"] == 2
+        assert entries[1]["evidence"] == "genuine entry"
+
+    def test_build_diagnoser_context_bundles_infeasible_acs(
+        self, tmp_path: Path
+    ) -> None:
+        """Integration-ish test of the diagnoser context bundle for
+        ``ralph_ac_infeasible``. Exercises
+        :meth:`daemon.DispatcherDaemon._build_diagnoser_context` against
+        a candidate dict mirroring what the post-exit parse path
+        produces — the bundle must carry ``infeasible_acs`` +
+        ``issue_acceptance_criteria`` so the diagnoser skill can
+        correlate index → criterion text without a re-fetch.
+
+        This is the issue #3010 AC #6 "full ralph_ac_infeasible flow
+        through the DB" verification — rather than spinning up pg, we
+        drive :meth:`_build_diagnoser_context` (the function that
+        materializes the context JSONB) with a candidate that matches
+        what :meth:`_run_ralph_phase` writes via :meth:`_write_failure`.
+        End-to-end: ralph emits AC_INFEASIBLE → daemon writes failure
+        row with ``details.infeasible_acs`` → supervisor tick lifts the
+        candidate and calls _build_diagnoser_context → JSONB lands on
+        ``dispatcher.diagnoses.context`` → diagnoser skill reads it.
+        This test locks the middle two steps.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        # Stub DB-read helpers the real context builder uses so we don't
+        # need a live pg. The test verifies the bundle-assembly logic,
+        # not the DB plumbing (covered by test_daemon_phase3d.py).
+        conn.cursor_instance.fetch_queue = [
+            # agent row: (issue_number, worktree_path, pr_number)
+            (3010, "/tmp/wt", None),
+        ]
+        conn.cursor_instance.fetchall_queue = [
+            [],  # phase_transitions
+            [],  # prior_failures
+        ]
+        # Subprocess call for issue body — short-circuit to empty.
+        import subprocess as _sp
+
+        class _FakeResult:
+            returncode = 0
+            stdout = (
+                '{"title": "Test issue 3010", '
+                '"body": "## Acceptance criteria\\n'
+                "- [ ] First AC\\n"
+                "- [ ] Second AC\\n"
+                '- [ ] Third AC\\n"}'
+            )
+
+        original_run = _sp.run
+
+        def fake_run(*args: Any, **kwargs: Any) -> Any:
+            return _FakeResult()
+
+        _sp.run = fake_run  # type: ignore[assignment]
+
+        try:
+            candidate = {
+                "failure_id": 42,
+                "agent_id": "agent-test",
+                "category": daemon.FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
+                "tier": 3,
+                "issue_number": 3010,
+                "details": {
+                    "infeasible_acs": [
+                        {
+                            "index": 2,
+                            "evidence": (
+                                "AC #2 references a `--court` flag that "
+                                "does not exist on scripts/rebuild_db.py."
+                            ),
+                        }
+                    ],
+                    "agent_id": "agent-test",
+                    "issue_number": 3010,
+                },
+                "failure_ts": None,
+            }
+            bundle = d._build_diagnoser_context(candidate)
+        finally:
+            _sp.run = original_run  # type: ignore[assignment]
+
+        # Core envelope — same fields every diagnosis has.
+        assert bundle["agent_id"] == "agent-test"
+        assert bundle["failure_id"] == 42
+        assert bundle["failure_category"] == (
+            daemon.FAILURE_CATEGORY_RALPH_AC_INFEASIBLE
+        )
+        assert bundle["tier"] == 3
+        assert bundle["issue_number"] == 3010
+        # #3010-specific — infeasible_acs carried through.
+        assert "infeasible_acs" in bundle
+        assert len(bundle["infeasible_acs"]) == 1
+        assert bundle["infeasible_acs"][0]["index"] == 2
+        assert "rebuild_db" in bundle["infeasible_acs"][0]["evidence"]
+        # #3010-specific — issue_acceptance_criteria threaded through
+        # so the diagnoser can correlate index → criterion text.
+        assert "issue_acceptance_criteria" in bundle
+        assert bundle["issue_acceptance_criteria"] == [
+            "First AC",
+            "Second AC",
+            "Third AC",
+        ]
+        # Summary-specific fields are NOT present on the ralph path —
+        # keeps the bundle shape minimal for each category.
+        assert "ralph_diff" not in bundle
+        assert "summary_ac_mapping" not in bundle
+        assert "deferred_acs" not in bundle
+
+    def test_ac_infeasible_missing_list_still_writes_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """If verdict is AC_INFEASIBLE but the list is missing (skill
+        contract violation), the daemon still writes a failure row with
+        an empty ``infeasible_acs``. The diagnoser can escalate from
+        there; silently dropping the signal would be worse."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        _patch_ralph_helpers(
+            d,
+            ralph_output={
+                "verdict": "AC_INFEASIBLE",
+                "iterations_used": 3,
+                "block_reason": None,
+                "changed_files": [],
+                # no infeasible_acs key at all
+                "summary": "oops — skill forgot the list",
+            },
+        )
+
+        ok = d._run_ralph_phase("agent-empty", 3010, worktree)
+
+        assert ok is False
+        d._write_failure.assert_called_once()  # type: ignore[union-attr]
+        call_kwargs = d._write_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert call_kwargs["category"] == daemon.FAILURE_CATEGORY_RALPH_AC_INFEASIBLE
+        assert call_kwargs["details"]["infeasible_acs"] == []

--- a/scripts/dispatcher/tests/test_daemon_summary_ac_infeasible.py
+++ b/scripts/dispatcher/tests/test_daemon_summary_ac_infeasible.py
@@ -1,0 +1,491 @@
+"""Unit tests for summary-originated ``AC_INFEASIBLE`` verdict handling (#3010).
+
+Covers:
+
+* :meth:`daemon.DispatcherDaemon._run_summary_phase` writes a
+  ``dispatcher.failures(category='summary_ac_infeasible')`` row with
+  ``details`` containing ``infeasible_acs`` + ``deferred_acs`` +
+  ``ralph_diff`` + ``summary_ac_mapping`` + ``agent_id`` +
+  ``issue_number`` when summary's ``verdict == 'AC_INFEASIBLE'``.
+* push_and_pr is NOT advanced to (method returns False).
+* OK verdict + empty ``unmet_criteria`` still advances to push_and_pr
+  (regression guard so the AC_INFEASIBLE branch doesn't swallow the
+  happy path).
+* ``summary_ac_infeasible`` is in :data:`daemon.TIER_3_CATEGORIES`.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.summary_ac_infeasible.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+def _patch_summary_helpers(
+    d: daemon.DispatcherDaemon, *, summary_output: dict[str, Any]
+) -> None:
+    """Stub the helpers _run_summary_phase relies on so the test doesn't
+    need a real subprocess or issue-bundle fetch. The ralph-side output
+    stash (``_agent_ralph_output``) is set to a minimal SHIP dict so
+    the summary phase sees the expected predecessor state."""
+    d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+    d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+    d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+    d._read_phase_output = MagicMock(return_value=summary_output)  # type: ignore[method-assign]
+    d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+    d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
+    d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+    d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+    d._write_failure = MagicMock()  # type: ignore[method-assign]
+    # Pretend ralph shipped so the summary phase has the expected
+    # precursor state. The real summary_input build reads
+    # ``_agent_ralph_output.summary`` and ``changed_files`` from here.
+    d._agent_ralph_output = {
+        "verdict": "SHIP",
+        "summary": "ralph shipped something",
+        "changed_files": ["scripts/foo.py"],
+    }
+    d._agent_plan_output = {"acceptance_criteria": [], "scope_check": []}
+    # Issue bundle fetch — short-circuit.
+    d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
+        return_value={
+            "issue_number": 3010,
+            "issue_title": "Test issue",
+            "issue_body": "",
+            "issue_comments": [],
+            "issue_labels": [],
+            "blocked_by": [],
+            "parent_issue": None,
+        }
+    )
+
+
+# --------------------------------------------------------------------------
+# Tier-3 registration
+# --------------------------------------------------------------------------
+
+
+class TestTierRegistration:
+    def test_summary_ac_infeasible_is_tier_3(self) -> None:
+        """``summary_ac_infeasible`` diagnoses on first occurrence."""
+        assert daemon.FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE in daemon.TIER_3_CATEGORIES
+
+    def test_summary_ac_infeasible_not_in_auto_retry(self) -> None:
+        """Summary-AC-infeasible is NOT auto-retried — the diagnoser
+        must decide reissue vs. escalate vs. close."""
+        assert (
+            daemon.FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE
+            not in daemon.AUTO_RETRY_CATEGORIES
+        )
+
+
+# --------------------------------------------------------------------------
+# _run_summary_phase behavior on verdict=AC_INFEASIBLE
+# --------------------------------------------------------------------------
+
+
+class TestRunSummaryPhaseAcInfeasible:
+    def test_ac_infeasible_writes_failure_with_full_bundle(
+        self, tmp_path: Path
+    ) -> None:
+        """Summary's AC_INFEASIBLE writes a failure row whose details
+        carry the full diagnoser-context prelude: ``infeasible_acs``,
+        ``deferred_acs``, ``ralph_diff``, ``summary_ac_mapping``."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        _patch_summary_helpers(
+            d,
+            summary_output={
+                "verdict": "AC_INFEASIBLE",
+                "process_summary_md": "## Process Summary\n\n…",
+                "commit_message": "feat: wip",
+                "pr_title": "feat: wip",
+                "pr_body_md": "## Summary\n…",
+                "deferred_acs": [
+                    {
+                        "index": 5,
+                        "reason": "marker",
+                        "verify_instruction": "Verify: (post-deploy) query OS",
+                    }
+                ],
+                "infeasible_acs": [
+                    {
+                        "index": 3,
+                        "evidence": (
+                            "AC #3 requires a column `confidence_score` "
+                            "that does not exist on `derived.rulings`."
+                        ),
+                    }
+                ],
+                "unmet_criteria": [],
+                "ac_mapping": [
+                    {
+                        "index": 1,
+                        "criterion": "c1",
+                        "status": "met",
+                        "evidence": "path/to/file.py",
+                    },
+                    {
+                        "index": 3,
+                        "criterion": "c3",
+                        "status": "infeasible",
+                        "evidence": "confidence_score does not exist",
+                    },
+                    {
+                        "index": 5,
+                        "criterion": "c5",
+                        "status": "deferred",
+                        "evidence": "post-deploy marker",
+                    },
+                ],
+            },
+        )
+
+        ok = d._run_summary_phase("agent-sum-inf", 3010, worktree)
+
+        # Summary does not advance — _push_and_open_pr would have been
+        # called otherwise by the caller; _run_summary_phase returns
+        # False so the caller aborts.
+        assert ok is False
+        # Failure row written with the right category and full bundle.
+        d._write_failure.assert_called_once()  # type: ignore[union-attr]
+        call_kwargs = d._write_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert call_kwargs["agent_id"] == "agent-sum-inf"
+        assert call_kwargs["category"] == daemon.FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE
+        assert call_kwargs["detected_by"] == "summary_output_parse"
+        details = call_kwargs["details"]
+        assert details["agent_id"] == "agent-sum-inf"
+        assert details["issue_number"] == 3010
+        # The infeasible_acs list is present and normalized.
+        assert len(details["infeasible_acs"]) == 1
+        assert details["infeasible_acs"][0]["index"] == 3
+        assert "confidence_score" in details["infeasible_acs"][0]["evidence"]
+        # The deferred list is carried forward so the diagnoser can
+        # distinguish deferred vs infeasible.
+        assert len(details["deferred_acs"]) == 1
+        assert details["deferred_acs"][0]["index"] == 5
+        # ralph_diff is present (empty string because we stubbed
+        # subprocess; the key exists).
+        assert "ralph_diff" in details
+        # summary_ac_mapping preserves summary's per-AC classification.
+        assert len(details["summary_ac_mapping"]) == 3
+        # Agent marked failed at the summary phase.
+        d._mark_agent_terminal.assert_called_once()  # type: ignore[union-attr]
+        terminal_kwargs = d._mark_agent_terminal.call_args.kwargs  # type: ignore[union-attr]
+        assert terminal_kwargs["status"] == "failed"
+        assert terminal_kwargs["phase"] == "summary"
+        assert terminal_kwargs["issue_number"] == 3010
+        # Observability event.
+        events = handler.events("summary_ac_infeasible")
+        assert events
+        assert getattr(events[0], "infeasible_acs_count", None) == 1
+
+    def test_ok_verdict_still_advances_with_no_unmet(self, tmp_path: Path) -> None:
+        """Regression guard — the AC_INFEASIBLE branch must not
+        short-circuit the OK path."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        _patch_summary_helpers(
+            d,
+            summary_output={
+                "verdict": "OK",
+                "process_summary_md": "ok",
+                "commit_message": "feat: ship",
+                "pr_title": "feat: ship",
+                "pr_body_md": "summary",
+                "unmet_criteria": [],
+                "deferred_acs": [],
+                "infeasible_acs": [],
+            },
+        )
+
+        ok = d._run_summary_phase("agent-ok", 3010, worktree)
+
+        assert ok is True
+        d._write_failure.assert_not_called()  # type: ignore[union-attr]
+        d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
+        assert d._agent_summary_output is not None
+        assert str(d._agent_summary_output.get("verdict")).upper() == "OK"
+
+    def test_ok_with_unmet_takes_needs_review_path_not_ac_infeasible(
+        self, tmp_path: Path
+    ) -> None:
+        """Non-empty `unmet_criteria` continues to route to the draft-PR
+        needs_review flow (issue #2856) — it must NOT accidentally land
+        on the AC_INFEASIBLE path just because it's a failure mode
+        adjacent to it."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        _patch_summary_helpers(
+            d,
+            summary_output={
+                "verdict": "OK",
+                "process_summary_md": "ok",
+                "commit_message": "feat: ship",
+                "pr_title": "feat: ship",
+                "pr_body_md": "summary",
+                "unmet_criteria": ["shape-mismatch AC"],
+                "deferred_acs": [],
+                "infeasible_acs": [],
+            },
+        )
+
+        ok = d._run_summary_phase("agent-needs-review", 3010, worktree)
+
+        # OK path returns True and _push_and_open_pr runs elsewhere
+        # (the draft-PR flow).
+        assert ok is True
+        d._write_failure.assert_not_called()  # type: ignore[union-attr]
+        assert d._agent_unmet_criteria == ["shape-mismatch AC"]
+
+    def test_build_diagnoser_context_bundles_summary_extras(
+        self, tmp_path: Path
+    ) -> None:
+        """Issue #3010 AC #6 integration-style check — the
+        ``summary_ac_infeasible`` context bundle carries the
+        summary-specific extras: ``ralph_diff``, ``summary_ac_mapping``,
+        ``deferred_acs``, alongside the shared ``infeasible_acs`` +
+        ``issue_acceptance_criteria`` fields.
+
+        End-to-end: summary emits AC_INFEASIBLE → daemon writes a
+        ``summary_ac_infeasible`` failure row whose details carry the
+        full salvage context → supervisor tick lifts the candidate and
+        calls ``_build_diagnoser_context`` → JSONB lands on
+        ``dispatcher.diagnoses.context``. This test locks the middle
+        two steps.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [
+            # agent row: (issue_number, worktree_path, pr_number)
+            (3010, "/tmp/wt", None),
+        ]
+        conn.cursor_instance.fetchall_queue = [
+            [],  # phase_transitions
+            [],  # prior_failures
+        ]
+        import subprocess as _sp
+
+        class _FakeResult:
+            returncode = 0
+            stdout = (
+                '{"title": "Test issue 3010", '
+                '"body": "## Acceptance criteria\\n'
+                "- [ ] AC one\\n"
+                "- [ ] AC two\\n"
+                '- [ ] AC three (infeasible)\\n"}'
+            )
+
+        original_run = _sp.run
+        _sp.run = lambda *a, **kw: _FakeResult()  # type: ignore[assignment]
+
+        try:
+            candidate = {
+                "failure_id": 99,
+                "agent_id": "agent-sum",
+                "category": daemon.FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
+                "tier": 3,
+                "issue_number": 3010,
+                "details": {
+                    "infeasible_acs": [
+                        {
+                            "index": 3,
+                            "evidence": "AC #3 demands a non-existent column",
+                        }
+                    ],
+                    "deferred_acs": [
+                        {
+                            "index": 2,
+                            "reason": "marker",
+                            "verify_instruction": "Verify: (post-deploy) curl",
+                        }
+                    ],
+                    "ralph_diff": (
+                        "--- a/file.py\n+++ b/file.py\n@@ -1 +1 @@\n-old\n+new\n"
+                    ),
+                    "summary_ac_mapping": [
+                        {
+                            "index": 1,
+                            "criterion": "AC one",
+                            "status": "met",
+                            "evidence": "file.py::test_one",
+                        },
+                        {
+                            "index": 3,
+                            "criterion": "AC three",
+                            "status": "infeasible",
+                            "evidence": "non-existent column",
+                        },
+                    ],
+                    "agent_id": "agent-sum",
+                    "issue_number": 3010,
+                },
+                "failure_ts": None,
+            }
+            bundle = d._build_diagnoser_context(candidate)
+        finally:
+            _sp.run = original_run  # type: ignore[assignment]
+
+        # Shared core fields.
+        assert bundle["agent_id"] == "agent-sum"
+        assert bundle["failure_id"] == 99
+        assert bundle["failure_category"] == (
+            daemon.FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE
+        )
+        assert bundle["tier"] == 3
+        # Shared AC-infeasibility fields (same as ralph path).
+        assert "infeasible_acs" in bundle
+        assert bundle["infeasible_acs"][0]["index"] == 3
+        assert "issue_acceptance_criteria" in bundle
+        assert len(bundle["issue_acceptance_criteria"]) == 3
+        # Summary-specific extras — present only on this category.
+        assert "deferred_acs" in bundle
+        assert bundle["deferred_acs"][0]["index"] == 2
+        assert bundle["deferred_acs"][0]["reason"] == "marker"
+        assert "ralph_diff" in bundle
+        assert "old" in bundle["ralph_diff"]
+        assert "new" in bundle["ralph_diff"]
+        assert "summary_ac_mapping" in bundle
+        assert len(bundle["summary_ac_mapping"]) == 2
+        assert bundle["summary_ac_mapping"][1]["status"] == "infeasible"
+
+    def test_ac_infeasible_without_infeasible_acs_still_routes(
+        self, tmp_path: Path
+    ) -> None:
+        """Defensive — if summary emits verdict=AC_INFEASIBLE but the
+        list is empty/missing (skill contract violation), the daemon
+        still writes a failure row (empty list) so the diagnoser can
+        escalate. Silently dropping the verdict would be worse."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        _patch_summary_helpers(
+            d,
+            summary_output={
+                "verdict": "AC_INFEASIBLE",
+                "process_summary_md": "…",
+                "commit_message": "",
+                "pr_title": "",
+                "pr_body_md": "",
+                # no infeasible_acs key
+                "unmet_criteria": [],
+            },
+        )
+
+        ok = d._run_summary_phase("agent-empty", 3010, worktree)
+
+        assert ok is False
+        d._write_failure.assert_called_once()  # type: ignore[union-attr]
+        details = d._write_failure.call_args.kwargs["details"]  # type: ignore[union-attr]
+        assert details["infeasible_acs"] == []

--- a/scripts/dispatcher/tests/test_daemon_summary_deferred_acs.py
+++ b/scripts/dispatcher/tests/test_daemon_summary_deferred_acs.py
@@ -1,0 +1,413 @@
+"""Unit tests for summary-emitted ``deferred_acs`` persistence + verify threading (#3010).
+
+Covers:
+
+* :meth:`daemon.DispatcherDaemon._run_summary_phase` persists the whole
+  summary output (including ``deferred_acs``) via
+  :meth:`_persist_phase_output` when ``verdict == 'OK'`` and proceeds to
+  the downstream push_and_pr flow.
+* The verify input-bundle build threads ``deferred_acs`` through from
+  the persisted summary output, per the spec §6a `^verify-deferred-acs`
+  footnote — the verify skill reads this list and runs the deferred ACs
+  first post-deploy.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.summary_deferred_acs.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# _run_summary_phase — OK verdict persists full output incl. deferred_acs.
+# --------------------------------------------------------------------------
+
+
+class TestSummaryDeferredAcsPersisted:
+    def test_deferred_acs_persisted_alongside_summary_output(
+        self, tmp_path: Path
+    ) -> None:
+        """On verdict=OK, the whole summary output (including
+        ``deferred_acs``) is persisted to ``dispatcher.phase_outputs``.
+        The verify phase reads the same row later to pick up the list."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        summary_output = {
+            "verdict": "OK",
+            "process_summary_md": "…",
+            "commit_message": "feat: x",
+            "pr_title": "feat: x",
+            "pr_body_md": "…",
+            "unmet_criteria": [],
+            "deferred_acs": [
+                {
+                    "index": 5,
+                    "reason": "marker",
+                    "verify_instruction": (
+                        "Verify: (post-deploy) query OS count against dev"
+                    ),
+                },
+                {
+                    "index": 7,
+                    "reason": "heuristic",
+                    "verify_instruction": "Verify: curl dev.api.judgemind.org/foo",
+                },
+            ],
+            "infeasible_acs": [],
+        }
+
+        # Stub helpers.
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+        d._read_phase_output = MagicMock(return_value=summary_output)  # type: ignore[method-assign]
+        d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+        d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._write_failure = MagicMock()  # type: ignore[method-assign]
+        d._agent_ralph_output = {
+            "verdict": "SHIP",
+            "summary": "…",
+            "changed_files": ["scripts/foo.py"],
+        }
+        d._agent_plan_output = {"acceptance_criteria": [], "scope_check": []}
+        d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "issue_number": 3010,
+                "issue_title": "",
+                "issue_body": "",
+                "issue_comments": [],
+                "issue_labels": [],
+                "blocked_by": [],
+                "parent_issue": None,
+            }
+        )
+
+        ok = d._run_summary_phase("agent-def", 3010, worktree)
+
+        assert ok is True
+        # _persist_phase_output was called with summary_output that
+        # includes deferred_acs verbatim.
+        d._persist_phase_output.assert_called_once()  # type: ignore[union-attr]
+        persisted_call = d._persist_phase_output.call_args  # type: ignore[union-attr]
+        # _persist_phase_output positional args: (agent_id, phase, output_dict, ...)
+        persisted_args = persisted_call.args
+        assert persisted_args[0] == "agent-def"
+        assert persisted_args[1] == "summary"
+        persisted_output = persisted_args[2]
+        assert persisted_output["deferred_acs"] == summary_output["deferred_acs"]
+        # The normal push-and-pr branch is taken (no failure, no
+        # terminal, no AC_INFEASIBLE write).
+        d._write_failure.assert_not_called()  # type: ignore[union-attr]
+        d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
+
+    def test_ok_verdict_with_empty_deferred_acs_still_persisted(
+        self, tmp_path: Path
+    ) -> None:
+        """Empty deferred_acs is the common case (no post-deploy ACs).
+        The key still exists in the persisted output so verify can
+        read a stable shape."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        summary_output = {
+            "verdict": "OK",
+            "process_summary_md": "…",
+            "commit_message": "feat: x",
+            "pr_title": "feat: x",
+            "pr_body_md": "…",
+            "unmet_criteria": [],
+            "deferred_acs": [],
+            "infeasible_acs": [],
+        }
+
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+        d._read_phase_output = MagicMock(return_value=summary_output)  # type: ignore[method-assign]
+        d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+        d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._agent_ralph_output = {
+            "verdict": "SHIP",
+            "summary": "",
+            "changed_files": [],
+        }
+        d._agent_plan_output = {"acceptance_criteria": [], "scope_check": []}
+        d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "issue_number": 3010,
+                "issue_title": "",
+                "issue_body": "",
+                "issue_comments": [],
+                "issue_labels": [],
+                "blocked_by": [],
+                "parent_issue": None,
+            }
+        )
+
+        ok = d._run_summary_phase("agent-empty", 3010, worktree)
+
+        assert ok is True
+        persisted_args = d._persist_phase_output.call_args.args  # type: ignore[union-attr]
+        assert persisted_args[2]["deferred_acs"] == []
+
+
+# --------------------------------------------------------------------------
+# Verify input-bundle build — threads deferred_acs from persisted summary.
+# --------------------------------------------------------------------------
+
+
+class TestVerifyInputThreadsDeferredAcs:
+    """The verify input build reads ``deferred_acs`` from the persisted
+    summary output (via ``_fetch_phase_output``) and injects it into
+    ``verify.json`` so the verify skill can run those ACs first
+    post-deploy."""
+
+    def _make_agent(self) -> dict[str, Any]:
+        return {
+            "agent_id": "agent-verify",
+            "issue_number": 3010,
+            "pr_number": 4242,
+            "worktree_path": "/tmp/fake-worktree",
+        }
+
+    def test_verify_input_contains_deferred_acs_from_summary(
+        self, tmp_path: Path
+    ) -> None:
+        """When the summary output in ``dispatcher.phase_outputs``
+        carries a non-empty ``deferred_acs`` list, the verify input
+        bundle includes it verbatim."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        agent = self._make_agent()
+        agent["worktree_path"] = str(worktree)
+
+        deferred_acs_persisted = [
+            {
+                "index": 5,
+                "reason": "marker",
+                "verify_instruction": "Verify: (post-deploy) query OS count",
+            }
+        ]
+
+        # Stub helpers _spawn_verify_phase relies on.
+        d._read_verify_skip_reason = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "issue_number": 3010,
+                "issue_title": "Test",
+                "issue_body": "",
+                "issue_comments": [],
+                "issue_labels": [],
+                "blocked_by": [],
+                "parent_issue": None,
+            }
+        )
+        d._extract_acceptance_criteria = MagicMock(return_value=[])  # type: ignore[method-assign]
+        d._select_deploy_status = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "workflow_name": "deploy-api.yml",
+                "run_id": 1,
+                "conclusion": "success",
+                "duration_s": 120,
+            }
+        )
+        d._infer_change_type = MagicMock(return_value="api")  # type: ignore[method-assign]
+        d._touched_services_from_runs = MagicMock(  # type: ignore[method-assign]
+            return_value=["judgemind-api-dev"]
+        )
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "verdict": "OK",
+                "deferred_acs": deferred_acs_persisted,
+            }
+        )
+        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._run_subprocess_or_fail = MagicMock(return_value=None)  # type: ignore[method-assign]
+
+        # Contract: during verify-input assembly, the daemon calls
+        # ``_write_phase_input(worktree, "verify", {...})`` with a dict
+        # that includes the ``deferred_acs`` threaded from the summary
+        # output. The verify-spawn entry point is
+        # ``_run_verify_and_complete(agent, pr_status, merge_sha,
+        # deploy_runs)`` — see daemon.py.
+        d._run_verify_and_complete(
+            agent, pr_status={}, merge_sha="deadbee", deploy_runs=[]
+        )
+
+        # The write_phase_input call for phase="verify" must have
+        # included the deferred_acs threaded from the summary output.
+        verify_writes = [
+            call
+            for call in d._write_phase_input.call_args_list  # type: ignore[union-attr]
+            if len(call.args) >= 2 and call.args[1] == "verify"
+        ]
+        assert verify_writes, (
+            "verify input must be written via _write_phase_input(worktree, 'verify', ...)"
+        )
+        verify_input = verify_writes[0].args[2]
+        assert "deferred_acs" in verify_input
+        assert verify_input["deferred_acs"] == deferred_acs_persisted
+
+    def test_verify_input_no_deferred_acs_when_summary_absent(
+        self, tmp_path: Path
+    ) -> None:
+        """Backwards compatibility — on pre-#3010 agents the summary
+        row has no deferred_acs key. The verify input still includes
+        the ``deferred_acs`` field (empty list) so the verify skill's
+        input contract is stable across agent vintages."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        agent = self._make_agent()
+        agent["worktree_path"] = str(worktree)
+
+        d._read_verify_skip_reason = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "issue_number": 3010,
+                "issue_title": "",
+                "issue_body": "",
+                "issue_comments": [],
+                "issue_labels": [],
+                "blocked_by": [],
+                "parent_issue": None,
+            }
+        )
+        d._extract_acceptance_criteria = MagicMock(return_value=[])  # type: ignore[method-assign]
+        d._select_deploy_status = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._infer_change_type = MagicMock(return_value="docs")  # type: ignore[method-assign]
+        d._touched_services_from_runs = MagicMock(return_value=[])  # type: ignore[method-assign]
+        # Pre-#3010 row — no deferred_acs key.
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={"verdict": "OK"}
+        )
+        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._run_subprocess_or_fail = MagicMock(return_value=None)  # type: ignore[method-assign]
+
+        d._run_verify_and_complete(
+            agent, pr_status={}, merge_sha="deadbee", deploy_runs=[]
+        )
+
+        verify_writes = [
+            call
+            for call in d._write_phase_input.call_args_list  # type: ignore[union-attr]
+            if len(call.args) >= 2 and call.args[1] == "verify"
+        ]
+        assert verify_writes
+        verify_input = verify_writes[0].args[2]
+        assert verify_input.get("deferred_acs") == []

--- a/scripts/dispatcher/tests/test_skill_md_contracts.py
+++ b/scripts/dispatcher/tests/test_skill_md_contracts.py
@@ -8,6 +8,18 @@ These tests assert that:
   Claude-reviewer prompt (AC b.4).
 * ``iteration_feedback.py`` and ``## Iteration feedback`` appear in
   ``task-v2-ralph/SKILL.md`` Step 4 (AC a.1 grep half).
+* ``AC_INFEASIBLE`` verdict + ``infeasible_acs`` array are documented in
+  ``task-v2-ralph/SKILL.md`` (issue #3010).
+* ``AC_INFEASIBLE`` + positive triggers + negative guardrails appear in
+  ``ralph/SKILL.md`` (issue #3010).
+* ``deferred_acs``, ``infeasible_acs``, and classifier ordering appear in
+  ``task-v2-summary/SKILL.md`` (issue #3010).
+* ``deferred_acs`` + per-AC deferred labeling appear in
+  ``task-v2-verify/SKILL.md`` (issue #3010).
+* Per-category sections for ``ralph_ac_infeasible`` and
+  ``summary_ac_infeasible``, the default-action vocabulary, and the
+  wholesale-replace requirement for ``new_scope`` all appear in
+  ``diagnose-failure/SKILL.md`` (issue #3010).
 
 These are grep-style assertions against the literal SKILL.md text — they catch
 regressions where an edit removes or renames a required marker.
@@ -21,6 +33,15 @@ _REPO_ROOT = Path(__file__).resolve().parents[3]  # worktree root
 
 _TASK_V2_RALPH_SKILL = _REPO_ROOT / ".claude" / "skills" / "task-v2-ralph" / "SKILL.md"
 _RALPH_SKILL = _REPO_ROOT / ".claude" / "skills" / "ralph" / "SKILL.md"
+_TASK_V2_SUMMARY_SKILL = (
+    _REPO_ROOT / ".claude" / "skills" / "task-v2-summary" / "SKILL.md"
+)
+_TASK_V2_VERIFY_SKILL = (
+    _REPO_ROOT / ".claude" / "skills" / "task-v2-verify" / "SKILL.md"
+)
+_DIAGNOSE_FAILURE_SKILL = (
+    _REPO_ROOT / ".claude" / "skills" / "diagnose-failure" / "SKILL.md"
+)
 
 
 def _read(path: Path) -> str:
@@ -105,4 +126,228 @@ class TestRalphSkillContracts:
         content = _read(_RALPH_SKILL)
         assert "prior_attempts.md" in content, (
             "ralph/SKILL.md must reference prior_attempts.md so workers know where to look"
+        )
+
+
+# ------------------------------------------------------------------
+# Issue #3010 — AC_INFEASIBLE + deferred_acs contract coverage.
+# ------------------------------------------------------------------
+
+
+class TestTaskV2RalphAcInfeasibleContracts:
+    """task-v2-ralph/SKILL.md must document the AC_INFEASIBLE verdict
+    and ``infeasible_acs`` array shape (issue #3010 AC #1)."""
+
+    def test_ac_infeasible_verdict_documented(self) -> None:
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "AC_INFEASIBLE" in content, (
+            "task-v2-ralph/SKILL.md must document the AC_INFEASIBLE verdict "
+            "(issue #3010)"
+        )
+
+    def test_infeasible_acs_array_documented(self) -> None:
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "infeasible_acs" in content, (
+            "task-v2-ralph/SKILL.md must document the infeasible_acs array "
+            "(issue #3010)"
+        )
+        # The normative shape must mention ``index`` and ``evidence``.
+        assert "index" in content and "evidence" in content, (
+            "task-v2-ralph/SKILL.md infeasible_acs shape must name "
+            "index + evidence fields"
+        )
+
+    def test_ralph_ac_infeasible_failure_category_referenced(self) -> None:
+        """Output-contract prose must reference the daemon's
+        ``ralph_ac_infeasible`` failure category so the skill author
+        and the daemon author stay in sync on the routing."""
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "ralph_ac_infeasible" in content, (
+            "task-v2-ralph/SKILL.md must reference the ralph_ac_infeasible "
+            "failure category (issue #3010)"
+        )
+
+
+class TestRalphAcInfeasibleContracts:
+    """ralph/SKILL.md must describe positive triggers AND negative
+    guardrails for AC_INFEASIBLE (issue #3010 AC #2)."""
+
+    def test_ac_infeasible_emit_rules_section(self) -> None:
+        content = _read(_RALPH_SKILL)
+        assert "AC_INFEASIBLE emit rules" in content, (
+            'ralph/SKILL.md must have a §"AC_INFEASIBLE emit rules" section '
+            "(issue #3010)"
+        )
+
+    def test_positive_triggers_listed(self) -> None:
+        content = _read(_RALPH_SKILL)
+        # All three positive trigger kinds named in the scope section.
+        assert "Non-existent symbol" in content
+        assert "Self-contradiction" in content
+        assert "Out-of-scope dependency" in content
+
+    def test_negative_guardrails_listed(self) -> None:
+        """The guardrail rules must be explicit so the worker does not
+        raise AC_INFEASIBLE for legitimate failure modes."""
+        content = _read(_RALPH_SKILL)
+        # Exact phrases from the guardrail list — renaming is OK but
+        # the concept must remain locked into the spec.
+        assert "Hard to implement" in content, (
+            "ralph/SKILL.md must explicitly guard against 'Hard to implement' "
+            "as an AC_INFEASIBLE trigger"
+        )
+        assert "Max iterations exhausted" in content, (
+            "ralph/SKILL.md must explicitly guard against 'Max iterations "
+            "exhausted' as an AC_INFEASIBLE trigger (it is ralph_max_iterations)"
+        )
+
+    def test_worker_prompt_mentions_ac_infeasible(self) -> None:
+        content = _read(_RALPH_SKILL)
+        # The testable worker prompt must instruct workers about the emit
+        # path — look for the work-status.txt contract change.
+        assert "AC_INFEASIBLE" in content and "work-status.txt" in content, (
+            "ralph/SKILL.md worker prompt must instruct workers to write "
+            "AC_INFEASIBLE to work-status.txt"
+        )
+
+    def test_claude_reviewer_prompt_has_ac_infeasible_branch(self) -> None:
+        content = _read(_RALPH_SKILL)
+        reviewer_idx = content.find("Claude reviewer prompt")
+        assert reviewer_idx != -1
+        reviewer_section = content[reviewer_idx:]
+        # The reviewer's three-way decision now includes AC_INFEASIBLE.
+        assert "AC_INFEASIBLE" in reviewer_section, (
+            "ralph/SKILL.md Claude reviewer prompt must document the "
+            "AC_INFEASIBLE branch (issue #3010)"
+        )
+
+
+class TestTaskV2SummaryContracts:
+    """task-v2-summary/SKILL.md must document the extended output shape
+    (deferred_acs, infeasible_acs, unmet_criteria) and the classifier
+    order (deferred → validate → unmet → classify) per issue #3010."""
+
+    def test_deferred_acs_documented(self) -> None:
+        content = _read(_TASK_V2_SUMMARY_SKILL)
+        assert "deferred_acs" in content, (
+            "task-v2-summary/SKILL.md must document deferred_acs (issue #3010)"
+        )
+
+    def test_infeasible_acs_documented(self) -> None:
+        content = _read(_TASK_V2_SUMMARY_SKILL)
+        assert "infeasible_acs" in content, (
+            "task-v2-summary/SKILL.md must document infeasible_acs (issue #3010)"
+        )
+
+    def test_classifier_keyword_present(self) -> None:
+        content = _read(_TASK_V2_SUMMARY_SKILL)
+        assert "classifier" in content.lower(), (
+            "task-v2-summary/SKILL.md must describe the classifier (issue #3010)"
+        )
+
+    def test_classifier_order_deferred_first(self) -> None:
+        """The deferred check runs BEFORE the validate-against-diff check."""
+        content = _read(_TASK_V2_SUMMARY_SKILL)
+        # Verbatim section titles from the new classifier ordering.
+        assert "Deferred check (runs FIRST" in content, (
+            "task-v2-summary/SKILL.md classifier must put the deferred "
+            "check FIRST (issue #3010)"
+        )
+
+    def test_shape_mismatch_vs_structural_impossibility(self) -> None:
+        """Summary must distinguish shape-mismatch (needs_review) from
+        structural-impossibility (AC_INFEASIBLE)."""
+        content = _read(_TASK_V2_SUMMARY_SKILL)
+        assert "Shape mismatch" in content or "shape-mismatch" in content
+        assert (
+            "Structural impossibility" in content
+            or "structural impossibility" in content
+        )
+
+    def test_summary_ac_infeasible_failure_category_referenced(self) -> None:
+        content = _read(_TASK_V2_SUMMARY_SKILL)
+        assert "summary_ac_infeasible" in content, (
+            "task-v2-summary/SKILL.md must reference the "
+            "summary_ac_infeasible failure category (issue #3010)"
+        )
+
+    def test_verdict_field_documented(self) -> None:
+        """The output JSON's ``verdict`` field must be documented."""
+        content = _read(_TASK_V2_SUMMARY_SKILL)
+        # Match the output-JSON snippet literal.
+        assert '"verdict": "OK" | "AC_INFEASIBLE"' in content, (
+            "task-v2-summary/SKILL.md output contract must show "
+            "verdict: OK | AC_INFEASIBLE"
+        )
+
+
+class TestTaskV2VerifyContracts:
+    """task-v2-verify/SKILL.md must describe reading deferred_acs from
+    summary and labeling per-AC evidence as deferred vs pre-merge
+    (issue #3010)."""
+
+    def test_deferred_acs_input_documented(self) -> None:
+        content = _read(_TASK_V2_VERIFY_SKILL)
+        assert "deferred_acs" in content, (
+            "task-v2-verify/SKILL.md must document reading deferred_acs (issue #3010)"
+        )
+
+    def test_deferred_labeling_vocabulary(self) -> None:
+        """The evidence comment distinguishes deferred-marker from
+        deferred-heuristic from pre-merge-belt."""
+        content = _read(_TASK_V2_VERIFY_SKILL)
+        assert "deferred (marker)" in content, (
+            "task-v2-verify/SKILL.md must use the 'deferred (marker)' label"
+        )
+        assert "deferred (heuristic)" in content, (
+            "task-v2-verify/SKILL.md must use the 'deferred (heuristic)' label"
+        )
+        assert "pre-merge validated" in content, (
+            "task-v2-verify/SKILL.md must use the 'pre-merge validated' label "
+            "for non-deferred ACs re-confirmed post-deploy"
+        )
+
+
+class TestDiagnoseFailureContracts:
+    """diagnose-failure/SKILL.md must have per-category sections for
+    ralph_ac_infeasible and summary_ac_infeasible, plus the
+    wholesale-replace requirement for new_scope (issue #3010)."""
+
+    def test_ralph_ac_infeasible_section(self) -> None:
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        assert "ralph_ac_infeasible" in content, (
+            "diagnose-failure/SKILL.md must have a ralph_ac_infeasible "
+            "section (issue #3010)"
+        )
+
+    def test_summary_ac_infeasible_section(self) -> None:
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        assert "summary_ac_infeasible" in content, (
+            "diagnose-failure/SKILL.md must have a summary_ac_infeasible "
+            "section (issue #3010)"
+        )
+
+    def test_default_action_vocabulary(self) -> None:
+        """The three default actions must all appear in the
+        per-category guidance."""
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        for action in ("reissue", "escalate", "close"):
+            assert action in content, (
+                f"diagnose-failure/SKILL.md must name the '{action}' action "
+                "(issue #3010)"
+            )
+
+    def test_new_scope_wholesale_replace_requirement(self) -> None:
+        """``new_scope`` is always the complete rewritten issue body —
+        not a diff, not a patch, not a partial splice."""
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        # The SKILL.md uses "wholesale replace" or "complete rewritten
+        # issue body" (or both) — lock on either phrase.
+        assert (
+            "wholesale" in content.lower()
+            or "complete rewritten issue body" in content.lower()
+            or "complete, well-formed issue body" in content.lower()
+        ), (
+            "diagnose-failure/SKILL.md must document the wholesale-replace "
+            "requirement for new_scope (issue #3010)"
         )


### PR DESCRIPTION
## Summary

Closes three dispatcher pipeline reliability gaps in one PR:

1. **Ralph emits `AC_INFEASIBLE`** when one or more acceptance criteria are structurally impossible (non-existent symbol / self-contradiction / out-of-scope dependency). The daemon writes `dispatcher.failures(category='ralph_ac_infeasible')` and routes to the diagnoser — no mechanical retry, since a structurally wrong AC will hit the same wall on a second attempt.
2. **Summary also emits `AC_INFEASIBLE`** after ralph SHIPs, and the daemon writes `summary_ac_infeasible` with the full salvage bundle (`ralph_diff` + `summary_ac_mapping` + `deferred_acs`) so the diagnoser's `reissue` can align the rewritten issue body with what ralph already built.
3. **Summary defers post-deploy ACs to verify** via a new classifier order: deferred check FIRST (marker `(post-deploy)` is authoritative; heuristic against dev/prod-artifact tokens handles the pre-convention backlog), then validate against diff, then classify unmet as shape-mismatch (existing `needs_review` path) vs. structural-impossibility (`AC_INFEASIBLE`). `deferred_acs` is persisted alongside summary output and threaded into `verify.json`; `/task-v2-verify` runs those ACs first post-deploy and labels each result as `deferred (marker|heuristic) → pass|fail` vs. `pre-merge validated, re-confirmed post-deploy`.

Closes #3010

Spec refs: `docs/specs/dispatcher-v2-spec.md` §6, §6a, §8 — commits `b1fed729`, `f40e3a42`, `603e9b5c`.

## Scope boundaries (honored)

- Reuses the diagnoser; does NOT introduce a `replan` skill.
- Does NOT change `ralph_max_iterations` behavior — that stays a tier-1 retry category. AC_INFEASIBLE's negative guardrails explicitly exclude "max iterations exhausted" as a trigger.
- Does NOT over-tune inner ralph reviewer prompts — minimal three-way verdict addition only.
- Does NOT update authoring-guide docs (the `(post-deploy)` marker is supported; agent adoption is a parallel doc effort).
- Does NOT retrofit the backlog — heuristic handles pre-convention issues.
- `new_scope` is always the complete rewritten issue body — `diagnose-failure/SKILL.md` documents wholesale replace via `gh issue edit --body-file`, zero splicing or patching in Python.

## Test plan

### Automated checks
- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — full dispatcher suite 844 passed, 1 skipped; 30 contract assertions, 19 new daemon routing tests)
- [x] Markdown-link check clean
- [x] CI green

### Post-deploy verification

Dev verification per AC #8 in the issue body is post-deploy and will be run by `/task-v2-verify` once the deploy workflow lands:

- [ ] File a test issue whose AC references `--nonexistent-flag`; spawn a dispatcher agent; confirm `dispatcher.failures(category='ralph_ac_infeasible')` materializes with non-empty `infeasible_acs` in details; confirm `dispatcher.diagnoses` row populates with `infeasible_acs` + `issue_acceptance_criteria` in context; confirm the diagnoser's recommendation is executed (issue body rewrite on `reissue`, or `status/needs-human` label on `escalate`).
- [ ] File a test issue with an AC `Verify: (post-deploy) query OS index count`; observe summary's `deferred_acs` land in the `dispatcher.phase_outputs` row for that agent; confirm `verify.json` carries the same list; confirm the post-deploy evidence comment labels that AC as `deferred (marker) → pass|fail`.
- [ ] Verification evidence posted on #3010 (DB snapshots from `dispatcher.failures`, `dispatcher.diagnoses`, `dispatcher.phase_outputs` + rendered evidence comment on the test issue).

## Key files changed

- `.claude/skills/task-v2-ralph/SKILL.md` — AC_INFEASIBLE in output contract + Step 3 ralph-done mapping.
- `.claude/skills/ralph/SKILL.md` — new §"AC_INFEASIBLE emit rules" with positive triggers + negative guardrails; worker + Claude reviewer prompt branches.
- `.claude/skills/task-v2-summary/SKILL.md` — verdict field, deferred_acs/infeasible_acs/ac_mapping output, classifier order (2a deferred → 2b validate → 2c classify unmet).
- `.claude/skills/task-v2-verify/SKILL.md` — deferred_acs input, deferred-first execution, evidence labeling vocabulary.
- `.claude/skills/diagnose-failure/SKILL.md` — per-category guidance for ralph_ac_infeasible + summary_ac_infeasible; `new_scope` wholesale-replace requirement.
- `scripts/dispatcher/daemon.py` — two new tier-3 categories; `_run_ralph_phase` and `_run_summary_phase` detection branches; verify input threading; `_build_diagnoser_context` category-conditional extras.
- `scripts/dispatcher/tests/test_daemon_ralph_ac_infeasible.py` — 8 tests.
- `scripts/dispatcher/tests/test_daemon_summary_ac_infeasible.py` — 7 tests.
- `scripts/dispatcher/tests/test_daemon_summary_deferred_acs.py` — 4 tests.
- `scripts/dispatcher/tests/test_skill_md_contracts.py` — grew from 9 → 30 assertions.
- `scripts/dispatcher/tests/test_daemon_failure_summary.py` — `_CATEGORY_DISPLAY_NAMES` map-contents test extended with two new entries.
