### PR TITLE
feat(dispatcher): agent-runner task def + entrypoint (#3090)

### DIFF
--- a/.github/workflows/deploy-dispatcher.yml
+++ b/.github/workflows/deploy-dispatcher.yml
@@ -36,6 +36,15 @@ on:
       # a rollout. Excluded so new helpers can be added without a
       # gratuitous redeploy or a workflow-yml edit each time.
       - "!scripts/dispatcher/helpers/**"
+      # scripts/dispatcher/agent-runner-entrypoint.sh is the entrypoint
+      # for the separate `judgemind/dispatcher-agent-runner` image
+      # (#3090, Stage 1b of #3086). It is NOT baked into the daemon
+      # image and the daemon does not invoke it at runtime — the
+      # dispatcher-daemon Dockerfile's `COPY scripts/dispatcher/` ships
+      # it for forward-compat only. Changes to the entrypoint should
+      # not force a daemon redeploy; the agent-runner image has its
+      # own (future) build workflow.
+      - "!scripts/dispatcher/agent-runner-entrypoint.sh"
       - "scripts/check-issue-author.sh"
       - ".github/workflows/deploy-dispatcher.yml"
       # scripts/wait-for-rollout.sh is invoked by the deploy-to-dev job

--- a/Dockerfile.dispatcher-agent-runner
+++ b/Dockerfile.dispatcher-agent-runner
@@ -1,0 +1,187 @@
+# Dispatcher v2 agent-runner container image (issue #3090 — Stage 1b of
+# #3086's per-agent ECS migration; design in #3078).
+#
+# One instance of this image runs per agent on ECS Fargate, executing
+# the full phase pipeline (plan → ralph → summary → push_and_pr →
+# awaiting_ci → merge → awaiting_deploy → verify → retro → done)
+# inside a single task. The daemon (once Stage 2 lands) spawns one of
+# these per agent via `ecs:RunTask`; the daemon does not spawn any
+# claude subprocesses itself in the ecs execution_mode.
+#
+# Why this image is distinct from Dockerfile.dispatcher
+# -----------------------------------------------------
+# The daemon image boots `python -m scripts.dispatcher.daemon`; the
+# agent-runner image boots `scripts/dispatcher/agent-runner-entrypoint.sh`.
+# Both need the same tooling — claude CLI, git, gh, psycopg, boto3,
+# preflight hooks — so the layer contents are nearly identical; only
+# the ENTRYPOINT + CMD differ.
+#
+# Keeping them as two sibling Dockerfiles (rather than a multi-stage
+# single file with --target flags) is the house pattern the operator
+# wanted per the #3090 issue scope note: "Dockerfile.dispatcher-agent-runner
+# (or --target agent-runner variant of the existing Dockerfile)". Two
+# files reads cleaner for a reader trying to diff "what does the
+# agent-runner have that the daemon doesn't" without scrolling through
+# 400 lines of shared setup.
+#
+# Build (from repo root):
+#     docker build -f Dockerfile.dispatcher-agent-runner \
+#         -t judgemind-dispatcher-agent-runner-local \
+#         --build-arg GIT_SHA=$(git rev-parse --short HEAD) .
+#
+# Run locally (requires DATABASE_URL + a real GitHub PAT):
+#     docker run --rm \
+#         -e AGENT_ID=test-$(uuidgen) \
+#         -e DATABASE_URL="postgres://..." \
+#         -e GITHUB_TOKEN="..." \
+#         judgemind-dispatcher-agent-runner-local
+#
+# See `scripts/dispatcher/agent-runner-entrypoint.sh` for the
+# environment contract the container consumes.
+
+FROM python:3.12-slim
+
+# ---------------------------------------------------------------------------
+# System deps — identical to Dockerfile.dispatcher. See that file for the
+# rationale behind the base-image choice and each apt package.
+# ---------------------------------------------------------------------------
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        gnupg \
+        git \
+        jq \
+        postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# Node.js 20 via NodeSource — Claude Code CLI requires Node 20+. Same
+# rationale as Dockerfile.dispatcher.
+# ---------------------------------------------------------------------------
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# GitHub CLI — the agent-runner uses `gh pr create`, `gh pr checks`,
+# `gh pr merge` etc. during the push_and_pr / awaiting_ci / merge phases.
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------
+# Python dependencies
+#
+# - psycopg[binary]: the agent-runner entrypoint shells out to `psql`
+#   for most DB interactions, but the imported `phase_transitions` is
+#   pure-Python and doesn't need psycopg at runtime. We still install
+#   psycopg because Stage 2 Python-side orchestration helpers (if any
+#   land on this image in a followup) will need it.
+# - boto3: not strictly required today (the entrypoint uses the `aws`
+#   CLI, which ships below) but kept for parity with the daemon image
+#   so future Python helpers don't force a rebuild.
+# ---------------------------------------------------------------------------
+RUN pip install --no-cache-dir \
+    "psycopg[binary]>=3.1,<4" \
+    "boto3>=1.34,<2"
+
+# AWS CLI — the entrypoint uses `aws secretsmanager get-secret-value` +
+# `aws ecs describe-task` when polling task metadata. Installed via pip
+# rather than the bundled installer so the image stays slim.
+RUN pip install --no-cache-dir "awscli>=1.33,<2"
+
+# ---------------------------------------------------------------------------
+# Claude Code CLI — pinned to the same version as Dockerfile.dispatcher
+# so the daemon and agent-runner produce identical phase outputs for
+# skills they both happen to invoke. Bump in lockstep with the daemon
+# image.
+# ---------------------------------------------------------------------------
+RUN npm install -g @anthropic-ai/claude-code@2.1.114
+
+# Canary — verify the platform-native binary actually installed. See
+# Dockerfile.dispatcher for the #3040 incident rationale.
+RUN claude --version
+
+# ---------------------------------------------------------------------------
+# Dispatcher user + HOME — same pattern as Dockerfile.dispatcher. The
+# Claude Code CLI refuses `--dangerously-skip-permissions` when UID=0.
+# ---------------------------------------------------------------------------
+ENV HOME=/home/dispatcher
+RUN groupadd --gid 1000 dispatcher \
+    && useradd --uid 1000 --gid 1000 --shell /bin/bash --home-dir "$HOME" dispatcher \
+    && mkdir -p "$HOME" \
+    && chown -R dispatcher:dispatcher "$HOME"
+
+# ---------------------------------------------------------------------------
+# Per-agent workspace root. The entrypoint clones the repo into
+# `${AGENT_WORKSPACE}/repo` at boot and uses it as the agent's cwd for
+# every phase. Kept under /var/lib so it doesn't collide with the
+# daemon image's /app.
+# ---------------------------------------------------------------------------
+RUN mkdir -p /var/lib/agent-runner \
+    && chown -R dispatcher:dispatcher /var/lib/agent-runner
+ENV AGENT_WORKSPACE=/var/lib/agent-runner
+
+WORKDIR /app
+
+# ---------------------------------------------------------------------------
+# Application code
+#
+# The agent-runner needs:
+#   1. The shared `scripts/dispatcher/` Python modules (primarily
+#      `phase_transitions.py` for the state machine, plus `phases.py`
+#      and `iteration_feedback.py` that `phase_transitions` imports).
+#   2. The entrypoint shell script (the agent-runner's init=0).
+#   3. `scripts/check-issue-author.sh` — the trust gate the entrypoint
+#      runs before spawning `claude -p /task-v2-plan`.
+#   4. `scripts/preflight.sh` + `scripts/preflight-bash-fargate.sh` —
+#      in-container ralph pre-push gate (matches Dockerfile.dispatcher's
+#      #2982 narrowing).
+# ---------------------------------------------------------------------------
+COPY scripts/dispatcher/ /app/scripts/dispatcher/
+COPY scripts/check-issue-author.sh /app/scripts/check-issue-author.sh
+COPY scripts/preflight.sh /app/scripts/preflight.sh
+COPY scripts/preflight-bash-fargate.sh /app/fargate-hooks/preflight-bash.sh
+COPY .claude/hooks/preflight_cross_worktree.py /app/fargate-hooks/preflight_cross_worktree.py
+RUN chmod +x /app/scripts/check-issue-author.sh \
+    && chmod +x /app/fargate-hooks/preflight-bash.sh \
+    && chmod +x /app/scripts/dispatcher/agent-runner-entrypoint.sh \
+    && chown -R dispatcher:dispatcher /app
+ENV DISPATCHER_FARGATE_HOOKS_DIR=/app/fargate-hooks
+
+# ---------------------------------------------------------------------------
+# Git committer identity — same values as Dockerfile.dispatcher so
+# commits produced by the agent-runner have the same author line as
+# the daemon's commit-amend step would have produced.
+# ---------------------------------------------------------------------------
+RUN git config --system user.email "noreply@judgemind.org" \
+    && git config --system user.name "Judgemind Dispatcher"
+
+# ---------------------------------------------------------------------------
+# Image provenance — CI sets GIT_SHA to the merge commit SHA. The
+# entrypoint writes it to `dispatcher.agents.runner_image_sha` (Stage 2
+# adds that column) so post-hoc forensics can pin an agent to a
+# specific image.
+# ---------------------------------------------------------------------------
+ARG GIT_SHA=unknown
+ENV GIT_SHA=${GIT_SHA}
+
+# Drop privileges before the entrypoint — same as Dockerfile.dispatcher.
+USER dispatcher
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+#
+# The agent-runner boots the shell orchestration script. ENTRYPOINT as
+# an exec-form array so argv from `aws ecs run-task --overrides` passes
+# through to the script untouched. CMD is empty — all inputs come from
+# environment variables (AGENT_ID, ISSUE_NUMBER, etc.), not argv.
+# ---------------------------------------------------------------------------
+ENTRYPOINT ["/app/scripts/dispatcher/agent-runner-entrypoint.sh"]
+CMD []

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -291,9 +291,63 @@ module "dispatcher_daemon" {
   alert_sns_topic_arn = module.compute.alerts_topic_arn
 }
 
+# ─── Dispatcher agent-runner task def (Stage 1b, #3090) ─────────────────────
+# One-shot ECS task definition run per-agent via `ecs:RunTask`. Stage 1b
+# ships the task def + entrypoint; Stage 2 (#3091) adds the daemon-side
+# launcher. Until Stage 2 lands, operators invoke this task manually via
+# `aws ecs run-task --overrides` (see the PR body in #3090 for the exact
+# command). No ECS service is provisioned — agent-runners are one-shot
+# leaves, not long-running singletons.
+module "dispatcher_agent_runner" {
+  source = "../../modules/dispatcher-agent-runner"
+
+  environment        = "dev"
+  vpc_id             = module.networking.vpc_id
+  private_subnet_ids = module.networking.private_subnet_ids
+  ecr_repository_url = module.ecr.dispatcher_agent_runner_repository_url
+
+  # Stage 1b baseline: 0.5 vCPU / 1 GiB. Bump (along with task_memory) if
+  # Stage 3 smoke shows the ralph workload needs more headroom.
+  task_cpu    = 512
+  task_memory = 1024
+
+  # Secret wiring — same ARNs the daemon uses.
+  anthropic_api_key_secret_arn = data.aws_secretsmanager_secret.anthropic_api_key.arn
+  db_connection_secret_arn     = module.database.db_connection_secret_arn
+  github_token_secret_arn      = "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/dispatcher/github-token-QOmHlJ"
+
+  github_repo = "judgemind/judgemind"
+  repo_url    = "https://github.com/judgemind/judgemind.git"
+}
+
 output "ecr_repository_url" {
   description = "Dev ECR repository URL for scraper images"
   value       = module.ecr.repository_url
+}
+
+output "dispatcher_agent_runner_task_definition_family" {
+  description = "Dev dispatcher agent-runner task definition family (used with `aws ecs run-task --task-definition`)"
+  value       = module.dispatcher_agent_runner.task_definition_family
+}
+
+output "dispatcher_agent_runner_log_group" {
+  description = "Dev CloudWatch log group for dispatcher agent-runner container output"
+  value       = module.dispatcher_agent_runner.log_group_name
+}
+
+output "dispatcher_agent_runner_task_role_arn" {
+  description = "Dev dispatcher agent-runner task role ARN (narrow: DB + PAT secret read, log-group scoped log writes — no RunTask, no ECS Exec)"
+  value       = module.dispatcher_agent_runner.task_role_arn
+}
+
+output "dispatcher_agent_runner_security_group_id" {
+  description = "Dev dispatcher agent-runner security group ID (outbound HTTPS + Postgres only)"
+  value       = module.dispatcher_agent_runner.security_group_id
+}
+
+output "dispatcher_agent_runner_ecr_repository_url" {
+  description = "Dev ECR repository URL for the dispatcher agent-runner image"
+  value       = module.ecr.dispatcher_agent_runner_repository_url
 }
 
 output "vpc_id" {

--- a/infra/terraform/modules/dispatcher-agent-runner/main.tf
+++ b/infra/terraform/modules/dispatcher-agent-runner/main.tf
@@ -1,0 +1,291 @@
+# Dispatcher v2 agent-runner module — ECS Fargate task definition for
+# per-agent runners (issue #3090; Stage 1b of the #3086 / #3078
+# per-agent-ECS migration).
+#
+# Unlike ``dispatcher-daemon`` this module DOES NOT provision an ECS
+# service — an agent-runner is a one-shot workload started via
+# ``ecs:RunTask`` (manually via ``aws ecs run-task --overrides`` for
+# the Stage 1b smoke, or by the daemon's future
+# ``_launch_agent_ecs_task`` in Stage 2). The task runs the full phase
+# pipeline inside the container and exits when the agent hits a
+# terminal phase.
+#
+# Resources created:
+# - CloudWatch log group ``/ecs/judgemind-dispatcher-agent-runner-<env>``.
+# - Execution role (ECR pull + log writes + secret fetches).
+# - Task role (narrow: Secrets Manager read on DATABASE_URL + GitHub
+#   PAT, CloudWatch log writes into the agent-runner log group only).
+#   Deliberately does NOT include ``ecs:RunTask`` or ECS Exec / SSM —
+#   the agent-runner is a leaf; it does not spawn further ECS tasks
+#   and operators don't need to shell into running agents (use
+#   CloudWatch log tail instead).
+# - Security group (outbound HTTPS + Postgres, same egress profile as
+#   the daemon so GitHub / Anthropic / Postgres all reach from inside).
+# - ECS task definition ``judgemind-dispatcher-agent-runner-<env>``
+#   wired at CPU=512 / memory=1024 per #3090's Stage 1b baseline. The
+#   issue note allows a bump to 1024 / 2048 if Stage 3 smoke says so.
+#
+# The security group ID + task-def family are exported so the daemon
+# (Stage 2) can reference them without re-declaring ARNs in the
+# environment wiring.
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  task_family    = "judgemind-dispatcher-agent-runner-${var.environment}"
+  log_group_name = "/ecs/judgemind-dispatcher-agent-runner-${var.environment}"
+  container_name = "agent-runner"
+
+  # Execution-role secret list uses compact() so unset ARNs drop out
+  # (mirrors the dispatcher-daemon pattern).
+  execution_secret_arns = compact([
+    var.anthropic_api_key_secret_arn,
+    var.db_connection_secret_arn,
+    var.github_token_secret_arn,
+  ])
+
+  # Task role gets a narrower set: DATABASE_URL (for direct psql calls
+  # from inside the container) + GitHub PAT (for `gh auth login`). The
+  # Anthropic API key is injected by the execution role at container
+  # start and read from env; the task role doesn't re-fetch it.
+  task_secret_arns = compact([
+    var.db_connection_secret_arn,
+    var.github_token_secret_arn,
+  ])
+}
+
+# ─── CloudWatch Log Group ──────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "agent_runner" {
+  name              = local.log_group_name
+  retention_in_days = var.log_retention_days
+}
+
+# ─── Security Group ────────────────────────────────────────────────────────
+# Outbound-only egress: HTTPS (GitHub / Anthropic / ECR / Secrets
+# Manager) + Postgres. No inbound traffic — agent-runners are leaves.
+
+resource "aws_security_group" "agent_runner" {
+  name        = local.task_family
+  description = "Dispatcher agent-runner ECS tasks - outbound only (HTTPS, Postgres)"
+  vpc_id      = var.vpc_id
+
+  egress {
+    description = "HTTPS to GitHub, Anthropic, ECR, Secrets Manager"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "PostgreSQL (dispatcher.* state)"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ─── IAM: Execution Role (ECS agent) ───────────────────────────────────────
+
+resource "aws_iam_role" "execution" {
+  name        = "${local.task_family}-exec"
+  description = "Dispatcher agent-runner execution role - pull ECR, read secrets, write logs"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "ecs-tasks.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "execution_managed" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "execution_secrets" {
+  count = length(local.execution_secret_arns) > 0 ? 1 : 0
+
+  name = "${local.task_family}-exec-secrets"
+  role = aws_iam_role.execution.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadAgentRunnerSecrets"
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = local.execution_secret_arns
+      }
+    ]
+  })
+}
+
+# ─── IAM: Task Role (container runtime) ────────────────────────────────────
+#
+# Narrow by design — the agent-runner is a leaf process. What it needs:
+#
+#   * Secrets Manager GetSecretValue on DATABASE_URL + GitHub PAT only
+#     (the container may re-read these during long-running phases).
+#   * CloudWatch `logs:PutLogEvents` on the agent-runner log group
+#     only (narrower than the daemon's wildcard).
+#
+# What it deliberately does NOT have:
+#
+#   * ``ecs:RunTask`` — the agent-runner is a terminal leaf; it does
+#     not spawn further ECS tasks. Granting RunTask would let a
+#     compromised agent kick off its own children (or arbitrary other
+#     task definitions).
+#   * ECS Exec (``ssmmessages:*``) — operators tail CloudWatch logs
+#     instead of shelling into a running agent. If exec access is ever
+#     needed for an incident, the operator can temporarily attach a
+#     policy out-of-band.
+#   * CloudWatch PutMetricData — the daemon emits agent metrics (Stage
+#     2+); the agent-runner itself is metered via phase_outputs rows,
+#     not directly.
+
+resource "aws_iam_role" "task" {
+  name        = "${local.task_family}-task"
+  description = "Dispatcher agent-runner task role - narrow runtime permissions for in-container DB + GitHub work"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "ecs-tasks.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "task_read_secrets" {
+  count = length(local.task_secret_arns) > 0 ? 1 : 0
+
+  name = "${local.task_family}-task-read-secrets"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadAgentRunnerRuntimeSecrets"
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = local.task_secret_arns
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "task_log_writes" {
+  name = "${local.task_family}-task-log-writes"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowAgentRunnerLogWrites"
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        # Scoped to the agent-runner log group only. The daemon's
+        # wildcard approach is unnecessary here because the task's
+        # only log destination is its own group.
+        Resource = "${aws_cloudwatch_log_group.agent_runner.arn}:*"
+      }
+    ]
+  })
+}
+
+# ─── ECS Task Definition ───────────────────────────────────────────────────
+#
+# CPU / memory: 512 / 1024 per #3090 Stage 1b baseline. Can be bumped
+# to 1024 / 2048 in a followup if smoke shows the ralph workload needs
+# more headroom (Fargate CPU/RAM pairing: 512 pairs with 1024-4096).
+#
+# stopTimeout: ECS/Fargate caps stopTimeout at 120 seconds. The #3090
+# issue text mentions "4h" but that's the expected agent lifetime, not
+# a Fargate-enforced timeout — tasks run until the container exits.
+# We set stopTimeout to 120 (the platform max) so the container has
+# enough time to update ``dispatcher.agents.ended_at`` and flush final
+# logs on a SIGTERM (e.g. during a force-stop).
+
+resource "aws_ecs_task_definition" "agent_runner" {
+  family                   = local.task_family
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  ephemeral_storage {
+    size_in_gib = var.ephemeral_storage_gib
+  }
+
+  container_definitions = jsonencode([
+    {
+      name      = local.container_name
+      image     = "${var.ecr_repository_url}:${var.image_tag}"
+      essential = true
+
+      # 120s — the platform max. See header comment for rationale.
+      stopTimeout = 120
+
+      environment = concat(
+        [
+          { name = "ENVIRONMENT", value = var.environment },
+          { name = "AGENT_WORKSPACE", value = "/var/lib/agent-runner" },
+          { name = "REPO_URL", value = var.repo_url },
+        ],
+        var.github_repo != "" ? [{ name = "GITHUB_REPO", value = var.github_repo }] : [],
+      )
+
+      secrets = concat(
+        var.anthropic_api_key_secret_arn != "" ? [
+          {
+            name      = "ANTHROPIC_API_KEY"
+            valueFrom = var.anthropic_api_key_secret_arn
+          }
+        ] : [],
+        var.db_connection_secret_arn != "" ? [
+          {
+            # Same JSON-key-suffix pattern as the daemon module —
+            # dispatcher-role DB secret has ``url`` at the top level.
+            name      = "DATABASE_URL"
+            valueFrom = "${var.db_connection_secret_arn}:url::"
+          }
+        ] : [],
+        var.github_token_secret_arn != "" ? [
+          {
+            name      = "GITHUB_TOKEN"
+            valueFrom = var.github_token_secret_arn
+          }
+        ] : [],
+      )
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.agent_runner.name
+          "awslogs-region"        = data.aws_region.current.id
+          "awslogs-stream-prefix" = "agent-runner"
+        }
+      }
+    }
+  ])
+}

