### PR TITLE
feat(dispatcher): daemon _launch_agent_ecs_task + reap + feature flag (#3091)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -311,6 +311,19 @@ module "dispatcher_daemon" {
   # notBreaching` on the alarm keeps it from paging while desired_count=0.
   enable_alerts       = true
   alert_sns_topic_arn = module.compute.alerts_topic_arn
+
+  # #3091 Stage 2 — per-agent ECS launcher wiring. Threads the
+  # agent-runner module's task-def family + security group + role ARNs
+  # through to the daemon's task role (for ecs:RunTask / DescribeTasks
+  # / StopTask / iam:PassRole) and to the daemon's container env vars
+  # (so _launch_agent_ecs_task knows what to run and where). Default
+  # ``dispatcher.config.agent_execution_mode`` stays at ``'subprocess'``
+  # — this wiring is inert until Stage 4 (#3093) flips the default.
+  agent_runner_task_definition_family = module.dispatcher_agent_runner.task_definition_family
+  agent_runner_execution_role_arn     = module.dispatcher_agent_runner.execution_role_arn
+  agent_runner_task_role_arn          = module.dispatcher_agent_runner.task_role_arn
+  agent_runner_subnet_ids             = module.networking.private_subnet_ids
+  agent_runner_security_group_id      = module.dispatcher_agent_runner.security_group_id
 }
 
 # ─── Dispatcher agent-runner task def (Stage 1b, #3090) ─────────────────────

--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -490,6 +490,109 @@ resource "aws_iam_role_policy" "task_put_metric" {
   })
 }
 
+# ─── Per-agent ECS task launcher (#3091 Stage 2) ────────────────────────────
+#
+# Grants the daemon's task role the narrow permissions required to
+# launch + observe + stop the per-agent agent-runner task
+# (`judgemind-dispatcher-agent-runner-<env>` family, shipped in Stage
+# 1b, #3090).
+#
+# Scope invariants:
+#   - ecs:RunTask / ecs:StopTask pinned to the agent-runner task-def
+#     family on this cluster — the daemon cannot spawn other workloads.
+#   - ecs:DescribeTasks uses Resource="*" (the AWS API does not accept
+#     ARN scoping on this action — same quirk as the oneshot policy)
+#     with a cluster-ARN condition.
+#   - iam:PassRole pinned to the agent-runner's execution + task role
+#     ARNs only. Without this, RunTask fails with `AccessDeniedException:
+#     User ... is not authorized to pass role ... because no identity-
+#     based policy allows the iam:PassRole action`.
+#
+# Disabled (count=0) when any of the three required variables is
+# empty. That state keeps the Stage 2 daemon code falling back to the
+# subprocess path regardless of what `dispatcher.config
+# .agent_execution_mode` says, preserving zero-change-on-deploy for
+# environments that haven't wired the agent-runner module yet (e.g.
+# staging / throwaway test stacks).
+
+locals {
+  agent_runner_launch_enabled = (
+    var.agent_runner_task_definition_family != "" &&
+    var.agent_runner_execution_role_arn != "" &&
+    var.agent_runner_task_role_arn != ""
+  )
+  agent_runner_family_arn_pattern = (
+    local.agent_runner_launch_enabled
+    ? "arn:aws:ecs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:task-definition/${var.agent_runner_task_definition_family}:*"
+    : ""
+  )
+  agent_runner_pass_role_arns = compact([
+    var.agent_runner_execution_role_arn,
+    var.agent_runner_task_role_arn,
+  ])
+}
+
+resource "aws_iam_role_policy" "task_launch_agent_runner" {
+  count = local.agent_runner_launch_enabled ? 1 : 0
+
+  name = "${local.service_name}-task-launch-agent-runner"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowRunAgentRunnerTask"
+        Effect   = "Allow"
+        Action   = "ecs:RunTask"
+        Resource = local.agent_runner_family_arn_pattern
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+      {
+        Sid      = "AllowStopAgentRunnerTask"
+        Effect   = "Allow"
+        Action   = "ecs:StopTask"
+        Resource = local.agent_runner_family_arn_pattern
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+      {
+        # DescribeTasks is the per-tick observer call. AWS requires
+        # Resource="*" on this action; the cluster-ARN condition is the
+        # defence-in-depth control (same pattern used by the oneshot
+        # policy above).
+        Sid      = "AllowDescribeAgentRunnerTasks"
+        Effect   = "Allow"
+        Action   = "ecs:DescribeTasks"
+        Resource = "*"
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+      {
+        Sid      = "AllowPassAgentRunnerRoles"
+        Effect   = "Allow"
+        Action   = "iam:PassRole"
+        Resource = local.agent_runner_pass_role_arns
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "ecs-tasks.amazonaws.com"
+          }
+        }
+      },
+    ]
+  })
+}
+
 # ─── ECS Task Definition ────────────────────────────────────────────────────
 # 1 vCPU / 2 GB RAM matches §14 of the spec. Ephemeral storage is pinned to
 # 50 GB per spike 0.6 (realistic mixed peak is ~10 GB across 5 concurrent
@@ -527,6 +630,20 @@ resource "aws_ecs_task_definition" "dispatcher" {
           { name = "HEARTBEAT_METRIC_NAMESPACE", value = "Judgemind/Dispatcher" },
         ],
         var.github_repo != "" ? [{ name = "GITHUB_REPO", value = var.github_repo }] : [],
