### PR TITLE
chore(dispatcher): remove vestigial phase2_concurrency_cap_nonzero warning (#2906)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -285,15 +285,6 @@ AGENT_RUNNER_RUN_TASK_RETRYABLE_CODES: frozenset[str] = frozenset(
     }
 )
 
-#: Phase 2 spawn-safety invariant: this value must be 0. The daemon
-#: asserts this on every scheduler tick and logs a warning if the live
-#: ``dispatcher.config.concurrency_cap`` is anything else. The actual
-#: spawn path was added in Phase 3A (#2783) but remains gated on
-#: ``concurrency_cap > 0`` — until Phase 3E flips it to 1, the
-#: orchestration path stays cold in production and the Phase 2 guard
-#: continues to warn on any non-zero value.
-PHASE_2_REQUIRED_CONCURRENCY_CAP = 0
-
 #: Killswitch terminal phase name (#2847). When the scheduler observes
 #: ``concurrency_cap=0`` mid-orchestration and the killswitch engages
 #: (not a #2884 graceful ``stop``), the worker thread aborts at the
@@ -1797,8 +1788,6 @@ class DispatcherDaemon:
               :meth:`_consume_commands`; each dispatched to its handler
               with consumed_at set AFTER the handler (#2801);
             - read ``dispatcher.config.concurrency_cap``;
-            - enforce the Phase 2 spawn-safety guard (warn if
-              ``concurrency_cap != 0``);
             - scan the GitHub ``agent/ready`` queue via ``gh issue list``
               and INSERT a row into ``dispatcher.queue_snapshots``;
             - **Phase 3A (#2783):** if ``concurrency_cap > 0`` AND no
@@ -2141,7 +2130,7 @@ class DispatcherDaemon:
     # ── scheduler tick (every ``tick_scheduler_seconds``) ───────────────
 
     def scheduler_tick(self) -> dict[str, int]:
-        """Run one scheduler tick. Phase 2 = queue scan + spawn-safety guard.
+        """Run one scheduler tick — queue scan + retry drain + Phase 3A orchestration.
 
         Steps (in order; DB work is one transaction per step for isolation):
             1. Consume any pending ``dispatcher.commands`` via
@@ -2153,8 +2142,7 @@ class DispatcherDaemon:
                observation, and SET (cap==0) or CLEAR (cap>0) the
                ``_pause_requested`` killswitch event for the worker thread
                to observe between phases (#2847).
-            3. Fire the Phase 2 spawn-safety guard (log-only warning).
-            4. Drain due retry markers whose reason is in
+            3. Drain due retry markers whose reason is in
                :data:`_INFRA_PREEMPTION_CATEGORIES` via
                :meth:`_process_retry_markers(only_infra_preemption=True)`
                (#2949). Those markers re-add ``agent/ready`` to the
@@ -2165,10 +2153,10 @@ class DispatcherDaemon:
                retries (``subprocess_crash``, ``stuck_timeout``,
                ``gh_rate_exhausted``, ``operator_retry``) stay on the
                supervisor-tick drain.
-            5. Scan the GitHub ``agent/ready`` queue and write a row to
+            4. Scan the GitHub ``agent/ready`` queue and write a row to
                ``dispatcher.queue_snapshots``; run the blocked-list scan
                on its slower cadence.
-            6. If the gate allows, spawn the orchestration worker thread
+            5. If the gate allows, spawn the orchestration worker thread
                (#2847). The spawn is non-blocking — the worker runs on a
                dedicated thread with its own psycopg connection so this
                tick returns promptly, preserving the 30s cadence even
@@ -2324,30 +2312,6 @@ class DispatcherDaemon:
                         "run_id": self._run_id,
                     },
                 )
-
-        # Phase 2 spawn-safety guard: the spawn path does not exist yet,
-        # but a future Phase 3 wiring mistake could activate it. Warn if
-        # the live config disagrees with the Phase 2 invariant. The
-        # guard is advisory only — no subprocess is spawned regardless of
-        # what ``concurrency_cap`` is set to in the database.
-        if (
-            concurrency_cap is not None
-            and concurrency_cap != PHASE_2_REQUIRED_CONCURRENCY_CAP
-        ):
-            self._log.warning(
-                "daemon.phase2_concurrency_cap_nonzero",
-                extra={
-                    "event": "phase2_concurrency_cap_nonzero",
-                    "run_id": self._run_id,
-                    "observed_concurrency_cap": concurrency_cap,
-                    "required_concurrency_cap": PHASE_2_REQUIRED_CONCURRENCY_CAP,
-                    "detail": (
-                        "Phase 2 is shadow mode — daemon must not spawn "
-                        "subprocesses. concurrency_cap should be 0 until "
-                        "Phase 3 cut-over."
-                    ),
-                },
-            )
 
         # Issue #2949 — process infra-preemption retry markers BEFORE
         # scanning the ``agent/ready`` queue. When a daemon restart

--- a/scripts/dispatcher/tests/test_daemon_phase2.py
+++ b/scripts/dispatcher/tests/test_daemon_phase2.py
@@ -459,12 +459,12 @@ class TestScanQueueAndSnapshot:
 
 
 # --------------------------------------------------------------------------
-# scheduler_tick — Phase 2 integration (guard + scan wired in)
+# scheduler_tick — Phase 2 integration (queue scan wired in)
 # --------------------------------------------------------------------------
 
 
 class TestSchedulerTickPhase2:
-    """Scheduler tick now runs queue scan + fires the concurrency guard."""
+    """Scheduler tick runs the queue scan and writes a snapshot row."""
 
     def test_runs_queue_scan_and_returns_depth(self) -> None:
         d, conn, handler = _make_daemon_with_capture()
@@ -490,36 +490,6 @@ class TestSchedulerTickPhase2:
         ticks = handler.events("scheduler_tick")
         assert len(ticks) == 1
         assert ticks[0].queue_depth == 1
-
-    def test_warns_when_concurrency_cap_nonzero(self) -> None:
-        d, conn, handler = _make_daemon_with_capture()
-        # Scheduler reads concurrency_cap = 5 (Phase 1 default seed).
-        conn.cursor_instance.fetch_queue = [(5,)]
-        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
-
-        d.scheduler_tick()
-        warnings = handler.events("phase2_concurrency_cap_nonzero")
-        assert len(warnings) == 1
-        assert warnings[0].observed_concurrency_cap == 5
-        assert warnings[0].required_concurrency_cap == 0
-
-    def test_no_warning_when_concurrency_cap_zero(self) -> None:
-        d, conn, handler = _make_daemon_with_capture()
-        conn.cursor_instance.fetch_queue = [(0,)]
-        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
-
-        d.scheduler_tick()
-        assert handler.events("phase2_concurrency_cap_nonzero") == []
-
-    def test_no_warning_when_concurrency_cap_missing(self) -> None:
-        """Missing config key is a soft no-op; daemon runs but does not warn."""
-        d, conn, handler = _make_daemon_with_capture()
-        conn.cursor_instance.fetch_queue = [None]
-        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
-
-        summary = d.scheduler_tick()
-        assert summary["concurrency_cap"] == -1
-        assert handler.events("phase2_concurrency_cap_nonzero") == []
 
     def test_queue_scan_failure_does_not_crash_tick(self) -> None:
         d, conn, handler = _make_daemon_with_capture()


### PR DESCRIPTION
## Summary

Removes the vestigial `daemon.phase2_concurrency_cap_nonzero` WARNING
that the dispatcher daemon has been emitting every ~30s (~2,880 rows/day)
since the Phase 3 cut-over. Cap=1 is the correct steady state; the
guard was advisory-only with no downstream reader, so deletion is a
pure log-noise cleanup.

Closes #2906

## What changed

- **`scripts/dispatcher/daemon.py`** — deleted the emit site in
  `scheduler_tick`, the supporting `PHASE_2_REQUIRED_CONCURRENCY_CAP`
  constant, and the two docstring bullets that referenced the guard.
  Renumbered the subsequent `scheduler_tick` steps (5 → 4, 6 → 5).
- **`scripts/dispatcher/tests/test_daemon_phase2.py`** — deleted the
  three tests that assert on the warning event
  (`test_warns_when_concurrency_cap_nonzero`,
  `test_no_warning_when_concurrency_cap_zero`,
  `test_no_warning_when_concurrency_cap_missing`). Kept
  `test_queue_scan_failure_does_not_crash_tick` (guard-independent).

**Verification:** `grep -rn "phase2_concurrency_cap_nonzero\|PHASE_2_REQUIRED_CONCURRENCY_CAP"` returns zero hits after the change. Full dispatcher test suite: `1260 passed, 1 skipped` locally.

## Audit per AC #2

Per the issue's second acceptance criterion, audit of adjacent
phase-rollout guards in `scripts/dispatcher/daemon.py`. After the
removal, `grep -n "phase2_\|phase3_\|shadow_mode\|Phase 2\|Phase 3\|PHASE_2\|PHASE_3"` returns:

| Category | Disposition |
|---|---|
| Module docstring line 2 (`Phase 2 shadow mode + Phase 3A wiring`) | Descriptive prose, not a guard. Kept — separate doc-hygiene concern. |
| CLI `--help` description line ~19020 (`Dispatcher v2 daemon — Phase 2 shadow mode (queue scan + heartbeat metric; no subprocess spawn)`) | Stale CLI description, not a runtime guard. Kept — separate doc-hygiene concern. |
| Inline section headers (`# Phase 3A orchestration`, `# Phase 3B post-PR`, etc.) | Git-archaeology bookmarks showing when code landed, not guards. Kept. |
| `DispatcherDaemon` class docstring bullet "enforce the Phase 2 spawn-safety guard" | Stale — **removed** (the guard is gone). |
| `scheduler_tick` docstring step 3 "Fire the Phase 2 spawn-safety guard" | Stale — **removed**; subsequent steps renumbered. |
| `KILLSWITCH_TERMINAL_PHASE` (unrelated killswitch constant) | Live logic, not a vestigial guard. Kept. |

No other `shadow_mode` emits, no other `phase2_*` / `phase3_*`
WARNING or log-emit guards exist. This was the sole vestigial log
guard in the daemon.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] CloudWatch Logs Insights query `filter @message like /phase2_concurrency_cap_nonzero/` over a 10-minute window post-deploy returns zero results
- [x] Verification evidence posted on issue (see A.8)
