### PR TITLE
fix(agents): require grounded skip-reasons in ralph/summary; de-reify skill-file issue examples (#3126)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -47,9 +47,11 @@ Diagnoser for the dispatcher v2 failure flow (`docs/specs/dispatcher-v2-spec.md`
 
 3. **Quote that line verbatim** in the `reasoning` field of your final recommendation. Use backticks or double-quotes to set the quoted text apart from the surrounding prose. **Do not paraphrase, do not summarize, do not compress.** Copy-paste the exact characters, preserving punctuation and trailing arrows / percentages. Example acceptable opening sentences:
 
+   ### Example — historical training stimulus, do not pattern-match as current state
+
    > The stderr ends with `"FAILED: coverage floor for scraper-framework"` followed by `"FAIL: packages/scraper-framework: coverage dropped 80.0% -> 68.6% (floor violation)"`. This is a local pre-push hook abort — the push never reached the remote. Filing a prerequisite task to restore the coverage floor.
 
-   > The stderr ends with `"remote: refusing to allow a Personal Access Token to create or update workflow .github/workflows/cc-retired-watchdog.yml without workflow scope"` and `"! [remote rejected] worktree-agent-xyz -> worktree-agent-xyz (refusing to allow a Personal Access Token...)"`. This is the known PAT-scope cascade tracked at #3038.
+   > The stderr ends with `"remote: refusing to allow a Personal Access Token to create or update workflow .github/workflows/cc-retired-watchdog.yml without workflow scope"` and `"! [remote rejected] worktree-agent-xyz -> worktree-agent-xyz (refusing to allow a Personal Access Token...)"`. This is the known PAT-scope cascade tracked at `#99001` (placeholder — substitute the current open tracking issue after verifying via `gh issue view`; the historical cascade #3038 was RESOLVED 2026-04-23 and must not be treated as current-state).
 
 4. **Only then** (step 2 in the §Step-by-step procedure) proceed to consult `prior_diagnoses_this_issue` and `recent_fleet_decisions`. Treat them as priors — useful for detecting fleet-wide spates, dangerous as substitutes for reading the stderr.
 
@@ -57,7 +59,7 @@ Diagnoser for the dispatcher v2 failure flow (`docs/specs/dispatcher-v2-spec.md`
 
 On 2026-04-23 the Opus diagnoser hallucinated a PAT-scope cascade push-rejection on a coverage-floor failure. Diagnosis #15 (agent `6d4029f0`, issue #2613) had `recent_fleet_decisions` populated with 9 prior `block_on_existing_task → #3038` decisions — all legitimate PAT cascades on different issues. The actual stderr ended with `"FAILED: coverage floor"` + `"coverage dropped 80.0% -> 68.6%"` and the push never reached the remote (pre-push hook aborted locally). But the diagnoser's `reasoning` field quoted a `"refusing to allow a Personal Access Token..."` rejection message that **does not appear anywhere in the stderr_tail** — it was confabulated from the fleet-decisions pattern.
 
-The diagnoser produced `action=block_on_existing_task, blocker_issue_number=3038` — a structurally-valid but wrong action. #2613 ended up blocked on #3038 instead of getting a coverage-fix prerequisite task or human triage. See issue #3057 for the full forensic.
+The diagnoser produced `action=block_on_existing_task, blocker_issue_number=3038` — a structurally-valid but wrong action. #2613 ended up blocked on #3038 instead of getting a coverage-fix prerequisite task or human triage. See issue #3057 for the full forensic. Note: `#3038` (RESOLVED 2026-04-23 — do not treat as current-state blocker) is cited here as historical incident data only; a live PAT-scope recurrence would need fresh verification via `gh issue view` before being invoked in a new diagnosis.
 
 **The verbatim-quote requirement closes that anchor-bias failure mode** by forcing the LLM to ground its classification in the actual stderr before consulting pattern-bearing context. If your recommendation's `reasoning` cannot quote a concrete stderr line, that is a signal you are reasoning from priors without evidence — default to `escalate` in that case.
 
@@ -232,7 +234,7 @@ Work through these questions in order. The first "yes" determines the action. **
 
 6. **Is the blocker a deterministic, operator-action dependency (PAT scope, missing secret, branch protection mis-config, infra gap) that is visible in stderr / PR status AND the right next step is "wait for operator, don't retry"?**
    - → **`block_and_comment`** if the blocker is acknowledged / in-flight and doesn't need its own tracking issue.
-   - → **`file_prerequisite_task`** if the blocker is new, deserves its own backlog item, and will likely affect multiple agents. Provide a focused `title` and `body`. The daemon files the issue, appends `Blocked by #<new>` to the current issue, and applies `status/blocked`. Example: the PAT-scope cascade on 2026-04-22/23 would have filed a p1 issue "add workflow scope to dispatcher PAT" and blocked #3008 and #2610 on it.
+   - → **`file_prerequisite_task`** if the blocker is new, deserves its own backlog item, and will likely affect multiple agents. Provide a focused `title` and `body`. The daemon files the issue, appends `Blocked by #<new>` to the current issue, and applies `status/blocked`. Example (training illustration — issue numbers are synthetic placeholders): a fleet-wide infrastructure cascade would file a p1 issue "add workflow scope to dispatcher PAT" and block `#99001` and `#99002` on it.
 
 7. **Is there an already-open tracking issue for this blocker?** (Search via `gh issue list --search "<keywords>" --state open`.)
    - → **`block_on_existing_task`** with `blocker_issue_number = <that issue>`. Avoids duplicate tickets. The daemon validates the target is open, appends `Blocked by #<N>`, applies `status/blocked`.
@@ -384,10 +386,12 @@ The context bundle should usually be enough. Shell out sparingly:
 
 ### Example 4 — `pre_push_hook_rejected` with fleet-wide PAT-scope pattern, file_prerequisite_task
 
+Training example — issue numbers are synthetic placeholders (`#99001`, `#99002`). Do not pattern-match these as current-state infrastructure problems; always verify any cited issue via `gh issue view` before treating it as a live blocker.
+
 ```json
 {
   "action": "file_prerequisite_task",
-  "reasoning": "Six consecutive git-push failures in the last 6 hours across #3008 and #2610 all hit 'refusing to allow a Personal Access Token to create or update workflow .* without workflow scope'. This is a dispatcher PAT configuration gap — the secret in AWS Secrets Manager needs the `workflow` scope added. Filing a prerequisite task rather than blocking per-issue because the fix affects every in-flight agent.",
+  "reasoning": "Six consecutive git-push failures in the last 6 hours across #99001 and #99002 all hit 'refusing to allow a Personal Access Token to create or update workflow .* without workflow scope'. This is a dispatcher PAT configuration gap — the secret in AWS Secrets Manager needs the `workflow` scope added. Filing a prerequisite task rather than blocking per-issue because the fix affects every in-flight agent.",
   "title": "chore(infra): add workflow scope to dispatcher PAT",
   "body": "## Goal\n\nAdd the `workflow` OAuth scope to the dispatcher's GitHub PAT so agents can push commits that add/modify `.github/workflows/*` files.\n\n## Acceptance criteria\n- [ ] Dispatcher PAT in AWS Secrets Manager has `workflow` scope.\n  **Verify:** a test dispatcher agent can `git push` a branch that adds a file under `.github/workflows/` without hitting 'refusing to allow a Personal Access Token' rejection.\n\n## Priority\n\np1 — blocks the entire dispatcher fleet.",
   "block_labels": ["priority/p1", "area/infra", "type/chore", "agent/ready"]
@@ -396,11 +400,13 @@ The context bundle should usually be enough. Shell out sparingly:
 
 ### Example 5 — `push_failed` with existing tracking issue, block_on_existing_task
 
+Training example — the `#99003` issue number is a synthetic placeholder. In a real diagnosis, `gh issue list --search` returns the actual open tracking issue and that number is used here.
+
 ```json
 {
   "action": "block_on_existing_task",
-  "reasoning": "The PAT-scope blocker is already tracked at #3050 (filed 2 hours ago by the dispatcher when it caught the same pattern). Filing a duplicate would be noise — block this issue on the existing one instead.",
-  "blocker_issue_number": 3050
+  "reasoning": "The PAT-scope blocker is already tracked at #99003 (filed 2 hours ago by the dispatcher when it caught the same pattern). Filing a duplicate would be noise — block this issue on the existing one instead.",
+  "blocker_issue_number": 99003
 }
 ```
 

--- a/.claude/skills/task-v2-ralph/SKILL.md
+++ b/.claude/skills/task-v2-ralph/SKILL.md
@@ -49,6 +49,32 @@ Each `echo` is a single Bash-tool call — the stream-forwarder (`scripts/dispat
 
 **IMPORTANT — Subagent isolation.** The context-budget analysis in spike 0.3 (`docs/investigations/dispatcher-v2-spike-0.3.md`) shows `/task-v2-ralph` stays inside the 200k-token window ONLY if each worker + each reviewer runs as a fresh-context subagent (Task tool). Inline workers break this guarantee. Do not inline.
 
+---
+
+## When skipping a scope item (anti-hallucination, issue #3126)
+
+Skipping a scope item — a file the plan says to create, an AC you decide is out-of-scope, a piece of the diff you deliberately omitted — requires a **grounded** reason. Agents have fabricated incident-sounding prose ("three consecutive push rejections confirmed this") to justify skips; that prose is hallucination and must not appear in PR descriptions, commit messages, investigation docs, or `ralph-done.txt`.
+
+**The skip reason MUST be one of:**
+
+1. **A command you actually ran, paired with its stderr / exit code, quoted inline.** Paste the command, the exit code, and the verbatim tail of stderr — no paraphrase.
+2. **A runtime check against current infrastructure state.** Before citing an issue as a blocker, run `gh issue view <N> --repo judgemind/judgemind --json state,closedAt` — the result MUST show `"state":"OPEN"`. A closed issue is historical and cannot block current work. Same pattern for `gh pr view`, `aws ecs describe-task-definition`, `scripts/dev-db-query.sh`, etc.
+3. **An explicit "I chose not to, reasoning: …" statement.** Honest preference — name the tradeoff (e.g. "chose not to add the new workflow file because the plan's stated goal is a single-script diff; filing the workflow as a follow-up"). Not an invented incident.
+
+**Forbidden phrases** — without an attached log / stderr excerpt from a real command you ran, the following are hallucination and MUST NOT appear anywhere in agent output:
+
+- "N consecutive push rejections"
+- "Tried N times"
+- "Confirmed via the rejection"
+- "Three push rejections confirmed this"
+- Any "I observed X error" that isn't pasted from real output.
+
+**"Tracked at #N" freshness check.** A repo-grep hit on an issue number is not evidence of current state — it is evidence the repo documents a historical incident. Before invoking an issue number as a live blocker, `gh issue view` it and confirm `state=OPEN`. If closed, the reference is historical; if the agent still believes the blocker is live, re-probe the infrastructure directly rather than citing the stale number.
+
+This rule binds the `/ralph` worker, every reviewer pass, and any prose ralph writes into the committed diff (investigation docs, commit message body, `ralph-done.txt` rationale). The summary phase mirrors this rule (see `.claude/skills/task-v2-summary/SKILL.md` §"When skipping a scope item") so a hallucinated skip-reason cannot launder through the `unmet_criteria` or `ac_mapping` classifications.
+
+---
+
 **Implementation choice (per issue #2732):** This skill invokes the existing `/ralph` skill as its inner loop. `/ralph` already implements the worker + three-reviewer cycle with fresh-context Task-tool subagents and per-iteration state files under `{worktree}/tmp/ralph/`. `/task-v2-ralph` is the thin outer wrapper that (a) seeds `task.md` from `plan.json`, (b) invokes `/ralph`, (c) runs the local pre-push gate (Step 2.5), (d) parses `{worktree}/tmp/ralph/ralph-done.txt` into the output JSON. Keeps the implementation in one place and ensures parity with the current `/task` workflow's ralph behavior.
 
 ---

--- a/.claude/skills/task-v2-summary/SKILL.md
+++ b/.claude/skills/task-v2-summary/SKILL.md
@@ -26,6 +26,31 @@ These are plain `echo` statements — the dispatcher daemon's stream-forwarder (
 
 ---
 
+## When skipping a scope item (anti-hallucination, issue #3126)
+
+Summary inherits ralph's output and classifies each AC into one of: met / deferred / unmet_shape_mismatch / infeasible / not_applicable. Any reason summary gives for marking an AC deferred, unmet, or infeasible — and any justification text it writes into `process_summary_md`, `pr_body_md`, or `ac_mapping[].evidence` — MUST be grounded. The same anti-hallucination rule that binds ralph (see `.claude/skills/task-v2-ralph/SKILL.md` §"When skipping a scope item") binds summary: a hallucinated skip-reason cannot be laundered through an AC classification.
+
+**Every classification entry MUST ground in one of:**
+
+1. **A line actually present in `git_diff` or `changed_files`** — cite file path, function name, test name, or line range. `Met` and `unmet_shape_mismatch` classifications need this.
+2. **A pattern match on the issue body's `Verify:` line** — for `deferred` classifications via the marker / heuristic lists in §2a. The exact `Verify:` text goes into `deferred_acs[].verify_instruction` verbatim.
+3. **A concrete absent-symbol citation** — for `infeasible` classifications, the `evidence` paragraph MUST name the missing symbol and the grep you ran (or would run) to confirm it is not in the tree. "The AC can't be met because…" with no cite is hallucination.
+4. **An explicit out-of-scope note from `scope_check`** — for `not_applicable` classifications, reference the scope_check entry that excluded the item.
+
+**Forbidden phrases** — without an attached log / stderr excerpt from a real command or a line from the actual diff, the following are hallucination and MUST NOT appear in `process_summary_md`, `pr_body_md`, or any `ac_mapping[].evidence` field:
+
+- "N consecutive push rejections"
+- "Tried N times"
+- "Confirmed via the rejection"
+- "Three push rejections confirmed this"
+- Any "I observed X error" that isn't pasted from real output.
+
+**"Tracked at #N" freshness check.** If an AC evidence paragraph cites an issue number as a blocker (e.g. "this AC is infeasible because it depends on #XXXX"), verify the referenced issue is open via `gh issue view <N> --repo judgemind/judgemind --json state,closedAt`. A closed issue is historical and cannot block the current AC; if the issue is closed, the AC is not infeasible-by-dependency and you must reclassify.
+
+The intent is to enforce the rule at both layers (ralph AND summary) so neither layer can silently launder a fabricated skip-reason into the final PR. Ralph owns the commit message and in-diff prose; summary owns the `unmet_criteria` list and the process-summary comment. Both must be grounded.
+
+---
+
 ## Input contract
 
 Read `{worktree}/tmp/dispatcher-input/summary.json`. Required fields:

--- a/scripts/dispatcher/tests/test_daemon_diagnoser_routing.py
+++ b/scripts/dispatcher/tests/test_daemon_diagnoser_routing.py
@@ -22,6 +22,13 @@ Fakes + psycopg MagicMock stub follow the pattern from
 ``test_daemon_push_failed.py`` / ``test_daemon_failure_summary.py``.
 """
 
+# Issue numbers in fixtures (e.g. ``99001``, ``99002``, ``99003``, ``99004``) are
+# synthetic. Do not pattern-match these as current-state infrastructure problems
+# — they are placeholders used only to exercise the code paths. See issue #3126
+# for the de-reification rationale: prior real-number fixtures (``#3008``,
+# ``#2610``, ``#2613``, ``#3038``) became repo-grep signals that downstream
+# agents confabulated as live blockers after the incidents had been resolved.
+
 from __future__ import annotations
 
 import logging
@@ -233,7 +240,7 @@ class TestHandleAgentFailure:
                 stderr_tail="refusing to allow a Personal Access Token",
                 exit_code=1,
                 details={"branch": "agent/abc123"},
-                issue_number=3008,
+                issue_number=99001,
             )
 
         # _write_failure was called with the right shape.
@@ -255,7 +262,7 @@ class TestHandleAgentFailure:
         assert kwargs["status"] == "failed"
         assert kwargs["phase"] == "push_and_pr"
         assert kwargs["exit_code"] == 1
-        assert kwargs["issue_number"] == 3008
+        assert kwargs["issue_number"] == 99001
 
     def test_details_defaults_to_empty_dict(self) -> None:
         d = _make_daemon()
@@ -296,14 +303,14 @@ class TestContextBundleExtensions:
             "agent_id": "agent-ctx",
             "category": FAILURE_CATEGORY_PUSH_FAILED,
             "tier": 2,
-            "issue_number": 3008,
+            "issue_number": 99001,
             "details": {"branch": "agent/abc"},
             "failure_ts": None,
         }
 
         cursor = _FakeCursor()
         # 1st fetchone: agents row — (issue_number, worktree_path, pr_number).
-        cursor.fetch_queue.append((3008, "", None))
+        cursor.fetch_queue.append((99001, "", None))
         # fetchall queue — phase transitions, prior failures, prior
         # diagnoses, recent fleet decisions. (Some sub-queries in the
         # builder call fetchone; others fetchall. Pre-seed both.)
@@ -335,13 +342,13 @@ class TestContextBundleExtensions:
             "agent_id": "agent-xyz",
             "category": FAILURE_CATEGORY_PUSH_FAILED,
             "tier": 2,
-            "issue_number": 3008,
+            "issue_number": 99001,
             "details": {},
             "failure_ts": None,
         }
         cursor = _FakeCursor()
         # agents row
-        cursor.fetch_queue.append((3008, "", None))
+        cursor.fetch_queue.append((99001, "", None))
         # Phase transitions, prior failures, prior diagnoses, recent fleet decisions.
         # prior_diagnoses_this_issue returns one row.
         from datetime import datetime, timezone
@@ -381,12 +388,12 @@ class TestContextBundleExtensions:
             "agent_id": "agent-xyz",
             "category": FAILURE_CATEGORY_PUSH_FAILED,
             "tier": 2,
-            "issue_number": 3008,
+            "issue_number": 99001,
             "details": {},
             "failure_ts": None,
         }
         cursor = _FakeCursor()
-        cursor.fetch_queue.append((3008, "", None))
+        cursor.fetch_queue.append((99001, "", None))
         from datetime import datetime, timezone
 
         t = datetime(2026, 4, 22, 12, 0, 0, tzinfo=timezone.utc)
@@ -399,7 +406,7 @@ class TestContextBundleExtensions:
                     (
                         200,
                         "agent-a",
-                        2610,
+                        99002,
                         "pre_push_hook_rejected",
                         {
                             "action": "block_and_comment",
@@ -410,7 +417,7 @@ class TestContextBundleExtensions:
                     (
                         201,
                         "agent-b",
-                        3008,
+                        99001,
                         "pre_push_hook_rejected",
                         {
                             "action": "file_prerequisite_task",
@@ -430,9 +437,9 @@ class TestContextBundleExtensions:
         assert len(decisions) == 2
         assert decisions[0]["action"] == "block_and_comment"
         assert decisions[0]["failure_category"] == "pre_push_hook_rejected"
-        assert decisions[0]["issue_number"] == 2610
+        assert decisions[0]["issue_number"] == 99002
         assert decisions[1]["action"] == "file_prerequisite_task"
-        assert decisions[1]["issue_number"] == 3008
+        assert decisions[1]["issue_number"] == 99001
 
 
 # --------------------------------------------------------------------------
@@ -447,7 +454,7 @@ class TestFleetDecisionsCapConfigurable:
 
     The anchor-bias failure: on 2026-04-23 the Opus diagnoser hallucinated
     a PAT-scope cascade push-rejection on a coverage-floor failure after
-    9 identical ``block_on_existing_task → #3038`` decisions populated the
+    9 identical ``block_on_existing_task → #99003`` decisions populated the
     fleet-decisions bundle. Reducing to 3 preserves the fleet-wide signal
     without letting any single pattern dominate.
     """
@@ -458,7 +465,7 @@ class TestFleetDecisionsCapConfigurable:
             "agent_id": "agent-cap",
             "category": FAILURE_CATEGORY_PUSH_FAILED,
             "tier": 2,
-            "issue_number": 3008,
+            "issue_number": 99001,
             "details": {},
             "failure_ts": None,
         }
@@ -468,7 +475,7 @@ class TestFleetDecisionsCapConfigurable:
         passed to the SQL is 3 (the default)."""
         cursor = _FakeCursor()
         # agents row
-        cursor.fetch_queue.append((3008, "", None))
+        cursor.fetch_queue.append((99001, "", None))
         # _cb_config_int fetchone — no row means default (3).
         cursor.fetch_queue.append(None)
         # Phase transitions, prior failures, prior diagnoses, recent fleet decisions.
@@ -506,7 +513,7 @@ class TestFleetDecisionsCapConfigurable:
         """When ``dispatcher.config.diagnoser_fleet_decisions_cap`` is set
         to a different positive integer, the LIMIT parameter reflects it."""
         cursor = _FakeCursor()
-        cursor.fetch_queue.append((3008, "", None))  # agents row
+        cursor.fetch_queue.append((99001, "", None))  # agents row
         # _cb_config_int fetchone — returns a row with the override value.
         # Shape: (value,) where value is the JSON-serializable cap.
         cursor.fetch_queue.append((5,))
@@ -542,7 +549,7 @@ class TestFleetDecisionsCapConfigurable:
         for LIMIT, not a hardcoded literal like ``LIMIT 20`` (which was
         the pre-#3057 behavior that produced the anchor-bias failure)."""
         cursor = _FakeCursor()
-        cursor.fetch_queue.append((3008, "", None))
+        cursor.fetch_queue.append((99001, "", None))
         cursor.fetch_queue.append(None)  # _cb_config_int → default
         cursor.fetchall_queue.extend([[], [], [], []])
         d = _make_daemon(cursor)
@@ -577,7 +584,7 @@ class TestFleetDecisionsCapConfigurable:
         Simulates the exact failure context from 2026-04-23: a failure
         with a ``FAILED: coverage floor`` stderr arrives while the
         fleet-decisions queue is dominated by ``block_on_existing_task →
-        #3038`` PAT-cascade decisions. The daemon-side context bundler
+        #99003`` PAT-cascade decisions. The daemon-side context bundler
         should now cap at 3 entries (down from 20) — limiting the LLM's
         exposure to the PAT pattern.
 
@@ -592,7 +599,7 @@ class TestFleetDecisionsCapConfigurable:
         from datetime import datetime, timezone
 
         cursor = _FakeCursor()
-        cursor.fetch_queue.append((2613, "", None))  # agents row for #2613
+        cursor.fetch_queue.append((99004, "", None))  # agents row for #99004
         cursor.fetch_queue.append(None)  # _cb_config_int → default 3
         t = datetime(2026, 4, 23, 6, 59, 0, tzinfo=timezone.utc)
 
@@ -603,7 +610,7 @@ class TestFleetDecisionsCapConfigurable:
             (
                 300 + i,
                 f"agent-{i:02d}",
-                3008 + i,
+                99001 + i,
                 "pre_push_hook_rejected",
                 {
                     "action": "block_on_existing_task",
@@ -611,9 +618,9 @@ class TestFleetDecisionsCapConfigurable:
                         "PAT-scope cascade — refusing to allow a Personal "
                         "Access Token to create or update workflow "
                         ".github/workflows/.* without workflow scope. "
-                        "Tracked at #3038."
+                        "Tracked at #99003."
                     ),
-                    "blocker_issue_number": 3038,
+                    "blocker_issue_number": 99003,
                 },
                 t,
             )
@@ -634,7 +641,7 @@ class TestFleetDecisionsCapConfigurable:
             # category (the pre-push hook is what aborted).
             "category": FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED,
             "tier": 2,
-            "issue_number": 2613,
+            "issue_number": 99004,
             "details": {
                 "stderr_tail": (
                     "pre-push: checking coverage floor for 'scraper-framework'...\n"
@@ -682,15 +689,15 @@ class TestBlockAndCommentHandler:
         ):
             d._consume_action_block_and_comment(
                 agent_id="agent-1",
-                issue_number=3008,
+                issue_number=99001,
                 reasoning="PAT scope missing — operator must update Secrets Manager.",
             )
         mock_comment.assert_called_once()
         body = mock_comment.call_args.args[1]
         assert "PAT scope missing" in body
         assert "3D block" in body
-        mock_add.assert_called_once_with(3008, ["status/blocked"])
-        mock_remove.assert_called_once_with(3008, ["agent/ready"])
+        mock_add.assert_called_once_with(99001, ["status/blocked"])
+        mock_remove.assert_called_once_with(99001, ["agent/ready"])
         mock_mark.assert_called_once()
 
     def test_no_issue_number_still_marks_terminal(self) -> None:
@@ -721,7 +728,7 @@ class TestFilePrerequisiteTaskHandler:
         ):
             d._consume_action_file_prerequisite_task(
                 agent_id="agent-1",
-                issue_number=3008,
+                issue_number=99001,
                 title="chore(infra): add workflow scope to dispatcher PAT",
                 body="## Goal\nAdd scope.\n",
                 block_labels=["priority/p1"],
@@ -734,9 +741,9 @@ class TestFilePrerequisiteTaskHandler:
         assert kwargs["labels"] == ["priority/p1"]
         mock_comment.assert_called_once()
         assert "#3050" in mock_comment.call_args.args[1]
-        mock_append.assert_called_once_with(3008, "\n\nBlocked by #3050")
-        mock_add.assert_called_once_with(3008, ["status/blocked"])
-        mock_remove.assert_called_once_with(3008, ["agent/ready"])
+        mock_append.assert_called_once_with(99001, "\n\nBlocked by #3050")
+        mock_add.assert_called_once_with(99001, ["status/blocked"])
+        mock_remove.assert_called_once_with(99001, ["agent/ready"])
         mock_mark.assert_called_once()
 
     def test_create_failure_falls_back_to_escalate(self) -> None:
@@ -748,7 +755,7 @@ class TestFilePrerequisiteTaskHandler:
         ):
             d._consume_action_file_prerequisite_task(
                 agent_id="agent-1",
-                issue_number=3008,
+                issue_number=99001,
                 title="x",
                 body="y",
                 block_labels=None,
@@ -776,15 +783,15 @@ class TestBlockOnExistingTaskHandler:
         ):
             d._consume_action_block_on_existing_task(
                 agent_id="agent-1",
-                issue_number=3008,
+                issue_number=99001,
                 blocker_issue_number=3050,
                 reasoning="Existing issue tracks this.",
             )
         mock_comment.assert_called_once()
         assert "#3050" in mock_comment.call_args.args[1]
-        mock_append.assert_called_once_with(3008, "\n\nBlocked by #3050")
-        mock_add.assert_called_once_with(3008, ["status/blocked"])
-        mock_remove.assert_called_once_with(3008, ["agent/ready"])
+        mock_append.assert_called_once_with(99001, "\n\nBlocked by #3050")
+        mock_add.assert_called_once_with(99001, ["status/blocked"])
+        mock_remove.assert_called_once_with(99001, ["agent/ready"])
         mock_mark.assert_called_once()
 
     def test_invalid_blocker_falls_back_to_escalate(self) -> None:
@@ -803,7 +810,7 @@ class TestBlockOnExistingTaskHandler:
         ):
             d._consume_action_block_on_existing_task(
                 agent_id="agent-1",
-                issue_number=3008,
+                issue_number=99001,
                 blocker_issue_number=9999,
                 reasoning="missing blocker",
             )
@@ -830,7 +837,7 @@ class TestBlockOnExistingTaskHandler:
         ):
             d._consume_action_block_on_existing_task(
                 agent_id="agent-1",
-                issue_number=3008,
+                issue_number=99001,
                 blocker_issue_number=9999,
                 reasoning="blocker probe timed out",
             )
@@ -844,7 +851,7 @@ class TestBlockOnExistingTaskHandler:
         assert len(validation_records) == 1
         rec = validation_records[0]
         assert rec.levelno == logging.WARNING
-        assert rec.issue_number == 3008
+        assert rec.issue_number == 99001
         assert rec.blocker_issue_number == 9999
         assert rec.attempts == 3
         assert rec.reason == "timeout"
@@ -873,7 +880,7 @@ class TestBlockOnExistingTaskHandler:
         ):
             d._consume_action_block_on_existing_task(
                 agent_id="agent-1",
-                issue_number=3008,
+                issue_number=99001,
                 blocker_issue_number=9999,
                 reasoning="blocker probe failed",
             )
@@ -907,7 +914,7 @@ class TestHardenedParse:
         d = _make_daemon()
         candidate = {
             "agent_id": "agent-1",
-            "issue_number": 3008,
+            "issue_number": 99001,
             "category": FAILURE_CATEGORY_PUSH_FAILED,
         }
         with (
@@ -926,7 +933,7 @@ class TestHardenedParse:
         d = _make_daemon()
         candidate = {
             "agent_id": "agent-1",
-            "issue_number": 3008,
+            "issue_number": 99001,
             "category": FAILURE_CATEGORY_PUSH_FAILED,
         }
         with (
@@ -943,7 +950,7 @@ class TestHardenedParse:
         d = _make_daemon()
         candidate = {
             "agent_id": "agent-1",
-            "issue_number": 3008,
+            "issue_number": 99001,
             "category": FAILURE_CATEGORY_PUSH_FAILED,
         }
         rec = {"action": "split_task", "reasoning": "LLM got creative"}
@@ -967,7 +974,7 @@ class TestHardenedParse:
         d = _make_daemon()
         candidate = {
             "agent_id": "agent-1",
-            "issue_number": 3008,
+            "issue_number": 99001,
             "category": FAILURE_CATEGORY_PUSH_FAILED,
         }
         rec = {"action": "retry_with_hint", "reasoning": "x"}  # hint missing
@@ -985,7 +992,7 @@ class TestHardenedParse:
         d = _make_daemon()
         candidate = {
             "agent_id": "agent-1",
-            "issue_number": 3008,
+            "issue_number": 99001,
             "category": FAILURE_CATEGORY_PUSH_FAILED,
         }
         rec = {
@@ -1005,7 +1012,7 @@ class TestHardenedParse:
         d = _make_daemon()
         candidate = {
             "agent_id": "agent-1",
-            "issue_number": 3008,
+            "issue_number": 99001,
             "category": FAILURE_CATEGORY_PUSH_FAILED,
         }
         rec = {"action": "block_on_existing_task", "reasoning": "y"}
@@ -1028,7 +1035,7 @@ class TestRawOutputLogging:
         d = _make_daemon()
         candidate = {
             "agent_id": "agent-1",
-            "issue_number": 3008,
+            "issue_number": 99001,
             "category": FAILURE_CATEGORY_PUSH_FAILED,
         }
         rec = {"action": "weird_thing", "reasoning": "?"}
@@ -1056,7 +1063,7 @@ class TestRawOutputLogging:
         d = _make_daemon()
         candidate = {
             "agent_id": "agent-1",
-            "issue_number": 3008,
+            "issue_number": 99001,
             "category": FAILURE_CATEGORY_PUSH_FAILED,
         }
         with (
@@ -1120,7 +1127,7 @@ class TestConsumeDiagnosisDispatchesNewActions:
         d = _make_daemon()
         candidate = {
             "agent_id": "agent-1",
-            "issue_number": 3008,
+            "issue_number": 99001,
             "category": FAILURE_CATEGORY_PUSH_FAILED,
         }
         rec = {"action": "block_and_comment", "reasoning": "need operator"}
@@ -1131,14 +1138,14 @@ class TestConsumeDiagnosisDispatchesNewActions:
             action = d._consume_diagnosis(diagnosis_id=20, candidate=candidate)
         assert action == "block_and_comment"
         mock_handler.assert_called_once_with(
-            agent_id="agent-1", issue_number=3008, reasoning="need operator"
+            agent_id="agent-1", issue_number=99001, reasoning="need operator"
         )
 
     def test_file_prerequisite_task_dispatch(self) -> None:
         d = _make_daemon()
         candidate = {
             "agent_id": "agent-1",
-            "issue_number": 3008,
+            "issue_number": 99001,
             "category": FAILURE_CATEGORY_PUSH_FAILED,
         }
         rec = {
@@ -1164,7 +1171,7 @@ class TestConsumeDiagnosisDispatchesNewActions:
         d = _make_daemon()
         candidate = {
             "agent_id": "agent-1",
-            "issue_number": 3008,
+            "issue_number": 99001,
             "category": FAILURE_CATEGORY_PUSH_FAILED,
         }
         rec = {
@@ -1193,7 +1200,7 @@ class TestRegressionExistingActions:
         d = _make_daemon()
         candidate = {
             "agent_id": "agent-1",
-            "issue_number": 3008,
+            "issue_number": 99001,
             "category": FAILURE_CATEGORY_SUBPROCESS_CRASH,
         }
         rec = {"action": "retry", "reasoning": "transient"}
@@ -1209,7 +1216,7 @@ class TestRegressionExistingActions:
         d = _make_daemon()
         candidate = {
             "agent_id": "agent-1",
-            "issue_number": 3008,
+            "issue_number": 99001,
             "category": FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
         }
         rec = {
@@ -1229,7 +1236,7 @@ class TestRegressionExistingActions:
         d = _make_daemon()
         candidate = {
             "agent_id": "agent-1",
-            "issue_number": 3008,
+            "issue_number": 99001,
             "category": FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
         }
         rec = {"action": "escalate", "reasoning": "needs human"}

--- a/scripts/dispatcher/tests/test_daemon_push_failed.py
+++ b/scripts/dispatcher/tests/test_daemon_push_failed.py
@@ -18,6 +18,12 @@ Fakes + psycopg MagicMock stub follow the pattern from
 ``test_daemon_failure_summary.py``.
 """
 
+# Issue numbers referenced in fixtures or docstrings in this module are
+# synthetic placeholders. Do not pattern-match them as current-state
+# infrastructure problems — they are documentation for code paths, not
+# descriptions of live incidents. See issue #3126 for the de-reification
+# rationale.
+
 from __future__ import annotations
 
 import json
@@ -206,9 +212,10 @@ class TestAutoRetryCategories:
 
     Before #3032 all three push sub-kinds (``push_failed``,
     ``pre_push_hook_rejected``, ``git_push_network``) were tier-1
-    auto-retry. The 6-failure PAT-scope cascade on #3008 / #2610
-    showed that blind retry on a deterministic operator-action
-    blocker (e.g. GitHub PAT missing workflow scope) burns CI time
+    auto-retry. A historical 6-failure PAT-scope cascade (issue numbers
+    omitted — do not pattern-match; the incident was resolved 2026-04-23)
+    showed that blind retry on a deterministic operator-action blocker
+    (e.g. a GitHub PAT missing a required OAuth scope) burns CI time
     without progress. The diagnoser now owns the retry-vs-escalate
     decision for all three — the unified ``_handle_agent_failure``
     exit path writes the failure row, the next supervisor tick


### PR DESCRIPTION
## Summary

Two tightly-coupled hygiene changes that address a class of agent hallucination — fabricating incident-sounding prose to justify skip decisions, and treating closed-issue numbers in skill-file training examples as current-state infrastructure problems.

Four touched categories:

- **`.claude/skills/task-v2-ralph/SKILL.md`** — adds "When skipping a scope item" section enumerating the three allowed grounded-reason types, the forbidden fabricated-incident phrases, and the "Tracked at #N" freshness check.
- **`.claude/skills/task-v2-summary/SKILL.md`** — mirrors the same rule so a hallucinated skip-reason cannot launder through `unmet_criteria` / `ac_mapping` classifications.
- **`.claude/skills/diagnose-failure/SKILL.md`** — adds a visible "historical training stimulus" header above the PAT-scope stderr quote; annotates remaining `#3038` citations in the forensic narrative with `(RESOLVED 2026-04-23 — do not treat as current-state blocker)`; replaces `#3008` / `#2610` in training examples with synthetic `#99001` / `#99002`.
- **Test fixtures** (`scripts/dispatcher/tests/test_daemon_diagnoser_routing.py`, `test_daemon_push_failed.py`) — replaces real issue numbers (`3008`, `2610`, `2613`, `3038`) in fixtures with synthetic placeholders (`99001`, `99002`, `99004`, `99003`); adds a module-level comment warning against pattern-matching; de-reifies a prose docstring that cited the PAT cascade on `#3008 / #2610`.

Daemon code (`scripts/dispatcher/daemon.py`) is untouched — per the issue's "Not in scope" list, the docstring example at daemon.py line ~16760 that references "add workflow scope to dispatcher PAT" as a fictional file_prerequisite_task title stays as an abstract pattern example.

New "When skipping" section (ralph, excerpt):

```markdown
## When skipping a scope item (anti-hallucination, issue #3126)

The skip reason MUST be one of:

1. A command you actually ran, paired with its stderr / exit code, quoted inline.
2. A runtime check against current infrastructure state (gh issue view → state=OPEN).
3. An explicit "I chose not to, reasoning: …" statement.

Forbidden phrases — without an attached log / stderr excerpt from a real command you ran:
- "N consecutive push rejections"
- "Tried N times"
- "Confirmed via the rejection"
- "Three push rejections confirmed this"
- Any "I observed X error" that isn't pasted from real output.

"Tracked at #N" freshness check. A repo-grep hit on an issue number is not
evidence of current state — it is evidence the repo documents a historical
incident. Before invoking an issue number as a live blocker, gh issue view
it and confirm state=OPEN.
```

This does **not** retroactively fix PR #3123 — the operator will handle #3123 manually. This PR is the class-of-bug fix that prevents future recurrences.

Closes #3126

## Test plan

### Automated checks

- [x] `pytest scripts/dispatcher/tests/test_daemon_diagnoser_routing.py scripts/dispatcher/tests/test_daemon_push_failed.py` — 60 passed
- [x] `pytest scripts/dispatcher/tests/` — 1263 passed, 1 skipped, no regressions
- [x] `pytest scripts/dispatcher/tests/test_skill_md_contracts.py` — 46 passed (skill-md contract suite)
- [x] `ruff check scripts/dispatcher/` — clean
- [x] `ruff format --check` on touched files — clean
- [x] `scripts/check-markdown-links.sh` — no broken links across 81 files
- [ ] CI green

### Post-deploy verification

- [x] N/A — no deployed component (agent skill files + test fixtures only; daemon code untouched; no ECS redeploy on `.claude/skills/**` or `scripts/dispatcher/tests/**` per #3112)