+        # #3091 Stage 2 — per-agent ECS launcher wiring. All three env
+        # vars are optional; an empty value means the launcher falls
+        # back to the subprocess path. When the agent-runner module is
+        # wired (see environments/dev/main.tf), the caller threads
+        # these values through from the module outputs.
+        var.agent_runner_task_definition_family != "" ? [
+          { name = "AGENT_RUNNER_TASK_DEFINITION_FAMILY", value = var.agent_runner_task_definition_family }
+        ] : [],
+        length(var.agent_runner_subnet_ids) > 0 ? [
+          { name = "AGENT_RUNNER_SUBNET_IDS", value = join(",", var.agent_runner_subnet_ids) }
+        ] : [],
+        var.agent_runner_security_group_id != "" ? [
+          { name = "AGENT_RUNNER_SECURITY_GROUP_ID", value = var.agent_runner_security_group_id }
+        ] : [],
       )
 
       secrets = concat(

--- a/infra/terraform/modules/dispatcher-daemon/variables.tf
+++ b/infra/terraform/modules/dispatcher-daemon/variables.tf
@@ -181,3 +181,46 @@ variable "oneshot_ecr_scraper_repository_arn" {
   type        = string
   default     = ""
 }
+
+# ─── Per-agent ECS task launcher (#3091 Stage 2) ────────────────────────────
+# Wiring the daemon to `ecs:RunTask` the agent-runner task definition
+# (shipped in Stage 1b, #3090) per-agent. When both ARNs below are
+# wired, the daemon's task role gains `ecs:RunTask` /
+# `ecs:DescribeTasks` / `ecs:StopTask` (scoped to the agent-runner
+# task-def family + this cluster) AND `iam:PassRole` (scoped to the
+# agent-runner's execution + task roles).
+#
+# Leave empty to skip the policy entirely — the daemon's self-
+# invocation policy (`task_run_task_self`) and oneshot policy
+# (`task_run_oneshot`) are untouched. Useful while Stage 2 is still
+# inert behind the `agent_execution_mode='subprocess'` default.
+
+variable "agent_runner_task_definition_family" {
+  description = "Family name of the dispatcher-agent-runner task definition (e.g. `judgemind-dispatcher-agent-runner-<env>`). Wired from the dispatcher-agent-runner module's `task_definition_family` output. When set alongside the two role ARNs below, the daemon's task role gains ecs:RunTask / ecs:DescribeTasks / ecs:StopTask scoped to this family. Empty disables — Stage 2 launcher falls back to the subprocess path."
+  type        = string
+  default     = ""
+}
+
+variable "agent_runner_execution_role_arn" {
+  description = "ARN of the agent-runner execution role (exported by the dispatcher-agent-runner module as `execution_role_arn`). Passed to the agent-runner task on RunTask, so the daemon's PassRole scope must include it. Empty disables the Stage 2 policy."
+  type        = string
+  default     = ""
+}
+
+variable "agent_runner_task_role_arn" {
+  description = "ARN of the agent-runner task role (exported by the dispatcher-agent-runner module as `task_role_arn`). Passed to the agent-runner task on RunTask, so the daemon's PassRole scope must include it. Empty disables the Stage 2 policy."
+  type        = string
+  default     = ""
+}
+
+variable "agent_runner_subnet_ids" {
+  description = "Private subnet IDs the agent-runner tasks launch into. Typically the same list as the daemon's `private_subnet_ids`. Threaded into the dispatcher container as AGENT_RUNNER_SUBNET_IDS (comma-separated) for the Stage 2 launcher's network_configuration. Empty list disables the env var — daemon falls back to subprocess mode."
+  type        = list(string)
+  default     = []
+}
+
+variable "agent_runner_security_group_id" {
+  description = "Security group ID attached to agent-runner tasks (exported by the dispatcher-agent-runner module as `security_group_id`). Threaded into the dispatcher container as AGENT_RUNNER_SECURITY_GROUP_ID. Empty disables the env var."
+  type        = string
+  default     = ""
+}

--- a/packages/api/migrations/41_dispatcher-agent-task-arn.sql
+++ b/packages/api/migrations/41_dispatcher-agent-task-arn.sql
@@ -1,0 +1,91 @@
+-- Up Migration
+--
+-- Dispatcher v2 — Stage 2 of the per-agent ECS migration (issue #3091,
+-- part of the #3086 / #3078 Option A plan). Adds two columns to
+-- ``dispatcher.agents`` so the daemon can track the lifecycle of a
+-- one-shot agent-runner ECS task per agent.
+--
+-- Stage 2 context
+-- ---------------
+-- Stage 1a shipped the shared ``scripts/dispatcher/phase_transitions``
+-- module (#3086). Stage 1b shipped the
+-- ``judgemind-dispatcher-agent-runner-dev`` task definition + entrypoint
+-- (#3090). Stage 2 wires the daemon to ``ecs:RunTask`` the new task def
+-- per agent and to observe its lifecycle via ``ecs:DescribeTasks``. The
+-- columns below are the persistence surface for that wiring:
+--
+--   * ``agent_task_arn`` — the ECS task ARN returned by ``ecs:RunTask``
+--     for this agent's runner. NULL while the agent is running in the
+--     legacy subprocess mode; populated the moment the daemon launches
+--     the per-agent ECS task. Reads across a daemon restart: a fresh
+--     daemon can ``ecs:DescribeTasks`` against every non-NULL value to
+--     resume observation without the #3078 "every in-flight agent gets
+--     killed on redeploy" bug.
+--
+--   * ``execution_mode`` — one of ``'subprocess'`` | ``'ecs'``. Set
+--     once at claim time from ``dispatcher.config.agent_execution_mode``
+--     and held immutable across the agent's lifetime (so a mid-flight
+--     flip of the config flag does not produce a hybrid agent). The
+--     default is ``'subprocess'`` — this PR is inert on deploy until
+--     Stage 3 smoke (#3092) and Stage 4 flip-default (#3093).
+--
+-- Design notes
+-- ------------
+-- - ``execution_mode`` is ``TEXT NOT NULL DEFAULT 'subprocess'`` rather
+--   than a CHECK-constrained enum. A TEXT column with a default lets
+--   pre-#3091 rows (backfilled via the ALTER DEFAULT) take the
+--   subprocess lane automatically, which is exactly the behaviour we
+--   want during the migration window. A CHECK constraint can be added
+--   in Stage 5 (#3094) once ``subprocess`` is removed and the value set
+--   shrinks to a single option.
+--
+-- - ``agent_task_arn`` is NULLable because the legacy subprocess mode
+--   does not populate it. Even in ``execution_mode='ecs'`` mode the
+--   ARN is NULL between claim and a successful ``ecs:RunTask`` (a few
+--   seconds at most); the reap path tolerates NULL.
+--
+-- - Partial index on ``(agent_task_arn) WHERE agent_task_arn IS NOT
+--   NULL`` so the daemon's reap pass (one ``ecs:DescribeTasks`` call
+--   per scheduler tick) can scan only the rows that have a live ECS
+--   task ARN attached. Without the WHERE predicate the full-table
+--   index would include every historical agent_task_arn=NULL row,
+--   which is most of the table for the life of the subprocess path.
+--
+-- Rollback
+-- --------
+-- Dropping the columns is safe — nothing else in the schema references
+-- them, and the daemon tolerates their absence at runtime (the Stage 2
+-- daemon code checks for the columns via the same ``SELECT column_name
+-- FROM information_schema.columns`` probe the test suite uses).
+
+ALTER TABLE dispatcher.agents
+    ADD COLUMN agent_task_arn TEXT NULL;
+
+ALTER TABLE dispatcher.agents
+    ADD COLUMN execution_mode TEXT NOT NULL DEFAULT 'subprocess';
+
+CREATE INDEX dispatcher_agents_task_arn_idx
+    ON dispatcher.agents (agent_task_arn)
+    WHERE agent_task_arn IS NOT NULL;
+
+COMMENT ON COLUMN dispatcher.agents.agent_task_arn IS
+    'ECS task ARN of the per-agent agent-runner task (#3091). NULL for '
+    'legacy subprocess-mode agents and between claim + ecs:RunTask in '
+    'ecs-mode agents. Partial-indexed so the daemon reap pass scans '
+    'only live ECS agents.';
+
+COMMENT ON COLUMN dispatcher.agents.execution_mode IS
+    'One of ''subprocess'' (legacy, default) | ''ecs'' (per-agent '
+    'Fargate task via ecs:RunTask). Set once at claim time from '
+    'dispatcher.config.agent_execution_mode and held immutable across '
+    'the agent''s lifetime. See #3091 / #3086 / #3078.';
+
+
+-- Down Migration
+DROP INDEX IF EXISTS dispatcher.dispatcher_agents_task_arn_idx;
+
+ALTER TABLE dispatcher.agents
+    DROP COLUMN IF EXISTS execution_mode;
+
+ALTER TABLE dispatcher.agents
+    DROP COLUMN IF EXISTS agent_task_arn;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 40 migrations.
+-- Generated from 41 migrations.
 
 
 
@@ -363,7 +363,9 @@ CREATE TABLE dispatcher.agents (
     merged_at timestamp with time zone,
     verified_at timestamp with time zone,
     verify_skip_reason text,
-    retroed_at timestamp with time zone
+    retroed_at timestamp with time zone,
+    agent_task_arn text,
+    execution_mode text DEFAULT 'subprocess'::text NOT NULL
 );
 
 
@@ -395,6 +397,12 @@ COMMENT ON COLUMN dispatcher.agents.verify_skip_reason IS 'Non-null when verify 
 
 
 COMMENT ON COLUMN dispatcher.agents.retroed_at IS 'Timestamp the retro phase reached PHASE_RETRO_DONE. NULL when retro crashed, when the worktree was already gone at retro time (fast-path to cleanup_done), or for pre-migration-35 rows. A merged row with ``verified_at`` set but ``retroed_at`` NULL renders as amber ✓ — "shipped + verified but retro bookkeeping did not complete". Issue #2953.';
+
+
+COMMENT ON COLUMN dispatcher.agents.agent_task_arn IS 'ECS task ARN of the per-agent agent-runner task (#3091). NULL for legacy subprocess-mode agents and between claim + ecs:RunTask in ecs-mode agents. Partial-indexed so the daemon reap pass scans only live ECS agents.';
+
+
+COMMENT ON COLUMN dispatcher.agents.execution_mode IS 'One of ''subprocess'' (legacy, default) | ''ecs'' (per-agent Fargate task via ecs:RunTask). Set once at claim time from dispatcher.config.agent_execution_mode and held immutable across the agent''s lifetime. See #3091 / #3086 / #3078.';
 
 
 CREATE TABLE dispatcher.blocked_snapshots (
@@ -1233,6 +1241,9 @@ CREATE INDEX idx_rulings_posted_at ON derived.rulings USING btree (posted_at DES
 
 
 CREATE UNIQUE INDEX uq_rulings_case_text_hash ON derived.rulings USING btree (case_id, ruling_text_hash) WHERE (ruling_text_hash IS NOT NULL);
+
+
+CREATE INDEX dispatcher_agents_task_arn_idx ON dispatcher.agents USING btree (agent_task_arn) WHERE (agent_task_arn IS NOT NULL);
 
 
 CREATE UNIQUE INDEX idx_dispatcher_agents_active_issue ON dispatcher.agents USING btree (issue_number) WHERE (status = ANY (ARRAY['running'::text, 'retrying'::text]));

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -18228,11 +18228,12 @@ class DispatcherDaemon:
                             "observed_phase": current_phase,
                         },
                     )
-                    # ROUTING (#3062 #3091): NOT routed via
+                    # ROUTING (#3062): NOT routed via
                     # ``_handle_agent_failure`` — container exit 0
-                    # means the agent-runner completed successfully;
-                    # the gap is a bookkeeping issue the daemon can
-                    # close without a diagnoser round-trip.
+                    # means the agent-runner (#3091) completed
+                    # successfully; the row gap is a bookkeeping issue
+                    # the daemon can close without a diagnoser
+                    # round-trip.
                     self._mark_agent_terminal(
                         agent_id,
                         status="succeeded",
@@ -18282,10 +18283,10 @@ class DispatcherDaemon:
                     },
                 )
                 exit_code_for_failure = exit_codes[0] if exit_codes else None
-                # ROUTING (#3062 #3091): ROUTED via
-                # ``_handle_agent_failure`` so the diagnoser can
-                # classify — ``agent_task_stopped_unexpectedly`` is the
-                # per-agent-ECS sibling of the subprocess-mode
+                # ROUTING (#3062): ROUTED via ``_handle_agent_failure``
+                # so the diagnoser can classify —
+                # ``agent_task_stopped_unexpectedly`` is the
+                # per-agent-ECS (#3091) sibling of the subprocess-mode
                 # ``subprocess_crash`` tier-1 failure.
                 self._handle_agent_failure(
                     agent_id=agent_id,

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -240,6 +240,51 @@ DEFAULT_HEARTBEAT_METRIC_NAMESPACE = "Judgemind/Dispatcher"
 #: (us-west-2).
 DEFAULT_AWS_REGION = "us-west-2"
 
+#: Default value for ``dispatcher.config.agent_execution_mode`` when the
+#: row is missing or malformed. ``'subprocess'`` keeps the pre-#3091
+#: behaviour — the daemon spawns per-phase ``claude -p`` subprocesses
+#: inside its own container — and is the safe default until Stage 3
+#: smoke (#3092) confirms the ECS path end-to-end and Stage 4 (#3093)
+#: flips this default.
+DEFAULT_AGENT_EXECUTION_MODE = "subprocess"
+
+#: Valid values for ``dispatcher.config.agent_execution_mode``. Anything
+#: outside this set falls back to :data:`DEFAULT_AGENT_EXECUTION_MODE`
+#: with a warning so a typo in the config row cannot route agents into
+#: an unknown launch lane.
+AGENT_EXECUTION_MODES: frozenset[str] = frozenset({"subprocess", "ecs"})
+
+#: Number of ``ecs:RunTask`` attempts per agent launch. Three attempts
+#: with 1s + 2s backoff mirrors the retry shape used by
+#: :meth:`DispatcherDaemon._baseline_fetch_origin_main` (issue #3085)
+#: and the ``gh`` retry path from #3053. Tested by
+#: ``test_daemon_launch_agent_ecs_task.py``.
+AGENT_RUNNER_RUN_TASK_MAX_ATTEMPTS = 3
+
+#: Backoff schedule (seconds) between ``ecs:RunTask`` retries. Length is
+#: ``AGENT_RUNNER_RUN_TASK_MAX_ATTEMPTS - 1`` so there's one backoff
+#: between each pair of attempts. ``1s + 2s`` matches #3053 / #3085.
+AGENT_RUNNER_RUN_TASK_BACKOFF_SECONDS: tuple[float, ...] = (1.0, 2.0)
+
+#: botocore error codes treated as transient for ``ecs:RunTask``
+#: purposes (retry). Anything outside this set fails immediately —
+#: retrying a throttle or capacity blip is cheap; retrying an
+#: AccessDenied or ValidationException will never recover on its own.
+AGENT_RUNNER_RUN_TASK_RETRYABLE_CODES: frozenset[str] = frozenset(
+    {
+        "ThrottlingException",
+        "Throttling",
+        "RequestLimitExceeded",
+        "ServiceUnavailable",
+        "InternalFailure",
+        "InternalServerError",
+        # ECS returns these when the cluster / capacity provider is
+        # under load — transient by nature.
+        "Server",
+        "Capacity",
+    }
+)
+
 #: Phase 2 spawn-safety invariant: this value must be 0. The daemon
 #: asserts this on every scheduler tick and logs a warning if the live
 #: ``dispatcher.config.concurrency_cap`` is anything else. The actual
@@ -1088,6 +1133,32 @@ def _stderr_tail(stderr: str | bytes | None) -> str:
     return stderr[-STRUCTURED_LOG_STDERR_MAX:]
 
 
+def _extract_botocore_error_code(exc: Exception) -> str:
+    """Return the botocore ``Error.Code`` string from a ClientError-like exception.
+
+    Used by :meth:`DispatcherDaemon._launch_agent_ecs_task` (issue
+    #3091) to decide whether an ``ecs:RunTask`` failure is transient
+    (retry) or deterministic (fail fast). Returns an empty string
+    when the exception is not a botocore ``ClientError`` or the
+    ``response`` structure is missing the expected fields. Defensive
+    enough that a random ``Exception`` raised by a test mock also
+    resolves to "" without crashing.
+
+    The real ``botocore.exceptions.ClientError`` exposes
+    ``exc.response['Error']['Code']``. We duck-type through
+    ``getattr`` so the daemon doesn't have to import botocore just
+    to classify errors in the retry wrapper.
+    """
+    response = getattr(exc, "response", None)
+    if not isinstance(response, dict):
+        return ""
+    error = response.get("Error")
+    if not isinstance(error, dict):
+        return ""
+    code = error.get("Code")
+    return str(code) if code else ""
+
+
 def _format_age_ago(seconds: float) -> str:
     """Render a compact human-readable age like ``2h 15m ago`` (#3026).
 
@@ -1520,6 +1591,27 @@ class DaemonConfig:
     #: and places per-agent worktrees at ``baseline_repo_root.parent /
     #: "worktrees" / agent-<uuid>`` (see :data:`DEFAULT_BASELINE_REPO_ROOT`).
     baseline_repo_root: Path | None = None
+    # ── Per-agent ECS task wiring (#3091 Stage 2) ────────────────────
+    #: ECS cluster ARN the agent-runner tasks launch into. Populated
+    #: from ``ECS_CLUSTER_ARN`` (shared with the RunTask-self policy
+    #: the daemon already consumes). Empty when the daemon runs
+    #: locally / in unit tests — :meth:`DispatcherDaemon._launch_agent_ecs_task`
+    #: fails closed with a structured log event in that case.
+    ecs_cluster_arn: str = ""
+    #: ECS task definition family for the per-agent runner. Populated
+    #: from ``AGENT_RUNNER_TASK_DEFINITION_FAMILY`` (wired from the
+    #: ``dispatcher-agent-runner`` Terraform module's
+    #: ``task_definition_family`` output). Empty in local/test mode.
+    agent_runner_task_definition_family: str = ""
+    #: Comma-separated private subnet IDs the agent-runner tasks run in.
+    #: Populated from ``AGENT_RUNNER_SUBNET_IDS``. Parsed to a tuple
+    #: by :func:`_build_config` for convenient consumption.
+    agent_runner_subnet_ids: tuple[str, ...] = ()
+    #: Security group ID attached to agent-runner tasks. Populated from
+    #: ``AGENT_RUNNER_SECURITY_GROUP_ID`` (wired from the
+    #: ``dispatcher-agent-runner`` Terraform module's
+    #: ``security_group_id`` output).
+    agent_runner_security_group_id: str = ""
     # Optional override used by tests to avoid os.environ mutation.
     config_override: dict[str, Any] = field(default_factory=dict)
 
@@ -1806,6 +1898,12 @@ class DispatcherDaemon:
         # ticks — boto3 clients are thread-safe and reusing one avoids
         # repeated credential lookups.
         self._cloudwatch_client: Any | None = None
+        # ECS client for the #3091 Stage 2 per-agent task launcher +
+        # reap loop. Same lazy-creation pattern as CloudWatch above so
+        # tests can stub ``_make_ecs_client`` without installing boto3.
+        # boto3 clients are thread-safe; reuse across scheduler + reap
+        # paths avoids redundant credential lookups.
+        self._ecs_client: Any | None = None
         # Phase 3A: within-tick handoff between phase helpers. Reset at
         # the start of each orchestration run so a previous failure's
         # partial state cannot leak into the next attempt.
@@ -2296,6 +2394,36 @@ class DispatcherDaemon:
                 },
             )
 
+        # #3091 Stage 2 reap pass. Observe any in-flight per-agent ECS
+        # tasks (``dispatcher.agents.agent_task_arn IS NOT NULL``) and
+        # act on STOPPED transitions. No-op on the subprocess path
+        # (no rows have ``agent_task_arn`` populated) and no-op when
+        # ``ecs_cluster_arn`` is unset (local dev / unit tests). This
+        # is the #3078 Option A payoff: a fresh daemon after a redeploy
+        # simply resumes observing the existing ARNs — every in-flight
+        # agent survives the redeploy without the pre-#3091 daemon-
+        # restart-abandoned cascade.
+        #
+        # Exceptions here are caught + logged but not re-raised — the
+        # scheduler tick must survive any reap failure so the downstream
+        # queue scan + claim gate still fire this tick.
+        reap_summary = {
+            "active": 0,
+            "reaped_success": 0,
+            "reaped_failure": 0,
+            "still_running": 0,
+        }
+        try:
+            reap_summary = self._reap_completed_agent_tasks()
+        except Exception:
+            self._log.exception(
+                "daemon.reap_agent_tasks_unhandled",
+                extra={
+                    "event": "reap_agent_tasks_unhandled",
+                    "run_id": self._run_id,
+                },
+            )
+
         # 3. Scan the ``agent/ready`` queue and persist a snapshot.
         #
         # Failures here (rate limit, network, auth) log + return -1 but
@@ -2393,6 +2521,11 @@ class DispatcherDaemon:
                 # before the queue scan this tick. Non-zero means an
                 # interrupted agent was reclaimed ahead of fresh work.
                 "retry_markers_prioritized": retry_markers_prioritized,
+                # #3091: per-agent ECS reap-pass observability.
+                "reap_active": reap_summary["active"],
+                "reap_success": reap_summary["reaped_success"],
+                "reap_failure": reap_summary["reaped_failure"],
+                "reap_still_running": reap_summary["still_running"],
             },
         )
         return {
@@ -2407,6 +2540,11 @@ class DispatcherDaemon:
             # #2949 observability — count of infra-preemption retry
             # markers drained before the queue scan.
             "retry_markers_prioritized": retry_markers_prioritized,
+            # #3091 observability — per-agent ECS reap-pass counters.
+            "reap_active": reap_summary["active"],
+            "reap_success": reap_summary["reaped_success"],
+            "reap_failure": reap_summary["reaped_failure"],
+            "reap_still_running": reap_summary["still_running"],
         }
 
     # ── command consumption (#2801) ────────────────────────────────────
@@ -3736,6 +3874,7 @@ class DispatcherDaemon:
         worktree_path: str,
         issue_title: str | None = None,
         priority: str | None = None,
+        execution_mode: str = DEFAULT_AGENT_EXECUTION_MODE,
     ) -> bool:
         """INSERT a new agent row; return True on success, False on race.
 
@@ -3759,6 +3898,14 @@ class DispatcherDaemon:
         admin cockpit's Active-agents and Recently-completed panels
         render this as a coloured badge; pre-migration-33 rows render
         an em-dash placeholder.
+
+        ``execution_mode`` is ``'subprocess'`` (default, legacy
+        in-container phase subprocesses) or ``'ecs'`` (per-agent
+        Fargate task via ``ecs:RunTask`` — issue #3091, migration 41).
+        Written once at claim time so an agent's execution lane is
+        immutable across its lifetime — a mid-flight flip of
+        ``dispatcher.config.agent_execution_mode`` does not produce
+        a hybrid agent.
         """
         assert self._conn is not None, "connect() must run before claiming"
 
@@ -3772,9 +3919,9 @@ class DispatcherDaemon:
                     "INSERT INTO dispatcher.agents "
                     "    (agent_id, parent_run_id, kind, issue_number, "
                     "     issue_title, worktree_path, phase, status, "
-                    "     priority) "
+                    "     priority, execution_mode) "
                     "VALUES (%s, %s, 'task', %s, %s, %s, 'claiming', "
-                    "        'running', %s)",
+                    "        'running', %s, %s)",
                     (
                         agent_id,
                         self._run_id,
@@ -3782,6 +3929,7 @@ class DispatcherDaemon:
                         issue_title,
                         worktree_path,
                         priority,
+                        execution_mode,
                     ),
                 )
             self._conn.commit()
@@ -7656,6 +7804,16 @@ class DispatcherDaemon:
         # blocks the claim.
         issue_priority = self._latest_queue_snapshot_priority_for(issue_number)
 
+        # Read the execution-mode flag once at claim time (#3091). The
+        # chosen mode is stored on the agent row and held immutable
+        # across the agent's lifetime — a mid-flight flip of
+        # ``dispatcher.config.agent_execution_mode`` does not produce
+        # a hybrid agent that launched as an ECS task but advanced
+        # its phases via the subprocess path. Defaults to
+        # ``'subprocess'`` (legacy in-container) until Stage 4 (#3093)
+        # flips the default.
+        execution_mode = self._read_agent_execution_mode()
+
         self._log.info(
             "daemon.candidate_picked",
             extra={
@@ -7665,6 +7823,7 @@ class DispatcherDaemon:
                 "issue_number": issue_number,
                 "issue_title_captured": issue_title is not None,
                 "issue_priority": issue_priority,
+                "execution_mode": execution_mode,
             },
         )
 
@@ -7674,9 +7833,40 @@ class DispatcherDaemon:
             str(worktree_path),
             issue_title=issue_title,
             priority=issue_priority,
+            execution_mode=execution_mode,
         ):
             # Race lost. Don't try the next candidate on this tick —
             # the next tick will re-scan the queue.
+            return
+
+        # #3091 Stage 2 claim-time dispatch. When the agent's
+        # execution_mode is ``'ecs'`` we launch a per-agent ECS task
+        # via :meth:`_launch_agent_ecs_task` and return. The per-agent
+        # agent-runner container runs the full phase pipeline
+        # internally (via the entrypoint shipped in Stage 1b, #3090)
+        # and persists its own ``dispatcher.agents`` updates; the
+        # daemon observes the lifecycle via
+        # :meth:`_reap_completed_agent_tasks` on every scheduler_tick.
+        # DO NOT call ``_create_worktree`` + ``_run_orchestration_phases``
+        # in this branch — that would double-dispatch the work.
+        if execution_mode == "ecs":
+            task_arn = self._launch_agent_ecs_task(agent_id, issue_number)
+            if task_arn is None:
+                # Launch failed after retries. Route through the
+                # unified failure path so the diagnoser can classify.
+                self._handle_agent_failure(
+                    agent_id=agent_id,
+                    phase="claiming",
+                    category="agent_task_launch_failed",
+                    stderr_tail="",
+                    exit_code=None,
+                    details={
+                        "task_definition_family": (
+                            self._cfg.agent_runner_task_definition_family
+                        ),
+                    },
+                    issue_number=issue_number,
+                )
             return
 
         # From here on, any failure must move the agent to status=failed
@@ -17475,6 +17665,677 @@ class DispatcherDaemon:
         )
         return True
 
+    # ── per-agent ECS launcher + reaper (#3091 Stage 2) ─────────────────
+    #
+    # These methods wire the daemon to the ``judgemind-dispatcher-agent-
+    # runner-<env>`` Fargate task definition shipped in Stage 1b (#3090).
+    # Gated behind ``dispatcher.config.agent_execution_mode == 'ecs'``
+    # which defaults to ``'subprocess'`` — until Stage 4 (#3093) flips
+    # the default the methods below are cold in production.
+    #
+    # Why this matters for #3078 Option A
+    # -----------------------------------
+    # In the pre-#3091 model the daemon runs every phase as a child
+    # subprocess (``claude -p /task-v2-<phase> <agent_id>``) inside its
+    # own container. A daemon redeploy SIGKILLs every in-flight child,
+    # abandoning every in-flight agent. Option A moves the long-running
+    # phase work into a per-agent ECS task: the daemon becomes a pure
+    # scheduler, and a daemon restart simply resumes observing the
+    # existing ``agent_task_arn`` ARNs via ``ecs:DescribeTasks`` — no
+    # abandonment, no retry cost, no operator-visible hiccup.
+
+    def _make_ecs_client(self) -> Any:
+        """Build a boto3 ECS client. Isolated so tests can mock it.
+
+        Mirrors :meth:`_make_cloudwatch_client` — lazy boto3 import so
+        tests that don't exercise the ECS launcher path do not have to
+        install boto3. Region comes from :attr:`DaemonConfig.aws_region`
+        which is already wired from ``AWS_REGION`` / ``AWS_DEFAULT_REGION``.
+        """
+        import boto3  # noqa: PLC0415 — lazy import
+
+        return boto3.client("ecs", region_name=self._cfg.aws_region)
+
+    def _cb_config_str(self, key: str, default: str) -> str:
+        """Read a string key from ``dispatcher.config`` with a fallback.
+
+        Sibling of :meth:`_cb_config_int`. Returns ``default`` on
+        missing row, malformed JSON, non-string value, or DB error —
+        config reads must never crash the claim or reap paths. Empty
+        strings are also treated as "not set" and fall back to
+        ``default`` so a ``NULL``-then-overwritten row doesn't accidentally
+        route agents into an empty execution mode.
+        """
+        assert self._conn is not None, "connect() must run before config read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    (key,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return default
+        if row is None or row[0] is None:
+            return default
+        raw = row[0]
+        # psycopg decodes JSONB strings natively to Python strings. Test
+        # fixtures sometimes feed raw JSON bytes (``'"ecs"'``) via a
+        # fake cursor, so re-parse strings through ``json.loads`` — if
+        # that fails, keep the raw string (a plain legacy TEXT value).
+        if isinstance(raw, str):
+            try:
+                parsed = json.loads(raw)
+                if isinstance(parsed, str):
+                    raw = parsed
+            except (json.JSONDecodeError, ValueError):
+                # Already a bare string — use verbatim.
+                pass
+        if not isinstance(raw, str) or not raw:
+            return default
+        return raw
+
+    def _read_agent_execution_mode(self) -> str:
+        """Return the configured agent execution mode.
+
+        Reads ``dispatcher.config.agent_execution_mode`` via
+        :meth:`_cb_config_str`. Validates against
+        :data:`AGENT_EXECUTION_MODES`; an unrecognized value (typo,
+        operator copy-paste slip) falls back to
+        :data:`DEFAULT_AGENT_EXECUTION_MODE` with a warning so the
+        daemon never routes agents into an unknown launch lane.
+        """
+        raw = self._cb_config_str("agent_execution_mode", DEFAULT_AGENT_EXECUTION_MODE)
+        if raw not in AGENT_EXECUTION_MODES:
+            self._log.warning(
+                "daemon.agent_execution_mode_unrecognized",
+                extra={
+                    "event": "agent_execution_mode_unrecognized",
+                    "run_id": self._run_id,
+                    "raw": raw,
+                    "fallback": DEFAULT_AGENT_EXECUTION_MODE,
+                },
+            )
+            return DEFAULT_AGENT_EXECUTION_MODE
+        return raw
+
+    def _agent_runner_wiring_ready(self) -> bool:
+        """Return True iff the ECS task-launch config is fully populated.
+
+        Guards :meth:`_launch_agent_ecs_task` — if the operator enabled
+        ``agent_execution_mode='ecs'`` but the terraform-wired env vars
+        are still empty (dev deploy out-of-order, test env, local dev),
+        the daemon must NOT call ``ecs:RunTask`` with missing required
+        fields. This check returns False in that state and the caller
+        falls back to the subprocess path for safety.
+        """
+        return bool(
+            self._cfg.ecs_cluster_arn
+            and self._cfg.agent_runner_task_definition_family
+            and self._cfg.agent_runner_subnet_ids
+            and self._cfg.agent_runner_security_group_id
+        )
+
+    def _launch_agent_ecs_task(
+        self, agent_id: str, issue_number: int | None
+    ) -> str | None:
+        """``ecs:RunTask`` the agent-runner task def for one agent.
+
+        Returns the launched task ARN on success or ``None`` on
+        failure. On success, UPDATEs ``dispatcher.agents`` with
+        ``agent_task_arn = <arn>`` and ``execution_mode = 'ecs'``.
+        On failure the caller is expected to terminate the agent via
+        :meth:`_handle_agent_failure` (``launch_failed`` category).
+
+        Retries up to :data:`AGENT_RUNNER_RUN_TASK_MAX_ATTEMPTS` times
+        on transient botocore errors (throttling, capacity, 5xx) with
+        :data:`AGENT_RUNNER_RUN_TASK_BACKOFF_SECONDS` backoffs. Mirrors
+        the retry pattern in
+        :meth:`_baseline_fetch_origin_main` (#3085) and the gh rate-
+        limit retry path from #3053.
+
+        Non-transient errors (AccessDenied, ValidationException) fail
+        immediately — retrying those will never succeed and burns
+        scheduler-tick time.
+        """
+        if not self._agent_runner_wiring_ready():
+            self._log.error(
+                "daemon.agent_runner_wiring_missing",
+                extra={
+                    "event": "agent_runner_wiring_missing",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "detail": (
+                        "agent_execution_mode=ecs but ECS_CLUSTER_ARN / "
+                        "AGENT_RUNNER_TASK_DEFINITION_FAMILY / "
+                        "AGENT_RUNNER_SUBNET_IDS / "
+                        "AGENT_RUNNER_SECURITY_GROUP_ID not fully wired"
+                    ),
+                },
+            )
+            return None
+
+        overrides = {
+            "containerOverrides": [
+                {
+                    "name": "agent-runner",
+                    "environment": [
+                        {"name": "AGENT_ID", "value": agent_id},
+                        {
+                            "name": "ISSUE_NUMBER",
+                            "value": str(issue_number)
+                            if issue_number is not None
+                            else "",
+                        },
+                    ],
+                }
+            ],
+        }
+        network_configuration = {
+            "awsvpcConfiguration": {
+                "subnets": list(self._cfg.agent_runner_subnet_ids),
+                "securityGroups": [self._cfg.agent_runner_security_group_id],
+                "assignPublicIp": "DISABLED",
+            }
+        }
+        tags = [
+            {"key": "agent_id", "value": agent_id},
+            {
+                "key": "issue_number",
+                "value": str(issue_number) if issue_number is not None else "",
+            },
+            {"key": "dispatcher_run_id", "value": self._run_id or ""},
+        ]
+
+        last_exc: Exception | None = None
+        for attempt in range(1, AGENT_RUNNER_RUN_TASK_MAX_ATTEMPTS + 1):
+            try:
+                if self._ecs_client is None:
+                    self._ecs_client = self._make_ecs_client()
+                response = self._ecs_client.run_task(
+                    cluster=self._cfg.ecs_cluster_arn,
+                    taskDefinition=self._cfg.agent_runner_task_definition_family,
+                    launchType="FARGATE",
+                    count=1,
+                    overrides=overrides,
+                    networkConfiguration=network_configuration,
+                    tags=tags,
+                    propagateTags="TASK_DEFINITION",
+                )
+            except Exception as exc:  # noqa: BLE001 — classified below
+                last_exc = exc
+                code = _extract_botocore_error_code(exc)
+                retryable = code in AGENT_RUNNER_RUN_TASK_RETRYABLE_CODES
+                self._log.warning(
+                    "daemon.agent_runner_run_task_attempt_failed",
+                    extra={
+                        "event": "agent_runner_run_task_attempt_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "issue_number": issue_number,
+                        "attempt": attempt,
+                        "max_attempts": AGENT_RUNNER_RUN_TASK_MAX_ATTEMPTS,
+                        "error_code": code,
+                        "retryable": retryable,
+                        "detail": str(exc),
+                    },
+                )
+                # Reset the client on error so the next attempt picks
+                # up fresh credentials / a rebound endpoint.
+                self._ecs_client = None
+                if not retryable:
+                    break
+                if attempt < AGENT_RUNNER_RUN_TASK_MAX_ATTEMPTS:
+                    backoff = AGENT_RUNNER_RUN_TASK_BACKOFF_SECONDS[attempt - 1]
+                    time.sleep(backoff)
+                    continue
+                break
+            # Success path: parse the response, persist the ARN.
+            failures = response.get("failures") or []
+            if failures:
+                # ``failures[]`` is how ECS surfaces per-task capacity
+                # reasons even when the HTTP call itself succeeded (200).
+                # Treat as a transient retryable signal — retrying
+                # in a few seconds commonly recovers when capacity
+                # briefly thins.
+                self._log.warning(
+                    "daemon.agent_runner_run_task_response_failure",
+                    extra={
+                        "event": "agent_runner_run_task_response_failure",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "issue_number": issue_number,
+                        "attempt": attempt,
+                        "failures": failures,
+                    },
+                )
+                if attempt < AGENT_RUNNER_RUN_TASK_MAX_ATTEMPTS:
+                    backoff = AGENT_RUNNER_RUN_TASK_BACKOFF_SECONDS[attempt - 1]
+                    time.sleep(backoff)
+                    continue
+                return None
+            tasks = response.get("tasks") or []
+            if not tasks:
+                # No failures, no tasks — defensive. Treat as a hard
+                # error because retrying an empty-response state
+                # without ``failures[]`` is not well-defined by the API.
+                self._log.error(
+                    "daemon.agent_runner_run_task_no_task",
+                    extra={
+                        "event": "agent_runner_run_task_no_task",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "issue_number": issue_number,
+                    },
+                )
+                return None
+            task_arn = tasks[0].get("taskArn")
+            if not task_arn:
+                self._log.error(
+                    "daemon.agent_runner_run_task_missing_arn",
+                    extra={
+                        "event": "agent_runner_run_task_missing_arn",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "issue_number": issue_number,
+                        "response_task": tasks[0],
+                    },
+                )
+                return None
+            self._persist_agent_task_arn(agent_id, task_arn)
+            self._log.info(
+                "daemon.agent_runner_run_task_succeeded",
+                extra={
+                    "event": "agent_runner_run_task_succeeded",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "attempt": attempt,
+                    "task_arn": task_arn,
+                },
+            )
+            return task_arn
+
+        # All attempts exhausted.
+        self._log.error(
+            "daemon.agent_runner_run_task_exhausted",
+            extra={
+                "event": "agent_runner_run_task_exhausted",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "attempts": AGENT_RUNNER_RUN_TASK_MAX_ATTEMPTS,
+                "detail": str(last_exc) if last_exc is not None else "",
+            },
+        )
+        return None
+
+    def _persist_agent_task_arn(self, agent_id: str, task_arn: str) -> None:
+        """UPDATE ``dispatcher.agents`` with the launched ECS task ARN.
+
+        Also flips ``execution_mode`` to ``'ecs'`` so reads across a
+        daemon restart observe the authoritative-mode signal — an
+        agent whose row carries a non-NULL ``agent_task_arn`` must be
+        observed via ``ecs:DescribeTasks`` rather than re-claimed
+        into the subprocess lane. Idempotent on re-run (the UPDATE is
+        a simple SET).
+        """
+        assert self._conn is not None, "connect() must run before update"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.agents "
+                    "SET agent_task_arn = %s, execution_mode = 'ecs' "
+                    "WHERE agent_id = %s",
+                    (task_arn, agent_id),
+                )
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            self._log.exception(
+                "daemon.persist_agent_task_arn_failed",
+                extra={
+                    "event": "persist_agent_task_arn_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "task_arn": task_arn,
+                },
+            )
+
+    def _reap_completed_agent_tasks(self) -> dict[str, int]:
+        """Observe lifecycle of active per-agent ECS tasks (#3091).
+
+        Runs on every :meth:`scheduler_tick`. Fetches every
+        ``dispatcher.agents`` row where ``agent_task_arn IS NOT NULL``
+        and ``status IN ('running', 'retrying')``, calls
+        ``ecs:DescribeTasks`` once for up to 100 ARNs (the ECS
+        page-size cap — more than we'll ever reap in one tick on a
+        concurrency_cap<=5 cluster), and acts on the returned
+        ``lastStatus``:
+
+        * ``STOPPED`` — terminal. The agent-runner itself updates
+          ``dispatcher.agents.status`` / ``phase`` before exit, so
+          the daemon's job is just to confirm the observation and log
+          the terminal reap. If the task stopped non-zero and the
+          agent row is NOT already terminal, route the failure via
+          :meth:`_handle_agent_failure` (category
+          ``agent_task_stopped_unexpectedly``).
+        * ``RUNNING``, ``PROVISIONING``, ``PENDING``, ``ACTIVATING``
+          — no-op; the agent-runner is still alive, re-check next tick.
+
+        **Fresh-daemon resume semantics (#3078 Option A payoff).** A
+        fresh daemon after a redeploy runs ``scheduler_tick`` → calls
+        this method → ``ecs:DescribeTasks`` returns the in-flight
+        tasks with ``lastStatus='RUNNING'`` and we take no action.
+        The pre-#3091 model marked every in-flight agent as
+        ``daemon_restart_abandoned`` on every redeploy — see
+        :meth:`_abandon_in_flight_agents_on_boot` for the legacy
+        path. The ECS path drops that bug entirely because the ECS
+        task outlives the daemon.
+
+        Returns a small summary dict for logging + tests:
+            * ``active``: int, count of ``agent_task_arn IS NOT NULL``
+              rows observed this tick.
+            * ``reaped_success``: int, count of STOPPED-success
+              transitions logged this tick.
+            * ``reaped_failure``: int, count of STOPPED-failure
+              transitions routed through ``_handle_agent_failure``.
+            * ``still_running``: int, count of non-terminal tasks
+              observed (no-op).
+        """
+        assert self._conn is not None, "connect() must run before reap"
+
+        # Fetch active agents with a launched ECS task ARN. Limit 100
+        # matches the ECS ``DescribeTasks`` page-size cap. For
+        # concurrency_cap<=5 dev this is always one call; a future
+        # production cap>5 would need pagination here.
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT agent_id, issue_number, agent_task_arn, "
+                    "       phase, status "
+                    "FROM dispatcher.agents "
+                    "WHERE agent_task_arn IS NOT NULL "
+                    "  AND status IN ('running', 'retrying') "
+                    "LIMIT 100"
+                )
+                rows = cur.fetchall()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            self._log.exception(
+                "daemon.reap_agent_tasks_select_failed",
+                extra={
+                    "event": "reap_agent_tasks_select_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            return {
+                "active": 0,
+                "reaped_success": 0,
+                "reaped_failure": 0,
+                "still_running": 0,
+            }
+
+        if not rows:
+            return {
+                "active": 0,
+                "reaped_success": 0,
+                "reaped_failure": 0,
+                "still_running": 0,
+            }
+
+        # Can't reap without cluster + ECS client. The wiring may be
+        # absent in local dev; log once per tick if we see active
+        # rows but no cluster wired.
+        if not self._cfg.ecs_cluster_arn:
+            self._log.warning(
+                "daemon.reap_agent_tasks_no_cluster",
+                extra={
+                    "event": "reap_agent_tasks_no_cluster",
+                    "run_id": self._run_id,
+                    "active_rows": len(rows),
+                },
+            )
+            return {
+                "active": len(rows),
+                "reaped_success": 0,
+                "reaped_failure": 0,
+                "still_running": 0,
+            }
+
+        arns = [row[2] for row in rows if row[2]]
+        arn_to_row = {row[2]: row for row in rows if row[2]}
+
+        try:
+            if self._ecs_client is None:
+                self._ecs_client = self._make_ecs_client()
+            response = self._ecs_client.describe_tasks(
+                cluster=self._cfg.ecs_cluster_arn,
+                tasks=arns,
+            )
+        except Exception as exc:
+            self._log.warning(
+                "daemon.reap_agent_tasks_describe_failed",
+                extra={
+                    "event": "reap_agent_tasks_describe_failed",
+                    "run_id": self._run_id,
+                    "detail": str(exc),
+                    "active_rows": len(rows),
+                },
+            )
+            # Reset the client so the next tick gets a fresh one.
+            self._ecs_client = None
+            return {
+                "active": len(rows),
+                "reaped_success": 0,
+                "reaped_failure": 0,
+                "still_running": 0,
+            }
+
+        tasks = response.get("tasks") or []
+        reaped_success = 0
+        reaped_failure = 0
+        still_running = 0
+
+        for task in tasks:
+            task_arn = task.get("taskArn", "")
+            last_status = (task.get("lastStatus") or "").upper()
+            stop_code = task.get("stopCode")
+            exit_codes = [
+                c.get("exitCode")
+                for c in task.get("containers") or []
+                if c.get("exitCode") is not None
+            ]
+            row = arn_to_row.get(task_arn)
+            if row is None:
+                continue
+            agent_id, issue_number, _arn, phase, status = row
+
+            if last_status != "STOPPED":
+                # Still running, pending, provisioning — re-check next
+                # tick. The agent-runner is alive; the daemon's role
+                # is passive observation.
+                still_running += 1
+                continue
+
+            # STOPPED path. Success = every container exit_code == 0
+            # AND stop_code is ``EssentialContainerExited`` (normal
+            # exit) OR unset. If stop_code is ``TaskFailedToStart``,
+            # ``ContainerRuntimeError``, etc., treat as failure even
+            # if exit_code happens to be 0.
+            task_success = (
+                bool(exit_codes)
+                and all(c == 0 for c in exit_codes)
+                and stop_code in (None, "", "EssentialContainerExited")
+            )
+
+            # Re-read the agent row post-STOPPED so we can tell
+            # "agent-runner wrote its own terminal status before exit"
+            # from "the container died before the entrypoint could
+            # update the row". Cheap — one SELECT per reaped agent
+            # per tick.
+            current_status, current_phase = self._read_agent_status_phase(agent_id)
+
+            if task_success:
+                # The agent-runner's own SQL writes should have set
+                # status=succeeded / failed / needs_review AND
+                # ended_at. If the row is NOT already terminal, it's
+                # a gap we need to log (the entrypoint crashed after
+                # phase work but before writing terminal). Still
+                # advance the phase via the shared module's
+                # terminal-check.
+                if current_status in TERMINAL_AGENT_STATUSES:
+                    self._log.info(
+                        "daemon.agent_runner_reaped_success",
+                        extra={
+                            "event": "agent_runner_reaped_success",
+                            "run_id": self._run_id,
+                            "agent_id": agent_id,
+                            "issue_number": issue_number,
+                            "task_arn": task_arn,
+                            "final_status": current_status,
+                            "final_phase": current_phase,
+                        },
+                    )
+                    reaped_success += 1
+                else:
+                    # Container exited 0 but agent row wasn't marked
+                    # terminal by the entrypoint. Mark it succeeded
+                    # via _mark_agent_terminal so the admin cockpit
+                    # doesn't render a stale ``running`` row.
+                    self._log.warning(
+                        "daemon.agent_runner_reaped_success_row_gap",
+                        extra={
+                            "event": "agent_runner_reaped_success_row_gap",
+                            "run_id": self._run_id,
+                            "agent_id": agent_id,
+                            "issue_number": issue_number,
+                            "task_arn": task_arn,
+                            "observed_status": current_status,
+                            "observed_phase": current_phase,
+                        },
+                    )
+                    # ROUTING (#3062 #3091): NOT routed via
+                    # ``_handle_agent_failure`` — container exit 0
+                    # means the agent-runner completed successfully;
+                    # the gap is a bookkeeping issue the daemon can
+                    # close without a diagnoser round-trip.
+                    self._mark_agent_terminal(
+                        agent_id,
+                        status="succeeded",
+                        phase=current_phase or "done",
+                        exit_code=0,
+                        issue_number=issue_number,
+                    )
+                    reaped_success += 1
+            else:
+                # STOPPED with non-zero exit or a non-normal stop_code.
+                # Route via _handle_agent_failure so the diagnoser
+                # picks it up on the next supervisor tick.
+                if current_status in TERMINAL_AGENT_STATUSES:
+                    # Agent-runner already wrote its own failure. Log
+                    # the reap but don't route again (we'd double-insert
+                    # a dispatcher.failures row).
+                    self._log.info(
+                        "daemon.agent_runner_reaped_failure_already_terminal",
+                        extra={
+                            "event": "agent_runner_reaped_failure_already_terminal",
+                            "run_id": self._run_id,
+                            "agent_id": agent_id,
+                            "issue_number": issue_number,
+                            "task_arn": task_arn,
+                            "stop_code": stop_code,
+                            "exit_codes": exit_codes,
+                            "final_status": current_status,
+                            "final_phase": current_phase,
+                        },
+                    )
+                    reaped_failure += 1
+                    continue
+                # Real failure — agent-runner died before it could write
+                # its own terminal row.
+                self._log.warning(
+                    "daemon.agent_runner_reaped_failure",
+                    extra={
+                        "event": "agent_runner_reaped_failure",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "issue_number": issue_number,
+                        "task_arn": task_arn,
+                        "stop_code": stop_code,
+                        "exit_codes": exit_codes,
+                        "observed_status": current_status,
+                        "observed_phase": current_phase,
+                    },
+                )
+                exit_code_for_failure = exit_codes[0] if exit_codes else None
+                # ROUTING (#3062 #3091): ROUTED via
+                # ``_handle_agent_failure`` so the diagnoser can
+                # classify — ``agent_task_stopped_unexpectedly`` is the
+                # per-agent-ECS sibling of the subprocess-mode
+                # ``subprocess_crash`` tier-1 failure.
+                self._handle_agent_failure(
+                    agent_id=agent_id,
+                    phase=current_phase or phase or "unknown",
+                    category="agent_task_stopped_unexpectedly",
+                    stderr_tail="",
+                    exit_code=exit_code_for_failure,
+                    details={
+                        "task_arn": task_arn,
+                        "stop_code": stop_code,
+                        "exit_codes": exit_codes,
+                    },
+                    issue_number=issue_number,
+                )
+                reaped_failure += 1
+
+        return {
+            "active": len(rows),
+            "reaped_success": reaped_success,
+            "reaped_failure": reaped_failure,
+            "still_running": still_running,
+        }
+
+    def _read_agent_status_phase(self, agent_id: str) -> tuple[str | None, str | None]:
+        """Fetch the current (status, phase) for an agent. Best-effort.
+
+        Used by :meth:`_reap_completed_agent_tasks` to distinguish
+        "agent-runner already wrote terminal" from "container died
+        before entrypoint finished". Returns ``(None, None)`` on DB
+        error — the caller treats that as "assume non-terminal".
+        """
+        assert self._conn is not None, "connect() must run before read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT status, phase FROM dispatcher.agents WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return (None, None)
+        if row is None:
+            return (None, None)
+        return (row[0], row[1])
+
     # ── housekeeping tick (every ``tick_housekeeping_seconds``) ─────────
 
     #: Retention targets the housekeeping tick prunes. Each entry is a
@@ -18097,6 +18958,23 @@ def _build_config(
     raw_baseline = env.get("DISPATCHER_BASELINE_REPO_ROOT", "").strip()
     baseline_repo_root = Path(raw_baseline) if raw_baseline else None
 
+    # Per-agent ECS task wiring (#3091 Stage 2). All four env vars are
+    # optional — when unset, the daemon falls back to the subprocess
+    # execution mode regardless of what ``dispatcher.config
+    # .agent_execution_mode`` says, because :meth:`_launch_agent_ecs_task`
+    # cannot run a task without a cluster + task-def + network config.
+    ecs_cluster_arn = env.get("ECS_CLUSTER_ARN", "").strip()
+    agent_runner_task_definition_family = env.get(
+        "AGENT_RUNNER_TASK_DEFINITION_FAMILY", ""
+    ).strip()
+    raw_subnets = env.get("AGENT_RUNNER_SUBNET_IDS", "").strip()
+    agent_runner_subnet_ids: tuple[str, ...] = tuple(
+        part.strip() for part in raw_subnets.split(",") if part.strip()
+    )
+    agent_runner_security_group_id = env.get(
+        "AGENT_RUNNER_SECURITY_GROUP_ID", ""
+    ).strip()
+
     override: dict[str, Any] = {}
     if args.config_override:
         try:
@@ -18122,6 +19000,10 @@ def _build_config(
         heartbeat_metric_namespace=heartbeat_namespace,
         aws_region=aws_region,
         baseline_repo_root=baseline_repo_root,
+        ecs_cluster_arn=ecs_cluster_arn,
+        agent_runner_task_definition_family=agent_runner_task_definition_family,
+        agent_runner_subnet_ids=agent_runner_subnet_ids,
+        agent_runner_security_group_id=agent_runner_security_group_id,
         config_override=override,
     )
 
@@ -18174,6 +19056,17 @@ def main(argv: list[str] | None = None) -> int:
             "tick_scheduler_seconds": cfg.tick_scheduler_seconds,
             "tick_supervisor_seconds": cfg.tick_supervisor_seconds,
             "tick_housekeeping_seconds": cfg.tick_housekeeping_seconds,
+            # #3091 Stage 2 — surface the per-agent ECS wiring at boot
+            # so CloudWatch verification can confirm the deploy picked
+            # up the correct task-def + cluster + network config. An
+            # empty value means the env var wasn't set (local dev /
+            # unit test); the daemon falls back to the subprocess path.
+            "ecs_cluster_arn_set": bool(cfg.ecs_cluster_arn),
+            "agent_runner_task_definition_family": (
+                cfg.agent_runner_task_definition_family or ""
+            ),
+            "agent_runner_subnet_count": len(cfg.agent_runner_subnet_ids),
+            "agent_runner_security_group_set": bool(cfg.agent_runner_security_group_id),
         },
     )
 

--- a/scripts/dispatcher/tests/test_daemon_execution_mode_flag.py
+++ b/scripts/dispatcher/tests/test_daemon_execution_mode_flag.py
@@ -1,0 +1,305 @@
+"""Unit tests for issue #3091 — ``dispatcher.config.agent_execution_mode`` flag.
+
+Coverage:
+
+* ``_cb_config_str`` reads a string key with a fallback and handles
+  missing rows / malformed JSON / empty values by returning the
+  default.
+* ``_read_agent_execution_mode`` returns the stored value when it's
+  one of the recognized modes (``'subprocess'`` / ``'ecs'``), falls
+  back to the default with a warning on an unrecognized value, and
+  defaults to ``'subprocess'`` when the row is missing.
+* Claim-time dispatch branches on the read mode: ``'ecs'`` calls
+  ``_launch_agent_ecs_task`` and skips ``_run_orchestration_phases``;
+  ``'subprocess'`` takes the legacy path.
+* Mode is immutable once written to the agent row — ``_atomic_claim``
+  persists it and later flips of the config don't produce hybrid
+  agents.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+# Only install a psycopg stub if one isn't already present — avoids
+# clobbering sibling test files' UniqueViolation sentinel. See
+# ``test_daemon_baseline_fetch_retry.py`` for the pattern.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        pass
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Shared fakes.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, value: Any = None) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self._value = value
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if self._value is _MISSING:
+            return None
+        return (self._value,)
+
+
+_MISSING = object()
+
+
+class _FakeConn:
+    def __init__(self, value: Any = _MISSING) -> None:
+        self.cursor_obj = _FakeCursor(value)
+        self.committed = 0
+        self.rolled_back = 0
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_obj
+
+    def commit(self) -> None:
+        self.committed += 1
+
+    def rollback(self) -> None:
+        self.rolled_back += 1
+
+
+def _make_daemon(value: Any = _MISSING) -> daemon.DispatcherDaemon:
+    import threading
+
+    d = daemon.DispatcherDaemon.__new__(daemon.DispatcherDaemon)
+    d._thread_state = threading.local()  # type: ignore[attr-defined]
+    d._main_conn = _FakeConn(value=value)  # type: ignore[attr-defined]
+    d._cfg = MagicMock()  # type: ignore[attr-defined]
+    d._log = logging.getLogger("test.daemon_execution_mode")  # type: ignore[attr-defined]
+    d._run_id = "test-run-id"  # type: ignore[attr-defined]
+    return d
+
+
+# --------------------------------------------------------------------------
+# _cb_config_str.
+# --------------------------------------------------------------------------
+
+
+class TestCBConfigStr:
+    def test_missing_row_returns_default(self) -> None:
+        d = _make_daemon(value=_MISSING)
+        assert d._cb_config_str("agent_execution_mode", "subprocess") == "subprocess"
+
+    def test_null_value_returns_default(self) -> None:
+        d = _make_daemon(value=None)
+        assert d._cb_config_str("agent_execution_mode", "subprocess") == "subprocess"
+
+    def test_bare_string_value(self) -> None:
+        d = _make_daemon(value="ecs")
+        assert d._cb_config_str("agent_execution_mode", "subprocess") == "ecs"
+
+    def test_json_encoded_string_value(self) -> None:
+        """Test fixtures sometimes feed raw JSON (``'"ecs"'``) — we unwrap."""
+        d = _make_daemon(value='"ecs"')
+        assert d._cb_config_str("agent_execution_mode", "subprocess") == "ecs"
+
+    def test_empty_string_returns_default(self) -> None:
+        d = _make_daemon(value="")
+        assert d._cb_config_str("agent_execution_mode", "subprocess") == "subprocess"
+
+
+# --------------------------------------------------------------------------
+# _read_agent_execution_mode.
+# --------------------------------------------------------------------------
+
+
+class TestReadAgentExecutionMode:
+    def test_default_is_subprocess(self) -> None:
+        d = _make_daemon(value=_MISSING)
+        assert d._read_agent_execution_mode() == "subprocess"
+
+    def test_recognizes_ecs(self) -> None:
+        d = _make_daemon(value="ecs")
+        assert d._read_agent_execution_mode() == "ecs"
+
+    def test_unrecognized_falls_back_with_warning(self, caplog: Any) -> None:
+        d = _make_daemon(value="docker")
+        caplog.set_level(logging.WARNING, logger="test.daemon_execution_mode")
+        assert d._read_agent_execution_mode() == "subprocess"
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_execution_mode_unrecognized" in events
+
+
+# --------------------------------------------------------------------------
+# Claim-time branching — the immutability + dispatch contract.
+# --------------------------------------------------------------------------
+
+
+class TestClaimTimeDispatch:
+    def test_ecs_mode_launches_ecs_task_and_skips_orchestration(self) -> None:
+        """When mode='ecs', _claim_and_orchestrate_one MUST call
+        _launch_agent_ecs_task and MUST NOT call
+        _run_orchestration_phases or _create_worktree.
+        """
+        d = _make_daemon()
+        # Stub all the helpers _claim_and_orchestrate_one touches.
+        with (
+            patch.object(d, "_resume_retrying_agent", return_value=False),
+            patch.object(
+                d,
+                "_latest_queue_snapshot_issues",
+                return_value=[{"number": 500}],
+            ),
+            patch.object(d, "_pick_candidate_issue", return_value=500),
+            patch.object(d, "_latest_queue_snapshot_title_for", return_value=None),
+            patch.object(d, "_latest_queue_snapshot_priority_for", return_value="p2"),
+            patch.object(d, "_read_agent_execution_mode", return_value="ecs"),
+            patch.object(d, "_atomic_claim", return_value=True) as claim_mock,
+            patch.object(
+                d, "_launch_agent_ecs_task", return_value="arn:ecs-task"
+            ) as launch_mock,
+            patch.object(d, "_create_worktree") as worktree_mock,
+            patch.object(d, "_run_orchestration_phases") as orch_mock,
+            patch.object(d, "_handle_agent_failure") as fail_mock,
+            patch.object(d, "_compute_worktree_path", return_value=Path("/tmp/wt")),
+        ):
+            d._claim_and_orchestrate_one()
+        # Claim call threads execution_mode='ecs' through.
+        claim_mock.assert_called_once()
+        kwargs = claim_mock.call_args.kwargs
+        assert kwargs.get("execution_mode") == "ecs"
+        # ECS launcher fired.
+        launch_mock.assert_called_once()
+        # Legacy path was NOT taken.
+        worktree_mock.assert_not_called()
+        orch_mock.assert_not_called()
+        fail_mock.assert_not_called()
+
+    def test_ecs_mode_launch_failure_routes_to_handle_agent_failure(self) -> None:
+        d = _make_daemon()
+        with (
+            patch.object(d, "_resume_retrying_agent", return_value=False),
+            patch.object(
+                d,
+                "_latest_queue_snapshot_issues",
+                return_value=[{"number": 700}],
+            ),
+            patch.object(d, "_pick_candidate_issue", return_value=700),
+            patch.object(d, "_latest_queue_snapshot_title_for", return_value=None),
+            patch.object(d, "_latest_queue_snapshot_priority_for", return_value="p2"),
+            patch.object(d, "_read_agent_execution_mode", return_value="ecs"),
+            patch.object(d, "_atomic_claim", return_value=True),
+            # Launch returned None => exhausted or wiring missing.
+            patch.object(d, "_launch_agent_ecs_task", return_value=None),
+            patch.object(d, "_create_worktree") as worktree_mock,
+            patch.object(d, "_run_orchestration_phases") as orch_mock,
+            patch.object(d, "_handle_agent_failure") as fail_mock,
+            patch.object(d, "_compute_worktree_path", return_value=Path("/tmp/wt")),
+        ):
+            d._claim_and_orchestrate_one()
+        worktree_mock.assert_not_called()
+        orch_mock.assert_not_called()
+        fail_mock.assert_called_once()
+        kw = fail_mock.call_args.kwargs
+        assert kw["category"] == "agent_task_launch_failed"
+        assert kw["phase"] == "claiming"
+        assert kw["issue_number"] == 700
+
+    def test_subprocess_mode_takes_legacy_path(self) -> None:
+        """When mode='subprocess' (default), the legacy worktree +
+        orchestration path runs; _launch_agent_ecs_task must NOT fire.
+        """
+        d = _make_daemon()
+        with (
+            patch.object(d, "_resume_retrying_agent", return_value=False),
+            patch.object(
+                d,
+                "_latest_queue_snapshot_issues",
+                return_value=[{"number": 900}],
+            ),
+            patch.object(d, "_pick_candidate_issue", return_value=900),
+            patch.object(d, "_latest_queue_snapshot_title_for", return_value=None),
+            patch.object(d, "_latest_queue_snapshot_priority_for", return_value="p2"),
+            patch.object(d, "_read_agent_execution_mode", return_value="subprocess"),
+            patch.object(d, "_atomic_claim", return_value=True) as claim_mock,
+            patch.object(d, "_launch_agent_ecs_task") as launch_mock,
+            patch.object(d, "_create_worktree", return_value=Path("/tmp/wt")),
+            patch.object(d, "_run_orchestration_phases") as orch_mock,
+            patch.object(d, "_compute_worktree_path", return_value=Path("/tmp/wt")),
+        ):
+            d._claim_and_orchestrate_one()
+        launch_mock.assert_not_called()
+        orch_mock.assert_called_once()
+        # Claim carries the subprocess mode through.
+        assert claim_mock.call_args.kwargs.get("execution_mode") == "subprocess"
+
+
+# --------------------------------------------------------------------------
+# Immutability — _atomic_claim writes the chosen mode at claim time.
+# --------------------------------------------------------------------------
+
+
+class TestExecutionModePersistenceAtomicClaim:
+    def test_atomic_claim_persists_execution_mode(self) -> None:
+        """The INSERT into dispatcher.agents MUST include execution_mode
+        as a parameter so the column is set authoritatively at claim
+        time (not relying on the DEFAULT from migration 41).
+        """
+        d = _make_daemon()
+        # _atomic_claim calls _gh_issue_add_labels post-INSERT; stub to
+        # avoid GitHub calls in tests.
+        with patch.object(d, "_gh_issue_add_labels"):
+            ok = d._atomic_claim(
+                issue_number=42,
+                agent_id="agent-x",
+                worktree_path="/tmp/wt",
+                execution_mode="ecs",
+            )
+        assert ok is True
+        # Check the INSERT SQL shape.
+        executed = d._main_conn.cursor_obj.executed  # type: ignore[attr-defined]
+        assert len(executed) == 1
+        sql, params = executed[0]
+        assert "INSERT INTO dispatcher.agents" in sql
+        assert "execution_mode" in sql
+        # The last param should be 'ecs'.
+        assert params[-1] == "ecs"
+
+    def test_atomic_claim_default_mode_is_subprocess(self) -> None:
+        """Callers that don't pass execution_mode get the module-level
+        default — preserving pre-#3091 behaviour.
+        """
+        d = _make_daemon()
+        with patch.object(d, "_gh_issue_add_labels"):
+            d._atomic_claim(
+                issue_number=1,
+                agent_id="agent-y",
+                worktree_path="/tmp/wt",
+            )
+        _sql, params = d._main_conn.cursor_obj.executed[0]  # type: ignore[attr-defined]
+        assert params[-1] == "subprocess"

--- a/scripts/dispatcher/tests/test_daemon_launch_agent_ecs_task.py
+++ b/scripts/dispatcher/tests/test_daemon_launch_agent_ecs_task.py
@@ -1,0 +1,375 @@
+"""Unit tests for issue #3091 — ``_launch_agent_ecs_task`` launches per-agent ECS tasks.
+
+Coverage (issue #3091 Stage 2 acceptance criteria):
+
+* Happy path — ``ecs:RunTask`` called with the task def family,
+  cluster, network config, and env overrides wired from ``DaemonConfig``.
+  On success the agent row is UPDATEd with ``agent_task_arn=<arn>`` and
+  ``execution_mode='ecs'``.
+* Retry on transient botocore ``ClientError`` (Throttling,
+  ServiceUnavailable) up to 3 attempts with 1s + 2s backoff.
+* NO retry on non-transient errors (AccessDenied, ValidationException).
+* Response-level ``failures[]`` (200 OK but no tasks started) is
+  treated as transient and retried.
+* Missing ECS wiring (empty cluster / task-def / subnets / SG) fails
+  closed with a structured log event and returns None.
+* Tags include ``agent_id`` + ``issue_number`` so CloudWatch +
+  admin-cockpit correlation works.
+
+Fakes follow the pattern from ``test_daemon_baseline_fetch_retry.py``
+— bypass ``__init__`` via ``__new__`` and stub the psycopg connection
+with a ``MagicMock``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+# Only install a psycopg stub if one isn't already set up by a
+# sibling test file. Overwriting would swap the ``UniqueViolation``
+# sentinel out from under the daemon's lazy ``import psycopg`` and
+# break the sibling's ``except`` clause. Mirrors the pattern used by
+# ``test_daemon_baseline_fetch_retry.py``.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        """Test sentinel for psycopg.errors.UniqueViolation."""
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — minimal cursor + conn that records executed SQL.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        return None
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.cursor_obj = _FakeCursor()
+        self.committed = 0
+        self.rolled_back = 0
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_obj
+
+    def commit(self) -> None:
+        self.committed += 1
+
+    def rollback(self) -> None:
+        self.rolled_back += 1
+
+
+def _make_daemon(
+    *,
+    cluster_arn: str = "arn:aws:ecs:us-west-2:123:cluster/judgemind-dev",
+    task_def_family: str = "judgemind-dispatcher-agent-runner-dev",
+    subnets: tuple[str, ...] = ("subnet-a", "subnet-b"),
+    sg: str = "sg-abc",
+) -> tuple[daemon.DispatcherDaemon, _FakeConn]:
+    import threading
+
+    d = daemon.DispatcherDaemon.__new__(daemon.DispatcherDaemon)
+    d._thread_state = threading.local()  # type: ignore[attr-defined]
+    conn = _FakeConn()
+    d._main_conn = conn  # type: ignore[attr-defined]
+    d._cfg = MagicMock(  # type: ignore[attr-defined]
+        aws_region="us-west-2",
+        ecs_cluster_arn=cluster_arn,
+        agent_runner_task_definition_family=task_def_family,
+        agent_runner_subnet_ids=subnets,
+        agent_runner_security_group_id=sg,
+    )
+    d._log = logging.getLogger("test.daemon_launch_agent_ecs_task")  # type: ignore[attr-defined]
+    d._run_id = "test-run-id"  # type: ignore[attr-defined]
+    d._ecs_client = None  # type: ignore[attr-defined]
+    return d, conn
+
+
+def _client_error(code: str) -> Exception:
+    """Build a faux botocore ClientError-shaped exception."""
+
+    class _Fake(Exception):
+        pass
+
+    exc = _Fake(f"An error occurred ({code}) when calling the RunTask operation")
+    exc.response = {"Error": {"Code": code, "Message": "test"}}
+    return exc
+
+
+# --------------------------------------------------------------------------
+# Happy path.
+# --------------------------------------------------------------------------
+
+
+class TestLaunchAgentECSTaskHappyPath:
+    def test_run_task_called_with_expected_arguments(self) -> None:
+        d, conn = _make_daemon()
+        fake_client = MagicMock()
+        fake_client.run_task.return_value = {
+            "tasks": [{"taskArn": "arn:aws:ecs:us-west-2:123:task/judgemind-dev/abc"}],
+            "failures": [],
+        }
+        with patch.object(d, "_make_ecs_client", return_value=fake_client):
+            result = d._launch_agent_ecs_task("agent-1", 42)
+        assert result == "arn:aws:ecs:us-west-2:123:task/judgemind-dev/abc"
+        fake_client.run_task.assert_called_once()
+        call_kwargs = fake_client.run_task.call_args.kwargs
+        assert (
+            call_kwargs["cluster"] == "arn:aws:ecs:us-west-2:123:cluster/judgemind-dev"
+        )
+        assert call_kwargs["taskDefinition"] == "judgemind-dispatcher-agent-runner-dev"
+        assert call_kwargs["launchType"] == "FARGATE"
+        assert call_kwargs["count"] == 1
+        # Env overrides carry AGENT_ID + ISSUE_NUMBER.
+        container_overrides = call_kwargs["overrides"]["containerOverrides"]
+        assert container_overrides[0]["name"] == "agent-runner"
+        env_vars = {
+            e["name"]: e["value"] for e in container_overrides[0]["environment"]
+        }
+        assert env_vars["AGENT_ID"] == "agent-1"
+        assert env_vars["ISSUE_NUMBER"] == "42"
+        # Network config uses the two subnets + security group.
+        netcfg = call_kwargs["networkConfiguration"]["awsvpcConfiguration"]
+        assert netcfg["subnets"] == ["subnet-a", "subnet-b"]
+        assert netcfg["securityGroups"] == ["sg-abc"]
+        assert netcfg["assignPublicIp"] == "DISABLED"
+        # Tags carry agent_id + issue_number for CloudWatch correlation.
+        tag_map = {t["key"]: t["value"] for t in call_kwargs["tags"]}
+        assert tag_map["agent_id"] == "agent-1"
+        assert tag_map["issue_number"] == "42"
+
+    def test_success_persists_task_arn_and_execution_mode(self) -> None:
+        d, conn = _make_daemon()
+        fake_client = MagicMock()
+        fake_client.run_task.return_value = {
+            "tasks": [{"taskArn": "arn:aws:ecs:us-west-2:123:task/abc"}],
+            "failures": [],
+        }
+        with patch.object(d, "_make_ecs_client", return_value=fake_client):
+            d._launch_agent_ecs_task("agent-2", 7)
+        # UPDATE dispatcher.agents was called with the ARN and mode.
+        assert any(
+            "UPDATE dispatcher.agents" in sql
+            and "agent_task_arn" in sql
+            and "execution_mode = 'ecs'" in sql
+            for sql, _ in conn.cursor_obj.executed
+        )
+
+    def test_log_event_on_success(self, caplog: Any) -> None:
+        d, _ = _make_daemon()
+        caplog.set_level(logging.INFO, logger="test.daemon_launch_agent_ecs_task")
+        fake_client = MagicMock()
+        fake_client.run_task.return_value = {
+            "tasks": [{"taskArn": "arn:aws:ecs:us-west-2:123:task/xyz"}],
+            "failures": [],
+        }
+        with patch.object(d, "_make_ecs_client", return_value=fake_client):
+            d._launch_agent_ecs_task("agent-ok", 101)
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_run_task_succeeded" in events
+
+
+# --------------------------------------------------------------------------
+# Retry on transient errors.
+# --------------------------------------------------------------------------
+
+
+class TestLaunchAgentECSTaskRetry:
+    def test_throttle_twice_then_success(self, caplog: Any) -> None:
+        d, _ = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_launch_agent_ecs_task")
+        fake_client = MagicMock()
+        fake_client.run_task.side_effect = [
+            _client_error("ThrottlingException"),
+            _client_error("ThrottlingException"),
+            {
+                "tasks": [{"taskArn": "arn:aws:ecs:us-west-2:123:task/good"}],
+                "failures": [],
+            },
+        ]
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch("dispatcher.daemon.time.sleep") as mock_sleep,
+        ):
+            result = d._launch_agent_ecs_task("agent-r", 1)
+        assert result == "arn:aws:ecs:us-west-2:123:task/good"
+        assert fake_client.run_task.call_count == 3
+        # 1s + 2s backoff between the three attempts.
+        assert mock_sleep.call_args_list[0].args[0] == 1.0
+        assert mock_sleep.call_args_list[1].args[0] == 2.0
+        # Two retry-attempt warnings, but NO exhausted warning.
+        retry_records = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "agent_runner_run_task_attempt_failed"
+        ]
+        assert len(retry_records) == 2
+        assert all(r.retryable is True for r in retry_records)
+        exhausted = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "agent_runner_run_task_exhausted"
+        ]
+        assert exhausted == []
+
+    def test_three_throttles_exhausts_and_returns_none(self, caplog: Any) -> None:
+        d, _ = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_launch_agent_ecs_task")
+        fake_client = MagicMock()
+        fake_client.run_task.side_effect = _client_error("ThrottlingException")
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch("dispatcher.daemon.time.sleep") as mock_sleep,
+        ):
+            result = d._launch_agent_ecs_task("agent-e", 2)
+        assert result is None
+        assert fake_client.run_task.call_count == 3
+        # Two backoffs between three attempts.
+        assert mock_sleep.call_count == 2
+        retry_records = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "agent_runner_run_task_attempt_failed"
+        ]
+        assert len(retry_records) == 3
+        exhausted = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "agent_runner_run_task_exhausted"
+        ]
+        assert len(exhausted) == 1
+
+    def test_non_retryable_fails_immediately(self, caplog: Any) -> None:
+        d, _ = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_launch_agent_ecs_task")
+        fake_client = MagicMock()
+        fake_client.run_task.side_effect = _client_error("AccessDeniedException")
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch("dispatcher.daemon.time.sleep") as mock_sleep,
+        ):
+            result = d._launch_agent_ecs_task("agent-perm", 3)
+        assert result is None
+        # Only one attempt — AccessDenied is not retryable.
+        assert fake_client.run_task.call_count == 1
+        # No backoff was incurred.
+        mock_sleep.assert_not_called()
+        retry_records = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "agent_runner_run_task_attempt_failed"
+        ]
+        assert len(retry_records) == 1
+        assert retry_records[0].retryable is False
+
+    def test_response_failures_trigger_retry(self) -> None:
+        d, _ = _make_daemon()
+        fake_client = MagicMock()
+        # First two responses: 200 OK but failures[] set (capacity
+        # unavailable). Third: success.
+        fake_client.run_task.side_effect = [
+            {"tasks": [], "failures": [{"reason": "AGENT", "detail": "capacity"}]},
+            {"tasks": [], "failures": [{"reason": "AGENT", "detail": "capacity"}]},
+            {
+                "tasks": [{"taskArn": "arn:aws:ecs:us-west-2:123:task/late"}],
+                "failures": [],
+            },
+        ]
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch("dispatcher.daemon.time.sleep"),
+        ):
+            result = d._launch_agent_ecs_task("agent-c", 4)
+        assert result == "arn:aws:ecs:us-west-2:123:task/late"
+        assert fake_client.run_task.call_count == 3
+
+
+# --------------------------------------------------------------------------
+# Wiring guard — missing config fails closed.
+# --------------------------------------------------------------------------
+
+
+class TestLaunchAgentECSTaskWiringGuard:
+    def test_missing_cluster_returns_none(self, caplog: Any) -> None:
+        d, _ = _make_daemon(cluster_arn="")
+        caplog.set_level(logging.ERROR, logger="test.daemon_launch_agent_ecs_task")
+        with patch.object(d, "_make_ecs_client") as mock_make:
+            result = d._launch_agent_ecs_task("agent-x", 1)
+        assert result is None
+        mock_make.assert_not_called()
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_wiring_missing" in events
+
+    def test_missing_task_def_returns_none(self) -> None:
+        d, _ = _make_daemon(task_def_family="")
+        with patch.object(d, "_make_ecs_client") as mock_make:
+            assert d._launch_agent_ecs_task("agent-x", 1) is None
+        mock_make.assert_not_called()
+
+    def test_missing_subnets_returns_none(self) -> None:
+        d, _ = _make_daemon(subnets=())
+        with patch.object(d, "_make_ecs_client") as mock_make:
+            assert d._launch_agent_ecs_task("agent-x", 1) is None
+        mock_make.assert_not_called()
+
+    def test_missing_sg_returns_none(self) -> None:
+        d, _ = _make_daemon(sg="")
+        with patch.object(d, "_make_ecs_client") as mock_make:
+            assert d._launch_agent_ecs_task("agent-x", 1) is None
+        mock_make.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# botocore error-code extractor.
+# --------------------------------------------------------------------------
+
+
+class TestExtractBotocoreErrorCode:
+    def test_client_error_shape_returns_code(self) -> None:
+        assert (
+            daemon._extract_botocore_error_code(_client_error("Throttling"))
+            == "Throttling"
+        )
+
+    def test_non_botocore_exception_returns_empty(self) -> None:
+        assert daemon._extract_botocore_error_code(RuntimeError("nope")) == ""
+
+    def test_missing_error_key_returns_empty(self) -> None:
+        exc = Exception("no error key")
+        exc.response = {"NotError": {}}  # type: ignore[attr-defined]
+        assert daemon._extract_botocore_error_code(exc) == ""

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -748,9 +748,10 @@ class TestAtomicClaim:
             for e in conn.cursor_instance.executed
             if "INSERT INTO dispatcher.agents" in e[0]
         ]
-        # Last bound parameter is the priority value.
+        # Priority is the second-to-last bound parameter; the last is
+        # the execution_mode (migration 41, issue #3091).
         _sql, params = inserts[0]
-        assert params[-1] == "p0"
+        assert params[-2] == "p0"
 
     def test_priority_default_none_passes_null(self, tmp_path: Path) -> None:
         """Priority is optional; omitting it stores NULL (pre-migration-33
@@ -765,7 +766,10 @@ class TestAtomicClaim:
             if "INSERT INTO dispatcher.agents" in e[0]
         ]
         _sql, params = inserts[0]
-        assert params[-1] is None
+        # Priority = NULL (second-to-last); execution_mode = 'subprocess'
+        # (last, migration 41 / #3091 default).
+        assert params[-2] is None
+        assert params[-1] == "subprocess"
 
     def test_unique_violation_returns_false(self, tmp_path: Path) -> None:
         d, conn, handler = _make_daemon(tmp_path)

--- a/scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py
+++ b/scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py
@@ -1,0 +1,458 @@
+"""Unit tests for issue #3091 — ``_reap_completed_agent_tasks`` observes per-agent ECS lifecycle.
+
+Coverage:
+
+* STOPPED-success + terminal DB row -> log-only reap (no double
+  terminal write).
+* STOPPED-success + non-terminal DB row -> row gap; daemon marks the
+  agent ``succeeded`` so the admin page clears.
+* STOPPED-failure -> routed through ``_handle_agent_failure`` with
+  category ``agent_task_stopped_unexpectedly``.
+* RUNNING / PENDING -> no-op; still_running counter increments.
+* Fresh-daemon-resumes-observation semantics (the #3078 Option A
+  payoff): a new daemon run_id observing the same ARNs does NOT
+  mark them terminal — it just re-reads their live status.
+* No ECS cluster wired -> log and early return (preserve subprocess
+  path).
+* Empty active-rows set -> zero-work early return.
+
+Fakes follow the pattern used by ``test_daemon_circuit_breaker.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+# Only install a psycopg stub if one isn't already present — avoids
+# clobbering sibling test files' UniqueViolation sentinel. See
+# ``test_daemon_baseline_fetch_retry.py`` for the pattern.
+if "psycopg" not in sys.modules or not isinstance(
+    getattr(sys.modules["psycopg"].errors, "UniqueViolation", None), type
+):
+
+    class _UniqueViolation(Exception):
+        pass
+
+    _psycopg_stub = MagicMock()
+    _psycopg_errors = MagicMock()
+    _psycopg_errors.UniqueViolation = _UniqueViolation
+    _psycopg_stub.errors = _psycopg_errors
+    sys.modules["psycopg"] = _psycopg_stub
+
+from dispatcher import daemon  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Shared fakes.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[Any] | None = None) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        # Queue of fetchone/fetchall results, consumed per-call.
+        self.fetchone_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = [rows] if rows is not None else []
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        return self.fetchone_queue.pop(0) if self.fetchone_queue else None
+
+    def fetchall(self) -> list[Any]:
+        if self.fetchall_queue:
+            return self.fetchall_queue.pop(0)
+        return []
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self._cursors: list[_FakeCursor] = []
+        self.committed = 0
+        self.rolled_back = 0
+
+    def queue_cursor(self, cur: _FakeCursor) -> None:
+        self._cursors.append(cur)
+
+    def cursor(self) -> _FakeCursor:
+        if self._cursors:
+            return self._cursors.pop(0)
+        return _FakeCursor()
+
+    def commit(self) -> None:
+        self.committed += 1
+
+    def rollback(self) -> None:
+        self.rolled_back += 1
+
+
+def _make_daemon(
+    cluster_arn: str = "arn:aws:ecs:us-west-2:123:cluster/jm-dev",
+) -> tuple[daemon.DispatcherDaemon, _FakeConn]:
+    import threading
+
+    d = daemon.DispatcherDaemon.__new__(daemon.DispatcherDaemon)
+    d._thread_state = threading.local()  # type: ignore[attr-defined]
+    conn = _FakeConn()
+    d._main_conn = conn  # type: ignore[attr-defined]
+    d._cfg = MagicMock(aws_region="us-west-2", ecs_cluster_arn=cluster_arn)  # type: ignore[attr-defined]
+    d._log = logging.getLogger("test.daemon_reap")  # type: ignore[attr-defined]
+    d._run_id = "test-run-id"  # type: ignore[attr-defined]
+    d._ecs_client = None  # type: ignore[attr-defined]
+    return d, conn
+
+
+# --------------------------------------------------------------------------
+# Happy-path reap transitions.
+# --------------------------------------------------------------------------
+
+
+class TestReapCompletedAgentTasks:
+    def test_stopped_success_terminal_row_logs_only(self, caplog: Any) -> None:
+        """STOPPED exit_code=0, row already ``succeeded`` -> reaped_success++."""
+        d, conn = _make_daemon()
+        caplog.set_level(logging.INFO, logger="test.daemon_reap")
+        # First cursor: the active-agents SELECT returns one row.
+        select_cur = _FakeCursor(
+            rows=[
+                (
+                    "agent-ok",
+                    101,
+                    "arn:aws:ecs:us-west-2:123:task/jm/good",
+                    "done",
+                    "running",
+                ),
+            ]
+        )
+        conn.queue_cursor(select_cur)
+        # Second cursor: _read_agent_status_phase returns (succeeded, done).
+        status_cur = _FakeCursor()
+        status_cur.fetchone_queue = [("succeeded", "done")]
+        conn.queue_cursor(status_cur)
+
+        fake_client = MagicMock()
+        fake_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": "arn:aws:ecs:us-west-2:123:task/jm/good",
+                    "lastStatus": "STOPPED",
+                    "stopCode": "EssentialContainerExited",
+                    "containers": [{"exitCode": 0}],
+                }
+            ]
+        }
+        with patch.object(d, "_make_ecs_client", return_value=fake_client):
+            summary = d._reap_completed_agent_tasks()
+
+        assert summary == {
+            "active": 1,
+            "reaped_success": 1,
+            "reaped_failure": 0,
+            "still_running": 0,
+        }
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_reaped_success" in events
+
+    def test_stopped_success_row_gap_marks_succeeded(self, caplog: Any) -> None:
+        """Container exited 0 but DB row still ``running`` -> daemon closes the gap."""
+        d, conn = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_reap")
+        select_cur = _FakeCursor(
+            rows=[
+                (
+                    "agent-gap",
+                    11,
+                    "arn:aws:ecs:us-west-2:123:task/gap",
+                    "verify",
+                    "running",
+                ),
+            ]
+        )
+        conn.queue_cursor(select_cur)
+        status_cur = _FakeCursor()
+        status_cur.fetchone_queue = [("running", "verify")]
+        conn.queue_cursor(status_cur)
+
+        fake_client = MagicMock()
+        fake_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": "arn:aws:ecs:us-west-2:123:task/gap",
+                    "lastStatus": "STOPPED",
+                    "stopCode": "EssentialContainerExited",
+                    "containers": [{"exitCode": 0}],
+                }
+            ]
+        }
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch.object(d, "_mark_agent_terminal") as mark_mock,
+        ):
+            summary = d._reap_completed_agent_tasks()
+
+        assert summary["reaped_success"] == 1
+        mark_mock.assert_called_once()
+        kwargs = mark_mock.call_args.kwargs
+        assert kwargs.get("status") == "succeeded"
+        assert kwargs.get("exit_code") == 0
+        assert kwargs.get("issue_number") == 11
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_reaped_success_row_gap" in events
+
+    def test_stopped_failure_routes_to_handle_agent_failure(self, caplog: Any) -> None:
+        d, conn = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_reap")
+        select_cur = _FakeCursor(
+            rows=[
+                (
+                    "agent-bad",
+                    200,
+                    "arn:aws:ecs:us-west-2:123:task/bad",
+                    "ralph",
+                    "running",
+                ),
+            ]
+        )
+        conn.queue_cursor(select_cur)
+        status_cur = _FakeCursor()
+        status_cur.fetchone_queue = [("running", "ralph")]
+        conn.queue_cursor(status_cur)
+
+        fake_client = MagicMock()
+        fake_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": "arn:aws:ecs:us-west-2:123:task/bad",
+                    "lastStatus": "STOPPED",
+                    "stopCode": "ContainerRuntimeError",
+                    "containers": [{"exitCode": 137}],
+                }
+            ]
+        }
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch.object(d, "_handle_agent_failure") as fail_mock,
+        ):
+            summary = d._reap_completed_agent_tasks()
+
+        assert summary["reaped_failure"] == 1
+        fail_mock.assert_called_once()
+        kw = fail_mock.call_args.kwargs
+        assert kw["agent_id"] == "agent-bad"
+        assert kw["category"] == "agent_task_stopped_unexpectedly"
+        assert kw["exit_code"] == 137
+        assert kw["details"]["stop_code"] == "ContainerRuntimeError"
+        assert kw["details"]["task_arn"] == "arn:aws:ecs:us-west-2:123:task/bad"
+        assert kw["issue_number"] == 200
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_reaped_failure" in events
+
+    def test_stopped_failure_already_terminal_skips_double_route(
+        self, caplog: Any
+    ) -> None:
+        """Don't re-insert a failure row if agent-runner wrote its own terminal."""
+        d, conn = _make_daemon()
+        caplog.set_level(logging.INFO, logger="test.daemon_reap")
+        select_cur = _FakeCursor(
+            rows=[
+                (
+                    "agent-done",
+                    300,
+                    "arn:aws:ecs:us-west-2:123:task/done",
+                    "ralph",
+                    "running",
+                ),
+            ]
+        )
+        conn.queue_cursor(select_cur)
+        status_cur = _FakeCursor()
+        # Agent-runner wrote ``failed`` before exiting.
+        status_cur.fetchone_queue = [("failed", "ralph")]
+        conn.queue_cursor(status_cur)
+
+        fake_client = MagicMock()
+        fake_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": "arn:aws:ecs:us-west-2:123:task/done",
+                    "lastStatus": "STOPPED",
+                    "stopCode": "EssentialContainerExited",
+                    "containers": [{"exitCode": 2}],  # non-zero exit
+                }
+            ]
+        }
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch.object(d, "_handle_agent_failure") as fail_mock,
+        ):
+            summary = d._reap_completed_agent_tasks()
+        assert summary["reaped_failure"] == 1
+        fail_mock.assert_not_called()
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_reaped_failure_already_terminal" in events
+
+    def test_running_task_is_noop(self) -> None:
+        d, conn = _make_daemon()
+        select_cur = _FakeCursor(
+            rows=[
+                (
+                    "agent-live",
+                    400,
+                    "arn:aws:ecs:us-west-2:123:task/live",
+                    "ralph",
+                    "running",
+                ),
+            ]
+        )
+        conn.queue_cursor(select_cur)
+
+        fake_client = MagicMock()
+        fake_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": "arn:aws:ecs:us-west-2:123:task/live",
+                    "lastStatus": "RUNNING",
+                    "containers": [],
+                }
+            ]
+        }
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch.object(d, "_mark_agent_terminal") as mark_mock,
+            patch.object(d, "_handle_agent_failure") as fail_mock,
+        ):
+            summary = d._reap_completed_agent_tasks()
+        # No action — agent is alive.
+        mark_mock.assert_not_called()
+        fail_mock.assert_not_called()
+        assert summary == {
+            "active": 1,
+            "reaped_success": 0,
+            "reaped_failure": 0,
+            "still_running": 1,
+        }
+
+
+# --------------------------------------------------------------------------
+# Fresh-daemon-resumes-observation — the #3078 Option A payoff.
+# --------------------------------------------------------------------------
+
+
+class TestFreshDaemonResumesObservation:
+    def test_fresh_run_id_observes_in_flight_without_abandonment(self) -> None:
+        """A brand-new daemon run sees in-flight agent-runner tasks as RUNNING
+        and leaves them alone. The pre-#3091 subprocess model marked every
+        in-flight agent as ``daemon_restart_abandoned`` on restart; this
+        test documents that the ECS-path reap does NOT do that.
+        """
+        d, conn = _make_daemon()
+        # The agent was launched by a PREVIOUS daemon run (run_id='old').
+        # This daemon has run_id='test-run-id' (from _make_daemon).
+        assert d._run_id == "test-run-id"
+        select_cur = _FakeCursor(
+            rows=[
+                (
+                    "agent-surv",
+                    50,
+                    "arn:aws:ecs:us-west-2:123:task/surv",
+                    "ralph",
+                    "running",
+                ),
+            ]
+        )
+        conn.queue_cursor(select_cur)
+        fake_client = MagicMock()
+        fake_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": "arn:aws:ecs:us-west-2:123:task/surv",
+                    "lastStatus": "RUNNING",
+                    "containers": [],
+                }
+            ]
+        }
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch.object(d, "_mark_agent_terminal") as mark_mock,
+            patch.object(d, "_handle_agent_failure") as fail_mock,
+        ):
+            summary = d._reap_completed_agent_tasks()
+        mark_mock.assert_not_called()
+        fail_mock.assert_not_called()
+        assert summary["still_running"] == 1
+        assert summary["reaped_success"] == 0
+        assert summary["reaped_failure"] == 0
+
+
+# --------------------------------------------------------------------------
+# Guards — empty rows, missing cluster, describe failure.
+# --------------------------------------------------------------------------
+
+
+class TestReapGuards:
+    def test_no_active_rows_early_returns(self) -> None:
+        d, conn = _make_daemon()
+        select_cur = _FakeCursor(rows=[])
+        conn.queue_cursor(select_cur)
+        with patch.object(d, "_make_ecs_client") as mock_make:
+            summary = d._reap_completed_agent_tasks()
+        # Never built the ECS client — no work to do.
+        mock_make.assert_not_called()
+        assert summary == {
+            "active": 0,
+            "reaped_success": 0,
+            "reaped_failure": 0,
+            "still_running": 0,
+        }
+
+    def test_missing_cluster_logs_and_returns(self, caplog: Any) -> None:
+        d, conn = _make_daemon(cluster_arn="")
+        caplog.set_level(logging.WARNING, logger="test.daemon_reap")
+        select_cur = _FakeCursor(
+            rows=[
+                ("agent-a", 1, "arn:aws:ecs:us-west-2:123:task/a", "ralph", "running"),
+            ]
+        )
+        conn.queue_cursor(select_cur)
+        with patch.object(d, "_make_ecs_client") as mock_make:
+            summary = d._reap_completed_agent_tasks()
+        mock_make.assert_not_called()
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "reap_agent_tasks_no_cluster" in events
+        assert summary["active"] == 1
+
+    def test_describe_tasks_exception_is_logged_not_raised(self, caplog: Any) -> None:
+        d, conn = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_reap")
+        select_cur = _FakeCursor(
+            rows=[
+                ("agent-a", 1, "arn:aws:ecs:us-west-2:123:task/a", "ralph", "running"),
+            ]
+        )
+        conn.queue_cursor(select_cur)
+        fake_client = MagicMock()
+        fake_client.describe_tasks.side_effect = RuntimeError("endpoint outage")
+        with patch.object(d, "_make_ecs_client", return_value=fake_client):
+            summary = d._reap_completed_agent_tasks()
+        # Does not raise; returns a neutral summary so the scheduler
+        # tick keeps ticking.
+        assert summary["still_running"] == 0
+        assert summary["reaped_success"] == 0
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "reap_agent_tasks_describe_failed" in events