--- a/infra/terraform/modules/dispatcher-agent-runner/outputs.tf
+++ b/infra/terraform/modules/dispatcher-agent-runner/outputs.tf
@@ -1,0 +1,34 @@
+output "task_definition_arn" {
+  description = "ARN of the agent-runner task definition. Use with `aws ecs run-task --task-definition <arn>` for Stage 1b manual smoke."
+  value       = aws_ecs_task_definition.agent_runner.arn
+}
+
+output "task_definition_family" {
+  description = "Family name of the agent-runner task definition (`judgemind-dispatcher-agent-runner-<env>`). Daemon Stage 2 passes this to `ecs:RunTask` so it always runs the latest revision."
+  value       = aws_ecs_task_definition.agent_runner.family
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group for agent-runner container output (`/ecs/judgemind-dispatcher-agent-runner-<env>`)."
+  value       = aws_cloudwatch_log_group.agent_runner.name
+}
+
+output "log_group_arn" {
+  description = "ARN of the agent-runner CloudWatch log group."
+  value       = aws_cloudwatch_log_group.agent_runner.arn
+}
+
+output "execution_role_arn" {
+  description = "ARN of the ECS task execution role (pulls ECR + fetches secrets + writes logs)."
+  value       = aws_iam_role.execution.arn
+}
+
+output "task_role_arn" {
+  description = "ARN of the agent-runner task role (narrow: Secrets Manager read on DATABASE_URL+PAT, CloudWatch log writes to the agent-runner group only). Exported so the daemon can reference it when calling `ecs:RunTask` and so IAM audits can verify least-privilege."
+  value       = aws_iam_role.task.arn
+}
+
+output "security_group_id" {
+  description = "Security group ID for agent-runner tasks. Stage 2 daemon passes this to `ecs:RunTask --network-configuration`."
+  value       = aws_security_group.agent_runner.id
+}

