### PR TITLE
fix(deploy-dispatcher): exclude tests/ from paths filter to avoid agent-killing redeploys (#3112)

### DIFF
--- a/.github/workflows/deploy-dispatcher.yml
+++ b/.github/workflows/deploy-dispatcher.yml
@@ -36,6 +36,15 @@ on:
       # a rollout. Excluded so new helpers can be added without a
       # gratuitous redeploy or a workflow-yml edit each time.
       - "!scripts/dispatcher/helpers/**"
+      # scripts/dispatcher/tests/ is pytest-only — never imported by
+      # daemon.py at runtime, so changes there do not affect the built
+      # image's behavior. Excluded so test-only PRs don't trigger a
+      # full daemon redeploy that kills in-flight agents (see #3112).
+      - "!scripts/dispatcher/tests/**"
+      # Markdown docs scattered throughout the dispatcher tree are
+      # operator-facing only and have no runtime effect. Excluded so
+      # doc-only tweaks don't force a rollout.
+      - "!scripts/dispatcher/**/*.md"
       # scripts/dispatcher/agent-runner-entrypoint.sh is the entrypoint
       # for the separate `judgemind/dispatcher-agent-runner` image
       # (#3090, Stage 1b of #3086). It is NOT baked into the daemon


### PR DESCRIPTION
## Summary

Exclude `scripts/dispatcher/tests/**` and `scripts/dispatcher/**/*.md` from the `deploy-dispatcher.yml` paths filter so test-only and doc-only PRs no longer trigger a full daemon redeploy.

These paths have no runtime effect on the daemon image — pytest files are never imported by `daemon.py`, and Markdown is operator-facing documentation. The previous behavior (see #3108 → run `24854064828`) killed in-flight agent `cd0fedf3` mid-ralph for a 4-line test-file rename. Mirrors the existing `!scripts/dispatcher/helpers/**` exclusion pattern.

## Test plan

- [x] YAML syntax validated via `yaml.safe_load`
- [x] `scripts/check-ci-job-skipped.sh` passes
- [x] Pre-push hook (`check-github-actions-workflows.sh`, `check-filename-separator-collisions.sh`) passes
- [ ] Merging this PR will itself trigger Deploy Dispatcher (expected — the workflow file is in its own paths filter). First in-anger test of the new filter.
- [ ] Future test-only PRs under `scripts/dispatcher/tests/` will NOT trigger Deploy Dispatcher (proven by absence over time).

Closes #3112
