### PR TITLE
fix(dispatcher): retry _gh_issue_is_open on transient gh flakes (#3053)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -406,8 +406,11 @@ DEPLOY_WORKFLOW_NAMES = frozenset(
 #: / ``gh pr merge`` / ``gh issue comment`` subprocess calls used by
 #: ``_advance_running_agents``. Short enough to avoid leaking a
 #: supervisor tick (120s default) if GitHub is slow, long enough that
-#: a normal call (<3s) always finishes.
-GH_POLL_SUBPROCESS_TIMEOUT_SECONDS = 15
+#: a normal call (<3s) always finishes. Bumped from 15s → 30s (#3053)
+#: after observing ``_gh_issue_is_open`` timing out at 15s during the
+#: dispatcher's background gh traffic spikes and silently falling
+#: back to escalate in ``_consume_action_block_on_existing_task``.
+GH_POLL_SUBPROCESS_TIMEOUT_SECONDS = 30
 
 #: Cap on how many ``failing_jobs`` entries we hand the fix-ci skill.
 #: Ten is already an unusually bad CI day and keeps the JSON payload
@@ -15400,7 +15403,32 @@ class DispatcherDaemon:
                 reasoning=reasoning,
             )
             return
-        if not self._gh_issue_is_open(blocker_issue_number):
+        is_open, is_open_detail = self._gh_issue_is_open_with_detail(
+            blocker_issue_number
+        )
+        if not is_open:
+            # Issue #3053 — emit a distinct WARNING so the silent
+            # fallback to escalate is visible in CloudWatch. Without
+            # this, a transient ``gh`` flake on the blocker probe is
+            # indistinguishable from the diagnoser choosing escalate
+            # and burns a ralph budget on every re-pick.
+            self._log.warning(
+                "block_on_existing_task validation failed for issue #%s "
+                "(blocker=#%s, attempts=%d, reason=%s) — falling back to escalate",
+                issue_number,
+                blocker_issue_number,
+                is_open_detail.get("attempts"),
+                is_open_detail.get("reason"),
+                extra={
+                    "event": "block_on_existing_task_validation_failed",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "blocker_issue_number": blocker_issue_number,
+                    "attempts": is_open_detail.get("attempts"),
+                    "reason": is_open_detail.get("reason"),
+                    "stderr_tail": is_open_detail.get("stderr_tail"),
+                },
+            )
             fallback_reasoning = (
                 f"{reasoning}\n\n"
                 f"_Diagnoser proposed `block_on_existing_task` "
@@ -15884,6 +15912,119 @@ class DispatcherDaemon:
         validate the diagnoser-proposed blocker before wiring up the
         dependency. Any read failure (not-found, transient gh error)
         returns False — the caller will fall back to escalate.
+
+        Thin wrapper over :meth:`_gh_issue_is_open_with_detail` that
+        discards the attempt count / failure reason. Prefer the detail
+        variant in call sites that need to emit a fallback WARNING
+        with the probe's final outcome (see
+        ``_consume_action_block_on_existing_task``). See issue #3053
+        for the retry-logic rationale.
+        """
+        is_open, _detail = self._gh_issue_is_open_with_detail(issue_number)
+        return is_open
+
+    def _gh_issue_is_open_with_detail(
+        self, issue_number: int
+    ) -> tuple[bool, dict[str, Any]]:
+        """Return ``(is_open, detail)`` with retry + flake logging.
+
+        Issue #3053 — retry on transient ``gh`` failures
+        (``TimeoutExpired`` or non-zero exit) up to 3 attempts total
+        with 1s + 2s backoff. The fallback path in
+        :meth:`_consume_action_block_on_existing_task` is destructive
+        (the agent terminates as ``diagnoser_escalate`` and
+        ``agent/ready`` gets re-added, so the daemon re-picks the
+        issue on the next cooldown tick). A single flaky ``gh`` call
+        should not tip a correct-by-diagnoser decision into a wrong-
+        action no-op. Emits a WARNING per failed attempt so operators
+        can see the flake pattern, and a final WARNING if all three
+        attempts exhaust. A genuine not-found (``returncode != 0``
+        with stderr indicating the issue doesn't exist) still pays
+        the 3-attempt cost — we can't distinguish "issue doesn't
+        exist" from "API is flaky" at the ``gh`` level, but the
+        block-on-existing-task path runs at most once per diagnosis
+        and the extra ~3s is negligible against the alternative
+        (burning a full ralph budget on a wrong action).
+
+        ``detail`` is a dict with ``attempts`` (int, always 1..3),
+        ``reason`` (str or None — None on success, token like
+        ``"timeout"`` / ``"nonzero_exit"`` / ``"json_parse"`` /
+        ``"gh_missing"`` on failure), and ``stderr_tail`` (str, last
+        ~200 chars of the final attempt's stderr or empty).
+        """
+        backoffs_seconds: tuple[float, ...] = (1.0, 2.0)
+        max_attempts = 1 + len(backoffs_seconds)  # 3
+        last_outcome: dict[str, Any] = {}
+        for attempt in range(1, max_attempts + 1):
+            outcome = self._gh_issue_is_open_once(issue_number)
+            last_outcome = outcome
+            if outcome.get("ok"):
+                # Terminal success (state determined, OPEN or CLOSED).
+                return (
+                    bool(outcome.get("is_open")),
+                    {
+                        "attempts": attempt,
+                        "reason": None,
+                        "stderr_tail": "",
+                    },
+                )
+            # Transient failure — log and (if attempts remain) back off.
+            self._log.warning(
+                "gh issue is-open probe failed (attempt %d/%d) for issue #%s: %s",
+                attempt,
+                max_attempts,
+                issue_number,
+                outcome.get("reason"),
+                extra={
+                    "event": "gh_issue_is_open_flake",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "attempt": attempt,
+                    "max_attempts": max_attempts,
+                    "reason": outcome.get("reason"),
+                    "stderr_tail": outcome.get("stderr_tail"),
+                },
+            )
+            if attempt < max_attempts:
+                time.sleep(backoffs_seconds[attempt - 1])
+        # All attempts exhausted — emit a final WARNING and return False.
+        self._log.warning(
+            "gh issue is-open probe exhausted %d attempts for issue #%s — "
+            "returning False (will fall back to escalate)",
+            max_attempts,
+            issue_number,
+            extra={
+                "event": "gh_issue_is_open_exhausted",
+                "run_id": self._run_id,
+                "issue_number": issue_number,
+                "attempts": max_attempts,
+                "reason": last_outcome.get("reason"),
+                "stderr_tail": last_outcome.get("stderr_tail"),
+            },
+        )
+        return (
+            False,
+            {
+                "attempts": max_attempts,
+                "reason": last_outcome.get("reason"),
+                "stderr_tail": last_outcome.get("stderr_tail") or "",
+            },
+        )
+
+    def _gh_issue_is_open_once(self, issue_number: int) -> dict[str, Any]:
+        """Single ``gh issue view`` probe — return structured outcome.
+
+        Helper for :meth:`_gh_issue_is_open`'s retry loop. Never raises.
+        Return shape:
+
+        - ``{"ok": True, "is_open": bool}`` — ``gh`` returned cleanly;
+          ``is_open`` reflects the parsed state.
+        - ``{"ok": False, "reason": str, "stderr_tail": str}`` —
+          transient failure worth retrying (timeout, non-zero exit,
+          JSON parse error). ``reason`` is a short token
+          (``"timeout"`` / ``"nonzero_exit"`` / ``"json_parse"`` /
+          ``"gh_missing"``). ``stderr_tail`` is the last ~200 chars
+          of stderr when applicable, for operator-visible context.
         """
         try:
             result = subprocess.run(
@@ -15902,17 +16043,29 @@ class DispatcherDaemon:
                 timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
                 check=False,
             )
-        except (FileNotFoundError, subprocess.TimeoutExpired):
-            return False
+        except FileNotFoundError:
+            return {"ok": False, "reason": "gh_missing", "stderr_tail": ""}
+        except subprocess.TimeoutExpired:
+            return {"ok": False, "reason": "timeout", "stderr_tail": ""}
         if result.returncode != 0:
-            return False
+            stderr_tail = (result.stderr or "")[-200:]
+            return {
+                "ok": False,
+                "reason": "nonzero_exit",
+                "stderr_tail": stderr_tail,
+            }
         try:
             payload = json.loads(result.stdout or "{}")
         except json.JSONDecodeError:
-            return False
+            stdout_tail = (result.stdout or "")[-200:]
+            return {
+                "ok": False,
+                "reason": "json_parse",
+                "stderr_tail": stdout_tail,
+            }
         # gh reports state as "OPEN" / "CLOSED".
         state = str(payload.get("state") or "").upper()
-        return state == "OPEN"
+        return {"ok": True, "is_open": state == "OPEN"}
 
     def _run_diagnoser_pass(self) -> int:
         """Find tier-2/3 candidates, spawn diagnosers, consume recommendations.

--- a/scripts/dispatcher/tests/test_daemon_diagnoser_routing.py
+++ b/scripts/dispatcher/tests/test_daemon_diagnoser_routing.py
@@ -532,7 +532,11 @@ class TestBlockOnExistingTaskHandler:
     def test_validates_blocker_and_appends_body(self) -> None:
         d = _make_daemon()
         with (
-            patch.object(d, "_gh_issue_is_open", return_value=True),
+            patch.object(
+                d,
+                "_gh_issue_is_open_with_detail",
+                return_value=(True, {"attempts": 1, "reason": None, "stderr_tail": ""}),
+            ),
             patch.object(d, "_gh_issue_comment") as mock_comment,
             patch.object(d, "_gh_issue_append_body") as mock_append,
             patch.object(d, "_gh_issue_add_labels") as mock_add,
@@ -555,7 +559,14 @@ class TestBlockOnExistingTaskHandler:
     def test_invalid_blocker_falls_back_to_escalate(self) -> None:
         d = _make_daemon()
         with (
-            patch.object(d, "_gh_issue_is_open", return_value=False),
+            patch.object(
+                d,
+                "_gh_issue_is_open_with_detail",
+                return_value=(
+                    False,
+                    {"attempts": 3, "reason": "timeout", "stderr_tail": ""},
+                ),
+            ),
             patch.object(d, "_consume_action_escalate") as mock_esc,
             patch.object(d, "_gh_issue_append_body") as mock_append,
         ):
@@ -567,6 +578,80 @@ class TestBlockOnExistingTaskHandler:
             )
         mock_esc.assert_called_once()
         mock_append.assert_not_called()
+
+    def test_invalid_blocker_emits_validation_failed_warning(self, caplog: Any) -> None:
+        """Issue #3053 — the silent fallback to escalate is now visible
+        via a distinct WARNING event carrying the blocker number,
+        current issue number, and the is-open probe's attempt count.
+        """
+        d = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon")
+        with (
+            patch.object(
+                d,
+                "_gh_issue_is_open_with_detail",
+                return_value=(
+                    False,
+                    {"attempts": 3, "reason": "timeout", "stderr_tail": ""},
+                ),
+            ),
+            patch.object(d, "_consume_action_escalate") as mock_esc,
+        ):
+            d._consume_action_block_on_existing_task(
+                agent_id="agent-1",
+                issue_number=3008,
+                blocker_issue_number=9999,
+                reasoning="blocker probe timed out",
+            )
+        mock_esc.assert_called_once()
+        # The new WARNING event fires exactly once on the fallback path.
+        validation_records = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "block_on_existing_task_validation_failed"
+        ]
+        assert len(validation_records) == 1
+        rec = validation_records[0]
+        assert rec.levelno == logging.WARNING
+        assert rec.issue_number == 3008
+        assert rec.blocker_issue_number == 9999
+        assert rec.attempts == 3
+        assert rec.reason == "timeout"
+
+    def test_agent_terminates_as_escalate_when_validation_fails(self) -> None:
+        """Issue #3053 — the fallback path must still terminate the
+        agent via ``_consume_action_escalate`` (which marks the agent
+        ``diagnoser_escalate``). The new WARNING is additive; it does
+        not change the control flow.
+        """
+        d = _make_daemon()
+        with (
+            patch.object(
+                d,
+                "_gh_issue_is_open_with_detail",
+                return_value=(
+                    False,
+                    {"attempts": 3, "reason": "timeout", "stderr_tail": ""},
+                ),
+            ),
+            patch.object(d, "_consume_action_escalate") as mock_esc,
+            patch.object(d, "_gh_issue_comment") as mock_comment,
+            patch.object(d, "_gh_issue_append_body") as mock_append,
+            patch.object(d, "_gh_issue_add_labels") as mock_add,
+            patch.object(d, "_gh_issue_remove_labels") as mock_remove,
+        ):
+            d._consume_action_block_on_existing_task(
+                agent_id="agent-1",
+                issue_number=3008,
+                blocker_issue_number=9999,
+                reasoning="blocker probe failed",
+            )
+        mock_esc.assert_called_once()
+        # The "happy path" side effects must NOT fire on the fallback.
+        mock_comment.assert_not_called()
+        mock_append.assert_not_called()
+        mock_add.assert_not_called()
+        mock_remove.assert_not_called()
 
     def test_no_current_issue_falls_back_to_escalate(self) -> None:
         d = _make_daemon()

--- a/scripts/dispatcher/tests/test_daemon_gh_issue_is_open_retry.py
+++ b/scripts/dispatcher/tests/test_daemon_gh_issue_is_open_retry.py
@@ -1,0 +1,331 @@
+"""Unit tests for issue #3053 — ``_gh_issue_is_open`` retries transient ``gh`` failures.
+
+Coverage:
+  - ``_gh_issue_is_open`` now retries on ``TimeoutExpired`` / non-zero
+    exit / JSON parse failure up to 3 total attempts with 1s + 2s
+    backoff, emitting a WARNING per failed attempt.
+  - A single transient failure followed by success still returns True
+    without false-negativing the call.
+  - All three attempts failing returns False *and* emits a final
+    ``gh_issue_is_open_exhausted`` WARNING so the flake is visible
+    in CloudWatch.
+  - ``_gh_issue_is_open_with_detail`` returns ``(is_open, detail)``
+    with ``attempts`` / ``reason`` / ``stderr_tail`` so
+    ``_consume_action_block_on_existing_task`` can emit a structured
+    fallback WARNING.
+  - ``GH_POLL_SUBPROCESS_TIMEOUT_SECONDS`` is bumped to 30s (AC#2).
+
+Fakes follow the pattern from ``test_daemon_diagnoser_routing.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Provide a stub ``psycopg`` module before importing the daemon.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — mirror the pattern from test_daemon_diagnoser_routing.py.
+# --------------------------------------------------------------------------
+
+
+def _make_daemon() -> daemon.DispatcherDaemon:
+    """Construct a DispatcherDaemon bypassing __init__ (no DB, no config)."""
+    import threading
+
+    d = daemon.DispatcherDaemon.__new__(daemon.DispatcherDaemon)
+    d._thread_state = threading.local()  # type: ignore[attr-defined]
+    d._main_conn = MagicMock()  # type: ignore[attr-defined]
+    d._cfg = MagicMock(github_repo="judgemind/judgemind")  # type: ignore[attr-defined]
+    d._log = logging.getLogger("test.daemon_gh_retry")  # type: ignore[attr-defined]
+    d._run_id = "test-run"  # type: ignore[attr-defined]
+    return d
+
+
+def _completed_process(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["gh", "issue", "view"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+# --------------------------------------------------------------------------
+# AC#2 — GH_POLL_SUBPROCESS_TIMEOUT_SECONDS bumped to 30.
+# --------------------------------------------------------------------------
+
+
+class TestPollSubprocessTimeout:
+    def test_timeout_is_30_seconds(self) -> None:
+        """Issue #3053 — bumped from 15 → 30 per issue body ``AC#2``."""
+        assert daemon.GH_POLL_SUBPROCESS_TIMEOUT_SECONDS == 30
+
+
+# --------------------------------------------------------------------------
+# AC#1 — _gh_issue_is_open retries on timeout / non-zero exit.
+# --------------------------------------------------------------------------
+
+
+class TestGhIssueIsOpenRetry:
+    def test_first_attempt_success_returns_true(self) -> None:
+        """Happy path — no retry needed when the first probe succeeds."""
+        d = _make_daemon()
+        ok = _completed_process(returncode=0, stdout='{"state":"OPEN"}')
+        with (
+            patch("dispatcher.daemon.subprocess.run", return_value=ok) as mock_run,
+            patch("dispatcher.daemon.time.sleep") as mock_sleep,
+        ):
+            assert d._gh_issue_is_open(3050) is True
+        assert mock_run.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_first_attempt_success_closed_returns_false(self) -> None:
+        """``state=CLOSED`` reports False without any retry."""
+        d = _make_daemon()
+        ok = _completed_process(returncode=0, stdout='{"state":"CLOSED"}')
+        with (
+            patch("dispatcher.daemon.subprocess.run", return_value=ok) as mock_run,
+            patch("dispatcher.daemon.time.sleep") as mock_sleep,
+        ):
+            assert d._gh_issue_is_open(3050) is False
+        assert mock_run.call_count == 1
+        mock_sleep.assert_not_called()
+
+    def test_timeout_twice_then_success_returns_true(self, caplog: Any) -> None:
+        """Issue #3053 AC#1 — two transient timeouts then success returns True."""
+        d = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_gh_retry")
+        ok = _completed_process(returncode=0, stdout='{"state":"OPEN"}')
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=[
+                    subprocess.TimeoutExpired(cmd="gh", timeout=30),
+                    subprocess.TimeoutExpired(cmd="gh", timeout=30),
+                    ok,
+                ],
+            ) as mock_run,
+            patch("dispatcher.daemon.time.sleep") as mock_sleep,
+        ):
+            assert d._gh_issue_is_open(3050) is True
+        assert mock_run.call_count == 3
+        # Two backoffs between the three attempts — 1s and 2s.
+        assert mock_sleep.call_args_list[0].args[0] == 1.0
+        assert mock_sleep.call_args_list[1].args[0] == 2.0
+        # Two flake WARNINGs emitted (one per failed attempt).
+        flake_records = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "gh_issue_is_open_flake"
+        ]
+        assert len(flake_records) == 2
+        assert flake_records[0].attempt == 1
+        assert flake_records[1].attempt == 2
+        assert flake_records[0].reason == "timeout"
+        # No "exhausted" record on success.
+        exhausted = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "gh_issue_is_open_exhausted"
+        ]
+        assert exhausted == []
+
+    def test_all_three_attempts_timeout_returns_false_and_warns(
+        self, caplog: Any
+    ) -> None:
+        """Issue #3053 AC#1 — three timeouts exhausts, returns False + final WARNING."""
+        d = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_gh_retry")
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=30),
+            ) as mock_run,
+            patch("dispatcher.daemon.time.sleep") as mock_sleep,
+        ):
+            assert d._gh_issue_is_open(3050) is False
+        assert mock_run.call_count == 3
+        # Two backoffs between the three attempts.
+        assert mock_sleep.call_count == 2
+        flake_records = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "gh_issue_is_open_flake"
+        ]
+        # One WARNING per failed attempt.
+        assert len(flake_records) == 3
+        exhausted = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "gh_issue_is_open_exhausted"
+        ]
+        # Plus a final "exhausted" WARNING.
+        assert len(exhausted) == 1
+        assert exhausted[0].attempts == 3
+        assert exhausted[0].reason == "timeout"
+        assert exhausted[0].issue_number == 3050
+
+    def test_nonzero_exit_retries_then_returns_false(self, caplog: Any) -> None:
+        """Non-zero exit counts as a transient failure (AC#1)."""
+        d = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_gh_retry")
+        bad = _completed_process(returncode=1, stdout="", stderr="HTTP 502 Bad Gateway")
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                return_value=bad,
+            ) as mock_run,
+            patch("dispatcher.daemon.time.sleep") as mock_sleep,
+        ):
+            assert d._gh_issue_is_open(3050) is False
+        # Three attempts, two sleeps.
+        assert mock_run.call_count == 3
+        assert mock_sleep.call_count == 2
+        flake_records = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "gh_issue_is_open_flake"
+        ]
+        assert len(flake_records) == 3
+        assert all(r.reason == "nonzero_exit" for r in flake_records)
+        # stderr_tail is propagated for operator visibility.
+        assert any("502 Bad Gateway" in (r.stderr_tail or "") for r in flake_records)
+
+    def test_json_parse_error_retries_then_returns_false(self, caplog: Any) -> None:
+        """Malformed ``gh`` stdout is treated as transient (retry + fail)."""
+        d = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_gh_retry")
+        garbage = _completed_process(returncode=0, stdout="not json at all")
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                return_value=garbage,
+            ) as mock_run,
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            assert d._gh_issue_is_open(3050) is False
+        assert mock_run.call_count == 3
+        flake_records = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "gh_issue_is_open_flake"
+        ]
+        assert all(r.reason == "json_parse" for r in flake_records)
+
+    def test_gh_missing_returns_false_without_retry_sleep_waste(
+        self, caplog: Any
+    ) -> None:
+        """``FileNotFoundError`` (gh CLI not installed) still retries to
+        keep the code path consistent — the retry cost is bounded at
+        2 × 1s / 2s sleeps worst case, which is negligible. This
+        asserts the control flow is the same as other transient
+        failures (no early-return special case).
+        """
+        d = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_gh_retry")
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=FileNotFoundError("gh not installed"),
+            ) as mock_run,
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            assert d._gh_issue_is_open(3050) is False
+        assert mock_run.call_count == 3
+        flake_records = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "gh_issue_is_open_flake"
+        ]
+        assert all(r.reason == "gh_missing" for r in flake_records)
+
+
+# --------------------------------------------------------------------------
+# Detail variant — surface attempt count + reason to the caller.
+# --------------------------------------------------------------------------
+
+
+class TestGhIssueIsOpenWithDetail:
+    def test_first_try_success_reports_attempts_1(self) -> None:
+        d = _make_daemon()
+        ok = _completed_process(returncode=0, stdout='{"state":"OPEN"}')
+        with (
+            patch("dispatcher.daemon.subprocess.run", return_value=ok),
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            is_open, detail = d._gh_issue_is_open_with_detail(3050)
+        assert is_open is True
+        assert detail == {"attempts": 1, "reason": None, "stderr_tail": ""}
+
+    def test_success_on_third_attempt_reports_attempts_3(self) -> None:
+        d = _make_daemon()
+        ok = _completed_process(returncode=0, stdout='{"state":"OPEN"}')
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=[
+                    subprocess.TimeoutExpired(cmd="gh", timeout=30),
+                    subprocess.TimeoutExpired(cmd="gh", timeout=30),
+                    ok,
+                ],
+            ),
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            is_open, detail = d._gh_issue_is_open_with_detail(3050)
+        assert is_open is True
+        assert detail["attempts"] == 3
+        assert detail["reason"] is None
+
+    def test_all_timeouts_reports_reason_timeout(self) -> None:
+        d = _make_daemon()
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=30),
+            ),
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            is_open, detail = d._gh_issue_is_open_with_detail(3050)
+        assert is_open is False
+        assert detail["attempts"] == 3
+        assert detail["reason"] == "timeout"
+
+    def test_nonzero_exit_reports_stderr_tail(self) -> None:
+        d = _make_daemon()
+        bad = _completed_process(returncode=1, stdout="", stderr="HTTP 502 Bad Gateway")
+        with (
+            patch("dispatcher.daemon.subprocess.run", return_value=bad),
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            is_open, detail = d._gh_issue_is_open_with_detail(3050)
+        assert is_open is False
+        assert detail["reason"] == "nonzero_exit"
+        assert "502 Bad Gateway" in detail["stderr_tail"]


### PR DESCRIPTION
## Summary

Fix the diagnoser's silent fallback from `block_on_existing_task` to `escalate` when `gh issue view` for the blocker transiently times out or returns non-zero. `_gh_issue_is_open` now retries transient failures up to 3 attempts with 1s + 2s backoff, logs each flake, and a new distinct WARNING event (`block_on_existing_task_validation_failed`) fires when the fallback path runs so the silent behavior becomes visible in CloudWatch. `GH_POLL_SUBPROCESS_TIMEOUT_SECONDS` bumped from 15 → 30s.

Closes #3053

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Redeploy completed; dispatcher running task-def revision 9 with fix code (`version_sha=0a88d79`, downstream of merge SHA `47c419dd`). AC#5 (live block_on_existing_task observation) deferred to live observation — no candidate fell through during the post-merge window. See verification evidence comment on #3053.
- [x] Verification evidence posted on #3053 (https://github.com/judgemind/judgemind/issues/3053#issuecomment-4305242896)
