### PR TITLE
fix(dispatcher): agent-runner phase-dispatch + skill-name fixes (#3117)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -30,13 +30,30 @@
 # use the in-process subprocess path.
 #
 # Per-phase mechanical side effects — the parts that today live in
-# `daemon._handle_phase_*` (push-and-pr's `git push` + `gh pr create`,
-# awaiting_ci's `gh pr checks` poll, etc.) — are stubbed as
-# per-phase helper functions (`_handle_phase_push_and_pr`, etc.) that
-# return sentinel outputs for verdict-driven phases (plan, ralph,
-# summary, push_and_pr, fix_ci, verify) and TODO exits for the
-# mechanical-only phases (merge, awaiting_ci, awaiting_deploy, retro).
-# Stage 2 fleshes each stub out.
+# `daemon._handle_phase_*` — split across three tiers in the Stage 1b
+# entrypoint (post-#3117):
+#
+#   1. **Claude-driven phases** (planning, ralph, summary, fix_ci,
+#      verify) → `run_claude_phase "<phase>"` which looks up the skill
+#      name via `phase_to_skill` and invokes `claude -p /task-v2-...`.
+#   2. **Mechanical pseudo-phase: claiming** → no-op; advances
+#      immediately to `planning`. The daemon has already written the
+#      agent row by the time this task boots, so the claim step is
+#      nothing but a lifecycle marker.
+#   3. **Mechanical phases with side effects** — `push_and_pr` has a
+#      minimal in-process implementation (`handle_push_and_pr` ==
+#      `git push` + `gh pr create`). `awaiting_ci`, `merge`,
+#      `awaiting_deploy`, `retro`, and `setup` are stubbed: they
+#      advance to the documented "next" phase on the happy path so
+#      the smoke test can reach `done` without a full daemon
+#      integration. Stage 2 fleshes each stub out.
+#
+# The phase → skill-name mapping (`phase_to_skill`) is explicit and
+# dies on an unknown phase. Prior to #3117 the entrypoint constructed
+# `/task-v2-$_phase` directly, which silently failed with "Unknown
+# command" for the `planning`/`plan` and `fix_ci`/`fix-ci` drift and
+# for the two mechanical phases (`claiming`, `push_and_pr`) that
+# never had skills.
 #
 # macOS bash 3.2 compatibility
 # ----------------------------
@@ -309,7 +326,17 @@ except ImportError:
 
 payload = json.load(sys.stdin)
 current_phase = payload.get("current_phase", "")
-output = payload.get("output") or {}
+output = payload.get("output")
+# Defensive coercion (#3117): a failed claude invocation (e.g. sandbox
+# deny, skill-name typo returning "Unknown command: ...", network
+# error) can surface as a plain-string `.result`. The downstream
+# transition functions call ``output.get("verdict")``, which crashes
+# with AttributeError on a str. Coerce any non-dict output to {} so
+# the transition falls through the missing-verdict branch and the
+# caller persists a structured failure row instead of crashing the
+# runner with a stack trace.
+if not isinstance(output, dict):
+    output = {}
 transition = pt.next_phase_from_verdict(current_phase, output)
 fields = [
     transition.action.value if transition.action else "",
@@ -349,6 +376,31 @@ transition_for() {
 # bundles) lands in Stage 2. Stage 1b proves the wire — not the
 # finish-line finesse.
 
+# Phase → skill name mapping (#3117). The phase-name constants emitted
+# by `scripts/dispatcher/phase_transitions.py` use underscored/present-
+# participle names (planning, fix_ci). The actual Claude skills on disk
+# are hyphenated/root-verb (task-v2-plan, task-v2-fix-ci). We do NOT
+# construct `/task-v2-$_phase` directly; we map to the literal skill
+# name via this case statement so any drift (new phase, renamed skill)
+# surfaces as an explicit die() instead of a silent "Unknown command"
+# string coming back from claude.
+#
+# Bash 3.2: a case statement is used instead of an associative array
+# (declare -A is bash 4+).
+phase_to_skill() {
+    # $1 = phase name. Prints the matching skill suffix (no `task-v2-`
+    # prefix) on stdout. die()s if no mapping exists.
+    case "$1" in
+        planning)  printf 'plan' ;;
+        ralph)     printf 'ralph' ;;
+        summary)   printf 'summary' ;;
+        fix_ci)    printf 'fix-ci' ;;
+        verify)    printf 'verify' ;;
+        retro)     printf 'retro' ;;
+        *)         die "no_skill_mapping_for_phase=$1" ;;
+    esac
+}
+
 run_claude_phase() {
     _phase="$1"
     _out_file="$AGENT_WORKSPACE/claude-p-$_phase.stdout.json"
@@ -359,12 +411,18 @@ run_claude_phase() {
         return 0
     fi
 
-    log "claude_phase_begin" "phase=$_phase"
+    # Map phase name → skill suffix. A bad phase (e.g. accidentally
+    # routed `claiming` or `push_and_pr` through this function) aborts
+    # the runner via die() so the symptom surfaces at test time, not
+    # as a silent "Unknown command" in production CloudWatch.
+    _skill=$(phase_to_skill "$_phase")
+
+    log "claude_phase_begin" "phase=$_phase" "skill=$_skill"
     # Do NOT fail the script on a non-zero exit — parse the envelope
     # and let the caller decide. Redirect stderr to a sibling file for
     # triage parity with the daemon.
     set +e
-    claude -p "/task-v2-$_phase $AGENT_ID" \
+    claude -p "/task-v2-$_skill $AGENT_ID" \
         --output-format json \
         --dangerously-skip-permissions \
         > "$_out_file" \
@@ -374,10 +432,22 @@ run_claude_phase() {
     log "claude_phase_done" "phase=$_phase" "exit_code=$_rc"
 
     # The `result` field of `claude -p --output-format json` is either
-    # a string (legacy path) or an object. The task-v2-* skills emit
-    # JSON objects in `result` (parsed by the daemon); we forward it
-    # unchanged for the transition shim.
-    jq -c '.result // {}' "$_out_file" 2>/dev/null || printf '{}'
+    # a string (legacy path, or a skill error like "Unknown command: ...")
+    # or an object. The task-v2-* skills emit JSON objects in `result`
+    # (parsed by the daemon); we forward an object unchanged for the
+    # transition shim.
+    #
+    # Defensive (#3117): when `.result` is not a JSON object, coerce
+    # to `{}` here so the downstream transition shim + persist path
+    # see a dict-shaped output and don't crash on `.get("verdict")`.
+    # The raw `.result` string is preserved on disk in `_out_file`
+    # for triage.
+    if jq -e '.result | type == "object"' "$_out_file" >/dev/null 2>&1; then
+        jq -c '.result' "$_out_file" 2>/dev/null || printf '{}'
+    else
+        log "claude_result_non_object" "phase=$_phase" "out_file=$_out_file"
+        printf '{}'
+    fi
 }
 
 persist_phase_output() {
@@ -405,6 +475,90 @@ persist_phase_output() {
     db_exec "INSERT INTO dispatcher.phase_outputs (agent_id, phase, output_json)
              VALUES ('$AGENT_ID', '$_phase', '$_escaped'::jsonb);"
     log "phase_output_persisted" "phase=$_phase"
+}
+
+handle_push_and_pr() {
+    # Mechanical implementation of the push_and_pr phase (#3117).
+    #
+    # This phase is NOT claude-driven — the daemon handles push + PR
+    # creation inline today via `_handle_phase_push_and_pr` (daemon.py
+    # ~L10544). Prior to this fix the entrypoint's phase-dispatch case
+    # lumped `push_and_pr` in with the claude-driven branches and
+    # called `/task-v2-push_and_pr`, which returned "Unknown command"
+    # (the skill does not exist).
+    #
+    # Stage 1b scope: the minimal viable push + PR, enough to get the
+    # smoke to exercise the phase boundary. Rich failure handling
+    # (commit --amend with the summary phase's commit_message, self-
+    # deploy detection, unmet-AC draft-PR, git_push_failed diagnoser
+    # routing) stays in the daemon's implementation and lands on the
+    # agent-runner side in a later Stage 2 PR.
+    #
+    # Prints the phase-output JSON envelope on stdout so the caller
+    # can persist it via persist_phase_output and drive the transition
+    # shim. Output shape matches `transition_from_push_and_pr`:
+    #   {"no_op": true}   → terminal success (no commit to push)
+    #   {"no_op": false}  → advance to awaiting_ci
+    #
+    # Note: if `AGENT_RUNNER_DRY_RUN=1`, emit `{"no_op": true}` so the
+    # loop reaches a terminal phase without actually shelling out.
+
+    if [[ "$AGENT_RUNNER_DRY_RUN" == "1" ]]; then
+        log "push_and_pr_dry_run"
+        printf '{"no_op": true}'
+        return 0
+    fi
+
+    # Detect the #3039 no-op-SHIP guardrail: ralph's SHIP with a clean
+    # working tree means `origin/main..HEAD` is empty — there's nothing
+    # to push and no PR to open. Terminate as no_op so the transition
+    # shim flips the agent to `succeeded`.
+    _ahead_count=$(git -C "$REPO_ROOT" rev-list --count origin/main..HEAD 2>/dev/null || printf '0')
+    if [[ "$_ahead_count" == "0" ]]; then
+        log "push_and_pr_no_op" "reason=clean_worktree_on_ship"
+        printf '{"no_op": true}'
+        return 0
+    fi
+
+    log "push_and_pr_push_begin" "branch=$BRANCH_NAME"
+    set +e
+    git -C "$REPO_ROOT" push -u origin "$BRANCH_NAME" \
+        > "$AGENT_WORKSPACE/git-push.stdout.log" \
+        2> "$AGENT_WORKSPACE/git-push.stderr.log"
+    _push_rc=$?
+    set -e
+    log "push_and_pr_push_done" "exit_code=$_push_rc"
+    if [[ "$_push_rc" -ne 0 ]]; then
+        log "push_and_pr_push_failed" "exit_code=$_push_rc"
+        # Emit a minimal failure envelope; the transition shim will
+        # route to the diagnoser via the unrecognized/non-SHIP path.
+        printf '{"no_op": false, "push_failed": true}'
+        return 0
+    fi
+
+    # Open the PR against main. `gh pr create` auto-picks the current
+    # branch as head and --base main. The title comes from the last
+    # commit subject on the branch (Stage 2 will plumb the summary
+    # phase's pr_title through here; Stage 1b keeps it minimal).
+    log "push_and_pr_pr_create_begin"
+    set +e
+    gh pr create \
+        --repo judgemind/judgemind \
+        --base main \
+        --head "$BRANCH_NAME" \
+        --fill \
+        > "$AGENT_WORKSPACE/gh-pr-create.stdout.log" \
+        2> "$AGENT_WORKSPACE/gh-pr-create.stderr.log"
+    _pr_rc=$?
+    set -e
+    log "push_and_pr_pr_create_done" "exit_code=$_pr_rc"
+    if [[ "$_pr_rc" -ne 0 ]]; then
+        log "push_and_pr_pr_create_failed" "exit_code=$_pr_rc"
+        printf '{"no_op": false, "pr_create_failed": true}'
+        return 0
+    fi
+
+    printf '{"no_op": false}'
 }
 
 persist_ralph_patch() {
@@ -525,8 +679,14 @@ while true; do
 
     # Phases the Stage 1b entrypoint actually runs. Each case writes
     # its phase_output, computes the transition, advances, and loops.
+    #
+    # Claude-driven phases (#3117): only the phases that map to a real
+    # `task-v2-*` skill belong here. `claiming` and `push_and_pr` are
+    # mechanical — they were incorrectly included in the original
+    # Stage 1b dispatch, which called `/task-v2-claiming` /
+    # `/task-v2-push_and_pr` and got "Unknown command" back.
     case "$_current" in
-        claiming|planning|ralph|summary|push_and_pr|fix_ci|verify)
+        planning|ralph|summary|fix_ci|verify)
             _output=$(run_claude_phase "$_current")
             persist_phase_output "$_current" "$_output"
             if [[ "$_current" == "ralph" ]]; then
@@ -559,6 +719,44 @@ while true; do
                     ;;
                 unrecognized|*)
                     log "transition_unrecognized" "phase=$_current" "action=$_action"
+                    advance_phase "daemon_restart_abandoned" "crashed"
+                    ;;
+            esac
+            ;;
+        claiming)
+            # Mechanical pseudo-phase (#3117): the daemon writes
+            # phase='claiming' only briefly while it inserts the
+            # dispatcher.agents row; the claim itself is a pure DB
+            # write, not an LLM pass. Any ECS task whose phase column
+            # reads `claiming` at boot is a post-claim lifecycle
+            # artifact — the claim already happened before the task
+            # was launched. Advance immediately to `planning` so the
+            # phase loop starts the real work without shelling out to
+            # a nonexistent `/task-v2-claiming` skill.
+            log "claiming_no_op_advance_to_planning"
+            persist_phase_output "claiming" '{"no_op": true}'
+            advance_phase "planning"
+            ;;
+        push_and_pr)
+            # Mechanical phase (#3117). See handle_push_and_pr for the
+            # git push + gh pr create implementation. On success the
+            # transition shim advances to awaiting_ci (or to no_op
+            # terminal if the worktree was clean at ralph SHIP time).
+            _output=$(handle_push_and_pr)
+            persist_phase_output "push_and_pr" "$_output"
+            _transition=$(transition_for "push_and_pr" "$_output")
+            _action=$(printf '%s' "$_transition" | cut -f1)
+            _next=$(printf '%s' "$_transition" | cut -f2)
+            _status=$(printf '%s' "$_transition" | cut -f3)
+            case "$_action" in
+                advance)
+                    advance_phase "$_next"
+                    ;;
+                advance_with_status)
+                    advance_phase "$_next" "$_status"
+                    ;;
+                *)
+                    log "push_and_pr_transition_unrecognized" "action=$_action"
                     advance_phase "daemon_restart_abandoned" "crashed"
                     ;;
             esac

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -169,23 +169,39 @@ set -u
 INVOCATIONS_DIR="${INVOCATIONS_DIR}"
 . "$(dirname "$0")/_record_invocation.sh" claude "$@"
 
