### PR TITLE
fix(dispatcher): route five audit-gap failure categories through unified path (#3067 #3068 #3069 #3070 #3071)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -288,6 +288,34 @@ Two categories land in this skill via the post-exit parse path added for #3010:
 
 ---
 
+## Per-category guidance — post-merge verify failure (issue #3071)
+
+### `verify_failed_post_merge` — post-merge regression signal
+
+**This category is fundamentally different from pre-merge failures.** The PR is already merged; the code is on `main`; the dispatcher has already posted "merged" state to the cockpit. `/task-v2-verify` then ran against the deployed service and returned `verdict='FAILED'` — which means the deployed behavior did not match the issue's acceptance criteria. Your diagnosis is about a live regression, not a blocked implementation.
+
+**Context bundle extras.** In addition to the shared bundle shape, the daemon populates:
+
+- `pr_number` + `merge_sha` — the merged PR and its merge commit.
+- `failure_reason` (str) — the one-line summary from `/task-v2-verify`'s output.
+- `evidence_md` (str) — the verify phase's per-AC evidence markdown that was ALSO posted as an issue comment. Usually has "PASS:" / "FAIL:" lines per criterion.
+
+**Default action selection:**
+
+| Situation | Action | Why |
+|---|---|---|
+| The deployed behavior is clearly broken (a specific AC shows a concrete failure — wrong output, 500 response, missing field), the regression is visible to users, and the root cause is not obvious from the diff alone | `file_prerequisite_task` with `priority/p1` | Open a focused regression issue so a fresh agent (or a human) can investigate on a clean baseline. Title should be conventional-commits style; body should paste the verify `evidence_md` verbatim so the new agent has a reproducer. The daemon applies `Blocked by #<new>` to the current issue — but note that the current issue is already closed-via-merge, so the block is a tracking breadcrumb, not an active gate. |
+| The verify failure is ambiguous (intermittent, flaky external dep, unclear whether deployed code or test infra) | `block_and_comment` | Post the verify evidence as a comment and mark `status/needs-human`. A human decides whether to re-run verify, roll back, or file a fresh regression ticket. Do NOT auto-rollback — the daemon never touches `main`. |
+| The verify reason is "the deploy workflow succeeded but the service isn't healthy yet" / "DNS cached" / "ECS task still draining" — i.e. it's the verify phase racing the deployment | `escalate` | `retry` is a no-op in this flow (the daemon doesn't re-run verify post-done); `escalate` at least surfaces the race to a human. A future follow-up could add a verify-phase retry loop, but that's not this skill's decision. |
+
+**Do NOT pick `retry` or `retry_with_hint` for this category.** `retry` is a no-op in the post-merge flow (the daemon does not re-run `/task-v2-verify` from the retry-marker path; `phase='done'` is terminal in the post-merge pipeline). Recommending `retry` here will cause the daemon to enqueue a marker that never runs, and the agent will sit forever in `phase='done' status='failed'`. If the failure genuinely looks transient, prefer `escalate` and let a human manually re-invoke verify.
+
+**Do NOT pick `reissue` for this category.** The issue is already closed via merge; editing its body with a new scope will not re-open the PR or revert the merge. `reissue` is a pre-merge remedy.
+
+**Do NOT pick `close` for this category.** The issue is already closed. Re-closing is a no-op that destroys context.
+
+---
+
 ## Investigation steps — only as needed
 
 The context bundle should usually be enough. Shell out sparingly:

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -899,6 +899,57 @@ FAILURE_CATEGORY_GIT_PUSH_NETWORK = "git_push_network"
 FAILURE_CATEGORY_PR_CREATE_FAILED = "pr_create_failed"
 FAILURE_CATEGORY_PHASE_OUTPUT_MISSING = "phase_output_missing"
 
+#: Tier-2 first-occurrence category from issue #3067 — the daemon-side
+#: ``git commit --amend`` invoked by ``_push_and_open_pr`` after ralph
+#: SHIPped failed (exception or non-zero exit). The worktree still holds
+#: ralph's changes so a ``retry`` from the diagnoser can succeed; but a
+#: deterministic break (hook script bug, pre-push coverage floor
+#: regression caught at amend-time) wants ``escalate`` /
+#: ``file_prerequisite_task``. Routing the two call sites in
+#: ``_push_and_open_pr`` through ``_handle_agent_failure`` writes a
+#: ``dispatcher.failures`` row the diagnoser picks up on the next
+#: supervisor tick.
+FAILURE_CATEGORY_GIT_COMMIT_FAILED = "git_commit_failed"
+
+#: Tier-3 category from issue #3068 — the ``/task-v2-fix-ci`` subprocess
+#: returned ``verdict='BLOCKED'`` with a ``block_reason``. Exact analog
+#: of :data:`FAILURE_CATEGORY_RALPH_NOT_SHIP` (#3054): "implementation
+#: can't continue" with no mechanical retry that fixes it. The
+#: diagnoser's ``block_on_existing_task`` / ``file_prerequisite_task``
+#: / ``block_and_comment`` / ``escalate`` actions all apply depending
+#: on the ``block_reason`` text fix-ci surfaced.
+FAILURE_CATEGORY_FIX_CI_BLOCKED = "fix_ci_blocked"
+
+#: Tier-2 first-occurrence category from issue #3069 — the
+#: ``_apply_fix_ci_patch`` method has eight ``_mark_agent_terminal``
+#: sites covering ``fix_ci_missing_commit_message`` + every git-add /
+#: git-commit / git-push failure mode for the fix-ci patch. Pre-#3069
+#: none wrote a ``dispatcher.failures`` row — a deterministic
+#: operator-action blocker (e.g. PAT scope) was indistinguishable from
+#: a flaky push. Routing the cluster under this one category lets the
+#: Opus diagnoser pick retry vs escalate based on the ``sub_reason``
+#: carried in ``details``. Mirrors the #3032 push+PR refactor shape.
+FAILURE_CATEGORY_FIX_CI_APPLY_FAILED = "fix_ci_apply_failed"
+
+#: Tier-2 first-occurrence category from issue #3070 — post-merge
+#: deploy workflow failed (``_advance_awaiting_deploy`` classifies the
+#: deploy runs as ``failure``). The diagnoser can ``file_prerequisite_
+#: task`` (e.g. "infra broken, fix deploy role") or ``block_and_
+#: comment`` on the issue; pre-#3070 operators had to triage from the
+#: ``daemon.deploy_failed`` CloudWatch event alone.
+FAILURE_CATEGORY_DEPLOY_FAILED = "deploy_failed"
+
+#: Tier-3 category from issue #3071 — post-merge ``/task-v2-verify``
+#: subprocess returned ``verdict='FAILED'``. Genuine regression signal
+#: (the deployed code didn't behave as expected). Post-merge context
+#: is different from pre-merge failures: the PR is merged, the code is
+#: on main. ``retry`` is a no-op in this case; the relevant diagnoser
+#: actions are ``file_prerequisite_task`` (file a priority/p1
+#: regression issue), ``block_and_comment`` (with repro steps), or
+#: ``escalate``. See :file:`.claude/skills/diagnose-failure/SKILL.md`
+#: for the dedicated per-category guidance.
+FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE = "verify_failed_post_merge"
+
 #: Which failure categories auto-create a retry marker (tier 1 per
 #: spec §8 table). ``subprocess_turn_limit`` (tier 2) and
 #: ``subprocess_auth_fail`` (halt — no retry) are intentionally
@@ -1094,6 +1145,10 @@ TIER_2_FIRST_OCCURRENCE_CATEGORIES: frozenset[str] = frozenset(
         FAILURE_CATEGORY_GIT_PUSH_NETWORK,
         FAILURE_CATEGORY_PR_CREATE_FAILED,
         FAILURE_CATEGORY_PHASE_OUTPUT_MISSING,
+        # Audit-gap follow-ups from #3062 (tier-2 first-occurrence):
+        FAILURE_CATEGORY_GIT_COMMIT_FAILED,  # #3067
+        FAILURE_CATEGORY_FIX_CI_APPLY_FAILED,  # #3069
+        FAILURE_CATEGORY_DEPLOY_FAILED,  # #3070
     }
 )
 
