### PR TITLE
feat(infra): grant dispatcher role ecs:RunTask on oneshot task def (#3048)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -283,6 +283,28 @@ module "dispatcher_daemon" {
 
   github_repo = "judgemind/judgemind"
 
+  # #3048 — grant the daemon's task role the IAM permissions needed by
+  # `scripts/ecs-run-task.sh` so ralph phases can run data scripts
+  # (rebuild_db, backfills, orphan cleanup) from the daemon context.
+  # Scoped to the `judgemind-oneshot-dev` family on this cluster; PassRole
+  # is pinned to the ingestion worker task + execution roles. See the
+  # `task_run_oneshot` policy in modules/dispatcher-daemon/main.tf for
+  # the full scope invariants. Keep these wired in dev only — production
+  # data-script execution stays human-gated.
+  oneshot_source_task_role_arn      = module.iam_scraper.role_arn
+  oneshot_source_execution_role_arn = module.compute.task_execution_role_arn
+  # `oneshot_maintenance_task_role_arn` stays empty — the
+  # `iam_maintenance` module is declared but not instantiated in dev. If
+  # a follow-up wires the module, plumb `module.iam_maintenance.role_arn`
+  # through here so `scripts/ecs-run-task.sh --role judgemind-maintenance-dev`
+  # also works from the daemon context.
+  oneshot_maintenance_task_role_arn = ""
+  # The `judgemind-assets-dev` bucket is provisioned outside Terraform
+  # (legacy). ARN pattern is deterministic — S3 bucket ARNs don't have a
+  # region or account-id segment, so hard-coding is safe here.
+  oneshot_script_bucket_arn          = "arn:aws:s3:::judgemind-assets-dev"
+  oneshot_ecr_scraper_repository_arn = module.ecr.repository_arn
+
   # Heartbeat alarm wired to the shared SNS topic once the daemon starts
   # emitting HeartbeatAge (Phase 2). Kept enabled in Phase 1 so the alarm
   # resource lands with the rest of the module; `treat_missing_data =

--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -257,6 +257,184 @@ resource "aws_iam_role_policy" "task_run_task_self" {
   })
 }
 
