### PR TITLE
fix(dispatcher): notify-telegram.sh exits non-zero on can't-send paths (#3061)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1194,11 +1194,22 @@ OVERNIGHT_CB_GOOD_OUTCOME_STATUSES: frozenset[str] = frozenset({"succeeded"})
 CAP_FLIPPED_BY_CIRCUIT_BREAKER = "circuit_breaker"
 
 #: Path to the Telegram notification helper. Invoked as a subprocess
-#: with ``--message-file <tmp>``. The helper exits 0 when Telegram is
-#: unconfigured (no-op), 2 when all sends fail — see
-#: ``scripts/notify-telegram.sh``. The daemon treats any non-zero exit
-#: as a warning, not a failure: the circuit-breaker flip has already
-#: happened regardless of whether the alert reaches the operator.
+#: with ``--message-file <tmp>``. Exit-code contract (see
+#: ``scripts/notify-telegram.sh``):
+#:
+#:   0 — at least one recipient received the message (HTTP 200).
+#:   1 — usage error (bad argv).
+#:   2 — all sends failed (every recipient got a non-200).
+#:   3 — secret fetch failed (e.g. InvalidRequestException, AccessDenied).
+#:   4 — bot_token empty in secret.
+#:   5 — allowed_user_ids empty in secret.
+#:
+#: The daemon treats any non-zero exit as a warning, not a failure: the
+#: circuit-breaker flip has already happened regardless of whether the
+#: alert reaches the operator. Issue #3061 — exit codes 3/4/5 were added
+#: so callers keying off ``returncode == 0`` no longer emit "sent" events
+#: for no-op / misconfigured paths (the prior script exited 0 on all
+#: three).
 NOTIFY_TELEGRAM_SCRIPT_RELPATH = "scripts/notify-telegram.sh"
 
 #: Hard timeout on the ``notify-telegram.sh`` subprocess. Short enough
@@ -1206,6 +1217,44 @@ NOTIFY_TELEGRAM_SCRIPT_RELPATH = "scripts/notify-telegram.sh"
 #: enough that AWS Secrets Manager + curl to the Bot API always fits
 #: on a healthy network.
 NOTIFY_TELEGRAM_SUBPROCESS_TIMEOUT_SECONDS = 30
+
+#: Per-exit-code mapping for ``scripts/notify-telegram.sh``. Values are
+#: ``(event_suffix, reason)`` tuples. Callers prepend a domain prefix
+#: (e.g. ``circuit_breaker_telegram_``) to build the full event name and
+#: include ``reason`` in the log extras when non-None (issue #3061).
+#:
+#: The dict is intentionally exhaustive for the known codes. An
+#: ``returncode`` not present here falls back to the caller's generic
+#: "nonzero_exit" event so we never silently swallow a new exit code.
+#:
+#: This helper exists as a module-level table so additional daemon
+#: callers (e.g. escalate-action wiring — the "Related" section of
+#: issue #3061) can reuse the mapping without duplicating the
+#: switch logic.
+NOTIFY_TELEGRAM_EXIT_CODE_MAPPING: dict[int, tuple[str, str | None]] = {
+    0: ("sent", None),
+    1: ("usage_error", None),
+    2: ("all_send_failed", None),
+    3: ("config_missing", "secret_fetch_failed"),
+    4: ("config_missing", "empty_bot_token"),
+    5: ("config_missing", "empty_user_ids"),
+}
+
+
+def _map_notify_telegram_exit_code(returncode: int) -> tuple[str, str | None]:
+    """Return ``(event_suffix, reason)`` for a ``notify-telegram.sh`` exit code.
+
+    ``event_suffix`` is the trailing portion of the structured log event
+    name (the caller prepends a domain prefix such as
+    ``circuit_breaker_telegram_``). ``reason`` is a free-text
+    discriminator for the ``config_missing`` bucket (which groups exit
+    codes 3/4/5 into one event) and is ``None`` for all other codes.
+
+    Unknown exit codes return ``("nonzero_exit", None)`` so a future
+    code added to the script without updating this mapping falls back
+    to the generic warning path — never silently treated as success.
+    """
+    return NOTIFY_TELEGRAM_EXIT_CODE_MAPPING.get(returncode, ("nonzero_exit", None))
 
 
 # --------------------------------------------------------------------------