@@ -1117,6 +1172,9 @@ TIER_3_CATEGORIES: frozenset[str] = frozenset(
         FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
         FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
         FAILURE_CATEGORY_RALPH_NOT_SHIP,
+        # Audit-gap follow-ups from #3062 (tier-3 first-occurrence):
+        FAILURE_CATEGORY_FIX_CI_BLOCKED,  # #3068
+        FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,  # #3071
     }
 )
 
@@ -10098,23 +10156,28 @@ class DispatcherDaemon:
                     "detail": str(exc),
                 },
             )
-            # ROUTING (#3062): NOT routed through
-            # ``_handle_agent_failure`` — pre-push ``git commit
-            # --amend`` exception. Filed as a follow-up in #3062
-            # because this is ralph_not_ship-adjacent: ralph SHIPped
-            # but the mechanical commit step crashed, so the
-            # diagnoser could usefully ``retry`` (worktree still
-            # holds ralph's changes). See follow-up for a
-            # ``FAILURE_CATEGORY_GIT_COMMIT_FAILED`` route.
-            self._mark_agent_terminal(
-                agent_id,
-                status="failed",
+            # ROUTING (#3062 #3067): ROUTED via ``_handle_agent_failure``
+            # — pre-push ``git commit --amend`` exception. Ralph SHIPped
+            # and the worktree still holds the changes, so the diagnoser
+            # can usefully ``retry`` on a transient exec / fs error, or
+            # ``escalate`` / ``file_prerequisite_task`` when the stderr
+            # shows a deterministic break (pre-push hook bug, coverage
+            # floor regression). Tier-2 first-occurrence.
+            self._handle_agent_failure(
+                agent_id=agent_id,
                 phase="push_and_pr",
+                category=FAILURE_CATEGORY_GIT_COMMIT_FAILED,
+                stderr_tail="",
                 exit_code=None,
+                details={
+                    "sub_reason": "commit_exception",
+                    "detail": str(exc),
+                },
                 issue_number=issue_number,
             )
             return
         if commit_result.returncode != 0:
+            tail = _stderr_tail(commit_result.stderr)
             self._log.warning(
                 "daemon.git_commit_failed",
                 extra={
@@ -10122,19 +10185,25 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "exit_code": commit_result.returncode,
-                    "stderr_tail": _stderr_tail(commit_result.stderr),
+                    "stderr_tail": tail,
                 },
             )
-            # ROUTING (#3062): NOT routed — see the exception branch
-            # above for the same rationale. Non-zero ``git commit
-            # --amend`` exit commonly indicates ralph's reset didn't
-            # produce a diff (the pre-#2971 bug class). Follow-up in
-            # #3062.
-            self._mark_agent_terminal(
-                agent_id,
-                status="failed",
+            # ROUTING (#3062 #3067): ROUTED via ``_handle_agent_failure``
+            # — non-zero ``git commit --amend`` exit. Commonly indicates
+            # ralph's reset didn't produce a diff (pre-#2971 bug class)
+            # or a local pre-push hook aborted the amend. Diagnoser
+            # reads stderr_tail + ralph_done + worktree state and picks
+            # retry / escalate / file_prerequisite_task accordingly.
+            self._handle_agent_failure(
+                agent_id=agent_id,
                 phase="push_and_pr",
-                exit_code=None,
+                category=FAILURE_CATEGORY_GIT_COMMIT_FAILED,
+                stderr_tail=tail,
+                exit_code=commit_result.returncode,
+                details={
+                    "sub_reason": "commit_nonzero_exit",
+                    "exit_code": commit_result.returncode,
+                },
                 issue_number=issue_number,
             )
             return
@@ -11187,6 +11256,7 @@ class DispatcherDaemon:
             )
             return
         # verdict == "BLOCKED" or unrecognized
+        block_reason = fix_ci_output.get("block_reason")
         self._log.warning(
             "daemon.fix_ci_blocked",
             extra={
@@ -11195,20 +11265,30 @@ class DispatcherDaemon:
                 "agent_id": agent_id,
                 "pr_number": pr_number,
                 "verdict": verdict,
-                "block_reason": fix_ci_output.get("block_reason"),
+                "block_reason": block_reason,
             },
         )
-        # ROUTING (#3062): NOT currently routed. This is an exact
-        # analog of the ralph_not_ship bug #3054 fixed — fix-ci
-        # returned a BLOCKED verdict with a ``block_reason``, no
-        # mechanical retry will help, and the diagnoser's
-        # ``block_on_existing_task`` / ``file_prerequisite_task`` /
-        # ``block_and_comment`` actions are exactly the right
-        # responses. Audit follow-up filed — should introduce
-        # ``FAILURE_CATEGORY_FIX_CI_BLOCKED`` as a tier-3 category
-        # and route via ``_handle_agent_failure``.
-        self._mark_agent_terminal(
-            agent_id, status="failed", phase="awaiting_ci", exit_code=exit_code
+        # ROUTING (#3062 #3068): ROUTED via ``_handle_agent_failure``
+        # with the tier-3 ``FAILURE_CATEGORY_FIX_CI_BLOCKED`` category.
+        # Exact analog of the ralph_not_ship fix (#3054): fix-ci
+        # returned BLOCKED with a ``block_reason``, no mechanical retry
+        # will help, and the diagnoser's ``block_on_existing_task`` /
+        # ``file_prerequisite_task`` / ``block_and_comment`` /
+        # ``escalate`` actions are the right responses.
+        self._handle_agent_failure(
+            agent_id=agent_id,
+            phase="awaiting_ci",
+            category=FAILURE_CATEGORY_FIX_CI_BLOCKED,
+            stderr_tail="",
+            exit_code=exit_code,
+            details={
+                "verdict": verdict,
+                "block_reason": block_reason,
+                "pr_number": pr_number,
+                "retries_used": retries_used,
+                "issue_number": issue_number,
+            },
+            issue_number=issue_number,
         )
 
     @staticmethod
@@ -11276,6 +11356,47 @@ class DispatcherDaemon:
         short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
         return f"agent/{short_id}"
 
+    def _handle_fix_ci_apply_failure(
+        self,
+        *,
+        agent_id: str,
+        sub_reason: str,
+        stderr_tail: str = "",
+        exit_code: int | None = None,
+        pr_number: int | None = None,
+        issue_number: int | None = None,
+        retries_used: int | None = None,
+        detail: str | None = None,
+    ) -> None:
+        """Route a fix-ci-apply failure through :meth:`_handle_agent_failure`.
+
+        Issue #3069: the eight terminal call sites inside
+        :meth:`_apply_fix_ci_patch` were pre-#3069 direct
+        ``_mark_agent_terminal`` calls with no failure row, making a
+        deterministic operator-action blocker (e.g. PAT scope on fix-ci
+        push) indistinguishable from a flaky push. This helper wraps
+        the common envelope so each site's call is one line and the
+        ``sub_reason`` carries the specific branch into the diagnoser's
+        ``details``. Mirrors the #3032 push+PR refactor shape.
+        """
+        details: dict[str, Any] = {
+            "sub_reason": sub_reason,
+            "pr_number": pr_number,
+            "issue_number": issue_number,
+            "retries_used": retries_used,
+        }
+        if detail is not None:
+            details["detail"] = detail
+        self._handle_agent_failure(
+            agent_id=agent_id,
+            phase="awaiting_ci",
+            category=FAILURE_CATEGORY_FIX_CI_APPLY_FAILED,
+            stderr_tail=stderr_tail,
+            exit_code=exit_code,
+            details=details,
+            issue_number=issue_number,
+        )
+
     def _apply_fix_ci_patch(
         self, agent: dict[str, Any], fix_ci_output: dict[str, Any]
     ) -> None:
@@ -11288,21 +11409,27 @@ class DispatcherDaemon:
         increment ``retries_used`` and leave the agent in
         ``awaiting_ci`` so the next supervisor tick re-polls.
 
-        ROUTING (#3062): the eight ``_mark_agent_terminal(status="failed")``
-        call sites inside this method are NOT routed through
-        ``_handle_agent_failure``. They cover
-        ``fix_ci_missing_commit_message`` + every git-add / git-commit
-        / git-push failure mode for the fix-ci patch. Audit follow-up
-        in #3062 proposes routing the whole cluster under a new
-        ``FAILURE_CATEGORY_FIX_CI_APPLY_FAILED`` tier-2 first-
-        occurrence category so the Opus diagnoser can distinguish a
-        flaky push (retry) from a deterministic worktree / permissions
-        break (escalate) — mirrors the #3032 push+PR refactor shape.
+        ROUTING (#3062 #3069): the eight
+        ``_mark_agent_terminal(status="failed")`` call sites inside
+        this method are now ROUTED through
+        :meth:`_handle_fix_ci_apply_failure` (and thence
+        :meth:`_handle_agent_failure`) under the tier-2 first-
+        occurrence ``FAILURE_CATEGORY_FIX_CI_APPLY_FAILED`` category.
+        Each site passes a distinct ``sub_reason`` string
+        (``missing_commit_message`` / ``git_add_exception`` /
+        ``git_add_nonzero_exit`` / ``git_commit_exception`` /
+        ``git_commit_nonzero_exit`` / ``git_push_timeout`` /
+        ``git_push_exception`` / ``git_push_nonzero_exit``) in
+        ``details`` so the diagnoser can distinguish a flaky push
+        (retry) from a deterministic worktree / permissions break
+        (escalate). Mirrors the #3032 push+PR refactor shape.
         """
         agent_id = agent["agent_id"]
         worktree = Path(agent["worktree_path"])
         branch = self._branch_for_agent(agent_id)
         retries_used = agent["retries_used"]
+        issue_number = agent.get("issue_number")
+        pr_number = agent.get("pr_number")
 
         commit_message = str(fix_ci_output.get("commit_message") or "").strip()
         if not commit_message:
@@ -11314,8 +11441,13 @@ class DispatcherDaemon:
                     "agent_id": agent_id,
                 },
             )
-            self._mark_agent_terminal(
-                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            # ROUTING (#3062 #3069): ROUTED via ``_handle_agent_failure``.
+            self._handle_fix_ci_apply_failure(
+                agent_id=agent_id,
+                sub_reason="missing_commit_message",
+                pr_number=pr_number,
+                issue_number=issue_number,
+                retries_used=retries_used,
             )
             return
 
@@ -11328,7 +11460,7 @@ class DispatcherDaemon:
                 timeout=60,
                 check=False,
             )
-        except Exception:
+        except Exception as exc:
             self._log.exception(
                 "daemon.fix_ci_git_add_failed",
                 extra={
@@ -11337,11 +11469,18 @@ class DispatcherDaemon:
                     "agent_id": agent_id,
                 },
             )
-            self._mark_agent_terminal(
-                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            # ROUTING (#3062 #3069): ROUTED via ``_handle_agent_failure``.
+            self._handle_fix_ci_apply_failure(
+                agent_id=agent_id,
+                sub_reason="git_add_exception",
+                pr_number=pr_number,
+                issue_number=issue_number,
+                retries_used=retries_used,
+                detail=str(exc),
             )
             return
         if add_result.returncode != 0:
+            tail = _stderr_tail(add_result.stderr)
             self._log.warning(
                 "daemon.fix_ci_git_add_failed",
                 extra={
@@ -11349,11 +11488,18 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "exit_code": add_result.returncode,
-                    "stderr_tail": _stderr_tail(add_result.stderr),
+                    "stderr_tail": tail,
                 },
             )
-            self._mark_agent_terminal(
-                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            # ROUTING (#3062 #3069): ROUTED via ``_handle_agent_failure``.
+            self._handle_fix_ci_apply_failure(
+                agent_id=agent_id,
+                sub_reason="git_add_nonzero_exit",
+                stderr_tail=tail,
+                exit_code=add_result.returncode,
+                pr_number=pr_number,
+                issue_number=issue_number,
+                retries_used=retries_used,
             )
             return
 
@@ -11377,7 +11523,7 @@ class DispatcherDaemon:
                 timeout=60,
                 check=False,
             )
-        except Exception:
+        except Exception as exc:
             self._log.exception(
                 "daemon.fix_ci_git_commit_failed",
                 extra={
@@ -11386,14 +11532,21 @@ class DispatcherDaemon:
                     "agent_id": agent_id,
                 },
             )
-            self._mark_agent_terminal(
-                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            # ROUTING (#3062 #3069): ROUTED via ``_handle_agent_failure``.
+            self._handle_fix_ci_apply_failure(
+                agent_id=agent_id,
+                sub_reason="git_commit_exception",
+                pr_number=pr_number,
+                issue_number=issue_number,
+                retries_used=retries_used,
+                detail=str(exc),
             )
             return
         if commit_result.returncode != 0:
             # ``git commit`` exits non-zero if nothing is staged —
             # that means the skill reported PATCHED but wrote no diff.
             # Treat as block.
+            tail = _stderr_tail(commit_result.stderr)
             self._log.warning(
                 "daemon.fix_ci_git_commit_failed",
                 extra={
@@ -11401,11 +11554,18 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "exit_code": commit_result.returncode,
-                    "stderr_tail": _stderr_tail(commit_result.stderr),
+                    "stderr_tail": tail,
                 },
             )
-            self._mark_agent_terminal(
-                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            # ROUTING (#3062 #3069): ROUTED via ``_handle_agent_failure``.
+            self._handle_fix_ci_apply_failure(
+                agent_id=agent_id,
+                sub_reason="git_commit_nonzero_exit",
+                stderr_tail=tail,
+                exit_code=commit_result.returncode,
+                pr_number=pr_number,
+                issue_number=issue_number,
+                retries_used=retries_used,
             )
             return
 
@@ -11436,11 +11596,17 @@ class DispatcherDaemon:
                     "detail": str(exc),
                 },
             )
-            self._mark_agent_terminal(
-                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            # ROUTING (#3062 #3069): ROUTED via ``_handle_agent_failure``.
+            self._handle_fix_ci_apply_failure(
+                agent_id=agent_id,
+                sub_reason="git_push_timeout",
+                pr_number=pr_number,
+                issue_number=issue_number,
+                retries_used=retries_used,
+                detail=str(exc),
             )
             return
-        except Exception:
+        except Exception as exc:
             self._log.exception(
                 "daemon.fix_ci_git_push_failed",
                 extra={
@@ -11449,11 +11615,18 @@ class DispatcherDaemon:
                     "agent_id": agent_id,
                 },
             )
-            self._mark_agent_terminal(
-                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            # ROUTING (#3062 #3069): ROUTED via ``_handle_agent_failure``.
+            self._handle_fix_ci_apply_failure(
+                agent_id=agent_id,
+                sub_reason="git_push_exception",
+                pr_number=pr_number,
+                issue_number=issue_number,
+                retries_used=retries_used,
+                detail=str(exc),
             )
             return
         if push_result.returncode != 0:
+            tail = _stderr_tail(push_result.stderr)
             self._log.warning(
                 "daemon.fix_ci_git_push_failed",
                 extra={
@@ -11461,11 +11634,18 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "exit_code": push_result.returncode,
-                    "stderr_tail": _stderr_tail(push_result.stderr),
+                    "stderr_tail": tail,
                 },
             )
-            self._mark_agent_terminal(
-                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            # ROUTING (#3062 #3069): ROUTED via ``_handle_agent_failure``.
+            self._handle_fix_ci_apply_failure(
+                agent_id=agent_id,
+                sub_reason="git_push_nonzero_exit",
+                stderr_tail=tail,
+                exit_code=push_result.returncode,
+                pr_number=pr_number,
+                issue_number=issue_number,
+                retries_used=retries_used,
             )
             return
 
@@ -11583,16 +11763,28 @@ class DispatcherDaemon:
                     "deploy_runs": deploy_runs,
                 },
             )
-            # ROUTING (#3062): NOT currently routed. A deploy workflow
-            # failure post-merge IS diagnoser-actionable — the
-            # diagnoser could ``file_prerequisite_task`` (e.g.
-            # "infra broken, fix deploy role") or
-            # ``block_and_comment`` on the issue. Audit follow-up
-            # proposes ``FAILURE_CATEGORY_DEPLOY_FAILED`` as a tier-2
-            # first-occurrence category. For now, operators triage
-            # from the ``daemon.deploy_failed`` event in CloudWatch.
-            self._mark_agent_terminal(
-                agent_id, status="failed", phase="awaiting_deploy", exit_code=None
+            # ROUTING (#3062 #3070): ROUTED via ``_handle_agent_failure``
+            # with the tier-2 first-occurrence
+            # ``FAILURE_CATEGORY_DEPLOY_FAILED`` category. A deploy
+            # workflow failure post-merge is diagnoser-actionable — the
+            # diagnoser picks ``file_prerequisite_task`` (e.g. "infra
+            # broken, fix deploy role"), ``block_and_comment``, or
+            # ``escalate`` based on the deploy-run metadata surfaced
+            # via ``details``.
+            issue_number_val = agent.get("issue_number")
+            self._handle_agent_failure(
+                agent_id=agent_id,
+                phase="awaiting_deploy",
+                category=FAILURE_CATEGORY_DEPLOY_FAILED,
+                stderr_tail="",
+                exit_code=None,
+                details={
+                    "pr_number": pr_number,
+                    "merge_sha": merge_sha,
+                    "deploy_runs": deploy_runs,
+                    "issue_number": issue_number_val,
+                },
+                issue_number=issue_number_val,
             )
             return
 
@@ -11963,6 +12155,7 @@ class DispatcherDaemon:
 
         verdict = str(verify_output.get("verdict") or "").upper()
         if verdict == "FAILED":
+            failure_reason = verify_output.get("failure_reason")
             self._log.warning(
                 "daemon.verify_failed",
                 extra={
@@ -11970,7 +12163,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "pr_number": pr_number,
-                    "failure_reason": verify_output.get("failure_reason"),
+                    "failure_reason": failure_reason,
                 },
             )
             # Issue #2953: verify failed post-merge is a genuine
@@ -11980,16 +12173,29 @@ class DispatcherDaemon:
             # tooltip can read "merged X · verify failed" instead of
             # hiding the shipment entirely.
             #
-            # ROUTING (#3062): NOT currently routed. A post-merge
-            # verify failure is genuine regression signal and
-            # diagnoser-actionable (file a priority/p1 regression
-            # issue via ``file_prerequisite_task``; or
-            # ``block_and_comment`` with repro steps). Audit follow-
-            # up proposes ``FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE``
-            # so the diagnoser gets the merged PR + verify evidence
-            # bundle and can pick the right escalation shape.
-            self._mark_agent_terminal(
-                agent_id, status="failed", phase="done", exit_code=exit_code
+            # ROUTING (#3062 #3071): ROUTED via ``_handle_agent_failure``
+            # with the tier-3 ``FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE``
+            # category. Post-merge context differs from pre-merge
+            # failures: the PR is merged, the code is on main.
+            # ``retry`` is a no-op; the diagnoser's primary actions
+            # are ``file_prerequisite_task`` (p1 regression issue),
+            # ``block_and_comment`` (repro steps), or ``escalate``.
+            # See :file:`.claude/skills/diagnose-failure/SKILL.md` for
+            # the dedicated per-category guidance.
+            self._handle_agent_failure(
+                agent_id=agent_id,
+                phase="done",
+                category=FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
+                stderr_tail="",
+                exit_code=exit_code,
+                details={
+                    "pr_number": pr_number,
+                    "merge_sha": merge_sha,
+                    "failure_reason": failure_reason,
+                    "evidence_md": evidence_md,
+                    "issue_number": issue_number,
+                },
+                issue_number=issue_number,
             )
             return
 

--- a/scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py
+++ b/scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py
@@ -1,0 +1,993 @@
+"""Unit tests for the five audit-gap routing fixes (#3067-#3071).
+
+Covers the five `_mark_agent_terminal(status="failed")` call sites
+identified by the #3062 audit that bypassed the #3032 unified failure
+path:
+
+* **#3067** — pre-push ``git commit --amend`` exception / non-zero exit
+  in :meth:`DispatcherDaemon._push_and_open_pr` routes through
+  :meth:`_handle_agent_failure` with
+  :data:`FAILURE_CATEGORY_GIT_COMMIT_FAILED` (tier-2 first-occurrence).
+
+* **#3068** — ``/task-v2-fix-ci`` ``verdict='BLOCKED'`` in
+  :meth:`_run_fix_ci` routes with
+  :data:`FAILURE_CATEGORY_FIX_CI_BLOCKED` (tier-3).
+
+* **#3069** — the eight terminal sites inside
+  :meth:`_apply_fix_ci_patch` (missing commit message + every git-add /
+  git-commit / git-push failure mode) route with
+  :data:`FAILURE_CATEGORY_FIX_CI_APPLY_FAILED` (tier-2 first-
+  occurrence), each carrying a distinct ``sub_reason`` in ``details``.
+
+* **#3070** — post-merge deploy workflow failure in
+  :meth:`_advance_awaiting_deploy` routes with
+  :data:`FAILURE_CATEGORY_DEPLOY_FAILED` (tier-2 first-occurrence).
+
+* **#3071** — post-merge ``/task-v2-verify`` ``verdict='FAILED'`` in
+  :meth:`_run_verify_and_complete` routes with
+  :data:`FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE` (tier-3).
+
+Each test class asserts:
+
+* Tier-set membership of the new category (AC #1 for each issue).
+* Call-site routes through ``_handle_agent_failure`` with the right
+  category + details shape (AC #2 for each issue).
+* The failure row is lifted by :meth:`_find_diagnoser_candidates` with
+  the expected ``tier`` (AC #3 — mirrors the ralph_not_ship
+  selection-helper coverage).
+
+Mirrors ``test_daemon_ralph_not_ship.py`` /
+``test_daemon_summary_output_incomplete.py`` style — same helper shape.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Install a psycopg stub whose ``errors.UniqueViolation`` is a real
+# Exception subclass — matches the pattern in earlier phase test files.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402 — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path, *, scope: str
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.audit_routing.{scope}.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+def _make_failure_row(
+    *,
+    failure_id: int,
+    agent_id: str,
+    category: str,
+    details: dict[str, Any],
+) -> tuple[int, str, str, dict[str, Any], datetime]:
+    return (
+        failure_id,
+        agent_id,
+        category,
+        details,
+        datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC),
+    )
+
+
+# ==========================================================================
+# #3067 — pre-push git_commit_failed routes through _handle_agent_failure
+# ==========================================================================
+
+
+class TestGitCommitFailedTierRegistration:
+    def test_git_commit_failed_is_tier_2_first_occurrence(self) -> None:
+        """``git_commit_failed`` diagnoses on first occurrence — the
+        worktree still holds ralph's changes so the diagnoser can pick
+        retry vs escalate based on stderr.
+        """
+        assert (
+            daemon.FAILURE_CATEGORY_GIT_COMMIT_FAILED
+            in daemon.TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        )
+
+    def test_git_commit_failed_not_in_auto_retry(self) -> None:
+        assert (
+            daemon.FAILURE_CATEGORY_GIT_COMMIT_FAILED
+            not in daemon.AUTO_RETRY_CATEGORIES
+        )
+
+    def test_git_commit_failed_not_in_tier3(self) -> None:
+        """Tier buckets must be disjoint — the candidate scanner's
+        tier assignment branches on exclusive membership."""
+        assert daemon.FAILURE_CATEGORY_GIT_COMMIT_FAILED not in daemon.TIER_3_CATEGORIES
+
+
+class TestGitCommitFailedRouting:
+    """Integration against ``_push_and_open_pr`` — focus on the two
+    ``git commit --amend`` terminal sites. Stubbing out enough of the
+    surrounding machinery that the commit branch can fire cleanly."""
+
+    def _patch(
+        self,
+        d: daemon.DispatcherDaemon,
+        *,
+        summary_output: dict[str, Any],
+        commit_raises: bool = False,
+        commit_nonzero: bool = False,
+    ) -> None:
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._is_noop_ship = MagicMock(return_value=False)  # type: ignore[method-assign]
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._agent_summary_output = summary_output
+        d._agent_unmet_criteria = []
+
+        import subprocess  # noqa: PLC0415
+
+        def fake_run(*args: Any, **kwargs: Any) -> Any:
+            if commit_raises:
+                raise OSError("cannot fork git")
+            result = MagicMock()
+            result.returncode = 1 if commit_nonzero else 0
+            result.stdout = ""
+            result.stderr = (
+                "error: no changes added to commit\n" if commit_nonzero else ""
+            )
+            return result
+
+        # Patch subprocess.run inside the daemon module.
+        self._orig_run = subprocess.run
+        subprocess.run = fake_run  # type: ignore[assignment]
+
+    def test_commit_exception_routes(self, tmp_path: Path, monkeypatch: Any) -> None:
+        """``git commit --amend`` raising triggers the unified handler
+        with ``sub_reason='commit_exception'``.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path, scope="git_commit_exc")
+        worktree = tmp_path / "wt"
+        (worktree / "tmp").mkdir(parents=True)
+
+        # Patch the subprocess call via monkeypatch so we restore cleanly.
+        import subprocess  # noqa: PLC0415
+
+        def _raise(*args: Any, **kwargs: Any) -> Any:
+            raise OSError("cannot fork git")
+
+        monkeypatch.setattr(subprocess, "run", _raise)
+
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._is_noop_ship = MagicMock(return_value=False)  # type: ignore[method-assign]
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._agent_summary_output = {
+            "commit_message": "feat(foo): bar (#3067)",
+            "pr_title": "feat(foo): bar (#3067)",
+            "pr_body_md": "## Summary\n\nBaz.\n\nCloses #3067",
+        }
+        d._agent_unmet_criteria = []
+
+        d._push_and_open_pr("agent-commit-exc", 3067, worktree)
+
+        d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
+        kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["agent_id"] == "agent-commit-exc"
+        assert kwargs["phase"] == "push_and_pr"
+        assert kwargs["category"] == daemon.FAILURE_CATEGORY_GIT_COMMIT_FAILED
+        assert kwargs["issue_number"] == 3067
+        assert kwargs["details"]["sub_reason"] == "commit_exception"
+        assert "cannot fork" in kwargs["details"]["detail"]
+        d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
+
+    def test_commit_nonzero_routes(self, tmp_path: Path, monkeypatch: Any) -> None:
+        """``git commit --amend`` returning non-zero triggers the
+        unified handler with ``sub_reason='commit_nonzero_exit'`` and
+        the stderr tail.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path, scope="git_commit_nonzero")
+        worktree = tmp_path / "wt"
+        (worktree / "tmp").mkdir(parents=True)
+
+        import subprocess  # noqa: PLC0415
+
+        def _nonzero(*args: Any, **kwargs: Any) -> Any:
+            result = MagicMock()
+            result.returncode = 1
+            result.stdout = ""
+            result.stderr = "error: nothing to commit, working tree clean\n"
+            return result
+
+        monkeypatch.setattr(subprocess, "run", _nonzero)
+
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._is_noop_ship = MagicMock(return_value=False)  # type: ignore[method-assign]
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._agent_summary_output = {
+            "commit_message": "feat(foo): bar (#3067)",
+            "pr_title": "feat(foo): bar (#3067)",
+            "pr_body_md": "## Summary\n\nBaz.\n\nCloses #3067",
+        }
+        d._agent_unmet_criteria = []
+
+        d._push_and_open_pr("agent-commit-nonzero", 3067, worktree)
+
+        d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
+        kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["category"] == daemon.FAILURE_CATEGORY_GIT_COMMIT_FAILED
+        assert kwargs["details"]["sub_reason"] == "commit_nonzero_exit"
+        assert kwargs["details"]["exit_code"] == 1
+        assert "nothing to commit" in kwargs["stderr_tail"]
+        d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
+
+
+class TestGitCommitFailedCandidatePickup:
+    def test_row_is_tier_2_candidate(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path, scope="git_commit_scan")
+        row = _make_failure_row(
+            failure_id=9001,
+            agent_id="agent-gc",
+            category=daemon.FAILURE_CATEGORY_GIT_COMMIT_FAILED,
+            details={
+                "issue_number": 3067,
+                "sub_reason": "commit_nonzero_exit",
+                "phase": "push_and_pr",
+                "exit_code": 1,
+                "stderr_tail": "error: nothing to commit",
+            },
+        )
+        conn.cursor_instance.fetchall_queue = [[row]]
+
+        candidates = d._find_diagnoser_candidates()
+
+        assert len(candidates) == 1
+        cand = candidates[0]
+        assert cand["failure_id"] == 9001
+        assert cand["category"] == daemon.FAILURE_CATEGORY_GIT_COMMIT_FAILED
+        assert cand["tier"] == 2
+        assert cand["issue_number"] == 3067
+
+
+# ==========================================================================
+# #3068 — fix_ci BLOCKED verdict routes through _handle_agent_failure
+# ==========================================================================
+
+
+class TestFixCiBlockedTierRegistration:
+    def test_fix_ci_blocked_is_tier_3(self) -> None:
+        """Exact analog of ralph_not_ship — fix-ci returning BLOCKED
+        with a block_reason is "implementation can't continue" with
+        no mechanical retry that fixes it.
+        """
+        assert daemon.FAILURE_CATEGORY_FIX_CI_BLOCKED in daemon.TIER_3_CATEGORIES
+
+    def test_fix_ci_blocked_not_in_auto_retry(self) -> None:
+        assert (
+            daemon.FAILURE_CATEGORY_FIX_CI_BLOCKED not in daemon.AUTO_RETRY_CATEGORIES
+        )
+
+    def test_fix_ci_blocked_not_in_tier2_buckets(self) -> None:
+        assert (
+            daemon.FAILURE_CATEGORY_FIX_CI_BLOCKED
+            not in daemon.TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        )
+        assert (
+            daemon.FAILURE_CATEGORY_FIX_CI_BLOCKED
+            not in daemon.TIER_2_RECURRENCE_CATEGORIES
+        )
+
+
+class TestFixCiBlockedRouting:
+    def _patch(
+        self,
+        d: daemon.DispatcherDaemon,
+        *,
+        fix_ci_output: dict[str, Any],
+    ) -> None:
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._materialize_prior_attempts = MagicMock(return_value=0)  # type: ignore[method-assign]
+        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+        d._read_phase_output = MagicMock(return_value=fix_ci_output)  # type: ignore[method-assign]
+        d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+        d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._extract_failing_jobs = MagicMock(return_value=[])  # type: ignore[method-assign]
+        d._fetch_pr_diff = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._apply_fix_ci_patch = MagicMock()  # type: ignore[method-assign]
+
+    def test_blocked_verdict_routes(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path, scope="fix_ci_blocked")
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        self._patch(
+            d,
+            fix_ci_output={
+                "verdict": "BLOCKED",
+                "block_reason": "pytest fixture relies on S3 creds not in CI",
+            },
+        )
+
+        agent = {
+            "agent_id": "agent-blocked",
+            "pr_number": 5001,
+            "issue_number": 3068,
+            "worktree_path": str(worktree),
+            "retries_used": 1,
+        }
+        pr_status: dict[str, Any] = {"statusCheckRollup": []}
+
+        d._run_fix_ci(agent, pr_status)
+
+        d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
+        kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["agent_id"] == "agent-blocked"
+        assert kwargs["phase"] == "awaiting_ci"
+        assert kwargs["category"] == daemon.FAILURE_CATEGORY_FIX_CI_BLOCKED
+        assert kwargs["issue_number"] == 3068
+        details = kwargs["details"]
+        assert details["verdict"] == "BLOCKED"
+        assert "pytest fixture" in details["block_reason"]
+        assert details["pr_number"] == 5001
+        assert details["retries_used"] == 1
+        d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
+
+    def test_unrecognized_verdict_also_routes(self, tmp_path: Path) -> None:
+        """Unrecognized verdict (neither PATCHED / FLAKY / BLOCKED) also
+        routes — the daemon's `else` branch treats it as BLOCKED."""
+        d, _conn, _handler = _make_daemon(tmp_path, scope="fix_ci_weird")
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        self._patch(
+            d,
+            fix_ci_output={"verdict": "CONFUSED", "block_reason": None},
+        )
+
+        agent = {
+            "agent_id": "agent-weird",
+            "pr_number": 5002,
+            "issue_number": 3068,
+            "worktree_path": str(worktree),
+            "retries_used": 0,
+        }
+
+        d._run_fix_ci(agent, {"statusCheckRollup": []})
+
+        d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
+        kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["category"] == daemon.FAILURE_CATEGORY_FIX_CI_BLOCKED
+        assert kwargs["details"]["verdict"] == "CONFUSED"
+        assert kwargs["details"]["block_reason"] is None
+
+    def test_patched_verdict_does_not_route(self, tmp_path: Path) -> None:
+        """Regression — PATCHED must still flow to ``_apply_fix_ci_patch``
+        and not touch the BLOCKED routing path."""
+        d, _conn, _handler = _make_daemon(tmp_path, scope="fix_ci_patched")
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        self._patch(
+            d,
+            fix_ci_output={
+                "verdict": "PATCHED",
+                "commit_message": "fix: y (#3068)",
+                "changed_files": ["foo.py"],
+            },
+        )
+
+        agent = {
+            "agent_id": "agent-patched",
+            "pr_number": 5003,
+            "issue_number": 3068,
+            "worktree_path": str(worktree),
+            "retries_used": 0,
+        }
+
+        d._run_fix_ci(agent, {"statusCheckRollup": []})
+
+        d._handle_agent_failure.assert_not_called()  # type: ignore[union-attr]
+        d._apply_fix_ci_patch.assert_called_once()  # type: ignore[union-attr]
+
+
+class TestFixCiBlockedCandidatePickup:
+    def test_row_is_tier_3_candidate(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path, scope="fix_ci_blocked_scan")
+        row = _make_failure_row(
+            failure_id=9002,
+            agent_id="agent-fcb",
+            category=daemon.FAILURE_CATEGORY_FIX_CI_BLOCKED,
+            details={
+                "issue_number": 3068,
+                "verdict": "BLOCKED",
+                "block_reason": "needs human review",
+                "pr_number": 5001,
+                "retries_used": 2,
+            },
+        )
+        conn.cursor_instance.fetchall_queue = [[row]]
+
+        candidates = d._find_diagnoser_candidates()
+
+        assert len(candidates) == 1
+        cand = candidates[0]
+        assert cand["category"] == daemon.FAILURE_CATEGORY_FIX_CI_BLOCKED
+        assert cand["tier"] == 3
+        assert cand["issue_number"] == 3068
+
+
+# ==========================================================================
+# #3069 — _apply_fix_ci_patch cluster routes through _handle_agent_failure
+# ==========================================================================
+
+
+class TestFixCiApplyFailedTierRegistration:
+    def test_fix_ci_apply_failed_is_tier_2_first_occurrence(self) -> None:
+        assert (
+            daemon.FAILURE_CATEGORY_FIX_CI_APPLY_FAILED
+            in daemon.TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        )
+
+    def test_fix_ci_apply_failed_not_in_auto_retry(self) -> None:
+        assert (
+            daemon.FAILURE_CATEGORY_FIX_CI_APPLY_FAILED
+            not in daemon.AUTO_RETRY_CATEGORIES
+        )
+
+
+class TestFixCiApplyFailedRouting:
+    """Each sub-reason routes through ``_handle_agent_failure`` with the
+    distinct ``sub_reason`` string in ``details``. The helper
+    :meth:`_handle_fix_ci_apply_failure` is the single ingress point —
+    testing that directly covers all eight terminal sites because every
+    one of them calls the helper (verified by code review + the
+    ``missing_commit_message`` end-to-end test below)."""
+
+    def test_helper_routes_with_correct_category(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path, scope="fix_ci_apply_helper")
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+
+        d._handle_fix_ci_apply_failure(
+            agent_id="agent-x",
+            sub_reason="git_push_nonzero_exit",
+            stderr_tail="remote rejected",
+            exit_code=1,
+            pr_number=42,
+            issue_number=3069,
+            retries_used=2,
+        )
+
+        d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
+        kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["agent_id"] == "agent-x"
+        assert kwargs["phase"] == "awaiting_ci"
+        assert kwargs["category"] == daemon.FAILURE_CATEGORY_FIX_CI_APPLY_FAILED
+        assert kwargs["issue_number"] == 3069
+        assert kwargs["stderr_tail"] == "remote rejected"
+        assert kwargs["exit_code"] == 1
+        details = kwargs["details"]
+        assert details["sub_reason"] == "git_push_nonzero_exit"
+        assert details["pr_number"] == 42
+        assert details["issue_number"] == 3069
+        assert details["retries_used"] == 2
+
+    def test_helper_populates_detail_field_when_provided(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path, scope="fix_ci_apply_detail")
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+
+        d._handle_fix_ci_apply_failure(
+            agent_id="agent-y",
+            sub_reason="git_push_timeout",
+            pr_number=43,
+            issue_number=3069,
+            retries_used=1,
+            detail="subprocess.TimeoutExpired after 60s",
+        )
+
+        kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["details"]["sub_reason"] == "git_push_timeout"
+        assert "TimeoutExpired" in kwargs["details"]["detail"]
+
+    def test_missing_commit_message_end_to_end(self, tmp_path: Path) -> None:
+        """End-to-end cover for one of the eight sites — the
+        ``missing_commit_message`` path fires before any subprocess
+        runs, so the test doesn't need subprocess patching."""
+        d, _conn, _handler = _make_daemon(tmp_path, scope="fix_ci_missing_msg")
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+
+        agent = {
+            "agent_id": "agent-empty-msg",
+            "worktree_path": str(worktree),
+            "retries_used": 0,
+            "issue_number": 3069,
+            "pr_number": 5050,
+        }
+        fix_ci_output: dict[str, Any] = {
+            "verdict": "PATCHED",
+            "commit_message": "",  # MISSING
+            "changed_files": ["foo.py"],
+        }
+
+        d._apply_fix_ci_patch(agent, fix_ci_output)
+
+        d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
+        kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["category"] == daemon.FAILURE_CATEGORY_FIX_CI_APPLY_FAILED
+        assert kwargs["details"]["sub_reason"] == "missing_commit_message"
+        assert kwargs["details"]["issue_number"] == 3069
+        assert kwargs["details"]["pr_number"] == 5050
+        d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
+
+
+class TestFixCiApplyFailedCandidatePickup:
+    def test_row_is_tier_2_candidate(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path, scope="fix_ci_apply_scan")
+        row = _make_failure_row(
+            failure_id=9003,
+            agent_id="agent-fca",
+            category=daemon.FAILURE_CATEGORY_FIX_CI_APPLY_FAILED,
+            details={
+                "issue_number": 3069,
+                "sub_reason": "git_push_nonzero_exit",
+                "phase": "awaiting_ci",
+                "exit_code": 1,
+                "stderr_tail": "",
+                "pr_number": 5051,
+                "retries_used": 2,
+            },
+        )
+        conn.cursor_instance.fetchall_queue = [[row]]
+
+        candidates = d._find_diagnoser_candidates()
+
+        assert len(candidates) == 1
+        cand = candidates[0]
+        assert cand["category"] == daemon.FAILURE_CATEGORY_FIX_CI_APPLY_FAILED
+        assert cand["tier"] == 2
+        assert cand["issue_number"] == 3069
+
+
+# ==========================================================================
+# #3070 — post-merge deploy_failed routes through _handle_agent_failure
+# ==========================================================================
+
+
+class TestDeployFailedTierRegistration:
+    def test_deploy_failed_is_tier_2_first_occurrence(self) -> None:
+        assert (
+            daemon.FAILURE_CATEGORY_DEPLOY_FAILED
+            in daemon.TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        )
+
+    def test_deploy_failed_not_in_auto_retry(self) -> None:
+        assert daemon.FAILURE_CATEGORY_DEPLOY_FAILED not in daemon.AUTO_RETRY_CATEGORIES
+
+
+class TestDeployFailedRouting:
+    def test_deploy_failure_routes(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path, scope="deploy_failed")
+
+        d._fetch_pr_status = MagicMock(  # type: ignore[method-assign]
+            return_value={"mergeCommit": {"oid": "beefface"}}
+        )
+        d._extract_merge_sha = MagicMock(return_value="beefface")  # type: ignore[method-assign]
+        deploy_runs = [
+            {
+                "databaseId": 111,
+                "workflowName": "Deploy dispatcher",
+                "status": "COMPLETED",
+                "conclusion": "FAILURE",
+                "createdAt": "2026-04-23T12:00:00Z",
+            }
+        ]
+        d._find_deploy_runs = MagicMock(return_value=deploy_runs)  # type: ignore[method-assign]
+        d._classify_deploy_runs = MagicMock(return_value="failure")  # type: ignore[method-assign]
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._run_verify_and_complete = MagicMock()  # type: ignore[method-assign]
+
+        agent = {
+            "agent_id": "agent-deploy-fail",
+            "pr_number": 7070,
+            "issue_number": 3070,
+        }
+
+        d._advance_awaiting_deploy(agent)
+
+        d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
+        kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["agent_id"] == "agent-deploy-fail"
+        assert kwargs["phase"] == "awaiting_deploy"
+        assert kwargs["category"] == daemon.FAILURE_CATEGORY_DEPLOY_FAILED
+        assert kwargs["issue_number"] == 3070
+        details = kwargs["details"]
+        assert details["pr_number"] == 7070
+        assert details["merge_sha"] == "beefface"
+        assert details["deploy_runs"] == deploy_runs
+        d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
+        d._run_verify_and_complete.assert_not_called()  # type: ignore[union-attr]
+
+    def test_deploy_success_still_advances_to_verify(self, tmp_path: Path) -> None:
+        """Regression — a successful deploy still reaches verify and
+        does NOT touch the new failure-routing path."""
+        d, _conn, _handler = _make_daemon(tmp_path, scope="deploy_success")
+
+        d._fetch_pr_status = MagicMock(  # type: ignore[method-assign]
+            return_value={"mergeCommit": {"oid": "cafed00d"}}
+        )
+        d._extract_merge_sha = MagicMock(return_value="cafed00d")  # type: ignore[method-assign]
+        d._find_deploy_runs = MagicMock(return_value=[])  # type: ignore[method-assign]
+        d._classify_deploy_runs = MagicMock(return_value="success")  # type: ignore[method-assign]
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._run_verify_and_complete = MagicMock()  # type: ignore[method-assign]
+
+        agent = {
+            "agent_id": "agent-deploy-ok",
+            "pr_number": 7071,
+            "issue_number": 3070,
+        }
+
+        d._advance_awaiting_deploy(agent)
+
+        d._handle_agent_failure.assert_not_called()  # type: ignore[union-attr]
+        d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
+        d._run_verify_and_complete.assert_called_once()  # type: ignore[union-attr]
+
+
+class TestDeployFailedCandidatePickup:
+    def test_row_is_tier_2_candidate(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path, scope="deploy_failed_scan")
+        row = _make_failure_row(
+            failure_id=9004,
+            agent_id="agent-df",
+            category=daemon.FAILURE_CATEGORY_DEPLOY_FAILED,
+            details={
+                "issue_number": 3070,
+                "phase": "awaiting_deploy",
+                "pr_number": 7070,
+                "merge_sha": "beefface",
+                "exit_code": None,
+                "stderr_tail": "",
+            },
+        )
+        conn.cursor_instance.fetchall_queue = [[row]]
+
+        candidates = d._find_diagnoser_candidates()
+
+        assert len(candidates) == 1
+        cand = candidates[0]
+        assert cand["category"] == daemon.FAILURE_CATEGORY_DEPLOY_FAILED
+        assert cand["tier"] == 2
+        assert cand["issue_number"] == 3070
+
+
+# ==========================================================================
+# #3071 — post-merge verify FAILED routes through _handle_agent_failure
+# ==========================================================================
+
+
+class TestVerifyFailedPostMergeTierRegistration:
+    def test_verify_failed_post_merge_is_tier_3(self) -> None:
+        assert (
+            daemon.FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE in daemon.TIER_3_CATEGORIES
+        )
+
+    def test_verify_failed_post_merge_not_in_auto_retry(self) -> None:
+        assert (
+            daemon.FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE
+            not in daemon.AUTO_RETRY_CATEGORIES
+        )
+
+    def test_verify_failed_post_merge_not_in_tier2_buckets(self) -> None:
+        assert (
+            daemon.FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE
+            not in daemon.TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        )
+        assert (
+            daemon.FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE
+            not in daemon.TIER_2_RECURRENCE_CATEGORIES
+        )
+
+
+class TestVerifyFailedPostMergeSkillContract:
+    """Issue #3071 AC #3: diagnose-failure skill must have a section
+    for verify_failed_post_merge distinguishing post-merge from pre-
+    merge failures."""
+
+    def _skill_content(self) -> str:
+        skill_path = (
+            Path(__file__).resolve().parents[3]
+            / ".claude"
+            / "skills"
+            / "diagnose-failure"
+            / "SKILL.md"
+        )
+        return skill_path.read_text()
+
+    def test_skill_has_verify_failed_post_merge_section(self) -> None:
+        content = self._skill_content()
+        assert "verify_failed_post_merge" in content, (
+            "diagnose-failure/SKILL.md must have a verify_failed_post_merge "
+            "section (issue #3071)"
+        )
+
+    def test_skill_discourages_retry_for_post_merge(self) -> None:
+        """The post-merge section must explicitly tell the diagnoser
+        not to pick ``retry`` (the daemon doesn't re-run verify from
+        the retry-marker path, so a retry recommendation here would
+        leave the agent stuck)."""
+        content = self._skill_content().lower()
+        # Either phrasing is acceptable — the contract is "don't pick retry".
+        assert (
+            "do not pick `retry`" in content
+            or "do not pick retry" in content
+            or "retry` or `retry_with_hint`" in content
+        ), (
+            "diagnose-failure/SKILL.md must discourage `retry` for "
+            "verify_failed_post_merge (issue #3071)"
+        )
+
+    def test_skill_mentions_primary_actions(self) -> None:
+        """The post-merge section must name ``file_prerequisite_task``
+        and ``block_and_comment`` as primary actions — those are the
+        diagnoser responses the issue explicitly calls out."""
+        content = self._skill_content()
+        # Both action names should appear in the new section.
+        new_section_start = content.find("verify_failed_post_merge")
+        assert new_section_start != -1
+        # Look in roughly the next 3000 chars for both mentions.
+        window = content[new_section_start : new_section_start + 4000]
+        assert "file_prerequisite_task" in window, (
+            "verify_failed_post_merge section must name `file_prerequisite_task`"
+        )
+        assert "block_and_comment" in window, (
+            "verify_failed_post_merge section must name `block_and_comment`"
+        )
+
+
+class TestVerifyFailedPostMergeRouting:
+    def test_failed_verdict_routes(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path, scope="verify_failed_pm")
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+        d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._read_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "verdict": "FAILED",
+                "failure_reason": "search endpoint returned 500 on sample ruling",
+                "evidence_md": "## Verify\n\n- FAIL: AC#1 — got 500",
+            }
+        )
+        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+        d._write_merged_at = MagicMock()  # type: ignore[method-assign]
+        d._read_verify_skip_reason = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._post_evidence_comment = MagicMock()  # type: ignore[method-assign]
+        d._write_verified_at = MagicMock()  # type: ignore[method-assign]
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._materialize_prior_attempts = MagicMock(return_value=0)  # type: ignore[method-assign]
+        d._extract_acceptance_criteria = MagicMock(return_value=[])  # type: ignore[method-assign]
+        d._fetch_issue_body = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._fetch_pr_diff = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._list_committed_files_at_head = MagicMock(return_value=[])  # type: ignore[method-assign]
+        d._detect_verify_skip_reason = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._restore_succeeded_and_advance_done = MagicMock()  # type: ignore[method-assign]
+
+        agent = {
+            "agent_id": "agent-verify-fail",
+            "issue_number": 3071,
+            "pr_number": 8080,
+            "worktree_path": str(worktree),
+            "merged_at": datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC),
+        }
+        pr_status = {"mergeCommit": {"oid": "f00dbabe"}}
+
+        d._run_verify_and_complete(agent, pr_status, "f00dbabe", [])
+
+        d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
+        kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["agent_id"] == "agent-verify-fail"
+        assert kwargs["phase"] == "done"
+        assert kwargs["category"] == daemon.FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE
+        assert kwargs["issue_number"] == 3071
+        details = kwargs["details"]
+        assert details["pr_number"] == 8080
+        assert details["merge_sha"] == "f00dbabe"
+        assert "returned 500" in details["failure_reason"]
+        assert "FAIL: AC#1" in details["evidence_md"]
+        assert details["issue_number"] == 3071
+        # Direct _mark_agent_terminal NOT used (pre-#3071 bypass fixed).
+        d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
+        # VERIFIED path not taken.
+        d._write_verified_at.assert_not_called()  # type: ignore[union-attr]
+
+    def test_verified_verdict_still_succeeds(self, tmp_path: Path) -> None:
+        """Regression — VERIFIED must still stamp verified_at and
+        advance phase without touching the new failure-routing path."""
+        d, _conn, _handler = _make_daemon(tmp_path, scope="verify_verified")
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+        d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._read_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "verdict": "VERIFIED",
+                "evidence_md": "## Verify\n\n- PASS: AC#1",
+            }
+        )
+        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+        d._write_merged_at = MagicMock()  # type: ignore[method-assign]
+        d._read_verify_skip_reason = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._post_evidence_comment = MagicMock()  # type: ignore[method-assign]
+        d._write_verified_at = MagicMock()  # type: ignore[method-assign]
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._materialize_prior_attempts = MagicMock(return_value=0)  # type: ignore[method-assign]
+        d._extract_acceptance_criteria = MagicMock(return_value=[])  # type: ignore[method-assign]
+        d._fetch_issue_body = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._fetch_pr_diff = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._list_committed_files_at_head = MagicMock(return_value=[])  # type: ignore[method-assign]
+        d._detect_verify_skip_reason = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+
+        agent = {
+            "agent_id": "agent-verified",
+            "issue_number": 3071,
+            "pr_number": 8081,
+            "worktree_path": str(worktree),
+            "merged_at": datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC),
+        }
+        pr_status = {"mergeCommit": {"oid": "f00dbabe"}}
+
+        d._run_verify_and_complete(agent, pr_status, "f00dbabe", [])
+
+        d._handle_agent_failure.assert_not_called()  # type: ignore[union-attr]
+        d._write_verified_at.assert_called_once()  # type: ignore[union-attr]
+        d._update_agent_phase.assert_called_with("agent-verified", "done")  # type: ignore[union-attr]
+
+
+class TestVerifyFailedPostMergeCandidatePickup:
+    def test_row_is_tier_3_candidate(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path, scope="verify_failed_scan")
+        row = _make_failure_row(
+            failure_id=9005,
+            agent_id="agent-vfpm",
+            category=daemon.FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
+            details={
+                "issue_number": 3071,
+                "phase": "done",
+                "pr_number": 8080,
+                "merge_sha": "f00dbabe",
+                "failure_reason": "search endpoint returned 500",
+                "evidence_md": "## Verify\n\n- FAIL: AC#1",
+                "exit_code": 0,
+                "stderr_tail": "",
+            },
+        )
+        conn.cursor_instance.fetchall_queue = [[row]]
+
+        candidates = d._find_diagnoser_candidates()
+
+        assert len(candidates) == 1
+        cand = candidates[0]
+        assert cand["category"] == daemon.FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE
+        assert cand["tier"] == 3
+        assert cand["issue_number"] == 3071


