### PR TITLE
feat(dx): enforce macOS bash 3.2 compatibility for shell scripts (#3082)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,6 +611,16 @@ jobs:
       # time.
       - name: Verify every daemon terminal site has a ROUTING comment
         run: scripts/check-terminal-routing-comments.sh
+      # Issue #3082: operator laptops run macOS's stock bash 3.2.
+      # Shell scripts under scripts/**/*.sh must stick to the bash 3.2
+      # subset — no mapfile, readarray, associative arrays, nameref,
+      # case-conversion parameter expansions, ;;& case fall-through,
+      # or |& pipe shorthand. Retro of #3081's near-miss: the first
+      # draft of check-terminal-routing-comments.sh used mapfile and
+      # silently exited 127 on the operator's laptop. See
+      # docs/agent/code-standards.md §macOS bash 3.2 compatibility.
+      - name: Verify scripts stay within the bash 3.2 feature subset
+        run: scripts/check-bash-compat.sh
       # Auto-discover and run every executable shell test under
       # scripts/tests/*.sh. Replaces the old per-script listing (#2505) so
       # that adding a new shell test is just `touch + chmod +x` — no

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -173,6 +173,31 @@ Then commit the updated `schema.sql` alongside the migration. `schema.sql` is au
 
 The same check runs in CI as the `schema-drift-check` job. The pre-push hook runs it whenever a `packages/api/migrations/*.sql` file is in the push (requires Docker + a running daemon; emits a WARNING and skips if Docker is unavailable), so migration-vs-schema drift is caught locally before the ~10 minute CI round trip. See #2702.
 
+### macOS bash 3.2 compatibility
+
+Operator laptops run macOS, which ships with bash 3.2.57 (Apple has frozen the OS bash at 3.2 since 2007 for GPLv3 licensing reasons). Shell scripts in this repo — especially `scripts/check-*.sh` hygiene guards and `scripts/tests/*.sh` unit tests — are run both from CI (ubuntu-latest, bash 5+) and from operator shells. A script that uses a bash 4+ feature passes CI but fails locally with a cryptic message such as `mapfile: command not found` (exit 127) or `bad substitution`.
+
+**`scripts/check-bash-compat.sh` enforces this**, scanning every `scripts/**/*.sh` file for the forbidden constructs below and exiting non-zero on a match. It is wired into the `scripts-tests` CI job (same path filter as the other hygiene checks). Comment lines are exempted, so prose referencing a forbidden token (e.g., "we avoid `mapfile` because...") is fine.
+
+**Forbidden constructs** (each has a bash 3.2-compatible rewrite):
+
+| Construct | Bash 3.2 behaviour | Use instead |
+|-----------|-------------------|-------------|
+| `mapfile` / `readarray` (bash 4+ builtin) | `command not found` → exit 127 | `while IFS= read -r line; do arr+=("$line"); done < <(cmd)` |
+| `declare -A` / `typeset -A` (bash 4+ associative arrays) | `declare: -A: invalid option` | Parallel indexed arrays, or namespaced variables (`var_foo`, `var_bar`) |
+| `declare -g` (bash 4.2+ global from function) | `declare: -g: invalid option` | Plain assignment at global scope, or `VAR=$(fn)` at caller |
+| `${var,,}` / `${var,}` / `${var^^}` / `${var^}` (bash 4+ case conversion) | `bad substitution` | `tr '[:upper:]' '[:lower:]'` (or the reverse) |
+| `local -n` / `declare -n` / `typeset -n` (bash 4.3+ namerefs) | `local: -n: invalid option` | Pass by value and return via stdout: `r=$(fn "$x")` |
+| `;;&` in `case` (bash 4+ fall-through) | `syntax error near unexpected token &` | Separate `if` arms, or repeat the body |
+| `\|&` pipe shorthand (bash 4+ pipe-both-streams) | `syntax error near unexpected token &` | `2>&1 \|` (more explicit and bash 3.2+ compatible) |
+
+**Not forbidden** (these work on bash 3.2):
+- `echo -e` — bash 3.2's `echo` builtin supports `-e`.
+- Process substitution `< <(...)` — bash 3.2 supports it.
+- `[[ ... ]]` conditionals, `$(...)` command substitution, indexed arrays — all bash 2+.
+
+**Historical context.** Two earlier check scripts (`scripts/check-admin-dispatcher-brand-accent.sh`, `scripts/check-no-inline-ecs-healthcheck.sh`) and the `scripts/check-terminal-routing-comments.sh` guard each carry inline comments explaining why they avoid `mapfile` — the convention existed as tribal knowledge for months. PR #3081's first draft still used `mapfile -t` and silently exited 127 on the operator's laptop; the author found the precedent only by grepping peer check scripts. Issue #3082 codified the convention into `check-bash-compat.sh` + this docs section.
+
 ### Hygiene-check CI steps
 
 When wiring a `scripts/check-no-*.sh`, `scripts/check-forbidden-*.sh`, or `scripts/check-deprecated-*.sh` guard into `.github/workflows/ci.yml`, **do not quote the forbidden string in the step's `name:` field** — the quoted pattern itself will trip the guard on the next CI run (see #2541/#2542 for the specific incident). Name the step after what the check *does* instead of what it *forbids* (e.g., name it after the replacement tool or the category of misuse, not the literal string).

--- a/scripts/check-bash-compat.sh
+++ b/scripts/check-bash-compat.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# check-bash-compat.sh — Forbid bash 4+ constructs in ``scripts/**/*.sh``
+# so shell scripts remain executable on operator laptops running macOS's
+# stock bash 3.2.
+#
+# Why this check exists
+# ---------------------
+# Operator laptops run macOS, which ships with bash 3.2.57 (Apple has
+# frozen the OS bash at 3.2 since 2007 for GPLv3 licensing reasons).
+# Shell scripts in this repo — especially ``scripts/check-*.sh`` hygiene
+# guards — are invoked both from CI (ubuntu-latest, bash 5+) and from
+# operator shells. A script that uses a bash 4+ feature passes CI but
+# fails locally with a cryptic error:
+#
+#     $ scripts/check-foo.sh
+#     /bin/bash: mapfile: command not found
+#     exit 127
+#
+# The #3081 PR (the ``check-terminal-routing-comments.sh`` guard) hit
+# this on its first draft — ``mapfile -t`` silently exited 127 on the
+# operator's laptop. The bug was caught only by grepping other check
+# scripts for the repo's unwritten convention; two existing guards
+# (``check-admin-dispatcher-brand-accent.sh``,
+# ``check-no-inline-ecs-healthcheck.sh``) had inline comments noting
+# the constraint, but it was not codified anywhere enforceable. Issue
+# #3082 codifies it: this check + the ``docs/agent/code-standards.md``
+# §macOS bash 3.2 compatibility note.
+#
+# Forbidden constructs
+# --------------------
+# Each of the following is a bash 4+ feature that emits either
+# ``command not found`` (builtins) or ``bad substitution`` / ``syntax
+# error`` (syntax) on bash 3.2:
+#
+#   1. ``mapfile`` / ``readarray`` (bash 4.0+ builtin) — read lines
+#      into an array. Use ``while IFS= read -r line; do arr+=("$line");
+#      done < <(cmd)`` instead.
+#
+#   2. ``declare -A`` / ``typeset -A`` (bash 4.0+) — associative arrays.
+#      Use parallel indexed arrays, namespaced variables (``var_foo``,
+#      ``var_bar``), or a temp file + grep.
+#
+#   3. ``declare -g`` (bash 4.2+) — declare a global from inside a
+#      function. Use plain ``VAR=value`` at global scope, or write to
+#      stdout and ``VAR=$(fn)`` at the caller.
+#
+#   4. ``${var,,}`` / ``${var,}`` / ``${var^^}`` / ``${var^}`` (bash
+#      4.0+) — case-modifying parameter expansion. Use
+#      ``tr '[:upper:]' '[:lower:]'`` (or ``[:lower:]`` → ``[:upper:]``)
+#      instead.
+#
+#   5. ``local -n`` / ``declare -n`` / ``typeset -n`` (bash 4.3+) —
+#      nameref variables. Pass the value by expansion, not by name, or
+#      use ``eval`` with strict quoting if a reference really is
+#      needed (rare).
+#
+#   6. ``;;&`` in ``case`` (bash 4.0+) — fall-through to the next
+#      pattern. Split into separate ``if`` arms or repeat the body.
+#
+#   7. ``|&`` pipe shorthand (bash 4.0+) — pipe both stdout and stderr.
+#      Use ``2>&1 |`` instead (works on bash 3.2+ and is more explicit).
+#
+# NOT forbidden (works on bash 3.2):
+#   - ``echo -e`` — bash 3.2's ``echo`` builtin supports ``-e``.
+#   - Process substitution ``< <(...)`` — bash 3.2 supports it.
+#   - ``[[ ... ]]`` conditional — bash 2+.
+#   - ``$(...)`` command substitution — bash 2+.
+#   - Indexed arrays ``arr=(a b c)`` + ``"${arr[@]}"`` — bash 2+.
+#
+# Pattern matching strategy
+# -------------------------
+# The check is text-based (not AST-based) so it runs in a few hundred
+# milliseconds on a cold macOS laptop. Each construct has its own
+# ``grep -nE`` pattern tuned to minimise false positives:
+#
+#   - Builtins (mapfile, readarray, declare -A, declare -g, local -n,
+#     declare -n, typeset -n, typeset -A) require a leading word
+#     boundary so the name is the start of a statement — not a
+#     substring of some longer token (e.g. ``my_mapfile_wrapper``).
+#
+#   - Parameter expansions (``${var,,}`` etc.) use the exact sigil form.
+#     The check does not flag ``${var,default}`` because that pattern
+#     simply isn't valid anywhere (bash has no such form) — any
+#     ``${x,...}`` you see in the wild is a case-conversion.
+#
+#   - Syntax shorthands (``;;&``, ``|&``) match the literal token
+#     surrounded by whitespace or line boundaries.
+#
+# Comment lines (first non-whitespace char is ``#``) are excluded, so
+# docstrings and explanatory prose may reference the forbidden tokens
+# freely. The check script and its test file are allow-listed by path
+# for the same reason.
+#
+# Usage
+# -----
+#   scripts/check-bash-compat.sh          # scan scripts/ under repo root
+#   scripts/check-bash-compat.sh [dir]    # scan a specific directory
+#
+# Exit codes
+# ----------
+#   0 — No bash 4+ constructs detected in tracked shell scripts.
+#   1 — One or more shell scripts use a forbidden construct. The
+#       offending lines are printed with file:line:content plus a
+#       pointer to docs/agent/code-standards.md §macOS bash 3.2
+#       compatibility.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-$REPO_ROOT}"
+
+# ─── Files that legitimately mention the forbidden tokens ────────────────
+# The check script itself and its test must spell the tokens literally.
+# scripts/check-terminal-routing-comments.sh,
+# scripts/check-admin-dispatcher-brand-accent.sh, and
+# scripts/check-no-inline-ecs-healthcheck.sh each have a comment
+# explaining that they avoid ``mapfile`` for bash 3.2 reasons — those
+# comments are excluded via the generic comment-line filter, not by
+# allow-listing.
+EXCLUDE_FILES=(
+    "scripts/check-bash-compat.sh"
+    "scripts/tests/test_check_bash_compat.sh"
+)
+
+# ─── Directories to exclude from the scan ────────────────────────────────
+# Anything outside scripts/ is not our concern for this check. Within
+# scripts/, exclude vendored/cache dirs that may contain shell fixtures
+# we do not author.
+EXCLUDE_DIRS=(
+    ".git"
+    ".venv"
+    "node_modules"
+    "__pycache__"
+    # Local developer scratch (not tracked).
+    "tmp"
+)
+
+# ─── The forbidden-construct patterns ────────────────────────────────────
+# Each entry is: <label>\t<extended-regex>.
+# The label is used for human-readable reporting; the regex is passed
+# to ``grep -nE``.
+#
+# Bash 3.2 doesn't support associative arrays (the first thing this
+# check forbids!), so we use parallel indexed arrays instead — which
+# is itself the recommended workaround documented in
+# docs/agent/code-standards.md §macOS bash 3.2 compatibility.
+PATTERN_LABELS=(
+    "mapfile (bash 4+ builtin)"
+    "readarray (bash 4+ builtin)"
+    "declare -A (associative array, bash 4+)"
+    "typeset -A (associative array, bash 4+)"
+    "declare -g (global declare, bash 4.2+)"
+    "local -n (nameref, bash 4.3+)"
+    "declare -n (nameref, bash 4.3+)"
+    "typeset -n (nameref, bash 4.3+)"
+    "\${var,,} / \${var,} (lowercase expansion, bash 4+)"
+    "\${var^^} / \${var^} (uppercase expansion, bash 4+)"
+    ";;& (case fall-through, bash 4+)"
+    "|& (stderr pipe shorthand, bash 4+)"
+)
+
+# Leading word boundary: start-of-line or whitespace or ``;``/``&``/
+# ``(``. This keeps ``my_mapfile_wrapper`` and ``foo.readarray`` from
+# tripping the check while catching ``mapfile -t`` at the start of a
+# line or after ``if ``/``then ``/``|``/``;``.
+_LB='(^|[[:space:];&|()])'
+
+PATTERN_REGEXES=(
+    "${_LB}mapfile([[:space:]]|$)"
+    "${_LB}readarray([[:space:]]|$)"
+    "${_LB}declare[[:space:]]+-[a-zA-Z]*A"
+    "${_LB}typeset[[:space:]]+-[a-zA-Z]*A"
+    "${_LB}declare[[:space:]]+-[a-zA-Z]*g"
+    "${_LB}local[[:space:]]+-[a-zA-Z]*n"
+    "${_LB}declare[[:space:]]+-[a-zA-Z]*n"
+    "${_LB}typeset[[:space:]]+-[a-zA-Z]*n"
+    '\$\{[A-Za-z_][A-Za-z0-9_]*,[,]?\}'
+    '\$\{[A-Za-z_][A-Za-z0-9_]*\^[\^]?\}'
+    ';;&'
+    '[^|]\|&([[:space:]]|$)'
+)
+
+# ─── Locate the shell scripts to scan ────────────────────────────────────
+# Only scripts/**/*.sh is in scope. Anything under scripts/archive/ or
+# scripts/tests/fixtures/ is still scanned — agents learning from the
+# test fixtures should see compliant patterns there too.
+SCRIPTS_DIR="$SCAN_DIR/scripts"
+if [[ ! -d "$SCRIPTS_DIR" ]]; then
+    # When invoked against a test TMPDIR that doesn't have a scripts/
+    # subdir, treat SCAN_DIR itself as the target. This lets the test
+    # harness construct minimal fixtures without mirroring the repo
+    # layout.
+    SCRIPTS_DIR="$SCAN_DIR"
+fi
+
+# Build a sorted list of *.sh files, excluding directories in
+# EXCLUDE_DIRS. Uses a while-read loop (not mapfile — see rule #1!).
+#
+# The find invocation uses the ``-prune`` idiom: for each excluded
+# directory name, ``-name <dir> -type d -prune -o`` short-circuits
+# the descent before printing. Ordering matters — the prune clauses
+# must come before the match clause so the prune applies first.
+prune_args=()
+for d in "${EXCLUDE_DIRS[@]}"; do
+    prune_args+=(-name "$d" -type d -prune -o)
+done
+
+sh_files=()
+while IFS= read -r f; do
+    [[ -n "$f" ]] && sh_files+=("$f")
+done < <(find "$SCRIPTS_DIR" "${prune_args[@]+"${prune_args[@]}"}" \
+    -type f -name '*.sh' -print 2>/dev/null | sort || true)
+
+if [[ ${#sh_files[@]} -eq 0 ]]; then
+    echo "check-bash-compat: no *.sh files found under $SCRIPTS_DIR — nothing to check."
+    exit 0
+fi
+
+# ─── Scan every file × every pattern ─────────────────────────────────────
+violations=0
+# Accumulate matches into a single text buffer so we can print them
+# grouped by construct at the end. Again — indexed arrays, not
+# associative.
+report_lines=()
+
+for file in "${sh_files[@]}"; do
+    # Skip allow-listed files by path suffix.
+    skip=false
+    for excl in "${EXCLUDE_FILES[@]}"; do
+        if [[ "$file" == *"$excl" ]]; then
+            skip=true
+            break
+        fi
+    done
+    if "$skip"; then
+        continue
+    fi
+
+    # Walk each pattern.
+    idx=0
+    while (( idx < ${#PATTERN_REGEXES[@]} )); do
+        label="${PATTERN_LABELS[$idx]}"
+        regex="${PATTERN_REGEXES[$idx]}"
+
+        # grep -nE emits ``lineno:content``. The leading filename is
+        # added by grep's ``-H`` when multiple files are provided; here
+        # we pass a single file and prepend the filename ourselves to
+        # keep the output format consistent.
+        matches=$(grep -nE "$regex" "$file" 2>/dev/null || true)
+        if [[ -z "$matches" ]]; then
+            idx=$((idx + 1))
+            continue
+        fi
+
+        while IFS= read -r m; do
+            [[ -z "$m" ]] && continue
+            lineno="${m%%:*}"
+            content="${m#*:}"
+
+            # Skip comment lines — the first non-whitespace character
+            # is ``#``. This lets this script, peer check scripts, and
+            # test fixtures discuss the forbidden tokens in prose.
+            if [[ "$content" =~ ^[[:space:]]*# ]]; then
+                continue
+            fi
+
+            report_lines+=("  [$label]")
+            report_lines+=("    $file:$lineno: $content")
+            violations=$((violations + 1))
+        done <<< "$matches"
+
+        idx=$((idx + 1))
+    done
+done
+
+if (( violations > 0 )); then
+    echo "ERROR: bash 4+ construct(s) detected in scripts/**/*.sh."
+    echo ""
+    echo "  These scripts must run on macOS's stock bash 3.2. Each"
+    echo "  forbidden construct has a bash 3.2-compatible rewrite — see"
+    echo "  docs/agent/code-standards.md §macOS bash 3.2 compatibility."
+    echo ""
+    for line in "${report_lines[@]}"; do
+        echo "$line"
+    done
+    echo ""
+    echo "  Total violations: $violations"
+    echo ""
+    echo "  If a construct must appear as explanatory context (e.g."
+    echo "  \"we avoid mapfile because ...\"), put it in a comment line"
+    echo "  (first non-whitespace char is '#'). Comments are exempted."
+    exit 1
+fi
+
+echo "check-bash-compat: ${#sh_files[@]} shell script(s) scanned — all clean."
+exit 0

--- a/scripts/tests/test_check_bash_compat.sh
+++ b/scripts/tests/test_check_bash_compat.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+# test_check_bash_compat.sh — Tests for scripts/check-bash-compat.sh
+#
+# Verifies that the checker fails on synthetic shell scripts using each
+# forbidden bash 4+ construct and passes on known-good shell scripts
+# that stick to the bash 3.2 subset. Also regression-tests that the
+# current ``scripts/**/*.sh`` tree passes — an existing script using a
+# forbidden construct would need to be fixed as part of the same PR
+# that introduces this check.
+#
+# Usage:
+#   scripts/tests/test_check_bash_compat.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-bash-compat.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+# The check expects a ``scripts/`` subdir; synthesize one inside the
+# temp dir. All per-test files are written under $TMPDIR_TEST/scripts/.
+mkdir -p "$TMPDIR_TEST/scripts"
+
+write_file() {
+    # $1: file path (relative to $TMPDIR_TEST/scripts/)
+    # $2: contents (via stdin)
+    local path="$TMPDIR_TEST/scripts/$1"
+    mkdir -p "$(dirname "$path")"
+    cat > "$path"
+    chmod +x "$path"
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST/scripts"
+    mkdir -p "$TMPDIR_TEST/scripts"
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+# ─── Test 1: Known-bad — mapfile in a script fails ──────────────────────
+write_file "bad_mapfile.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+mapfile -t lines < <(echo "a")
+echo "${lines[0]}"
+EOF
+assert_fails "mapfile triggers the check"
+reset_tmpdir
+
+# ─── Test 2: Known-bad — readarray fails ────────────────────────────────
+write_file "bad_readarray.sh" <<'EOF'
+#!/usr/bin/env bash
+readarray -t x < <(echo "b")
+EOF
+assert_fails "readarray triggers the check"
+reset_tmpdir
+
+# ─── Test 3: Known-bad — declare -A fails ───────────────────────────────
+write_file "bad_declare_A.sh" <<'EOF'
+#!/usr/bin/env bash
+declare -A colors=([red]=1 [blue]=2)
+echo "${colors[red]}"
+EOF
+assert_fails "declare -A triggers the check"
+reset_tmpdir
+
+# ─── Test 4: Known-bad — declare -g fails ───────────────────────────────
+write_file "bad_declare_g.sh" <<'EOF'
+#!/usr/bin/env bash
+f() {
+    declare -g X=1
+}
+f
+echo "$X"
+EOF
+assert_fails "declare -g triggers the check"
+reset_tmpdir
+
+# ─── Test 5: Known-bad — local -n nameref fails ─────────────────────────
+write_file "bad_local_n.sh" <<'EOF'
+#!/usr/bin/env bash
+f() {
+    local -n ref=$1
+    echo "$ref"
+}
+v=hi
+f v
+EOF
+assert_fails "local -n nameref triggers the check"
+reset_tmpdir
+
+# ─── Test 6: Known-bad — declare -n nameref fails ───────────────────────
+write_file "bad_declare_n.sh" <<'EOF'
+#!/usr/bin/env bash
+v=hi
+declare -n ref=v
+echo "$ref"
+EOF
+assert_fails "declare -n nameref triggers the check"
+reset_tmpdir
+
+# ─── Test 7: Known-bad — typeset -A fails ───────────────────────────────
+write_file "bad_typeset_A.sh" <<'EOF'
+#!/usr/bin/env bash
+typeset -A m=([a]=1)
+echo "${m[a]}"
+EOF
+assert_fails "typeset -A triggers the check"
+reset_tmpdir
+
+# ─── Test 8: Known-bad — \${var,,} lowercase expansion fails ────────────
+write_file "bad_lowercase.sh" <<'EOF'
+#!/usr/bin/env bash
+x=HELLO
+echo "${x,,}"
+EOF
+assert_fails "\${var,,} lowercase expansion triggers the check"
+reset_tmpdir
+
+# ─── Test 9: Known-bad — \${var,} first-char-lower fails ────────────────
+write_file "bad_lowercase_first.sh" <<'EOF'
+#!/usr/bin/env bash
+x=HELLO
+echo "${x,}"
+EOF
+assert_fails "\${var,} first-char-lower expansion triggers the check"
+reset_tmpdir
+
+# ─── Test 10: Known-bad — \${var^^} uppercase expansion fails ───────────
+write_file "bad_uppercase.sh" <<'EOF'
+#!/usr/bin/env bash
+x=hello
+echo "${x^^}"
+EOF
+assert_fails "\${var^^} uppercase expansion triggers the check"
+reset_tmpdir
+
+# ─── Test 11: Known-bad — \${var^} first-char-upper fails ───────────────
+write_file "bad_uppercase_first.sh" <<'EOF'
+#!/usr/bin/env bash
+x=hello
+echo "${x^}"
+EOF
+assert_fails "\${var^} first-char-upper expansion triggers the check"
+reset_tmpdir
+
+# ─── Test 12: Known-bad — ;;& case fall-through fails ───────────────────
+write_file "bad_fallthrough.sh" <<'EOF'
+#!/usr/bin/env bash
+case $1 in
+    a) echo a ;;&
+    b) echo b ;;
+esac
+EOF
+assert_fails ";;& case fall-through triggers the check"
+reset_tmpdir
+
+# ─── Test 13: Known-bad — |& pipe shorthand fails ───────────────────────
+write_file "bad_pipe_and.sh" <<'EOF'
+#!/usr/bin/env bash
+echo foo |& cat
+EOF
+assert_fails "|& pipe-both shorthand triggers the check"
+reset_tmpdir
+
+# ─── Test 14: Known-good — clean script passes ──────────────────────────
+write_file "good_clean.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+# A bash 3.2-compatible script that lists files and greps them.
+files=()
+while IFS= read -r f; do
+    files+=("$f")
+done < <(find . -type f -name '*.txt')
+for f in "${files[@]+"${files[@]}"}"; do
+    grep -l "hello" "$f" || true
+done
+EOF
+assert_passes "Clean bash 3.2-compatible script passes"
+reset_tmpdir
+
+# ─── Test 15: Known-good — comments referencing forbidden tokens pass ───
+write_file "good_comments.sh" <<'EOF'
+#!/usr/bin/env bash
+# We avoid mapfile and readarray because macOS bash 3.2 lacks them.
+# See docs/agent/code-standards.md for the compatibility rules.
+# Also avoid: declare -A, declare -g, local -n, declare -n, typeset -A,
+# typeset -n, ${var,,}, ${var,}, ${var^^}, ${var^}, ;;& and |&.
+echo "hello world"
+EOF
+assert_passes "Comments mentioning forbidden tokens are exempted"
+reset_tmpdir
+
+# ─── Test 16: Known-good — indented comment also exempted ───────────────
+write_file "good_indented_comment.sh" <<'EOF'
+#!/usr/bin/env bash
+case $1 in
+    a)
+        # ;;& would be nice here but bash 3.2 can't parse it; use
+        # separate arms instead.
+        echo a
+        ;;
+    *)
+        echo unknown
+        ;;
+esac
+EOF
+assert_passes "Indented comment mentioning ;;& is exempted"
+reset_tmpdir
+
+# ─── Test 17: Known-good — similar-looking but non-matching tokens pass ─
+# ``declare -a`` (lowercase — indexed array) is allowed. Only ``-A``
+# (associative) is forbidden. Similarly ``declare -r`` (readonly) is
+# fine.
+write_file "good_lookalikes.sh" <<'EOF'
+#!/usr/bin/env bash
+declare -a indexed=(a b c)
+declare -r readonly_var="x"
+echo "${indexed[0]} $readonly_var"
+# Variable names containing the forbidden substrings are fine:
+my_mapfile_wrapper() {
+    grep -l foo .
+}
+my_mapfile_wrapper
+EOF
+assert_passes "declare -a and declare -r (lookalikes) pass"
+reset_tmpdir
+
+# ─── Test 18: Known-good — function name containing 'mapfile' passes ────
+write_file "good_funcname.sh" <<'EOF'
+#!/usr/bin/env bash
+make_mapfile() {
+    # Intentionally named to confuse a naive substring match.
+    echo "ok"
+}
+make_mapfile
+EOF
+assert_passes "Function named make_mapfile is not flagged"
+reset_tmpdir
+
+# ─── Test 19: Known-good — regular pipe (|) passes ──────────────────────
+# ``|&`` is forbidden, but plain ``|`` must not be flagged. The
+# distinction matters: ``echo foo | cat`` is the 99% case in shell
+# scripts.
+write_file "good_plain_pipe.sh" <<'EOF'
+#!/usr/bin/env bash
+echo foo | cat
+echo bar | wc -l
+# The canonical bash 3.2 form for pipe-both-stdout-and-stderr:
+echo baz 2>&1 | cat
+EOF
+assert_passes "Plain | pipe and 2>&1 | pattern pass"
+reset_tmpdir
+
+# ─── Test 20: Known-good — no *.sh files passes ─────────────────────────
+assert_passes "Empty scripts/ directory passes"
+
+# ─── Test 21: Mixed — good + bad → fails (bad catches) ──────────────────
+write_file "good_in_mixed.sh" <<'EOF'
+#!/usr/bin/env bash
+echo ok
+EOF
+write_file "bad_in_mixed.sh" <<'EOF'
+#!/usr/bin/env bash
+mapfile -t x < <(echo a)
+EOF
+assert_fails "Mixed tree fails when any file has a forbidden construct"
+reset_tmpdir
+
+# ─── Test 22: Self-match — the check script itself must pass ────────────
+# Run the check against its own repo location. The check must not
+# trip on its own source file (which spells every forbidden token
+# literally in its header comments and pattern arrays).
+TESTS=$((TESTS + 1))
+if "$CHECK_SCRIPT" "$REPO_ROOT" > /dev/null 2>&1; then
+    echo "PASS: Real repo scripts/ tree passes (no forbidden constructs)"
+else
+    echo "FAIL: Real repo scripts/ tree contains a forbidden construct"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 23: No self-match on ci.yml step name ─────────────────────────
+# The step name in .github/workflows/ci.yml that runs this guard must
+# not itself contain a forbidden token. If it did, the guard would
+# fail on its first CI run (see #2541/#2542 for the class of bug).
+#
+# The shared helper _guard_self_match_helpers.sh writes extracted step
+# names to ``$TMPDIR_TEST/ci_step_names.<ext>`` — outside the
+# ``$TMPDIR_TEST/scripts/`` subtree this check scans. Rather than
+# restructure the helper, we inline the narrow version here: use awk to
+# pull step names that invoke the guard, write them to a .sh file
+# inside ``$TMPDIR_TEST/scripts/``, and re-run the check.
+CI_YML="$REPO_ROOT/.github/workflows/ci.yml"
+EXTRACTOR_AWK="$SCRIPT_DIR/tests/_extract_guard_step_names.awk"
+if [[ -f "$CI_YML" && -f "$EXTRACTOR_AWK" ]]; then
+    awk -v script="scripts/check-bash-compat.sh" -f "$EXTRACTOR_AWK" \
+        "$CI_YML" > "$TMPDIR_TEST/scripts/ci_step_names.sh"
+    assert_passes "No self-match on ci.yml step name for scripts/check-bash-compat.sh"
+    reset_tmpdir
+else
+    echo "SKIP: ci.yml or extractor awk missing — self-match assertion skipped"
+fi
+
+# ─── Summary ────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Codify the macOS bash 3.2 compatibility convention (previously tribal knowledge in three inline comments) into `docs/agent/code-standards.md` §macOS bash 3.2 compatibility and a new `scripts/check-bash-compat.sh` hygiene guard wired into CI. Motivated by #3081's near-miss: the first draft of `check-terminal-routing-comments.sh` used `mapfile -t`, which silently exits 127 on macOS's stock bash 3.2.

Closes #3082

## What the guard forbids

Each of these emits `command not found` / `invalid option` / `bad substitution` / `syntax error` on bash 3.2 (confirmed by running each against local `bash 3.2.57`):

1. `mapfile` / `readarray` (bash 4+ builtin)
2. `declare -A` / `typeset -A` (bash 4+ associative arrays)
3. `declare -g` (bash 4.2+ global from function)
4. `${var,,}` / `${var,}` / `${var^^}` / `${var^}` (bash 4+ case conversion)
5. `local -n` / `declare -n` / `typeset -n` (bash 4.3+ namerefs)
6. `;;&` (bash 4+ case fall-through)
7. `|&` (bash 4+ pipe shorthand for stderr-and-stdout)

`echo -e` and process substitution `< <(...)` are **not** forbidden — both work on bash 3.2 and are in active use throughout the repo.

Comment lines are exempted so prose discussing a forbidden token (e.g., "we avoid `mapfile` because...") stays legal.

## Files changed

- `scripts/check-bash-compat.sh` — the guard (new).
- `scripts/tests/test_check_bash_compat.sh` — 23 assertions covering every forbidden construct, known-good patterns, lookalike non-matches, and the ci.yml self-match check (new).
- `docs/agent/code-standards.md` — new §macOS bash 3.2 compatibility section with the forbidden-constructs table + rewrites.
- `.github/workflows/ci.yml` — wires the guard into the `scripts-tests` job, following the #3081 ROUTING-check pattern verbatim.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green — `scripts-tests` job exercises the new `check-bash-compat.sh` step and runs `test_check_bash_compat.sh` via auto-discovery

### Post-deploy verification
- [x] N/A — no deployed component (CI/tooling + docs only)
- [x] Verification evidence posted on issue (see #3082)
