### PR TITLE
chore(dispatcher): rename lambda param l to labels to fix E741 (#3101)

### DIFF
--- a/scripts/dispatcher/tests/test_daemon_phase3c.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3c.py
@@ -755,7 +755,7 @@ class TestProcessRetryMarkers:
             ],
         ]
         monkeypatch.setattr(d, "_drop_worktree_best_effort", lambda _p: True)
-        monkeypatch.setattr(d, "_gh_issue_add_labels", lambda n, l: None)
+        monkeypatch.setattr(d, "_gh_issue_add_labels", lambda n, labels: None)
 
         processed = d._process_retry_markers()
         assert processed == 1
@@ -813,7 +813,7 @@ class TestProcessRetryMarkers:
             ],
         ]
         monkeypatch.setattr(d, "_drop_worktree_best_effort", lambda _p: True)
-        monkeypatch.setattr(d, "_gh_issue_add_labels", lambda n, l: None)
+        monkeypatch.setattr(d, "_gh_issue_add_labels", lambda n, labels: None)
 
         processed = d._process_retry_markers()
         assert processed == 1

--- a/scripts/dispatcher/tests/test_daemon_restart_cascade.py
+++ b/scripts/dispatcher/tests/test_daemon_restart_cascade.py
@@ -966,7 +966,7 @@ class TestProcessRetryMarkersInfraPreemption:
         monkeypatch.setattr(d, "_drop_worktree_best_effort", lambda _p: True)
 
         gh_calls: list[tuple[int, list[str]]] = []
-        monkeypatch.setattr(d, "_gh_issue_add_labels", lambda n, l: gh_calls.append((n, l)))
+        monkeypatch.setattr(d, "_gh_issue_add_labels", lambda n, labels: gh_calls.append((n, labels)))
 
         processed = d._process_retry_markers()
         assert processed == 1
@@ -1001,7 +1001,7 @@ class TestProcessRetryMarkersInfraPreemption:
             issue_number=2925,
         )
         monkeypatch.setattr(d, "_drop_worktree_best_effort", lambda _p: True)
-        monkeypatch.setattr(d, "_gh_issue_add_labels", lambda n, l: None)
+        monkeypatch.setattr(d, "_gh_issue_add_labels", lambda n, labels: None)
 
         terminal_calls: list[dict[str, Any]] = []
 


### PR DESCRIPTION
## Summary

Rename four `lambda n, l: ...` stubs in dispatcher tests to `lambda n, labels: ...` to clear pre-existing `E741` ambiguous-variable-name errors. Purely mechanical, no behavioural change.

Closes #3101
