### PR TITLE
feat(dispatcher): retry hot-path git/gh subprocess calls via shared helper (#3089)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,6 +611,14 @@ jobs:
       # time.
       - name: Verify every daemon terminal site has a ROUTING comment
         run: scripts/check-terminal-routing-comments.sh
+      # Issue #3089: every ``subprocess.run([... "git" | "gh" ...])``
+      # call site in ``scripts/dispatcher/daemon.py`` must either route
+      # through the shared ``_subprocess_with_retry`` helper or carry a
+      # nearby ``# cold-path (#3089)`` annotation. Prevents the
+      # #3053/#3085 class of single-transient-failure bug from creeping
+      # back in.
+      - name: Verify every daemon git/gh subprocess site has retry or cold-path annotation
+        run: scripts/check-git-gh-retries.sh
       # Issue #3082: operator laptops run macOS's stock bash 3.2.
       # Shell scripts under scripts/**/*.sh must stick to the bash 3.2
       # subset — no mapfile, readarray, associative arrays, nameref,

--- a/scripts/check-git-gh-retries.sh
+++ b/scripts/check-git-gh-retries.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# check-git-gh-retries.sh — Every ``subprocess.run([... "git" | "gh" ...])``
+# call site in ``scripts/dispatcher/daemon.py`` must either:
+#   (a) route through the shared ``_subprocess_with_retry`` helper, OR
+#   (b) carry a nearby ``# cold-path (#3089)`` annotation explaining why
+#       a single-failure outcome is acceptable.
+#
+# Why this check exists
+# ---------------------
+# Each unretried network subprocess in the daemon hot path is a
+# single-transient-failure-cost bug of the same shape as #3053 (fixed
+# ``_gh_issue_is_open``) and #3085 (fixed ``_baseline_fetch_origin_main``).
+# Issue #3089 did an audit pass and decided per-site: wrap hot-path
+# calls in the shared ``_subprocess_with_retry`` helper; annotate
+# cold-path calls with a ``# cold-path (#3089): ...`` comment. This
+# check enforces that every future author of a new ``git`` / ``gh``
+# subprocess.run either picks up the retry helper or documents why not
+# — preventing the cascade of flake-induced agent terminations that
+# motivated the audit.
+#
+# Rule
+# ----
+# Every ``subprocess.run(...)`` call site in ``scripts/dispatcher/daemon.py``
+# whose first positional argument resolves to a list literal beginning
+# with ``"git"`` or ``"gh"`` MUST have a ``# cold-path (#3089)`` comment
+# within ``COLDPATH_WINDOW_LINES`` lines immediately above the call line.
+#
+# The check deliberately does NOT check for the retry helper wiring —
+# the helper itself uses ``subprocess.run(cmd, ...)`` internally, and
+# the parametric ``cmd`` arg means the first-literal-element heuristic
+# won't fire there. Hot-path sites route through the helper via
+# ``self._subprocess_with_retry(cmd, ...)`` (NOT ``subprocess.run``),
+# so they disappear from this check's radar entirely after the refactor
+# — no false positives. The ``# cold-path (#3089)`` comment annotates
+# the surviving direct-subprocess.run sites, which by definition are
+# cold-path by construction.
+#
+# Tracking: issue #3089.
+#
+# Usage
+# -----
+#   scripts/check-git-gh-retries.sh            # scan the real daemon.py
+#   scripts/check-git-gh-retries.sh [file]     # scan a specific file (tests)
+#
+# Exit codes
+# ----------
+#   0 — Every call site has a cold-path annotation within the window.
+#   1 — At least one call site is missing a nearby cold-path comment.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_FILE="${1:-$REPO_ROOT/scripts/dispatcher/daemon.py}"
+
+# Window size — 60 lines matches the typical subprocess.run call-site
+# shape (a few lines of setup + the call + try/except handler), with
+# some slack for docstrings or helper prologue. Override with the
+# COLDPATH_WINDOW_LINES env var for ad-hoc experiments; production
+# always uses the default.
+: "${COLDPATH_WINDOW_LINES:=60}"
+
+# ─── Fast exit if the target file does not exist ─────────────────────────
+if [[ ! -f "$TARGET_FILE" ]]; then
+    echo "check-git-gh-retries: no target file at $TARGET_FILE — nothing to check."
+    exit 0
+fi
+
+# ─── Locate candidate call sites ─────────────────────────────────────────
+# We use python to parse the AST because a regex-only approach would
+# either miss name-bound cmd lists (``cmd = [...]; subprocess.run(cmd, ...)``)
+# or produce too many false positives on multi-line calls. The python
+# helper emits one line per offending call site: just the line number.
+python_output="$(python3 - "$TARGET_FILE" <<'PYEOF'
+import ast
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+tree = ast.parse(path.read_text())
+
+
+def _literal_str(node):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _list_first_literal(node):
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return None
+    if not node.elts:
+        return None
+    return _literal_str(node.elts[0])
+
+
+def _enclosing_func(line_no):
+    best = None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.lineno <= line_no <= (node.end_lineno or node.lineno):
+                if best is None or node.lineno > best.lineno:
+                    best = node
+    return best
+
+
+def _resolve_name(name, before_line):
+    """Resolve ``name`` to its most recent list-literal Assign within
+    the enclosing function scope. Returns None if the name is a
+    function parameter (cannot resolve) or if no in-scope Assign
+    binds it to a list literal."""
+    scope = _enclosing_func(before_line)
+    if scope is None:
+        return None
+    best = None
+    for sub in ast.walk(scope):
+        if isinstance(sub, ast.Assign) and sub.lineno < before_line:
+            for target in sub.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    if isinstance(sub.value, (ast.List, ast.Tuple)):
+                        best = sub.value
+    return best
+
+
+for node in ast.walk(tree):
+    if not isinstance(node, ast.Call):
+        continue
+    func = node.func
+    if not (
+        isinstance(func, ast.Attribute)
+        and func.attr == "run"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "subprocess"
+    ):
+        continue
+    if not node.args:
+        continue
+    first = node.args[0]
+    tool = None
+    if isinstance(first, (ast.List, ast.Tuple)):
+        tool = _list_first_literal(first)
+    elif isinstance(first, ast.Name):
+        resolved = _resolve_name(first.id, node.lineno)
+        if resolved is not None:
+            tool = _list_first_literal(resolved)
+    if tool in ("git", "gh"):
+        print(node.lineno)
+PYEOF
+)"
+
+# ─── Check each call site ────────────────────────────────────────────────
+violations=0
+missing=()
+
+if [[ -z "${python_output// /}" ]]; then
+    echo "check-git-gh-retries: no git/gh subprocess.run sites in $TARGET_FILE — nothing to check."
+    exit 0
+fi
+
+while IFS= read -r call_line; do
+    [[ -z "$call_line" ]] && continue
+    window_start=$((call_line - COLDPATH_WINDOW_LINES))
+    (( window_start < 1 )) && window_start=1
+
+    # Use awk to extract the window lines and grep for the annotation.
+    # ``# cold-path (#3089)`` is the exact marker — any other form is
+    # rejected so operators can't accidentally satisfy the check with a
+    # generic cold-path comment.
+    window_text="$(awk -v s="$window_start" -v e="$call_line" \
+        'NR >= s && NR <= e' "$TARGET_FILE")"
+    if ! printf '%s' "$window_text" | grep -qE '# cold-path \(#3089\)'; then
+        missing+=("$call_line")
+        violations=$((violations + 1))
+    fi
+done <<< "$python_output"
+
+if (( violations > 0 )); then
+    echo "ERROR: subprocess.run([\"git\"|\"gh\", ...]) site(s) missing a nearby '# cold-path (#3089)' annotation."
+    echo ""
+    echo "  Target: $TARGET_FILE"
+    echo "  Window: ${COLDPATH_WINDOW_LINES} lines above each call site."
+    echo ""
+    echo "  Every git/gh subprocess call site must either:"
+    echo "    (a) route through self._subprocess_with_retry(...), OR"
+    echo "    (b) carry a '# cold-path (#3089): <reason>' comment nearby."
+    echo ""
+    echo "  See #3089 for the audit + classification reference."
+    echo ""
+    echo "  Sites missing an annotation:"
+    echo ""
+    for line in "${missing[@]}"; do
+        snippet="$(sed -n "${line}p" "$TARGET_FILE")"
+        echo "    $TARGET_FILE:${line}: ${snippet}"
+    done
+    echo ""
+    echo "  Fix: add a comment above the call such as"
+    echo ""
+    echo "    # cold-path (#3089): local fs op, no network — retry adds no value."
+    echo ""
+    echo "  Or route through the shared helper:"
+    echo ""
+    echo "    outcome = self._subprocess_with_retry(cmd, event_name='<site>', timeout=...)"
+    echo "    if not outcome['ok']:"
+    echo "        ..."
+    exit 1
+fi
+
+total_count="$(printf '%s\n' "$python_output" | grep -c . || true)"
+echo "check-git-gh-retries: ${total_count} direct git/gh subprocess.run site(s) all covered by a cold-path (#3089) annotation within ${COLDPATH_WINDOW_LINES} lines."
+exit 0

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -2954,31 +2954,35 @@ class DispatcherDaemon:
             "--limit",
             str(QUEUE_SCAN_PAGE_LIMIT),
         ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=QUEUE_SCAN_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except FileNotFoundError as exc:
-            raise RuntimeError(f"gh CLI not on PATH: {exc}") from exc
-        except subprocess.TimeoutExpired as exc:
-            raise RuntimeError(
-                f"gh issue list timed out after "
-                f"{QUEUE_SCAN_SUBPROCESS_TIMEOUT_SECONDS}s"
-            ) from exc
-
-        if result.returncode != 0:
+        # Issue #3089: hot-path queue scan — route through the shared
+        # 3-attempt 1s+2s retry helper so a single transient ``gh``
+        # flake doesn't convert an otherwise-healthy tick into a -1
+        # queue-depth snapshot.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="queue_scan",
+            timeout=QUEUE_SCAN_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+        if not outcome["ok"]:
+            reason = outcome.get("reason")
+            stderr_tail = outcome.get("stderr_tail") or ""
+            if reason == "gh_missing":
+                raise RuntimeError(f"gh CLI not on PATH: {stderr_tail}")
+            if reason == "timeout":
+                raise RuntimeError(
+                    f"gh issue list timed out after "
+                    f"{QUEUE_SCAN_SUBPROCESS_TIMEOUT_SECONDS}s"
+                )
             # Never include stderr verbatim in the daemon's structured log
             # at info level — it may echo the PAT on auth errors. A short
             # prefix is safe and sufficient for triage.
-            stderr_preview = (result.stderr or "").strip().splitlines()[:1]
+            stderr_preview = stderr_tail.strip().splitlines()[:1]
+            exit_code = outcome.get("exit_code")
             raise RuntimeError(
-                f"gh issue list exit={result.returncode}: "
+                f"gh issue list exit={exit_code}: "
                 f"{stderr_preview[0] if stderr_preview else '<no stderr>'}"
             )
+        result = outcome["result"]
 
         try:
             issues = json.loads(result.stdout or "[]")
@@ -3131,28 +3135,31 @@ class DispatcherDaemon:
             "--limit",
             str(BLOCKED_SCAN_PAGE_LIMIT),
         ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=QUEUE_SCAN_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except FileNotFoundError as exc:
-            raise RuntimeError(f"gh CLI not on PATH: {exc}") from exc
-        except subprocess.TimeoutExpired as exc:
+        # Issue #3089: hot-path blocked scan — route through the shared
+        # 3-attempt 1s+2s retry helper so a single transient ``gh``
+        # flake doesn't produce a -1 blocked-depth snapshot.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="blocked_scan",
+            timeout=QUEUE_SCAN_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+        if not outcome["ok"]:
+            reason = outcome.get("reason")
+            stderr_tail = outcome.get("stderr_tail") or ""
+            if reason == "gh_missing":
+                raise RuntimeError(f"gh CLI not on PATH: {stderr_tail}")
+            if reason == "timeout":
+                raise RuntimeError(
+                    f"gh issue list (blocked) timed out after "
+                    f"{QUEUE_SCAN_SUBPROCESS_TIMEOUT_SECONDS}s"
+                )
+            stderr_preview = stderr_tail.strip().splitlines()[:1]
+            exit_code = outcome.get("exit_code")
             raise RuntimeError(
-                f"gh issue list (blocked) timed out after "
-                f"{QUEUE_SCAN_SUBPROCESS_TIMEOUT_SECONDS}s"
-            ) from exc
-
-        if result.returncode != 0:
-            stderr_preview = (result.stderr or "").strip().splitlines()[:1]
-            raise RuntimeError(
-                f"gh issue list (blocked) exit={result.returncode}: "
+                f"gh issue list (blocked) exit={exit_code}: "
                 f"{stderr_preview[0] if stderr_preview else '<no stderr>'}"
             )
+        result = outcome["result"]
 
         try:
             issues = json.loads(result.stdout or "[]")
