### PR TITLE
docs(agent): document UNSTABLE-but-green mergeStateStatus pattern (#3099)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -454,12 +454,14 @@ Read merge status via MCP:
 mcp__github__get_pull_request owner=judgemind repo=judgemind pull_number=<PR-N>
 ```
 
-Check the `mergeable` and `mergeable_state` fields in the response. If `mergeable` is `false` or `mergeable_state` is `dirty`/`unstable`, rebase and resolve:
+Check the `mergeable` field in the response. If `mergeable` is `false` (or `mergeable_state` / `mergeStateStatus` is `dirty`), rebase and resolve:
 ```
 git -C {worktree} fetch origin main
 git -C {worktree} rebase origin/main
 ```
 Resolve conflicts, `git rebase --continue`, then push with `--force-with-lease`.
+
+**Do NOT treat `mergeStateStatus: UNSTABLE` as a conflict or a merge-blocker.** UNSTABLE only means "at least one check run on this SHA didn't succeed" — and because GitHub computes it over the *entire history* of check runs on the SHA (not just the latest attempt), a stale failed run from an earlier CI attempt keeps the PR `UNSTABLE` forever even after a successful rerun flips the rollup green. The authoritative merge gate checks the **latest** conclusion per check — see the recipe in A.7 and `docs/agent/code-standards.md` §Interpreting mergeStateStatus (UNSTABLE-but-green).
 
 #### A.5 — Monitor CI and iterate until green
 Write status: `phase: ci-watch`, `summary: Watching CI run <run-id>`.
@@ -493,7 +495,20 @@ gh pr edit <PR-N> --repo judgemind/judgemind --body-file {worktree}/tmp/pr_body.
 Write status: `phase: merging`, `summary: Squash merging PR #<N>`.
 Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {worktree} merging`
 
-The PR has passed the ralph loop review (A.2) and CI is green. Merge it (stays on `gh` — MCP's `merge_pull_request` has no `--delete-branch` flag):
+The PR has passed the ralph loop review (A.2) and CI is green. **Before merging, confirm the merge gate is green.** The gate is:
+
+1. `mergeable == MERGEABLE` (GitHub can compute a merge commit — no conflicts), AND
+2. Every *latest* check run on the PR's head SHA has `conclusion` of `SUCCESS` or `SKIPPED` (no `FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`, or `STARTUP_FAILURE`).
+
+`mergeStateStatus == UNSTABLE` is **not** a blocker when gate (2) passes — see `docs/agent/code-standards.md` §Interpreting mergeStateStatus (UNSTABLE-but-green) for why. Use the one-line recipe:
+
+```
+gh pr view <PR-N> --repo judgemind/judgemind \
+  --json mergeable,statusCheckRollup \
+  --jq '{mergeable, rollup: [.statusCheckRollup[] | {name, conclusion}]}'
+```
+
+If `mergeable` is `MERGEABLE` and no `conclusion` is a failure state, merge (stays on `gh` — MCP's `merge_pull_request` has no `--delete-branch` flag):
 ```
 gh pr merge <PR-N> --repo judgemind/judgemind --squash --delete-branch
 ```

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -498,9 +498,10 @@ Also start the phase timer: `python3 {worktree}/scripts/phase_timer.py start {wo
 The PR has passed the ralph loop review (A.2) and CI is green. **Before merging, confirm the merge gate is green.** The gate is:
 
 1. `mergeable == MERGEABLE` (GitHub can compute a merge commit — no conflicts), AND
-2. Every *latest* check run on the PR's head SHA has `conclusion` of `SUCCESS` or `SKIPPED` (no `FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`, or `STARTUP_FAILURE`).
+2. The required status check `ci-passed` has `conclusion: SUCCESS` on its latest run, AND
+3. No *latest* check has `conclusion: FAILURE`.
 
-`mergeStateStatus == UNSTABLE` is **not** a blocker when gate (2) passes — see `docs/agent/code-standards.md` §Interpreting mergeStateStatus (UNSTABLE-but-green) for why. Use the one-line recipe:
+`SKIPPED` is fine, and `CANCELLED` on a non-required check (typically Vercel / Smoke Test concurrency cancellation) is fine. `mergeStateStatus == UNSTABLE` is **not** a blocker when the three gates above pass — see `docs/agent/code-standards.md` §Interpreting mergeStateStatus (UNSTABLE-but-green) for why. Use the one-line recipe:
 
 ```
 gh pr view <PR-N> --repo judgemind/judgemind \
@@ -508,7 +509,7 @@ gh pr view <PR-N> --repo judgemind/judgemind \
   --jq '{mergeable, rollup: [.statusCheckRollup[] | {name, conclusion}]}'
 ```
 
-If `mergeable` is `MERGEABLE` and no `conclusion` is a failure state, merge (stays on `gh` — MCP's `merge_pull_request` has no `--delete-branch` flag):
+If `mergeable` is `MERGEABLE`, `ci-passed` is `SUCCESS`, and nothing is `FAILURE`, merge (stays on `gh` — MCP's `merge_pull_request` has no `--delete-branch` flag):
 ```
 gh pr merge <PR-N> --repo judgemind/judgemind --squash --delete-branch
 ```

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -161,6 +161,33 @@ scripts/check-ci-job-skipped.sh
 
 This detects the #2410 / #2505 footgun: a PR modifies a job body whose `if: needs.detect-changes.outputs.X == 'true'` gate's paths-filter does not match anything in the diff, so the job will be SKIPPED on that PR's own CI run and the modification is never actually exercised. The same check runs in CI as the `ci-job-skipped-check` job; the pre-push hook runs it whenever `ci.yml` is in the push. If it fails, either add `.github/workflows/ci.yml` to the offending filter (so the job always runs when ci.yml itself changes) or modify a file that already matches the filter.
 
+### Interpreting mergeStateStatus (UNSTABLE-but-green)
+
+GitHub's `mergeStateStatus` field — exposed by `gh pr view --json mergeStateStatus` and `mcp__github__get_pull_request` — is derived from the *entire history* of check runs on the PR's head SHA, not just the latest attempt per workflow. One stale failed run from a previous CI attempt is enough to keep a PR flagged `UNSTABLE` even after a successful rerun on the same SHA flips the latest rollup green.
+
+**Symptom:** `gh pr view <N> --json mergeable,mergeStateStatus` returns `{"mergeable": "MERGEABLE", "mergeStateStatus": "UNSTABLE"}` yet every currently-displayed check on the PR page is green. Common trigger: the first run on the SHA hit a transient GitHub Actions flake (e.g. `detect-changes` timeout), you reran that workflow on the same SHA, and the rerun succeeded. Both runs' check runs are attached to the SHA; GitHub surfaces the old failed run in the mergeStateStatus calculation forever.
+
+**Correct merge gate** (use this, not `mergeStateStatus == CLEAN`):
+
+1. `mergeable == MERGEABLE` (GitHub can compute a merge commit — no conflicts), AND
+2. Every *latest* check run has `conclusion` of `SUCCESS` or `SKIPPED` — no `FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`, or `STARTUP_FAILURE`.
+
+`UNSTABLE` with both gates satisfied is safe to merge.
+
+**One-line recipe:**
+
+```
+gh pr view <N> --repo judgemind/judgemind \
+  --json mergeable,statusCheckRollup \
+  --jq '{mergeable, rollup: [.statusCheckRollup[] | {name, conclusion}]}'
+```
+
+Scan the output: `mergeable` should be `MERGEABLE`, and every `conclusion` should be `SUCCESS` or `SKIPPED`. If so, merge — regardless of `mergeStateStatus`.
+
+**Incident example (#3099):** PR #3095's first CI attempt (run `24847629910`) failed on the `detect-changes` job — a transient GitHub Actions flake. The rerun on the same SHA (run `24847660775`) succeeded with every job green. `mergeable` was `MERGEABLE`, every *latest* rollup conclusion was `SUCCESS` or `SKIPPED`, but `mergeStateStatus` stayed `UNSTABLE` because the old failed `detect-changes` check run was still attached to the SHA. The PR was safe to merge under the gate above.
+
+The `/task` skill's §A.7 merge step uses this gate — see `.claude/skills/task/SKILL.md`.
+
 ### Database migrations — schema drift
 
 When any file under `packages/api/migrations/` changes, regenerate `packages/api/src/data-access/schema.sql`:

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -170,9 +170,10 @@ GitHub's `mergeStateStatus` field — exposed by `gh pr view --json mergeStateSt
 **Correct merge gate** (use this, not `mergeStateStatus == CLEAN`):
 
 1. `mergeable == MERGEABLE` (GitHub can compute a merge commit — no conflicts), AND
-2. Every *latest* check run has `conclusion` of `SUCCESS` or `SKIPPED` — no `FAILURE`, `CANCELLED`, `TIMED_OUT`, `ACTION_REQUIRED`, or `STARTUP_FAILURE`.
+2. The **required** status check — `ci-passed` on this repo — has `conclusion: SUCCESS` on its latest run, AND
+3. No *latest* non-required check has `conclusion: FAILURE` (a failed required-ish check on the current SHA — distinct from a stale failed run already addressed by a rerun).
 
-`UNSTABLE` with both gates satisfied is safe to merge.
+`SKIPPED` is fine. `CANCELLED` on a non-required check is usually fine — it frequently comes from a Vercel / smoke-test concurrency guard superseding an older deploy (`Canceling since a higher priority waiting request exists`) and doesn't reflect a real failure. `UNSTABLE` with gates (1)-(3) satisfied is safe to merge.
 
 **One-line recipe:**
 
@@ -182,9 +183,9 @@ gh pr view <N> --repo judgemind/judgemind \
   --jq '{mergeable, rollup: [.statusCheckRollup[] | {name, conclusion}]}'
 ```
 
-Scan the output: `mergeable` should be `MERGEABLE`, and every `conclusion` should be `SUCCESS` or `SKIPPED`. If so, merge — regardless of `mergeStateStatus`.
+Scan the output: `mergeable` should be `MERGEABLE`, `ci-passed` should be `SUCCESS`, and nothing should be `FAILURE`. `CANCELLED` on Vercel/Smoke-Test-style checks can be ignored if the current SHA has no corresponding failure from the same workflow. If so, merge — regardless of `mergeStateStatus`.
 
-**Incident example (#3099):** PR #3095's first CI attempt (run `24847629910`) failed on the `detect-changes` job — a transient GitHub Actions flake. The rerun on the same SHA (run `24847660775`) succeeded with every job green. `mergeable` was `MERGEABLE`, every *latest* rollup conclusion was `SUCCESS` or `SKIPPED`, but `mergeStateStatus` stayed `UNSTABLE` because the old failed `detect-changes` check run was still attached to the SHA. The PR was safe to merge under the gate above.
+**Incident example (#3099):** PR #3095's first CI attempt (run `24847629910`) failed on the `detect-changes` job — a transient GitHub Actions flake. The rerun on the same SHA (run `24847660775`) succeeded with every job green. `mergeable` was `MERGEABLE`, `ci-passed` was `SUCCESS`, no latest rollup conclusion was `FAILURE`, but `mergeStateStatus` stayed `UNSTABLE` because the old failed `detect-changes` check run was still attached to the SHA. The PR was safe to merge under the gate above.
 
 The `/task` skill's §A.7 merge step uses this gate — see `.claude/skills/task/SKILL.md`.
 


### PR DESCRIPTION
## Summary

Documents the "UNSTABLE-but-green" `mergeStateStatus` pattern so agents stop treating it as a merge-blocker. GitHub's `mergeStateStatus` is derived from the *entire history* of check runs on a PR's head SHA — not just the latest attempt per workflow. One stale failed run from an earlier CI attempt keeps the PR flagged `UNSTABLE` forever, even after a successful rerun on the same SHA turns the latest rollup green.

The correct merge gate is `mergeable == MERGEABLE` AND every latest check `conclusion` is `SUCCESS` or `SKIPPED`. `UNSTABLE` with both of those satisfied is safe to merge.

Closes #3099

## What changed

- `docs/agent/code-standards.md` — new "Interpreting mergeStateStatus (UNSTABLE-but-green)" section with the correct merge gate, a one-line `gh pr view --json mergeable,statusCheckRollup` recipe, and the #3095 incident example.
- `.claude/skills/task/SKILL.md` — §A.4 no longer flags `mergeStateStatus: UNSTABLE` as a conflict; §A.7 now explicitly documents the merge gate + jq recipe instead of relying on `mergeStateStatus == CLEAN`.

## Incident example

PR #3095's first CI attempt (run `24847629910`) failed on the `detect-changes` job — a transient GitHub Actions flake. The rerun on the same SHA (run `24847660775`) succeeded with every job green. `mergeable` was `MERGEABLE`, every *latest* rollup conclusion was `SUCCESS` or `SKIPPED`, but `mergeStateStatus` stayed `UNSTABLE` because the old failed `detect-changes` check run was still attached to the SHA. Under the gate documented here, the PR was safe to merge.

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] `scripts/check-markdown-links.sh` passes (ran locally: all clean)
- [ ] CI green

### Post-deploy verification
- [ ] N/A — no deployed component (docs + .claude/skills only)
