### PR TITLE
fix(dispatcher): add scheduler_tick stall watchdog for daemon wedge (#3097)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -126,6 +126,51 @@ DEFAULT_SUPERVISOR_TICK_SECONDS = 120
 #: heartbeat. Issue #2778 (closes the TODO in migration 24).
 DEFAULT_HOUSEKEEPING_TICK_SECONDS = 3600
 
+#: Scheduler-tick stall watchdog thresholds (#3097). The supervisor
+#: watchdog thread (:meth:`DispatcherDaemon._watchdog_loop`) observes
+#: ``self._last_scheduler_tick_at`` and fires two tiers of alarm when
+#: the main scheduler loop goes silent:
+#:
+#: * ``DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS`` (300 = 5 min) —
+#:   WARNING ``scheduler_tick_stalled`` with a bounded thread dump.
+#:   This is ~10× the default scheduler cadence, so a transient GitHub
+#:   or DB slowdown does not trigger a false positive while a real
+#:   wedge (30+ min observed silence on #3097 reproductions) is
+#:   caught well before the exit threshold.
+#: * ``DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS`` (3000 = 50 min) —
+#:   ERROR ``scheduler_tick_stalled_exiting`` with a final thread dump
+#:   followed by ``os._exit(137)``. ECS restarts the task. 50 min is
+#:   the MTTR ceiling the issue targets (vs. ~30 min of operator-
+#:   notice + ~5 min of manual ``update-service --force-new-deployment``
+#:   today). Exit code 137 mirrors the kernel's 128+SIGKILL convention
+#:   for operator-legible logs.
+#:
+#: Both thresholds are operator-tunable via
+#: ``dispatcher.config.scheduler_tick_stall_warn_seconds`` /
+#: ``scheduler_tick_stall_exit_seconds`` (read through
+#: :meth:`DispatcherDaemon._cb_config_int`, which fails closed to the
+#: default on any DB / parse error).
+DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS = 300
+DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS = 3000
+
+#: Watchdog poll cadence. The watchdog thread wakes every 30s to check
+#: the elapsed-since-last-tick gap against the thresholds above. Small
+#: enough to catch the exit threshold within one poll cycle; large
+#: enough that the watchdog overhead is negligible (~one wakeup per
+#: scheduler tick). Not operator-tunable — changing this is a code
+#: change, not a config flip.
+WATCHDOG_POLL_INTERVAL_SECONDS = 30
+
+#: Max stack frames per thread emitted in the stall thread dump. Each
+#: frame renders as ``file:line (function)`` — ~60-120 chars per frame.
+#: With ~10 threads (main + scheduler + ralph head-watcher + CloudWatch
+#: boto connections) and 20 frames per thread, the dump stays under
+#: ~24KB total which is well below CloudWatch's 256KB log-event limit.
+#: Deep-stack frames are the least useful for diagnosis anyway (they
+#: tend to be generic library internals); the top of the stack is where
+#: the wedge lives.
+WATCHDOG_THREAD_DUMP_MAX_FRAMES_PER_THREAD = 20
+
 #: Default retention window for ``dispatcher.queue_snapshots``. Matches
 #: the ``dispatcher_daemon`` CloudWatch log group default retention and
 #: covers the longest plausible multi-week post-mortem window. Overridable
@@ -1828,6 +1873,30 @@ class DispatcherDaemon:
         # for CloudWatch review.
         self._last_cap_observed: int | None = None
         self._last_cap_observed_monotonic: float | None = None
+        # Scheduler-tick stall watchdog (#3097). ``_last_scheduler_tick_at``
+        # is the shared atomic (single-writer from the scheduler thread at
+        # the top of every :meth:`scheduler_tick`, single-reader from the
+        # watchdog loop) that records the most recent tick's monotonic
+        # timestamp. Initialized to boot-time so the watchdog's first
+        # observation has a valid reference — run_forever fires the first
+        # tick within milliseconds of boot, so the initial value is only
+        # in play during the brief startup window before the first tick
+        # overwrites it.
+        #
+        # ``_watchdog_thread`` is the supervisor thread that polls the
+        # gap every :data:`WATCHDOG_POLL_INTERVAL_SECONDS` and fires
+        # WARN / EXIT tiers per :data:`DEFAULT_SCHEDULER_TICK_STALL_*`.
+        # ``_watchdog_stop`` is set during shutdown so the thread exits
+        # promptly instead of sleeping through its next poll.
+        # ``_watchdog_warn_emitted_for_gap`` is the debounce: once a
+        # WARNING has fired for a stall, don't spam CloudWatch with
+        # duplicate warnings every poll cycle until either (a) the tick
+        # recovers (gap returns below warn threshold) or (b) the EXIT
+        # threshold is hit and we call ``os._exit``.
+        self._last_scheduler_tick_at: float = time.monotonic()
+        self._watchdog_thread: threading.Thread | None = None
+        self._watchdog_stop: threading.Event = threading.Event()
+        self._watchdog_warn_emitted_for_gap: bool = False
 
     # ------------------------------------------------------------------
     # Thread-aware connection accessor (#2847).
@@ -2037,6 +2106,19 @@ class DispatcherDaemon:
               agent was reclaimed ahead of any fresh queue claim.
         """
         assert self._conn is not None, "connect() must run before ticks"
+
+        # Stall-watchdog heartbeat (#3097). Record the monotonic
+        # timestamp of this tick's entry. The watchdog thread reads
+        # this value to detect main-loop wedges — see
+        # :meth:`_watchdog_loop`. No lock needed: single writer (the
+        # scheduler thread), single reader (the watchdog thread),
+        # Python's atomic attribute assignment guarantees torn-read
+        # safety on CPython for a plain float. Placed BEFORE any other
+        # tick work so a DB hiccup in step 1 below still counts as
+        # "scheduler is alive and executing" — the only way this line
+        # fails to fire is a genuine tick-entry-level wedge, which is
+        # exactly what the watchdog exists to catch.
+        self._last_scheduler_tick_at = time.monotonic()
 
         # 1. Consume any pending commands. Each command is dispatched to
         # its handler; consumed_at is set AFTER the handler returns so
@@ -17564,6 +17646,270 @@ class DispatcherDaemon:
         self._housekeeping_ticks += 1
         return per_table
 
+    # ── scheduler-tick stall watchdog (#3097) ──────────────────────────
+
+    @staticmethod
+    def _format_thread_dump(
+        max_frames_per_thread: int = WATCHDOG_THREAD_DUMP_MAX_FRAMES_PER_THREAD,
+    ) -> list[dict[str, Any]]:
+        """Return a bounded dump of every live Python thread's stack.
+
+        Used by :meth:`_watchdog_loop` when the scheduler tick stalls.
+        Each entry is a dict with the thread name, ident, daemon flag,
+        alive flag, and a list of ``{file, line, function}`` stack
+        frames from innermost out to at most ``max_frames_per_thread``.
+        Bounded so a deep stack does not blow past CloudWatch's 256KB
+        log-event cap (see :data:`WATCHDOG_THREAD_DUMP_MAX_FRAMES_PER_THREAD`).
+
+        Safe to call from any thread — uses only introspection APIs
+        (:func:`sys._current_frames`, :func:`threading.enumerate`) that
+        don't acquire the GIL beyond a normal Python attribute read.
+        """
+        frames_by_ident = sys._current_frames()  # noqa: SLF001 — public API
+        dump: list[dict[str, Any]] = []
+        for thread in threading.enumerate():
+            frame = frames_by_ident.get(thread.ident)
+            stack: list[dict[str, Any]] = []
+            # ``traceback.extract_stack`` walks innermost → outermost. We
+            # want the top of the stack (innermost) for wedge diagnosis
+            # because deep library frames are low-signal. Cap at
+            # ``max_frames_per_thread`` to bound row size.
+            cur = frame
+            while cur is not None and len(stack) < max_frames_per_thread:
+                code = cur.f_code
+                stack.append(
+                    {
+                        "file": code.co_filename,
+                        "line": cur.f_lineno,
+                        "function": code.co_name,
+                    }
+                )
+                cur = cur.f_back
+            dump.append(
+                {
+                    "name": thread.name,
+                    "ident": thread.ident,
+                    "daemon": thread.daemon,
+                    "alive": thread.is_alive(),
+                    "frames": stack,
+                }
+            )
+        return dump
+
+    def _emit_scheduler_stall_warning(self, elapsed_seconds: float) -> None:
+        """Log a WARNING ``scheduler_tick_stalled`` with a thread dump.
+
+        Fired once per stall episode — debounced via
+        ``_watchdog_warn_emitted_for_gap`` to avoid spamming CloudWatch
+        while the wedge persists. Cleared when the tick recovers OR the
+        EXIT threshold hits.
+        """
+        thread_dump = self._format_thread_dump()
+        self._log.warning(
+            "daemon.scheduler_tick_stalled",
+            extra={
+                "event": "scheduler_tick_stalled",
+                "run_id": self._run_id,
+                "elapsed_seconds": round(elapsed_seconds, 1),
+                "warn_threshold_seconds": self._watchdog_warn_threshold(),
+                "exit_threshold_seconds": self._watchdog_exit_threshold(),
+                "thread_count": len(thread_dump),
+                "thread_dump": thread_dump,
+            },
+        )
+
+    def _emit_scheduler_stall_exit(self, elapsed_seconds: float) -> None:
+        """Log a critical ERROR + call ``os._exit(137)`` so ECS restarts.
+
+        ``os._exit`` (not ``sys.exit``) is deliberate: ``sys.exit`` runs
+        atexit handlers and flushes buffers, which can themselves block
+        if the wedged thread is holding a lock those handlers need. The
+        watchdog's job is to guarantee the process dies so ECS can
+        restart it; a clean shutdown is nice-to-have, not mandatory.
+        137 = 128 + SIGKILL; ECS interprets this as "killed by kernel"
+        in the console, matching the operator-legible convention used
+        elsewhere in the dispatcher logs.
+        """
+        thread_dump = self._format_thread_dump()
+        self._log.error(
+            "daemon.scheduler_tick_stalled_exiting",
+            extra={
+                "event": "scheduler_tick_stalled_exiting",
+                "run_id": self._run_id,
+                "elapsed_seconds": round(elapsed_seconds, 1),
+                "exit_threshold_seconds": self._watchdog_exit_threshold(),
+                "exit_code": 137,
+                "thread_count": len(thread_dump),
+                "thread_dump": thread_dump,
+            },
+        )
+        # Flush handlers before os._exit — the JSON log formatter writes
+        # to stdout via the root logger; CloudWatch won't see the final
+        # event otherwise. Wrap in try/except because we are committed
+        # to exiting regardless.
+        try:
+            for handler in list(self._log.handlers) + list(
+                logging.getLogger().handlers
+            ):
+                try:
+                    handler.flush()
+                except Exception:  # pragma: no cover — best-effort
+                    pass
+        except Exception:  # pragma: no cover — best-effort
+            pass
+        os._exit(137)
+
+    def _watchdog_warn_threshold(self) -> int:
+        """Read WARN threshold from ``dispatcher.config``; default 300s.
+
+        Reads through the existing :meth:`_cb_config_int` helper which
+        fails closed to the default on missing row / parse error / DB
+        exception. The watchdog thread's psycopg connection lives on
+        ``self._thread_state.conn`` (see :meth:`_watchdog_loop`) so
+        ``self._conn`` resolves correctly there.
+        """
+        return self._cb_config_int(
+            "scheduler_tick_stall_warn_seconds",
+            DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS,
+        )
+
+    def _watchdog_exit_threshold(self) -> int:
+        """Read EXIT threshold from ``dispatcher.config``; default 3000s."""
+        return self._cb_config_int(
+            "scheduler_tick_stall_exit_seconds",
+            DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS,
+        )
+
+    def _watchdog_loop(self) -> None:
+        """Run the supervisor watchdog thread (#3097).
+
+        Wakes every :data:`WATCHDOG_POLL_INTERVAL_SECONDS`. If the gap
+        between ``time.monotonic()`` and
+        ``self._last_scheduler_tick_at`` exceeds the WARN threshold,
+        emit a one-shot WARNING with a bounded thread dump. If the gap
+        exceeds the EXIT threshold, emit an ERROR with a final thread
+        dump and call ``os._exit(137)``.
+
+        Opens its own psycopg connection so the thresholds can be read
+        via ``_cb_config_int`` without contending with the main
+        thread's connection (psycopg3 Connections are not thread-safe).
+        A connection failure is tolerated — the thread falls back to the
+        defaults and keeps watching; losing the DB must not disable the
+        reliability net.
+
+        Runs until ``_watchdog_stop`` is set (normally in ``run_forever``
+        shutdown, or during tests). Exits cleanly on stop — no join
+        timeout needed because the loop sleeps on the event, not on a
+        bare ``time.sleep``.
+        """
+        import psycopg  # noqa: PLC0415 — lazy, matches sibling watchers
+
+        watcher_conn: Connection[Any] | None = None
+        try:
+            watcher_conn = psycopg.connect(self._cfg.database_url, connect_timeout=10)
+            watcher_conn.autocommit = False
+            self._thread_state.conn = watcher_conn
+        except Exception as exc:
+            # No DB → thresholds fall back to defaults via _cb_config_int's
+            # exception path. Keep watching; the reliability net is more
+            # valuable than config tunability.
+            self._log.warning(
+                "daemon.watchdog_no_db",
+                extra={
+                    "event": "watchdog_no_db",
+                    "run_id": self._run_id,
+                    "detail": _stderr_tail(str(exc)),
+                },
+            )
+
+        self._log.info(
+            "daemon.watchdog_started",
+            extra={
+                "event": "watchdog_started",
+                "run_id": self._run_id,
+                "poll_interval_seconds": WATCHDOG_POLL_INTERVAL_SECONDS,
+                "warn_threshold_seconds": self._watchdog_warn_threshold(),
+                "exit_threshold_seconds": self._watchdog_exit_threshold(),
+            },
+        )
+
+        try:
+            while not self._watchdog_stop.is_set():
+                try:
+                    now = time.monotonic()
+                    elapsed = now - self._last_scheduler_tick_at
+                    warn_threshold = self._watchdog_warn_threshold()
+                    exit_threshold = self._watchdog_exit_threshold()
+
+                    if elapsed >= exit_threshold:
+                        # Terminal path — emit + os._exit. Does not return.
+                        self._emit_scheduler_stall_exit(elapsed)
+                        return  # pragma: no cover — _exit never returns
+
+                    if elapsed >= warn_threshold:
+                        if not self._watchdog_warn_emitted_for_gap:
+                            self._emit_scheduler_stall_warning(elapsed)
+                            self._watchdog_warn_emitted_for_gap = True
+                    else:
+                        # Gap recovered below the warn threshold. Clear
+                        # the debounce so a future stall re-fires.
+                        if self._watchdog_warn_emitted_for_gap:
+                            self._log.info(
+                                "daemon.watchdog_tick_recovered",
+                                extra={
+                                    "event": "watchdog_tick_recovered",
+                                    "run_id": self._run_id,
+                                    "elapsed_seconds": round(elapsed, 1),
+                                },
+                            )
+                        self._watchdog_warn_emitted_for_gap = False
+                except Exception:  # pragma: no cover — defensive
+                    # Any watchdog exception is logged and the loop
+                    # continues — a bug in the watchdog must not disable
+                    # the reliability net for subsequent polls.
+                    self._log.exception(
+                        "daemon.watchdog_poll_failed",
+                        extra={
+                            "event": "watchdog_poll_failed",
+                            "run_id": self._run_id,
+                        },
+                    )
+
+                # Sleep on the event so shutdown is prompt.
+                if self._watchdog_stop.wait(WATCHDOG_POLL_INTERVAL_SECONDS):
+                    break
+        finally:
+            self._log.info(
+                "daemon.watchdog_stopped",
+                extra={
+                    "event": "watchdog_stopped",
+                    "run_id": self._run_id,
+                },
+            )
+            self._thread_state.conn = None
+            if watcher_conn is not None:
+                try:
+                    watcher_conn.close()
+                except Exception:  # pragma: no cover — best-effort
+                    pass
+
+    def _start_watchdog(self) -> None:
+        """Spawn the supervisor watchdog thread (#3097).
+
+        Idempotent — a second call while the thread is alive is a no-op.
+        Called from :meth:`run_forever` after the initial tick so the
+        watchdog starts only when the daemon is fully up.
+        """
+        if self._watchdog_thread is not None and self._watchdog_thread.is_alive():
+            return
+        self._watchdog_stop.clear()
+        self._watchdog_thread = threading.Thread(
+            target=self._watchdog_loop,
+            name="dispatcher-watchdog",
+            daemon=True,
+        )
+        self._watchdog_thread.start()
+
     # ── signal handling ────────────────────────────────────────────────
 
     def request_stop(self, signum: int | None = None, _frame: Any = None) -> None:
@@ -17605,6 +17951,11 @@ class DispatcherDaemon:
             self._log.exception("daemon.initial_tick_failed")
             return 1
 
+        # #3097: spawn the stall-watchdog thread after the initial tick
+        # so it begins observing from a known-fresh baseline. See
+        # :meth:`_watchdog_loop` for the WARN/EXIT tier semantics.
+        self._start_watchdog()
+
         # Poll the stop flag in 1-second slices so SIGTERM lands promptly.
         while not self._stop.is_set():
             now = time.monotonic()
@@ -17632,6 +17983,14 @@ class DispatcherDaemon:
             self._stop.wait(1.0)
 
         self._log.info("daemon.shutdown_begin", extra={"event": "shutdown_begin"})
+        # #3097: stop the stall watchdog first so it doesn't race us
+        # into ``os._exit(137)`` during a clean shutdown (e.g. a slow
+        # orchestration-join + CloudWatch flush that takes longer than
+        # the watchdog exit threshold — unlikely but not impossible).
+        # Daemon=True so a missing join doesn't leak; setting the stop
+        # event unblocks the next poll sleep within
+        # :data:`WATCHDOG_POLL_INTERVAL_SECONDS`.
+        self._watchdog_stop.set()
         # #2847: signal the orchestration worker thread (if any) to
         # abort at its next phase boundary, then give it a short
         # window to exit cleanly. The thread is daemon=True so a

--- a/scripts/dispatcher/tests/test_daemon_watchdog.py
+++ b/scripts/dispatcher/tests/test_daemon_watchdog.py
@@ -1,0 +1,692 @@
+"""Unit tests for the scheduler_tick stall watchdog (#3097).
+
+The watchdog is a supervisor thread alongside the scheduler thread
+that records ``time.monotonic()`` of each ``scheduler_tick`` entry to
+``self._last_scheduler_tick_at`` and fires two tiers of alarm when the
+gap exceeds configurable thresholds:
+
+* ``SCHEDULER_TICK_STALL_WARN_SECONDS`` (default 300s) — WARNING
+  ``scheduler_tick_stalled`` with a bounded thread dump. Debounced so
+  duplicate warnings don't spam CloudWatch while the stall persists.
+* ``SCHEDULER_TICK_STALL_EXIT_SECONDS`` (default 3000s) — ERROR
+  ``scheduler_tick_stalled_exiting`` with a final thread dump followed
+  by ``os._exit(137)`` so ECS restarts the task.
+
+Tests cover:
+
+* AC #1 — the scheduler_tick records ``_last_scheduler_tick_at``.
+* AC #2 — WARNING fires at the WARN threshold with thread-dump output.
+* AC #3 — ERROR + ``os._exit(137)`` fires at the EXIT threshold.
+* AC #4 — config overrides via ``dispatcher.config.scheduler_tick_stall_*``
+  seconds are honored.
+* AC #5 — thread dump is bounded, contains thread names + frame info.
+* AC #6 — WARNING debounce: doesn't re-fire while the stall persists;
+  does re-fire after recovery.
+* AC #7 — watchdog exits cleanly on ``_watchdog_stop``.
+
+No real ``os._exit`` is ever called — the test monkeypatches it to a
+sentinel-raising stub. No real Postgres is used — the watchdog's
+``psycopg.connect`` is stubbed so it falls back to the defaults.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+class _UniqueViolation(Exception):
+    """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+
+_psycopg_stub = MagicMock()
+_psycopg_errors = MagicMock()
+_psycopg_errors.UniqueViolation = _UniqueViolation
+_psycopg_stub.errors = _psycopg_errors
+sys.modules.setdefault("psycopg", _psycopg_stub)
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+class _ExitCalled(BaseException):
+    """Sentinel raised in place of ``os._exit`` during tests.
+
+    BaseException (not Exception) so the watchdog loop's defensive
+    ``except Exception`` does NOT catch it — matching the real
+    ``os._exit`` semantics where nothing can catch the process death.
+    """
+
+    def __init__(self, code: int) -> None:
+        self.code = code
+        super().__init__(f"os._exit({code})")
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.watchdog.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    # Stub the queue scan so scheduler_tick does not touch ``gh``.
+    d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+    d._scan_blocked_and_snapshot = lambda: 0  # type: ignore[method-assign]
+    d._maybe_spawn_orchestration_thread = MagicMock(return_value=False)  # type: ignore[method-assign]
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# Module-level constants
+# --------------------------------------------------------------------------
+
+
+class TestModuleConstants:
+    def test_warn_default_is_300(self) -> None:
+        assert daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS == 300
+
+    def test_exit_default_is_3000(self) -> None:
+        assert daemon.DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS == 3000
+
+    def test_exit_is_10x_warn(self) -> None:
+        """#3097 design — exit threshold is 10× warn so a transient
+        slowdown is caught loudly (WARN) but not escalated to a
+        process restart until the gap becomes catastrophic."""
+        assert (
+            daemon.DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS
+            == 10 * daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS
+        )
+
+    def test_poll_interval_is_positive(self) -> None:
+        assert daemon.WATCHDOG_POLL_INTERVAL_SECONDS > 0
+        # Bounded reasonable window — at most once every 2 min.
+        assert 10 <= daemon.WATCHDOG_POLL_INTERVAL_SECONDS <= 120
+
+    def test_max_frames_per_thread_is_bounded(self) -> None:
+        assert daemon.WATCHDOG_THREAD_DUMP_MAX_FRAMES_PER_THREAD > 0
+        # Hard-bound so a deep stack cannot blow past CloudWatch's
+        # 256KB log-event limit.
+        assert daemon.WATCHDOG_THREAD_DUMP_MAX_FRAMES_PER_THREAD <= 100
+
+
+# --------------------------------------------------------------------------
+# AC #1 — scheduler_tick records _last_scheduler_tick_at
+# --------------------------------------------------------------------------
+
+
+class TestSchedulerTickRecordsTimestamp:
+    def test_scheduler_tick_updates_last_scheduler_tick_at(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(1,)]
+
+        before = time.monotonic()
+        d._last_scheduler_tick_at = 0.0  # reset to a known-stale value
+        d.scheduler_tick()
+        after = time.monotonic()
+
+        assert before <= d._last_scheduler_tick_at <= after
+
+    def test_last_scheduler_tick_at_initialized_in_ctor(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        # Ctor seeds a fresh value so the watchdog's first observation
+        # has a valid reference even before the first tick fires.
+        assert isinstance(d._last_scheduler_tick_at, float)
+        assert d._last_scheduler_tick_at > 0.0
+
+
+# --------------------------------------------------------------------------
+# AC #5 — thread dump formatting
+# --------------------------------------------------------------------------
+
+
+class TestThreadDumpFormat:
+    def test_thread_dump_contains_current_thread(self) -> None:
+        dump = daemon.DispatcherDaemon._format_thread_dump()
+        assert isinstance(dump, list)
+        assert len(dump) >= 1
+        # Each entry has the expected shape.
+        for entry in dump:
+            assert "name" in entry
+            assert "ident" in entry
+            assert "daemon" in entry
+            assert "alive" in entry
+            assert "frames" in entry
+            assert isinstance(entry["frames"], list)
+
+    def test_thread_dump_frames_have_file_line_function(self) -> None:
+        dump = daemon.DispatcherDaemon._format_thread_dump()
+        # At least the current (main/test) thread has some frames.
+        main = next((e for e in dump if e["frames"]), None)
+        assert main is not None, "expected at least one thread with frames"
+        first_frame = main["frames"][0]
+        assert "file" in first_frame
+        assert "line" in first_frame
+        assert "function" in first_frame
+        assert isinstance(first_frame["line"], int)
+        assert isinstance(first_frame["function"], str)
+
+    def test_thread_dump_respects_max_frames(self) -> None:
+        """Frames are bounded per thread so CloudWatch row-size caps
+        are respected even on a deep stack."""
+        dump = daemon.DispatcherDaemon._format_thread_dump(max_frames_per_thread=2)
+        for entry in dump:
+            assert len(entry["frames"]) <= 2
+
+    def test_thread_dump_contains_spawned_thread_by_name(self) -> None:
+        """Named threads show up in the dump so the operator can
+        identify which thread was wedged."""
+        ready = threading.Event()
+        done = threading.Event()
+
+        def _worker() -> None:
+            ready.set()
+            done.wait(timeout=5.0)
+
+        t = threading.Thread(target=_worker, name="test-wedge-dummy", daemon=True)
+        t.start()
+        try:
+            assert ready.wait(timeout=2.0)
+            dump = daemon.DispatcherDaemon._format_thread_dump()
+            names = {entry["name"] for entry in dump}
+            assert "test-wedge-dummy" in names
+        finally:
+            done.set()
+            t.join(timeout=2.0)
+
+
+# --------------------------------------------------------------------------
+# AC #2 / AC #3 — WARN + EXIT tiers via the watchdog loop
+#
+# We test the helpers directly AND test the loop end-to-end by shrinking
+# the poll interval and advancing monotonic() via a stub.
+# --------------------------------------------------------------------------
+
+
+class TestEmitHelpers:
+    def test_emit_warning_logs_scheduler_tick_stalled(self, tmp_path: Path) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+        d._emit_scheduler_stall_warning(elapsed_seconds=350.0)
+        events = handler.events("scheduler_tick_stalled")
+        assert len(events) == 1
+        rec = events[0]
+        assert rec.levelno == logging.WARNING
+        assert getattr(rec, "elapsed_seconds", None) == 350.0
+        dump = getattr(rec, "thread_dump", None)
+        assert isinstance(dump, list)
+        assert len(dump) >= 1
+
+    def test_emit_exit_logs_error_and_calls_os_exit(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        def fake_exit(code: int) -> None:
+            raise _ExitCalled(code)
+
+        monkeypatch.setattr(daemon.os, "_exit", fake_exit)
+        with pytest.raises(_ExitCalled) as excinfo:
+            d._emit_scheduler_stall_exit(elapsed_seconds=3100.0)
+        assert excinfo.value.code == 137
+
+        events = handler.events("scheduler_tick_stalled_exiting")
+        assert len(events) == 1
+        rec = events[0]
+        assert rec.levelno == logging.ERROR
+        assert getattr(rec, "elapsed_seconds", None) == 3100.0
+        assert getattr(rec, "exit_code", None) == 137
+        dump = getattr(rec, "thread_dump", None)
+        assert isinstance(dump, list)
+
+
+# --------------------------------------------------------------------------
+# AC #4 — config overrides honored
+# --------------------------------------------------------------------------
+
+
+class TestConfigOverrides:
+    def test_warn_threshold_reads_config_row(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        # _cb_config_int does SELECT value FROM dispatcher.config WHERE key = %s
+        conn.cursor_instance.fetch_queue = [(123,)]
+        assert d._watchdog_warn_threshold() == 123
+
+    def test_warn_threshold_falls_back_on_missing_row(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        assert (
+            d._watchdog_warn_threshold()
+            == daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS
+        )
+
+    def test_exit_threshold_reads_config_row(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(9999,)]
+        assert d._watchdog_exit_threshold() == 9999
+
+    def test_exit_threshold_falls_back_on_missing_row(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        assert (
+            d._watchdog_exit_threshold()
+            == daemon.DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS
+        )
+
+    def test_thresholds_fall_back_on_db_error(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """The watchdog must survive a DB hiccup — _cb_config_int
+        catches the exception and returns the default."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        class _BoomCursor(_FakeCursor):
+            def execute(self, sql: str, params: Any = None) -> None:
+                raise RuntimeError("db down")
+
+        boom = _BoomCursor()
+
+        class _BoomConn(_FakeConnection):
+            def cursor(self) -> _BoomCursor:
+                return boom
+
+        d._conn = _BoomConn()  # type: ignore[assignment]
+        assert (
+            d._watchdog_warn_threshold()
+            == daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS
+        )
+        assert (
+            d._watchdog_exit_threshold()
+            == daemon.DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS
+        )
+
+
+# --------------------------------------------------------------------------
+# End-to-end loop — the watchdog thread observes stall → WARN → EXIT
+# --------------------------------------------------------------------------
+
+
+class _TickClock:
+    """Monotonic-time stub driven by the test."""
+
+    def __init__(self, start: float = 0.0) -> None:
+        self.value = start
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+    def __call__(self) -> float:
+        return self.value
+
+
+class TestWatchdogLoopBehaviour:
+    def _run_loop_in_thread(
+        self,
+        d: daemon.DispatcherDaemon,
+    ) -> threading.Thread:
+        t = threading.Thread(target=d._watchdog_loop, daemon=True)
+        t.start()
+        return t
+
+    def _wait_for_event(
+        self, handler: _CapturingLogHandler, name: str, timeout: float = 3.0
+    ) -> logging.LogRecord | None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            events = handler.events(name)
+            if events:
+                return events[-1]
+            time.sleep(0.01)
+        return None
+
+    def test_warning_fires_when_elapsed_exceeds_warn_threshold(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """AC #2 — a mocked monotonic that simulates a 301s stall
+        against a 300s threshold triggers exactly one WARNING."""
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # Shrink poll interval so the loop spins fast.
+        monkeypatch.setattr(daemon, "WATCHDOG_POLL_INTERVAL_SECONDS", 0)
+
+        # Control time. Start at 1000.0; tick was at 1000.0. Then
+        # advance to 1301.0 so elapsed = 301 > 300 (warn) but
+        # < 3000 (exit).
+        clock = _TickClock(start=1000.0)
+        d._last_scheduler_tick_at = 1000.0
+        monkeypatch.setattr(daemon.time, "monotonic", clock)
+
+        # Stub _cb_config_int to return defaults — avoid DB-cursor
+        # interaction ordering in the background thread.
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_cb_config_int",
+            lambda self, key, default: default,
+        )
+
+        # Stub psycopg.connect so the watchdog's DB setup path is inert.
+        sys.modules["psycopg"].connect = MagicMock(return_value=_FakeConnection())
+
+        clock.advance(301.0)
+        t = self._run_loop_in_thread(d)
+        try:
+            rec = self._wait_for_event(handler, "scheduler_tick_stalled")
+            assert rec is not None, "expected a scheduler_tick_stalled WARNING"
+            assert rec.levelno == logging.WARNING
+            assert getattr(rec, "elapsed_seconds", 0) >= 300
+        finally:
+            d._watchdog_stop.set()
+            t.join(timeout=2.0)
+            assert not t.is_alive()
+
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnhandledThreadExceptionWarning")
+    def test_exit_fires_when_elapsed_exceeds_exit_threshold(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """AC #3 — a 3001s stall against a 3000s threshold triggers
+        ``os._exit(137)`` with an ERROR log.
+
+        The fake ``os._exit`` raises ``_ExitCalled`` (a BaseException
+        subclass) from the watchdog thread — pytest captures that as
+        an "unhandled thread exception" warning. That is by design:
+        real ``os._exit`` is uncatchable by any handler. The
+        ``filterwarnings`` decorator suppresses the noise.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        monkeypatch.setattr(daemon, "WATCHDOG_POLL_INTERVAL_SECONDS", 0)
+
+        clock = _TickClock(start=5000.0)
+        d._last_scheduler_tick_at = 5000.0
+        monkeypatch.setattr(daemon.time, "monotonic", clock)
+
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_cb_config_int",
+            lambda self, key, default: default,
+        )
+        sys.modules["psycopg"].connect = MagicMock(return_value=_FakeConnection())
+
+        exit_calls: list[int] = []
+
+        def fake_exit(code: int) -> None:
+            exit_calls.append(code)
+            raise _ExitCalled(code)
+
+        monkeypatch.setattr(daemon.os, "_exit", fake_exit)
+
+        clock.advance(3001.0)
+        t = self._run_loop_in_thread(d)
+        try:
+            rec = self._wait_for_event(handler, "scheduler_tick_stalled_exiting")
+            assert rec is not None, "expected a scheduler_tick_stalled_exiting ERROR"
+            assert rec.levelno == logging.ERROR
+            assert getattr(rec, "exit_code", None) == 137
+            # Wait for os._exit to be called.
+            deadline = time.monotonic() + 2.0
+            while not exit_calls and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert exit_calls == [137]
+        finally:
+            d._watchdog_stop.set()
+            t.join(timeout=2.0)
+
+    def test_no_warning_below_threshold(self, tmp_path: Path, monkeypatch: Any) -> None:
+        """A healthy tick cadence produces no WARN / EXIT events."""
+        d, conn, handler = _make_daemon(tmp_path)
+        monkeypatch.setattr(daemon, "WATCHDOG_POLL_INTERVAL_SECONDS", 0)
+
+        clock = _TickClock(start=10.0)
+        d._last_scheduler_tick_at = 10.0
+        monkeypatch.setattr(daemon.time, "monotonic", clock)
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_cb_config_int",
+            lambda self, key, default: default,
+        )
+        sys.modules["psycopg"].connect = MagicMock(return_value=_FakeConnection())
+
+        # Only advance 30s — well below the 300s WARN threshold.
+        clock.advance(30.0)
+        t = self._run_loop_in_thread(d)
+        try:
+            # Let the loop run a few polls.
+            time.sleep(0.05)
+            assert handler.events("scheduler_tick_stalled") == []
+            assert handler.events("scheduler_tick_stalled_exiting") == []
+        finally:
+            d._watchdog_stop.set()
+            t.join(timeout=2.0)
+
+    def test_warning_debounces_while_stall_persists(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """AC #6 — a persistent stall fires WARNING exactly once, not
+        once per poll cycle."""
+        d, conn, handler = _make_daemon(tmp_path)
+        monkeypatch.setattr(daemon, "WATCHDOG_POLL_INTERVAL_SECONDS", 0)
+
+        clock = _TickClock(start=1000.0)
+        d._last_scheduler_tick_at = 1000.0
+        monkeypatch.setattr(daemon.time, "monotonic", clock)
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_cb_config_int",
+            lambda self, key, default: default,
+        )
+        sys.modules["psycopg"].connect = MagicMock(return_value=_FakeConnection())
+
+        # Advance into the WARN zone but not the EXIT zone.
+        clock.advance(500.0)
+        t = self._run_loop_in_thread(d)
+        try:
+            rec = self._wait_for_event(handler, "scheduler_tick_stalled")
+            assert rec is not None
+            # Let the loop cycle a few more times.
+            time.sleep(0.05)
+            # Exactly one WARNING, debounced.
+            assert len(handler.events("scheduler_tick_stalled")) == 1
+        finally:
+            d._watchdog_stop.set()
+            t.join(timeout=2.0)
+
+    def test_warning_rearms_after_recovery(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """AC #6 — after the tick recovers (gap drops below WARN),
+        a subsequent stall fires a fresh WARNING."""
+        d, conn, handler = _make_daemon(tmp_path)
+        monkeypatch.setattr(daemon, "WATCHDOG_POLL_INTERVAL_SECONDS", 0)
+
+        clock = _TickClock(start=1000.0)
+        d._last_scheduler_tick_at = 1000.0
+        monkeypatch.setattr(daemon.time, "monotonic", clock)
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_cb_config_int",
+            lambda self, key, default: default,
+        )
+        sys.modules["psycopg"].connect = MagicMock(return_value=_FakeConnection())
+
+        # Step 1: stall → WARN.
+        clock.advance(500.0)
+        t = self._run_loop_in_thread(d)
+        try:
+            rec1 = self._wait_for_event(handler, "scheduler_tick_stalled")
+            assert rec1 is not None
+
+            # Step 2: "tick" — scheduler wakes up again. Advance the
+            # last_tick_at to the current clock (simulates a real tick
+            # writing the timestamp at the top of scheduler_tick).
+            d._last_scheduler_tick_at = clock.value
+            # Wait for the loop to observe recovery.
+            deadline = time.monotonic() + 2.0
+            while d._watchdog_warn_emitted_for_gap and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert not d._watchdog_warn_emitted_for_gap
+
+            # Step 3: stall again.
+            clock.advance(500.0)
+            deadline = time.monotonic() + 2.0
+            while (
+                len(handler.events("scheduler_tick_stalled")) < 2
+                and time.monotonic() < deadline
+            ):
+                time.sleep(0.01)
+            assert len(handler.events("scheduler_tick_stalled")) >= 2
+        finally:
+            d._watchdog_stop.set()
+            t.join(timeout=2.0)
+
+    def test_watchdog_exits_cleanly_on_stop(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """AC #7 — setting ``_watchdog_stop`` terminates the loop."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        monkeypatch.setattr(daemon, "WATCHDOG_POLL_INTERVAL_SECONDS", 0)
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_cb_config_int",
+            lambda self, key, default: default,
+        )
+        sys.modules["psycopg"].connect = MagicMock(return_value=_FakeConnection())
+
+        # A future-tick time so the loop sees no stall.
+        d._last_scheduler_tick_at = time.monotonic() + 10_000.0
+
+        t = self._run_loop_in_thread(d)
+        # Let it loop a couple times, then stop.
+        time.sleep(0.02)
+        d._watchdog_stop.set()
+        t.join(timeout=2.0)
+        assert not t.is_alive()
+
+
+# --------------------------------------------------------------------------
+# _start_watchdog idempotency + daemon flag
+# --------------------------------------------------------------------------
+
+
+class TestStartWatchdog:
+    def test_start_watchdog_spawns_named_daemon_thread(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        # Replace the loop with a stop-aware stub so the thread exits.
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_watchdog_loop",
+            lambda self: self._watchdog_stop.wait(),
+        )
+        d._start_watchdog()
+        try:
+            assert d._watchdog_thread is not None
+            assert d._watchdog_thread.daemon is True
+            assert d._watchdog_thread.name == "dispatcher-watchdog"
+            assert d._watchdog_thread.is_alive()
+        finally:
+            d._watchdog_stop.set()
+            if d._watchdog_thread is not None:
+                d._watchdog_thread.join(timeout=2.0)
+
+    def test_start_watchdog_is_idempotent_when_alive(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_watchdog_loop",
+            lambda self: self._watchdog_stop.wait(),
+        )
+        d._start_watchdog()
+        first = d._watchdog_thread
+        d._start_watchdog()  # second call — no-op.
+        try:
+            assert d._watchdog_thread is first
+        finally:
+            d._watchdog_stop.set()
+            if d._watchdog_thread is not None:
+                d._watchdog_thread.join(timeout=2.0)


### PR DESCRIPTION
## Summary

Adds a supervisor watchdog thread to `scripts/dispatcher/daemon.py` that detects scheduler-tick stalls and auto-restarts a wedged daemon via `os._exit(137)`. Converts today's 3-in-one-session manual-recovery pattern (30 min of operator notice + manual `aws ecs update-service --force-new-deployment`) into a 50 min auto-restart with thread-dump forensic data for root-cause diagnosis.

- WARN at 300 s (10× scheduler cadence) — logs `scheduler_tick_stalled` with a bounded per-thread stack dump.
- EXIT at 3000 s (50 min) — logs `scheduler_tick_stalled_exiting`, flushes handlers, `os._exit(137)` → ECS restarts.
- Thresholds operator-tunable via `dispatcher.config.scheduler_tick_stall_{warn,exit}_seconds` (fail-closed to defaults on DB error).

Not a root-cause fix. The next stall's thread dump gives us the evidence to diagnose the underlying deadlock (suspects: `#3022` subprocess stream-forwarder, `#3042` HEAD-watcher).

Closes #3097

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Confirm deploy-dispatcher workflow green on merge. (run 24851753159, both jobs green)
- [x] CloudWatch Logs Insights: `watchdog_started` emitted at 2026-04-23 18:29:19 UTC on the new task (version_sha `f543eed`) with `poll_interval_seconds=30`, `warn_threshold_seconds=300`, `exit_threshold_seconds=3000`. Scheduler cadence healthy (2 ticks/min).
- [x] Verification evidence posted on issue #3097.
