### PR TITLE
fix(agent-runner): self-diagnosing non-object claude result (#3131)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -445,7 +445,86 @@ run_claude_phase() {
     if jq -e '.result | type == "object"' "$_out_file" >/dev/null 2>&1; then
         jq -c '.result' "$_out_file" 2>/dev/null || printf '{}'
     else
+        # Self-diagnosing branch (#3131). Every ECS agent today is dying
+        # because `.result` comes back non-object; operators have no way
+        # to see WHY without a second deploy-instrument cycle. Log the
+        # structured triage fields directly on the failure event so the
+        # first post-deploy ECS agent surfaces the actual payload in
+        # CloudWatch. Preserves the existing `claude_result_non_object`
+        # event name (load-bearing for log-insights queries) and adds a
+        # sibling `claude_result_non_object_diag` event carrying:
+        #
+        #   * result_type   — jq's type of `.result` (string/null/number/...).
+        #   * result_bytes  — byte length of `.result` stringified.
+        #   * result_head_512  — first 512 bytes of `.result` stringified,
+        #     newlines replaced with `\n` and double quotes escaped so
+        #     the line stays a single JSON-ish record the log() function
+        #     can emit without breaking CloudWatch line boundaries.
+        #   * stderr_head_1024 — first 1024 bytes of the sibling
+        #     `.stderr.log` file, same escaping. Omitted when the stderr
+        #     file is empty / missing so the common "no stderr" case
+        #     isn't noise.
+        #
+        # All payload extraction happens in-process via `jq` + shell
+        # builtins — no extra tools, no new dependencies. Bash 3.2
+        # compatible (`cut -c` + `tr` + `sed`; no `${var:0:512}` slicing
+        # on multi-byte-safe boundaries is required because we're only
+        # emitting the first 512 BYTES for triage, not interpreting them).
         log "claude_result_non_object" "phase=$_phase" "out_file=$_out_file"
+
+        _result_type=$(jq -r '.result | type' "$_out_file" 2>/dev/null || printf 'unparseable')
+        # `.result | tostring` stringifies any type — strings pass
+        # through, objects/arrays/null serialize to their JSON form.
+        # `-r` emits raw (no wrapping quotes) so the byte count matches
+        # the actual payload length. Falls back to the raw file on a
+        # parse failure (malformed JSON) so the diag still shows the
+        # first 512 bytes of whatever claude wrote.
+        _result_str_file="$AGENT_WORKSPACE/claude-p-$_phase.result.str"
+        if ! jq -r '.result | tostring' "$_out_file" > "$_result_str_file" 2>/dev/null; then
+            cp "$_out_file" "$_result_str_file" 2>/dev/null || printf '' > "$_result_str_file"
+        fi
+        _result_bytes=$(wc -c < "$_result_str_file" 2>/dev/null | tr -d ' ' || printf '0')
+
+        # Shape for embedding in log() key=value pairs. log() handles
+        # double-quote escaping; we handle backslash escaping (log()
+        # doesn't) and control-char squashing (so the output stays one
+        # line and does not split CloudWatch log events). Order matters:
+        # escape backslashes FIRST so we don't double-escape the ones we
+        # just added. Use `tr` to replace newlines/CRs/tabs with spaces
+        # rather than emitting literal `\n` (which would require
+        # teaching log() to not re-escape the backslash). This keeps
+        # the triage payload human-readable in CloudWatch at the cost
+        # of losing exact whitespace boundaries — fine for a first-512
+        # smoke.
+        _result_head_512=$(head -c 512 "$_result_str_file" 2>/dev/null \
+            | tr '\n\r\t' '   ' \
+            | sed -e 's/\\/\\\\/g' || printf '')
+
+        # Stderr tail — only emit when non-empty so the common healthy
+        # path doesn't bloat log lines.
+        _stderr_file="$AGENT_WORKSPACE/claude-p-$_phase.stderr.log"
+        _stderr_head_1024=""
+        if [[ -s "$_stderr_file" ]]; then
+            _stderr_head_1024=$(head -c 1024 "$_stderr_file" 2>/dev/null \
+                | tr '\n\r\t' '   ' \
+                | sed -e 's/\\/\\\\/g' || printf '')
+        fi
+
+        if [[ -n "$_stderr_head_1024" ]]; then
+            log "claude_result_non_object_diag" \
+                "phase=$_phase" \
+                "result_type=$_result_type" \
+                "result_bytes=$_result_bytes" \
+                "result_head_512=$_result_head_512" \
+                "stderr_head_1024=$_stderr_head_1024"
+        else
+            log "claude_result_non_object_diag" \
+                "phase=$_phase" \
+                "result_type=$_result_type" \
+                "result_bytes=$_result_bytes" \
+                "result_head_512=$_result_head_512"
+        fi
+
         printf '{}'
     fi
 }

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -191,6 +191,15 @@ done
 # Set CLAUDE_RESULT_OVERRIDE to the exact JSON payload to emit. Set
 # CLAUDE_RESULT_OVERRIDE_SKILL to scope the override to one skill
 # only; leave unset to apply it to every skill invocation.
