### PR TITLE
feat(agent-runner): Stage 2 input parity for summary/fix-ci/verify/retro (#3135)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -382,15 +382,20 @@ transition_for() {
 # own path uses the same CLI); non-interactive auth is already wired
 # up in the entrypoint's ``gh auth login --with-token`` step earlier.
 #
-# Stage 1b scope (#3133): plan + ralph inputs are built fully so the
-# smoke exercises planning → ralph with real object `.result` values.
-# summary / fix-ci / verify / retro inputs are minimal — they include
-# the required identifier fields (agent_id, issue_number, worktree_path)
-# plus whatever the shim can derive locally, but the richer context
-# (git diff, CI failing jobs, deploy status, phase_transitions) stays
-# the daemon's job. Each of those skills will still BLOCK cleanly when
-# its input is incomplete, which is the correct behaviour for a
-# smoke-only image — Stage 2 fleshes out the per-phase wiring.
+# Stage 2 scope (#3135): every claude-driven phase's input is built to
+# the same shape the daemon's ``_handle_phase_*`` builders assemble.
+# Plan + ralph continue to mirror the daemon's identifier + issue
+# bundle; summary now carries ralph_summary + git_diff + branch +
+# plan-derived acceptance_criteria; fix-ci reads pr_number + the PR's
+# failing-job metadata + per-job log tails via ``gh run view
+# --log-failed --job``; verify reads the merged commit SHA + deploy-
+# run conclusion + deferred_acs (from summary's persisted output);
+# retro reads phase_transitions + failures from their respective
+# ``dispatcher.*`` tables plus counter derivations that match the
+# daemon's ``_build_retro_input``. Every gh / psql call is best-
+# effort — a missing row / 404 returns an empty value so each skill's
+# own guard clauses still produce a structured BLOCKED / FAILED
+# verdict when data genuinely isn't available.
 #
 # Module lookup matches phase_transitions_shim.py: PHASE_INPUT_DIR /
 # PHASE_INPUT_PARENT env vars let tests stub the script at a writable
@@ -407,17 +412,47 @@ Invoked with argv = [phase, agent_id, issue_number, repo_root]. Writes
 ``{repo_root}/tmp/dispatcher-input/<phase>.json`` matching each skill's
 input contract (see .claude/skills/task-v2-<phase>/SKILL.md).
 
-Minimal Stage 1b scope (#3133):
+Stage 2 scope (#3135): every phase's input is built to the same shape
+the daemon's ``_handle_phase_*`` builders assemble, so ECS-mode agents
+reach the same verdicts as subprocess-mode agents. Specifically:
+
   * planning — full input via ``gh issue view --json`` (mirrors the
     daemon's ``_fetch_issue_bundle``). Non-bot comments filtered.
     ``Blocked by #N`` + ``Parent: #N`` parsed from body.
   * ralph — plan output from ``dispatcher-output/plan.json`` + the
     identifiers; ``max_iterations`` defaults to 5 matching the daemon.
-  * summary / fix-ci / verify / retro — identifier fields + whatever
-    can be derived locally (prior phase outputs, branch name, git diff
-    for summary). Fields the daemon has (CI job logs, deploy status,
-    phase_transitions timing) are left empty; each skill short-circuits
-    with a structured BLOCKED verdict rather than a string ``.result``.
+  * summary — refetched issue bundle, ralph_summary from
+    ``dispatcher-output/ralph.json``, ``changed_files``, ``git_diff``
+    against ``origin/main``, ``branch``, and plan-derived
+    ``plan_acceptance_criteria`` + ``scope_check``.
+  * fix-ci — ``pr_number`` from ``dispatcher.agents`` plus the
+    failing-job metadata via ``gh pr view --json statusCheckRollup``,
+    each enriched with ``log_tail`` via
+    ``gh run view --log-failed --job <id>``. ``git_diff_base_to_head``
+    from ``gh pr diff``, ``previous_fix_attempts`` from
+    ``dispatcher.agents.retries_used``.
+  * verify — ``pr_number`` + ``merged_commit_sha`` from
+    ``gh pr view --json mergeCommit``; ``deploy_status`` +
+    ``touched_services`` + ``change_type`` from ``gh run list``
+    filtered to the merge SHA; ``deferred_acs`` from
+    ``dispatcher.phase_outputs WHERE phase='summary'``;
+    ``acceptance_criteria`` extracted from the issue body via the same
+    regex the daemon uses.
+  * retro — ``phase_transitions`` + ``failures`` from their
+    respective ``dispatcher.*`` tables, ``ralph_iterations`` /
+    ``ci_attempts`` / ``fix_ci_attempts`` derived from the transitions
+    log, ``total_duration_s`` from ``now() - agents.started_at``,
+    ``scope_check_followups`` / ``plan_follow_ups`` from plan output,
+    ``verify_evidence_md`` from the verify phase_outputs row.
+
+All DB reads go through ``psql $DATABASE_URL -At`` (the same
+connection string the entrypoint already trusts for its own
+``db_exec`` / ``db_query_one`` shell helpers). GitHub reads go through
+``gh`` which is already authenticated by the entrypoint's
+``gh auth login --with-token`` step. Every fetch is best-effort: a
+missing row or a ``gh`` 404 returns an empty / zero value so the
+skill's own guard clauses are what trigger a BLOCKED verdict — never
+an uncaught exception from this shim.
 
 Exit codes: 0 on write success, 2 on unrecoverable error (caller
 should log + continue — the skill's missing-input path still works).
@@ -428,6 +463,18 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+
+
+# Cap on failing jobs embedded in fix-ci input — mirrors the daemon's
+# ``FIX_CI_MAX_FAILING_JOBS`` constant. Keeps the payload bounded when
+# a PR has dozens of red checks (e.g. matrix explosions).
+FIX_CI_MAX_FAILING_JOBS = 10
+
+# Cap on log bytes captured per failing job. The daemon lets the skill
+# pull tails itself, but in ECS mode we do it here because the skill's
+# container does not have PAT scopes for CloudWatch Logs / Actions API.
+# 200 lines * ~200 bytes/line = ~40KB; cap to 64KB per job for safety.
+FIX_CI_LOG_TAIL_BYTES = 64 * 1024
 
 
 def _run(cmd: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
@@ -441,15 +488,248 @@ def _run(cmd: list[str], timeout: int = 30) -> subprocess.CompletedProcess:
     )
 
 
+# ─────────────────────────────────────────────────────────────────────
+# Parsing helpers (mirror DispatcherDaemon)
+# ─────────────────────────────────────────────────────────────────────
+
+
 def _parse_blocked_by(body: str) -> list[int]:
     """Mirror DispatcherDaemon._parse_blocked_by."""
     return [int(m) for m in re.findall(r"(?im)^\s*blocked by\s+#(\d+)\s*$", body)]
 
 
-def _parse_parent_issue(body: str) -> int | None:
+def _parse_parent_issue(body):
     """Mirror DispatcherDaemon._parse_parent_issue."""
     match = re.search(r"(?im)^\s*parent\s*:\s*#(\d+)\s*$", body)
     return int(match.group(1)) if match else None
+
+
+def _extract_acceptance_criteria(body: str) -> list[str]:
+    """Mirror DispatcherDaemon._extract_acceptance_criteria.
+
+    Pull ``- [ ] …`` checkboxes out of the issue body, skipping
+    verification / automated-checks / test-plan sections.
+    """
+    lines = body.splitlines()
+    skip_sections = {"post-deploy verification", "automated checks", "test plan"}
+    in_skip_section = False
+    criteria: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            heading_text = stripped.lstrip("#").strip().lower()
+            in_skip_section = any(tag in heading_text for tag in skip_sections)
+            continue
+        if in_skip_section:
+            continue
+        match = re.match(r"^\s*-\s*\[[ xX]\]\s*(.+)$", line)
+        if match:
+            criteria.append(match.group(1).strip())
+    return criteria
+
+
+# ─────────────────────────────────────────────────────────────────────
+# DB helpers (shell out to psql — entrypoint already uses it)
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _db_query_one(sql: str) -> str:
+    """Execute a SELECT against ``$DATABASE_URL`` and return stdout.
+
+    Uses ``psql -At`` (unaligned, tuples-only) so the result is the
+    raw first-row value. Empty string on error — the caller is
+    expected to tolerate missing data.
+    """
+    database_url = os.environ.get("DATABASE_URL", "")
+    if not database_url:
+        return ""
+    try:
+        outcome = _run(
+            ["psql", database_url, "-v", "ON_ERROR_STOP=1", "-At", "-c", sql],
+            timeout=20,
+        )
+    except Exception:
+        return ""
+    if outcome.returncode != 0:
+        return ""
+    return (outcome.stdout or "").rstrip("\n")
+
+
+def _db_query_rows(sql: str, field_sep: str = "\t") -> list[list[str]]:
+    """Execute a SELECT and return a list of row field lists.
+
+    Uses ``psql -At -F <sep>`` so each line is one row and each field
+    is separated by ``field_sep``. Default TAB — tolerates values with
+    newlines only if the caller ensures there are none (e.g. by
+    rtrimming / replacing in SQL). Empty list on error.
+    """
+    database_url = os.environ.get("DATABASE_URL", "")
+    if not database_url:
+        return []
+    try:
+        outcome = _run(
+            [
+                "psql",
+                database_url,
+                "-v",
+                "ON_ERROR_STOP=1",
+                "-At",
+                "-F",
+                field_sep,
+                "-c",
+                sql,
+            ],
+            timeout=20,
+        )
+    except Exception:
+        return []
+    if outcome.returncode != 0:
+        return []
+    rows: list[list[str]] = []
+    for line in (outcome.stdout or "").splitlines():
+        if not line:
+            continue
+        rows.append(line.split(field_sep))
+    return rows
+
+
+def _db_fetch_agent_pr_number(agent_id: str) -> int:
+    """Return the agent's ``dispatcher.agents.pr_number`` or 0."""
+    # Escape single quotes in agent_id for the SQL literal. Agent IDs
+    # are UUIDs so this is defensive but not load-bearing.
+    agent_sql = agent_id.replace("'", "''")
+    raw = _db_query_one(
+        "SELECT COALESCE(pr_number::text, '0') "
+        "FROM dispatcher.agents "
+        f"WHERE agent_id = '{agent_sql}' "
+        "LIMIT 1;"
+    )
+    try:
+        return int(raw) if raw else 0
+    except ValueError:
+        return 0
+
+
+def _db_fetch_agent_retries_used(agent_id: str) -> int:
+    """Return ``dispatcher.agents.retries_used`` or 0."""
+    agent_sql = agent_id.replace("'", "''")
+    raw = _db_query_one(
+        "SELECT COALESCE(retries_used, 0)::text "
+        "FROM dispatcher.agents "
+        f"WHERE agent_id = '{agent_sql}' "
+        "LIMIT 1;"
+    )
+    try:
+        return int(raw) if raw else 0
+    except ValueError:
+        return 0
+
+
+def _db_fetch_agent_total_duration_s(agent_id: str) -> int:
+    """Seconds since ``dispatcher.agents.started_at``.
+
+    Matches DispatcherDaemon._fetch_agent_total_duration_s. 0 on error
+    or missing row.
+    """
+    agent_sql = agent_id.replace("'", "''")
+    raw = _db_query_one(
+        "SELECT COALESCE("
+        "  EXTRACT(EPOCH FROM (now() - started_at))::int, "
+        "  0"
+        ")::text "
+        "FROM dispatcher.agents "
+        f"WHERE agent_id = '{agent_sql}' "
+        "LIMIT 1;"
+    )
+    try:
+        return int(raw) if raw else 0
+    except ValueError:
+        return 0
+
+
+def _db_fetch_phase_output(agent_id: str, phase: str) -> dict:
+    """Read ``dispatcher.phase_outputs.output_json`` for (agent_id, phase).
+
+    Returns the parsed JSON object or ``{}`` if missing / malformed /
+    not-a-dict. Mirrors DispatcherDaemon._fetch_phase_output.
+    """
+    agent_sql = agent_id.replace("'", "''")
+    phase_sql = phase.replace("'", "''")
+    raw = _db_query_one(
+        "SELECT output_json::text "
+        "FROM dispatcher.phase_outputs "
+        f"WHERE agent_id = '{agent_sql}' AND phase = '{phase_sql}' "
+        "ORDER BY ts DESC LIMIT 1;"
+    )
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _db_fetch_phase_transitions(agent_id: str) -> list[dict]:
+    """Read ``dispatcher.phase_transitions`` ordered oldest-first.
+
+    Returns ``[{phase, ts}]``. Mirrors
+    DispatcherDaemon._fetch_phase_transitions — the retro skill's
+    input contract lists richer fields (``started_at`` / ``ended_at`` /
+    ``duration_s`` / ``outcome``) but the daemon only populates
+    ``{phase, ts}`` because that's what the table stores. We match.
+    """
+    agent_sql = agent_id.replace("'", "''")
+    rows = _db_query_rows(
+        "SELECT phase, ts::text "
+        "FROM dispatcher.phase_transitions "
+        f"WHERE agent_id = '{agent_sql}' "
+        "ORDER BY ts ASC;"
+    )
+    result: list[dict] = []
+    for row in rows:
+        if len(row) < 2:
+            continue
+        result.append({"phase": row[0], "ts": row[1]})
+    return result
+
+
+def _db_fetch_failures_grouped(agent_id: str) -> list[dict]:
+    """Read ``dispatcher.failures`` grouped by category, highest-count first.
+
+    Returns ``[{category, count, first_seen, last_seen}]``. Mirrors
+    DispatcherDaemon._fetch_failures_grouped.
+    """
+    agent_sql = agent_id.replace("'", "''")
+    rows = _db_query_rows(
+        "SELECT category, count(*)::text, min(ts)::text, max(ts)::text "
+        "FROM dispatcher.failures "
+        f"WHERE agent_id = '{agent_sql}' "
+        "GROUP BY category "
+        "ORDER BY count(*) DESC;"
+    )
+    result: list[dict] = []
+    for row in rows:
+        if len(row) < 4:
+            continue
+        try:
+            count = int(row[1])
+        except ValueError:
+            count = 0
+        result.append(
+            {
+                "category": row[0],
+                "count": count,
+                "first_seen": row[2],
+                "last_seen": row[3],
+            }
+        )
+    return result
+
+
+# ─────────────────────────────────────────────────────────────────────
+# GitHub helpers
+# ─────────────────────────────────────────────────────────────────────
 
 
 def _fetch_issue_bundle(repo: str, issue_number: int) -> dict:
@@ -529,15 +809,260 @@ def _fetch_issue_bundle(repo: str, issue_number: int) -> dict:
     }
 
 
+def _fetch_pr_status(repo: str, pr_number: int) -> dict:
+    """Return the ``gh pr view --json ...`` payload or ``{}``.
+
+    Pulls the same fields the daemon's ``_fetch_pr_status`` asks for.
+    """
+    if not pr_number:
+        return {}
+    cmd = [
+        "gh",
+        "pr",
+        "view",
+        str(pr_number),
+        "--repo",
+        repo,
+        "--json",
+        "statusCheckRollup,mergeable,mergeStateStatus,headRefOid,mergeCommit",
+    ]
+    outcome = _run(cmd, timeout=30)
+    if outcome.returncode != 0:
+        return {}
+    try:
+        payload = json.loads(outcome.stdout or "{}")
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _fetch_pr_diff(repo: str, pr_number: int) -> str:
+    """Return the PR's base-to-head diff, empty string on error."""
+    if not pr_number:
+        return ""
+    cmd = ["gh", "pr", "diff", str(pr_number), "--repo", repo]
+    outcome = _run(cmd, timeout=60)
+    if outcome.returncode != 0:
+        return ""
+    return outcome.stdout or ""
+
+
+def _extract_failing_jobs(pr_status: dict) -> list[dict]:
+    """Mirror DispatcherDaemon._extract_failing_jobs (pre-log-tail).
+
+    Returns up to ``FIX_CI_MAX_FAILING_JOBS`` entries.
+    """
+    failure_conclusions = {
+        "FAILURE",
+        "CANCELLED",
+        "TIMED_OUT",
+        "ACTION_REQUIRED",
+        "STARTUP_FAILURE",
+    }
+    rollup = pr_status.get("statusCheckRollup") or []
+    failing: list[dict] = []
+    for check in rollup:
+        if not isinstance(check, dict):
+            continue
+        conclusion = str(check.get("conclusion") or "").upper()
+        status = str(check.get("status") or "").upper()
+        if status == "COMPLETED" and conclusion in failure_conclusions:
+            failing.append(
+                {
+                    "name": check.get("name") or check.get("context") or "",
+                    "conclusion": conclusion,
+                    "databaseId": check.get("databaseId"),
+                    "detailsUrl": check.get("detailsUrl"),
+                }
+            )
+        if len(failing) >= FIX_CI_MAX_FAILING_JOBS:
+            break
+    return failing
+
+
+def _fetch_job_log_tail(repo: str, job_database_id) -> str:
+    """Fetch ``gh run view --log-failed --job <id>`` output.
+
+    Uses ``--job`` with the job's ``databaseId`` — the daemon comment
+    references this shape. Caps at ``FIX_CI_LOG_TAIL_BYTES`` so a
+    multi-megabyte build log doesn't bloat the skill input. Empty
+    string on any failure.
+    """
+    if not job_database_id:
+        return ""
+    cmd = [
+        "gh",
+        "run",
+        "view",
+        "--repo",
+        repo,
+        "--log-failed",
+        "--job",
+        str(job_database_id),
+    ]
+    try:
+        outcome = _run(cmd, timeout=60)
+    except Exception:
+        return ""
+    if outcome.returncode != 0:
+        return ""
+    out = outcome.stdout or ""
+    if len(out) > FIX_CI_LOG_TAIL_BYTES:
+        # Keep the tail — failures usually surface near the end of the
+        # log, and the skill explicitly expects "last ~200 lines".
+        out = out[-FIX_CI_LOG_TAIL_BYTES:]
+    return out
+
+
+def _enrich_failing_jobs_with_logs(repo: str, jobs: list[dict]) -> list[dict]:
+    """Attach a ``log_tail`` to each failing-job entry."""
+    enriched: list[dict] = []
+    for job in jobs:
+        tail = _fetch_job_log_tail(repo, job.get("databaseId"))
+        enriched.append({**job, "log_tail": tail})
+    return enriched
+
+
+def _fetch_merged_pr_info(repo: str, pr_number: int) -> dict:
+    """Return ``{merge_commit_sha, pr_state}`` for a PR."""
+    if not pr_number:
+        return {"merge_commit_sha": "", "pr_state": ""}
+    cmd = [
+        "gh",
+        "pr",
+        "view",
+        str(pr_number),
+        "--repo",
+        repo,
+        "--json",
+        "state,mergeCommit,headRefOid",
+    ]
+    outcome = _run(cmd, timeout=30)
+    if outcome.returncode != 0:
+        return {"merge_commit_sha": "", "pr_state": ""}
+    try:
+        payload = json.loads(outcome.stdout or "{}")
+    except json.JSONDecodeError:
+        return {"merge_commit_sha": "", "pr_state": ""}
+    sha = ""
+    merge_commit = payload.get("mergeCommit")
+    if isinstance(merge_commit, dict):
+        sha = str(merge_commit.get("oid") or "")
+    if not sha:
+        head = payload.get("headRefOid")
+        if isinstance(head, str):
+            sha = head
+    return {
+        "merge_commit_sha": sha,
+        "pr_state": str(payload.get("state") or ""),
+    }
+
+
+def _fetch_deploy_runs_for_sha(repo: str, sha: str) -> list[dict]:
+    """Return workflow runs with ``headSha`` equal to ``sha``.
+
+    Matches the daemon's post-merge deploy-run filter: only runs on
+    the merge commit count toward ``deploy_status``. Empty list on
+    error or no runs.
+    """
+    if not sha:
+        return []
+    cmd = [
+        "gh",
+        "run",
+        "list",
+        "--repo",
+        repo,
+        "--commit",
+        sha,
+        "--limit",
+        "20",
+        "--json",
+        "databaseId,workflowName,conclusion,status,headSha,createdAt,updatedAt",
+    ]
+    outcome = _run(cmd, timeout=30)
+    if outcome.returncode != 0:
+        return []
+    try:
+        payload = json.loads(outcome.stdout or "[]")
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(payload, list):
+        return []
+    # Keep only entries whose name starts with ``Deploy`` or is
+    # ``Terraform`` — matches the daemon's workflow-name-to-type map.
+    filtered: list[dict] = []
+    for run in payload:
+        if not isinstance(run, dict):
+            continue
+        name = str(run.get("workflowName") or "")
+        if name.startswith("Deploy") or name == "Terraform":
+            filtered.append(run)
+    return filtered
+
+
+def _select_deploy_status(deploy_runs: list[dict]):
+    """Mirror DispatcherDaemon._select_deploy_status."""
+    if not deploy_runs:
+        return None
+    first = deploy_runs[0]
+    return {
+        "workflow_name": first.get("workflowName"),
+        "run_id": first.get("databaseId"),
+        "conclusion": first.get("conclusion"),
+        "duration_s": None,
+    }
+
+
+def _infer_change_type(deploy_runs: list[dict]) -> str:
+    """Mirror DispatcherDaemon._infer_change_type."""
+    if not deploy_runs:
+        return "no_deployed_component"
+    name_to_type = {
+        "Deploy API": "api",
+        "Deploy Dispatcher": "dx_tooling",
+        "Deploy Scraper": "scraper",
+        "Deploy Production": "web",
+        "Deploy Production (Web)": "web",
+        "Terraform": "dx_tooling",
+    }
+    for run in deploy_runs:
+        mapped = name_to_type.get(str(run.get("workflowName") or ""))
+        if mapped:
+            return mapped
+    return "dx_tooling"
+
+
+def _touched_services_from_runs(deploy_runs: list[dict]) -> list[str]:
+    """Mirror DispatcherDaemon._touched_services_from_runs."""
+    name_to_service = {
+        "Deploy API": "judgemind-api-dev",
+        "Deploy Dispatcher": "judgemind-dispatcher-dev",
+        "Deploy Scraper": "judgemind-scraper-dev",
+    }
+    services: list[str] = []
+    for run in deploy_runs:
+        svc = name_to_service.get(str(run.get("workflowName") or ""))
+        if svc and svc not in services:
+            services.append(svc)
+    return services
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Local state helpers (worktree filesystem + git)
+# ─────────────────────────────────────────────────────────────────────
+
+
 def _read_prior_output(repo_root: Path, phase: str) -> dict:
     """Read ``{repo_root}/tmp/dispatcher-output/<phase>.json`` if present."""
     path = repo_root / "tmp" / "dispatcher-output" / f"{phase}.json"
     if not path.exists():
         return {}
     try:
-        return json.loads(path.read_text())
+        parsed = json.loads(path.read_text())
     except (json.JSONDecodeError, OSError):
         return {}
+    return parsed if isinstance(parsed, dict) else {}
 
 
 def _git_diff(repo_root: Path) -> str:
@@ -585,6 +1110,246 @@ def _git_current_branch(repo_root: Path) -> str:
     return (out.stdout or "").strip() if out.returncode == 0 else ""
 
 
+def _git_diff_stats(repo_root: Path) -> dict:
+    """Return ``{files_changed, insertions, deletions}`` from shortstat.
+
+    Uses ``git diff --shortstat origin/main...HEAD``. Empty on failure
+    with zeros so the retro skill's required ``diff_stats`` field is
+    always a dict of ints (not None).
+    """
+    zero = {"files_changed": 0, "insertions": 0, "deletions": 0}
+    try:
+        out = _run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "diff",
+                "--shortstat",
+                "origin/main...HEAD",
+            ],
+            timeout=30,
+        )
+    except Exception:
+        return zero
+    if out.returncode != 0:
+        return zero
+    line = (out.stdout or "").strip()
+    # Example: " 3 files changed, 42 insertions(+), 5 deletions(-)"
+    files = 0
+    ins = 0
+    dels = 0
+    m = re.search(r"(\d+)\s+files?\s+changed", line)
+    if m:
+        files = int(m.group(1))
+    m = re.search(r"(\d+)\s+insertions?\(\+\)", line)
+    if m:
+        ins = int(m.group(1))
+    m = re.search(r"(\d+)\s+deletions?\(-\)", line)
+    if m:
+        dels = int(m.group(1))
+    return {"files_changed": files, "insertions": ins, "deletions": dels}
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Per-phase builders
+# ─────────────────────────────────────────────────────────────────────
+
+
+def _normalize_deferred_acs(raw) -> list[dict]:
+    """Mirror the daemon's deferred_acs coercion in _run_verify_and_complete."""
+    result: list[dict] = []
+    if not isinstance(raw, list):
+        return result
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        idx = entry.get("index")
+        try:
+            idx_int = int(idx) if idx is not None else None
+        except (TypeError, ValueError):
+            idx_int = None
+        result.append(
+            {
+                "index": idx_int,
+                "reason": str(entry.get("reason") or ""),
+                "verify_instruction": str(entry.get("verify_instruction") or ""),
+            }
+        )
+    return result
+
+
+def _build_summary_input(
+    agent_id: str,
+    issue_number: int,
+    repo_root: Path,
+    github_repo: str,
+) -> dict:
+    """Match DispatcherDaemon._run_summary_phase's summary_input shape."""
+    bundle = _fetch_issue_bundle(github_repo, issue_number)
+    plan = _read_prior_output(repo_root, "plan")
+    ralph = _read_prior_output(repo_root, "ralph")
+    # The daemon prefers ralph's own ``changed_files`` list if populated;
+    # falls back to a git diff read against HEAD. We match, except we
+    # fall back to ``origin/main...HEAD`` instead of ``HEAD`` because
+    # the entrypoint's git state includes the ralph-committed work on
+    # the branch rather than a dirty worktree (#2971).
+    changed_files = ralph.get("changed_files") or _git_changed_files(repo_root)
+    return {
+        "agent_id": agent_id,
+        "issue_number": issue_number,
+        "issue_title": bundle.get("issue_title", ""),
+        "issue_body": bundle.get("issue_body", ""),
+        "issue_comments": bundle.get("issue_comments", []),
+        "ralph_summary": ralph.get("summary", ""),
+        "changed_files": changed_files,
+        "git_diff": _git_diff(repo_root),
+        "worktree_path": str(repo_root),
+        "repo_root": str(repo_root),
+        "branch": _git_current_branch(repo_root),
+        "plan_acceptance_criteria": plan.get("acceptance_criteria", []) or [],
+        "scope_check": plan.get("scope_check", []) or [],
+    }
+
+
+def _build_fix_ci_input(
+    agent_id: str,
+    issue_number: int,
+    repo_root: Path,
+    github_repo: str,
+) -> dict:
+    """Match DispatcherDaemon._run_fix_ci's fix_ci_input shape."""
+    pr_number = _db_fetch_agent_pr_number(agent_id)
+    retries_used = _db_fetch_agent_retries_used(agent_id)
+    pr_status = _fetch_pr_status(github_repo, pr_number)
+    failing_jobs_raw = _extract_failing_jobs(pr_status)
+    failing_jobs = _enrich_failing_jobs_with_logs(github_repo, failing_jobs_raw)
+    # Prefer the PR's full base-to-head diff so fix-ci sees exactly
+    # what shipped (matches daemon behaviour). Fall back to local
+    # ``git diff`` if gh is unreachable.
+    git_diff = _fetch_pr_diff(github_repo, pr_number) or _git_diff(repo_root)
+    plan = _read_prior_output(repo_root, "plan")
+    branch = _git_current_branch(repo_root)
+    return {
+        "agent_id": agent_id,
+        "issue_number": issue_number,
+        "pr_number": pr_number,
+        "branch": branch,
+        "failing_jobs": failing_jobs,
+        "git_diff_base_to_head": git_diff,
+        "worktree_path": str(repo_root),
+        "repo_root": str(repo_root),
+        "previous_fix_attempts": retries_used,
+        "change_type": plan.get("change_type", "") if isinstance(plan, dict) else "",
+    }
+
+
+def _build_verify_input(
+    agent_id: str,
+    issue_number: int,
+    repo_root: Path,
+    github_repo: str,
+) -> dict:
+    """Match DispatcherDaemon._run_verify_and_complete's verify_input shape."""
+    pr_number = _db_fetch_agent_pr_number(agent_id)
+    merge_info = _fetch_merged_pr_info(github_repo, pr_number)
+    merge_sha = merge_info.get("merge_commit_sha", "")
+    deploy_runs = _fetch_deploy_runs_for_sha(github_repo, merge_sha)
+    deploy_status = _select_deploy_status(deploy_runs)
+    change_type = _infer_change_type(deploy_runs)
+    touched_services = _touched_services_from_runs(deploy_runs)
+    bundle = _fetch_issue_bundle(github_repo, issue_number)
+    # Prefer plan-output's AC list (authoritative at claim time); fall
+    # back to extracting from the issue body via the same regex the
+    # daemon uses. If both are empty the verify skill tolerates that
+    # with a FAILED verdict.
+    plan = _read_prior_output(repo_root, "plan")
+    acceptance_criteria = plan.get("acceptance_criteria") or []
+    if not acceptance_criteria:
+        acceptance_criteria = _extract_acceptance_criteria(bundle.get("issue_body") or "")
+    # deferred_acs lives in summary's persisted output — the daemon
+    # reads it from dispatcher.phase_outputs WHERE phase='summary'. We
+    # do the same via _db_fetch_phase_output, then normalize.
+    summary_persisted = _db_fetch_phase_output(agent_id, "summary")
+    deferred_acs = _normalize_deferred_acs(summary_persisted.get("deferred_acs"))
+    return {
+        "agent_id": agent_id,
+        "issue_number": issue_number,
+        "pr_number": pr_number,
+        "acceptance_criteria": acceptance_criteria,
+        "change_type": change_type,
+        "touched_services": touched_services,
+        "deploy_status": deploy_status,
+        "merged_commit_sha": merge_sha,
+        "worktree_path": str(repo_root),
+        "repo_root": str(repo_root),
+        "plan_text": plan.get("plan_text", "") if isinstance(plan, dict) else "",
+        "scope_check": plan.get("scope_check", []) or [],
+        "deferred_acs": deferred_acs,
+    }
+
+
+def _build_retro_input(
+    agent_id: str,
+    issue_number: int,
+    repo_root: Path,
+) -> dict:
+    """Match DispatcherDaemon._build_retro_input's payload shape."""
+    pr_number = _db_fetch_agent_pr_number(agent_id)
+    phase_transitions = _db_fetch_phase_transitions(agent_id)
+    failures = _db_fetch_failures_grouped(agent_id)
+    # Counters derived from phase_transitions, with floors of 1 for
+    # ralph_iterations + ci_attempts matching the daemon.
+    ralph_iterations = sum(
+        1 for p in phase_transitions if p.get("phase") == "ralph"
+    )
+    ci_attempts = sum(
+        1 for p in phase_transitions if p.get("phase") == "awaiting_ci"
+    )
+    fix_ci_attempts = sum(
+        1 for p in phase_transitions if p.get("phase") == "fix_ci"
+    )
+    if ralph_iterations < 1:
+        ralph_iterations = 1
+    if ci_attempts < 1:
+        ci_attempts = 1
+    total_duration_s = _db_fetch_agent_total_duration_s(agent_id)
+    plan = _read_prior_output(repo_root, "plan")
+    scope_check_followups: list[str] = []
+    plan_follow_ups: list[str] = []
+    if isinstance(plan, dict):
+        scope_raw = plan.get("scope_check_followups") or []
+        if isinstance(scope_raw, list):
+            scope_check_followups = [str(x) for x in scope_raw if x]
+        follow_raw = (
+            plan.get("follow_ups")
+            or plan.get("plan_follow_ups")
+            or []
+        )
+        if isinstance(follow_raw, list):
+            plan_follow_ups = [str(x) for x in follow_raw if x]
+    verify_output = _db_fetch_phase_output(agent_id, "verify")
+    verify_evidence_md = str(verify_output.get("evidence_md") or "")
+    diff_stats = _git_diff_stats(repo_root)
+    return {
+        "agent_id": agent_id,
+        "issue_number": issue_number,
+        "pr_number": pr_number,
+        "phase_transitions": phase_transitions,
+        "failures": failures,
+        "ralph_iterations": ralph_iterations,
+        "ci_attempts": ci_attempts,
+        "fix_ci_attempts": fix_ci_attempts,
+        "total_duration_s": total_duration_s,
+        "diff_stats": diff_stats,
+        "worktree_path": str(repo_root),
+        "repo_root": str(repo_root),
+        "scope_check_followups": scope_check_followups,
+        "plan_follow_ups": plan_follow_ups,
+        "verify_evidence_md": verify_evidence_md,
+    }
+
+
 def _build_input(
     phase: str,
     agent_id: str,
@@ -611,61 +1376,13 @@ def _build_input(
             "dependencies_installed": plan.get("dependencies_to_install", []) or [],
         }
     if phase == "summary":
-        bundle = _fetch_issue_bundle(github_repo, issue_number)
-        plan = _read_prior_output(repo_root, "plan")
-        ralph = _read_prior_output(repo_root, "ralph")
-        changed_files = ralph.get("changed_files") or _git_changed_files(repo_root)
-        return {
-            **base,
-            "issue_title": bundle.get("issue_title", ""),
-            "issue_body": bundle.get("issue_body", ""),
-            "issue_comments": bundle.get("issue_comments", []),
-            "ralph_summary": ralph.get("summary", "") if isinstance(ralph, dict) else "",
-            "changed_files": changed_files,
-            "git_diff": _git_diff(repo_root),
-            "branch": _git_current_branch(repo_root),
-            "plan_acceptance_criteria": plan.get("acceptance_criteria", []) or [],
-            "scope_check": plan.get("scope_check", []) or [],
-        }
+        return _build_summary_input(agent_id, issue_number, repo_root, github_repo)
     if phase == "fix-ci":
-        plan = _read_prior_output(repo_root, "plan")
-        return {
-            **base,
-            "pr_number": 0,
-            "branch": _git_current_branch(repo_root),
-            "failing_jobs": [],
-            "git_diff_base_to_head": _git_diff(repo_root),
-            "previous_fix_attempts": 0,
-            "change_type": plan.get("change_type", "") if isinstance(plan, dict) else "",
-        }
+        return _build_fix_ci_input(agent_id, issue_number, repo_root, github_repo)
     if phase == "verify":
-        plan = _read_prior_output(repo_root, "plan")
-        return {
-            **base,
-            "pr_number": 0,
-            "acceptance_criteria": plan.get("acceptance_criteria", []) or [],
-            "change_type": plan.get("change_type", "") if isinstance(plan, dict) else "",
-            "touched_services": [],
-            "deploy_status": None,
-            "merged_commit_sha": "",
-            "plan_text": plan.get("plan_text", "") if isinstance(plan, dict) else "",
-            "scope_check": plan.get("scope_check", []) or [],
-            "deferred_acs": [],
-        }
+        return _build_verify_input(agent_id, issue_number, repo_root, github_repo)
     if phase == "retro":
-        return {
-            **base,
-            "pr_number": 0,
-            "phase_transitions": [],
-            "failures": [],
-            "ralph_iterations": 0,
-            "ci_attempts": 0,
-            "fix_ci_attempts": 0,
-            "total_duration_s": 0,
-            "diff_stats": {"files_changed": 0, "insertions": 0, "deletions": 0},
-            "scope_check_followups": [],
-            "plan_follow_ups": [],
-        }
+        return _build_retro_input(agent_id, issue_number, repo_root)
     # Unknown phase — return the base shape; skill will BLOCK on
     # missing required fields, which is the correct behaviour.
     return base

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -1425,6 +1425,733 @@ else
     pass "#3133 — output-file path suppresses .result diag when file present"
 fi
 
+# ══════════════════════════════════════════════════════════════════════════
+# Stage 2 (#3135) — summary / fix-ci / verify / retro input parity
+#
+# The Stage 1b shim wrote identifier-only stubs for these four phases;
+# Stage 2 builds the same field set the daemon's ``_handle_phase_*``
+# builders assemble so ECS-mode agents reach the same verdicts as
+# subprocess-mode agents. These tests exercise ``phase_input_shim.py``
+# directly — running the full entrypoint per phase would require
+# stubbing an entire phase-sequence walk, which obscures the actual
+# input-build assertions.
+#
+# Setup: extract the shim file onto disk by running the entrypoint
+# once (in dry-run mode so it stops before the first claude invoke).
+# ══════════════════════════════════════════════════════════════════════════
+
+shim_workspace="$TEST_TMP/shim-workspace"
+mkdir -p "$shim_workspace"
+
+# Run the entrypoint with AGENT_RUNNER_DRY_RUN=1 so it stamps the shim
+# file under $AGENT_WORKSPACE and then short-circuits the phase loop.
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-shim-extract.txt"
+printf 'done\n' > "$PHASE_FIXTURE_FILE"
+set +e
+AGENT_ID="00000000-0000-0000-0000-000000000000" \
+    ISSUE_NUMBER="3135" \
+    DATABASE_URL="postgres://test" \
+    GITHUB_TOKEN="" \
+    AGENT_WORKSPACE="$shim_workspace" \
+    REPO_URL="https://example.invalid/repo.git" \
+    PATH="$STUB_BIN:$PATH" \
+    INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+    PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+    PRIOR_PATCH_FIXTURE="" \
+    CLAUDE_VERDICT_FIXTURE="" \
+    PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+    PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+    AGENT_RUNNER_DRY_RUN=1 \
+    bash "$ENTRYPOINT" >/dev/null 2>&1
+set -e
+
+SHIM_PY="$shim_workspace/phase_input_shim.py"
+if [[ -f "$SHIM_PY" ]]; then
+    pass "#3135 — entrypoint stamps phase_input_shim.py file on disk"
+else
+    fail "#3135 — entrypoint stamps phase_input_shim.py file on disk" \
+         "expected file not found: $SHIM_PY"
+fi
+
+# Extend the gh stub with richer routes for the Stage 2 fetches:
+#   * ``gh issue view <N> --json ...``    → read $GH_ISSUE_FIXTURE
+#   * ``gh pr view <N> --json ...``       → read $GH_PR_FIXTURE
+#   * ``gh pr diff <N>``                  → read $GH_PR_DIFF_FIXTURE
+#   * ``gh run view --log-failed --job``  → read $GH_RUN_LOG_FIXTURE
+#   * ``gh run list --commit <sha>``      → read $GH_RUN_LIST_FIXTURE
+cat > "$STUB_BIN/gh" <<'GHEOF'
+#!/usr/bin/env bash
+set -u
+INVOCATIONS_DIR="${INVOCATIONS_DIR}"
+. "$(dirname "$0")/_record_invocation.sh" gh "$@"
+
+# Parse subcommand chain: ``gh issue view`` or ``gh pr view`` or
+# ``gh run view`` / ``gh run list`` — anything else is a no-op success.
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+    if [[ -n "${GH_ISSUE_FIXTURE:-}" && -f "$GH_ISSUE_FIXTURE" ]]; then
+        cat "$GH_ISSUE_FIXTURE"
+        exit 0
+    fi
+    exit 1
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+    if [[ -n "${GH_PR_FIXTURE:-}" && -f "$GH_PR_FIXTURE" ]]; then
+        cat "$GH_PR_FIXTURE"
+        exit 0
+    fi
+    exit 1
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "diff" ]]; then
+    if [[ -n "${GH_PR_DIFF_FIXTURE:-}" && -f "$GH_PR_DIFF_FIXTURE" ]]; then
+        cat "$GH_PR_DIFF_FIXTURE"
+        exit 0
+    fi
+    exit 1
+fi
+
+if [[ "${1:-}" == "run" && "${2:-}" == "view" ]]; then
+    if [[ -n "${GH_RUN_LOG_FIXTURE:-}" && -f "$GH_RUN_LOG_FIXTURE" ]]; then
+        cat "$GH_RUN_LOG_FIXTURE"
+        exit 0
+    fi
+    exit 1
+fi
+
+if [[ "${1:-}" == "run" && "${2:-}" == "list" ]]; then
+    if [[ -n "${GH_RUN_LIST_FIXTURE:-}" && -f "$GH_RUN_LIST_FIXTURE" ]]; then
+        cat "$GH_RUN_LIST_FIXTURE"
+        exit 0
+    fi
+    exit 1
+fi
+
+# Legacy route kept for push_and_pr tests.
+sub=""
+for arg in "$@"; do
+    if [[ "$sub" == "" && "$arg" != --* && "$arg" != -* ]]; then
+        sub="$arg"
+        continue
+    fi
+    if [[ -n "$sub" && "$sub" == "pr" && "$arg" != --* && "$arg" != -* ]]; then
+        if [[ "$arg" == "create" ]]; then
+            printf 'https://github.com/judgemind/judgemind/pull/9999\n'
+            exit "${GH_PR_CREATE_EXIT:-0}"
+        fi
+    fi
+done
+
+exit 0
+GHEOF
+chmod +x "$STUB_BIN/gh"
+
+# Extend the psql stub with Stage 2 SELECTs on dispatcher.agents,
+# dispatcher.phase_outputs, dispatcher.phase_transitions, and
+# dispatcher.failures. Each new fixture env var is read on-demand so
+# individual tests configure only what they need.
+cat > "$STUB_BIN/psql" <<'PSQLEOF'
+#!/usr/bin/env bash
+set -u
+INVOCATIONS_DIR="${INVOCATIONS_DIR}"
+. "$(dirname "$0")/_record_invocation.sh" psql "$@"
+
+query=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -c)
+            shift
+            query="$1"
+            ;;
+    esac
+    shift || true
+done
+
+case "$query" in
+    *"SELECT phase"*"FROM dispatcher.agents"*)
+        if [[ -f "${PHASE_FIXTURE_FILE:-}" ]]; then
+            head -n 1 "$PHASE_FIXTURE_FILE"
+        fi
+        exit 0
+        ;;
+    *"SELECT COALESCE(pr_number"*"FROM dispatcher.agents"*)
+        printf '%s' "${DB_AGENT_PR_NUMBER:-0}"
+        exit 0
+        ;;
+    *"SELECT COALESCE(retries_used"*"FROM dispatcher.agents"*)
+        printf '%s' "${DB_AGENT_RETRIES_USED:-0}"
+        exit 0
+        ;;
+    *"EXTRACT(EPOCH FROM (now() - started_at))"*"FROM dispatcher.agents"*)
+        printf '%s' "${DB_AGENT_TOTAL_DURATION_S:-0}"
+        exit 0
+        ;;
+    *"SELECT output_json"*"FROM dispatcher.phase_outputs"*)
+        # Route by phase name substring.
+        if [[ "$query" == *"phase = 'summary'"* && -f "${DB_SUMMARY_OUTPUT_FIXTURE:-}" ]]; then
+            cat "$DB_SUMMARY_OUTPUT_FIXTURE"
+        elif [[ "$query" == *"phase = 'verify'"* && -f "${DB_VERIFY_OUTPUT_FIXTURE:-}" ]]; then
+            cat "$DB_VERIFY_OUTPUT_FIXTURE"
+        fi
+        exit 0
+        ;;
+    *"FROM dispatcher.phase_transitions"*)
+        if [[ -f "${DB_PHASE_TRANSITIONS_FIXTURE:-}" ]]; then
+            cat "$DB_PHASE_TRANSITIONS_FIXTURE"
+        fi
+        exit 0
+        ;;
+    *"FROM dispatcher.failures"*)
+        if [[ -f "${DB_FAILURES_FIXTURE:-}" ]]; then
+            cat "$DB_FAILURES_FIXTURE"
+        fi
+        exit 0
+        ;;
+    *"SELECT patch_content"*)
+        if [[ -f "${PRIOR_PATCH_FIXTURE:-}" ]]; then
+            cat "$PRIOR_PATCH_FIXTURE"
+        fi
+        exit 0
+        ;;
+    *"UPDATE dispatcher.agents"*"SET phase ="*)
+        new_phase=$(printf '%s' "$query" | sed -n "s/.*SET phase = '\\([^']*\\)'.*/\\1/p")
+        if [[ -n "$new_phase" && -f "${PHASE_FIXTURE_FILE:-}" ]]; then
+            printf '%s\n' "$new_phase" > "$PHASE_FIXTURE_FILE"
+        fi
+        exit 0
+        ;;
+    *"UPDATE dispatcher.agents"*"SET ended_at"*)
+        exit 0
+        ;;
+    *"INSERT INTO dispatcher.phase_outputs"*)
+        exit 0
+        ;;
+    *"INSERT INTO dispatcher.ralph_patches"*)
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+PSQLEOF
+chmod +x "$STUB_BIN/psql"
+
+# Helper: invoke the shim directly and print the JSON payload path.
+run_shim() {
+    # $1 phase, $2 agent_id, $3 issue_number, $4 repo_root
+    local rc
+    set +e
+    python3 "$SHIM_PY" "$1" "$2" "$3" "$4" >/dev/null 2>&1
+    rc=$?
+    set -e
+    return $rc
+}
+
+# ── Test 17: summary input parity (AC-1 of #3135) ─────────────────────────
+setup_fixtures
+
+t17_repo="$TEST_TMP/t17-repo"
+mkdir -p "$t17_repo/.git" "$t17_repo/tmp/dispatcher-output"
+
+# Stage ralph output so the shim reads ralph_summary + changed_files.
+cat > "$t17_repo/tmp/dispatcher-output/ralph.json" <<'EOF'
+{
+  "agent_id": "17171717-1717-1717-1717-171717171717",
+  "verdict": "SHIP",
+  "summary": "Extended phase_input_shim with per-phase builders",
+  "changed_files": ["scripts/dispatcher/agent-runner-entrypoint.sh", "scripts/tests/test_agent_runner_entrypoint.sh"]
+}
+EOF
+
+cat > "$t17_repo/tmp/dispatcher-output/plan.json" <<'EOF'
+{
+  "agent_id": "17171717-1717-1717-1717-171717171717",
+  "acceptance_criteria": ["summary parity", "fix-ci parity", "verify parity", "retro parity"],
+  "scope_check": ["no daemon changes"],
+  "change_type": "dx_tooling",
+  "plan_text": "fixture plan body"
+}
+EOF
+
+GH_ISSUE_FIXTURE="$TEST_TMP/t17-issue.json"
+cat > "$GH_ISSUE_FIXTURE" <<'EOF'
+{
+  "number": 3135,
+  "title": "feat(agent-runner): Stage 2 input parity",
+  "body": "Body with AC.\n\n- [ ] summary parity\n- [ ] fix-ci parity",
+  "labels": [{"name": "area/infra"}],
+  "comments": [
+    {"author": {"login": "drewthaler"}, "authorAssociation": "COLLABORATOR", "createdAt": "2026-04-23T00:00:00Z", "body": "human comment"},
+    {"author": {"login": "github-actions[bot]"}, "authorAssociation": "NONE", "createdAt": "2026-04-23T00:00:00Z", "body": "bot comment"}
+  ],
+  "updatedAt": "2026-04-23T23:50:00Z"
+}
+EOF
+
+set +e
+DATABASE_URL="postgres://test" \
+    GITHUB_REPO="judgemind/judgemind" \
+    PATH="$STUB_BIN:$PATH" \
+    INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+    GH_ISSUE_FIXTURE="$GH_ISSUE_FIXTURE" \
+    python3 "$SHIM_PY" summary "17171717-1717-1717-1717-171717171717" 3135 "$t17_repo" \
+    >/dev/null 2>&1
+t17_rc=$?
+set -e
+
+t17_input="$t17_repo/tmp/dispatcher-input/summary.json"
+
+if [[ $t17_rc -eq 0 && -f "$t17_input" ]]; then
+    pass "#3135 AC-1 — summary shim writes dispatcher-input/summary.json"
+else
+    fail "#3135 AC-1 — summary shim writes dispatcher-input/summary.json" \
+         "rc=$t17_rc, path=$t17_input"
+fi
+
+for field in agent_id issue_number issue_title issue_body issue_comments \
+             ralph_summary changed_files git_diff branch \
+             plan_acceptance_criteria scope_check worktree_path repo_root; do
+    if jq -e "has(\"$field\")" "$t17_input" >/dev/null 2>&1; then
+        pass "#3135 AC-1 — summary.json carries $field"
+    else
+        fail "#3135 AC-1 — summary.json carries $field" \
+             "content: $(cat "$t17_input" 2>/dev/null)"
+    fi
+done
+
+if jq -e '.ralph_summary == "Extended phase_input_shim with per-phase builders"' \
+     "$t17_input" >/dev/null 2>&1; then
+    pass "#3135 AC-1 — ralph_summary is read from ralph.json"
+else
+    fail "#3135 AC-1 — ralph_summary is read from ralph.json"
+fi
+
+if jq -e '.issue_title == "feat(agent-runner): Stage 2 input parity"' \
+     "$t17_input" >/dev/null 2>&1; then
+    pass "#3135 AC-1 — issue_title is refetched via gh issue view"
+else
+    fail "#3135 AC-1 — issue_title is refetched via gh issue view"
+fi
+
+if jq -e '.issue_comments | length == 1 and .[0].author == "drewthaler"' \
+     "$t17_input" >/dev/null 2>&1; then
+    pass "#3135 AC-1 — issue_comments excludes bot comments"
+else
+    fail "#3135 AC-1 — issue_comments excludes bot comments" \
+         "content: $(jq '.issue_comments' "$t17_input" 2>/dev/null)"
+fi
+
+if jq -e '.plan_acceptance_criteria | length == 4' "$t17_input" >/dev/null 2>&1; then
+    pass "#3135 AC-1 — plan_acceptance_criteria pulled from plan output"
+else
+    fail "#3135 AC-1 — plan_acceptance_criteria pulled from plan output"
+fi
+
+if jq -e '.changed_files | contains(["scripts/dispatcher/agent-runner-entrypoint.sh"])' \
+     "$t17_input" >/dev/null 2>&1; then
+    pass "#3135 AC-1 — changed_files preferred from ralph output"
+else
+    fail "#3135 AC-1 — changed_files preferred from ralph output"
+fi
+
+# ── Test 18: fix-ci input parity (AC-2 of #3135) ──────────────────────────
+setup_fixtures
+
+t18_repo="$TEST_TMP/t18-repo"
+mkdir -p "$t18_repo/.git" "$t18_repo/tmp/dispatcher-output"
+
+cat > "$t18_repo/tmp/dispatcher-output/plan.json" <<'EOF'
+{"agent_id": "18181818-1818-1818-1818-181818181818", "change_type": "api"}
+EOF
+
+GH_PR_FIXTURE="$TEST_TMP/t18-pr.json"
+cat > "$GH_PR_FIXTURE" <<'EOF'
+{
+  "statusCheckRollup": [
+    {"name": "CI / python-tests", "status": "COMPLETED", "conclusion": "FAILURE", "databaseId": 9001, "detailsUrl": "https://github.com/judgemind/judgemind/actions/runs/9001"},
+    {"name": "CI / lint", "status": "COMPLETED", "conclusion": "SUCCESS", "databaseId": 9002}
+  ],
+  "mergeable": "MERGEABLE",
+  "mergeStateStatus": "CLEAN",
+  "headRefOid": "deadbeef",
+  "mergeCommit": null
+}
+EOF
+
+GH_PR_DIFF_FIXTURE="$TEST_TMP/t18-pr-diff.patch"
+cat > "$GH_PR_DIFF_FIXTURE" <<'EOF'
+diff --git a/foo.py b/foo.py
+index 111..222 100644
+--- a/foo.py
++++ b/foo.py
+@@ -1 +1,2 @@
+ def f(): return 1
++# new line
+EOF
+
+GH_RUN_LOG_FIXTURE="$TEST_TMP/t18-run-log.txt"
+cat > "$GH_RUN_LOG_FIXTURE" <<'EOF'
+FAIL tests/test_foo.py::test_bar
+AssertionError: expected 2, got 1
+EOF
+
+set +e
+DATABASE_URL="postgres://test" \
+    GITHUB_REPO="judgemind/judgemind" \
+    PATH="$STUB_BIN:$PATH" \
+    INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+    GH_PR_FIXTURE="$GH_PR_FIXTURE" \
+    GH_PR_DIFF_FIXTURE="$GH_PR_DIFF_FIXTURE" \
+    GH_RUN_LOG_FIXTURE="$GH_RUN_LOG_FIXTURE" \
+    DB_AGENT_PR_NUMBER="4242" \
+    DB_AGENT_RETRIES_USED="2" \
+    python3 "$SHIM_PY" fix-ci "18181818-1818-1818-1818-181818181818" 3135 "$t18_repo" \
+    >/dev/null 2>&1
+t18_rc=$?
+set -e
+
+t18_input="$t18_repo/tmp/dispatcher-input/fix-ci.json"
+if [[ $t18_rc -eq 0 && -f "$t18_input" ]]; then
+    pass "#3135 AC-2 — fix-ci shim writes dispatcher-input/fix-ci.json"
+else
+    fail "#3135 AC-2 — fix-ci shim writes dispatcher-input/fix-ci.json" \
+         "rc=$t18_rc, path=$t18_input"
+fi
+
+if jq -e '.pr_number == 4242' "$t18_input" >/dev/null 2>&1; then
+    pass "#3135 AC-2 — pr_number read from dispatcher.agents"
+else
+    fail "#3135 AC-2 — pr_number read from dispatcher.agents" \
+         "content: $(cat "$t18_input" 2>/dev/null)"
+fi
+
+if jq -e '.previous_fix_attempts == 2' "$t18_input" >/dev/null 2>&1; then
+    pass "#3135 AC-2 — previous_fix_attempts read from dispatcher.agents.retries_used"
+else
+    fail "#3135 AC-2 — previous_fix_attempts read from dispatcher.agents.retries_used"
+fi
+
+if jq -e '.failing_jobs | length == 1' "$t18_input" >/dev/null 2>&1; then
+    pass "#3135 AC-2 — failing_jobs filters to FAILURE conclusion"
+else
+    fail "#3135 AC-2 — failing_jobs filters to FAILURE conclusion" \
+         "content: $(jq '.failing_jobs' "$t18_input" 2>/dev/null)"
+fi
+
+if jq -e '.failing_jobs[0].name == "CI / python-tests"' "$t18_input" >/dev/null 2>&1; then
+    pass "#3135 AC-2 — failing_jobs carries job name"
+else
+    fail "#3135 AC-2 — failing_jobs carries job name"
+fi
+
+if jq -e '.failing_jobs[0].log_tail | contains("FAIL tests/test_foo.py")' \
+     "$t18_input" >/dev/null 2>&1; then
+    pass "#3135 AC-2 — failing_jobs[*].log_tail fetched via gh run view --log-failed"
+else
+    fail "#3135 AC-2 — failing_jobs[*].log_tail fetched via gh run view --log-failed" \
+         "content: $(jq '.failing_jobs' "$t18_input" 2>/dev/null)"
+fi
+
+if jq -e '.git_diff_base_to_head | contains("def f(): return 1")' \
+     "$t18_input" >/dev/null 2>&1; then
+    pass "#3135 AC-2 — git_diff_base_to_head read via gh pr diff"
+else
+    fail "#3135 AC-2 — git_diff_base_to_head read via gh pr diff" \
+         "content: $(jq -r '.git_diff_base_to_head' "$t18_input" 2>/dev/null | head -c 200)"
+fi
+
+if jq -e '.change_type == "api"' "$t18_input" >/dev/null 2>&1; then
+    pass "#3135 AC-2 — change_type forwarded from plan output"
+else
+    fail "#3135 AC-2 — change_type forwarded from plan output"
+fi
+
+# Verify gh run view was called with --log-failed and --job.
+if grep -F -- "--log-failed" "$INVOCATIONS_DIR/gh.log" >/dev/null 2>&1 \
+   && grep -F -- "--job" "$INVOCATIONS_DIR/gh.log" >/dev/null 2>&1; then
+    pass "#3135 AC-2 — shim invokes gh run view --log-failed --job"
+else
+    fail "#3135 AC-2 — shim invokes gh run view --log-failed --job" \
+         "gh log: $(cat "$INVOCATIONS_DIR/gh.log")"
+fi
+
+# ── Test 19: verify input parity (AC-3 of #3135) ──────────────────────────
+setup_fixtures
+
+t19_repo="$TEST_TMP/t19-repo"
+mkdir -p "$t19_repo/.git" "$t19_repo/tmp/dispatcher-output"
+
+cat > "$t19_repo/tmp/dispatcher-output/plan.json" <<'EOF'
+{
+  "agent_id": "19191919-1919-1919-1919-191919191919",
+  "acceptance_criteria": ["AC from plan"],
+  "scope_check": ["scope_check entry"],
+  "change_type": "api",
+  "plan_text": "plan body text"
+}
+EOF
+
+# gh issue view returns the issue bundle (used as fallback for AC).
+GH_ISSUE_FIXTURE="$TEST_TMP/t19-issue.json"
+cat > "$GH_ISSUE_FIXTURE" <<'EOF'
+{
+  "number": 3135,
+  "title": "feat(agent-runner)",
+  "body": "Body\n\n- [ ] AC from issue body\n",
+  "labels": [],
+  "comments": [],
+  "updatedAt": "2026-04-23T00:00:00Z"
+}
+EOF
+
+# gh pr view for the merged PR (mergeCommit.oid).
+GH_PR_FIXTURE="$TEST_TMP/t19-pr.json"
+cat > "$GH_PR_FIXTURE" <<'EOF'
+{
+  "state": "MERGED",
+  "mergeCommit": {"oid": "abc123def456"},
+  "headRefOid": "deadbeef"
+}
+EOF
+
+# gh run list returns the deploy runs for the merge SHA.
+GH_RUN_LIST_FIXTURE="$TEST_TMP/t19-run-list.json"
+cat > "$GH_RUN_LIST_FIXTURE" <<'EOF'
+[
+  {"databaseId": 7001, "workflowName": "Deploy Dispatcher", "conclusion": "success", "status": "completed", "headSha": "abc123def456"},
+  {"databaseId": 7002, "workflowName": "CI", "conclusion": "success", "status": "completed", "headSha": "abc123def456"}
+]
+EOF
+
+# Summary's persisted phase_output carries deferred_acs.
+DB_SUMMARY_OUTPUT_FIXTURE="$TEST_TMP/t19-summary-output.json"
+cat > "$DB_SUMMARY_OUTPUT_FIXTURE" <<'EOF'
+{"deferred_acs": [{"index": 3, "reason": "marker", "verify_instruction": "Verify: curl dev"}]}
+EOF
+
+set +e
+DATABASE_URL="postgres://test" \
+    GITHUB_REPO="judgemind/judgemind" \
+    PATH="$STUB_BIN:$PATH" \
+    INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+    GH_ISSUE_FIXTURE="$GH_ISSUE_FIXTURE" \
+    GH_PR_FIXTURE="$GH_PR_FIXTURE" \
+    GH_RUN_LIST_FIXTURE="$GH_RUN_LIST_FIXTURE" \
+    DB_AGENT_PR_NUMBER="5050" \
+    DB_SUMMARY_OUTPUT_FIXTURE="$DB_SUMMARY_OUTPUT_FIXTURE" \
+    python3 "$SHIM_PY" verify "19191919-1919-1919-1919-191919191919" 3135 "$t19_repo" \
+    >/dev/null 2>&1
+t19_rc=$?
+set -e
+
+t19_input="$t19_repo/tmp/dispatcher-input/verify.json"
+if [[ $t19_rc -eq 0 && -f "$t19_input" ]]; then
+    pass "#3135 AC-3 — verify shim writes dispatcher-input/verify.json"
+else
+    fail "#3135 AC-3 — verify shim writes dispatcher-input/verify.json" \
+         "rc=$t19_rc, path=$t19_input"
+fi
+
+if jq -e '.pr_number == 5050' "$t19_input" >/dev/null 2>&1; then
+    pass "#3135 AC-3 — pr_number read from dispatcher.agents"
+else
+    fail "#3135 AC-3 — pr_number read from dispatcher.agents"
+fi
+
+if jq -e '.merged_commit_sha == "abc123def456"' "$t19_input" >/dev/null 2>&1; then
+    pass "#3135 AC-3 — merged_commit_sha read via gh pr view --json mergeCommit"
+else
+    fail "#3135 AC-3 — merged_commit_sha read via gh pr view --json mergeCommit" \
+         "content: $(cat "$t19_input" 2>/dev/null)"
+fi
+
+if jq -e '.deploy_status.workflow_name == "Deploy Dispatcher"' \
+     "$t19_input" >/dev/null 2>&1; then
+    pass "#3135 AC-3 — deploy_status derived from gh run list"
+else
+    fail "#3135 AC-3 — deploy_status derived from gh run list" \
+         "content: $(jq '.deploy_status' "$t19_input" 2>/dev/null)"
+fi
+
+if jq -e '.touched_services | contains(["judgemind-dispatcher-dev"])' \
+     "$t19_input" >/dev/null 2>&1; then
+    pass "#3135 AC-3 — touched_services derived from deploy workflow names"
+else
+    fail "#3135 AC-3 — touched_services derived from deploy workflow names"
+fi
+
+if jq -e '.change_type == "dx_tooling"' "$t19_input" >/dev/null 2>&1; then
+    pass "#3135 AC-3 — change_type inferred from deploy workflow"
+else
+    fail "#3135 AC-3 — change_type inferred from deploy workflow" \
+         "value: $(jq -r '.change_type' "$t19_input" 2>/dev/null)"
+fi
+
+if jq -e '.deferred_acs | length == 1 and .[0].index == 3' \
+     "$t19_input" >/dev/null 2>&1; then
+    pass "#3135 AC-3 — deferred_acs read from summary's persisted phase_output"
+else
+    fail "#3135 AC-3 — deferred_acs read from summary's persisted phase_output" \
+         "content: $(jq '.deferred_acs' "$t19_input" 2>/dev/null)"
+fi
+
+if jq -e '.acceptance_criteria | contains(["AC from plan"])' \
+     "$t19_input" >/dev/null 2>&1; then
+    pass "#3135 AC-3 — acceptance_criteria preferred from plan output"
+else
+    fail "#3135 AC-3 — acceptance_criteria preferred from plan output"
+fi
+
+# ── Test 20: retro input parity (AC-4 of #3135) ───────────────────────────
+setup_fixtures
+
+t20_repo="$TEST_TMP/t20-repo"
+mkdir -p "$t20_repo/.git" "$t20_repo/tmp/dispatcher-output"
+
+cat > "$t20_repo/tmp/dispatcher-output/plan.json" <<'EOF'
+{
+  "agent_id": "20202020-2020-2020-2020-202020202020",
+  "scope_check_followups": ["scope item 1"],
+  "follow_ups": ["follow-up A"]
+}
+EOF
+
+# phase_transitions rows — two ralph, one awaiting_ci, one fix_ci.
+DB_PHASE_TRANSITIONS_FIXTURE="$TEST_TMP/t20-phase-transitions.tsv"
+printf 'planning\t2026-04-23T00:00:00Z\n' > "$DB_PHASE_TRANSITIONS_FIXTURE"
+printf 'ralph\t2026-04-23T00:05:00Z\n' >> "$DB_PHASE_TRANSITIONS_FIXTURE"
+printf 'ralph\t2026-04-23T00:10:00Z\n' >> "$DB_PHASE_TRANSITIONS_FIXTURE"
+printf 'awaiting_ci\t2026-04-23T00:15:00Z\n' >> "$DB_PHASE_TRANSITIONS_FIXTURE"
+printf 'fix_ci\t2026-04-23T00:20:00Z\n' >> "$DB_PHASE_TRANSITIONS_FIXTURE"
+
+DB_FAILURES_FIXTURE="$TEST_TMP/t20-failures.tsv"
+printf 'ci_red_after_retries\t2\t2026-04-23T00:15:00Z\t2026-04-23T00:20:00Z\n' > "$DB_FAILURES_FIXTURE"
+
+DB_VERIFY_OUTPUT_FIXTURE="$TEST_TMP/t20-verify-output.json"
+cat > "$DB_VERIFY_OUTPUT_FIXTURE" <<'EOF'
+{"evidence_md": "## Verification evidence\n\nAll ACs pass."}
+EOF
+
+set +e
+DATABASE_URL="postgres://test" \
+    GITHUB_REPO="judgemind/judgemind" \
+    PATH="$STUB_BIN:$PATH" \
+    INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+    DB_AGENT_PR_NUMBER="6060" \
+    DB_AGENT_TOTAL_DURATION_S="1800" \
+    DB_PHASE_TRANSITIONS_FIXTURE="$DB_PHASE_TRANSITIONS_FIXTURE" \
+    DB_FAILURES_FIXTURE="$DB_FAILURES_FIXTURE" \
+    DB_VERIFY_OUTPUT_FIXTURE="$DB_VERIFY_OUTPUT_FIXTURE" \
+    python3 "$SHIM_PY" retro "20202020-2020-2020-2020-202020202020" 3135 "$t20_repo" \
+    >/dev/null 2>&1
+t20_rc=$?
+set -e
+
+t20_input="$t20_repo/tmp/dispatcher-input/retro.json"
+if [[ $t20_rc -eq 0 && -f "$t20_input" ]]; then
+    pass "#3135 AC-4 — retro shim writes dispatcher-input/retro.json"
+else
+    fail "#3135 AC-4 — retro shim writes dispatcher-input/retro.json" \
+         "rc=$t20_rc, path=$t20_input"
+fi
+
+if jq -e '.phase_transitions | length == 5' "$t20_input" >/dev/null 2>&1; then
+    pass "#3135 AC-4 — phase_transitions read from dispatcher.phase_transitions"
+else
+    fail "#3135 AC-4 — phase_transitions read from dispatcher.phase_transitions" \
+         "content: $(jq '.phase_transitions' "$t20_input" 2>/dev/null)"
+fi
+
+if jq -e '.ralph_iterations == 2' "$t20_input" >/dev/null 2>&1; then
+    pass "#3135 AC-4 — ralph_iterations derived from phase_transitions count"
+else
+    fail "#3135 AC-4 — ralph_iterations derived from phase_transitions count" \
+         "value: $(jq -r '.ralph_iterations' "$t20_input" 2>/dev/null)"
+fi
+
+if jq -e '.ci_attempts == 1 and .fix_ci_attempts == 1' "$t20_input" >/dev/null 2>&1; then
+    pass "#3135 AC-4 — ci_attempts and fix_ci_attempts counted from transitions"
+else
+    fail "#3135 AC-4 — ci_attempts and fix_ci_attempts counted from transitions"
+fi
+
+if jq -e '.failures | length == 1 and .[0].category == "ci_red_after_retries" and .[0].count == 2' \
+     "$t20_input" >/dev/null 2>&1; then
+    pass "#3135 AC-4 — failures read from dispatcher.failures grouped"
+else
+    fail "#3135 AC-4 — failures read from dispatcher.failures grouped" \
+         "content: $(jq '.failures' "$t20_input" 2>/dev/null)"
+fi
+
+if jq -e '.total_duration_s == 1800' "$t20_input" >/dev/null 2>&1; then
+    pass "#3135 AC-4 — total_duration_s read via EXTRACT(EPOCH FROM ...)"
+else
+    fail "#3135 AC-4 — total_duration_s read via EXTRACT(EPOCH FROM ...)"
+fi
+
+if jq -e '.pr_number == 6060' "$t20_input" >/dev/null 2>&1; then
+    pass "#3135 AC-4 — pr_number read from dispatcher.agents"
+else
+    fail "#3135 AC-4 — pr_number read from dispatcher.agents"
+fi
+
+if jq -e '.scope_check_followups | contains(["scope item 1"])' "$t20_input" >/dev/null 2>&1; then
+    pass "#3135 AC-4 — scope_check_followups pulled from plan output"
+else
+    fail "#3135 AC-4 — scope_check_followups pulled from plan output"
+fi
+
+if jq -e '.plan_follow_ups | contains(["follow-up A"])' "$t20_input" >/dev/null 2>&1; then
+    pass "#3135 AC-4 — plan_follow_ups pulled from plan output"
+else
+    fail "#3135 AC-4 — plan_follow_ups pulled from plan output"
+fi
+
+if jq -e '.verify_evidence_md | contains("Verification evidence")' \
+     "$t20_input" >/dev/null 2>&1; then
+    pass "#3135 AC-4 — verify_evidence_md read from phase_outputs"
+else
+    fail "#3135 AC-4 — verify_evidence_md read from phase_outputs"
+fi
+
+for field in diff_stats; do
+    if jq -e "has(\"$field\")" "$t20_input" >/dev/null 2>&1; then
+        pass "#3135 AC-4 — retro.json carries $field"
+    else
+        fail "#3135 AC-4 — retro.json carries $field"
+    fi
+done
+
+# ── Test 21: fallback cleanliness (unknown phase returns base) ────────────
+setup_fixtures
+
+t21_repo="$TEST_TMP/t21-repo"
+mkdir -p "$t21_repo/.git"
+
+set +e
+DATABASE_URL="postgres://test" \
+    GITHUB_REPO="judgemind/judgemind" \
+    PATH="$STUB_BIN:$PATH" \
+    INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+    python3 "$SHIM_PY" bogus "21212121-2121-2121-2121-212121212121" 3135 "$t21_repo" \
+    >/dev/null 2>&1
+t21_rc=$?
+set -e
+
+t21_input="$t21_repo/tmp/dispatcher-input/bogus.json"
+if [[ $t21_rc -eq 0 && -f "$t21_input" ]]; then
+    pass "#3135 — unknown phase falls back to base identifiers (no crash)"
+else
+    fail "#3135 — unknown phase falls back to base identifiers (no crash)" \
+         "rc=$t21_rc"
+fi
+
+if jq -e '.agent_id == "21212121-2121-2121-2121-212121212121"' "$t21_input" >/dev/null 2>&1; then
+    pass "#3135 — unknown-phase fallback carries agent_id"
+else
+    fail "#3135 — unknown-phase fallback carries agent_id"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Stage 2 of the per-agent ECS migration (parent #3086). Extends the `phase_input_shim.py` embedded in `scripts/dispatcher/agent-runner-entrypoint.sh` so every claude-driven phase (`summary`, `fix-ci`, `verify`, `retro`) receives the same input shape the daemon's subprocess path writes via `_handle_phase_*`. ECS-mode agents can now reach the same verdicts as subprocess-mode agents — the final substantive piece of Option A.

- **summary** — `ralph_summary` + `git_diff` + `branch` + plan-derived `plan_acceptance_criteria` / `scope_check` + refetched issue bundle via `gh issue view`.
- **fix-ci** — `pr_number` + `retries_used` from `dispatcher.agents`; failing jobs from `gh pr view --json statusCheckRollup`, each enriched with `log_tail` via `gh run view --log-failed --job`; `git_diff_base_to_head` from `gh pr diff`.
- **verify** — `merged_commit_sha` from `gh pr view --json mergeCommit`; `deploy_status` + `change_type` + `touched_services` from `gh run list --commit <sha>` filtered to the merge SHA; `deferred_acs` from summary's persisted `dispatcher.phase_outputs` row.
- **retro** — `phase_transitions` + `failures` from their respective tables; `ralph_iterations`/`ci_attempts`/`fix_ci_attempts` counters derived from transitions; `total_duration_s` via `EXTRACT(EPOCH FROM now() - started_at)`; `diff_stats` via `git diff --shortstat`; `verify_evidence_md` from verify's persisted phase_output.

Every `gh` / `psql` read is best-effort — a missing row / 404 / auth failure returns an empty / zero / null value so each skill's own input-guard still produces a structured `BLOCKED` / `FAILED` verdict rather than an `AttributeError`.

**Scope guardrails:**
- No changes to `daemon.py` — the subprocess path is correct.
- No changes to `.claude/skills/task-v2-*/SKILL.md` — each skill's input contract is the source of truth; the shim matches it.

## Test plan

- [x] `scripts/tests/test_agent_runner_entrypoint.sh` — 108/108 pass. Fifty new assertions cover AC-1 through AC-4 directly against the shim with gh/psql/git stubs. Stage 1b happy-path + dry-run paths regression-pass unchanged.
- [x] `scripts/check-bash-compat.sh` — 121 shell scripts scanned, all clean (bash 3.2 compatibility preserved).
- [x] `shellcheck scripts/dispatcher/agent-runner-entrypoint.sh` — clean.
- [ ] Post-merge AC-4 smoke (operator): flip `dispatcher.config.agent_execution_mode` back to `'ecs'`, let the daemon claim a real issue, observe the full pipeline: planning → ralph → summary → push_and_pr → awaiting_ci → merge → verify → retro. Verification evidence comment lands on #3135 after that smoke.

Closes #3135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
