### PR TITLE
refactor(dispatcher): generalize post-merge phase cwd policy (#3065)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -348,6 +348,38 @@ PHASE_MODELS = {
     "retro": "haiku",
 }
 
+#: Phases that run *after* the PR has merged and the per-agent worktree
+#: may have been wiped from ephemeral storage. These phases must be
+#: spawned with ``cwd=baseline_repo_root`` (the stable clone re-populated
+#: at daemon boot by :meth:`DispatcherDaemon.ensure_baseline_clone`) so
+#: ``claude -p /task-v2-<phase>`` can resolve the matching
+#: ``.claude/skills/task-v2-<phase>/`` tree even when the worktree is
+#: empty.
+#:
+#: **Why this matters.** Fargate ``force-new-deployment`` (the daemon's
+#: restart mechanism) wipes the container's ephemeral storage under
+#: ``/var/lib/dispatcher/worktrees/``. Any phase that runs after that
+#: wipe — typically verify and retro, which sit past the ``merge`` step
+#: where the worktree has no further role — would otherwise inherit
+#: ``cwd=<wiped-worktree>`` and fail with ``Unknown command: /task-v2-<phase>``
+#: within ~50ms. Pre-merge phases (``plan``, ``ralph``, ``summary``,
+#: ``fix-ci``) keep ``cwd=worktree`` because (a) the worktree is
+#: guaranteed live while the agent is pre-merge, and (b) they run git
+#: operations that depend on the worktree's working tree.
+#:
+#: **Grep-able trail.** Each instance of this class of bug was first
+#: fixed per-phase, then generalized here:
+#:
+#: - #3034 — diagnoser subprocess cwd (``_spawn_diagnoser_subprocess``)
+#:   was the first instance; fixed by setting ``cwd=baseline_repo_root``
+#:   unconditionally.
+#: - #3060 (and #3055) — verify phase was the second; fixed by a
+#:   one-phase-name branch ``if phase == "verify"``.
+#: - #3065 — this generalization: every post-merge phase lives in this
+#:   set, so future additions (e.g. a post-retro bookkeeping phase)
+#:   inherit the correct cwd policy automatically.
+POST_MERGE_PHASES_USING_BASELINE_CWD: frozenset[str] = frozenset({"verify", "retro"})
+
 
 def _ralph_model_for_attempt(attempt_n: int) -> str:
     """Return the ``--model`` value for a ralph attempt (#2955).
@@ -6990,33 +7022,42 @@ class DispatcherDaemon:
         ``cwd=`` is the correct knob for "start the child process in
         this directory".
 
-        **Cwd for verify must be the baseline clone (#3055).** Verify is
-        a post-merge phase that runs on the recovery path after a
-        force-new-deployment (the prior daemon died mid-verify; the new
-        daemon picks up an ``awaiting_deploy/succeeded`` agent whose
-        worktree was wiped along with the prior container's ephemeral
-        storage). In that state, the per-agent worktree directory does
-        not exist on disk, and the ``.claude/skills/task-v2-verify/``
-        tree — which ``claude -p /task-v2-verify`` resolves relative to
-        ``cwd`` — is therefore not discoverable. The ``_write_phase_input``
-        call above happens to ``mkdir(parents=True)`` the worktree path
-        so ``Popen`` itself does not raise ``FileNotFoundError``, but the
-        re-created directory is empty of ``.claude/skills/`` so the
-        ``claude`` CLI exits ~50ms with ``result="Unknown command:
-        /task-v2-verify"``. The fix, paralleling #3034 for the diagnoser,
-        is to set ``cwd=baseline_repo_root`` on the verify spawn: the
-        baseline clone is re-populated at daemon boot by
-        :meth:`ensure_baseline_clone` and contains the full
-        ``.claude/skills/`` tree. The verify skill reads its own
-        ``worktree_path`` from the input JSON so it does not need to
-        start inside the worktree itself.
+        **Pre-merge vs post-merge cwd policy.** The subprocess ``cwd``
+        selection depends on whether the phase runs before or after the
+        PR has merged:
 
-        The other phases (plan, ralph, summary, fix-ci, retro) keep
-        ``cwd=str(worktree)`` because they run inside an active worktree
-        that is guaranteed to exist (they only execute while the agent
-        is pre-merge, so the worktree has not been wiped by a restart)
-        and they need the worktree's working tree available for git
-        operations (``git status``, ``git add``, ``git commit``).
+        - **Pre-merge phases** (``plan``, ``ralph``, ``summary``,
+          ``fix-ci``) use ``cwd=str(worktree)`` because they run inside
+          an active worktree that is guaranteed to exist (agent is still
+          pre-merge, so the worktree has not been wiped by a restart)
+          and they need the worktree's working tree available for git
+          operations (``git status``, ``git add``, ``git commit``).
+        - **Post-merge phases** (the members of
+          :data:`POST_MERGE_PHASES_USING_BASELINE_CWD`: currently
+          ``verify`` and ``retro``) use ``cwd=baseline_repo_root`` when
+          Fargate mode is active, because the per-agent worktree may
+          have been wiped by a ``force-new-deployment`` between merge
+          and the phase's first spawn. In that state the re-created
+          worktree directory (``_write_phase_input`` ``mkdir`` s it) is
+          empty of ``.claude/skills/``, so ``claude -p /task-v2-<phase>``
+          would exit ~50ms with ``result="Unknown command:
+          /task-v2-<phase>"``. The baseline clone is re-populated at
+          daemon boot by :meth:`ensure_baseline_clone` and contains the
+          full ``.claude/skills/`` tree. Post-merge skills read
+          ``worktree_path`` from their input JSON so they don't need to
+          start inside the worktree itself.
+
+        This policy was generalized in #3065. Prior incarnations fixed
+        the same class of bug per-phase:
+
+        - #3034 — diagnoser subprocess cwd (``_spawn_diagnoser_subprocess``).
+        - #3060 (and #3055) — verify phase cwd (``if phase == "verify"``
+          branch, now absorbed into the frozenset lookup below).
+
+        Adding a future post-merge phase (e.g. a bookkeeping ``close``
+        phase) requires only adding its name to
+        :data:`POST_MERGE_PHASES_USING_BASELINE_CWD`; the spawn code
+        below inherits the correct cwd automatically.
         """
         max_turns = PHASE_MAX_TURNS[phase]
         model = self._model_for_phase(phase, agent_id)