### PR DESCRIPTION
## Summary

Five audit-gap routing fixes identified by #3062's audit of every
`_mark_agent_terminal(status="failed")` call site in `scripts/dispatcher/daemon.py`. Each pre-#3062 site marked the agent terminal without writing a `dispatcher.failures` row, bypassing the #3032 unified failure routing — which means the Opus diagnoser never ran and operators had to triage from CloudWatch. This PR routes all five through `_handle_agent_failure` with dedicated categories, following the #3054 / #3073 pattern.

| # | Category | Tier | Site |
|---|---|---|---|
| #3067 | `git_commit_failed` | 2 first-occurrence | `_push_and_open_pr` — `git commit --amend` exception + non-zero exit (2 sites) |
| #3068 | `fix_ci_blocked` | 3 | `_run_fix_ci` — BLOCKED verdict terminal |
| #3069 | `fix_ci_apply_failed` | 2 first-occurrence | `_apply_fix_ci_patch` — 8 sites, consolidated through a new `_handle_fix_ci_apply_failure` helper that carries `sub_reason` in `details` |
| #3070 | `deploy_failed` | 2 first-occurrence | `_advance_awaiting_deploy` — post-merge deploy workflow failure |
| #3071 | `verify_failed_post_merge` | 3 | `_run_verify_and_complete` — post-merge verify FAILED verdict; also adds a dedicated `verify_failed_post_merge` section to `.claude/skills/diagnose-failure/SKILL.md` |