@@ -3978,6 +3985,9 @@ class DispatcherDaemon:
         startup error.
         """
         cmd = ["gh", "auth", "setup-git"]
+        # cold-path (#3089): boot-time one-shot; a failure is logged and
+        # startup continues. The ECS task restart loop re-runs this on
+        # the next boot if credentials genuinely are broken.
         try:
             result = subprocess.run(
                 cmd,
@@ -4054,6 +4064,9 @@ class DispatcherDaemon:
         ]
         attempted = 0
         for name, colour, description in required:
+            # cold-path (#3089): boot-time one-shot; failures are logged
+            # and startup continues. The diagnoser path still works
+            # without the GitHub-visible label hint.
             try:
                 subprocess.run(
                     [
@@ -4321,6 +4334,10 @@ class DispatcherDaemon:
             BASELINE_CLONE_URL,
             str(baseline),
         ]
+        # cold-path (#3089): boot-time one-shot clone. A fatal error
+        # here is the right terminal signal — ECS restarts the task,
+        # re-clones from a clean slate. Mechanical retry inside the
+        # same task adds no value (pre-#3089 status quo).
         try:
             result = subprocess.run(
                 cmd,
@@ -4349,6 +4366,181 @@ class DispatcherDaemon:
                 "action": "clone",
             },
         )
+
+    # ------------------------------------------------------------------
+    # Shared subprocess retry helper (#3089).
+    #
+    # Every network-bound ``git`` or ``gh`` call in the hot path should
+    # route through ``_subprocess_with_retry`` — 3 attempts with 1s +
+    # 2s backoff, ``<event_name>_flake`` WARNING per failed attempt,
+    # ``<event_name>_exhausted`` WARNING on full exhaustion. Mirrors the
+    # shape established by :meth:`_baseline_fetch_origin_main` (#3085)
+    # and :meth:`_gh_issue_is_open_with_detail` (#3053) and folds their
+    # boilerplate into a single helper.
+    #
+    # The helper is transient-failure agnostic: ``TimeoutExpired``,
+    # ``FileNotFoundError`` (CLI missing), and non-zero exit codes all
+    # count as retryable. JSON parse failures are the caller's
+    # responsibility (same split as the pre-#3089 helpers) — a zero-exit
+    # ``subprocess.run`` whose stdout is malformed JSON should not
+    # trigger an extra network round-trip.
+    #
+    # Cold-path sites (local filesystem ops, boot-time one-shots,
+    # already-tier-routed failures) do NOT use this helper — they
+    # carry a ``# cold-path (#3089): ...`` comment explaining why a
+    # single-failure outcome is acceptable. The
+    # ``scripts/check-git-gh-retries.sh`` hygiene check enforces the
+    # routing.
+    # ------------------------------------------------------------------
+
+    def _subprocess_with_retry(
+        self,
+        cmd: list[str],
+        *,
+        event_name: str,
+        timeout: float,
+        extra_log_fields: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Run ``cmd`` with 3-attempt 1s+2s backoff retry. Never raises.
+
+        Issue #3089. Generalises the retry envelopes from #3053
+        (``_gh_issue_is_open_with_detail``) and #3085
+        (``_baseline_fetch_origin_main``) into a single shared helper
+        so every network-bound ``git`` / ``gh`` call in the daemon hot
+        path can opt in with one line. The retry budget (3 attempts,
+        1s + 2s backoff) and the flake/exhausted logging convention
+        are deliberately identical to #3053 / #3085 so operators see
+        one consistent event shape in CloudWatch.
+
+        Return shape (never raises):
+
+        * ``{"ok": True, "result": CompletedProcess, "attempts": int}``
+          — subprocess exited 0 on attempt ``attempts``. Caller
+          inspects ``result.stdout`` / ``result.returncode`` normally.
+        * ``{"ok": False, "reason": str, "stderr_tail": str,
+              "exit_code": int|None, "attempts": int}`` — all 3
+          attempts failed with the same or mixed transient reasons.
+          ``reason`` is one of ``"timeout"`` / ``"nonzero_exit"`` /
+          ``"gh_missing"``; ``exit_code`` is populated when the final
+          attempt was a non-zero exit. Callers emit their site-
+          specific fallback (return None, raise, route via
+          ``_handle_agent_failure``, etc.).
+
+        Log events:
+
+        * Happy-path first-attempt success: silent — preserves the
+          pre-retry log cadence so the common case doesn't flood
+          CloudWatch.
+        * Each failed attempt: WARNING with ``event=<name>_flake``,
+          carrying ``attempt`` / ``max_attempts`` / ``reason`` /
+          ``stderr_tail`` plus any ``extra_log_fields`` the caller
+          passes (e.g. ``issue_number``, ``pr_number``).
+        * Full exhaustion: WARNING with ``event=<name>_exhausted``,
+          carrying ``attempts`` / ``reason`` / ``stderr_tail`` plus
+          the same ``extra_log_fields``.
+
+        ``cmd`` must be a list (``subprocess.run`` with ``shell=False``
+        by default). ``timeout`` is passed verbatim to each
+        ``subprocess.run`` attempt — NOT the total budget, since the
+        retry loop adds at most 3s of sleep between attempts. Callers
+        that care about wall-clock can halve their per-attempt
+        ``timeout`` to keep the worst-case in line with the pre-retry
+        budget, but most callers will be fine with the full per-attempt
+        budget since transient GitHub flakes return quickly.
+
+        This helper is hot-path only. Cold-path local-only git
+        operations (``git rev-parse``, ``git format-patch``, ``git am``,
+        ``git worktree add``) and boot-time one-shots (``git clone``,
+        ``gh auth setup-git``, ``ensure_required_labels``) carry a
+        ``# cold-path (#3089): <reason>`` comment at the call site
+        rather than routing through here — a retry on a local-only
+        failure just burns 3s to re-hit the same deterministic error.
+        See ``scripts/check-git-gh-retries.sh`` for the hygiene check.
+        """
+        backoffs_seconds: tuple[float, ...] = (1.0, 2.0)
+        max_attempts = 1 + len(backoffs_seconds)  # 3
+        last_reason: str | None = None
+        last_stderr_tail = ""
+        last_stderr_full = ""
+        last_exit_code: int | None = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    check=False,
+                )
+            except FileNotFoundError as exc:
+                last_reason = "gh_missing"
+                last_stderr_tail = str(exc)
+                last_stderr_full = str(exc)
+                last_exit_code = None
+            except subprocess.TimeoutExpired:
+                last_reason = "timeout"
+                last_stderr_tail = ""
+                last_stderr_full = ""
+                last_exit_code = None
+            else:
+                if result.returncode == 0:
+                    return {
+                        "ok": True,
+                        "result": result,
+                        "attempts": attempt,
+                    }
+                last_reason = "nonzero_exit"
+                last_stderr_tail = _stderr_tail(result.stderr)
+                last_stderr_full = result.stderr or ""
+                last_exit_code = result.returncode
+            # Transient failure — emit flake WARNING and (if attempts
+            # remain) back off.
+            flake_extra: dict[str, Any] = {
+                "event": f"{event_name}_flake",
+                "run_id": self._run_id,
+                "attempt": attempt,
+                "max_attempts": max_attempts,
+                "reason": last_reason,
+                "stderr_tail": last_stderr_tail,
+            }
+            if extra_log_fields:
+                flake_extra.update(extra_log_fields)
+            self._log.warning(
+                "daemon.%s_flake (attempt %d/%d): %s",
+                event_name,
+                attempt,
+                max_attempts,
+                last_reason,
+                extra=flake_extra,
+            )
+            if attempt < max_attempts:
+                time.sleep(backoffs_seconds[attempt - 1])
+        # All attempts exhausted — emit final WARNING and return
+        # structured outcome so callers can take their site-specific
+        # fallback.
+        exhausted_extra: dict[str, Any] = {
+            "event": f"{event_name}_exhausted",
+            "run_id": self._run_id,
+            "attempts": max_attempts,
+            "reason": last_reason,
+            "stderr_tail": last_stderr_tail,
+        }
+        if extra_log_fields:
+            exhausted_extra.update(extra_log_fields)
+        self._log.warning(
+            "daemon.%s_exhausted %d attempts — surfacing outcome",
+            event_name,
+            max_attempts,
+            extra=exhausted_extra,
+        )
+        return {
+            "ok": False,
+            "reason": last_reason,
+            "stderr_tail": last_stderr_tail,
+            "stderr_full": last_stderr_full,
+            "exit_code": last_exit_code,
+            "attempts": max_attempts,
+        }
 
     def _baseline_fetch_origin_main(self) -> None:
         """Run ``git -C <baseline> fetch origin main``. Raise on failure.
@@ -4457,6 +4649,9 @@ class DispatcherDaemon:
           ``exit=<code>`` shape.
         """
         cmd = ["git", "-C", str(baseline), "fetch", "origin", "main"]
+        # cold-path (#3089): the ``_once`` probe itself is wrapped in a
+        # 3-attempt 1s+2s retry loop by the parent
+        # ``_baseline_fetch_origin_main`` (#3085).
         try:
             result = subprocess.run(
                 cmd,
@@ -4512,6 +4707,9 @@ class DispatcherDaemon:
             "rev-parse",
             "--is-shallow-repository",
         ]
+        # cold-path (#3089): local rev-parse probe, best-effort at
+        # boot. The subsequent ``_baseline_fetch_origin_main`` retry
+        # still runs and will surface any actual connectivity problem.
         try:
             probe = subprocess.run(
                 is_shallow_cmd,
@@ -4559,6 +4757,9 @@ class DispatcherDaemon:
             "origin",
             "main",
         ]
