### PR TITLE
feat(infra): auto-apply terraform on dev after infra merges (#3104)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -80,3 +80,91 @@ jobs:
           done
           echo "::error::Terraform plan failed after 3 attempts"
           exit 1
+
+  # Auto-apply for the dev environment after infra changes merge to main.
+  # Runs only on push:main (skipped for pull_request events) and depends on
+  # the `terraform` job above, so apply only fires if validate + plan both
+  # succeeded on the merge commit. Production applies remain human-only
+  # (#3104).
+  dev-apply:
+    name: Apply dev
+    needs: terraform
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: us-west-2
+      TF_IN_AUTOMATION: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "~1.5"
+
+      - name: Skip if AWS credentials are missing
+        if: ${{ env.AWS_ACCESS_KEY_ID == '' }}
+        run: |
+          echo "::warning::AWS credentials are not configured; skipping dev apply."
+          echo "Skipped: AWS credentials not configured." >> "$GITHUB_STEP_SUMMARY"
+
+      # Fresh init on the runner: no -lockfile=readonly so the provider cache
+      # can be populated. Backend access requires the repo's AWS creds.
+      - name: Terraform Init (dev)
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' }}
+        run: terraform -chdir=infra/terraform/environments/dev init -input=false
+
+      # Apply mirrors the plan job's 3-attempt retry pattern so transient
+      # state-lock timeouts don't fail the merge commit's apply.
+      - name: Terraform Apply (dev)
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' }}
+        id: apply
+        run: |
+          set -o pipefail
+          apply_log="${RUNNER_TEMP}/terraform-apply-dev.log"
+          : > "$apply_log"
+          for attempt in 1 2 3; do
+            echo "::group::Apply attempt $attempt"
+            if terraform -chdir=infra/terraform/environments/dev apply \
+                -auto-approve -input=false -lock-timeout=120s -no-color \
+                2>&1 | tee -a "$apply_log"; then
+              echo "::endgroup::"
+              echo "apply_log=$apply_log" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            ec=$?
+            echo "::endgroup::"
+            if [ "$attempt" -lt 3 ]; then
+              echo "Apply attempt $attempt failed (exit $ec), retrying in 10s..."
+              sleep 10
+            fi
+          done
+          echo "::error::Terraform apply failed after 3 attempts"
+          echo "apply_log=$apply_log" >> "$GITHUB_OUTPUT"
+          exit 1
+
+      # Inline audit trail: paste the last section of the apply output
+      # (which includes the "Apply complete! N added, M changed, K destroyed"
+      # summary line) into the workflow run's step summary.
+      - name: Publish apply summary
+        if: ${{ always() && env.AWS_ACCESS_KEY_ID != '' && steps.apply.outputs.apply_log != '' }}
+        run: |
+          apply_log="${{ steps.apply.outputs.apply_log }}"
+          {
+            echo "## Terraform apply (dev)"
+            echo
+            echo "Commit: \`${GITHUB_SHA}\`"
+            echo
+            echo "### Tail of apply output"
+            echo
+            echo '```'
+            tail -n 200 "$apply_log" || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,7 +254,7 @@ See **`docs/specs/architecture-spec-v1.md` §3.3** for the full ingestion pipeli
 - **Do NOT add `tags` blocks to individual resources** — the AWS provider's `default_tags` handles this.
 - Never commit AWS credentials or state files.
 - **Always run `terraform init` with `-lockfile=readonly`** for agent-side validation (#2582). See `docs/agent/code-standards.md` §Terraform.
-- **Dev terraform apply is automated.** After a PR that touches `infra/terraform/` merges, the dispatcher runs `terraform apply` for dev. Production applies remain human-only.
+- **Dev terraform apply is automated.** The `dev-apply` job in `.github/workflows/terraform.yml` runs `terraform apply -auto-approve` against `environments/dev` on every `push:main` that touches `infra/terraform/**`, once the plan job succeeds. Production applies remain human-only — there is no apply job for `environments/production/`. See `docs/agent/infrastructure-reference.md` §Terraform for the troubleshooting flow when the workflow fails.
 
 ### Running Data Scripts on Dev
 

--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -55,15 +55,28 @@ vercel list judgemind-web-dev --token "$VERCEL_API_TOKEN"
 
 ### Terraform apply after merge
 
-**Dev apply is automated by the dispatcher.** When the dispatcher merges a PR that touches `infra/terraform/`, it automatically runs `terraform apply` for the dev environment. The dispatcher detects infra PRs by checking changed file paths, determines which environments need an apply, and handles init/plan/apply inline. See `.claude/skills/dispatcher/SKILL.md` "Auto-apply dev terraform" for the full procedure.
+**Dev apply is automated by the `Terraform / dev-apply` GitHub Actions job** (`.github/workflows/terraform.yml`). When a PR that touches `infra/terraform/**` merges to `main`, the `terraform` job runs validate + plan first; if that passes, the `dev-apply` job runs `terraform -chdir=infra/terraform/environments/dev apply -auto-approve -input=false -lock-timeout=120s` against the merge commit. Apply output (including the "Apply complete! N added, M changed, K destroyed" summary) is captured as a step summary on the workflow run for audit. The `dev-apply` job is gated on `push:main` + `paths: infra/terraform/**`, so PR events never trigger an apply.
 
-**If the dispatcher is not running** (e.g., during interactive sessions), the subagent that authored the PR must apply to dev manually:
-```
-terraform -chdir=$REPO_ROOT/infra/terraform/environments/dev apply -target=module.<module_name> -auto-approve
-```
-Verify the apply succeeds. If it fails, file a `priority/p1` issue.
+**Production applies are NOT automated.** `environments/production/` is human-only and has no apply job in the workflow.
 
-**For DNS/hosting environments** that require the Cloudflare API token:
+**If the `dev-apply` workflow fails:**
+
+1. Pull the latest `main` and re-run apply locally against the dev environment:
+   ```
+   terraform -chdir=infra/terraform/environments/dev init
+   terraform -chdir=infra/terraform/environments/dev plan
+   terraform -chdir=infra/terraform/environments/dev apply -auto-approve -input=false -lock-timeout=120s
+   ```
+2. If the failure is a state lock timeout, check for a concurrent apply (prior failed run still holding the lock) via the DynamoDB lock table `judgemind-terraform-locks`. The local apply with `-lock-timeout=120s` is typically enough to ride out transient locks.
+3. If the failure is a legitimate apply error (IAM, resource conflict, module bug), fix the root cause and land a follow-up PR.
+4. File a `priority/p1` issue if the failure looks like a workflow regression (e.g., the job no longer fires, creds expired).
+
+**Targeted module applies** (e.g., while debugging an isolated module):
+```
+terraform -chdir=infra/terraform/environments/dev apply -target=module.<module_name> -auto-approve
+```
+
+**For DNS/hosting environments** that require the Cloudflare API token (not yet wired into the workflow — these stay manual):
 ```
 scripts/with-secret.sh -e CLOUDFLARE_API_TOKEN=judgemind/cloudflare/api-token -- terraform -chdir=infra/terraform/environments/dns apply -auto-approve
 ```


### PR DESCRIPTION
## Summary

Fixes #3104 — CLAUDE.md claimed "Dev terraform apply is automated" but the workflow was plan-only and the dispatcher daemon had no terraform subprocess call. Option B per the issue: implement the auto-apply.

- New `dev-apply` job in `.github/workflows/terraform.yml`, gated on `push:main` + `paths: infra/terraform/**` and `needs: terraform` so it only runs after validate+plan pass. Uses the same AWS creds as the plan job. `terraform apply -auto-approve -input=false -lock-timeout=120s`, with the same 3-attempt retry shape as the existing plan step. Captures the apply output tail in `$GITHUB_STEP_SUMMARY` for audit.
- Production apply stays human-only — no job for `environments/production/`. The workflow explicitly skips apply on PR events.
- `CLAUDE.md` §Terraform now names the specific workflow job and points at the new troubleshooting section.
- `docs/agent/infrastructure-reference.md` §Terraform apply after merge was rewritten to describe the workflow-driven flow + local recovery steps when it fails.

## Backfill apply for #3090 (one-time)

The #3090 dispatcher-agent-runner module was sitting unapplied on dev (this was the concrete symptom that motivated the issue). Since the new workflow starts applying from its own first merge — not retroactively — I ran the apply locally from this worktree before pushing:

```
$ terraform -chdir=infra/terraform/environments/dev apply -auto-approve -input=false -lock-timeout=120s
# Plan: 13 to add, 0 to change, 0 to destroy.
# ... (all dispatcher-agent-runner module resources: ECR, IAM roles/policies, SG, log group, task def)
Apply complete!

$ aws ecs describe-task-definition --task-definition judgemind-dispatcher-agent-runner-dev \
    --query 'taskDefinition.{family:family,revision:revision,status:status,cpu:cpu,memory:memory}'
{
    "family": "judgemind-dispatcher-agent-runner-dev",
    "revision": 1,
    "status": "ACTIVE",
    "cpu": "512",
    "memory": "1024"
}
```

## Pre-existing drift surfaced by the plan

After the backfill apply, a follow-up `terraform plan` showed `0 to add, 1 to change, 0 to destroy` — an orphan drift in `module.compute.aws_security_group.scraper`. This is an in-state inline `egress` rule for the residential proxy that was refactored to a separate `aws_security_group_rule` resource in an earlier PR; the refactor was merged but never applied. This is NOT from #3090/#3104 — it's a pre-existing data point that further confirms the issue (merges sitting unapplied). The first auto-apply run on this PR's merge commit will clean it up.

## Test plan

- [ ] Validate + plan jobs pass on this PR (standard `terraform` job path).
- [ ] After merge: the `dev-apply` job fires on the merge commit, applies cleanly, and posts an apply summary to the run. Since the agent-runner backfill already landed locally, the dev-apply diff on the merge commit should be the single orphan scraper-SG change (proving the workflow writes state, not just plans it).
- [ ] `aws ecs describe-task-definition --task-definition judgemind-dispatcher-agent-runner-dev` returns an ACTIVE definition (already verified locally; re-verified in the #3104 closing comment).

Closes #3104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
