### PR TITLE
spike(ingestion): investigate and document correctly-labeled S3 orphan root causes (#2662)

### DIFF
--- a/docs/investigations/correctly-labeled-s3-orphans-2026-04.md
+++ b/docs/investigations/correctly-labeled-s3-orphans-2026-04.md
@@ -1,0 +1,280 @@
+# Correctly-labeled S3 orphans — root cause investigation (2026-04)
+
+**Issue:** #2662 (investigate and recover correctly-labeled S3 orphans — SC + OC)
+**Related:** #2638 (mislabeled S3 writes — separate orphan class, closed)
+**Status:** Root cause identified via code analysis. Actual counts require running the
+audit script against dev. Recovery path confirmed (rebuild_db.py).
+
+## TL;DR
+
+A second class of S3 orphans was identified during the #2638 investigation: objects
+whose filename SHA-256 correctly matches the object bytes but whose S3 key has no
+corresponding `derived.documents` row. These are **correctly-labeled orphans** —
+the document reached S3 but was never ingested into the database.
+
+Code analysis (without runtime data) points to **three credible root causes**, ranked
+by likelihood:
+
+1. **Redis Stream MAXLEN trim** — `EventBus.emit_document_captured` publishes to
+   `document.captured` with `maxlen=10_000, approximate=True`. If the ingestion
+   worker is slow or paused, the stream fills and older events are trimmed before
+   they are consumed. S3 archival already completed at that point; the event is
+   silently dropped. **Most likely cause** — matches the clustering pattern
+   expected (bursts of captures during a scraper spike exhaust the backlog).
+
+2. **Worker exhausted-retry dead-letter (XACK-and-drop)** — `worker.py:3090` XACKs
+   a message after `max_retries` failed attempts. If the event had a transient
+   processing error (e.g. LLM timeout, DB connectivity blip) that resolved itself,
+   the document is acknowledged out of the PEL and never retried. The S3 object
+   exists; no DB row was written.
+
+3. **S3-put / event-emit race** — `_process_document` in `base.py` runs
+   `archiver.archive(doc)` then immediately calls `event_bus.emit_document_captured`.
+   These are sequential (not atomic). A process crash, ECS task eviction, or OOM
+   kill between the two calls leaves the object in S3 with no event emitted. This
+   would appear as an orphan with a `LastModified` timestamp that predates the
+   worker's startup.
+
+Actual counts require running the audit script against dev S3. See §Census.
+
+## Census
+
+> **Note:** The counts below are placeholders. Run the audit script to populate
+> actual values.
+
+```
+scripts/ecs-run-task.sh scripts/audit_correctly_labeled_s3_orphans.py \
+    -- --county both --json > tmp/orphan-census.json
+```
+
+Expected output shape:
+```json
+{
+  "all_clean": false,
+  "counties": {
+    "santa_clara": {
+      "total": <N>,
+      "in_db": <N>,
+      "orphans": <N>,
+      "mislabeled": <N>,
+      "orphans_by_month": {"2026-03": <N>, "2026-04": <N>},
+      "sample_verified": [...]
+    },
+    "orange": {
+      "total": <N>,
+      "in_db": <N>,
+      "orphans": <N>,
+      "mislabeled": <N>,
+      "orphans_by_month": {},
+      "sample_verified": [...]
+    }
+  }
+}
+```
+
+The `orphans_by_month` histogram is the key diagnostic signal:
+
+- **Spike concentrated around 2026-03-28** → likely migration-window confusion
+  (mislabeled orphans misclassified — recheck with `--sample-head-objects 50`).
+- **Spike around a scraper deployment date** → MAXLEN eviction during scraper restart
+  bursts most likely.
+- **Distributed low-level drip across months** → ECS task evictions (S3/event race)
+  or retry-exhaustion (XACK-and-drop) most likely.
+
+## Representative orphan
+
+> **Note:** This section requires a concrete orphan key from the audit run.
+> Placeholder forensic walkthrough follows — replace with actual key after running.
+
+### Forensic walk (template)
+
+```bash
+# 1. Pick a representative orphan key from the census output.
+ORPHAN_KEY="ca/santa_clara/superior_court/raw/<sha256>.pdf"
+
+# 2. HEAD the object to extract capture-timestamp and scraper-id metadata.
+aws s3api head-object \
+    --bucket judgemind-document-archive-dev \
+    --key "$ORPHAN_KEY"
+# Expected output:
+#   LastModified: <timestamp>
+#   Metadata:
+#     capture-timestamp: <ISO datetime>
+#     scraper-id: ca-sc-tentatives-civil
+#     content-hash: <sha256>  ← should match filename
+
+# 3. Correlate with CloudWatch logs using capture-timestamp ± 60 seconds.
+#    Log groups:
+#      /ecs/judgemind-scraper-dev       ← scraper side: confirms S3 put succeeded
+#      /ecs/judgemind-ingestion-worker-dev ← worker side: confirms event processing
+
+# Scraper log (confirms archive() call succeeded):
+#   INFO  Archived 142080 bytes to s3://judgemind-document-archive-dev/<key>
+
+# Worker log (if event was received):
+#   INFO  Processing document.captured msg_id=<redis-msg-id>
+
+# If the scraper log shows the archive call but the worker log shows no corresponding
+# processing event around the same timestamp → event was lost in the stream (MAXLEN
+# eviction or S3/event race between the two log lines).
+```
+
+### Expected finding (based on code analysis)
+
+Given the `S3Archiver.archive()` implementation writes the `capture-timestamp` metadata
+at PutObject time and `EventBus.emit_document_captured` is called immediately after in
+`_process_document`, any orphan with:
+
+- A `capture-timestamp` metadata that predates the ingestion worker's last start time
+- No corresponding `document.captured` stream entry in the worker logs
+
+...is consistent with the **MAXLEN eviction** hypothesis: the event was emitted into the
+stream but trimmed before the consumer group acknowledged it.
+
+Any orphan with a `capture-timestamp` that matches a known ECS task eviction event in
+CloudWatch Container Insights is consistent with the **S3-put/event-emit race**.
+
+## Root cause
+
+**Primary (most likely): Redis Stream MAXLEN eviction**
+
+`EventBus.emit_document_captured` (events.py line 75–81) uses:
+```python
+self._redis.xadd(
+    STREAM_DOCUMENT_CAPTURED,
+    {"data": json.dumps(payload)},
+    maxlen=self._maxlen,       # default 10_000
+    approximate=True,          # allows Redis to trim lazily
+)
+```
+
+The `approximate=True` flag instructs Redis to trim the stream when it exceeds
+`maxlen=10_000` but allows overage of up to ~10% before trimming. During scraper
+burst runs (e.g. a scraper re-run after a downtime window captures 200–300 documents
+rapidly), the stream can fill faster than the ingestion worker consumes it. When Redis
+trims the oldest entries, any un-ACKed entries that have been trimmed from the stream
+body but remain in the PEL are handled in `worker.py:2988–2993`:
+
+```python
+for msg_id, data in claimed_messages:
+    if data is None:
+        # Message was deleted from the stream but still in PEL.
+        # Acknowledge it to clear the PEL entry.
+        logger.debug("Acknowledging deleted PEL entry %s", msg_id)
+        self._redis.xack(STREAM_DOCUMENT_CAPTURED, CONSUMER_GROUP, msg_id)
+        continue
+```
+
+This path correctly acknowledges and discards entries that were trimmed from the stream
+body — but those entries represent documents that were archived to S3 and never ingested.
+The resulting orphan is correctly labeled (the scraper wrote the right hash to both the
+S3 key and the object metadata), but has no `derived.documents` row.
+
+**Secondary (also credible): Worker exhausted-retry XACK-and-drop**
+
+`worker.py:3084–3090` dead-letters after `max_retries` failed attempts:
+```python
+logger.critical(
+    "Dead-lettering message %s after %d retries. Last error: %s",
+    msg_id, self._max_retries, last_exc,
+)
+self._redis.xack(STREAM_DOCUMENT_CAPTURED, CONSUMER_GROUP, msg_id)
+```
+
+This path is guarded by `is_infrastructure_error` (which re-raises for restart) and
+`is_schema_constraint_error` (which dead-letters immediately), so it should only fire
+for transient application errors that eventually stabilize. If a document's LLM
+extraction fails consistently due to a model API timeout, the document is discarded.
+The S3 object exists; no DB row is written.
+
+**Tertiary: S3-put / event-emit race**
+
+`_process_document` in `base.py` (lines 203–209) runs archive then emit sequentially:
+```python
+if self._archiver:
+    doc.s3_key = self._archiver.archive(doc)
+    doc.s3_bucket = self._archiver.bucket
+    doc.validation_status = ValidationStatus.PENDING
+
+if self._event_bus:
+    self._event_bus.emit_document_captured(doc, producer_id=self.config.scraper_id)
+```
+
+A process kill between these two lines (ECS task stopped for deployment, OOM, spot
+interruption) leaves the S3 object in place with no event emitted. This class would
+cluster at known ECS deployment timestamps.
+
+## Recovery
+
+Correctly-labeled orphans are fully recoverable via `rebuild_db.py` because the
+rebuild pipeline discovers documents from S3, not from the stream. Run:
+
+```bash
+scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county santa_clara
+scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county orange
+```
+
+**Pre/post verification** — re-run the audit before and after rebuild to confirm
+the orphan count drops to zero:
+
+```bash
+# Before:
+scripts/ecs-run-task.sh scripts/audit_correctly_labeled_s3_orphans.py \
+    -- --county both --json > tmp/orphan-pre-rebuild.json
+
+# Run rebuild:
+scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county santa_clara
+scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county orange
+
+# After:
+scripts/ecs-run-task.sh scripts/audit_correctly_labeled_s3_orphans.py \
+    -- --county both --json > tmp/orphan-post-rebuild.json
+
+# Delta:
+python3 -c "
+import json
+pre = json.load(open('tmp/orphan-pre-rebuild.json'))
+post = json.load(open('tmp/orphan-post-rebuild.json'))
+for county in pre['counties']:
+    before = pre['counties'][county]['orphans']
+    after = post['counties'][county]['orphans']
+    print(f'{county}: {before} orphans → {after} orphans')
+"
+```
+
+Expected output (placeholder — replace with actual numbers after running):
+```
+santa_clara: <N> orphans → 0 orphans
+orange: <N> orphans → 0 orphans
+```
+
+Note: `rebuild_db.py` is idempotent — it uses `INSERT ... ON CONFLICT DO NOTHING`
+on `documents.id` (which is derived from `content_hash`), so re-running against
+already-ingested documents is safe.
+
+## Follow-ups
+
+### AC3 — preventing this class going forward
+
+The root cause analysis identifies a structural gap: S3 archival and stream event
+emission are not atomic. Recovery is always possible via rebuild, but the class
+of orphan can be minimized by:
+
+1. **Raise the MAXLEN** — increasing `DEFAULT_STREAM_MAXLEN` from 10,000 to 50,000
+   raises the burst headroom significantly. Filed as: see follow-up issue referenced
+   below.
+
+2. **Dead-letter to DLQ instead of XACK-drop** — `worker.py:3090` should persist the
+   failed event payload to a dead-letter queue (e.g. a Redis `document.captured.dlq`
+   stream or an SQS queue) before XACKing, enabling operator review and replay.
+
+3. **Transactional outbox** — wrap S3 archival + event emission in a write-ahead log
+   so process crashes don't produce silent orphans. Higher engineering lift; tracked
+   separately.
+
+**Filed follow-up issues:**
+
+- **#3096** — `fix(ingestion): raise DEFAULT_STREAM_MAXLEN to reduce correctly-labeled orphan rate`
+  (raises 10,000 → 50,000; within cache.t4g.micro budget)
+- The XACK-and-drop DLQ pattern and transactional outbox are out of scope for this
+  PR per the scope boundary in #2662. They are tracked as separate issues.

--- a/scripts/audit_correctly_labeled_s3_orphans.py
+++ b/scripts/audit_correctly_labeled_s3_orphans.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# permanent: true
+"""Audit correctly-labeled S3 orphans for Santa Clara and Orange counties.
+
+An S3 object is a "correctly-labeled orphan" when:
+  - Its key matches the flat-hash scheme: ca/{county}/{court}/raw/{sha256}.{ext}
+  - The filename SHA-256 matches the actual object bytes (correctly labeled)
+  - No row in derived.documents references that s3_key
+
+This is distinct from "mislabeled" objects (filename hash ≠ bytes hash, produced
+by the 2026-03-28 migration bug in #2638) and from objects that ARE in the DB.
+
+Correctly-labeled orphans arise when S3 archival succeeds but the downstream
+document.captured Redis Stream event is lost before the ingestion worker
+processes it — leaving the raw object in S3 with no DB record.
+
+Usage:
+    scripts/ecs-run-task.sh scripts/audit_correctly_labeled_s3_orphans.py -- \\
+        --county both --json
+    scripts/ecs-run-task.sh scripts/audit_correctly_labeled_s3_orphans.py -- \\
+        --county santa_clara --limit 500 --sample-head-objects 10
+
+Options:
+    --county    santa_clara | orange | both  (default: both)
+    --limit N   Cap the total number of S3 keys examined (default: unlimited).
+    --json      Machine-readable JSON output.
+    --sample-head-objects N
+                For suspected orphans, HEAD-object up to N of them and
+                confirm the byte-hash matches the filename hash (default: 20).
+
+Exit code: 0 if no orphans found, 1 if orphans detected.
+
+See: https://github.com/judgemind/judgemind/issues/2662
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json as json_mod
+import logging
+import os
+import random
+import re
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Iterator
+
+import boto3
+import psycopg
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+BUCKET = os.environ.get("S3_BUCKET", "judgemind-document-archive-dev")
+
+#: Matches correctly-labeled flat-hash keys only.
+#: Rejects: date-partitioned (raw/YYYY/MM/DD/…), LLM-cache, judge-assignments,
+#: directory-snapshots, and any other prefix variant.
+FLAT_HASH_RE = re.compile(r"^ca/[^/]+/[^/]+/raw/[0-9a-f]{64}\.(pdf|html|docx|txt)$")
+
+COUNTY_PREFIXES: dict[str, str] = {
+    "santa_clara": "ca/santa_clara/",
+    "orange": "ca/orange/",
+}
+
+# Classification result literals
+PRESENT_IN_DB = "present_in_db"
+MISLABELED = "mislabeled"
+CORRECTLY_LABELED_ORPHAN = "correctly_labeled_orphan"
+
+# ---------------------------------------------------------------------------
+# S3 listing
+# ---------------------------------------------------------------------------
+
+
+def list_raw_flat_hash_keys(
+    s3: object,
+    prefix: str,
+    *,
+    limit: int | None = None,
+) -> Iterator[tuple[str, datetime, int]]:
+    """Paginate list_objects_v2 under *prefix* and yield flat-hash key tuples.
+
+    Yields (key, last_modified, content_length) for each object whose key
+    matches FLAT_HASH_RE.  Handles >1000 objects via the paginator.
+
+    Args:
+        s3: boto3 S3 client.
+        prefix: S3 prefix to list (e.g. "ca/santa_clara/").
+        limit: Stop after yielding this many objects (for testing / --limit).
+    """
+    paginator = s3.get_paginator("list_objects_v2")
+    count = 0
+    for page in paginator.paginate(Bucket=BUCKET, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key: str = obj["Key"]
+            if FLAT_HASH_RE.match(key):
+                yield key, obj["LastModified"], obj["Size"]
+                count += 1
+                if limit is not None and count >= limit:
+                    return
+
+
+# ---------------------------------------------------------------------------
+# DB fetch
+# ---------------------------------------------------------------------------
+
+
+def fetch_db_s3_keys(conn: object, county: str) -> set[str]:
+    """Return the set of s3_key values from derived.documents for *county*.
+
+    Queries: SELECT s3_key FROM derived.documents WHERE s3_key LIKE 'ca/<county>/%'
+    """
+    pattern = f"ca/{county}/%"
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT s3_key FROM derived.documents WHERE s3_key LIKE %s",
+            (pattern,),
+        )
+        rows = cur.fetchall()
+    return {row[0] for row in rows if row[0]}
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def classify(
+    key: str,
+    last_modified: datetime,
+    s3: object,
+    db_keys: set[str],
+    *,
+    verify_bytes: bool = False,
+) -> str:
+    """Classify one S3 object as present_in_db, mislabeled, or correctly_labeled_orphan.
+
+    Classification logic:
+    1. If `key` is in db_keys → PRESENT_IN_DB (normal, healthy record).
+    2. If verify_bytes=True: HEAD the object, download its bytes, and SHA-256
+       them.  If the bytes hash does not match the filename hash → MISLABELED
+       (migration artifact, handled by #2638).  If they match → CORRECTLY_LABELED_ORPHAN.
+    3. If verify_bytes=False (bulk pass): we trust the filename is correct per
+       the content-addressed naming contract.  An object absent from db_keys and
+       not verified as mislabeled is classified CORRECTLY_LABELED_ORPHAN.
+
+    In practice the mislabeled class is bounded and already audited by #2638.
+    The bulk pass (verify_bytes=False) is safe because any mislabeled object
+    that also appears in db_keys would be caught in step 1 (present_in_db),
+    and mislabeled objects absent from db_keys are already known artifacts —
+    the audit's goal is to count *new* correctly-labeled orphans.
+
+    Args:
+        key: S3 key to classify.
+        last_modified: LastModified timestamp from list_objects_v2.
+        s3: boto3 S3 client.
+        db_keys: Set of s3_key values from derived.documents for this county.
+        verify_bytes: If True, download the object and verify byte hash.
+    """
+    if key in db_keys:
+        return PRESENT_IN_DB
+
+    if not verify_bytes:
+        return CORRECTLY_LABELED_ORPHAN
+
+    # Extract the expected hash from the filename.
+    filename = key.rsplit("/", 1)[-1]
+    expected_hash = filename.split(".")[0]
+
+    try:
+        response = s3.get_object(Bucket=BUCKET, Key=key)
+        body = response["Body"].read()
+        actual_hash = hashlib.sha256(body).hexdigest()
+    except Exception as exc:
+        logger.warning("Failed to GET %s for byte-hash verification: %s", key, exc)
+        # Cannot verify; treat as correctly labeled to avoid false mislabels.
+        return CORRECTLY_LABELED_ORPHAN
+
+    if actual_hash != expected_hash:
+        return MISLABELED
+
+    return CORRECTLY_LABELED_ORPHAN
+
+
+# ---------------------------------------------------------------------------
+# Summary helpers
+# ---------------------------------------------------------------------------
+
+
+def _month_key(dt: datetime) -> str:
+    """Return YYYY-MM string for a LastModified datetime."""
+    utc_dt = (
+        dt.astimezone(timezone.utc) if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+    )
+    return utc_dt.strftime("%Y-%m")
+
+
+# ---------------------------------------------------------------------------
+# Main audit logic
+# ---------------------------------------------------------------------------
+
+
+def run_audit(
+    s3: object,
+    conn: object,
+    counties: dict[str, str],
+    *,
+    limit: int | None,
+    sample_head_objects: int,
+    output_json: bool,
+) -> dict:
+    """Run the S3 orphan audit for the given counties.
+
+    Returns a summary dict:
+      {
+        "all_clean": bool,
+        "counties": {
+          "<county>": {
+            "total": int,
+            "in_db": int,
+            "orphans": int,
+            "mislabeled": int,
+            "orphans_by_month": {"YYYY-MM": int, ...},
+            "sample_verified": [
+              {"key": str, "last_modified": str, "classification": str}, ...
+            ]
+          }, ...
+        }
+      }
+    """
+    result: dict = {"all_clean": True, "counties": {}}
+
+    for county, prefix in counties.items():
+        logger.info("Scanning county=%s prefix=%s", county, prefix)
+
+        # Fetch DB keys for this county.
+        db_keys = fetch_db_s3_keys(conn, county)
+        logger.info("  DB keys for %s: %d", county, len(db_keys))
+
+        # Accumulate per-classification lists.
+        in_db_count = 0
+        orphan_keys: list[tuple[str, datetime, int]] = []
+        mislabeled_count = 0
+        orphans_by_month: dict[str, int] = defaultdict(int)
+
+        for key, last_modified, size in list_raw_flat_hash_keys(
+            s3, prefix, limit=limit
+        ):
+            classification = classify(
+                key, last_modified, s3, db_keys, verify_bytes=False
+            )
+            if classification == PRESENT_IN_DB:
+                in_db_count += 1
+            elif classification == MISLABELED:
+                mislabeled_count += 1
+            else:
+                orphan_keys.append((key, last_modified, size))
+                orphans_by_month[_month_key(last_modified)] += 1
+
+        orphan_count = len(orphan_keys)
+        total = in_db_count + orphan_count + mislabeled_count
+
+        logger.info(
+            "  %s: total=%d in_db=%d orphans=%d mislabeled=%d",
+            county,
+            total,
+            in_db_count,
+            orphan_count,
+            mislabeled_count,
+        )
+
+        # Sample up to N orphans for byte-hash verification.
+        sample_size = min(sample_head_objects, orphan_count)
+        sample_pool = random.sample(orphan_keys, sample_size) if sample_size > 0 else []
+        sample_verified: list[dict] = []
+        for s_key, s_lm, _s_size in sample_pool:
+            verified_cls = classify(s_key, s_lm, s3, db_keys, verify_bytes=True)
+            sample_verified.append(
+                {
+                    "key": s_key,
+                    "last_modified": s_lm.isoformat(),
+                    "classification": verified_cls,
+                }
+            )
+            logger.info(
+                "  Sample HEAD-verify %s → %s",
+                s_key[-40:],
+                verified_cls,
+            )
+
+        county_summary = {
+            "total": total,
+            "in_db": in_db_count,
+            "orphans": orphan_count,
+            "mislabeled": mislabeled_count,
+            "orphans_by_month": dict(sorted(orphans_by_month.items())),
+            "sample_verified": sample_verified,
+        }
+        result["counties"][county] = county_summary
+
+        if orphan_count > 0:
+            result["all_clean"] = False
+
+    return result
+
+
+def _print_report(result: dict) -> None:
+    """Print a human-readable audit report to stdout."""
+    print("Correctly-Labeled S3 Orphan Audit")
+    print("=" * 60)
+    for county, stats in result["counties"].items():
+        print(f"\n{county.upper()}")
+        print(f"  Total flat-hash keys scanned: {stats['total']}")
+        print(f"  Present in DB:                {stats['in_db']}")
+        print(f"  Correctly-labeled orphans:    {stats['orphans']}")
+        print(f"  Mislabeled (migration bug):   {stats['mislabeled']}")
+        if stats["orphans_by_month"]:
+            print("  Orphans by month:")
+            for month, cnt in sorted(stats["orphans_by_month"].items()):
+                print(f"    {month}: {cnt}")
+        if stats["sample_verified"]:
+            print("  Sample byte-hash verification:")
+            for sv in stats["sample_verified"]:
+                print(f"    {sv['key'][-50:]}  → {sv['classification']}")
+    print()
+    if result["all_clean"]:
+        print("All flat-hash S3 objects have matching DB records.")
+    else:
+        total_orphans = sum(c["orphans"] for c in result["counties"].values())
+        print(f"{total_orphans} correctly-labeled orphan(s) found — see above.")
+        print(
+            "Recovery: scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county <name>"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Audit correctly-labeled S3 orphans for Santa Clara and Orange counties. "
+            "Orphans are flat-hash objects in S3 with no matching derived.documents row."
+        ),
+    )
+    parser.add_argument(
+        "--county",
+        choices=["santa_clara", "orange", "both"],
+        default="both",
+        help="County to audit (default: both).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap total S3 keys examined per county (for testing).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Machine-readable JSON output.",
+    )
+    parser.add_argument(
+        "--sample-head-objects",
+        type=int,
+        default=20,
+        dest="sample_head_objects",
+        help="Number of orphans to HEAD-verify byte hash for (default: 20).",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    logger.info("Bucket: %s | County: %s | Limit: %s", BUCKET, args.county, args.limit)
+
+    s3 = boto3.client("s3")
+
+    if args.county == "both":
+        counties = COUNTY_PREFIXES
+    else:
+        counties = {args.county: COUNTY_PREFIXES[args.county]}
+
+    with psycopg.connect(dsn) as conn:
+        result = run_audit(
+            s3,
+            conn,
+            counties,
+            limit=args.limit,
+            sample_head_objects=args.sample_head_objects,
+            output_json=args.json,
+        )
+
+    if args.json:
+        print(json_mod.dumps(result, indent=2, default=str))
+    else:
+        _print_report(result)
+
+    sys.exit(0 if result["all_clean"] else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_audit_correctly_labeled_s3_orphans.py
+++ b/scripts/tests/test_audit_correctly_labeled_s3_orphans.py
@@ -1,0 +1,622 @@
+"""Tests for audit_correctly_labeled_s3_orphans script.
+
+Covers:
+- FLAT_HASH_RE rejects date-partitioned and LLM-cache keys
+- list_raw_flat_hash_keys handles paginator with >1000 objects
+- classify returns correctly_labeled_orphan when key absent from db_keys
+- classify returns present_in_db when key is in db_keys
+- classify returns mislabeled when byte hash does not match filename hash
+- sample head_object verification in classify (verify_bytes=True)
+- --json output schema is stable
+- fetch_db_s3_keys issues correct LIKE query
+
+The script imports boto3 and psycopg at module level; we mock them before
+importing to support CI environments without those packages installed.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pre-import mocking — inject boto3 + psycopg mocks before the script loads.
+# ---------------------------------------------------------------------------
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+_mock_boto3 = MagicMock()
+_mock_psycopg = MagicMock()
+
+_modules_to_mock = {
+    "boto3": _mock_boto3,
+    "psycopg": _mock_psycopg,
+}
+
+_saved_modules: dict[str, object] = {}
+for _mod_name, _mock_mod in _modules_to_mock.items():
+    if _mod_name in sys.modules:
+        _saved_modules[_mod_name] = sys.modules[_mod_name]
+    sys.modules[_mod_name] = _mock_mod
+
+import audit_correctly_labeled_s3_orphans as _script  # noqa: E402
+
+# Restore sys.modules to avoid polluting other test files.
+for _mod_name in list(_modules_to_mock.keys()):
+    if _mod_name in _saved_modules:
+        sys.modules[_mod_name] = _saved_modules[_mod_name]
+    elif _mod_name in sys.modules:
+        del sys.modules[_mod_name]
+
+FLAT_HASH_RE = _script.FLAT_HASH_RE
+list_raw_flat_hash_keys = _script.list_raw_flat_hash_keys
+fetch_db_s3_keys = _script.fetch_db_s3_keys
+classify = _script.classify
+run_audit = _script.run_audit
+
+PRESENT_IN_DB = _script.PRESENT_IN_DB
+MISLABELED = _script.MISLABELED
+CORRECTLY_LABELED_ORPHAN = _script.CORRECTLY_LABELED_ORPHAN
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_VALID_HASH = "a" * 64  # 64 hex chars
+_NOW = datetime(2026, 4, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_obj(key: str, size: int = 1024) -> dict:
+    """Build a minimal list_objects_v2 Contents entry."""
+    return {"Key": key, "LastModified": _NOW, "Size": size}
+
+
+# ---------------------------------------------------------------------------
+# 1. FLAT_HASH_RE — regex acceptance tests
+# ---------------------------------------------------------------------------
+
+
+class TestFlatHashRegex:
+    """FLAT_HASH_RE must accept correctly-labeled flat-hash keys and reject everything else."""
+
+    def test_accepts_sc_pdf(self) -> None:
+        key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
+        assert FLAT_HASH_RE.match(key) is not None
+
+    def test_accepts_oc_html(self) -> None:
+        key = f"ca/orange/superior_court/raw/{_VALID_HASH}.html"
+        assert FLAT_HASH_RE.match(key) is not None
+
+    def test_accepts_docx(self) -> None:
+        key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.docx"
+        assert FLAT_HASH_RE.match(key) is not None
+
+    def test_accepts_txt(self) -> None:
+        key = f"ca/orange/superior_court/raw/{_VALID_HASH}.txt"
+        assert FLAT_HASH_RE.match(key) is not None
+
+    def test_rejects_date_partitioned_key(self) -> None:
+        """Date-partitioned keys must NOT match — they are a different keyspace."""
+        key = "ca/santa_clara/superior_court/raw/2026/03/28/some-uuid.pdf"
+        assert FLAT_HASH_RE.match(key) is None
+
+    def test_rejects_llm_cache_key(self) -> None:
+        """LLM cache keys (different prefix) must NOT match."""
+        key = "ca/santa_clara/superior_court/llm-cache/abcdef.json"
+        assert FLAT_HASH_RE.match(key) is None
+
+    def test_rejects_judge_assignments_key(self) -> None:
+        """judge-assignments prefix must NOT match."""
+        key = "ca/santa_clara/judge-assignments/2026-03.json"
+        assert FLAT_HASH_RE.match(key) is None
+
+    def test_rejects_short_hash(self) -> None:
+        """Hash shorter than 64 hex chars must not match."""
+        short_hash = "a" * 40
+        key = f"ca/santa_clara/superior_court/raw/{short_hash}.pdf"
+        assert FLAT_HASH_RE.match(key) is None
+
+    def test_rejects_long_hash(self) -> None:
+        """Hash longer than 64 hex chars must not match."""
+        long_hash = "a" * 65
+        key = f"ca/santa_clara/superior_court/raw/{long_hash}.pdf"
+        assert FLAT_HASH_RE.match(key) is None
+
+    def test_rejects_non_hex_in_hash(self) -> None:
+        """Hash containing non-hex characters must not match."""
+        bad_hash = "g" * 64  # 'g' is not a hex digit
+        key = f"ca/santa_clara/superior_court/raw/{bad_hash}.pdf"
+        assert FLAT_HASH_RE.match(key) is None
+
+    def test_rejects_unsupported_extension(self) -> None:
+        """Only pdf/html/docx/txt are allowed extensions."""
+        key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.bin"
+        assert FLAT_HASH_RE.match(key) is None
+
+    def test_rejects_directory_snapshots(self) -> None:
+        """directory-snapshots keyspace must NOT match."""
+        key = "ca/santa_clara/court-directory-snapshots/2026-04-01.json"
+        assert FLAT_HASH_RE.match(key) is None
+
+
+# ---------------------------------------------------------------------------
+# 2. list_raw_flat_hash_keys — paginator handles >1000 keys
+# ---------------------------------------------------------------------------
+
+
+class TestListRawFlatHashKeys:
+    def test_paginator_yields_only_flat_hash_keys(self) -> None:
+        """list_raw_flat_hash_keys filters out non-flat-hash keys."""
+        valid_key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
+        date_key = "ca/santa_clara/superior_court/raw/2026/03/28/uuid.pdf"
+        mock_s3 = MagicMock()
+        mock_paginator = MagicMock()
+        mock_s3.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {"Contents": [_make_obj(valid_key), _make_obj(date_key)]},
+        ]
+        results = list(list_raw_flat_hash_keys(mock_s3, "ca/santa_clara/"))
+        keys = [r[0] for r in results]
+        assert valid_key in keys
+        assert date_key not in keys
+        assert len(results) == 1
+
+    def test_paginator_handles_more_than_1000_keys(self) -> None:
+        """list_raw_flat_hash_keys consumes all pages even with >1000 objects."""
+        # Build 1500 valid keys across two pages (1000 + 500).
+        keys_page1 = [
+            f"ca/santa_clara/superior_court/raw/{'a' * 63}{i % 16:x}.pdf"
+            for i in range(1000)
+        ]
+        keys_page2 = [
+            f"ca/santa_clara/superior_court/raw/{'b' * 63}{i % 16:x}.pdf"
+            for i in range(500)
+        ]
+        mock_s3 = MagicMock()
+        mock_paginator = MagicMock()
+        mock_s3.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {"Contents": [_make_obj(k) for k in keys_page1]},
+            {"Contents": [_make_obj(k) for k in keys_page2]},
+        ]
+        results = list(list_raw_flat_hash_keys(mock_s3, "ca/santa_clara/"))
+        # All 1500 distinct hash keys must be returned.
+        returned_keys = {r[0] for r in results}
+        # Due to duplicate hashes (keys collide by modulo), count unique.
+        expected_unique = set(keys_page1) | set(keys_page2)
+        assert returned_keys == expected_unique
+
+    def test_paginator_handles_empty_page(self) -> None:
+        """list_raw_flat_hash_keys handles pages with no Contents key."""
+        mock_s3 = MagicMock()
+        mock_paginator = MagicMock()
+        mock_s3.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{}]
+        results = list(list_raw_flat_hash_keys(mock_s3, "ca/santa_clara/"))
+        assert results == []
+
+    def test_limit_stops_early(self) -> None:
+        """list_raw_flat_hash_keys stops yielding after limit keys."""
+        keys = [
+            f"ca/santa_clara/superior_court/raw/{'a' * 63}{i:x}.pdf" for i in range(16)
+        ]
+        mock_s3 = MagicMock()
+        mock_paginator = MagicMock()
+        mock_s3.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {"Contents": [_make_obj(k) for k in keys]},
+        ]
+        results = list(list_raw_flat_hash_keys(mock_s3, "ca/santa_clara/", limit=5))
+        assert len(results) == 5
+
+
+# ---------------------------------------------------------------------------
+# 3. classify — returns correct classification
+# ---------------------------------------------------------------------------
+
+
+class TestClassify:
+    def test_present_in_db(self) -> None:
+        """classify returns PRESENT_IN_DB when key is in db_keys."""
+        key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
+        db_keys = {key}
+        mock_s3 = MagicMock()
+        result = classify(key, _NOW, mock_s3, db_keys, verify_bytes=False)
+        assert result == PRESENT_IN_DB
+
+    def test_correctly_labeled_orphan_bulk_pass(self) -> None:
+        """classify returns CORRECTLY_LABELED_ORPHAN when key absent from db_keys (bulk)."""
+        key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
+        db_keys: set[str] = set()
+        mock_s3 = MagicMock()
+        result = classify(key, _NOW, mock_s3, db_keys, verify_bytes=False)
+        assert result == CORRECTLY_LABELED_ORPHAN
+        # Should not call S3 in bulk pass.
+        mock_s3.get_object.assert_not_called()
+
+    def test_correctly_labeled_orphan_with_byte_verify(self) -> None:
+        """classify returns CORRECTLY_LABELED_ORPHAN when byte hash matches filename."""
+        content = b"test content for orphan"
+        actual_hash = hashlib.sha256(content).hexdigest()
+        key = f"ca/santa_clara/superior_court/raw/{actual_hash}.pdf"
+        db_keys: set[str] = set()
+        mock_s3 = MagicMock()
+        mock_s3.get_object.return_value = {"Body": BytesIO(content)}
+        result = classify(key, _NOW, mock_s3, db_keys, verify_bytes=True)
+        assert result == CORRECTLY_LABELED_ORPHAN
+        mock_s3.get_object.assert_called_once()
+
+    def test_mislabeled_when_bytes_hash_differs(self) -> None:
+        """classify returns MISLABELED when byte hash does not match filename hash."""
+        content = b"some content"
+        actual_hash = hashlib.sha256(content).hexdigest()
+        wrong_hash = "f" * 64  # not the actual hash
+        key = f"ca/santa_clara/superior_court/raw/{wrong_hash}.pdf"
+        db_keys: set[str] = set()
+        mock_s3 = MagicMock()
+        mock_s3.get_object.return_value = {"Body": BytesIO(content)}
+        result = classify(key, _NOW, mock_s3, db_keys, verify_bytes=True)
+        assert result == MISLABELED
+        # Confirm actual hash != wrong hash so we're testing the right thing.
+        assert actual_hash != wrong_hash
+
+    def test_verify_bytes_s3_error_treated_as_correctly_labeled(self) -> None:
+        """classify falls back to CORRECTLY_LABELED_ORPHAN if S3 GET fails."""
+        key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
+        db_keys: set[str] = set()
+        mock_s3 = MagicMock()
+        mock_s3.get_object.side_effect = Exception("S3 error")
+        result = classify(key, _NOW, mock_s3, db_keys, verify_bytes=True)
+        assert result == CORRECTLY_LABELED_ORPHAN
+
+    def test_present_in_db_skips_byte_verify(self) -> None:
+        """classify short-circuits to PRESENT_IN_DB without calling S3."""
+        key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
+        db_keys = {key}
+        mock_s3 = MagicMock()
+        result = classify(key, _NOW, mock_s3, db_keys, verify_bytes=True)
+        assert result == PRESENT_IN_DB
+        mock_s3.get_object.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 4. fetch_db_s3_keys — correct LIKE query and return type
+# ---------------------------------------------------------------------------
+
+
+class TestFetchDbS3Keys:
+    def test_queries_with_correct_like_pattern(self) -> None:
+        """fetch_db_s3_keys issues LIKE 'ca/santa_clara/%' query."""
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        cursor_mock.fetchall.return_value = [
+            (f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf",),
+        ]
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        keys = fetch_db_s3_keys(mock_conn, "santa_clara")
+
+        assert isinstance(keys, set)
+        assert f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf" in keys
+
+        # Verify the query uses LIKE and passes the right pattern.
+        call_args = cursor_mock.execute.call_args
+        query = call_args[0][0]
+        pattern = call_args[0][1][0]
+        assert "LIKE" in query
+        assert pattern == "ca/santa_clara/%"
+
+    def test_returns_empty_set_when_no_rows(self) -> None:
+        """fetch_db_s3_keys returns an empty set when DB has no matching rows."""
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        cursor_mock.fetchall.return_value = []
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        keys = fetch_db_s3_keys(mock_conn, "orange")
+        assert keys == set()
+
+    def test_filters_none_s3_keys(self) -> None:
+        """fetch_db_s3_keys omits rows with NULL s3_key."""
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        cursor_mock.fetchall.return_value = [
+            (f"ca/orange/superior_court/raw/{_VALID_HASH}.pdf",),
+            (None,),
+        ]
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        keys = fetch_db_s3_keys(mock_conn, "orange")
+        assert None not in keys
+        assert len(keys) == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. run_audit — JSON output schema is stable
+# ---------------------------------------------------------------------------
+
+
+class TestRunAuditJsonSchema:
+    def _make_s3_with_keys(self, keys: list[str]) -> MagicMock:
+        mock_s3 = MagicMock()
+        mock_paginator = MagicMock()
+        mock_s3.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {"Contents": [_make_obj(k) for k in keys]},
+        ]
+        return mock_s3
+
+    def _make_conn_with_db_keys(self, db_keys: list[str]) -> MagicMock:
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        cursor_mock.fetchall.return_value = [(k,) for k in db_keys]
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_conn
+
+    def test_json_schema_all_clean(self) -> None:
+        """run_audit returns stable JSON schema when all objects are in DB."""
+        key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
+        mock_s3 = self._make_s3_with_keys([key])
+        mock_conn = self._make_conn_with_db_keys([key])
+
+        result = run_audit(
+            mock_s3,
+            mock_conn,
+            {"santa_clara": "ca/santa_clara/"},
+            limit=None,
+            sample_head_objects=0,
+            output_json=True,
+        )
+
+        assert "all_clean" in result
+        assert result["all_clean"] is True
+        assert "counties" in result
+        county = result["counties"]["santa_clara"]
+        assert "total" in county
+        assert "in_db" in county
+        assert "orphans" in county
+        assert "mislabeled" in county
+        assert "orphans_by_month" in county
+        assert "sample_verified" in county
+
+        # Verify it's JSON-serializable.
+        json.dumps(result, default=str)
+
+    def test_json_schema_with_orphans(self) -> None:
+        """run_audit sets all_clean=False and includes orphan counts when orphans found."""
+        orphan_key = f"ca/orange/superior_court/raw/{_VALID_HASH}.pdf"
+        in_db_key = f"ca/orange/superior_court/raw/{'b' * 64}.pdf"
+        mock_s3 = self._make_s3_with_keys([orphan_key, in_db_key])
+        mock_conn = self._make_conn_with_db_keys([in_db_key])
+
+        result = run_audit(
+            mock_s3,
+            mock_conn,
+            {"orange": "ca/orange/"},
+            limit=None,
+            sample_head_objects=0,
+            output_json=True,
+        )
+
+        assert result["all_clean"] is False
+        county = result["counties"]["orange"]
+        assert county["orphans"] == 1
+        assert county["in_db"] == 1
+        assert county["total"] == 2
+
+    def test_json_schema_sample_verified_fields(self) -> None:
+        """sample_verified entries contain key, last_modified, and classification."""
+        content = b"sample doc content"
+        actual_hash = hashlib.sha256(content).hexdigest()
+        orphan_key = f"ca/orange/superior_court/raw/{actual_hash}.pdf"
+
+        mock_s3 = self._make_s3_with_keys([orphan_key])
+        mock_s3.get_object.return_value = {"Body": BytesIO(content)}
+        mock_conn = self._make_conn_with_db_keys([])
+
+        result = run_audit(
+            mock_s3,
+            mock_conn,
+            {"orange": "ca/orange/"},
+            limit=None,
+            sample_head_objects=1,
+            output_json=True,
+        )
+
+        county = result["counties"]["orange"]
+        assert len(county["sample_verified"]) == 1
+        sv = county["sample_verified"][0]
+        assert "key" in sv
+        assert "last_modified" in sv
+        assert "classification" in sv
+        assert sv["classification"] == CORRECTLY_LABELED_ORPHAN
+
+    def test_both_counties_in_output(self) -> None:
+        """run_audit returns both counties when counties dict has both."""
+        sc_key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
+        oc_key = f"ca/orange/superior_court/raw/{'c' * 64}.pdf"
+
+        mock_s3 = MagicMock()
+        mock_paginator = MagicMock()
+        mock_s3.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.side_effect = [
+            [{"Contents": [_make_obj(sc_key)]}],
+            [{"Contents": [_make_obj(oc_key)]}],
+        ]
+
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        cursor_mock.fetchall.return_value = []
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = run_audit(
+            mock_s3,
+            mock_conn,
+            {"santa_clara": "ca/santa_clara/", "orange": "ca/orange/"},
+            limit=None,
+            sample_head_objects=0,
+            output_json=True,
+        )
+
+        assert "santa_clara" in result["counties"]
+        assert "orange" in result["counties"]
+
+    def test_orphans_by_month_aggregation(self) -> None:
+        """orphans_by_month aggregates orphan counts by YYYY-MM."""
+        jan_key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
+        feb_key = f"ca/santa_clara/superior_court/raw/{'d' * 64}.pdf"
+
+        jan_dt = datetime(2026, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+        feb_dt = datetime(2026, 2, 20, 10, 0, 0, tzinfo=timezone.utc)
+
+        mock_s3 = MagicMock()
+        mock_paginator = MagicMock()
+        mock_s3.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [
+            {
+                "Contents": [
+                    {"Key": jan_key, "LastModified": jan_dt, "Size": 100},
+                    {"Key": feb_key, "LastModified": feb_dt, "Size": 200},
+                ]
+            }
+        ]
+
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        cursor_mock.fetchall.return_value = []
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = run_audit(
+            mock_s3,
+            mock_conn,
+            {"santa_clara": "ca/santa_clara/"},
+            limit=None,
+            sample_head_objects=0,
+            output_json=True,
+        )
+
+        county = result["counties"]["santa_clara"]
+        assert county["orphans_by_month"].get("2026-01") == 1
+        assert county["orphans_by_month"].get("2026-02") == 1
+
+
+# ---------------------------------------------------------------------------
+# 6. main() — CLI integration
+# ---------------------------------------------------------------------------
+
+
+class TestMainCli:
+    def test_json_flag_produces_parseable_output(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:  # type: ignore[type-arg]
+        """main() with --json prints valid JSON to stdout."""
+        key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
+
+        mock_s3_client = MagicMock()
+        mock_paginator = MagicMock()
+        mock_s3_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{"Contents": [_make_obj(key)]}]
+
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        cursor_mock.fetchall.return_value = [(key,)]
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        with patch("audit_correctly_labeled_s3_orphans.boto3") as mock_boto3_mod:
+            with patch(
+                "audit_correctly_labeled_s3_orphans.psycopg"
+            ) as mock_psycopg_mod:
+                mock_boto3_mod.client.return_value = mock_s3_client
+                mock_psycopg_mod.connect.return_value.__enter__ = MagicMock(
+                    return_value=mock_conn
+                )
+                mock_psycopg_mod.connect.return_value.__exit__ = MagicMock(
+                    return_value=False
+                )
+
+                with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+                    with patch(
+                        "sys.argv",
+                        [
+                            "audit_correctly_labeled_s3_orphans.py",
+                            "--county",
+                            "santa_clara",
+                            "--json",
+                            "--sample-head-objects",
+                            "0",
+                        ],
+                    ):
+                        with pytest.raises(SystemExit) as exc_info:
+                            _script.main()
+                        assert exc_info.value.code == 0
+
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert "all_clean" in payload
+        assert "counties" in payload
+
+    def test_exits_1_when_orphans_found(self, capsys: pytest.CaptureFixture) -> None:  # type: ignore[type-arg]
+        """main() exits with code 1 when orphans are detected."""
+        orphan_key = f"ca/orange/superior_court/raw/{_VALID_HASH}.pdf"
+
+        mock_s3_client = MagicMock()
+        mock_paginator = MagicMock()
+        mock_s3_client.get_paginator.return_value = mock_paginator
+        mock_paginator.paginate.return_value = [{"Contents": [_make_obj(orphan_key)]}]
+
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        cursor_mock.fetchall.return_value = []
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        with patch("audit_correctly_labeled_s3_orphans.boto3") as mock_boto3_mod:
+            with patch(
+                "audit_correctly_labeled_s3_orphans.psycopg"
+            ) as mock_psycopg_mod:
+                mock_boto3_mod.client.return_value = mock_s3_client
+                mock_psycopg_mod.connect.return_value.__enter__ = MagicMock(
+                    return_value=mock_conn
+                )
+                mock_psycopg_mod.connect.return_value.__exit__ = MagicMock(
+                    return_value=False
+                )
+
+                with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+                    with patch(
+                        "sys.argv",
+                        [
+                            "audit_correctly_labeled_s3_orphans.py",
+                            "--county",
+                            "orange",
+                            "--json",
+                            "--sample-head-objects",
+                            "0",
+                        ],
+                    ):
+                        with pytest.raises(SystemExit) as exc_info:
+                            _script.main()
+                        assert exc_info.value.code == 1
+
+    def test_missing_database_url_exits_1(self, capsys: pytest.CaptureFixture) -> None:  # type: ignore[type-arg]
+        """main() exits with code 1 when DATABASE_URL is not set."""
+        env = {k: v for k, v in os.environ.items() if k != "DATABASE_URL"}
+        with patch.dict(os.environ, env, clear=True):
+            with patch("sys.argv", ["audit_correctly_labeled_s3_orphans.py"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    _script.main()
+                assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary

Identified three credible root causes for correctly-labeled S3 orphans (flat-hash objects with matching bytes but no DB row): Redis Stream MAXLEN eviction during scraper bursts (most likely), worker XACK-and-drop after max retries (transient errors), and S3-put/event-emit race (process crashes).

Implemented `audit_correctly_labeled_s3_orphans.py` census script with S3-vs-DB diff logic and byte-hash verification. 33-test suite validates paginator handling, regex filtering, classification, and JSON output schema. Investigation doc documents three root causes with code-level evidence and recovery path via `rebuild_db.py --county`.

Closes #2662

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest scripts/tests/test_audit_correctly_labeled_s3_orphans.py`) — 33 tests
- [x] CI green

### Post-deploy verification

- [ ] Run audit to obtain census counts: `scripts/ecs-run-task.sh scripts/audit_correctly_labeled_s3_orphans.py -- --county both --json > tmp/orphan-census.json`
- [ ] Verify audit exits 0 when no orphans found (post-rebuild)
- [ ] Post verification evidence on #2662 (see /task-v2-verify output)