-# Determine phase from /task-v2-<phase> in argv.
-phase=""
+# Determine skill-suffix from /task-v2-<skill> in argv. Note that
+# post-#3117 the caller passes the SKILL NAME (plan, ralph, summary,
+# fix-ci, verify, retro) not the phase name — this stub looks up
+# verdicts by skill name for that reason. Tests that want to assert
+# the entrypoint sent the right /task-v2-<skill> literal grep the
+# claude.log directly.
+skill=""
 for arg in "$@"; do
     case "$arg" in
         /task-v2-*)
-            # Strip "/task-v2-" prefix and trailing agent id.
             stripped="${arg#/task-v2-}"
-            phase="${stripped%% *}"
+            skill="${stripped%% *}"
             break
             ;;
     esac
 done
 
-# Look up verdict for this phase from CLAUDE_VERDICT_FIXTURE (TSV).
+# Allow tests to inject a non-object `.result` (e.g. a plain string
+# "Unknown command: /task-v2-foo") to exercise the defensive shim.
+# Set CLAUDE_RESULT_OVERRIDE to the exact JSON payload to emit. Set
+# CLAUDE_RESULT_OVERRIDE_SKILL to scope the override to one skill
+# only; leave unset to apply it to every skill invocation.
+if [[ -n "${CLAUDE_RESULT_OVERRIDE:-}" ]]; then
+    if [[ -z "${CLAUDE_RESULT_OVERRIDE_SKILL:-}" || "${CLAUDE_RESULT_OVERRIDE_SKILL}" == "$skill" ]]; then
+        printf '%s\n' "$CLAUDE_RESULT_OVERRIDE"
+        exit 0
+    fi
+fi
+
+# Look up verdict for this skill from CLAUDE_VERDICT_FIXTURE (TSV).
 verdict="SHIP"