+#
+# CLAUDE_STDERR_OVERRIDE lets tests write a stderr payload the
+# entrypoint captures via its `2> $AGENT_WORKSPACE/claude-p-<phase>.stderr.log`
+# redirect — exercise the #3131 diag path's stderr_head_1024 field.
+if [[ -n "${CLAUDE_STDERR_OVERRIDE:-}" ]]; then
+    if [[ -z "${CLAUDE_RESULT_OVERRIDE_SKILL:-}" || "${CLAUDE_RESULT_OVERRIDE_SKILL}" == "$skill" ]]; then
+        printf '%s\n' "$CLAUDE_STDERR_OVERRIDE" >&2
+    fi
+fi
 if [[ -n "${CLAUDE_RESULT_OVERRIDE:-}" ]]; then
     if [[ -z "${CLAUDE_RESULT_OVERRIDE_SKILL:-}" || "${CLAUDE_RESULT_OVERRIDE_SKILL}" == "$skill" ]]; then
         printf '%s\n' "$CLAUDE_RESULT_OVERRIDE"
@@ -1042,6 +1051,204 @@ if printf '%s' "$out" | grep -q "claude_result_non_object"; then
 else
     fail "malformed JSON output surfaces via claude_result_non_object" \
          "output: $out"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 12: #3131 — non-object `.result` also emits a
