### PR TITLE
fix(dispatcher): defuse diagnoser anchor-bias on prior decisions (#3057)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -23,6 +23,54 @@ Diagnoser for the dispatcher v2 failure flow (`docs/specs/dispatcher-v2-spec.md`
 
 ---
 
+## Step 1 — Parse the failure signature FIRST (anchor-bias defense — issue #3057)
+
+**This is a mandatory first step.** Before you read `prior_diagnoses_this_issue`, `recent_fleet_decisions`, or any other pattern-bearing field in the context bundle, find the **actual failure signature in the raw stderr** and quote it verbatim.
+
+**The rule: the stderr is ground truth; prior decisions are priors, not evidence.**
+
+### Procedure
+
+1. From the context bundle, locate the raw stderr text. Depending on the category, it lives in one of:
+   - `context.prior_failures[0].details.stderr_tail` (the most recent failure on this issue, when it matches the triggering failure_id)
+   - `context.details.stderr_tail` (when the daemon inlined the triggering failure's details at the top level — category-dependent)
+   - The `ralph_done_content` string (for ralph-phase failures)
+   - The `ci_log_url` / `gh run view --log-failed` output (for `ci_red_after_retries`)
+
+2. Scan the stderr from the **bottom up** and extract the **last** concrete failure line. "Concrete" means one of:
+   - A line starting with `FAILED:` (pre-push hook convention)
+   - A line containing `[remote rejected]` or `! [rejected]` (git push output)
+   - A line starting with `error:` or `fatal:` (git / ruff / pytest conventions)
+   - An explicit banner like `Push aborted.`, `check(s) failed.`, `tests failed`, `coverage dropped`, `floor violation`
+   - For pytest: the last `FAILED packages/... ::test_name` line from the summary
+   - For CI log: the last `##[error]` line or the last non-zero-exit line
+
+3. **Quote that line verbatim** in the `reasoning` field of your final recommendation. Use backticks or double-quotes to set the quoted text apart from the surrounding prose. **Do not paraphrase, do not summarize, do not compress.** Copy-paste the exact characters, preserving punctuation and trailing arrows / percentages. Example acceptable opening sentences:
+
+   > The stderr ends with `"FAILED: coverage floor for scraper-framework"` followed by `"FAIL: packages/scraper-framework: coverage dropped 80.0% -> 68.6% (floor violation)"`. This is a local pre-push hook abort — the push never reached the remote. Filing a prerequisite task to restore the coverage floor.
+
+   > The stderr ends with `"remote: refusing to allow a Personal Access Token to create or update workflow .github/workflows/cc-retired-watchdog.yml without workflow scope"` and `"! [remote rejected] worktree-agent-xyz -> worktree-agent-xyz (refusing to allow a Personal Access Token...)"`. This is the known PAT-scope cascade tracked at #3038.
+
+4. **Only then** (step 2 in the §Step-by-step procedure) proceed to consult `prior_diagnoses_this_issue` and `recent_fleet_decisions`. Treat them as priors — useful for detecting fleet-wide spates, dangerous as substitutes for reading the stderr.
+
+### Why this step exists
+
+On 2026-04-23 the Opus diagnoser hallucinated a PAT-scope cascade push-rejection on a coverage-floor failure. Diagnosis #15 (agent `6d4029f0`, issue #2613) had `recent_fleet_decisions` populated with 9 prior `block_on_existing_task → #3038` decisions — all legitimate PAT cascades on different issues. The actual stderr ended with `"FAILED: coverage floor"` + `"coverage dropped 80.0% -> 68.6%"` and the push never reached the remote (pre-push hook aborted locally). But the diagnoser's `reasoning` field quoted a `"refusing to allow a Personal Access Token..."` rejection message that **does not appear anywhere in the stderr_tail** — it was confabulated from the fleet-decisions pattern.
+
+The diagnoser produced `action=block_on_existing_task, blocker_issue_number=3038` — a structurally-valid but wrong action. #2613 ended up blocked on #3038 instead of getting a coverage-fix prerequisite task or human triage. See issue #3057 for the full forensic.
+
+**The verbatim-quote requirement closes that anchor-bias failure mode** by forcing the LLM to ground its classification in the actual stderr before consulting pattern-bearing context. If your recommendation's `reasoning` cannot quote a concrete stderr line, that is a signal you are reasoning from priors without evidence — default to `escalate` in that case.
+
+### When the stderr has no identifiable failure line
+
+If the stderr is truly empty, or contains only progress output with no `FAILED:` / `error:` / `[remote rejected]` / banner, say so verbatim in the reasoning:
+
+> `stderr_tail` contains no FAILED: / [remote rejected] / error: line — only progress output from the phase.
+
+Then proceed to step 3 (§Step-by-step procedure) with `escalate` as the strong default. Do not invent a failure line from priors.
+
+---
+
 ## Input contract
 
 The argument is a single integer `diagnosis_id` (from `dispatcher.diagnoses.diagnosis_id`).
@@ -64,7 +112,7 @@ The `context` JSONB contains (schema stable — the daemon serializes this):
 - `recent_phase_transitions` (list of `{phase, ts}`) — last ~10 transitions for this agent, newest first.
 - `prior_failures` (list of `{failure_id, category, ts, details}`) — prior `dispatcher.failures` rows on the same issue across all agents (not just this one).
 - `prior_diagnoses_this_issue` (list of `{diagnosis_id, failure_category, recommendation, completed_at}`) — prior completed diagnoses on the same `issue_number`. **Use this to avoid repeating a decision that already failed** — e.g. if `retry` was recommended twice and the failure recurred twice, escalate or change strategy. (Added in #3032.)
-- `recent_fleet_decisions` (list of `{diagnosis_id, agent_id, issue_number, failure_category, action, reasoning, completed_at}`) — the diagnoser's last ~20 decisions across ALL issues in the past 6 hours. **Use this to detect fleet-wide spates** — if 5 different issues hit the same failure class today, the right action may be `file_prerequisite_task` or `escalate`, not patch-per-issue. (Added in #3032. The PAT-scope cascade on 2026-04-22/23 is the canonical example.)
+- `recent_fleet_decisions` (list of `{diagnosis_id, agent_id, issue_number, failure_category, action, reasoning, completed_at}`) — the diagnoser's most-recent decisions across ALL issues in the past 6 hours. Capped at 3 entries by default (tunable via `dispatcher.config.diagnoser_fleet_decisions_cap`; see issue #3057). **Use this to detect fleet-wide spates** — if several different issues hit the same failure class today, the right action may be `file_prerequisite_task` or `escalate`, not patch-per-issue. **But treat these as priors, not evidence** — always cross-check against the verbatim stderr quote from §Step 1. (Added in #3032. The PAT-scope cascade on 2026-04-22/23 is the canonical example; the cap reduction from 20 → 3 is the anchor-bias defense for #3057.)
 - `ralph_done_content` (str | null) — contents of `{worktree}/tmp/ralph/ralph-done.txt` if present, else null.
 - `pr_url` (str | null) — if a PR was opened.
 - `pr_number` (int | null).
@@ -150,7 +198,7 @@ The recommendation JSON has this shape:
 Field rules:
 
 - `action` (required) — one of the eight known strings above, OR a novel action string if none fit. Novel actions persist to `dispatcher.unrecognized_diagnoser_actions` and fall back to `escalate` — use only when genuinely needed and the `reasoning` paragraph makes the intended behavior unambiguous.
-- `reasoning` (required) — a single paragraph (≤500 chars) explaining the choice in plain English. This gets surfaced in operator dashboards and the §8 weekly report. The first 1-3 sentences are also written to `dispatcher.agents.failure_summary` (issue #2900) so the admin cockpit can show an LLM-authored tooltip on hover over the outcome glyph — keep the opening sentences self-contained ("what happened + why this action"), not mid-argument.
+- `reasoning` (required) — a single paragraph (≤500 chars) explaining the choice in plain English. **The first sentence MUST include the verbatim stderr failure line you identified in §Step 1** (in backticks or double-quotes), unless the stderr genuinely had no failure line — in which case the first sentence must say so explicitly. This gets surfaced in operator dashboards and the §8 weekly report. The first 1-3 sentences are also written to `dispatcher.agents.failure_summary` (issue #2900) so the admin cockpit can show an LLM-authored tooltip on hover over the outcome glyph — keep the opening sentences self-contained ("what happened + why this action"), not mid-argument.
 - `hint` (conditional) — required when `action='retry_with_hint'`; the daemon posts it verbatim as an issue comment before enqueueing the retry marker. Ignored for other actions.
 - `new_scope` (conditional) — required when `action='reissue'`. **The daemon replaces the issue body wholesale** via `gh issue edit --body-file` (no splicing, no patching — Python writes the string to a file and `gh` edits the body). MUST be a complete, well-formed issue body with `## Goal`, `## Scope`, `## Acceptance criteria`, `## Priority`, `## References` sections and any `Parent: #N` / `Blocked by #N` lines. A diff, patch, or partial body will truncate the issue. Issue #3010.
 - `title` + `body` (conditional) — required when `action='file_prerequisite_task'`. Daemon runs `gh issue create --title <title> --body-file <body>`. The title must be conventional-commits style (e.g. `chore(dispatcher): add workflow scope to dispatcher PAT`); the body must be a well-formed issue body with acceptance criteria and verify lines.
@@ -163,7 +211,7 @@ Exit 0 regardless of recommendation. If the recommendation cannot be written (DB
 
 ## Action selection — decision tree
 
-Work through these questions in order. The first "yes" determines the action.
+Work through these questions in order. The first "yes" determines the action. **Remember §Step 1: every answer must be consistent with the verbatim stderr signature you already quoted. If a prior-decisions pattern suggests one category but your stderr quote contradicts it, trust the quote.**
 
 1. **Is this failure caused by an external dependency outage or a transient GitHub/Anthropic/AWS hiccup?** (Signs: `subprocess_crash` category, stderr mentions 5xx / timeouts / DNS / network errors, prior failures on unrelated issues in the same window but NOT a fleet-wide spate on the same category.)
    - → **`retry`**. The mechanical retry already ran once (tier 2), but if the root cause was a transient that has since cleared, a second attempt may succeed. No comment needed.
@@ -189,7 +237,7 @@ Work through these questions in order. The first "yes" determines the action.
 7. **Is there an already-open tracking issue for this blocker?** (Search via `gh issue list --search "<keywords>" --state open`.)
    - → **`block_on_existing_task`** with `blocker_issue_number = <that issue>`. Avoids duplicate tickets. The daemon validates the target is open, appends `Blocked by #<N>`, applies `status/blocked`.
 
-8. **Does `recent_fleet_decisions` show this same failure class hitting 3+ different issues in the last 6 hours?** (Regardless of which single action category above fits.)
+8. **Does `recent_fleet_decisions` show this same failure class hitting 3+ different issues in the last 6 hours?** (Regardless of which single action category above fits. **Cross-check: does your verbatim stderr quote match the failure class the fleet decisions describe?** If not, the pattern is a coincidence — do not anchor on it. See §Step 1.)
    - → **`file_prerequisite_task`** or **`escalate`** — the pattern is fleet-wide, a per-issue patch won't fix it. Prefer `file_prerequisite_task` if the root cause is trackable; `escalate` if it needs a human to even diagnose.
 
 **When uncertain, prefer `escalate` over a wrong guess.** A human re-classification is cheap; a wrong `close` or `reissue` can destroy context, and a wrong `block_*` may leave the issue stuck until an operator notices.
@@ -262,13 +310,15 @@ The context bundle should usually be enough. Shell out sparingly:
 
 1. **Set up.** Write `{worktree}/tmp/dispatcher-diagnoser/read_context.py` and `{worktree}/tmp/dispatcher-diagnoser/write_recommendation.py` helpers (code above). Run the reader with the `diagnosis_id` argument to pull the JSONB context into memory.
 
-2. **Classify.** Identify `failure_category` and `tier` from the context. Read `prior_mechanical_fix` (tier 2) or `ci_log_url` (tier 3) to understand what already failed. Scan `prior_diagnoses_this_issue` + `recent_fleet_decisions` for patterns.
+2. **Parse the failure signature FIRST (§Step 1 above, issue #3057).** Locate the raw `stderr_tail` in the context bundle, find the last concrete failure line (`FAILED:` / `[remote rejected]` / `error:` / banner), and write it verbatim into the `reasoning` field you will build. **Do this before reading any pattern-bearing field.** The stderr is ground truth; prior decisions are priors, not evidence.
 
-3. **Decide.** Walk the decision tree above. Do not fetch anything you don't need — context bundle first, GitHub reads only when a specific question remains.
+3. **Classify.** Identify `failure_category` and `tier` from the context. Read `prior_mechanical_fix` (tier 2) or `ci_log_url` (tier 3) to understand what already failed. Now — and only now — scan `prior_diagnoses_this_issue` + `recent_fleet_decisions` for patterns. If a pattern suggests a category that conflicts with your verbatim quote from step 2, trust the quote; the pattern is noise.
 
-4. **Write recommendation.** Serialize the recommendation dict to `{worktree}/tmp/dispatcher-diagnoser/recommendation.json`, then run the writer helper with the `diagnosis_id`, the `agent_id` (from `context.agent_id`), and the JSON file path. The helper writes both the diagnosis row AND the `dispatcher.agents.failure_summary` upgrade in one transaction — issue #2900.
+4. **Decide.** Walk the decision tree above. Do not fetch anything you don't need — context bundle first, GitHub reads only when a specific question remains.
 
-5. **Exit 0.** Done. The daemon picks up the recommendation on the next supervisor tick.
+5. **Write recommendation.** Serialize the recommendation dict to `{worktree}/tmp/dispatcher-diagnoser/recommendation.json`, then run the writer helper with the `diagnosis_id`, the `agent_id` (from `context.agent_id`), and the JSON file path. The helper writes both the diagnosis row AND the `dispatcher.agents.failure_summary` upgrade in one transaction — issue #2900.
+
+6. **Exit 0.** Done. The daemon picks up the recommendation on the next supervisor tick.
 
 ---
 
@@ -335,6 +385,18 @@ The context bundle should usually be enough. Shell out sparingly:
 }
 ```
 
+### Example 7 — coverage-floor pre-push abort, `file_prerequisite_task` (anchor-bias regression, #3057)
+
+```json
+{
+  "action": "file_prerequisite_task",
+  "reasoning": "The stderr ends with `\"FAILED: coverage floor for scraper-framework\"` followed by `\"FAIL: packages/scraper-framework: coverage dropped 80.0% -> 68.6% (floor violation)\"` and `\"1 check(s) failed. Push aborted.\"`. This is a local pre-push hook abort — the push never reached the remote. Despite several PAT-cascade decisions in recent_fleet_decisions, the verbatim stderr signature is coverage regression, not PAT scope. Filing a prerequisite task to restore the coverage floor before retrying.",
+  "title": "chore(scraper-framework): restore coverage floor after watchdog expansion",
+  "body": "## Goal\n\nRestore the `packages/scraper-framework` coverage floor to 80.0% (currently 68.6%) after the cc-retired watchdog expansion added uncovered branches.\n\n## Acceptance criteria\n- [ ] `scripts/update-coverage-baselines.py --package packages/scraper-framework` exits 0 at 80.0%+.\n  **Verify:** run pre-push hook against a no-op push on the worktree; the coverage-floor check passes.\n\n## Priority\n\np1 — blocks merge of the cc-retired watchdog work.",
+  "block_labels": ["priority/p1", "area/scraping", "agent/ready"]
+}
+```
+
 ---
 
 ## Reminders
@@ -344,3 +406,4 @@ The context bundle should usually be enough. Shell out sparingly:
 - This skill is Opus-tier per spec §18 — but the task is narrow. Do NOT over-investigate. The decision tree is intentionally short.
 - **Known actions (the daemon recognizes these eight):** `retry`, `retry_with_hint`, `reissue`, `escalate`, `close`, `block_and_comment`, `file_prerequisite_task`, `block_on_existing_task`. You MAY propose a novel action string when none of the known set fits the situation — the daemon will log the action name and payload to `dispatcher.unrecognized_diagnoser_actions` and fall back to `escalate` so an operator can review it. Novel actions are an explicit escape hatch; prefer a known action when one fits.
 - Exit 0 means "recommendation written". Exit non-zero means "I could not diagnose" — the daemon falls back to fixed mechanical escalation.
+- **§Step 1 is mandatory — always quote the verbatim stderr failure line before consulting priors (issue #3057).**

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -14654,6 +14654,16 @@ class DispatcherDaemon:
                 except Exception:  # pragma: no cover
                     pass
 
+        # Issue #3057 — cap the fleet-decisions bundle at N (default 3)
+        # to defuse anchor-bias on the Opus diagnoser. Prior behavior
+        # (LIMIT 20) let 9+ identical ``block_on_existing_task`` rows
+        # dominate the LLM's reasoning; on 2026-04-23 the diagnoser
+        # hallucinated a PAT-cascade push-rejection on a coverage-floor
+        # failure because of that pattern. With 3 most-recent entries
+        # the fleet-wide signal is still visible but cannot drown out
+        # the actual stderr. Operators can tune via
+        # ``dispatcher.config.diagnoser_fleet_decisions_cap``.
+        fleet_cap = self._cb_config_int("diagnoser_fleet_decisions_cap", 3)
         recent_fleet_decisions: list[dict[str, Any]] = []
         try:
             with self._conn.cursor() as cur:
@@ -14665,7 +14675,8 @@ class DispatcherDaemon:
                     "JOIN dispatcher.failures f ON f.failure_id = d.failure_id "
                     "WHERE d.status = 'completed' "
                     "  AND d.completed_at > now() - interval '6 hours' "
-                    "ORDER BY d.completed_at DESC LIMIT 20",
+                    "ORDER BY d.completed_at DESC LIMIT %s",
+                    (fleet_cap,),
                 )
                 rows = cur.fetchall()
             self._conn.commit()

--- a/scripts/dispatcher/tests/test_daemon_diagnoser_routing.py
+++ b/scripts/dispatcher/tests/test_daemon_diagnoser_routing.py
@@ -436,6 +436,237 @@ class TestContextBundleExtensions:
 
 
 # --------------------------------------------------------------------------
+# Issue #3057 — recent_fleet_decisions cap is configurable (anchor-bias defense)
+# --------------------------------------------------------------------------
+
+
+class TestFleetDecisionsCapConfigurable:
+    """Issue #3057 — ``recent_fleet_decisions`` defaults to LIMIT 3 instead
+    of the prior LIMIT 20, and the cap is tunable via
+    ``dispatcher.config.diagnoser_fleet_decisions_cap``.
+
+    The anchor-bias failure: on 2026-04-23 the Opus diagnoser hallucinated
+    a PAT-scope cascade push-rejection on a coverage-floor failure after
+    9 identical ``block_on_existing_task → #3038`` decisions populated the
+    fleet-decisions bundle. Reducing to 3 preserves the fleet-wide signal
+    without letting any single pattern dominate.
+    """
+
+    def _build_candidate(self) -> dict[str, Any]:
+        return {
+            "failure_id": 42,
+            "agent_id": "agent-cap",
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+            "tier": 2,
+            "issue_number": 3008,
+            "details": {},
+            "failure_ts": None,
+        }
+
+    def test_default_cap_is_three(self) -> None:
+        """With no ``diagnoser_fleet_decisions_cap`` row, the LIMIT parameter
+        passed to the SQL is 3 (the default)."""
+        cursor = _FakeCursor()
+        # agents row
+        cursor.fetch_queue.append((3008, "", None))
+        # _cb_config_int fetchone — no row means default (3).
+        cursor.fetch_queue.append(None)
+        # Phase transitions, prior failures, prior diagnoses, recent fleet decisions.
+        cursor.fetchall_queue.extend(
+            [
+                [],  # phase_transitions
+                [],  # prior_failures
+                [],  # prior_diagnoses_this_issue
+                [],  # recent_fleet_decisions
+            ]
+        )
+        d = _make_daemon(cursor)
+        with patch("dispatcher.daemon.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+            d._build_diagnoser_context(self._build_candidate())
+
+        # Find the SELECT that builds recent_fleet_decisions — the one
+        # joining dispatcher.diagnoses / agents / failures with the 6-hour
+        # window. Its params tuple should be ``(3,)`` — the default cap.
+        fleet_selects = [
+            (sql, params)
+            for (sql, params) in cursor.executed
+            if "FROM dispatcher.diagnoses d" in sql
+            and "JOIN dispatcher.agents" in sql
+            and "JOIN dispatcher.failures" in sql
+            and "interval '6 hours'" in sql
+        ]
+        assert len(fleet_selects) == 1, (
+            f"expected exactly one fleet-decisions SELECT, got {len(fleet_selects)}"
+        )
+        _sql, params = fleet_selects[0]
+        assert params == (3,), f"default cap should be 3; got {params!r}. SQL: {_sql!r}"
+
+    def test_cap_honors_dispatcher_config_override(self) -> None:
+        """When ``dispatcher.config.diagnoser_fleet_decisions_cap`` is set
+        to a different positive integer, the LIMIT parameter reflects it."""
+        cursor = _FakeCursor()
+        cursor.fetch_queue.append((3008, "", None))  # agents row
+        # _cb_config_int fetchone — returns a row with the override value.
+        # Shape: (value,) where value is the JSON-serializable cap.
+        cursor.fetch_queue.append((5,))
+        cursor.fetchall_queue.extend(
+            [
+                [],  # phase_transitions
+                [],  # prior_failures
+                [],  # prior_diagnoses_this_issue
+                [],  # recent_fleet_decisions
+            ]
+        )
+        d = _make_daemon(cursor)
+        with patch("dispatcher.daemon.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+            d._build_diagnoser_context(self._build_candidate())
+
+        fleet_selects = [
+            (sql, params)
+            for (sql, params) in cursor.executed
+            if "FROM dispatcher.diagnoses d" in sql
+            and "JOIN dispatcher.agents" in sql
+            and "JOIN dispatcher.failures" in sql
+            and "interval '6 hours'" in sql
+        ]
+        assert len(fleet_selects) == 1
+        _sql, params = fleet_selects[0]
+        assert params == (5,), (
+            f"override cap should be 5; got {params!r}. SQL: {_sql!r}"
+        )
+
+    def test_cap_uses_limit_parameter_not_hardcoded_literal(self) -> None:
+        """Regression guard: the SELECT must use a bound ``%s`` parameter
+        for LIMIT, not a hardcoded literal like ``LIMIT 20`` (which was
+        the pre-#3057 behavior that produced the anchor-bias failure)."""
+        cursor = _FakeCursor()
+        cursor.fetch_queue.append((3008, "", None))
+        cursor.fetch_queue.append(None)  # _cb_config_int → default
+        cursor.fetchall_queue.extend([[], [], [], []])
+        d = _make_daemon(cursor)
+        with patch("dispatcher.daemon.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+            d._build_diagnoser_context(self._build_candidate())
+
+        fleet_selects = [
+            sql
+            for (sql, _params) in cursor.executed
+            if "FROM dispatcher.diagnoses d" in sql
+            and "JOIN dispatcher.agents" in sql
+            and "interval '6 hours'" in sql
+        ]
+        assert len(fleet_selects) == 1
+        sql = fleet_selects[0]
+        # The old behavior baked 20 into the SQL string. The new behavior
+        # must parameterize the cap.
+        assert "LIMIT 20" not in sql, (
+            "LIMIT 20 literal still present — the #3057 fix should use "
+            "``LIMIT %s`` with the configurable cap"
+        )
+        assert "LIMIT %s" in sql, (
+            "expected ``LIMIT %s`` in fleet-decisions SELECT (issue #3057)"
+        )
+
+    def test_simulated_pat_cascade_context_does_not_crash_with_new_cap(
+        self,
+    ) -> None:
+        """Golden regression test for the anchor-bias bug (issue #3057).
+
+        Simulates the exact failure context from 2026-04-23: a failure
+        with a ``FAILED: coverage floor`` stderr arrives while the
+        fleet-decisions queue is dominated by ``block_on_existing_task →
+        #3038`` PAT-cascade decisions. The daemon-side context bundler
+        should now cap at 3 entries (down from 20) — limiting the LLM's
+        exposure to the PAT pattern.
+
+        The full anti-hallucination behavior is LLM-side (skill §Step 1
+        mandates a verbatim stderr quote before consulting priors), so
+        this test locks the structural half: the context bundle the
+        daemon hands the skill contains at most 3 fleet decisions, even
+        when the DB has more. The SQL ``LIMIT 3`` enforces the cap
+        server-side; this test asserts the Python-side bundle respects
+        it when the DB honors the LIMIT.
+        """
+        from datetime import datetime, timezone
+
+        cursor = _FakeCursor()
+        cursor.fetch_queue.append((2613, "", None))  # agents row for #2613
+        cursor.fetch_queue.append(None)  # _cb_config_int → default 3
+        t = datetime(2026, 4, 23, 6, 59, 0, tzinfo=timezone.utc)
+
+        # Simulate the DB-respected LIMIT 3 — three PAT-cascade decisions.
+        # (In real life, 9+ existed in the diagnoses table; the SQL
+        # LIMIT 3 means only the 3 most-recent come back.)
+        pat_decisions = [
+            (
+                300 + i,
+                f"agent-{i:02d}",
+                3008 + i,
+                "pre_push_hook_rejected",
+                {
+                    "action": "block_on_existing_task",
+                    "reasoning": (
+                        "PAT-scope cascade — refusing to allow a Personal "
+                        "Access Token to create or update workflow "
+                        ".github/workflows/.* without workflow scope. "
+                        "Tracked at #3038."
+                    ),
+                    "blocker_issue_number": 3038,
+                },
+                t,
+            )
+            for i in range(3)
+        ]
+        cursor.fetchall_queue.extend(
+            [
+                [],  # phase_transitions
+                [],  # prior_failures
+                [],  # prior_diagnoses_this_issue
+                pat_decisions,  # recent_fleet_decisions (capped at 3)
+            ]
+        )
+        candidate = {
+            "failure_id": 99,
+            "agent_id": "6d4029f0",
+            # A coverage-floor failure comes in as pre_push_hook_rejected
+            # category (the pre-push hook is what aborted).
+            "category": FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED,
+            "tier": 2,
+            "issue_number": 2613,
+            "details": {
+                "stderr_tail": (
+                    "pre-push: checking coverage floor for 'scraper-framework'...\n"
+                    "  FAILED: coverage floor for scraper-framework\n"
+                    "  Last 20 lines of output:\n"
+                    "    FAIL: packages/scraper-framework: coverage dropped "
+                    "80.0% -> 68.6% (floor violation)\n"
+                    "pre-push: 1 check(s) failed. Push aborted."
+                )
+            },
+            "failure_ts": None,
+        }
+        d = _make_daemon(cursor)
+        with patch("dispatcher.daemon.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="")
+            bundle = d._build_diagnoser_context(candidate)
+
+        # Structural assertion: the bundle's recent_fleet_decisions has
+        # at most 3 entries (SQL LIMIT 3 with default cap).
+        assert len(bundle["recent_fleet_decisions"]) <= 3
+        assert len(bundle["recent_fleet_decisions"]) == 3
+
+        # The fleet-decisions SELECT was called with LIMIT 3 bound param.
+        fleet_selects = [
+            (sql, params)
+            for (sql, params) in cursor.executed
+            if "FROM dispatcher.diagnoses d" in sql and "interval '6 hours'" in sql
+        ]
+        assert fleet_selects[0][1] == (3,)
+
+
+# --------------------------------------------------------------------------
 # AC#5 — new action handlers
 # --------------------------------------------------------------------------
 

--- a/scripts/dispatcher/tests/test_skill_md_contracts.py
+++ b/scripts/dispatcher/tests/test_skill_md_contracts.py
@@ -354,6 +354,74 @@ class TestDiagnoseFailureContracts:
             "requirement for new_scope (issue #3010)"
         )
 
+    # ------------------------------------------------------------------
+    # Issue #3057 — anchor-bias defense contracts
+    # ------------------------------------------------------------------
+
+    def test_step_1_parse_failure_signature_section(self) -> None:
+        """SKILL.md must have a "parse the failure signature" step that
+        runs BEFORE consulting prior decisions (issue #3057)."""
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        # The step heading. Allow either "Step 1" or "parse the failure
+        # signature" in a heading — the contract is that the first
+        # procedural step is to parse the signature, not consult priors.
+        lower = content.lower()
+        assert "parse the failure signature" in lower, (
+            "diagnose-failure/SKILL.md must have a "
+            "'parse the failure signature' step (issue #3057)"
+        )
+
+    def test_ground_truth_vs_priors_framing(self) -> None:
+        """SKILL.md must frame stderr as ground truth and prior decisions
+        as priors (not evidence). This is the core framing that defuses
+        the anchor-bias failure mode."""
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        lower = content.lower()
+        assert "stderr is ground truth" in lower, (
+            "diagnose-failure/SKILL.md must frame the stderr as "
+            "'ground truth' (issue #3057)"
+        )
+        assert "priors, not evidence" in lower, (
+            "diagnose-failure/SKILL.md must frame prior decisions as "
+            "'priors, not evidence' (issue #3057)"
+        )
+
+    def test_verbatim_quote_requirement(self) -> None:
+        """SKILL.md must require the diagnoser to quote the actual stderr
+        failure line verbatim in the ``reasoning`` field."""
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        lower = content.lower()
+        # The verbatim-quote language: must mention both "verbatim" and
+        # "reasoning" (the field where the quote lands).
+        assert "verbatim" in lower, (
+            "diagnose-failure/SKILL.md must mention 'verbatim' quoting "
+            "of the stderr failure line (issue #3057)"
+        )
+        assert "reasoning" in lower, (
+            "diagnose-failure/SKILL.md must describe where the verbatim "
+            "stderr quote lands (the ``reasoning`` field — issue #3057)"
+        )
+
+    def test_3057_issue_reference(self) -> None:
+        """SKILL.md must reference issue #3057 so future readers can
+        find the anchor-bias forensic."""
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        assert "#3057" in content, (
+            "diagnose-failure/SKILL.md must reference issue #3057 "
+            "(the anchor-bias forensic that motivated §Step 1)"
+        )
+
+    def test_fleet_decisions_cap_documented(self) -> None:
+        """SKILL.md must document the configurable cap on
+        ``recent_fleet_decisions`` (issue #3057 — default 3, tunable
+        via ``dispatcher.config.diagnoser_fleet_decisions_cap``)."""
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        assert "diagnoser_fleet_decisions_cap" in content, (
+            "diagnose-failure/SKILL.md must document the tunable cap "
+            "``dispatcher.config.diagnoser_fleet_decisions_cap`` "
+            "(issue #3057)"
+        )
+
 
 # ------------------------------------------------------------------
 # Issue #3017 — Per-skill heartbeat lines contract coverage.


### PR DESCRIPTION
## Summary

Defuse the Opus diagnoser's prior-decisions anchor bias that caused it to hallucinate a PAT-scope cascade push-rejection on a coverage-floor failure (agent `6d4029f0`, issue #2613, 2026-04-23). Two coordinated fixes: (1) a mandatory SKILL.md §Step 1 "parse the failure signature FIRST — quote the stderr verbatim before consulting priors," and (2) cap `recent_fleet_decisions` at 3 (was 20) via a new `dispatcher.config.diagnoser_fleet_decisions_cap` knob.

Closes #3057

## Test plan

### Automated checks
- [x] Lint passes (ruff check on touched files)
- [x] Format check passes (ruff format --check on touched files)
- [x] Tests pass (1031/1032 dispatcher suite + 629/652 scripts suite; pre-existing skips only)
- [x] CI green (run 24841403389 — `ci-passed` SUCCESS)

### Post-deploy verification
- [ ] Confirm the Fargate daemon deploy rolls the new dispatcher image after this merge (`deploy-dispatcher.yml`), verified by `DescribeServices` revision bump on `judgemind-dispatcher-dev`.
- [ ] On the next real diagnoser invocation post-deploy, inspect `dispatcher.diagnoses.recommendation->>'reasoning'` — it should contain a verbatim stderr quote (backticks or double-quotes wrapping a line from the triggering stderr_tail). If the failure signature is a coverage-floor / pre-push-hook-abort, the action MUST NOT be `block_on_existing_task` with `blocker_issue_number=3038`.
- [ ] Query `SELECT jsonb_array_length(context->'recent_fleet_decisions') FROM dispatcher.diagnoses WHERE diagnosis_id = (SELECT MAX(diagnosis_id) FROM dispatcher.diagnoses)` on dev — result should be ≤3.
- [ ] Verification evidence posted on issue (see A.8).