-if [[ -f "${CLAUDE_VERDICT_FIXTURE:-}" && -n "$phase" ]]; then
-    match=$(grep -E "^${phase}	" "$CLAUDE_VERDICT_FIXTURE" 2>/dev/null || true)
+if [[ -f "${CLAUDE_VERDICT_FIXTURE:-}" && -n "$skill" ]]; then
+    match=$(grep -E "^${skill}	" "$CLAUDE_VERDICT_FIXTURE" 2>/dev/null || true)
     if [[ -n "$match" ]]; then
         verdict=$(printf '%s' "$match" | cut -f2)
     fi
@@ -243,12 +259,24 @@ case "$subcommand" in
         printf 'deadbeefcafe\n'
         exit 0
         ;;
+    rev-list)
+        # `git rev-list --count origin/main..HEAD` — tests that want
+        # to exercise push_and_pr's push-and-PR path set
+        # GIT_REV_LIST_COUNT=1 (or higher); tests that want the no-op
+        # branch leave it unset (defaults to 0).
+        printf '%s\n' "${GIT_REV_LIST_COUNT:-0}"
+        exit 0
+        ;;
     format-patch)
         printf 'From deadbeefcafe Mon Sep 17 00:00:00 2001\nfake patch content\n'
         exit 0
         ;;
     am)
         exit 0