@@ -14263,12 +14312,19 @@ class DispatcherDaemon:
     ) -> None:
         """Fire a Telegram alert via ``scripts/notify-telegram.sh``.
 
-        Best-effort — the helper script exits 0 when Telegram is
-        unconfigured (secret missing, no allowed user IDs) so the
-        daemon never depends on Telegram being wired up in a given
-        environment. A non-zero exit is logged as a warning and the
-        breaker is still considered "opened" (the cap flip is the
-        safety action; the alert is operator-UX).
+        Best-effort — a non-zero exit from the helper is logged as a
+        warning and the breaker is still considered "opened" (the cap
+        flip is the safety action; the alert is operator-UX).
+
+        Exit-code handling is delegated to
+        :func:`_map_notify_telegram_exit_code` so new daemon callers can
+        reuse the mapping. Issue #3061: prior to this change the helper
+        script exited 0 on three "misconfigured" paths (secret fetch
+        fail, empty bot_token, empty user_ids), so this method logged
+        ``circuit_breaker_telegram_sent`` for deliveries that never
+        actually happened. The helper now exits 3/4/5 on those paths
+        and this method maps them to ``circuit_breaker_telegram_config_missing``
+        with a ``reason`` field so the false-success events are gone.
         """
         repo_root = self._repo_root_for_notify_script()
         notify_script = repo_root / NOTIFY_TELEGRAM_SCRIPT_RELPATH
@@ -14316,24 +14372,22 @@ class DispatcherDaemon:
             )
             return
 
+        event_suffix, reason = _map_notify_telegram_exit_code(result.returncode)
+        event_name = f"circuit_breaker_telegram_{event_suffix}"
+        log_extra: dict[str, Any] = {
+            "event": event_name,
+            "run_id": self._run_id,
+            "exit_code": result.returncode,
+        }
+        if reason is not None:
+            log_extra["reason"] = reason
+        if result.returncode != 0:
+            log_extra["stderr_tail"] = (result.stderr or "")[-500:]
+
         if result.returncode == 0:
-            self._log.info(
-                "daemon.circuit_breaker_telegram_sent",
-                extra={
-                    "event": "circuit_breaker_telegram_sent",
-                    "run_id": self._run_id,
-                },
-            )
+            self._log.info(f"daemon.{event_name}", extra=log_extra)
         else:
-            self._log.warning(
-                "daemon.circuit_breaker_telegram_nonzero_exit",
-                extra={
-                    "event": "circuit_breaker_telegram_nonzero_exit",
-                    "run_id": self._run_id,
-                    "exit_code": result.returncode,
-                    "stderr_tail": (result.stderr or "")[-500:],
-                },
-            )
+            self._log.warning(f"daemon.{event_name}", extra=log_extra)
 
     def _render_circuit_breaker_telegram_message(
         self,

--- a/scripts/dispatcher/tests/test_daemon_circuit_breaker_tg.py
+++ b/scripts/dispatcher/tests/test_daemon_circuit_breaker_tg.py
@@ -1,0 +1,384 @@
+"""Exit-code → event mapping for ``_send_circuit_breaker_telegram_alert``.
+
+Issue #3061. The ``notify-telegram.sh`` helper now distinguishes
+"sent", "usage error", "all sends failed", and three
+"misconfigured — couldn't send" paths (secret fetch fail, empty
+bot_token, empty user_ids) via exit codes 0/1/2/3/4/5. The daemon
+caller must map those to distinct structured log events instead of
+logging ``circuit_breaker_telegram_sent`` for every exit-0 return (the
+pre-#3061 behavior that hid a ~4-week outage of real Telegram
+delivery).
+
+These tests exercise ``_send_circuit_breaker_telegram_alert`` with
+``subprocess.run`` mocked to return each exit code in turn and assert
+the correct event name + reason field fire. They also cover the
+module-level helper ``_map_notify_telegram_exit_code`` in isolation so
+future daemon callers (escalate, block_and_comment, …) can reuse the
+mapping without duplicating the switch logic.
+
+All external calls (subprocess, psycopg) are mocked — tests run in
+milliseconds and do not depend on AWS or Telegram.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+class _UniqueViolation(Exception):
+    """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+
+_psycopg_stub = MagicMock()
+_psycopg_errors = MagicMock()
+_psycopg_errors.UniqueViolation = _UniqueViolation
+_psycopg_stub.errors = _psycopg_errors
+sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — same shape as test_daemon_circuit_breaker.py. Kept
+# local so these tests don't import private fixtures from sibling files.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon_with_script(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler, Path]:
+    """Make a daemon plus a placeholder notify-telegram.sh under ``tmp_path``.
+
+    The send method short-circuits if the script path does not exist on
+    disk, so we write a stub file (never executed — subprocess.run is
+    mocked) inside ``tmp_path/scripts/``.
+    """
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.cb_tg.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+        baseline_repo_root=str(tmp_path),
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    notify = scripts_dir / "notify-telegram.sh"
+    notify.write_text("#!/bin/sh\n")
+    notify.chmod(0o755)
+
+    return d, conn, handler, notify
+
+
+def _invoke_alert_with_returncode(
+    d: daemon.DispatcherDaemon,
+    monkeypatch: Any,
+    returncode: int,
+    stderr: str = "",
+) -> None:
+    """Call ``_send_circuit_breaker_telegram_alert`` with subprocess mocked."""
+
+    def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+        r = MagicMock()
+        r.returncode = returncode
+        r.stdout = ""
+        r.stderr = stderr
+        return r
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    d._send_circuit_breaker_telegram_alert(
+        bad_count=5,
+        window_size=10,
+        window_minutes=30,
+        statuses=["failed", "crashed"],
+    )
+
+
+# --------------------------------------------------------------------------
+# Module-level helper — pure function, no daemon state needed.
+# --------------------------------------------------------------------------
+
+
+class TestMapNotifyTelegramExitCode:
+    """``_map_notify_telegram_exit_code`` maps each known exit code."""
+
+    def test_exit_0_maps_to_sent_without_reason(self) -> None:
+        event_suffix, reason = daemon._map_notify_telegram_exit_code(0)
+        assert event_suffix == "sent"
+        assert reason is None
+
+    def test_exit_1_maps_to_usage_error(self) -> None:
+        event_suffix, reason = daemon._map_notify_telegram_exit_code(1)
+        assert event_suffix == "usage_error"
+        assert reason is None
+
+    def test_exit_2_maps_to_all_send_failed(self) -> None:
+        event_suffix, reason = daemon._map_notify_telegram_exit_code(2)
+        assert event_suffix == "all_send_failed"
+        assert reason is None
+
+    def test_exit_3_maps_to_config_missing_secret_fetch_failed(self) -> None:
+        event_suffix, reason = daemon._map_notify_telegram_exit_code(3)
+        assert event_suffix == "config_missing"
+        assert reason == "secret_fetch_failed"
+
+    def test_exit_4_maps_to_config_missing_empty_bot_token(self) -> None:
+        event_suffix, reason = daemon._map_notify_telegram_exit_code(4)
+        assert event_suffix == "config_missing"
+        assert reason == "empty_bot_token"
+
+    def test_exit_5_maps_to_config_missing_empty_user_ids(self) -> None:
+        event_suffix, reason = daemon._map_notify_telegram_exit_code(5)
+        assert event_suffix == "config_missing"
+        assert reason == "empty_user_ids"
+
+    def test_unknown_exit_code_falls_back_to_nonzero_exit(self) -> None:
+        """An exit code we haven't mapped yet must fall through to the
+        generic warning path — never silently treated as success."""
+        event_suffix, reason = daemon._map_notify_telegram_exit_code(42)
+        assert event_suffix == "nonzero_exit"
+        assert reason is None
+
+    def test_negative_exit_code_falls_back_to_nonzero_exit(self) -> None:
+        """subprocess.run can return negative codes when the child was
+        killed by a signal. Those must also not be misread as success."""
+        event_suffix, reason = daemon._map_notify_telegram_exit_code(-9)
+        assert event_suffix == "nonzero_exit"
+        assert reason is None
+
+
+# --------------------------------------------------------------------------
+# End-to-end: ``_send_circuit_breaker_telegram_alert`` emits the right
+# event for each returncode. These are the tests that would have caught
+# the #3061 incident — exit codes 3/4/5 must NOT produce a "sent" event.
+# --------------------------------------------------------------------------
+
+
+class TestSendCircuitBreakerTelegramAlertEvents:
+    def test_returncode_0_emits_sent_info(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Happy path: exit 0 → INFO event circuit_breaker_telegram_sent."""
+        d, _c, handler, _notify = _make_daemon_with_script(tmp_path)
+
+        _invoke_alert_with_returncode(d, monkeypatch, returncode=0)
+
+        sent = handler.events("circuit_breaker_telegram_sent")
+        assert len(sent) == 1
+        record = sent[0]
+        assert record.levelno == logging.INFO
+        assert record.exit_code == 0  # type: ignore[attr-defined]
+        # No config_missing event — the sent event is exclusive.
+        assert handler.events("circuit_breaker_telegram_config_missing") == []
+        assert handler.events("circuit_breaker_telegram_nonzero_exit") == []
+
+    def test_returncode_1_emits_usage_error_warning(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _c, handler, _notify = _make_daemon_with_script(tmp_path)
+
+        _invoke_alert_with_returncode(
+            d, monkeypatch, returncode=1, stderr="Usage: notify-telegram.sh <msg>"
+        )
+
+        usage = handler.events("circuit_breaker_telegram_usage_error")
+        assert len(usage) == 1
+        assert usage[0].levelno == logging.WARNING
+        assert usage[0].exit_code == 1  # type: ignore[attr-defined]
+        # stderr tail carried into extras so the operator can diagnose.
+        assert "Usage" in usage[0].stderr_tail  # type: ignore[attr-defined]
+        # No false sent event.
+        assert handler.events("circuit_breaker_telegram_sent") == []
+
+    def test_returncode_2_emits_all_send_failed_warning(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Every recipient got a non-200 — explicit, distinct from
+        the pre-#3061 generic ``_nonzero_exit``."""
+        d, _c, handler, _notify = _make_daemon_with_script(tmp_path)
+
+        _invoke_alert_with_returncode(
+            d, monkeypatch, returncode=2, stderr="all 2 send(s) failed"
+        )
+
+        evts = handler.events("circuit_breaker_telegram_all_send_failed")
+        assert len(evts) == 1
+        assert evts[0].levelno == logging.WARNING
+        assert evts[0].exit_code == 2  # type: ignore[attr-defined]
+        assert handler.events("circuit_breaker_telegram_sent") == []
+
+    def test_returncode_3_emits_config_missing_secret_fetch_failed(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """#3061 primary regression: secret fetch fail must NOT log sent."""
+        d, _c, handler, _notify = _make_daemon_with_script(tmp_path)
+
+        _invoke_alert_with_returncode(
+            d,
+            monkeypatch,
+            returncode=3,
+            stderr="failed to fetch Telegram secret — Telegram notification NOT sent",
+        )
+
+        evts = handler.events("circuit_breaker_telegram_config_missing")
+        assert len(evts) == 1
+        record = evts[0]
+        assert record.levelno == logging.WARNING
+        assert record.exit_code == 3  # type: ignore[attr-defined]
+        assert record.reason == "secret_fetch_failed"  # type: ignore[attr-defined]
+        # Critical: the pre-#3061 false-success event must NOT fire.
+        assert handler.events("circuit_breaker_telegram_sent") == []
+
+    def test_returncode_4_emits_config_missing_empty_bot_token(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _c, handler, _notify = _make_daemon_with_script(tmp_path)
+
+        _invoke_alert_with_returncode(
+            d, monkeypatch, returncode=4, stderr="bot_token is empty in secret"
+        )
+
+        evts = handler.events("circuit_breaker_telegram_config_missing")
+        assert len(evts) == 1
+        assert evts[0].reason == "empty_bot_token"  # type: ignore[attr-defined]
+        assert handler.events("circuit_breaker_telegram_sent") == []
+
+    def test_returncode_5_emits_config_missing_empty_user_ids(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _c, handler, _notify = _make_daemon_with_script(tmp_path)
+
+        _invoke_alert_with_returncode(
+            d, monkeypatch, returncode=5, stderr="allowed_user_ids is empty in secret"
+        )
+
+        evts = handler.events("circuit_breaker_telegram_config_missing")
+        assert len(evts) == 1
+        assert evts[0].reason == "empty_user_ids"  # type: ignore[attr-defined]
+        assert handler.events("circuit_breaker_telegram_sent") == []
+
+    def test_unknown_returncode_emits_nonzero_exit_fallback(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """A future/unmapped exit code falls back to the generic
+        ``_nonzero_exit`` event — never ``_sent``."""
+        d, _c, handler, _notify = _make_daemon_with_script(tmp_path)
+
+        _invoke_alert_with_returncode(
+            d, monkeypatch, returncode=99, stderr="unexpected"
+        )
+
+        evts = handler.events("circuit_breaker_telegram_nonzero_exit")
+        assert len(evts) == 1
+        assert evts[0].levelno == logging.WARNING
+        assert evts[0].exit_code == 99  # type: ignore[attr-defined]
+        assert handler.events("circuit_breaker_telegram_sent") == []
+        assert handler.events("circuit_breaker_telegram_config_missing") == []
+
+
+# --------------------------------------------------------------------------
+# Regression: the sent-path must stay the happy path. This is the
+# acceptance criterion #3 from the issue — backward-compat with the
+# existing consumer (CloudWatch queries grepping for
+# ``circuit_breaker_telegram_sent``).
+# --------------------------------------------------------------------------
+
+
+class TestHappyPathBackwardCompat:
+    def test_returncode_0_event_name_matches_pre_3061(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """The exit-0 event name is unchanged so existing CloudWatch
+        queries / alarms keying off ``circuit_breaker_telegram_sent``
+        continue to fire without modification."""
+        d, _c, handler, _notify = _make_daemon_with_script(tmp_path)
+
+        _invoke_alert_with_returncode(d, monkeypatch, returncode=0)
+
+        sent = handler.events("circuit_breaker_telegram_sent")
+        assert len(sent) == 1
+        # The message prefix ("daemon.") + event name is what appears in
+        # CloudWatch Logs Insights queries. Lock in the full string.
+        assert sent[0].msg == "daemon.circuit_breaker_telegram_sent"

--- a/scripts/notify-telegram.sh
+++ b/scripts/notify-telegram.sh
@@ -15,9 +15,17 @@
 #   AWS_REGION defaults to us-west-2 if not set.
 #
 # Exit codes:
-#   0  — message sent successfully to at least one recipient (or no recipients configured)
-#   1  — usage error or secret retrieval failure
+#   0  — message sent successfully to at least one recipient
+#   1  — usage error
 #   2  — all sends failed (logged to stderr)
+#   3  — secret fetch failed (e.g. InvalidRequestException, AccessDenied)
+#   4  — bot_token is empty in the fetched secret
+#   5  — allowed_user_ids is empty in the fetched secret
+#
+# Exit codes 3/4/5 distinguish "misconfigured — can't actually send" from
+# success (exit 0). Prior to issue #3061 these paths exited 0 with a
+# stderr message, which caused daemon callers keying off the exit status
+# to log false "sent" events for deliveries that never happened.
 
 set -euo pipefail
 
@@ -56,8 +64,8 @@ SECRET_JSON="$(aws secretsmanager get-secret-value \
     --region "$AWS_REGION" \
     --query SecretString \
     --output text 2>/dev/null)" || {
-    echo "$SCRIPT_NAME: failed to fetch Telegram secret — skipping notification" >&2
-    exit 0
+    echo "$SCRIPT_NAME: failed to fetch Telegram secret — Telegram notification NOT sent" >&2
+    exit 3
 }
 
 # Extract bot token and user IDs using Python (available on all GHA runners)
@@ -65,13 +73,13 @@ BOT_TOKEN="$(echo "$SECRET_JSON" | python3 -c "import sys,json; print(json.load(
 USER_IDS="$(echo "$SECRET_JSON" | python3 -c "import sys,json; print(' '.join(str(x) for x in json.load(sys.stdin).get('allowed_user_ids',[])))")"
 
 if [ -z "$BOT_TOKEN" ]; then
-    echo "$SCRIPT_NAME: bot token is empty — Telegram not configured, skipping" >&2
-    exit 0
+    echo "$SCRIPT_NAME: bot_token is empty in secret — Telegram notification NOT sent" >&2
+    exit 4
 fi
 
 if [ -z "$USER_IDS" ]; then
-    echo "$SCRIPT_NAME: no allowed_user_ids configured — skipping" >&2
-    exit 0
+    echo "$SCRIPT_NAME: allowed_user_ids is empty in secret — Telegram notification NOT sent" >&2
+    exit 5
 fi
 
 # JSON-escape the message text for the Telegram API payload.

--- a/scripts/tests/test_notify_telegram_exit_codes.sh
+++ b/scripts/tests/test_notify_telegram_exit_codes.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# test_notify_telegram_exit_codes.sh — Tests for scripts/notify-telegram.sh exit codes
+#
+# Issue #3061. Asserts the script's exit-code contract:
+#
+#   0 — at least one recipient received HTTP 200
+#   1 — usage error (no args)
+#   2 — all sends failed (every recipient non-200)
+#   3 — secret fetch failed (aws returns non-zero)
+#   4 — bot_token empty in secret
+#   5 — allowed_user_ids empty in secret
+#
+# Strategy: run the script with a temp PATH that shadows `aws` and `curl`
+# with bash-function stubs. Each test controls the stubs' behavior via
+# env vars so we never touch real AWS or real Telegram.
+#
+# Usage:
+#   scripts/tests/test_notify_telegram_exit_codes.sh
+#
+# Exit codes:
+#   0 — all tests passed
+#   1 — one or more tests failed
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+NOTIFY_SCRIPT="$SCRIPT_DIR/notify-telegram.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+
+cleanup() {
+    set +eu
+    for d in "${TEMP_DIRS[@]}"; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Create a temp "bin" directory with stub `aws` and `curl` commands.
+# The stubs' behavior is controlled by env vars exported by each test:
+#   STUB_AWS_EXIT      — exit code for the `aws` stub (default 0)
+#   STUB_AWS_STDOUT    — stdout for the `aws` stub (default: valid secret JSON)
+#   STUB_CURL_HTTP     — value `curl` writes for `-w '%{http_code}'` (default 200)
+make_stub_bin() {
+    local bindir
+    bindir=$(mktemp -d)
+    TEMP_DIRS+=("$bindir")
+
+    cat > "$bindir/aws" <<'AWS_STUB'
+#!/usr/bin/env bash
+# Stub `aws` for notify-telegram.sh tests. Emits STUB_AWS_STDOUT
+# and exits with STUB_AWS_EXIT.
+exit_code="${STUB_AWS_EXIT:-0}"
+default_secret='{"bot_token":"test-token","allowed_user_ids":[42,43]}'
+if [ "$exit_code" = "0" ]; then
+    printf '%s' "${STUB_AWS_STDOUT:-$default_secret}"
+else
+    echo "stub-aws: simulated failure (STUB_AWS_EXIT=$exit_code)" >&2
+fi
+exit "$exit_code"
+AWS_STUB
+    chmod +x "$bindir/aws"
+
+    cat > "$bindir/curl" <<'CURL_STUB'
+#!/usr/bin/env bash
+# Stub `curl` for notify-telegram.sh tests. Writes STUB_CURL_HTTP to
+# stdout (the script uses -w '%{http_code}' -o /dev/null so we only
+# emit the HTTP code). Always exits 0.
+printf '%s' "${STUB_CURL_HTTP:-200}"
+CURL_STUB
+    chmod +x "$bindir/curl"
+
+    echo "$bindir"
+}
+
+# Run the notify script with a stubbed PATH. Echo exit code to stdout.
+run_notify() {
+    local bindir="$1"
+    shift
+    local exit_code=0
+    PATH="$bindir:$PATH" "$NOTIFY_SCRIPT" "$@" > /dev/null 2>&1 || exit_code=$?
+    echo "$exit_code"
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+test_usage_error_exits_1() {
+    local bindir
+    bindir=$(make_stub_bin)
+    local ec=0
+    PATH="$bindir:$PATH" "$NOTIFY_SCRIPT" > /dev/null 2>&1 || ec=$?
+    if [ "$ec" = "1" ]; then
+        pass "usage error (no args) exits 1"
+    else
+        fail "usage error (no args) exits 1" "got $ec, expected 1"
+    fi
+}
+
+test_secret_fetch_failure_exits_3() {
+    local bindir
+    bindir=$(make_stub_bin)
+    local ec
+    ec=$(STUB_AWS_EXIT=1 run_notify "$bindir" "test message")
+    if [ "$ec" = "3" ]; then
+        pass "secret fetch failure exits 3"
+    else
+        fail "secret fetch failure exits 3" "got $ec, expected 3"
+    fi
+}
+
+test_empty_bot_token_exits_4() {
+    local bindir
+    bindir=$(make_stub_bin)
+    local ec
+    ec=$(STUB_AWS_STDOUT='{"bot_token":"","allowed_user_ids":[42]}' \
+        run_notify "$bindir" "test message")
+    if [ "$ec" = "4" ]; then
+        pass "empty bot_token exits 4"
+    else
+        fail "empty bot_token exits 4" "got $ec, expected 4"
+    fi
+}
+
+test_missing_bot_token_key_exits_4() {
+    # When the key is absent, python3 .get('bot_token','') returns ''.
+    local bindir
+    bindir=$(make_stub_bin)
+    local ec
+    ec=$(STUB_AWS_STDOUT='{"allowed_user_ids":[42]}' \
+        run_notify "$bindir" "test message")
+    if [ "$ec" = "4" ]; then
+        pass "missing bot_token key exits 4"
+    else
+        fail "missing bot_token key exits 4" "got $ec, expected 4"
+    fi
+}
+
+test_empty_user_ids_exits_5() {
+    local bindir
+    bindir=$(make_stub_bin)
+    local ec
+    ec=$(STUB_AWS_STDOUT='{"bot_token":"test-token","allowed_user_ids":[]}' \
+        run_notify "$bindir" "test message")
+    if [ "$ec" = "5" ]; then
+        pass "empty allowed_user_ids exits 5"
+    else
+        fail "empty allowed_user_ids exits 5" "got $ec, expected 5"
+    fi
+}
+
+test_missing_user_ids_key_exits_5() {
+    local bindir
+    bindir=$(make_stub_bin)
+    local ec
+    ec=$(STUB_AWS_STDOUT='{"bot_token":"test-token"}' \
+        run_notify "$bindir" "test message")
+    if [ "$ec" = "5" ]; then
+        pass "missing allowed_user_ids key exits 5"
+    else
+        fail "missing allowed_user_ids key exits 5" "got $ec, expected 5"
+    fi
+}
+
+test_happy_path_exits_0() {
+    local bindir
+    bindir=$(make_stub_bin)
+    # Default stub secrets + default STUB_CURL_HTTP=200.
+    local ec
+    ec=$(run_notify "$bindir" "test message")
+    if [ "$ec" = "0" ]; then
+        pass "happy path (200 to all recipients) exits 0"
+    else
+        fail "happy path exits 0" "got $ec, expected 0"
+    fi
+}
+
+test_all_send_fail_exits_2() {
+    local bindir
+    bindir=$(make_stub_bin)
+    # Stub curl returns 500 for every recipient.
+    local ec
+    ec=$(STUB_CURL_HTTP=500 run_notify "$bindir" "test message")
+    if [ "$ec" = "2" ]; then
+        pass "all sends failed exits 2"
+    else
+        fail "all sends failed exits 2" "got $ec, expected 2"
+    fi
+}
+
+test_empty_message_exits_0() {
+    # The empty-message short-circuit is intentionally kept as exit 0
+    # (caller-side — "I handed you a blank message, nothing to do").
+    # The issue's exit-0-is-a-lie concern is about the CONFIG paths,
+    # not this argv-validation short-circuit.
+    local bindir
+    bindir=$(make_stub_bin)
+    local ec
+    ec=$(run_notify "$bindir" "")
+    if [ "$ec" = "0" ]; then
+        pass "empty message exits 0"
+    else
+        fail "empty message exits 0" "got $ec, expected 0"
+    fi
+}
+
+test_stderr_mentions_not_sent_on_config_paths() {
+    # Regression: the stderr message on exit codes 3/4/5 should
+    # make it unambiguous that nothing was delivered, so an operator
+    # grepping logs for "sent" doesn't get a false positive.
+    local bindir
+    bindir=$(make_stub_bin)
+    local stderr_out
+    stderr_out=$(STUB_AWS_EXIT=1 PATH="$bindir:$PATH" "$NOTIFY_SCRIPT" "msg" 2>&1 1>/dev/null || true)
+    if echo "$stderr_out" | grep -qi "NOT sent"; then
+        pass "exit 3 stderr includes 'NOT sent'"
+    else
+        fail "exit 3 stderr includes 'NOT sent'" "got: $stderr_out"
+    fi
+}
+
+# ── Run ────────────────────────────────────────────────────────────────────
+
+test_usage_error_exits_1
+test_secret_fetch_failure_exits_3
+test_empty_bot_token_exits_4
+test_missing_bot_token_key_exits_4
+test_empty_user_ids_exits_5
+test_missing_user_ids_key_exits_5
+test_happy_path_exits_0
+test_all_send_fail_exits_2
+test_empty_message_exits_0
+test_stderr_mentions_not_sent_on_config_paths
+
+echo ""
+echo "Ran $TESTS tests, $FAILURES failures"
+if [ "$FAILURES" -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

`scripts/notify-telegram.sh` previously `exit 0`'d on three "misconfigured — can't actually send" paths (missing AWS secret, empty `bot_token`, empty `allowed_user_ids`), so daemon callers keying off subprocess exit status logged `circuit_breaker_telegram_sent` events for deliveries that never happened. This PR makes those paths exit 3/4/5 and teaches `_send_circuit_breaker_telegram_alert` to map each exit code to a distinct structured log event via a reusable `_map_notify_telegram_exit_code()` helper.

Closes #3061

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Dispatcher deployed to dev (rollout completed, daemon booted healthy — evidence on #3061)
- [x] Verification evidence posted on #3061 (live CB-trip evidence deferred to next natural trip — unit-test-only acceptable per task spec)

## Exit-code → event mapping

| Exit code | Event name | Level | Reason field |
|---|---|---|---|
| 0 | `circuit_breaker_telegram_sent` | INFO | — |
| 1 | `circuit_breaker_telegram_usage_error` | WARNING | — |
| 2 | `circuit_breaker_telegram_all_send_failed` | WARNING | — |
| 3 | `circuit_breaker_telegram_config_missing` | WARNING | `secret_fetch_failed` |
| 4 | `circuit_breaker_telegram_config_missing` | WARNING | `empty_bot_token` |
| 5 | `circuit_breaker_telegram_config_missing` | WARNING | `empty_user_ids` |
| other | `circuit_breaker_telegram_nonzero_exit` | WARNING | — |

The `_map_notify_telegram_exit_code()` helper is module-level so future daemon callers (escalate wiring, etc. — see the "Related" section of #3061) can reuse the mapping without duplicating the switch.