+# `claude_result_non_object_diag` event with structured triage fields
+# (result_type, result_bytes, result_head_512). Without this, every
+# ECS agent dies opaquely — operators have no way to tell whether
+# claude said "Unknown command" vs a conversational response vs a
+# permission denial without a second deploy-instrument cycle.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t12.txt"
+printf 'planning\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t12_workspace="$TEST_TMP/t12-workspace"
+mkdir -p "$t12_workspace"
+
+# Exact "Unknown command" payload that hit every Stage 3 smoke agent.
+set +e
+out=$(AGENT_ID="cccccccc-dddd-eeee-ffff-000000000000" \
+      ISSUE_NUMBER="3131" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t12_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="$PRIOR_PATCH_FIXTURE" \
+      CLAUDE_VERDICT_FIXTURE="" \
+      CLAUDE_RESULT_OVERRIDE='{"result": "Unknown command: /task-v2-plan"}' \
+      CLAUDE_RESULT_OVERRIDE_SKILL="plan" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+# The diag event must have fired.
+if printf '%s' "$out" | grep -q "claude_result_non_object_diag"; then
+    pass "non-object .result emits claude_result_non_object_diag"
+else
+    fail "non-object .result emits claude_result_non_object_diag" \
+         "output tail: $(printf '%s' "$out" | tail -20)"
+fi
+
+# The diag line must carry the structured type field — `.result` was a
+# JSON string, so `jq .result | type` returns "string". This is the
+# single most important field for #3131 triage: it tells us at a
+# glance that claude returned a conversational/error string, not the
+# structured envelope the skill is supposed to emit.
+diag_line=$(printf '%s' "$out" | grep "claude_result_non_object_diag" | head -n 1)
+if printf '%s' "$diag_line" | grep -q 'result_type.*string'; then
+    pass "diag event carries result_type=string for string .result"
+else
+    fail "diag event carries result_type=string for string .result" \
+         "diag line: $diag_line"
+fi
+
+# The diag line must carry the actual payload text in result_head_512.
+# The string "Unknown command: /task-v2-plan" is 31 bytes, well under
+# the 512 cap.
+if printf '%s' "$diag_line" | grep -q 'Unknown command: /task-v2-plan'; then
+    pass "diag event result_head_512 contains the actual .result text"
+else
+    fail "diag event result_head_512 contains the actual .result text" \
+         "diag line: $diag_line"
+fi
+
+# result_bytes is the byte count of `.result | tostring`. "Unknown
+# command: /task-v2-plan" is 31 bytes. Assert the field is present
+# and numeric; exact value doesn't matter (jq versions may differ in
+# tostring whitespace handling, though for a raw string they
+# shouldn't).
+if printf '%s' "$diag_line" | grep -qE 'result_bytes": "[0-9]+"'; then
+    pass "diag event carries numeric result_bytes"
+else
+    fail "diag event carries numeric result_bytes" \
+         "diag line: $diag_line"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 13: #3131 — when claude writes to stderr, the diag event
+# carries the first 1024 bytes of that stderr file. Exercises the
+# `stderr_head_1024` field independently of the `.result` path.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t13.txt"
+printf 'planning\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t13_workspace="$TEST_TMP/t13-workspace"
+mkdir -p "$t13_workspace"
+
+# Stderr payload representative of a real claude-cli failure: a line
+# about a skill-resolution problem. Keep under 1024 bytes so the test
+# asserts against the full payload, not a truncation boundary.
+stderr_payload='Error: skill /task-v2-plan not found in any registry. Searched: /home/dispatcher/.claude/skills, /app/.claude/skills, /var/lib/agent-runner/repo/.claude/skills'
+
+set +e
+out=$(AGENT_ID="dddddddd-eeee-ffff-0000-111111111111" \
+      ISSUE_NUMBER="3131" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t13_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="$PRIOR_PATCH_FIXTURE" \
+      CLAUDE_VERDICT_FIXTURE="" \
+      CLAUDE_RESULT_OVERRIDE='{"result": "Unknown command: /task-v2-plan"}' \
+      CLAUDE_RESULT_OVERRIDE_SKILL="plan" \
+      CLAUDE_STDERR_OVERRIDE="$stderr_payload" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+diag_line=$(printf '%s' "$out" | grep "claude_result_non_object_diag" | head -n 1)
+
+# stderr_head_1024 field should contain a distinctive substring of the
+# stub's stderr payload. Don't assert the full string — log() escapes
+# embedded `"` / `\` and the test parses its own stdout capture which
+# picks up shell-quoting noise.
+if printf '%s' "$diag_line" | grep -q 'stderr_head_1024'; then
+    pass "diag event carries stderr_head_1024 when claude writes to stderr"
+else
+    fail "diag event carries stderr_head_1024 when claude writes to stderr" \
+         "diag line: $diag_line"
+fi
+
+if printf '%s' "$diag_line" | grep -q 'skill /task-v2-plan not found'; then
+    pass "stderr_head_1024 contains the actual stderr text"
+else
+    fail "stderr_head_1024 contains the actual stderr text" \
+         "diag line: $diag_line"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 14: #3131 — when claude writes NOTHING to stderr, the diag
+# event OMITS the stderr_head_1024 field entirely rather than emitting
+# an empty value. Keeps CloudWatch log lines short on the common case
+# and signals "no stderr" unambiguously.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t14.txt"
+printf 'planning\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t14_workspace="$TEST_TMP/t14-workspace"
+mkdir -p "$t14_workspace"
+
+set +e
+out=$(AGENT_ID="eeeeeeee-ffff-0000-1111-222222222222" \
+      ISSUE_NUMBER="3131" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t14_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="$PRIOR_PATCH_FIXTURE" \
+      CLAUDE_VERDICT_FIXTURE="" \
+      CLAUDE_RESULT_OVERRIDE='{"result": "Unknown command: /task-v2-plan"}' \
+      CLAUDE_RESULT_OVERRIDE_SKILL="plan" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+diag_line=$(printf '%s' "$out" | grep "claude_result_non_object_diag" | head -n 1)
+if printf '%s' "$diag_line" | grep -q 'stderr_head_1024'; then
+    fail "diag event omits stderr_head_1024 when claude stderr is empty" \
+         "diag line unexpectedly contains stderr_head_1024: $diag_line"
+else
+    pass "diag event omits stderr_head_1024 when claude stderr is empty"
+fi
+
+# The existing `claude_result_non_object` event should still fire
+# alongside the diag event — downstream consumers (CloudWatch
+# Insights queries, log parsers) rely on the original event name and
+# must not be broken by the diag addition.
+if printf '%s' "$out" | grep -q 'claude_result_non_object"'; then
+    pass "original claude_result_non_object event still fires (no regression)"
+else
+    fail "original claude_result_non_object event still fires (no regression)" \
+         "output tail: $(printf '%s' "$out" | tail -30)"
 fi
 
 # ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Step 1 of #3131: make the ECS agent-runner's non-object `.result` failure self-diagnosing.
- `run_claude_phase` now emits a sibling `claude_result_non_object_diag` CloudWatch event carrying `result_type` (jq type), `result_bytes`, first-512-bytes of `.result` stringified, and first-1024-bytes of the sibling stderr file when present.
- Existing `claude_result_non_object` event preserved so downstream log-parsers aren't broken; `printf '{}'` downstream behavior unchanged.

## Why

Every ECS-mode agent today fails identically: claude's `.result` comes back as a non-object string, entrypoint defensively coerces to `{}`, routes to `daemon_restart_abandoned`, dies after ~2 minutes. Three agents today all hit this (`e6dcfe10` #2717, `429055d2` #2741, `997533da` #2777). Current logging only records the out_file path — operators can't see what claude actually said without another deploy-instrument cycle.

This PR ships the observability so the first post-deploy ECS agent surfaces the actual `.result` payload + stderr in CloudWatch, letting Step 2 (the real fix — likely skill-discovery / HOME / settings.json) be scoped from data rather than hypothesis.

## Changes

- `scripts/dispatcher/agent-runner-entrypoint.sh` — extends `run_claude_phase`'s non-object branch to emit `claude_result_non_object_diag` with the structured triage fields. Pure-shell, no new deps, bash 3.2 compatible (uses `head -c`, `tr`, `sed`, `wc -c`; no `${var:0:N}` slicing). Escapes backslashes + squashes newlines/CRs/tabs in the payload so CloudWatch receives a single log line per event.
- `scripts/tests/test_agent_runner_entrypoint.sh` — 8 new assertions across 3 test cases (T12 string .result, T13 stderr payload, T14 empty stderr + regression guard). Claude stub gains `CLAUDE_STDERR_OVERRIDE` support.

## Test plan

- [x] `scripts/tests/test_agent_runner_entrypoint.sh` — 51/51 passed (was 43).
- [x] `scripts/check-bash-compat.sh` — clean.
- [ ] CI green on the PR.
- [ ] After merge + auto-rebuild via deploy-agent-runner.yml, seed ONE ECS-mode agent on a synthetic test issue. Capture the `claude_result_non_object_diag` payload from CloudWatch. File Step-2 follow-up issue with the root cause.
- [ ] Keep `dispatcher.config.agent_execution_mode='subprocess'` — do NOT flip to ECS until Step 2 lands.

Related: #3090, #3117, #3121. Blocks #3086 Option A rollout until Step 2 is identified and fixed.

Refs #3131 — Step 1 only. Step 2 (the actual fix) will ship in a follow-up once CloudWatch data from a post-deploy smoke tells us what claude is actually saying. Keeping #3131 open until Step 2 lands.
