### PR TITLE
feat(dx): verify-pr-in-deployed-sha.sh for dispatcher deploy-cancel case (#3076)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -557,6 +557,8 @@ A successful deploy only means the new image is running — not that the service
 
 **Script-producing tasks:** If a task produces a backfill, migration, or one-off fixup script that is meant to be run, executing it on dev and verifying results is part of the definition of done. When filing issues that include "create a backfill script" or similar, always include "backfill executed on dev and results verified" in the acceptance criteria.
 
+**Dispatcher PRs — concurrent-merge cancellation:** When two dispatcher PRs merge within a few minutes of each other, `deploy-dispatcher.yml`'s `concurrency: cancel-in-progress: true` can cancel the earlier PR's `deploy-to-dev` stage even after a successful build-and-push. The later PR's rollout is usually a superset and still ships the earlier PR's code — but the observability is misleading (your deploy run shows CANCELLED). Use `scripts/verify-pr-in-deployed-sha.sh <pr-number>` as the go-to check for "did my PR actually land in the deployed dispatcher?" The helper fetches the PR's merge SHA via `gh pr view --json mergeCommit`, reads the latest `version_sha` from the dispatcher's CloudWatch startup log in `/ecs/judgemind-dispatcher-dev`, and runs `git merge-base --is-ancestor`. Exit 0 = landed, exit 1 = not yet deployed, exit 2 = usage/data error (missing arg, PR not merged, CloudWatch empty, git can't resolve the deployed SHA locally). See #3076.
+
 **Acceptance criteria re-verification (MANDATORY for deployed changes):**
 
 After verifying deployment health, go back to the issue's acceptance criteria and verify EACH one against the live environment. This is distinct from the A.2b process summary (which verifies against code/tests) — this step verifies against deployed reality.

--- a/scripts/tests/test_verify_pr_in_deployed_sha.sh
+++ b/scripts/tests/test_verify_pr_in_deployed_sha.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+# test_verify_pr_in_deployed_sha.sh — Tests for scripts/verify-pr-in-deployed-sha.sh
+#
+# Covers the three documented exit codes plus the common error paths:
+#   0 — PR merge SHA is an ancestor of deployed SHA (PR landed)
+#   1 — PR merge SHA is NOT an ancestor of deployed SHA (not yet deployed)
+#   2 — Usage / environment / data error (missing arg, PR not merged,
+#       missing tool on PATH, no startup log, git can't resolve SHA)
+#
+# Strategy: each test runs the script under an isolated temp PATH that
+# masks the real `gh`, `aws`, and `git` binaries with tiny bash stubs.
+# Each stub emits canned output matching the real tool's JSON shape,
+# so the script sees exactly what it would see against the live APIs
+# — without any network calls.
+#
+# Usage:
+#   scripts/tests/test_verify_pr_in_deployed_sha.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/verify-pr-in-deployed-sha.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+ORIG_PATH_SAVE="$PATH"
+
+cleanup() {
+    set +eu
+    for d in "${TEMP_DIRS[@]}"; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+    export PATH="$ORIG_PATH_SAVE"
+}
+trap cleanup EXIT
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    echo "$dir"
+}
+
+# Create a mock `gh` stub that echoes the canned JSON on `pr view ... --json`.
+# Args: <mock-bin-dir> <canned-json>
+install_gh_mock() {
+    local bin_dir="$1"
+    local json="$2"
+    cat > "$bin_dir/gh" << MOCKGH
+#!/usr/bin/env bash
+# Mock gh: emit canned JSON on 'gh pr view <N> --json ...'.
+if [[ "\${1:-}" == "pr" && "\${2:-}" == "view" ]]; then
+    printf '%s' '$json'
+    exit 0
+fi
+echo "mock gh: unexpected invocation: \$*" >&2
+exit 2
+MOCKGH
+    chmod +x "$bin_dir/gh"
+}
+
+# Create a mock `gh` stub that fails (exit 1) on every invocation —
+# simulates an unauthenticated / rate-limited / API-down scenario.
+install_gh_mock_fail() {
+    local bin_dir="$1"
+    cat > "$bin_dir/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+echo "mock gh: simulated API failure" >&2
+exit 1
+MOCKGH
+    chmod +x "$bin_dir/gh"
+}
+
+# Create a mock `aws` stub that echoes canned events JSON on
+# `aws logs filter-log-events ...`.
+# Args: <mock-bin-dir> <events-json-array>  e.g. '[{"timestamp":1,"message":"..."}]'
+install_aws_mock() {
+    local bin_dir="$1"
+    local events_json="$2"
+    cat > "$bin_dir/aws" << MOCKAWS
+#!/usr/bin/env bash
+# Mock aws: emit canned filter-log-events response.
+if [[ "\${1:-}" == "logs" && "\${2:-}" == "filter-log-events" ]]; then
+    printf '{"events": %s}' '$events_json'
+    exit 0
+fi
+echo "mock aws: unexpected invocation: \$*" >&2
+exit 2
+MOCKAWS
+    chmod +x "$bin_dir/aws"
+}
+
+# Create a mock `git` stub that delegates to the real git binary EXCEPT
+# for merge-base / rev-parse / rev-list, which are controlled by an
+# environment variable to force a specific outcome.
+# Args: <mock-bin-dir> <is-ancestor-exit:0|1> <rev-parse-deployed-ok:0|1> <rev-parse-merge-ok:0|1>
+install_git_mock() {
+    local bin_dir="$1"
+    local is_ancestor_exit="$2"
+    local rev_parse_deployed_ok="$3"
+    local rev_parse_merge_ok="$4"
+    cat > "$bin_dir/git" << MOCKGIT
+#!/usr/bin/env bash
+# Mock git: handle merge-base / rev-parse / rev-list deterministically.
+# Any other subcommand defers to the real git.
+case "\${1:-}" in
+    merge-base)
+        # '\$1=merge-base \$2=--is-ancestor \$3=<merge> \$4=<deployed>'
+        if [[ "\${2:-}" == "--is-ancestor" ]]; then
+            exit $is_ancestor_exit
+        fi
+        ;;
+    rev-parse)
+        # Called with '\$1=rev-parse \$2=--verify \$3=--quiet \$4=<sha>^{commit}'
+        # The test uses 'DEPLOYED_SHA' as the deployed stand-in literal and
+        # 'MERGE_SHA' for the merge SHA literal; we key on substring.
+        sha_arg="\${4:-}"
+        if [[ "\$sha_arg" == *DEPLOYED* ]]; then
+            if [[ "$rev_parse_deployed_ok" == "0" ]]; then exit 0; else exit 1; fi
+        fi
+        if [[ "\$sha_arg" == *MERGE* ]]; then
+            if [[ "$rev_parse_merge_ok" == "0" ]]; then exit 0; else exit 1; fi
+        fi
+        # Unknown SHA — fall back to failing safe.
+        exit 1
+        ;;
+    rev-list)
+        # --count returns a plausible distance count.
+        echo "3"
+        exit 0
+        ;;
+esac
+echo "mock git: unexpected invocation: \$*" >&2
+exit 2
+MOCKGIT
+    chmod +x "$bin_dir/git"
+}
+
+# ── Precondition: script under test exists and is executable ──────────────
+
+if [[ ! -x "$SCRIPT_UNDER_TEST" ]]; then
+    echo "FATAL: $SCRIPT_UNDER_TEST is not executable (or does not exist)" >&2
+    exit 1
+fi
+
+# ── Test 1: exit 2 when called with no argument ────────────────────────────
+
+exit_code=0
+"$SCRIPT_UNDER_TEST" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "exits 2 with no argument"
+else
+    fail "exits 2 with no argument" "expected exit 2, got $exit_code"
+fi
+
+# ── Test 2: exit 2 on non-integer argument ─────────────────────────────────
+
+exit_code=0
+"$SCRIPT_UNDER_TEST" notanumber > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "exits 2 on non-integer argument"
+else
+    fail "exits 2 on non-integer argument" "expected exit 2, got $exit_code"
+fi
+
+# ── Test 3: --help prints usage and exits 0 ────────────────────────────────
+
+exit_code=0
+output=$("$SCRIPT_UNDER_TEST" --help 2>&1) || exit_code=$?
+if [[ "$exit_code" -eq 0 && "$output" == *"Usage:"* ]]; then
+    pass "--help prints usage and exits 0"
+else
+    fail "--help prints usage and exits 0" "exit=$exit_code output='$output'"
+fi
+
+# ── Test 4: exit 0 when PR merge SHA is an ancestor of deployed SHA ────────
+
+TDIR=$(make_temp_dir)
+install_gh_mock "$TDIR" '{"mergeCommit":{"oid":"MERGESHAfull1234567890"},"number":3066,"state":"MERGED"}'
+# Build a filter-log-events response with one startup event containing the deployed sha.
+# The mock 'aws' printf-substitutes an events-array literal — build carefully.
+EVENTS='[{"timestamp": 1700000000000, "message": "{\"event\":\"startup\",\"version_sha\":\"DEPLOYEDsha\",\"host\":\"h\",\"pid\":1}"}]'
+install_aws_mock "$TDIR" "$EVENTS"
+install_git_mock "$TDIR" 0 0 0
+
+export PATH="$TDIR:$ORIG_PATH_SAVE"
+exit_code=0
+output=$("$SCRIPT_UNDER_TEST" 3066 2>&1) || exit_code=$?
+export PATH="$ORIG_PATH_SAVE"
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "exits 0 when PR is ancestor of deployed SHA"
+else
+    fail "exits 0 when PR is ancestor of deployed SHA" "exit=$exit_code output='$output'"
+fi
+
+if [[ "$output" == *"landed"* && "$output" == *"DEPLOYEDsha"* && "$output" == *"MERGESH"* ]]; then
+    pass "prints 'landed' + deployed SHA + merge SHA prefix on success"
+else
+    fail "prints 'landed' + deployed SHA + merge SHA prefix on success" "got '$output'"
+fi
+
+# ── Test 5: exit 1 when PR merge SHA is NOT an ancestor of deployed SHA ───
+
+TDIR=$(make_temp_dir)
+install_gh_mock "$TDIR" '{"mergeCommit":{"oid":"MERGESHAfull1234567890"},"number":3099,"state":"MERGED"}'
+install_aws_mock "$TDIR" "$EVENTS"
+install_git_mock "$TDIR" 1 0 0
+
+export PATH="$TDIR:$ORIG_PATH_SAVE"
+exit_code=0
+output=$("$SCRIPT_UNDER_TEST" 3099 2>&1) || exit_code=$?
+export PATH="$ORIG_PATH_SAVE"
+
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "exits 1 when PR is NOT ancestor of deployed SHA"
+else
+    fail "exits 1 when PR is NOT ancestor of deployed SHA" "exit=$exit_code output='$output'"
+fi
+
+if [[ "$output" == *"NOT in deployed"* ]]; then
+    pass "prints 'NOT in deployed' on exit-1"
+else
+    fail "prints 'NOT in deployed' on exit-1" "got '$output'"
+fi
+
+# ── Test 6: exit 2 when PR is OPEN (not merged) ────────────────────────────
+
+TDIR=$(make_temp_dir)
+install_gh_mock "$TDIR" '{"mergeCommit":null,"number":3044,"state":"OPEN"}'
+# Even though we don't expect aws/git to be called, install stubs so a
+# bug that lets the script fall through yields a clear failure, not a
+# mysterious "aws not found" from the stripped PATH.
+install_aws_mock "$TDIR" "[]"
+install_git_mock "$TDIR" 0 0 0
+
+export PATH="$TDIR:$ORIG_PATH_SAVE"
+exit_code=0
+output=$("$SCRIPT_UNDER_TEST" 3044 2>&1) || exit_code=$?
+export PATH="$ORIG_PATH_SAVE"
+
+if [[ "$exit_code" -eq 2 && "$output" == *"not merged"* ]]; then
+    pass "exits 2 when PR is OPEN (not merged)"
+else
+    fail "exits 2 when PR is OPEN (not merged)" "exit=$exit_code output='$output'"
+fi
+
+# ── Test 7: exit 2 when CloudWatch returns no startup events ──────────────
+
+TDIR=$(make_temp_dir)
+install_gh_mock "$TDIR" '{"mergeCommit":{"oid":"MERGESHAfull1234567890"},"number":3066,"state":"MERGED"}'
+install_aws_mock "$TDIR" "[]"
+install_git_mock "$TDIR" 0 0 0
+
+export PATH="$TDIR:$ORIG_PATH_SAVE"
+exit_code=0
+output=$("$SCRIPT_UNDER_TEST" 3066 2>&1) || exit_code=$?
+export PATH="$ORIG_PATH_SAVE"
+
+if [[ "$exit_code" -eq 2 && "$output" == *"no recent"* ]]; then
+    pass "exits 2 when CloudWatch returns no startup events"
+else
+    fail "exits 2 when CloudWatch returns no startup events" "exit=$exit_code output='$output'"
+fi
+
+# ── Test 8: exit 2 when gh pr view fails (API error) ──────────────────────
+
+TDIR=$(make_temp_dir)
+install_gh_mock_fail "$TDIR"
+install_aws_mock "$TDIR" "$EVENTS"
+install_git_mock "$TDIR" 0 0 0
+
+export PATH="$TDIR:$ORIG_PATH_SAVE"
+exit_code=0
+output=$("$SCRIPT_UNDER_TEST" 3066 2>&1) || exit_code=$?
+export PATH="$ORIG_PATH_SAVE"
+
+if [[ "$exit_code" -eq 2 && "$output" == *"gh pr view"* ]]; then
+    pass "exits 2 when gh pr view fails"
+else
+    fail "exits 2 when gh pr view fails" "exit=$exit_code output='$output'"
+fi
+
+# ── Test 9: exit 2 when deployed SHA not resolvable in local git ──────────
+
+TDIR=$(make_temp_dir)
+install_gh_mock "$TDIR" '{"mergeCommit":{"oid":"MERGESHAfull1234567890"},"number":3066,"state":"MERGED"}'
+install_aws_mock "$TDIR" "$EVENTS"
+# rev_parse_deployed_ok=1 → simulate the local clone not having the deployed SHA.
+install_git_mock "$TDIR" 0 1 0
+
+export PATH="$TDIR:$ORIG_PATH_SAVE"
+exit_code=0
+output=$("$SCRIPT_UNDER_TEST" 3066 2>&1) || exit_code=$?
+export PATH="$ORIG_PATH_SAVE"
+
+if [[ "$exit_code" -eq 2 && "$output" == *"deployed SHA"* && "$output" == *"not resolvable"* ]]; then
+    pass "exits 2 when deployed SHA not resolvable locally"
+else
+    fail "exits 2 when deployed SHA not resolvable locally" "exit=$exit_code output='$output'"
+fi
+
+# ── Test 10: strips leading '#' from the pr-number argument ────────────────
+
+TDIR=$(make_temp_dir)
+install_gh_mock "$TDIR" '{"mergeCommit":{"oid":"MERGESHAfull1234567890"},"number":3066,"state":"MERGED"}'
+install_aws_mock "$TDIR" "$EVENTS"
+install_git_mock "$TDIR" 0 0 0
+
+export PATH="$TDIR:$ORIG_PATH_SAVE"
+exit_code=0
+output=$("$SCRIPT_UNDER_TEST" "#3066" 2>&1) || exit_code=$?
+export PATH="$ORIG_PATH_SAVE"
+
+if [[ "$exit_code" -eq 0 && "$output" == *"PR #3066 landed"* ]]; then
+    pass "strips leading '#' from the pr-number argument"
+else
+    fail "strips leading '#' from the pr-number argument" "exit=$exit_code output='$output'"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/verify-pr-in-deployed-sha.sh
+++ b/scripts/verify-pr-in-deployed-sha.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# verify-pr-in-deployed-sha.sh — Verify whether a merged PR's code is present
+# in the currently-deployed dispatcher image.
+#
+# Motivated by the concurrent-merge deploy-cancellation scenario documented
+# in #3076: when two dispatcher PRs merge within ~5 minutes of each other,
+# the earlier PR's `deploy-dispatcher.yml` run is cancelled at the
+# deploy-to-dev stage (concurrency: cancel-in-progress=true). The later
+# PR's deploy then ships a build whose commit is a descendant of the
+# earlier one — so the earlier PR's code DID land, piggybacking on the
+# superseding rollout. GitHub Actions just shows the earlier run as
+# CANCELLED, which is observably misleading.
+#
+# This helper closes the loop: given a PR number, it fetches the PR's
+# merge commit SHA, reads the currently-deployed `version_sha` from the
+# dispatcher's CloudWatch startup log, and tests whether the merge SHA
+# is an ancestor of the deployed SHA via `git merge-base --is-ancestor`.
+#
+# Replaces the manual ritual an operator otherwise runs:
+#   gh pr view <N> --json mergeCommit
+#   aws logs filter-log-events ... | jq ... (find version_sha)
+#   git merge-base --is-ancestor <merge-sha> <deployed-sha>
+#
+# Usage:
+#   scripts/verify-pr-in-deployed-sha.sh <pr-number>
+#   scripts/verify-pr-in-deployed-sha.sh 3066
+#   scripts/verify-pr-in-deployed-sha.sh '#3066'   # leading # is stripped
+#
+# Exit codes (matching the #3076 acceptance criteria):
+#   0 — PR's merge SHA is an ancestor of the deployed SHA (PR landed).
+#       A "PR #N landed in deployed SHA <sha> (distance: <n> commits)"
+#       line is printed to stdout.
+#   1 — PR's merge SHA is NOT an ancestor of the deployed SHA (not yet
+#       deployed). A "PR #N is NOT in deployed SHA <sha>" line is
+#       printed to stdout.
+#   2 — Usage / environment / data error: missing argument, PR not
+#       merged, git/gh/aws unavailable, deployed SHA not resolvable
+#       locally, or CloudWatch returned no recent startup log. An
+#       "error: <reason>" line is printed to stderr.
+#
+# Environment variables (for testing and overrides):
+#   AWS_CLI              — binary name for aws CLI (default: aws).
+#                          Tests inject a mock via PATH; this env var
+#                          is for callers who want a different aws
+#                          wrapper (e.g. scripts/with-secret.sh-style).
+#   GH_CLI               — binary name for gh CLI (default: gh).
+#   GIT_CLI              — binary name for git CLI (default: git).
+#   DISPATCHER_LOG_GROUP — CloudWatch log group (default:
+#                          /ecs/judgemind-dispatcher-dev).
+#   STARTUP_LOOKBACK_MIN — minutes of history to scan for the latest
+#                          startup log line (default: 1440 = 24h).
+#                          The daemon emits a startup event on every
+#                          Fargate task boot, so 24h is an ample window.
+#   AWS_REGION           — AWS region (default: us-west-2).
+
+set -uo pipefail
+
+# ── Defaults ────────────────────────────────────────────────────────────────
+
+AWS_CLI="${AWS_CLI:-aws}"
+GH_CLI="${GH_CLI:-gh}"
+GIT_CLI="${GIT_CLI:-git}"
+DISPATCHER_LOG_GROUP="${DISPATCHER_LOG_GROUP:-/ecs/judgemind-dispatcher-dev}"
+STARTUP_LOOKBACK_MIN="${STARTUP_LOOKBACK_MIN:-1440}"
+AWS_REGION="${AWS_REGION:-us-west-2}"
+
+# ── Usage ───────────────────────────────────────────────────────────────────
+
+usage() {
+    cat <<'USAGE'
+Usage: scripts/verify-pr-in-deployed-sha.sh <pr-number>
+
+Arguments:
+  <pr-number>   Merged pull request number (e.g. 3066 or '#3066').
+
+Options:
+  --help, -h    Show this help message.
+
+Exit codes:
+  0 — PR landed in deployed SHA.
+  1 — PR is NOT in deployed SHA (not yet deployed).
+  2 — Usage / environment / data error.
+USAGE
+}
+
+# ── Parse arguments ─────────────────────────────────────────────────────────
+
+if [[ $# -eq 0 ]]; then
+    echo "error: pr-number is required" >&2
+    usage >&2
+    exit 2
+fi
+
+case "${1:-}" in
+    --help|-h)
+        usage
+        exit 0
+        ;;
+esac
+
+PR_ARG="$1"
+PR_NUM="${PR_ARG#\#}"
+
+if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+    echo "error: pr-number must be an integer (got '$PR_ARG')" >&2
+    exit 2
+fi
+
+# ── 1. Fetch PR merge commit SHA via gh ────────────────────────────────────
+
+if ! command -v "$GH_CLI" > /dev/null 2>&1; then
+    echo "error: $GH_CLI CLI not found on PATH" >&2
+    exit 2
+fi
+
+PR_JSON=$("$GH_CLI" pr view "$PR_NUM" --repo judgemind/judgemind --json mergeCommit,state,number 2>/dev/null) || {
+    echo "error: gh pr view #$PR_NUM failed (authentication, rate limit, or PR not found?)" >&2
+    exit 2
+}
+
+PR_STATE=$(echo "$PR_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("state",""))')
+if [[ "$PR_STATE" != "MERGED" ]]; then
+    echo "error: PR #$PR_NUM is not merged (state=$PR_STATE); nothing to verify" >&2
+    exit 2
+fi
+
+MERGE_SHA=$(echo "$PR_JSON" | python3 -c 'import json,sys; mc=json.load(sys.stdin).get("mergeCommit") or {}; print(mc.get("oid",""))')
+if [[ -z "$MERGE_SHA" ]]; then
+    echo "error: PR #$PR_NUM has no mergeCommit.oid (API shape change?)" >&2
+    exit 2
+fi
+
+# ── 2. Fetch deployed version_sha from CloudWatch ──────────────────────────
+
+if ! command -v "$AWS_CLI" > /dev/null 2>&1; then
+    echo "error: $AWS_CLI CLI not found on PATH" >&2
+    exit 2
+fi
+
+# Resolve the start of the lookback window in millis-since-epoch. Using
+# python3 (already required above for JSON parsing) avoids a GNU-vs-BSD
+# `date -d` portability trap.
+START_MS=$(python3 -c "import time; print(int((time.time() - ${STARTUP_LOOKBACK_MIN} * 60) * 1000))")
+
+# Grep the log group for any line containing `"event": "startup"` — the
+# daemon emits it as a JSON-formatted log record per _JsonFormatter in
+# scripts/dispatcher/daemon.py. Ordering events by @timestamp desc via
+# filter-log-events requires an Insights query; for the CLI path we
+# instead fetch matching events, sort by timestamp in python, and pick
+# the latest. Cheap enough — the filter keeps the payload small.
+FILTER_JSON=$("$AWS_CLI" logs filter-log-events \
+    --log-group-name "$DISPATCHER_LOG_GROUP" \
+    --start-time "$START_MS" \
+    --filter-pattern '"event" "startup"' \
+    --region "$AWS_REGION" \
+    --no-cli-pager \
+    --output json 2>/dev/null) || {
+    echo "error: aws logs filter-log-events failed for $DISPATCHER_LOG_GROUP" >&2
+    exit 2
+}
+
+DEPLOYED_SHA=$(echo "$FILTER_JSON" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+events = data.get("events", []) or []
+# Each event.message is a single JSON log line emitted by
+# dispatcher/daemon.py _JsonFormatter. Parse and keep only real startup
+# events (event == "startup"), then pick the latest by timestamp.
+best = None
+for ev in events:
+    msg = ev.get("message", "") or ""
+    try:
+        parsed = json.loads(msg)
+    except ValueError:
+        continue
+    if parsed.get("event") != "startup":
+        continue
+    ts = ev.get("timestamp", 0) or 0
+    vs = parsed.get("version_sha")
+    if not vs:
+        continue
+    if best is None or ts > best[0]:
+        best = (ts, vs)
+if best:
+    print(best[1])
+')
+
+if [[ -z "$DEPLOYED_SHA" || "$DEPLOYED_SHA" == "unknown" ]]; then
+    echo "error: no recent dispatcher startup log with a resolvable version_sha in $DISPATCHER_LOG_GROUP (last ${STARTUP_LOOKBACK_MIN} min)" >&2
+    exit 2
+fi
+
+# ── 3. Compare via git merge-base --is-ancestor ────────────────────────────
+
+if ! command -v "$GIT_CLI" > /dev/null 2>&1; then
+    echo "error: $GIT_CLI CLI not found on PATH" >&2
+    exit 2
+fi
+
+# Make sure the deployed SHA is resolvable locally. The daemon logs the
+# short (7-char) SHA baked at build time; if the operator's working copy
+# is stale, the short SHA may not exist locally yet. Attempt to resolve
+# it before calling merge-base so we can emit a clearer error.
+if ! "$GIT_CLI" rev-parse --verify --quiet "${DEPLOYED_SHA}^{commit}" > /dev/null; then
+    echo "error: deployed SHA '$DEPLOYED_SHA' not resolvable in local git — run 'git fetch origin main' and retry" >&2
+    exit 2
+fi
+
+if ! "$GIT_CLI" rev-parse --verify --quiet "${MERGE_SHA}^{commit}" > /dev/null; then
+    echo "error: PR merge SHA '$MERGE_SHA' not resolvable in local git — run 'git fetch origin main' and retry" >&2
+    exit 2
+fi
+
+# Distance: how many commits between merge_sha (exclusive) and deployed_sha
+# (inclusive). Useful operator context — a distance of 0 means the deploy
+# is exactly this PR; a distance of N means N commits followed it.
+DISTANCE=$("$GIT_CLI" rev-list --count "${MERGE_SHA}..${DEPLOYED_SHA}" 2>/dev/null || echo "?")
+
+ancestor_rc=0
+"$GIT_CLI" merge-base --is-ancestor "$MERGE_SHA" "$DEPLOYED_SHA" || ancestor_rc=$?
+
+case "$ancestor_rc" in
+    0)
+        echo "PR #${PR_NUM} landed in deployed SHA ${DEPLOYED_SHA} (merge SHA ${MERGE_SHA:0:7}, distance: ${DISTANCE} commits)"
+        exit 0
+        ;;
+    1)
+        echo "PR #${PR_NUM} is NOT in deployed SHA ${DEPLOYED_SHA} (merge SHA ${MERGE_SHA:0:7})"
+        exit 1
+        ;;
+    *)
+        echo "error: git merge-base --is-ancestor returned unexpected exit $ancestor_rc" >&2
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
## Summary