Every touched site updates its inline `ROUTING (#3062)` comment to document the new routing (e.g. `ROUTING (#3062 #3067): ROUTED via _handle_agent_failure ...`). Sites classified as intentionally unrouted in #3073 (infra-preemption, correct-outcome terminals, defensive invariants) are left alone.

## Diff shape

* `scripts/dispatcher/daemon.py` — 5 new `FAILURE_CATEGORY_*` constants with Sphinx-style docstrings; 3 new tier-set entries (`TIER_2_FIRST_OCCURRENCE_CATEGORIES`: git_commit_failed, fix_ci_apply_failed, deploy_failed); 2 new tier-set entries (`TIER_3_CATEGORIES`: fix_ci_blocked, verify_failed_post_merge); one new helper `_handle_fix_ci_apply_failure` that wraps the 8 fix-ci-apply sites; 12 call-site replacements.
* `scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py` — new, 33 tests across 5 category groups (tier registration + call-site routing + candidate scanner pickup). Follows `test_daemon_ralph_not_ship.py` / `test_daemon_summary_output_incomplete.py` template.
* `.claude/skills/diagnose-failure/SKILL.md` — new `verify_failed_post_merge` section that explicitly discourages `retry` (no-op post-merge), `reissue` (issue already closed), and `close` (already closed); names `file_prerequisite_task` + `block_and_comment` + `escalate` as primary actions.