+        ;;
+    push)
+        # Honor GIT_PUSH_EXIT to simulate push failures.
+        exit "${GIT_PUSH_EXIT:-0}"
         ;;
     *)
         exit 0
@@ -264,6 +292,22 @@ cat > "$STUB_BIN/gh" <<'GHEOF'
 set -u
 INVOCATIONS_DIR="${INVOCATIONS_DIR}"
 . "$(dirname "$0")/_record_invocation.sh" gh "$@"
+
+# Simulate `gh pr create` outcomes based on GH_PR_CREATE_EXIT.
+sub=""
+for arg in "$@"; do
+    if [[ "$sub" == "" && "$arg" != --* && "$arg" != -* ]]; then
+        sub="$arg"
+        continue
+    fi
+    if [[ -n "$sub" && "$sub" == "pr" && "$arg" != --* && "$arg" != -* ]]; then
+        if [[ "$arg" == "create" ]]; then
+            printf 'https://github.com/judgemind/judgemind/pull/9999\n'
+            exit "${GH_PR_CREATE_EXIT:-0}"
+        fi
+    fi
+done
+
 exit 0
 GHEOF
 chmod +x "$STUB_BIN/gh"
@@ -362,12 +406,13 @@ PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t2.txt"
 printf 'planning\n' > "$PHASE_FIXTURE_FILE"
 
 CLAUDE_VERDICT_FIXTURE="$TEST_TMP/verdicts-t2.tsv"
+# Verdicts keyed by SKILL NAME (post-#3117), not phase name. The
+# entrypoint maps `planning → plan`, `fix_ci → fix-ci`, etc.
 cat > "$CLAUDE_VERDICT_FIXTURE" <<'EOF'
-planning	OK
+plan	OK
 ralph	SHIP
 summary	OK
-push_and_pr	OK
-fix_ci	PATCHED
+fix-ci	PATCHED
 verify	VERIFIED
 EOF
 
@@ -391,6 +436,7 @@ out=$(AGENT_ID="11111111-2222-3333-4444-555555555555" \
       PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
       PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
       AGENT_RUNNER_MAX_PHASE_ITERATIONS=40 \
+      GIT_REV_LIST_COUNT=1 \
       bash "$ENTRYPOINT" 2>&1)
 rc=$?
 set -e
@@ -459,12 +505,57 @@ else
     fail "phase advances through the happy-path sequence" "expected ≥7 phase updates, got $update_count"
 fi
 
