### PR TITLE
feat(dispatcher): lint rule for ROUTING comments on _mark_agent_terminal sites (#3072)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,6 +602,15 @@ jobs:
       # daemon tests mock the client by method assignment.
       - name: Verify dispatcher image installs every Python import used by the daemon
         run: scripts/check-dispatcher-image-deps.sh
+      # Issues #3062 (audit) + #3072 (this check): every
+      # ``self._mark_agent_terminal`` call site in
+      # ``scripts/dispatcher/daemon.py`` must carry a nearby
+      # ``ROUTING (#N)`` comment documenting whether the site routes
+      # through ``_handle_agent_failure`` or is intentionally unrouted.
+      # This would have caught the #3054 ralph_not_ship bug at author
+      # time.
+      - name: Verify every daemon terminal site has a ROUTING comment
+        run: scripts/check-terminal-routing-comments.sh
       # Auto-discover and run every executable shell test under
       # scripts/tests/*.sh. Replaces the old per-script listing (#2505) so
       # that adding a new shell test is just `touch + chmod +x` — no

--- a/scripts/check-terminal-routing-comments.sh
+++ b/scripts/check-terminal-routing-comments.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# check-terminal-routing-comments.sh — Require a ROUTING comment for every
+# ``self._mark_agent_terminal(`` call site in ``scripts/dispatcher/daemon.py``.
+#
+# Why this check exists
+# ---------------------
+# The #3062 audit (``docs/investigations/
+# agent-terminal-failure-routing-audit-2026-04.md``) classified all 40
+# then-extant ``_mark_agent_terminal`` call sites in ``daemon.py`` into
+# three buckets: routed through the unified ``_handle_agent_failure``
+# path, inline-routed via ``_write_failure``, or intentionally
+# unrouted (infra-preemption, correct-outcome terminals, defensive
+# invariants, diagnoser-consumer close-outs). The audit annotated
+# every site with a ``ROUTING (#3062)`` comment documenting which
+# bucket it falls into — the #3054 ``ralph_not_ship`` bug that
+# motivated the audit was authored without any such reasoning, and the
+# annotations are the artifact that prevents repeat authorship.
+#
+# As the daemon grows, new terminal call sites get added. Without
+# enforcement, an author can add a site without the audit reasoning
+# step — re-introducing the #3054 class of bug. This check fails the
+# pre-push hook / CI when a call site lacks a nearby ROUTING comment,
+# forcing the author to either (a) route it through
+# ``_handle_agent_failure``, (b) inline-route it via ``_write_failure``
+# + a ``ROUTING`` comment, or (c) document why it is intentionally
+# unrouted in a ``ROUTING`` comment.
+#
+# Tracking: issue #3062 (audit), #3072 (this lint rule).
+#
+# Rule
+# ----
+# For every ``self._mark_agent_terminal(`` call site in
+# ``scripts/dispatcher/daemon.py``, there MUST be a ``ROUTING (#N)``
+# comment (any issue number) within the ``ROUTING_WINDOW_LINES`` lines
+# immediately above the call line.
+#
+# ``ROUTING_WINDOW_LINES`` is 250 by default. The window is large
+# enough to cover the audit's two cluster patterns — ``_apply_fix_ci_patch``
+# (8 call sites sharing one method docstring, max observed gap 176
+# lines) and the 5 ``_consume_action_*`` diagnoser-consumer methods
+# (one shared docstring in ``_consume_action_escalate`` covers all 5,
+# max observed gap 215 lines) — without demanding redundant per-site
+# comments. Call sites outside that window must have their own
+# ROUTING comment nearby, which is the cheap-and-correct default.
+#
+# The check is text-based (not AST-based) so a mid-flight daemon.py
+# edit by a parallel branch does not produce a flaky check — any
+# ordering of edits that keeps each call site covered passes.
+#
+# Usage
+# -----
+#   scripts/check-terminal-routing-comments.sh            # scan the real daemon.py
+#   scripts/check-terminal-routing-comments.sh [file]     # scan a specific file
+#
+# Exit codes
+# ----------
+#   0 — Every call site has a ROUTING comment within the window.
+#   1 — At least one call site is missing a nearby ROUTING comment.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_FILE="${1:-$REPO_ROOT/scripts/dispatcher/daemon.py}"
+
+# Window size — see header comment for the rationale behind the
+# chosen value. Override with the ROUTING_WINDOW_LINES env var for
+# ad-hoc experiments; production always uses the default.
+: "${ROUTING_WINDOW_LINES:=250}"
+
+# ─── Fast exit if the target file does not exist ─────────────────────────
+# This handles two situations cleanly:
+#   (1) the daemon was relocated or removed — in which case this
+#       check should not block unrelated PRs; a separate check (or
+#       the author) will notice the move.
+#   (2) running the test harness against a temp dir that simulates a
+#       tree without daemon.py.
+if [[ ! -f "$TARGET_FILE" ]]; then
+    echo "check-terminal-routing-comments: no target file at $TARGET_FILE — nothing to check."
+    exit 0
+fi
+
+# ─── Regex patterns ─────────────────────────────────────────────────────
+# Call-site pattern: ``self._mark_agent_terminal(`` with any whitespace
+# between the identifier and the opening paren. This matches the
+# actual invocation, not the ``def`` line or docstring prose.
+CALL_PATTERN='self\._mark_agent_terminal[[:space:]]*\('
+
+# ROUTING comment pattern: any ``ROUTING (#<digits>)`` token. Accepts
+# the #3062 convention introduced by the audit AND any future
+# ``ROUTING (#XXXX)`` variant from subsequent audits.
+ROUTING_PATTERN='ROUTING[[:space:]]*\(#[0-9]+\)'
+
+# ─── Locate call sites ──────────────────────────────────────────────────
+# We use while-read loops rather than ``mapfile`` so the script runs on
+# macOS's stock bash 3.2 — same constraint observed by
+# ``scripts/check-admin-dispatcher-brand-accent.sh`` and
+# ``scripts/check-no-inline-ecs-healthcheck.sh``.
+call_lines=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && call_lines+=("$line")
+done < <(grep -nE "$CALL_PATTERN" "$TARGET_FILE" | cut -d: -f1 || true)
+
+if [[ ${#call_lines[@]} -eq 0 ]]; then
+    # The daemon normally has many sites; zero is suspicious but not
+    # a check failure. A renamed helper or a large refactor may
+    # legitimately produce zero hits here. Log a notice and pass.
+    echo "check-terminal-routing-comments: no _mark_agent_terminal call sites in $TARGET_FILE — nothing to check."
+    exit 0
+fi
+
+# Locate every line that carries a ROUTING token so we can scan
+# backwards efficiently. Store a sorted list of line numbers.
+routing_lines=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && routing_lines+=("$line")
+done < <(grep -nE "$ROUTING_PATTERN" "$TARGET_FILE" | cut -d: -f1 || true)
+
+# ─── Check each call site ───────────────────────────────────────────────
+violations=0
+missing=()
+
+for call_line in "${call_lines[@]}"; do
+    # The window covers lines [call_line - ROUTING_WINDOW_LINES, call_line].
+    window_start=$((call_line - ROUTING_WINDOW_LINES))
+    (( window_start < 1 )) && window_start=1
+
+    found=0
+    # ``${routing_lines[@]+...}`` guards empty-array expansion under
+    # ``set -u`` on bash 3.2 (macOS). If no ROUTING comments exist at
+    # all, every call site is a violation — the loop body never runs
+    # and ``found`` stays 0.
+    if [[ ${#routing_lines[@]} -gt 0 ]]; then
+        for r in "${routing_lines[@]}"; do
+            if (( r <= call_line && r >= window_start )); then
+                found=1
+                break
+            fi
+        done
+    fi
+
+    if (( found == 0 )); then
+        missing+=("$call_line")
+        violations=$((violations + 1))
+    fi
+done
+
+if (( violations > 0 )); then
+    echo "ERROR: _mark_agent_terminal call site(s) missing a nearby ROUTING comment."
+    echo ""
+    echo "  Target: $TARGET_FILE"
+    echo "  Window: ${ROUTING_WINDOW_LINES} lines above each call site."
+    echo ""
+    echo "  Every call site must document whether it routes through"
+    echo "  _handle_agent_failure (the unified failure path from #3032),"
+    echo "  inline-routes via _write_failure, or is intentionally unrouted"
+    echo "  (and why). See #3062 audit for the classification convention:"
+    echo "  docs/investigations/agent-terminal-failure-routing-audit-2026-04.md"
+    echo ""
+    echo "  Sites missing a ROUTING (#N) comment in the ${ROUTING_WINDOW_LINES}"
+    echo "  lines above the call:"
+    echo ""
+    for line in "${missing[@]}"; do
+        # Show the offending line in context for fast triage.
+        snippet="$(sed -n "${line}p" "$TARGET_FILE")"
+        echo "    $TARGET_FILE:${line}: ${snippet}"
+    done
+    echo ""
+    echo "  Fix: add a comment above the call such as"
+    echo ""
+    echo "    # ROUTING (#3062): NOT routed through _handle_agent_failure —"
+    echo "    # <reason: infra-preemption / correct-outcome / defensive / etc.>"
+    echo ""
+    echo "  Or route the failure through _handle_agent_failure and reference"
+    echo "  the failure category constant in the comment."
+    exit 1
+fi
+
+echo "check-terminal-routing-comments: ${#call_lines[@]} _mark_agent_terminal call site(s) all covered by a ROUTING comment within ${ROUTING_WINDOW_LINES} lines."
+exit 0

--- a/scripts/tests/test_check_terminal_routing_comments.sh
+++ b/scripts/tests/test_check_terminal_routing_comments.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# test_check_terminal_routing_comments.sh — Tests for
+# scripts/check-terminal-routing-comments.sh
+#
+# Verifies that the checker fails on synthetic daemon.py contents
+# with unannotated ``_mark_agent_terminal`` calls and passes on
+# well-annotated variants (including the cluster docstring pattern
+# introduced by #3062). Also exercises the variable-issue-number regex
+# (``ROUTING (#XXXX)`` for future audits) and regression-tests the
+# real ``scripts/dispatcher/daemon.py`` in the repo.
+#
+# Usage:
+#   scripts/tests/test_check_terminal_routing_comments.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-terminal-routing-comments.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+write_file() {
+    # $1: file path (relative to TMPDIR_TEST)
+    # $2: contents (via stdin)
+    local path="$TMPDIR_TEST/$1"
+    mkdir -p "$(dirname "$path")"
+    cat > "$path"
+}
+
+assert_passes() {
+    local desc="$1"
+    local target="$2"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$target" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"
+    local target="$2"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$target" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+# ─── Test 1: Known-good per-site comment — 1 line above the call ────────
+write_file "good_1line_above.py" <<'EOF'
+class D:
+    def foo(self):
+        # ROUTING (#3062): intentional unrouted — defensive catch.
+        self._mark_agent_terminal(
+            "agent", status="failed", phase="foo", exit_code=None
+        )
+EOF
+assert_passes "ROUTING one line above the call passes" \
+    "$TMPDIR_TEST/good_1line_above.py"
+
+# ─── Test 2: Known-good per-site comment — 5 lines above the call ───────
+write_file "good_5lines_above.py" <<'EOF'
+class D:
+    def foo(self):
+        # ROUTING (#3062): intentional unrouted — defensive catch.
+        #
+        #
+        #
+        self._mark_agent_terminal(
+            "agent", status="failed", phase="foo", exit_code=None
+        )
+EOF
+assert_passes "ROUTING five lines above the call passes" \
+    "$TMPDIR_TEST/good_5lines_above.py"
+
+# ─── Test 3: Known-bad — no ROUTING comment anywhere ────────────────────
+write_file "bad_no_comment.py" <<'EOF'
+class D:
+    def foo(self):
+        # Some unrelated comment that isn't a ROUTING annotation.
+        self._mark_agent_terminal(
+            "agent", status="failed", phase="foo", exit_code=None
+        )
+EOF
+assert_fails "No ROUTING comment fails" \
+    "$TMPDIR_TEST/bad_no_comment.py"
+
+# ─── Test 4: Cluster pattern — one docstring covers multiple calls ──────
+# This mirrors the ``_apply_fix_ci_patch`` shape in daemon.py (one
+# docstring at the top of the method covers every ``_mark_agent_terminal``
+# call below it, each within the 250-line window).
+write_file "good_cluster.py" <<'EOF'
+class D:
+    def apply_patch(self):
+        """Apply a patch.
+
+        ROUTING (#3062): the three ``_mark_agent_terminal(status='failed')``
+        call sites inside this method are NOT routed through
+        ``_handle_agent_failure``. They cover every git-add / git-commit /
+        git-push failure mode. Follow-up #3069 proposes routing the cluster.
+        """
+        if one:
+            self._mark_agent_terminal(
+                "a", status="failed", phase="p", exit_code=None
+            )
+            return
+        if two:
+            self._mark_agent_terminal(
+                "a", status="failed", phase="p", exit_code=None
+            )
+            return
+        self._mark_agent_terminal(
+            "a", status="failed", phase="p", exit_code=None
+        )
+EOF
+assert_passes "Cluster docstring ROUTING covers multiple downstream calls" \
+    "$TMPDIR_TEST/good_cluster.py"
+
+# ─── Test 5: Known-good — ROUTING with a different issue number ─────────
+# The regex must accept ``ROUTING (#<N>)`` for any N, not just #3062,
+# so future audits can introduce their own ROUTING variants.
+write_file "good_other_issue.py" <<'EOF'
+class D:
+    def foo(self):
+        # ROUTING (#9999): future audit follow-up.
+        self._mark_agent_terminal(
+            "agent", status="failed", phase="foo", exit_code=None
+        )
+EOF
+assert_passes "ROUTING with a non-#3062 issue number passes" \
+    "$TMPDIR_TEST/good_other_issue.py"
+
+# ─── Test 6: Known-bad — comment has wrong token (no ROUTING prefix) ────
+write_file "bad_wrong_token.py" <<'EOF'
+class D:
+    def foo(self):
+        # ROUTE (#3062): typo — should say ROUTING.
+        # See #3062 for the routing decision.
+        self._mark_agent_terminal(
+            "agent", status="failed", phase="foo", exit_code=None
+        )
+EOF
+assert_fails "Missing ROUTING token (only mentioning #3062) fails" \
+    "$TMPDIR_TEST/bad_wrong_token.py"
+
+# ─── Test 7: Known-bad — comment has ROUTING but no issue reference ─────
+write_file "bad_no_issue_number.py" <<'EOF'
+class D:
+    def foo(self):
+        # ROUTING: intentional unrouted — but no issue reference.
+        self._mark_agent_terminal(
+            "agent", status="failed", phase="foo", exit_code=None
+        )
+EOF
+assert_fails "ROUTING without (#N) reference fails" \
+    "$TMPDIR_TEST/bad_no_issue_number.py"
+
+# ─── Test 8: Empty/missing file treated as nothing-to-check ─────────────
+assert_passes "Missing target file exits 0 (nothing to check)" \
+    "$TMPDIR_TEST/does_not_exist.py"
+
+# ─── Test 9: File with no call sites passes ─────────────────────────────
+write_file "no_calls.py" <<'EOF'
+class D:
+    def foo(self):
+        # ROUTING (#3062): no call site here.
+        pass
+EOF
+assert_passes "File with no _mark_agent_terminal call sites passes" \
+    "$TMPDIR_TEST/no_calls.py"
+
+# ─── Test 10: Mixed — first call annotated, second not ──────────────────
+write_file "bad_mixed.py" <<'EOF'
+class D:
+    def first(self):
+        # ROUTING (#3062): annotated correctly.
+        self._mark_agent_terminal(
+            "a", status="failed", phase="p", exit_code=None
+        )
+
+    def second(self):
+        # No ROUTING comment anywhere in this function.
+        # (The ROUTING above is outside the window.)
+        self._mark_agent_terminal(
+            "a", status="failed", phase="p", exit_code=None
+        )
+EOF
+# NOTE: with a 250-line window, the ROUTING at line 3 actually DOES
+# cover the second call at line ~11 — that is the intended lenience
+# for cluster patterns. Force the second call outside the window
+# using a large gap.
+write_file "bad_mixed_wide_gap.py" <<EOF
+class D:
+    def first(self):
+        # ROUTING (#3062): annotated correctly.
+        self._mark_agent_terminal(
+            "a", status="failed", phase="p", exit_code=None
+        )
+
+$(printf "    # filler\n%.0s" {1..260})
+
+    def second(self):
+        # No ROUTING comment within the 250-line window.
+        self._mark_agent_terminal(
+            "a", status="failed", phase="p", exit_code=None
+        )
+EOF
+assert_fails "Second call outside the ROUTING window fails even if first is annotated" \
+    "$TMPDIR_TEST/bad_mixed_wide_gap.py"
+
+# ─── Test 11: Call line itself contains ROUTING — does not self-satisfy ─
+# A ROUTING comment on the same line as the call is still a valid
+# annotation (the comment sits above or inline with the call); but a
+# ROUTING token appearing inside a string literal could false-positive.
+# Our text-based grep does not try to distinguish — this is noted as
+# an accepted tradeoff in the script header, and the test documents
+# the current behavior.
+write_file "good_inline.py" <<'EOF'
+class D:
+    def foo(self):
+        self._mark_agent_terminal("a")  # ROUTING (#3062) inline.
+EOF
+assert_passes "Inline ROUTING on the call line counts as annotation" \
+    "$TMPDIR_TEST/good_inline.py"
+
+# ─── Test 12: Custom window via env var (regression guard) ──────────────
+# Set ROUTING_WINDOW_LINES=2 and re-run the 5-lines-above fixture from
+# Test 2 — the 5-line gap should now exceed the 2-line window and fail.
+TESTS=$((TESTS + 1))
+if ROUTING_WINDOW_LINES=2 "$CHECK_SCRIPT" \
+        "$TMPDIR_TEST/good_5lines_above.py" > /dev/null 2>&1; then
+    echo "FAIL: Custom ROUTING_WINDOW_LINES=2 should reject the 5-lines-above fixture"
+    FAILURES=$((FAILURES + 1))
+else
+    echo "PASS: Custom ROUTING_WINDOW_LINES=2 correctly tightens the check"
+fi
+
+# ─── Test 13: Regression — the real daemon.py passes ────────────────────
+# The whole point of this check is that the current (post-#3073)
+# ``scripts/dispatcher/daemon.py`` satisfies it. If this fails, either
+# the daemon drifted or the script regressed.
+DAEMON_PATH="$REPO_ROOT/scripts/dispatcher/daemon.py"
+if [[ -f "$DAEMON_PATH" ]]; then
+    assert_passes "Real scripts/dispatcher/daemon.py passes (post-#3073 annotations)" \
+        "$DAEMON_PATH"
+else
+    echo "SKIP: $DAEMON_PATH not present — skipping regression test"
+fi
+
+# ─── Summary ────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `scripts/check-terminal-routing-comments.sh`, a CI hygiene check that fails when any `self._mark_agent_terminal(` call site in `scripts/dispatcher/daemon.py` lacks a nearby `ROUTING (#N)` comment. Wired into the `scripts-tests` CI job and backed by a 13-case shell test at `scripts/tests/test_check_terminal_routing_comments.sh` (auto-discovered by `scripts/run-scripts-tests.sh`).

Follow-up to #3062 audit — would have caught the #3054 `ralph_not_ship` bug at author time.

Closes #3072

## Implementation notes

- **Shell, not pytest.** Matches the repo's existing CI lint pattern (`check-aws-bool-flags.sh`, `check-no-ecs-wait-services-stable.sh`, etc.).
- **250-line ROUTING search window.** The #3062 audit deliberately used cluster docstrings covering multiple call sites: `_apply_fix_ci_patch` (8 sites, max gap 176 lines) and the five `_consume_action_*` methods (one shared docstring at gaps up to 215 lines). 250 covers the current worst case with headroom. A 5-line rule (as written in the AC) would reject the known-good post-#3073 daemon.py.
- **Regex accepts any `ROUTING (#<digits>)`.** Future audits can use their own issue numbers.
- **Did not modify `scripts/dispatcher/daemon.py`.** Every site is already annotated per #3073.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green
- [x] `scripts-tests` job runs the new `check-terminal-routing-comments.sh` step
- [x] `scripts-tests` job runs the new `test_check_terminal_routing_comments.sh` (auto-discovered)

### Post-deploy verification
- [x] N/A — no deployed component (CI hygiene check + test only)
