### PR TITLE
feat(dispatcher): persist ralph SHIP patches in postgres (#3012)

### DIFF
--- a/.claude/skills/task-v2-ralph/SKILL.md
+++ b/.claude/skills/task-v2-ralph/SKILL.md
@@ -84,6 +84,8 @@ Read `{worktree}/tmp/dispatcher-input/ralph.json`. Required fields:
 
 If the file is missing or malformed, exit 0 with `verdict=BLOCKED, block_reason="input JSON missing or malformed"`.
 
+**Pre-applied prior SHIP'd patch (#3012).** The daemon may have `git am`-applied a prior SHIP'd patch onto your fresh worktree before invoking you, when a previous agent on this issue ran ralph to SHIP but the daemon never reached `gh pr create` (restart, push timeout, crash). If applied cleanly, HEAD already carries the prior agent's `WIP: ralph output` commit — iterate on top of the inherited diff (`git diff origin/main...HEAD`) rather than re-implementing from scratch. If `git am` failed (base drift, conflicts), HEAD is clean origin/main and the patch text appears in `prior_attempts.md` under a `## Prior SHIP'd patch (did NOT apply cleanly)` section so the worker can cherry-pick manually. Transparent from the skill's perspective — no new input field; the worktree and `prior_attempts.md` arrive pre-populated.
+
 ---
 
 ## Output contract

--- a/packages/api/migrations/38_dispatcher-ralph-patches.sql
+++ b/packages/api/migrations/38_dispatcher-ralph-patches.sql
@@ -1,0 +1,102 @@
+-- Up Migration
+--
+-- Dispatcher v2 — persist ralph SHIP'd patches in postgres to survive
+-- daemon restart during the push-and-pr window (#3012).
+--
+-- Motivation
+-- ----------
+-- Today, ralph's SHIP'd diff lives only in the worktree until the
+-- daemon's ``_push_and_open_pr`` successfully runs ``gh pr create``.
+-- Between ralph SHIP exit and a successful ``gh pr create`` the diff is
+-- ephemeral:
+--
+--   1. The branch is on ralph's worktree but NOT on origin yet.
+--   2. A daemon restart (deploy, crash, operator kill) triggers a
+--      worktree sweep (``_create_worktree`` re-uses a clean base for
+--      the next attempt), which wipes the diff.
+--   3. The next claim starts fresh and re-runs ralph from scratch,
+--      burning the prior hour-plus of work.
+--
+-- Concrete cost observed 2026-04-21: #2564 agent c3a69458 shipped after
+-- 1h 48m of ralph, hit ``git_push_timeout`` at 15:17, and the deploy of
+-- PR #2999 killed the daemon minutes later. Four subsequent attempts
+-- re-ralph'd the same task, eating hours of cycle time. See #3012 for
+-- the incident narrative and fix design.
+--
+-- The fix
+-- -------
+-- Persist ralph's SHIP'd diff in postgres for the narrow window between
+-- ralph SHIP exit and successful ``gh pr create``. Once the PR exists,
+-- the branch is durably on origin and the postgres copy is redundant —
+-- delete it. Patch lifetime is typically 5-15 min in the happy path;
+-- failures extend up to the stuck-timeout budget. 7-day TTL catches
+-- pathological cases (daemon crash between SHIP and PR create, operator
+-- force-stop).
+--
+-- Design notes
+-- ------------
+-- - Dedicated table (not a new column on ``phase_outputs.log_text``).
+--   ``phase_outputs.log_text`` holds the phase narrative; mixing raw
+--   patches into it blurs two separate concerns (observability narrative
+--   vs. recoverable artifact) and complicates the ``DELETE on PR create``
+--   semantics. A separate table lets the delete target one row by
+--   ``agent_id`` without risking the phase log rows the admin page reads.
+-- - ``patch_content TEXT`` — git format-patch output is ASCII plus the
+--   file diff bytes. PostgreSQL's TOAST + pglz compression applies
+--   automatically for rows over ~2kB. No explicit compression setting
+--   needed.
+-- - ``commit_sha`` is nullable — the daemon writes it when available from
+--   ``git rev-parse HEAD`` but a patch apply failure during the read path
+--   doesn't need the SHA to know the patch is gone.
+-- - Two indexes:
+--     * ``issue_number`` — the read path queries "does a prior SHIP'd
+--       patch exist for this issue?" on every ``_create_worktree``.
+--     * ``created_at`` — the housekeeping sweep prunes rows older than
+--       7 days. A btree on ``created_at`` supports the range scan.
+-- - Nullable ``patch_id`` FK on ``phase_outputs`` — the ralph SHIP row is
+--   the only row that ever gets populated; every other phase row stays
+--   NULL. ``ON DELETE SET NULL`` so the ralph phase_outputs row survives
+--   the patch cleanup (the admin log view and metering aggregates still
+--   work). Rows for non-SHIP ralph exits (AC_INFEASIBLE, max-iterations,
+--   crashes) never get a patch_id.
+-- - No dedicated retention config key — 7 days is a safety-net window,
+--   not an operator-tunable observability knob. The existing retention
+--   config keys (``phase_output_retention_days``, etc.) all describe
+--   telemetry retention; patches are ephemeral recovery state. If
+--   operators ever need to tune this, a ``ralph_patch_retention_days``
+--   config key can be added later without a migration.
+
+CREATE TABLE dispatcher.ralph_patches (
+    patch_id       UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id       UUID        NOT NULL REFERENCES dispatcher.agents(agent_id),
+    issue_number   INT         NOT NULL,
+    patch_content  TEXT        NOT NULL,
+    commit_sha     TEXT,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX ralph_patches_issue_idx
+    ON dispatcher.ralph_patches (issue_number);
+
+CREATE INDEX ralph_patches_created_at_idx
+    ON dispatcher.ralph_patches (created_at);
+
+COMMENT ON TABLE dispatcher.ralph_patches IS
+    'Patches from ralph SHIP exits, persisted for the narrow window between SHIP and a successful gh pr create. Issue #3012.';
+
+COMMENT ON COLUMN dispatcher.ralph_patches.patch_content IS
+    'git format-patch -1 HEAD --stdout output. Applied with git am when a retry inherits the prior SHIP.';
+
+COMMENT ON COLUMN dispatcher.ralph_patches.commit_sha IS
+    'ralph''s HEAD SHA at SHIP time. Nullable — written when git rev-parse succeeds; informational only (the patch is the authoritative artifact).';
+
+ALTER TABLE dispatcher.phase_outputs
+    ADD COLUMN patch_id UUID REFERENCES dispatcher.ralph_patches(patch_id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN dispatcher.phase_outputs.patch_id IS
+    'FK to dispatcher.ralph_patches when this is the ralph SHIP row; NULL for every other phase and for ralph non-SHIP exits. ON DELETE SET NULL so phase_outputs survives patch cleanup. Issue #3012.';
+
+
+-- Down Migration
+ALTER TABLE dispatcher.phase_outputs DROP COLUMN IF EXISTS patch_id;
+DROP TABLE IF EXISTS dispatcher.ralph_patches;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 33 migrations.
+-- Generated from 38 migrations.
 
 
 
@@ -80,8 +80,6 @@ CREATE TYPE public.validation_status AS ENUM (
 );
 
 
--- Name: issue_cooldown_remaining_seconds(integer, integer); Type: FUNCTION; Schema: dispatcher; Owner: -
-
 CREATE FUNCTION dispatcher.issue_cooldown_remaining_seconds(p_issue_number integer, p_cooldown_seconds integer) RETURNS integer
     LANGUAGE sql STABLE
     AS $$
@@ -94,12 +92,8 @@ CREATE FUNCTION dispatcher.issue_cooldown_remaining_seconds(p_issue_number integ
 $$;
 
 
--- Name: FUNCTION issue_cooldown_remaining_seconds(p_issue_number integer, p_cooldown_seconds integer); Type: COMMENT; Schema: dispatcher; Owner: -
-
 COMMENT ON FUNCTION dispatcher.issue_cooldown_remaining_seconds(p_issue_number integer, p_cooldown_seconds integer) IS 'Returns the seconds remaining in the cooldown window keyed on MAX(started_at) for any prior agent row for this issue. NULL when there is no prior row (never attempted). 0 when cooldown has elapsed (GREATEST keeps it non-negative). Issue #3001.';
 
-
--- Name: issue_has_active_agent(integer); Type: FUNCTION; Schema: dispatcher; Owner: -
 
 CREATE FUNCTION dispatcher.issue_has_active_agent(p_issue_number integer) RETURNS boolean
     LANGUAGE sql STABLE
@@ -112,8 +106,6 @@ CREATE FUNCTION dispatcher.issue_has_active_agent(p_issue_number integer) RETURN
     );
 $$;
 
-
--- Name: FUNCTION issue_has_active_agent(p_issue_number integer); Type: COMMENT; Schema: dispatcher; Owner: -
 
 COMMENT ON FUNCTION dispatcher.issue_has_active_agent(p_issue_number integer) IS 'Returns TRUE when dispatcher.agents has any row for this issue with status IN (''running'', ''retrying'', ''succeeded'', ''needs_review''). Mirrors ACTIVE_AGENT_STATUSES in scripts/dispatcher/daemon.py:354. Issue #3001.';
 
@@ -542,7 +534,8 @@ CREATE TABLE dispatcher.phase_outputs (
     tokens_cache_read bigint,
     tokens_cache_write bigint,
     cost_usd numeric(10,4),
-    model_used text
+    model_used text,
+    patch_id uuid
 );
 
 
@@ -568,6 +561,9 @@ COMMENT ON COLUMN dispatcher.phase_outputs.cost_usd IS 'Claude Code''s list-pric
 
 
 COMMENT ON COLUMN dispatcher.phase_outputs.model_used IS 'The resolved Claude model the phase ran on (e.g. ``"sonnet"``, ``"claude-sonnet-4-5"``). Free-form text — adding a new model never requires a migration. Nullable. Issue #2869.';
+
+
+COMMENT ON COLUMN dispatcher.phase_outputs.patch_id IS 'FK to dispatcher.ralph_patches when this is the ralph SHIP row; NULL for every other phase and for ralph non-SHIP exits. ON DELETE SET NULL so phase_outputs survives patch cleanup. Issue #3012.';
 
 
 CREATE SEQUENCE dispatcher.phase_outputs_output_id_seq
@@ -624,6 +620,25 @@ COMMENT ON COLUMN dispatcher.queue_snapshots.run_id IS 'Owning daemon run. Snaps
 
 
 COMMENT ON COLUMN dispatcher.queue_snapshots.issues_json IS 'Enriched issue metadata as observed at scan time: [{number, title, labels: [string], createdAt}, ...]. Populated by the daemon from the ``gh issue list --json number,title,labels,createdAt`` response. Source of truth for the /admin/dispatcher queue-ready panel (issue #2820). Kept in lock-step with ``issue_numbers`` — the two columns MUST describe the same issues in the same order.';
+
+
+CREATE TABLE dispatcher.ralph_patches (
+    patch_id uuid DEFAULT gen_random_uuid() NOT NULL,
+    agent_id uuid NOT NULL,
+    issue_number integer NOT NULL,
+    patch_content text NOT NULL,
+    commit_sha text,
+    created_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+COMMENT ON TABLE dispatcher.ralph_patches IS 'Patches from ralph SHIP exits, persisted for the narrow window between SHIP and a successful gh pr create. Issue #3012.';
+
+
+COMMENT ON COLUMN dispatcher.ralph_patches.patch_content IS 'git format-patch -1 HEAD --stdout output. Applied with git am when a retry inherits the prior SHIP.';
+
+
+COMMENT ON COLUMN dispatcher.ralph_patches.commit_sha IS 'ralph''s HEAD SHA at SHIP time. Nullable — written when git rev-parse succeeds; informational only (the patch is the authoritative artifact).';
 
 
 CREATE TABLE dispatcher.retry_markers (
@@ -1003,6 +1018,10 @@ ALTER TABLE ONLY dispatcher.queue_snapshots
     ADD CONSTRAINT queue_snapshots_pkey PRIMARY KEY (snapshot_id);
 
 
+ALTER TABLE ONLY dispatcher.ralph_patches
+    ADD CONSTRAINT ralph_patches_pkey PRIMARY KEY (patch_id);
+
+
 ALTER TABLE ONLY dispatcher.retry_markers
     ADD CONSTRAINT retry_markers_pkey PRIMARY KEY (marker_id);
 
@@ -1223,6 +1242,12 @@ CREATE INDEX idx_dispatcher_retry_markers_pending ON dispatcher.retry_markers US
 CREATE INDEX idx_dispatcher_terminal_outcomes_ended_at ON dispatcher.terminal_outcomes USING btree (ended_at DESC);
 
 
+CREATE INDEX ralph_patches_created_at_idx ON dispatcher.ralph_patches USING btree (created_at);
+
+
+CREATE INDEX ralph_patches_issue_idx ON dispatcher.ralph_patches USING btree (issue_number);
+
+
 CREATE INDEX idx_alert_events_sub_id ON public.alert_events USING btree (subscription_id);
 
 
@@ -1383,12 +1408,20 @@ ALTER TABLE ONLY dispatcher.phase_outputs
     ADD CONSTRAINT phase_outputs_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES dispatcher.agents(agent_id);
 
 
+ALTER TABLE ONLY dispatcher.phase_outputs
+    ADD CONSTRAINT phase_outputs_patch_id_fkey FOREIGN KEY (patch_id) REFERENCES dispatcher.ralph_patches(patch_id) ON DELETE SET NULL;
+
+
 ALTER TABLE ONLY dispatcher.phase_transitions
     ADD CONSTRAINT phase_transitions_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES dispatcher.agents(agent_id);
 
 
 ALTER TABLE ONLY dispatcher.queue_snapshots
     ADD CONSTRAINT queue_snapshots_run_id_fkey FOREIGN KEY (run_id) REFERENCES dispatcher.runs(run_id) ON DELETE CASCADE;
+
+
+ALTER TABLE ONLY dispatcher.ralph_patches
+    ADD CONSTRAINT ralph_patches_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES dispatcher.agents(agent_id);
 
 
 ALTER TABLE ONLY dispatcher.retry_markers

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -124,6 +124,16 @@ DEFAULT_PHASE_OUTPUT_RETENTION_DAYS = 30
 #: ``notification_retention_days`` row in ``dispatcher.config``. Issue #2779.
 DEFAULT_NOTIFICATION_RETENTION_DAYS = 30
 
+#: Default retention window for ``dispatcher.ralph_patches``. Safety-net
+#: only — the happy-path cleanup is the ``DELETE`` at ``gh pr create``
+#: success in :meth:`_push_and_open_pr`. Seven days catches pathological
+#: cases (daemon crash between SHIP and PR create, operator force-stop)
+#: without keeping large patch blobs indefinitely. Not operator-tunable
+#: today — if that changes, add a ``ralph_patch_retention_days`` row in
+#: ``dispatcher.config`` and thread it through ``_read_retention_days``
+#: the same way the other targets do. Issue #3012.
+DEFAULT_RALPH_PATCH_RETENTION_DAYS = 7
+
 #: Default repo the daemon watches. Overridden by the ``GITHUB_REPO``
 #: env var, wired in the terraform module.
 DEFAULT_GITHUB_REPO = "judgemind/judgemind"
@@ -4424,6 +4434,461 @@ class DispatcherDaemon:
         except (TypeError, ValueError):  # pragma: no cover — defensive
             return 0
 
+    # ── ralph patch persistence (issue #3012) ──────────────────────────
+    #
+    # Persist ralph's SHIP'd diff to ``dispatcher.ralph_patches`` so a
+    # daemon restart between SHIP and a successful ``gh pr create`` does
+    # not lose the work. Three helpers:
+    #
+    #   - :meth:`_capture_and_persist_ralph_patch` runs after
+    #     ``verdict=SHIP`` in :meth:`_run_ralph_phase`. It captures the
+    #     patch with ``git format-patch -1 HEAD --stdout``, DELETEs any
+    #     prior row for the same ``issue_number`` (supersede semantics),
+    #     INSERTs the fresh row, and UPDATEs the matching ralph
+    #     ``phase_outputs`` row's ``patch_id`` FK.
+    #   - :meth:`_delete_ralph_patches_for_agent` runs after ``gh pr
+    #     create`` succeeds in :meth:`_push_and_open_pr`. Once the
+    #     branch is on origin, the postgres copy is redundant.
+    #   - :meth:`_apply_prior_ralph_patch` runs at the top of
+    #     :meth:`_run_ralph_phase` BEFORE ralph spawns. If a prior SHIP
+    #     for the same issue exists in ``ralph_patches``, it tries to
+    #     ``git am`` the patch onto the fresh worktree. On apply success,
+    #     ralph iterates on top of the inherited diff. On apply failure,
+    #     it aborts cleanly (``git am --abort``) and records the patch
+    #     text so ralph can see it in ``prior_attempts.md``.
+    #
+    # All three are best-effort by design — a DB error does not fail the
+    # agent, it just logs and falls through to the pre-#3012 behavior.
+    # The feature is a latency/cost optimization layered on top of the
+    # existing pipeline; it must not be able to wedge the pipeline.
+
+    def _capture_and_persist_ralph_patch(
+        self,
+        agent_id: str,
+        issue_number: int,
+        worktree: Path,
+    ) -> str | None:
+        """Capture ralph's SHIP'd diff, persist to postgres, return patch_id.
+
+        Runs at the end of :meth:`_run_ralph_phase` on ``verdict=SHIP``.
+        The commit model after #2971 is "ralph commits directly, daemon
+        amends" — so at SHIP time HEAD carries ralph's placeholder
+        commit (``WIP: ralph output``) and the diff is trapped in that
+        one commit. ``git format-patch -1 HEAD --stdout`` dumps the
+        full patch (including the ``--- a/path`` / ``+++ b/path``
+        hunks ``git am`` needs to replay).
+
+        Supersedes any prior row for the same ``issue_number`` — covers
+        the retry-after-failure case where a prior agent SHIPped but
+        never got its PR created (c3a69458 @ 2026-04-21).
+
+        On success, also UPDATEs the matching ``phase_outputs`` row's
+        ``patch_id`` FK so the admin page and diagnoser can correlate
+        the ralph SHIP row to its persisted patch.
+
+        Returns the new ``patch_id`` on success, ``None`` on any
+        failure (empty patch, git error, DB error). All failures are
+        logged but non-fatal — the happy path continues in
+        :meth:`_push_and_open_pr` regardless.
+        """
+        assert self._conn is not None, "connect() must run before persist"
+
+        # Capture the patch via git format-patch -1 HEAD --stdout.
+        # A 60s timeout is generous — format-patch is local-only and
+        # typically finishes in <1s even on large worktrees.
+        try:
+            patch_result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(worktree),
+                    "format-patch",
+                    "-1",
+                    "HEAD",
+                    "--stdout",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except Exception as exc:
+            self._log.warning(
+                "daemon.ralph_patch_capture_failed",
+                extra={
+                    "event": "ralph_patch_capture_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "detail": str(exc),
+                },
+            )
+            return None
+        if patch_result.returncode != 0 or not (patch_result.stdout or "").strip():
+            # Empty or failed patch → nothing to persist. Empty is
+            # legitimately possible if ralph's "SHIP" commit has no
+            # tracked changes (shouldn't happen per the #2971 contract,
+            # but don't blow up on it).
+            self._log.info(
+                "daemon.ralph_patch_empty_or_failed",
+                extra={
+                    "event": "ralph_patch_empty_or_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "exit_code": patch_result.returncode,
+                    "stderr_tail": _stderr_tail(patch_result.stderr),
+                },
+            )
+            return None
+        patch_content = patch_result.stdout
+
+        # Best-effort HEAD SHA — informational only, NULL on failure.
+        commit_sha: str | None = None
+        try:
+            sha_result = subprocess.run(
+                ["git", "-C", str(worktree), "rev-parse", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if sha_result.returncode == 0:
+                candidate = (sha_result.stdout or "").strip()
+                if candidate:
+                    commit_sha = candidate
+        except Exception:  # pragma: no cover — defensive
+            pass
+
+        # Supersede + INSERT + UPDATE phase_outputs.patch_id in a single
+        # transaction so observers never see a mid-state (stale row
+        # deleted but new row not yet inserted). ``cur.fetchone()``
+        # after the INSERT retrieves the generated ``patch_id``; we
+        # bind that to both the phase_outputs UPDATE and the return
+        # value.
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM dispatcher.ralph_patches WHERE issue_number = %s",
+                    (issue_number,),
+                )
+                cur.execute(
+                    "INSERT INTO dispatcher.ralph_patches "
+                    "    (agent_id, issue_number, patch_content, commit_sha) "
+                    "VALUES (%s, %s, %s, %s) "
+                    "RETURNING patch_id",
+                    (agent_id, issue_number, patch_content, commit_sha),
+                )
+                row = cur.fetchone()
+                patch_id = str(row[0]) if row and row[0] else None
+                if patch_id is not None:
+                    cur.execute(
+                        "UPDATE dispatcher.phase_outputs "
+                        "SET patch_id = %s "
+                        "WHERE agent_id = %s AND phase = 'ralph'",
+                        (patch_id, agent_id),
+                    )
+            self._conn.commit()
+        except Exception as exc:
+            self._log.exception(
+                "daemon.ralph_patch_persist_failed",
+                extra={
+                    "event": "ralph_patch_persist_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "detail": str(exc),
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return None
+
+        self._log.info(
+            "daemon.ralph_patch_persisted",
+            extra={
+                "event": "ralph_patch_persisted",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "patch_id": patch_id,
+                "commit_sha": commit_sha,
+                "patch_bytes": len(patch_content),
+            },
+        )
+        return patch_id
+
+    def _delete_ralph_patches_for_agent(self, agent_id: str) -> int:
+        """DELETE this agent's ``ralph_patches`` row after ``gh pr create``.
+
+        Runs at the end of :meth:`_push_and_open_pr` on a successful PR
+        open. Once the branch is on origin and the PR exists, the
+        postgres copy is redundant — origin/<branch> is the durable
+        source. Targeting by ``agent_id`` (rather than ``issue_number``)
+        ensures a racing second claim on the same issue won't clobber
+        a newer agent's patch: the row we just wrote carries this
+        agent's id.
+
+        Returns the row count deleted. A value of 0 is fine — it just
+        means we're on the fallback path (patch capture earlier failed,
+        no row to clean up). A DB error logs + rolls back; the PR is
+        already open so we don't block the happy path on cleanup.
+        """
+        assert self._conn is not None, "connect() must run before delete"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM dispatcher.ralph_patches WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                deleted = cur.rowcount or 0
+            self._conn.commit()
+        except Exception as exc:
+            self._log.exception(
+                "daemon.ralph_patch_delete_failed",
+                extra={
+                    "event": "ralph_patch_delete_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "detail": str(exc),
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return 0
+
+        self._log.info(
+            "daemon.ralph_patch_deleted",
+            extra={
+                "event": "ralph_patch_deleted",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "rows_deleted": deleted,
+            },
+        )
+        return deleted
+
+    def _apply_prior_ralph_patch(
+        self,
+        agent_id: str,
+        issue_number: int,
+        worktree: Path,
+    ) -> dict[str, Any] | None:
+        """Apply a prior SHIP'd patch to the fresh worktree, if one exists.
+
+        Called at the top of :meth:`_run_ralph_phase` before ralph is
+        spawned. If a prior agent on this issue SHIPped but never got a
+        PR created, the patch is sitting in ``dispatcher.ralph_patches``
+        from :meth:`_capture_and_persist_ralph_patch`. This helper:
+
+        1. Queries the latest ``ralph_patches`` row for ``issue_number``.
+        2. If none exists → returns ``None`` (no-op first-attempt path).
+        3. If one exists, writes the patch to
+           ``{worktree}/tmp/dispatcher-input/prior-ralph.patch`` and
+           tries ``git am <patchfile>``.
+        4. On apply success → returns
+           ``{"applied": True, "patch_id": ..., "commit_sha": ..., "bytes": ...}``.
+           Ralph starts with the prior diff already on HEAD and iterates
+           on top.
+        5. On apply failure → runs ``git am --abort`` to restore the
+           clean worktree state, then returns
+           ``{"applied": False, "patch_id": ..., "patch_content": ..., "reason": ...}``
+           so the caller can surface the patch text to ralph via
+           ``prior_attempts.md``.
+
+        A DB lookup failure returns ``None`` — same effect as "no prior
+        patch" — so a transient postgres hiccup never wedges the agent.
+        """
+        assert self._conn is not None, "connect() must run before query"
+
+        # Query the latest patch for this issue (ORDER BY created_at
+        # DESC so if somehow two rows exist, we pick the newest).
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT patch_id, patch_content, commit_sha, agent_id "
+                    "FROM dispatcher.ralph_patches "
+                    "WHERE issue_number = %s "
+                    "ORDER BY created_at DESC LIMIT 1",
+                    (issue_number,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception as exc:
+            self._log.exception(
+                "daemon.ralph_patch_query_failed",
+                extra={
+                    "event": "ralph_patch_query_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "detail": str(exc),
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return None
+
+        if row is None:
+            return None
+
+        prior_patch_id = str(row[0])
+        patch_content = row[1] or ""
+        prior_commit_sha = row[2] or None
+        prior_agent_id = str(row[3]) if row[3] is not None else None
+        if not patch_content.strip():
+            # Defensive — NOT NULL constraint guarantees non-null, but
+            # the content could be an empty-ish blob from a pathological
+            # capture. Treat as "no usable patch".
+            return None
+
+        # Guard: don't try to inherit from *this same* agent. That
+        # shouldn't happen in normal flow (prior SHIP rows belong to a
+        # previous agent id), but tier-1 retry paths re-use agent_id,
+        # and re-applying a patch to a worktree that's already at the
+        # same commit just produces "patch does not apply" noise.
+        if prior_agent_id == agent_id:
+            self._log.info(
+                "daemon.ralph_patch_self_inherit_skipped",
+                extra={
+                    "event": "ralph_patch_self_inherit_skipped",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "patch_id": prior_patch_id,
+                },
+            )
+            return None
+
+        # Write patch to a scratch file under {worktree}/tmp/.
+        input_dir = worktree / "tmp" / "dispatcher-input"
+        input_dir.mkdir(parents=True, exist_ok=True)
+        patch_file = input_dir / "prior-ralph.patch"
+        try:
+            patch_file.write_text(patch_content, encoding="utf-8")
+        except OSError as exc:
+            self._log.warning(
+                "daemon.ralph_patch_write_failed",
+                extra={
+                    "event": "ralph_patch_write_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "detail": str(exc),
+                },
+            )
+            return None
+
+        # Try ``git am <patchfile>``.  --3way gives a better chance of
+        # success when base has moved; without it, any drift produces
+        # an apply failure even for non-overlapping hunks. Keeping
+        # semantics the issue specified, but --3way is the gentler
+        # form that doesn't hurt when base matches.
+        try:
+            am_result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(worktree),
+                    "am",
+                    "--3way",
+                    str(patch_file),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except Exception as exc:
+            self._log.warning(
+                "daemon.ralph_patch_am_invocation_failed",
+                extra={
+                    "event": "ralph_patch_am_invocation_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "patch_id": prior_patch_id,
+                    "detail": str(exc),
+                },
+            )
+            # Best-effort abort in case am started but we lost the
+            # process — ignore errors since there may be no in-progress
+            # am to abort.
+            self._git_am_abort(worktree)
+            return {
+                "applied": False,
+                "patch_id": prior_patch_id,
+                "patch_content": patch_content,
+                "reason": f"am invocation failed: {exc}",
+            }
+
+        if am_result.returncode == 0:
+            self._log.info(
+                "daemon.ralph_patch_applied",
+                extra={
+                    "event": "ralph_patch_applied",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "patch_id": prior_patch_id,
+                    "prior_commit_sha": prior_commit_sha,
+                    "patch_bytes": len(patch_content),
+                },
+            )
+            return {
+                "applied": True,
+                "patch_id": prior_patch_id,
+                "commit_sha": prior_commit_sha,
+                "bytes": len(patch_content),
+            }
+
+        # Apply failed — abort cleanly so the worktree is back to
+        # origin/main HEAD before ralph spawns.
+        reason = _stderr_tail(am_result.stderr) or f"exit={am_result.returncode}"
+        self._git_am_abort(worktree)
+        self._log.warning(
+            "daemon.ralph_patch_apply_failed",
+            extra={
+                "event": "ralph_patch_apply_failed",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "patch_id": prior_patch_id,
+                "exit_code": am_result.returncode,
+                "stderr_tail": reason,
+            },
+        )
+        return {
+            "applied": False,
+            "patch_id": prior_patch_id,
+            "patch_content": patch_content,
+            "reason": reason,
+        }
+
+    def _git_am_abort(self, worktree: Path) -> None:
+        """Best-effort ``git am --abort`` to restore a clean worktree.
+
+        Ignores exit codes — the abort is itself allowed to fail
+        (e.g. if there's no in-progress am), and we've already logged
+        the underlying apply failure.
+        """
+        try:
+            subprocess.run(
+                ["git", "-C", str(worktree), "am", "--abort"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except Exception:  # pragma: no cover — defensive
+            pass
+
     def _update_agent_phase(self, agent_id: str, phase: str) -> None:
         """UPDATE ``dispatcher.agents.phase`` so the scheduler + admin
         page see where the agent currently sits."""
@@ -6829,6 +7294,63 @@ class DispatcherDaemon:
         (output_dir / "prior_attempts.md").write_text(content, encoding="utf-8")
         return len(attempts)
 
+    def _append_unapplied_patch_to_prior_attempts(
+        self,
+        worktree: Path,
+        patch_info: dict[str, Any],
+    ) -> None:
+        """Append an unapplied prior SHIP'd patch to ``prior_attempts.md``.
+
+        Called from :meth:`_run_ralph_phase` when
+        :meth:`_apply_prior_ralph_patch` returned ``{"applied": False}``.
+        The patch couldn't be ``git am``'d onto the fresh worktree
+        (base drift, conflicts, corrupt patch), but the patch text is
+        still useful — ralph can see the *intended* diff and
+        cherry-pick or re-derive manually.
+
+        Appends (creates if missing) to
+        ``{worktree}/tmp/dispatcher-output/prior_attempts.md`` so the
+        ralph skill's existing prior-attempts surfacing picks it up
+        verbatim. Best-effort — a write failure just means ralph misses
+        the patch context, which is the pre-#3012 status quo.
+        """
+        output_dir = worktree / "tmp" / "dispatcher-output"
+        try:
+            output_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            return
+
+        target = output_dir / "prior_attempts.md"
+        patch_content = patch_info.get("patch_content") or ""
+        patch_id = patch_info.get("patch_id") or "unknown"
+        reason = patch_info.get("reason") or "unknown"
+
+        section = (
+            f"\n\n---\n\n## Prior SHIP'd patch (did NOT apply cleanly)\n\n"
+            f"**Patch id:** {patch_id}\n\n"
+            f"**Apply failure reason:** {reason}\n\n"
+            f"A previous agent SHIP'd this issue but the daemon did not reach "
+            f"``gh pr create`` (crash, deploy, timeout). The patch below was "
+            f"their final diff. ``git am`` could not replay it onto the fresh "
+            f"worktree (base drift, conflicts, etc.), so you are starting from "
+            f"clean origin/main — but you can cherry-pick / re-derive the "
+            f"relevant hunks manually from this text.\n\n"
+            f"```diff\n{patch_content}\n```\n"
+        )
+
+        try:
+            if target.exists():
+                existing = target.read_text(encoding="utf-8")
+                target.write_text(existing + section, encoding="utf-8")
+            else:
+                # No prior_attempts.md yet — write a standalone file
+                # with just the patch section. Strip the leading
+                # newlines + separator so the first-section case looks
+                # clean.
+                target.write_text(section.lstrip("\n-").lstrip(), encoding="utf-8")
+        except OSError:  # pragma: no cover — defensive
+            return
+
     def _run_plan_phase(self, agent_id: str, issue_number: int, worktree: Path) -> bool:
         """Run ``/task-v2-plan``. Returns True to continue, False to stop."""
         self._update_agent_phase(agent_id, "planning")
@@ -6988,12 +7510,36 @@ class DispatcherDaemon:
         """Run ``/task-v2-ralph``. Returns True to continue, False to stop."""
         self._update_agent_phase(agent_id, "ralph")
 
+        # ── Prior-SHIP'd patch inheritance (#3012) ─────────────────────────
+        # If a prior agent on this issue SHIPped but never got a PR
+        # created (daemon restart between ralph exit and ``gh pr
+        # create``), the patch is sitting in ``dispatcher.ralph_patches``.
+        # Try to apply it to the fresh worktree so ralph iterates on top
+        # of the inherited diff rather than re-ralph'ing from scratch.
+        #
+        # ``prior_patch_info`` shape:
+        #   None                              — no prior patch (first attempt)
+        #   {"applied": True, ...}            — patch applied; HEAD has the diff
+        #   {"applied": False, "patch_content": ..., "reason": ...}
+        #                                     — apply failed; patch text is
+        #                                       included so _materialize_prior_attempts
+        #                                       can surface it to ralph
+        prior_patch_info = self._apply_prior_ralph_patch(
+            agent_id, issue_number, worktree
+        )
+        # ── end prior-SHIP'd patch inheritance ─────────────────────────────
+
         # ── Prior-attempt context (#2984) ──────────────────────────────────
         # Before seeding the ralph input bundle, materialize prior failed
         # attempts (non-infra-preempted) into prior_attempts.md so the
         # /task-v2-ralph skill can surface them to fresh workers.  The call
         # is a no-op (returns 0, writes no file) on first-attempt spawns.
         prior_attempts_count = self._materialize_prior_attempts(worktree, issue_number)
+        # If a prior SHIP'd patch failed to apply cleanly, append its
+        # text to prior_attempts.md so ralph can see the intended diff
+        # and cherry-pick / re-derive manually.
+        if prior_patch_info is not None and not prior_patch_info.get("applied"):
+            self._append_unapplied_patch_to_prior_attempts(worktree, prior_patch_info)
         self._log.info(
             "daemon.ralph_spawn",
             extra={
@@ -7002,6 +7548,12 @@ class DispatcherDaemon:
                 "agent_id": agent_id,
                 "issue_number": issue_number,
                 "prior_attempts_count": prior_attempts_count,
+                "prior_patch_applied": (
+                    bool(prior_patch_info and prior_patch_info.get("applied"))
+                ),
+                "prior_patch_id": (
+                    prior_patch_info.get("patch_id") if prior_patch_info else None
+                ),
             },
         )
         # ── end prior-attempt context ──────────────────────────────────────
@@ -7140,6 +7692,16 @@ class DispatcherDaemon:
                 issue_number=issue_number,
             )
             return False
+
+        # ── SHIP'd — persist the patch (#3012) ─────────────────────────────
+        # Capture ralph's SHIP'd diff to ``dispatcher.ralph_patches`` so a
+        # daemon restart between here and a successful ``gh pr create``
+        # does not lose the work. Supersedes any prior row for the same
+        # issue (covers retry-after-failure). Returns None on capture /
+        # DB failure; that's non-fatal — the happy path continues and
+        # pre-#3012 behavior resumes (loss on daemon restart).
+        self._capture_and_persist_ralph_patch(agent_id, issue_number, worktree)
+        # ── end SHIP patch persist ─────────────────────────────────────────
 
         self._agent_ralph_output = ralph_output
         return True
@@ -8147,6 +8709,17 @@ class DispatcherDaemon:
                 "is_draft": is_needs_review,
             },
         )
+
+        # ── Cleanup persisted ralph patch (#3012) ──────────────────────────
+        # The branch is now on origin and the PR exists — origin/<branch>
+        # is the durable source and the postgres copy is redundant.
+        # DELETE by agent_id so a racing second claim on the same issue
+        # doesn't clobber a newer agent's patch (rows keyed by the
+        # specific agent that wrote them). Best-effort — the PR is open,
+        # so a delete failure just means the housekeeping sweep will
+        # catch it within 7 days.
+        self._delete_ralph_patches_for_agent(agent_id)
+        # ── end cleanup ────────────────────────────────────────────────────
 
         if is_needs_review:
             # #2856: side-effect — post an issue comment linking the
@@ -13810,6 +14383,17 @@ class DispatcherDaemon:
             "created_at",
             "notification_retention_days",
             DEFAULT_NOTIFICATION_RETENTION_DAYS,
+        ),
+        (
+            # Safety-net only — happy-path cleanup is the DELETE inside
+            # ``_push_and_open_pr`` after a successful ``gh pr create``.
+            # The 7-day TTL catches pathological cases (daemon crash
+            # between SHIP and PR create, operator force-stop) without
+            # keeping large patch blobs indefinitely. Issue #3012.
+            "ralph_patches",
+            "created_at",
+            "ralph_patch_retention_days",
+            DEFAULT_RALPH_PATCH_RETENTION_DAYS,
         ),
     )
 

--- a/scripts/dispatcher/tests/test_daemon_housekeeping.py
+++ b/scripts/dispatcher/tests/test_daemon_housekeeping.py
@@ -664,6 +664,7 @@ class TestHousekeepingTickAllLiveTargets:
             "blocked_snapshots",
             "phase_outputs",
             "notifications",
+            "ralph_patches",
         }
 
         # One DELETE per live target, and each uses the right column.
@@ -678,12 +679,14 @@ class TestHousekeepingTickAllLiveTargets:
             "blocked_snapshots",
             "phase_outputs",
             "notifications",
+            "ralph_patches",
         }
         # Per-target column assertions — matches the migration schema.
         assert "observed_at <" in deletes_by_table["queue_snapshots"][0]
         assert "observed_at <" in deletes_by_table["blocked_snapshots"][0]
         assert "ts <" in deletes_by_table["phase_outputs"][0]
         assert "created_at <" in deletes_by_table["notifications"][0]
+        assert "created_at <" in deletes_by_table["ralph_patches"][0]
 
     def test_per_target_failure_isolation_across_live_targets(
         self, monkeypatch: pytest.MonkeyPatch

--- a/scripts/dispatcher/tests/test_daemon_ralph_patches.py
+++ b/scripts/dispatcher/tests/test_daemon_ralph_patches.py
@@ -1,0 +1,899 @@
+"""Unit tests for ralph SHIP'd-patch persistence (issue #3012).
+
+Covers the three daemon-side helpers introduced to persist ralph's
+SHIP'd diff to ``dispatcher.ralph_patches`` so a daemon restart between
+ralph SHIP exit and a successful ``gh pr create`` does not lose the work:
+
+* :meth:`DispatcherDaemon._capture_and_persist_ralph_patch` — on SHIP,
+  runs ``git format-patch -1 HEAD --stdout``, supersedes any prior row
+  for the same ``issue_number``, INSERTs the fresh row, and UPDATEs the
+  matching ralph ``phase_outputs.patch_id`` FK.
+* :meth:`DispatcherDaemon._delete_ralph_patches_for_agent` — on a
+  successful ``gh pr create``, DELETEs the patch by ``agent_id``.
+* :meth:`DispatcherDaemon._apply_prior_ralph_patch` — at the top of the
+  ralph phase, queries the latest ``ralph_patches`` row for the issue
+  and attempts ``git am``. On success, HEAD carries the inherited diff.
+  On failure, ``git am --abort`` restores a clean worktree and the
+  patch text is returned for surfacing in ``prior_attempts.md``.
+
+The housekeeping 7-day sweep is covered by the new entry added to
+``_HOUSEKEEPING_TARGETS`` + the whole-tuple assertions in
+``test_daemon_housekeeping.py``; the specific-target test below pins
+the column + config key.
+
+All DB interaction is against the same ``_FakeCursor`` /
+``_FakeConnection`` stubs used elsewhere; no real Postgres required.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Provide a stub ``psycopg`` module before importing the daemon, matching
+# the pattern used across the sibling tests.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        pass
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — same shape as test_daemon_push_failed.py / test_daemon_housekeeping.py
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.ralph_patches.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# _capture_and_persist_ralph_patch
+# --------------------------------------------------------------------------
+
+
+class TestCaptureAndPersistRalphPatch:
+    """AC #2 — on SHIP exit, supersede + INSERT + UPDATE sequence fires."""
+
+    def test_insert_delete_update_sequence_on_ship(self, tmp_path: Path) -> None:
+        """Happy path: format-patch succeeds, DB INSERT+DELETE+UPDATE
+        all run, and the returned patch_id is threaded back correctly.
+
+        The pivotal assertion is that the DELETE-prior-rows query runs
+        BEFORE the INSERT so a retry-after-failure scenario cleanly
+        supersedes the stale row rather than accumulating rows per
+        attempt.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        agent_id = "11111111-2222-3333-4444-555555555555"
+
+        # Fake patch bytes + SHA.
+        patch_bytes = (
+            "From abc1234 Mon Sep 17 00:00:00 2001\n"
+            "Subject: [PATCH] WIP: ralph output\n"
+            "---\n"
+            " src/foo.py | 2 +-\n"
+            " 1 file changed, 1 insertion(+), 1 deletion(-)\n"
+        )
+        format_patch_ok = subprocess.CompletedProcess(
+            args=["git", "format-patch"], returncode=0, stdout=patch_bytes, stderr=""
+        )
+        rev_parse_ok = subprocess.CompletedProcess(
+            args=["git", "rev-parse"],
+            returncode=0,
+            stdout="deadbeefcafe1234\n",
+            stderr="",
+        )
+
+        # INSERT returns a patch_id row. The cursor's fetch_queue feeds
+        # the RETURNING on the INSERT.
+        conn.cursor_instance.fetch_queue = [("generated-patch-uuid",)]
+
+        with patch("subprocess.run", side_effect=[format_patch_ok, rev_parse_ok]):
+            result = d._capture_and_persist_ralph_patch(
+                agent_id=agent_id, issue_number=3012, worktree=worktree
+            )
+
+        assert result == "generated-patch-uuid"
+
+        # DELETE prior rows must precede INSERT.
+        executed = conn.cursor_instance.executed
+        sql_only = [sql for sql, _params in executed]
+        delete_idx = next(
+            i
+            for i, sql in enumerate(sql_only)
+            if "DELETE FROM dispatcher.ralph_patches" in sql
+            and "WHERE issue_number" in sql
+        )
+        insert_idx = next(
+            i
+            for i, sql in enumerate(sql_only)
+            if "INSERT INTO dispatcher.ralph_patches" in sql
+        )
+        update_idx = next(
+            i
+            for i, sql in enumerate(sql_only)
+            if "UPDATE dispatcher.phase_outputs" in sql and "SET patch_id" in sql
+        )
+        assert delete_idx < insert_idx < update_idx, (
+            f"Expected DELETE({delete_idx}) < INSERT({insert_idx}) < UPDATE({update_idx}); "
+            f"executed SQL order: {sql_only}"
+        )
+
+        # DELETE is parameterised by issue_number.
+        assert executed[delete_idx][1] == (3012,)
+        # INSERT params: (agent_id, issue_number, patch_content, commit_sha)
+        insert_params = executed[insert_idx][1]
+        assert insert_params[0] == agent_id
+        assert insert_params[1] == 3012
+        assert insert_params[2] == patch_bytes
+        assert insert_params[3] == "deadbeefcafe1234"
+        # UPDATE params: (patch_id, agent_id)
+        update_params = executed[update_idx][1]
+        assert update_params[0] == "generated-patch-uuid"
+        assert update_params[1] == agent_id
+        # UPDATE targets only the ralph phase row.
+        assert "phase = 'ralph'" in executed[update_idx][0]
+
+        # Transaction committed.
+        assert conn.commits >= 1
+
+    def test_empty_patch_logged_and_returns_none(self, tmp_path: Path) -> None:
+        """format-patch returned empty stdout → no DB write; no patch_id."""
+        d, conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        empty_patch = subprocess.CompletedProcess(
+            args=["git", "format-patch"], returncode=0, stdout="", stderr=""
+        )
+        with patch("subprocess.run", side_effect=[empty_patch]):
+            result = d._capture_and_persist_ralph_patch(
+                agent_id="aaaa-bbbb", issue_number=42, worktree=worktree
+            )
+
+        assert result is None
+        # No DB writes to ralph_patches.
+        assert not any(
+            "dispatcher.ralph_patches" in sql
+            for sql, _p in conn.cursor_instance.executed
+        )
+        # Diagnostic event emitted.
+        assert handler.events("ralph_patch_empty_or_failed")
+
+    def test_format_patch_failure_returns_none(self, tmp_path: Path) -> None:
+        """format-patch non-zero exit → no DB write; warning logged."""
+        d, conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        fail = subprocess.CompletedProcess(
+            args=["git", "format-patch"],
+            returncode=128,
+            stdout="",
+            stderr="fatal: not a git repo",
+        )
+        with patch("subprocess.run", side_effect=[fail]):
+            result = d._capture_and_persist_ralph_patch(
+                agent_id="aaaa-bbbb", issue_number=42, worktree=worktree
+            )
+
+        assert result is None
+        assert not any(
+            "dispatcher.ralph_patches" in sql
+            for sql, _p in conn.cursor_instance.executed
+        )
+        assert handler.events("ralph_patch_empty_or_failed")
+
+    def test_db_error_rolls_back_and_returns_none(self, tmp_path: Path) -> None:
+        """A DB error during the INSERT transaction rolls back; no patch_id."""
+        d, conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        format_patch_ok = subprocess.CompletedProcess(
+            args=["git", "format-patch"],
+            returncode=0,
+            stdout="From abc Mon...\n--- patch body ---\n",
+            stderr="",
+        )
+        rev_parse_ok = subprocess.CompletedProcess(
+            args=["git", "rev-parse"], returncode=0, stdout="sha\n", stderr=""
+        )
+        original_execute = conn.cursor_instance.execute
+
+        def failing_execute(sql: str, params: Any = None) -> None:
+            original_execute(sql, params)
+            if "INSERT INTO dispatcher.ralph_patches" in sql:
+                raise RuntimeError("connection broken mid-insert")
+
+        conn.cursor_instance.execute = failing_execute  # type: ignore[method-assign]
+
+        with patch("subprocess.run", side_effect=[format_patch_ok, rev_parse_ok]):
+            result = d._capture_and_persist_ralph_patch(
+                agent_id="aaa", issue_number=7, worktree=worktree
+            )
+
+        assert result is None
+        assert conn.rollbacks >= 1
+        assert handler.events("ralph_patch_persist_failed")
+
+    def test_commit_sha_none_still_inserts(self, tmp_path: Path) -> None:
+        """rev-parse failure → commit_sha=NULL; INSERT still runs."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        format_patch_ok = subprocess.CompletedProcess(
+            args=["git", "format-patch"],
+            returncode=0,
+            stdout="From abc Mon...\n",
+            stderr="",
+        )
+        rev_parse_fail = subprocess.CompletedProcess(
+            args=["git", "rev-parse"],
+            returncode=128,
+            stdout="",
+            stderr="fatal: not a git repo",
+        )
+        conn.cursor_instance.fetch_queue = [("uuid-1",)]
+
+        with patch("subprocess.run", side_effect=[format_patch_ok, rev_parse_fail]):
+            result = d._capture_and_persist_ralph_patch(
+                agent_id="ag1", issue_number=100, worktree=worktree
+            )
+
+        assert result == "uuid-1"
+        insert = next(
+            (sql, p)
+            for sql, p in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.ralph_patches" in sql
+        )
+        # commit_sha (4th param) is None on rev-parse failure.
+        assert insert[1][3] is None
+
+
+# --------------------------------------------------------------------------
+# _delete_ralph_patches_for_agent
+# --------------------------------------------------------------------------
+
+
+class TestDeleteRalphPatchesForAgent:
+    """AC #3 — on ``gh pr create`` success, DELETE by agent_id."""
+
+    def test_delete_fires_with_agent_id(self, tmp_path: Path) -> None:
+        """DELETE targets the specific agent row, not issue_number."""
+        d, conn, handler = _make_daemon(tmp_path)
+        agent_id = "deadbeef-0000-1111-2222-333333333333"
+        conn.cursor_instance.rowcount = 1
+
+        deleted = d._delete_ralph_patches_for_agent(agent_id)
+
+        assert deleted == 1
+        deletes = [
+            (sql, p)
+            for sql, p in conn.cursor_instance.executed
+            if "DELETE FROM dispatcher.ralph_patches" in sql
+        ]
+        assert len(deletes) == 1
+        sql, params = deletes[0]
+        assert "WHERE agent_id = %s" in sql
+        assert params == (agent_id,)
+        assert handler.events("ralph_patch_deleted")
+
+    def test_delete_zero_rows_is_fine(self, tmp_path: Path) -> None:
+        """No prior capture → delete returns 0; no warning."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.rowcount = 0
+
+        assert d._delete_ralph_patches_for_agent("agent-xyz") == 0
+
+    def test_db_error_rolls_back_returns_zero(self, tmp_path: Path) -> None:
+        """DB error during DELETE rolls back, logs, returns 0."""
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def boom(sql: str, params: Any = None) -> None:
+            raise RuntimeError("deadlock")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+
+        assert d._delete_ralph_patches_for_agent("agent-1") == 0
+        assert conn.rollbacks >= 1
+        assert handler.events("ralph_patch_delete_failed")
+
+
+# --------------------------------------------------------------------------
+# _apply_prior_ralph_patch
+# --------------------------------------------------------------------------
+
+
+class TestApplyPriorRalphPatch:
+    """AC #4 — at claim, check for prior patch and apply via git am."""
+
+    def test_returns_none_when_no_prior_patch(self, tmp_path: Path) -> None:
+        """First-attempt path: query returns no row → None, no git call."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        # fetchone → None (no row).
+        conn.cursor_instance.fetch_queue = [None]
+
+        with patch("subprocess.run") as run_mock:
+            result = d._apply_prior_ralph_patch(
+                agent_id="new-agent",
+                issue_number=9999,
+                worktree=worktree,
+            )
+
+        assert result is None
+        # No git am call when there's no prior patch.
+        assert run_mock.call_count == 0
+
+    def test_apply_clean_returns_applied_true(self, tmp_path: Path) -> None:
+        """git am success → returns {applied: True, patch_id, ...}
+        and the patch file is staged in the worktree."""
+        d, conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        patch_content = (
+            "From abc1234 Mon Sep 17 00:00:00 2001\n"
+            "Subject: [PATCH] WIP: ralph output\n"
+            "---\n"
+        )
+        # Row shape: (patch_id, patch_content, commit_sha, agent_id)
+        conn.cursor_instance.fetch_queue = [
+            ("prior-patch-uuid", patch_content, "prior-sha-abc", "prior-agent-uuid"),
+        ]
+
+        am_ok = subprocess.CompletedProcess(
+            args=["git", "am"], returncode=0, stdout="Applying: WIP\n", stderr=""
+        )
+
+        with patch("subprocess.run", side_effect=[am_ok]):
+            result = d._apply_prior_ralph_patch(
+                agent_id="new-agent-uuid",
+                issue_number=3012,
+                worktree=worktree,
+            )
+
+        assert result == {
+            "applied": True,
+            "patch_id": "prior-patch-uuid",
+            "commit_sha": "prior-sha-abc",
+            "bytes": len(patch_content),
+        }
+        # The patch file is written into tmp/dispatcher-input/.
+        patch_file = worktree / "tmp" / "dispatcher-input" / "prior-ralph.patch"
+        assert patch_file.exists()
+        assert patch_file.read_text() == patch_content
+        # Success event emitted.
+        assert handler.events("ralph_patch_applied")
+
+    def test_apply_conflicts_aborts_and_returns_applied_false(
+        self, tmp_path: Path
+    ) -> None:
+        """git am failure → runs ``git am --abort``, returns
+        {applied: False, patch_content: ..., reason: ...}."""
+        d, conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        patch_content = "From abc...\npatch body with conflicts\n"
+        conn.cursor_instance.fetch_queue = [
+            ("prior-patch-uuid", patch_content, None, "prior-agent"),
+        ]
+
+        am_fail = subprocess.CompletedProcess(
+            args=["git", "am"],
+            returncode=128,
+            stdout="",
+            stderr="error: patch failed: src/foo.py:1\nerror: patch does not apply",
+        )
+        am_abort_ok = subprocess.CompletedProcess(
+            args=["git", "am", "--abort"], returncode=0, stdout="", stderr=""
+        )
+
+        with patch("subprocess.run", side_effect=[am_fail, am_abort_ok]) as run_mock:
+            result = d._apply_prior_ralph_patch(
+                agent_id="new-agent",
+                issue_number=3012,
+                worktree=worktree,
+            )
+
+        assert result is not None
+        assert result["applied"] is False
+        assert result["patch_id"] == "prior-patch-uuid"
+        assert result["patch_content"] == patch_content
+        assert "patch does not apply" in result["reason"]
+
+        # git am --abort was called exactly once after the failed am.
+        abort_calls = [
+            call
+            for call in run_mock.call_args_list
+            if len(call.args[0]) >= 5 and call.args[0][3:5] == ["am", "--abort"]
+        ]
+        assert len(abort_calls) == 1
+        # Warning log emitted.
+        assert handler.events("ralph_patch_apply_failed")
+
+    def test_self_inherit_skipped(self, tmp_path: Path) -> None:
+        """If the prior row's agent_id equals the current agent's,
+        skip — same agent re-running the same phase should not
+        re-apply its own patch to an already-at-HEAD worktree."""
+        d, conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        same_agent_id = "same-agent-uuid"
+        conn.cursor_instance.fetch_queue = [
+            ("prior-patch-uuid", "patch body", None, same_agent_id),
+        ]
+
+        with patch("subprocess.run") as run_mock:
+            result = d._apply_prior_ralph_patch(
+                agent_id=same_agent_id,
+                issue_number=123,
+                worktree=worktree,
+            )
+
+        assert result is None
+        assert run_mock.call_count == 0
+        assert handler.events("ralph_patch_self_inherit_skipped")
+
+    def test_db_query_failure_returns_none(self, tmp_path: Path) -> None:
+        """A DB error on the SELECT is non-fatal — returns None
+        (as if there's no prior patch) so the agent continues normally."""
+        d, conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        def boom(sql: str, params: Any = None) -> None:
+            raise RuntimeError("connection lost")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+
+        with patch("subprocess.run") as run_mock:
+            result = d._apply_prior_ralph_patch(
+                agent_id="ag", issue_number=1, worktree=worktree
+            )
+
+        assert result is None
+        assert run_mock.call_count == 0
+        assert conn.rollbacks >= 1
+        assert handler.events("ralph_patch_query_failed")
+
+
+# --------------------------------------------------------------------------
+# _append_unapplied_patch_to_prior_attempts
+# --------------------------------------------------------------------------
+
+
+class TestAppendUnappliedPatch:
+    """Unapplied patch text gets surfaced to the ralph worker via
+    ``prior_attempts.md`` so the worker can cherry-pick manually."""
+
+    def test_appends_when_prior_attempts_md_exists(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        (worktree / "tmp" / "dispatcher-output").mkdir(parents=True)
+        existing = worktree / "tmp" / "dispatcher-output" / "prior_attempts.md"
+        existing.write_text("# prior attempts\n\nAttempt 1 content.\n")
+
+        d._append_unapplied_patch_to_prior_attempts(
+            worktree,
+            {
+                "applied": False,
+                "patch_id": "pid-1",
+                "patch_content": "From abc...\npatch body\n",
+                "reason": "patch does not apply",
+            },
+        )
+
+        content = existing.read_text()
+        assert "Attempt 1 content." in content
+        assert "## Prior SHIP'd patch (did NOT apply cleanly)" in content
+        assert "pid-1" in content
+        assert "patch does not apply" in content
+        # The patch body is present, fenced as a diff block.
+        assert "```diff" in content
+        assert "patch body" in content
+
+    def test_creates_file_when_prior_attempts_md_missing(self, tmp_path: Path) -> None:
+        """If prior_attempts.md doesn't exist (no prior FAILED attempts
+        but we did have a SHIP'd-but-not-pushed patch), still write a
+        standalone file so the worker gets the patch context."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+
+        d._append_unapplied_patch_to_prior_attempts(
+            worktree,
+            {
+                "applied": False,
+                "patch_id": "pid-2",
+                "patch_content": "standalone patch body\n",
+                "reason": "no current patch",
+            },
+        )
+
+        target = worktree / "tmp" / "dispatcher-output" / "prior_attempts.md"
+        assert target.exists()
+        content = target.read_text()
+        assert "Prior SHIP'd patch" in content
+        assert "standalone patch body" in content
+
+
+# --------------------------------------------------------------------------
+# Housekeeping target — ``ralph_patches`` pruning (AC #6)
+# --------------------------------------------------------------------------
+
+
+class TestRalphPatchesHousekeepingTarget:
+    """AC #6 — housekeeping tick DELETEs patches older than 7 days."""
+
+    def test_ralph_patches_entry_in_targets(self) -> None:
+        entry = next(
+            t
+            for t in daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS
+            if t[0] == "ralph_patches"
+        )
+        assert entry == (
+            "ralph_patches",
+            "created_at",
+            "ralph_patch_retention_days",
+            daemon.DEFAULT_RALPH_PATCH_RETENTION_DAYS,
+        )
+        assert daemon.DEFAULT_RALPH_PATCH_RETENTION_DAYS == 7
+
+    def test_delete_runs_with_default_7d_cutoff(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Single-target monkeypatch — only ``ralph_patches`` fires."""
+        entry = next(
+            t
+            for t in daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS
+            if t[0] == "ralph_patches"
+        )
+        monkeypatch.setattr(daemon.DispatcherDaemon, "_HOUSEKEEPING_TARGETS", (entry,))
+        d, conn, handler = _make_daemon(tmp_path)
+        # config lookup returns None → falls back to default
+        conn.cursor_instance.fetch_queue = [None]
+
+        original_execute = conn.cursor_instance.execute
+
+        def patched_execute(sql: str, params: Any = None) -> None:
+            original_execute(sql, params)
+            if "DELETE FROM dispatcher.ralph_patches" in sql:
+                conn.cursor_instance.rowcount = 3
+
+        conn.cursor_instance.execute = patched_execute  # type: ignore[method-assign]
+
+        result = d._housekeeping_tick()
+
+        deletes = [
+            (sql, p)
+            for sql, p in conn.cursor_instance.executed
+            if sql.startswith("DELETE FROM dispatcher.ralph_patches")
+        ]
+        assert len(deletes) == 1
+        sql, params = deletes[0]
+        assert "created_at < now() - make_interval(days => %s)" in sql
+        assert params == (daemon.DEFAULT_RALPH_PATCH_RETENTION_DAYS,)
+
+        ticks = handler.events("housekeeping_tick")
+        assert any(
+            r.table == "ralph_patches"
+            and r.cutoff_days == daemon.DEFAULT_RALPH_PATCH_RETENTION_DAYS
+            and r.rows_deleted == 3
+            for r in ticks
+        )
+        assert result == {"ralph_patches": 3}
+
+
+# --------------------------------------------------------------------------
+# Cleanup on gh pr create success (AC #3, integration view)
+# --------------------------------------------------------------------------
+
+
+class TestPushAndOpenPrDeletesRalphPatch:
+    """AC #3 — ``_push_and_open_pr`` calls the delete helper after a
+    successful ``gh pr create`` so the postgres copy is cleaned up the
+    moment the branch lands on origin."""
+
+    def test_pr_create_success_triggers_delete(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        agent_id = "aaaabbbb-0000-0000-0000-000000000111"
+
+        # Stub the DB methods _push_and_open_pr touches.
+        d._agent_summary_output = {  # type: ignore[attr-defined]
+            "commit_message": "feat(dispatcher): ralph patches (#3012)",
+            "pr_title": "feat(dispatcher): ralph patches (#3012)",
+            "pr_body_md": "body",
+        }
+        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
+        d._delete_ralph_patches_for_agent = MagicMock(  # type: ignore[method-assign]
+            return_value=1
+        )
+
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
+        )
+        git_show_empty = subprocess.CompletedProcess(
+            args=["git", "show"], returncode=0, stdout="", stderr=""
+        )
+        push_ok = subprocess.CompletedProcess(
+            args=["git", "push"], returncode=0, stdout="", stderr=""
+        )
+        pr_create_ok = subprocess.CompletedProcess(
+            args=["gh", "pr", "create"],
+            returncode=0,
+            stdout="https://github.com/x/y/pull/4242\n",
+            stderr="",
+        )
+
+        with patch(
+            "subprocess.run",
+            side_effect=[commit_ok, git_show_empty, push_ok, pr_create_ok],
+        ):
+            d._push_and_open_pr(
+                agent_id=agent_id,
+                issue_number=3012,
+                worktree=worktree,
+            )
+
+        # Delete helper invoked exactly once with the agent_id.
+        d._delete_ralph_patches_for_agent.assert_called_once_with(agent_id)
+
+    def test_push_failure_does_not_trigger_delete(self, tmp_path: Path) -> None:
+        """If push fails, the PR was never created — we must NOT delete
+        the persisted patch, because the whole point is to survive to
+        the next retry."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        agent_id = "aaaabbbb-0000-0000-0000-000000000222"
+
+        d._agent_summary_output = {  # type: ignore[attr-defined]
+            "commit_message": "c",
+            "pr_title": "t",
+            "pr_body_md": "b",
+        }
+        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
+        d._delete_ralph_patches_for_agent = MagicMock(  # type: ignore[method-assign]
+            return_value=0
+        )
+
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
+        )
+        git_show_empty = subprocess.CompletedProcess(
+            args=["git", "show"], returncode=0, stdout="", stderr=""
+        )
+        push_fail = subprocess.CompletedProcess(
+            args=["git", "push"],
+            returncode=1,
+            stdout="",
+            stderr="fatal: unable to access",
+        )
+
+        with patch(
+            "subprocess.run", side_effect=[commit_ok, git_show_empty, push_fail]
+        ):
+            d._push_and_open_pr(
+                agent_id=agent_id,
+                issue_number=3012,
+                worktree=worktree,
+            )
+
+        # Delete helper was NOT invoked — the patch must survive the
+        # push failure so the retry can inherit it.
+        d._delete_ralph_patches_for_agent.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Integration view — real git + daemon capture_and_persist end-to-end
+# --------------------------------------------------------------------------
+
+
+def _git(worktree: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    """Run ``git -C <worktree> <args>`` with minimal env for hermetic tests."""
+    env = {
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "HOME": str(worktree.parent),
+        "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+    }
+    return subprocess.run(
+        ["git", "-C", str(worktree), *args],
+        capture_output=True,
+        text=True,
+        check=check,
+        env=env,
+    )
+
+
+class TestCaptureThenApplyRoundtrip:
+    """End-to-end: daemon captures ralph's SHIP'd commit as a patch, a
+    fresh worktree off origin/main applies it via ``git am`` and the
+    diff lands.  Exercises the real ``git format-patch`` + ``git am``
+    invocations, not mocks.  The DB side is still stubbed — the round
+    trip through postgres is covered by the unit tests above.
+    """
+
+    def test_format_patch_then_git_am_roundtrip(self, tmp_path: Path) -> None:
+        # Seed a "shared origin" bare repo.
+        origin = tmp_path / "origin.git"
+        _git(tmp_path, "init", "--bare", str(origin), check=True)
+        # Seed a working clone with one commit on main.
+        source = tmp_path / "source"
+        source.mkdir()
+        _git(source, "init", "-b", "main", "--quiet")
+        _git(source, "config", "commit.gpgsign", "false")
+        _git(source, "remote", "add", "origin", str(origin))
+        (source / "README.md").write_text("# test\n")
+        _git(source, "add", "README.md")
+        _git(source, "commit", "-m", "initial", "--quiet")
+        _git(source, "push", "origin", "main")
+
+        # "Agent A" worktree: create branch, make a ralph-style commit.
+        agent_a = tmp_path / "agent-a"
+        _git(tmp_path, "clone", str(origin), str(agent_a), check=True)
+        _git(agent_a, "config", "commit.gpgsign", "false")
+        _git(agent_a, "checkout", "-b", "agent/a", "--quiet")
+        (agent_a / "new_file.py").write_text("def hello():\n    return 42\n")
+        _git(agent_a, "add", "new_file.py")
+        _git(agent_a, "commit", "-m", "WIP: ralph output", "--quiet")
+
+        # Capture the patch the way ``_capture_and_persist_ralph_patch``
+        # does — ``git format-patch -1 HEAD --stdout``.
+        result = subprocess.run(
+            ["git", "-C", str(agent_a), "format-patch", "-1", "HEAD", "--stdout"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        patch_bytes = result.stdout
+        assert "new_file.py" in patch_bytes
+        assert "WIP: ralph output" in patch_bytes
+
+        # "Agent B" worktree: fresh clone off origin/main; apply patch
+        # via ``git am`` the way ``_apply_prior_ralph_patch`` does.
+        agent_b = tmp_path / "agent-b"
+        _git(tmp_path, "clone", str(origin), str(agent_b), check=True)
+        _git(agent_b, "config", "commit.gpgsign", "false")
+        _git(agent_b, "checkout", "-b", "agent/b", "--quiet")
+        patch_file = agent_b / "prior-ralph.patch"
+        patch_file.write_text(patch_bytes)
+
+        am = subprocess.run(
+            ["git", "-C", str(agent_b), "am", "--3way", str(patch_file)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert am.returncode == 0, (
+            f"git am failed: stderr={am.stderr!r} stdout={am.stdout!r}"
+        )
+        # The inherited diff landed on agent-b's branch.
+        assert (agent_b / "new_file.py").exists()
+        log = _git(agent_b, "log", "-1", "--format=%s").stdout.strip()
+        assert log == "WIP: ralph output"

--- a/scripts/dispatcher/tests/test_daemon_ralph_patches.py
+++ b/scripts/dispatcher/tests/test_daemon_ralph_patches.py
@@ -864,14 +864,13 @@ class TestCaptureThenApplyRoundtrip:
         _git(agent_a, "commit", "-m", "WIP: ralph output", "--quiet")
 
         # Capture the patch the way ``_capture_and_persist_ralph_patch``
-        # does — ``git format-patch -1 HEAD --stdout``.
-        result = subprocess.run(
-            ["git", "-C", str(agent_a), "format-patch", "-1", "HEAD", "--stdout"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        patch_bytes = result.stdout
+        # does — ``git format-patch -1 HEAD --stdout``. Routed through
+        # ``_git`` so the hermetic env (no user.email / user.name lookup)
+        # propagates — CI runners don't set a global identity, and
+        # format-patch inherits the committer env from the caller.
+        patch_bytes = _git(
+            agent_a, "format-patch", "-1", "HEAD", "--stdout", check=True
+        ).stdout
         assert "new_file.py" in patch_bytes
         assert "WIP: ralph output" in patch_bytes
 
@@ -884,12 +883,13 @@ class TestCaptureThenApplyRoundtrip:
         patch_file = agent_b / "prior-ralph.patch"
         patch_file.write_text(patch_bytes)
 
-        am = subprocess.run(
-            ["git", "-C", str(agent_b), "am", "--3way", str(patch_file)],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        # ``git am`` re-uses committer/author from the patch header but
+        # still requires a default identity to be resolvable. Route
+        # through ``_git`` so the test env's GIT_AUTHOR_* /
+        # GIT_COMMITTER_* envs apply — matches the hermetic pattern in
+        # test_daemon_amend_commit.py and avoids the "empty ident name"
+        # failure on CI runners that don't set a global git identity.
+        am = _git(agent_b, "am", "--3way", str(patch_file), check=False)
         assert am.returncode == 0, (
             f"git am failed: stderr={am.stderr!r} stdout={am.stdout!r}"
         )


### PR DESCRIPTION
## Summary

Persist ralph's SHIP'd diff to `dispatcher.ralph_patches` so a daemon restart between `verdict=SHIP` and a successful `gh pr create` does not lose the work. Motivated by the 2026-04-21 c3a69458 incident: ralph SHIPped after 1h 48m, `git_push_timeout` at 15:17, deploy of PR #2999 killed the container before the retry landed, diff was lost, four subsequent attempts re-ralph'd the same task for hours.

Happy-path lifetime of a row is 5-15 minutes (SHIP → summary → push → `gh pr create` → DELETE). Failures extend up to the stuck-timeout budget. A 7-day housekeeping TTL catches pathological cases.

Closes #3012

## Design

- **Migration 38** (`packages/api/migrations/38_dispatcher-ralph-patches.sql`) — `dispatcher.ralph_patches` table with `patch_id, agent_id, issue_number, patch_content, commit_sha, created_at`; two indexes (issue_number, created_at); nullable `patch_id` FK on `phase_outputs` with `ON DELETE SET NULL`.
- **`_capture_and_persist_ralph_patch`** — runs on verdict=SHIP in `_run_ralph_phase` after the ralph phase_output has been persisted. `git format-patch -1 HEAD --stdout`, DELETE prior rows for the issue (supersede semantics for retry-after-failure), INSERT, UPDATE `phase_outputs.patch_id` — all in one transaction.
- **`_delete_ralph_patches_for_agent`** — runs in `_push_and_open_pr` immediately after the `daemon.pr_opened` log. Keyed by `agent_id` (not `issue_number`) so a racing second claim on the same issue can't clobber a newer agent's patch.
- **`_apply_prior_ralph_patch`** — runs at the top of `_run_ralph_phase` before spawning ralph. Queries the latest `ralph_patches` row for the issue; if one exists, writes it to `{worktree}/tmp/dispatcher-input/prior-ralph.patch` and `git am --3way`s it. On success ralph iterates on top of the inherited diff. On failure `git am --abort` restores clean state and the patch text is appended to `prior_attempts.md` via `_append_unapplied_patch_to_prior_attempts`.
- **Housekeeping sweep** — `ralph_patches` added to `_HOUSEKEEPING_TARGETS` with `DEFAULT_RALPH_PATCH_RETENTION_DAYS = 7`. Safety net only; the happy path cleanup is the DELETE at PR create.
- **`/task-v2-ralph` SKILL.md** — input contract documents the "patch pre-applied" scenario (grep `prior SHIP`).

All helpers are best-effort: format-patch / git am / DB errors log and fall through to pre-#3012 behavior rather than failing the pipeline. The feature is a latency/cost optimization layered on top — it must never wedge the pipeline.

## Scope boundaries

- No staging remote, no S3 — postgres-only storage.
- Patches live in their own table; `phase_outputs.log_text` stays the phase narrative.
- Only SHIP exits store patches. AC_INFEASIBLE / max-iterations / crashes never hit the capture call.
- DELETE fires on `gh pr create` success, not PR close/merge (listening for PR-close events would leak dispatcher to GitHub webhooks).
- No per-iteration commits/patches — separate follow-up ticket.
- No dedicated retention config key — 7 days is a safety-net window, not operator-tunable observability. Code comments document how to add one later if needed.
- No spec edit — internal reliability detail per the issue instruction.

## Test plan

### Automated checks

- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (864 dispatcher tests pass locally, including 20 new ones in `test_daemon_ralph_patches.py`)
- [x] CI green

### Post-deploy verification

Reproduces c3a69458's scenario end-to-end on dev:

- [ ] File a throwaway test issue with a trivial docs change.
- [ ] Let `agent/ready` flip and the daemon claim it.
- [ ] Watch `ralph_spawn` log then wait for `ralph_patch_persisted` to appear in the CloudWatch Insights query against `/ecs/judgemind-dispatcher-dev`.
- [ ] Snapshot `dispatcher.ralph_patches` via `scripts/dev-db-query.sh` — confirm the row exists with the expected `agent_id`, `issue_number`, and non-empty `patch_content`.
- [ ] Kill the daemon before `gh pr create` runs (force a new task definition via `ecs update-service --force-new-deployment`, or scale to 0 and back up).
- [ ] When the daemon boots back up, confirm it re-claims the same issue (or manually flip `agent/ready` back on).
- [ ] Watch the next agent's logs for `ralph_patch_applied` with the prior `patch_id` and `prior_commit_sha`.
- [ ] `git log` inside the daemon's worktree (via `ecs execute-command`) confirms the inherited `WIP: ralph output` commit is on HEAD before ralph spawns.
- [ ] The second agent SHIPs, `gh pr create` succeeds, and `ralph_patch_deleted` fires.
- [ ] `dispatcher.ralph_patches` row is gone; the PR contains the intended diff.
- [ ] Verification evidence comment posted on #3012 (see A.8).

This plan is what `/task-v2-verify` should run post-deploy.
