### PR TITLE
feat(web): show start/duration/end PT tooltip on Recently Completed (#3024)

### DIFF
--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -411,6 +411,7 @@ async function queryRecentCompletions(pool: Pool, limit: number): Promise<Row[]>
             a.issue_title,
             a.priority,
             a.status,
+            a.started_at,
             a.ended_at,
             a.pr_number,
             a.failure_summary,
@@ -697,6 +698,13 @@ function recentCompletionsToGraphQL(
       // ``#<number>``.
       issueTitle: title,
       status: row.status,
+      // #3024: ``started_at`` paired with ``ended_at`` so the admin cockpit
+      // can render a Start/Duration/End tooltip on the relative-time cell.
+      // ``dispatcher.agents.started_at`` is non-nullable per migration 25,
+      // so this never collapses to null in practice — fall through to the
+      // raw row value and let GraphQL surface a coercion error if a future
+      // migration ever relaxes the column.
+      startedAt: row.started_at,
       endedAt: row.ended_at,
       prNumber: row.pr_number ?? null,
       // #2869: metering fields. Coerced to Number because pg returns

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -256,6 +256,12 @@ export const dispatcherTypeDefs = `#graphql
     """One of succeeded | failed | crashed | plan_blocked | needs_review.
     See \`DispatcherAgent.status\` for the semantics of each value."""
     status: String!
+    """Timestamp the agent claimed the issue (\`dispatcher.agents.started_at\`).
+    Always populated — \`started_at\` is non-nullable on the agents table.
+    Issue #3024: paired with \`endedAt\` so the admin cockpit can render a
+    Start/Duration/End tooltip on the relative-time cell in the Recently
+    completed panel."""
+    startedAt: DateTime!
     endedAt: DateTime!
     """PR number if the agent produced one; null otherwise. \`needs_review\`
     rows (#2856) always have \`prNumber\` populated because the whole

--- a/packages/api/tests/dispatcher-enrichment.unit.test.ts
+++ b/packages/api/tests/dispatcher-enrichment.unit.test.ts
@@ -182,6 +182,9 @@ describe('recentCompletionsToGraphQL', () => {
         // #2899 — priority is captured at claim time.
         priority: 'p2',
         status: 'succeeded',
+        // #3024 — started_at paired with ended_at so the admin cockpit
+        // tooltip can render Start/Duration/End.
+        started_at: '2026-04-18T11:50:00Z',
         ended_at: '2026-04-18T12:00:00Z',
         pr_number: 2824,
         total_tokens: 12345,
@@ -196,6 +199,7 @@ describe('recentCompletionsToGraphQL', () => {
         issueTitle: 'Fix the thing',
         priority: 'p2',
         status: 'succeeded',
+        startedAt: '2026-04-18T11:50:00Z',
         endedAt: '2026-04-18T12:00:00Z',
         prNumber: 2824,
         totalTokens: 12345,
@@ -211,6 +215,24 @@ describe('recentCompletionsToGraphQL', () => {
         retroedAt: null,
       },
     ]);
+  });
+
+  // #3024 — started_at passthrough.
+  it('#3024: passes ``started_at`` through verbatim for the Start/End tooltip', () => {
+    const rows = [
+      {
+        agent_id: 'uuid-3024',
+        issue_number: 3024,
+        issue_title: 'Tooltip test',
+        status: 'succeeded',
+        started_at: '2026-04-22T16:41:16Z',
+        ended_at: '2026-04-22T16:56:33Z',
+        pr_number: 3025,
+      },
+    ];
+    const result = recentCompletionsToGraphQL(rows);
+    expect(result[0].startedAt).toBe('2026-04-22T16:41:16Z');
+    expect(result[0].endedAt).toBe('2026-04-22T16:56:33Z');
   });
 
   // #2900: failure_summary passthrough + trimming/empty handling.

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -3,6 +3,7 @@
 import type { CSSProperties } from 'react';
 import { SECTION_HEADING } from '@/lib/typography';
 import type { RecentCompletion } from '@/lib/dispatcher-queries';
+import { formatDurationMs } from './format-helpers';
 import { IssueLink, OutcomePill, PriorityBadge, PRLink } from './ui-primitives';
 
 interface RecentCompletionsPanelProps {
@@ -52,6 +53,13 @@ interface RecentCompletionsPanelProps {
  * ago" / "2 months ago"). Native `title` attribute exposes the full
  * datetime in Pacific time on hover. Operator gets at-a-glance "when
  * did this happen" without clicking into the agent detail page.
+ *
+ * #3024 extends the `title` tooltip to three lines — start time,
+ * duration, and end time — all in Pacific time. Today's investigations
+ * frequently need the exact wall-clock numbers ("when did this start",
+ * "how long did it run"), and surfacing them in the hover tooltip
+ * eliminates a database round-trip. The visible relative label
+ * ("5m ago") is unchanged — this is an additive enhancement.
  */
 export function RecentCompletionsPanel({
   completions,
@@ -99,11 +107,20 @@ function RecentCompletionRow({
   // prop so we fall back to `Date.now()`.
   const effectiveNowMs = nowMs ?? Date.now();
   const endedMs = Date.parse(completion.endedAt);
+  const startedMs = Date.parse(completion.startedAt);
   const relativeTime = Number.isFinite(endedMs)
     ? formatRelativeTime(endedMs, effectiveNowMs)
     : null;
+  // #3024: native `title` attribute carries a three-line tooltip with
+  // Start / Duration / End in Pacific time. The visible label still
+  // shows the relative "Nm ago" string — the tooltip is the precise
+  // overlay for operators who need the exact numbers during failure
+  // investigation. Falls back to a single-line PT end-time string when
+  // either timestamp is unparseable so we never render an empty tooltip.
   const pacificTitle = Number.isFinite(endedMs)
-    ? formatPacificDatetime(endedMs)
+    ? Number.isFinite(startedMs)
+      ? formatStartDurationEndTitle(startedMs, endedMs)
+      : formatPacificDatetime(endedMs)
     : '';
   // Magic Move (#2967): each completed row carries the agent identity
   // so that the inner `agent-X` wrapper of the matching Active row can
@@ -311,6 +328,39 @@ function formatPacificDatetime(timestampMs: number): string {
   );
 }
 
+/** Build the three-line "Start / Duration / End" tooltip body for the
+ * relative-time cell (#3024). All timestamps are formatted in Pacific
+ * time with an explicit `PDT` / `PST` suffix; the duration reuses
+ * `formatDurationMs` from `format-helpers.ts` so the dispatcher cockpit
+ * uses one consistent compact-duration style across panels.
+ *
+ * The native HTML `title` attribute renders embedded `\n` as line
+ * breaks across all browsers we target, so we hand back a single
+ * `\n`-joined string instead of structured lines. Field labels are
+ * column-padded with two spaces after the colon so the values align in
+ * the tooltip:
+ *
+ *     Start:    2026-04-22 09:41:16 PDT
+ *     Duration: 15m 17s
+ *     End:      2026-04-22 09:56:34 PDT
+ *
+ * The `Duration:` row drops the seconds component once the run is at
+ * least an hour long (`formatDurationMs` already does this) — the
+ * issue spec calls out `2h 3m` as acceptable when seconds are zero.
+ */
+function formatStartDurationEndTitle(
+  startedMs: number,
+  endedMs: number,
+): string {
+  const durationMs = endedMs - startedMs;
+  const start = formatPacificDatetime(startedMs);
+  const end = formatPacificDatetime(endedMs);
+  // Negative or NaN durations (clock skew, malformed timestamps) collapse
+  // to an em-dash via `formatDurationMs` so the tooltip stays readable.
+  const duration = formatDurationMs(durationMs);
+  return `Start:    ${start}\nDuration: ${duration}\nEnd:      ${end}`;
+}
+
 // Exported for unit testing; the helpers stay co-located with the
 // component because they are presentation-only and not reused elsewhere.
 // See ``__tests__/RecentCompletionsPanel.test.tsx``.
@@ -319,4 +369,5 @@ export {
   formatTokenCount,
   formatRelativeTime,
   formatPacificDatetime,
+  formatStartDurationEndTitle,
 };

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
@@ -6,6 +6,7 @@ import {
   formatTokenCount,
   formatRelativeTime,
   formatPacificDatetime,
+  formatStartDurationEndTitle,
 } from '../RecentCompletionsPanel';
 import type { RecentCompletion } from '@/lib/dispatcher-queries';
 
@@ -18,6 +19,10 @@ function completion(overrides: Partial<RecentCompletion>): RecentCompletion {
     issueTitle: 'wire dispatcher admin dashboard',
     priority: 'p2',
     status: 'succeeded',
+    // #3024: startedAt is now a non-nullable field on RecentCompletion.
+    // Default to 5 minutes before endedAt so the tooltip duration math
+    // resolves to a tidy "5m 0s" in the existing assertions.
+    startedAt: '2026-04-18T11:50:00Z',
     endedAt: '2026-04-18T11:55:00Z',
     prNumber: 2811,
     totalTokens: null,
@@ -292,10 +297,11 @@ describe('RecentCompletionsPanel', () => {
     ).toBeTruthy();
   });
 
-  it('#2932: sets the native `title` attribute on the cell to a Pacific-time datetime', () => {
+  it('#2932 / #3024: sets the native `title` attribute on the cell to a Pacific-time tooltip', () => {
     const items = [
       completion({
         agentId: 'agent-pacific',
+        startedAt: '2026-04-18T11:50:00Z',
         endedAt: '2026-04-18T11:55:00Z',
       }),
     ];
@@ -303,12 +309,12 @@ describe('RecentCompletionsPanel', () => {
     const cell = screen.getByTestId('completion-row-relative-time');
     const title = cell.getAttribute('title');
     expect(title).not.toBeNull();
-    // Format: "YYYY-MM-DD HH:MM:SS PDT" or "PST" — Pacific time always
-    // abbreviates to one of these two. April is PDT.
-    expect(title).toMatch(
-      /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} P[DS]T$/,
-    );
+    // #3024 expanded the tooltip to three lines (Start / Duration / End)
+    // — assert the End line still carries a PT abbreviation (April → PDT).
     expect(title).toContain('PDT');
+    expect(title).toMatch(
+      /End:\s+\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} P[DS]T/,
+    );
   });
 
   it('#2932: falls back to Date.now() when nowMs prop is omitted', () => {
@@ -321,6 +327,8 @@ describe('RecentCompletionsPanel', () => {
     const cell = screen.getByTestId('completion-row-relative-time');
     expect(cell).toBeInTheDocument();
     // Must have a non-empty title attribute (Pacific datetime).
+    // #3024: the tooltip is now multi-line; the End line is the last and
+    // still ends with the PT abbreviation.
     expect(cell.getAttribute('title')).toMatch(/P[DS]T$/);
   });
 
@@ -511,6 +519,149 @@ describe('formatPacificDatetime (#2932)', () => {
     expect(formatPacificDatetime(ms)).toMatch(
       /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} P[DS]T$/,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3024 — Recently completed tooltip: Start / Duration / End in PT.
+// ---------------------------------------------------------------------------
+
+describe('RecentCompletionsPanel — #3024 Start/Duration/End tooltip', () => {
+  it('renders a three-line tooltip on the relative-time cell', () => {
+    // 5-minute run ending 5 minutes before the fixed `now`.
+    const items = [
+      completion({
+        agentId: 'agent-3024-3line',
+        startedAt: '2026-04-18T11:50:00Z',
+        endedAt: '2026-04-18T11:55:00Z',
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    const cell = screen.getByTestId('completion-row-relative-time');
+    const title = cell.getAttribute('title');
+    expect(title).not.toBeNull();
+    // Three lines, one for each of Start / Duration / End.
+    const lines = (title as string).split('\n');
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toMatch(/^Start:\s+\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} P[DS]T$/);
+    expect(lines[1]).toMatch(/^Duration:\s+/);
+    expect(lines[2]).toMatch(/^End:\s+\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} P[DS]T$/);
+  });
+
+  it('renders the exact start, duration, and end values for a known fixture', () => {
+    // 11:50:00Z → 04:50:00 PDT, 11:55:00Z → 04:55:00 PDT, 5-minute span.
+    const items = [
+      completion({
+        agentId: 'agent-3024-known',
+        startedAt: '2026-04-18T11:50:00Z',
+        endedAt: '2026-04-18T11:55:00Z',
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    const cell = screen.getByTestId('completion-row-relative-time');
+    expect(cell.getAttribute('title')).toBe(
+      'Start:    2026-04-18 04:50:00 PDT\n' +
+        'Duration: 5m 0s\n' +
+        'End:      2026-04-18 04:55:00 PDT',
+    );
+  });
+
+  it('falls back to a single-line PT end-time tooltip when startedAt is unparseable', () => {
+    // Defensive case — `RecentCompletion.startedAt` is non-nullable on
+    // the API side, but the panel still degrades gracefully if a
+    // garbage value ever sneaks through (e.g. a future migration drift).
+    const items = [
+      completion({
+        agentId: 'agent-3024-bad-start',
+        // Intentionally feeding an unparseable string — `RecentCompletion.
+        // startedAt` is typed `string` so this is type-valid; we only
+        // care that the runtime path is defensive.
+        startedAt: 'not-a-date',
+        endedAt: '2026-04-18T11:55:00Z',
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    const cell = screen.getByTestId('completion-row-relative-time');
+    const title = cell.getAttribute('title');
+    expect(title).toBe('2026-04-18 04:55:00 PDT');
+    // No newlines — fallback is single-line.
+    expect(title).not.toContain('\n');
+  });
+});
+
+describe('formatStartDurationEndTitle (#3024)', () => {
+  function ms(iso: string): number {
+    return Date.parse(iso);
+  }
+
+  it('formats a sub-minute run as a three-line PT tooltip', () => {
+    const start = ms('2026-04-18T11:50:00Z');
+    const end = ms('2026-04-18T11:50:42Z');
+    expect(formatStartDurationEndTitle(start, end)).toBe(
+      'Start:    2026-04-18 04:50:00 PDT\n' +
+        'Duration: 42s\n' +
+        'End:      2026-04-18 04:50:42 PDT',
+    );
+  });
+
+  it('formats a 15m 17s run with explicit minutes+seconds', () => {
+    const start = ms('2026-04-22T16:41:16Z'); // 09:41:16 PDT
+    const end = ms('2026-04-22T16:56:33Z'); // 09:56:33 PDT
+    expect(formatStartDurationEndTitle(start, end)).toBe(
+      'Start:    2026-04-22 09:41:16 PDT\n' +
+        'Duration: 15m 17s\n' +
+        'End:      2026-04-22 09:56:33 PDT',
+    );
+  });
+
+  it('drops the seconds component once the run is at least an hour long', () => {
+    // 2h 3m 0s span — the duration string must collapse to "2h 3m" per
+    // the spec ("`2h 3m` is fine if seconds are 0").
+    const start = ms('2026-04-18T10:00:00Z');
+    const end = ms('2026-04-18T12:03:00Z');
+    const result = formatStartDurationEndTitle(start, end);
+    expect(result).toContain('Duration: 2h 3m');
+    // Seconds explicitly absent — shouldn't render "2h 3m 0s".
+    expect(result).not.toContain('Duration: 2h 3m 0s');
+  });
+
+  it('formats a multi-day run with days+hours', () => {
+    const start = ms('2026-04-15T10:00:00Z');
+    const end = ms('2026-04-16T14:00:00Z'); // 1 day 4 hours
+    expect(formatStartDurationEndTitle(start, end)).toContain(
+      'Duration: 1d 4h',
+    );
+  });
+
+  it('formats a January run with PST (standard time) on both lines', () => {
+    const start = ms('2026-01-15T18:00:00Z');
+    const end = ms('2026-01-15T18:30:00Z');
+    expect(formatStartDurationEndTitle(start, end)).toBe(
+      'Start:    2026-01-15 10:00:00 PST\n' +
+        'Duration: 30m 0s\n' +
+        'End:      2026-01-15 10:30:00 PST',
+    );
+  });
+
+  it('renders an em-dash duration when end precedes start (clock skew)', () => {
+    // Defensive: negative durations collapse to the em-dash sentinel
+    // from `formatDurationMs` rather than rendering "-3m 0s".
+    const start = ms('2026-04-18T12:00:00Z');
+    const end = ms('2026-04-18T11:57:00Z'); // 3 minutes earlier
+    const result = formatStartDurationEndTitle(start, end);
+    expect(result).toContain('Duration: —');
+  });
+
+  it('uses two-space alignment after the field labels', () => {
+    // Visual-alignment guard: the field labels are padded so the values
+    // line up across all three rows when the tooltip is rendered.
+    const start = ms('2026-04-18T11:50:00Z');
+    const end = ms('2026-04-18T11:55:00Z');
+    const result = formatStartDurationEndTitle(start, end);
+    const lines = result.split('\n');
+    expect(lines[0].startsWith('Start:    ')).toBe(true); // 4 trailing spaces
+    expect(lines[1].startsWith('Duration: ')).toBe(true); // 1 trailing space
+    expect(lines[2].startsWith('End:      ')).toBe(true); // 6 trailing spaces
   });
 });
 

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -73,6 +73,7 @@ export const DISPATCHER_STATE_QUERY = gql`
         issueTitle
         priority
         status
+        startedAt
         endedAt
         prNumber
         totalTokens
@@ -209,6 +210,10 @@ export interface RecentCompletion {
   priority: string | null;
   /** One of `succeeded | failed | crashed`. */
   status: string;
+  /** Timestamp the agent claimed the issue (`dispatcher.agents.started_at`).
+   * Non-nullable on the API side. Issue #3024 — paired with `endedAt` for
+   * the Start/Duration/End hover tooltip in the Recently completed panel. */
+  startedAt: string;
   endedAt: string;
   prNumber: number | null;
   /** Sum of input+output tokens across every phase the agent ran


### PR DESCRIPTION
## Summary

Extends the existing relative-time hover tooltip on the dispatcher
admin's Recently Completed panel from a single-line "end-time PT"
string to a three-line `Start: / Duration: / End:` layout in Pacific
time. Lets operators read concrete wall-clock numbers during failure
investigation without dropping into the agent detail page or querying
the DB.

Closes #3024

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Open `/admin/dispatcher` on dev, hover a Recently Completed row's
      relative-time cell, capture screenshot or DOM snippet showing
      the three-line `Start: / Duration: / End:` tooltip with `PT`
      abbreviations
- [x] Verification evidence posted on issue #3024 (see A.8)
