### PR TITLE
feat(dispatcher): route all agent-terminal failures through the diagnoser (#3032)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Diagnose a tier 2/3 dispatcher failure. Reads context from dispatcher.diagnoses.context, returns a structured recommendation that the daemon consumes deterministically.
+description: Diagnose a dispatcher agent-terminal failure. Reads context from dispatcher.diagnoses.context, returns a structured recommendation that the daemon consumes deterministically.
 argument-hint: "<diagnosis_id>"
 maxTurns: 30
 model: opus
@@ -7,11 +7,13 @@ model: opus
 
 # /diagnose-failure skill
 
-Diagnoser for the dispatcher v2 tier-2/3 failure flow (`docs/specs/dispatcher-v2-spec.md` §8). Invoked as `claude -p '/diagnose-failure <diagnosis_id>'` by the daemon when a tier-2 failure recurs after its mechanical retry, or when a tier-3 failure fires on first occurrence (`ci_red_after_retries`). Reads the context bundle the daemon wrote to `dispatcher.diagnoses.context`, proposes one of five deterministic actions (`retry`, `retry_with_hint`, `reissue`, `escalate`, `close`), and writes a structured recommendation back to the same row. The daemon executes the chosen action — this skill does not write to GitHub directly.
+Diagnoser for the dispatcher v2 failure flow (`docs/specs/dispatcher-v2-spec.md` §8). Invoked as `claude -p '/diagnose-failure <diagnosis_id>'` by the daemon for every agent-terminal failure the unified `_handle_agent_failure` path routes here — including `git_push_failed` / `pr_create_failed` / `phase_output_missing` (first occurrence, issue #3032) and the original tier-2 recurrences / tier-3 first-occurrence categories (`ci_red_after_retries`, `ralph_ac_infeasible`, `summary_ac_infeasible`, `subprocess_turn_limit`). Reads the context bundle the daemon wrote to `dispatcher.diagnoses.context`, proposes one of eight known actions (or, if none fit, a novel action string the daemon will log for operator review), and writes a structured recommendation back to the same row. The daemon executes the chosen action — this skill does not write to GitHub directly.
+
+**Known actions (eight).** The daemon's deterministic consumer handles these exactly: `retry`, `retry_with_hint`, `reissue`, `escalate`, `close`, `block_and_comment`, `file_prerequisite_task`, `block_on_existing_task`. Any other action string is logged to `dispatcher.unrecognized_diagnoser_actions` and falls back to `escalate` so the failure still surfaces. See §Action selection below for the decision tree.
 
 **Prerequisites:** The daemon has already (a) written a `dispatcher.diagnoses` row with `status='pending'` and a serialized context bundle, (b) spawned this skill with the `diagnosis_id` as the argument.
 
-**Goal:** Update `dispatcher.diagnoses.recommendation` (JSONB) with `{action, reasoning, hint?, new_scope?}` and set `status='completed'`, `completed_at=now()`. Additionally, UPDATE `dispatcher.agents.failure_summary` with the first 1-3 sentences of the recommendation's `reasoning` (truncated to 240 chars) so the admin cockpit's "Recently completed" panel shows an LLM-authored summary on hover instead of the daemon's terminal-time template (issue #2900). The daemon's next supervisor tick consumes the recommendation.
+**Goal:** Update `dispatcher.diagnoses.recommendation` (JSONB) with `{action, reasoning, ...payload fields}` and set `status='completed'`, `completed_at=now()`. Additionally, UPDATE `dispatcher.agents.failure_summary` with the first 1-3 sentences of the recommendation's `reasoning` (truncated to 240 chars) so the admin cockpit's "Recently completed" panel shows an LLM-authored summary on hover instead of the daemon's terminal-time template (issue #2900). The daemon's next supervisor tick consumes the recommendation.
 
 **IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation. This subprocess is already a dispatcher-spawned background task.
 
@@ -54,13 +56,15 @@ The `context` JSONB contains (schema stable — the daemon serializes this):
 
 - `agent_id` (str) — the failing agent's UUID. **Required for the `failure_summary` upgrade write (#2900).**
 - `failure_id` (int) — `dispatcher.failures.failure_id` for the triggering failure.
-- `failure_category` (str) — one of `subprocess_turn_limit`, `stuck_timeout`, `gh_rate_exhausted`, `subprocess_crash`, `ci_red_after_retries`, or any other §8 category the daemon has routed here.
+- `failure_category` (str) — one of `subprocess_turn_limit`, `stuck_timeout`, `gh_rate_exhausted`, `subprocess_crash`, `ci_red_after_retries`, `push_failed`, `pre_push_hook_rejected`, `git_push_network`, `pr_create_failed`, `phase_output_missing`, `ralph_ac_infeasible`, `summary_ac_infeasible`, or any other §8 category the daemon has routed here.
 - `tier` (int) — `2` or `3`.
 - `issue_number` (int).
 - `issue_title` (str).
 - `issue_body` (str).
 - `recent_phase_transitions` (list of `{phase, ts}`) — last ~10 transitions for this agent, newest first.
 - `prior_failures` (list of `{failure_id, category, ts, details}`) — prior `dispatcher.failures` rows on the same issue across all agents (not just this one).
+- `prior_diagnoses_this_issue` (list of `{diagnosis_id, failure_category, recommendation, completed_at}`) — prior completed diagnoses on the same `issue_number`. **Use this to avoid repeating a decision that already failed** — e.g. if `retry` was recommended twice and the failure recurred twice, escalate or change strategy. (Added in #3032.)
+- `recent_fleet_decisions` (list of `{diagnosis_id, agent_id, issue_number, failure_category, action, reasoning, completed_at}`) — the diagnoser's last ~20 decisions across ALL issues in the past 6 hours. **Use this to detect fleet-wide spates** — if 5 different issues hit the same failure class today, the right action may be `file_prerequisite_task` or `escalate`, not patch-per-issue. (Added in #3032. The PAT-scope cascade on 2026-04-22/23 is the canonical example.)
 - `ralph_done_content` (str | null) — contents of `{worktree}/tmp/ralph/ralph-done.txt` if present, else null.
 - `pr_url` (str | null) — if a PR was opened.
 - `pr_number` (int | null).
@@ -104,7 +108,7 @@ def _summary_from_reasoning(reasoning: str, cap: int = 240) -> str:
     sentences = re.split(r"(?<=[.!?])\s+", text)
     head = " ".join(sentences[:3]).strip()
     if len(head) > cap:
-        head = head[: cap - 1].rstrip() + "\u2026"
+        head = head[: cap - 1].rstrip() + "…"
     return head
 
 summary = _summary_from_reasoning(recommendation.get("reasoning", ""))
@@ -132,19 +136,26 @@ The recommendation JSON has this shape:
 
 ```json
 {
-  "action": "retry" | "retry_with_hint" | "reissue" | "escalate" | "close",
+  "action": "retry" | "retry_with_hint" | "reissue" | "escalate" | "close" | "block_and_comment" | "file_prerequisite_task" | "block_on_existing_task" | "<novel-action-string>",
   "reasoning": "<one paragraph — why this action fits>",
-  "hint": "<optional — comment text to post on the issue before retry>",
-  "new_scope": "<optional — rewritten issue body for action='reissue'>"
+  "hint": "<conditional — retry_with_hint only>",
+  "new_scope": "<conditional — reissue only>",
+  "title": "<conditional — file_prerequisite_task only>",
+  "body": "<conditional — file_prerequisite_task only>",
+  "block_labels": ["<conditional — file_prerequisite_task only>"],
+  "blocker_issue_number": 42
 }
 ```
 
 Field rules:
 
-- `action` (required) — exactly one of the five strings above.
+- `action` (required) — one of the eight known strings above, OR a novel action string if none fit. Novel actions persist to `dispatcher.unrecognized_diagnoser_actions` and fall back to `escalate` — use only when genuinely needed and the `reasoning` paragraph makes the intended behavior unambiguous.
 - `reasoning` (required) — a single paragraph (≤500 chars) explaining the choice in plain English. This gets surfaced in operator dashboards and the §8 weekly report. The first 1-3 sentences are also written to `dispatcher.agents.failure_summary` (issue #2900) so the admin cockpit can show an LLM-authored tooltip on hover over the outcome glyph — keep the opening sentences self-contained ("what happened + why this action"), not mid-argument.
 - `hint` (conditional) — required when `action='retry_with_hint'`; the daemon posts it verbatim as an issue comment before enqueueing the retry marker. Ignored for other actions.
 - `new_scope` (conditional) — required when `action='reissue'`. **The daemon replaces the issue body wholesale** via `gh issue edit --body-file` (no splicing, no patching — Python writes the string to a file and `gh` edits the body). MUST be a complete, well-formed issue body with `## Goal`, `## Scope`, `## Acceptance criteria`, `## Priority`, `## References` sections and any `Parent: #N` / `Blocked by #N` lines. A diff, patch, or partial body will truncate the issue. Issue #3010.
+- `title` + `body` (conditional) — required when `action='file_prerequisite_task'`. Daemon runs `gh issue create --title <title> --body-file <body>`. The title must be conventional-commits style (e.g. `chore(dispatcher): add workflow scope to dispatcher PAT`); the body must be a well-formed issue body with acceptance criteria and verify lines.
+- `block_labels` (optional) — applies to `file_prerequisite_task`. List of label names to apply to the newly-created issue (e.g. `["priority/p1", "area/infra", "agent/ready"]`).
+- `blocker_issue_number` (conditional) — required when `action='block_on_existing_task'`. Positive integer issue number that the daemon will validate is open + append to the current issue body as `Blocked by #<N>`.
 
 Exit 0 regardless of recommendation. If the recommendation cannot be written (DB down, malformed JSON, subprocess error), exit non-zero so the daemon marks the diagnosis `status='failed'` and falls back to the fixed mechanical escalation policy.
 
@@ -154,7 +165,7 @@ Exit 0 regardless of recommendation. If the recommendation cannot be written (DB
 
 Work through these questions in order. The first "yes" determines the action.
 
-1. **Is this failure caused by an external dependency outage or a transient GitHub/Anthropic/AWS hiccup?** (Signs: `subprocess_crash` category, stderr mentions 5xx / timeouts / DNS / network errors, prior failures on unrelated issues in the same window.)
+1. **Is this failure caused by an external dependency outage or a transient GitHub/Anthropic/AWS hiccup?** (Signs: `subprocess_crash` category, stderr mentions 5xx / timeouts / DNS / network errors, prior failures on unrelated issues in the same window but NOT a fleet-wide spate on the same category.)
    - → **`retry`**. The mechanical retry already ran once (tier 2), but if the root cause was a transient that has since cleared, a second attempt may succeed. No comment needed.
 
 2. **Is the failure caused by a scope ambiguity or a missing piece of context the agent needed?** (Signs: `subprocess_turn_limit` with ralph spinning on the same scope item; `ci_red_after_retries` where the fix-CI phase kept trying to fix symptoms of a larger design issue.)
@@ -165,13 +176,25 @@ Work through these questions in order. The first "yes" determines the action.
 3. **Is the issue's scope wrong — i.e. the agent correctly implemented what was asked, but the acceptance criteria no longer match reality?** (Signs: ralph completed with SHIP but CI caught a drift; the issue was filed against an older codebase state; the AC uses a field/endpoint that has been renamed/removed.)
    - → **`reissue`**. Write a `new_scope` issue body with corrected acceptance criteria. Include `Parent: #<parent>` if the original had one. Keep the `Verify:` lines concrete.
 
-4. **Does the failure require a human decision that the agent cannot make safely?** (Signs: `subprocess_auth_fail`, missing secret, security question, architectural decision, vendor billing concern, any issue label with `type/decision`.)
+4. **Does the failure require a human decision that the agent cannot make safely AND you cannot easily file a specific tracking issue?** (Signs: `subprocess_auth_fail`, missing secret, security question, architectural decision, vendor billing concern, any issue label with `type/decision`.)
    - → **`escalate`**. The daemon will add `status/needs-human` + `priority/p1` and post the reasoning as a comment. No retry.
 
 5. **Is the issue itself invalid — duplicate, already-completed, out-of-date, or not actually reproducible?** (Signs: a PR already merged that Closes this issue; the behavior described is the current behavior; the issue is a duplicate of another open issue.)
    - → **`close`**. The daemon will close with `status/invalid` and post the reasoning as the close comment.
 
-**When uncertain, prefer `escalate` over a wrong guess.** A human re-classification is cheap; a wrong `close` or `reissue` can destroy context.
+6. **Is the blocker a deterministic, operator-action dependency (PAT scope, missing secret, branch protection mis-config, infra gap) that is visible in stderr / PR status AND the right next step is "wait for operator, don't retry"?**
+   - → **`block_and_comment`** if the blocker is acknowledged / in-flight and doesn't need its own tracking issue.
+   - → **`file_prerequisite_task`** if the blocker is new, deserves its own backlog item, and will likely affect multiple agents. Provide a focused `title` and `body`. The daemon files the issue, appends `Blocked by #<new>` to the current issue, and applies `status/blocked`. Example: the PAT-scope cascade on 2026-04-22/23 would have filed a p1 issue "add workflow scope to dispatcher PAT" and blocked #3008 and #2610 on it.
+
+7. **Is there an already-open tracking issue for this blocker?** (Search via `gh issue list --search "<keywords>" --state open`.)
+   - → **`block_on_existing_task`** with `blocker_issue_number = <that issue>`. Avoids duplicate tickets. The daemon validates the target is open, appends `Blocked by #<N>`, applies `status/blocked`.
+
+8. **Does `recent_fleet_decisions` show this same failure class hitting 3+ different issues in the last 6 hours?** (Regardless of which single action category above fits.)
+   - → **`file_prerequisite_task`** or **`escalate`** — the pattern is fleet-wide, a per-issue patch won't fix it. Prefer `file_prerequisite_task` if the root cause is trackable; `escalate` if it needs a human to even diagnose.
+
+**When uncertain, prefer `escalate` over a wrong guess.** A human re-classification is cheap; a wrong `close` or `reissue` can destroy context, and a wrong `block_*` may leave the issue stuck until an operator notices.
+
+**Novel actions.** If none of the eight fit — for example, you want "split_task" because the issue's acceptance criteria are actually two independent issues — you MAY emit a novel action string. The daemon will persist `{action_name, payload}` to `dispatcher.unrecognized_diagnoser_actions` and fall back to `escalate` so operators can review. Use novel actions sparingly; the reasoning paragraph MUST make the intended behavior unambiguous.
 
 ---
 
@@ -224,6 +247,7 @@ The context bundle should usually be enough. Shell out sparingly:
 - `gh issue view <N> --repo judgemind/judgemind --json number,title,body,state,labels,comments` — when the context is stale and the issue may have been edited or commented on since the daemon fetched it.
 - `gh pr view <PR> --repo judgemind/judgemind --json statusCheckRollup,files,commits,mergeable,mergeStateStatus` — for tier-3 `ci_red_after_retries` where the failing checks tell you the fix approach.
 - `gh run view <run_id> --repo judgemind/judgemind --log-failed` — to read the specific failing CI log. Cap at ~200 lines; the relevant signal is usually at the start or end.
+- `gh issue list --search "<keywords>" --state open --repo judgemind/judgemind` — before emitting `file_prerequisite_task`, check whether an open tracking issue already exists; if so, prefer `block_on_existing_task` with that number.
 - `git -C {worktree} log --oneline -20` — to see the commit history of the failing agent's branch.
 - `git -C {worktree} diff origin/main...HEAD` — the full PR diff. Only needed when deciding between `retry_with_hint` and `reissue`.
 
@@ -238,7 +262,7 @@ The context bundle should usually be enough. Shell out sparingly:
 
 1. **Set up.** Write `{worktree}/tmp/dispatcher-diagnoser/read_context.py` and `{worktree}/tmp/dispatcher-diagnoser/write_recommendation.py` helpers (code above). Run the reader with the `diagnosis_id` argument to pull the JSONB context into memory.
 
-2. **Classify.** Identify `failure_category` and `tier` from the context. Read `prior_mechanical_fix` (tier 2) or `ci_log_url` (tier 3) to understand what already failed.
+2. **Classify.** Identify `failure_category` and `tier` from the context. Read `prior_mechanical_fix` (tier 2) or `ci_log_url` (tier 3) to understand what already failed. Scan `prior_diagnoses_this_issue` + `recent_fleet_decisions` for patterns.
 
 3. **Decide.** Walk the decision tree above. Do not fetch anything you don't need — context bundle first, GitHub reads only when a specific question remains.
 
@@ -280,6 +304,37 @@ The context bundle should usually be enough. Shell out sparingly:
 }
 ```
 
+### Example 4 — `pre_push_hook_rejected` with fleet-wide PAT-scope pattern, file_prerequisite_task
+
+```json
+{
+  "action": "file_prerequisite_task",
+  "reasoning": "Six consecutive git-push failures in the last 6 hours across #3008 and #2610 all hit 'refusing to allow a Personal Access Token to create or update workflow .* without workflow scope'. This is a dispatcher PAT configuration gap — the secret in AWS Secrets Manager needs the `workflow` scope added. Filing a prerequisite task rather than blocking per-issue because the fix affects every in-flight agent.",
+  "title": "chore(infra): add workflow scope to dispatcher PAT",
+  "body": "## Goal\n\nAdd the `workflow` OAuth scope to the dispatcher's GitHub PAT so agents can push commits that add/modify `.github/workflows/*` files.\n\n## Acceptance criteria\n- [ ] Dispatcher PAT in AWS Secrets Manager has `workflow` scope.\n  **Verify:** a test dispatcher agent can `git push` a branch that adds a file under `.github/workflows/` without hitting 'refusing to allow a Personal Access Token' rejection.\n\n## Priority\n\np1 — blocks the entire dispatcher fleet.",
+  "block_labels": ["priority/p1", "area/infra", "type/chore", "agent/ready"]
+}
+```
+
+### Example 5 — `push_failed` with existing tracking issue, block_on_existing_task
+
+```json
+{
+  "action": "block_on_existing_task",
+  "reasoning": "The PAT-scope blocker is already tracked at #3050 (filed 2 hours ago by the dispatcher when it caught the same pattern). Filing a duplicate would be noise — block this issue on the existing one instead.",
+  "blocker_issue_number": 3050
+}
+```
+
+### Example 6 — `phase_output_missing` on ralph, block_and_comment
+
+```json
+{
+  "action": "block_and_comment",
+  "reasoning": "Ralph's subprocess exited 0 but `{worktree}/tmp/dispatcher-output/ralph.json` is missing. The last 200 lines of the phase log show Claude Code's internal harness dumped a JSON parse error before the skill could write. This is a dispatcher-image bug that needs a Claude Code version bump — not something a fresh retry will fix. Marking blocked so no other agent picks this up while the operator investigates."
+}
+```
+
 ---
 
 ## Reminders
@@ -287,5 +342,5 @@ The context bundle should usually be enough. Shell out sparingly:
 - No `$()`, no heredocs, no `python -c`. See `CLAUDE.md` Critical Rules. Write helper scripts to `{worktree}/tmp/dispatcher-diagnoser/` first, then invoke them.
 - All temp files go under `{worktree}/tmp/`, never `/tmp/`.
 - This skill is Opus-tier per spec §18 — but the task is narrow. Do NOT over-investigate. The decision tree is intentionally short.
-- **The five actions are exhaustive.** Do not invent a sixth (`defer`, `split`, `merge`, etc.) — the daemon's consumer has five deterministic branches and will fall back to escalation on any other string.
+- **Known actions (the daemon recognizes these eight):** `retry`, `retry_with_hint`, `reissue`, `escalate`, `close`, `block_and_comment`, `file_prerequisite_task`, `block_on_existing_task`. You MAY propose a novel action string when none of the known set fits the situation — the daemon will log the action name and payload to `dispatcher.unrecognized_diagnoser_actions` and fall back to `escalate` so an operator can review it. Novel actions are an explicit escape hatch; prefer a known action when one fits.
 - Exit 0 means "recommendation written". Exit non-zero means "I could not diagnose" — the daemon falls back to fixed mechanical escalation.

--- a/packages/api/migrations/40_dispatcher-unrecognized-diagnoser-actions.sql
+++ b/packages/api/migrations/40_dispatcher-unrecognized-diagnoser-actions.sql
@@ -1,0 +1,61 @@
+-- Up Migration
+--
+-- Dispatcher v2 — adds the `dispatcher.unrecognized_diagnoser_actions`
+-- table so the daemon can persist diagnoser recommendation strings that
+-- fall outside the known action set. Every terminal agent failure now
+-- routes through the Opus diagnoser (issue #3032), and the closed-enum
+-- guardrail on the diagnoser skill has been removed. That opens the
+-- door for the LLM to propose novel actions the daemon does not yet
+-- recognize — this table is how we persist + review those proposals.
+--
+-- Issue #3032. Builds on #2795 (diagnoser introduction) and #3010
+-- (AC-infeasibility routing).
+--
+-- Design notes
+-- ------------
+-- - Minimal schema: one row per unrecognized action emission. The
+--   operator's "5+ instances of the same `action_name` is signal to
+--   implement a handler" workflow is a simple `SELECT action_name,
+--   count(*) FROM dispatcher.unrecognized_diagnoser_actions WHERE
+--   observed_at > now() - interval '7 days' GROUP BY 1 ORDER BY 2
+--   DESC` — no fancy aggregation, no automated alerting.
+-- - FK to `dispatcher.diagnoses(diagnosis_id)` so the original LLM
+--   context / recommendation is always retrievable via JOIN. ON DELETE
+--   stays at the default (RESTRICT) — unrecognized-action rows should
+--   outlive diagnosis cleanup since they are the audit trail we need
+--   for the operator review cadence.
+-- - `payload` JSONB stores the full recommendation dict verbatim so
+--   future handler implementations can see the shape the LLM proposed
+--   without re-running the diagnoser.
+-- - Index on `(action_name, observed_at DESC)` because the primary
+--   operator query groups by action name and wants newest-first.
+
+CREATE TABLE dispatcher.unrecognized_diagnoser_actions (
+    id             BIGSERIAL   PRIMARY KEY,
+    diagnosis_id   BIGINT      NOT NULL REFERENCES dispatcher.diagnoses(diagnosis_id),
+    action_name    TEXT        NOT NULL,
+    payload        JSONB       NOT NULL DEFAULT '{}',
+    observed_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_dispatcher_unrec_actions_action
+    ON dispatcher.unrecognized_diagnoser_actions (action_name, observed_at DESC);
+
+COMMENT ON TABLE dispatcher.unrecognized_diagnoser_actions IS
+    'Diagnoser actions the daemon did not recognize. Operator reviews '
+    'periodically; 5+ instances of a new action is signal to implement '
+    'a handler. See issue #3032.';
+COMMENT ON COLUMN dispatcher.unrecognized_diagnoser_actions.action_name IS
+    'The action string as emitted by the diagnoser (e.g. "split_task"). '
+    'Not constrained — anything the LLM proposed that was not in the '
+    'known set lands here.';
+COMMENT ON COLUMN dispatcher.unrecognized_diagnoser_actions.payload IS
+    'The full recommendation dict (action + reasoning + any payload '
+    'fields the LLM proposed) serialized as JSONB. Lets a future '
+    'handler implementer see the proposed shape without replaying '
+    'the diagnosis.';
+
+
+-- Down Migration
+DROP INDEX IF EXISTS dispatcher.idx_dispatcher_unrec_actions_action;
+DROP TABLE IF EXISTS dispatcher.unrecognized_diagnoser_actions;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 39 migrations.
+-- Generated from 40 migrations.
 
 
 
@@ -720,6 +720,35 @@ CREATE SEQUENCE dispatcher.terminal_outcomes_outcome_id_seq
 ALTER SEQUENCE dispatcher.terminal_outcomes_outcome_id_seq OWNED BY dispatcher.terminal_outcomes.outcome_id;
 
 
+CREATE TABLE dispatcher.unrecognized_diagnoser_actions (
+    id bigint NOT NULL,
+    diagnosis_id bigint NOT NULL,
+    action_name text NOT NULL,
+    payload jsonb DEFAULT '{}'::jsonb NOT NULL,
+    observed_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
+COMMENT ON TABLE dispatcher.unrecognized_diagnoser_actions IS 'Diagnoser actions the daemon did not recognize. Operator reviews periodically; 5+ instances of a new action is signal to implement a handler. See issue #3032.';
+
+
+COMMENT ON COLUMN dispatcher.unrecognized_diagnoser_actions.action_name IS 'The action string as emitted by the diagnoser (e.g. "split_task"). Not constrained — anything the LLM proposed that was not in the known set lands here.';
+
+
+COMMENT ON COLUMN dispatcher.unrecognized_diagnoser_actions.payload IS 'The full recommendation dict (action + reasoning + any payload fields the LLM proposed) serialized as JSONB. Lets a future handler implementer see the proposed shape without replaying the diagnosis.';
+
+
+CREATE SEQUENCE dispatcher.unrecognized_diagnoser_actions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER SEQUENCE dispatcher.unrecognized_diagnoser_actions_id_seq OWNED BY dispatcher.unrecognized_diagnoser_actions.id;
+
+
 CREATE TABLE public.alert_events (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     subscription_id uuid NOT NULL,
@@ -903,6 +932,9 @@ ALTER TABLE ONLY dispatcher.retry_markers ALTER COLUMN marker_id SET DEFAULT nex
 ALTER TABLE ONLY dispatcher.terminal_outcomes ALTER COLUMN outcome_id SET DEFAULT nextval('dispatcher.terminal_outcomes_outcome_id_seq'::regclass);
 
 
+ALTER TABLE ONLY dispatcher.unrecognized_diagnoser_actions ALTER COLUMN id SET DEFAULT nextval('dispatcher.unrecognized_diagnoser_actions_id_seq'::regclass);
+
+
 ALTER TABLE ONLY telemetry.data_quality_metrics ALTER COLUMN id SET DEFAULT nextval('telemetry.data_quality_metrics_id_seq'::regclass);
 
 
@@ -1040,6 +1072,10 @@ ALTER TABLE ONLY dispatcher.runs
 
 ALTER TABLE ONLY dispatcher.terminal_outcomes
     ADD CONSTRAINT terminal_outcomes_pkey PRIMARY KEY (outcome_id);
+
+
+ALTER TABLE ONLY dispatcher.unrecognized_diagnoser_actions
+    ADD CONSTRAINT unrecognized_diagnoser_actions_pkey PRIMARY KEY (id);
 
 
 ALTER TABLE ONLY public.alert_events
@@ -1250,6 +1286,9 @@ CREATE INDEX idx_dispatcher_retry_markers_pending ON dispatcher.retry_markers US
 CREATE INDEX idx_dispatcher_terminal_outcomes_ended_at ON dispatcher.terminal_outcomes USING btree (ended_at DESC);
 
 
+CREATE INDEX idx_dispatcher_unrec_actions_action ON dispatcher.unrecognized_diagnoser_actions USING btree (action_name, observed_at DESC);
+
+
 CREATE INDEX ralph_patches_created_at_idx ON dispatcher.ralph_patches USING btree (created_at);
 
 
@@ -1434,6 +1473,10 @@ ALTER TABLE ONLY dispatcher.ralph_patches
 
 ALTER TABLE ONLY dispatcher.retry_markers
     ADD CONSTRAINT retry_markers_agent_id_fkey FOREIGN KEY (agent_id) REFERENCES dispatcher.agents(agent_id);
+
+
+ALTER TABLE ONLY dispatcher.unrecognized_diagnoser_actions
+    ADD CONSTRAINT unrecognized_diagnoser_actions_diagnosis_id_fkey FOREIGN KEY (diagnosis_id) REFERENCES dispatcher.diagnoses(diagnosis_id);
 
 
 ALTER TABLE ONLY public.alert_events

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -795,29 +795,40 @@ FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE = "summary_ac_infeasible"
 #: Git-push failure categories for the ``push_and_pr`` phase (issue #2902).
 #: ``push_failed`` is the generic catch-all; the two sub-kinds are
 #: classifier-derived from stderr content via ``_classify_push_failure``.
-#: All three are tier-1 auto-retry — a transient network or pre-push hook
-#: failure on the first attempt is commonly self-healing.
+#: Issue #3032 moved these from the tier-1 auto-retry set to the
+#: tier-2 first-occurrence diagnoser set — the LLM now owns the
+#: retry/escalate decision on push failures (remote rejections like
+#: PAT scope need operator action, not blind retry).
 FAILURE_CATEGORY_PUSH_FAILED = "push_failed"
 FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED = "pre_push_hook_rejected"
 FAILURE_CATEGORY_GIT_PUSH_NETWORK = "git_push_network"
+
+#: Additional terminal-failure categories routed through the diagnoser
+#: by the unified ``_handle_agent_failure`` path (issue #3032).
+#: ``pr_create_failed`` — ``gh pr create`` non-zero exit or exception;
+#: commonly caused by a duplicate PR from a prior crashed agent, bad
+#: base ref, or a GitHub API hiccup — all benefit from Opus judgment.
+#: ``phase_output_missing`` — a per-phase subprocess exited 0 but the
+#: expected structured output JSON is missing (indicates prompt drift
+#: or skill bug); hardcoded retry does not help.
+FAILURE_CATEGORY_PR_CREATE_FAILED = "pr_create_failed"
+FAILURE_CATEGORY_PHASE_OUTPUT_MISSING = "phase_output_missing"
 
 #: Which failure categories auto-create a retry marker (tier 1 per
 #: spec §8 table). ``subprocess_turn_limit`` (tier 2) and
 #: ``subprocess_auth_fail`` (halt — no retry) are intentionally
 #: excluded; 3D's diagnoser owns the escalation path for both.
-#: ``stuck_timeout``, ``gh_rate_exhausted``, and ``subprocess_crash``
-#: are the three that retry mechanically. The three push-failure
-#: sub-kinds (#2902) are also tier-1 — transient network and pre-push
-#: hook failures are self-healing on a fresh retry.
+#: ``stuck_timeout``, ``gh_rate_exhausted``, ``subprocess_crash``, and
+#: ``daemon_restart_abandoned`` are the infra-preemption / crash
+#: categories that retry mechanically. Push and PR-create failures
+#: (formerly tier-1 auto-retry) were moved to the diagnoser path by
+#: issue #3032 — see :data:`TIER_2_FIRST_OCCURRENCE_CATEGORIES`.
 AUTO_RETRY_CATEGORIES = frozenset(
     {
         FAILURE_CATEGORY_STUCK_TIMEOUT,
         FAILURE_CATEGORY_GH_RATE_EXHAUSTED,
         FAILURE_CATEGORY_SUBPROCESS_CRASH,
         FAILURE_CATEGORY_DAEMON_RESTART_ABANDONED,
-        FAILURE_CATEGORY_PUSH_FAILED,
-        FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED,
-        FAILURE_CATEGORY_GIT_PUSH_NETWORK,
     }
 )
 
@@ -980,9 +991,24 @@ TIER_2_RECURRENCE_CATEGORIES: frozenset[str] = frozenset(
 #: tier 2 with mechanical hint = "retry once with narrower scope"; we
 #: delegate that retry-vs-escalate choice to the diagnoser immediately
 #: rather than hard-coding one mechanical retry.
+#:
+#: Issue #3032 extended this set: ``push_failed`` /
+#: ``pre_push_hook_rejected`` / ``git_push_network`` /
+#: ``pr_create_failed`` / ``phase_output_missing`` now diagnose on
+#: first occurrence (they used to tier-1 auto-retry or skip the
+#: failure-row write entirely). The cascade of 6 consecutive
+#: ``git_push_failed`` events in 2026-04-22/23 on #3008 and #2610 —
+#: all with a deterministic PAT-scope stderr that blind retry could
+#: not resolve — made the case for routing every agent-terminal
+#: failure through the LLM, not just tier-2 recurrences.
 TIER_2_FIRST_OCCURRENCE_CATEGORIES: frozenset[str] = frozenset(
     {
         FAILURE_CATEGORY_SUBPROCESS_TURN_LIMIT,
+        FAILURE_CATEGORY_PUSH_FAILED,
+        FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED,
+        FAILURE_CATEGORY_GIT_PUSH_NETWORK,
+        FAILURE_CATEGORY_PR_CREATE_FAILED,
+        FAILURE_CATEGORY_PHASE_OUTPUT_MISSING,
     }
 )
 
@@ -1031,10 +1057,36 @@ DIAGNOSER_MODEL = "opus"
 
 #: Valid ``action`` strings a diagnoser recommendation may set. The
 #: daemon's deterministic consumer switches on these; any other value
-#: falls through to ``escalate`` as a safe default (logged as
-#: ``daemon.diagnosis_action_unknown``).
+#: falls through to ``escalate`` as a safe default and persists a row
+#: to ``dispatcher.unrecognized_diagnoser_actions`` (logged as
+#: ``daemon.diagnosis_action_unknown``) so operators can notice
+#: patterns. Issue #3032 removed the closed-enum guardrail in the
+#: diagnoser skill — the LLM may propose a novel action when none of
+#: these fit, and the unrecognized-actions table is the review path.
+#:
+#: The first five (``retry`` through ``close``) are the original set
+#: from issue #2795. The last three are added in #3032:
+#:   - ``block_and_comment`` — apply ``status/blocked`` + remove
+#:     ``agent/ready`` + post comment. For operator-action blockers
+#:     (PAT scope, missing secret, infra gap) that do not warrant a
+#:     tracking issue yet.
+#:   - ``file_prerequisite_task`` — create a new issue via
+#:     ``gh issue create`` with diagnoser-provided ``title`` + ``body``,
+#:     then block the current issue on the new one.
+#:   - ``block_on_existing_task`` — append ``Blocked by #<N>`` to the
+#:     current issue body when the diagnoser identifies an already-open
+#:     tracking issue for the root cause. Avoids duplicate tickets.
 DIAGNOSER_ACTIONS: frozenset[str] = frozenset(
-    {"retry", "retry_with_hint", "reissue", "escalate", "close"}
+    {
+        "retry",
+        "retry_with_hint",
+        "reissue",
+        "escalate",
+        "close",
+        "block_and_comment",
+        "file_prerequisite_task",
+        "block_on_existing_task",
+    }
 )
 
 #: Circuit-breaker bounds (spec §8 "Budget & safety"). When the
@@ -7993,11 +8045,16 @@ class DispatcherDaemon:
             if preview:
                 extra["stderr_preview"] = preview
             self._log.warning("daemon.phase_output_missing", extra=extra)
-            self._mark_agent_terminal(
-                agent_id,
-                status="failed",
+            # Issue #3032: route through the unified failure handler
+            # so the diagnoser can pick up the missing-output failure
+            # on the next supervisor tick.
+            self._handle_agent_failure(
+                agent_id=agent_id,
                 phase="planning",
+                category=FAILURE_CATEGORY_PHASE_OUTPUT_MISSING,
+                stderr_tail=preview or "",
                 exit_code=exit_code,
+                details={"missing_phase_output": "plan"},
                 issue_number=issue_number,
             )
             return False
@@ -8150,11 +8207,14 @@ class DispatcherDaemon:
             if preview:
                 extra["stderr_preview"] = preview
             self._log.warning("daemon.phase_output_missing", extra=extra)
-            self._mark_agent_terminal(
-                agent_id,
-                status="failed",
+            # Issue #3032: route through the unified failure handler.
+            self._handle_agent_failure(
+                agent_id=agent_id,
                 phase="ralph",
+                category=FAILURE_CATEGORY_PHASE_OUTPUT_MISSING,
+                stderr_tail=preview or "",
                 exit_code=exit_code,
+                details={"missing_phase_output": "ralph"},
                 issue_number=issue_number,
             )
             return False
@@ -8381,11 +8441,14 @@ class DispatcherDaemon:
             if preview:
                 extra["stderr_preview"] = preview
             self._log.warning("daemon.phase_output_missing", extra=extra)
-            self._mark_agent_terminal(
-                agent_id,
-                status="failed",
+            # Issue #3032: route through the unified failure handler.
+            self._handle_agent_failure(
+                agent_id=agent_id,
                 phase="summary",
+                category=FAILURE_CATEGORY_PHASE_OUTPUT_MISSING,
+                stderr_tail=preview or "",
                 exit_code=exit_code,
+                details={"missing_phase_output": "summary"},
                 issue_number=issue_number,
             )
             return False
@@ -8750,6 +8813,84 @@ class DispatcherDaemon:
         if category in AUTO_RETRY_CATEGORIES:
             self._create_retry_marker(agent_id=agent_id, reason=category)
 
+    def _handle_agent_failure(
+        self,
+        *,
+        agent_id: str,
+        phase: str,
+        category: str,
+        stderr_tail: str,
+        exit_code: int | None,
+        details: dict[str, Any] | None = None,
+        issue_number: int | None = None,
+    ) -> None:
+        """Unified agent-terminal failure exit path (issue #3032).
+
+        Writes a ``dispatcher.failures`` row AND marks the agent
+        terminal, so the next ``_run_diagnoser_pass`` (supervisor tick)
+        picks it up via :meth:`_find_diagnoser_candidates` and routes
+        it through Opus.
+
+        Categories in :data:`TIER_2_FIRST_OCCURRENCE_CATEGORIES`,
+        :data:`TIER_2_RECURRENCE_CATEGORIES`, or
+        :data:`TIER_3_CATEGORIES` will be diagnosed; others fall back
+        to the existing mechanical-retry policy (e.g.
+        ``daemon_restart_abandoned`` stays on the infra-preemption
+        path).
+
+        Before #3032, ``git_push_failed``, ``pr_create_failed``, and
+        ``phase_output_missing`` either wrote no failure row at all
+        (pr_create_failed, phase_output_missing) or landed in the
+        tier-1 auto-retry set (push categories). Neither route gave
+        the Opus diagnoser a chance to differentiate a self-healing
+        transient from a deterministic operator-action blocker like
+        the PAT-scope cascade on 2026-04-22/23. This method
+        standardizes the exit: write the row, mark terminal, let the
+        supervisor tick pick it up on the next pass.
+
+        Not used for the per-phase subprocess failures —
+        :meth:`_handle_subprocess_failure` already handles the
+        classifier, secondary-log-dump event, and tier-1 auto-retry
+        semantics for those.
+        """
+        failure_details: dict[str, Any] = {
+            "phase": phase,
+            "stderr_tail": stderr_tail,
+            "exit_code": int(exit_code) if exit_code is not None else None,
+        }
+        if details:
+            # Caller-supplied fields take precedence but still layer
+            # over the standard envelope above so downstream readers
+            # always have the canonical three keys.
+            failure_details.update(details)
+
+        self._log.warning(
+            "daemon.agent_failure_routed",
+            extra={
+                "event": "agent_failure_routed",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "phase": phase,
+                "category": category,
+                "exit_code": failure_details.get("exit_code"),
+                "issue_number": issue_number,
+            },
+        )
+
+        self._write_failure(
+            agent_id=agent_id,
+            category=category,
+            detected_by="scheduler",
+            details=failure_details,
+        )
+        self._mark_agent_terminal(
+            agent_id,
+            status="failed",
+            phase=phase,
+            exit_code=exit_code,
+            issue_number=issue_number,
+        )
+
     def _log_tail(self, worktree: Path, phase: str, max_chars: int = 500) -> str:
         """Return the last ``max_chars`` of the phase log, or an empty string."""
         log_path = worktree / "tmp" / f"claude-p-{phase}.log"
@@ -9078,29 +9219,23 @@ class DispatcherDaemon:
                     "detail": str(exc),
                 },
             )
-            self._write_failure(
-                agent_id=agent_id,
-                category=FAILURE_CATEGORY_GIT_PUSH_NETWORK,
-                detected_by="scheduler",
-                details={
-                    "phase": "push_and_pr",
-                    "branch": branch,
-                    "stderr_tail": tail,
-                    "exit_code": None,
-                    "reason": "timeout",
-                },
-            )
             self._persist_phase_output(
                 agent_id,
                 phase="push_and_pr",
                 output_json={"event": "git_push_timeout", "branch": branch},
                 log_text=tail,
             )
-            self._mark_agent_terminal(
-                agent_id,
-                status="failed",
+            # Issue #3032: route through the unified failure handler so
+            # the diagnoser picks this up on the next supervisor tick.
+            # ``git_push_network`` is now a TIER_2_FIRST_OCCURRENCE
+            # category.
+            self._handle_agent_failure(
+                agent_id=agent_id,
                 phase="push_and_pr",
+                category=FAILURE_CATEGORY_GIT_PUSH_NETWORK,
+                stderr_tail=tail,
                 exit_code=None,
+                details={"branch": branch, "reason": "timeout"},
                 issue_number=issue_number,
             )
             return
@@ -9114,28 +9249,20 @@ class DispatcherDaemon:
                     "detail": str(exc),
                 },
             )
-            self._write_failure(
-                agent_id=agent_id,
-                category=FAILURE_CATEGORY_PUSH_FAILED,
-                detected_by="scheduler",
-                details={
-                    "phase": "push_and_pr",
-                    "branch": branch,
-                    "stderr_tail": str(exc),
-                    "exit_code": None,
-                },
-            )
             self._persist_phase_output(
                 agent_id,
                 phase="push_and_pr",
                 output_json={"event": "git_push_failed", "branch": branch},
                 log_text=str(exc),
             )
-            self._mark_agent_terminal(
-                agent_id,
-                status="failed",
+            # Issue #3032: route through the unified failure handler.
+            self._handle_agent_failure(
+                agent_id=agent_id,
                 phase="push_and_pr",
+                category=FAILURE_CATEGORY_PUSH_FAILED,
+                stderr_tail=str(exc),
                 exit_code=None,
+                details={"branch": branch},
                 issue_number=issue_number,
             )
             return
@@ -9154,17 +9281,6 @@ class DispatcherDaemon:
                     "branch": branch,
                 },
             )
-            self._write_failure(
-                agent_id=agent_id,
-                category=category,
-                detected_by="scheduler",
-                details={
-                    "phase": "push_and_pr",
-                    "branch": branch,
-                    "stderr_tail": tail,
-                    "exit_code": push_result.returncode,
-                },
-            )
             self._persist_phase_output(
                 agent_id,
                 phase="push_and_pr",
@@ -9175,11 +9291,16 @@ class DispatcherDaemon:
                 },
                 log_text=(push_result.stderr or ""),
             )
-            self._mark_agent_terminal(
-                agent_id,
-                status="failed",
+            # Issue #3032: route through the unified failure handler.
+            # The classifier's pre_push_hook_rejected / git_push_network
+            # / push_failed categories are all tier-2 first-occurrence.
+            self._handle_agent_failure(
+                agent_id=agent_id,
                 phase="push_and_pr",
-                exit_code=None,
+                category=category,
+                stderr_tail=tail,
+                exit_code=push_result.returncode,
+                details={"branch": branch},
                 issue_number=issue_number,
             )
             return
@@ -9225,15 +9346,21 @@ class DispatcherDaemon:
                     "detail": str(exc),
                 },
             )
-            self._mark_agent_terminal(
-                agent_id,
-                status="failed",
+            # Issue #3032: route through the unified failure handler so
+            # the Opus diagnoser can tell a duplicate-PR hit from a
+            # genuine gh-CLI break from a transient GitHub API wobble.
+            self._handle_agent_failure(
+                agent_id=agent_id,
                 phase="push_and_pr",
+                category=FAILURE_CATEGORY_PR_CREATE_FAILED,
+                stderr_tail=str(exc),
                 exit_code=None,
+                details={"branch": branch, "reason": "exception"},
                 issue_number=issue_number,
             )
             return
         if pr_result.returncode != 0:
+            pr_stderr_tail = _stderr_tail(pr_result.stderr)
             self._log.warning(
                 "daemon.pr_create_failed",
                 extra={
@@ -9241,14 +9368,17 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "exit_code": pr_result.returncode,
-                    "stderr_tail": _stderr_tail(pr_result.stderr),
+                    "stderr_tail": pr_stderr_tail,
                 },
             )
-            self._mark_agent_terminal(
-                agent_id,
-                status="failed",
+            # Issue #3032: route through the unified failure handler.
+            self._handle_agent_failure(
+                agent_id=agent_id,
                 phase="push_and_pr",
-                exit_code=None,
+                category=FAILURE_CATEGORY_PR_CREATE_FAILED,
+                stderr_tail=pr_stderr_tail,
+                exit_code=pr_result.returncode,
+                details={"branch": branch},
                 issue_number=issue_number,
             )
             return
@@ -9994,8 +10124,14 @@ class DispatcherDaemon:
             if preview:
                 extra["stderr_preview"] = preview
             self._log.warning("daemon.phase_output_missing", extra=extra)
-            self._mark_agent_terminal(
-                agent_id, status="failed", phase="awaiting_ci", exit_code=exit_code
+            # Issue #3032: route through the unified failure handler.
+            self._handle_agent_failure(
+                agent_id=agent_id,
+                phase="awaiting_ci",
+                category=FAILURE_CATEGORY_PHASE_OUTPUT_MISSING,
+                stderr_tail=preview or "",
+                exit_code=exit_code,
+                details={"missing_phase_output": "fix-ci"},
             )
             return
 
@@ -10655,8 +10791,14 @@ class DispatcherDaemon:
             if preview:
                 extra["stderr_preview"] = preview
             self._log.warning("daemon.phase_output_missing", extra=extra)
-            self._mark_agent_terminal(
-                agent_id, status="failed", phase="awaiting_deploy", exit_code=exit_code
+            # Issue #3032: route through the unified failure handler.
+            self._handle_agent_failure(
+                agent_id=agent_id,
+                phase="awaiting_deploy",
+                category=FAILURE_CATEGORY_PHASE_OUTPUT_MISSING,
+                stderr_tail=preview or "",
+                exit_code=exit_code,
+                details={"missing_phase_output": "verify"},
             )
             return
 
@@ -13830,6 +13972,104 @@ class DispatcherDaemon:
                     if isinstance(raw_map, list):
                         summary_ac_mapping = [e for e in raw_map if isinstance(e, dict)]
 
+        # Issue #3032 — expanded context bundle for the open-menu
+        # diagnoser. ``prior_diagnoses_this_issue`` lets the LLM see
+        # "I recommended retry twice and it failed twice — try
+        # something else" without re-deriving from the failure log.
+        # ``recent_fleet_decisions`` lets it detect fleet-wide spates
+        # ("5 different issues hit the same PAT-scope failure today —
+        # the right action is to file a prerequisite task, not patch
+        # per issue"). Both are best-effort; empty list on any DB
+        # error — the skill's decision tree tolerates sparse context.
+        prior_diagnoses_this_issue: list[dict[str, Any]] = []
+        if issue_number is not None:
+            try:
+                with self._conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT d.diagnosis_id, f.category, d.recommendation, "
+                        "       d.completed_at "
+                        "FROM dispatcher.diagnoses d "
+                        "JOIN dispatcher.agents a ON a.agent_id = d.agent_id "
+                        "JOIN dispatcher.failures f ON f.failure_id = d.failure_id "
+                        "WHERE a.issue_number = %s "
+                        "  AND d.status = 'completed' "
+                        "  AND d.failure_id <> %s "
+                        "ORDER BY d.completed_at DESC LIMIT 10",
+                        (issue_number, failure_id),
+                    )
+                    rows = cur.fetchall()
+                self._conn.commit()
+                for r in rows:
+                    rec = r[2]
+                    if isinstance(rec, str):
+                        try:
+                            rec = json.loads(rec)
+                        except json.JSONDecodeError:
+                            rec = {}
+                    prior_diagnoses_this_issue.append(
+                        {
+                            "diagnosis_id": int(r[0]),
+                            "failure_category": str(r[1]),
+                            "recommendation": rec if isinstance(rec, dict) else {},
+                            "completed_at": r[3].isoformat()
+                            if r[3] is not None
+                            else None,
+                        }
+                    )
+            except Exception:
+                try:
+                    self._conn.rollback()
+                except Exception:  # pragma: no cover
+                    pass
+
+        recent_fleet_decisions: list[dict[str, Any]] = []
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT d.diagnosis_id, d.agent_id, a.issue_number, "
+                    "       f.category, d.recommendation, d.completed_at "
+                    "FROM dispatcher.diagnoses d "
+                    "JOIN dispatcher.agents a ON a.agent_id = d.agent_id "
+                    "JOIN dispatcher.failures f ON f.failure_id = d.failure_id "
+                    "WHERE d.status = 'completed' "
+                    "  AND d.completed_at > now() - interval '6 hours' "
+                    "ORDER BY d.completed_at DESC LIMIT 20",
+                )
+                rows = cur.fetchall()
+            self._conn.commit()
+            for r in rows:
+                rec = r[4]
+                if isinstance(rec, str):
+                    try:
+                        rec = json.loads(rec)
+                    except json.JSONDecodeError:
+                        rec = {}
+                action = ""
+                reasoning = ""
+                if isinstance(rec, dict):
+                    raw_action = rec.get("action")
+                    if isinstance(raw_action, str):
+                        action = raw_action
+                    raw_reasoning = rec.get("reasoning")
+                    if isinstance(raw_reasoning, str):
+                        reasoning = raw_reasoning
+                recent_fleet_decisions.append(
+                    {
+                        "diagnosis_id": int(r[0]),
+                        "agent_id": str(r[1]) if r[1] is not None else None,
+                        "issue_number": int(r[2]) if r[2] is not None else None,
+                        "failure_category": str(r[3]),
+                        "action": action,
+                        "reasoning": reasoning,
+                        "completed_at": r[5].isoformat() if r[5] is not None else None,
+                    }
+                )
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+
         bundle: dict[str, Any] = {
             "agent_id": agent_id,
             "failure_id": failure_id,
@@ -13840,6 +14080,8 @@ class DispatcherDaemon:
             "issue_body": issue_body,
             "recent_phase_transitions": phase_transitions,
             "prior_failures": prior_failures,
+            "prior_diagnoses_this_issue": prior_diagnoses_this_issue,
+            "recent_fleet_decisions": recent_fleet_decisions,
             "ralph_done_content": ralph_done_content,
             "pr_url": pr_url,
             "pr_number": pr_number,
@@ -14081,9 +14323,20 @@ class DispatcherDaemon:
         """Return the action string if valid, None otherwise.
 
         Shape check: ``action`` must be in :data:`DIAGNOSER_ACTIONS`.
-        ``retry_with_hint`` requires a non-empty string ``hint``;
-        ``reissue`` requires a non-empty string ``new_scope``. All
-        other fields are advisory.
+        Per-action required-payload checks:
+          - ``retry_with_hint`` — non-empty string ``hint``.
+          - ``reissue`` — non-empty string ``new_scope``.
+          - ``file_prerequisite_task`` — non-empty string ``title`` and
+            ``body``.
+          - ``block_on_existing_task`` — positive integer
+            ``blocker_issue_number``.
+        All other fields are advisory.
+
+        Returns None when the action is missing, not in the known set,
+        or when a required payload field for the action is missing or
+        malformed. Callers treat None as "escalate fallback" per the
+        hardened parse path added in issue #3032 — never silently
+        retrying on malformed input.
         """
         action = recommendation.get("action")
         if not isinstance(action, str) or action not in DIAGNOSER_ACTIONS:
@@ -14096,6 +14349,21 @@ class DispatcherDaemon:
             new_scope = recommendation.get("new_scope")
             if not isinstance(new_scope, str) or not new_scope.strip():
                 return None
+        if action == "file_prerequisite_task":
+            title = recommendation.get("title")
+            body = recommendation.get("body")
+            if not isinstance(title, str) or not title.strip():
+                return None
+            if not isinstance(body, str) or not body.strip():
+                return None
+        if action == "block_on_existing_task":
+            blocker = recommendation.get("blocker_issue_number")
+            if (
+                not isinstance(blocker, int)
+                or isinstance(blocker, bool)
+                or blocker <= 0
+            ):
+                return None
         return action
 
     def _consume_diagnosis(self, diagnosis_id: int, candidate: dict[str, Any]) -> str:
@@ -14104,9 +14372,31 @@ class DispatcherDaemon:
         Returns the action string that was consumed (one of
         :data:`DIAGNOSER_ACTIONS`, or ``"escalate_fallback"`` when the
         recommendation was malformed and we escalated mechanically).
+
+        Issue #3032 hardens the parse path:
+          - Missing recommendation (row absent or JSONB NULL) → escalate
+            with reason ``recommendation_missing_or_malformed_json``.
+          - Valid dict but unknown ``action`` string → escalate AND
+            persist a row to ``dispatcher.unrecognized_diagnoser_actions``
+            so operators can review.
+          - Valid dict + known action but required payload missing
+            (e.g. ``retry_with_hint`` without ``hint``) → escalate.
+          - Every branch now logs the raw LLM output via
+            ``daemon.diagnoser_parse_failed`` so prompt tuning has a
+            signal trail. Never silently retries.
         """
         recommendation = self._read_recommendation(diagnosis_id)
         if recommendation is None:
+            self._log.warning(
+                "daemon.diagnoser_parse_failed",
+                extra={
+                    "event": "diagnoser_parse_failed",
+                    "run_id": self._run_id,
+                    "diagnosis_id": diagnosis_id,
+                    "reason": "recommendation_missing_or_malformed_json",
+                    "raw_output": None,
+                },
+            )
             self._mark_diagnosis_failed(
                 diagnosis_id, reason="recommendation_missing_or_malformed_json"
             )
@@ -14115,18 +14405,49 @@ class DispatcherDaemon:
 
         action = self._validate_recommendation(recommendation)
         if action is None:
+            # Distinguish unrecognized action strings (a novel LLM
+            # proposal — persist for operator review) from missing /
+            # malformed required payload fields.
+            raw_action = recommendation.get("action")
+            raw_output = self._serialize_raw_output(recommendation)
+            if (
+                isinstance(raw_action, str)
+                and raw_action.strip()
+                and raw_action not in DIAGNOSER_ACTIONS
+            ):
+                self._persist_unrecognized_action(
+                    diagnosis_id=diagnosis_id,
+                    action_name=raw_action,
+                    payload=recommendation,
+                )
+                reason = "unrecognized_action"
+            elif not isinstance(raw_action, str) or not raw_action.strip():
+                reason = "action_field_missing_or_non_string"
+            else:
+                reason = "missing_required_payload"
+            self._log.warning(
+                "daemon.diagnoser_parse_failed",
+                extra={
+                    "event": "diagnoser_parse_failed",
+                    "run_id": self._run_id,
+                    "diagnosis_id": diagnosis_id,
+                    "reason": reason,
+                    "raw_output": raw_output,
+                },
+            )
+            # Keep the legacy ``diagnosis_action_unknown`` event so
+            # existing CloudWatch dashboards do not regress.
             self._log.warning(
                 "daemon.diagnosis_action_unknown",
                 extra={
                     "event": "diagnosis_action_unknown",
                     "run_id": self._run_id,
                     "diagnosis_id": diagnosis_id,
+                    "reason": reason,
                     "raw_recommendation": recommendation,
                 },
             )
-            self._mark_diagnosis_failed(
-                diagnosis_id, reason="recommendation_failed_validation"
-            )
+            self._mark_diagnosis_failed(diagnosis_id, reason=reason)
             self._apply_mechanical_escalation(candidate)
             return "escalate_fallback"
 
@@ -14175,8 +14496,102 @@ class DispatcherDaemon:
                 issue_number=issue_number,
                 reasoning=reasoning,
             )
+        elif action == "block_and_comment":
+            self._consume_action_block_and_comment(
+                agent_id=agent_id,
+                issue_number=issue_number,
+                reasoning=reasoning,
+            )
+        elif action == "file_prerequisite_task":
+            self._consume_action_file_prerequisite_task(
+                agent_id=agent_id,
+                issue_number=issue_number,
+                title=str(recommendation.get("title") or ""),
+                body=str(recommendation.get("body") or ""),
+                block_labels=self._coerce_str_list(recommendation.get("block_labels")),
+                reasoning=reasoning,
+            )
+        elif action == "block_on_existing_task":
+            blocker_issue_number = recommendation.get("blocker_issue_number")
+            self._consume_action_block_on_existing_task(
+                agent_id=agent_id,
+                issue_number=issue_number,
+                blocker_issue_number=int(blocker_issue_number)
+                if isinstance(blocker_issue_number, int)
+                and not isinstance(blocker_issue_number, bool)
+                else 0,
+                reasoning=reasoning,
+            )
 
         return action
+
+    @staticmethod
+    def _coerce_str_list(value: Any) -> list[str]:
+        """Return ``value`` as a list of strings, dropping non-string items."""
+        if not isinstance(value, list):
+            return []
+        return [item for item in value if isinstance(item, str) and item.strip()]
+
+    @staticmethod
+    def _serialize_raw_output(recommendation: Any) -> str:
+        """Serialize the raw LLM recommendation for the parse-fail log.
+
+        Always returns a bounded JSON string so CloudWatch Insights
+        queries do not blow out memory on a pathological LLM output.
+        Failures fall back to ``str(...)`` truncated at 4 KiB — we'd
+        rather log a partial representation than drop the field
+        entirely.
+        """
+        try:
+            text = json.dumps(recommendation, default=str, sort_keys=True)
+        except Exception:  # pragma: no cover — defensive
+            text = str(recommendation)
+        return text[:4096]
+
+    def _persist_unrecognized_action(
+        self, *, diagnosis_id: int, action_name: str, payload: Any
+    ) -> None:
+        """Insert a row into ``dispatcher.unrecognized_diagnoser_actions``.
+
+        Issue #3032 opens the diagnoser action menu — the LLM may
+        propose a novel action the daemon does not recognize. Rather
+        than silently drop it, persist the action name + the full
+        recommendation payload so operators can review and decide
+        whether to implement a handler. The caller still falls through
+        to ``escalate`` so the current failure is not stuck.
+
+        Row-insert failures here are logged and swallowed — the
+        escalate fallback is the authoritative recovery path, and a
+        broken log row must not block it.
+        """
+        assert self._conn is not None, "connect() must run before action persist"
+        try:
+            payload_json = json.dumps(payload, default=str)
+        except Exception:  # pragma: no cover — defensive
+            payload_json = "{}"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO dispatcher.unrecognized_diagnoser_actions "
+                    "    (diagnosis_id, action_name, payload) "
+                    "VALUES (%s, %s, %s)",
+                    (diagnosis_id, action_name, payload_json),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.unrecognized_action_persist_failed",
+                extra={
+                    "event": "unrecognized_action_persist_failed",
+                    "run_id": self._run_id,
+                    "diagnosis_id": diagnosis_id,
+                    "action_name": action_name,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
 
     def _consume_action_retry(self, *, agent_id: str) -> None:
         """Create a tier-1-shaped retry marker via the existing machinery.
@@ -14267,6 +14682,155 @@ class DispatcherDaemon:
             self._gh_issue_close(issue_number, comment=summary, reason="not planned")
         self._mark_agent_terminal(
             agent_id, status="failed", phase="diagnoser_close", exit_code=None
+        )
+
+    def _consume_action_block_and_comment(
+        self,
+        *,
+        agent_id: str,
+        issue_number: int | None,
+        reasoning: str,
+    ) -> None:
+        """Apply ``status/blocked``, remove ``agent/ready``, post a comment.
+
+        Issue #3032. Used when the diagnoser identifies a deterministic
+        operator-action blocker (PAT scope, missing secret, branch
+        protection, infra gap) that does not yet deserve a tracking
+        issue of its own. The current issue is marked blocked so no
+        other agent picks it up, the ``agent/ready`` label is stripped
+        so the dispatcher queue-scan skips it, and the reasoning is
+        posted as a comment so the operator sees the context.
+        """
+        if issue_number is not None:
+            summary = (
+                "## Diagnosis (3D block)\n\n"
+                f"{reasoning}\n\n"
+                "_Blocked — operator action required before work resumes._"
+            )
+            self._gh_issue_comment(issue_number, summary)
+            self._gh_issue_add_labels(issue_number, ["status/blocked"])
+            self._gh_issue_remove_labels(issue_number, ["agent/ready"])
+        self._mark_agent_terminal(
+            agent_id,
+            status="failed",
+            phase="diagnoser_block_and_comment",
+            exit_code=None,
+        )
+
+    def _consume_action_file_prerequisite_task(
+        self,
+        *,
+        agent_id: str,
+        issue_number: int | None,
+        title: str,
+        body: str,
+        block_labels: list[str] | None,
+        reasoning: str,
+    ) -> None:
+        """Create a new tracking issue and block the current issue on it.
+
+        Issue #3032. Used when the diagnoser identifies a root cause
+        that deserves its own tracking issue (e.g. "add workflow scope
+        to dispatcher PAT"). Runs ``gh issue create`` with the
+        diagnoser-supplied title + body, captures the new issue
+        number, then appends ``Blocked by #<new>`` to the current
+        issue body and applies ``status/blocked``. If the new-issue
+        create fails, falls back to :meth:`_consume_action_escalate`
+        so the current failure still surfaces to the operator.
+        """
+        new_issue_number = self._gh_issue_create(
+            title=title, body=body, labels=block_labels or None
+        )
+        if new_issue_number is None or issue_number is None:
+            # Fall back to escalate — record the intended action in the
+            # reasoning so the operator sees what the diagnoser wanted.
+            fallback_reasoning = (
+                f"{reasoning}\n\n"
+                "_Diagnoser proposed `file_prerequisite_task` "
+                f"(title={title!r}) but the new-issue create failed "
+                "or the current issue has no number. Escalating instead._"
+            )
+            self._consume_action_escalate(
+                agent_id=agent_id,
+                issue_number=issue_number,
+                reasoning=fallback_reasoning,
+            )
+            return
+
+        summary = (
+            "## Diagnosis (3D block-on-prerequisite)\n\n"
+            f"{reasoning}\n\n"
+            f"Filed a prerequisite tracking issue: #{new_issue_number}. "
+            "This issue is blocked until that lands.\n\n"
+            "_Blocked via `file_prerequisite_task`._"
+        )
+        self._gh_issue_comment(issue_number, summary)
+        self._gh_issue_append_body(issue_number, f"\n\nBlocked by #{new_issue_number}")
+        self._gh_issue_add_labels(issue_number, ["status/blocked"])
+        self._gh_issue_remove_labels(issue_number, ["agent/ready"])
+        self._mark_agent_terminal(
+            agent_id,
+            status="failed",
+            phase="diagnoser_file_prerequisite_task",
+            exit_code=None,
+        )
+
+    def _consume_action_block_on_existing_task(
+        self,
+        *,
+        agent_id: str,
+        issue_number: int | None,
+        blocker_issue_number: int,
+        reasoning: str,
+    ) -> None:
+        """Block the current issue on an already-open tracking issue.
+
+        Issue #3032. Used when the diagnoser identifies an existing
+        open issue that tracks the blocker (avoids duplicate tickets).
+        Validates the blocker exists and is open via ``gh issue view``;
+        if validation fails, falls back to escalate.
+        """
+        if issue_number is None:
+            # No current issue to update — escalate.
+            self._consume_action_escalate(
+                agent_id=agent_id,
+                issue_number=issue_number,
+                reasoning=reasoning,
+            )
+            return
+        if not self._gh_issue_is_open(blocker_issue_number):
+            fallback_reasoning = (
+                f"{reasoning}\n\n"
+                f"_Diagnoser proposed `block_on_existing_task` "
+                f"(blocker=#{blocker_issue_number}) but the target "
+                "issue is not open (not found, closed, or validation "
+                "error). Escalating instead._"
+            )
+            self._consume_action_escalate(
+                agent_id=agent_id,
+                issue_number=issue_number,
+                reasoning=fallback_reasoning,
+            )
+            return
+
+        summary = (
+            "## Diagnosis (3D block-on-existing)\n\n"
+            f"{reasoning}\n\n"
+            f"This issue is blocked on existing tracking issue "
+            f"#{blocker_issue_number}.\n\n"
+            "_Blocked via `block_on_existing_task`._"
+        )
+        self._gh_issue_comment(issue_number, summary)
+        self._gh_issue_append_body(
+            issue_number, f"\n\nBlocked by #{blocker_issue_number}"
+        )
+        self._gh_issue_add_labels(issue_number, ["status/blocked"])
+        self._gh_issue_remove_labels(issue_number, ["agent/ready"])
+        self._mark_agent_terminal(
+            agent_id,
+            status="failed",
+            phase="diagnoser_block_on_existing_task",
+            exit_code=None,
         )
 
     def _apply_mechanical_escalation(self, candidate: dict[str, Any]) -> None:
@@ -14565,6 +15129,188 @@ class DispatcherDaemon:
                 },
             )
             return None
+
+    def _gh_issue_create(
+        self, *, title: str, body: str, labels: list[str] | None
+    ) -> int | None:
+        """Create a new GitHub issue via ``gh issue create``.
+
+        Returns the integer issue number of the created issue, or None
+        on any failure (logged). Added by issue #3032 for the
+        ``file_prerequisite_task`` diagnoser action: the daemon needs
+        to synthesize a tracking issue from LLM-provided title + body.
+        """
+        tmp_file = self._write_gh_tmp_body(body, prefix="diagnoser-prereq-body")
+        if tmp_file is None:
+            return None
+        cmd = [
+            "gh",
+            "issue",
+            "create",
+            "--repo",
+            self._cfg.github_repo,
+            "--title",
+            title,
+            "--body-file",
+            str(tmp_file),
+        ]
+        if labels:
+            cmd.extend(["--label", ",".join(labels)])
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            self._log.warning(
+                "daemon.diagnoser_gh_create_failed",
+                extra={
+                    "event": "diagnoser_gh_create_failed",
+                    "run_id": self._run_id,
+                    "title": title,
+                    "detail": str(exc),
+                },
+            )
+            return None
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.diagnoser_gh_create_nonzero",
+                extra={
+                    "event": "diagnoser_gh_create_nonzero",
+                    "run_id": self._run_id,
+                    "title": title,
+                    "exit_code": result.returncode,
+                    "stderr_tail": _stderr_tail(result.stderr),
+                },
+            )
+            return None
+        # gh issue create prints the URL on stdout: last non-empty line.
+        stdout = (result.stdout or "").strip()
+        if not stdout:
+            return None
+        last_line = stdout.splitlines()[-1].strip()
+        import re  # noqa: PLC0415 — local import matches _parse_pr_number pattern
+
+        match = re.search(r"/issues/(\d+)", last_line)
+        if not match:
+            self._log.warning(
+                "daemon.diagnoser_gh_create_parse_failed",
+                extra={
+                    "event": "diagnoser_gh_create_parse_failed",
+                    "run_id": self._run_id,
+                    "title": title,
+                    "stdout_tail": last_line[-200:],
+                },
+            )
+            return None
+        try:
+            return int(match.group(1))
+        except (TypeError, ValueError):  # pragma: no cover — regex already gated
+            return None
+
+    def _gh_issue_append_body(self, issue_number: int, addition: str) -> None:
+        """Append ``addition`` to the issue's body via gh.
+
+        Reads the current body via ``gh issue view --json body``,
+        concatenates, then writes back via :meth:`_gh_issue_set_body`.
+        Best-effort — a read or write failure is logged and swallowed
+        so the diagnoser's recommendation still lands.
+        """
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "view",
+                    str(issue_number),
+                    "--repo",
+                    self._cfg.github_repo,
+                    "--json",
+                    "body",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            self._log.warning(
+                "daemon.diagnoser_gh_append_failed",
+                extra={
+                    "event": "diagnoser_gh_append_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "detail": str(exc),
+                },
+            )
+            return
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.diagnoser_gh_append_nonzero",
+                extra={
+                    "event": "diagnoser_gh_append_nonzero",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "exit_code": result.returncode,
+                    "stderr_tail": _stderr_tail(result.stderr),
+                },
+            )
+            return
+        try:
+            payload = json.loads(result.stdout or "{}")
+        except json.JSONDecodeError:
+            self._log.warning(
+                "daemon.diagnoser_gh_append_parse_failed",
+                extra={
+                    "event": "diagnoser_gh_append_parse_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                },
+            )
+            return
+        current_body = str(payload.get("body") or "")
+        new_body = current_body + addition
+        self._gh_issue_set_body(issue_number, new_body)
+
+    def _gh_issue_is_open(self, issue_number: int) -> bool:
+        """Return True if the issue exists and is in ``state=OPEN``.
+
+        Used by :meth:`_consume_action_block_on_existing_task` to
+        validate the diagnoser-proposed blocker before wiring up the
+        dependency. Any read failure (not-found, transient gh error)
+        returns False — the caller will fall back to escalate.
+        """
+        try:
+            result = subprocess.run(
+                [
+                    "gh",
+                    "issue",
+                    "view",
+                    str(issue_number),
+                    "--repo",
+                    self._cfg.github_repo,
+                    "--json",
+                    "state",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return False
+        if result.returncode != 0:
+            return False
+        try:
+            payload = json.loads(result.stdout or "{}")
+        except json.JSONDecodeError:
+            return False
+        # gh reports state as "OPEN" / "CLOSED".
+        state = str(payload.get("state") or "").upper()
+        return state == "OPEN"
 
     def _run_diagnoser_pass(self) -> int:
         """Find tier-2/3 candidates, spawn diagnosers, consume recommendations.

--- a/scripts/dispatcher/tests/test_daemon_diagnoser_routing.py
+++ b/scripts/dispatcher/tests/test_daemon_diagnoser_routing.py
@@ -1,0 +1,926 @@
+"""Unit tests for issue #3032 — route all agent-terminal failures through the diagnoser.
+
+Coverage:
+  - Expanded ``DIAGNOSER_ACTIONS`` (now 8 known actions).
+  - ``_build_diagnoser_context`` includes ``prior_diagnoses_this_issue``
+    and ``recent_fleet_decisions`` keys (empty lists when the DB is
+    empty).
+  - Three new handlers — ``_consume_action_block_and_comment``,
+    ``_consume_action_file_prerequisite_task``,
+    ``_consume_action_block_on_existing_task``.
+  - Hardened parse path: malformed JSON / missing action / unknown
+    action / missing required payload field all fall back to
+    ``escalate`` (never silent retry). Raw LLM output is logged.
+  - Unknown action additionally persists to
+    ``dispatcher.unrecognized_diagnoser_actions``.
+  - Unified ``_handle_agent_failure`` writes a failures row and marks
+    terminal (so the supervisor tick's diagnoser pass picks it up).
+  - Regression: tier sets still include ``ralph_ac_infeasible``,
+    ``summary_ac_infeasible``, ``subprocess_crash`` (via recurrence).
+
+Fakes + psycopg MagicMock stub follow the pattern from
+``test_daemon_push_failed.py`` / ``test_daemon_failure_summary.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Provide a stub ``psycopg`` module before importing the daemon.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402
+from dispatcher.daemon import (  # noqa: E402
+    AUTO_RETRY_CATEGORIES,
+    DIAGNOSER_ACTIONS,
+    FAILURE_CATEGORY_GIT_PUSH_NETWORK,
+    FAILURE_CATEGORY_PHASE_OUTPUT_MISSING,
+    FAILURE_CATEGORY_PR_CREATE_FAILED,
+    FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED,
+    FAILURE_CATEGORY_PUSH_FAILED,
+    FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
+    FAILURE_CATEGORY_SUBPROCESS_CRASH,
+    FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
+    TIER_2_FIRST_OCCURRENCE_CATEGORIES,
+    TIER_2_RECURRENCE_CATEGORIES,
+    TIER_3_CATEGORIES,
+)
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — mirror the pattern from test_daemon_push_failed.py
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+        self.rowcount = 1
+
+    def fetchone(self) -> Any:
+        if self.fetch_queue:
+            return self.fetch_queue.pop(0)
+        return None
+
+    def fetchall(self) -> list[Any]:
+        if self.fetchall_queue:
+            return self.fetchall_queue.pop(0)
+        return []
+
+
+class _FakeConn:
+    def __init__(self, cursor: _FakeCursor | None = None) -> None:
+        self._cursor = cursor or _FakeCursor()
+        self.committed = 0
+        self.rolled_back = 0
+
+    def cursor(self) -> _FakeCursor:
+        return self._cursor
+
+    def commit(self) -> None:
+        self.committed += 1
+
+    def rollback(self) -> None:
+        self.rolled_back += 1
+
+
+def _make_daemon(cursor: _FakeCursor | None = None) -> daemon.DispatcherDaemon:
+    """Construct a DispatcherDaemon with a fake conn for unit tests.
+
+    The ``_conn`` accessor is a property with a setter that writes to
+    ``_main_conn``. We bypass ``__init__`` (no DB, no config), then
+    manually populate the fields the unit-under-test reads. The
+    ``_thread_state`` attribute is a ``threading.local`` instance in
+    real code; a bare ``MagicMock`` suffices here since the property
+    falls back to ``_main_conn`` when ``_thread_state.conn`` is None.
+    """
+    import threading
+
+    d = daemon.DispatcherDaemon.__new__(daemon.DispatcherDaemon)
+    d._thread_state = threading.local()  # type: ignore[attr-defined]
+    d._main_conn = _FakeConn(cursor)  # type: ignore[attr-defined]
+    d._cfg = MagicMock(github_repo="judgemind/judgemind")  # type: ignore[attr-defined]
+    d._log = logging.getLogger("test.daemon")  # type: ignore[attr-defined]
+    d._run_id = "test-run"  # type: ignore[attr-defined]
+    return d
+
+
+# --------------------------------------------------------------------------
+# AC#4 — DIAGNOSER_ACTIONS is now 8 (open menu, issue #3032)
+# --------------------------------------------------------------------------
+
+
+class TestDiagnoserActionsExpanded:
+    def test_eight_known_actions(self) -> None:
+        assert DIAGNOSER_ACTIONS == frozenset(
+            {
+                "retry",
+                "retry_with_hint",
+                "reissue",
+                "escalate",
+                "close",
+                "block_and_comment",
+                "file_prerequisite_task",
+                "block_on_existing_task",
+            }
+        )
+
+    def test_original_five_still_present(self) -> None:
+        for action in ("retry", "retry_with_hint", "reissue", "escalate", "close"):
+            assert action in DIAGNOSER_ACTIONS
+
+    def test_three_new_actions(self) -> None:
+        assert "block_and_comment" in DIAGNOSER_ACTIONS
+        assert "file_prerequisite_task" in DIAGNOSER_ACTIONS
+        assert "block_on_existing_task" in DIAGNOSER_ACTIONS
+
+
+# --------------------------------------------------------------------------
+# AC#2 — tier sets include the new categories routed via _handle_agent_failure
+# --------------------------------------------------------------------------
+
+
+class TestTierSetsIncludeNewCategories:
+    def test_push_categories_in_tier2_first_occurrence(self) -> None:
+        assert FAILURE_CATEGORY_PUSH_FAILED in TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        assert (
+            FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED
+            in TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        )
+        assert FAILURE_CATEGORY_GIT_PUSH_NETWORK in TIER_2_FIRST_OCCURRENCE_CATEGORIES
+
+    def test_pr_create_failed_in_tier2_first_occurrence(self) -> None:
+        assert FAILURE_CATEGORY_PR_CREATE_FAILED in TIER_2_FIRST_OCCURRENCE_CATEGORIES
+
+    def test_phase_output_missing_in_tier2_first_occurrence(self) -> None:
+        assert (
+            FAILURE_CATEGORY_PHASE_OUTPUT_MISSING in TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        )
+
+    def test_regression_ac_infeasible_categories_still_tier3(self) -> None:
+        assert FAILURE_CATEGORY_RALPH_AC_INFEASIBLE in TIER_3_CATEGORIES
+        assert FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE in TIER_3_CATEGORIES
+
+    def test_regression_subprocess_crash_still_tier2_recurrence(self) -> None:
+        assert FAILURE_CATEGORY_SUBPROCESS_CRASH in TIER_2_RECURRENCE_CATEGORIES
+
+    def test_push_categories_removed_from_auto_retry(self) -> None:
+        # Deliberate behavior change (#3032) — the diagnoser now owns
+        # the retry-vs-escalate decision for push failures.
+        assert FAILURE_CATEGORY_PUSH_FAILED not in AUTO_RETRY_CATEGORIES
+        assert FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED not in AUTO_RETRY_CATEGORIES
+        assert FAILURE_CATEGORY_GIT_PUSH_NETWORK not in AUTO_RETRY_CATEGORIES
+
+    def test_tier_sets_still_disjoint(self) -> None:
+        # Mutual exclusion is a required invariant of the candidate
+        # scanner — a category in two sets would be double-tiered.
+        assert (
+            TIER_2_RECURRENCE_CATEGORIES & TIER_2_FIRST_OCCURRENCE_CATEGORIES
+            == frozenset()
+        )
+        assert TIER_2_RECURRENCE_CATEGORIES & TIER_3_CATEGORIES == frozenset()
+        assert TIER_2_FIRST_OCCURRENCE_CATEGORIES & TIER_3_CATEGORIES == frozenset()
+
+
+# --------------------------------------------------------------------------
+# AC#1 — _handle_agent_failure writes failures row + marks terminal
+# --------------------------------------------------------------------------
+
+
+class TestHandleAgentFailure:
+    def test_writes_failure_row_and_marks_terminal(self) -> None:
+        d = _make_daemon()
+        with (
+            patch.object(d, "_write_failure") as mock_write,
+            patch.object(d, "_mark_agent_terminal") as mock_mark,
+        ):
+            d._handle_agent_failure(
+                agent_id="agent-1",
+                phase="push_and_pr",
+                category=FAILURE_CATEGORY_PUSH_FAILED,
+                stderr_tail="refusing to allow a Personal Access Token",
+                exit_code=1,
+                details={"branch": "agent/abc123"},
+                issue_number=3008,
+            )
+
+        # _write_failure was called with the right shape.
+        mock_write.assert_called_once()
+        kwargs = mock_write.call_args.kwargs
+        assert kwargs["agent_id"] == "agent-1"
+        assert kwargs["category"] == FAILURE_CATEGORY_PUSH_FAILED
+        assert kwargs["detected_by"] == "scheduler"
+        details = kwargs["details"]
+        assert details["phase"] == "push_and_pr"
+        assert details["stderr_tail"] == "refusing to allow a Personal Access Token"
+        assert details["exit_code"] == 1
+        assert details["branch"] == "agent/abc123"
+
+        # _mark_agent_terminal called with failed status + phase.
+        mock_mark.assert_called_once()
+        args, kwargs = mock_mark.call_args
+        assert args[0] == "agent-1"
+        assert kwargs["status"] == "failed"
+        assert kwargs["phase"] == "push_and_pr"
+        assert kwargs["exit_code"] == 1
+        assert kwargs["issue_number"] == 3008
+
+    def test_details_defaults_to_empty_dict(self) -> None:
+        d = _make_daemon()
+        with (
+            patch.object(d, "_write_failure") as mock_write,
+            patch.object(d, "_mark_agent_terminal"),
+        ):
+            d._handle_agent_failure(
+                agent_id="agent-2",
+                phase="push_and_pr",
+                category=FAILURE_CATEGORY_PR_CREATE_FAILED,
+                stderr_tail="HTTP 422",
+                exit_code=1,
+            )
+        details = mock_write.call_args.kwargs["details"]
+        # Canonical envelope always present even with no caller details.
+        assert details["phase"] == "push_and_pr"
+        assert details["stderr_tail"] == "HTTP 422"
+        assert details["exit_code"] == 1
+
+
+# --------------------------------------------------------------------------
+# AC#3 — context bundle includes prior_diagnoses_this_issue + recent_fleet_decisions
+# --------------------------------------------------------------------------
+
+
+class TestContextBundleExtensions:
+    def test_bundle_always_includes_new_keys(self) -> None:
+        """Issue #3032 — both keys are always present in the bundle.
+
+        When the DB is empty both come back as empty lists, but the
+        keys are guaranteed — so downstream consumers (and tests) can
+        count on stable shape.
+        """
+        # A minimal candidate for a push_failed first-occurrence.
+        candidate = {
+            "failure_id": 42,
+            "agent_id": "agent-ctx",
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+            "tier": 2,
+            "issue_number": 3008,
+            "details": {"branch": "agent/abc"},
+            "failure_ts": None,
+        }
+
+        cursor = _FakeCursor()
+        # 1st fetchone: agents row — (issue_number, worktree_path, pr_number).
+        cursor.fetch_queue.append((3008, "", None))
+        # fetchall queue — phase transitions, prior failures, prior
+        # diagnoses, recent fleet decisions. (Some sub-queries in the
+        # builder call fetchone; others fetchall. Pre-seed both.)
+        cursor.fetchall_queue.extend(
+            [
+                [],  # phase_transitions
+                [],  # prior_failures
+                [],  # prior_diagnoses_this_issue
+                [],  # recent_fleet_decisions
+            ]
+        )
+
+        d = _make_daemon(cursor)
+        # Short-circuit the gh issue view subprocess with an empty
+        # issue fetch — we're only checking the bundle shape.
+        with patch("dispatcher.daemon.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+            bundle = d._build_diagnoser_context(candidate)
+
+        assert "prior_diagnoses_this_issue" in bundle
+        assert "recent_fleet_decisions" in bundle
+        assert bundle["prior_diagnoses_this_issue"] == []
+        assert bundle["recent_fleet_decisions"] == []
+
+    def test_prior_diagnoses_this_issue_populated(self) -> None:
+        """When the DB has prior diagnoses on the same issue, they land in the bundle."""
+        candidate = {
+            "failure_id": 42,
+            "agent_id": "agent-xyz",
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+            "tier": 2,
+            "issue_number": 3008,
+            "details": {},
+            "failure_ts": None,
+        }
+        cursor = _FakeCursor()
+        # agents row
+        cursor.fetch_queue.append((3008, "", None))
+        # Phase transitions, prior failures, prior diagnoses, recent fleet decisions.
+        # prior_diagnoses_this_issue returns one row.
+        from datetime import datetime, timezone
+
+        completed_at = datetime(2026, 4, 22, 12, 0, 0, tzinfo=timezone.utc)
+        cursor.fetchall_queue.extend(
+            [
+                [],  # phase_transitions
+                [],  # prior_failures
+                [
+                    (
+                        100,
+                        "push_failed",
+                        {"action": "retry", "reasoning": "transient"},
+                        completed_at,
+                    )
+                ],  # prior_diagnoses_this_issue
+                [],  # recent_fleet_decisions
+            ]
+        )
+        d = _make_daemon(cursor)
+        with patch("dispatcher.daemon.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+            bundle = d._build_diagnoser_context(candidate)
+
+        assert len(bundle["prior_diagnoses_this_issue"]) == 1
+        row = bundle["prior_diagnoses_this_issue"][0]
+        assert row["diagnosis_id"] == 100
+        assert row["failure_category"] == "push_failed"
+        assert row["recommendation"] == {"action": "retry", "reasoning": "transient"}
+        assert row["completed_at"] == completed_at.isoformat()
+
+    def test_recent_fleet_decisions_populated(self) -> None:
+        """Recent fleet decisions (last 6h, cap 20) land as action+reasoning tuples."""
+        candidate = {
+            "failure_id": 42,
+            "agent_id": "agent-xyz",
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+            "tier": 2,
+            "issue_number": 3008,
+            "details": {},
+            "failure_ts": None,
+        }
+        cursor = _FakeCursor()
+        cursor.fetch_queue.append((3008, "", None))
+        from datetime import datetime, timezone
+
+        t = datetime(2026, 4, 22, 12, 0, 0, tzinfo=timezone.utc)
+        cursor.fetchall_queue.extend(
+            [
+                [],
+                [],
+                [],
+                [
+                    (
+                        200,
+                        "agent-a",
+                        2610,
+                        "pre_push_hook_rejected",
+                        {
+                            "action": "block_and_comment",
+                            "reasoning": "PAT scope missing",
+                        },
+                        t,
+                    ),
+                    (
+                        201,
+                        "agent-b",
+                        3008,
+                        "pre_push_hook_rejected",
+                        {
+                            "action": "file_prerequisite_task",
+                            "reasoning": "Fleet-wide PAT",
+                        },
+                        t,
+                    ),
+                ],
+            ]
+        )
+        d = _make_daemon(cursor)
+        with patch("dispatcher.daemon.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+            bundle = d._build_diagnoser_context(candidate)
+
+        decisions = bundle["recent_fleet_decisions"]
+        assert len(decisions) == 2
+        assert decisions[0]["action"] == "block_and_comment"
+        assert decisions[0]["failure_category"] == "pre_push_hook_rejected"
+        assert decisions[0]["issue_number"] == 2610
+        assert decisions[1]["action"] == "file_prerequisite_task"
+        assert decisions[1]["issue_number"] == 3008
+
+
+# --------------------------------------------------------------------------
+# AC#5 — new action handlers
+# --------------------------------------------------------------------------
+
+
+class TestBlockAndCommentHandler:
+    def test_applies_blocked_removes_ready_posts_comment(self) -> None:
+        d = _make_daemon()
+        with (
+            patch.object(d, "_gh_issue_comment") as mock_comment,
+            patch.object(d, "_gh_issue_add_labels") as mock_add,
+            patch.object(d, "_gh_issue_remove_labels") as mock_remove,
+            patch.object(d, "_mark_agent_terminal") as mock_mark,
+        ):
+            d._consume_action_block_and_comment(
+                agent_id="agent-1",
+                issue_number=3008,
+                reasoning="PAT scope missing — operator must update Secrets Manager.",
+            )
+        mock_comment.assert_called_once()
+        body = mock_comment.call_args.args[1]
+        assert "PAT scope missing" in body
+        assert "3D block" in body
+        mock_add.assert_called_once_with(3008, ["status/blocked"])
+        mock_remove.assert_called_once_with(3008, ["agent/ready"])
+        mock_mark.assert_called_once()
+
+    def test_no_issue_number_still_marks_terminal(self) -> None:
+        d = _make_daemon()
+        with (
+            patch.object(d, "_gh_issue_comment") as mock_comment,
+            patch.object(d, "_mark_agent_terminal") as mock_mark,
+        ):
+            d._consume_action_block_and_comment(
+                agent_id="agent-1",
+                issue_number=None,
+                reasoning="whatever",
+            )
+        mock_comment.assert_not_called()
+        mock_mark.assert_called_once()
+
+
+class TestFilePrerequisiteTaskHandler:
+    def test_creates_new_issue_and_blocks_current(self) -> None:
+        d = _make_daemon()
+        with (
+            patch.object(d, "_gh_issue_create", return_value=3050) as mock_create,
+            patch.object(d, "_gh_issue_comment") as mock_comment,
+            patch.object(d, "_gh_issue_append_body") as mock_append,
+            patch.object(d, "_gh_issue_add_labels") as mock_add,
+            patch.object(d, "_gh_issue_remove_labels") as mock_remove,
+            patch.object(d, "_mark_agent_terminal") as mock_mark,
+        ):
+            d._consume_action_file_prerequisite_task(
+                agent_id="agent-1",
+                issue_number=3008,
+                title="chore(infra): add workflow scope to dispatcher PAT",
+                body="## Goal\nAdd scope.\n",
+                block_labels=["priority/p1"],
+                reasoning="Fleet-wide PAT scope blocker.",
+            )
+        mock_create.assert_called_once()
+        kwargs = mock_create.call_args.kwargs
+        assert kwargs["title"] == "chore(infra): add workflow scope to dispatcher PAT"
+        assert kwargs["body"] == "## Goal\nAdd scope.\n"
+        assert kwargs["labels"] == ["priority/p1"]
+        mock_comment.assert_called_once()
+        assert "#3050" in mock_comment.call_args.args[1]
+        mock_append.assert_called_once_with(3008, "\n\nBlocked by #3050")
+        mock_add.assert_called_once_with(3008, ["status/blocked"])
+        mock_remove.assert_called_once_with(3008, ["agent/ready"])
+        mock_mark.assert_called_once()
+
+    def test_create_failure_falls_back_to_escalate(self) -> None:
+        d = _make_daemon()
+        with (
+            patch.object(d, "_gh_issue_create", return_value=None),
+            patch.object(d, "_consume_action_escalate") as mock_esc,
+            patch.object(d, "_gh_issue_append_body") as mock_append,
+        ):
+            d._consume_action_file_prerequisite_task(
+                agent_id="agent-1",
+                issue_number=3008,
+                title="x",
+                body="y",
+                block_labels=None,
+                reasoning="root",
+            )
+        # Fall through to escalate; no body append.
+        mock_esc.assert_called_once()
+        mock_append.assert_not_called()
+
+
+class TestBlockOnExistingTaskHandler:
+    def test_validates_blocker_and_appends_body(self) -> None:
+        d = _make_daemon()
+        with (
+            patch.object(d, "_gh_issue_is_open", return_value=True),
+            patch.object(d, "_gh_issue_comment") as mock_comment,
+            patch.object(d, "_gh_issue_append_body") as mock_append,
+            patch.object(d, "_gh_issue_add_labels") as mock_add,
+            patch.object(d, "_gh_issue_remove_labels") as mock_remove,
+            patch.object(d, "_mark_agent_terminal") as mock_mark,
+        ):
+            d._consume_action_block_on_existing_task(
+                agent_id="agent-1",
+                issue_number=3008,
+                blocker_issue_number=3050,
+                reasoning="Existing issue tracks this.",
+            )
+        mock_comment.assert_called_once()
+        assert "#3050" in mock_comment.call_args.args[1]
+        mock_append.assert_called_once_with(3008, "\n\nBlocked by #3050")
+        mock_add.assert_called_once_with(3008, ["status/blocked"])
+        mock_remove.assert_called_once_with(3008, ["agent/ready"])
+        mock_mark.assert_called_once()
+
+    def test_invalid_blocker_falls_back_to_escalate(self) -> None:
+        d = _make_daemon()
+        with (
+            patch.object(d, "_gh_issue_is_open", return_value=False),
+            patch.object(d, "_consume_action_escalate") as mock_esc,
+            patch.object(d, "_gh_issue_append_body") as mock_append,
+        ):
+            d._consume_action_block_on_existing_task(
+                agent_id="agent-1",
+                issue_number=3008,
+                blocker_issue_number=9999,
+                reasoning="missing blocker",
+            )
+        mock_esc.assert_called_once()
+        mock_append.assert_not_called()
+
+    def test_no_current_issue_falls_back_to_escalate(self) -> None:
+        d = _make_daemon()
+        with patch.object(d, "_consume_action_escalate") as mock_esc:
+            d._consume_action_block_on_existing_task(
+                agent_id="agent-1",
+                issue_number=None,
+                blocker_issue_number=3050,
+                reasoning="no current issue",
+            )
+        mock_esc.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# AC#6/7 — hardened parse path: escalate on malformed / unknown / missing
+# --------------------------------------------------------------------------
+
+
+class TestHardenedParse:
+    def test_missing_recommendation_escalates_not_retries(self) -> None:
+        """Issue #3032 — parse failure falls back to escalate (NOT retry)."""
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-1",
+            "issue_number": 3008,
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+        }
+        with (
+            patch.object(d, "_read_recommendation", return_value=None),
+            patch.object(d, "_mark_diagnosis_failed") as mock_marked_failed,
+            patch.object(d, "_apply_mechanical_escalation") as mock_escalate,
+            patch.object(d, "_create_retry_marker") as mock_retry,
+        ):
+            action = d._consume_diagnosis(diagnosis_id=1, candidate=candidate)
+        assert action == "escalate_fallback"
+        mock_marked_failed.assert_called_once()
+        mock_escalate.assert_called_once()
+        mock_retry.assert_not_called()  # must NOT silently retry
+
+    def test_missing_action_field_escalates(self) -> None:
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-1",
+            "issue_number": 3008,
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+        }
+        with (
+            patch.object(d, "_read_recommendation", return_value={"reasoning": "..."}),
+            patch.object(d, "_apply_mechanical_escalation") as mock_escalate,
+            patch.object(d, "_create_retry_marker") as mock_retry,
+        ):
+            action = d._consume_diagnosis(diagnosis_id=2, candidate=candidate)
+        assert action == "escalate_fallback"
+        mock_escalate.assert_called_once()
+        mock_retry.assert_not_called()
+
+    def test_unknown_action_persists_row_and_escalates(self) -> None:
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-1",
+            "issue_number": 3008,
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+        }
+        rec = {"action": "split_task", "reasoning": "LLM got creative"}
+        with (
+            patch.object(d, "_read_recommendation", return_value=rec),
+            patch.object(d, "_persist_unrecognized_action") as mock_persist,
+            patch.object(d, "_apply_mechanical_escalation") as mock_escalate,
+            patch.object(d, "_create_retry_marker") as mock_retry,
+        ):
+            action = d._consume_diagnosis(diagnosis_id=3, candidate=candidate)
+        assert action == "escalate_fallback"
+        mock_persist.assert_called_once()
+        kwargs = mock_persist.call_args.kwargs
+        assert kwargs["diagnosis_id"] == 3
+        assert kwargs["action_name"] == "split_task"
+        assert kwargs["payload"] == rec
+        mock_escalate.assert_called_once()
+        mock_retry.assert_not_called()
+
+    def test_retry_with_hint_missing_hint_escalates(self) -> None:
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-1",
+            "issue_number": 3008,
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+        }
+        rec = {"action": "retry_with_hint", "reasoning": "x"}  # hint missing
+        with (
+            patch.object(d, "_read_recommendation", return_value=rec),
+            patch.object(d, "_apply_mechanical_escalation") as mock_escalate,
+            patch.object(d, "_create_retry_marker") as mock_retry,
+        ):
+            action = d._consume_diagnosis(diagnosis_id=4, candidate=candidate)
+        assert action == "escalate_fallback"
+        mock_escalate.assert_called_once()
+        mock_retry.assert_not_called()
+
+    def test_file_prerequisite_task_missing_body_escalates(self) -> None:
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-1",
+            "issue_number": 3008,
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+        }
+        rec = {
+            "action": "file_prerequisite_task",
+            "title": "chore: x",
+            "reasoning": "y",
+        }
+        with (
+            patch.object(d, "_read_recommendation", return_value=rec),
+            patch.object(d, "_apply_mechanical_escalation") as mock_escalate,
+        ):
+            action = d._consume_diagnosis(diagnosis_id=5, candidate=candidate)
+        assert action == "escalate_fallback"
+        mock_escalate.assert_called_once()
+
+    def test_block_on_existing_task_missing_blocker_escalates(self) -> None:
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-1",
+            "issue_number": 3008,
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+        }
+        rec = {"action": "block_on_existing_task", "reasoning": "y"}
+        with (
+            patch.object(d, "_read_recommendation", return_value=rec),
+            patch.object(d, "_apply_mechanical_escalation") as mock_escalate,
+        ):
+            action = d._consume_diagnosis(diagnosis_id=6, candidate=candidate)
+        assert action == "escalate_fallback"
+        mock_escalate.assert_called_once()
+
+
+# --------------------------------------------------------------------------
+# AC#6 — raw LLM output logged on parse failure
+# --------------------------------------------------------------------------
+
+
+class TestRawOutputLogging:
+    def test_diagnoser_parse_failed_event_logged_on_unknown(self, caplog: Any) -> None:
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-1",
+            "issue_number": 3008,
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+        }
+        rec = {"action": "weird_thing", "reasoning": "?"}
+        with (
+            patch.object(d, "_read_recommendation", return_value=rec),
+            patch.object(d, "_persist_unrecognized_action"),
+            patch.object(d, "_apply_mechanical_escalation"),
+            caplog.at_level(logging.WARNING, logger="test.daemon"),
+        ):
+            d._consume_diagnosis(diagnosis_id=99, candidate=candidate)
+        # Assert the daemon.diagnoser_parse_failed event fired with
+        # a non-empty raw_output string.
+        matching = [r for r in caplog.records if r.name == "test.daemon"]
+        parse_failed_records = [
+            r for r in matching if getattr(r, "event", "") == "diagnoser_parse_failed"
+        ]
+        assert parse_failed_records, "expected diagnoser_parse_failed event"
+        r = parse_failed_records[0]
+        assert getattr(r, "reason", "") == "unrecognized_action"
+        raw_output = getattr(r, "raw_output", None)
+        assert raw_output is not None
+        assert "weird_thing" in raw_output
+
+    def test_none_recommendation_logs_raw_output_null(self, caplog: Any) -> None:
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-1",
+            "issue_number": 3008,
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+        }
+        with (
+            patch.object(d, "_read_recommendation", return_value=None),
+            patch.object(d, "_apply_mechanical_escalation"),
+            caplog.at_level(logging.WARNING, logger="test.daemon"),
+        ):
+            d._consume_diagnosis(diagnosis_id=100, candidate=candidate)
+        matching = [r for r in caplog.records if r.name == "test.daemon"]
+        parse_failed_records = [
+            r for r in matching if getattr(r, "event", "") == "diagnoser_parse_failed"
+        ]
+        assert parse_failed_records
+        r = parse_failed_records[0]
+        assert getattr(r, "raw_output", "sentinel") is None
+
+
+# --------------------------------------------------------------------------
+# AC#6 — _persist_unrecognized_action writes the expected row
+# --------------------------------------------------------------------------
+
+
+class TestPersistUnrecognizedAction:
+    def test_insert_shape(self) -> None:
+        cursor = _FakeCursor()
+        d = _make_daemon(cursor)
+        payload = {"action": "split_task", "reasoning": "r"}
+        d._persist_unrecognized_action(
+            diagnosis_id=7, action_name="split_task", payload=payload
+        )
+        assert len(cursor.executed) == 1
+        sql, params = cursor.executed[0]
+        assert "INSERT INTO dispatcher.unrecognized_diagnoser_actions" in sql
+        assert params[0] == 7
+        assert params[1] == "split_task"
+        # payload serialized to JSON string.
+        assert "split_task" in params[2]
+
+    def test_db_error_does_not_propagate(self) -> None:
+        """A bad INSERT must not block the escalate fallback path."""
+        cursor = _FakeCursor()
+
+        def _boom(_sql: str, _params: Any = None) -> None:
+            raise RuntimeError("boom")
+
+        cursor.execute = _boom  # type: ignore[assignment]
+        d = _make_daemon(cursor)
+        # Should not raise.
+        d._persist_unrecognized_action(
+            diagnosis_id=8, action_name="x", payload={"a": 1}
+        )
+
+
+# --------------------------------------------------------------------------
+# AC#5 — _consume_diagnosis dispatches to new handlers
+# --------------------------------------------------------------------------
+
+
+class TestConsumeDiagnosisDispatchesNewActions:
+    def test_block_and_comment_dispatch(self) -> None:
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-1",
+            "issue_number": 3008,
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+        }
+        rec = {"action": "block_and_comment", "reasoning": "need operator"}
+        with (
+            patch.object(d, "_read_recommendation", return_value=rec),
+            patch.object(d, "_consume_action_block_and_comment") as mock_handler,
+        ):
+            action = d._consume_diagnosis(diagnosis_id=20, candidate=candidate)
+        assert action == "block_and_comment"
+        mock_handler.assert_called_once_with(
+            agent_id="agent-1", issue_number=3008, reasoning="need operator"
+        )
+
+    def test_file_prerequisite_task_dispatch(self) -> None:
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-1",
+            "issue_number": 3008,
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+        }
+        rec = {
+            "action": "file_prerequisite_task",
+            "title": "chore: x",
+            "body": "## Goal\nx",
+            "reasoning": "root cause",
+            "block_labels": ["priority/p1"],
+        }
+        with (
+            patch.object(d, "_read_recommendation", return_value=rec),
+            patch.object(d, "_consume_action_file_prerequisite_task") as mock_handler,
+        ):
+            action = d._consume_diagnosis(diagnosis_id=21, candidate=candidate)
+        assert action == "file_prerequisite_task"
+        mock_handler.assert_called_once()
+        kwargs = mock_handler.call_args.kwargs
+        assert kwargs["title"] == "chore: x"
+        assert kwargs["body"] == "## Goal\nx"
+        assert kwargs["block_labels"] == ["priority/p1"]
+
+    def test_block_on_existing_task_dispatch(self) -> None:
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-1",
+            "issue_number": 3008,
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+        }
+        rec = {
+            "action": "block_on_existing_task",
+            "blocker_issue_number": 3050,
+            "reasoning": "exists",
+        }
+        with (
+            patch.object(d, "_read_recommendation", return_value=rec),
+            patch.object(d, "_consume_action_block_on_existing_task") as mock_handler,
+        ):
+            action = d._consume_diagnosis(diagnosis_id=22, candidate=candidate)
+        assert action == "block_on_existing_task"
+        mock_handler.assert_called_once()
+        kwargs = mock_handler.call_args.kwargs
+        assert kwargs["blocker_issue_number"] == 3050
+
+
+# --------------------------------------------------------------------------
+# Regression — existing five actions still dispatch correctly
+# --------------------------------------------------------------------------
+
+
+class TestRegressionExistingActions:
+    def test_retry_still_dispatches(self) -> None:
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-1",
+            "issue_number": 3008,
+            "category": FAILURE_CATEGORY_SUBPROCESS_CRASH,
+        }
+        rec = {"action": "retry", "reasoning": "transient"}
+        with (
+            patch.object(d, "_read_recommendation", return_value=rec),
+            patch.object(d, "_consume_action_retry") as mock_handler,
+        ):
+            action = d._consume_diagnosis(diagnosis_id=30, candidate=candidate)
+        assert action == "retry"
+        mock_handler.assert_called_once()
+
+    def test_reissue_still_dispatches(self) -> None:
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-1",
+            "issue_number": 3008,
+            "category": FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
+        }
+        rec = {
+            "action": "reissue",
+            "reasoning": "AC outdated",
+            "new_scope": "## Goal\nRewritten body\n",
+        }
+        with (
+            patch.object(d, "_read_recommendation", return_value=rec),
+            patch.object(d, "_consume_action_reissue") as mock_handler,
+        ):
+            action = d._consume_diagnosis(diagnosis_id=31, candidate=candidate)
+        assert action == "reissue"
+        mock_handler.assert_called_once()
+
+    def test_escalate_still_dispatches(self) -> None:
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-1",
+            "issue_number": 3008,
+            "category": FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
+        }
+        rec = {"action": "escalate", "reasoning": "needs human"}
+        with (
+            patch.object(d, "_read_recommendation", return_value=rec),
+            patch.object(d, "_consume_action_escalate") as mock_handler,
+        ):
+            action = d._consume_diagnosis(diagnosis_id=32, candidate=candidate)
+        assert action == "escalate"
+        mock_handler.assert_called_once()

--- a/scripts/dispatcher/tests/test_daemon_phase3d.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3d.py
@@ -1253,11 +1253,24 @@ class TestConstants:
         assert daemon.FAILURE_CATEGORY_CI_RED_AFTER_RETRIES == "ci_red_after_retries"
 
     def test_diagnoser_actions_exhaustive(self) -> None:
-        # Spec §8 lists exactly 5 actions. Lock it in so a sixth cannot
-        # be added without also updating the daemon's deterministic
-        # consumer (`_consume_diagnosis` has explicit branches).
+        # Issue #3032 expanded the known action set from 5 to 8. The
+        # daemon's consumer still has an explicit switch so any
+        # addition here must also land in ``_consume_diagnosis``. The
+        # closed-enum guardrail in the diagnoser skill itself is
+        # REMOVED — novel LLM-proposed actions persist to the
+        # ``dispatcher.unrecognized_diagnoser_actions`` table and fall
+        # back to ``escalate``.
         assert daemon.DIAGNOSER_ACTIONS == frozenset(
-            {"retry", "retry_with_hint", "reissue", "escalate", "close"}
+            {
+                "retry",
+                "retry_with_hint",
+                "reissue",
+                "escalate",
+                "close",
+                "block_and_comment",
+                "file_prerequisite_task",
+                "block_on_existing_task",
+            }
         )
 
     def test_tier_sets_are_disjoint(self) -> None:

--- a/scripts/dispatcher/tests/test_daemon_push_failed.py
+++ b/scripts/dispatcher/tests/test_daemon_push_failed.py
@@ -202,16 +202,39 @@ class TestClassifyPushFailure:
 
 
 class TestAutoRetryCategories:
-    """AC#2 — all three push failure categories are in AUTO_RETRY_CATEGORIES."""
+    """Issue #3032 moved push failure categories out of AUTO_RETRY_CATEGORIES.
 
-    def test_auto_retry_categories_include_push_failed(self) -> None:
-        assert FAILURE_CATEGORY_PUSH_FAILED in AUTO_RETRY_CATEGORIES
+    Before #3032 all three push sub-kinds (``push_failed``,
+    ``pre_push_hook_rejected``, ``git_push_network``) were tier-1
+    auto-retry. The 6-failure PAT-scope cascade on #3008 / #2610
+    showed that blind retry on a deterministic operator-action
+    blocker (e.g. GitHub PAT missing workflow scope) burns CI time
+    without progress. The diagnoser now owns the retry-vs-escalate
+    decision for all three — the unified ``_handle_agent_failure``
+    exit path writes the failure row, the next supervisor tick
+    picks it up via ``_find_diagnoser_candidates``, and Opus
+    decides.
+    """
 
-    def test_auto_retry_categories_include_pre_push_hook_rejected(self) -> None:
-        assert FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED in AUTO_RETRY_CATEGORIES
+    def test_auto_retry_categories_excludes_push_failed(self) -> None:
+        assert FAILURE_CATEGORY_PUSH_FAILED not in AUTO_RETRY_CATEGORIES
 
-    def test_auto_retry_categories_include_git_push_network(self) -> None:
-        assert FAILURE_CATEGORY_GIT_PUSH_NETWORK in AUTO_RETRY_CATEGORIES
+    def test_auto_retry_categories_excludes_pre_push_hook_rejected(self) -> None:
+        assert FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED not in AUTO_RETRY_CATEGORIES
+
+    def test_auto_retry_categories_excludes_git_push_network(self) -> None:
+        assert FAILURE_CATEGORY_GIT_PUSH_NETWORK not in AUTO_RETRY_CATEGORIES
+
+    def test_push_categories_now_in_tier_2_first_occurrence(self) -> None:
+        # Issue #3032: push failures now diagnose on first occurrence.
+        from dispatcher.daemon import TIER_2_FIRST_OCCURRENCE_CATEGORIES
+
+        assert FAILURE_CATEGORY_PUSH_FAILED in TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        assert (
+            FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED
+            in TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        )
+        assert FAILURE_CATEGORY_GIT_PUSH_NETWORK in TIER_2_FIRST_OCCURRENCE_CATEGORIES
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Unifies the dispatcher daemon's failure handling under a single `_handle_agent_failure()` exit path so every agent-terminal failure routes through the Opus diagnoser — not just tier-2 recurrences and tier-3 first-occurrences. Expands the diagnoser action menu from 5 to 8 known actions, opens the menu (novel actions persist to a new audit table and fall back to `escalate`), extends the context bundle with `prior_diagnoses_this_issue` + `recent_fleet_decisions`, and hardens parsing so malformed / unknown / missing-payload recommendations escalate rather than silently retry.

Closes #3032

## Test plan

### Automated checks
- [x] Lint passes (`ruff check scripts/dispatcher/`)
- [x] Format check passes (`ruff format --check scripts/dispatcher/*.py scripts/dispatcher/tests/test_daemon_{diagnoser_routing,push_failed,phase3d}.py`)
- [x] Tests pass (966 passed, 1 skipped — full dispatcher suite, including new `test_daemon_diagnoser_routing.py` with 38 tests)
- [x] API lint passes (`npm --prefix packages/api run lint`)
- [x] Markdown link check passes (SKILL.md edits)
- [x] Schema regenerated (`scripts/regenerate_schema.sh`) — `dispatcher.unrecognized_diagnoser_actions` table added
- [x] CI green

### Post-deploy verification
- [ ] Next real `git_push_failed` / `pr_create_failed` / `phase_output_missing` event triggers the Opus diagnoser (CloudWatch `diagnoser_spawn` event correlated with the new failure row)
- [ ] Recommendation row in `dispatcher.diagnoses` is `status=completed` with a valid action in the expanded 8-set (or a novel action logged to `dispatcher.unrecognized_diagnoser_actions`)
- [ ] Verification evidence posted on #3032 showing the end-to-end path

## Key changes

**`scripts/dispatcher/daemon.py`:**
- New unified `_handle_agent_failure()` method — writes `dispatcher.failures` row + marks terminal, letting `_run_diagnoser_pass` pick it up on next supervisor tick.
- Call sites converted: `_push_and_open_pr` (3 branches: timeout, Exception, non-zero returncode), `pr_create_failed` (2 branches), `phase_output_missing` (5 sites: plan / ralph / summary / fix-ci / verify).
- New categories: `FAILURE_CATEGORY_PR_CREATE_FAILED`, `FAILURE_CATEGORY_PHASE_OUTPUT_MISSING`.
- `DIAGNOSER_ACTIONS` expanded from 5 to 8 with `block_and_comment`, `file_prerequisite_task`, `block_on_existing_task`.
- Three new action handlers: `_consume_action_block_and_comment`, `_consume_action_file_prerequisite_task`, `_consume_action_block_on_existing_task` — each with proper gh helper usage, appropriate fall-back-to-escalate on validation failure.
- Three new gh helpers: `_gh_issue_create`, `_gh_issue_append_body`, `_gh_issue_is_open`.
- `_build_diagnoser_context` extended with `prior_diagnoses_this_issue` (last 10 completed diagnoses on same issue) and `recent_fleet_decisions` (last 20 completed diagnoses fleet-wide, last 6h).
- Hardened parse: `_consume_diagnosis` now emits `daemon.diagnoser_parse_failed` with `raw_output` field on every failure branch; unknown actions persist to `dispatcher.unrecognized_diagnoser_actions` via `_persist_unrecognized_action`. No path falls through to `retry` on malformed input.
- Push categories removed from `AUTO_RETRY_CATEGORIES` — the LLM owns retry/escalate for these now.

**`packages/api/migrations/40_dispatcher-unrecognized-diagnoser-actions.sql`** — new minimal table.

**`packages/api/src/data-access/schema.sql`** — regenerated from migrations 1-40.

**`.claude/skills/diagnose-failure/SKILL.md`** — guardrail "The five actions are exhaustive" removed; 8 known actions documented; novel-action escape hatch explicit; decision tree extended with 3 new branches (ops-action blocker → `block_and_comment` / `file_prerequisite_task`, existing tracking issue → `block_on_existing_task`); 3 new examples including the PAT-scope cascade pattern.

**Tests:** new `scripts/dispatcher/tests/test_daemon_diagnoser_routing.py` (38 tests) covers the expanded action set, context bundle extensions, all three new handlers, hardened parse paths, unrecognized-action persistence, and regression of existing action dispatch. Existing tests updated: `test_daemon_phase3d.py` for the 8-action invariant; `test_daemon_push_failed.py` for the deliberate removal of push categories from `AUTO_RETRY_CATEGORIES`.

## Out of scope

- `daemon_restart_abandoned` stays on mechanical retry (infra-preemption, not agent content).
- No pre-filter for transient errors (cost-optimization followup).
- `subprocess_crash` stays on tier-1 mechanical retry for first occurrence + tier-2 diagnoser on recurrence (existing behavior preserved).