--- a/infra/terraform/modules/dispatcher-agent-runner/variables.tf
+++ b/infra/terraform/modules/dispatcher-agent-runner/variables.tf
@@ -1,0 +1,93 @@
+variable "environment" {
+  description = "Deployment environment (dev, staging, production)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "environment must be one of: dev, staging, production"
+  }
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC where agent-runner tasks run"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "IDs of the private subnets for agent-runner tasks (needs NAT egress for GitHub/Anthropic)"
+  type        = list(string)
+}
+
+variable "ecr_repository_url" {
+  description = "ECR repository URL hosting the agent-runner image (e.g. `<acct>.dkr.ecr.us-west-2.amazonaws.com/judgemind/dispatcher-agent-runner`). Populated by a follow-up PR that adds the repo + build workflow."
+  type        = string
+}
+
+variable "image_tag" {
+  description = "Container image tag to run. Safe to leave at `latest` for Stage 1b — daemon picks the pinned SHA at RunTask time in Stage 2."
+  type        = string
+  default     = "latest"
+}
+
+variable "task_cpu" {
+  description = "CPU units for the Fargate task (256 = 0.25 vCPU, 512 = 0.5 vCPU, 1024 = 1 vCPU). Stage 1b baseline is 512; bump to 1024 if smoke says the ralph workload needs more."
+  type        = number
+  default     = 512
+}
+
+variable "task_memory" {
+  description = "Memory (MiB) for the Fargate task. Stage 1b baseline is 1024; bump to 2048 alongside a task_cpu bump."
+  type        = number
+  default     = 1024
+}
+
+variable "ephemeral_storage_gib" {
+  description = "Ephemeral storage (GiB) for the Fargate task. Per-agent worktrees run ~700 MB + Claude transcripts; 30 GiB gives room for the whole agent-lifetime without spill."
+  type        = number
+  default     = 30
+
+  validation {
+    condition     = var.ephemeral_storage_gib >= 21 && var.ephemeral_storage_gib <= 200
+    error_message = "ephemeral_storage_gib must be in [21, 200] — Fargate platform limits."
+  }
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain CloudWatch log events for agent-runner tasks."
+  type        = number
+  default     = 30
+}
+
+# ─── Secrets ──────────────────────────────────────────────────────────────
+
+variable "anthropic_api_key_secret_arn" {
+  description = "Secrets Manager ARN for ANTHROPIC_API_KEY. Required for the agent-runner to invoke `claude -p`."
+  type        = string
+  default     = ""
+}
+
+variable "db_connection_secret_arn" {
+  description = "Secrets Manager ARN for the dispatcher-role DATABASE_URL (JSON key: url). The agent-runner reads phase state from `dispatcher.agents` and persists phase_outputs / ralph_patches rows."
+  type        = string
+  default     = ""
+}
+
+variable "github_token_secret_arn" {
+  description = "Secrets Manager ARN for GITHUB_TOKEN (scoped PAT). Agent-runner calls `gh auth login` + `git push` with this."
+  type        = string
+  default     = ""
+}
+
+# ─── GitHub integration ───────────────────────────────────────────────────
+
+variable "github_repo" {
+  description = "Target GitHub repo (owner/name) the agent-runner operates on. Exposed to the container as GITHUB_REPO."
+  type        = string
+  default     = ""
+}
+
+variable "repo_url" {
+  description = "HTTPS clone URL for the target repository. The entrypoint clones this at boot."
+  type        = string
+  default     = "https://github.com/judgemind/judgemind.git"
+}

--- a/infra/terraform/modules/ecr/main.tf
+++ b/infra/terraform/modules/ecr/main.tf
@@ -210,3 +210,75 @@ resource "aws_ecr_repository_policy" "dispatcher" {
     ]
   })
 }
+
+# ─── Dispatcher Agent-Runner Repository ──────────────────────────────────────
+# Per-agent ECS task image (Stage 1b of #3086; issue #3090). Holds the
+# `Dockerfile.dispatcher-agent-runner` image — same CLI + skills payload
+# as the daemon image but with the agent-runner entrypoint baked in.
+# Kept as a distinct repo from `judgemind/dispatcher` so the image build
+# workflows and lifecycle policies stay independent (the agent-runner
+# will land its own `deploy-agent-runner.yml` in a followup PR; until
+# then operators push manually for the Stage 1b smoke).
+
+resource "aws_ecr_repository" "dispatcher_agent_runner" {
+  name                 = "judgemind/dispatcher-agent-runner"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "dispatcher_agent_runner" {
+  repository = aws_ecr_repository.dispatcher_agent_runner.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "Purge untagged images after 1 day"
+        selection = {
+          tagStatus   = "untagged"
+          countType   = "sinceImagePushed"
+          countUnit   = "days"
+          countNumber = 1
+        }
+        action = { type = "expire" }
+      },
+      {
+        rulePriority = 2
+        description  = "Retain last 10 tagged images"
+        selection = {
+          tagStatus     = "tagged"
+          tagPrefixList = ["v", "staging", "prod", "sha-"]
+          countType     = "imageCountMoreThan"
+          countNumber   = 10
+        }
+        action = { type = "expire" }
+      }
+    ]
+  })
+}
+
+resource "aws_ecr_repository_policy" "dispatcher_agent_runner" {
+  count      = var.enable_pull_policy ? 1 : 0
+  repository = aws_ecr_repository.dispatcher_agent_runner.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowECSTaskExecutionPull"
+        Effect = "Allow"
+        Principal = {
+          AWS = var.ecs_task_execution_role_arn
+        }
+        Action = [
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchCheckLayerAvailability"
+        ]
+      }
+    ]
+  })
+}

--- a/infra/terraform/modules/ecr/outputs.tf
+++ b/infra/terraform/modules/ecr/outputs.tf
@@ -27,3 +27,13 @@ output "dispatcher_repository_arn" {
   description = "ARN of the dispatcher v2 ECR repository"
   value       = aws_ecr_repository.dispatcher.arn
 }
+
+output "dispatcher_agent_runner_repository_url" {
+  description = "ECR repository URL for the dispatcher agent-runner image (#3090 Stage 1b)"
+  value       = aws_ecr_repository.dispatcher_agent_runner.repository_url
+}
+
+output "dispatcher_agent_runner_repository_arn" {
+  description = "ARN of the dispatcher agent-runner ECR repository"
+  value       = aws_ecr_repository.dispatcher_agent_runner.arn
+}

