### PR TITLE
feat(dispatcher): per-iteration ralph patches + cross-agent resume with conflict-handoff (#3026)

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -477,7 +477,34 @@ If the predicate is satisfied: the loop is done. Continue to Step 3.
 
 - If the required reviewer(s) say **REVISE** (and no persistent-dissent override applies): Increment iteration. If `iteration > max_iterations`, stop the loop and comment on the issue that the ralph loop hit its max iterations — block the issue with `scripts/block-issue.sh <issue> <blocker>` (if applicable) or add `status/blocked` manually, and return with failure. Otherwise:
   - Consolidate feedback from ALL reviewers that said REVISE into `{worktree}/tmp/ralph/feedback.md`. Include feedback from `gemini-feedback.md`, `adversarial-feedback.md`, and/or `feedback.md` as appropriate. On the non-testable branch, only Claude's `feedback.md` is relevant (the Gemini files are SKIPPED placeholders).
+  - Before bumping `iteration.txt`, **persist the current iteration's patch** (see 2f below).
   - Create new todos for the next iteration (using the branch-appropriate todo list from Step 1), then return to 2a.
+
+### 2f — Persist per-iteration patch (#3026)
+
+At the end of every iteration (whether the loop decision is SHIP, REVISE, or BLOCKED), invoke the per-iteration persistence helper so the patch is saved to `dispatcher.ralph_patches` before the next iteration begins (or before the loop ends). This is the resilience hook from #3026: a daemon crash, timeout, or retry mid-loop can resume from the most recent iteration's state instead of re-ralph'ing from scratch.
+
+**Prerequisite:** the worker has committed the iteration's work via `git commit --amend --no-edit` (Step 2.5a in `/task-v2-ralph`, or the inner commit step in non-testable branches). The helper reads `git format-patch origin/main..HEAD --stdout` so a commit must exist.
+
+**Invocation (single Bash call, no heredoc):**
+
+```
+python3 {worktree}/scripts/dispatcher/persist_ralph_iteration.py --worktree {worktree} --agent-id {agent_id} --issue-number {N} --iteration {iteration} --verdict {VERDICT}
+```
+
+Where:
+- `{agent_id}` and `{N}` come from the ralph input bundle (ralph receives these via `{worktree}/tmp/dispatcher-input/ralph.json`, or the outer `/task-v2-ralph` wrapper — propagate them into the inner `/ralph` via the worker's state).
+- `{iteration}` is the current value in `{worktree}/tmp/ralph/iteration.txt`.
+- `{VERDICT}` is:
+  - `LOOP` when reviewers said REVISE and the loop will continue to the next iteration.
+  - `SHIP` when reviewers agreed to SHIP (or the persistent-dissent override fired).
+  - `ABORT` when the worker wrote STUCK or the loop is stopping with BLOCKED.
+
+**Failure behaviour.** The helper exits 0 on every failure path (missing `DATABASE_URL` env — e.g. local smoke tests, subprocess error, DB outage). A stdout line of the form `persisted=<uuid>`, `skipped=<reason>`, or `error=<detail>` is emitted for log forensics but does not affect ralph's control flow. **Never branch on the helper's exit code** — it is always 0.
+
+**When to skip.** If `git format-patch origin/main..HEAD --stdout` would produce no output (working tree matches `origin/main` — a no-op iteration, which is unusual), the helper emits `skipped=empty_or_failed_format_patch` and returns. No special handling needed.
+
+This hook is the cross-agent / same-agent resume path's upstream write: the daemon's unified resume lookup (`DispatcherDaemon._apply_prior_ralph_patch`) queries the most-recent row for the issue within the 7-day TTL, regardless of `agent_id`, so any iteration's saved patch is a valid starting point for a future retry.
 
 ---
 

--- a/.claude/skills/task-v2-ralph/SKILL.md
+++ b/.claude/skills/task-v2-ralph/SKILL.md
@@ -94,7 +94,26 @@ Read `{worktree}/tmp/dispatcher-input/ralph.json`. Required fields:
 
 If the file is missing or malformed, exit 0 with `verdict=BLOCKED, block_reason="input JSON missing or malformed"`.
 
-**Pre-applied prior SHIP'd patch (#3012).** The daemon may have `git am`-applied a prior SHIP'd patch onto your fresh worktree before invoking you, when a previous agent on this issue ran ralph to SHIP but the daemon never reached `gh pr create` (restart, push timeout, crash). If applied cleanly, HEAD already carries the prior agent's `WIP: ralph output` commit — iterate on top of the inherited diff (`git diff origin/main...HEAD`) rather than re-implementing from scratch. If `git am` failed (base drift, conflicts), HEAD is clean origin/main and the patch text appears in `prior_attempts.md` under a `## Prior SHIP'd patch (did NOT apply cleanly)` section so the worker can cherry-pick manually. Transparent from the skill's perspective — no new input field; the worktree and `prior_attempts.md` arrive pre-populated.
+**Pre-applied prior ralph patch (#3012, extended by #3026).** The daemon may have `git am --3way`-applied a prior ralph patch onto your fresh worktree before invoking you, when a previous agent on this issue produced cumulative work (per-iteration snapshot or terminal SHIP) but the daemon never reached `gh pr create` (restart, push timeout, crash, retry exhaustion). The unified resume lookup picks the most-recent patch for the `issue_number` within a 7-day TTL — any `agent_id`, any `verdict`. Three outcomes:
+
+1. **Clean apply.** HEAD carries the prior `WIP: ralph output` commit. Iterate on top of the inherited diff (`git diff origin/main...HEAD`) rather than re-implementing from scratch. No additional signal in `task.md`.
+2. **Conflict, am-in-progress left intact (#3026 conflict-handoff).** The daemon did **NOT** run `git am --abort`. The worktree is in the `git am --3way` conflict state (unmerged index entries, `.git/rebase-apply/` present, conflict markers in affected files). A structured **"RESUME WITH CONFLICT"** block appears at the top of `prior_attempts.md` (which the inner `/ralph` surfaces into `task.md`). The ralph worker **decides** whether to resolve + `git am --continue` or `git am --abort` + start fresh — see §"Resume with conflict" below for the contract.
+3. **Invocation error (no conflict resolution possible).** `git am` failed before conflict resolution (corrupt patch, subprocess error). The daemon aborted the am cleanly; HEAD is at origin/main. The patch text appears in `prior_attempts.md` under a `## Prior ralph patch (did NOT apply cleanly)` section so the worker can cherry-pick manually.
+
+Transparent from the skill's perspective — no new input field; the worktree state and `prior_attempts.md` arrive pre-populated.
+
+### Resume with conflict (#3026 contract)
+
+When `prior_attempts.md` contains a heading whose first line reads `RESUME WITH CONFLICT`, the inner `/ralph` worker enters a special first-iteration path:
+
+1. **Inspect the worktree.** `git status` shows unmerged paths; `git diff --diff-filter=U --name-only` lists them; `.git/rebase-apply/` is present. The block names the source `agent_id` (short), iteration number, verdict, and age; the conflict file list and count are also surfaced.
+2. **Decide: continue or abort.** This is the worker's judgment call. Guidelines:
+   - Choose **`git am --continue`** (after resolving conflicts) when: the prior work is recent (< 24 h) AND directly relevant to the current issue understanding AND the conflict volume is tractable (typically ≤ 5 files with surface-level conflicts) AND the acceptance criteria have not materially changed. Resolve the conflict markers, `git add` the resolved files, run `git am --continue`. The am-in-progress finalises into a commit on the branch; proceed into iteration 1 normally.
+   - Choose **`git am --abort`** when: the prior work is stale (> 48 h) OR wrong for the current understanding (issue comments contradict the prior diff) OR the conflict volume is unbounded (entire file rewrites on both sides) OR the prior verdict was `ABORT` already. Run `git am --abort`; HEAD returns to `origin/main`; proceed as a fresh first iteration.
+3. **Both paths are valid.** The RESUME WITH CONFLICT block is advisory — the daemon surfaces prior work so it isn't lost, not as a directive. A worker that chooses `--abort` is not wasting work; it's exercising the judgment the contract explicitly asks for.
+4. **After deciding**, the worker need not rewrite `task.md` — the block stays in `prior_attempts.md` as a breadcrumb either way; what matters is that the git state on disk reflects the chosen path before iteration 1 begins.
+
+The block's exact wording is fixed (daemon side — `DispatcherDaemon._format_resume_with_conflict_block`) so pattern-matching the literal `RESUME WITH CONFLICT` heading is safe.
 
 ---
 

--- a/packages/api/migrations/39_dispatcher-ralph-patches-per-iteration.sql
+++ b/packages/api/migrations/39_dispatcher-ralph-patches-per-iteration.sql
@@ -1,0 +1,91 @@
+-- Up Migration
+--
+-- Dispatcher v2 — per-iteration ralph patch persistence (#3026).
+--
+-- Motivation
+-- ----------
+-- #3013 persisted a ralph patch to ``dispatcher.ralph_patches`` only on the
+-- SHIP verdict — the narrow window between ralph reaching SHIP and the
+-- daemon's ``gh pr create`` succeeding. Everything before SHIP was
+-- ephemeral; a ralph crash, timeout, or abandonment mid-loop destroyed
+-- every iteration's accumulated work.
+--
+-- Concrete cost observed 2026-04-22 on #2564: attempts 2, 3, and 4 each
+-- accumulated significant ralph work (reviewer passes complete, pytest
+-- green, failing only in pre-push) that was destroyed by retry-related
+-- worktree cleanup. Each fresh attempt started from zero. Across the
+-- three attempts this cost ~9 hours of compute with no durable progress.
+--
+-- The fix
+-- -------
+-- Save a cumulative patch to ``dispatcher.ralph_patches`` after every
+-- ralph iteration (not only on SHIP). On resume (same agent or fresh
+-- claim on the same issue, within 7-day TTL), apply the most recent
+-- saved patch via ``git am --3way``. On conflict, the daemon LEAVES
+-- the conflicted state intact and hands the decision to ralph via a
+-- structured "RESUME WITH CONFLICT" prompt block — ralph judges whether
+-- the prior work is recoverable or should be discarded.
+--
+-- Schema change
+-- -------------
+-- Two nullable columns on the existing ``dispatcher.ralph_patches`` table:
+--
+-- * ``iteration_n INT``
+--     - 1-based iteration number at the time the row was written.
+--     - NULL for legacy rows from #3013 era (pre-migration) and for
+--       SHIP rows (the SHIP write keeps the #3013 DELETE-supersede
+--       semantics and carries verdict='SHIP' with iteration_n=NULL so
+--       the unified resume lookup orders by created_at DESC uniformly).
+--     - Operators can distinguish legacy rows (``iteration_n IS NULL
+--       AND verdict IS NULL``) from new SHIP rows (``iteration_n IS
+--       NULL AND verdict = 'SHIP'``) from per-iteration intermediate
+--       rows (``iteration_n IS NOT NULL AND verdict IN ('LOOP',
+--       'SHIP')``).
+--
+-- * ``verdict TEXT``
+--     - 'LOOP' (iteration finished, loop continues), 'SHIP' (terminal
+--       SHIP verdict), 'ABORT' (iteration gave up), or NULL (legacy).
+--     - Not a CHECK-constrained enum — the daemon writes one of these
+--       four values and readers must tolerate unknown strings from
+--       future versions (forward-compat).
+--
+-- Lifecycle
+-- ---------
+-- * Rows accumulate per-iteration during a ralph run: INSERT (no
+--   supersede) per iteration with the daemon's cumulative-patch
+--   (``git format-patch origin/main..HEAD --stdout``). Multiple rows
+--   for the same (agent_id, iteration_n) are tolerated — the unified
+--   resume lookup picks the most recent by ``created_at``.
+-- * On SHIP, the existing #3013 DELETE-by-issue-number-then-INSERT
+--   path still runs, supersedeing the intermediate rows and writing
+--   the authoritative SHIP row with verdict='SHIP'.
+-- * On successful ``gh pr create``, the existing #3013 DELETE-by-
+--   agent-id path still runs, cleaning up all rows (SHIP + any
+--   intermediate rows the SHIP delete didn't catch).
+-- * The 7-day TTL housekeeping sweep from #3012 catches everything
+--   else (abandoned runs, daemon crashes, operator force-stops).
+--
+-- Resume lookup (see daemon ``_apply_prior_ralph_patch``)
+-- -------------------------------------------------------
+-- ``SELECT ... WHERE issue_number = %s AND created_at > now() -
+-- interval '7 days' ORDER BY created_at DESC LIMIT 1;``
+--
+-- Any agent_id matches — same-agent restart, cross-agent fresh claim,
+-- or legacy same-issue-retry all use the unified lookup. The 7-day TTL
+-- predicate is redundant with the housekeeping sweep but keeps a
+-- partial-sweep state from surfacing stale patches.
+
+ALTER TABLE dispatcher.ralph_patches
+    ADD COLUMN iteration_n INT,
+    ADD COLUMN verdict      TEXT;
+
+COMMENT ON COLUMN dispatcher.ralph_patches.iteration_n IS
+    '1-based ralph iteration number at the time the row was written. NULL for legacy #3013 rows (pre-#3026 migration) and for SHIP rows (the SHIP DELETE-supersede path carries verdict=SHIP with iteration_n=NULL). Non-NULL for per-iteration intermediate rows. Issue #3026.';
+
+COMMENT ON COLUMN dispatcher.ralph_patches.verdict IS
+    'Ralph verdict when the row was captured: LOOP (iteration continuing), SHIP (terminal SHIP), ABORT (gave up), or NULL (legacy pre-#3026). Not CHECK-constrained so forward-version daemons can introduce new verdicts without a migration. Issue #3026.';
+
+
+-- Down Migration
+ALTER TABLE dispatcher.ralph_patches DROP COLUMN IF EXISTS verdict;
+ALTER TABLE dispatcher.ralph_patches DROP COLUMN IF EXISTS iteration_n;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 38 migrations.
+-- Generated from 39 migrations.
 
 
 
@@ -628,7 +628,9 @@ CREATE TABLE dispatcher.ralph_patches (
     issue_number integer NOT NULL,
     patch_content text NOT NULL,
     commit_sha text,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    iteration_n integer,
+    verdict text
 );
 
 
@@ -639,6 +641,12 @@ COMMENT ON COLUMN dispatcher.ralph_patches.patch_content IS 'git format-patch -1
 
 
 COMMENT ON COLUMN dispatcher.ralph_patches.commit_sha IS 'ralph''s HEAD SHA at SHIP time. Nullable — written when git rev-parse succeeds; informational only (the patch is the authoritative artifact).';
+
+
+COMMENT ON COLUMN dispatcher.ralph_patches.iteration_n IS '1-based ralph iteration number at the time the row was written. NULL for legacy #3013 rows (pre-#3026 migration) and for SHIP rows (the SHIP DELETE-supersede path carries verdict=SHIP with iteration_n=NULL). Non-NULL for per-iteration intermediate rows. Issue #3026.';
+
+
+COMMENT ON COLUMN dispatcher.ralph_patches.verdict IS 'Ralph verdict when the row was captured: LOOP (iteration continuing), SHIP (terminal SHIP), ABORT (gave up), or NULL (legacy pre-#3026). Not CHECK-constrained so forward-version daemons can introduce new verdicts without a migration. Issue #3026.';
 
 
 CREATE TABLE dispatcher.retry_markers (

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -896,6 +896,35 @@ def _stderr_tail(stderr: str | bytes | None) -> str:
     return stderr[-STRUCTURED_LOG_STDERR_MAX:]
 
 
+def _format_age_ago(seconds: float) -> str:
+    """Render a compact human-readable age like ``2h 15m ago`` (#3026).
+
+    Used to populate the ``{age_ago}`` placeholder in the RESUME WITH
+    CONFLICT prompt block. Resolution is intentionally coarse — ralph
+    only needs to know "is this patch stale or fresh" to make the
+    continue-vs-abort judgment; exact seconds add noise.
+
+    Buckets:
+
+    * < 60 s   → ``"just now"``
+    * < 60 min → ``"{N}m ago"``
+    * < 24 h   → ``"{N}h {M}m ago"``
+    * else     → ``"{N}d {H}h ago"``
+    """
+    if seconds < 60:
+        return "just now"
+    if seconds < 3600:
+        minutes = int(seconds // 60)
+        return f"{minutes}m ago"
+    if seconds < 86400:
+        hours = int(seconds // 3600)
+        minutes = int((seconds % 3600) // 60)
+        return f"{hours}h {minutes}m ago"
+    days = int(seconds // 86400)
+    hours = int((seconds % 86400) // 3600)
+    return f"{days}d {hours}h ago"
+
+
 def _classify_push_failure(stderr: str) -> str:
     """Classify a ``git push`` non-zero exit by inspecting stderr.
 
@@ -4642,6 +4671,15 @@ class DispatcherDaemon:
         # after the INSERT retrieves the generated ``patch_id``; we
         # bind that to both the phase_outputs UPDATE and the return
         # value.
+        #
+        # Note on verdict column (#3026): this helper runs on the SHIP
+        # path, so the inserted row carries ``verdict='SHIP'`` with
+        # ``iteration_n=NULL``. Per-iteration intermediate rows (written
+        # by :meth:`_persist_ralph_iteration_patch`) carry the actual
+        # iteration number and verdict. The DELETE-by-issue_number
+        # supersede here cleans up all intermediate rows for the same
+        # issue, so the post-SHIP table state has exactly one row for
+        # this agent/issue (the authoritative SHIP row).
         try:
             with self._conn.cursor() as cur:
                 cur.execute(
@@ -4650,10 +4688,11 @@ class DispatcherDaemon:
                 )
                 cur.execute(
                     "INSERT INTO dispatcher.ralph_patches "
-                    "    (agent_id, issue_number, patch_content, commit_sha) "
-                    "VALUES (%s, %s, %s, %s) "
+                    "    (agent_id, issue_number, patch_content, commit_sha, "
+                    "     iteration_n, verdict) "
+                    "VALUES (%s, %s, %s, %s, %s, %s) "
                     "RETURNING patch_id",
-                    (agent_id, issue_number, patch_content, commit_sha),
+                    (agent_id, issue_number, patch_content, commit_sha, None, "SHIP"),
                 )
                 row = cur.fetchone()
                 patch_id = str(row[0]) if row and row[0] else None
@@ -4754,43 +4793,69 @@ class DispatcherDaemon:
         issue_number: int,
         worktree: Path,
     ) -> dict[str, Any] | None:
-        """Apply a prior SHIP'd patch to the fresh worktree, if one exists.
+        """Apply a prior ralph patch to the fresh worktree, if one exists.
 
         Called at the top of :meth:`_run_ralph_phase` before ralph is
-        spawned. If a prior agent on this issue SHIPped but never got a
-        PR created, the patch is sitting in ``dispatcher.ralph_patches``
-        from :meth:`_capture_and_persist_ralph_patch`. This helper:
+        spawned. Runs the **unified resume lookup** (#3026): the most
+        recent patch for ``issue_number``, any ``agent_id``, any
+        ``verdict``, within the 7-day TTL. This is the single code path
+        for both same-agent resume (daemon restart mid-ralph) and
+        cross-agent resume (fresh claim on an issue whose prior
+        attempts were abandoned).
 
-        1. Queries the latest ``ralph_patches`` row for ``issue_number``.
+        1. Queries the latest ``ralph_patches`` row for ``issue_number``
+           within the 7-day TTL, ordered by ``created_at DESC``.
         2. If none exists → returns ``None`` (no-op first-attempt path).
         3. If one exists, writes the patch to
            ``{worktree}/tmp/dispatcher-input/prior-ralph.patch`` and
-           tries ``git am <patchfile>``.
+           tries ``git am --3way <patchfile>``.
         4. On apply success → returns
-           ``{"applied": True, "patch_id": ..., "commit_sha": ..., "bytes": ...}``.
+           ``{"applied": True, "patch_id": ..., "commit_sha": ...,
+             "source_agent_id": ..., "iteration_n": ..., "verdict": ...,
+             "bytes": ...}``.
            Ralph starts with the prior diff already on HEAD and iterates
            on top.
-        5. On apply failure → runs ``git am --abort`` to restore the
-           clean worktree state, then returns
-           ``{"applied": False, "patch_id": ..., "patch_content": ..., "reason": ...}``
-           so the caller can surface the patch text to ralph via
-           ``prior_attempts.md``.
+        5. On apply **conflict** → **does NOT abort** (issue #3026
+           conflict-handoff contract). The worktree is left in the
+           conflicted am-in-progress state (``.git/rebase-apply/``
+           intact, unmerged index entries) so ralph can inspect and
+           decide whether to ``git am --continue`` or ``git am --abort``.
+           Returns
+           ``{"applied": False, "conflicted": True, "patch_id": ...,
+             "patch_content": ..., "source_agent_id": ...,
+             "iteration_n": ..., "verdict": ..., "age_seconds": ...,
+             "conflict_files": [...], "reason": ...}``
+           so the caller can build the "RESUME WITH CONFLICT" prompt
+           block that goes into ralph's task.md.
 
         A DB lookup failure returns ``None`` — same effect as "no prior
         patch" — so a transient postgres hiccup never wedges the agent.
+
+        Same-agent-resume note (#3026 supersedes #3013): the previous
+        self-inherit guard is removed because the unified lookup
+        semantics explicitly allow same-agent rows. Fresh worktrees are
+        always at origin/main HEAD on ralph entry, so applying the
+        agent's own last iteration is a valid resume of cumulative work.
         """
         assert self._conn is not None, "connect() must run before query"
 
-        # Query the latest patch for this issue (ORDER BY created_at
-        # DESC so if somehow two rows exist, we pick the newest).
+        # Query the latest patch for this issue within the 7-day TTL.
+        # The TTL predicate is redundant with the housekeeping sweep
+        # (which runs on the same 7-day window) but keeps a partial-
+        # sweep state from surfacing stale patches. Any agent_id, any
+        # verdict — same-agent resume, cross-agent resume, legacy rows
+        # from #3013 era all flow through this single lookup.
         try:
             with self._conn.cursor() as cur:
                 cur.execute(
-                    "SELECT patch_id, patch_content, commit_sha, agent_id "
+                    "SELECT patch_id, patch_content, commit_sha, agent_id, "
+                    "       iteration_n, verdict, "
+                    "       EXTRACT(EPOCH FROM (now() - created_at)) "
                     "FROM dispatcher.ralph_patches "
                     "WHERE issue_number = %s "
+                    "  AND created_at > now() - make_interval(days => %s) "
                     "ORDER BY created_at DESC LIMIT 1",
-                    (issue_number,),
+                    (issue_number, DEFAULT_RALPH_PATCH_RETENTION_DAYS),
                 )
                 row = cur.fetchone()
             self._conn.commit()
@@ -4818,28 +4883,17 @@ class DispatcherDaemon:
         patch_content = row[1] or ""
         prior_commit_sha = row[2] or None
         prior_agent_id = str(row[3]) if row[3] is not None else None
+        prior_iteration_n = row[4] if len(row) > 4 else None
+        prior_verdict = row[5] if len(row) > 5 else None
+        age_seconds_raw = row[6] if len(row) > 6 else None
+        try:
+            age_seconds = float(age_seconds_raw) if age_seconds_raw is not None else 0.0
+        except (TypeError, ValueError):
+            age_seconds = 0.0
         if not patch_content.strip():
             # Defensive — NOT NULL constraint guarantees non-null, but
             # the content could be an empty-ish blob from a pathological
             # capture. Treat as "no usable patch".
-            return None
-
-        # Guard: don't try to inherit from *this same* agent. That
-        # shouldn't happen in normal flow (prior SHIP rows belong to a
-        # previous agent id), but tier-1 retry paths re-use agent_id,
-        # and re-applying a patch to a worktree that's already at the
-        # same commit just produces "patch does not apply" noise.
-        if prior_agent_id == agent_id:
-            self._log.info(
-                "daemon.ralph_patch_self_inherit_skipped",
-                extra={
-                    "event": "ralph_patch_self_inherit_skipped",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "issue_number": issue_number,
-                    "patch_id": prior_patch_id,
-                },
-            )
             return None
 
         # Write patch to a scratch file under {worktree}/tmp/.
@@ -4861,11 +4915,9 @@ class DispatcherDaemon:
             )
             return None
 
-        # Try ``git am <patchfile>``.  --3way gives a better chance of
-        # success when base has moved; without it, any drift produces
-        # an apply failure even for non-overlapping hunks. Keeping
-        # semantics the issue specified, but --3way is the gentler
-        # form that doesn't hurt when base matches.
+        # Try ``git am --3way <patchfile>``. --3way gives a better
+        # chance of success when base has moved; without it, any drift
+        # produces an apply failure even for non-overlapping hunks.
         try:
             am_result = subprocess.run(
                 [
@@ -4894,13 +4946,21 @@ class DispatcherDaemon:
                 },
             )
             # Best-effort abort in case am started but we lost the
-            # process — ignore errors since there may be no in-progress
-            # am to abort.
+            # process. Unlike the conflict path below, an invocation
+            # failure leaves no structured am-in-progress state for
+            # ralph to inspect, so aborting is safer than leaving
+            # undefined git state.
             self._git_am_abort(worktree)
             return {
                 "applied": False,
+                "conflicted": False,
                 "patch_id": prior_patch_id,
                 "patch_content": patch_content,
+                "source_agent_id": prior_agent_id,
+                "iteration_n": prior_iteration_n,
+                "verdict": prior_verdict,
+                "age_seconds": age_seconds,
+                "conflict_files": [],
                 "reason": f"am invocation failed: {exc}",
             }
 
@@ -4914,6 +4974,9 @@ class DispatcherDaemon:
                     "issue_number": issue_number,
                     "patch_id": prior_patch_id,
                     "prior_commit_sha": prior_commit_sha,
+                    "source_agent_id": prior_agent_id,
+                    "iteration_n": prior_iteration_n,
+                    "verdict": prior_verdict,
                     "patch_bytes": len(patch_content),
                 },
             )
@@ -4921,29 +4984,53 @@ class DispatcherDaemon:
                 "applied": True,
                 "patch_id": prior_patch_id,
                 "commit_sha": prior_commit_sha,
+                "source_agent_id": prior_agent_id,
+                "iteration_n": prior_iteration_n,
+                "verdict": prior_verdict,
+                "age_seconds": age_seconds,
                 "bytes": len(patch_content),
             }
 
-        # Apply failed — abort cleanly so the worktree is back to
-        # origin/main HEAD before ralph spawns.
+        # Apply failed with a conflict. Per issue #3026, the daemon
+        # does NOT ``git am --abort`` here — the worktree is left in
+        # the conflicted am-in-progress state so ralph can inspect
+        # the unmerged files, read the conflict markers, and decide
+        # whether to ``git am --continue`` (resolve + keep prior work)
+        # or ``git am --abort`` (discard + start fresh from main).
+        #
+        # The conflict-handoff contract is documented in
+        # ``.claude/skills/task-v2-ralph/SKILL.md`` §"Resume with
+        # conflict". The daemon surfaces the RESUME WITH CONFLICT
+        # prompt block (built via ``_format_resume_with_conflict_block``)
+        # in ralph's task.md; ralph's worker makes the judgment call.
         reason = _stderr_tail(am_result.stderr) or f"exit={am_result.returncode}"
-        self._git_am_abort(worktree)
+        conflict_files = self._list_git_am_conflict_files(worktree)
         self._log.warning(
-            "daemon.ralph_patch_apply_failed",
+            "daemon.ralph_patch_apply_conflict",
             extra={
-                "event": "ralph_patch_apply_failed",
+                "event": "ralph_patch_apply_conflict",
                 "run_id": self._run_id,
                 "agent_id": agent_id,
                 "issue_number": issue_number,
                 "patch_id": prior_patch_id,
+                "source_agent_id": prior_agent_id,
+                "iteration_n": prior_iteration_n,
+                "verdict": prior_verdict,
                 "exit_code": am_result.returncode,
                 "stderr_tail": reason,
+                "conflict_file_count": len(conflict_files),
             },
         )
         return {
             "applied": False,
+            "conflicted": True,
             "patch_id": prior_patch_id,
             "patch_content": patch_content,
+            "source_agent_id": prior_agent_id,
+            "iteration_n": prior_iteration_n,
+            "verdict": prior_verdict,
+            "age_seconds": age_seconds,
+            "conflict_files": conflict_files,
             "reason": reason,
         }
 
@@ -4964,6 +5051,275 @@ class DispatcherDaemon:
             )
         except Exception:  # pragma: no cover — defensive
             pass
+
+    def _list_git_am_conflict_files(self, worktree: Path) -> list[str]:
+        """Return the list of files in unmerged (conflict) state.
+
+        Called on the conflict-handoff path of
+        :meth:`_apply_prior_ralph_patch`. ``git diff --name-only
+        --diff-filter=U`` lists paths with unmerged index entries —
+        exactly the files ``git am`` marked as conflicts.
+
+        Returns an empty list on subprocess failure so the caller's
+        placeholder formatting uses ``K=0`` rather than raising. The
+        conflict count is advisory in the RESUME WITH CONFLICT prompt
+        block (it tells ralph how much work it's inheriting); a wrong
+        count does not affect correctness.
+        """
+        try:
+            result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(worktree),
+                    "diff",
+                    "--name-only",
+                    "--diff-filter=U",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except Exception:  # pragma: no cover — defensive
+            return []
+        if result.returncode != 0:
+            return []
+        return [
+            line.strip() for line in (result.stdout or "").splitlines() if line.strip()
+        ]
+
+    def _persist_ralph_iteration_patch(
+        self,
+        agent_id: str,
+        issue_number: int,
+        iteration_n: int,
+        verdict: str,
+        worktree: Path,
+    ) -> str | None:
+        """Persist a per-iteration ralph patch snapshot (#3026).
+
+        Called by the daemon at end-of-iteration (via a ralph-invoked
+        helper CLI, see ``scripts/dispatcher/persist_ralph_iteration.py``)
+        after ralph has committed the iteration's work with the
+        placeholder ``WIP: ralph output`` message (see
+        ``.claude/skills/task-v2-ralph/SKILL.md`` §2.5a).
+
+        Unlike :meth:`_capture_and_persist_ralph_patch` — which runs
+        only on the SHIP verdict and supersedes prior rows via DELETE-
+        by-issue-number — this helper is **additive**: it INSERTs a
+        new row per iteration, keyed on (agent_id, iteration_n,
+        verdict). Rows accumulate for the agent's lifetime so a mid-
+        run daemon crash or cross-agent retry can replay the most
+        recent intermediate state.
+
+        The patch is captured via ``git format-patch origin/main..HEAD
+        --stdout`` (full cumulative range, not ``-1 HEAD``) so a
+        resume on a branch with multiple commits still replays
+        everything. Matches the resume path's ``git am --3way``.
+
+        Returns the new ``patch_id`` on success, ``None`` on any
+        failure (empty patch, git error, DB error). All failures are
+        logged but non-fatal — the happy path continues and a missed
+        intermediate write just means the resume inherits the
+        previous iteration's state instead of this one.
+
+        The three bundled assurances:
+
+        1. The INSERT does not delete prior rows — intermediate rows
+           accumulate so a crash after iteration N+1 still has
+           iteration N available.
+        2. On SHIP, the existing #3013 supersede-by-issue-number
+           DELETE path (see :meth:`_capture_and_persist_ralph_patch`)
+           cleans up these intermediate rows; the authoritative SHIP
+           row replaces them.
+        3. The 7-day TTL housekeeping sweep catches everything
+           abandoned (daemon crash, operator stop, ralph BLOCKED).
+        """
+        assert self._conn is not None, "connect() must run before persist"
+
+        # Capture the cumulative patch via git format-patch
+        # origin/main..HEAD --stdout. Full range (not -1 HEAD) so
+        # resumes work across multiple commits on the branch — e.g.
+        # when a prior iteration's `git am --continue` left an
+        # additional commit beyond the placeholder. Ralph amends
+        # in-place per #2971 so there's typically one commit, but the
+        # range form is safe regardless.
+        try:
+            patch_result = subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(worktree),
+                    "format-patch",
+                    "origin/main..HEAD",
+                    "--stdout",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except Exception as exc:
+            self._log.warning(
+                "daemon.ralph_iteration_patch_capture_failed",
+                extra={
+                    "event": "ralph_iteration_patch_capture_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "iteration_n": iteration_n,
+                    "verdict": verdict,
+                    "detail": str(exc),
+                },
+            )
+            return None
+        if patch_result.returncode != 0 or not (patch_result.stdout or "").strip():
+            self._log.info(
+                "daemon.ralph_iteration_patch_empty_or_failed",
+                extra={
+                    "event": "ralph_iteration_patch_empty_or_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "iteration_n": iteration_n,
+                    "verdict": verdict,
+                    "exit_code": patch_result.returncode,
+                    "stderr_tail": _stderr_tail(patch_result.stderr),
+                },
+            )
+            return None
+        patch_content = patch_result.stdout
+
+        # Best-effort HEAD SHA — same pattern as _capture_and_persist_ralph_patch.
+        commit_sha: str | None = None
+        try:
+            sha_result = subprocess.run(
+                ["git", "-C", str(worktree), "rev-parse", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if sha_result.returncode == 0:
+                candidate = (sha_result.stdout or "").strip()
+                if candidate:
+                    commit_sha = candidate
+        except Exception:  # pragma: no cover — defensive
+            pass
+
+        # Additive INSERT (no DELETE). Intermediate rows accumulate.
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO dispatcher.ralph_patches "
+                    "    (agent_id, issue_number, patch_content, commit_sha, "
+                    "     iteration_n, verdict) "
+                    "VALUES (%s, %s, %s, %s, %s, %s) "
+                    "RETURNING patch_id",
+                    (
+                        agent_id,
+                        issue_number,
+                        patch_content,
+                        commit_sha,
+                        iteration_n,
+                        verdict,
+                    ),
+                )
+                row = cur.fetchone()
+                patch_id = str(row[0]) if row and row[0] else None
+            self._conn.commit()
+        except Exception as exc:
+            self._log.exception(
+                "daemon.ralph_iteration_patch_persist_failed",
+                extra={
+                    "event": "ralph_iteration_patch_persist_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "iteration_n": iteration_n,
+                    "verdict": verdict,
+                    "detail": str(exc),
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return None
+
+        self._log.info(
+            "daemon.ralph_iteration_patch_persisted",
+            extra={
+                "event": "ralph_iteration_patch_persisted",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "iteration_n": iteration_n,
+                "verdict": verdict,
+                "patch_id": patch_id,
+                "commit_sha": commit_sha,
+                "patch_bytes": len(patch_content),
+            },
+        )
+        return patch_id
+
+    @staticmethod
+    def _format_resume_with_conflict_block(
+        issue_number: int,
+        conflict_info: dict[str, Any],
+    ) -> str:
+        """Render the RESUME WITH CONFLICT prompt block (#3026).
+
+        Called by :meth:`_run_ralph_phase` when
+        :meth:`_apply_prior_ralph_patch` returned
+        ``{"applied": False, "conflicted": True, ...}``. The returned
+        string is appended to the agent's ``prior_attempts.md`` so the
+        ralph skill surfaces it to the worker via ``task.md``.
+
+        The block's exact wording matches the #3026 issue body
+        contract — ralph's worker is trained to recognise this
+        heading and handle the ``git am --continue`` vs. ``git am
+        --abort`` decision accordingly. Do not reword without also
+        updating ``.claude/skills/task-v2-ralph/SKILL.md`` and the
+        ralph worker prompt in ``.claude/skills/ralph/SKILL.md``.
+        """
+        source_agent_id = conflict_info.get("source_agent_id") or "unknown"
+        agent_id_short = source_agent_id[:8] if source_agent_id else "unknown"
+        iter_n = conflict_info.get("iteration_n")
+        iter_display = str(iter_n) if iter_n is not None else "SHIP (no iteration)"
+        verdict = conflict_info.get("verdict") or "(unknown)"
+        age_seconds = float(conflict_info.get("age_seconds") or 0.0)
+        age_ago = _format_age_ago(age_seconds)
+        conflict_files = conflict_info.get("conflict_files") or []
+        k = len(conflict_files)
+
+        lines = [
+            "RESUME WITH CONFLICT",
+            "",
+            f"You are resuming work on issue #{issue_number}. A prior attempt saved a",
+            f"cumulative patch (agent {agent_id_short}, iteration {iter_display},",
+            f"verdict {verdict}, saved {age_ago}). The daemon attempted to",
+            f"apply it with `git am --3way` and {k} files are in conflict.",
+            "",
+            "Your options:",
+            "1. Resolve the conflicts and `git am --continue`. Use this path",
+            "   if the prior work is a reasonable starting point and the",
+            "   conflicts are tractable.",
+            "2. `git am --abort` and start fresh from main. Use this path if",
+            "   the prior work is stale, wrong for the current issue",
+            "   understanding, or the conflict volume exceeds what's worth",
+            "   salvaging.",
+            "",
+            "Use your judgment. Both paths are valid — prior work is",
+            "advisory, not binding.",
+        ]
+        if conflict_files:
+            lines.append("")
+            lines.append("Conflict files:")
+            for path in conflict_files:
+                lines.append(f"  - {path}")
+        return "\n".join(lines)
 
     def _update_agent_phase(self, agent_id: str, phase: str) -> None:
         """UPDATE ``dispatcher.agents.phase`` so the scheduler + admin
@@ -7459,21 +7815,36 @@ class DispatcherDaemon:
         self,
         worktree: Path,
         patch_info: dict[str, Any],
+        *,
+        issue_number: int | None = None,
     ) -> None:
-        """Append an unapplied prior SHIP'd patch to ``prior_attempts.md``.
+        """Append an unapplied prior ralph patch to ``prior_attempts.md``.
 
         Called from :meth:`_run_ralph_phase` when
         :meth:`_apply_prior_ralph_patch` returned ``{"applied": False}``.
-        The patch couldn't be ``git am``'d onto the fresh worktree
-        (base drift, conflicts, corrupt patch), but the patch text is
-        still useful — ralph can see the *intended* diff and
-        cherry-pick or re-derive manually.
+
+        Two branches (#3026):
+
+        * **Conflict branch** (``patch_info["conflicted"] == True``):
+          the daemon LEFT the worktree in the ``git am --3way``
+          conflict state (per the #3026 conflict-handoff contract).
+          The section written is the structured "RESUME WITH
+          CONFLICT" block from
+          :meth:`_format_resume_with_conflict_block` — ralph reads
+          the heading and handles the ``git am --continue`` vs.
+          ``git am --abort`` decision on its own.
+
+        * **Invocation-failure branch** (``patch_info["conflicted"] ==
+          False``): ``git am`` failed before conflict resolution
+          started (invocation error, corrupt patch). The worktree is
+          aborted clean; the patch text is surfaced verbatim so ralph
+          can cherry-pick manually.
 
         Appends (creates if missing) to
         ``{worktree}/tmp/dispatcher-output/prior_attempts.md`` so the
         ralph skill's existing prior-attempts surfacing picks it up
-        verbatim. Best-effort — a write failure just means ralph misses
-        the patch context, which is the pre-#3012 status quo.
+        verbatim. Best-effort — a write failure just means ralph
+        misses the patch context, which is the pre-#3012 status quo.
         """
         output_dir = worktree / "tmp" / "dispatcher-output"
         try:
@@ -7485,19 +7856,44 @@ class DispatcherDaemon:
         patch_content = patch_info.get("patch_content") or ""
         patch_id = patch_info.get("patch_id") or "unknown"
         reason = patch_info.get("reason") or "unknown"
+        conflicted = bool(patch_info.get("conflicted"))
 
-        section = (
-            f"\n\n---\n\n## Prior SHIP'd patch (did NOT apply cleanly)\n\n"
-            f"**Patch id:** {patch_id}\n\n"
-            f"**Apply failure reason:** {reason}\n\n"
-            f"A previous agent SHIP'd this issue but the daemon did not reach "
-            f"``gh pr create`` (crash, deploy, timeout). The patch below was "
-            f"their final diff. ``git am`` could not replay it onto the fresh "
-            f"worktree (base drift, conflicts, etc.), so you are starting from "
-            f"clean origin/main — but you can cherry-pick / re-derive the "
-            f"relevant hunks manually from this text.\n\n"
-            f"```diff\n{patch_content}\n```\n"
-        )
+        if conflicted:
+            # Conflict-handoff path — surface the structured
+            # RESUME WITH CONFLICT prompt block so ralph's worker
+            # handles the continue-vs-abort judgment. See
+            # ``.claude/skills/task-v2-ralph/SKILL.md`` §"Resume with
+            # conflict" for the contract.
+            effective_issue = issue_number if issue_number is not None else 0
+            resume_block = self._format_resume_with_conflict_block(
+                effective_issue, patch_info
+            )
+            section = (
+                f"\n\n---\n\n## {resume_block.splitlines()[0]}\n\n"
+                f"**Patch id:** {patch_id}\n\n"
+                f"**Apply failure reason:** {reason}\n\n"
+                f"{resume_block}\n\n"
+                f"Reference — the patch bytes follow (the worktree already has"
+                f" these partially applied in the am-in-progress state; this"
+                f" block is for manual inspection if you choose `git am"
+                f" --abort`):\n\n"
+                f"```diff\n{patch_content}\n```\n"
+            )
+        else:
+            # Legacy non-conflict failure path (invocation error,
+            # corrupt patch). Worktree is clean; patch is advisory.
+            section = (
+                f"\n\n---\n\n## Prior ralph patch (did NOT apply cleanly)\n\n"
+                f"**Patch id:** {patch_id}\n\n"
+                f"**Apply failure reason:** {reason}\n\n"
+                f"A previous agent's ralph iteration was saved but the daemon"
+                f" could not ``git am`` it onto the fresh worktree (invocation"
+                f" error, corrupt patch). The worktree was aborted clean — you"
+                f" are starting from origin/main. The patch text below is"
+                f" advisory; cherry-pick or re-derive the relevant hunks"
+                f" manually if they look useful.\n\n"
+                f"```diff\n{patch_content}\n```\n"
+            )
 
         try:
             if target.exists():
@@ -7700,7 +8096,9 @@ class DispatcherDaemon:
         # text to prior_attempts.md so ralph can see the intended diff
         # and cherry-pick / re-derive manually.
         if prior_patch_info is not None and not prior_patch_info.get("applied"):
-            self._append_unapplied_patch_to_prior_attempts(worktree, prior_patch_info)
+            self._append_unapplied_patch_to_prior_attempts(
+                worktree, prior_patch_info, issue_number=issue_number
+            )
         self._log.info(
             "daemon.ralph_spawn",
             extra={
@@ -7711,6 +8109,9 @@ class DispatcherDaemon:
                 "prior_attempts_count": prior_attempts_count,
                 "prior_patch_applied": (
                     bool(prior_patch_info and prior_patch_info.get("applied"))
+                ),
+                "prior_patch_conflicted": (
+                    bool(prior_patch_info and prior_patch_info.get("conflicted"))
                 ),
                 "prior_patch_id": (
                     prior_patch_info.get("patch_id") if prior_patch_info else None

--- a/scripts/dispatcher/persist_ralph_iteration.py
+++ b/scripts/dispatcher/persist_ralph_iteration.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# venv: scripts
+# permanent: true
+"""CLI helper — persist a per-iteration ralph patch to postgres (#3026).
+
+Called by the ralph skill at end-of-iteration to save a cumulative
+patch snapshot to ``dispatcher.ralph_patches`` so a daemon crash or
+retry mid-loop can resume from the most recent iteration's state
+instead of re-ralph'ing from scratch.
+
+Design
+------
+Ralph runs as a Task-tool subagent inside the daemon's ``/task-v2-ralph``
+subprocess. The daemon cannot directly hook into ralph's per-iteration
+boundaries (the inner ``/ralph`` skill owns the iteration loop), so
+this helper bridges the gap: ralph shells out to this script at the
+end of each iteration, and the script does the DB write against the
+shared ``DATABASE_URL`` env var.
+
+The script is deliberately narrow and idempotent-ish:
+
+* Captures the cumulative patch via
+  ``git format-patch origin/main..HEAD --stdout``.
+* INSERTs a fresh row (no DELETE supersede — additive per-iteration
+  semantics from #3026).
+* Exits 0 on all failure paths so a persistence hiccup never kills
+  ralph. The happy path emits ``persisted=<patch_id>`` on stdout;
+  failures emit ``skipped=<reason>`` or ``error=<reason>`` for log
+  forensics.
+
+Usage
+-----
+::
+
+    scripts/dispatcher/persist_ralph_iteration.py \\
+        --worktree "{worktree}" \\
+        --agent-id "{agent_id}" \\
+        --issue-number "{N}" \\
+        --iteration "{iter_n}" \\
+        --verdict LOOP|SHIP|ABORT
+
+Env
+---
+* ``DATABASE_URL`` — postgres connection string. Required. Absent →
+  stdout ``skipped=no_database_url``, exit 0.
+
+See ``.claude/skills/ralph/SKILL.md`` §"Per-iteration patch persistence"
+for where this hooks into the ralph loop, and
+``scripts/dispatcher/daemon.py::_persist_ralph_iteration_patch`` for the
+daemon-side helper (same semantics, different code path — the daemon
+uses its own connection pool when the ralph subprocess is not
+available, e.g. for unit tests).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _emit(status: str, detail: str = "") -> int:
+    """Write a single status line to stdout and return exit code 0.
+
+    The ralph skill swallows stdout — emitting a diagnostic is purely
+    for the agent log / CloudWatch forensics. Exit 0 even on errors
+    so ralph never gets a non-zero return code that would pollute its
+    control flow.
+    """
+    if detail:
+        sys.stdout.write(f"{status}={detail}\n")
+    else:
+        sys.stdout.write(f"{status}\n")
+    sys.stdout.flush()
+    return 0
+
+
+def _capture_patch(worktree: Path) -> tuple[str | None, str | None]:
+    """Return (patch_content, commit_sha). Both are None on failure."""
+    try:
+        patch_result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(worktree),
+                "format-patch",
+                "origin/main..HEAD",
+                "--stdout",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+    except Exception:
+        return None, None
+    if patch_result.returncode != 0 or not (patch_result.stdout or "").strip():
+        return None, None
+
+    commit_sha: str | None = None
+    try:
+        sha_result = subprocess.run(
+            ["git", "-C", str(worktree), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        if sha_result.returncode == 0:
+            candidate = (sha_result.stdout or "").strip()
+            if candidate:
+                commit_sha = candidate
+    except Exception:
+        pass
+    return patch_result.stdout, commit_sha
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Persist a per-iteration ralph patch to postgres (#3026)",
+    )
+    parser.add_argument("--worktree", required=True, type=Path)
+    parser.add_argument("--agent-id", required=True)
+    parser.add_argument("--issue-number", required=True, type=int)
+    parser.add_argument("--iteration", required=True, type=int)
+    parser.add_argument(
+        "--verdict",
+        required=True,
+        help="Iteration verdict: LOOP, SHIP, ABORT, or a custom string.",
+    )
+    args = parser.parse_args(argv)
+
+    database_url = os.environ.get("DATABASE_URL")
+    if not database_url:
+        return _emit("skipped", "no_database_url")
+
+    if not args.worktree.exists():
+        return _emit("skipped", f"worktree_missing:{args.worktree}")
+
+    patch_content, commit_sha = _capture_patch(args.worktree)
+    if not patch_content:
+        return _emit("skipped", "empty_or_failed_format_patch")
+
+    # Import psycopg lazily — only needed on the happy path.
+    try:
+        import psycopg  # type: ignore[import-not-found]
+    except ImportError:
+        return _emit("skipped", "psycopg_not_installed")
+
+    try:
+        with psycopg.connect(database_url, connect_timeout=10) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO dispatcher.ralph_patches "
+                    "    (agent_id, issue_number, patch_content, commit_sha, "
+                    "     iteration_n, verdict) "
+                    "VALUES (%s, %s, %s, %s, %s, %s) "
+                    "RETURNING patch_id",
+                    (
+                        args.agent_id,
+                        args.issue_number,
+                        patch_content,
+                        commit_sha,
+                        args.iteration,
+                        args.verdict,
+                    ),
+                )
+                row = cur.fetchone()
+                patch_id = str(row[0]) if row and row[0] else ""
+            conn.commit()
+    except Exception as exc:
+        return _emit("error", str(exc)[:200])
+
+    return _emit("persisted", patch_id)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dispatcher/tests/test_daemon_ralph_opus_final_attempt.py
+++ b/scripts/dispatcher/tests/test_daemon_ralph_opus_final_attempt.py
@@ -24,6 +24,14 @@ Same mocking strategy as :mod:`test_daemon_token_metering` — psycopg
 is stubbed before the daemon import so the test runner never needs a
 real DB or the ``psycopg`` wheel. No ``claude`` / ``gh`` / ``git``
 subprocesses run.
+
+Implementation note (#3022): ``_spawn_phase_subprocess`` uses
+``subprocess.Popen`` + the async stream forwarder, not
+``subprocess.run``. Each test must monkeypatch ``subprocess.Popen`` and
+``daemon.stream_subprocess_output_async`` together so the forwarder
+plumbing is short-circuited — otherwise the tests try to spawn a real
+``claude`` binary and fail with ``FileNotFoundError``. See the
+``_patch_popen_and_forwarder`` fixture below.
 """
 
 from __future__ import annotations
@@ -191,6 +199,42 @@ def _extract_model_arg(cmd: list[str]) -> str:
     return cmd[cmd.index("--model") + 1]
 
 
+def _patch_popen_and_forwarder(
+    monkeypatch: Any,
+    captured: dict[str, Any] | None = None,
+) -> None:
+    """Install test doubles for ``subprocess.Popen`` + the stream forwarder.
+
+    ``_spawn_phase_subprocess`` (#3022) calls:
+    1. ``subprocess.Popen(cmd, ...)`` — we intercept to capture ``cmd``.
+    2. ``stream_subprocess_output_async(proc, ...)`` — the async
+       forwarder that would normally spawn reader threads; we replace
+       it with a no-op that returns a handle with a ``.join(timeout)``.
+    3. ``proc.wait(timeout=...)`` — we return 0.
+
+    If ``captured`` is provided, the invoked ``cmd`` list is stored under
+    ``captured["cmd"]`` on Popen invocation.
+    """
+    fake_proc = MagicMock()
+    fake_proc.wait.return_value = 0
+    fake_proc.returncode = 0
+    fake_proc.stdout = None
+    fake_proc.stderr = None
+
+    def fake_popen(cmd: list[str], **_kwargs: Any) -> Any:
+        if captured is not None:
+            captured["cmd"] = cmd
+        return fake_proc
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    fake_threads = MagicMock()
+    fake_threads.join.return_value = None
+    monkeypatch.setattr(
+        daemon, "stream_subprocess_output_async", lambda *a, **kw: fake_threads
+    )
+
+
 class TestRalphSpawnUsesAttemptAwareModel:
     """``_spawn_phase_subprocess("ralph", ...)`` reads
     ``dispatcher.agents.retries_used`` via :meth:`_current_attempt_for`
@@ -204,14 +248,7 @@ class TestRalphSpawnUsesAttemptAwareModel:
         conn.cursor_instance.fetch_queue = [(0,)]
 
         captured: dict[str, Any] = {}
-
-        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
-            captured["cmd"] = cmd
-            r = MagicMock()
-            r.returncode = 0
-            return r
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        _patch_popen_and_forwarder(monkeypatch, captured)
         d._spawn_phase_subprocess("ralph", tmp_path, "agent-uuid")
 
         assert _extract_model_arg(captured["cmd"]) == "sonnet"
@@ -225,14 +262,7 @@ class TestRalphSpawnUsesAttemptAwareModel:
         conn.cursor_instance.fetch_queue = [(daemon.MAX_RETRY_ATTEMPTS - 1,)]
 
         captured: dict[str, Any] = {}
-
-        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
-            captured["cmd"] = cmd
-            r = MagicMock()
-            r.returncode = 0
-            return r
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        _patch_popen_and_forwarder(monkeypatch, captured)
         d._spawn_phase_subprocess("ralph", tmp_path, "agent-uuid")
 
         assert _extract_model_arg(captured["cmd"]) == "opus"
@@ -248,14 +278,7 @@ class TestRalphSpawnUsesAttemptAwareModel:
         conn.cursor_instance.fetch_queue = [(daemon.MAX_RETRY_ATTEMPTS - 2,)]
 
         captured: dict[str, Any] = {}
-
-        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
-            captured["cmd"] = cmd
-            r = MagicMock()
-            r.returncode = 0
-            return r
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        _patch_popen_and_forwarder(monkeypatch, captured)
         d._spawn_phase_subprocess("ralph", tmp_path, "agent-uuid")
 
         assert _extract_model_arg(captured["cmd"]) == "sonnet"
@@ -270,12 +293,7 @@ class TestRalphSpawnUsesAttemptAwareModel:
         d, conn, handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetch_queue = [(daemon.MAX_RETRY_ATTEMPTS - 1,)]
 
-        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
-            r = MagicMock()
-            r.returncode = 0
-            return r
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        _patch_popen_and_forwarder(monkeypatch)
         d._spawn_phase_subprocess("ralph", tmp_path, "agent-uuid")
 
         starts = handler.events("phase_started")
@@ -291,12 +309,7 @@ class TestRalphSpawnUsesAttemptAwareModel:
         d, conn, handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetch_queue = [(0,)]
 
-        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
-            r = MagicMock()
-            r.returncode = 0
-            return r
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        _patch_popen_and_forwarder(monkeypatch)
         d._spawn_phase_subprocess("ralph", tmp_path, "agent-uuid")
 
         starts = handler.events("phase_started")
@@ -321,14 +334,7 @@ class TestRalphSpawnUsesAttemptAwareModel:
         conn.cursor_instance.fetch_queue = []
 
         captured: dict[str, Any] = {}
-
-        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
-            captured["cmd"] = cmd
-            r = MagicMock()
-            r.returncode = 0
-            return r
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
+        _patch_popen_and_forwarder(monkeypatch, captured)
         d._spawn_phase_subprocess("plan", tmp_path, "agent-uuid")
 
         assert _extract_model_arg(captured["cmd"]) == daemon.PHASE_MODELS["plan"]

--- a/scripts/dispatcher/tests/test_daemon_ralph_patches.py
+++ b/scripts/dispatcher/tests/test_daemon_ralph_patches.py
@@ -444,9 +444,18 @@ class TestApplyPriorRalphPatch:
             "Subject: [PATCH] WIP: ralph output\n"
             "---\n"
         )
-        # Row shape: (patch_id, patch_content, commit_sha, agent_id)
+        # Row shape (#3026): (patch_id, patch_content, commit_sha,
+        # agent_id, iteration_n, verdict, age_seconds).
         conn.cursor_instance.fetch_queue = [
-            ("prior-patch-uuid", patch_content, "prior-sha-abc", "prior-agent-uuid"),
+            (
+                "prior-patch-uuid",
+                patch_content,
+                "prior-sha-abc",
+                "prior-agent-uuid",
+                3,
+                "LOOP",
+                120.0,
+            ),
         ]
 
         am_ok = subprocess.CompletedProcess(
@@ -464,6 +473,10 @@ class TestApplyPriorRalphPatch:
             "applied": True,
             "patch_id": "prior-patch-uuid",
             "commit_sha": "prior-sha-abc",
+            "source_agent_id": "prior-agent-uuid",
+            "iteration_n": 3,
+            "verdict": "LOOP",
+            "age_seconds": 120.0,
             "bytes": len(patch_content),
         }
         # The patch file is written into tmp/dispatcher-input/.
@@ -473,18 +486,26 @@ class TestApplyPriorRalphPatch:
         # Success event emitted.
         assert handler.events("ralph_patch_applied")
 
-    def test_apply_conflicts_aborts_and_returns_applied_false(
-        self, tmp_path: Path
-    ) -> None:
-        """git am failure → runs ``git am --abort``, returns
-        {applied: False, patch_content: ..., reason: ...}."""
+    def test_apply_conflict_leaves_am_in_progress(self, tmp_path: Path) -> None:
+        """git am conflict (#3026) → daemon does NOT run ``git am
+        --abort``; the worktree is left in am-in-progress state so
+        ralph can decide continue-vs-abort. Returns
+        {applied: False, conflicted: True, patch_content, ...}."""
         d, conn, handler = _make_daemon(tmp_path)
         worktree = tmp_path / "worktree"
         worktree.mkdir()
 
         patch_content = "From abc...\npatch body with conflicts\n"
         conn.cursor_instance.fetch_queue = [
-            ("prior-patch-uuid", patch_content, None, "prior-agent"),
+            (
+                "prior-patch-uuid",
+                patch_content,
+                None,
+                "prior-agent",
+                2,
+                "LOOP",
+                600.0,
+            ),
         ]
 
         am_fail = subprocess.CompletedProcess(
@@ -493,11 +514,14 @@ class TestApplyPriorRalphPatch:
             stdout="",
             stderr="error: patch failed: src/foo.py:1\nerror: patch does not apply",
         )
-        am_abort_ok = subprocess.CompletedProcess(
-            args=["git", "am", "--abort"], returncode=0, stdout="", stderr=""
+        diff_u = subprocess.CompletedProcess(
+            args=["git", "diff"],
+            returncode=0,
+            stdout="src/foo.py\n",
+            stderr="",
         )
 
-        with patch("subprocess.run", side_effect=[am_fail, am_abort_ok]) as run_mock:
+        with patch("subprocess.run", side_effect=[am_fail, diff_u]) as run_mock:
             result = d._apply_prior_ralph_patch(
                 agent_id="new-agent",
                 issue_number=3012,
@@ -506,43 +530,81 @@ class TestApplyPriorRalphPatch:
 
         assert result is not None
         assert result["applied"] is False
+        assert result["conflicted"] is True
         assert result["patch_id"] == "prior-patch-uuid"
         assert result["patch_content"] == patch_content
+        assert result["source_agent_id"] == "prior-agent"
+        assert result["iteration_n"] == 2
+        assert result["verdict"] == "LOOP"
+        assert result["age_seconds"] == 600.0
+        assert result["conflict_files"] == ["src/foo.py"]
         assert "patch does not apply" in result["reason"]
 
-        # git am --abort was called exactly once after the failed am.
+        # CRITICAL (#3026): ``git am --abort`` must NOT be called on
+        # the conflict-handoff path. The worktree is left in the
+        # am-in-progress state so ralph can inspect it.
         abort_calls = [
             call
             for call in run_mock.call_args_list
             if len(call.args[0]) >= 5 and call.args[0][3:5] == ["am", "--abort"]
         ]
-        assert len(abort_calls) == 1
-        # Warning log emitted.
-        assert handler.events("ralph_patch_apply_failed")
+        assert len(abort_calls) == 0
+        # Conflict event emitted (replaces the pre-#3026
+        # ``ralph_patch_apply_failed`` event).
+        assert handler.events("ralph_patch_apply_conflict")
 
-    def test_self_inherit_skipped(self, tmp_path: Path) -> None:
-        """If the prior row's agent_id equals the current agent's,
-        skip — same agent re-running the same phase should not
-        re-apply its own patch to an already-at-HEAD worktree."""
+    def test_unified_resume_lookup_uses_ttl_predicate(self, tmp_path: Path) -> None:
+        """The resume SELECT uses the 7-day TTL predicate AND returns
+        the most-recent row regardless of agent_id (unified lookup,
+        #3026). Same-agent rows are valid resume candidates — the
+        pre-#3026 self-inherit guard is removed."""
         d, conn, handler = _make_daemon(tmp_path)
         worktree = tmp_path / "worktree"
         worktree.mkdir()
 
         same_agent_id = "same-agent-uuid"
+        # Prior row is the SAME agent as the caller — post-#3026 this
+        # must be applied, not skipped, because fresh worktrees always
+        # start at origin/main HEAD so there's no "already at HEAD"
+        # conflict to worry about.
         conn.cursor_instance.fetch_queue = [
-            ("prior-patch-uuid", "patch body", None, same_agent_id),
+            (
+                "prior-patch-uuid",
+                "patch body\n",
+                None,
+                same_agent_id,
+                1,
+                "LOOP",
+                30.0,
+            ),
         ]
-
-        with patch("subprocess.run") as run_mock:
+        am_ok = subprocess.CompletedProcess(
+            args=["git", "am"], returncode=0, stdout="Applying\n", stderr=""
+        )
+        with patch("subprocess.run", side_effect=[am_ok]):
             result = d._apply_prior_ralph_patch(
                 agent_id=same_agent_id,
                 issue_number=123,
                 worktree=worktree,
             )
 
-        assert result is None
-        assert run_mock.call_count == 0
-        assert handler.events("ralph_patch_self_inherit_skipped")
+        assert result is not None
+        assert result["applied"] is True
+        assert result["source_agent_id"] == same_agent_id
+        # Verify the SELECT query carries the TTL predicate.
+        selects = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "SELECT" in sql and "FROM dispatcher.ralph_patches" in sql
+        ]
+        assert len(selects) == 1
+        sql, params = selects[0]
+        assert "make_interval(days => %s)" in sql
+        # Parameters: (issue_number, retention_days).
+        assert params[0] == 123
+        assert params[1] == daemon.DEFAULT_RALPH_PATCH_RETENTION_DAYS
+        # No self-inherit skip event; the unified lookup applies.
+        assert not handler.events("ralph_patch_self_inherit_skipped")
 
     def test_db_query_failure_returns_none(self, tmp_path: Path) -> None:
         """A DB error on the SELECT is non-fatal — returns None
@@ -577,6 +639,9 @@ class TestAppendUnappliedPatch:
     ``prior_attempts.md`` so the worker can cherry-pick manually."""
 
     def test_appends_when_prior_attempts_md_exists(self, tmp_path: Path) -> None:
+        """Invocation-failure branch (``conflicted=False``) — renders
+        the legacy "Prior ralph patch" heading with the patch text
+        below for manual cherry-pick."""
         d, _conn, _handler = _make_daemon(tmp_path)
         worktree = tmp_path / "worktree"
         (worktree / "tmp" / "dispatcher-output").mkdir(parents=True)
@@ -587,24 +652,25 @@ class TestAppendUnappliedPatch:
             worktree,
             {
                 "applied": False,
+                "conflicted": False,
                 "patch_id": "pid-1",
                 "patch_content": "From abc...\npatch body\n",
-                "reason": "patch does not apply",
+                "reason": "am invocation failed: timeout",
             },
         )
 
         content = existing.read_text()
         assert "Attempt 1 content." in content
-        assert "## Prior SHIP'd patch (did NOT apply cleanly)" in content
+        assert "## Prior ralph patch (did NOT apply cleanly)" in content
         assert "pid-1" in content
-        assert "patch does not apply" in content
+        assert "am invocation failed" in content
         # The patch body is present, fenced as a diff block.
         assert "```diff" in content
         assert "patch body" in content
 
     def test_creates_file_when_prior_attempts_md_missing(self, tmp_path: Path) -> None:
-        """If prior_attempts.md doesn't exist (no prior FAILED attempts
-        but we did have a SHIP'd-but-not-pushed patch), still write a
+        """If prior_attempts.md doesn't exist and the am failed before
+        conflict resolution (invocation failure), still write a
         standalone file so the worker gets the patch context."""
         d, _conn, _handler = _make_daemon(tmp_path)
         worktree = tmp_path / "worktree"
@@ -613,6 +679,7 @@ class TestAppendUnappliedPatch:
             worktree,
             {
                 "applied": False,
+                "conflicted": False,
                 "patch_id": "pid-2",
                 "patch_content": "standalone patch body\n",
                 "reason": "no current patch",
@@ -622,8 +689,51 @@ class TestAppendUnappliedPatch:
         target = worktree / "tmp" / "dispatcher-output" / "prior_attempts.md"
         assert target.exists()
         content = target.read_text()
-        assert "Prior SHIP'd patch" in content
+        assert "Prior ralph patch" in content
         assert "standalone patch body" in content
+
+    def test_conflicted_branch_renders_resume_block(self, tmp_path: Path) -> None:
+        """Conflict-handoff branch (#3026, ``conflicted=True``) — renders
+        the RESUME WITH CONFLICT structured prompt block for ralph."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+
+        d._append_unapplied_patch_to_prior_attempts(
+            worktree,
+            {
+                "applied": False,
+                "conflicted": True,
+                "patch_id": "pid-3",
+                "patch_content": "patch body\n",
+                "source_agent_id": "aaaabbbbccccdddd",
+                "iteration_n": 4,
+                "verdict": "LOOP",
+                "age_seconds": 3725.0,  # 1h 2m
+                "conflict_files": ["src/foo.py", "src/bar.py"],
+                "reason": "patch does not apply",
+            },
+            issue_number=3026,
+        )
+
+        target = worktree / "tmp" / "dispatcher-output" / "prior_attempts.md"
+        content = target.read_text()
+        # Structured block heading must appear verbatim — ralph's
+        # worker is trained to recognise this exact phrase.
+        assert "RESUME WITH CONFLICT" in content
+        assert "issue #3026" in content
+        assert "agent aaaabbbb" in content  # agent_id_short
+        assert "iteration 4" in content
+        assert "verdict LOOP" in content
+        assert "1h 2m ago" in content
+        assert "2 files are in conflict" in content
+        assert "git am --continue" in content
+        assert "git am --abort" in content
+        # Patch body is still included for manual inspection.
+        assert "```diff" in content
+        assert "patch body" in content
+        # Conflict files listed.
+        assert "src/foo.py" in content
+        assert "src/bar.py" in content
 
 
 # --------------------------------------------------------------------------

--- a/scripts/dispatcher/tests/test_daemon_ralph_patches_per_iteration.py
+++ b/scripts/dispatcher/tests/test_daemon_ralph_patches_per_iteration.py
@@ -1,0 +1,553 @@
+"""Unit tests for per-iteration ralph patch persistence (issue #3026).
+
+Covers the new daemon helpers layered on top of the #3012 / #3013
+SHIP-only path:
+
+* :meth:`DispatcherDaemon._persist_ralph_iteration_patch` — additive
+  INSERT per ralph iteration (no DELETE supersede). Called at
+  end-of-iteration via the ``scripts/dispatcher/persist_ralph_iteration.py``
+  helper CLI, writes a row carrying ``(agent_id, issue_number,
+  iteration_n, verdict, patch_content, commit_sha)``.
+* :meth:`DispatcherDaemon._format_resume_with_conflict_block` — renders
+  the structured "RESUME WITH CONFLICT" prompt block surfaced to
+  ralph when the unified resume lookup's ``git am --3way`` hit a
+  conflict.
+* :func:`daemon._format_age_ago` — compact human age formatter for the
+  RESUME WITH CONFLICT ``{age_ago}`` placeholder.
+
+Schema coverage: the migration adding ``iteration_n`` and ``verdict``
+columns is structural (no new function to exercise); the columns are
+asserted indirectly here by checking the INSERT SQL signature.
+
+All DB interaction is against the same ``_FakeCursor`` /
+``_FakeConnection`` stubs used by the sibling tests; no real Postgres.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        pass
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — identical shape to test_daemon_ralph_patches.py
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.per_iteration.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# _persist_ralph_iteration_patch
+# --------------------------------------------------------------------------
+
+
+class TestPersistRalphIterationPatch:
+    """AC #2, #3 — additive INSERT per iteration (no DELETE supersede)."""
+
+    def test_insert_runs_with_iteration_and_verdict_columns(
+        self, tmp_path: Path
+    ) -> None:
+        """Happy path: format-patch returns bytes, INSERT runs with
+        ``iteration_n`` and ``verdict`` columns populated."""
+        d, conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        agent_id = "11111111-2222-3333-4444-555555555555"
+
+        patch_bytes = (
+            "From abc1234 Mon Sep 17 00:00:00 2001\n"
+            "Subject: [PATCH] WIP: ralph output\n"
+            "---\n"
+            " src/foo.py | 2 +-\n"
+        )
+        format_patch_ok = subprocess.CompletedProcess(
+            args=["git", "format-patch"],
+            returncode=0,
+            stdout=patch_bytes,
+            stderr="",
+        )
+        rev_parse_ok = subprocess.CompletedProcess(
+            args=["git", "rev-parse"],
+            returncode=0,
+            stdout="deadbeefcafe1234\n",
+            stderr="",
+        )
+        conn.cursor_instance.fetch_queue = [("generated-iter-patch-uuid",)]
+
+        with patch("subprocess.run", side_effect=[format_patch_ok, rev_parse_ok]):
+            result = d._persist_ralph_iteration_patch(
+                agent_id=agent_id,
+                issue_number=3026,
+                iteration_n=2,
+                verdict="LOOP",
+                worktree=worktree,
+            )
+
+        assert result == "generated-iter-patch-uuid"
+
+        # Exactly one INSERT, no DELETE (additive semantics).
+        executed = conn.cursor_instance.executed
+        inserts = [
+            (s, p) for s, p in executed if "INSERT INTO dispatcher.ralph_patches" in s
+        ]
+        deletes = [
+            (s, p) for s, p in executed if "DELETE FROM dispatcher.ralph_patches" in s
+        ]
+        assert len(inserts) == 1
+        assert len(deletes) == 0
+
+        # INSERT params shape: (agent_id, issue_number, patch_content,
+        # commit_sha, iteration_n, verdict).
+        sql, params = inserts[0]
+        assert "iteration_n" in sql
+        assert "verdict" in sql
+        assert params == (
+            agent_id,
+            3026,
+            patch_bytes,
+            "deadbeefcafe1234",
+            2,
+            "LOOP",
+        )
+        assert conn.commits >= 1
+        # Success event emitted with the iteration_n + verdict fields
+        # for CloudWatch querying.
+        events = handler.events("ralph_iteration_patch_persisted")
+        assert len(events) == 1
+        record = events[0]
+        assert record.agent_id == agent_id
+        assert record.issue_number == 3026
+        assert record.iteration_n == 2
+        assert record.verdict == "LOOP"
+
+    def test_format_patch_uses_origin_main_range(self, tmp_path: Path) -> None:
+        """The capture uses ``format-patch origin/main..HEAD --stdout``
+        (full cumulative range) rather than ``-1 HEAD``. Regression
+        guard against silently dropping to single-commit mode."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        format_patch_ok = subprocess.CompletedProcess(
+            args=["git", "format-patch"],
+            returncode=0,
+            stdout="patch bytes\n",
+            stderr="",
+        )
+        rev_parse_ok = subprocess.CompletedProcess(
+            args=["git", "rev-parse"], returncode=0, stdout="sha\n", stderr=""
+        )
+        conn.cursor_instance.fetch_queue = [("uuid",)]
+
+        with patch(
+            "subprocess.run", side_effect=[format_patch_ok, rev_parse_ok]
+        ) as run_mock:
+            d._persist_ralph_iteration_patch(
+                agent_id="ag",
+                issue_number=1,
+                iteration_n=1,
+                verdict="LOOP",
+                worktree=worktree,
+            )
+
+        # First subprocess call is format-patch; verify the range form.
+        first_call_args = run_mock.call_args_list[0].args[0]
+        assert "format-patch" in first_call_args
+        assert "origin/main..HEAD" in first_call_args
+        assert "--stdout" in first_call_args
+        # Guard against the -1 HEAD form.
+        assert "-1" not in first_call_args
+
+    def test_multiple_iterations_accumulate_rows(self, tmp_path: Path) -> None:
+        """Calling the helper 3 times for 3 iterations produces 3
+        INSERTs, no DELETE between them — rows accumulate so a crash
+        after iteration N+1 can still resume from iteration N."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        format_patch_ok = subprocess.CompletedProcess(
+            args=["git", "format-patch"],
+            returncode=0,
+            stdout="patch\n",
+            stderr="",
+        )
+        rev_parse_ok = subprocess.CompletedProcess(
+            args=["git", "rev-parse"], returncode=0, stdout="sha\n", stderr=""
+        )
+
+        # 3 iterations × 2 subprocess calls each = 6 side_effects, and
+        # 3 fetch_queue entries for the INSERT RETURNING.
+        conn.cursor_instance.fetch_queue = [("u1",), ("u2",), ("u3",)]
+        side_effects = [format_patch_ok, rev_parse_ok] * 3
+
+        with patch("subprocess.run", side_effect=side_effects):
+            for n in (1, 2, 3):
+                d._persist_ralph_iteration_patch(
+                    agent_id="ag",
+                    issue_number=99,
+                    iteration_n=n,
+                    verdict="LOOP",
+                    worktree=worktree,
+                )
+
+        inserts = [
+            (s, p)
+            for s, p in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.ralph_patches" in s
+        ]
+        deletes = [
+            (s, p)
+            for s, p in conn.cursor_instance.executed
+            if "DELETE FROM dispatcher.ralph_patches" in s
+        ]
+        assert len(inserts) == 3
+        assert len(deletes) == 0
+        # iteration_n ascends 1, 2, 3.
+        iter_ns = [params[4] for _sql, params in inserts]
+        assert iter_ns == [1, 2, 3]
+
+    def test_empty_patch_returns_none_and_skips_insert(self, tmp_path: Path) -> None:
+        """No diff → no DB write, no crash."""
+        d, conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        empty_patch = subprocess.CompletedProcess(
+            args=["git", "format-patch"], returncode=0, stdout="", stderr=""
+        )
+        with patch("subprocess.run", side_effect=[empty_patch]):
+            result = d._persist_ralph_iteration_patch(
+                agent_id="ag",
+                issue_number=1,
+                iteration_n=1,
+                verdict="LOOP",
+                worktree=worktree,
+            )
+
+        assert result is None
+        assert not any(
+            "dispatcher.ralph_patches" in sql
+            for sql, _p in conn.cursor_instance.executed
+        )
+        assert handler.events("ralph_iteration_patch_empty_or_failed")
+
+    def test_db_error_rolls_back_returns_none(self, tmp_path: Path) -> None:
+        """A DB error during INSERT rolls back; helper returns None.
+        Non-fatal: ralph keeps iterating — missing an intermediate
+        write just means resume inherits the previous iteration's state."""
+        d, conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        format_patch_ok = subprocess.CompletedProcess(
+            args=["git", "format-patch"],
+            returncode=0,
+            stdout="patch\n",
+            stderr="",
+        )
+        rev_parse_ok = subprocess.CompletedProcess(
+            args=["git", "rev-parse"], returncode=0, stdout="sha\n", stderr=""
+        )
+
+        original = conn.cursor_instance.execute
+
+        def failing(sql: str, params: Any = None) -> None:
+            original(sql, params)
+            if "INSERT INTO dispatcher.ralph_patches" in sql:
+                raise RuntimeError("deadlock")
+
+        conn.cursor_instance.execute = failing  # type: ignore[method-assign]
+
+        with patch("subprocess.run", side_effect=[format_patch_ok, rev_parse_ok]):
+            result = d._persist_ralph_iteration_patch(
+                agent_id="ag",
+                issue_number=1,
+                iteration_n=1,
+                verdict="LOOP",
+                worktree=worktree,
+            )
+
+        assert result is None
+        assert conn.rollbacks >= 1
+        assert handler.events("ralph_iteration_patch_persist_failed")
+
+
+# --------------------------------------------------------------------------
+# _format_resume_with_conflict_block
+# --------------------------------------------------------------------------
+
+
+class TestFormatResumeWithConflictBlock:
+    """AC #6 — the RESUME WITH CONFLICT prompt block contains the
+    exact placeholders the issue body specifies: ``{N}``,
+    ``{agent_id_short}``, ``{iter_n}``, ``{verdict}``, ``{age_ago}``,
+    ``{K}``."""
+
+    def test_all_placeholders_populated(self) -> None:
+        block = daemon.DispatcherDaemon._format_resume_with_conflict_block(
+            issue_number=3026,
+            conflict_info={
+                "source_agent_id": "abcdef0123456789",
+                "iteration_n": 3,
+                "verdict": "LOOP",
+                "age_seconds": 3725.0,  # 1h 2m
+                "conflict_files": ["src/foo.py", "src/bar.py"],
+            },
+        )
+
+        # Heading (must match exactly — ralph's worker is trained on
+        # this verbatim string).
+        assert block.startswith("RESUME WITH CONFLICT")
+        # Issue number placeholder.
+        assert "issue #3026" in block
+        # agent_id_short = first 8 chars of source_agent_id.
+        assert "agent abcdef01" in block
+        # iter_n.
+        assert "iteration 3" in block
+        # verdict.
+        assert "verdict LOOP" in block
+        # age_ago (coarse: 1h 2m).
+        assert "1h 2m ago" in block
+        # K = count of conflict files.
+        assert "2 files are in conflict" in block
+        # The two canonical options ralph must choose between.
+        assert "git am --continue" in block
+        assert "git am --abort" in block
+        # Conflict files enumerated for operator visibility.
+        assert "src/foo.py" in block
+        assert "src/bar.py" in block
+
+    def test_unknown_source_agent_id_uses_placeholder(self) -> None:
+        block = daemon.DispatcherDaemon._format_resume_with_conflict_block(
+            issue_number=1,
+            conflict_info={
+                # No source_agent_id — defensive fallback.
+                "iteration_n": 1,
+                "verdict": "LOOP",
+                "age_seconds": 30.0,
+                "conflict_files": [],
+            },
+        )
+        assert "agent unknown" in block
+
+    def test_ship_verdict_no_iteration_n_renders_marker(self) -> None:
+        """SHIP rows carry ``iteration_n=NULL`` by #3026 convention —
+        the block must render a non-numeric marker rather than
+        "iteration None"."""
+        block = daemon.DispatcherDaemon._format_resume_with_conflict_block(
+            issue_number=42,
+            conflict_info={
+                "source_agent_id": "11111111-xxxx",
+                "iteration_n": None,
+                "verdict": "SHIP",
+                "age_seconds": 600.0,
+                "conflict_files": [],
+            },
+        )
+        assert "iteration SHIP (no iteration)" in block
+        assert "iteration None" not in block
+
+    def test_zero_conflict_files_still_renders(self) -> None:
+        """K=0 is possible when ``git am`` fails with no unmerged
+        paths (e.g. pure index corruption). The block still renders
+        and reports 0."""
+        block = daemon.DispatcherDaemon._format_resume_with_conflict_block(
+            issue_number=7,
+            conflict_info={
+                "source_agent_id": "a" * 16,
+                "iteration_n": 1,
+                "verdict": "LOOP",
+                "age_seconds": 0.0,
+                "conflict_files": [],
+            },
+        )
+        assert "0 files are in conflict" in block
+        # No "Conflict files:" sub-section when the list is empty.
+        assert "Conflict files:" not in block
+
+
+# --------------------------------------------------------------------------
+# _format_age_ago
+# --------------------------------------------------------------------------
+
+
+class TestFormatAgeAgo:
+    """Coarse age buckets used by the RESUME WITH CONFLICT block."""
+
+    @pytest.mark.parametrize(
+        "seconds,expected",
+        [
+            (0.0, "just now"),
+            (30.0, "just now"),
+            (59.9, "just now"),
+            (60.0, "1m ago"),
+            (120.0, "2m ago"),
+            (3599.0, "59m ago"),
+            (3600.0, "1h 0m ago"),
+            (3725.0, "1h 2m ago"),
+            (86399.0, "23h 59m ago"),
+            (86400.0, "1d 0h ago"),
+            (90000.0, "1d 1h ago"),
+            (259200.0, "3d 0h ago"),
+        ],
+    )
+    def test_buckets(self, seconds: float, expected: str) -> None:
+        assert daemon._format_age_ago(seconds) == expected
+
+
+# --------------------------------------------------------------------------
+# _list_git_am_conflict_files
+# --------------------------------------------------------------------------
+
+
+class TestListGitAmConflictFiles:
+    """Helper used by ``_apply_prior_ralph_patch`` on the conflict path
+    to populate ``conflict_files`` in the return dict."""
+
+    def test_returns_unmerged_paths(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        diff_result = subprocess.CompletedProcess(
+            args=["git", "diff"],
+            returncode=0,
+            stdout="src/foo.py\nsrc/bar.py\n",
+            stderr="",
+        )
+        with patch("subprocess.run", side_effect=[diff_result]):
+            files = d._list_git_am_conflict_files(worktree)
+
+        assert files == ["src/foo.py", "src/bar.py"]
+
+    def test_uses_diff_filter_U(self, tmp_path: Path) -> None:
+        """Query must use ``--diff-filter=U`` to catch unmerged entries."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        diff_result = subprocess.CompletedProcess(
+            args=["git", "diff"],
+            returncode=0,
+            stdout="",
+            stderr="",
+        )
+        with patch("subprocess.run", side_effect=[diff_result]) as run_mock:
+            d._list_git_am_conflict_files(worktree)
+
+        args = run_mock.call_args_list[0].args[0]
+        assert "--diff-filter=U" in args
+        assert "--name-only" in args
+
+    def test_returns_empty_on_subprocess_error(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+
+        with patch("subprocess.run", side_effect=Exception("boom")):
+            files = d._list_git_am_conflict_files(worktree)
+
+        assert files == []

--- a/scripts/dispatcher/tests/test_persist_ralph_iteration_cli.py
+++ b/scripts/dispatcher/tests/test_persist_ralph_iteration_cli.py
@@ -1,0 +1,204 @@
+"""Unit tests for ``scripts/dispatcher/persist_ralph_iteration.py`` (#3026).
+
+The CLI is the bridge that lets the ralph skill call back into
+postgres at end-of-iteration without requiring the daemon to own the
+per-iteration hook directly. All failure paths exit 0 — ralph must
+never get a non-zero exit from this helper.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from dispatcher import persist_ralph_iteration  # noqa: E402
+
+
+def _args(
+    worktree: Path,
+    *,
+    agent_id: str = "agent-1",
+    issue_number: int = 42,
+    iteration: int = 1,
+    verdict: str = "LOOP",
+) -> list[str]:
+    return [
+        "--worktree",
+        str(worktree),
+        "--agent-id",
+        agent_id,
+        "--issue-number",
+        str(issue_number),
+        "--iteration",
+        str(iteration),
+        "--verdict",
+        verdict,
+    ]
+
+
+def test_no_database_url_exits_0_and_emits_skipped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Absent ``DATABASE_URL`` env → exit 0, stdout ``skipped=no_database_url``.
+    Ralph must keep going even when the daemon / env is misconfigured."""
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+
+    rc = persist_ralph_iteration.main(_args(worktree))
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out.strip() == "skipped=no_database_url"
+
+
+def test_missing_worktree_exits_0_with_skipped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Worktree path doesn't exist → skipped, exit 0."""
+    monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+    missing = tmp_path / "missing"
+
+    rc = persist_ralph_iteration.main(_args(missing))
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out.startswith("skipped=worktree_missing:")
+
+
+def test_empty_patch_skips(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``git format-patch`` returns no bytes → skipped, exit 0, no DB write."""
+    monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+
+    empty = subprocess.CompletedProcess(
+        args=["git", "format-patch"], returncode=0, stdout="", stderr=""
+    )
+    with patch("subprocess.run", side_effect=[empty]):
+        rc = persist_ralph_iteration.main(_args(worktree))
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out.strip() == "skipped=empty_or_failed_format_patch"
+
+
+def test_happy_path_inserts_and_emits_persisted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Happy path: format-patch + rev-parse + psycopg.connect.execute
+    all succeed; stdout says ``persisted=<patch_id>``."""
+    monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+
+    format_patch_ok = subprocess.CompletedProcess(
+        args=["git", "format-patch"],
+        returncode=0,
+        stdout="From abc Mon...\npatch body\n",
+        stderr="",
+    )
+    rev_parse_ok = subprocess.CompletedProcess(
+        args=["git", "rev-parse"], returncode=0, stdout="deadbeef\n", stderr=""
+    )
+
+    # Fake psycopg: connect → context mgr → cursor() → context mgr →
+    # execute() + fetchone() returning the new patch_id tuple.
+    fake_cursor = MagicMock()
+    fake_cursor.__enter__ = MagicMock(return_value=fake_cursor)
+    fake_cursor.__exit__ = MagicMock(return_value=None)
+    fake_cursor.fetchone = MagicMock(return_value=("generated-uuid",))
+    fake_cursor.execute = MagicMock()
+
+    fake_conn = MagicMock()
+    fake_conn.__enter__ = MagicMock(return_value=fake_conn)
+    fake_conn.__exit__ = MagicMock(return_value=None)
+    fake_conn.cursor = MagicMock(return_value=fake_cursor)
+    fake_conn.commit = MagicMock()
+
+    fake_psycopg = MagicMock()
+    fake_psycopg.connect = MagicMock(return_value=fake_conn)
+
+    with patch.dict(sys.modules, {"psycopg": fake_psycopg}):
+        with patch(
+            "subprocess.run",
+            side_effect=[format_patch_ok, rev_parse_ok],
+        ):
+            rc = persist_ralph_iteration.main(
+                _args(worktree, iteration=3, verdict="LOOP", agent_id="ag-xyz")
+            )
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out.strip() == "persisted=generated-uuid"
+
+    # INSERT params carry iteration + verdict columns.
+    fake_cursor.execute.assert_called_once()
+    call_args = fake_cursor.execute.call_args
+    sql = call_args.args[0]
+    params = call_args.args[1]
+    assert "INSERT INTO dispatcher.ralph_patches" in sql
+    assert "iteration_n" in sql
+    assert "verdict" in sql
+    # (agent_id, issue_number, patch_content, commit_sha, iteration_n, verdict).
+    assert params[0] == "ag-xyz"
+    assert params[1] == 42
+    assert params[3] == "deadbeef"
+    assert params[4] == 3
+    assert params[5] == "LOOP"
+    fake_conn.commit.assert_called_once()
+
+
+def test_db_error_emits_error_and_exits_0(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A DB exception during INSERT → stdout ``error=...``, exit 0.
+    Never propagates to ralph."""
+    monkeypatch.setenv("DATABASE_URL", "postgres://fake")
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+
+    format_patch_ok = subprocess.CompletedProcess(
+        args=["git", "format-patch"],
+        returncode=0,
+        stdout="patch bytes\n",
+        stderr="",
+    )
+    rev_parse_ok = subprocess.CompletedProcess(
+        args=["git", "rev-parse"], returncode=0, stdout="sha\n", stderr=""
+    )
+
+    fake_psycopg = MagicMock()
+    fake_psycopg.connect = MagicMock(side_effect=RuntimeError("connection refused"))
+
+    with patch.dict(sys.modules, {"psycopg": fake_psycopg}):
+        with patch(
+            "subprocess.run",
+            side_effect=[format_patch_ok, rev_parse_ok],
+        ):
+            rc = persist_ralph_iteration.main(_args(worktree))
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert captured.out.startswith("error=")
+    assert "connection refused" in captured.out


### PR DESCRIPTION
## Summary

Extends #3013's `dispatcher.ralph_patches` persistence with per-iteration additive writes (migration 39 adds `iteration_n INT` + `verdict TEXT`) and unified cross-agent resume: `_apply_prior_ralph_patch` now queries any `agent_id` within a 7-day TTL, and on `git am --3way` conflict it LEAVES the am-in-progress state so ralph decides `git am --continue` vs `git am --abort` via a structured "RESUME WITH CONFLICT" prompt block surfaced through `prior_attempts.md`. A new CLI `scripts/dispatcher/persist_ralph_iteration.py` is the ralph-side hook called at end of every iteration. All pre-existing #3013 SHIP → PR → delete semantics preserved.

Closes #3026

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (29 new unit tests across two files, 20 pre-existing tests updated + 6 Opus tests fixed for #3022's Popen transition)
- [x] CI green

### Post-deploy verification
- [ ] The migration column names appear on live dev postgres: `\d dispatcher.ralph_patches` shows `iteration_n` and `verdict` columns
- [ ] The dispatcher image rebuild + task-def bump triggers on merge (side effect picks up #3025's pytest-cov 7.1.0 pin for Fargate ralph worktrees)
- [ ] On the next live ralph attempt, CloudWatch Logs shows `ralph_iteration_patch_persisted` events with `iteration_n` populated
- [ ] Verification evidence posted on issue #3026

## Implementation notes

- **Per-iteration hook placement.** Ralph runs as a Task subagent inside the `/task-v2-ralph` claude subprocess, so the daemon can't directly hook into its iteration boundaries. The new CLI `scripts/dispatcher/persist_ralph_iteration.py` bridges ralph back into postgres via `DATABASE_URL`. `.claude/skills/ralph/SKILL.md` §2f documents the hook. The helper exits 0 on every failure path so a persistence hiccup never kills ralph.
- **Conflict-handoff contract.** The daemon no longer runs `git am --abort` on conflict. The worktree is left in am-in-progress with unmerged paths; `_format_resume_with_conflict_block` renders the exact "RESUME WITH CONFLICT" text from the #3026 issue body (including the `{N}` / `{agent_id_short}` / `{iter_n}` / `{verdict}` / `{age_ago}` / `{K}` placeholders); `.claude/skills/task-v2-ralph/SKILL.md` §"Resume with conflict" documents the continue-vs-abort contract with heuristics (recency < 24 h + ≤ 5 conflict files for continue; stale > 48 h or ABORT verdict for abort).
- **Self-inherit guard removed.** Pre-#3026 `_apply_prior_ralph_patch` skipped applying a patch whose `agent_id` matched the current agent. The unified lookup explicitly permits same-agent rows (same-agent restart is a valid resume scenario on a fresh worktree). `test_self_inherit_skipped` replaced with `test_unified_resume_lookup_uses_ttl_predicate`.
- **SHIP-path preserved.** `_capture_and_persist_ralph_patch` still runs the DELETE-supersede-by-`issue_number` + INSERT + UPDATE-`phase_outputs.patch_id` transaction on SHIP, now writing `verdict='SHIP'` with `iteration_n=NULL`. `_delete_ralph_patches_for_agent` on `gh pr create` success is unchanged — still cleans up every row for the agent, including the newly-written intermediate rows.
- **Second commit unblocks `scripts-tests` CI.** The 4 `test_daemon_ralph_opus_final_attempt.py::TestRalphSpawnUsesAttemptAwareModel` tests were failing on tip-of-main after #3022 switched `_spawn_phase_subprocess` from `subprocess.run` to `subprocess.Popen` + the async stream forwarder. The tests mocked only `subprocess.run` and therefore silently spawned real `claude` binaries on CI. A `_patch_popen_and_forwarder` helper fixes all six tests; the fix is in the same PR because otherwise CI would remain red and block merge.
