### PR TITLE
fix(dispatcher): verify-phase cwd + recovery short-circuit on merged agents (#3055)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -6027,6 +6027,102 @@ class DispatcherDaemon:
             except Exception:  # pragma: no cover — defensive
                 pass
 
+    def _read_merged_at_and_verified_at(self, agent_id: str) -> tuple[bool, bool]:
+        """Return ``(merged, verified)`` booleans for an agent.
+
+        Issue #3055. Used by :meth:`_run_verify_and_complete` to
+        short-circuit the recovery path — when the dispatcher daemon
+        restarts mid-``awaiting_deploy`` (force-new-deployment drops the
+        ephemeral container and wipes the per-agent worktree), the new
+        daemon picks up the row on the next supervisor tick and would
+        otherwise re-spawn ``claude -p /task-v2-verify``. A post-merge
+        verify re-run that fails (for any reason — skill not found,
+        worktree missing, transient CloudWatch hiccup) should NOT flip
+        a ``status='succeeded'`` row to ``failed``: the PR already
+        shipped, ``merged_at`` is stamped, and the agent row's success
+        is authoritative.
+
+        Returns ``(False, False)`` on any DB error so the caller falls
+        back to the pre-#3055 behaviour — the short-circuit is purely
+        additive protection. A missing row also returns ``(False,
+        False)``.
+        """
+        assert self._conn is not None, "connect() must run before read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT merged_at IS NOT NULL, verified_at IS NOT NULL "
+                    "FROM dispatcher.agents WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.read_merged_at_failed",
+                extra={
+                    "event": "read_merged_at_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — defensive
+                pass
+            return (False, False)
+        if row is None:
+            return (False, False)
+        merged = bool(row[0])
+        verified = bool(row[1])
+        return (merged, verified)
+
+    def _restore_succeeded_and_advance_done(self, agent_id: str) -> None:
+        """Restore ``status='succeeded'`` + set ``phase='done'`` on an agent.
+
+        Issue #3055. Called from :meth:`_run_verify_and_complete` when a
+        verify subprocess fails on an already-merged agent (``merged_at
+        IS NOT NULL``). :meth:`_run_subprocess_or_fail` already flipped
+        the row to ``status='failed'`` via
+        :meth:`_handle_subprocess_failure` before this method runs — we
+        need the single UPDATE here to re-write both columns atomically
+        so the admin row doesn't briefly flicker green → red → green on
+        the supervisor tick.
+
+        Best-effort: a DB error here is logged but does not raise, so
+        the outer verify flow continues cleanly. The worst case of a
+        failed restore is that the row stays red until the next
+        terminal-outcome sweep — a regression relative to the pre-crash
+        state, but not a correctness bug (``merged_at`` is still set
+        and the retro / cleanup state-machine can still drive the row
+        to completion from there).
+        """
+        assert self._conn is not None, "connect() must run before update"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.agents "
+                    "SET status = 'succeeded', "
+                    "    phase = 'done', "
+                    "    failure_summary = NULL "
+                    "WHERE agent_id = %s",
+                    (agent_id,),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.restore_succeeded_failed",
+                extra={
+                    "event": "restore_succeeded_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — defensive
+                pass
+
     def _read_verify_skip_reason(self, agent_id: str) -> str | None:
         """Return the current ``verify_skip_reason`` for an agent, or None."""
         assert self._conn is not None, "connect() must run before read"
@@ -6804,6 +6900,34 @@ class DispatcherDaemon:
         ``error: unknown option '--cwd'`` (#2821). Python's stdlib
         ``cwd=`` is the correct knob for "start the child process in
         this directory".
+
+        **Cwd for verify must be the baseline clone (#3055).** Verify is
+        a post-merge phase that runs on the recovery path after a
+        force-new-deployment (the prior daemon died mid-verify; the new
+        daemon picks up an ``awaiting_deploy/succeeded`` agent whose
+        worktree was wiped along with the prior container's ephemeral
+        storage). In that state, the per-agent worktree directory does
+        not exist on disk, and the ``.claude/skills/task-v2-verify/``
+        tree — which ``claude -p /task-v2-verify`` resolves relative to
+        ``cwd`` — is therefore not discoverable. The ``_write_phase_input``
+        call above happens to ``mkdir(parents=True)`` the worktree path
+        so ``Popen`` itself does not raise ``FileNotFoundError``, but the
+        re-created directory is empty of ``.claude/skills/`` so the
+        ``claude`` CLI exits ~50ms with ``result="Unknown command:
+        /task-v2-verify"``. The fix, paralleling #3034 for the diagnoser,
+        is to set ``cwd=baseline_repo_root`` on the verify spawn: the
+        baseline clone is re-populated at daemon boot by
+        :meth:`ensure_baseline_clone` and contains the full
+        ``.claude/skills/`` tree. The verify skill reads its own
+        ``worktree_path`` from the input JSON so it does not need to
+        start inside the worktree itself.
+
+        The other phases (plan, ralph, summary, fix-ci, retro) keep
+        ``cwd=str(worktree)`` because they run inside an active worktree
+        that is guaranteed to exist (they only execute while the agent
+        is pre-merge, so the worktree has not been wiped by a restart)
+        and they need the worktree's working tree available for git
+        operations (``git status``, ``git add``, ``git commit``).
         """
         max_turns = PHASE_MAX_TURNS[phase]
         model = self._model_for_phase(phase, agent_id)
@@ -6812,6 +6936,16 @@ class DispatcherDaemon:
         stderr_path = worktree / "tmp" / f"claude-p-{phase}.stderr.log"
         jsonl_path = worktree / ".dispatcher" / f"{phase}-{agent_id}.jsonl"
         log_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # #3055 — verify phase must resolve the ``task-v2-verify`` skill
+        # from the baseline clone when running on the recovery path
+        # (post-restart, worktree wiped). Fall back to the worktree only
+        # when ``baseline_repo_root`` is unset (local-dev / unit-test
+        # mode), mirroring :meth:`_spawn_diagnoser_subprocess`. See the
+        # docstring rationale above.
+        popen_cwd: Path = worktree
+        if phase == "verify" and self._cfg.baseline_repo_root is not None:
+            popen_cwd = self._cfg.baseline_repo_root
 
         cmd = [
             "claude",
@@ -6890,7 +7024,7 @@ class DispatcherDaemon:
                     stderr=subprocess.PIPE,
                     text=True,
                     bufsize=1,
-                    cwd=str(worktree),
+                    cwd=str(popen_cwd),
                 )
                 threads = stream_subprocess_output_async(
                     proc,
@@ -11280,6 +11414,37 @@ class DispatcherDaemon:
             self._update_agent_phase(agent_id, "done")
             return
 
+        # Issue #3055 — short-circuit when verify has already completed
+        # for this agent. Happens on the recovery path where the prior
+        # daemon ran verify successfully (stamped ``verified_at``) but
+        # died before :meth:`_update_agent_phase` advanced the row from
+        # ``awaiting_deploy`` to ``done``. On restart, the new daemon's
+        # supervisor tick picks the agent up via
+        # :meth:`_list_advanceable_agents` (``status='succeeded' AND
+        # phase='awaiting_deploy'``) and would naively re-enter this
+        # method. Re-running verify on an already-verified agent adds
+        # noise and — in the most common recovery scenario where the
+        # worktree has also been wiped from ephemeral storage — flips
+        # ``succeeded`` to ``failed`` via the ``phase_output_missing``
+        # path, inverting the audit-trail signal.
+        merged_at_set, verified_at_set = self._read_merged_at_and_verified_at(agent_id)
+        if verified_at_set:
+            self._log.info(
+                "daemon.verify_already_completed",
+                extra={
+                    "event": "verify_already_completed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "pr_number": pr_number,
+                },
+            )
+            # Just advance phase — retro picks it up on the next tick.
+            # ``verified_at`` is already stamped so the admin cockpit
+            # pill colour stays correct.
+            self._update_agent_phase(agent_id, "done")
+            return
+
         # Fetch the issue bundle for acceptance criteria. Best-effort —
         # the verify skill tolerates an empty AC list with a failure row.
         try:
@@ -11362,7 +11527,31 @@ class DispatcherDaemon:
 
         exit_code = self._run_subprocess_or_fail(agent_id, "verify", worktree)
         if exit_code is None:
-            return  # subprocess failure already marked failed
+            # Issue #3055 — ``_run_subprocess_or_fail`` already flipped
+            # the row to ``status='failed'`` via its internal failure
+            # handlers. On an already-merged agent that is wrong: the
+            # PR shipped, ``merged_at`` is stamped, and a verify
+            # subprocess crash shouldn't retroactively invert the audit
+            # trail. Any post-merge verify infra failure is bookkeeping
+            # noise, not a product regression. Restore the row to
+            # ``status='succeeded'`` and advance phase to ``done`` so
+            # retro runs on the next tick. The distinct
+            # ``verify_infra_failure_post_merge`` event gives operators
+            # the grep hook for "verify-was-broken-but-shipped" cases.
+            if merged_at_set:
+                self._log.warning(
+                    "daemon.verify_infra_failure_post_merge",
+                    extra={
+                        "event": "verify_infra_failure_post_merge",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "issue_number": issue_number,
+                        "pr_number": pr_number,
+                        "detail": "subprocess failed before output parse",
+                    },
+                )
+                self._restore_succeeded_and_advance_done(agent_id)
+            return  # subprocess failure already marked (or restored) by now
 
         verify_output = self._read_phase_output(worktree, "verify")
         if verify_output is None:
@@ -11376,6 +11565,32 @@ class DispatcherDaemon:
             if preview:
                 extra["stderr_preview"] = preview
             self._log.warning("daemon.phase_output_missing", extra=extra)
+            # Issue #3055 — on an already-merged agent, a
+            # ``phase_output_missing`` verdict is bookkeeping noise
+            # (typically the recovery-path case where the prior daemon
+            # died mid-verify and the worktree has since been wiped by
+            # the force-new-deployment). Route through
+            # :meth:`_restore_succeeded_and_advance_done` instead of
+            # :meth:`_handle_agent_failure` so ``status`` stays
+            # ``succeeded`` and the admin cockpit doesn't render an
+            # already-shipped PR red. Pre-#3055 this path flipped the
+            # row to ``failed`` and the Opus diagnoser then escalated
+            # it to ``diagnoser_escalate/failed`` — inverting the
+            # authoritative success signal on an already-shipped PR.
+            if merged_at_set:
+                self._log.warning(
+                    "daemon.verify_infra_failure_post_merge",
+                    extra={
+                        "event": "verify_infra_failure_post_merge",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "issue_number": issue_number,
+                        "pr_number": pr_number,
+                        "detail": "output JSON missing or malformed",
+                    },
+                )
+                self._restore_succeeded_and_advance_done(agent_id)
+                return
             # Issue #3032: route through the unified failure handler.
             self._handle_agent_failure(
                 agent_id=agent_id,

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -1434,3 +1434,369 @@ class TestSupervisorTickIntegration:
         summary = d.supervisor_tick()
         assert handler.events("advance_pass_failed")
         assert summary["agents_advanced"] == 0
+
+
+# --------------------------------------------------------------------------
+# #3055 — verify-phase spawn cwd + recovery short-circuit on merged agents
+# --------------------------------------------------------------------------
+
+
+class TestVerifyPhaseSpawnCwd:
+    """Issue #3055 — on the recovery path (force-new-deployment drops the
+    per-agent worktree from ephemeral storage), the verify phase spawn must
+    still discover ``.claude/skills/task-v2-verify/SKILL.md``. Paralleling
+    #3034's diagnoser fix, the fix sets ``cwd=baseline_repo_root`` for the
+    verify spawn (in Fargate mode). Other phases continue to run inside
+    the per-agent worktree because they need the working tree available
+    for git operations."""
+
+    def test_verify_spawn_uses_baseline_repo_root_as_cwd(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """In Fargate mode (``baseline_repo_root`` set), the verify phase
+        subprocess must be launched with ``cwd=str(baseline_repo_root)`` so
+        the ``task-v2-verify`` skill is discoverable even when the per-agent
+        worktree was wiped by a container restart."""
+        from dispatcher.tests._popen_fake import make_popen_factory
+
+        d, _conn, _handler = _make_daemon(tmp_path)
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        d._cfg.baseline_repo_root = baseline
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        captured: dict[str, Any] = {}
+
+        def on_start(cmd: list[str], kwargs: dict[str, Any]) -> None:
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+
+        monkeypatch.setattr(
+            subprocess,
+            "Popen",
+            make_popen_factory(
+                stdout_chunks=('{"result":"ok","is_error":false}\n',),
+                on_start=on_start,
+            ),
+        )
+        # ``_spawn_phase_subprocess`` calls ``_agent_issue_number`` which
+        # hits the DB; short-circuit it to avoid stubbing the whole cursor
+        # state for this narrowly-scoped assertion.
+        monkeypatch.setattr(d, "_agent_issue_number", lambda _aid: 42)
+
+        d._spawn_phase_subprocess("verify", worktree, "agent-id")
+
+        assert "cwd" in captured["kwargs"], (
+            "Popen must be invoked with cwd= so the /task-v2-verify skill "
+            f"is discoverable (got kwargs={sorted(captured['kwargs'])})"
+        )
+        assert captured["kwargs"]["cwd"] == str(baseline), (
+            f"Popen cwd for verify must be the baseline_repo_root. "
+            f"Expected {baseline!s}, got {captured['kwargs']['cwd']!r}"
+        )
+
+    def test_verify_spawn_falls_back_to_worktree_in_local_mode(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """In local-dev mode (``baseline_repo_root`` unset), the verify phase
+        spawn must still pass ``cwd=str(worktree)`` — the per-agent worktree
+        IS the skill-containing tree in local dev because ``_compute_worktree_path``
+        falls back to ``<repo_root>/.claude/worktrees/agent-*``."""
+        from dispatcher.tests._popen_fake import make_popen_factory
+
+        d, _conn, _handler = _make_daemon(tmp_path)
+        assert d._cfg.baseline_repo_root is None  # local-dev mode
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        captured: dict[str, Any] = {}
+
+        def on_start(cmd: list[str], kwargs: dict[str, Any]) -> None:
+            captured["kwargs"] = kwargs
+
+        monkeypatch.setattr(
+            subprocess,
+            "Popen",
+            make_popen_factory(
+                stdout_chunks=('{"result":"ok","is_error":false}\n',),
+                on_start=on_start,
+            ),
+        )
+        monkeypatch.setattr(d, "_agent_issue_number", lambda _aid: 42)
+
+        d._spawn_phase_subprocess("verify", worktree, "agent-id")
+
+        assert captured["kwargs"]["cwd"] == str(worktree), (
+            f"Popen cwd for verify in local-dev mode must be the worktree. "
+            f"Expected {worktree!s}, got {captured['kwargs']['cwd']!r}"
+        )
+
+    def test_non_verify_phases_always_use_worktree_as_cwd(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Regression guard: the #3055 fix must NOT change the cwd for
+        plan / ralph / summary / fix-ci / retro spawns. Those phases run
+        pre-merge inside a live worktree, need the worktree's working
+        tree for git operations, and are not subject to the recovery-path
+        bug (the worktree can't be wiped while the agent is still
+        pre-merge and advancing)."""
+        from dispatcher.tests._popen_fake import make_popen_factory
+
+        d, _conn, _handler = _make_daemon(tmp_path)
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        d._cfg.baseline_repo_root = baseline  # Fargate mode
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        captured_cwds: dict[str, str] = {}
+
+        def make_on_start(
+            phase: str,
+        ) -> Any:
+            def on_start(cmd: list[str], kwargs: dict[str, Any]) -> None:
+                captured_cwds[phase] = kwargs.get("cwd", "")
+
+            return on_start
+
+        monkeypatch.setattr(d, "_agent_issue_number", lambda _aid: 42)
+        # Avoid firing the ralph head watcher during ralph-phase spawns
+        # — it spawns a thread that polls git and would complicate the
+        # assertion set.
+        monkeypatch.setattr(d, "_start_ralph_head_watcher", lambda **_kwargs: None)
+
+        for phase in ("plan", "ralph", "summary", "fix-ci", "retro"):
+            monkeypatch.setattr(
+                subprocess,
+                "Popen",
+                make_popen_factory(
+                    stdout_chunks=('{"result":"ok","is_error":false}\n',),
+                    on_start=make_on_start(phase),
+                ),
+            )
+            d._spawn_phase_subprocess(phase, worktree, "agent-id")
+
+        for phase, cwd in captured_cwds.items():
+            assert cwd == str(worktree), (
+                f"Non-verify phase {phase!r} must run in worktree cwd, "
+                f"not the baseline. Got cwd={cwd!r}, expected {worktree!s}."
+            )
+
+
+class TestVerifyRecoveryShortCircuit:
+    """Issue #3055 — when the daemon restarts mid-awaiting_deploy and the
+    supervisor tick re-enters :meth:`_run_verify_and_complete` on an agent
+    whose PR has already merged, the behaviour must be:
+
+    1. If ``verified_at`` is already stamped, skip the subprocess entirely
+       and advance phase → done (the prior verify ran; the phase advance
+       was what the crashed daemon missed).
+    2. If ``verified_at`` is NULL but ``merged_at`` is stamped, and the
+       verify subprocess fails (phase_output_missing, nonzero exit,
+       timeout), do NOT flip the row to ``status='failed'``. Restore
+       status='succeeded' and advance phase → done. The agent row's
+       ``merged_at`` is authoritative — a post-merge verify infra
+       failure is bookkeeping noise, not a product regression, and
+       must not tip the admin cockpit colour from green ✓ to red ✗.
+    """
+
+    def _agent(
+        self,
+        tmp_path: Path,
+        *,
+        phase: str = "awaiting_deploy",
+        pr_number: int = 3051,
+    ) -> dict[str, Any]:
+        worktree = tmp_path / "wt"
+        worktree.mkdir(exist_ok=True)
+        return {
+            "agent_id": "cdf48cc7",
+            "issue_number": 3051,
+            "phase": phase,
+            "pr_number": pr_number,
+            "worktree_path": str(worktree),
+            "retries_used": 0,
+            "status": "succeeded",
+        }
+
+    def test_verified_at_already_stamped_short_circuits_to_done(
+        self, tmp_path: Path
+    ) -> None:
+        """When ``verified_at`` is already stamped, re-entering
+        ``_run_verify_and_complete`` must skip the subprocess and just
+        advance phase to ``done`` so retro picks up the row."""
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = self._agent(tmp_path)
+        pr_status: dict[str, Any] = {}
+        deploy_runs: list[dict[str, Any]] = []
+
+        # _read_verify_skip_reason fetches first (returns None → no skip).
+        # _read_merged_at_and_verified_at fetches second (merged=True,
+        # verified=True).
+        conn.cursor_instance.fetch_queue = [
+            (None,),  # verify_skip_reason
+            (True, True),  # (merged_at IS NOT NULL, verified_at IS NOT NULL)
+        ]
+
+        # Subprocess MUST NOT be spawned on the short-circuit path.
+        spawn_called: dict[str, int] = {"n": 0}
+
+        def forbid_spawn(*_a: Any, **_kw: Any) -> None:
+            spawn_called["n"] += 1
+
+        d._spawn_phase_subprocess = forbid_spawn  # type: ignore[method-assign]
+
+        d._run_verify_and_complete(agent, pr_status, "merge-sha", deploy_runs)
+
+        assert spawn_called["n"] == 0, (
+            "Re-entering verify on an already-verified agent must not "
+            "spawn the subprocess again"
+        )
+        # The short-circuit logs verify_already_completed AND advances
+        # phase to ``done`` — both are required for the admin cockpit
+        # to render the row correctly.
+        assert handler.events("verify_already_completed")
+        phase_done_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and "SET phase" in e[0]
+            and e[1] is not None
+            and "done" in e[1]
+        ]
+        assert phase_done_updates, (
+            "Short-circuit must still advance phase=done so retro runs "
+            "on the next supervisor tick"
+        )
+
+    def test_phase_output_missing_on_merged_agent_preserves_succeeded(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """When the verify subprocess returns exit 0 but fails to write
+        ``verify.json`` (the #3055 recovery-path failure mode — claude
+        CLI ran but the skill was not resolvable in the post-restart
+        worktree), the pre-#3055 behaviour was to call
+        :meth:`_handle_agent_failure` which flipped the row to
+        ``status='failed'`` and handed it to the Opus diagnoser. On a
+        merged PR that's wrong — restore ``status='succeeded'`` and
+        advance phase → ``done`` instead."""
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = self._agent(tmp_path)
+        pr_status: dict[str, Any] = {}
+        deploy_runs: list[dict[str, Any]] = []
+
+        # First: _read_verify_skip_reason returns None.
+        # Second: _read_merged_at_and_verified_at returns (True, False) —
+        # PR merged but verify has never run.
+        conn.cursor_instance.fetch_queue = [
+            (None,),
+            (True, False),
+        ]
+
+        # Short-circuit the input-assembly helpers so we land directly
+        # on the phase_output_missing branch.
+        d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "issue_number": agent["issue_number"],
+                "issue_title": "t",
+                "issue_body": "- [ ] criterion",
+                "issue_comments": [],
+                "issue_labels": [],
+                "blocked_by": [],
+                "parent_issue": None,
+            }
+        )
+        d._select_deploy_status = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._infer_change_type = MagicMock(return_value="dx")  # type: ignore[method-assign]
+        d._touched_services_from_runs = MagicMock(return_value=[])  # type: ignore[method-assign]
+        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+        # The output file is not written — simulate the #3055 failure.
+        d._read_phase_output = MagicMock(return_value=None)  # type: ignore[method-assign]
+        # Guard rail: the failure handler must NOT be called on the
+        # merged-agent path.
+        handle_failure_calls: list[Any] = []
+
+        def forbid_handle_failure(**kwargs: Any) -> None:
+            handle_failure_calls.append(kwargs)
+
+        d._handle_agent_failure = forbid_handle_failure  # type: ignore[method-assign]
+
+        d._run_verify_and_complete(agent, pr_status, "merge-sha", deploy_runs)
+
+        assert not handle_failure_calls, (
+            "Must NOT flip status=failed on a phase_output_missing "
+            "verify failure when the PR has already merged"
+        )
+        # The dedicated observability event must fire.
+        assert handler.events("verify_infra_failure_post_merge")
+        # The row must be restored to status=succeeded + phase=done.
+        restore_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and "SET status = 'succeeded'" in e[0]
+            and "phase = 'done'" in e[0]
+        ]
+        assert restore_updates, (
+            "Must restore status='succeeded' + phase='done' on the "
+            "merged-agent recovery failure path"
+        )
+
+    def test_phase_output_missing_on_unmerged_agent_still_flips_failed(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Regression guard: on the rare ``merged_at IS NULL`` code path
+        (pre-#2953 agents, or a state inconsistency), the original
+        failure routing via :meth:`_handle_agent_failure` must still
+        fire. Otherwise we'd silently hide genuine verify regressions
+        for agents whose merge-time columns somehow never got stamped."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        agent = self._agent(tmp_path)
+        pr_status: dict[str, Any] = {}
+        deploy_runs: list[dict[str, Any]] = []
+
+        conn.cursor_instance.fetch_queue = [
+            (None,),
+            (False, False),  # not merged, not verified
+        ]
+
+        d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "issue_number": agent["issue_number"],
+                "issue_title": "t",
+                "issue_body": "- [ ] criterion",
+                "issue_comments": [],
+                "issue_labels": [],
+                "blocked_by": [],
+                "parent_issue": None,
+            }
+        )
+        d._select_deploy_status = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._infer_change_type = MagicMock(return_value="dx")  # type: ignore[method-assign]
+        d._touched_services_from_runs = MagicMock(return_value=[])  # type: ignore[method-assign]
+        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+        d._read_phase_output = MagicMock(return_value=None)  # type: ignore[method-assign]
+
+        handle_failure_calls: list[Any] = []
+
+        def record_handle_failure(**kwargs: Any) -> None:
+            handle_failure_calls.append(kwargs)
+
+        d._handle_agent_failure = record_handle_failure  # type: ignore[method-assign]
+
+        d._run_verify_and_complete(agent, pr_status, "merge-sha", deploy_runs)
+
+        assert handle_failure_calls, (
+            "Legacy (unmerged) phase_output_missing path must still "
+            "route through _handle_agent_failure so genuine failures "
+            "reach the Opus diagnoser"
+        )
+        assert handle_failure_calls[0]["category"] == (
+            daemon.FAILURE_CATEGORY_PHASE_OUTPUT_MISSING
+        )


### PR DESCRIPTION
## Summary

Fixes #3055 — force-new-deployment recovery path flipped `awaiting_deploy/succeeded` agents to `diagnoser_escalate/failed` because (a) the verify subprocess's `cwd` pointed at a wiped worktree so `/task-v2-verify` resolved as `Unknown command`, and (b) the resulting `phase_output_missing` routed through `_handle_agent_failure` which inverted the success status on an already-shipped PR.

Two structural fixes, parallel to #3034's diagnoser cwd fix:

- `_spawn_phase_subprocess` uses `cwd=baseline_repo_root` for the verify phase when baseline is set. Other phases unchanged.
- `_run_verify_and_complete` short-circuits on `verified_at IS NOT NULL` (idempotency), and on any verify subprocess failure with `merged_at IS NOT NULL` restores `status='succeeded' + phase='done'` instead of flipping to `failed`. Pre-#2953 (unmerged) code paths remain routed through `_handle_agent_failure`.

Closes #3055

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass — 6 new unit tests in `scripts/dispatcher/tests/test_daemon_phase3b.py` (3 for the cwd fix, 3 for the recovery short-circuit + status preservation)
- [x] CI green

### Post-deploy verification
- [x] Live verification: deploy landed at `version_sha=fb8778b` via workflow `Deploy Dispatcher` run `24840899777`. No natural `awaiting_deploy` recovery trigger in the observation window; per issue instructions, unit-test coverage is the acceptance signal. No `Unknown command`, `phase_output_missing`, or `verify_infra_failure_post_merge` emissions since deploy.
- [x] Verification evidence posted on issue #3055
