### PR TITLE
feat(infra): size agent-runner to subprocess envelope (4 vCPU / 16 GiB) (#3153)

### DIFF
--- a/docs/specs/dispatcher-v2-spec.md
+++ b/docs/specs/dispatcher-v2-spec.md
@@ -278,6 +278,10 @@ Skills read from the input file and write to the output file; neither should dep
 - `scripts/dispatcher/agent-runner-entrypoint.sh` is explicitly `!`-excluded from `deploy-dispatcher.yml` paths so entrypoint changes don't force a daemon redeploy.
 - `infra/terraform/modules/dispatcher-agent-runner/` defines the task-def, IAM role, security group, log group, and ECR repo. Auto-applied on merge by `.github/workflows/terraform.yml`'s `dev-apply` job (#3107).
 
+#### Sizing
+
+Agent-runner sizing matches the subprocess-daemon envelope (4 vCPU / 16 GiB) while subprocess mode remains the default. Can shrink once subprocess is retired and the dispatcher daemon scales down correspondingly. The initial Stage 1b baseline (512 CPU / 1024 MB) pegged memory at 1022/1024 MB for hours and saturated CPU at 509/512 in bursts under real ralph workload (#3153).
+
 #### Debugging a live ECS agent
 
 When an agent-runner task is stuck or behaving unexpectedly and CloudWatch tail doesn't reveal enough, an operator can shell into the running container via ECS Exec (#3145). Prerequisites (all wired in terraform + daemon):

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -341,10 +341,14 @@ module "dispatcher_agent_runner" {
   private_subnet_ids = module.networking.private_subnet_ids
   ecr_repository_url = module.ecr.dispatcher_agent_runner_repository_url
 
-  # Stage 1b baseline: 0.5 vCPU / 1 GiB. Bump (along with task_memory) if
-  # Stage 3 smoke shows the ralph workload needs more headroom.
-  task_cpu    = 512
-  task_memory = 1024
+  # Sized to match the subprocess-daemon envelope (4 vCPU / 16 GiB) — the
+  # envelope ralph was designed against. The Stage 1b baseline (512 / 1024)
+  # pegged memory at 1022/1024 MB for hours under real ralph workload and
+  # CPU-saturated at 509/512 in bursts (see #3153 evidence). Can shrink once
+  # subprocess mode is retired and the dispatcher daemon scales down
+  # correspondingly.
+  task_cpu    = 4096
+  task_memory = 16384
 
   # Secret wiring — same ARNs the daemon uses.
   anthropic_api_key_secret_arn = data.aws_secretsmanager_secret.anthropic_api_key.arn

--- a/infra/terraform/modules/dispatcher-agent-runner/main.tf
+++ b/infra/terraform/modules/dispatcher-agent-runner/main.tf
@@ -21,8 +21,11 @@
 # - Security group (outbound HTTPS + Postgres, same egress profile as
 #   the daemon so GitHub / Anthropic / Postgres all reach from inside).
 # - ECS task definition ``judgemind-dispatcher-agent-runner-<env>``
-#   wired at CPU=512 / memory=1024 per #3090's Stage 1b baseline. The
-#   issue note allows a bump to 1024 / 2048 if Stage 3 smoke says so.
+#   wired at CPU=4096 / memory=16384 to match the subprocess-daemon
+#   envelope — the sizing ralph was designed against. The initial
+#   Stage 1b baseline (512 / 1024) pegged memory at 1022/1024 MB and
+#   CPU at 509/512 under real ralph workload (#3153); can shrink once
+#   subprocess mode is retired.
 #
 # The security group ID + task-def family are exported so the daemon
 # (Stage 2) can reference them without re-declaring ARNs in the
@@ -248,9 +251,11 @@ resource "aws_iam_role_policy" "task_ecs_exec_ssm" {
 
 # ─── ECS Task Definition ───────────────────────────────────────────────────
 #
-# CPU / memory: 512 / 1024 per #3090 Stage 1b baseline. Can be bumped
-# to 1024 / 2048 in a followup if smoke shows the ralph workload needs
-# more headroom (Fargate CPU/RAM pairing: 512 pairs with 1024-4096).
+# CPU / memory: 4096 / 16384 to match the subprocess-daemon envelope —
+# the sizing ralph was designed against. Earlier Stage 1b baseline
+# (512 / 1024) saturated CPU at 509/512 and memory at 1022/1024 MB under
+# real ralph workload (#3153). Can shrink once subprocess mode is retired
+# and the dispatcher daemon scales down correspondingly.
 #
 # stopTimeout: ECS/Fargate caps stopTimeout at 120 seconds. The #3090
 # issue text mentions "4h" but that's the expected agent lifetime, not

--- a/infra/terraform/modules/dispatcher-agent-runner/variables.tf
+++ b/infra/terraform/modules/dispatcher-agent-runner/variables.tf
@@ -30,15 +30,15 @@ variable "image_tag" {
 }
 
 variable "task_cpu" {
-  description = "CPU units for the Fargate task (256 = 0.25 vCPU, 512 = 0.5 vCPU, 1024 = 1 vCPU). Stage 1b baseline is 512; bump to 1024 if smoke says the ralph workload needs more."
+  description = "CPU units for the Fargate task (256 = 0.25 vCPU, 512 = 0.5 vCPU, 1024 = 1 vCPU, 4096 = 4 vCPU). Default is 4096 to match the subprocess-daemon envelope — ralph workload under the 512-baseline saturated CPU at 509/512 for extended bursts (#3153)."
   type        = number
-  default     = 512
+  default     = 4096
 }
 
 variable "task_memory" {
-  description = "Memory (MiB) for the Fargate task. Stage 1b baseline is 1024; bump to 2048 alongside a task_cpu bump."
+  description = "Memory (MiB) for the Fargate task. Default is 16384 (16 GiB) to match the subprocess-daemon envelope — ralph pegged memory at 1022/1024 MB for hours under the 1024-baseline (#3153). Fargate valid pair: 4096 CPU / 16384 MB."
   type        = number
-  default     = 1024
+  default     = 16384
 }
 
 variable "ephemeral_storage_gib" {


### PR DESCRIPTION
## Summary

Raise `judgemind-dispatcher-agent-runner-dev` task-def from **512 CPU / 1024 MB** to **4096 CPU / 16384 MB** to match the subprocess-daemon envelope — the sizing ralph was designed against.

## Why

Real ralph workload at the Stage 1b baseline (see #3153 body, agent `6e79fb52` on #2671, ~2h window):

- **Memory:** pegged at 1022–1023/1024 MB for 90+ minutes after ralph starts. Brief drops to 750–900 MB only when a subprocess (git, review) completes.
- **CPU:** saturated at 509/512 in extended bursts during ralph. Still 200–275 between bursts (background threads).

Net effect: ECS-mode ralph runs 2–3× slower than the equivalent subprocess-mode ralph. That blocks confident Phase 4 `cap>1` rollout on ECS mode.

Fargate valid pair: `4096 CPU / 16384 MB` = 4 vCPU / 16 GiB. Matches the dispatcher daemon subprocess task exactly.

## Changes

- `infra/terraform/environments/dev/main.tf` — `dispatcher_agent_runner` module call: `task_cpu = 512 → 4096`, `task_memory = 1024 → 16384`.
- `infra/terraform/modules/dispatcher-agent-runner/variables.tf` — bump the `task_cpu` / `task_memory` defaults to match, update descriptions.
- `infra/terraform/modules/dispatcher-agent-runner/main.tf` — refresh the header + task-def rationale comments.
- `docs/specs/dispatcher-v2-spec.md` §6c — new `#### Sizing` paragraph noting the match-the-subprocess-envelope rule and the shrink condition.

## Terraform plan (local)

```
Plan: 1 to add, 1 to change, 1 to destroy.

# module.dispatcher_agent_runner.aws_ecs_task_definition.agent_runner must be replaced
~ cpu     = "512"  -> "4096"  # forces replacement
~ memory  = "1024" -> "16384" # forces replacement
```

No IAM, networking, log-group, or security-group changes on the agent-runner module. The only other resource touched is a pre-existing unrelated drift on `module.compute.aws_security_group.scraper`.

## Test plan

- [x] `terraform -chdir=infra/terraform/environments/dev init -lockfile=readonly`
- [x] `terraform plan` — single task-def revision bump on the agent-runner module
- [x] `scripts/check-markdown-links.sh` — all clean
- [ ] CI green, auto-merge
- [ ] Post-merge `dev-apply` job publishes the new task-def revision
- [ ] `aws ecs describe-task-definition --task-definition judgemind-dispatcher-agent-runner-dev` returns `cpu=4096, memory=16384` on the new revision
- [ ] Verification evidence comment posted on #3153

Closes #3153
