### PR TITLE
fix(infra): grant ecs:TagResource to dispatcher task role (#3129)

### DIFF
--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -526,6 +526,15 @@ locals {
     ? "arn:aws:ecs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:task-definition/${var.agent_runner_task_definition_family}:*"
     : ""
   )
+  # `ecs:TagResource` authorisation for RunTask-with-tags is evaluated
+  # against the task-instance ARN (task/CLUSTER/*), not the task-def ARN.
+  # Cluster name is the last path segment of the cluster ARN (split index
+  # 1 of `.../cluster/NAME`).
+  agent_runner_task_instance_arn_pattern = (
+    local.agent_runner_launch_enabled
+    ? "arn:aws:ecs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:task/${split("/", var.ecs_cluster_arn)[1]}/*"
+    : ""
+  )
   agent_runner_pass_role_arns = compact([
     var.agent_runner_execution_role_arn,
     var.agent_runner_task_role_arn,
@@ -557,6 +566,23 @@ resource "aws_iam_role_policy" "task_launch_agent_runner" {
         Effect   = "Allow"
         Action   = "ecs:StopTask"
         Resource = local.agent_runner_family_arn_pattern
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+      {
+        # ecs:TagResource is invoked implicitly by RunTask when the call
+        # includes a `tags` list. AWS evaluates authorization against the
+        # task-instance ARN (task/CLUSTER/*), not the task-definition ARN —
+        # the Stage 2 daemon tags every agent-runner task with `agent_id`
+        # and `issue_number`, so without this statement every ECS-mode
+        # claim fails with AccessDeniedException (#3129).
+        Sid      = "AllowTagAgentRunnerTask"
+        Effect   = "Allow"
+        Action   = "ecs:TagResource"
+        Resource = local.agent_runner_task_instance_arn_pattern
         Condition = {
           ArnEquals = {
             "ecs:cluster" = var.ecs_cluster_arn


### PR DESCRIPTION
## Summary

Grants `ecs:TagResource` to the dispatcher task role so that ECS-mode agent-runner claims (which `RunTask` with `agent_id`/`issue_number` tags, added in #3091) stop failing with `AccessDeniedException`. Closes #3129.

Five ECS claims failed in a row today between 22:27–22:30Z, tripping the circuit breaker to `cap=0`. Root cause: the `task_launch_agent_runner` policy had `ecs:RunTask`/`StopTask`/`DescribeTasks`/`iam:PassRole` but no `ecs:TagResource`, and AWS evaluates `TagResource` on the runtime task-instance ARN (`task/CLUSTER/*`), not the task-definition ARN.

## Change

Adds one statement (`AllowTagAgentRunnerTask`) to the existing `task_launch_agent_runner` policy, scoped to `arn:aws:ecs:REGION:ACCOUNT:task/<cluster>/*` with the same `ecs:cluster` ArnEquals condition as the surrounding statements. Cluster name is derived from `var.ecs_cluster_arn` via `split()` to avoid adding a new variable.

No daemon code changes. No other resources modified by this diff.

## Terraform plan (targeted at the policy)

```
  ~ resource "aws_iam_role_policy" "task_launch_agent_runner" {
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                    ...
                  + {
                      + Action    = "ecs:TagResource"
                      + Condition = {
                          + ArnEquals = {
                              + "ecs:cluster" = "arn:aws:ecs:us-west-2:155326049300:cluster/judgemind-dev"
                            }
                        }
                      + Effect    = "Allow"
                      + Resource  = "arn:aws:ecs:us-west-2:155326049300:task/judgemind-dev/*"
                      + Sid       = "AllowTagAgentRunnerTask"
                    },
                    ...
                ]
            }
        )
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Full-env plan shows 3 total changes, but the other two (`module.compute.aws_scheduler_schedule.scraper` task-def revision drift, `module.compute.aws_security_group.scraper` egress drift) are pre-existing drift unrelated to this PR and independent of the module I edited.

## Post-merge

Dev terraform auto-apply (#3107) propagates this. After apply, the operator flow is:

1. `aws iam simulate-principal-policy` for `ecs:TagResource` on `task/judgemind-dev/*` → `allowed`.
2. Reset the circuit breaker:
   ```sql
   UPDATE dispatcher.config SET value='1'::jsonb, updated_by='operator:post-3129', updated_at=now() WHERE key='concurrency_cap';
   DELETE FROM dispatcher.config WHERE key='cap_flipped_by';
   ```
3. Wait one scheduler_tick (~60s), verify `dispatcher.agents` row with `execution_mode='ecs'` and non-null `agent_task_arn`.

Evidence comment with all three will land on #3129 after auto-apply completes.

Closes #3129