Closes #3067
Closes #3068
Closes #3069
Closes #3070
Closes #3071

## Test plan

### Automated checks
- [x] Lint passes — `ruff check scripts/dispatcher/daemon.py scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py` → `All checks passed!`
- [x] Format check passes — `ruff format --check scripts/dispatcher/daemon.py scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py` → both already formatted
- [x] Full dispatcher test suite green — `pytest scripts/dispatcher/tests/ -q` → 1096 passed, 1 skipped (with 33 new tests in the new file)
- [x] `scripts/check-dispatcher-image-deps.sh` → ok
- [x] `scripts/check-markdown-links.sh` → 80 files, no broken links

### Post-deploy verification
- [ ] N/A behavioral change for production traffic. The five new routing paths only fire on failure-terminal branches that would otherwise have left the agent `failed` with no `dispatcher.failures` row. The change is additive: where pre-PR the diagnoser never ran, post-PR it gets a row and can escalate / file a prerequisite. No happy-path behavior changes — the regression guards (`test_patched_verdict_does_not_route`, `test_deploy_success_still_advances_to_verify`, `test_verified_verdict_still_succeeds`) lock that in.
- [ ] Dispatcher is currently paused (`cap=0`), per the task brief — there is no in-flight daemon agent to worry about. The PR merge triggers a redeploy with the new routing active; the next failure that hits one of the five paths will write a row and land on the diagnoser queue.
- [ ] Verification evidence comment posted on #3067 summarizing the fix, referenced from #3068 / #3069 / #3070 / #3071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