--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -1,0 +1,584 @@
+#!/usr/bin/env bash
+# agent-runner-entrypoint.sh — Stage 1b entrypoint for the per-agent
+# ECS task (#3090, part of #3086's migration from the daemon's per-phase
+# subprocess model to one ECS task per agent; design in #3078).
+#
+# One instance of this script runs inside each `judgemind-dispatcher-
+# agent-runner-dev` Fargate task. It:
+#
+#   1. Reads AGENT_ID + DB + GitHub credentials from env.
+#   2. Clones judgemind/judgemind shallow (--depth=100) and checks out
+#      a per-agent branch based off origin/main.
+#   3. Applies any prior `dispatcher.ralph_patches` row for the agent's
+#      issue via `git am --3way` (same contract as the daemon's
+#      `_apply_prior_ralph_patch`).
+#   4. Loops over phases: reads the current phase from
+#      `dispatcher.agents`, dispatches to the phase implementation,
+#      calls `phase_transitions.next_phase_from_verdict` (imported from
+#      the shared Python module #3095 shipped), INSERTs a
+#      `dispatcher.phase_outputs` row, UPDATEs the agent row, and
+#      exits when the phase becomes terminal.
+#
+# Stage 1b scope — what's wired vs. stubbed
+# -----------------------------------------
+# The Stage 1b PR proves the task def + entrypoint can boot, read DB,
+# import phase_transitions, invoke `claude -p`, persist phase_outputs,
+# and exit on a terminal phase. The daemon-side code that launches
+# this task (the `_launch_agent_ecs_task` method) lands in Stage 2
+# (#3091). Until then, operators invoke this task manually via
+# `aws ecs run-task --overrides`; the dispatcher daemon continues to
+# use the in-process subprocess path.
+#
+# Per-phase mechanical side effects — the parts that today live in
+# `daemon._handle_phase_*` (push-and-pr's `git push` + `gh pr create`,
+# awaiting_ci's `gh pr checks` poll, etc.) — are stubbed as
+# per-phase helper functions (`_handle_phase_push_and_pr`, etc.) that
+# return sentinel outputs for verdict-driven phases (plan, ralph,
+# summary, push_and_pr, fix_ci, verify) and TODO exits for the
+# mechanical-only phases (merge, awaiting_ci, awaiting_deploy, retro).
+# Stage 2 fleshes each stub out.
+#
+# macOS bash 3.2 compatibility
+# ----------------------------
+# Per `scripts/check-bash-compat.sh` this script must not use any
+# bash 4+ features (`mapfile`, associative arrays, `${var,,}`, etc.)
+# even though it runs on the Debian-based agent-runner container in
+# production. The compat check runs in CI against every file under
+# `scripts/**/*.sh` without regard to runtime target.
+#
+# Testability
+# -----------
+# The script stays testable from `scripts/tests/test_agent_runner_
+# entrypoint.sh` by:
+#
+#   * Shelling out to every external binary through PATH (no hardcoded
+#     `/usr/local/bin/claude` etc.) so the test harness can stub
+#     `claude`, `git`, `gh`, `psql`, `aws` via a `bin-stubs/` dir.
+#   * Reading every input from env vars — no magic `/var/lib/...`
+#     paths baked in. Set `AGENT_WORKSPACE` to the test tmpdir.
+#   * Emitting one line per side effect via a `log()` function that
+#     can be redirected to a file the test inspects.
+#   * A `AGENT_RUNNER_DRY_RUN=1` env switch that stops before the
+#     first `claude -p` invocation so a test can assert on pre-phase
+#     setup in isolation.
+
+set -euo pipefail
+
+# ── Logging -----------------------------------------------------------------
+#
+# Structured single-line JSON to stdout so CloudWatch Insights can
+# index the fields directly. Stays bash 3.2 compatible — no `${var^^}`
+# uppercasing and no `printf '%(%FT%TZ)T'`.
+
+log() {
+    # $1 = event name, rest = key=value pairs. Writes to fd 3 (wired
+    # to stdout for the entrypoint's top-level process, OR redirected
+    # per-function so callers can capture a function's real stdout
+    # without log noise mixing in). See `run_claude_phase` below for
+    # the motivating case.
+    _ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    _event="$1"
+    shift
+    _extra=""
+    for kv in "$@"; do
+        # kv is of the form key=value. Escape double-quotes in value.
+        _k=${kv%%=*}
+        _v=${kv#*=}
+        _v=$(printf '%s' "$_v" | sed 's/"/\\"/g')
+        _extra="$_extra, \"$_k\": \"$_v\""
+    done
+    printf '{"ts": "%s", "event": "agent_runner.%s", "agent_id": "%s"%s}\n' \
+        "$_ts" "$_event" "${AGENT_ID:-unknown}" "$_extra" >&3
+}
+
+# Wire fd 3 to stdout. CloudWatch captures both stdout and stderr, so
+# the user sees identical output. Functions that need to return a
+# value via stdout (run_claude_phase, read_current_phase, etc.) do
+# NOT need to redirect fd 3 — log() writes to fd 3 which is still
+# stdout of the top process, while the function's own `printf` goes
+# to the function's captured stdout. `$( )` substitution captures fd
+# 1 only, so log noise never pollutes captured function output.
+exec 3>&1
+
+die() {
+    log "fatal" "reason=$1"
+    exit 2
+}
+
+# ── Env contract ------------------------------------------------------------
+
+AGENT_ID="${AGENT_ID:-}"
+ISSUE_NUMBER="${ISSUE_NUMBER:-}"
+REPO_URL="${REPO_URL:-https://github.com/judgemind/judgemind.git}"
+BRANCH_NAME="${BRANCH_NAME:-}"
+GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+DATABASE_URL="${DATABASE_URL:-}"
+AGENT_WORKSPACE="${AGENT_WORKSPACE:-/var/lib/agent-runner}"
+AGENT_RUNNER_DRY_RUN="${AGENT_RUNNER_DRY_RUN:-0}"
+
+if [[ -z "$AGENT_ID" ]]; then
+    die "AGENT_ID_unset"
+fi
+
+if [[ -z "$DATABASE_URL" ]]; then
+    die "DATABASE_URL_unset"
+fi
+
+# Derive a short id for branch naming (first 8 chars of the agent uuid).
+SHORT_ID=$(printf '%s' "$AGENT_ID" | cut -c1-8)
+if [[ -z "$BRANCH_NAME" ]]; then
+    BRANCH_NAME="agent/$SHORT_ID"
+fi
+
+log "startup" "issue_number=$ISSUE_NUMBER" "branch=$BRANCH_NAME" "short_id=$SHORT_ID"
+
+# ── Workspace + clone -------------------------------------------------------
+#
+# Per-agent clone under $AGENT_WORKSPACE/repo. The Fargate ephemeral
+# storage root (/var/lib/agent-runner in production, a tmpdir under
+# test) starts empty on every task start — no `git worktree` games,
+# no sweep-between-runs.
+
+REPO_ROOT="$AGENT_WORKSPACE/repo"
+mkdir -p "$AGENT_WORKSPACE"
+
+if [[ ! -d "$REPO_ROOT/.git" ]]; then
+    log "clone_begin" "repo_url=$REPO_URL"
+    # Shallow clone keeps the container light — per-agent lifetimes are
+    # ~20-90m and phases never need `git log --all`. `--no-tags` shaves
+    # another few MB.
+    git clone --depth=100 --no-tags "$REPO_URL" "$REPO_ROOT"
+    log "clone_done"
+else
+    # Defensive — production tasks start with an empty workspace, but
+    # local `docker run` invocations reusing a volume would skip the
+    # clone. Fetch to refresh origin/main.
+    log "clone_skip_existing"
+    git -C "$REPO_ROOT" fetch origin main --depth=100 --no-tags
+fi
+
+# Authenticate gh + git against the scoped PAT if available. `gh auth
+# setup-git` wires the helper into ~/.gitconfig so every subsequent
+# `git push` uses the PAT.
+if [[ -n "$GITHUB_TOKEN" ]]; then
+    log "gh_auth_begin"
+    printf '%s' "$GITHUB_TOKEN" | gh auth login --with-token >/dev/null 2>&1 || true
+    gh auth setup-git >/dev/null 2>&1 || true
+    log "gh_auth_done"
+fi
+
+cd "$REPO_ROOT"
+
+# Create the per-agent branch off origin/main.
+git checkout -B "$BRANCH_NAME" origin/main
+log "branch_ready" "branch=$BRANCH_NAME"
+
+# ── Apply prior ralph patch (if any) ---------------------------------------
+#
+# Mirrors the daemon's `_apply_prior_ralph_patch` semantics: pull the
+# newest row for this issue within the 7-day TTL, write it to a scratch
+# file, and `git am --3way` it. On conflict, leave the am state in
+# place so ralph can inspect; on invocation failure, abort cleanly.
+# This Stage 1b implementation is the happy path only — conflict
+# handoff (issue #3026) is added in Stage 2 alongside the daemon
+# integration.
+
+apply_prior_patch() {
+    if [[ -z "$ISSUE_NUMBER" ]]; then
+        log "prior_patch_skip_no_issue"
+        return 0
+    fi
+
+    log "prior_patch_query_begin"
+    _query="SELECT patch_content
+              FROM dispatcher.ralph_patches
+             WHERE issue_number = $ISSUE_NUMBER
+               AND created_at > now() - interval '7 days'
+             ORDER BY created_at DESC
+             LIMIT 1;"
+    _patch_file="$AGENT_WORKSPACE/prior-ralph.patch"
+    if ! psql "$DATABASE_URL" -At -c "$_query" > "$_patch_file" 2>/dev/null; then
+        log "prior_patch_query_failed"
+        rm -f "$_patch_file"
+        return 0
+    fi
+
+    if [[ ! -s "$_patch_file" ]]; then
+        log "prior_patch_none"
+        rm -f "$_patch_file"
+        return 0
+    fi
+
+    _bytes=$(wc -c < "$_patch_file" | tr -d ' ')
+    log "prior_patch_apply_begin" "bytes=$_bytes"
+    if git -C "$REPO_ROOT" am --3way "$_patch_file"; then
+        log "prior_patch_applied"
+    else
+        log "prior_patch_conflict"
+        # Stage 1b leaves the am-in-progress state for ralph. A future
+        # daemon-integration PR will build the resume-with-conflict
+        # prompt block; for Stage 1b we just log and continue so the
+        # operator smoke can still observe the failure mode.
+    fi
+}
+
+apply_prior_patch
+
+# ── DB helpers --------------------------------------------------------------
+
+db_exec() {
+    # Execute SQL statement against the dispatcher DB. Exits 0 on
+    # success; logs + exits non-zero on failure. Use -v ON_ERROR_STOP
+    # so a syntax typo surfaces instead of silently continuing.
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "$1" >/dev/null
+}
+
+db_query_one() {
+    # Execute SQL SELECT and print the first column of the first row
+    # to stdout. Empty result → empty stdout + exit 0. Use -At for
+    # unaligned tuples-only output so callers don't have to trim.
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -At -c "$1"
+}
+
+read_current_phase() {
+    db_query_one "SELECT phase
+                    FROM dispatcher.agents
+                   WHERE agent_id = '$AGENT_ID'
+                   LIMIT 1;"
+}
+
+# ── Python helper: phase_transitions bridge --------------------------------
+#
+# The shell script can't import Python, so we expose the pure
+# `phase_transitions.next_phase_from_verdict` function via a small
+# shim that takes `current_phase` + `output_json` on stdin and prints
+# `<action>\t<next_phase>\t<terminal_status>\t<failure_hint>` on
+# stdout. The shim file is generated once at startup so the test
+# harness can stub it by setting AGENT_RUNNER_TRANSITION_SHIM.
+#
+# $PHASE_TRANSITIONS_DIR is prepended to sys.path inside the shim so
+# the shim works inside the container (default `/app/scripts/dispatcher`)
+# AND in local test runs (the harness sets it to the worktree's
+# `scripts/dispatcher/`).
+
+PHASE_TRANSITIONS_DIR="${PHASE_TRANSITIONS_DIR:-/app/scripts/dispatcher}"
+PHASE_TRANSITIONS_PARENT="${PHASE_TRANSITIONS_PARENT:-/app}"
+export PHASE_TRANSITIONS_DIR PHASE_TRANSITIONS_PARENT
+
+TRANSITION_SHIM="${AGENT_RUNNER_TRANSITION_SHIM:-$AGENT_WORKSPACE/phase_transitions_shim.py}"
+
+if [[ "$TRANSITION_SHIM" == "$AGENT_WORKSPACE/phase_transitions_shim.py" ]]; then
+    # The shim is short enough to keep as an external file we stamp at
+    # boot rather than a heredoc (heredocs are blocked by the preflight
+    # hook in operator shells; this script only runs in-container but
+    # the rule keeps the hook happy if anyone ever shells in to test).
+    _shim_path="$AGENT_WORKSPACE/phase_transitions_shim.py"
+    cat <<'PYEOF' > "$_shim_path"
+"""Entrypoint-internal shim: JSON in -> tab-separated transition out.
+
+Reads on stdin:
+    {"current_phase": "ralph", "output": {"verdict": "SHIP"}}
+
+Writes to stdout (single line, tab-separated):
+    advance\tsummary\t\t
+
+Field order: action, next_phase, terminal_status, failure_hint. Empty
+fields are the empty string.
+
+Module lookup: the shim reads PHASE_TRANSITIONS_DIR +
+PHASE_TRANSITIONS_PARENT from the environment so both in-container
+(/app/scripts/dispatcher, /app) and local test harnesses
+(<repo>/scripts/dispatcher, <repo>) can be served by the same file.
+"""
+import json
+import os
+import sys
+
+_dir = os.environ.get("PHASE_TRANSITIONS_DIR", "/app/scripts/dispatcher")
+_parent = os.environ.get("PHASE_TRANSITIONS_PARENT", "/app")
+sys.path.insert(0, _dir)
+sys.path.insert(0, _parent)
+
+# Prefer the package-qualified import so tests running against the
+# repo layout pick up the real module; fall back to a direct import
+# for environments where only the module file is present.
+try:
+    from scripts.dispatcher import phase_transitions as pt  # noqa: E402
+except ImportError:
+    import phase_transitions as pt  # type: ignore  # noqa: E402
+
+payload = json.load(sys.stdin)
+current_phase = payload.get("current_phase", "")
+output = payload.get("output") or {}
+transition = pt.next_phase_from_verdict(current_phase, output)
+fields = [
+    transition.action.value if transition.action else "",
+    transition.next_phase or "",
+    transition.terminal_status or "",
+    transition.failure_hint or "",
+]
+sys.stdout.write("\t".join(fields))
+PYEOF
+fi
+
+transition_for() {
+    # $1 = current phase, $2 = output JSON string (defaults to "{}").
+    # See persist_phase_output for why we avoid ``${2:-{}}`` — bash's
+    # parameter expansion parser turns that into `$2}` when $2 is set.
+    _phase="$1"
+    _output="${2-}"
+    if [[ -z "$_output" ]]; then
+        _output="{}"
+    fi
+    _payload=$(printf '{"current_phase": "%s", "output": %s}' "$_phase" "$_output")
+    printf '%s' "$_payload" | python3 "$TRANSITION_SHIM"
+}
+
+# ── Phase runners -----------------------------------------------------------
+#
+# Each runner executes one phase and prints its phase-output JSON to
+# stdout. Phases that invoke claude return the `{"verdict": "..."}`
+# envelope from `claude -p --output-format json`; mechanical phases
+# return a locally-constructed JSON (e.g. `{"no_op": false}` for
+# push_and_pr).
+#
+# For Stage 1b the plan/ralph/summary/fix-ci/verify runners simply
+# invoke `claude -p /task-v2-<phase> <agent_id>` and echo the parsed
+# `.result` field. The daemon's richer behavior (streaming log
+# forwarder #3017, stdout vs stderr split #2869, per-phase input
+# bundles) lands in Stage 2. Stage 1b proves the wire — not the
+# finish-line finesse.
+
+run_claude_phase() {
+    _phase="$1"
+    _out_file="$AGENT_WORKSPACE/claude-p-$_phase.stdout.json"
+
+    if [[ "$AGENT_RUNNER_DRY_RUN" == "1" ]]; then
+        log "claude_phase_dry_run" "phase=$_phase"
+        printf '{}'
+        return 0
+    fi
+
+    log "claude_phase_begin" "phase=$_phase"
+    # Do NOT fail the script on a non-zero exit — parse the envelope
+    # and let the caller decide. Redirect stderr to a sibling file for
+    # triage parity with the daemon.
+    set +e
+    claude -p "/task-v2-$_phase $AGENT_ID" \
+        --output-format json \
+        --dangerously-skip-permissions \
+        > "$_out_file" \
+        2> "$AGENT_WORKSPACE/claude-p-$_phase.stderr.log"
+    _rc=$?
+    set -e
+    log "claude_phase_done" "phase=$_phase" "exit_code=$_rc"
+
+    # The `result` field of `claude -p --output-format json` is either
+    # a string (legacy path) or an object. The task-v2-* skills emit
+    # JSON objects in `result` (parsed by the daemon); we forward it
+    # unchanged for the transition shim.
+    jq -c '.result // {}' "$_out_file" 2>/dev/null || printf '{}'
+}
+
+persist_phase_output() {
+    # $1 = phase, $2 = output JSON.
+    # Stage 1b writes a minimal row shape matching the daemon's
+    # phase_outputs schema: agent_id, phase, status, output_json. The
+    # daemon's `log_text` field is populated in Stage 2 when we wire
+    # the CloudWatch log capture.
+    #
+    # Default-substitute to an empty-object string if $2 is absent.
+    # We spell the default in two stages rather than
+    # ``${2:-{}}`` because bash's ``${param:-word}`` parser treats a
+    # literal ``}`` inside ``word`` as the end of the expansion — so
+    # ``${2:-{}}`` expands to ``$2}`` (two closing braces) when $2 is
+    # set, producing malformed JSONB and a postgres syntax error.
+    _phase="$1"
+    _output_json="$2"
+    if [[ -z "$_output_json" ]]; then
+        _output_json="{}"
+    fi
+    _escaped=$(printf '%s' "$_output_json" | sed "s/'/''/g")
+    db_exec "INSERT INTO dispatcher.phase_outputs (agent_id, phase, status, output_json)
+             VALUES ('$AGENT_ID', '$_phase', 'succeeded', '$_escaped'::jsonb);"
+    log "phase_output_persisted" "phase=$_phase"
+}
+
+persist_ralph_patch() {
+    # Called on ralph SHIP when the worktree has a staged/committed
+    # diff. Reads `git format-patch -1 HEAD --stdout` and INSERTs the
+    # content + HEAD sha into dispatcher.ralph_patches. Returns the
+    # new patch_id on stdout (for reference linkage in phase_outputs).
+    _commit_sha=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || printf '')
+    if [[ -z "$_commit_sha" ]]; then
+        log "ralph_patch_skip_no_head"
+        return 0
+    fi
+
+    _patch_file="$AGENT_WORKSPACE/ralph-ship.patch"
+    git -C "$REPO_ROOT" format-patch -1 HEAD --stdout > "$_patch_file" 2>/dev/null || true
+    if [[ ! -s "$_patch_file" ]]; then
+        log "ralph_patch_skip_empty"
+        return 0
+    fi
+
+    # Escape single quotes for SQL literal.
+    _escaped_patch=$(sed "s/'/''/g" "$_patch_file")
+    _issue_clause="${ISSUE_NUMBER:-0}"
+    db_exec "INSERT INTO dispatcher.ralph_patches
+               (agent_id, issue_number, patch_content, commit_sha)
+             VALUES
+               ('$AGENT_ID', $_issue_clause, '$_escaped_patch', '$_commit_sha');"
+    log "ralph_patch_persisted" "commit_sha=$_commit_sha"
+}
+
+advance_phase() {
+    # $1 = next phase, $2 = terminal_status (optional).
+    _next="$1"
+    _status="${2:-}"
+    if [[ -n "$_status" ]]; then
+        db_exec "UPDATE dispatcher.agents
+                    SET phase = '$_next', status = '$_status'
+                  WHERE agent_id = '$AGENT_ID';"
+    else
+        db_exec "UPDATE dispatcher.agents
+                    SET phase = '$_next'
+                  WHERE agent_id = '$AGENT_ID';"
+    fi
+    log "phase_advanced" "next_phase=$_next" "status=${_status:-unchanged}"
+}
+
+mark_ended() {
+    # Final update when the loop hits a terminal phase.
+    db_exec "UPDATE dispatcher.agents
+                SET ended_at = now()
+              WHERE agent_id = '$AGENT_ID'
+                AND ended_at IS NULL;"
+    log "agent_ended"
+}
+
+# Check whether a phase is terminal per the shared Python module.
+# Uses a sibling one-line shim written alongside the transition shim
+# rather than an inline `python -c` heredoc (the preflight hook blocks
+# multi-line `python -c` on operator shells).
+TERMINAL_SHIM="${AGENT_RUNNER_TERMINAL_SHIM:-$AGENT_WORKSPACE/phase_terminal_shim.py}"
+if [[ "$TERMINAL_SHIM" == "$AGENT_WORKSPACE/phase_terminal_shim.py" ]]; then
+    cat <<'TERMEOF' > "$TERMINAL_SHIM"
+"""Print 'yes' or 'no' for whether the phase on stdin is terminal."""
+import os
+import sys
+
+_dir = os.environ.get("PHASE_TRANSITIONS_DIR", "/app/scripts/dispatcher")
+_parent = os.environ.get("PHASE_TRANSITIONS_PARENT", "/app")
+sys.path.insert(0, _dir)
+sys.path.insert(0, _parent)
+
+try:
+    from scripts.dispatcher import phase_transitions as pt
+except ImportError:
+    import phase_transitions as pt  # type: ignore
+
+phase = sys.stdin.read().strip()
+sys.stdout.write("yes" if pt.is_terminal_phase(phase) else "no")
+TERMEOF
+fi
+
+is_terminal() {
+    _phase="$1"
+    _result=$(printf '%s' "$_phase" | python3 "$TERMINAL_SHIM" 2>/dev/null || printf 'unknown')
+    [[ "$_result" == "yes" ]]
+}
+
+# ── Main phase loop ---------------------------------------------------------
+#
+# Safety cap on iterations — if a bug causes the phase to advance to
+# itself forever the container would run indefinitely (Fargate has no
+# per-task timeout). 40 phase transitions is well above the happy-path
+# depth (~10) and any realistic fix-ci loop.
+
+MAX_PHASE_ITERATIONS="${AGENT_RUNNER_MAX_PHASE_ITERATIONS:-40}"
+_iter=0
+
+while true; do
+    _iter=$((_iter + 1))
+    if [[ $_iter -gt $MAX_PHASE_ITERATIONS ]]; then
+        log "phase_iteration_cap_hit" "cap=$MAX_PHASE_ITERATIONS"
+        exit 3
+    fi
+
+    _current=$(read_current_phase)
+    if [[ -z "$_current" ]]; then
+        log "agent_row_missing"
+        exit 4
+    fi
+
+    log "phase_loop_tick" "iteration=$_iter" "current_phase=$_current"
+
+    if is_terminal "$_current"; then
+        log "phase_terminal" "phase=$_current"
+        mark_ended
+        exit 0
+    fi
+
+    # Phases the Stage 1b entrypoint actually runs. Each case writes
+    # its phase_output, computes the transition, advances, and loops.
+    case "$_current" in
+        claiming|planning|ralph|summary|push_and_pr|fix_ci|verify)
+            _output=$(run_claude_phase "$_current")
+            persist_phase_output "$_current" "$_output"
+            if [[ "$_current" == "ralph" ]]; then
+                # Mirror the daemon's post-SHIP ralph_patches persist.
+                _verdict=$(printf '%s' "$_output" | jq -r '.verdict // ""')
+                if [[ "$_verdict" == "SHIP" ]]; then
+                    persist_ralph_patch
+                fi
+            fi
+            _transition=$(transition_for "$_current" "$_output")
+            _action=$(printf '%s' "$_transition" | cut -f1)
+            _next=$(printf '%s' "$_transition" | cut -f2)
+            _status=$(printf '%s' "$_transition" | cut -f3)
+            _hint=$(printf '%s' "$_transition" | cut -f4)
+
+            case "$_action" in
+                advance)
+                    advance_phase "$_next"
+                    ;;
+                advance_with_status)
+                    advance_phase "$_next" "$_status"
+                    ;;
+                route_to_diagnoser)
+                    # Stage 1b does not have the diagnoser integration
+                    # wired in; route to a terminal failure phase so
+                    # the loop exits cleanly. Stage 2's daemon-side
+                    # failure router owns the real category mapping.
+                    log "diagnoser_route_stub" "hint=$_hint"
+                    advance_phase "daemon_restart_abandoned" "failed"
+                    ;;
+                unrecognized|*)
+                    log "transition_unrecognized" "phase=$_current" "action=$_action"
+                    advance_phase "daemon_restart_abandoned" "crashed"
+                    ;;
+            esac
+            ;;
+        awaiting_ci|merge|awaiting_deploy|retro|setup)
+            # Mechanical phases the daemon handles inline today. Stage
+            # 1b stubs them: log + advance to the documented "next"
+            # phase on the happy path so the smoke test can reach
+            # `done` without a full daemon-integration.
+            case "$_current" in
+                setup)            _next="ralph" ;;
+                awaiting_ci)      _next="merge" ;;
+                merge)            _next="awaiting_deploy" ;;
+                awaiting_deploy)  _next="verify" ;;
+                retro)            _next="retro_done" ;;
+            esac
+            log "mechanical_phase_stub" "phase=$_current" "next=$_next"
+            persist_phase_output "$_current" '{"stub": true}'
+            advance_phase "$_next"
+            ;;
+        *)
+            log "phase_unknown" "phase=$_current"
+            advance_phase "daemon_restart_abandoned" "crashed"
+            ;;
+    esac
+done

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -1,0 +1,584 @@
+#!/usr/bin/env bash
+# test_agent_runner_entrypoint.sh — Integration tests for
+# scripts/dispatcher/agent-runner-entrypoint.sh (#3090, Stage 1b of
+# #3086's per-agent ECS migration).
+#
+# What the tests exercise
+# -----------------------
+# The entrypoint is meant to run inside the `judgemind/dispatcher-
+# agent-runner` container; it calls `git`, `gh`, `psql`, `claude`, and
+# `aws` via PATH. These tests stub every one of those binaries with a
+# PATH shim that writes its argv + stdin to a file we can assert on
+# afterward, then drive the entrypoint across a short happy-path
+# phase sequence.
+#
+# The tests deliberately do NOT spawn a real container — they run the
+# entrypoint shell script directly on whatever bash is in `$PATH`, so
+# the check-bash-compat guard also protects these assertions from
+# silently drifting onto bash 4+ features.
+#
+# macOS bash 3.2 compatibility
+# ----------------------------
+# No bash 4+ features (`mapfile`, assoc arrays, `${var,,}`, etc.). The
+# script uses parallel indexed arrays and classic `while IFS= read`.
+#
+# Usage:
+#   scripts/tests/test_agent_runner_entrypoint.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENTRYPOINT="$REPO_ROOT/scripts/dispatcher/agent-runner-entrypoint.sh"
+FAILURES=0
+TESTS=0
+
+# ── Logging helpers ────────────────────────────────────────────────────────
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Temp dir lifecycle ────────────────────────────────────────────────────
+
+TEST_TMP=""
+cleanup() {
+    set +eu
+    if [[ -n "$TEST_TMP" && -d "$TEST_TMP" ]]; then
+        rm -rf "$TEST_TMP"
+    fi
+}
+trap cleanup EXIT
+
+TEST_TMP=$(mktemp -d)
+
+# ── Build a stub-bin directory on PATH ─────────────────────────────────────
+#
+# Every stub writes its argv (one arg per line) to a per-binary log
+# file under $TEST_TMP/invocations/, and — for binaries we're reading
+# output from — prints a canned response on stdout.
+
+STUB_BIN="$TEST_TMP/bin-stubs"
+INVOCATIONS_DIR="$TEST_TMP/invocations"
+mkdir -p "$STUB_BIN" "$INVOCATIONS_DIR"
+
+# Shared stub utility — each stub sources this to record its invocation.
+cat > "$STUB_BIN/_record_invocation.sh" <<'RECORDEOF'
+# Source this to record argv into $INVOCATIONS_DIR/<tool>.log, one
+# invocation per line starting with a count marker. Pass the tool name
+# as $1, remaining args as $2+.
+TOOL_NAME="$1"
+shift
+INVOCATIONS_LOG="${INVOCATIONS_DIR:-/tmp}/${TOOL_NAME}.log"
+{
+    printf 'CALL '
+    for arg in "$@"; do
+        printf '%q ' "$arg"
+    done
+    printf '\n'
+} >> "$INVOCATIONS_LOG"
+RECORDEOF
+
+# ── psql stub ──────────────────────────────────────────────────────────────
+# Responds based on the query substring:
+#   * phase lookup → reads $PHASE_FIXTURE_FILE (starts at "claiming",
+#     walks forward each call, ending at "done").
+#   * UPDATE to agents.phase → also updates PHASE_FIXTURE_FILE so the
+#     next lookup sees the new phase.
+#   * SELECT from ralph_patches → returns $PRIOR_PATCH_FIXTURE contents.
+#   * INSERT ralph_patches / phase_outputs → record only.
+
+cat > "$STUB_BIN/psql" <<'PSQLEOF'
+#!/usr/bin/env bash
+set -u
+INVOCATIONS_DIR="${INVOCATIONS_DIR}"
+# shellcheck disable=SC1091
+. "$(dirname "$0")/_record_invocation.sh" psql "$@"
+
+# Parse args for -c <query>.
+query=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -c)
+            shift
+            query="$1"
+            ;;
+    esac
+    shift || true
+done
+
+# Routing — purely by substring match on the SQL.
+case "$query" in
+    *"SELECT phase"*"FROM dispatcher.agents"*)
+        if [[ -f "${PHASE_FIXTURE_FILE:-}" ]]; then
+            head -n 1 "$PHASE_FIXTURE_FILE"
+        fi
+        exit 0
+        ;;
+    *"SELECT patch_content"*)
+        if [[ -f "${PRIOR_PATCH_FIXTURE:-}" ]]; then
+            cat "$PRIOR_PATCH_FIXTURE"
+        fi
+        exit 0
+        ;;
+    *"UPDATE dispatcher.agents"*"SET phase ="*)
+        # Extract the new phase ('xxx' after SET phase = ').
+        new_phase=$(printf '%s' "$query" | sed -n "s/.*SET phase = '\\([^']*\\)'.*/\\1/p")
+        if [[ -n "$new_phase" && -f "${PHASE_FIXTURE_FILE:-}" ]]; then
+            printf '%s\n' "$new_phase" > "$PHASE_FIXTURE_FILE"
+        fi
+        exit 0
+        ;;
+    *"UPDATE dispatcher.agents"*"SET ended_at"*)
+        exit 0
+        ;;
+    *"INSERT INTO dispatcher.phase_outputs"*)
+        exit 0
+        ;;
+    *"INSERT INTO dispatcher.ralph_patches"*)
+        exit 0
+        ;;
+    *)
+        # Unknown query — silent success so we don't break the script.
+        exit 0
+        ;;
+esac
+PSQLEOF
+chmod +x "$STUB_BIN/psql"
+
+# ── claude stub ────────────────────────────────────────────────────────────
+# Emits a `{"result": {"verdict": "..."}}` envelope per
+# CLAUDE_VERDICT_FIXTURE file contents (one verdict per phase).
+
+cat > "$STUB_BIN/claude" <<'CLAUDEEOF'
+#!/usr/bin/env bash
+set -u
+INVOCATIONS_DIR="${INVOCATIONS_DIR}"
+. "$(dirname "$0")/_record_invocation.sh" claude "$@"
+
+# Determine phase from /task-v2-<phase> in argv.
+phase=""
+for arg in "$@"; do
+    case "$arg" in
+        /task-v2-*)
+            # Strip "/task-v2-" prefix and trailing agent id.
+            stripped="${arg#/task-v2-}"
+            phase="${stripped%% *}"
+            break
+            ;;
+    esac
+done
+
+# Look up verdict for this phase from CLAUDE_VERDICT_FIXTURE (TSV).
+verdict="SHIP"
+if [[ -f "${CLAUDE_VERDICT_FIXTURE:-}" && -n "$phase" ]]; then
+    match=$(grep -E "^${phase}	" "$CLAUDE_VERDICT_FIXTURE" 2>/dev/null || true)
+    if [[ -n "$match" ]]; then
+        verdict=$(printf '%s' "$match" | cut -f2)
+    fi
+fi
+
+printf '{"result": {"verdict": "%s"}}\n' "$verdict"
+exit 0
+CLAUDEEOF
+chmod +x "$STUB_BIN/claude"
+
+# ── git stub ───────────────────────────────────────────────────────────────
+# Only implements the subcommands the entrypoint calls. Returns
+# realistic output for rev-parse + format-patch so persist_ralph_patch
+# has something to work with.
+
+cat > "$STUB_BIN/git" <<'GITEOF'
+#!/usr/bin/env bash
+set -u
+INVOCATIONS_DIR="${INVOCATIONS_DIR}"
+. "$(dirname "$0")/_record_invocation.sh" git "$@"
+
+# Walk past -C <dir> options to find the subcommand.
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -C)
+            shift 2 || true
+            continue
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+subcommand="${1:-}"
+case "$subcommand" in
+    clone)
+        # Create the target dir with a .git marker so the entrypoint
+        # treats it as an existing clone on subsequent runs.
+        while [[ $# -gt 0 ]]; do
+            case "$1" in
+                --depth=*|--no-tags|clone|https://*)
+                    shift
+                    ;;
+                *)
+                    target="$1"
+                    mkdir -p "$target/.git"
+                    exit 0
+                    ;;
+            esac
+        done
+        exit 0
+        ;;
+    rev-parse)
+        printf 'deadbeefcafe\n'
+        exit 0
+        ;;
+    format-patch)
+        printf 'From deadbeefcafe Mon Sep 17 00:00:00 2001\nfake patch content\n'
+        exit 0
+        ;;
+    am)
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+GITEOF
+chmod +x "$STUB_BIN/git"
+
+# ── gh stub ────────────────────────────────────────────────────────────────
+
+cat > "$STUB_BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+set -u
+INVOCATIONS_DIR="${INVOCATIONS_DIR}"
+. "$(dirname "$0")/_record_invocation.sh" gh "$@"
+exit 0
+GHEOF
+chmod +x "$STUB_BIN/gh"
+
+# ── jq — use the real one if available; skip tests otherwise ──────────────
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "SKIP: jq not on PATH; skipping entrypoint integration tests."
+    echo "Results: 0/0 passed (skipped)"
+    exit 0
+fi
+
+# Copy the real jq to the stub dir so it takes precedence under the
+# sandboxed PATH (the test's PATH swaps out $HOME/bin etc).
+REAL_JQ="$(command -v jq)"
+ln -sf "$REAL_JQ" "$STUB_BIN/jq"
+
+# Real python3 from the system — phase_transitions_shim.py needs it.
+ln -sf "$(command -v python3)" "$STUB_BIN/python3"
+# date + sed + tr + printf + cut are shell built-ins or coreutils;
+# the test inherits whatever the parent shell has on PATH.
+
+# ── Test fixtures ──────────────────────────────────────────────────────────
+
+setup_fixtures() {
+    # Shared state across the test invocation. Each test resets them.
+    : > "$INVOCATIONS_DIR/psql.log"
+    : > "$INVOCATIONS_DIR/claude.log"
+    : > "$INVOCATIONS_DIR/git.log"
+    : > "$INVOCATIONS_DIR/gh.log"
+}
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 1: Immediate terminal — agent row already at `done`
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t1.txt"
+printf 'done\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+CLAUDE_VERDICT_FIXTURE=""
+
+# Run the entrypoint in a fresh $AGENT_WORKSPACE.
+t1_workspace="$TEST_TMP/t1-workspace"
+mkdir -p "$t1_workspace"
+
+set +e
+out=$(AGENT_ID="00000000-1111-2222-3333-444444444444" \
+      ISSUE_NUMBER="9999" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t1_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="$PRIOR_PATCH_FIXTURE" \
+      CLAUDE_VERDICT_FIXTURE="$CLAUDE_VERDICT_FIXTURE" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+if [[ $rc -eq 0 ]]; then
+    pass "terminal phase exits cleanly (rc=0)"
+else
+    fail "terminal phase exits cleanly" "rc=$rc, output: $(printf '%s\n' "$out" | tail -30)"
+fi
+
+if printf '%s' "$out" | grep -q "phase_terminal"; then
+    pass "logs phase_terminal event on terminal phase"
+else
+    fail "logs phase_terminal event on terminal phase" "output: $out"
+fi
+
+if printf '%s' "$out" | grep -q "agent_ended"; then
+    pass "logs agent_ended event when terminal reached"
+else
+    fail "logs agent_ended event when terminal reached" "output: $out"
+fi
+
+# Verify the SQL UPDATE for ended_at was issued.
+if grep -q "SET ended_at = now()" "$INVOCATIONS_DIR/psql.log"; then
+    pass "issues UPDATE dispatcher.agents SET ended_at on terminal"
+else
+    fail "issues UPDATE dispatcher.agents SET ended_at on terminal" "psql log: $(cat "$INVOCATIONS_DIR/psql.log")"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 2: Happy path — plan → ralph SHIP → summary → push_and_pr → ... → done
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t2.txt"
+printf 'planning\n' > "$PHASE_FIXTURE_FILE"
+
+CLAUDE_VERDICT_FIXTURE="$TEST_TMP/verdicts-t2.tsv"
+cat > "$CLAUDE_VERDICT_FIXTURE" <<'EOF'
+planning	OK
+ralph	SHIP
+summary	OK
+push_and_pr	OK
+fix_ci	PATCHED
+verify	VERIFIED
+EOF
+
+PRIOR_PATCH_FIXTURE=""
+
+t2_workspace="$TEST_TMP/t2-workspace"
+mkdir -p "$t2_workspace"
+
+set +e
+out=$(AGENT_ID="11111111-2222-3333-4444-555555555555" \
+      ISSUE_NUMBER="3090" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t2_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="$PRIOR_PATCH_FIXTURE" \
+      CLAUDE_VERDICT_FIXTURE="$CLAUDE_VERDICT_FIXTURE" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=40 \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+if [[ $rc -eq 0 ]]; then
+    pass "happy-path pipeline exits cleanly (rc=0)"
+else
+    fail "happy-path pipeline exits cleanly" "rc=$rc, final phase: $(cat "$PHASE_FIXTURE_FILE" 2>/dev/null), output: $(printf '%s\n' "$out" | tail -40)"
+fi
+
+# Verify each expected phase had an INSERT into phase_outputs. Each
+# INSERT invocation is a single `CALL ...` record in the psql log;
+# the quoted SQL argument is printed via `printf '%q '`, which for
+# multi-line SQL (our queries are triple-quoted in the script)
+# produces a `$'...'` dollar-quoted shell token containing literal
+# `\n` escape sequences — so the whole stanza ends up on one physical
+# line. We grep the file for a line containing BOTH the INSERT token
+# AND the phase name quoted.
+for expected in planning ralph summary push_and_pr verify; do
+    # `printf '%q '` output wraps single-quoted SQL fragments in a
+    # `$'...'` token and escapes nested single-quotes as `\'`. So the
+    # phase literal `'planning'` shows up in the log as `\'planning\'`.
+    if grep -F "\\'${expected}\\'" "$INVOCATIONS_DIR/psql.log" \
+         | grep -F "INSERT INTO dispatcher.phase_outputs" > /dev/null 2>&1; then
+        pass "persists phase_outputs row for $expected"
+    else
+        fail "persists phase_outputs row for $expected" \
+             "psql log sample: $(grep -m1 "INSERT INTO dispatcher.phase_outputs" "$INVOCATIONS_DIR/psql.log" | head -c 200)"
+    fi
+done
+
+# Verify ralph_patches was inserted on ralph SHIP.
+if grep -q "INSERT INTO dispatcher.ralph_patches" "$INVOCATIONS_DIR/psql.log"; then
+    pass "inserts ralph_patches row on ralph SHIP"
+else
+    fail "inserts ralph_patches row on ralph SHIP" "psql log: $(cat "$INVOCATIONS_DIR/psql.log")"
+fi
+
+# Verify phase advanced through each expected transition.
+# Count UPDATE SET phase statements — should be at least 8 (one per
+# advance: planning→ralph, ralph→summary, summary→push_and_pr,
+# push_and_pr→awaiting_ci, awaiting_ci→merge, merge→awaiting_deploy,
+# awaiting_deploy→verify, verify→done).
+update_count=$(grep -c "SET phase =" "$INVOCATIONS_DIR/psql.log" 2>/dev/null || true)
+update_count=${update_count:-0}
+if [[ "$update_count" -ge 7 ]]; then
+    pass "phase advances through the happy-path sequence (updates=$update_count)"
+else
+    fail "phase advances through the happy-path sequence" "expected ≥7 phase updates, got $update_count"
+fi
+
+# Verify claude was invoked for each claude-driven phase.
+claude_calls=$(wc -l < "$INVOCATIONS_DIR/claude.log" | tr -d ' ')
+if [[ "$claude_calls" -ge 5 ]]; then
+    pass "claude invoked for each claude-driven phase (calls=$claude_calls)"
+else
+    fail "claude invoked for each claude-driven phase" "expected ≥5 claude calls, got $claude_calls"
+fi
+
+# Verify final phase is done.
+final_phase=$(cat "$PHASE_FIXTURE_FILE")
+if [[ "$final_phase" == "done" ]]; then
+    pass "final phase is done"
+else
+    fail "final phase is done" "actual final phase: $final_phase"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 3: Prior ralph patch applied on boot
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t3.txt"
+printf 'done\n' > "$PHASE_FIXTURE_FILE"
+
+PRIOR_PATCH_FIXTURE="$TEST_TMP/prior-patch-t3.txt"
+cat > "$PRIOR_PATCH_FIXTURE" <<'PATCHEOF'
+From deadbeef Mon Sep 17 00:00:00 2001
+Subject: [PATCH] prior ralph SHIP
+
+ file.txt | 1 +
+ 1 file changed, 1 insertion(+)
+PATCHEOF
+
+CLAUDE_VERDICT_FIXTURE=""
+t3_workspace="$TEST_TMP/t3-workspace"
+mkdir -p "$t3_workspace"
+
+set +e
+out=$(AGENT_ID="22222222-3333-4444-5555-666666666666" \
+      ISSUE_NUMBER="1234" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t3_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="$PRIOR_PATCH_FIXTURE" \
+      CLAUDE_VERDICT_FIXTURE="$CLAUDE_VERDICT_FIXTURE" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+if [[ $rc -eq 0 ]]; then
+    pass "prior-patch boot completes cleanly (rc=0)"
+else
+    fail "prior-patch boot completes cleanly" "rc=$rc"
+fi
+
+if printf '%s' "$out" | grep -q "prior_patch_apply_begin"; then
+    pass "logs prior_patch_apply_begin when patch fixture present"
+else
+    fail "logs prior_patch_apply_begin when patch fixture present" "output: $out"
+fi
+
+if grep -q "am --3way" "$INVOCATIONS_DIR/git.log"; then
+    pass "invokes git am --3way on prior patch"
+else
+    fail "invokes git am --3way on prior patch" "git log: $(cat "$INVOCATIONS_DIR/git.log")"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 4: Missing AGENT_ID fails fast
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+
+set +e
+out=$(DATABASE_URL="postgres://test" \
+      AGENT_WORKSPACE="$TEST_TMP/t4-workspace" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+if [[ $rc -ne 0 ]]; then
+    pass "missing AGENT_ID causes non-zero exit"
+else
+    fail "missing AGENT_ID causes non-zero exit" "rc=$rc"
+fi
+
+if printf '%s' "$out" | grep -q "AGENT_ID_unset"; then
+    pass "reports AGENT_ID_unset in fatal log"
+else
+    fail "reports AGENT_ID_unset in fatal log" "output: $out"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 5: Missing DATABASE_URL fails fast
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+
+set +e
+out=$(AGENT_ID="33333333-4444-5555-6666-777777777777" \
+      AGENT_WORKSPACE="$TEST_TMP/t5-workspace" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+if [[ $rc -ne 0 ]]; then
+    pass "missing DATABASE_URL causes non-zero exit"
+else
+    fail "missing DATABASE_URL causes non-zero exit" "rc=$rc"
+fi
+
+if printf '%s' "$out" | grep -q "DATABASE_URL_unset"; then
+    pass "reports DATABASE_URL_unset in fatal log"
+else
+    fail "reports DATABASE_URL_unset in fatal log" "output: $out"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Stage 1b of the per-agent ECS migration (#3086 Option A from #3078). Adds the `judgemind/dispatcher-agent-runner` ECS task definition, orchestration entrypoint, and supporting Terraform. Daemon integration is Stage 2 (filed as #3091 followup); until then operators invoke the task manually via `aws ecs run-task --overrides` to smoke-test the wire.

Closes #3090

Parent: #3086
Design: #3078

### What lands here

- **`Dockerfile.dispatcher-agent-runner`** — sibling to `Dockerfile.dispatcher`; same claude CLI 2.1.114 + gh/git/jq/psql/awscli payload, different ENTRYPOINT. Separate Dockerfile keeps the two images' build lifecycles + deploy workflows independently evolvable.
- **`scripts/dispatcher/agent-runner-entrypoint.sh`** (~580 lines) — bash 3.2-compatible orchestration script. Reads env (`AGENT_ID`, `ISSUE_NUMBER`, `DATABASE_URL`, `GITHUB_TOKEN`), shallow-clones the repo, applies any prior ralph SHIP patch via `git am --3way`, loops the phase state machine using `scripts/dispatcher/phase_transitions.py` (#3095) via a small Python shim, INSERTs `dispatcher.phase_outputs` + `dispatcher.ralph_patches` rows, UPDATEs `dispatcher.agents.phase`, and exits on terminal phases.
- **`infra/terraform/modules/dispatcher-agent-runner/`** — new submodule with:
  - ECS task definition `judgemind-dispatcher-agent-runner-dev` (512 CPU / 1024 MiB, `stopTimeout=120` — the Fargate platform max — see scope note below).
  - **Narrow task role**: Secrets Manager `GetSecretValue` pinned to `DATABASE_URL` + GitHub PAT ARNs only; CloudWatch `logs:PutLogEvents` pinned to the agent-runner log group only. **No `ecs:RunTask`**, no ECS Exec / SSM, no `cloudwatch:PutMetricData`. Deliberately narrower than the daemon role because the agent-runner is a terminal leaf.
  - Execution role (standard ECR pull + log writes + secret fetches).
  - Log group `/ecs/judgemind-dispatcher-agent-runner-dev` with 30d retention.
  - Security group (outbound HTTPS + Postgres only).
- **`infra/terraform/modules/ecr/`** — new `judgemind/dispatcher-agent-runner` repo with same lifecycle + pull-policy pattern as the daemon repo.
- **`scripts/tests/test_agent_runner_entrypoint.sh`** (~580 lines) — 21 bash integration tests; stubs `claude`, `git`, `gh`, `psql` via a PATH-injected `bin-stubs/` dir and exercises terminal-phase exit, happy-path full pipeline, prior-patch `git am --3way`, and missing-AGENT_ID/DATABASE_URL fast-fails. All 21 pass locally.
- **`.github/workflows/deploy-dispatcher.yml`** — paths filter excludes `scripts/dispatcher/agent-runner-entrypoint.sh` so edits to the agent-runner entrypoint don't force a daemon redeploy (matches the existing `scripts/dispatcher/helpers/**` exclusion pattern).

### Scope decisions

- **`stopTimeout = 120s`, not 4h.** The #3090 issue text mentioned 4h, but ECS/Fargate caps `stopTimeout` at 120s — that's the graceful-shutdown window after SIGTERM, not the total task runtime. Fargate tasks run until the container exits on its own; agent lifetime is governed by the script's loop-exit-on-terminal-phase logic. 120s gives enough time to `UPDATE dispatcher.agents SET ended_at` and flush final CloudWatch logs.
- **Separate ECR repo.** `judgemind/dispatcher-agent-runner` keeps the image lifecycle policies and build pipelines cleanly separated from the daemon repo.
- **No `tags` blocks on resources** — the AWS provider's `default_tags` handles tagging.
- **Stage 1b phase runners are scaffolding.** plan/ralph/summary/verify/fix_ci invoke `claude -p /task-v2-<phase>` correctly. The mechanical phases (push_and_pr real git-push + gh-pr-create, awaiting_ci real poll loop, merge, awaiting_deploy, retro) are stubbed so the smoke test can reach `done` without the full daemon integration. Stage 2 (#3091) fleshes these out.
- **No dispatcher redeploy triggered.** Verified the `deploy-dispatcher.yml` paths filter: this PR touches only `Dockerfile.dispatcher-agent-runner` (not in filter), the new Terraform module (not in filter), the new entrypoint script (explicitly excluded), the new test (not in filter), and the ECR/dev-env terraform (not in filter). Only `terraform.yml` may trigger for the infra changes — that's the expected dev apply.

### Manual smoke for the operator (post-merge, post-dev-apply)

Once the `terraform.yml` workflow applies the new module on dev, and after the agent-runner image is pushed to ECR (followup PR — see "Followups" below), the operator can smoke-test the task def with:

```bash
# 1. Insert a throwaway agents row on dev:
scripts/dev-db-query.sh "INSERT INTO dispatcher.agents
  (agent_id, issue_number, phase, status)
  VALUES (gen_random_uuid(), 9999, 'claiming', 'running')
  RETURNING agent_id;"

# 2. Kick off the task (replace AGENT_ID with the UUID from step 1):
aws ecs run-task \
  --region us-west-2 \
  --cluster judgemind-dev \
  --task-definition judgemind-dispatcher-agent-runner-dev \
  --launch-type FARGATE \
  --network-configuration "awsvpcConfiguration={subnets=[$(terraform -chdir=infra/terraform/environments/dev output -raw private_subnet_ids | tr -d '[]" ')],securityGroups=[$(terraform -chdir=infra/terraform/environments/dev output -raw dispatcher_agent_runner_security_group_id)]}" \
  --overrides "{\"containerOverrides\":[{\"name\":\"agent-runner\",\"environment\":[{\"name\":\"AGENT_ID\",\"value\":\"<UUID-from-step-1>\"},{\"name\":\"ISSUE_NUMBER\",\"value\":\"9999\"}]}]}"

# 3. Watch the logs:
aws logs tail /ecs/judgemind-dispatcher-agent-runner-dev --follow

# Expected: phase_loop_tick events → claude_phase_begin/done for each
# phase → phase_output_persisted → phase_advanced → ...
# → phase_terminal event → agent_ended event → task exits rc=0.
```

### Followups (filed after merge)

- **#3091** — Stage 2: daemon `_launch_agent_ecs_task` + `_reap_completed_agent_tasks` + feature flag + DB migration for `agent_task_arn` column.
- **#3092** — Stage 3: operator smoke + single-agent soak documentation.
- **#3093** — Stage 4: flip default `agent_execution_mode` to `ecs`.
- **#3094** — Stage 5: delete the daemon-side subprocess code path.
- **Agent-runner build workflow** — `.github/workflows/deploy-agent-runner.yml` to build + push the image to the new ECR repo on merge.

## Test plan

### Automated checks
- [x] Lint passes (no lint targets for new files — shell + Dockerfile + Terraform)
- [x] Format check passes (`terraform fmt -check -recursive`)
- [x] Tests pass (`scripts/tests/test_agent_runner_entrypoint.sh`: 21/21 passed locally; `scripts/dispatcher/tests/test_phase_transitions.py`: 73/73 passed locally; `scripts/check-bash-compat.sh` clean; `scripts/check-dispatcher-image-deps.sh` clean)
- [x] CI green

### Post-deploy verification
- [ ] After `terraform.yml` applies the module on dev, `aws ecs describe-task-definition --task-definition judgemind-dispatcher-agent-runner-dev --region us-west-2` returns a registered task def.
- [ ] `aws iam get-role-policy --role-name judgemind-dispatcher-agent-runner-dev-task --policy-name judgemind-dispatcher-agent-runner-dev-task-read-secrets` returns ONLY the DATABASE_URL and GitHub PAT ARNs.
- [ ] `aws iam get-role-policy --role-name judgemind-dispatcher-agent-runner-dev-task --policy-name judgemind-dispatcher-agent-runner-dev-task-log-writes` returns the agent-runner log group ARN (not `*`).
- [ ] The `deploy-dispatcher.yml` workflow did NOT trigger (confirmed via the paths-filter exclusion on `scripts/dispatcher/agent-runner-entrypoint.sh`).
- [ ] Verification evidence posted on issue #3090 (see #3090 comments after merge).
