### PR TITLE
docs(agent): document ecs-run-task.sh timeout expectation for subagents (#2652)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -747,7 +747,7 @@ Worktree cleanup is handled automatically by Claude Code when the agent exits.
 - **All temp files go in `{worktree}/tmp/`**, not `/tmp/`.
 - **Multi-line Python always goes in a `.py` file**, never `-c '...'`.
 - **No `run_in_background`.** All commands — CI watches, test suites, deploy watches, and reviewer invocations — must run in the foreground. Subagents are already background tasks from the parent's perspective. Further backgrounding causes `<task-notification>` messages to surface in the wrong context, leading to confusion and lost results.
-- **Use `timeout: 1200000`** on Bash commands that may exceed 2 minutes: `pytest`, `gh run watch`, `pip install`, `npm install`, `npm run build`, `terraform apply`, `ruff check` on large codebases, and any data-processing script.
+- **Use `timeout: 1200000`** on Bash commands that may exceed 2 minutes: `pytest`, `gh run watch`, `pip install`, `npm install`, `npm run build`, `terraform apply`, `ruff check` on large codebases, `scripts/ecs-run-task.sh`, `scripts/ecs-run.sh --script`, `scripts/rebuild_db.sh`, and any data-processing script.
 - **After any context reset, run §A.0 / §B.0 recovery** — `{worktree}/scripts/check-task-recovery.sh {worktree}` is the authoritative "am I done?" check.
 - **Prefer MCP for reads** (`mcp__github__get_issue`, `get_pull_request`, `list_issues`, `list_pull_requests`, `get_pull_request_status`). Keep `gh` for writes and for workflow-run operations. See `docs/agent/github-api-access.md`.
 - See CLAUDE.md §Unattended Operation Patterns for the full list.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ Shell-interactive prompt-prevention rules (`$()`, heredocs, inline `python -c`, 
 - Watch CI to completion (`gh run watch`) before doing anything else after pushing.
 - Create a PR immediately after your first push to a branch.
 - Re-fetch GitHub issue or PR state before acting on it if more than a few minutes have elapsed.
-- Set `timeout: 1200000` (20 minutes) on Bash commands that may take longer than 2 minutes: `pytest`, `gh run watch`, `terraform apply`, `pip install`, `npm install`, `npm run build`, `ruff check` on large codebases, any data-processing script.
+- Set `timeout: 1200000` (20 minutes) on Bash commands that may take longer than 2 minutes: `pytest`, `gh run watch`, `terraform apply`, `pip install`, `npm install`, `npm run build`, `ruff check` on large codebases, `scripts/ecs-run-task.sh`, `scripts/ecs-run.sh --script`, `scripts/rebuild_db.sh`, any data-processing script.
 
 ## Enforced Rules — Automated Checks
 

--- a/scripts/ecs-run-task.sh
+++ b/scripts/ecs-run-task.sh
@@ -21,6 +21,7 @@
 #   - AWS CLI v2
 #   - Credentials for the judgemind AWS account (155326049300)
 #   - The ingestion worker task definition must exist
+# When invoked from a Claude Code Bash tool call, set `timeout: 1200000` (20 minutes) — oneshot reingests commonly exceed the 2-minute default.
 #
 # Usage:
 #   scripts/ecs-run-task.sh <script-path> [-- script-args...]


### PR DESCRIPTION
## Summary

Added explicit documentation of the 20-minute timeout requirement for `scripts/ecs-run-task.sh` and related long-running scripts in CLAUDE.md and .claude/skills/task/SKILL.md. Also added a visible comment to the script's --help output mentioning the timeout expectation. This resolves the root cause of the timeout issue observed during #2628's post-deploy verification.

Closes #2652

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green
- [x] Markdown link check passed (all 78 files)

### Post-deploy verification

- [ ] N/A — no deployed component (documentation and script comments only)