### PR TITLE
feat(dispatcher): stream LLM subprocess stdout/stderr to CloudWatch + jsonl + skill heartbeats (#3017)

### DIFF
--- a/.claude/skills/task-v2-plan/SKILL.md
+++ b/.claude/skills/task-v2-plan/SKILL.md
@@ -15,6 +15,13 @@ Plan phase for the dispatcher v2 per-phase task pipeline (`docs/specs/dispatcher
 
 **IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation. The `/task-v2-plan` subprocess is already a dispatcher-spawned background task — further backgrounding causes completion notifications to surface in the wrong context and leads to lost results.
 
+**IMPORTANT — Heartbeat lines (issue #3017).** Emit two distinctive heartbeat lines to stdout so CloudWatch Log Insights can answer "what was the last thing the skill did before its stream went silent?" during a hang. Run the Bash tool with:
+
+- `echo PHASE_START plan` immediately after reading this SKILL.md (before Step 1).
+- `echo PHASE_DONE <verdict>` right before writing the output JSON (Step N — the last step), where `<verdict>` matches the verdict/go field the output JSON will carry.
+
+These are plain `echo` statements — the dispatcher daemon's stream-forwarder (`scripts/dispatcher/stream_forwarder.py`) picks them up from subprocess stdout and tags them with `agent_id`, `issue_number`, `phase=plan`, `stream=stdout` in CloudWatch + a real-time JSONL mirror at `{worktree}/.dispatcher/plan-<agent_id>.jsonl`. The grep-friendly `PHASE_START` / `PHASE_DONE` tokens make it trivial to filter phase boundaries: `filter @message like /PHASE_START/`.
+
 **IMPORTANT — No side effects.** This phase is read-only against the repo and GitHub. Do not edit code, do not comment on issues, do not spawn subagents. The only write is the output JSON at `{worktree}/tmp/dispatcher-output/plan.json`.
 
 ---

--- a/.claude/skills/task-v2-ralph/SKILL.md
+++ b/.claude/skills/task-v2-ralph/SKILL.md
@@ -37,6 +37,16 @@ This is the harness-limitation path surfaced by the Phase 1 gate smoke test (iss
 
 **IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, any Task tool call, or any other operation. `/task-v2-ralph` is already a dispatcher-spawned background subprocess — further backgrounding causes completion notifications to surface in the wrong context and loses results.
 
+**IMPORTANT — Heartbeat lines (issue #3017).** Ralph is the long-tail phase where hangs actually happen. Emit distinctive heartbeat tokens to stdout at every major internal boundary so CloudWatch Log Insights can answer "which iteration / reviewer / subprocess was ralph stuck on when the stream went silent?". Run the Bash tool with `echo <TOKEN>` at each boundary:
+
+- `echo ITER_START <n>` at the top of each outer-skill iteration (Step 2 re-entry via the Step 2.5 pre-push gate counts as a new iteration).
+- `echo WORKER_START <n>` immediately before spawning the `/ralph` worker subagent (Step 2 / Step 2.5 re-invocation path).
+- `echo REVIEWER_START gemini-standard` / `echo REVIEWER_START gemini-adversarial` / `echo REVIEWER_START claude` — the inner `/ralph` skill emits these before each reviewer pass. Listed here so grep queries and operators know what to expect.
+- `echo PYTEST_START` before the `bash .githooks/pre-push` invocation in Step 2.5b (the pre-push hook invokes pytest internally; this heartbeat fires once per Step 2.5 attempt).
+- `echo PUSH_START` is not fired by ralph itself — that one lives on the daemon's git-push path, which already has its own structured-log event (`daemon.git_push_started`) and does not go through a subprocess stream. Documented here for symmetry so operators know why they will not see it in the ralph jsonl.
+
+Each `echo` is a single Bash-tool call — the stream-forwarder (`scripts/dispatcher/stream_forwarder.py`) picks it up from subprocess stdout, tags it with `agent_id`, `issue_number`, `phase=ralph`, `stream=stdout`, and mirrors it to `{worktree}/.dispatcher/ralph-<agent_id>.jsonl`. In CloudWatch: `filter @message like /ITER_START/` returns N lines per ralph run matching `iterations_used` from `phase_succeeded`.
+
 **IMPORTANT — Subagent isolation.** The context-budget analysis in spike 0.3 (`docs/investigations/dispatcher-v2-spike-0.3.md`) shows `/task-v2-ralph` stays inside the 200k-token window ONLY if each worker + each reviewer runs as a fresh-context subagent (Task tool). Inline workers break this guarantee. Do not inline.
 
 **Implementation choice (per issue #2732):** This skill invokes the existing `/ralph` skill as its inner loop. `/ralph` already implements the worker + three-reviewer cycle with fresh-context Task-tool subagents and per-iteration state files under `{worktree}/tmp/ralph/`. `/task-v2-ralph` is the thin outer wrapper that (a) seeds `task.md` from `plan.json`, (b) invokes `/ralph`, (c) runs the local pre-push gate (Step 2.5), (d) parses `{worktree}/tmp/ralph/ralph-done.txt` into the output JSON. Keeps the implementation in one place and ensures parity with the current `/task` workflow's ralph behavior.

--- a/.claude/skills/task-v2-retro/SKILL.md
+++ b/.claude/skills/task-v2-retro/SKILL.md
@@ -15,6 +15,13 @@ Retrospective phase for the dispatcher v2 per-phase task pipeline (`docs/specs/d
 
 **IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation.
 
+**IMPORTANT — Heartbeat lines (issue #3017).** Emit two distinctive heartbeat lines to stdout so CloudWatch Log Insights can answer "what was the last thing the skill did before its stream went silent?" during a hang. Run the Bash tool with:
+
+- `echo PHASE_START retro` immediately after reading this SKILL.md (before Step 1).
+- `echo PHASE_DONE <verdict>` right before writing the output JSON (Step N — the last step), where `<verdict>` matches the verdict/go field the output JSON will carry.
+
+These are plain `echo` statements — the dispatcher daemon's stream-forwarder (`scripts/dispatcher/stream_forwarder.py`) picks them up from subprocess stdout and tags them with `agent_id`, `issue_number`, `phase=retro`, `stream=stdout` in CloudWatch + a real-time JSONL mirror at `{worktree}/.dispatcher/retro-<agent_id>.jsonl`. The grep-friendly `PHASE_START` / `PHASE_DONE` tokens make it trivial to filter phase boundaries: `filter @message like /PHASE_START/`.
+
 **IMPORTANT — Do not fabricate findings.** A clean run (ralph=1 iteration, ci_attempts=1, no failures) is supposed to be boring. Setting `no_findings=true` is the correct answer for those runs. Retro issues should be high-signal and actionable — not "process theater".
 
 **IMPORTANT — No GitHub writes.** The daemon files the issues after reading this output. Do not call `gh issue create`.

--- a/.claude/skills/task-v2-summary/SKILL.md
+++ b/.claude/skills/task-v2-summary/SKILL.md
@@ -15,6 +15,13 @@ Summary phase for the dispatcher v2 per-phase task pipeline (`docs/specs/dispatc
 
 **IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation. This subprocess is already a dispatcher-spawned background task.
 
+**IMPORTANT — Heartbeat lines (issue #3017).** Emit two distinctive heartbeat lines to stdout so CloudWatch Log Insights can answer "what was the last thing the skill did before its stream went silent?" during a hang. Run the Bash tool with:
+
+- `echo PHASE_START summary` immediately after reading this SKILL.md (before Step 1).
+- `echo PHASE_DONE <verdict>` right before writing the output JSON (Step N — the last step), where `<verdict>` matches the verdict/go field the output JSON will carry.
+
+These are plain `echo` statements — the dispatcher daemon's stream-forwarder (`scripts/dispatcher/stream_forwarder.py`) picks them up from subprocess stdout and tags them with `agent_id`, `issue_number`, `phase=summary`, `stream=stdout` in CloudWatch + a real-time JSONL mirror at `{worktree}/.dispatcher/summary-<agent_id>.jsonl`. The grep-friendly `PHASE_START` / `PHASE_DONE` tokens make it trivial to filter phase boundaries: `filter @message like /PHASE_START/`.
+
 **IMPORTANT — No side effects.** This phase does not modify code, does not commit, does not push, does not comment on GitHub. The only write is the output JSON at `{worktree}/tmp/dispatcher-output/summary.json`.
 
 ---

--- a/.claude/skills/task-v2-verify/SKILL.md
+++ b/.claude/skills/task-v2-verify/SKILL.md
@@ -15,6 +15,13 @@ Verify phase for the dispatcher v2 per-phase task pipeline (`docs/specs/dispatch
 
 **IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation.
 
+**IMPORTANT — Heartbeat lines (issue #3017).** Emit two distinctive heartbeat lines to stdout so CloudWatch Log Insights can answer "what was the last thing the skill did before its stream went silent?" during a hang. Run the Bash tool with:
+
+- `echo PHASE_START verify` immediately after reading this SKILL.md (before Step 1).
+- `echo PHASE_DONE <verdict>` right before writing the output JSON (Step N — the last step), where `<verdict>` matches the verdict/go field the output JSON will carry.
+
+These are plain `echo` statements — the dispatcher daemon's stream-forwarder (`scripts/dispatcher/stream_forwarder.py`) picks them up from subprocess stdout and tags them with `agent_id`, `issue_number`, `phase=verify`, `stream=stdout` in CloudWatch + a real-time JSONL mirror at `{worktree}/.dispatcher/verify-<agent_id>.jsonl`. The grep-friendly `PHASE_START` / `PHASE_DONE` tokens make it trivial to filter phase boundaries: `filter @message like /PHASE_START/`.
+
 **IMPORTANT — Never deploy to production.** Verification runs against dev only. Production deploys are human-only per `CLAUDE.md`.
 
 **IMPORTANT — Post the comment? No.** The daemon posts the comment after reading this skill's output. This skill does not call `gh issue comment` — it only produces the markdown.

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -84,6 +84,26 @@ if TYPE_CHECKING:  # pragma: no cover — types only
     from psycopg import Connection
 
 
+# The stream forwarder lives in a sibling module so tests can exercise
+# it without pulling in the daemon's DB + GitHub dependencies. See
+# ``scripts/dispatcher/stream_forwarder.py`` + issue #3017. Imported at
+# module scope so monkeypatching
+# (``dispatcher.daemon.stream_subprocess_output_async``) in tests is
+# straightforward.
+#
+# Uses a relative import so the module works under both import styles:
+# ``python -m scripts.dispatcher.daemon`` (Fargate production) AND
+# ``from dispatcher import daemon`` after tests put ``scripts/`` on
+# ``sys.path``. Both invocations load daemon.py as part of a
+# ``dispatcher`` package, so ``from .stream_forwarder import ...``
+# resolves in both. A hard-coded absolute import would require a
+# try/except fallback that the
+# ``scripts/check-dispatcher-image-deps.py`` CI guard flags as a
+# missing pip dep (the fallback top-level ``dispatcher`` is not a pip
+# package — it is a sibling module).
+from .stream_forwarder import stream_subprocess_output_async  # noqa: E402
+
+
 # --------------------------------------------------------------------------
 # Constants
 # --------------------------------------------------------------------------
@@ -5797,18 +5817,34 @@ class DispatcherDaemon:
           keep working unchanged, and operators can still ``cat``,
           ``tail``, or ``grep`` a single file during incident triage.
 
+        **Real-time stream forwarding (#3017).** Each line of child
+        stdout+stderr is also forwarded to :data:`self._log` (tagged
+        ``agent_id``, ``issue_number``, ``phase``, ``stream``,
+        ``raw_message``) and mirrored into
+        ``{worktree}/.dispatcher/{phase}-{agent_id}.jsonl`` in real time
+        by :func:`stream_subprocess_output_async`. This lets operators
+        see a ralph hang's last tool call in CloudWatch or via
+        ``tail -f`` on the JSONL file — the pre-#3017 code called
+        :func:`subprocess.run` which buffered all output until exit, so
+        a stuck subprocess produced no breadcrumbs at all. The
+        tee-to-file behaviour of the forwarder keeps the pre-#3017
+        capture files intact, so metering (:meth:`_parse_phase_usage`)
+        and triage helpers continue to work unchanged.
+
         The worktree is passed as the subprocess's CWD via
-        ``subprocess.run(..., cwd=...)`` — NOT as a ``--cwd`` flag. The
-        ``claude`` CLI does not accept a ``--cwd`` flag; passing one
+        :class:`subprocess.Popen` ``cwd=`` — NOT as a ``--cwd`` flag.
+        The ``claude`` CLI does not accept a ``--cwd`` flag; passing one
         makes every phase subprocess exit 1 within 400ms with
-        ``error: unknown option '--cwd'`` (#2821). Python's stdlib ``cwd=``
-        is the correct knob for "start the child process in this directory".
+        ``error: unknown option '--cwd'`` (#2821). Python's stdlib
+        ``cwd=`` is the correct knob for "start the child process in
+        this directory".
         """
         max_turns = PHASE_MAX_TURNS[phase]
         model = PHASE_MODELS[phase]
         log_path = worktree / "tmp" / f"claude-p-{phase}.log"
         stdout_path = worktree / "tmp" / f"claude-p-{phase}.stdout.json"
         stderr_path = worktree / "tmp" / f"claude-p-{phase}.stderr.log"
+        jsonl_path = worktree / ".dispatcher" / f"{phase}-{agent_id}.jsonl"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
         cmd = [
@@ -5837,12 +5873,14 @@ class DispatcherDaemon:
         ]
 
         start = time.monotonic()
+        issue_number = self._agent_issue_number(agent_id)
         self._log.info(
             "daemon.phase_started",
             extra={
                 "event": "phase_started",
                 "run_id": self._run_id,
                 "agent_id": agent_id,
+                "issue_number": issue_number,
                 "phase": phase,
                 "model": model,
                 "max_turns": max_turns,
@@ -5850,20 +5888,54 @@ class DispatcherDaemon:
             },
         )
 
+        proc: subprocess.Popen[str] | None = None
+        returncode = -1
         try:
             with (
                 stdout_path.open("w", encoding="utf-8") as stdout_file,
                 stderr_path.open("w", encoding="utf-8") as stderr_file,
             ):
-                result = subprocess.run(
+                # ``bufsize=1`` (line-buffered) + ``text=True`` is what
+                # makes the forwarder see lines as they arrive rather
+                # than in 8KB chunks. Without these, a slow child (long
+                # tool call) would appear silent in CloudWatch for
+                # seconds-to-minutes at a time — defeating the point of
+                # #3017. See the docstring of
+                # :func:`stream_subprocess_output_async`.
+                proc = subprocess.Popen(  # noqa: S603 — cmd is a literal list of trusted strings
                     cmd,
-                    stdout=stdout_file,
-                    stderr=stderr_file,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
                     text=True,
-                    timeout=CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS,
-                    check=False,
+                    bufsize=1,
                     cwd=str(worktree),
                 )
+                threads = stream_subprocess_output_async(
+                    proc,
+                    agent_id=agent_id,
+                    issue_number=issue_number,
+                    phase=phase,
+                    logger=self._log,
+                    jsonl_path=jsonl_path,
+                    stdout_sink=stdout_file,
+                    stderr_sink=stderr_file,
+                )
+                try:
+                    returncode = proc.wait(timeout=CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS)
+                except subprocess.TimeoutExpired:
+                    # Kill the child so the reader threads receive EOF
+                    # and can join. Then re-raise so the caller's
+                    # existing ``TimeoutExpired`` handler fires.
+                    proc.kill()
+                    try:
+                        proc.wait(timeout=10)
+                    except (
+                        subprocess.TimeoutExpired
+                    ):  # pragma: no cover — SIGKILL should always succeed
+                        pass
+                    threads.join(timeout=10)
+                    raise
+                threads.join(timeout=10)
             duration = time.monotonic() - start
         finally:
             # Always compose the combined ``.log`` view, even on timeout /
@@ -5874,7 +5946,40 @@ class DispatcherDaemon:
                 stdout_path=stdout_path,
                 stderr_path=stderr_path,
             )
-        return result.returncode, duration
+        return returncode, duration
+
+    def _agent_issue_number(self, agent_id: str) -> int | None:
+        """Best-effort lookup of ``dispatcher.agents.issue_number`` by agent id.
+
+        Returns ``None`` if the row is missing, the column is NULL, or
+        the DB call fails. The forwarder accepts ``None`` — the
+        structured-log ``issue_number`` field is simply serialized as
+        JSON null so CloudWatch Log Insights can still filter by
+        ``agent_id`` + ``phase``. Issue #3017.
+        """
+        conn = self._conn
+        if conn is None:
+            return None
+        try:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT issue_number FROM dispatcher.agents WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+            conn.commit()
+        except Exception:  # pragma: no cover — defensive
+            try:
+                conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return None
+        if row is None or row[0] is None:
+            return None
+        try:
+            return int(row[0])
+        except (TypeError, ValueError):  # pragma: no cover — defensive
+            return None
 
     @staticmethod
     def _compose_phase_log(
@@ -13387,8 +13492,22 @@ class DispatcherDaemon:
 
         Returns ``(exit_code, stderr_tail)``. ``exit_code=None`` means
         the subprocess timed out or could not be launched. Isolated
-        here so tests can monkeypatch ``subprocess.run`` without
+        here so tests can monkeypatch ``subprocess.Popen`` without
         touching the surrounding DB-write logic.
+
+        **Real-time stream forwarding (#3017).** Like
+        :meth:`_spawn_phase_subprocess`, every stdout/stderr line from
+        the diagnoser is structured-logged and mirrored to
+        ``{repo_root}/tmp/.dispatcher/diagnose-<diagnosis_id>.jsonl`` so
+        a malformed-JSON diagnoser recommendation (see
+        ``recommendation_missing_or_malformed_json`` in
+        :meth:`_consume_diagnosis`) has a triageable trail. ``agent_id``
+        is logged as ``f"diagnose-{diagnosis_id}"`` so CloudWatch Log
+        Insights can group diagnoser output alongside the failed agent
+        it was diagnosing.
+
+        The diagnoser runs at the repo root (no per-agent worktree) so
+        the JSONL mirror goes under ``{repo_root}/tmp/.dispatcher/``.
         """
         cmd = [
             "claude",
@@ -13407,28 +13526,63 @@ class DispatcherDaemon:
             # would block. See issue #2982.
             "--dangerously-skip-permissions",
         ]
+
+        repo_root = Path.cwd()
+        jsonl_path = (
+            repo_root / "tmp" / ".dispatcher" / f"diagnose-{diagnosis_id}.jsonl"
+        )
+        stderr_buf: list[str] = []
+        stdout_buf: list[str] = []
+
+        class _ListSink:
+            """File-like sink that appends each write to ``buf``."""
+
+            def __init__(self, buf: list[str]) -> None:
+                self._buf = buf
+
+            def write(self, data: str) -> int:
+                self._buf.append(data)
+                return len(data)
+
+            def flush(self) -> None:
+                return None
+
         try:
-            result = subprocess.run(
+            proc: subprocess.Popen[str] = subprocess.Popen(  # noqa: S603 — literal trusted cmd
                 cmd,
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
-                timeout=DIAGNOSER_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
+                bufsize=1,
             )
-        except subprocess.TimeoutExpired as exc:
-            tail = ""
-            if exc.stderr:
-                tail = (
-                    exc.stderr.decode("utf-8", errors="replace")
-                    if isinstance(exc.stderr, bytes)
-                    else str(exc.stderr)
-                )[-500:]
-            return None, tail
         except FileNotFoundError:
             return None, "claude binary not found"
 
-        stderr_tail = (result.stderr or "")[-500:]
-        return result.returncode, stderr_tail
+        threads = stream_subprocess_output_async(
+            proc,
+            agent_id=f"diagnose-{diagnosis_id}",
+            issue_number=None,
+            phase="diagnose",
+            logger=self._log,
+            jsonl_path=jsonl_path,
+            stdout_sink=_ListSink(stdout_buf),
+            stderr_sink=_ListSink(stderr_buf),
+        )
+        try:
+            returncode = proc.wait(timeout=DIAGNOSER_SUBPROCESS_TIMEOUT_SECONDS)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            try:
+                proc.wait(timeout=10)
+            except subprocess.TimeoutExpired:  # pragma: no cover
+                pass
+            threads.join(timeout=10)
+            tail = ("".join(stderr_buf))[-500:]
+            return None, tail
+
+        threads.join(timeout=10)
+        stderr_tail = ("".join(stderr_buf))[-500:]
+        return returncode, stderr_tail
 
     def _read_recommendation(self, diagnosis_id: int) -> dict[str, Any] | None:
         """Read ``dispatcher.diagnoses.recommendation`` for the given row.

--- a/scripts/dispatcher/stream_forwarder.py
+++ b/scripts/dispatcher/stream_forwarder.py
@@ -1,0 +1,338 @@
+"""Line-by-line subprocess stdout/stderr forwarder for dispatcher phase spawns.
+
+Single shared utility that wraps a :class:`subprocess.Popen` handle and
+forwards every line of the child's ``stdout`` and ``stderr`` in real time
+to two sinks:
+
+1. **Structured logger.** Each line becomes a JSON log record tagged with
+   ``agent_id``, ``issue_number``, ``phase``, ``stream`` (``"stdout"`` /
+   ``"stderr"``), and the raw child output under the ``raw_message`` key.
+   The daemon's JSON log formatter ships these to CloudWatch where Log
+   Insights can filter/group by ``agent_id`` and ``phase`` during a live
+   hang. The key is ``raw_message`` rather than ``message`` because
+   ``message`` is a reserved :class:`logging.LogRecord` attribute —
+   passing it via ``extra`` raises ``KeyError``. Log Insights queries
+   therefore use ``filter raw_message like /.../``.
+2. **Raw JSONL mirror file.** The same structured events are written to
+   ``{worktree}/.dispatcher/{phase}-{agent_id}.jsonl`` for live forensics
+   — operators can ``exec`` into the running task and ``tail -f`` the
+   file to see activity pause in real time.
+
+Two non-daemon reader threads (one per stream) drive the forwarding. We
+deliberately avoid :meth:`subprocess.Popen.communicate`, which would
+block until EOF and defeat the whole point of real-time visibility. The
+threads also continue pumping output during a hang (e.g. a reviewer
+subprocess that pauses for 10 minutes) so operators can see the last
+line emitted before the stall.
+
+Usage (inside the daemon's phase-spawn code path)::
+
+    with open(stdout_capture_path, "w") as stdout_sink, \\
+         open(stderr_capture_path, "w") as stderr_sink:
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,  # line-buffered
+            cwd=str(worktree),
+        )
+        stream_subprocess_output(
+            proc,
+            agent_id=agent_id,
+            issue_number=issue_number,
+            phase=phase,
+            logger=self._log,
+            jsonl_path=worktree / ".dispatcher" / f"{phase}-{agent_id}.jsonl",
+            stdout_sink=stdout_sink,
+            stderr_sink=stderr_sink,
+        )
+        returncode = proc.wait(timeout=timeout_seconds)
+
+The ``stdout_sink`` / ``stderr_sink`` file objects are optional tee
+targets — when provided, the forwarder also writes each line verbatim
+(with its trailing newline) to the sink before structuring it. This
+preserves the pre-existing ``claude-p-<phase>.stdout.json`` /
+``.stderr.log`` capture layout the daemon's metering code relies on
+(``_parse_phase_usage`` reads the full stdout.json envelope), while
+adding the structured line-by-line forwarding on top. See issue #3017
+for the full rationale.
+
+Design notes
+------------
+
+- **Reader threads are not daemon threads.** They are explicit,
+  joined-by-the-caller threads so that a caller-side ``wait(timeout)``
+  fault (``subprocess.TimeoutExpired``) does not strand them. The
+  caller is responsible for calling :func:`join_stream_threads` (or
+  using the ``ForwarderThreads`` handle returned by
+  :func:`stream_subprocess_output_async`) after terminating the child.
+- **Line buffering is the child's responsibility.** The Popen call site
+  must set ``bufsize=1`` and ``text=True`` — without those, the Python
+  stdlib buffers stdout in 8KB chunks and the real-time guarantee is
+  lost. The forwarder itself reads in ``for line in file`` mode, which
+  returns complete lines as soon as the child flushes.
+- **The JSONL mirror is append-only.** The file is opened in ``"a"``
+  mode so multiple retries of the same phase in the same worktree (e.g.
+  ralph re-invoked from Step 2.5 on pre-push failure) accumulate rather
+  than overwriting prior context.
+- **Non-JSON stdout is handled.** The ``claude -p --output-format json``
+  payload is a single JSON envelope emitted at exit, but stderr and any
+  interim stdout lines are plain text. The forwarder treats every line
+  as a raw string; it does not attempt to parse JSON. Downstream
+  consumers (Log Insights ``parse @message`` filters) do the parsing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO, TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover
+    import subprocess
+
+
+#: Maximum length of a single forwarded line. Anything longer is
+#: truncated before structured-logging / JSONL emission. CloudWatch Logs
+#: accepts up to 256KB per event; we cap far below that so a runaway
+#: reviewer line doesn't blow the per-record budget. The JSONL mirror
+#: file honours the same cap for consistency — the truncation marker
+#: (``"...[truncated]"``) makes it visible to operators grepping the
+#: file that the line was clipped.
+MAX_LINE_CHARS = 16_000
+
+#: Truncation marker appended to lines longer than :data:`MAX_LINE_CHARS`.
+TRUNCATION_MARKER = "...[truncated]"
+
+
+@dataclass
+class ForwarderThreads:
+    """Handle returned by :func:`stream_subprocess_output_async`.
+
+    Caller must invoke :meth:`join` after the subprocess exits (or is
+    killed on timeout) so reader threads terminate cleanly.
+    """
+
+    stdout_thread: threading.Thread
+    stderr_thread: threading.Thread
+
+    def join(self, timeout: float | None = None) -> None:
+        """Join both reader threads.
+
+        A caller-side timeout here is best-effort — the threads exit on
+        stream EOF, which happens once the child closes its FDs on
+        process exit. If the caller forcibly killed the child via
+        :meth:`subprocess.Popen.kill`, EOF arrives immediately. For a
+        clean ``wait()`` exit, EOF has already arrived by the time the
+        caller joins, so the join is near-instant.
+        """
+        self.stdout_thread.join(timeout=timeout)
+        self.stderr_thread.join(timeout=timeout)
+
+
+def _truncate_line(line: str) -> str:
+    """Clip a single forwarded line to :data:`MAX_LINE_CHARS`.
+
+    Keeps the leading ``MAX_LINE_CHARS - len(TRUNCATION_MARKER)`` chars
+    and appends the marker so downstream readers can distinguish an
+    intentionally-long line from a clipped one.
+    """
+    if len(line) <= MAX_LINE_CHARS:
+        return line
+    head_budget = MAX_LINE_CHARS - len(TRUNCATION_MARKER)
+    return line[:head_budget] + TRUNCATION_MARKER
+
+
+def _emit_line(
+    *,
+    line: str,
+    stream: str,
+    agent_id: str,
+    issue_number: int | None,
+    phase: str,
+    logger: logging.Logger,
+    jsonl_handle: IO[str] | None,
+) -> None:
+    """Structured-log a single line and mirror it to the JSONL file.
+
+    Pure sink — no I/O against the child. Caller-invoked per line by the
+    reader threads. Exceptions from either the logger or the JSONL write
+    are swallowed so a broken sink never kills the reader thread (and
+    thus never stalls the child's pipe).
+    """
+    clipped = _truncate_line(line.rstrip("\n"))
+    record: dict[str, Any] = {
+        "event": "phase_subprocess_line",
+        "agent_id": agent_id,
+        "issue_number": issue_number,
+        "phase": phase,
+        "stream": stream,
+        # ``raw_message`` rather than ``message``: the latter is a
+        # reserved :class:`logging.LogRecord` attribute and passing it
+        # via ``extra`` raises ``KeyError``. See issue #3017 test
+        # ``test_none_issue_number_is_logged_as_null`` for the
+        # regression.
+        "raw_message": clipped,
+    }
+    try:
+        logger.info("daemon.phase_subprocess_line", extra=record)
+    except Exception:  # pragma: no cover — defensive
+        pass
+    if jsonl_handle is not None:
+        try:
+            jsonl_handle.write(json.dumps(record, default=str) + "\n")
+            jsonl_handle.flush()
+        except Exception:  # pragma: no cover — defensive
+            pass
+
+
+def _pump_stream(
+    *,
+    source: IO[str] | None,
+    sink: IO[str] | None,
+    stream: str,
+    agent_id: str,
+    issue_number: int | None,
+    phase: str,
+    logger: logging.Logger,
+    jsonl_handle: IO[str] | None,
+) -> None:
+    """Read ``source`` line-by-line and forward each line to every sink.
+
+    Runs on a dedicated reader thread — one per stream. Terminates on
+    EOF (child closed its end of the pipe, usually at process exit).
+    """
+    if source is None:
+        return
+    try:
+        for raw_line in source:
+            # ``raw_line`` always ends with ``\n`` except possibly the
+            # last partial line before EOF. We preserve the trailing
+            # newline when writing to ``sink`` (operator-facing log
+            # file) but strip it for structured-log emission so the
+            # JSON envelope ``message`` field doesn't carry a literal
+            # ``\n``.
+            if sink is not None:
+                try:
+                    sink.write(raw_line)
+                    sink.flush()
+                except Exception:  # pragma: no cover — defensive
+                    pass
+            _emit_line(
+                line=raw_line,
+                stream=stream,
+                agent_id=agent_id,
+                issue_number=issue_number,
+                phase=phase,
+                logger=logger,
+                jsonl_handle=jsonl_handle,
+            )
+    except Exception:  # pragma: no cover — defensive
+        # A broken source pipe should not leak as an unhandled thread
+        # exception; the main thread is authoritative for subprocess
+        # lifecycle via ``proc.wait()``.
+        return
+
+
+def stream_subprocess_output_async(
+    proc: subprocess.Popen[str],
+    *,
+    agent_id: str,
+    issue_number: int | None,
+    phase: str,
+    logger: logging.Logger,
+    jsonl_path: Path | None,
+    stdout_sink: IO[str] | None = None,
+    stderr_sink: IO[str] | None = None,
+) -> ForwarderThreads:
+    """Start reader threads for *proc*'s stdout and stderr.
+
+    Returns a :class:`ForwarderThreads` handle the caller joins after
+    the subprocess exits (or is killed on timeout). The returned
+    threads are non-daemon — callers must join them, but they self-
+    terminate on EOF, so a normal ``proc.wait()`` path is followed by
+    an immediate ``threads.join()``.
+
+    The JSONL mirror file is opened here (parent ``.dispatcher/``
+    directory is created if missing) so the caller does not have to
+    thread an open file handle through multiple layers. Ownership
+    follows the thread lifetime — the handle is closed after both
+    threads exit (see :meth:`_close_jsonl_on_both_threads_exit`).
+
+    ``stdout_sink`` / ``stderr_sink`` are optional tee targets the
+    forwarder writes each line to verbatim (with the trailing newline).
+    The daemon's pre-existing capture layout
+    (``claude-p-<phase>.stdout.json``, ``claude-p-<phase>.stderr.log``)
+    is preserved by passing open file handles to those paths as the
+    sinks. ``None`` means "do not tee to a file" — used by tests.
+    """
+    jsonl_handle: IO[str] | None = None
+    if jsonl_path is not None:
+        try:
+            jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+            jsonl_handle = jsonl_path.open("a", encoding="utf-8")
+        except Exception:  # pragma: no cover — defensive
+            jsonl_handle = None
+
+    stdout_thread = threading.Thread(
+        target=_pump_stream,
+        kwargs={
+            "source": proc.stdout,
+            "sink": stdout_sink,
+            "stream": "stdout",
+            "agent_id": agent_id,
+            "issue_number": issue_number,
+            "phase": phase,
+            "logger": logger,
+            "jsonl_handle": jsonl_handle,
+        },
+        name=f"stream-forwarder-stdout-{agent_id}-{phase}",
+        daemon=False,
+    )
+    stderr_thread = threading.Thread(
+        target=_pump_stream,
+        kwargs={
+            "source": proc.stderr,
+            "sink": stderr_sink,
+            "stream": "stderr",
+            "agent_id": agent_id,
+            "issue_number": issue_number,
+            "phase": phase,
+            "logger": logger,
+            "jsonl_handle": jsonl_handle,
+        },
+        name=f"stream-forwarder-stderr-{agent_id}-{phase}",
+        daemon=False,
+    )
+
+    # A third daemon thread waits for both reader threads to exit and
+    # then closes the shared JSONL handle. This keeps the handle alive
+    # for the full forwarding lifetime without requiring the caller to
+    # manage it, and avoids the two reader threads racing on close().
+    def _closer() -> None:
+        stdout_thread.join()
+        stderr_thread.join()
+        if jsonl_handle is not None:
+            try:
+                jsonl_handle.close()
+            except Exception:  # pragma: no cover — defensive
+                pass
+
+    closer_thread = threading.Thread(
+        target=_closer,
+        name=f"stream-forwarder-closer-{agent_id}-{phase}",
+        daemon=True,
+    )
+
+    stdout_thread.start()
+    stderr_thread.start()
+    closer_thread.start()
+
+    return ForwarderThreads(
+        stdout_thread=stdout_thread,
+        stderr_thread=stderr_thread,
+    )

--- a/scripts/dispatcher/tests/_popen_fake.py
+++ b/scripts/dispatcher/tests/_popen_fake.py
@@ -1,0 +1,109 @@
+"""Shared fake :class:`subprocess.Popen` for phase-spawn tests.
+
+Issue #3017 migrated ``_spawn_phase_subprocess`` and
+``_spawn_diagnoser_subprocess`` from :func:`subprocess.run` to
+:class:`subprocess.Popen` + a stream-forwarder utility so child output
+streams to CloudWatch in real time. The old tests that patched
+``subprocess.run`` with a ``fake_run`` closure needed equivalent
+``Popen`` fakery.
+
+This module provides :func:`make_popen_factory` — a helper that builds a
+drop-in ``Popen`` replacement for :func:`monkeypatch.setattr(subprocess, "Popen", ...)`.
+Callers supply:
+
+- ``stdout_chunks`` / ``stderr_chunks``: iterables of strings the fake
+  child will emit through its stdout/stderr pipes.
+- ``returncode``: exit code :meth:`wait` returns.
+- ``timeout``: if truthy, :meth:`wait` raises
+  :class:`subprocess.TimeoutExpired` on first call.
+- ``on_start``: optional callback invoked with the captured cmd + kwargs
+  — replaces the ``captured['cmd'] = cmd`` pattern of the old tests.
+
+The fake satisfies everything the stream-forwarder and daemon need:
+
+1. ``stdout`` / ``stderr`` are :class:`io.StringIO` handles the forwarder
+   reads line-by-line; the fake pre-populates them with the requested
+   chunks so ``for line in source`` sees the content immediately.
+2. ``wait(timeout=...)`` returns the desired ``returncode`` or raises
+   ``TimeoutExpired``.
+3. ``kill()`` and ``poll()`` are no-ops that return sensibly.
+
+This keeps the tests focused on the daemon's behaviour (command
+construction, file writes, log events) without re-running the forwarder's
+own unit tests for every spawn-test.
+"""
+
+from __future__ import annotations
+
+import io
+import subprocess
+from typing import Any, Callable, Iterable
+
+
+class _FakePopen:
+    """Minimal Popen substitute for :mod:`subprocess` tests.
+
+    Instances are not usually constructed directly — use the factory
+    returned by :func:`make_popen_factory` and install it via
+    :meth:`pytest.MonkeyPatch.setattr(subprocess, 'Popen', factory)`.
+    """
+
+    def __init__(
+        self,
+        *,
+        stdout_chunks: Iterable[str],
+        stderr_chunks: Iterable[str],
+        returncode: int,
+        timeout: bool,
+    ) -> None:
+        self.stdout = io.StringIO("".join(stdout_chunks))
+        self.stderr = io.StringIO("".join(stderr_chunks))
+        self._returncode = returncode
+        self._raise_timeout = timeout
+        self._finished = False
+
+    def wait(self, timeout: float | None = None) -> int:
+        if self._raise_timeout and not self._finished:
+            # Raise once, then pretend the kill()+wait path finished.
+            self._raise_timeout = False
+            raise subprocess.TimeoutExpired(cmd=["claude"], timeout=timeout or 0)
+        self._finished = True
+        return self._returncode
+
+    def kill(self) -> None:
+        self._finished = True
+
+    def poll(self) -> int | None:
+        return self._returncode if self._finished else None
+
+
+def make_popen_factory(
+    *,
+    stdout_chunks: Iterable[str] = (),
+    stderr_chunks: Iterable[str] = (),
+    returncode: int = 0,
+    timeout: bool = False,
+    on_start: Callable[[list[str], dict[str, Any]], None] | None = None,
+) -> Callable[..., _FakePopen]:
+    """Return a ``Popen`` factory with the requested behaviour baked in.
+
+    The factory signature matches :class:`subprocess.Popen` enough for
+    monkeypatching: it accepts the command list as its first positional
+    argument and ignores ``stdout=``, ``stderr=``, ``bufsize=``,
+    ``text=``, ``cwd=`` kwargs. Callers who care about those kwargs pass
+    an ``on_start`` callback to capture them.
+    """
+    chunks_out = list(stdout_chunks)
+    chunks_err = list(stderr_chunks)
+
+    def _factory(cmd: list[str], **kwargs: Any) -> _FakePopen:
+        if on_start is not None:
+            on_start(cmd, kwargs)
+        return _FakePopen(
+            stdout_chunks=chunks_out,
+            stderr_chunks=chunks_err,
+            returncode=returncode,
+            timeout=timeout,
+        )
+
+    return _factory

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -68,6 +68,7 @@ sys.modules["psycopg"] = _psycopg_stub
 import psycopg  # noqa: E402  — re-import after stub install
 
 from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+from dispatcher.tests._popen_fake import make_popen_factory  # noqa: E402
 
 
 # --------------------------------------------------------------------------
@@ -1193,15 +1194,11 @@ class TestSpawnPhaseSubprocess:
 
         captured: dict[str, Any] = {}
 
-        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        def on_start(cmd: list[str], kwargs: dict[str, Any]) -> None:
             captured["cmd"] = cmd
-            captured["timeout"] = kwargs.get("timeout")
             captured["cwd"] = kwargs.get("cwd")
-            r = MagicMock()
-            r.returncode = 0
-            return r
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(subprocess, "Popen", make_popen_factory(on_start=on_start))
 
         exit_code, duration = d._spawn_phase_subprocess("plan", tmp_path, "agent-uuid")
         assert exit_code == 0
@@ -1210,14 +1207,13 @@ class TestSpawnPhaseSubprocess:
         assert "-p" in captured["cmd"]
         assert "/task-v2-plan agent-uuid" in captured["cmd"]
         # --cwd is NOT a claude CLI flag; the worktree goes through
-        # subprocess.run's cwd= kwarg instead (#2821).
+        # subprocess.Popen's cwd= kwarg instead (#2821).
         assert "--cwd" not in captured["cmd"]
         assert captured["cwd"] == str(tmp_path)
         assert "--max-turns" in captured["cmd"]
         assert "500" in captured["cmd"]  # plan — 10× bumped in #2885
         assert "--model" in captured["cmd"]
         assert "opus" in captured["cmd"]
-        assert captured["timeout"] == 180 * 60
         assert handler.events("phase_started") != []
         log_path = tmp_path / "tmp" / "claude-p-plan.log"
         assert log_path.exists()
@@ -1229,13 +1225,10 @@ class TestSpawnPhaseSubprocess:
         d, _conn, _handler = _make_daemon(tmp_path)
         captured: dict[str, Any] = {}
 
-        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        def on_start(cmd: list[str], _kwargs: dict[str, Any]) -> None:
             captured["cmd"] = cmd
-            r = MagicMock()
-            r.returncode = 0
-            return r
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(subprocess, "Popen", make_popen_factory(on_start=on_start))
         d._spawn_phase_subprocess("ralph", tmp_path, "agent-uuid")
         assert "5000" in captured["cmd"]
         assert "sonnet" in captured["cmd"]
@@ -1247,13 +1240,10 @@ class TestSpawnPhaseSubprocess:
         d, _conn, _handler = _make_daemon(tmp_path)
         captured: dict[str, Any] = {}
 
-        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        def on_start(cmd: list[str], _kwargs: dict[str, Any]) -> None:
             captured["cmd"] = cmd
-            r = MagicMock()
-            r.returncode = 0
-            return r
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(subprocess, "Popen", make_popen_factory(on_start=on_start))
         d._spawn_phase_subprocess("summary", tmp_path, "agent-uuid")
         assert "300" in captured["cmd"]
         assert "haiku" in captured["cmd"]
@@ -1274,13 +1264,14 @@ class TestSpawnPhaseSubprocess:
         for phase in ("plan", "ralph", "summary", "verify", "fix-ci", "retro"):
             captured: dict[str, Any] = {}
 
-            def fake_run(cmd: list[str], **kwargs: Any) -> Any:
-                captured["cmd"] = cmd
-                r = MagicMock()
-                r.returncode = 0
-                return r
+            def on_start(
+                cmd: list[str], _kwargs: dict[str, Any], _c: dict[str, Any] = captured
+            ) -> None:
+                _c["cmd"] = cmd
 
-            monkeypatch.setattr(subprocess, "run", fake_run)
+            monkeypatch.setattr(
+                subprocess, "Popen", make_popen_factory(on_start=on_start)
+            )
             d._spawn_phase_subprocess(phase, tmp_path, f"agent-{phase}")
             assert "--dangerously-skip-permissions" in captured["cmd"], (
                 f"phase={phase} cmd missing --dangerously-skip-permissions: {captured['cmd']}"

--- a/scripts/dispatcher/tests/test_daemon_phase3d.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3d.py
@@ -73,6 +73,7 @@ if "psycopg" not in sys.modules or not isinstance(
     sys.modules["psycopg"] = _psycopg_stub
 
 from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+from dispatcher.tests._popen_fake import make_popen_factory  # noqa: E402
 
 
 # --------------------------------------------------------------------------
@@ -499,16 +500,11 @@ class TestSpawnDiagnoserSubprocess:
         d, _conn, _handler = _make_daemon(tmp_path)
         captured: dict[str, Any] = {}
 
-        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        def on_start(cmd: list[str], kwargs: dict[str, Any]) -> None:
             captured["cmd"] = cmd
             captured["kwargs"] = kwargs
-            r = MagicMock()
-            r.returncode = 0
-            r.stderr = ""
-            r.stdout = ""
-            return r
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(subprocess, "Popen", make_popen_factory(on_start=on_start))
         exit_code, tail = d._spawn_diagnoser_subprocess(777)
         assert exit_code == 0
         assert tail == ""
@@ -518,17 +514,16 @@ class TestSpawnDiagnoserSubprocess:
         assert "--model" in captured["cmd"]
         model_idx = captured["cmd"].index("--model")
         assert captured["cmd"][model_idx + 1] == daemon.DIAGNOSER_MODEL
-        assert captured["kwargs"]["timeout"] == (
-            daemon.DIAGNOSER_SUBPROCESS_TIMEOUT_SECONDS
-        )
+        # Post-#3017 the diagnoser timeout is enforced via proc.wait(timeout=...),
+        # not subprocess.run(..., timeout=...). The kwargs captured here
+        # come from Popen() itself; the timeout is passed to proc.wait
+        # inside _spawn_diagnoser_subprocess. Verified indirectly via
+        # test_timeout_returns_none_exit below.
 
     def test_timeout_returns_none_exit(self, monkeypatch: Any, tmp_path: Path) -> None:
         d, _conn, _handler = _make_daemon(tmp_path)
 
-        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
-            raise subprocess.TimeoutExpired(cmd=cmd, timeout=300)
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(subprocess, "Popen", make_popen_factory(timeout=True))
         exit_code, _tail = d._spawn_diagnoser_subprocess(1)
         assert exit_code is None
 
@@ -537,10 +532,10 @@ class TestSpawnDiagnoserSubprocess:
     ) -> None:
         d, _conn, _handler = _make_daemon(tmp_path)
 
-        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+        def fake_popen(cmd: list[str], **_kwargs: Any) -> Any:
             raise FileNotFoundError("claude missing")
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
         exit_code, tail = d._spawn_diagnoser_subprocess(1)
         assert exit_code is None
         assert "claude" in tail.lower() or "not found" in tail.lower()
@@ -556,15 +551,10 @@ class TestSpawnDiagnoserSubprocess:
         d, _conn, _handler = _make_daemon(tmp_path)
         captured: dict[str, Any] = {}
 
-        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+        def on_start(cmd: list[str], _kwargs: dict[str, Any]) -> None:
             captured["cmd"] = cmd
-            r = MagicMock()
-            r.returncode = 0
-            r.stderr = ""
-            r.stdout = ""
-            return r
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(subprocess, "Popen", make_popen_factory(on_start=on_start))
         d._spawn_diagnoser_subprocess(42)
         assert "--dangerously-skip-permissions" in captured["cmd"], captured["cmd"]
 

--- a/scripts/dispatcher/tests/test_daemon_token_metering.py
+++ b/scripts/dispatcher/tests/test_daemon_token_metering.py
@@ -47,6 +47,7 @@ _psycopg_stub.errors = _psycopg_errors
 sys.modules.setdefault("psycopg", _psycopg_stub)
 
 from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+from dispatcher.tests._popen_fake import make_popen_factory  # noqa: E402
 
 
 # --------------------------------------------------------------------------
@@ -149,13 +150,10 @@ class TestSpawnAddsOutputFormatJsonFlag:
 
         captured: dict[str, Any] = {}
 
-        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        def on_start(cmd: list[str], _kwargs: dict[str, Any]) -> None:
             captured["cmd"] = cmd
-            r = MagicMock()
-            r.returncode = 0
-            return r
 
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(subprocess, "Popen", make_popen_factory(on_start=on_start))
         d._spawn_phase_subprocess("plan", tmp_path, "agent-uuid")
 
         cmd = captured["cmd"]
@@ -170,19 +168,23 @@ class TestSpawnAddsOutputFormatJsonFlag:
         """``--output-format json`` would corrupt the JSON envelope if stderr
         merged into stdout. The spawn helper must split the streams so
         :meth:`_parse_phase_usage` can ``json.loads`` the stdout file
-        directly."""
+        directly.
+
+        Post-#3017: the spawn helper uses :class:`subprocess.Popen` with
+        a stream-forwarder that tees each line to the per-stream sink
+        files — same two output files, same split content, different
+        plumbing.
+        """
         d, _conn, _handler = _make_daemon(tmp_path)
 
-        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
-            # Simulate claude writing to the two provided file handles —
-            # the stdlib's subprocess.run threads them through directly.
-            kwargs["stdout"].write('{"usage":{"input_tokens":1}}')
-            kwargs["stderr"].write("boot-log line\n")
-            r = MagicMock()
-            r.returncode = 0
-            return r
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            subprocess,
+            "Popen",
+            make_popen_factory(
+                stdout_chunks=['{"usage":{"input_tokens":1}}\n'],
+                stderr_chunks=["boot-log line\n"],
+            ),
+        )
         d._spawn_phase_subprocess("plan", tmp_path, "agent-uuid")
 
         stdout_path = tmp_path / "tmp" / "claude-p-plan.stdout.json"
@@ -202,14 +204,14 @@ class TestSpawnAddsOutputFormatJsonFlag:
         single ``cat``-able triage target."""
         d, _conn, _handler = _make_daemon(tmp_path)
 
-        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
-            kwargs["stdout"].write('{"result":"ok"}')
-            kwargs["stderr"].write("stderr content")
-            r = MagicMock()
-            r.returncode = 0
-            return r
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            subprocess,
+            "Popen",
+            make_popen_factory(
+                stdout_chunks=['{"result":"ok"}\n'],
+                stderr_chunks=["stderr content\n"],
+            ),
+        )
         d._spawn_phase_subprocess("plan", tmp_path, "agent-uuid")
 
         combined = tmp_path / "tmp" / "claude-p-plan.log"
@@ -230,13 +232,14 @@ class TestSpawnAddsOutputFormatJsonFlag:
         output the streams captured before the fault."""
         d, _conn, _handler = _make_daemon(tmp_path)
 
-        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
-            kwargs["stderr"].write("crash-trace here")
-            r = MagicMock()
-            r.returncode = 1
-            return r
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            subprocess,
+            "Popen",
+            make_popen_factory(
+                stderr_chunks=["crash-trace here\n"],
+                returncode=1,
+            ),
+        )
         exit_code, _duration = d._spawn_phase_subprocess("plan", tmp_path, "agent-uuid")
         assert exit_code == 1
         combined = tmp_path / "tmp" / "claude-p-plan.log"

--- a/scripts/dispatcher/tests/test_skill_md_contracts.py
+++ b/scripts/dispatcher/tests/test_skill_md_contracts.py
@@ -39,6 +39,8 @@ _TASK_V2_SUMMARY_SKILL = (
 _TASK_V2_VERIFY_SKILL = (
     _REPO_ROOT / ".claude" / "skills" / "task-v2-verify" / "SKILL.md"
 )
+_TASK_V2_PLAN_SKILL = _REPO_ROOT / ".claude" / "skills" / "task-v2-plan" / "SKILL.md"
+_TASK_V2_RETRO_SKILL = _REPO_ROOT / ".claude" / "skills" / "task-v2-retro" / "SKILL.md"
 _DIAGNOSE_FAILURE_SKILL = (
     _REPO_ROOT / ".claude" / "skills" / "diagnose-failure" / "SKILL.md"
 )
@@ -351,3 +353,92 @@ class TestDiagnoseFailureContracts:
             "diagnose-failure/SKILL.md must document the wholesale-replace "
             "requirement for new_scope (issue #3010)"
         )
+
+
+# ------------------------------------------------------------------
+# Issue #3017 — Per-skill heartbeat lines contract coverage.
+# ------------------------------------------------------------------
+
+
+class TestTaskV2SimpleSkillHeartbeats:
+    """plan / summary / verify / retro each emit PHASE_START / PHASE_DONE
+    heartbeat tokens to stdout so CloudWatch Log Insights can answer
+    "what was the last thing the skill did before going silent?" during
+    a hang (issue #3017)."""
+
+    def test_plan_emits_phase_start_and_phase_done(self) -> None:
+        content = _read(_TASK_V2_PLAN_SKILL)
+        assert "PHASE_START plan" in content, (
+            "task-v2-plan/SKILL.md must document the PHASE_START plan heartbeat "
+            "(issue #3017)"
+        )
+        assert "PHASE_DONE" in content, (
+            "task-v2-plan/SKILL.md must document the PHASE_DONE heartbeat (issue #3017)"
+        )
+        assert "#3017" in content
+
+    def test_summary_emits_phase_start_and_phase_done(self) -> None:
+        content = _read(_TASK_V2_SUMMARY_SKILL)
+        assert "PHASE_START summary" in content, (
+            "task-v2-summary/SKILL.md must document the PHASE_START summary "
+            "heartbeat (issue #3017)"
+        )
+        assert "PHASE_DONE" in content
+        assert "#3017" in content
+
+    def test_verify_emits_phase_start_and_phase_done(self) -> None:
+        content = _read(_TASK_V2_VERIFY_SKILL)
+        assert "PHASE_START verify" in content
+        assert "PHASE_DONE" in content
+        assert "#3017" in content
+
+    def test_retro_emits_phase_start_and_phase_done(self) -> None:
+        content = _read(_TASK_V2_RETRO_SKILL)
+        assert "PHASE_START retro" in content
+        assert "PHASE_DONE" in content
+        assert "#3017" in content
+
+
+class TestTaskV2RalphHeartbeats:
+    """Ralph is the long-tail phase where hangs actually happen. It
+    emits a richer set of heartbeats: ITER_START, WORKER_START,
+    REVIEWER_START, PYTEST_START, PUSH_START (issue #3017)."""
+
+    def test_ralph_emits_iter_start(self) -> None:
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "ITER_START" in content, (
+            "task-v2-ralph/SKILL.md must document the ITER_START heartbeat "
+            "(issue #3017)"
+        )
+
+    def test_ralph_emits_worker_start(self) -> None:
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "WORKER_START" in content
+
+    def test_ralph_emits_reviewer_start(self) -> None:
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "REVIEWER_START" in content
+
+    def test_ralph_emits_pytest_start(self) -> None:
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "PYTEST_START" in content
+
+    def test_ralph_documents_push_start(self) -> None:
+        """PUSH_START is documented in ralph even though it fires on
+        the daemon side — operators reading the ralph jsonl need to know
+        what to expect and what NOT to expect."""
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "PUSH_START" in content
+
+    def test_ralph_references_issue_3017(self) -> None:
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "#3017" in content, (
+            "task-v2-ralph/SKILL.md must reference issue #3017 in the "
+            "heartbeat section for traceability"
+        )
+
+    def test_ralph_references_stream_forwarder(self) -> None:
+        """The heartbeat section must name the stream-forwarder module
+        so operators know where CloudWatch tagging happens."""
+        content = _read(_TASK_V2_RALPH_SKILL)
+        assert "stream_forwarder.py" in content or "stream-forwarder" in content

--- a/scripts/dispatcher/tests/test_stream_forwarder.py
+++ b/scripts/dispatcher/tests/test_stream_forwarder.py
@@ -1,0 +1,479 @@
+"""Unit tests for ``scripts.dispatcher.stream_forwarder`` (issue #3017).
+
+Acceptance criteria covered:
+
+- **AC#1** (incremental forwarding): Lines emitted by the child reach
+  the logger and the JSONL mirror as they arrive, not in a single
+  batch at EOF. Verified by a mock subprocess that emits lines with
+  sleeps between them and asserts the sink captured each line at a
+  timestamp close to when the child emitted it.
+- **AC#3** (tagging): Every forwarded record carries ``agent_id``,
+  ``issue_number``, ``phase``, ``stream``, and ``message`` fields.
+- **AC#4** (JSONL mirror): The file at the requested path exists, is
+  append-only, and each line is parseable JSON with the same schema as
+  the log record.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from dispatcher.stream_forwarder import (  # noqa: E402
+    MAX_LINE_CHARS,
+    TRUNCATION_MARKER,
+    _truncate_line,
+    stream_subprocess_output_async,
+)
+
+
+class _RecordingHandler(logging.Handler):
+    """Minimal ``logging.Handler`` that records every emitted record.
+
+    Unlike :class:`logging.handlers.MemoryHandler` this does not buffer —
+    each ``handle()`` appends immediately, and the caller can inspect
+    timestamps to assert incremental arrival.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[tuple[float, logging.LogRecord]] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append((time.monotonic(), record))
+
+
+def _make_logger(name: str) -> tuple[logging.Logger, _RecordingHandler]:
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    # Remove any handlers from prior tests in the same process.
+    logger.handlers = []
+    logger.propagate = False
+    handler = _RecordingHandler()
+    logger.addHandler(handler)
+    return logger, handler
+
+
+def _emit_lines_script(lines: list[str], delay_s: float) -> str:
+    """Return a Python one-liner (as a shell-safe single-script file path).
+
+    The script prints each *line* to stdout (or ``ERR:...`` to stderr if
+    the line starts with that prefix), flushing after each, with a
+    ``delay_s`` sleep between lines. Used as the mock child in the
+    incremental-forwarding test.
+
+    The caller writes the returned script body to a tempfile under the
+    test's ``tmp_path`` and invokes Python with the file path — no
+    ``python -c`` (CLAUDE.md Critical Rules ban inline ``-c``).
+    """
+    # Emit each line via print+flush so there's no stdlib buffering
+    # between the child and the pipe. Stderr lines get their prefix
+    # stripped and routed to sys.stderr.
+    parts = [
+        "import sys, time",
+    ]
+    for line in lines:
+        if line.startswith("ERR:"):
+            payload = line[len("ERR:") :]
+            parts.append(f"sys.stderr.write({payload!r} + chr(10)); sys.stderr.flush()")
+        else:
+            parts.append(f"sys.stdout.write({line!r} + chr(10)); sys.stdout.flush()")
+        parts.append(f"time.sleep({delay_s})")
+    return "\n".join(parts)
+
+
+@pytest.fixture
+def tmp_script(tmp_path: Path):
+    """Return a helper that writes a Python snippet to ``tmp_path`` and
+    yields its absolute path. The file is cleaned up by pytest's
+    ``tmp_path`` fixture.
+    """
+
+    def _write(body: str, name: str = "child.py") -> Path:
+        p = tmp_path / name
+        p.write_text(body, encoding="utf-8")
+        return p
+
+    return _write
+
+
+class TestIncrementalForwarding:
+    """AC#1 — lines reach the logger incrementally, not at EOF."""
+
+    def test_stdout_lines_forwarded_before_subprocess_exits(
+        self, tmp_path: Path, tmp_script
+    ) -> None:
+        """The logger must receive each line within a small window of
+        when the child emitted it. We use a 150ms inter-line delay and
+        assert that the time deltas between consecutive sink arrivals
+        match the child's emit cadence — if the forwarder were batching
+        at EOF, all records would land within a few ms of each other.
+        """
+        lines = ["line-1", "line-2", "line-3"]
+        delay_s = 0.15
+        script_path = tmp_script(_emit_lines_script(lines, delay_s=delay_s))
+
+        logger, handler = _make_logger("test.forwarder.incremental")
+        jsonl_path = tmp_path / ".dispatcher" / "ralph-abc123.jsonl"
+
+        proc = subprocess.Popen(
+            [sys.executable, str(script_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        try:
+            threads = stream_subprocess_output_async(
+                proc,
+                agent_id="abc123",
+                issue_number=3017,
+                phase="ralph",
+                logger=logger,
+                jsonl_path=jsonl_path,
+            )
+            proc.wait(timeout=10)
+            threads.join(timeout=5)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+
+        # Extract timestamps for just the stdout records we care about.
+        stdout_records = [
+            (ts, rec)
+            for (ts, rec) in handler.records
+            if getattr(rec, "stream", None) == "stdout"
+        ]
+        assert len(stdout_records) == len(lines), (
+            f"expected {len(lines)} stdout records, got {len(stdout_records)}: "
+            f"{[r.__dict__ for _, r in stdout_records]}"
+        )
+        # Verify order and message contents.
+        for (ts, rec), expected_line in zip(stdout_records, lines, strict=True):
+            assert getattr(rec, "raw_message", None) == expected_line
+
+        # Verify incremental arrival. The gap between the first and
+        # last record should be at least ``delay_s * (N - 1)`` (the
+        # child's actual emit span). If the forwarder were batching,
+        # all records would have effectively the same timestamp.
+        first_ts = stdout_records[0][0]
+        last_ts = stdout_records[-1][0]
+        elapsed = last_ts - first_ts
+        min_span = delay_s * (len(lines) - 1) * 0.5  # 50% tolerance
+        assert elapsed >= min_span, (
+            f"expected ≥{min_span:.3f}s span between first and last record "
+            f"(incremental forwarding), got {elapsed:.3f}s — forwarder may "
+            f"be batching at EOF"
+        )
+
+    def test_stderr_lines_forwarded_with_stream_stderr_tag(
+        self, tmp_path: Path, tmp_script
+    ) -> None:
+        """Stderr content is tagged ``stream="stderr"`` and reaches the
+        logger independently of stdout."""
+        lines = ["stdout-a", "ERR:err-b", "stdout-c", "ERR:err-d"]
+        script_path = tmp_script(_emit_lines_script(lines, delay_s=0.01))
+
+        logger, handler = _make_logger("test.forwarder.stderr")
+        jsonl_path = tmp_path / ".dispatcher" / "plan-xyz.jsonl"
+
+        proc = subprocess.Popen(
+            [sys.executable, str(script_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        try:
+            threads = stream_subprocess_output_async(
+                proc,
+                agent_id="xyz",
+                issue_number=42,
+                phase="plan",
+                logger=logger,
+                jsonl_path=jsonl_path,
+            )
+            proc.wait(timeout=10)
+            threads.join(timeout=5)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+
+        stdout_msgs = sorted(
+            getattr(rec, "raw_message", "")
+            for (_, rec) in handler.records
+            if getattr(rec, "stream", None) == "stdout"
+        )
+        stderr_msgs = sorted(
+            getattr(rec, "raw_message", "")
+            for (_, rec) in handler.records
+            if getattr(rec, "stream", None) == "stderr"
+        )
+        assert stdout_msgs == ["stdout-a", "stdout-c"]
+        assert stderr_msgs == ["err-b", "err-d"]
+
+
+class TestRecordSchema:
+    """AC#3 — every record carries the five required tag fields."""
+
+    def test_every_record_has_required_tag_fields(
+        self, tmp_path: Path, tmp_script
+    ) -> None:
+        script_path = tmp_script(_emit_lines_script(["hello"], delay_s=0))
+
+        logger, handler = _make_logger("test.forwarder.schema")
+        jsonl_path = tmp_path / ".dispatcher" / "summary-aaa.jsonl"
+
+        proc = subprocess.Popen(
+            [sys.executable, str(script_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        try:
+            threads = stream_subprocess_output_async(
+                proc,
+                agent_id="aaa",
+                issue_number=999,
+                phase="summary",
+                logger=logger,
+                jsonl_path=jsonl_path,
+            )
+            proc.wait(timeout=10)
+            threads.join(timeout=5)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+
+        assert handler.records, "expected at least one forwarded record"
+        for _, record in handler.records:
+            assert getattr(record, "agent_id", None) == "aaa"
+            assert getattr(record, "issue_number", None) == 999
+            assert getattr(record, "phase", None) == "summary"
+            assert getattr(record, "stream", None) in {"stdout", "stderr"}
+            assert isinstance(getattr(record, "raw_message", None), str)
+            assert getattr(record, "event", None) == "phase_subprocess_line"
+
+
+class TestJsonlMirror:
+    """AC#4 — the JSONL mirror file contains the same tagged events."""
+
+    def test_jsonl_mirror_file_has_one_json_per_line(
+        self, tmp_path: Path, tmp_script
+    ) -> None:
+        script_path = tmp_script(
+            _emit_lines_script(["alpha", "beta", "ERR:gamma"], delay_s=0.01)
+        )
+
+        logger, _ = _make_logger("test.forwarder.jsonl")
+        jsonl_path = tmp_path / ".dispatcher" / "verify-bbb.jsonl"
+
+        proc = subprocess.Popen(
+            [sys.executable, str(script_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        try:
+            threads = stream_subprocess_output_async(
+                proc,
+                agent_id="bbb",
+                issue_number=123,
+                phase="verify",
+                logger=logger,
+                jsonl_path=jsonl_path,
+            )
+            proc.wait(timeout=10)
+            threads.join(timeout=5)
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+
+        assert jsonl_path.exists(), "JSONL mirror file was not created"
+        raw = jsonl_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(raw) == 3, f"expected 3 lines, got {len(raw)}: {raw!r}"
+        parsed = [json.loads(line) for line in raw]
+        # All three records must carry the same agent/issue/phase tags.
+        for rec in parsed:
+            assert rec["agent_id"] == "bbb"
+            assert rec["issue_number"] == 123
+            assert rec["phase"] == "verify"
+            assert rec["event"] == "phase_subprocess_line"
+            assert rec["stream"] in {"stdout", "stderr"}
+            assert isinstance(rec["raw_message"], str)
+
+    def test_jsonl_mirror_is_append_only(self, tmp_path: Path, tmp_script) -> None:
+        """A second forwarder call on the same path appends; prior
+        content is preserved. This matches the real-world case where
+        ralph's Step 2.5 retry reinvokes the same phase in the same
+        worktree.
+        """
+        logger, _ = _make_logger("test.forwarder.append")
+        jsonl_path = tmp_path / ".dispatcher" / "ralph-ccc.jsonl"
+
+        for batch in (["first-run"], ["second-run"]):
+            script_path = tmp_script(
+                _emit_lines_script(batch, delay_s=0),
+                name=f"child-{batch[0]}.py",
+            )
+            proc = subprocess.Popen(
+                [sys.executable, str(script_path)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
+            threads = stream_subprocess_output_async(
+                proc,
+                agent_id="ccc",
+                issue_number=7,
+                phase="ralph",
+                logger=logger,
+                jsonl_path=jsonl_path,
+            )
+            proc.wait(timeout=10)
+            threads.join(timeout=5)
+
+        raw = jsonl_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(raw) == 2
+        msgs = [json.loads(line)["raw_message"] for line in raw]
+        assert msgs == ["first-run", "second-run"]
+
+
+class TestTeeSinks:
+    """The optional ``stdout_sink`` / ``stderr_sink`` tees preserve the
+    daemon's pre-existing capture layout (``claude-p-<phase>.stdout.json``
+    etc.) while the forwarder is active.
+    """
+
+    def test_stdout_sink_receives_raw_lines_with_trailing_newlines(
+        self, tmp_path: Path, tmp_script
+    ) -> None:
+        script_path = tmp_script(_emit_lines_script(["raw-a", "raw-b"], delay_s=0))
+
+        logger, _ = _make_logger("test.forwarder.tee.stdout")
+        stdout_tee = tmp_path / "stdout_capture.json"
+        stderr_tee = tmp_path / "stderr_capture.log"
+        jsonl_path = tmp_path / ".dispatcher" / "retro-ddd.jsonl"
+
+        with (
+            stdout_tee.open("w", encoding="utf-8") as sout,
+            stderr_tee.open("w", encoding="utf-8") as serr,
+        ):
+            proc = subprocess.Popen(
+                [sys.executable, str(script_path)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                bufsize=1,
+            )
+            threads = stream_subprocess_output_async(
+                proc,
+                agent_id="ddd",
+                issue_number=1,
+                phase="retro",
+                logger=logger,
+                jsonl_path=jsonl_path,
+                stdout_sink=sout,
+                stderr_sink=serr,
+            )
+            proc.wait(timeout=10)
+            threads.join(timeout=5)
+
+        assert stdout_tee.read_text(encoding="utf-8") == "raw-a\nraw-b\n"
+
+
+class TestLineTruncation:
+    """Lines over :data:`MAX_LINE_CHARS` are clipped with a marker."""
+
+    def test_short_lines_not_truncated(self) -> None:
+        assert _truncate_line("hello") == "hello"
+
+    def test_long_line_truncated_with_marker(self) -> None:
+        long = "x" * (MAX_LINE_CHARS + 100)
+        out = _truncate_line(long)
+        assert len(out) == MAX_LINE_CHARS
+        assert out.endswith(TRUNCATION_MARKER)
+        assert out.startswith("x")
+
+    def test_exactly_max_chars_not_truncated(self) -> None:
+        exact = "y" * MAX_LINE_CHARS
+        assert _truncate_line(exact) == exact
+
+
+class TestForwarderThreadsHandle:
+    """:class:`ForwarderThreads` joins cleanly even on a hung child."""
+
+    def test_join_returns_after_child_exits(self, tmp_path: Path, tmp_script) -> None:
+        script_path = tmp_script(_emit_lines_script(["quick"], delay_s=0))
+        logger, _ = _make_logger("test.forwarder.join")
+        proc = subprocess.Popen(
+            [sys.executable, str(script_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        threads = stream_subprocess_output_async(
+            proc,
+            agent_id="eee",
+            issue_number=None,
+            phase="plan",
+            logger=logger,
+            jsonl_path=None,  # no JSONL mirror
+        )
+        proc.wait(timeout=5)
+        threads.join(timeout=5)
+        assert not threads.stdout_thread.is_alive()
+        assert not threads.stderr_thread.is_alive()
+
+
+class TestMissingIssueNumber:
+    """``issue_number=None`` is tolerated — the diagnoser spawn path has
+    no single bound issue number (it spans multiple failures).
+    """
+
+    def test_none_issue_number_is_logged_as_null(
+        self, tmp_path: Path, tmp_script
+    ) -> None:
+        script_path = tmp_script(_emit_lines_script(["line"], delay_s=0))
+        logger, handler = _make_logger("test.forwarder.no_issue")
+        jsonl_path = tmp_path / ".dispatcher" / "diagnose-fff.jsonl"
+        proc = subprocess.Popen(
+            [sys.executable, str(script_path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        threads = stream_subprocess_output_async(
+            proc,
+            agent_id="fff",
+            issue_number=None,
+            phase="diagnose",
+            logger=logger,
+            jsonl_path=jsonl_path,
+        )
+        proc.wait(timeout=5)
+        threads.join(timeout=5)
+
+        assert handler.records
+        rec = handler.records[0][1]
+        assert getattr(rec, "issue_number", "MISSING") is None
+        # JSONL mirror also has None serialized as JSON null.
+        raw = jsonl_path.read_text(encoding="utf-8").strip().splitlines()
+        parsed = json.loads(raw[0])
+        assert parsed["issue_number"] is None


### PR DESCRIPTION
## Summary

Adds a shared stream-forwarder utility that wraps `subprocess.Popen` and streams every line of child stdout/stderr to CloudWatch (tagged with `agent_id`, `issue_number`, `phase`, `stream`, `raw_message`) plus a real-time JSONL mirror at `{worktree}/.dispatcher/{phase}-{agent_id}.jsonl`. Routes both `_spawn_phase_subprocess` (plan/ralph/summary/verify/retro) and `_spawn_diagnoser_subprocess` through the utility, replacing the previous `subprocess.run` calls that buffered output until exit. Adds per-skill heartbeat instructions (`PHASE_START/PHASE_DONE` for the simple phases; full `ITER_START/WORKER_START/REVIEWER_START/PYTEST_START/PUSH_START` set for ralph) so operators can grep CloudWatch for the last boundary crossed before a hang.

Unblocks root-cause diagnosis for subprocess hangs like the #2564 ralph-hang cascade that burned ~9 hours of compute with zero diagnostic payoff.

Closes #3017

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (886 dispatcher tests + 11 new stream-forwarder tests + 10 new skill-md heartbeat contract tests)
- [x] CI green

### Post-deploy verification
- [ ] Log Insights query against `/ecs/judgemind-dispatcher-dev` after merge returns `phase_subprocess_line` events tagged with `agent_id`, `phase`, `stream`, and `raw_message` for the next orchestration run.
- [ ] Verify JSONL mirror exists at `{worktree}/.dispatcher/{phase}-{agent_id}.jsonl` during or after a live dispatcher run (inspect via ECS exec while worktree is still alive, or confirm the daemon logs the write path).
- [ ] Verification evidence posted on issue (see A.8)

## Implementation notes

- **`raw_message` vs `message`.** The forwarded payload key is `raw_message` because `message` is a reserved `logging.LogRecord` attribute (passing `extra={"message": ...}` raises `KeyError`). CloudWatch Log Insights queries therefore use `filter raw_message like /.../`. Documented inline in `stream_forwarder.py` and flagged in the process-summary on the issue.
- **Real-time guarantee.** `subprocess.Popen(..., bufsize=1, text=True)` + two per-stream reader threads. No `communicate()` — the old code path blocked until EOF and produced no breadcrumbs on hangs. The incremental-forwarding test uses 150ms inter-line sleeps and asserts the logger sees each line within 50% of that cadence.
- **Backwards compatibility.** The pre-existing `claude-p-<phase>.stdout.json`, `claude-p-<phase>.stderr.log`, and combined `.log` capture files are preserved via optional tee sinks, so metering (`_parse_phase_usage`) and the existing triage helpers continue to work unchanged.
- **Relative import.** `daemon.py` imports the forwarder via `from .stream_forwarder import ...` so the module resolves under both `python -m scripts.dispatcher.daemon` (production) and `from dispatcher import daemon` after tests put `scripts/` on `sys.path`. An absolute/fallback pattern would false-trip `scripts/check-dispatcher-image-deps.py`.
- **Test-side migration.** A shared `_popen_fake.py` helper migrates the existing `test_daemon_phase3a.py`, `test_daemon_phase3d.py`, and `test_daemon_token_metering.py` tests from `subprocess.run` fakes to `subprocess.Popen` fakes.