@@ -7026,14 +7067,20 @@ class DispatcherDaemon:
         jsonl_path = worktree / ".dispatcher" / f"{phase}-{agent_id}.jsonl"
         log_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # #3055 — verify phase must resolve the ``task-v2-verify`` skill
-        # from the baseline clone when running on the recovery path
-        # (post-restart, worktree wiped). Fall back to the worktree only
-        # when ``baseline_repo_root`` is unset (local-dev / unit-test
-        # mode), mirroring :meth:`_spawn_diagnoser_subprocess`. See the
-        # docstring rationale above.
+        # #3065 — post-merge phases must resolve their ``task-v2-<phase>``
+        # skill from the baseline clone when running on the recovery
+        # path (post-restart, worktree wiped). Generalizes the
+        # phase-specific fix from #3055 (verify) by looking up the
+        # phase name in :data:`POST_MERGE_PHASES_USING_BASELINE_CWD`.
+        # Falls back to the worktree only when ``baseline_repo_root``
+        # is unset (local-dev / unit-test mode), mirroring
+        # :meth:`_spawn_diagnoser_subprocess`. See the docstring
+        # rationale above for the pre- vs post-merge split.
         popen_cwd: Path = worktree
-        if phase == "verify" and self._cfg.baseline_repo_root is not None:
+        if (
+            phase in POST_MERGE_PHASES_USING_BASELINE_CWD
+            and self._cfg.baseline_repo_root is not None
+        ):
             popen_cwd = self._cfg.baseline_repo_root
 
         cmd = [

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -1442,13 +1442,16 @@ class TestSupervisorTickIntegration:
 
 
 class TestVerifyPhaseSpawnCwd:
-    """Issue #3055 — on the recovery path (force-new-deployment drops the
-    per-agent worktree from ephemeral storage), the verify phase spawn must
-    still discover ``.claude/skills/task-v2-verify/SKILL.md``. Paralleling
-    #3034's diagnoser fix, the fix sets ``cwd=baseline_repo_root`` for the
-    verify spawn (in Fargate mode). Other phases continue to run inside
-    the per-agent worktree because they need the working tree available
-    for git operations."""
+    """Issue #3055 (verify) + #3065 (retro generalization) — on the
+    recovery path (force-new-deployment drops the per-agent worktree from
+    ephemeral storage), every post-merge phase spawn must still discover
+    its ``.claude/skills/task-v2-<phase>/SKILL.md``. Paralleling #3034's
+    diagnoser fix, the fix sets ``cwd=baseline_repo_root`` for every
+    phase listed in
+    :data:`dispatcher.daemon.POST_MERGE_PHASES_USING_BASELINE_CWD`
+    (currently ``verify`` and ``retro``) in Fargate mode. Pre-merge
+    phases continue to run inside the per-agent worktree because they
+    need the working tree available for git operations."""
 
     def test_verify_spawn_uses_baseline_repo_root_as_cwd(
         self, monkeypatch: Any, tmp_path: Path
@@ -1534,15 +1537,99 @@ class TestVerifyPhaseSpawnCwd:
             f"Expected {worktree!s}, got {captured['kwargs']['cwd']!r}"
         )
 
-    def test_non_verify_phases_always_use_worktree_as_cwd(
+    def test_retro_spawn_uses_baseline_repo_root_as_cwd(
         self, monkeypatch: Any, tmp_path: Path
     ) -> None:
-        """Regression guard: the #3055 fix must NOT change the cwd for
-        plan / ralph / summary / fix-ci / retro spawns. Those phases run
-        pre-merge inside a live worktree, need the worktree's working
-        tree for git operations, and are not subject to the recovery-path
-        bug (the worktree can't be wiped while the agent is still
-        pre-merge and advancing)."""
+        """Issue #3065 — generalization of #3055 to the retro phase.
+        In Fargate mode (``baseline_repo_root`` set), the retro phase
+        subprocess must be launched with ``cwd=str(baseline_repo_root)``
+        so the ``task-v2-retro`` skill is discoverable even when the
+        per-agent worktree was wiped by a container restart between
+        merge and retro."""
+        from dispatcher.tests._popen_fake import make_popen_factory
+
+        d, _conn, _handler = _make_daemon(tmp_path)
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        d._cfg.baseline_repo_root = baseline
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        captured: dict[str, Any] = {}
+
+        def on_start(cmd: list[str], kwargs: dict[str, Any]) -> None:
+            captured["cmd"] = cmd
+            captured["kwargs"] = kwargs
+
+        monkeypatch.setattr(
+            subprocess,
+            "Popen",
+            make_popen_factory(
+                stdout_chunks=('{"result":"ok","is_error":false}\n',),
+                on_start=on_start,
+            ),
+        )
+        monkeypatch.setattr(d, "_agent_issue_number", lambda _aid: 42)
+
+        d._spawn_phase_subprocess("retro", worktree, "agent-id")
+
+        assert captured["kwargs"]["cwd"] == str(baseline), (
+            f"Popen cwd for retro must be the baseline_repo_root. "
+            f"Expected {baseline!s}, got {captured['kwargs']['cwd']!r}"
+        )
+
+    def test_retro_spawn_falls_back_to_worktree_in_local_mode(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """In local-dev mode (``baseline_repo_root`` unset), the retro
+        phase spawn must still pass ``cwd=str(worktree)`` — the per-agent
+        worktree IS the skill-containing tree in local dev."""
+        from dispatcher.tests._popen_fake import make_popen_factory
+
+        d, _conn, _handler = _make_daemon(tmp_path)
+        assert d._cfg.baseline_repo_root is None  # local-dev mode
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        captured: dict[str, Any] = {}
+
+        def on_start(cmd: list[str], kwargs: dict[str, Any]) -> None:
+            captured["kwargs"] = kwargs
+
+        monkeypatch.setattr(
+            subprocess,
+            "Popen",
+            make_popen_factory(
+                stdout_chunks=('{"result":"ok","is_error":false}\n',),
+                on_start=on_start,
+            ),
+        )
+        monkeypatch.setattr(d, "_agent_issue_number", lambda _aid: 42)
+
+        d._spawn_phase_subprocess("retro", worktree, "agent-id")
+
+        assert captured["kwargs"]["cwd"] == str(worktree), (
+            f"Popen cwd for retro in local-dev mode must be the worktree. "
+            f"Expected {worktree!s}, got {captured['kwargs']['cwd']!r}"
+        )
+
+    def test_pre_merge_phases_always_use_worktree_as_cwd(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Regression guard: the #3055 / #3065 generalization must NOT
+        change the cwd for ``plan`` / ``ralph`` / ``summary`` / ``fix-ci``
+        spawns. Those phases run pre-merge inside a live worktree, need
+        the worktree's working tree for git operations, and are not
+        subject to the recovery-path bug (the worktree can't be wiped
+        while the agent is still pre-merge and advancing).
+
+        Extend the tuple below if a new pre-merge phase is added. Do
+        not add post-merge phases here — those belong in
+        :data:`dispatcher.daemon.POST_MERGE_PHASES_USING_BASELINE_CWD`
+        and in the positive-side per-phase tests above."""
+        from dispatcher.daemon import POST_MERGE_PHASES_USING_BASELINE_CWD
         from dispatcher.tests._popen_fake import make_popen_factory
 
         d, _conn, _handler = _make_daemon(tmp_path)
@@ -1569,7 +1656,17 @@ class TestVerifyPhaseSpawnCwd:
         # assertion set.
         monkeypatch.setattr(d, "_start_ralph_head_watcher", lambda **_kwargs: None)
 
-        for phase in ("plan", "ralph", "summary", "fix-ci", "retro"):
+        pre_merge_phases = ("plan", "ralph", "summary", "fix-ci")
+        # Belt-and-braces: make sure the tuple above and the post-merge
+        # set are disjoint, so a future edit adding a phase to both
+        # surfaces as a test failure rather than silent drift.
+        assert set(pre_merge_phases) & POST_MERGE_PHASES_USING_BASELINE_CWD == set(), (
+            f"Pre-merge and post-merge phase sets must not overlap. "
+            f"Intersection: "
+            f"{set(pre_merge_phases) & POST_MERGE_PHASES_USING_BASELINE_CWD}"
+        )
+
+        for phase in pre_merge_phases:
             monkeypatch.setattr(
                 subprocess,
                 "Popen",
@@ -1582,9 +1679,23 @@ class TestVerifyPhaseSpawnCwd:
 
         for phase, cwd in captured_cwds.items():
             assert cwd == str(worktree), (
-                f"Non-verify phase {phase!r} must run in worktree cwd, "
+                f"Pre-merge phase {phase!r} must run in worktree cwd, "
                 f"not the baseline. Got cwd={cwd!r}, expected {worktree!s}."
             )
+
+    def test_post_merge_phase_set_membership(self) -> None:
+        """Issue #3065 — the module-level frozenset is the single source
+        of truth for which phases run post-merge. Lock in the current
+        membership (``verify``, ``retro``) so the generalization is not
+        silently undone, and adding a new post-merge phase is an
+        intentional edit accompanied by a test update."""
+        from dispatcher.daemon import POST_MERGE_PHASES_USING_BASELINE_CWD
+
+        assert POST_MERGE_PHASES_USING_BASELINE_CWD == frozenset({"verify", "retro"}), (
+            "POST_MERGE_PHASES_USING_BASELINE_CWD membership changed. If "
+            "intentional, update this assertion AND add a per-phase "
+            "cwd test for the new member. See #3065 for rationale."
+        )
 
 
 class TestVerifyRecoveryShortCircuit:


### PR DESCRIPTION
## Summary

Generalize the per-phase `cwd=baseline_repo_root` workaround that #3060 (verify) and #3034 (diagnoser) each applied one phase at a time. A new module-level `POST_MERGE_PHASES_USING_BASELINE_CWD = frozenset({"verify", "retro"})` drives the spawn-time cwd selection in `_spawn_phase_subprocess`, so retro — the next post-merge phase — is now protected against the same recovery-path bug, and future post-merge phases inherit the policy by membership instead of waiting for another incident.

Closes #3065

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] N/A — dispatcher daemon change; exercised by the existing per-agent Fargate rollout + the new unit tests in `test_daemon_phase3b.py`. The next Fargate redeploy will abandon the current in-flight ralph on #2655, which is expected per the issue's "Known context" section. The policy is validated by six unit tests (`TestVerifyPhaseSpawnCwd`) that monkeypatch `subprocess.Popen` and assert the `cwd` kwarg per-phase in Fargate and local-dev modes.
- [x] Verification evidence posted on #3065