Adds `scripts/verify-pr-in-deployed-sha.sh <pr-number>` — a helper that answers "did my dispatcher PR actually land in the deployed image?" when `deploy-dispatcher.yml`'s concurrency cancellation shows the run as CANCELLED after a successful build-and-push. Resolves the PR's merge commit via `gh pr view --json mergeCommit`, reads the latest `version_sha` from the dispatcher's CloudWatch startup log, and runs `git merge-base --is-ancestor`. Exit 0 = landed, 1 = not deployed, 2 = usage/data error.

### Approach chosen

**Approach 2 from the task brief (detection helper).** Rejected the workflow-refactor option (adding a `cancelled()` step to `deploy-dispatcher.yml`) because GitHub Actions concurrency groups guarantee in-order build+push against ECR — the cancelled earlier run never overwrites `:latest` ahead of the superseding build, so the PR's code is never actually dropped, only its deploy-run status becomes a post-hoc interpretation problem. A detection helper closes that gap cleanly without adding conditional status-posting logic to the workflow.

Closes #3076

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (new `scripts/tests/test_verify_pr_in_deployed_sha.sh` — 12/12 passing locally and in the `scripts-tests` CI job)
- [x] CI green

### Post-deploy verification
- [x] N/A — no deployed component (operator tooling only; `deploy-dispatcher.yml` paths filter is unchanged)
- [x] Live-evidence run of the new helper against a recent merged dispatcher PR (e.g. #3066) posted on #3076 as verification evidence

## Notes

- Script uses `aws logs filter-log-events` (filter pattern `"event" "startup"`) over a 24-hour configurable lookback, client-side sort on timestamp to pick the latest `version_sha`. Cheaper and fewer moving parts than `start-query` Insights for a single-line lookup.
- Tool binaries are swappable via `AWS_CLI` / `GH_CLI` / `GIT_CLI` env vars so the shell test can mock each one on PATH (same pattern as `test_check_duplicate_pr.sh`, `test_wait_for_rollout.sh`).
- `.claude/skills/task/SKILL.md` §A.8 gains one paragraph pointing /task subagents at the helper when verifying dispatcher PRs during concurrent-merge windows.
- No changes to `Dockerfile.dispatcher`, `scripts/dispatcher/daemon.py`, or any deploy workflow.
