### PR TITLE
chore(dispatcher): silence cleanup_script_missing WARNING in Fargate (#3056)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -613,10 +613,18 @@ PHASE_NO_OP = "no_op"
 #: supervisor advances apply.
 PHASE_CLEANUP_DONE = "cleanup_done"
 
-#: Phase value written when ``scripts/cleanup_worktree.sh`` refuses to
-#: remove the worktree (locked, no session log, etc.). The daemon does
-#: NOT bypass the safety check with ``--force`` — an operator sweep can
-#: clean up the worktree manually. This is also a terminal phase.
+#: Phase value written when ``scripts/cleanup_worktree.sh`` exists but
+#: refuses to remove the worktree (locked, no session log, etc.). The
+#: daemon does NOT bypass the safety check with ``--force`` — an
+#: operator sweep can clean up the worktree manually. This is also a
+#: terminal phase.
+#:
+#: Note: when the script is absent entirely (the normal Fargate case —
+#: ``Dockerfile.dispatcher`` does not COPY ``scripts/cleanup_worktree.sh``
+#: because its safety checks assume laptop-dispatcher state that doesn't
+#: exist in Fargate), the daemon falls back to ``git worktree remove
+#: --force`` via :meth:`_drop_worktree_best_effort` rather than marking
+#: this phase. See #3056.
 PHASE_CLEANUP_BLOCKED = "cleanup_blocked"
 
 #: Hard wall-clock timeout for the ``scripts/cleanup_worktree.sh``
@@ -12524,16 +12532,40 @@ class DispatcherDaemon:
         cleanup_script = repo_root / "scripts" / "cleanup_worktree.sh"
 
         if not cleanup_script.exists():
-            self._log.warning(
-                "daemon.cleanup_script_missing",
+            # This is the normal Fargate path. ``Dockerfile.dispatcher``
+            # deliberately does NOT COPY ``scripts/cleanup_worktree.sh``
+            # into the image — the script's safety checks depend on
+            # laptop-only state ($HOME/.claude/projects JSONL logs and
+            # the ``.claude/worktrees/agent-*`` path convention) that
+            # doesn't apply in Fargate, so shipping it would only make
+            # every safety check fail. Fall through to ``git worktree
+            # remove --force`` via :meth:`_drop_worktree_best_effort`
+            # (which is already the fallback wired up for the retry-
+            # marker path) so Fargate cleanup actually completes
+            # instead of stalling at ``cleanup_blocked`` forever. #3056.
+            self._log.info(
+                "daemon.cleanup_script_absent_using_git",
                 extra={
-                    "event": "cleanup_script_missing",
+                    "event": "cleanup_script_absent_using_git",
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "expected_path": str(cleanup_script),
+                    "worktree_path": worktree_path,
                 },
             )
-            self._update_agent_phase(agent_id, PHASE_CLEANUP_BLOCKED)
+            if self._drop_worktree_best_effort(worktree_path):
+                self._update_agent_phase(agent_id, PHASE_CLEANUP_DONE)
+                self._log.info(
+                    "daemon.cleanup_done",
+                    extra={
+                        "event": "cleanup_done",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "worktree_path": worktree_path,
+                    },
+                )
+            else:
+                self._update_agent_phase(agent_id, PHASE_CLEANUP_BLOCKED)
             return
 
         try:

--- a/scripts/dispatcher/tests/test_daemon_phase3e.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3e.py
@@ -969,16 +969,69 @@ class TestCleanupAgentWorktree:
         assert cleanup_done_updates
         assert handler.events("cleanup_already_gone")
 
-    def test_missing_cleanup_script_marks_blocked(
+    def test_missing_cleanup_script_falls_back_to_git_remove_success(
         self, monkeypatch: Any, tmp_path: Path
     ) -> None:
+        """Fargate case: script is intentionally not shipped in the
+        container. Instead of emitting a WARNING and stalling at
+        ``cleanup_blocked`` forever, the daemon falls back to
+        ``git worktree remove --force`` via
+        :meth:`_drop_worktree_best_effort`. See #3056."""
         d, conn, handler = _make_daemon(tmp_path)
         agent = _succeeded_agent(tmp_path, phase=daemon.PHASE_RETRO_DONE)
         # Repo root with no cleanup script present.
         empty_repo = tmp_path / "empty-repo"
         empty_repo.mkdir(parents=True, exist_ok=True)
         monkeypatch.setattr(d, "_repo_root", lambda: empty_repo)
+        # Fake ``_drop_worktree_best_effort`` to report success.
+        drop_calls: list[str] = []
+
+        def fake_drop(worktree_path: str) -> bool:
+            drop_calls.append(worktree_path)
+            return True
+
+        monkeypatch.setattr(d, "_drop_worktree_best_effort", fake_drop)
         d._cleanup_agent_worktree(agent)
+
+        # Delegated to the best-effort drop with the agent's worktree path.
+        assert drop_calls == [agent["worktree_path"]]
+
+        # Phase flipped to cleanup_done (not cleanup_blocked).
+        done_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and daemon.PHASE_CLEANUP_DONE in str(e[1])
+        ]
+        assert done_updates
+
+        # Must NOT have emitted the noisy WARNING from #3056. The new
+        # event name is INFO-level and explicitly narrates the fallback.
+        assert not handler.events("cleanup_script_missing"), (
+            "missing script is the expected Fargate condition; must not WARN"
+        )
+        assert handler.events("cleanup_script_absent_using_git")
+        assert handler.events("cleanup_done")
+
+    def test_missing_cleanup_script_falls_back_to_git_remove_failure(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """If the git fallback itself fails (e.g. worktree is locked),
+        the agent lands at ``cleanup_blocked`` — an operator sweep can
+        clean up manually. Still no ``cleanup_script_missing`` WARNING."""
+        d, conn, handler = _make_daemon(tmp_path)
+        agent = _succeeded_agent(tmp_path, phase=daemon.PHASE_RETRO_DONE)
+        empty_repo = tmp_path / "empty-repo"
+        empty_repo.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setattr(d, "_repo_root", lambda: empty_repo)
+
+        def fake_drop(worktree_path: str) -> bool:
+            return False
+
+        monkeypatch.setattr(d, "_drop_worktree_best_effort", fake_drop)
+        d._cleanup_agent_worktree(agent)
+
         blocked_updates = [
             e
             for e in conn.cursor_instance.executed
@@ -987,7 +1040,8 @@ class TestCleanupAgentWorktree:
             and daemon.PHASE_CLEANUP_BLOCKED in str(e[1])
         ]
         assert blocked_updates
-        assert handler.events("cleanup_script_missing")
+        assert not handler.events("cleanup_script_missing")
+        assert handler.events("cleanup_script_absent_using_git")
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Every succeeded Fargate agent emitted a WARNING `daemon.cleanup_script_missing` because `Dockerfile.dispatcher` intentionally does not ship `scripts/cleanup_worktree.sh` (the script's safety checks depend on `$HOME/.claude/projects` JSONL logs and the `.claude/worktrees/agent-*` path convention — laptop-only state). The other cleanup call path (`_drop_worktree_best_effort`, used for retry markers) already handles this correctly by falling through to `git worktree remove --force`. This PR mirrors that pattern in `_cleanup_agent_worktree`: missing script → INFO `cleanup_script_absent_using_git` + delegate to `_drop_worktree_best_effort`. The "trust the safety check" invariant (script-present + non-zero exit → `cleanup_blocked` with NO `--force`) is preserved.

Closes #3056

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Dispatcher image redeployed with the fix (Deploy Dispatcher workflow run 24841728669, SHA 744a2368, ✓ at 14:56:16Z). CloudWatch confirmation from the next succeeded agent is deferred; unit tests mechanically prove the WARNING no longer fires on the script-absent branch.
- [x] Verification evidence posted on #3056 (see issue comment).