+# Oneshot task launcher — permissions required by
+# `scripts/ecs-run-task.sh` so the daemon can run data scripts
+# (rebuild_db, backfills, orphan cleanup) without a human on a laptop.
+# See #3048 for the root cause: the `task_run_task_self` policy above
+# only permits RunTask on the dispatcher's own family, which blocks
+# every data-script path from ralph.
+#
+# Wiring lives in `environments/dev/main.tf`: the caller passes the
+# ingestion worker's task + execution role ARNs, the shared assets
+# bucket ARN, and the scraper ECR repo ARN. If either of the two role
+# ARNs is empty the policy is skipped entirely — preserves a safe
+# default for callers that haven't opted in (e.g. staging / throwaway
+# test stacks).
+#
+# Scope invariants (audited in dev apply + `get-role-policy`):
+#   - RunTask restricted to the `judgemind-oneshot-${env}` family on
+#     `var.ecs_cluster_arn` — daemon cannot start prod tasks or spawn
+#     arbitrary workloads.
+#   - Deregister restricted to the same family. The daemon cannot
+#     rewrite the ingestion-worker or dispatcher task defs.
+#   - DescribeTaskDefinition uses `Resource = "*"` because the AWS API
+#     does not accept ARN scoping on that action (same pattern as the
+#     scheduler role); the cluster-ARN condition on RunTask is the
+#     defence-in-depth control.
+#   - PassRole limited to the ingestion worker's task + execution roles
+#     (and the optional maintenance role) — the oneshot task cannot
+#     assume the daemon's own task role or any cross-environment role.
+#   - S3 PutObject/DeleteObject scoped to `oneshot-scripts/*` under the
+#     caller-supplied assets bucket.
+#   - ecr:DescribeImages on the caller-supplied scraper repo ARN only.
+#
+# Widening any of the above should be paired with an updated issue
+# reference — #3048 is the current scope boundary.
+locals {
+  oneshot_enabled = (
+    var.oneshot_source_task_role_arn != "" &&
+    var.oneshot_source_execution_role_arn != ""
+  )
+  oneshot_family_arn_pattern = "arn:aws:ecs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:task-definition/judgemind-oneshot-${var.environment}:*"
+  oneshot_pass_role_arns = compact([
+    var.oneshot_source_task_role_arn,
+    var.oneshot_source_execution_role_arn,
+    var.oneshot_maintenance_task_role_arn,
+  ])
+}
+
+resource "aws_iam_role_policy" "task_run_oneshot" {
+  count = local.oneshot_enabled ? 1 : 0
+
+  name = "${local.service_name}-task-run-oneshot"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      [
+        {
+          # AWS requires Resource = "*" for RegisterTaskDefinition — the
+          # API does not accept ARN scoping. Deregister accepts an ARN,
+          # so that one below is pinned to the oneshot family.
+          Sid      = "AllowRegisterOneshotTaskDefinition"
+          Effect   = "Allow"
+          Action   = "ecs:RegisterTaskDefinition"
+          Resource = "*"
+        },
+        {
+          Sid      = "AllowDeregisterOneshotTaskDefinition"
+          Effect   = "Allow"
+          Action   = "ecs:DeregisterTaskDefinition"
+          Resource = local.oneshot_family_arn_pattern
+        },
+        {
+          # DescribeTaskDefinition reads the source (ingestion worker)
+          # task def as a template and the freshly registered oneshot
+          # task def. AWS requires `*` on this action.
+          Sid      = "AllowDescribeTaskDefinitions"
+          Effect   = "Allow"
+          Action   = "ecs:DescribeTaskDefinition"
+          Resource = "*"
+        },
+        {
+          # Launch the oneshot task. Restricted to the oneshot family on
+          # the dev cluster — no other family, no other cluster.
+          Sid      = "AllowRunOneshotTask"
+          Effect   = "Allow"
+          Action   = "ecs:RunTask"
+          Resource = local.oneshot_family_arn_pattern
+          Condition = {
+            ArnEquals = {
+              "ecs:cluster" = var.ecs_cluster_arn
+            }
+          }
+        },
+        {
+          # DescribeTasks (poll loop) and DescribeServices (resolve
+          # networking). Gated on the dev cluster via the condition.
+          Sid    = "AllowDescribeRunningTasks"
+          Effect = "Allow"
+          Action = [
+            "ecs:DescribeTasks",
+            "ecs:DescribeServices",
+          ]
+          Resource = "*"
+          Condition = {
+            ArnEquals = {
+              "ecs:cluster" = var.ecs_cluster_arn
+            }
+          }
+        },
+        {
+          # Pass the ingestion worker's task + execution roles to the
+          # oneshot task. Without this, RunTask fails with
+          # `AccessDeniedException: User ... is not authorized to pass
+          # role ... because no identity-based policy allows the
+          # iam:PassRole action`.
+          Sid      = "AllowPassOneshotRoles"
+          Effect   = "Allow"
+          Action   = "iam:PassRole"
+          Resource = local.oneshot_pass_role_arns
+          Condition = {
+            StringEquals = {
+              "iam:PassedToService" = "ecs-tasks.amazonaws.com"
+            }
+          }
+        },
+        {
+          # Resolve the `--role <name>` override in ecs-run-task.sh. The
+          # script calls `aws iam get-role --role-name <name>` to map a
+          # role name to an ARN before RunTask. Scoped to the account's
+          # judgemind-* roles for this environment.
+          Sid      = "AllowResolveMaintenanceRole"
+          Effect   = "Allow"
+          Action   = "iam:GetRole"
+          Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/judgemind-*-${var.environment}"
+        },
+        {
+          # Stream logs from the running oneshot task. The script tails
+          # the ingestion-worker log group (that's where oneshot tasks
+          # write — the log config is inherited from the source task
+          # def). Scoped to the dev account's judgemind-* log groups so
+          # the daemon cannot read unrelated log groups.
+          Sid    = "AllowReadOneshotLogs"
+          Effect = "Allow"
+          Action = [
+            "logs:DescribeLogStreams",
+            "logs:GetLogEvents",
+            "logs:FilterLogEvents",
+          ]
+          Resource = "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/judgemind-*:*"
+        },
+      ],
+      var.oneshot_script_bucket_arn != "" ? [
+        {
+          # Upload scripts >8KB via pre-signed URL. Scoped to the
+          # oneshot-scripts/ prefix inside the caller-supplied bucket.
+          Sid    = "AllowUploadOneshotScripts"
+          Effect = "Allow"
+          Action = [
+            "s3:PutObject",
+            "s3:DeleteObject",
+          ]
+          Resource = "${var.oneshot_script_bucket_arn}/oneshot-scripts/*"
+        },
+      ] : [],
+      var.oneshot_ecr_scraper_repository_arn != "" ? [
+        {
+          # Resolve the latest image digest in the scraper ECR repo
+          # (stale-image detection path in ecs-run-task.sh).
+          Sid      = "AllowDescribeScraperImages"
+          Effect   = "Allow"
+          Action   = "ecr:DescribeImages"
+          Resource = var.oneshot_ecr_scraper_repository_arn
+        },
+      ] : [],
+    )
+  })
+}
+
 resource "aws_iam_role_policy" "task_ecs_exec_ssm" {
   name = "${local.service_name}-task-ecs-exec-ssm"
   role = aws_iam_role.task.id

--- a/infra/terraform/modules/dispatcher-daemon/variables.tf
+++ b/infra/terraform/modules/dispatcher-daemon/variables.tf
@@ -139,3 +139,45 @@ variable "heartbeat_stale_seconds" {
   type        = number
   default     = 300
 }
+
+# ─── Oneshot task launcher (scripts/ecs-run-task.sh) ────────────────────────
+# When these ARNs are wired, the daemon's task role gets the permission set
+# required by `scripts/ecs-run-task.sh` so ralph phases can launch data
+# scripts (rebuild_db, backfills, orphan cleanup, etc.) from the daemon
+# context without needing a human to run them on a laptop. See #3048.
+#
+# Scope: dev-only. Writes stay scoped to the `judgemind-oneshot-${env}`
+# task-definition family and the dev cluster; `iam:PassRole` is scoped to
+# the ingestion worker's task and execution roles (the roles the oneshot
+# task assumes). Leave empty to skip the policy entirely — the daemon's
+# self-invocation policy (`task_run_task_self`) is untouched.
+
+variable "oneshot_source_task_role_arn" {
+  description = "ARN of the task role the oneshot task definition will assume (typically the ingestion worker / scraper task role). When set alongside oneshot_source_execution_role_arn, the daemon's task role is granted the permission set required by scripts/ecs-run-task.sh. Empty disables the feature."
+  type        = string
+  default     = ""
+}
+
+variable "oneshot_source_execution_role_arn" {
+  description = "ARN of the execution role the oneshot task definition will use (typically the shared ECS task execution role). When set alongside oneshot_source_task_role_arn, the daemon's task role is granted the permission set required by scripts/ecs-run-task.sh."
+  type        = string
+  default     = ""
+}
+
+variable "oneshot_maintenance_task_role_arn" {
+  description = "ARN of the optional maintenance role that scripts/ecs-run-task.sh --role can swap in. When set, iam:PassRole is also granted for this role so the --role override works from the daemon context."
+  type        = string
+  default     = ""
+}
+
+variable "oneshot_script_bucket_arn" {
+  description = "ARN of the S3 bucket where scripts/ecs-run-task.sh uploads scripts larger than the 8KB command-override limit (typically judgemind-assets-<env>). When set, the daemon task role is granted PutObject/DeleteObject under oneshot-scripts/*. Empty disables S3 uploads — scripts under ~6KB still work inline."
+  type        = string
+  default     = ""
+}
+
+variable "oneshot_ecr_scraper_repository_arn" {
+  description = "ARN of the ECR repository that hosts the scraper/ingestion-worker image (used by scripts/ecs-run-task.sh to resolve image digests). When set, the daemon task role is granted ecr:DescribeImages on that repo. Empty disables — ecs-run-task.sh still works using the service image without the digest-check step."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Grant the dispatcher daemon's task role the IAM permission set required by
`scripts/ecs-run-task.sh`, so ralph phases can launch data scripts
(`rebuild_db.py`, backfills, orphan cleanup, etc.) from the daemon context
without a human on a laptop. The existing `task_run_task_self` policy only
covers self-invocation of the dispatcher family, which is why the
Santa Clara / Orange County flat-hash orphan backfill ralph phase for
#2630 couldn't execute its plan.

Implements Option A from #3048.

## Scope

- New `aws_iam_role_policy.task_run_oneshot` on the dispatcher task role.
- Policy is opt-in at the module boundary: it's skipped entirely unless
  the caller wires both `oneshot_source_task_role_arn` and
  `oneshot_source_execution_role_arn`. Staging / blank test stacks are
  untouched.
- Wired in `environments/dev/main.tf` only. Production data-script
  execution stays human-gated.
- `task_run_task_self` is NOT modified — still scoped to the dispatcher
  family only.

## Permission scope (dev only)

- `ecs:RunTask` / `ecs:DeregisterTaskDefinition` → `judgemind-oneshot-dev:*` on the dev cluster.
- `ecs:RegisterTaskDefinition` / `ecs:DescribeTaskDefinition` → `*` (AWS API constraint; cluster-ARN condition on RunTask is the defence-in-depth control).
- `ecs:DescribeTasks` / `ecs:DescribeServices` → dev cluster only.
- `iam:PassRole` → ingestion worker task + execution roles, with `iam:PassedToService = ecs-tasks.amazonaws.com`.
- `iam:GetRole` → `judgemind-*-dev` roles only (for the `--role` override).
- `logs:*` (read-only) → `/ecs/judgemind-*:*` only.
- `s3:PutObject` / `s3:DeleteObject` → `judgemind-assets-dev/oneshot-scripts/*` only.
- `ecr:DescribeImages` → the scraper ECR repo only.

## Plan output

```
Plan: 1 to add, 2 to change, 0 to destroy.

  # module.dispatcher_daemon.aws_iam_role_policy.task_run_oneshot[0] will be created
  + resource "aws_iam_role_policy" "task_run_oneshot" {
      + name = "judgemind-dispatcher-dev-task-run-oneshot"
      + role = "judgemind-dispatcher-dev-task"
      ...
    }
```

The 2 pre-existing drifts (`module.compute.aws_scheduler_schedule.scraper`
task_definition_arn rollback, `module.compute.aws_security_group.scraper`
removing a port 33335 egress rule) are unrelated to this PR — they're
state-drift against main that the next scheduled apply would pick up
regardless.

## Test plan

- [x] `terraform fmt -check -recursive` clean.
- [x] `terraform plan` shows exactly one new resource
      (`aws_iam_role_policy.task_run_oneshot[0]`) on the dispatcher task role.
- [ ] After the dev terraform-apply workflow runs on merge:
      `aws iam get-role-policy --role-name judgemind-dispatcher-dev-task --policy-name judgemind-dispatcher-dev-task-run-oneshot`
      returns the expected Resource ARNs. Evidence posted on #3048.

Closes #3048
