### PR TITLE
fix(dispatcher): set cwd=baseline_repo_root on diagnoser Popen (#3033)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -13965,6 +13965,22 @@ class DispatcherDaemon:
 
         The diagnoser runs at the repo root (no per-agent worktree) so
         the JSONL mirror goes under ``{repo_root}/tmp/.dispatcher/``.
+
+        **Cwd must be the baseline clone (#3033).** The dispatcher
+        Fargate image's ``WORKDIR`` is ``/app``, which does NOT contain
+        ``.claude/skills/diagnose-failure/`` — only
+        ``scripts/dispatcher/`` and a few hook/preflight files are
+        ``COPY``ed into the image. The full ``.claude/skills/`` tree
+        lives in the baseline git clone at
+        ``self._cfg.baseline_repo_root`` (e.g.
+        ``/var/lib/dispatcher/repo``). Without ``cwd=`` set, the
+        ``claude`` CLI inherits ``/app`` as cwd and exits in <11s with
+        a NULL recommendation because the ``/diagnose-failure`` skill
+        isn't discoverable — the exact symptom documented on #3033
+        (five consecutive failures with sub-11s durations and NULL
+        recommendation). The same cwd anchor is applied to the JSONL
+        mirror path so the triage trail lands alongside the phase
+        spawns' own ``tmp/.dispatcher/`` files.
         """
         cmd = [
             "claude",
@@ -13984,7 +14000,7 @@ class DispatcherDaemon:
             "--dangerously-skip-permissions",
         ]
 
-        repo_root = Path.cwd()
+        repo_root = self._repo_root_for_notify_script()
         jsonl_path = (
             repo_root / "tmp" / ".dispatcher" / f"diagnose-{diagnosis_id}.jsonl"
         )
@@ -14011,6 +14027,7 @@ class DispatcherDaemon:
                 stderr=subprocess.PIPE,
                 text=True,
                 bufsize=1,
+                cwd=str(repo_root),
             )
         except FileNotFoundError:
             return None, "claude binary not found"

--- a/scripts/dispatcher/tests/test_daemon_phase3d.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3d.py
@@ -558,6 +558,51 @@ class TestSpawnDiagnoserSubprocess:
         d._spawn_diagnoser_subprocess(42)
         assert "--dangerously-skip-permissions" in captured["cmd"], captured["cmd"]
 
+    def test_popen_cwd_is_baseline_repo_root(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Issue #3033 — ``_spawn_diagnoser_subprocess`` must launch the
+        ``claude`` CLI with ``cwd=str(baseline_repo_root)`` so the
+        ``/diagnose-failure`` skill is discoverable.
+
+        The Fargate dispatcher image's ``WORKDIR`` is ``/app``; only
+        ``scripts/dispatcher/`` and a few hook files are ``COPY``ed
+        into it. ``.claude/skills/diagnose-failure/`` lives exclusively
+        in the baseline git clone at ``self._cfg.baseline_repo_root``
+        (e.g. ``/var/lib/dispatcher/repo``). Without ``cwd=`` set on
+        the Popen call, the child inherits ``/app`` as cwd and the
+        skill isn't found — ``claude`` exits in <11s with a NULL
+        recommendation. Five consecutive production failures with
+        sub-11s durations and NULL recommendation (see #3033 evidence
+        table) confirmed the bug before this fix landed.
+
+        Phase spawns (``_spawn_phase_subprocess``) already set
+        ``cwd=str(worktree)`` correctly because each worktree is a
+        ``git-worktree`` off the baseline clone and so contains the
+        full ``.claude/skills/`` tree. The diagnoser has no worktree —
+        it runs at the baseline clone root directly."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        # Point the daemon at a concrete baseline-repo-root path so the
+        # assertion compares to a known value. Production sets this via
+        # ``DaemonConfig.baseline_repo_root = Path("/var/lib/dispatcher/repo")``.
+        d._cfg.baseline_repo_root = tmp_path
+        captured: dict[str, Any] = {}
+
+        def on_start(cmd: list[str], kwargs: dict[str, Any]) -> None:
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+
+        monkeypatch.setattr(subprocess, "Popen", make_popen_factory(on_start=on_start))
+        d._spawn_diagnoser_subprocess(42)
+        assert "cwd" in captured["kwargs"], (
+            "Popen must be invoked with cwd= so the /diagnose-failure skill is "
+            f"discoverable (got kwargs={sorted(captured['kwargs'])})"
+        )
+        assert captured["kwargs"]["cwd"] == str(tmp_path), (
+            f"Popen cwd must be the baseline_repo_root path. "
+            f"Expected {tmp_path!s}, got {captured['kwargs']['cwd']!r}"
+        )
+
 
 # --------------------------------------------------------------------------
 # _read_recommendation — JSONB round-trip + validation


### PR DESCRIPTION
## Summary

Sets `cwd=str(baseline_repo_root)` on the diagnoser `subprocess.Popen` in `scripts/dispatcher/daemon.py::_spawn_diagnoser_subprocess` so the `claude` CLI can find `.claude/skills/diagnose-failure/SKILL.md`. Without this, every diagnoser invocation since the feature landed exited in <11s with a NULL recommendation — the daemon's `/app` cwd (from `Dockerfile.dispatcher`'s `WORKDIR`) doesn't contain `.claude/skills/`. The baseline git clone at `self._cfg.baseline_repo_root` does.

Also adds a focused unit test that mocks `subprocess.Popen` and asserts the captured kwargs include `cwd=str(self._cfg.baseline_repo_root)`. Verified FAILS pre-fix and PASSES post-fix.

Closes #3033

## Test plan

### Automated checks
- [x] Lint passes (ruff check, ruff format --check — both green locally)
- [x] Format check passes
- [x] Tests pass (full 928-test dispatcher suite green locally; `TestSpawnDiagnoserSubprocess` 5/5 including the new test)
- [x] CI green

### Post-deploy verification
- [ ] Dispatcher redeploy lands (via merge → `deploy-dispatcher.yml` or equivalent)
- [ ] Next tier-2/3 diagnoser invocation produces a non-NULL `dispatcher.diagnoses.recommendation` with `duration >= 10s` (full verification requires an organic tier-2/3 failure after redeploy; noted on the issue as a post-deploy follow-up per AC #5)
- [ ] Verification evidence posted on issue (see A.8)
