### PR TITLE
dx(task): rebase worktree onto origin/main at setup (#3075)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -267,6 +267,37 @@ Follow the full PR Workflow defined in CLAUDE.md. **All commits must be on the w
 
 **Why this section exists:** Two confirmed incidents (#2500, #2502) showed /task agents emitting `end_turn` after autocompact with `phase=ralph-worker (1)` in the status file — i.e. still mid-implementation, with uncommitted changes, no PR, and no merge. The agents read their own "iteration 1 COMPLETE" artifact as a done-signal and stopped. The recovery script is the mechanical self-check that prevents this failure mode.
 
+#### A.1a — Refresh worktree base onto origin/main (MANDATORY)
+
+**First action after worktree verification.** When Claude Code creates a worktree with `isolation: "worktree"`, the branch is cut from whatever `origin/main` was at the *moment of worktree creation* — which can be many merged PRs stale by the time the agent actually begins editing. Refresh the base before touching any files so the ralph loop and subsequent push don't hit surprise merge-bases (see #3075).
+
+The step runs `git fetch origin main` + `git rebase origin/main` under the hood, wrapped behind the `preflight_branch_fresh --fetch` helper (already defined in `scripts/preflight.sh`). Use the standalone wrapper — prevent stale-worktree-base merge-base surprises — see #3075:
+
+```
+{worktree}/scripts/preflight-branch-fresh.sh --fetch
+```
+
+`preflight-branch-fresh.sh` is a thin wrapper around `preflight_branch_fresh` in `scripts/preflight.sh`. The wrapper lets the check run in a single Bash tool call — `source scripts/preflight.sh && preflight_branch_fresh --fetch` trips the preflight hook's "quoted strings combined with &&" check. Same pattern as `check-duplicate-pr.sh` (see #2706).
+
+- **Exit 0 (fresh):** the worktree branch is at or ahead of `origin/main`. No rebase needed — continue to A.1.
+- **Exit 1 (behind origin/main):** a `PREFLIGHT FAIL: Branch is N commit(s) behind origin/main.` message was printed to stderr. Run the rebase as a separate tool call (CLAUDE.md §ALWAYS requires fetch-then-rebase; the wrapper already fetched, so only the rebase is left):
+  ```
+  git -C {worktree} rebase origin/main
+  ```
+  - **Rebase succeeds (clean fast-forward):** re-run `scripts/preflight-branch-fresh.sh` (no `--fetch` — we just fetched) to confirm the gap is closed, then continue to A.1.
+  - **Rebase fails with conflicts — STOP, do NOT auto-resolve.** This is the #3075 case where another PR landed that changed a file we would be editing. The agent has not yet started work, so there is no reasonable way to resolve conflicts against intent that has not yet been captured in code. Abort the rebase, post a block on the issue, release the `status/in-progress` label, and stop:
+    ```
+    git -C {worktree} rebase --abort
+    ```
+    Write a short block comment to `{worktree}/tmp/rebase_block.txt` naming the conflicting files and the competing origin/main commit(s), then (writes — stay on `gh`):
+    ```
+    gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/rebase_block.txt
+    gh issue edit <N> --repo judgemind/judgemind --add-label status/blocked --remove-label status/in-progress
+    ```
+    Stop — do not proceed to A.1. Worktree cleanup is automatic. A follow-up agent (or a human) can pick the issue up after the conflicting PR has been triaged.
+
+The daemon-side path (Fargate, `_create_worktree` in `scripts/dispatcher/daemon.py`) already runs `_baseline_fetch_origin_main` before `git worktree add` — see `scripts/dispatcher/tests/test_daemon_baseline_clone.py::TestCreateWorktreeBaselineMode`. A.1a exists because Claude Code's local `isolation: "worktree"` mode has no equivalent hook: the platform cuts the branch from whatever `origin/main` happens to be at worktree-creation time, which is minutes-to-hours before the agent actually starts editing.
+
 #### A.1 — Set up dependencies
 Write status: `phase: setup`, `summary: Installing dependencies for <packages>`.
 Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} setup`

--- a/scripts/preflight-branch-fresh.sh
+++ b/scripts/preflight-branch-fresh.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# preflight-branch-fresh.sh — Standalone wrapper around preflight_branch_fresh.
+#
+# Verifies the current branch is not behind origin/main. Used by the /task
+# skill's A.1a step (see .claude/skills/task/SKILL.md) to refresh the worktree
+# base before implementing, preventing stale-merge-base surprises at push time
+# (see #3075).
+#
+# This wrapper exists because calling the underlying function in a single Bash
+# tool invocation requires `source scripts/preflight.sh && preflight_branch_fresh
+# --fetch`, which the preflight hook blocks (quoted strings combined with `&&`).
+# A standalone script under scripts/ is covered by the `Bash(scripts/*)`
+# permission and runs without prompts — same pattern as check-duplicate-pr.sh
+# (see #2706).
+#
+# Usage:
+#   scripts/preflight-branch-fresh.sh           # check only (no fetch)
+#   scripts/preflight-branch-fresh.sh --fetch   # fetch origin main first, then check
+#
+# Exit codes (pass-through from preflight_branch_fresh):
+#   0 — Branch is at or ahead of origin/main. Safe to proceed.
+#   1 — Branch is behind origin/main. A PREFLIGHT FAIL line is printed to
+#       stderr with the commit-count gap. Caller should rebase.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=./preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+
+exit_code=0
+preflight_branch_fresh "$@" || exit_code=$?
+
+exit "$exit_code"

--- a/scripts/tests/test_preflight_branch_fresh.sh
+++ b/scripts/tests/test_preflight_branch_fresh.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# test_preflight_branch_fresh.sh — Tests for scripts/preflight-branch-fresh.sh
+#
+# The wrapper delegates to preflight_branch_fresh in scripts/preflight.sh.
+# This test sets up small temporary git repos that stand in for a freshly
+# created worktree (either up-to-date with origin/main, or behind by N
+# commits) and asserts the wrapper's exit code and stderr output.
+#
+# Covers:
+#   exit 0 — branch is at or ahead of origin/main
+#   exit 1 — branch is behind origin/main (PREFLIGHT FAIL printed to stderr)
+#   --fetch — the flag runs `git fetch origin main` before checking (the
+#             fetch itself is a no-op here because the "remote" is a local
+#             bare clone, but it exercises the same code path)
+#
+# Usage:
+#   scripts/tests/test_preflight_branch_fresh.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$SCRIPT_DIR/preflight-branch-fresh.sh"
+FAILURES=0
+TESTS=0
+
+TEMP_DIRS=()
+ORIG_PWD=$(pwd)
+
+cleanup() {
+    set +eu
+    cd "$ORIG_PWD" || true
+    for d in "${TEMP_DIRS[@]}"; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Precondition: wrapper exists and is executable ─────────────────────────
+
+if [[ ! -x "$WRAPPER" ]]; then
+    echo "FAIL: $WRAPPER is not executable (or does not exist)" >&2
+    exit 1
+fi
+
+# ── make_test_repo_fresh — worktree at origin/main HEAD ───────────────────
+#
+# Creates:
+#   $PAIR_DIR/remote.git — bare upstream with one commit on main
+#   $PAIR_DIR/wt         — worktree branch checked out at origin/main
+make_test_repo_fresh() {
+    local pair_dir
+    pair_dir=$(mktemp -d)
+    TEMP_DIRS+=("$pair_dir")
+
+    # Bootstrap the upstream.
+    git init --quiet --initial-branch=main "$pair_dir/upstream"
+    (
+        cd "$pair_dir/upstream"
+        git config user.email "test@example.com"
+        git config user.name "Test"
+        echo "hello" > README.md
+        git add README.md
+        git commit --quiet -m "initial"
+    )
+    git clone --quiet --bare "$pair_dir/upstream" "$pair_dir/remote.git" > /dev/null
+
+    # Clone into the worktree-like path, then branch off on an agent branch
+    # so we are not on main (preflight_not_on_main would fail, but this
+    # wrapper does not call it — still, mirror real worktree layout).
+    git clone --quiet "$pair_dir/remote.git" "$pair_dir/wt"
+    (
+        cd "$pair_dir/wt"
+        git config user.email "test@example.com"
+        git config user.name "Test"
+        git checkout --quiet -b agent/test
+    )
+
+    echo "$pair_dir"
+}
+
+# ── make_test_repo_behind — worktree behind origin/main by N commits ──────
+make_test_repo_behind() {
+    local behind_by="${1:-1}"
+    local pair_dir
+    pair_dir=$(make_test_repo_fresh)
+
+    # Advance origin/main ahead of the worktree branch. The upstream repo is
+    # the source of truth for remote.git (clone was --bare from it), so push
+    # new commits there via a second worktree-style clone that has remote.git
+    # as its origin.
+    local push_clone
+    push_clone=$(mktemp -d)
+    TEMP_DIRS+=("$push_clone")
+    git clone --quiet "$pair_dir/remote.git" "$push_clone/push" > /dev/null
+    (
+        cd "$push_clone/push"
+        git config user.email "test@example.com"
+        git config user.name "Test"
+        git checkout --quiet main
+        for i in $(seq 1 "$behind_by"); do
+            echo "advance $i" >> README.md
+            git add README.md
+            git commit --quiet -m "advance $i"
+        done
+        git push --quiet origin main
+    )
+
+    # Fetch the new origin/main into the worktree clone so HEAD..origin/main
+    # reports the advance.
+    (
+        cd "$pair_dir/wt"
+        git fetch --quiet origin main
+    )
+
+    echo "$pair_dir"
+}
+
+# ── Test 1: exit 0 when worktree is fresh (no flag) ────────────────────────
+
+fresh_pair=$(make_test_repo_fresh)
+exit_code=0
+(cd "$fresh_pair/wt" && "$WRAPPER") > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "exits 0 when branch is at origin/main (no --fetch)"
+else
+    fail "exits 0 when branch is at origin/main (no --fetch)" "expected 0, got $exit_code"
+fi
+
+# ── Test 2: exit 0 when worktree is fresh (--fetch) ────────────────────────
+
+exit_code=0
+(cd "$fresh_pair/wt" && "$WRAPPER" --fetch) > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "exits 0 when branch is at origin/main (with --fetch)"
+else
+    fail "exits 0 when branch is at origin/main (with --fetch)" "expected 0, got $exit_code"
+fi
+
+# ── Test 3: exit 1 when worktree is behind origin/main by 1 ────────────────
+
+behind_pair=$(make_test_repo_behind 1)
+exit_code=0
+stderr_output=$(cd "$behind_pair/wt" && "$WRAPPER" 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "exits 1 when branch is 1 commit behind origin/main"
+else
+    fail "exits 1 when branch is 1 commit behind origin/main" "expected 1, got $exit_code"
+fi
+
+if [[ "$stderr_output" == *"PREFLIGHT FAIL"* && "$stderr_output" == *"behind origin/main"* ]]; then
+    pass "prints PREFLIGHT FAIL message to stderr when behind"
+else
+    fail "prints PREFLIGHT FAIL message to stderr when behind" \
+        "expected stderr containing 'PREFLIGHT FAIL' and 'behind origin/main', got '$stderr_output'"
+fi
+
+# ── Test 4: exit 1 when worktree is behind by 3 (commit count in message) ──
+
+behind3_pair=$(make_test_repo_behind 3)
+exit_code=0
+stderr_output=$(cd "$behind3_pair/wt" && "$WRAPPER" 2>&1 >/dev/null) || exit_code=$?
+if [[ "$exit_code" -eq 1 && "$stderr_output" == *"3 commit"* ]]; then
+    pass "reports the commit-count gap when behind by 3"
+else
+    fail "reports the commit-count gap when behind by 3" \
+        "expected exit 1 and stderr containing '3 commit', got exit=$exit_code stderr='$stderr_output'"
+fi
+
+# ── Test 5: --fetch flag is passed through (exercises the fetch branch) ────
+#
+# We cannot easily distinguish "fetched" from "not fetched" without a network
+# dependency, but we can confirm the flag does not change the exit code or
+# break the function when invoked on an up-to-date worktree.
+
+exit_code=0
+(cd "$fresh_pair/wt" && "$WRAPPER" --fetch) > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "--fetch flag is accepted and does not break fresh-branch case"
+else
+    fail "--fetch flag is accepted and does not break fresh-branch case" "expected 0, got $exit_code"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add `A.1a — Refresh worktree base onto origin/main` to the `/task` skill so the worktree branch is rebased onto the freshest `origin/main` before the agent starts editing. Prevents stale-merge-base surprises at push time (#3065 retro). Implemented via a new `scripts/preflight-branch-fresh.sh` wrapper around the existing `preflight_branch_fresh` helper — same pattern as `check-duplicate-pr.sh` (#2706).

Scope is **local `/task` skill only.** The Fargate daemon's `_create_worktree` already calls `_baseline_fetch_origin_main` before `git worktree add` (daemon.py:4389-4390, covered by `test_daemon_baseline_clone.py::TestCreateWorktreeBaselineMode`).

Closes #3075

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (new `scripts/tests/test_preflight_branch_fresh.sh` + existing dispatcher suite)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (skill + helper script + shell test only; Fargate daemon unchanged)
- [x] Verification evidence posted on issue #3075