--- a/scripts/dispatcher/tests/test_daemon_skeleton.py
+++ b/scripts/dispatcher/tests/test_daemon_skeleton.py
@@ -208,19 +208,21 @@ class TestSchedulerTick:
         summary = d.scheduler_tick()
         assert summary["commands_consumed"] == 3
         assert summary["concurrency_cap"] == 0
-        # Four commits on the first tick:
+        # Five commits on the first tick:
         #   1. config read (command consumption is now its own transaction
         #      managed by _consume_commands, which is stubbed here),
         #   2. infra-preemption retry-marker SELECT (#2949 pre-scan drain
         #      runs in its own transaction; the fake cursor returns an
         #      empty fetchall so no markers are processed here),
-        #   3. queue_snapshots INSERT (Phase 2 addition, #2768),
-        #   4. blocked_snapshots INSERT (#2820) — always runs on the
+        #   3. per-agent ECS reap SELECT (#3091 — empty active-rows,
+        #      early returns after commit),
+        #   4. queue_snapshots INSERT (Phase 2 addition, #2768),
+        #   5. blocked_snapshots INSERT (#2820) — always runs on the
         #      first tick so the admin page has a populated blocked
         #      panel immediately after daemon boot.
         # Each scan is isolated in its own transaction. Phase 3A gate stays
         # closed at ``concurrency_cap=0`` so no additional reads/commits.
