### PR TITLE
fix(dispatcher): drop shallow baseline clone and detect ralph no-op SHIP (#3039)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -578,6 +578,18 @@ PHASE_RETRO_DONE = "retro_done"
 #: Cleanup still runs from this terminal-with-retro-failed state.
 PHASE_RETRO_FAILED = "retro_failed"
 
+#: Phase value written when :meth:`_push_and_open_pr` detects that
+#: ralph's §2.5d no-op guardrail fired — the working tree was clean
+#: on SHIP and no commit was created on top of ``origin/main``. The
+#: deliverable for a no-op SHIP is ralph's evidence comment on the
+#: issue (data-only tasks like SQL backfills); there is nothing to
+#: push or PR. Distinct terminal phase so the admin cockpit can
+#: filter / count these separately from the normal
+#: ``done``/``retro_done`` success states, and so a post-hoc query
+#: like ``SELECT count(*) FROM dispatcher.agents WHERE phase='no_op'``
+#: trivially counts them. Status remains ``succeeded``. Issue #3039.
+PHASE_NO_OP = "no_op"
+
 #: Phase value written after ``scripts/cleanup_worktree.sh`` succeeds.
 #: This is the final terminal phase for a successful agent — no further
 #: supervisor advances apply.
@@ -3986,10 +3998,21 @@ class DispatcherDaemon:
         self._setup_git_credentials()
 
         if (baseline / ".git").exists():
-            # Existing clone — fetch so worktrees branch from up-to-date
-            # ``origin/main``. Cheap (shallow fetch) and prevents
+            # Existing clone — unshallow if needed, then fetch so
+            # worktrees branch from up-to-date ``origin/main``. Prevents
             # "worktree branched from a stale main" bugs as the daemon
             # stays up across many merges.
+            #
+            # Issue #3039: pre-#3039 the baseline was cloned shallow
+            # (``--depth=1 --no-tags``), which produced orphan-commit
+            # PRs on the ralph "no-op SHIP" path (``git commit --amend``
+            # against HEAD dropped the unreachable parent and ``gh pr
+            # create`` failed with "no history in common with main").
+            # Any container image built before the fix still has a
+            # shallow on-disk baseline from a prior boot; unshallow it
+            # here so the correctness fix applies without a full
+            # re-clone or container rebuild.
+            self._unshallow_baseline_if_needed()
             self._baseline_fetch_origin_main()
             self._log.info(
                 "daemon.baseline_clone_ready",
@@ -4004,13 +4027,21 @@ class DispatcherDaemon:
 
         # Fresh clone. Create the parent directory (e.g. /var/lib/dispatcher/)
         # so the sibling worktrees directory can also be created later.
+        #
+        # Issue #3039: DO NOT pass ``--depth=1`` / ``--no-tags`` here.
+        # The shallow boundary commit has no accessible parent; a later
+        # ``git commit --amend`` against that commit (ralph's no-op SHIP
+        # path in :meth:`_push_and_open_pr`) produces an orphan root
+        # commit and ``gh pr create`` fails with "no history in common
+        # with main". A full clone of judgemind/judgemind is under 200MB
+        # and finishes in ~30-60s on the ECS task cold path — tasks run
+        # for hours, so the one-time cost is invisible and the
+        # correctness win is absolute.
         baseline.parent.mkdir(parents=True, exist_ok=True)
 
         cmd = [
             "git",
             "clone",
-            "--depth=1",
-            "--no-tags",
             BASELINE_CLONE_URL,
             str(baseline),
         ]
@@ -4073,6 +4104,125 @@ class DispatcherDaemon:
         if result.returncode != 0:
             stderr_preview = _stderr_tail(result.stderr)
             raise RuntimeError(f"git fetch exit={result.returncode}: {stderr_preview}")
+
+    def _unshallow_baseline_if_needed(self) -> None:
+        """Upgrade a pre-existing shallow baseline to a full clone.
+
+        Issue #3039. The pre-#3039 :meth:`ensure_baseline_clone` wrote
+        shallow clones (``git clone --depth=1 --no-tags``). After the
+        fix lands, any container image whose ephemeral storage still
+        contains a shallow clone from a prior boot would continue to
+        hit the orphan-commit bug. This method detects that state
+        (``git rev-parse --is-shallow-repository == "true"``) and
+        runs ``git fetch --unshallow origin main`` to upgrade it in
+        place — no full re-clone, no container rebuild required.
+
+        Best-effort. A failure here does NOT raise — the caller's
+        :meth:`_baseline_fetch_origin_main` is still going to run and
+        will surface any actual connectivity or auth problem. The
+        worst case of a silent unshallow failure is that the next
+        no-op SHIP continues to produce orphan commits (the pre-#3039
+        status quo), which logs are already instrumented to detect.
+        """
+        baseline = self._cfg.baseline_repo_root
+        if baseline is None:  # pragma: no cover — guarded by callers
+            return
+
+        is_shallow_cmd = [
+            "git",
+            "-C",
+            str(baseline),
+            "rev-parse",
+            "--is-shallow-repository",
+        ]
+        try:
+            probe = subprocess.run(
+                is_shallow_cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            self._log.warning(
+                "daemon.baseline_unshallow_probe_failed",
+                extra={
+                    "event": "baseline_unshallow_probe_failed",
+                    "run_id": self._run_id,
+                    "baseline_repo_root": str(baseline),
+                    "detail": str(exc),
+                },
+            )
+            return
+
+        if probe.returncode != 0:
+            self._log.warning(
+                "daemon.baseline_unshallow_probe_failed",
+                extra={
+                    "event": "baseline_unshallow_probe_failed",
+                    "run_id": self._run_id,
+                    "baseline_repo_root": str(baseline),
+                    "exit_code": probe.returncode,
+                    "stderr_tail": _stderr_tail(probe.stderr),
+                },
+            )
+            return
+
+        if (probe.stdout or "").strip() != "true":
+            # Already a full clone — nothing to do. No event; the
+            # common case should stay quiet.
+            return
+
+        unshallow_cmd = [
+            "git",
+            "-C",
+            str(baseline),
+            "fetch",
+            "--unshallow",
+            "origin",
+            "main",
+        ]
+        try:
+            result = subprocess.run(
+                unshallow_cmd,
+                capture_output=True,
+                text=True,
+                timeout=BASELINE_CLONE_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+            self._log.warning(
+                "daemon.baseline_unshallow_failed",
+                extra={
+                    "event": "baseline_unshallow_failed",
+                    "run_id": self._run_id,
+                    "baseline_repo_root": str(baseline),
+                    "detail": str(exc),
+                },
+            )
+            return
+
+        if result.returncode != 0:
+            self._log.warning(
+                "daemon.baseline_unshallow_failed",
+                extra={
+                    "event": "baseline_unshallow_failed",
+                    "run_id": self._run_id,
+                    "baseline_repo_root": str(baseline),
+                    "exit_code": result.returncode,
+                    "stderr_tail": _stderr_tail(result.stderr),
+                },
+            )
+            return
+
+        self._log.info(
+            "daemon.baseline_unshallowed",
+            extra={
+                "event": "baseline_unshallowed",
+                "run_id": self._run_id,
+                "baseline_repo_root": str(baseline),
+            },
+        )
 
     def _create_worktree(self, agent_id: str) -> Path:
         """``git worktree add`` a fresh worktree + branch for this agent.
@@ -5657,6 +5807,55 @@ class DispatcherDaemon:
                 if path.startswith(prefix):
                     return VERIFY_SKIP_REASON_SELF_DEPLOY
         return None
+
+    def _is_noop_ship(self, worktree: Path) -> bool:
+        """Return True when ralph SHIPped without creating a commit.
+
+        Issue #3039. Ralph's §2.5d "no-op guardrail" skips the
+        pre-push commit when the working tree is clean at SHIP time
+        (data-only / no-code-change task whose deliverable is the
+        evidence comment ralph posts on the issue). In that state
+        the worktree branch tip is still ``origin/main`` and there
+        is nothing to amend, push, or PR.
+
+        Implementation: ``git rev-list --count origin/main..HEAD``.
+        Return value ``0`` → no-op SHIP; any positive integer → real
+        commits on the branch. Subprocess failures fail-closed to
+        ``False`` (treat as "normal commits ahead" and let the rest
+        of :meth:`_push_and_open_pr` run normally — worst case is the
+        pre-#3039 failure mode, which is already instrumented by the
+        ``pr_create_failed`` classifier).
+
+        Pure on a single ``subprocess.run`` so the unit tests can
+        stub it with the standard ``patch('subprocess.run',
+        side_effect=[...])`` pattern used across the dispatcher
+        tests.
+        """
+        cmd = [
+            "git",
+            "-C",
+            str(worktree),
+            "rev-list",
+            "--count",
+            "origin/main..HEAD",
+        ]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            return False
+        if result.returncode != 0:
+            return False
+        try:
+            ahead = int((result.stdout or "").strip())
+        except ValueError:
+            return False
+        return ahead == 0
 
     def _list_committed_files_at_head(self, worktree: Path) -> list[str]:
         """Return the file list of the most recent commit on ``worktree``.
@@ -9023,6 +9222,53 @@ class DispatcherDaemon:
         marks ready + merges, or closes.
         """
         self._update_agent_phase(agent_id, "push_and_pr")
+
+        # Issue #3039: ralph §2.5d "no-op guardrail" SHIP detection.
+        # When ralph's working tree was clean at SHIP time (no code
+        # changes needed — e.g. data-only SQL backfill task whose
+        # deliverable is ralph's evidence comment on the issue), ralph
+        # intentionally did not create a commit. The branch tip is
+        # still ``origin/main`` and ``git rev-list --count
+        # origin/main..HEAD`` returns 0.
+        #
+        # Pre-#3039 the daemon unconditionally ran ``git commit
+        # --amend`` below, which against the shallow-boundary ``HEAD``
+        # produced an orphan root commit ("no history in common with
+        # main" from ``gh pr create``). Even with the shallow-clone
+        # fix (Fix a), amending ``origin/main`` on a non-shallow clone
+        # would rewrite the main-branch commit on the local branch
+        # tip — the resulting PR's diff would be empty and
+        # confusing, and a push would fail because the branch is
+        # not ahead of origin/main.
+        #
+        # The ralph skill already logs "pre-push gate skipped —
+        # working tree clean; no commit created" for this path. The
+        # daemon mirrors that with a clean terminal: mark the agent
+        # ``status='succeeded' phase=PHASE_NO_OP`` and emit
+        # :event:`daemon.push_and_pr_skipped_no_op`. No amend, no
+        # push, no PR. Ralph's issue comment is the deliverable.
+        if self._is_noop_ship(worktree):
+            self._log.info(
+                "daemon.push_and_pr_skipped_no_op",
+                extra={
+                    "event": "push_and_pr_skipped_no_op",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "detail": (
+                        "origin/main..HEAD is empty — ralph's §2.5d "
+                        "no-op guardrail fired; no commit to push."
+                    ),
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id,
+                status="succeeded",
+                phase=PHASE_NO_OP,
+                exit_code=0,
+                issue_number=issue_number,
+            )
+            return
 
         unmet_criteria = self._agent_unmet_criteria or []
         is_needs_review = bool(unmet_criteria)

--- a/scripts/dispatcher/tests/test_daemon_amend_commit.py
+++ b/scripts/dispatcher/tests/test_daemon_amend_commit.py
@@ -178,9 +178,18 @@ class TestPushAndOpenPrUsesAmend:
             stderr="",
         )
 
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
         with patch(
             "subprocess.run",
-            side_effect=[commit_ok, git_show_empty, push_ok, pr_create_ok],
+            side_effect=[
+                rev_list_ahead,
+                commit_ok,
+                git_show_empty,
+                push_ok,
+                pr_create_ok,
+            ],
         ) as run_mock:
             d._push_and_open_pr(
                 agent_id="amend-test-0000-0000-0000-000000000001",
@@ -249,9 +258,18 @@ class TestPushAndOpenPrUsesAmend:
             stderr="",
         )
 
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
         with patch(
             "subprocess.run",
-            side_effect=[commit_ok, git_show_empty, push_ok, pr_create_ok],
+            side_effect=[
+                rev_list_ahead,
+                commit_ok,
+                git_show_empty,
+                push_ok,
+                pr_create_ok,
+            ],
         ) as run_mock:
             d._push_and_open_pr(
                 agent_id="amend-test-0000-0000-0000-000000000002",
@@ -297,9 +315,18 @@ class TestPushAndOpenPrUsesAmend:
             stderr="",
         )
 
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
         with patch(
             "subprocess.run",
-            side_effect=[commit_ok, git_show_empty, push_ok, pr_create_ok],
+            side_effect=[
+                rev_list_ahead,
+                commit_ok,
+                git_show_empty,
+                push_ok,
+                pr_create_ok,
+            ],
         ):
             d._push_and_open_pr(
                 agent_id="amend-test-0000-0000-0000-000000000003",

--- a/scripts/dispatcher/tests/test_daemon_baseline_clone.py
+++ b/scripts/dispatcher/tests/test_daemon_baseline_clone.py
@@ -240,8 +240,16 @@ class TestEnsureBaselineClone:
         clone_calls = [c for c in calls if c[:2] == ["git", "clone"]]
         assert len(clone_calls) == 1
         clone_cmd = clone_calls[0]
-        assert "--depth=1" in clone_cmd
-        assert "--no-tags" in clone_cmd
+        # Issue #3039: must NOT pass --depth=1 / --no-tags. A shallow
+        # baseline produces orphan-commit PRs on the ralph no-op SHIP
+        # path (``git commit --amend`` against the shallow boundary
+        # commit drops the unreachable parent).
+        assert "--depth=1" not in clone_cmd, (
+            f"Shallow clone regression — --depth=1 re-introduced: {clone_cmd}"
+        )
+        assert "--no-tags" not in clone_cmd, (
+            f"Shallow clone regression — --no-tags re-introduced: {clone_cmd}"
+        )
         assert daemon.BASELINE_CLONE_URL in clone_cmd
         assert str(baseline) in clone_cmd
         # No fetch when the path is missing — clone already pulls main.
@@ -264,7 +272,14 @@ class TestEnsureBaselineClone:
             calls.append(cmd)
             r = MagicMock()
             r.returncode = 0
-            r.stdout = ""
+            # Issue #3039: the unshallow probe runs ``git rev-parse
+            # --is-shallow-repository`` — default to ``false`` so the
+            # unshallow-fetch branch doesn't run in this "already full"
+            # baseline case.
+            if "rev-parse" in cmd and "--is-shallow-repository" in cmd:
+                r.stdout = "false\n"
+            else:
+                r.stdout = ""
             r.stderr = ""
             return r
 
@@ -278,10 +293,14 @@ class TestEnsureBaselineClone:
             for c in calls
             if c[:2] == ["git", "-C"] and "fetch" in c and "origin" in c
         ]
+        # Issue #3039: exactly one fetch — the normal baseline fetch.
+        # The unshallow fetch is gated on the is-shallow probe returning
+        # ``true``, which we mocked to ``false``, so no --unshallow call.
         assert len(fetch_calls) == 1
         fetch_cmd = fetch_calls[0]
         assert fetch_cmd[2] == str(baseline)
         assert fetch_cmd[-2:] == ["origin", "main"]
+        assert "--unshallow" not in fetch_cmd
         # No clone when the path exists.
         assert not any(c[:2] == ["git", "clone"] for c in calls)
 

--- a/scripts/dispatcher/tests/test_daemon_baseline_not_shallow.py
+++ b/scripts/dispatcher/tests/test_daemon_baseline_not_shallow.py
@@ -1,0 +1,421 @@
+"""Unit + integration tests for the non-shallow baseline clone (#3039).
+
+Background
+----------
+Pre-#3039 the daemon cloned the baseline repo with ``git clone
+--depth=1 --no-tags`` (``ensure_baseline_clone`` in
+``scripts/dispatcher/daemon.py``). The resulting shallow clone has a
+single commit with its parent marked unreachable. When ralph's §2.5d
+"no-op guardrail" fires (working tree clean, no commit created on
+top of ``origin/main``), the daemon's pre-#3039 ``_push_and_open_pr``
+unconditionally ran ``git commit --amend -F <msg>`` against HEAD.
+HEAD was the shallow-boundary commit, so the amend dropped the
+parent and produced an orphan/root commit. ``gh pr create`` then
+failed with ``The agent/<short-id> branch has no history in common
+with main``.
+
+Fix
+---
+Drop ``--depth=1`` / ``--no-tags`` from the baseline clone so HEAD
+always has an accessible parent chain, AND add an
+unshallow-on-boot path so pre-existing shallow clones (from
+containers built before the fix) are upgraded in place without a
+full re-clone.
+
+Test coverage
+-------------
+- ``test_fresh_clone_is_full`` (unit) — ``ensure_baseline_clone``
+  does NOT pass ``--depth=1`` / ``--no-tags`` when it clones a fresh
+  baseline.
+- ``test_fresh_clone_integration_not_shallow`` (integration) — the
+  subprocess really runs against a tmp-dir "remote" and the resulting
+  clone reports ``git rev-parse --is-shallow-repository == false``.
+- ``test_unshallow_on_boot`` (integration) — if the on-disk baseline
+  is already shallow, ``ensure_baseline_clone`` upgrades it to a
+  full clone via ``git fetch --unshallow``. Real git, no mocks.
+- ``test_already_full_skips_unshallow`` (unit) — the unshallow path
+  is a no-op when the baseline is already full (no ``--unshallow``
+  fetch).
+- ``test_unshallow_probe_failure_is_soft`` (unit) — a ``git
+  rev-parse`` failure does NOT raise; the method logs a warning and
+  falls through to the normal fetch (best-effort upgrade).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+class _UniqueViolation(Exception):
+    """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — matches the pattern in test_daemon_baseline_clone.py
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+    baseline_repo_root: Path | None,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.noshallow.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+        baseline_repo_root=baseline_repo_root,
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# Unit — fresh clone does NOT pass --depth / --no-tags
+# --------------------------------------------------------------------------
+
+
+class TestFreshCloneIsFull:
+    def test_fresh_clone_omits_shallow_flags(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        baseline = tmp_path / "repo"  # does NOT exist — fresh clone path
+        d, _conn, _handler = _make_daemon(tmp_path, baseline_repo_root=baseline)
+
+        clone_calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            if cmd[:2] == ["git", "clone"]:
+                clone_calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d.ensure_baseline_clone()
+
+        assert len(clone_calls) == 1, (
+            f"Expected exactly one git clone call; got {clone_calls}"
+        )
+        clone_cmd = clone_calls[0]
+        # Issue #3039 core AC — the shallow flags MUST NOT be passed.
+        assert "--depth=1" not in clone_cmd, f"Shallow clone regression: {clone_cmd}"
+        assert not any(a.startswith("--depth") for a in clone_cmd), (
+            f"Any --depth variant is a regression: {clone_cmd}"
+        )
+        assert "--no-tags" not in clone_cmd, f"--no-tags regression: {clone_cmd}"
+        # The clone URL and target path still appear.
+        assert daemon.BASELINE_CLONE_URL in clone_cmd
+        assert str(baseline) in clone_cmd
+
+
+# --------------------------------------------------------------------------
+# Integration — real git, real shallow / non-shallow state transitions
+# --------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    """Run ``git`` with a hermetic env (no global config, no user lookup)."""
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+        }
+    )
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        check=check,
+        env=env,
+    )
+
+
+def _seed_remote(remote_dir: Path, num_commits: int = 3) -> None:
+    """Build a throwaway "remote" bare-ish repo with ``num_commits`` commits
+    on ``main``. Using a non-bare repo with a real working tree keeps the
+    ``git clone`` / ``git fetch --unshallow`` commands simple — they
+    accept a filesystem path as the URL."""
+    remote_dir.mkdir(parents=True)
+    _git(remote_dir, "init", "-b", "main", "--quiet")
+    _git(remote_dir, "config", "commit.gpgsign", "false")
+    _git(remote_dir, "config", "receive.denyCurrentBranch", "ignore")
+    for i in range(num_commits):
+        (remote_dir / f"f{i}.txt").write_text(f"content {i}\n")
+        _git(remote_dir, "add", f"f{i}.txt")
+        _git(remote_dir, "commit", "-m", f"commit {i}", "--quiet")
+
+
+def _is_shallow(repo: Path) -> bool:
+    result = _git(repo, "rev-parse", "--is-shallow-repository", check=False)
+    return (result.stdout or "").strip() == "true"
+
+
+class TestFreshCloneIntegrationNotShallow:
+    """Run ``ensure_baseline_clone`` against a real tmp-dir 'remote' and
+    confirm the resulting clone is NOT shallow.
+
+    No mocks around subprocess; the only stubs are
+    :meth:`_setup_git_credentials` (which otherwise tries to run
+    ``gh auth setup-git``) and the psycopg stub at module load time.
+    """
+
+    def test_real_clone_is_not_shallow(self, monkeypatch: Any, tmp_path: Path) -> None:
+        remote = tmp_path / "remote"
+        _seed_remote(remote, num_commits=3)
+        baseline = tmp_path / "baseline"  # does NOT exist yet
+
+        d, _conn, _handler = _make_daemon(tmp_path, baseline_repo_root=baseline)
+
+        # Swap the clone URL to the tmp-dir "remote" for the duration of
+        # this test — no network, no auth.
+        monkeypatch.setattr(daemon, "BASELINE_CLONE_URL", str(remote))
+        # Skip ``gh auth setup-git`` — no gh on tmp paths.
+        d._setup_git_credentials = lambda: None  # type: ignore[method-assign]
+
+        d.ensure_baseline_clone()
+
+        # Baseline now exists, is a valid git repo, and is NOT shallow.
+        assert (baseline / ".git").exists(), "baseline .git missing after clone"
+        assert not _is_shallow(baseline), (
+            "Fresh clone reported shallow — --depth=1 regression"
+        )
+        # And the full 3-commit history is accessible (the point of the fix).
+        count = _git(baseline, "rev-list", "--count", "HEAD").stdout.strip()
+        assert count == "3", f"Expected 3 commits in full clone; got {count}"
+
+
+class TestUnshallowOnBoot:
+    """Pre-existing shallow baseline → ensure_baseline_clone upgrades to full.
+
+    This mirrors the real-world scenario where a container image built
+    before #3039 has a shallow baseline on ephemeral storage from a prior
+    boot. After the fix lands and the container restarts, the daemon must
+    unshallow that baseline before running any worktree operations that
+    would hit the orphan-commit bug.
+    """
+
+    def test_shallow_baseline_is_unshallowed(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        remote = tmp_path / "remote"
+        _seed_remote(remote, num_commits=4)
+        baseline = tmp_path / "baseline"
+
+        # Simulate the pre-#3039 state: a shallow clone on disk.
+        # ``file://`` forces the non-local protocol so ``--depth=1``
+        # actually produces a shallow repo. A plain filesystem path
+        # uses git's local protocol, which ignores depth limits.
+        _git(
+            tmp_path,
+            "clone",
+            "--depth=1",
+            "--no-tags",
+            f"file://{remote}",
+            str(baseline),
+        )
+        assert _is_shallow(baseline), (
+            "Test setup invariant failed — --depth=1 clone should be shallow"
+        )
+
+        d, _conn, handler = _make_daemon(tmp_path, baseline_repo_root=baseline)
+        # The existing-clone branch runs fetch origin main — point the
+        # origin remote at the local tmp-dir remote (via ``file://`` so
+        # both the unshallow fetch and the follow-up baseline fetch can
+        # reach it) so it succeeds without network.
+        _git(baseline, "remote", "set-url", "origin", f"file://{remote}")
+        d._setup_git_credentials = lambda: None  # type: ignore[method-assign]
+
+        d.ensure_baseline_clone()
+
+        # After the boot path, the baseline is no longer shallow AND
+        # contains all 4 commits from the remote.
+        assert not _is_shallow(baseline), (
+            "Baseline still shallow after ensure_baseline_clone — "
+            "unshallow-on-boot did not run"
+        )
+        count = _git(baseline, "rev-list", "--count", "HEAD").stdout.strip()
+        assert count == "4", (
+            f"Expected all 4 remote commits after unshallow; got {count}"
+        )
+        # The structured log event was emitted so operators can see the
+        # upgrade happened.
+        assert handler.events("baseline_unshallowed"), (
+            "Expected baseline_unshallowed log event"
+        )
+
+
+class TestAlreadyFullSkipsUnshallow:
+    """Unit-level guard — a baseline that's already full must NOT run
+    ``git fetch --unshallow``. A second unshallow is a git error ("fatal:
+    --unshallow on a complete repository does not make sense") but more
+    importantly it wastes a subprocess + remote round-trip."""
+
+    def test_full_baseline_no_unshallow_fetch(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        baseline = tmp_path / "baseline"
+        (baseline / ".git").mkdir(parents=True)
+        d, _conn, handler = _make_daemon(tmp_path, baseline_repo_root=baseline)
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            calls.append(cmd)
+            r = MagicMock()
+            r.returncode = 0
+            # The probe asks "is this shallow?" → "false" (already full).
+            if "rev-parse" in cmd and "--is-shallow-repository" in cmd:
+                r.stdout = "false\n"
+            else:
+                r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d.ensure_baseline_clone()
+
+        # No ``fetch --unshallow`` call.
+        unshallow_calls = [c for c in calls if "--unshallow" in c]
+        assert unshallow_calls == [], (
+            f"Unshallow fetched on an already-full clone: {unshallow_calls}"
+        )
+        # And no event — the common case stays quiet.
+        assert handler.events("baseline_unshallowed") == []
+
+
+class TestUnshallowProbeFailureIsSoft:
+    """A rev-parse probe failure must log a warning and fall through to
+    the normal fetch — the unshallow path is best-effort, NOT a blocker
+    for daemon boot.
+
+    Rationale: the baseline-fetch call right after will surface a real
+    connectivity / auth problem and raise RuntimeError. A probe failure
+    at startup (very rare in practice) shouldn't block the daemon from
+    trying the normal boot path.
+    """
+
+    def test_probe_nonzero_exit_does_not_raise(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        baseline = tmp_path / "baseline"
+        (baseline / ".git").mkdir(parents=True)
+        d, _conn, handler = _make_daemon(tmp_path, baseline_repo_root=baseline)
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            calls.append(cmd)
+            r = MagicMock()
+            if "rev-parse" in cmd and "--is-shallow-repository" in cmd:
+                # Probe fails — fail-soft branch.
+                r.returncode = 128
+                r.stdout = ""
+                r.stderr = "fatal: not a git repository\n"
+                return r
+            r.returncode = 0
+            r.stdout = ""
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        # Should not raise.
+        d.ensure_baseline_clone()
+
+        # Warning event was emitted so the operator sees something went wrong.
+        assert handler.events("baseline_unshallow_probe_failed") != [], (
+            "Expected a probe-failure warning log event"
+        )
+        # No --unshallow attempted after the probe failed.
+        assert not any("--unshallow" in c for c in calls), (
+            f"Unshallow ran despite probe failure: {calls}"
+        )

--- a/scripts/dispatcher/tests/test_daemon_milestone_columns.py
+++ b/scripts/dispatcher/tests/test_daemon_milestone_columns.py
@@ -416,9 +416,12 @@ class TestSelfDeployDetectionPrePush:
 
         from unittest.mock import patch
 
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
         with patch(
             "subprocess.run",
-            side_effect=[commit_ok, git_show, push_ok, pr_create_ok],
+            side_effect=[rev_list_ahead, commit_ok, git_show, push_ok, pr_create_ok],
         ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=2953, worktree=worktree)
 
@@ -486,9 +489,12 @@ class TestSelfDeployDetectionPrePush:
 
         from unittest.mock import patch
 
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
         with patch(
             "subprocess.run",
-            side_effect=[commit_ok, git_show, push_ok, pr_create_ok],
+            side_effect=[rev_list_ahead, commit_ok, git_show, push_ok, pr_create_ok],
         ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=42, worktree=worktree)
 
@@ -544,9 +550,18 @@ class TestSelfDeployDetectionPrePush:
 
         from unittest.mock import patch
 
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
         with patch(
             "subprocess.run",
-            side_effect=[commit_ok, git_show_fail, push_ok, pr_create_ok],
+            side_effect=[
+                rev_list_ahead,
+                commit_ok,
+                git_show_fail,
+                push_ok,
+                pr_create_ok,
+            ],
         ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=50, worktree=worktree)
 

--- a/scripts/dispatcher/tests/test_daemon_push_and_pr_noop.py
+++ b/scripts/dispatcher/tests/test_daemon_push_and_pr_noop.py
@@ -1,0 +1,470 @@
+"""Unit + integration tests for the ralph no-op SHIP path in
+``_push_and_open_pr`` (#3039).
+
+Background
+----------
+Ralph's §2.5d "no-op guardrail" skips the pre-push commit when the
+worktree is clean at SHIP time — data-only / no-code-change tasks
+whose deliverable is ralph's evidence comment on the issue. The
+branch tip stays at ``origin/main`` (``git rev-list --count
+origin/main..HEAD == 0``).
+
+Pre-#3039 the daemon's ``_push_and_open_pr`` did not check for this
+state. It unconditionally ran ``git commit --amend -F <message
+file>`` against ``HEAD``. Combined with the shallow baseline clone,
+this produced an orphan commit; ``gh pr create`` then failed with
+"no history in common with main".
+
+Fix: detect the no-op path at the top of ``_push_and_open_pr`` via
+``git rev-list --count origin/main..HEAD`` and terminate the agent
+cleanly as ``status='succeeded', phase=PHASE_NO_OP``. No amend, no
+push, no PR.
+
+Test coverage
+-------------
+- ``test_rev_list_zero_short_circuits`` — unit: when ``git rev-list
+  --count`` returns ``0``, the method does NOT run ``git commit``,
+  ``git push``, or ``gh pr create``. Only ONE subprocess call fires
+  (the rev-list probe itself).
+- ``test_noop_marks_agent_succeeded_with_phase_no_op`` — unit: the
+  terminal status is ``succeeded`` and the phase is ``PHASE_NO_OP``.
+- ``test_noop_emits_push_and_pr_skipped_no_op_event`` — unit: a
+  structured log event ``push_and_pr_skipped_no_op`` is emitted with
+  the agent id and issue number.
+- ``test_noop_does_not_invoke_delete_ralph_patches`` — unit: the
+  ralph-patch cleanup runs only on the "PR opened" path; a no-op
+  terminal must NOT touch persisted ralph patches (there's nothing
+  to clean; the issue's evidence comment is the artifact).
+- ``test_normal_ship_path_unaffected`` — unit: with rev-list
+  returning ``1``, the method continues through commit/push/PR
+  exactly as before. Smoke test to pin the non-no-op regression path.
+- ``test_noop_integration_no_subprocess_side_effects`` — integration:
+  a real on-disk git repo with zero commits ahead of ``origin/main``
+  exercises the full method; ``_mark_agent_terminal`` is stubbed so
+  we can assert the terminal transition.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+class _UniqueViolation(Exception):
+    """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — mirror the pattern in test_daemon_push_failed.py
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.noopship.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+
+    # Supply the summary output so the non-no-op path has everything it
+    # needs to run (defensive — individual tests only exercise the no-op
+    # path where this data is never read).
+    d._agent_summary_output = {  # type: ignore[attr-defined]
+        "commit_message": "feat(dispatcher): test (#3039)",
+        "pr_title": "feat(dispatcher): test (#3039)",
+        "pr_body_md": "body",
+    }
+    d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+    d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+    d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+    d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
+    d._delete_ralph_patches_for_agent = MagicMock()  # type: ignore[method-assign]
+
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# Unit — no-op SHIP short-circuits commit/push/PR
+# --------------------------------------------------------------------------
+
+
+class TestNoOpShipShortCircuits:
+    def test_rev_list_zero_short_circuits(self, tmp_path: Path) -> None:
+        """``git rev-list --count origin/main..HEAD == 0`` → no commit,
+        no push, no PR. Only the probe subprocess fires."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        rev_list_zero = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="0\n", stderr=""
+        )
+
+        with patch("subprocess.run", side_effect=[rev_list_zero]) as run_mock:
+            d._push_and_open_pr(
+                agent_id="noop-test-0000-0000-0000-000000000001",
+                issue_number=2626,
+                worktree=worktree,
+            )
+
+        # Exactly one subprocess call — the rev-list probe. No commit /
+        # push / gh pr create ran.
+        assert len(run_mock.call_args_list) == 1, (
+            "Expected exactly one subprocess call on no-op SHIP; "
+            f"got {[c.args[0] for c in run_mock.call_args_list]}"
+        )
+        argv = run_mock.call_args_list[0].args[0]
+        assert "rev-list" in argv, f"Expected rev-list probe; got {argv}"
+        assert "origin/main..HEAD" in argv
+
+    def test_noop_marks_agent_succeeded_with_phase_no_op(self, tmp_path: Path) -> None:
+        """Terminal: status='succeeded', phase=PHASE_NO_OP.
+
+        Chosen over ``verify_skip_reason='no_op'`` because the no-op
+        path never produces a PR; ``verify_skip_reason`` is a signal
+        that applies after a PR merges (see issue #2953 docstring on
+        ``dispatcher.agents.verify_skip_reason``).
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        rev_list_zero = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="0\n", stderr=""
+        )
+
+        with patch("subprocess.run", side_effect=[rev_list_zero]):
+            d._push_and_open_pr(
+                agent_id="noop-test-0000-0000-0000-000000000002",
+                issue_number=2626,
+                worktree=worktree,
+            )
+
+        d._mark_agent_terminal.assert_called_once()
+        kwargs = d._mark_agent_terminal.call_args.kwargs
+        args = d._mark_agent_terminal.call_args.args
+        # The call uses kwargs-only so both the positional agent_id and
+        # the keyword-only status/phase are set.
+        assert args[0] == "noop-test-0000-0000-0000-000000000002"
+        assert kwargs["status"] == "succeeded", (
+            f"Expected status='succeeded'; got {kwargs.get('status')!r}"
+        )
+        assert kwargs["phase"] == daemon.PHASE_NO_OP, (
+            f"Expected phase=PHASE_NO_OP; got {kwargs.get('phase')!r}"
+        )
+        assert kwargs["exit_code"] == 0
+        assert kwargs["issue_number"] == 2626
+
+    def test_noop_emits_push_and_pr_skipped_no_op_event(self, tmp_path: Path) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        rev_list_zero = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="0\n", stderr=""
+        )
+
+        with patch("subprocess.run", side_effect=[rev_list_zero]):
+            d._push_and_open_pr(
+                agent_id="noop-test-0000-0000-0000-000000000003",
+                issue_number=7777,
+                worktree=worktree,
+            )
+
+        events = handler.events("push_and_pr_skipped_no_op")
+        assert events, "Expected a push_and_pr_skipped_no_op log event; got none"
+        event = events[0]
+        assert getattr(event, "issue_number", None) == 7777
+        assert getattr(event, "agent_id", None) == (
+            "noop-test-0000-0000-0000-000000000003"
+        )
+
+    def test_noop_does_not_invoke_delete_ralph_patches(self, tmp_path: Path) -> None:
+        """The ralph-patch delete helper runs on the PR-opened path
+        (after ``gh pr create`` succeeds, #3012). A no-op SHIP opens no
+        PR, so the helper must NOT be called."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        rev_list_zero = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="0\n", stderr=""
+        )
+
+        with patch("subprocess.run", side_effect=[rev_list_zero]):
+            d._push_and_open_pr(
+                agent_id="noop-test-0000-0000-0000-000000000004",
+                issue_number=42,
+                worktree=worktree,
+            )
+
+        d._delete_ralph_patches_for_agent.assert_not_called()
+
+    def test_noop_does_not_write_commit_message_file(self, tmp_path: Path) -> None:
+        """A downstream sanity check — the commit message file is
+        written just before the amend call. A no-op short-circuit
+        MUST return before that write so we don't leave a stale
+        file behind in the worktree tmp/ dir."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        rev_list_zero = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="0\n", stderr=""
+        )
+
+        with patch("subprocess.run", side_effect=[rev_list_zero]):
+            d._push_and_open_pr(
+                agent_id="noop-test-0000-0000-0000-000000000005",
+                issue_number=42,
+                worktree=worktree,
+            )
+
+        # ``tmp/commit_msg.txt`` would be written by the amend path
+        # (``commit_msg_path.write_text(commit_message)``). No write =>
+        # the file does not exist.
+        assert not (worktree / "tmp" / "commit_msg.txt").exists()
+
+
+# --------------------------------------------------------------------------
+# Unit — the normal SHIP path (rev-list > 0) is unaffected
+# --------------------------------------------------------------------------
+
+
+class TestNormalShipPathUnaffected:
+    def test_rev_list_positive_runs_full_flow(self, tmp_path: Path) -> None:
+        """Smoke test: when rev-list reports 1 commit ahead, the method
+        proceeds through commit → git show → push → gh pr create."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir()
+
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
+        )
+        git_show_empty = subprocess.CompletedProcess(
+            args=["git", "show"], returncode=0, stdout="", stderr=""
+        )
+        push_ok = subprocess.CompletedProcess(
+            args=["git", "push"], returncode=0, stdout="", stderr=""
+        )
+        pr_create_ok = subprocess.CompletedProcess(
+            args=["gh", "pr", "create"],
+            returncode=0,
+            stdout="https://github.com/judgemind/judgemind/pull/9999\n",
+            stderr="",
+        )
+
+        with patch(
+            "subprocess.run",
+            side_effect=[
+                rev_list_ahead,
+                commit_ok,
+                git_show_empty,
+                push_ok,
+                pr_create_ok,
+            ],
+        ) as run_mock:
+            d._push_and_open_pr(
+                agent_id="normal-ship-0000-0000-0000-000000000001",
+                issue_number=9999,
+                worktree=worktree,
+            )
+
+        # All five subprocess calls fired in order.
+        argvs = [call.args[0] for call in run_mock.call_args_list]
+        assert len(argvs) == 5, (
+            f"Expected 5 subprocess calls on normal SHIP; got {argvs}"
+        )
+        assert "rev-list" in argvs[0]
+        assert "commit" in argvs[1] and "--amend" in argvs[1]
+        assert "show" in argvs[2]
+        assert "push" in argvs[3]
+        assert argvs[4][:3] == ["gh", "pr", "create"]
+
+        # No push_and_pr_skipped_no_op event on the normal path.
+        # (The method transitions to awaiting_ci via _mark_agent_terminal
+        # on the normal path.)
+        d._mark_agent_terminal.assert_called_once()
+        kwargs = d._mark_agent_terminal.call_args.kwargs
+        assert kwargs["status"] == "running", (
+            "Normal SHIP keeps status=running for Phase 3B pickup"
+        )
+        assert kwargs["phase"] == "awaiting_ci", (
+            f"Normal SHIP transitions to awaiting_ci; got {kwargs['phase']!r}"
+        )
+
+
+# --------------------------------------------------------------------------
+# Integration — real git repo, real rev-list semantics
+# --------------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+        }
+    )
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        check=check,
+        env=env,
+    )
+
+
+class TestNoOpIntegration:
+    """Real git repo, real subprocess calls. ``_push_and_open_pr`` sees
+    HEAD == origin/main and short-circuits."""
+
+    def test_real_rev_list_zero_short_circuits(self, tmp_path: Path) -> None:
+        # Seed a local repo that will play the role of the worktree.
+        worktree = tmp_path / "worktree"
+        worktree.mkdir()
+        _git(worktree, "init", "-b", "main", "--quiet")
+        _git(worktree, "config", "commit.gpgsign", "false")
+        (worktree / "README.md").write_text("# seed\n")
+        _git(worktree, "add", "README.md")
+        _git(worktree, "commit", "-m", "seed", "--quiet")
+
+        # Create an ``origin/main`` ref that points at HEAD — so
+        # ``git rev-list --count origin/main..HEAD`` returns 0.
+        head_sha = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+        _git(
+            worktree,
+            "update-ref",
+            "refs/remotes/origin/main",
+            head_sha,
+        )
+
+        # Sanity: confirm the setup invariant.
+        ahead = _git(
+            worktree, "rev-list", "--count", "origin/main..HEAD"
+        ).stdout.strip()
+        assert ahead == "0", f"test setup failed: rev-list says {ahead!r}"
+
+        # tmp/ for commit message file (daemon would create it otherwise).
+        (worktree / "tmp").mkdir()
+
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        # No subprocess mocking — real git runs against the real repo.
+        d._push_and_open_pr(
+            agent_id="int-noop-0000-0000-0000-000000000001",
+            issue_number=3039,
+            worktree=worktree,
+        )
+
+        # Terminal: succeeded + PHASE_NO_OP.
+        d._mark_agent_terminal.assert_called_once()
+        kwargs = d._mark_agent_terminal.call_args.kwargs
+        assert kwargs["status"] == "succeeded"
+        assert kwargs["phase"] == daemon.PHASE_NO_OP
+
+        # No commit_msg.txt written (short-circuit before the amend).
+        assert not (worktree / "tmp" / "commit_msg.txt").exists()
+
+        # Structured log event emitted.
+        assert handler.events("push_and_pr_skipped_no_op") != []

--- a/scripts/dispatcher/tests/test_daemon_push_failed.py
+++ b/scripts/dispatcher/tests/test_daemon_push_failed.py
@@ -295,15 +295,23 @@ class TestGitPushFailedWritesFailureRow:
         worktree.mkdir()
         (worktree / "tmp").mkdir()
 
+        # Issue #3039: ``_push_and_open_pr`` runs ``git rev-list
+        # --count origin/main..HEAD`` at the top to detect ralph's
+        # no-op SHIP path. A ``stdout="1\n"`` means one commit ahead
+        # (normal SHIP), so the method proceeds to the commit+push
+        # path under test.
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
         # Issue #2953: ``_push_and_open_pr`` runs ``git show
         # --name-only HEAD`` between commit and push to detect
-        # dispatcher-self-PRs. The third entry below answers that
+        # dispatcher-self-PRs. The entry below answers that
         # call with an empty file list (no self-deploy detected) so
         # the test's push-failed path is unaffected.
         git_show_empty = subprocess.CompletedProcess(
             args=["git", "show"], returncode=0, stdout="", stderr=""
         )
-        run_side_effects = [commit_ok, git_show_empty, push_fail]
+        run_side_effects = [rev_list_ahead, commit_ok, git_show_empty, push_fail]
         with patch("subprocess.run", side_effect=run_side_effects):
             d._push_and_open_pr(
                 agent_id=agent_id,
@@ -361,6 +369,11 @@ class TestGitPushFailedWritesFailureRow:
         worktree.mkdir()
         (worktree / "tmp").mkdir()
 
+        # Issue #3039: rev-list probe at the top — return "1" ahead so
+        # the no-op guardrail does not short-circuit.
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
         # Issue #2953: inject a no-op ``git show --name-only HEAD``
         # between commit and push for the self-deploy detection step.
         git_show_empty = subprocess.CompletedProcess(
@@ -368,7 +381,7 @@ class TestGitPushFailedWritesFailureRow:
         )
         with patch(
             "subprocess.run",
-            side_effect=[commit_ok, git_show_empty, push_fail],
+            side_effect=[rev_list_ahead, commit_ok, git_show_empty, push_fail],
         ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=99, worktree=worktree)
 
@@ -419,6 +432,11 @@ class TestGitPushFailedWritesPhaseOutputRow:
         worktree.mkdir()
         (worktree / "tmp").mkdir()
 
+        # Issue #3039: rev-list probe at the top — return "1" ahead so
+        # the no-op guardrail does not short-circuit.
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
         # Issue #2953: inject a no-op ``git show --name-only HEAD``
         # between commit and push for the self-deploy detection step.
         git_show_empty = subprocess.CompletedProcess(
@@ -426,7 +444,7 @@ class TestGitPushFailedWritesPhaseOutputRow:
         )
         with patch(
             "subprocess.run",
-            side_effect=[commit_ok, git_show_empty, push_fail],
+            side_effect=[rev_list_ahead, commit_ok, git_show_empty, push_fail],
         ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=7, worktree=worktree)
 

--- a/scripts/dispatcher/tests/test_daemon_ralph_patches.py
+++ b/scripts/dispatcher/tests/test_daemon_ralph_patches.py
@@ -851,9 +851,18 @@ class TestPushAndOpenPrDeletesRalphPatch:
             stderr="",
         )
 
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
         with patch(
             "subprocess.run",
-            side_effect=[commit_ok, git_show_empty, push_ok, pr_create_ok],
+            side_effect=[
+                rev_list_ahead,
+                commit_ok,
+                git_show_empty,
+                push_ok,
+                pr_create_ok,
+            ],
         ):
             d._push_and_open_pr(
                 agent_id=agent_id,
@@ -901,8 +910,12 @@ class TestPushAndOpenPrDeletesRalphPatch:
             stderr="fatal: unable to access",
         )
 
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
         with patch(
-            "subprocess.run", side_effect=[commit_ok, git_show_empty, push_fail]
+            "subprocess.run",
+            side_effect=[rev_list_ahead, commit_ok, git_show_empty, push_fail],
         ):
             d._push_and_open_pr(
                 agent_id=agent_id,


### PR DESCRIPTION
## Summary

Two targeted fixes in `scripts/dispatcher/daemon.py` behind the orphan-commit bug observed on agent `0da2ab18` / #2626:

- **Fix (a)** — `ensure_baseline_clone` no longer passes `--depth=1` / `--no-tags`. A new `_unshallow_baseline_if_needed` method upgrades pre-existing shallow baselines in place (`git rev-parse --is-shallow-repository` → `git fetch --unshallow origin main`) so container images built before this fix recover on their next boot without a full re-clone.
- **Fix (c)** — `_push_and_open_pr` now starts with `_is_noop_ship` which detects ralph's §2.5d no-op guardrail (`git rev-list --count origin/main..HEAD == 0`). On detection: emit `daemon.push_and_pr_skipped_no_op` and mark the agent `status='succeeded', phase=PHASE_NO_OP`. No amend, no push, no PR — ralph's evidence comment on the issue is the deliverable.

### Terminal-status design choice: `phase='no_op'`

Picked `phase='no_op'` (new `PHASE_NO_OP` constant) over `verify_skip_reason='no_op'`. Reasoning:

- `dispatcher.agents.verify_skip_reason` is documented (packages/api schema + `packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx`) as a **post-merge** signal. It only changes the outcome-pill tooltip when `mergedAt` is non-null (the "shipped + verify does not apply" case, #2953).
- A no-op SHIP opens no PR, so `mergedAt` stays null and the cockpit takes the "no mergedAt → status-only pill" branch. A `verify_skip_reason` set on a row with null `mergedAt` would never render.
- `phase='no_op'` is a clean, grep-able terminal that composes with the existing "succeeded + null mergedAt → green ✓" cockpit path without introducing a third display branch. Operators can filter with `WHERE phase = 'no_op'` to count data-only successes.

Status remains `succeeded` (exit_code 0, ended_at set) — the green ✓ glyph is correct because the agent completed its deliverable (ralph's evidence comment on the issue).

Closes #3039

## Test plan

### Automated checks
- [x] Lint passes (`ruff check` on touched files — all green locally)
- [x] Format check passes (`ruff format --check` — all green locally)
- [x] Tests pass (`pytest scripts/dispatcher/tests/`: 979 passed, 1 skipped locally)
- [x] CI green

### New test coverage
- `test_daemon_baseline_not_shallow.py` — unit + integration: fresh clone omits `--depth`/`--no-tags`, real clone is non-shallow, pre-existing shallow baseline is unshallowed on boot (real git repo against a `file://` remote), already-full baselines skip unshallow, probe failures are soft.
- `test_daemon_push_and_pr_noop.py` — unit + integration: rev-list == 0 short-circuits with exactly one subprocess call, terminal is `succeeded`/`PHASE_NO_OP`, event is emitted, ralph-patch delete is NOT called, commit message file is NOT written; normal SHIP path (rev-list > 0) unaffected; real-git integration with a seeded `origin/main` pointing at HEAD.

### Regression test mock updates (six files)
- `test_daemon_amend_commit.py`, `test_daemon_push_failed.py`, `test_daemon_milestone_columns.py`, `test_daemon_ralph_patches.py` — prepend a `rev_list_ahead` result (`stdout="1\n"`) to each `subprocess.run` side-effect list so the new probe is answered "1 ahead" (non-no-op) and the pre-existing commit/push/PR mock sequence runs unchanged.
- `test_daemon_baseline_clone.py` — asserts shallow flags are absent from the clone argv, and the existing-path test answers the new `rev-parse --is-shallow-repository` probe with `"false\n"` so the unshallow branch does not run.

### Post-deploy verification
- [x] dispatcher-deploy-dev workflow green (run 24815609496, deployed at 2026-04-23T03:53Z)
- [x] Dev `/ecs/judgemind-dispatcher-dev` logs show `baseline_clone_ready` on container restart with `action=clone` (fresh full clone completed in ~3s with the new non-shallow command)
- [ ] Next data-only / no-op task emits `push_and_pr_skipped_no_op` and the row lands `phase='no_op'`, `status='succeeded'` — awaits a live agent exercising the path; unit-tested via `test_daemon_push_and_pr_noop.py`
- [x] No `pr_create_failed` rows with "no history in common with main" after deploy (CloudWatch Insights query returned 0 records)
- [x] Verification evidence posted on issue #3039
