### PR TITLE
fix(dispatcher): agent-runner phase_outputs INSERT schema mismatch (#3115)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -383,9 +383,12 @@ run_claude_phase() {
 persist_phase_output() {
     # $1 = phase, $2 = output JSON.
     # Stage 1b writes a minimal row shape matching the daemon's
-    # phase_outputs schema: agent_id, phase, status, output_json. The
-    # daemon's `log_text` field is populated in Stage 2 when we wire
-    # the CloudWatch log capture.
+    # phase_outputs schema: (agent_id, phase, output_json) — NOT a
+    # `status` column, which does not exist on `dispatcher.phase_outputs`
+    # (#3115). The daemon's subprocess-mode persist writes the same
+    # three columns. The `log_text` / `attempt` / token + cost columns
+    # stay NULL here; Stage 2 wiring populates them once the daemon-
+    # side log-capture path is in place.
     #
     # Default-substitute to an empty-object string if $2 is absent.
     # We spell the default in two stages rather than
@@ -399,8 +402,8 @@ persist_phase_output() {
         _output_json="{}"
     fi
     _escaped=$(printf '%s' "$_output_json" | sed "s/'/''/g")
-    db_exec "INSERT INTO dispatcher.phase_outputs (agent_id, phase, status, output_json)
-             VALUES ('$AGENT_ID', '$_phase', 'succeeded', '$_escaped'::jsonb);"
+    db_exec "INSERT INTO dispatcher.phase_outputs (agent_id, phase, output_json)
+             VALUES ('$AGENT_ID', '$_phase', '$_escaped'::jsonb);"
     log "phase_output_persisted" "phase=$_phase"
 }
 

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -422,6 +422,23 @@ for expected in planning ralph summary push_and_pr verify; do
     fi
 done
 
+# Verify the phase_outputs INSERT column list matches the real
+# `dispatcher.phase_outputs` schema — specifically, that it does NOT
+# include a `status` column. Regression guard for #3115: the initial
+# Stage 1b entrypoint diverged from the daemon's insert shape by
+# adding a `status` column that doesn't exist in the schema, which
+# crashed every per-agent ECS task at the first phase-output persist.
+# Authoritative schema columns (as of migration 41): output_id,
+# agent_id, phase, output_json, ts, log_text, attempt, tokens_*,
+# cost_usd, model_used, patch_id. No `status`.
+if grep -F "INSERT INTO dispatcher.phase_outputs" "$INVOCATIONS_DIR/psql.log" \
+     | grep -q "status" 2>/dev/null; then
+    fail "phase_outputs INSERT omits nonexistent status column (#3115)" \
+         "Found 'status' in INSERT column list. Sample: $(grep -m1 "INSERT INTO dispatcher.phase_outputs" "$INVOCATIONS_DIR/psql.log" | head -c 300)"
+else
+    pass "phase_outputs INSERT omits nonexistent status column (#3115)"
+fi
+
 # Verify ralph_patches was inserted on ralph SHIP.
 if grep -q "INSERT INTO dispatcher.ralph_patches" "$INVOCATIONS_DIR/psql.log"; then
     pass "inserts ralph_patches row on ralph SHIP"


### PR DESCRIPTION
## Summary

Stage 1b agent-runner entrypoint INSERTed into `dispatcher.phase_outputs` with a nonexistent `status` column, crashing every per-agent ECS task at the first phase-output persist. Discovered during #3092 Stage 3 smoke. The daemon's subprocess-mode persist already writes the correct 3-column shape; the entrypoint author diverged when porting.

Closes #3115

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass (`scripts/tests/test_agent_runner_entrypoint.sh` → 22/22 passed locally with new regression guard)
- [ ] CI green

### Post-deploy verification
- [ ] Rebuild + push `Dockerfile.dispatcher-agent-runner` image and re-run #3092 Stage 3 smoke — agent advances past the `claiming → planning` transition without the `ERROR:  column "status"...` crash
- [ ] Verification evidence posted on #3115 (and on #3092 smoke timeline)