-        assert fake_conn.commits == 4
+        assert fake_conn.commits == 5
         # Tick counter incremented.
         assert d._scheduler_ticks == 1
 


### PR DESCRIPTION
## Summary

Stage 2 of the per-agent ECS migration (#3086 / #3078 Option A). Wires the dispatcher daemon to launch per-agent ECS tasks via the agent-runner task definition shipped in Stage 1b (#3090) and to observe their lifecycle via `ecs:DescribeTasks`. Feature-flagged behind `dispatcher.config.agent_execution_mode` which **defaults to `'subprocess'`** — this PR is inert on deploy until Stage 3 smoke (#3092) and Stage 4 flip-default (#3093).

The daemon-restart-abandonment cascade (#3078 root cause) goes away in the ECS mode: a fresh daemon after a redeploy simply resumes observing the existing `agent_task_arn` ARNs via `ecs:DescribeTasks` — every in-flight agent survives the redeploy.

## What shipped

**Migration 41** — `packages/api/migrations/41_dispatcher-agent-task-arn.sql`
- `dispatcher.agents.agent_task_arn TEXT NULL`
- `dispatcher.agents.execution_mode TEXT NOT NULL DEFAULT 'subprocess'`
- Partial index on `(agent_task_arn) WHERE agent_task_arn IS NOT NULL` so the reap pass scans only live ECS agents.

**Daemon** — `scripts/dispatcher/daemon.py`
- `_cb_config_str` + `_read_agent_execution_mode` read the flag with default-to-subprocess semantics; unrecognized values fall back with a warning.
- `_launch_agent_ecs_task(agent_id, issue_number)` calls `ecs:RunTask` with a 3-attempt / 1s+2s backoff retry loop matching #3053 / #3085. Retries on throttling / 5xx / response-level `failures[]`; fails fast on `AccessDenied` / `ValidationException`. On success: `UPDATE dispatcher.agents SET agent_task_arn = $arn, execution_mode = 'ecs'`.
- `_reap_completed_agent_tasks` runs in `scheduler_tick`. `ecs:DescribeTasks` on all non-NULL `agent_task_arn` rows; STOPPED-success → noop (or close-the-gap via `_mark_agent_terminal` when the container exited 0 but the row is still `running`); STOPPED-failure → route through `_handle_agent_failure` with category `agent_task_stopped_unexpectedly`; RUNNING → noop. Fresh-daemon-resumes-observation semantics documented inline.
- Claim-time dispatch in `_claim_and_orchestrate_one` branches on the read mode: `'ecs'` calls the launcher and returns (no subprocess path); `'subprocess'` takes the unchanged legacy path. Mode is persisted on the agent row in `_atomic_claim` so mid-flight config flips never produce hybrid agents.
- Startup log surfaces the ECS wiring state so CloudWatch can confirm deploys picked up the correct task-def + cluster + network config.

**Terraform** — `infra/terraform/modules/dispatcher-daemon/`
- New `task_launch_agent_runner` IAM policy: `ecs:RunTask`, `ecs:StopTask` scoped to the agent-runner task-def family on this cluster; `ecs:DescribeTasks` with cluster-ARN condition; `iam:PassRole` scoped to the agent-runner execution + task roles. Four actions, no wildcards on the ARN list.
- Dispatcher container gains `AGENT_RUNNER_TASK_DEFINITION_FAMILY`, `AGENT_RUNNER_SUBNET_IDS`, `AGENT_RUNNER_SECURITY_GROUP_ID` env vars.
- `environments/dev/main.tf` threads the agent-runner module's outputs through.

## Key tests

- `scripts/dispatcher/tests/test_daemon_launch_agent_ecs_task.py` — happy path (env overrides, network config, tags), 3-attempt retry on `ThrottlingException` with 1s+2s backoff, no-retry on `AccessDeniedException`, response-level `failures[]` retry, wiring-guard fail-closed (missing cluster/task-def/subnets/SG).
- `scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py` — STOPPED-success (terminal + row-gap), STOPPED-failure (with + without pre-existing terminal), RUNNING noop, **fresh-daemon-resumes-observation semantics** (the #3078 payoff), cluster-missing guard, describe failure isolation.
- `scripts/dispatcher/tests/test_daemon_execution_mode_flag.py` — `_cb_config_str` fallbacks across missing/null/empty/JSON-wrapped values, `_read_agent_execution_mode` validation, **claim-time dispatch branch** on mode, **mode persisted immutable** at INSERT.

Full dispatcher suite: **1245 passed, 1 skipped** (`pytest scripts/dispatcher/tests/` in CI's serial mode).

## Terraform plan snippet

```
# module.dispatcher_daemon.aws_iam_role_policy.task_launch_agent_runner[0] will be created
+ resource "aws_iam_role_policy" "task_launch_agent_runner" {
    + policy = jsonencode({
        Statement = [
          { Action = "ecs:RunTask",    Resource = "arn:aws:ecs:us-west-2:155326049300:task-definition/judgemind-dispatcher-agent-runner-dev:*", ... },
          { Action = "ecs:StopTask",   Resource = "arn:aws:ecs:us-west-2:155326049300:task-definition/judgemind-dispatcher-agent-runner-dev:*", ... },
          { Action = "ecs:DescribeTasks", Resource = "*", Condition = { ArnEquals = { "ecs:cluster" = "arn:aws:ecs:us-west-2:155326049300:cluster/judgemind-dev" } } },
          { Action = "iam:PassRole",   Resource = ["…-exec", "…-task"], Condition = { "iam:PassedToService" = "ecs-tasks.amazonaws.com" } },
        ]
      })
  }

Plan: 3 to add, 0 to change, 1 to destroy.
```

## Inert-by-default guarantee

The seed `dispatcher.config.agent_execution_mode` row is **not touched** by this PR — operators would need to `INSERT INTO dispatcher.config (key, value) VALUES ('agent_execution_mode', '"ecs"')` before any agent uses the new path. Until Stage 3 smoke validates the path end-to-end and Stage 4 flips the default, every claim still takes the legacy subprocess lane.

## Test plan

- [x] Full `pytest scripts/dispatcher/tests/` green locally (1245 passed, 1 skipped).
- [x] `ruff check` + `ruff format --check` pass on `scripts/dispatcher/`.
- [x] `terraform validate` + `terraform plan` clean in `infra/terraform/environments/dev/`.
- [x] `scripts/regenerate_schema.sh` picked up migration 41.
- [ ] CI green.
- [ ] Post-deploy: CloudWatch `event='startup'` shows the new SHA + `agent_runner_*` fields populated. `event='scheduler_tick'` cadence unchanged. No `agent_runner_run_task_*` events (because default mode stays `'subprocess'`).

Next step: Stage 3 smoke (#3092).

Closes #3091