-# Verify claude was invoked for each claude-driven phase.
+# Verify claude was invoked for each claude-driven phase. Post-#3117
+# the happy path calls claude for planning, ralph, summary, verify
+# (4 calls) — push_and_pr is mechanical, and fix_ci only runs when
+# CI goes red (which the stub doesn't simulate).
 claude_calls=$(wc -l < "$INVOCATIONS_DIR/claude.log" | tr -d ' ')
-if [[ "$claude_calls" -ge 5 ]]; then
+if [[ "$claude_calls" -ge 4 ]]; then
     pass "claude invoked for each claude-driven phase (calls=$claude_calls)"
 else
-    fail "claude invoked for each claude-driven phase" "expected ≥5 claude calls, got $claude_calls"
+    fail "claude invoked for each claude-driven phase" "expected ≥4 claude calls, got $claude_calls"
+fi
+
+# Verify the entrypoint invoked claude with the real SKILL names, not
+# the raw phase names (#3117 bug #1). This is the regression guard
+# against the `planning → plan` and `fix_ci → fix-ci` drift that
+# caused every Stage 3 smoke agent to die at the first phase with
+# "Unknown command: /task-v2-planning".
+# The `-p` flag quotes its argument as a single token: `/task-v2-plan
+# <agent_id>`. printf '%q' escapes the embedded space as `\ ` in the
+# invocations log, so the literal `/task-v2-plan\ ` appears in the
+# log when (and only when) the skill suffix is exactly `plan`. A
+# phase-name-drift bug would produce `/task-v2-planning\ ` which we
+# rule out with the negative grep below.
+if grep -F "/task-v2-plan\\ " "$INVOCATIONS_DIR/claude.log" >/dev/null 2>&1; then
+    pass "entrypoint invokes /task-v2-plan skill (not /task-v2-planning)"
+else
+    fail "entrypoint invokes /task-v2-plan skill (not /task-v2-planning)" \
+         "claude log: $(head -c 300 "$INVOCATIONS_DIR/claude.log")"
+fi
+
+# Negative: /task-v2-planning must NOT appear anywhere in the log.
+if grep -F "/task-v2-planning" "$INVOCATIONS_DIR/claude.log" >/dev/null 2>&1; then
+    fail "entrypoint does not invoke /task-v2-planning (phase-name drift)" \
+         "Found /task-v2-planning in claude log."
+else
+    pass "entrypoint does not invoke /task-v2-planning (phase-name drift)"
+fi
+
+# Negative: /task-v2-claiming and /task-v2-push_and_pr skills do not
+# exist and must never be invoked.
+if grep -F "/task-v2-claiming" "$INVOCATIONS_DIR/claude.log" >/dev/null 2>&1; then
+    fail "entrypoint does not invoke /task-v2-claiming (mechanical pseudo-phase)" \
+         "Found /task-v2-claiming in claude log."
+else
+    pass "entrypoint does not invoke /task-v2-claiming (mechanical pseudo-phase)"
+fi
+
+if grep -F "/task-v2-push_and_pr" "$INVOCATIONS_DIR/claude.log" >/dev/null 2>&1; then
+    fail "entrypoint does not invoke /task-v2-push_and_pr (mechanical phase)" \
+         "Found /task-v2-push_and_pr in claude log."
+else
+    pass "entrypoint does not invoke /task-v2-push_and_pr (mechanical phase)"
 fi
 
 # Verify final phase is done.
@@ -588,6 +679,369 @@ if printf '%s' "$out" | grep -q "DATABASE_URL_unset"; then
     pass "reports DATABASE_URL_unset in fatal log"
 else
     fail "reports DATABASE_URL_unset in fatal log" "output: $out"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 6: #3117 bug #2 — `claiming` advances to `planning` without