+        # cold-path (#3089): boot-time one-shot upgrade of a legacy
+        # shallow clone. A failure is logged and the daemon continues;
+        # the next boot re-probes and retries.
         try:
             result = subprocess.run(
                 unshallow_cmd,
@@ -4641,6 +4842,8 @@ class DispatcherDaemon:
         # branch -D`` returns 1 when the branch doesn't exist, which is
         # the happy case on first attempt. The 10s timeout guards
         # against a wedged git process without blocking normal flow.
+        # cold-path (#3089): local fs operation, no network; exit code
+        # is intentionally ignored.
         subprocess.run(
             [
                 "git",
@@ -4667,6 +4870,10 @@ class DispatcherDaemon:
             branch,
             "origin/main",
         ]
+        # cold-path (#3089): local fs operation (``git worktree add``
+        # consults the already-fetched baseline clone — no network).
+        # Failures are deterministic (disk full, permission bit,
+        # conflicting worktree dir); retry adds cost without value.
         try:
             result = subprocess.run(
                 cmd,
@@ -4793,6 +5000,10 @@ class DispatcherDaemon:
         for target in (target_hook, target_helper):
             # Repo-relative path for the update-index call.
             rel = target.relative_to(worktree_path)
+            # cold-path (#3089): local fs ``git update-index``,
+            # best-effort. Failure means the ``git status`` / pre-push /
+            # PR diff carries the hook swap as a noise change; the hook
+            # file itself is still swapped.
             try:
                 subprocess.run(
                     [
@@ -4854,24 +5065,25 @@ class DispatcherDaemon:
             "--json",
             "number,title,body,labels,comments,updatedAt",
         ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=30,
-                check=False,
-            )
-        except FileNotFoundError as exc:
-            raise RuntimeError(f"gh CLI not on PATH: {exc}") from exc
-        except subprocess.TimeoutExpired as exc:
-            raise RuntimeError("gh issue view timed out after 30s") from exc
-
-        if result.returncode != 0:
-            stderr_preview = _stderr_tail(result.stderr)
-            raise RuntimeError(
-                f"gh issue view exit={result.returncode}: {stderr_preview}"
-            )
+        # Issue #3089: hot-path issue-bundle fetch for plan phase —
+        # retry transient ``gh`` flakes so a single timeout doesn't
+        # tank the agent's whole plan pipeline.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="issue_bundle_fetch",
+            timeout=30,
+            extra_log_fields={"issue_number": issue_number},
+        )
+        if not outcome["ok"]:
+            reason = outcome.get("reason")
+            stderr_tail = outcome.get("stderr_tail") or ""
+            if reason == "gh_missing":
+                raise RuntimeError(f"gh CLI not on PATH: {stderr_tail}")
+            if reason == "timeout":
+                raise RuntimeError("gh issue view timed out after 30s")
+            exit_code = outcome.get("exit_code")
+            raise RuntimeError(f"gh issue view exit={exit_code}: {stderr_tail}")
+        result = outcome["result"]
 
         try:
             payload = json.loads(result.stdout or "{}")
@@ -5180,6 +5392,7 @@ class DispatcherDaemon:
         # Capture the patch via git format-patch -1 HEAD --stdout.
         # A 60s timeout is generous — format-patch is local-only and
         # typically finishes in <1s even on large worktrees.
+        # cold-path (#3089): local fs operation, no network.
         try:
             patch_result = subprocess.run(
                 [
@@ -5228,6 +5441,7 @@ class DispatcherDaemon:
         patch_content = patch_result.stdout
 
         # Best-effort HEAD SHA — informational only, NULL on failure.
+        # cold-path (#3089): local rev-parse, no network.
         commit_sha: str | None = None
         try:
             sha_result = subprocess.run(
@@ -5497,6 +5711,9 @@ class DispatcherDaemon:
         # Try ``git am --3way <patchfile>``. --3way gives a better
         # chance of success when base has moved; without it, any drift
         # produces an apply failure even for non-overlapping hunks.
+        # cold-path (#3089): local fs operation; failures are real
+        # merge conflicts (not transient), so retrying the same patch
+        # won't change the outcome.
         try:
             am_result = subprocess.run(
                 [
@@ -5620,6 +5837,7 @@ class DispatcherDaemon:
         (e.g. if there's no in-progress am), and we've already logged
         the underlying apply failure.
         """
+        # cold-path (#3089): local fs am --abort; best-effort teardown.
         try:
             subprocess.run(
                 ["git", "-C", str(worktree), "am", "--abort"],
@@ -5645,6 +5863,7 @@ class DispatcherDaemon:
         block (it tells ralph how much work it's inheriting); a wrong
         count does not affect correctness.
         """
+        # cold-path (#3089): local fs ``git diff``.
         try:
             result = subprocess.run(
                 [
@@ -5917,6 +6136,8 @@ class DispatcherDaemon:
         SHA sequence without faking ``subprocess.run`` for every call
         in :meth:`_ralph_head_watcher_loop`.
         """
+        # cold-path (#3089): local rev-parse, no network; a missed read
+        # is handled by the caller polling again on the next tick.
         try:
             result = subprocess.run(
                 ["git", "-C", str(worktree), "rev-parse", "HEAD"],
@@ -6012,6 +6233,7 @@ class DispatcherDaemon:
         # additional commit beyond the placeholder. Ralph amends
         # in-place per #2971 so there's typically one commit, but the
         # range form is safe regardless.
+        # cold-path (#3089): local fs format-patch, no network.
         try:
             patch_result = subprocess.run(
                 [
@@ -6059,6 +6281,7 @@ class DispatcherDaemon:
         patch_content = patch_result.stdout
 
         # Best-effort HEAD SHA — same pattern as _capture_and_persist_ralph_patch.
+        # cold-path (#3089): local rev-parse, no network.
         commit_sha: str | None = None
         try:
             sha_result = subprocess.run(
@@ -6600,6 +6823,7 @@ class DispatcherDaemon:
             "--count",
             "origin/main..HEAD",
         ]
+        # cold-path (#3089): local rev-list, no network.
         try:
             result = subprocess.run(
                 cmd,
@@ -6638,6 +6862,7 @@ class DispatcherDaemon:
             "--pretty=format:",
             "HEAD",
         ]
+        # cold-path (#3089): local git show, no network.
         try:
             result = subprocess.run(
                 cmd,
@@ -8062,38 +8287,28 @@ class DispatcherDaemon:
             "--json",
             "comments",
         ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=PLAN_BLOCKED_GH_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        # Issue #3089: hot-path sentinel check in the plan-blocked
+        # handler — route through the shared retry helper so a single
+        # transient flake does not double-post the plan-blocked comment.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="plan_blocked_sentinel_check",
+            timeout=PLAN_BLOCKED_GH_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"issue_number": issue_number},
+        )
+        if not outcome["ok"]:
             self._log.warning(
                 "daemon.plan_blocked_sentinel_check_failed",
                 extra={
                     "event": "plan_blocked_sentinel_check_failed",
                     "run_id": self._run_id,
                     "issue_number": issue_number,
-                    "error": str(exc),
+                    "error": outcome.get("reason"),
+                    "stderr_preview": outcome.get("stderr_tail"),
                 },
             )
             return None
-
-        if result.returncode != 0:
-            self._log.warning(
-                "daemon.plan_blocked_sentinel_check_failed",
-                extra={
-                    "event": "plan_blocked_sentinel_check_failed",
-                    "run_id": self._run_id,
-                    "issue_number": issue_number,
-                    "exit_code": result.returncode,
-                    "stderr_preview": _stderr_tail(result.stderr),
-                },
-            )
-            return None
+        result = outcome["result"]
 
         try:
             payload = json.loads(result.stdout or "{}")
@@ -8216,28 +8431,16 @@ class DispatcherDaemon:
             "--body-file",
             str(body_path),
         ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=PLAN_BLOCKED_GH_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            self._log.exception(
-                "daemon.plan_blocked_comment_failed",
-                extra={
-                    "event": "plan_blocked_comment_failed",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "issue_number": issue_number,
-                    "error": str(exc),
-                },
-            )
-            return False
-
-        if result.returncode != 0:
+        # Issue #3089: hot-path plan-blocked comment post — retry
+        # transient flakes so operators see the block reason even
+        # through a GitHub hiccup.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="plan_blocked_comment_post",
+            timeout=PLAN_BLOCKED_GH_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"agent_id": agent_id, "issue_number": issue_number},
+        )
+        if not outcome["ok"]:
             self._log.warning(
                 "daemon.plan_blocked_comment_failed",
                 extra={
@@ -8245,8 +8448,9 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "issue_number": issue_number,
-                    "exit_code": result.returncode,
-                    "stderr_preview": _stderr_tail(result.stderr),
+                    "exit_code": outcome.get("exit_code"),
+                    "error": outcome.get("reason"),
+                    "stderr_preview": outcome.get("stderr_tail"),
                 },
             )
             return False
@@ -8283,28 +8487,16 @@ class DispatcherDaemon:
             "--add-label",
             "status/triage",
         ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=PLAN_BLOCKED_GH_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            self._log.exception(
-                "daemon.plan_blocked_labels_failed",
-                extra={
-                    "event": "plan_blocked_labels_failed",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "issue_number": issue_number,
-                    "error": str(exc),
-                },
-            )
-            return False
-
-        if result.returncode != 0:
+        # Issue #3089: hot-path label mutation — retry transient flakes
+        # so the claim interlock swap completes even through a GitHub
+        # hiccup.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="plan_blocked_labels",
+            timeout=PLAN_BLOCKED_GH_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"agent_id": agent_id, "issue_number": issue_number},
+        )
+        if not outcome["ok"]:
             self._log.warning(
                 "daemon.plan_blocked_labels_failed",
                 extra={
@@ -8312,8 +8504,9 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "issue_number": issue_number,
-                    "exit_code": result.returncode,
-                    "stderr_preview": _stderr_tail(result.stderr),
+                    "exit_code": outcome.get("exit_code"),
+                    "error": outcome.get("reason"),
+                    "stderr_preview": outcome.get("stderr_tail"),
                 },
             )
             return False
@@ -8500,38 +8693,29 @@ class DispatcherDaemon:
             "--json",
             "comments",
         ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=NEEDS_REVIEW_GH_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+        # Issue #3089: hot-path sentinel check in the needs-review
+        # handler — retry transient flakes so operators see the draft
+        # PR link even through a GitHub hiccup.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="needs_review_sentinel_check",
+            timeout=NEEDS_REVIEW_GH_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"issue_number": issue_number},
+        )
+        if not outcome["ok"]:
             self._log.warning(
                 "daemon.needs_review_sentinel_check_failed",
                 extra={
                     "event": "needs_review_sentinel_check_failed",
                     "run_id": self._run_id,
                     "issue_number": issue_number,
-                    "error": str(exc),
+                    "exit_code": outcome.get("exit_code"),
+                    "error": outcome.get("reason"),
+                    "stderr_preview": outcome.get("stderr_tail"),
                 },
             )
             return None
-
-        if result.returncode != 0:
-            self._log.warning(
-                "daemon.needs_review_sentinel_check_failed",
-                extra={
-                    "event": "needs_review_sentinel_check_failed",
-                    "run_id": self._run_id,
-                    "issue_number": issue_number,
-                    "exit_code": result.returncode,
-                    "stderr_preview": _stderr_tail(result.stderr),
-                },
-            )
-            return None
+        result = outcome["result"]
 
         try:
             payload = json.loads(result.stdout or "{}")
@@ -8617,28 +8801,15 @@ class DispatcherDaemon:
             "--body-file",
             str(body_path),
         ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=NEEDS_REVIEW_GH_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            self._log.exception(
-                "daemon.needs_review_comment_failed",
-                extra={
-                    "event": "needs_review_comment_failed",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "issue_number": issue_number,
-                    "error": str(exc),
-                },
-            )
-            return False
-
-        if result.returncode != 0:
+        # Issue #3089: hot-path needs-review comment post — retry
+        # transient flakes.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="needs_review_comment_post",
+            timeout=NEEDS_REVIEW_GH_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"agent_id": agent_id, "issue_number": issue_number},
+        )
+        if not outcome["ok"]:
             self._log.warning(
                 "daemon.needs_review_comment_failed",
                 extra={
@@ -8646,8 +8817,9 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "issue_number": issue_number,
-                    "exit_code": result.returncode,
-                    "stderr_preview": _stderr_tail(result.stderr),
+                    "exit_code": outcome.get("exit_code"),
+                    "error": outcome.get("reason"),
+                    "stderr_preview": outcome.get("stderr_tail"),
                 },
             )
             return False
@@ -9456,6 +9628,9 @@ class DispatcherDaemon:
         # summary phase to map back to AC. The diff is against
         # ``origin/main`` since the agent branch was just created from
         # it in ``_create_worktree``.
+        # cold-path (#3089): local fs ``git diff`` on the worktree, no
+        # network; failure falls back to an empty diff and the summary
+        # skill tolerates it.
         try:
             diff_result = subprocess.run(
                 [
@@ -9479,6 +9654,7 @@ class DispatcherDaemon:
         # Fall back to a git-state read if ralph didn't populate
         # changed_files (non-testable short-circuit path).
         if not changed_files:
+            # cold-path (#3089): local fs ``git diff --name-only``.
             try:
                 status_result = subprocess.run(
                     [
@@ -10313,6 +10489,10 @@ class DispatcherDaemon:
         commit_msg_path.parent.mkdir(parents=True, exist_ok=True)
         commit_msg_path.write_text(commit_message)
 
+        # cold-path (#3089): local fs ``git commit --amend``; failures
+        # are deterministic (pre-push hook, empty diff) and route
+        # through ``_handle_agent_failure`` → diagnoser, which reads
+        # stderr and decides retry/escalate.
         try:
             commit_result = subprocess.run(
                 [
@@ -10434,84 +10614,90 @@ class DispatcherDaemon:
         # git push -u origin <branch>
         short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
         branch = f"agent/{short_id}"
-        try:
-            push_result = subprocess.run(
-                [
-                    "git",
-                    "-C",
-                    str(worktree),
-                    "push",
-                    "-u",
-                    "origin",
-                    branch,
-                ],
-                capture_output=True,
-                text=True,
-                timeout=GIT_PUSH_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except subprocess.TimeoutExpired as exc:
-            tail = _stderr_tail(getattr(exc, "stderr", None))
-            self._log.exception(
-                "daemon.git_push_timeout",
-                extra={
-                    "event": "git_push_timeout",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "timeout_seconds": GIT_PUSH_TIMEOUT_SECONDS,
-                    "stderr_tail": tail,
-                    "detail": str(exc),
-                },
-            )
-            self._persist_phase_output(
-                agent_id,
-                phase="push_and_pr",
-                output_json={"event": "git_push_timeout", "branch": branch},
-                log_text=tail,
-            )
-            # Issue #3032: route through the unified failure handler so
-            # the diagnoser picks this up on the next supervisor tick.
-            # ``git_push_network`` is now a TIER_2_FIRST_OCCURRENCE
-            # category.
-            self._handle_agent_failure(
-                agent_id=agent_id,
-                phase="push_and_pr",
-                category=FAILURE_CATEGORY_GIT_PUSH_NETWORK,
-                stderr_tail=tail,
-                exit_code=None,
-                details={"branch": branch, "reason": "timeout"},
-                issue_number=issue_number,
-            )
-            return
-        except Exception as exc:
-            self._log.exception(
-                "daemon.git_push_failed",
-                extra={
-                    "event": "git_push_failed",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "detail": str(exc),
-                },
-            )
-            self._persist_phase_output(
-                agent_id,
-                phase="push_and_pr",
-                output_json={"event": "git_push_failed", "branch": branch},
-                log_text=str(exc),
-            )
-            # Issue #3032: route through the unified failure handler.
-            self._handle_agent_failure(
-                agent_id=agent_id,
-                phase="push_and_pr",
-                category=FAILURE_CATEGORY_PUSH_FAILED,
-                stderr_tail=str(exc),
-                exit_code=None,
-                details={"branch": branch},
-                issue_number=issue_number,
-            )
-            return
-        if push_result.returncode != 0:
-            tail = _stderr_tail(push_result.stderr)
+        push_cmd = [
+            "git",
+            "-C",
+            str(worktree),
+            "push",
+            "-u",
+            "origin",
+            branch,
+        ]
+        # Issue #3089: hot-path ``git push`` — retry transient flakes
+        # (network blips, GitHub 5xx) before falling through to the
+        # existing ``_handle_agent_failure`` routing that kicks the
+        # diagnoser on persistent failure. Retries save the diagnoser
+        # cycle on true flakes; deterministic failures (hook rejection,
+        # PAT scope) still route through the same classification path.
+        push_outcome = self._subprocess_with_retry(
+            push_cmd,
+            event_name="git_push",
+            timeout=GIT_PUSH_TIMEOUT_SECONDS,
+            extra_log_fields={
+                "agent_id": agent_id,
+                "branch": branch,
+                "issue_number": issue_number,
+            },
+        )
+        if not push_outcome["ok"]:
+            reason = push_outcome.get("reason")
+            tail = push_outcome.get("stderr_tail") or ""
+            stderr_full = push_outcome.get("stderr_full") or ""
+            if reason == "timeout":
+                self._log.exception(
+                    "daemon.git_push_timeout",
+                    extra={
+                        "event": "git_push_timeout",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "timeout_seconds": GIT_PUSH_TIMEOUT_SECONDS,
+                        "stderr_tail": tail,
+                    },
+                )
+                self._persist_phase_output(
+                    agent_id,
+                    phase="push_and_pr",
+                    output_json={"event": "git_push_timeout", "branch": branch},
+                    log_text=tail,
+                )
+                self._handle_agent_failure(
+                    agent_id=agent_id,
+                    phase="push_and_pr",
+                    category=FAILURE_CATEGORY_GIT_PUSH_NETWORK,
+                    stderr_tail=tail,
+                    exit_code=None,
+                    details={"branch": branch, "reason": "timeout"},
+                    issue_number=issue_number,
+                )
+                return
+            if reason == "gh_missing":
+                self._log.exception(
+                    "daemon.git_push_failed",
+                    extra={
+                        "event": "git_push_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "detail": tail,
+                    },
+                )
+                self._persist_phase_output(
+                    agent_id,
+                    phase="push_and_pr",
+                    output_json={"event": "git_push_failed", "branch": branch},
+                    log_text=tail,
+                )
+                self._handle_agent_failure(
+                    agent_id=agent_id,
+                    phase="push_and_pr",
+                    category=FAILURE_CATEGORY_PUSH_FAILED,
+                    stderr_tail=tail,
+                    exit_code=None,
+                    details={"branch": branch},
+                    issue_number=issue_number,
+                )
+                return
+            # nonzero_exit — classify + route
+            exit_code = push_outcome.get("exit_code")
             category = _classify_push_failure(tail)
             self._log.warning(
                 "daemon.git_push_failed",
@@ -10519,7 +10705,7 @@ class DispatcherDaemon:
                     "event": "git_push_failed",
                     "run_id": self._run_id,
                     "agent_id": agent_id,
-                    "exit_code": push_result.returncode,
+                    "exit_code": exit_code,
                     "stderr_tail": tail,
                     "category": category,
                     "branch": branch,
@@ -10530,24 +10716,25 @@ class DispatcherDaemon:
                 phase="push_and_pr",
                 output_json={
                     "event": "git_push_failed",
-                    "exit_code": push_result.returncode,
+                    "exit_code": exit_code,
                     "branch": branch,
                 },
-                log_text=(push_result.stderr or ""),
+                # Preserve the pre-#3089 contract: ``log_text`` is the
+                # FULL stderr (not the 4000-char tail) so operators
+                # reading ``phase_outputs`` see the whole diagnostic.
+                log_text=stderr_full or tail,
             )
-            # Issue #3032: route through the unified failure handler.
-            # The classifier's pre_push_hook_rejected / git_push_network
-            # / push_failed categories are all tier-2 first-occurrence.
             self._handle_agent_failure(
                 agent_id=agent_id,
                 phase="push_and_pr",
                 category=category,
                 stderr_tail=tail,
-                exit_code=push_result.returncode,
+                exit_code=exit_code,
                 details={"branch": branch},
                 issue_number=issue_number,
             )
             return
+        push_result = push_outcome["result"]  # noqa: F841 — preserved for parity with pre-#3089 flow
 
         # gh pr create with --body-file pointing to a scratch file in
         # the worktree's tmp/. ``--draft`` is added on the needs_review
@@ -10572,60 +10759,67 @@ class DispatcherDaemon:
         ]
         if is_needs_review:
             pr_create_cmd.append("--draft")
-        try:
-            pr_result = subprocess.run(
-                pr_create_cmd,
-                capture_output=True,
-                text=True,
-                timeout=120,
-                check=False,
-            )
-        except Exception as exc:
-            self._log.exception(
-                "daemon.pr_create_failed",
-                extra={
-                    "event": "pr_create_failed",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "detail": str(exc),
-                },
-            )
-            # Issue #3032: route through the unified failure handler so
-            # the Opus diagnoser can tell a duplicate-PR hit from a
-            # genuine gh-CLI break from a transient GitHub API wobble.
-            self._handle_agent_failure(
-                agent_id=agent_id,
-                phase="push_and_pr",
-                category=FAILURE_CATEGORY_PR_CREATE_FAILED,
-                stderr_tail=str(exc),
-                exit_code=None,
-                details={"branch": branch, "reason": "exception"},
-                issue_number=issue_number,
-            )
-            return
-        if pr_result.returncode != 0:
-            pr_stderr_tail = _stderr_tail(pr_result.stderr)
+        # Issue #3089: hot-path ``gh pr create`` — retry transient
+        # flakes before routing through the diagnoser. A duplicate-PR
+        # stderr is deterministic (retry is wasteful but harmless);
+        # a 502/timeout is the common transient failure mode that
+        # benefits from retry.
+        pr_outcome = self._subprocess_with_retry(
+            pr_create_cmd,
+            event_name="pr_create",
+            timeout=120,
+            extra_log_fields={
+                "agent_id": agent_id,
+                "branch": branch,
+                "issue_number": issue_number,
+            },
+        )
+        if not pr_outcome["ok"]:
+            reason = pr_outcome.get("reason")
+            pr_stderr_tail = pr_outcome.get("stderr_tail") or ""
+            exit_code = pr_outcome.get("exit_code")
+            if reason in ("timeout", "gh_missing"):
+                self._log.exception(
+                    "daemon.pr_create_failed",
+                    extra={
+                        "event": "pr_create_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "detail": pr_stderr_tail or reason,
+                    },
+                )
+                self._handle_agent_failure(
+                    agent_id=agent_id,
+                    phase="push_and_pr",
+                    category=FAILURE_CATEGORY_PR_CREATE_FAILED,
+                    stderr_tail=pr_stderr_tail or str(reason),
+                    exit_code=None,
+                    details={"branch": branch, "reason": reason},
+                    issue_number=issue_number,
+                )
+                return
+            # nonzero_exit
             self._log.warning(
                 "daemon.pr_create_failed",
                 extra={
                     "event": "pr_create_failed",
                     "run_id": self._run_id,
                     "agent_id": agent_id,
-                    "exit_code": pr_result.returncode,
+                    "exit_code": exit_code,
                     "stderr_tail": pr_stderr_tail,
                 },
             )
-            # Issue #3032: route through the unified failure handler.
             self._handle_agent_failure(
                 agent_id=agent_id,
                 phase="push_and_pr",
                 category=FAILURE_CATEGORY_PR_CREATE_FAILED,
                 stderr_tail=pr_stderr_tail,
-                exit_code=pr_result.returncode,
+                exit_code=exit_code,
                 details={"branch": branch},
                 issue_number=issue_number,
             )
             return
+        pr_result = pr_outcome["result"]
 
         pr_number = self._parse_pr_number(pr_result.stdout or "")
         pr_url = (
@@ -11043,47 +11237,47 @@ class DispatcherDaemon:
             "--json",
             "statusCheckRollup,mergeable,mergeStateStatus,headRefOid,mergeCommit",
         ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except FileNotFoundError:
-            self._log.warning(
-                "daemon.gh_missing",
-                extra={
-                    "event": "gh_missing",
-                    "run_id": self._run_id,
-                    "pr_number": pr_number,
-                },
-            )
+        # Issue #3089: hot-path PR status poll — retry transient flakes
+        # so a single GitHub 502 doesn't waste a supervisor tick.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="pr_view",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"pr_number": pr_number},
+        )
+        if not outcome["ok"]:
+            reason = outcome.get("reason")
+            if reason == "gh_missing":
+                self._log.warning(
+                    "daemon.gh_missing",
+                    extra={
+                        "event": "gh_missing",
+                        "run_id": self._run_id,
+                        "pr_number": pr_number,
+                    },
+                )
+            elif reason == "timeout":
+                self._log.warning(
+                    "daemon.pr_view_timeout",
+                    extra={
+                        "event": "pr_view_timeout",
+                        "run_id": self._run_id,
+                        "pr_number": pr_number,
+                    },
+                )
+            else:
+                self._log.warning(
+                    "daemon.pr_view_failed",
+                    extra={
+                        "event": "pr_view_failed",
+                        "run_id": self._run_id,
+                        "pr_number": pr_number,
+                        "exit_code": outcome.get("exit_code"),
+                        "stderr_tail": outcome.get("stderr_tail"),
+                    },
+                )
             return None
-        except subprocess.TimeoutExpired:
-            self._log.warning(
-                "daemon.pr_view_timeout",
-                extra={
-                    "event": "pr_view_timeout",
-                    "run_id": self._run_id,
-                    "pr_number": pr_number,
-                },
-            )
-            return None
-
-        if result.returncode != 0:
-            self._log.warning(
-                "daemon.pr_view_failed",
-                extra={
-                    "event": "pr_view_failed",
-                    "run_id": self._run_id,
-                    "pr_number": pr_number,
-                    "exit_code": result.returncode,
-                    "stderr_tail": _stderr_tail(result.stderr),
-                },
-            )
-            return None
+        result = outcome["result"]
 
         try:
             return json.loads(result.stdout or "{}")
@@ -11195,48 +11389,47 @@ class DispatcherDaemon:
             "--squash",
             "--delete-branch",
         ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS * 2,
-                check=False,
-            )
-        except FileNotFoundError:
-            self._log.warning(
-                "daemon.gh_missing",
-                extra={
-                    "event": "gh_missing",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                },
-            )
-            return
-        except subprocess.TimeoutExpired:
-            self._log.warning(
-                "daemon.pr_merge_timeout",
-                extra={
-                    "event": "pr_merge_timeout",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "pr_number": pr_number,
-                },
-            )
-            return
-
-        if result.returncode != 0:
-            self._log.warning(
-                "daemon.pr_merge_failed",
-                extra={
-                    "event": "pr_merge_failed",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "pr_number": pr_number,
-                    "exit_code": result.returncode,
-                    "stderr_tail": _stderr_tail(result.stderr),
-                },
-            )
+        # Issue #3089: hot-path PR merge — retry transient flakes so a
+        # single GitHub 502 doesn't waste a supervisor tick.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="pr_merge",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS * 2,
+            extra_log_fields={"agent_id": agent_id, "pr_number": pr_number},
+        )
+        if not outcome["ok"]:
+            reason = outcome.get("reason")
+            if reason == "gh_missing":
+                self._log.warning(
+                    "daemon.gh_missing",
+                    extra={
+                        "event": "gh_missing",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                    },
+                )
+            elif reason == "timeout":
+                self._log.warning(
+                    "daemon.pr_merge_timeout",
+                    extra={
+                        "event": "pr_merge_timeout",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "pr_number": pr_number,
+                    },
+                )
+            else:
+                self._log.warning(
+                    "daemon.pr_merge_failed",
+                    extra={
+                        "event": "pr_merge_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "pr_number": pr_number,
+                        "exit_code": outcome.get("exit_code"),
+                        "stderr_tail": outcome.get("stderr_tail"),
+                    },
+                )
             return
 
         # Extract the merge commit SHA from the PR status if available;
@@ -11520,19 +11713,18 @@ class DispatcherDaemon:
             "--repo",
             self._cfg.github_repo,
         ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired):
+        # Issue #3089: hot-path PR diff fetch for fix-CI input — retry
+        # transient flakes so the fix-CI skill gets real diff context
+        # instead of falling back to an empty input.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="pr_diff_fetch",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"pr_number": pr_number},
+        )
+        if not outcome["ok"]:
             return ""
-        if result.returncode != 0:
-            return ""
-        return result.stdout or ""
+        return outcome["result"].stdout or ""
 
     def _branch_for_agent(self, agent_id: str) -> str:
         """Return the agent's branch name derived from agent_id."""
@@ -11635,6 +11827,9 @@ class DispatcherDaemon:
             return
 
         # git add -A
+        # cold-path (#3089): local fs ``git add``; failures are
+        # deterministic and route via ``_handle_fix_ci_apply_failure``
+        # → diagnoser.
         try:
             add_result = subprocess.run(
                 ["git", "-C", str(worktree), "add", "-A"],
@@ -11691,6 +11886,9 @@ class DispatcherDaemon:
         commit_msg_path.parent.mkdir(parents=True, exist_ok=True)
         commit_msg_path.write_text(commit_message)
 
+        # cold-path (#3089): local fs ``git commit``; failures are
+        # deterministic (nothing staged, pre-push hook) and route via
+        # ``_handle_fix_ci_apply_failure`` → diagnoser.
         try:
             commit_result = subprocess.run(
                 [
@@ -11753,70 +11951,77 @@ class DispatcherDaemon:
             return
 
         # git push
-        try:
-            push_result = subprocess.run(
-                [
-                    "git",
-                    "-C",
-                    str(worktree),
-                    "push",
-                    "origin",
-                    branch,
-                ],
-                capture_output=True,
-                text=True,
-                timeout=GIT_PUSH_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except subprocess.TimeoutExpired as exc:
-            self._log.exception(
-                "daemon.fix_ci_git_push_timeout",
-                extra={
-                    "event": "fix_ci_git_push_timeout",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "timeout_seconds": GIT_PUSH_TIMEOUT_SECONDS,
-                    "detail": str(exc),
-                },
-            )
-            # ROUTING (#3062 #3069): ROUTED via ``_handle_agent_failure``.
-            self._handle_fix_ci_apply_failure(
-                agent_id=agent_id,
-                sub_reason="git_push_timeout",
-                pr_number=pr_number,
-                issue_number=issue_number,
-                retries_used=retries_used,
-                detail=str(exc),
-            )
-            return
-        except Exception as exc:
-            self._log.exception(
-                "daemon.fix_ci_git_push_failed",
-                extra={
-                    "event": "fix_ci_git_push_failed",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                },
-            )
-            # ROUTING (#3062 #3069): ROUTED via ``_handle_agent_failure``.
-            self._handle_fix_ci_apply_failure(
-                agent_id=agent_id,
-                sub_reason="git_push_exception",
-                pr_number=pr_number,
-                issue_number=issue_number,
-                retries_used=retries_used,
-                detail=str(exc),
-            )
-            return
-        if push_result.returncode != 0:
-            tail = _stderr_tail(push_result.stderr)
+        # Issue #3089: hot-path ``git push`` in fix-CI — retry
+        # transient flakes before routing to the diagnoser. Same
+        # rationale as ``_push_and_open_pr``'s push retry.
+        push_cmd = [
+            "git",
+            "-C",
+            str(worktree),
+            "push",
+            "origin",
+            branch,
+        ]
+        push_outcome = self._subprocess_with_retry(
+            push_cmd,
+            event_name="fix_ci_git_push",
+            timeout=GIT_PUSH_TIMEOUT_SECONDS,
+            extra_log_fields={
+                "agent_id": agent_id,
+                "pr_number": pr_number,
+                "issue_number": issue_number,
+            },
+        )
+        if not push_outcome["ok"]:
+            reason = push_outcome.get("reason")
+            tail = push_outcome.get("stderr_tail") or ""
+            if reason == "timeout":
+                self._log.exception(
+                    "daemon.fix_ci_git_push_timeout",
+                    extra={
+                        "event": "fix_ci_git_push_timeout",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "timeout_seconds": GIT_PUSH_TIMEOUT_SECONDS,
+                    },
+                )
+                # ROUTING (#3062 #3069): ROUTED via ``_handle_agent_failure``.
+                self._handle_fix_ci_apply_failure(
+                    agent_id=agent_id,
+                    sub_reason="git_push_timeout",
+                    pr_number=pr_number,
+                    issue_number=issue_number,
+                    retries_used=retries_used,
+                    detail=tail,
+                )
+                return
+            if reason == "gh_missing":
+                self._log.exception(
+                    "daemon.fix_ci_git_push_failed",
+                    extra={
+                        "event": "fix_ci_git_push_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                    },
+                )
+                # ROUTING (#3062 #3069): ROUTED via ``_handle_agent_failure``.
+                self._handle_fix_ci_apply_failure(
+                    agent_id=agent_id,
+                    sub_reason="git_push_exception",
+                    pr_number=pr_number,
+                    issue_number=issue_number,
+                    retries_used=retries_used,
+                    detail=tail,
+                )
+                return
+            # nonzero_exit
             self._log.warning(
                 "daemon.fix_ci_git_push_failed",
                 extra={
                     "event": "fix_ci_git_push_failed",
                     "run_id": self._run_id,
                     "agent_id": agent_id,
-                    "exit_code": push_result.returncode,
+                    "exit_code": push_outcome.get("exit_code"),
                     "stderr_tail": tail,
                 },
             )
@@ -11825,7 +12030,7 @@ class DispatcherDaemon:
                 agent_id=agent_id,
                 sub_reason="git_push_nonzero_exit",
                 stderr_tail=tail,
-                exit_code=push_result.returncode,
+                exit_code=push_outcome.get("exit_code"),
                 pr_number=pr_number,
                 issue_number=issue_number,
                 retries_used=retries_used,
@@ -11996,28 +12201,30 @@ class DispatcherDaemon:
             "--limit",
             "20",
         ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired):
+        # Issue #3089: hot-path deploy-run lookup — retry transient
+        # flakes so a single GitHub 502 doesn't send the supervisor
+        # back into "waiting for deploy" limbo for an extra tick.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="deploy_run_list",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"merge_sha": merge_sha},
+        )
+        if not outcome["ok"]:
+            reason = outcome.get("reason")
+            if reason not in ("timeout", "gh_missing"):
+                self._log.warning(
+                    "daemon.run_list_failed",
+                    extra={
+                        "event": "run_list_failed",
+                        "run_id": self._run_id,
+                        "merge_sha": merge_sha,
+                        "exit_code": outcome.get("exit_code"),
+                        "stderr_tail": outcome.get("stderr_tail"),
+                    },
+                )
             return []
-        if result.returncode != 0:
-            self._log.warning(
-                "daemon.run_list_failed",
-                extra={
-                    "event": "run_list_failed",
-                    "run_id": self._run_id,
-                    "merge_sha": merge_sha,
-                    "exit_code": result.returncode,
-                    "stderr_tail": _stderr_tail(result.stderr),
-                },
-            )
-            return []
+        result = outcome["result"]
         try:
             payload = json.loads(result.stdout or "[]")
         except json.JSONDecodeError:
@@ -12523,15 +12730,16 @@ class DispatcherDaemon:
             "--body-file",
             str(evidence_path),
         ]
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired):
+        # Issue #3089: hot-path verification-evidence comment — retry
+        # transient flakes so operators see the evidence even through
+        # a GitHub hiccup.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="evidence_comment",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"agent_id": agent_id, "issue_number": issue_number},
+        )
+        if not outcome["ok"]:
             self._log.warning(
                 "daemon.evidence_comment_failed",
                 extra={
@@ -12539,20 +12747,9 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "issue_number": issue_number,
-                    "reason": "subprocess",
-                },
-            )
-            return
-        if result.returncode != 0:
-            self._log.warning(
-                "daemon.evidence_comment_failed",
-                extra={
-                    "event": "evidence_comment_failed",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "issue_number": issue_number,
-                    "exit_code": result.returncode,
-                    "stderr_tail": _stderr_tail(result.stderr),
+                    "reason": outcome.get("reason"),
+                    "exit_code": outcome.get("exit_code"),
+                    "stderr_tail": outcome.get("stderr_tail"),
                 },
             )
             return
@@ -13104,40 +13301,41 @@ class DispatcherDaemon:
         for label in labels:
             cmd.extend(["--label", label])
 
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=RETRO_GH_ISSUE_CREATE_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            self._log.warning(
-                "daemon.retro_issue_create_subprocess_error",
-                extra={
-                    "event": "retro_issue_create_subprocess_error",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "title": title,
-                    "detail": str(exc),
-                },
-            )
+        # Issue #3089: hot-path retro issue create — retry transient
+        # flakes so the retrospective finding lands on a real issue.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="retro_issue_create",
+            timeout=RETRO_GH_ISSUE_CREATE_TIMEOUT_SECONDS,
+            extra_log_fields={"agent_id": agent_id, "title": title},
+        )
+        if not outcome["ok"]:
+            reason = outcome.get("reason")
+            if reason in ("timeout", "gh_missing"):
+                self._log.warning(
+                    "daemon.retro_issue_create_subprocess_error",
+                    extra={
+                        "event": "retro_issue_create_subprocess_error",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "title": title,
+                        "detail": outcome.get("stderr_tail") or reason,
+                    },
+                )
+            else:
+                self._log.warning(
+                    "daemon.retro_issue_create_failed",
+                    extra={
+                        "event": "retro_issue_create_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "title": title,
+                        "exit_code": outcome.get("exit_code"),
+                        "stderr_tail": outcome.get("stderr_tail"),
+                    },
+                )
             return None
-
-        if result.returncode != 0:
-            self._log.warning(
-                "daemon.retro_issue_create_failed",
-                extra={
-                    "event": "retro_issue_create_failed",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "title": title,
-                    "exit_code": result.returncode,
-                    "stderr_tail": _stderr_tail(result.stderr),
-                },
-            )
-            return None
+        result = outcome["result"]
 
         # ``gh issue create`` prints the issue URL on stdout. Parse the
         # trailing ``/issues/<N>`` segment for logging.
@@ -13733,6 +13931,10 @@ class DispatcherDaemon:
             "--jq",
             ".resources.core",
         ]
+        # cold-path (#3089): per-tick advisory probe; a failed probe
+        # means this tick proceeds without rate-limit gating and the
+        # next tick re-probes. Tick-level cadence already provides the
+        # equivalent of a retry.
         try:
             result = subprocess.run(
                 cmd,
@@ -14100,6 +14302,8 @@ class DispatcherDaemon:
         # whether we leave an orphan entry in ``git worktree list``.
         # ``-C <git_parent>`` anchors the command to the baseline clone's
         # ``.git`` rather than the daemon's CWD — see docstring.
+        # cold-path (#3089): local fs housekeeping; an orphan entry is
+        # swept by subsequent housekeeping sweeps.
         try:
             result = subprocess.run(
                 [
@@ -15456,36 +15660,35 @@ class DispatcherDaemon:
         # Issue title + body — fetch lazily via gh so the daemon does
         # not duplicate the ``_fetch_issue_bundle`` MCP path. The skill
         # can always re-fetch if the context is stale.
+        # Issue #3089: hot-path diagnoser-context fetch — retry
+        # transient flakes so a single ``gh`` hiccup doesn't degrade
+        # the diagnoser's input quality.
         issue_title = ""
         issue_body = ""
         if issue_number is not None:
-            try:
-                result = subprocess.run(
-                    [
-                        "gh",
-                        "issue",
-                        "view",
-                        str(issue_number),
-                        "--repo",
-                        self._cfg.github_repo,
-                        "--json",
-                        "title,body",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
-                    check=False,
-                )
-                if result.returncode == 0 and result.stdout:
-                    payload = json.loads(result.stdout)
+            diag_cmd = [
+                "gh",
+                "issue",
+                "view",
+                str(issue_number),
+                "--repo",
+                self._cfg.github_repo,
+                "--json",
+                "title,body",
+            ]
+            diag_outcome = self._subprocess_with_retry(
+                diag_cmd,
+                event_name="diagnoser_context_fetch",
+                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                extra_log_fields={"issue_number": issue_number},
+            )
+            if diag_outcome["ok"]:
+                try:
+                    payload = json.loads(diag_outcome["result"].stdout or "{}")
                     issue_title = str(payload.get("title") or "")
                     issue_body = str(payload.get("body") or "")
-            except (
-                FileNotFoundError,
-                subprocess.TimeoutExpired,
-                json.JSONDecodeError,
-            ):
-                pass
+                except json.JSONDecodeError:
+                    pass
 
         # prior_mechanical_fix — tier 2 only, describes what was tried.
         prior_mechanical_fix: dict[str, Any] | None = None
@@ -16528,43 +16731,35 @@ class DispatcherDaemon:
         tmp_file = self._write_gh_tmp_body(body, prefix="diagnoser-comment")
         if tmp_file is None:
             return
-        try:
-            result = subprocess.run(
-                [
-                    "gh",
-                    "issue",
-                    "comment",
-                    str(issue_number),
-                    "--repo",
-                    self._cfg.github_repo,
-                    "--body-file",
-                    str(tmp_file),
-                ],
-                capture_output=True,
-                text=True,
-                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            self._log.warning(
-                "daemon.diagnoser_gh_comment_failed",
-                extra={
-                    "event": "diagnoser_gh_comment_failed",
-                    "run_id": self._run_id,
-                    "issue_number": issue_number,
-                    "detail": str(exc),
-                },
-            )
-            return
-        if result.returncode != 0:
+        # Issue #3089: hot-path diagnoser comment — retry transient
+        # flakes so the operator-visible decision doesn't silently
+        # drop.
+        cmd = [
+            "gh",
+            "issue",
+            "comment",
+            str(issue_number),
+            "--repo",
+            self._cfg.github_repo,
+            "--body-file",
+            str(tmp_file),
+        ]
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="diagnoser_gh_comment",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"issue_number": issue_number},
+        )
+        if not outcome["ok"]:
             self._log.warning(
                 "daemon.diagnoser_gh_comment_nonzero",
                 extra={
                     "event": "diagnoser_gh_comment_nonzero",
                     "run_id": self._run_id,
                     "issue_number": issue_number,
-                    "exit_code": result.returncode,
-                    "stderr_tail": _stderr_tail(result.stderr),
+                    "exit_code": outcome.get("exit_code"),
+                    "reason": outcome.get("reason"),
+                    "stderr_tail": outcome.get("stderr_tail"),
                 },
             )
 
@@ -16573,43 +16768,34 @@ class DispatcherDaemon:
         tmp_file = self._write_gh_tmp_body(new_body, prefix="diagnoser-body")
         if tmp_file is None:
             return
-        try:
-            result = subprocess.run(
-                [
-                    "gh",
-                    "issue",
-                    "edit",
-                    str(issue_number),
-                    "--repo",
-                    self._cfg.github_repo,
-                    "--body-file",
-                    str(tmp_file),
-                ],
-                capture_output=True,
-                text=True,
-                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            self._log.warning(
-                "daemon.diagnoser_gh_body_failed",
-                extra={
-                    "event": "diagnoser_gh_body_failed",
-                    "run_id": self._run_id,
-                    "issue_number": issue_number,
-                    "detail": str(exc),
-                },
-            )
-            return
-        if result.returncode != 0:
+        # Issue #3089: hot-path diagnoser body edit — retry transient
+        # flakes.
+        cmd = [
+            "gh",
+            "issue",
+            "edit",
+            str(issue_number),
+            "--repo",
+            self._cfg.github_repo,
+            "--body-file",
+            str(tmp_file),
+        ]
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="diagnoser_gh_body",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"issue_number": issue_number},
+        )
+        if not outcome["ok"]:
             self._log.warning(
                 "daemon.diagnoser_gh_body_nonzero",
                 extra={
                     "event": "diagnoser_gh_body_nonzero",
                     "run_id": self._run_id,
                     "issue_number": issue_number,
-                    "exit_code": result.returncode,
-                    "stderr_tail": _stderr_tail(result.stderr),
+                    "exit_code": outcome.get("exit_code"),
+                    "reason": outcome.get("reason"),
+                    "stderr_tail": outcome.get("stderr_tail"),
                 },
             )
 
@@ -16622,43 +16808,34 @@ class DispatcherDaemon:
         if not labels:
             return
         label_csv = ",".join(labels)
-        try:
-            result = subprocess.run(
-                [
-                    "gh",
-                    "issue",
-                    "edit",
-                    str(issue_number),
-                    "--repo",
-                    self._cfg.github_repo,
-                    "--add-label",
-                    label_csv,
-                ],
-                capture_output=True,
-                text=True,
-                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            self._log.warning(
-                "daemon.diagnoser_gh_label_failed",
-                extra={
-                    "event": "diagnoser_gh_label_failed",
-                    "run_id": self._run_id,
-                    "issue_number": issue_number,
-                    "detail": str(exc),
-                },
-            )
-            return
-        if result.returncode != 0:
+        # Issue #3089: hot-path label-add mutation — retry transient
+        # flakes so the claim interlock + status labels land reliably.
+        cmd = [
+            "gh",
+            "issue",
+            "edit",
+            str(issue_number),
+            "--repo",
+            self._cfg.github_repo,
+            "--add-label",
+            label_csv,
+        ]
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="diagnoser_gh_label",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"issue_number": issue_number},
+        )
+        if not outcome["ok"]:
             self._log.warning(
                 "daemon.diagnoser_gh_label_nonzero",
                 extra={
                     "event": "diagnoser_gh_label_nonzero",
                     "run_id": self._run_id,
                     "issue_number": issue_number,
-                    "exit_code": result.returncode,
-                    "stderr_tail": _stderr_tail(result.stderr),
+                    "exit_code": outcome.get("exit_code"),
+                    "reason": outcome.get("reason"),
+                    "stderr_tail": outcome.get("stderr_tail"),
                 },
             )
 
@@ -16674,43 +16851,36 @@ class DispatcherDaemon:
         if not labels:
             return
         label_csv = ",".join(labels)
-        try:
-            result = subprocess.run(
-                [
-                    "gh",
-                    "issue",
-                    "edit",
-                    str(issue_number),
-                    "--repo",
-                    self._cfg.github_repo,
-                    "--remove-label",
-                    label_csv,
-                ],
-                capture_output=True,
-                text=True,
-                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            self._log.warning(
-                "daemon.label_remove_failed",
-                extra={
-                    "event": "label_remove_failed",
-                    "run_id": self._run_id,
-                    "issue_number": issue_number,
-                    "detail": str(exc),
-                },
-            )
-            return
-        if result.returncode != 0:
+        # Issue #3089: hot-path label-remove mutation — retry transient
+        # flakes so the claim interlock releases reliably (a stuck
+        # ``status/in-progress`` label hides the issue from the queue
+        # scan indefinitely — #2927).
+        cmd = [
+            "gh",
+            "issue",
+            "edit",
+            str(issue_number),
+            "--repo",
+            self._cfg.github_repo,
+            "--remove-label",
+            label_csv,
+        ]
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="label_remove",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"issue_number": issue_number},
+        )
+        if not outcome["ok"]:
             self._log.warning(
                 "daemon.label_remove_nonzero",
                 extra={
                     "event": "label_remove_nonzero",
                     "run_id": self._run_id,
                     "issue_number": issue_number,
-                    "exit_code": result.returncode,
-                    "stderr_tail": _stderr_tail(result.stderr),
+                    "exit_code": outcome.get("exit_code"),
+                    "reason": outcome.get("reason"),
+                    "stderr_tail": outcome.get("stderr_tail"),
                 },
             )
 
@@ -16719,45 +16889,36 @@ class DispatcherDaemon:
         tmp_file = self._write_gh_tmp_body(comment, prefix="diagnoser-close")
         if tmp_file is None:
             return
-        try:
-            result = subprocess.run(
-                [
-                    "gh",
-                    "issue",
-                    "close",
-                    str(issue_number),
-                    "--repo",
-                    self._cfg.github_repo,
-                    "--reason",
-                    reason,
-                    "--comment",
-                    comment,
-                ],
-                capture_output=True,
-                text=True,
-                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            self._log.warning(
-                "daemon.diagnoser_gh_close_failed",
-                extra={
-                    "event": "diagnoser_gh_close_failed",
-                    "run_id": self._run_id,
-                    "issue_number": issue_number,
-                    "detail": str(exc),
-                },
-            )
-            return
-        if result.returncode != 0:
+        # Issue #3089: hot-path diagnoser close — retry transient
+        # flakes.
+        cmd = [
+            "gh",
+            "issue",
+            "close",
+            str(issue_number),
+            "--repo",
+            self._cfg.github_repo,
+            "--reason",
+            reason,
+            "--comment",
+            comment,
+        ]
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="diagnoser_gh_close",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"issue_number": issue_number},
+        )
+        if not outcome["ok"]:
             self._log.warning(
                 "daemon.diagnoser_gh_close_nonzero",
                 extra={
                     "event": "diagnoser_gh_close_nonzero",
                     "run_id": self._run_id,
                     "issue_number": issue_number,
-                    "exit_code": result.returncode,
-                    "stderr_tail": _stderr_tail(result.stderr),
+                    "exit_code": outcome.get("exit_code"),
+                    "reason": outcome.get("reason"),
+                    "stderr_tail": outcome.get("stderr_tail"),
                 },
             )
 
@@ -16815,37 +16976,29 @@ class DispatcherDaemon:
         ]
         if labels:
             cmd.extend(["--label", ",".join(labels)])
-        try:
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            self._log.warning(
-                "daemon.diagnoser_gh_create_failed",
-                extra={
-                    "event": "diagnoser_gh_create_failed",
-                    "run_id": self._run_id,
-                    "title": title,
-                    "detail": str(exc),
-                },
-            )
-            return None
-        if result.returncode != 0:
+        # Issue #3089: hot-path diagnoser prereq-issue create — retry
+        # transient flakes so the file_prerequisite_task diagnoser
+        # action lands reliably.
+        outcome = self._subprocess_with_retry(
+            cmd,
+            event_name="diagnoser_gh_create",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"title": title},
+        )
+        if not outcome["ok"]:
             self._log.warning(
                 "daemon.diagnoser_gh_create_nonzero",
                 extra={
                     "event": "diagnoser_gh_create_nonzero",
                     "run_id": self._run_id,
                     "title": title,
-                    "exit_code": result.returncode,
-                    "stderr_tail": _stderr_tail(result.stderr),
+                    "exit_code": outcome.get("exit_code"),
+                    "reason": outcome.get("reason"),
+                    "stderr_tail": outcome.get("stderr_tail"),
                 },
             )
             return None
+        result = outcome["result"]
         # gh issue create prints the URL on stdout: last non-empty line.
         stdout = (result.stdout or "").strip()
         if not stdout:
@@ -16878,46 +17031,37 @@ class DispatcherDaemon:
         Best-effort — a read or write failure is logged and swallowed
         so the diagnoser's recommendation still lands.
         """
-        try:
-            result = subprocess.run(
-                [
-                    "gh",
-                    "issue",
-                    "view",
-                    str(issue_number),
-                    "--repo",
-                    self._cfg.github_repo,
-                    "--json",
-                    "body",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
-                check=False,
-            )
-        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
-            self._log.warning(
-                "daemon.diagnoser_gh_append_failed",
-                extra={
-                    "event": "diagnoser_gh_append_failed",
-                    "run_id": self._run_id,
-                    "issue_number": issue_number,
-                    "detail": str(exc),
-                },
-            )
-            return
-        if result.returncode != 0:
+        # Issue #3089: hot-path diagnoser body-append read — retry
+        # transient flakes before falling back.
+        outcome = self._subprocess_with_retry(
+            [
+                "gh",
+                "issue",
+                "view",
+                str(issue_number),
+                "--repo",
+                self._cfg.github_repo,
+                "--json",
+                "body",
+            ],
+            event_name="diagnoser_gh_append",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+            extra_log_fields={"issue_number": issue_number},
+        )
+        if not outcome["ok"]:
             self._log.warning(
                 "daemon.diagnoser_gh_append_nonzero",
                 extra={
                     "event": "diagnoser_gh_append_nonzero",
                     "run_id": self._run_id,
                     "issue_number": issue_number,
-                    "exit_code": result.returncode,
-                    "stderr_tail": _stderr_tail(result.stderr),
+                    "exit_code": outcome.get("exit_code"),
+                    "reason": outcome.get("reason"),
+                    "stderr_tail": outcome.get("stderr_tail"),
                 },
             )
             return
+        result = outcome["result"]
         try:
             payload = json.loads(result.stdout or "{}")
         except json.JSONDecodeError:
@@ -17055,6 +17199,9 @@ class DispatcherDaemon:
           ``"gh_missing"``). ``stderr_tail`` is the last ~200 chars
           of stderr when applicable, for operator-visible context.
         """
+        # cold-path (#3089): the ``_once`` probe is wrapped in a
+        # 3-attempt 1s+2s retry loop by the parent
+        # ``_gh_issue_is_open_with_detail`` (#3053).
         try:
             result = subprocess.run(
                 [

--- a/scripts/dispatcher/tests/test_daemon_git_push_timeout.py
+++ b/scripts/dispatcher/tests/test_daemon_git_push_timeout.py
@@ -60,44 +60,84 @@ def test_git_push_timeout_constant_is_1800_seconds() -> None:
     )
 
 
+def _list_literals_have_git_push(cmd_arg: ast.expr) -> bool:
+    """Return True if ``cmd_arg`` is a list literal with ``git`` + ``push``.
+
+    Accepts both:
+      - direct list literal passed to subprocess.run
+      - list literal bound to a local name then passed to either
+        subprocess.run or self._subprocess_with_retry.
+    """
+    if not isinstance(cmd_arg, ast.List):
+        return False
+    literals: list[str] = []
+    for elt in cmd_arg.elts:
+        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+            literals.append(elt.value)
+        else:
+            literals.append("")
+    return bool(literals) and literals[0] == "git" and "push" in literals
+
+
+def _resolve_name_to_list(name: str, tree: ast.Module, call_line: int) -> ast.List | None:
+    """Find the nearest preceding ``<name> = [...]`` assignment before call_line."""
+    best: ast.List | None = None
+    best_line = -1
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and node.lineno < call_line:
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id == name
+                    and isinstance(node.value, ast.List)
+                    and node.lineno > best_line
+                ):
+                    best = node.value
+                    best_line = node.lineno
+    return best
+
+
 def _collect_subprocess_run_push_calls() -> list[ast.Call]:
-    """Return every ``subprocess.run(...)`` call in daemon.py whose
-    first positional arg starts with ``['git', '-C', ..., 'push', ...]``.
+    """Return every git-push subprocess call in daemon.py.
+
+    Matches both pre-#3089 direct ``subprocess.run([... 'git' ... 'push' ...])``
+    and post-#3089 ``self._subprocess_with_retry([... 'git' ... 'push' ...])``
+    (which wraps ``subprocess.run`` with retry). Also resolves the
+    ``cmd = [...]; self._subprocess_with_retry(cmd, ...)`` name-binding
+    pattern.
     """
     tree = ast.parse(_DAEMON_PATH.read_text())
     out: list[ast.Call] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
-        # Match ``subprocess.run(...)``.
         func = node.func
-        if not (
+        is_subprocess_run = (
             isinstance(func, ast.Attribute)
             and func.attr == "run"
             and isinstance(func.value, ast.Name)
             and func.value.id == "subprocess"
-        ):
+        )
+        is_retry_helper = (
+            isinstance(func, ast.Attribute)
+            and func.attr == "_subprocess_with_retry"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "self"
+        )
+        if not (is_subprocess_run or is_retry_helper):
             continue
         if not node.args:
             continue
         cmd_arg = node.args[0]
-        if not isinstance(cmd_arg, ast.List):
+        # Inline list literal.
+        if _list_literals_have_git_push(cmd_arg):
+            out.append(node)
             continue
-        # Extract string literals so we can detect ``"git" ... "push"``.
-        literals: list[str] = []
-        for elt in cmd_arg.elts:
-            if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
-                literals.append(elt.value)
-            else:
-                # Non-literal elements (e.g. ``str(worktree)``, branch
-                # variables) don't carry the command shape we care about
-                # — skip them for detection purposes.
-                literals.append("")
-        if not literals or literals[0] != "git":
-            continue
-        if "push" not in literals:
-            continue
-        out.append(node)
+        # ``cmd = [...]; self._subprocess_with_retry(cmd, ...)`` pattern.
+        if isinstance(cmd_arg, ast.Name):
+            resolved = _resolve_name_to_list(cmd_arg.id, tree, node.lineno)
+            if resolved is not None and _list_literals_have_git_push(resolved):
+                out.append(node)
     return out
 
 

--- a/scripts/dispatcher/tests/test_daemon_phase3e.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3e.py
@@ -638,13 +638,20 @@ class TestRunRetroPhaseFailures:
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
 
+        # Issue #3089: ``_file_retro_issue`` now routes through the
+        # shared 3-attempt 1s+2s retry helper (``_subprocess_with_retry``).
+        # The first retro's ``gh issue create`` exhausts all 3 attempts
+        # → the second retro still runs on its own first attempt and
+        # succeeds. Total subprocess.run calls: 3 (first retro) + 1
+        # (second retro) = 4.
         call_n = {"i": 0}
 
         def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
             r = MagicMock()
             call_n["i"] += 1
-            # First call fails, second succeeds.
-            if call_n["i"] == 1:
+            # First retro (call 1/2/3) all fail with 503 — exhaust retry.
+            # Second retro (call 4) succeeds.
+            if call_n["i"] <= 3:
                 r.returncode = 1
                 r.stdout = ""
                 r.stderr = "github 503"
@@ -655,14 +662,17 @@ class TestRunRetroPhaseFailures:
             return r
 
         monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(daemon.time, "sleep", lambda *_a, **_kw: None)
         d._run_retro_phase(agent)
 
-        # Both calls happened.
-        assert call_n["i"] == 2
-        # First failed, second succeeded → 1 issue created.
+        # First retro: 3 retry attempts exhausted. Second retro: 1 attempt.
+        assert call_n["i"] == 4
+        # First retro failed, second succeeded → 1 issue created.
         created = handler.events("retro_issue_created")
         assert len(created) == 1
-        # Failure logged.
+        # Failure logged (the retry-exhausted WARNING OR the
+        # ``retro_issue_create_failed`` nonzero_exit WARNING — either
+        # counts as "failure was recorded").
         failures = handler.events("retro_issue_create_failed")
         assert len(failures) == 1
 

--- a/scripts/dispatcher/tests/test_daemon_push_failed.py
+++ b/scripts/dispatcher/tests/test_daemon_push_failed.py
@@ -311,8 +311,22 @@ class TestGitPushFailedWritesFailureRow:
         git_show_empty = subprocess.CompletedProcess(
             args=["git", "show"], returncode=0, stdout="", stderr=""
         )
-        run_side_effects = [rev_list_ahead, commit_ok, git_show_empty, push_fail]
-        with patch("subprocess.run", side_effect=run_side_effects):
+        # Issue #3089: ``git push`` now routes through the shared
+        # 3-attempt retry helper, so the failing push consumes 3
+        # ``subprocess.run`` calls instead of 1. ``time.sleep`` is
+        # stubbed to keep the test fast.
+        run_side_effects = [
+            rev_list_ahead,
+            commit_ok,
+            git_show_empty,
+            push_fail,
+            push_fail,
+            push_fail,
+        ]
+        with (
+            patch("subprocess.run", side_effect=run_side_effects),
+            patch("dispatcher.daemon.time.sleep"),
+        ):
             d._push_and_open_pr(
                 agent_id=agent_id,
                 issue_number=42,
@@ -379,9 +393,20 @@ class TestGitPushFailedWritesFailureRow:
         git_show_empty = subprocess.CompletedProcess(
             args=["git", "show"], returncode=0, stdout="", stderr=""
         )
-        with patch(
-            "subprocess.run",
-            side_effect=[rev_list_ahead, commit_ok, git_show_empty, push_fail],
+        # Issue #3089: 3-attempt retry — 3 push_fail results needed.
+        with (
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    rev_list_ahead,
+                    commit_ok,
+                    git_show_empty,
+                    push_fail,
+                    push_fail,
+                    push_fail,
+                ],
+            ),
+            patch("dispatcher.daemon.time.sleep"),
         ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=99, worktree=worktree)
 
@@ -442,9 +467,20 @@ class TestGitPushFailedWritesPhaseOutputRow:
         git_show_empty = subprocess.CompletedProcess(
             args=["git", "show"], returncode=0, stdout="", stderr=""
         )
-        with patch(
-            "subprocess.run",
-            side_effect=[rev_list_ahead, commit_ok, git_show_empty, push_fail],
+        # Issue #3089: 3-attempt retry — 3 push_fail results needed.
+        with (
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    rev_list_ahead,
+                    commit_ok,
+                    git_show_empty,
+                    push_fail,
+                    push_fail,
+                    push_fail,
+                ],
+            ),
+            patch("dispatcher.daemon.time.sleep"),
         ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=7, worktree=worktree)
 

--- a/scripts/dispatcher/tests/test_daemon_ralph_patches.py
+++ b/scripts/dispatcher/tests/test_daemon_ralph_patches.py
@@ -913,9 +913,22 @@ class TestPushAndOpenPrDeletesRalphPatch:
         rev_list_ahead = subprocess.CompletedProcess(
             args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
         )
-        with patch(
-            "subprocess.run",
-            side_effect=[rev_list_ahead, commit_ok, git_show_empty, push_fail],
+        # Issue #3089: ``git push`` now retries 3 times before falling
+        # through to ``_handle_agent_failure``. Provide three push_fail
+        # results and stub ``time.sleep`` to keep the test fast.
+        with (
+            patch(
+                "subprocess.run",
+                side_effect=[
+                    rev_list_ahead,
+                    commit_ok,
+                    git_show_empty,
+                    push_fail,
+                    push_fail,
+                    push_fail,
+                ],
+            ),
+            patch("dispatcher.daemon.time.sleep"),
         ):
             d._push_and_open_pr(
                 agent_id=agent_id,

--- a/scripts/dispatcher/tests/test_daemon_subprocess_retries.py
+++ b/scripts/dispatcher/tests/test_daemon_subprocess_retries.py
@@ -1,0 +1,421 @@
+"""Unit tests for issue #3089 — shared ``_subprocess_with_retry`` helper + hot-path site retries.
+
+Coverage:
+  - ``_subprocess_with_retry`` is a general 3-attempt 1s+2s backoff
+    retry envelope that mirrors the shape established by #3053
+    (``_gh_issue_is_open_with_detail``) and #3085
+    (``_baseline_fetch_origin_main``).
+  - Every hot-path git/gh call site that gained retry under #3089
+    survives a single transient failure without surfacing an error.
+  - Happy-path first-attempt success stays silent (no new log events)
+    so the common case does not flood CloudWatch.
+
+Fakes mirror the pattern from ``test_daemon_gh_issue_is_open_retry.py``
+(PR #3058) and ``test_daemon_baseline_fetch_retry.py`` (PR #3087).
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+# Provide a stub ``psycopg`` module before importing the daemon.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel — stands in for real psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Shared fakes.
+# --------------------------------------------------------------------------
+
+
+def _make_daemon() -> daemon.DispatcherDaemon:
+    """Construct a DispatcherDaemon bypassing __init__ (no DB, no config)."""
+    import threading
+
+    d = daemon.DispatcherDaemon.__new__(daemon.DispatcherDaemon)
+    d._thread_state = threading.local()  # type: ignore[attr-defined]
+    d._main_conn = MagicMock()  # type: ignore[attr-defined]
+    d._cfg = MagicMock(github_repo="judgemind/judgemind")  # type: ignore[attr-defined]
+    d._log = logging.getLogger("test.daemon_subprocess_retries")  # type: ignore[attr-defined]
+    d._run_id = "test-run"  # type: ignore[attr-defined]
+    return d
+
+
+def _cp(
+    returncode: int = 0, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["fake"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+# --------------------------------------------------------------------------
+# Shared helper: _subprocess_with_retry
+# --------------------------------------------------------------------------
+
+
+class TestSubprocessWithRetry:
+    def test_first_attempt_success_no_retry_silent(self) -> None:
+        """Happy path: first attempt returncode=0 → ok=True, attempts=1, no warnings."""
+        d = _make_daemon()
+        with patch("dispatcher.daemon.subprocess.run", return_value=_cp(0, "hi")) as m:
+            outcome = d._subprocess_with_retry(
+                ["git", "status"], event_name="fake_site", timeout=30
+            )
+        assert outcome == {
+            "ok": True,
+            "result": outcome["result"],
+            "attempts": 1,
+        }
+        assert outcome["result"].returncode == 0
+        assert m.call_count == 1
+
+    def test_happy_path_no_flake_warning(self, caplog: Any) -> None:
+        """First-attempt success emits no ``*_flake`` / ``*_exhausted`` events."""
+        d = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_subprocess_retries")
+        with patch("dispatcher.daemon.subprocess.run", return_value=_cp(0, "ok")):
+            d._subprocess_with_retry(["git"], event_name="probe", timeout=30)
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "probe_flake" not in events
+        assert "probe_exhausted" not in events
+
+    def test_timeout_then_success_retries_and_logs_flake(self, caplog: Any) -> None:
+        """One transient timeout then success → ok=True after one retry,
+        one flake WARNING, one backoff sleep."""
+        d = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_subprocess_retries")
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=[
+                    subprocess.TimeoutExpired(cmd="x", timeout=30),
+                    _cp(0, "recovered"),
+                ],
+            ) as m_run,
+            patch("dispatcher.daemon.time.sleep") as m_sleep,
+        ):
+            outcome = d._subprocess_with_retry(["git"], event_name="probe", timeout=30)
+        assert outcome["ok"] is True
+        assert outcome["attempts"] == 2
+        assert m_run.call_count == 2
+        assert m_sleep.call_args_list == [((1.0,), {})]
+        flakes = [
+            r for r in caplog.records if getattr(r, "event", None) == "probe_flake"
+        ]
+        assert len(flakes) == 1
+        assert flakes[0].reason == "timeout"
+
+    def test_nonzero_exit_then_success_returns_ok(self, caplog: Any) -> None:
+        """One non-zero exit then success → ok=True, one flake with reason=nonzero_exit."""
+        d = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_subprocess_retries")
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=[_cp(128, "", "HTTP 500"), _cp(0, "ok")],
+            ) as m_run,
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            outcome = d._subprocess_with_retry(["gh"], event_name="probe", timeout=30)
+        assert outcome["ok"] is True
+        assert outcome["attempts"] == 2
+        assert m_run.call_count == 2
+        flakes = [
+            r for r in caplog.records if getattr(r, "event", None) == "probe_flake"
+        ]
+        assert len(flakes) == 1
+        assert flakes[0].reason == "nonzero_exit"
+        assert "HTTP 500" in (flakes[0].stderr_tail or "")
+
+    def test_three_timeouts_exhausts_returns_not_ok(self, caplog: Any) -> None:
+        """All 3 attempts timeout → ok=False, reason=timeout, attempts=3,
+        one exhausted WARNING."""
+        d = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_subprocess_retries")
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="x", timeout=30),
+            ) as m_run,
+            patch("dispatcher.daemon.time.sleep") as m_sleep,
+        ):
+            outcome = d._subprocess_with_retry(["gh"], event_name="probe", timeout=30)
+        assert outcome["ok"] is False
+        assert outcome["reason"] == "timeout"
+        assert outcome["attempts"] == 3
+        assert outcome["exit_code"] is None
+        assert m_run.call_count == 3
+        assert m_sleep.call_count == 2
+        exh = [
+            r for r in caplog.records if getattr(r, "event", None) == "probe_exhausted"
+        ]
+        assert len(exh) == 1
+        assert exh[0].reason == "timeout"
+
+    def test_three_nonzero_exits_preserves_exit_code(self, caplog: Any) -> None:
+        """All 3 attempts non-zero → ok=False with exit_code surfaced."""
+        d = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_subprocess_retries")
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                return_value=_cp(128, "", "RPC failed"),
+            ),
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            outcome = d._subprocess_with_retry(["git"], event_name="probe", timeout=30)
+        assert outcome["ok"] is False
+        assert outcome["reason"] == "nonzero_exit"
+        assert outcome["exit_code"] == 128
+        assert "RPC failed" in outcome["stderr_tail"]
+
+    def test_file_not_found_retries_then_exhausts(self, caplog: Any) -> None:
+        """``FileNotFoundError`` (CLI missing) is retried, then surfaces as
+        ``reason=gh_missing`` on exhaustion."""
+        d = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_subprocess_retries")
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=FileNotFoundError("gh not installed"),
+            ) as m_run,
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            outcome = d._subprocess_with_retry(["gh"], event_name="probe", timeout=30)
+        assert outcome["ok"] is False
+        assert outcome["reason"] == "gh_missing"
+        assert m_run.call_count == 3
+        assert "gh not installed" in outcome["stderr_tail"]
+
+    def test_extra_log_fields_propagate_to_events(self, caplog: Any) -> None:
+        """``extra_log_fields`` (e.g. issue_number) appear on both flake and
+        exhausted events."""
+        d = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_subprocess_retries")
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="x", timeout=30),
+            ),
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            d._subprocess_with_retry(
+                ["gh"],
+                event_name="probe",
+                timeout=30,
+                extra_log_fields={"issue_number": 42, "pr_number": 99},
+            )
+        flakes = [
+            r for r in caplog.records if getattr(r, "event", None) == "probe_flake"
+        ]
+        assert all(
+            getattr(r, "issue_number", None) == 42
+            and getattr(r, "pr_number", None) == 99
+            for r in flakes
+        )
+        exh = [
+            r for r in caplog.records if getattr(r, "event", None) == "probe_exhausted"
+        ]
+        assert len(exh) == 1
+        assert getattr(exh[0], "issue_number", None) == 42
+        assert getattr(exh[0], "pr_number", None) == 99
+
+    def test_timeout_arg_passed_through(self) -> None:
+        """The per-attempt ``timeout`` is forwarded to ``subprocess.run``."""
+        d = _make_daemon()
+        with patch("dispatcher.daemon.subprocess.run", return_value=_cp(0)) as m:
+            d._subprocess_with_retry(["gh"], event_name="probe", timeout=17)
+        assert m.call_args.kwargs["timeout"] == 17
+        assert m.call_args.kwargs["check"] is False
+        assert m.call_args.kwargs["capture_output"] is True
+        assert m.call_args.kwargs["text"] is True
+
+    def test_stderr_full_preserved_on_exhaustion(self) -> None:
+        """On exhaust, the final attempt's raw stderr is preserved in
+        ``stderr_full`` so callers that persist the full diagnostic
+        (e.g. ``_persist_phase_output``'s ``log_text``) don't lose
+        context beyond the 4000-char tail."""
+        d = _make_daemon()
+        long_stderr = (
+            "boom " * 2000
+        )  # 10,000 chars — well past STRUCTURED_LOG_STDERR_MAX
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                return_value=_cp(128, "", long_stderr),
+            ),
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            outcome = d._subprocess_with_retry(["gh"], event_name="probe", timeout=30)
+        assert outcome["ok"] is False
+        # stderr_tail is bounded to STRUCTURED_LOG_STDERR_MAX; stderr_full is the
+        # untruncated payload for log_text callers.
+        assert len(outcome["stderr_full"]) == len(long_stderr)
+        assert len(outcome["stderr_tail"]) <= len(long_stderr)
+
+
+# --------------------------------------------------------------------------
+# Hot-path site smoke tests — a single transient flake at each site that
+# gained retry under #3089 no longer surfaces as a hard failure.
+# --------------------------------------------------------------------------
+
+
+class TestHotPathRetries:
+    """Covers #3089-added retries by exercising each hot-path site once
+    with a one-flake-then-success subprocess pattern. Documents the
+    new contract in test form."""
+
+    def test_fetch_agent_ready_issues_retries_transient_flake(self) -> None:
+        """``_fetch_agent_ready_issues`` survives one transient ``gh`` flake."""
+        d = _make_daemon()
+        ok = _cp(0, '[{"number": 1, "title": "t", "labels": [], "createdAt": "x"}]')
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=[_cp(1, "", "HTTP 502"), ok],
+            ) as m_run,
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            result = d._fetch_agent_ready_issues()
+        assert m_run.call_count == 2
+        assert result == [{"number": 1, "title": "t", "labels": [], "createdAt": "x"}]
+
+    def test_fetch_blocked_issues_retries_transient_flake(self) -> None:
+        """``_fetch_blocked_issues`` survives one transient ``gh`` flake."""
+        d = _make_daemon()
+        ok = _cp(
+            0,
+            '[{"number": 2, "title": "b", "labels": [], "createdAt": "x", "body": ""}]',
+        )
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=[subprocess.TimeoutExpired(cmd="gh", timeout=30), ok],
+            ) as m_run,
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            result = d._fetch_blocked_issues()
+        assert m_run.call_count == 2
+        assert len(result) == 1
+
+    def test_fetch_pr_status_retries_transient_flake(self) -> None:
+        """``_fetch_pr_status`` survives one transient ``gh`` flake."""
+        d = _make_daemon()
+        ok = _cp(0, '{"statusCheckRollup": [], "mergeable": "MERGEABLE"}')
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=[_cp(1, "", "HTTP 502"), ok],
+            ) as m_run,
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            result = d._fetch_pr_status(42)
+        assert m_run.call_count == 2
+        assert result is not None
+        assert result.get("mergeable") == "MERGEABLE"
+
+    def test_fetch_issue_bundle_retries_transient_flake(self) -> None:
+        """``_fetch_issue_bundle`` survives one transient ``gh`` flake."""
+        d = _make_daemon()
+        ok = _cp(
+            0,
+            '{"number": 7, "title": "t", "body": "b", "labels": [], "comments": [], "updatedAt": "x"}',
+        )
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=[_cp(1, "", "HTTP 502"), ok],
+            ) as m_run,
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            bundle = d._fetch_issue_bundle(7)
+        assert m_run.call_count == 2
+        assert bundle["issue_number"] == 7
+
+    def test_gh_issue_add_labels_retries_transient_flake(self) -> None:
+        """``_gh_issue_add_labels`` survives one transient ``gh`` flake.
+        The claim interlock's ``status/in-progress`` add depends on this
+        — a missed add desyncs dispatcher-v2 and the /task skill."""
+        d = _make_daemon()
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=[_cp(1, "", "HTTP 502"), _cp(0, "")],
+            ) as m_run,
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            d._gh_issue_add_labels(99, ["status/in-progress"])
+        assert m_run.call_count == 2
+
+    def test_gh_issue_remove_labels_retries_transient_flake(self) -> None:
+        """``_gh_issue_remove_labels`` survives one transient ``gh`` flake.
+        The #2927 claim interlock releases by removing ``status/in-progress``;
+        a stuck label would hide the issue from the queue scan forever."""
+        d = _make_daemon()
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=[
+                    subprocess.TimeoutExpired(cmd="gh", timeout=30),
+                    _cp(0, ""),
+                ],
+            ) as m_run,
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            d._gh_issue_remove_labels(99, ["status/in-progress"])
+        assert m_run.call_count == 2
+
+    def test_gh_issue_comment_retries_transient_flake(self) -> None:
+        """``_gh_issue_comment`` survives one transient ``gh`` flake."""
+        d = _make_daemon()
+        # Monkeypatch the tmp-file writer so the test doesn't touch disk.
+        d._write_gh_tmp_body = MagicMock(return_value=Path("/tmp/fake"))  # type: ignore[method-assign]
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=[_cp(1, "", "503"), _cp(0, "")],
+            ) as m_run,
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            d._gh_issue_comment(99, "body")
+        assert m_run.call_count == 2
+
+    def test_gh_issue_close_retries_transient_flake(self) -> None:
+        """``_gh_issue_close`` survives one transient ``gh`` flake."""
+        d = _make_daemon()
+        d._write_gh_tmp_body = MagicMock(return_value=Path("/tmp/fake"))  # type: ignore[method-assign]
+        with (
+            patch(
+                "dispatcher.daemon.subprocess.run",
+                side_effect=[_cp(1, "", "503"), _cp(0, "")],
+            ) as m_run,
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            d._gh_issue_close(99, comment="done", reason="completed")
+        assert m_run.call_count == 2

--- a/scripts/tests/test_check_git_gh_retries.sh
+++ b/scripts/tests/test_check_git_gh_retries.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# test_check_git_gh_retries.sh — Tests for
+# scripts/check-git-gh-retries.sh
+#
+# Verifies that the checker:
+#   - passes on synthetic daemon.py contents with well-annotated git/gh
+#     subprocess.run sites
+#   - fails on unannotated ``subprocess.run(["git"|"gh", ...])`` sites
+#   - correctly resolves the ``cmd = [...]; subprocess.run(cmd, ...)``
+#     name-binding pattern
+#   - tolerates non-git/gh subprocess.run calls (python, ruff, etc.)
+#   - passes on the real ``scripts/dispatcher/daemon.py``.
+#
+# Usage:
+#   scripts/tests/test_check_git_gh_retries.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-git-gh-retries.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+write_file() {
+    local path="$TMPDIR_TEST/$1"
+    mkdir -p "$(dirname "$path")"
+    cat > "$path"
+}
+
+assert_passes() {
+    local desc="$1"
+    local target="$2"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$target" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        "$CHECK_SCRIPT" "$target" 2>&1 | sed 's/^/    /'
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"
+    local target="$2"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$target" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+# ─── Test 1: direct list literal with cold-path comment passes ────────────
+write_file "good_direct.py" <<'EOF'
+import subprocess
+
+def handler():
+    # cold-path (#3089): local fs op, no network.
+    subprocess.run(
+        ["git", "-C", "/tmp", "rev-parse", "HEAD"],
+        capture_output=True,
+    )
+EOF
+assert_passes "direct list literal with nearby cold-path annotation" \
+    "$TMPDIR_TEST/good_direct.py"
+
+# ─── Test 2: direct list literal WITHOUT annotation fails ─────────────────
+write_file "bad_direct.py" <<'EOF'
+import subprocess
+
+def handler():
+    subprocess.run(
+        ["git", "-C", "/tmp", "rev-parse", "HEAD"],
+        capture_output=True,
+    )
+EOF
+assert_fails "direct list literal without cold-path annotation" \
+    "$TMPDIR_TEST/bad_direct.py"
+
+# ─── Test 3: name-bound cmd with cold-path annotation passes ──────────────
+write_file "good_cmd_name.py" <<'EOF'
+import subprocess
+
+def handler():
+    # cold-path (#3089): local op.
+    cmd = ["gh", "auth", "setup-git"]
+    subprocess.run(cmd, capture_output=True)
+EOF
+assert_passes "name-bound cmd with cold-path annotation" \
+    "$TMPDIR_TEST/good_cmd_name.py"
+
+# ─── Test 4: name-bound cmd WITHOUT annotation fails ──────────────────────
+write_file "bad_cmd_name.py" <<'EOF'
+import subprocess
+
+def handler():
+    cmd = ["gh", "auth", "setup-git"]
+    subprocess.run(cmd, capture_output=True)
+EOF
+assert_fails "name-bound cmd without cold-path annotation" \
+    "$TMPDIR_TEST/bad_cmd_name.py"
+
+# ─── Test 5: non-git/gh subprocess.run is ignored ─────────────────────────
+write_file "other_subprocess.py" <<'EOF'
+import subprocess
+
+def handler():
+    subprocess.run(["python", "-c", "print(1)"], capture_output=True)
+    subprocess.run(["ruff", "check", "."], capture_output=True)
+EOF
+assert_passes "non-git/gh subprocess.run is ignored" \
+    "$TMPDIR_TEST/other_subprocess.py"
+
+# ─── Test 6: function-parameter cmd is NOT flagged (retry helper shape) ──
+# The shared ``_subprocess_with_retry`` helper takes ``cmd`` as a
+# function parameter. The checker must NOT flag the internal
+# ``subprocess.run(cmd, ...)`` as missing an annotation, because cmd
+# is unresolvable (it's a parameter, not an in-scope Assign).
+write_file "helper_param.py" <<'EOF'
+import subprocess
+
+class D:
+    def _subprocess_with_retry(self, cmd, timeout):
+        # No cold-path annotation needed — cmd is a function parameter,
+        # so the checker cannot resolve its shape. The helper itself
+        # is the retry wrapper.
+        subprocess.run(cmd, timeout=timeout, capture_output=True)
+EOF
+assert_passes "function-parameter cmd is not flagged" \
+    "$TMPDIR_TEST/helper_param.py"
+
+# ─── Test 7: annotation outside the window fails ──────────────────────────
+write_file "too_far.py" <<'EOF'
+import subprocess
+
+# cold-path (#3089): this annotation is too far from the call below.
+def handler():
+    # filler line 1
+    pass
+
+def other():
+    pass
+
+# filler
+EOF
+# Append 70 lines of filler to push the annotation well beyond the 60-line window.
+python3 -c "
+p = '$TMPDIR_TEST/too_far.py'
+with open(p, 'a') as f:
+    for i in range(70):
+        f.write(f'# filler line {i}\n')
+    f.write('''
+def later_handler():
+    subprocess.run([\"gh\", \"issue\", \"view\", \"1\"])
+''')
+"
+assert_fails "annotation outside the 60-line window fails" \
+    "$TMPDIR_TEST/too_far.py"
+
+# ─── Test 8: annotation with wrong issue number fails ─────────────────────
+# Only ``# cold-path (#3089)`` is accepted — a generic cold-path
+# comment without the issue reference should not satisfy the check.
+write_file "wrong_annotation.py" <<'EOF'
+import subprocess
+
+def handler():
+    # cold-path: this is a local op (no issue reference).
+    subprocess.run(["git", "status"], capture_output=True)
+EOF
+assert_fails "annotation missing issue reference fails" \
+    "$TMPDIR_TEST/wrong_annotation.py"
+
+# ─── Test 9: the real daemon.py passes ────────────────────────────────────
+# Regression gate: after #3089 lands, the real daemon.py must satisfy
+# the checker indefinitely. If a future author adds a new git/gh
+# subprocess.run, they must either route through the retry helper or
+# add a ``# cold-path (#3089)`` comment.
+assert_passes "real scripts/dispatcher/daemon.py passes" \
+    "$REPO_ROOT/scripts/dispatcher/daemon.py"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "$TESTS tests run, $FAILURES failed"
+if (( FAILURES > 0 )); then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Audit pass: every `subprocess.run(["git" | "gh", ...])` call site in `scripts/dispatcher/daemon.py` is now either routed through a shared 3-attempt retry helper (`_subprocess_with_retry`) or carries a `# cold-path (#3089)` annotation. Prevents the #3053 / #3085 class of single-transient-failure bug from creeping back in.

Closes #3089

## Classification table

### Cold-path sites (27, annotated with `# cold-path (#3089)`)

| daemon.py line | function | argv | reason |
|---|---|---|---|
| 3992 | `_setup_git_credentials` | `gh auth setup-git` | boot-time one-shot; ECS restarts task on failure |
| 4071 | `ensure_required_labels` | `gh label create ...` | boot-time one-shot, best-effort |
| 4342 | `ensure_baseline_clone` | `git clone` | boot-time one-shot clone |
| 4656 | `_baseline_fetch_origin_main_once` | `git fetch origin main` | already retried by `_baseline_fetch_origin_main` (#3085 wrapper) |
| 4714 | `_unshallow_baseline_if_needed` | `git rev-parse --is-shallow-repository` | boot-time probe, best-effort |
| 4764 | `_unshallow_baseline_if_needed` | `git fetch --unshallow origin main` | boot-time one-shot upgrade |
| 4847 | `_create_worktree` | `git branch -D` | local fs, exit code ignored |
| 4878 | `_create_worktree` | `git worktree add ...` | local fs op, deterministic failures |
| 5008 | `_install_fargate_preflight_hook` | `git update-index --skip-worktree` | local fs, best-effort |
| 5397 | `_capture_and_persist_ralph_patch` | `git format-patch -1 HEAD` | local fs, no network |
| 5447 | `_capture_and_persist_ralph_patch` | `git rev-parse HEAD` | local rev-parse |
| 5718 | `_apply_prior_ralph_patch` | `git am --3way` | real conflicts, retry won't change outcome |
| 5842 | `_git_am_abort` | `git am --abort` | local fs teardown |
| 5868 | `_list_git_am_conflict_files` | `git diff --name-only --diff-filter=U` | local diff |
| 6142 | `_read_head_sha` | `git rev-parse HEAD` | local rev-parse |
| 6238 | `_persist_ralph_iteration_patch` | `git format-patch origin/main..HEAD` | local format-patch |
| 6287 | `_persist_ralph_iteration_patch` | `git rev-parse HEAD` | local rev-parse |
| 6828 | `_is_noop_ship` | `git rev-list --count origin/main..HEAD` | local rev-list |
| 6867 | `_list_committed_files_at_head` | `git show --name-only HEAD` | local show |
| 9635 | `_run_summary_phase` | `git diff origin/main...HEAD` | local diff on worktree |
| 9659 | `_run_summary_phase` | `git diff --name-only HEAD` | local diff |
| 10497 | `_push_and_open_pr` | `git commit --amend -F` | local commit; routes via `_handle_agent_failure` → diagnoser |
| 11834 | `_apply_fix_ci_patch` | `git add -A` | local stage; routes via `_handle_fix_ci_apply_failure` |
| 11893 | `_apply_fix_ci_patch` | `git commit -F` | local commit; routes via `_handle_fix_ci_apply_failure` |
| 13939 | `_check_gh_rate_limit` | `gh api rate_limit` | per-tick advisory; tick-level retry already implicit |
| 14308 | `_drop_worktree_best_effort` | `git worktree remove --force` | local fs housekeeping |
| 17206 | `_gh_issue_is_open_once` | `gh issue view --json state` | already retried by `_gh_issue_is_open_with_detail` (#3053 wrapper) |

### Hot-path sites (25, routed through `_subprocess_with_retry`)

| function | event_name | tool | argv |
|---|---|---|---|
| `_fetch_agent_ready_issues` | `queue_scan` | gh | `gh issue list --label agent/ready --json ...` |
| `_fetch_blocked_issues` | `blocked_scan` | gh | `gh issue list --label status/blocked --json ...` |
| `_fetch_issue_bundle` | `issue_bundle_fetch` | gh | `gh issue view --json number,title,body,...` |
| `_plan_blocked_comment_already_posted` | `plan_blocked_sentinel_check` | gh | `gh issue view --json comments` |
| `_post_plan_blocked_comment` | `plan_blocked_comment_post` | gh | `gh issue comment --body-file` |
| `_swap_plan_blocked_labels` | `plan_blocked_labels` | gh | `gh issue edit --remove-label --add-label` |
| `_needs_review_comment_already_posted` | `needs_review_sentinel_check` | gh | `gh issue view --json comments` |
| `_post_needs_review_comment` | `needs_review_comment_post` | gh | `gh issue comment --body-file` |
| `_push_and_open_pr` | `git_push` | git | `git push -u origin <branch>` |
| `_push_and_open_pr` | `pr_create` | gh | `gh pr create --base main --head <branch>` |
| `_fetch_pr_status` | `pr_view` | gh | `gh pr view --json statusCheckRollup,...` |
| `_merge_pr_and_advance` | `pr_merge` | gh | `gh pr merge --squash --delete-branch` |
| `_fetch_pr_diff` | `pr_diff_fetch` | gh | `gh pr diff <pr>` |
| `_apply_fix_ci_patch` | `fix_ci_git_push` | git | `git push origin <branch>` |
| `_find_deploy_runs` | `deploy_run_list` | gh | `gh run list --commit <sha> --json ...` |
| `_post_evidence_comment` | `evidence_comment` | gh | `gh issue comment --body-file <evidence>` |
| `_file_retro_issue` | `retro_issue_create` | gh | `gh issue create --title --body-file --label` |
| `_build_diagnoser_context` | `diagnoser_context_fetch` | gh | `gh issue view --json title,body` |
| `_gh_issue_comment` | `diagnoser_gh_comment` | gh | `gh issue comment --body-file` |
| `_gh_issue_set_body` | `diagnoser_gh_body` | gh | `gh issue edit --body-file` |
| `_gh_issue_add_labels` | `diagnoser_gh_label` | gh | `gh issue edit --add-label` |
| `_gh_issue_remove_labels` | `label_remove` | gh | `gh issue edit --remove-label` (claim interlock release) |
| `_gh_issue_close` | `diagnoser_gh_close` | gh | `gh issue close --reason --comment` |
| `_gh_issue_create` | `diagnoser_gh_create` | gh | `gh issue create --title --body-file --label` |
| `_gh_issue_append_body` | `diagnoser_gh_append` | gh | `gh issue view --json body` |

## Shared helper

`DispatcherDaemon._subprocess_with_retry(cmd, *, event_name, timeout, extra_log_fields=None)` — 3 attempts, 1s + 2s backoff. First-attempt success returns silently. Each failed attempt emits a `<event_name>_flake` WARNING; full exhaustion emits `<event_name>_exhausted` and returns `{ok: False, reason, stderr_tail, stderr_full, exit_code, attempts}`. Never raises. Caller-specific fallback (RuntimeError re-raise, `_handle_agent_failure` routing, return None) lives at each call site.

## Hygiene check

`scripts/check-git-gh-retries.sh` — AST-based grep for every `subprocess.run([... "git"|"gh" ...])` call site in `daemon.py`, requires a nearby `# cold-path (#3089)` annotation. Resolves `cmd = [...]; subprocess.run(cmd, ...)` name-binding patterns within the enclosing function scope. Function-parameter `cmd` (the retry helper itself) is correctly not flagged. Wired into CI's `scripts-tests` job. 9-test shell suite at `scripts/tests/test_check_git_gh_retries.sh`.

## Test plan

### Automated checks
- [x] Lint passes (`ruff check scripts/dispatcher/daemon.py scripts/dispatcher/tests/test_daemon_subprocess_retries.py`)
- [x] Format check passes (`ruff format --check`)
- [x] Dispatcher tests pass (`pytest scripts/dispatcher/tests/` — 1227 passed, 1 skipped)
- [x] New retry helper tests pass (18 tests in `test_daemon_subprocess_retries.py`)
- [x] Hygiene check test passes (9 tests in `scripts/tests/test_check_git_gh_retries.sh`)
- [x] Bash 3.2 compatibility (`scripts/check-bash-compat.sh`)
- [x] CI green

### Post-deploy verification
- [x] `claim_succeeded` events visible in CloudWatch within 30 minutes of rollout (confirms the hot-path refactor doesn't regress claim behaviour) — confirmed at 2026-04-23T19:11:32Z on issue #2663
- [x] Verification evidence posted on issue #3089