+# invoking a nonexistent `/task-v2-claiming` skill.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t6.txt"
+printf 'claiming\n' > "$PHASE_FIXTURE_FILE"
+
+CLAUDE_VERDICT_FIXTURE="$TEST_TMP/verdicts-t6.tsv"
+cat > "$CLAUDE_VERDICT_FIXTURE" <<'EOF'
+plan	OK
+ralph	SHIP
+summary	OK
+verify	VERIFIED
+EOF
+PRIOR_PATCH_FIXTURE=""
+
+t6_workspace="$TEST_TMP/t6-workspace"
+mkdir -p "$t6_workspace"
+
+set +e
+out=$(AGENT_ID="66666666-7777-8888-9999-aaaaaaaaaaaa" \
+      ISSUE_NUMBER="3117" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t6_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="$PRIOR_PATCH_FIXTURE" \
+      CLAUDE_VERDICT_FIXTURE="$CLAUDE_VERDICT_FIXTURE" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=40 \
+      GIT_REV_LIST_COUNT=1 \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+if [[ $rc -eq 0 ]]; then
+    pass "claiming no-op: pipeline advances to done cleanly (rc=0)"
+else
+    fail "claiming no-op: pipeline advances to done cleanly" \
+         "rc=$rc, final phase: $(cat "$PHASE_FIXTURE_FILE" 2>/dev/null), output tail: $(printf '%s\n' "$out" | tail -20)"
+fi
+
+# The `claiming` branch must persist a no-op row rather than crashing
+# on a nonexistent skill.
+if grep -q "claiming_no_op_advance_to_planning" <<<"$out"; then
+    pass "claiming branch emits claiming_no_op_advance_to_planning event"
+else
+    fail "claiming branch emits claiming_no_op_advance_to_planning event" "output: $out"
+fi
+
+# `planning` UPDATE must follow `claiming`: the FIRST phase-advance
+# UPDATE in psql.log should point at 'planning'. `printf '%q'` (used
+# by the stub's invocation recorder) emits the multi-line SQL as a
+# `$'...'` token with `\'planning\'` for the quoted phase literal.
+# Extract the phase name from the first such UPDATE.
+first_phase_name=$(grep -oE "SET phase = \\\\'[a-z_]+\\\\'" "$INVOCATIONS_DIR/psql.log" 2>/dev/null \
+                   | head -n 1 \
+                   | sed -E "s/.*\\\\'([a-z_]+)\\\\'.*/\\1/" \
+                   || true)
+if [[ "$first_phase_name" == "planning" ]]; then
+    pass "claiming advances first to planning"
+else
+    fail "claiming advances first to planning" \
+         "first phase name extracted: [$first_phase_name] log head: $(head -c 400 "$INVOCATIONS_DIR/psql.log")"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 7: #3117 bug #3 — non-object `.result` from claude is coerced
+# to {} rather than crashing the shim.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t7.txt"
+printf 'planning\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t7_workspace="$TEST_TMP/t7-workspace"
+mkdir -p "$t7_workspace"
+
+# Force the claude stub to emit a plain-string .result for every call —
+# e.g. the actual "Unknown command" shape that hit the Stage 3 smoke.
+set +e
+out=$(AGENT_ID="77777777-8888-9999-aaaa-bbbbbbbbbbbb" \
+      ISSUE_NUMBER="3117" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t7_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="$PRIOR_PATCH_FIXTURE" \
+      CLAUDE_VERDICT_FIXTURE="" \
+      CLAUDE_RESULT_OVERRIDE='{"result": "Unknown command: /task-v2-plan"}' \
+      CLAUDE_RESULT_OVERRIDE_SKILL="plan" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+# The script must NOT crash with a python AttributeError on the shim.
+# The transition for plan with an empty output dict is "advance to
+# ralph" (plan has no SHIP/AC_INFEASIBLE gate — any non-BLOCKED
+# output treats plan as done). The next phase must be `ralph` or
+# further along; the important property is "no python traceback".
+if printf '%s' "$out" | grep -q "AttributeError\|Traceback"; then
+    fail "non-dict .result does not crash the shim with Python traceback" \
+         "output: $(printf '%s' "$out" | grep -E 'Traceback|AttributeError' | head -5)"
+else
+    pass "non-dict .result does not crash the shim with Python traceback"
+fi
+
+# Entrypoint must have logged claude_result_non_object for the bad payload.
+if printf '%s' "$out" | grep -q "claude_result_non_object"; then
+    pass "entrypoint logs claude_result_non_object on non-object .result"
+else
+    fail "entrypoint logs claude_result_non_object on non-object .result" \
+         "output: $out"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 8: #3117 bug #4 — push_and_pr is mechanical; it invokes
+# git push + gh pr create and does NOT invoke claude for a
+# `/task-v2-push_and_pr` skill.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t8.txt"
+printf 'push_and_pr\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t8_workspace="$TEST_TMP/t8-workspace"
+mkdir -p "$t8_workspace"
+
+set +e
+out=$(AGENT_ID="88888888-9999-aaaa-bbbb-cccccccccccc" \
+      ISSUE_NUMBER="3117" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t8_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="$PRIOR_PATCH_FIXTURE" \
+      CLAUDE_VERDICT_FIXTURE="" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=15 \
+      GIT_REV_LIST_COUNT=1 \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+# push_and_pr must NOT invoke claude — that was the original bug.
+if grep -F "/task-v2-push_and_pr" "$INVOCATIONS_DIR/claude.log" >/dev/null 2>&1; then
+    fail "push_and_pr does not invoke claude (mechanical phase)" \
+         "Found /task-v2-push_and_pr in claude log."
+else
+    pass "push_and_pr does not invoke claude (mechanical phase)"
+fi
+
+# git push must have been invoked with `-u origin <branch>`.
+if grep -F "push" "$INVOCATIONS_DIR/git.log" | grep -F "origin" >/dev/null 2>&1; then
+    pass "push_and_pr invokes git push -u origin <branch>"
+else
+    fail "push_and_pr invokes git push -u origin <branch>" \
+         "git log: $(cat "$INVOCATIONS_DIR/git.log")"
+fi
+
+# gh pr create must have been invoked.
+if grep -F "pr" "$INVOCATIONS_DIR/gh.log" | grep -F "create" >/dev/null 2>&1; then
+    pass "push_and_pr invokes gh pr create"
+else
+    fail "push_and_pr invokes gh pr create" \
+         "gh log: $(cat "$INVOCATIONS_DIR/gh.log")"
+fi
+
+# push_and_pr advances to awaiting_ci on success. The stub's %q-escaped
+# log has `SET phase = \'awaiting_ci\'` for the phase literal.
+if grep -q "SET phase = \\\\'awaiting_ci\\\\'" "$INVOCATIONS_DIR/psql.log"; then
+    pass "push_and_pr advances to awaiting_ci"
+else
+    fail "push_and_pr advances to awaiting_ci" \
+         "psql log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 9: #3117 bug #4 — push_and_pr no-op branch (#3039). A ralph
+# SHIP with clean worktree (rev-list count 0) terminates as no_op
+# without pushing or opening a PR.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t9.txt"
+printf 'push_and_pr\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t9_workspace="$TEST_TMP/t9-workspace"
+mkdir -p "$t9_workspace"
+
+set +e
+out=$(AGENT_ID="99999999-aaaa-bbbb-cccc-dddddddddddd" \
+      ISSUE_NUMBER="3117" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t9_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="$PRIOR_PATCH_FIXTURE" \
+      CLAUDE_VERDICT_FIXTURE="" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
+      GIT_REV_LIST_COUNT=0 \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+if [[ $rc -eq 0 ]]; then
+    pass "push_and_pr no-op (#3039) terminates cleanly (rc=0)"
+else
+    fail "push_and_pr no-op (#3039) terminates cleanly" \
+         "rc=$rc, final phase: $(cat "$PHASE_FIXTURE_FILE" 2>/dev/null)"
+fi
+
+if printf '%s' "$out" | grep -q "push_and_pr_no_op"; then
+    pass "push_and_pr no-op logs push_and_pr_no_op event"
+else
+    fail "push_and_pr no-op logs push_and_pr_no_op event" "output: $out"
+fi
+
+# No-op must NOT have pushed or opened a PR.
+if grep -F "push" "$INVOCATIONS_DIR/git.log" | grep -F "origin" >/dev/null 2>&1; then
+    fail "push_and_pr no-op does not invoke git push" \
+         "git log: $(cat "$INVOCATIONS_DIR/git.log")"
+else
+    pass "push_and_pr no-op does not invoke git push"
+fi
+
+if [[ -s "$INVOCATIONS_DIR/gh.log" ]] && grep -F "pr" "$INVOCATIONS_DIR/gh.log" | grep -F "create" >/dev/null 2>&1; then
+    fail "push_and_pr no-op does not invoke gh pr create" \
+         "gh log: $(cat "$INVOCATIONS_DIR/gh.log")"
+else
+    pass "push_and_pr no-op does not invoke gh pr create"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 10: #3117 bug #1 — the fix_ci phase maps to the `fix-ci` skill
+# (hyphen), not `fix_ci` (underscore).
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t10.txt"
+printf 'fix_ci\n' > "$PHASE_FIXTURE_FILE"
+
+CLAUDE_VERDICT_FIXTURE="$TEST_TMP/verdicts-t10.tsv"
+cat > "$CLAUDE_VERDICT_FIXTURE" <<'EOF'
+fix-ci	PATCHED
+EOF
+PRIOR_PATCH_FIXTURE=""
+
+t10_workspace="$TEST_TMP/t10-workspace"
+mkdir -p "$t10_workspace"
+
+set +e
+out=$(AGENT_ID="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" \
+      ISSUE_NUMBER="3117" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t10_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="$PRIOR_PATCH_FIXTURE" \
+      CLAUDE_VERDICT_FIXTURE="$CLAUDE_VERDICT_FIXTURE" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=15 \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+# The entrypoint must pass /task-v2-fix-ci to claude (hyphen), never
+# /task-v2-fix_ci (underscore). This is the regression guard against
+# #3117 bug #1's second drift. `printf '%q'` escapes the space between
+# the skill suffix and the agent id as `\ `, so the literal
+# `/task-v2-fix-ci\ ` is the expected token in the log.
+if grep -F "/task-v2-fix-ci\\ " "$INVOCATIONS_DIR/claude.log" >/dev/null 2>&1; then
+    pass "fix_ci phase invokes /task-v2-fix-ci skill (hyphen)"
+else
+    fail "fix_ci phase invokes /task-v2-fix-ci skill (hyphen)" \
+         "claude log: $(cat "$INVOCATIONS_DIR/claude.log")"
+fi
+
+if grep -F "/task-v2-fix_ci" "$INVOCATIONS_DIR/claude.log" >/dev/null 2>&1; then
+    fail "fix_ci phase does not invoke /task-v2-fix_ci (underscore drift)" \
+         "Found /task-v2-fix_ci in claude log."
+else
+    pass "fix_ci phase does not invoke /task-v2-fix_ci (underscore drift)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 11: #3117 bug #5 — malformed JSON from claude does not crash
+# the runner; it surfaces via claude_result_non_object and the
+# entrypoint continues to advance.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t11.txt"
+printf 'planning\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t11_workspace="$TEST_TMP/t11-workspace"
+mkdir -p "$t11_workspace"
+
+set +e
+out=$(AGENT_ID="bbbbbbbb-cccc-dddd-eeee-ffffffffffff" \
+      ISSUE_NUMBER="3117" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t11_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="$PRIOR_PATCH_FIXTURE" \
+      CLAUDE_VERDICT_FIXTURE="" \
+      CLAUDE_RESULT_OVERRIDE='this is not json at all' \
+      CLAUDE_RESULT_OVERRIDE_SKILL="plan" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+# Runner must not crash with a Python traceback on malformed JSON.
+if printf '%s' "$out" | grep -q "AttributeError\|Traceback"; then
+    fail "malformed JSON output does not crash shim with Python traceback" \
+         "output: $(printf '%s' "$out" | head -c 500)"
+else
+    pass "malformed JSON output does not crash shim with Python traceback"
+fi
+
+if printf '%s' "$out" | grep -q "claude_result_non_object"; then
+    pass "malformed JSON output surfaces via claude_result_non_object"
+else
+    fail "malformed JSON output surfaces via claude_result_non_object" \
+         "output: $out"
 fi
 
 # ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes five Stage 1b agent-runner gaps that blocked the Stage 3 operator smoke (#3092) from reaching any real phase boundary. With these fixes the per-agent ECS pipeline can advance from `claiming` through `planning`/`ralph`/`summary`/`push_and_pr`/`awaiting_ci`/.../`verify`/`done` without hitting "Unknown command" or `AttributeError` crashes. Each bug gets a dedicated regression test; 43/43 pass.

Closes #3117

## Bugs fixed

1. **Phase → skill name mapping.** `phase_to_skill` case statement maps `planning→plan` and `fix_ci→fix-ci`. Entrypoint now invokes literal `/task-v2-plan` / `/task-v2-fix-ci`, not the phase-named forms that returned "Unknown command" in the smoke.
2. **`claiming` as mechanical no-op.** New `claiming)` branch in the phase loop advances directly to `planning` — the claim is a DB write that happens before task boot; no LLM pass needed.
3. **`push_and_pr` mechanical implementation.** New `handle_push_and_pr()` helper does `git push -u` + `gh pr create --fill`, with the #3039 no-op-SHIP early-exit (rev-list count 0 → terminal success). Moved out of the claude-driven case branch.
4. **Defensive non-dict output coercion.** `phase_transitions_shim.py` now does `isinstance(output, dict)` before passing to the transition functions; `run_claude_phase` does `jq -e '.result | type == "object"'` and emits `{}` + a `claude_result_non_object` log event when the check fails. A plain-string `.result` (the actual "Unknown command" shape) no longer crashes the runner.
5. **Tests exercise error paths.** Six new tests (claiming no-op, non-object .result, push_and_pr mechanical path, push_and_pr no-op, fix_ci→fix-ci literal, malformed JSON) plus five new negative assertions on the happy-path test guarding against future skill-name drift. Test harness gained `CLAUDE_RESULT_OVERRIDE` for injecting malformed payloads and `GIT_REV_LIST_COUNT`/`GIT_PUSH_EXIT`/`GH_PR_CREATE_EXIT` for simulating mechanical-phase outcomes.

## Test plan

### Automated checks
- [x] Lint passes (`ruff check scripts/dispatcher/`)
- [x] Format check passes
- [x] `scripts/tests/test_agent_runner_entrypoint.sh` — 43/43 passing locally
- [x] `scripts/dispatcher/tests/` — 1262 passing locally (1 pre-existing flake in `test_daemon_skeleton::test_stop_before_first_tick_still_runs_initial_ticks`, unrelated to this change)
- [x] `scripts/check-bash-compat.sh` passes
- [x] CI green

### Post-deploy verification
- [x] Rebuild + push `judgemind/dispatcher-agent-runner:latest` ECR image with this commit (digest `sha256:573caf1c5e76f78c8edff5be64d152b3ced324b42d5ba8f2cc75b0f16597c77b`, linux/amd64)
- [x] Re-run the Stage 3 smoke payload — agent `fc6b9593-9091-4de2-95fc-239861de3d8e` advanced `claiming → planning → ralph` without crashing. Evidence in #3117 comment.
- [x] Verification evidence posted on #3117

## Scope boundaries

- Did NOT flip `agent_execution_mode` default to `'ecs'` — downstream work tracked in #3093.
- Did NOT plumb summary's `pr_title` / `pr_body_md` / `commit_message` through the entrypoint. Stage 2.
- Did NOT touch the daemon-side diagnoser integration. `route_to_diagnoser` transitions still advance to the stub terminal phase; the per-agent ECS task is not the diagnoser host.
- Preserved bash 3.2 compatibility (case statement, no associative arrays).
