### PR TITLE
feat(web): expand dispatcher cockpit queue counts to full-list dialogs (#3159)

### DIFF
--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -32,6 +32,16 @@ const FAILED_AGENT_COOLDOWN_SECONDS = parseInt(
 );
 
 /**
+ * Hard upper bound for `dispatcherQueueFull` — the cockpit dialog reads
+ * the entire snapshot, but we cap at 1000 so a runaway snapshot (e.g. an
+ * unbounded daemon scrape) can't OOM the resolver. In practice the
+ * `agent/ready` and `status/blocked` open-issue lists are <100 (issue
+ * #3159 expects ~83 max). Same cap applies to the recent-completions
+ * lookup. Issue #3159.
+ */
+const DISPATCHER_QUEUE_FULL_LIMIT = 1000;
+
+/**
  * Shape of a single entry in the enrichment JSON the daemon writes
  * into ``dispatcher.queue_snapshots.issues_json`` /
  * ``dispatcher.blocked_snapshots.issues_json`` (issue #2820). Must
@@ -958,6 +968,57 @@ export const dispatcherResolvers = {
       requireDispatcherAdmin(user);
       const row = await queryAgent(pool, agentId);
       return row ? agentRowToGraphQL(row) : null;
+    },
+
+    /**
+     * Full-list payload for the cockpit's expand-count dialogs (issue
+     * #3159). One request returns every item in the requested bucket —
+     * no 10-cap. Reads exclusively from the same snapshot tables as the
+     * capped `DispatcherState` fields, so there are no GitHub API calls
+     * and no risk of fanning the API container's PAT budget.
+     *
+     * Implementation reuses `queryQueueReady` / `queryQueueBlocked` /
+     * `queryRecentCompletions` with a deliberately loose cap
+     * (`DISPATCHER_QUEUE_FULL_LIMIT`). The snapshot tables hold "open
+     * issues observed by the daemon's last scan" so the absolute upper
+     * bound is the open-issue count — typically <100, hard-capped here
+     * at 1000 so a runaway snapshot can't OOM the response.
+     *
+     * Routed by `kind`:
+     *   - READY → `queueItems` populated from queue_snapshots, completions empty.
+     *   - BLOCKED → `queueItems` populated from blocked_snapshots, completions empty.
+     *   - COMPLETED → `completions` populated from agents, queueItems empty.
+     */
+    dispatcherQueueFull: async (
+      _: unknown,
+      { kind }: { kind: 'READY' | 'BLOCKED' | 'COMPLETED' },
+      { pool, user }: DispatcherContext,
+    ) => {
+      requireDispatcherAdmin(user);
+      if (kind === 'READY') {
+        const queueItems = await queryQueueReady(
+          pool,
+          DISPATCHER_QUEUE_FULL_LIMIT,
+        );
+        return { kind, queueItems, completions: [] };
+      }
+      if (kind === 'BLOCKED') {
+        const queueItems = await queryQueueBlocked(
+          pool,
+          DISPATCHER_QUEUE_FULL_LIMIT,
+        );
+        return { kind, queueItems, completions: [] };
+      }
+      // COMPLETED
+      const rows = await queryRecentCompletions(
+        pool,
+        DISPATCHER_QUEUE_FULL_LIMIT,
+      );
+      return {
+        kind,
+        queueItems: [],
+        completions: recentCompletionsToGraphQL(rows),
+      };
     },
   },
 

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -354,15 +354,24 @@ export const dispatcherTypeDefs = `#graphql
     render \`{shown} / {total}\` without losing the tail beyond the server-side
     cap of 10 (issue #2886)."""
     blockedDepth: Int!
-    """Top 10 ready-for-pickup issues (#2805 §1.3). Sourced from the most
-    recent \`dispatcher.queue_snapshots\` row, joined with a GitHub API
-    lookup for title/labels. Empty list when the queue is empty OR when
-    the daemon has not yet written a snapshot."""
+    """Top 10 ready-for-pickup issues (#2805 §1.3). Sourced exclusively from
+    the most recent \`dispatcher.queue_snapshots.issues_json\` row — the
+    daemon pre-enriches title/labels/createdAt at scrape time so this
+    resolver makes no GitHub API calls (issue #2820). Issues with an
+    active agent are filtered out; the remaining items are sorted by
+    priority then createdAt ASC and capped at 10. Empty list when the
+    daemon has not yet written a snapshot. Use \`dispatcherQueueFull(kind: READY)\`
+    to fetch the full list (no 10-cap) on demand for the cockpit's
+    expand-count dialog (issue #3159)."""
     queueReady: [QueueItem!]!
-    """Top 10 blocked issues (#2805 §1.3). Fetched live from the GitHub
-    API — \`status/blocked\` issues are not tracked in
-    \`dispatcher.queue_snapshots\`. Empty list when the lookup fails or
-    when nothing is blocked."""
+    """Top 10 blocked issues (#2805 §1.3). Sourced exclusively from the
+    most recent \`dispatcher.blocked_snapshots.issues_json\` row — same
+    snapshot-only data path as \`queueReady\`, no GitHub API calls
+    (issue #2820). Sorted by priority then createdAt ASC and capped at
+    10. Empty list when nothing is blocked or when the daemon has not
+    yet written a blocked snapshot. Use \`dispatcherQueueFull(kind: BLOCKED)\`
+    to fetch the full list (no 10-cap) on demand for the cockpit's
+    expand-count dialog (issue #3159)."""
     queueBlocked: [QueueItem!]!
     """Top 10 recently-completed agents (#2805 §1.5). Rows from
     \`dispatcher.agents\` where status IN
@@ -386,6 +395,49 @@ export const dispatcherTypeDefs = `#graphql
     capFlippedBy: String
   }
 
+  """Which queue bucket a \`dispatcherQueueFull\` lookup is for (issue #3159)."""
+  enum DispatcherQueueKind {
+    """Open \`agent/ready\` issues — fetched from
+    \`dispatcher.queue_snapshots.issues_json\`. Same data path and ordering
+    as \`DispatcherState.queueReady\`, just without the 10-cap."""
+    READY
+    """Open \`status/blocked\` issues — fetched from
+    \`dispatcher.blocked_snapshots.issues_json\`. Same data path and ordering
+    as \`DispatcherState.queueBlocked\`, just without the 10-cap."""
+    BLOCKED
+    """Recently terminal agents (\`succeeded | failed | crashed | plan_blocked | needs_review\`)
+    — fetched from \`dispatcher.agents\`. Same query as
+    \`DispatcherState.recentCompletions\`, just without the 10-cap."""
+    COMPLETED
+  }
+
+  """Full-list payload for the cockpit's expand-count dialogs (issue #3159).
+  Read on dialog open only — NOT in the 2s \`dispatcherState\` poll path.
+  Reads exclusively from \`dispatcher.queue_snapshots.issues_json\` /
+  \`dispatcher.blocked_snapshots.issues_json\` / \`dispatcher.agents\` —
+  no GitHub API calls.
+
+  Exactly one of \`queueItems\` or \`completions\` is populated per
+  request, keyed by \`kind\`:
+    - kind=READY / BLOCKED → \`queueItems\` populated, \`completions\` empty.
+    - kind=COMPLETED → \`completions\` populated, \`queueItems\` empty.
+  """
+  type DispatcherQueueFull {
+    """Echoes the \`kind\` argument so Apollo can normalize cache entries
+    by bucket (\`keyFields: ['kind']\` on the client)."""
+    kind: DispatcherQueueKind!
+    """Every QueueItem in the snapshot for kind=READY / BLOCKED. Sorted by
+    priority then createdAt ASC — same comparator as the capped
+    \`DispatcherState.queueReady\` / \`queueBlocked\` panels. Empty when
+    \`kind=COMPLETED\`."""
+    queueItems: [QueueItem!]!
+    """Every recent terminal agent for kind=COMPLETED. Ordered by
+    \`endedAt\` DESC — same query as the capped
+    \`DispatcherState.recentCompletions\` panel. Empty when
+    \`kind=READY\` or \`kind=BLOCKED\`."""
+    completions: [RecentCompletion!]!
+  }
+
   # ---------------------------------------------------------------------------
   # Queries + Mutations — merged into the root schema by concatenation.
   # The root Query/Mutation types are open for extension via the
@@ -400,6 +452,13 @@ export const dispatcherTypeDefs = `#graphql
     Returns null when the agentId does not exist.
     Admin-only; non-admins receive "not found"."""
     dispatcherAgent(agentId: ID!): DispatcherAgent
+
+    """Full list of one cockpit queue bucket (issue #3159). Used by the
+    expand-count dialog on the dispatcher cockpit. Returns every item the
+    daemon snapshot knows about — no 10-cap. Reads from the same snapshot
+    tables as the capped \`DispatcherState\` fields; no GitHub API calls.
+    Admin-only; non-admins receive "not found"."""
+    dispatcherQueueFull(kind: DispatcherQueueKind!): DispatcherQueueFull!
   }
 
   extend type Mutation {

--- a/packages/api/tests/dispatcher.integration.test.ts
+++ b/packages/api/tests/dispatcher.integration.test.ts
@@ -721,3 +721,226 @@ describe('queueReady — SQL predicate functions contract (#3001)', () => {
     expect(rowsA[0].result).toBe(false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// dispatcherQueueFull — full-list payload for the cockpit's expand-count
+// dialog (issue #3159). Verifies:
+//   - Auth gate (non-admin → NOT_FOUND).
+//   - kind=READY returns every snapshot row (no 10-cap) when the snapshot
+//     has > 10 issues.
+//   - kind=BLOCKED returns every snapshot row when blocked snapshot has > 10.
+//   - kind=COMPLETED returns every recent terminal agent (no 10-cap) when
+//     there are > 10.
+//   - The capped `dispatcherState.queueReady` / `queueBlocked` /
+//     `recentCompletions` paths still cap at 10 — i.e. we did not break
+//     the existing surface.
+// ---------------------------------------------------------------------------
+
+describe('dispatcherQueueFull — admin (#3159)', () => {
+  let queueRunId: string;
+  // Use a sentinel issue-number range outside everything else this file
+  // seeds (so other describe blocks' rows don't bleed in).
+  const READY_BASE = 31590;
+  const BLOCKED_BASE = 31700;
+  const COMPLETED_AGENT_BASE = `dqf-3159-${MARKER}-`;
+
+  beforeAll(async () => {
+    queueRunId = await insertRun();
+
+    // -- Seed a queue snapshot with 25 ready issues — well past the
+    //    server-side 10-cap on `dispatcherState.queueReady`.
+    const readyIssues = Array.from({ length: 25 }, (_, i) => ({
+      number: READY_BASE + i,
+      title: `ready test ${i}`,
+      labels: ['priority/p2', 'agent/ready'],
+      createdAt: '2026-04-01T00:00:00Z',
+    }));
+    await pool.query(
+      `INSERT INTO dispatcher.queue_snapshots
+         (observed_at, queue_depth, issue_numbers, issues_json, run_id)
+       VALUES (now(), $1, $2::int[], $3::jsonb, $4)`,
+      [
+        readyIssues.length,
+        readyIssues.map((i) => i.number),
+        JSON.stringify(readyIssues),
+        queueRunId,
+      ],
+    );
+
+    // -- Seed a blocked snapshot with 12 blocked issues.
+    const blockedIssues = Array.from({ length: 12 }, (_, i) => ({
+      number: BLOCKED_BASE + i,
+      title: `blocked test ${i}`,
+      labels: ['priority/p2', 'status/blocked'],
+      createdAt: '2026-04-01T00:00:00Z',
+      body: '',
+    }));
+    await pool.query(
+      `INSERT INTO dispatcher.blocked_snapshots
+         (observed_at, blocked_depth, issue_numbers, issues_json, run_id)
+       VALUES (now(), $1, $2::int[], $3::jsonb, $4)`,
+      [
+        blockedIssues.length,
+        blockedIssues.map((i) => i.number),
+        JSON.stringify(blockedIssues),
+        queueRunId,
+      ],
+    );
+
+    // -- Seed 15 terminal agents (succeeded). Spread `ended_at` so the
+    //    `ORDER BY ended_at DESC` is deterministic.
+    for (let i = 0; i < 15; i += 1) {
+      const { rows } = await pool.query<{ agent_id: string }>(
+        `INSERT INTO dispatcher.agents
+           (parent_run_id, kind, issue_number, worktree_path, phase, status,
+            started_at, ended_at)
+         VALUES ($1, 'task', $2, $3, 'retro', 'succeeded',
+                 now() - interval '1 hour',
+                 now() - ($4 || ' seconds')::interval)
+         RETURNING agent_id`,
+        [
+          queueRunId,
+          400000 + i,
+          `/tmp/${MARKER}/${COMPLETED_AGENT_BASE}${i}`,
+          String(i * 10),
+        ],
+      );
+      insertedAgentIds.push(rows[0].agent_id);
+    }
+  }, 30_000);
+
+  it('non-admin: dispatcherQueueFull returns "not found"', async () => {
+    const body = await gql(
+      `query($k: DispatcherQueueKind!) {
+        dispatcherQueueFull(kind: $k) { kind }
+      }`,
+      { k: 'READY' },
+      userToken,
+    );
+    expect(body.errors).toBeDefined();
+    expect(body.errors![0].extensions?.code).toBe('NOT_FOUND');
+  });
+
+  it('kind=READY returns ALL snapshot issues (no 10-cap)', async () => {
+    const body = await gql(
+      `query($k: DispatcherQueueKind!) {
+        dispatcherQueueFull(kind: $k) {
+          kind
+          queueItems { issueNumber title }
+          completions { agentId }
+        }
+      }`,
+      { k: 'READY' },
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const payload = (body.data?.dispatcherQueueFull as Record<string, unknown>) ?? {};
+    expect(payload.kind).toBe('READY');
+    const items = payload.queueItems as Array<{ issueNumber: number }>;
+    const completions = payload.completions as Array<unknown>;
+    // Every seeded ready issue must appear (the resolver also filters out
+    // active agents, but we did not seed active agents in this range).
+    const numbers = items.map((i) => i.issueNumber);
+    for (let i = 0; i < 25; i += 1) {
+      expect(numbers).toContain(READY_BASE + i);
+    }
+    // completions must be empty for kind=READY.
+    expect(completions).toEqual([]);
+  });
+
+  it('kind=BLOCKED returns ALL blocked snapshot issues (no 10-cap)', async () => {
+    const body = await gql(
+      `query($k: DispatcherQueueKind!) {
+        dispatcherQueueFull(kind: $k) {
+          kind
+          queueItems { issueNumber }
+          completions { agentId }
+        }
+      }`,
+      { k: 'BLOCKED' },
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const payload = (body.data?.dispatcherQueueFull as Record<string, unknown>) ?? {};
+    expect(payload.kind).toBe('BLOCKED');
+    const items = payload.queueItems as Array<{ issueNumber: number }>;
+    const numbers = items.map((i) => i.issueNumber);
+    for (let i = 0; i < 12; i += 1) {
+      expect(numbers).toContain(BLOCKED_BASE + i);
+    }
+    expect(payload.completions).toEqual([]);
+  });
+
+  it('kind=COMPLETED returns recent terminal agents (no 10-cap)', async () => {
+    const body = await gql(
+      `query($k: DispatcherQueueKind!) {
+        dispatcherQueueFull(kind: $k) {
+          kind
+          queueItems { issueNumber }
+          completions { agentId issueNumber status }
+        }
+      }`,
+      { k: 'COMPLETED' },
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const payload = (body.data?.dispatcherQueueFull as Record<string, unknown>) ?? {};
+    expect(payload.kind).toBe('COMPLETED');
+    expect(payload.queueItems).toEqual([]);
+    const completions = payload.completions as Array<{
+      issueNumber: number;
+      status: string;
+    }>;
+    // We seeded 15 of our own — at least 15 must be present (other
+    // tests' agents may also appear, but the resolver order is by
+    // `ended_at DESC` and our seed used now()-N seconds so they sort
+    // first within their cohort). Spot-check a few of our seeded
+    // numbers are present.
+    const numbers = completions.map((c) => c.issueNumber);
+    for (let i = 0; i < 15; i += 1) {
+      expect(numbers).toContain(400000 + i);
+    }
+  });
+
+  it('regression: dispatcherState.queueReady is STILL capped at 10 (#3159 AC5)', async () => {
+    // The cap was added in resolver `queryQueueReady(pool, 10)`. The
+    // expand-count dialog uses a separate field so the existing capped
+    // surface must not change shape — operators rely on the panel
+    // staying short.
+    const body = await gql(
+      `{ dispatcherState { queueReady { issueNumber } } }`,
+      undefined,
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const state = body.data?.dispatcherState as Record<string, unknown>;
+    const queueReady = state.queueReady as Array<{ issueNumber: number }>;
+    // Snapshot has 25 ready issues; must surface only 10.
+    expect(queueReady.length).toBeLessThanOrEqual(10);
+  });
+
+  it('regression: dispatcherState.queueBlocked is STILL capped at 10 (#3159 AC5)', async () => {
+    const body = await gql(
+      `{ dispatcherState { queueBlocked { issueNumber } } }`,
+      undefined,
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const state = body.data?.dispatcherState as Record<string, unknown>;
+    const queueBlocked = state.queueBlocked as Array<{ issueNumber: number }>;
+    // Snapshot has 12 blocked issues; must surface only 10.
+    expect(queueBlocked.length).toBeLessThanOrEqual(10);
+  });
+
+  it('regression: dispatcherState.recentCompletions is STILL capped at 10 (#3159 AC5)', async () => {
+    const body = await gql(
+      `{ dispatcherState { recentCompletions { agentId } } }`,
+      undefined,
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const state = body.data?.dispatcherState as Record<string, unknown>;
+    const completions = state.recentCompletions as Array<{ agentId: string }>;
+    expect(completions.length).toBeLessThanOrEqual(10);
+  });
+});

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -13,6 +13,7 @@ import {
   DISPATCHER_STATE_QUERY,
   type DispatcherCommand,
   type DispatcherControlData,
+  type DispatcherQueueKind,
   type DispatcherSetConfigData,
   type DispatcherStateData,
 } from '@/lib/dispatcher-queries';
@@ -24,6 +25,7 @@ import { RecentCompletionsPanel } from './RecentCompletionsPanel';
 import { RecentFailuresPanel } from './RecentFailuresPanel';
 import { ConfigPanel } from './ConfigPanel';
 import { ConfirmDialog, type ConfirmableCommand } from './ConfirmDialog';
+import { QueueFullDialog } from './QueueFullDialog';
 
 /**
  * Polling interval for `dispatcherState`. Per spec §11, the daemon runs on
@@ -109,6 +111,12 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
   const [commandError, setCommandError] = useState<string | null>(null);
   const [configError, setConfigError] = useState<string | null>(null);
   const [busyConfigKey, setBusyConfigKey] = useState<string | null>(null);
+  // #3159: which expand-count dialog is open (Ready / Blocked / Recently
+  // Completed). Null when no dialog is open. Drives both `<QueueFullDialog>`'s
+  // visibility and the `dispatcherQueueFull` query's `skip` flag — closing
+  // the dialog cancels any in-flight fetch the next time the operator
+  // clicks a count.
+  const [fullDialogKind, setFullDialogKind] = useState<DispatcherQueueKind | null>(null);
 
   const { data, loading, error, refetch } = useQuery<DispatcherStateData>(
     DISPATCHER_STATE_QUERY,
@@ -397,6 +405,7 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
               <QueueReadyPanel
                 items={state?.queueReady ?? []}
                 total={state?.queueDepth}
+                onCountClick={() => setFullDialogKind('READY')}
               />
             </div>
 
@@ -409,10 +418,12 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
             <div className="flex flex-col gap-6" data-testid="dispatcher-column-right">
               <RecentCompletionsPanel
                 completions={state?.recentCompletions ?? []}
+                onCountClick={() => setFullDialogKind('COMPLETED')}
               />
               <QueueBlockedPanel
                 items={state?.queueBlocked ?? []}
                 total={state?.blockedDepth}
+                onCountClick={() => setFullDialogKind('BLOCKED')}
               />
             </div>
           </div>
@@ -450,6 +461,18 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
         capDetail={pendingCommand === LOWER_CAP_CONFIRM ? pendingCap : null}
         onConfirm={handleConfirm}
         onCancel={handleCancel}
+      />
+
+      {/*
+       * #3159: full-list expand dialog for the cockpit's three count
+       * badges. The query inside `QueueFullDialog` is gated on
+       * `kind !== null`, so closing the dialog (ESC, click outside,
+       * X button) cancels future fetches until the operator clicks a
+       * count again.
+       */}
+      <QueueFullDialog
+        kind={fullDialogKind}
+        onClose={() => setFullDialogKind(null)}
       />
     </div>
   );

--- a/packages/web/src/app/(main)/admin/dispatcher/QueueFullDialog.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/QueueFullDialog.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useQuery } from '@apollo/client';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  DISPATCHER_QUEUE_FULL_QUERY,
+  type DispatcherQueueFullData,
+  type DispatcherQueueKind,
+} from '@/lib/dispatcher-queries';
+import { QueueRow } from './QueuePanel';
+import { RecentCompletionRow } from './RecentCompletionsPanel';
+
+/**
+ * Full-list expand-count dialog for the dispatcher cockpit (issue #3159).
+ * Triggered by clicking the count badge on any of the three bottom-row
+ * panels (Ready / Blocked / Recently Completed). Renders every item the
+ * daemon snapshot knows about — no 10-cap.
+ *
+ * Data path: a separate `dispatcherQueueFull(kind)` GraphQL query, fired
+ * only when `kind !== null`. The 2s `dispatcherState` poll on the parent
+ * dashboard is unaffected — opening this dialog adds no traffic to the
+ * hot path. Apollo's cache normalizes per-`kind` (see
+ * `apollo-client.ts`), and `fetchPolicy: 'network-only'` forces a fresh
+ * fetch on each open so the dialog always reflects the latest snapshot.
+ *
+ * Reuses `QueueRow` (Ready/Blocked) and `RecentCompletionRow`
+ * (Completed) so the dialog rows are visually identical to the panel
+ * rows — operators don't have to relearn the row layout when they
+ * expand.
+ */
+export function QueueFullDialog({
+  kind,
+  onClose,
+}: {
+  /** Open when not null — also drives which kind to fetch. */
+  kind: DispatcherQueueKind | null;
+  /** Called when the dialog closes (ESC, click outside, X button). */
+  onClose: () => void;
+}) {
+  const open = kind !== null;
+  const { data, loading, error } = useQuery<DispatcherQueueFullData>(
+    DISPATCHER_QUEUE_FULL_QUERY,
+    {
+      variables: kind !== null ? { kind } : undefined,
+      // Skip when the dialog is closed — Apollo will not fire the query
+      // until the operator actually clicks a count badge.
+      skip: kind === null,
+      // Network-only on each open: the snapshot updates every 30s on
+      // the daemon side, and the operator has just clicked because they
+      // want to see the current tail. A cache hit could show stale rows.
+      fetchPolicy: 'network-only',
+    },
+  );
+
+  const payload = data?.dispatcherQueueFull;
+  const queueItems = payload?.queueItems ?? [];
+  const completions = payload?.completions ?? [];
+  const totalCount =
+    kind === 'COMPLETED' ? completions.length : queueItems.length;
+
+  const titleText = formatDialogTitle(kind, totalCount, loading);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent
+        className="max-w-2xl"
+        data-testid="queue-full-dialog"
+      >
+        <DialogHeader>
+          <DialogTitle data-testid="queue-full-dialog-title">
+            {titleText}
+          </DialogTitle>
+          <DialogDescription className="sr-only">
+            Full list of items the dispatcher snapshot knows about for the
+            selected bucket. Press Escape or click outside to close.
+          </DialogDescription>
+        </DialogHeader>
+        <div
+          className="max-h-[60vh] overflow-y-auto"
+          data-testid="queue-full-dialog-body"
+        >
+          {loading && (
+            <p
+              className="py-2 text-sm text-muted-foreground"
+              data-testid="queue-full-dialog-loading"
+            >
+              Loading…
+            </p>
+          )}
+          {error && !loading && (
+            <p
+              role="alert"
+              className="py-2 text-sm text-red-600 dark:text-red-400"
+              data-testid="queue-full-dialog-error"
+            >
+              Failed to load: {error.message}
+            </p>
+          )}
+          {!loading && !error && payload && (
+            <DialogList
+              kind={payload.kind}
+              queueItems={queueItems}
+              completions={completions}
+            />
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Inner list renderer — split out so the empty / non-empty branches
+ * stay readable inside the dialog's loading/error scaffolding.
+ */
+function DialogList({
+  kind,
+  queueItems,
+  completions,
+}: {
+  kind: DispatcherQueueKind;
+  queueItems: DispatcherQueueFullData['dispatcherQueueFull']['queueItems'];
+  completions: DispatcherQueueFullData['dispatcherQueueFull']['completions'];
+}) {
+  if (kind === 'READY') {
+    if (queueItems.length === 0) {
+      return (
+        <p
+          className="py-2 text-sm text-muted-foreground"
+          data-testid="queue-full-dialog-empty"
+        >
+          Queue empty — file an issue with{' '}
+          <code className="font-mono">agent/ready</code> to seed.
+        </p>
+      );
+    }
+    return (
+      <ul
+        className="divide-y divide-border"
+        data-testid="queue-full-dialog-list"
+      >
+        {queueItems.map((item) => (
+          // Ready rows do NOT carry the `animated` view-transition-name
+          // here — the dialog list is a separate DOM tree from the
+          // panel list, and giving rows the same `issue-<N>` name in
+          // both would collide on the next view-transition tick (#2967).
+          <QueueRow key={item.issueNumber} item={item} />
+        ))}
+      </ul>
+    );
+  }
+  if (kind === 'BLOCKED') {
+    if (queueItems.length === 0) {
+      return (
+        <p
+          className="py-2 text-sm text-muted-foreground"
+          data-testid="queue-full-dialog-empty"
+        >
+          No blocked issues.
+        </p>
+      );
+    }
+    return (
+      <ul
+        className="divide-y divide-border"
+        data-testid="queue-full-dialog-list"
+      >
+        {queueItems.map((item) => (
+          <QueueRow key={item.issueNumber} item={item} />
+        ))}
+      </ul>
+    );
+  }
+  // COMPLETED
+  if (completions.length === 0) {
+    return (
+      <p
+        className="py-2 text-sm text-muted-foreground"
+        data-testid="queue-full-dialog-empty"
+      >
+        No completed agents yet.
+      </p>
+    );
+  }
+  return (
+    <ul
+      className="divide-y divide-border"
+      data-testid="queue-full-dialog-list"
+    >
+      {completions.map((completion) => (
+        <RecentCompletionRow
+          key={completion.agentId}
+          completion={completion}
+        />
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * Format the dialog title — the heading text mirrors which bucket the
+ * operator opened. Pure helper so the test can exercise the formatting
+ * without rendering the dialog. Issue #3159.
+ */
+export function formatDialogTitle(
+  kind: DispatcherQueueKind | null,
+  count: number,
+  loading: boolean,
+): string {
+  if (kind === null) return '';
+  const label =
+    kind === 'READY'
+      ? 'Agent-ready queue'
+      : kind === 'BLOCKED'
+        ? 'Blocked queue'
+        : 'Recently completed';
+  if (loading) return `${label} (loading…)`;
+  return `${label} (${count})`;
+}

--- a/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
@@ -96,12 +96,66 @@ function formatCountLabel(shown: number, total: number | undefined): string {
   return `${shown} shown`;
 }
 
+/**
+ * Render the count label as either a static `<span>` (back-compat) or a
+ * clickable `<button>` when `onClick` is provided. The button-mode keeps
+ * the same font-mono micro-typography as the original span — operators
+ * scanning the panel header should not have to relearn the visual
+ * shape of the count. We only add an underline-on-hover affordance and
+ * a pointer cursor so the click target reads as actionable. Issue #3159.
+ */
+function CountLabel({
+  shown,
+  total,
+  testId,
+  onClick,
+  ariaLabel,
+}: {
+  shown: number;
+  total: number | undefined;
+  testId: string;
+  onClick?: () => void;
+  ariaLabel?: string;
+}) {
+  const text = formatCountLabel(shown, total);
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        data-testid={testId}
+        aria-label={ariaLabel ?? `${text} — open full list`}
+        className="font-mono text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm cursor-pointer"
+      >
+        {text}
+      </button>
+    );
+  }
+  return (
+    <span
+      className="font-mono text-xs text-muted-foreground"
+      data-testid={testId}
+    >
+      {text}
+    </span>
+  );
+}
+
 export function QueueReadyPanel({
   items,
   total,
+  onCountClick,
 }: {
   items: readonly QueueItem[];
   total?: number;
+  /**
+   * When provided, the count label becomes a clickable button that
+   * triggers this callback. The cockpit dashboard wires this to open
+   * the full-list dialog (issue #3159). When omitted, the count
+   * renders as a static span — preserves back-compat for tests and any
+   * caller that hasn't wired up the dialog.
+   */
+  onCountClick?: () => void;
 }) {
   return (
     <section aria-labelledby="queue-ready-heading">
@@ -109,12 +163,17 @@ export function QueueReadyPanel({
         <h2 id="queue-ready-heading" className={SECTION_HEADING}>
           Queue: Agent-ready
         </h2>
-        <span
-          className="font-mono text-xs text-muted-foreground"
-          data-testid="queue-ready-count"
-        >
-          {formatCountLabel(items.length, total)}
-        </span>
+        <CountLabel
+          shown={items.length}
+          total={total}
+          testId="queue-ready-count"
+          onClick={onCountClick}
+          ariaLabel={
+            onCountClick
+              ? `Show full agent-ready queue (${formatCountLabel(items.length, total)})`
+              : undefined
+          }
+        />
       </div>
       {items.length === 0 ? (
         <p className="py-2 text-sm text-muted-foreground">
@@ -138,9 +197,12 @@ export function QueueReadyPanel({
 export function QueueBlockedPanel({
   items,
   total,
+  onCountClick,
 }: {
   items: readonly QueueItem[];
   total?: number;
+  /** See `QueueReadyPanel.onCountClick`. Issue #3159. */
+  onCountClick?: () => void;
 }) {
   return (
     <section aria-labelledby="queue-blocked-heading">
@@ -148,12 +210,17 @@ export function QueueBlockedPanel({
         <h2 id="queue-blocked-heading" className={SECTION_HEADING}>
           Queue: Blocked
         </h2>
-        <span
-          className="font-mono text-xs text-muted-foreground"
-          data-testid="queue-blocked-count"
-        >
-          {formatCountLabel(items.length, total)}
-        </span>
+        <CountLabel
+          shown={items.length}
+          total={total}
+          testId="queue-blocked-count"
+          onClick={onCountClick}
+          ariaLabel={
+            onCountClick
+              ? `Show full blocked queue (${formatCountLabel(items.length, total)})`
+              : undefined
+          }
+        />
       </div>
       {items.length === 0 ? (
         <p className="py-2 text-sm text-muted-foreground">
@@ -183,7 +250,12 @@ export function formatCooldown(seconds: number): string {
   return `${Math.floor(seconds / 60)}m`;
 }
 
-function QueueRow({
+/**
+ * One row in the queue panel. Exported so the full-list dialog
+ * (`QueueFullDialog`, issue #3159) can render the same row layout
+ * without duplicating the markup.
+ */
+export function QueueRow({
   item,
   animated = false,
 }: {

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -14,6 +14,15 @@ interface RecentCompletionsPanelProps {
    * row falls back to `Date.now()` at render time.
    */
   nowMs?: number;
+  /**
+   * When provided, the count label in the panel header becomes a
+   * clickable button that triggers this callback. The cockpit
+   * dashboard wires this to open the full-list dialog (issue #3159).
+   * When omitted, the count renders as the existing inline parenthesised
+   * count — preserves back-compat for tests and any caller that hasn't
+   * wired up the dialog.
+   */
+  onCountClick?: () => void;
 }
 
 /**
@@ -56,13 +65,32 @@ interface RecentCompletionsPanelProps {
 export function RecentCompletionsPanel({
   completions,
   nowMs,
+  onCountClick,
 }: RecentCompletionsPanelProps) {
+  // #3159: when a click handler is provided, surface a separate
+  // clickable count badge (matching the QueuePanel pattern) so the
+  // operator has a consistent expand-affordance across all three
+  // bottom-row panels. The legacy inline `({n})` rendering is preserved
+  // for back-compat when no handler is wired (existing test fixtures
+  // and any non-cockpit caller).
+  const countText = String(completions.length);
   return (
     <section aria-labelledby="recent-completions-heading">
       <div className="flex items-center justify-between border-b border-border pb-2 mb-2">
         <h2 id="recent-completions-heading" className={SECTION_HEADING}>
-          Recently completed ({completions.length})
+          {onCountClick ? 'Recently completed' : `Recently completed (${countText})`}
         </h2>
+        {onCountClick && (
+          <button
+            type="button"
+            onClick={onCountClick}
+            data-testid="recent-completions-count"
+            aria-label={`Show full recent-completions list (${countText})`}
+            className="font-mono text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm cursor-pointer"
+          >
+            {countText}
+          </button>
+        )}
       </div>
       {completions.length === 0 ? (
         <p className="py-2 text-sm text-muted-foreground">
@@ -83,7 +111,12 @@ export function RecentCompletionsPanel({
   );
 }
 
-function RecentCompletionRow({
+/**
+ * One row in the Recently Completed panel. Exported so the full-list
+ * dialog (`QueueFullDialog`, issue #3159) can render the same row layout
+ * without duplicating the markup.
+ */
+export function RecentCompletionRow({
   completion,
   nowMs,
 }: {

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
@@ -27,17 +27,60 @@ const mockSetConfigMutate = vi.fn().mockResolvedValue({ data: {} });
 const mockRefetch = vi.fn().mockResolvedValue({ data: {} });
 
 let mockQueryData: { dispatcherState?: Record<string, unknown> } | undefined;
+// #3159: separate mock data for the `dispatcherQueueFull` query fired
+// only when the operator opens an expand-count dialog. Keyed by the
+// `kind` variable so the mock can serve READY / BLOCKED / COMPLETED
+// distinctly. Default empty so existing tests don't accidentally render
+// dialog rows.
+const mockQueueFullData: Record<
+  string,
+  { dispatcherQueueFull?: Record<string, unknown> } | undefined
+> = {
+  READY: undefined,
+  BLOCKED: undefined,
+  COMPLETED: undefined,
+};
 
 vi.mock('@apollo/client', async () => {
   const actual = await vi.importActual<typeof import('@apollo/client')>('@apollo/client');
   return {
     ...actual,
-    useQuery: () => ({
-      data: mockQueryData,
-      loading: false,
-      error: undefined,
-      refetch: mockRefetch,
-    }),
+    useQuery: (
+      doc: { definitions?: Array<{ name?: { value?: string } }> },
+      options?: {
+        variables?: { kind?: string };
+        skip?: boolean;
+      },
+    ) => {
+      const opName = doc?.definitions?.[0]?.name?.value ?? '';
+      if (opName === 'DispatcherQueueFull') {
+        // #3159: serve per-kind mock data. When `skip` is true (dialog
+        // closed) Apollo would return `data: undefined`; mirror that
+        // semantic here so tests that don't open the dialog don't see
+        // stray dialog rows.
+        if (options?.skip) {
+          return {
+            data: undefined,
+            loading: false,
+            error: undefined,
+            refetch: mockRefetch,
+          };
+        }
+        const kind = options?.variables?.kind ?? 'READY';
+        return {
+          data: mockQueueFullData[kind],
+          loading: false,
+          error: undefined,
+          refetch: mockRefetch,
+        };
+      }
+      return {
+        data: mockQueryData,
+        loading: false,
+        error: undefined,
+        refetch: mockRefetch,
+      };
+    },
     useMutation: (doc: { definitions?: Array<{ name?: { value?: string } }> }) => {
       const opName = doc?.definitions?.[0]?.name?.value ?? '';
       if (opName === 'DispatcherControl') {
@@ -475,5 +518,104 @@ describe('DispatcherDashboard — #2967 Magic Move state update wrapping', () =>
     };
     renderDashboard();
     expect(screen.getByTestId('queue-ready-count')).toHaveTextContent('0 / 7');
+  });
+});
+
+describe('DispatcherDashboard — #3159 expand-count dialog wiring', () => {
+  beforeEach(() => {
+    mockControlMutate.mockClear();
+    mockSetConfigMutate.mockClear();
+    mockRefetch.mockClear();
+    mockQueryData = { dispatcherState: { ...BASE_STATE } };
+    mockQueueFullData.READY = undefined;
+    mockQueueFullData.BLOCKED = undefined;
+    mockQueueFullData.COMPLETED = undefined;
+  });
+
+  it('renders all three count badges as buttons (Ready, Blocked, Recently Completed)', () => {
+    renderDashboard();
+    expect(screen.getByTestId('queue-ready-count').tagName).toBe('BUTTON');
+    expect(screen.getByTestId('queue-blocked-count').tagName).toBe('BUTTON');
+    expect(screen.getByTestId('recent-completions-count').tagName).toBe(
+      'BUTTON',
+    );
+  });
+
+  it('clicking the Ready count opens the dialog with the READY title', async () => {
+    mockQueueFullData.READY = {
+      dispatcherQueueFull: {
+        kind: 'READY',
+        queueItems: [],
+        completions: [],
+      },
+    };
+    renderDashboard();
+    expect(screen.queryByTestId('queue-full-dialog')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('queue-ready-count'));
+    const title = await screen.findByTestId('queue-full-dialog-title');
+    expect(title.textContent).toMatch(/agent-ready queue/i);
+  });
+
+  it('clicking the Blocked count opens the dialog with the BLOCKED title', async () => {
+    mockQueueFullData.BLOCKED = {
+      dispatcherQueueFull: {
+        kind: 'BLOCKED',
+        queueItems: [],
+        completions: [],
+      },
+    };
+    renderDashboard();
+    fireEvent.click(screen.getByTestId('queue-blocked-count'));
+    const title = await screen.findByTestId('queue-full-dialog-title');
+    expect(title.textContent).toMatch(/blocked queue/i);
+  });
+
+  it('clicking the Recently Completed count opens the dialog with the COMPLETED title', async () => {
+    mockQueueFullData.COMPLETED = {
+      dispatcherQueueFull: {
+        kind: 'COMPLETED',
+        queueItems: [],
+        completions: [],
+      },
+    };
+    renderDashboard();
+    fireEvent.click(screen.getByTestId('recent-completions-count'));
+    const title = await screen.findByTestId('queue-full-dialog-title');
+    expect(title.textContent).toMatch(/recently completed/i);
+  });
+
+  it('dialog does NOT open by default and does NOT prefetch on mount', () => {
+    renderDashboard();
+    // No dialog DOM, no list rendered.
+    expect(screen.queryByTestId('queue-full-dialog')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('queue-full-dialog-list')).not.toBeInTheDocument();
+  });
+
+  it('dialog renders the full list with no 10-cap (READY, 25 items)', async () => {
+    const items = Array.from({ length: 25 }, (_, i) => ({
+      issueNumber: 9000 + i,
+      title: `issue ${9000 + i}`,
+      priority: 'p2',
+      labels: ['priority/p2', 'agent/ready'],
+      createdAt: '2026-04-18T11:00:00Z',
+      blockedBy: [],
+      cooldownSecondsRemaining: null,
+    }));
+    mockQueueFullData.READY = {
+      dispatcherQueueFull: {
+        kind: 'READY',
+        queueItems: items,
+        completions: [],
+      },
+    };
+    renderDashboard();
+    fireEvent.click(screen.getByTestId('queue-ready-count'));
+    await screen.findByTestId('queue-full-dialog-list');
+    // 25 issue links rendered — well past the 10-cap.
+    for (const it of items) {
+      expect(
+        screen.getByTestId(`issue-link-${it.issueNumber}`),
+      ).toBeInTheDocument();
+    }
   });
 });

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueueFullDialog.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueueFullDialog.test.tsx
@@ -1,0 +1,345 @@
+/**
+ * Tests for the cockpit's expand-count full-list dialog (issue #3159).
+ *
+ * Coverage:
+ *   - kind=null (closed) does NOT fire the underlying GraphQL query.
+ *   - Empty list per kind renders the per-kind empty-state copy.
+ *   - Small list (3 items) — every item rendered.
+ *   - Large list (50 items) — every item rendered (no 10-cap).
+ *   - Loading state shows the "Loading…" copy.
+ *   - Error state shows the error message.
+ *   - ESC / overlay click triggers `onClose` (the radix Dialog handles
+ *     these natively; we exercise the path through `onOpenChange`).
+ *   - `formatDialogTitle` pure-function unit tests.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Apollo mock — the dialog's `useQuery` returns one of three states:
+//   - `skip: true` (kind=null): `{ data: undefined, loading: false }`.
+//   - normal: returns the data we set on `mockData[kind]`, plus the
+//     loading/error flags.
+// We track invocation count so the kind=null assertion can verify the
+// query was NOT fired.
+// ---------------------------------------------------------------------------
+
+const useQueryCalls: Array<{
+  opName: string;
+  variables?: { kind?: string };
+  skip?: boolean;
+}> = [];
+
+let mockLoading = false;
+let mockError: Error | undefined;
+
+const mockData: Record<
+  string,
+  { dispatcherQueueFull?: Record<string, unknown> } | undefined
+> = {
+  READY: undefined,
+  BLOCKED: undefined,
+  COMPLETED: undefined,
+};
+
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual<typeof import('@apollo/client')>(
+    '@apollo/client',
+  );
+  return {
+    ...actual,
+    useQuery: (
+      doc: { definitions?: Array<{ name?: { value?: string } }> },
+      options?: {
+        variables?: { kind?: string };
+        skip?: boolean;
+      },
+    ) => {
+      const opName = doc?.definitions?.[0]?.name?.value ?? '';
+      useQueryCalls.push({
+        opName,
+        variables: options?.variables,
+        skip: options?.skip,
+      });
+      if (options?.skip) {
+        return {
+          data: undefined,
+          loading: false,
+          error: undefined,
+          refetch: vi.fn(),
+        };
+      }
+      const kind = options?.variables?.kind ?? 'READY';
+      return {
+        data: mockData[kind],
+        loading: mockLoading,
+        error: mockError,
+        refetch: vi.fn(),
+      };
+    },
+  };
+});
+
+import {
+  QueueFullDialog,
+  formatDialogTitle,
+} from '../QueueFullDialog';
+
+function resetMocks() {
+  useQueryCalls.length = 0;
+  mockLoading = false;
+  mockError = undefined;
+  mockData.READY = undefined;
+  mockData.BLOCKED = undefined;
+  mockData.COMPLETED = undefined;
+}
+
+describe('QueueFullDialog — kind=null (closed)', () => {
+  it('does NOT render dialog content when kind is null', () => {
+    resetMocks();
+    render(<QueueFullDialog kind={null} onClose={vi.fn()} />);
+    // Closed Dialog: the content is unmounted via radix portal — the
+    // body / title are not present in the DOM.
+    expect(screen.queryByTestId('queue-full-dialog-body')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('queue-full-dialog-title')).not.toBeInTheDocument();
+  });
+
+  it('skips the `dispatcherQueueFull` query when kind is null', () => {
+    resetMocks();
+    render(<QueueFullDialog kind={null} onClose={vi.fn()} />);
+    // The query was hooked, but with `skip: true` — we don't fetch.
+    const calls = useQueryCalls.filter((c) => c.opName === 'DispatcherQueueFull');
+    expect(calls.length).toBe(1);
+    expect(calls[0].skip).toBe(true);
+  });
+});
+
+describe('QueueFullDialog — empty list per kind', () => {
+  it('READY: renders the agent-ready empty-state copy', () => {
+    resetMocks();
+    mockData.READY = {
+      dispatcherQueueFull: {
+        kind: 'READY',
+        queueItems: [],
+        completions: [],
+      },
+    };
+    render(<QueueFullDialog kind="READY" onClose={vi.fn()} />);
+    expect(screen.getByTestId('queue-full-dialog-empty')).toHaveTextContent(
+      /Queue empty/i,
+    );
+  });
+
+  it('BLOCKED: renders the blocked empty-state copy', () => {
+    resetMocks();
+    mockData.BLOCKED = {
+      dispatcherQueueFull: {
+        kind: 'BLOCKED',
+        queueItems: [],
+        completions: [],
+      },
+    };
+    render(<QueueFullDialog kind="BLOCKED" onClose={vi.fn()} />);
+    expect(screen.getByTestId('queue-full-dialog-empty')).toHaveTextContent(
+      /no blocked issues/i,
+    );
+  });
+
+  it('COMPLETED: renders the recently-completed empty-state copy', () => {
+    resetMocks();
+    mockData.COMPLETED = {
+      dispatcherQueueFull: {
+        kind: 'COMPLETED',
+        queueItems: [],
+        completions: [],
+      },
+    };
+    render(<QueueFullDialog kind="COMPLETED" onClose={vi.fn()} />);
+    expect(screen.getByTestId('queue-full-dialog-empty')).toHaveTextContent(
+      /no completed agents yet/i,
+    );
+  });
+});
+
+describe('QueueFullDialog — small list', () => {
+  it('READY: renders all 3 issue links', () => {
+    resetMocks();
+    mockData.READY = {
+      dispatcherQueueFull: {
+        kind: 'READY',
+        queueItems: [
+          {
+            issueNumber: 100,
+            title: 'first',
+            priority: 'p1',
+            labels: ['priority/p1'],
+            createdAt: '2026-04-18T11:00:00Z',
+            blockedBy: [],
+            cooldownSecondsRemaining: null,
+          },
+          {
+            issueNumber: 101,
+            title: 'second',
+            priority: 'p2',
+            labels: ['priority/p2'],
+            createdAt: '2026-04-18T11:00:00Z',
+            blockedBy: [],
+            cooldownSecondsRemaining: null,
+          },
+          {
+            issueNumber: 102,
+            title: 'third',
+            priority: 'p3',
+            labels: ['priority/p3'],
+            createdAt: '2026-04-18T11:00:00Z',
+            blockedBy: [],
+            cooldownSecondsRemaining: null,
+          },
+        ],
+        completions: [],
+      },
+    };
+    render(<QueueFullDialog kind="READY" onClose={vi.fn()} />);
+    expect(screen.getByTestId('queue-full-dialog-list')).toBeInTheDocument();
+    expect(screen.getByTestId('issue-link-100')).toBeInTheDocument();
+    expect(screen.getByTestId('issue-link-101')).toBeInTheDocument();
+    expect(screen.getByTestId('issue-link-102')).toBeInTheDocument();
+  });
+});
+
+describe('QueueFullDialog — large list (no 10-cap)', () => {
+  it('READY: renders all 50 issues', () => {
+    resetMocks();
+    const items = Array.from({ length: 50 }, (_, i) => ({
+      issueNumber: 1000 + i,
+      title: `issue ${1000 + i}`,
+      priority: 'p2',
+      labels: ['priority/p2'],
+      createdAt: '2026-04-18T11:00:00Z',
+      blockedBy: [],
+      cooldownSecondsRemaining: null,
+    }));
+    mockData.READY = {
+      dispatcherQueueFull: {
+        kind: 'READY',
+        queueItems: items,
+        completions: [],
+      },
+    };
+    render(<QueueFullDialog kind="READY" onClose={vi.fn()} />);
+    // Spot-check the boundary entries (well past the panel's 10-cap).
+    expect(screen.getByTestId('issue-link-1000')).toBeInTheDocument();
+    expect(screen.getByTestId('issue-link-1010')).toBeInTheDocument();
+    expect(screen.getByTestId('issue-link-1025')).toBeInTheDocument();
+    expect(screen.getByTestId('issue-link-1049')).toBeInTheDocument();
+  });
+
+  it('COMPLETED: renders all 30 completions', () => {
+    resetMocks();
+    const completions = Array.from({ length: 30 }, (_, i) => ({
+      agentId: `aaaaaaaa-bbbb-cccc-dddd-${String(i).padStart(12, '0')}`,
+      issueNumber: 5000 + i,
+      issueTitle: `done ${5000 + i}`,
+      priority: 'p2',
+      status: 'succeeded',
+      endedAt: '2026-04-18T11:55:00Z',
+      prNumber: 6000 + i,
+      totalTokens: null,
+      totalCostUsd: null,
+      failureSummary: null,
+      mergedAt: '2026-04-18T11:50:00Z',
+      verifiedAt: '2026-04-18T11:53:00Z',
+      verifySkipReason: null,
+      retroedAt: '2026-04-18T11:55:00Z',
+    }));
+    mockData.COMPLETED = {
+      dispatcherQueueFull: {
+        kind: 'COMPLETED',
+        queueItems: [],
+        completions,
+      },
+    };
+    render(<QueueFullDialog kind="COMPLETED" onClose={vi.fn()} />);
+    // Each completion row is keyed by `completion-row-<agentId>`.
+    expect(
+      screen.getByTestId(
+        'completion-row-aaaaaaaa-bbbb-cccc-dddd-000000000000',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(
+        'completion-row-aaaaaaaa-bbbb-cccc-dddd-000000000029',
+      ),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('QueueFullDialog — loading + error states', () => {
+  it('shows the loading copy when the query is in flight', () => {
+    resetMocks();
+    mockLoading = true;
+    render(<QueueFullDialog kind="READY" onClose={vi.fn()} />);
+    expect(screen.getByTestId('queue-full-dialog-loading')).toHaveTextContent(
+      /Loading/i,
+    );
+  });
+
+  it('shows the error copy when the query fails', () => {
+    resetMocks();
+    mockError = new Error('Network down');
+    render(<QueueFullDialog kind="READY" onClose={vi.fn()} />);
+    expect(screen.getByTestId('queue-full-dialog-error')).toHaveTextContent(
+      /Network down/i,
+    );
+  });
+});
+
+describe('QueueFullDialog — close handling', () => {
+  it('triggers onClose when the dialog dismisses (ESC / overlay click)', () => {
+    resetMocks();
+    mockData.READY = {
+      dispatcherQueueFull: {
+        kind: 'READY',
+        queueItems: [],
+        completions: [],
+      },
+    };
+    const onClose = vi.fn();
+    render(<QueueFullDialog kind="READY" onClose={onClose} />);
+    // Simulate ESC by firing keyDown on the dialog content.
+    fireEvent.keyDown(screen.getByTestId('queue-full-dialog'), {
+      key: 'Escape',
+      code: 'Escape',
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+});
+
+describe('formatDialogTitle', () => {
+  it('returns empty string for kind=null', () => {
+    expect(formatDialogTitle(null, 0, false)).toBe('');
+  });
+
+  it('renders Agent-ready queue (N) for READY', () => {
+    expect(formatDialogTitle('READY', 12, false)).toBe(
+      'Agent-ready queue (12)',
+    );
+  });
+
+  it('renders Blocked queue (N) for BLOCKED', () => {
+    expect(formatDialogTitle('BLOCKED', 5, false)).toBe('Blocked queue (5)');
+  });
+
+  it('renders Recently completed (N) for COMPLETED', () => {
+    expect(formatDialogTitle('COMPLETED', 7, false)).toBe(
+      'Recently completed (7)',
+    );
+  });
+
+  it('appends a (loading…) marker while loading', () => {
+    expect(formatDialogTitle('READY', 0, true)).toBe(
+      'Agent-ready queue (loading…)',
+    );
+  });
+});

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueuePanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueuePanel.test.tsx
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import { QueuePanel } from '../QueuePanel';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueueBlockedPanel, QueuePanel, QueueReadyPanel } from '../QueuePanel';
 import { formatCooldown } from '../QueuePanel';
 import type { QueueItem } from '@/lib/dispatcher-queries';
 
@@ -224,6 +224,72 @@ describe('QueuePanel', () => {
     ];
     render(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
     expect(screen.queryByTestId('cooldown-badge-3003')).toBeNull();
+  });
+});
+
+// --- #3159 — clickable count opens the full-list dialog. The count
+//             label becomes a `<button>` when `onCountClick` is provided,
+//             and falls back to a static `<span>` otherwise (back-compat).
+describe('QueuePanel — #3159 clickable count', () => {
+  const items = [
+    item({ issueNumber: 2801, title: 'first' }),
+    item({ issueNumber: 2802, title: 'second' }),
+  ];
+
+  it('ready: count renders as a span when onCountClick is omitted (back-compat)', () => {
+    render(<QueueReadyPanel items={items} total={50} />);
+    const count = screen.getByTestId('queue-ready-count');
+    expect(count.tagName).toBe('SPAN');
+  });
+
+  it('ready: count renders as a button and fires onCountClick when provided', () => {
+    const onCountClick = vi.fn();
+    render(
+      <QueueReadyPanel
+        items={items}
+        total={50}
+        onCountClick={onCountClick}
+      />,
+    );
+    const count = screen.getByTestId('queue-ready-count');
+    expect(count.tagName).toBe('BUTTON');
+    expect(count).toHaveTextContent('2 / 50');
+    fireEvent.click(count);
+    expect(onCountClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocked: count renders as a span when onCountClick is omitted (back-compat)', () => {
+    render(<QueueBlockedPanel items={[]} total={5} />);
+    const count = screen.getByTestId('queue-blocked-count');
+    expect(count.tagName).toBe('SPAN');
+  });
+
+  it('blocked: count renders as a button and fires onCountClick when provided', () => {
+    const onCountClick = vi.fn();
+    render(
+      <QueueBlockedPanel
+        items={items}
+        total={50}
+        onCountClick={onCountClick}
+      />,
+    );
+    const count = screen.getByTestId('queue-blocked-count');
+    expect(count.tagName).toBe('BUTTON');
+    fireEvent.click(count);
+    expect(onCountClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('button has accessible aria-label that names the bucket', () => {
+    const onCountClick = vi.fn();
+    render(
+      <QueueReadyPanel
+        items={items}
+        total={50}
+        onCountClick={onCountClick}
+      />,
+    );
+    const count = screen.getByTestId('queue-ready-count');
+    expect(count.getAttribute('aria-label')).toMatch(/agent-ready/i);
   });
 });
 

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
 import {
   RecentCompletionsPanel,
   formatCostFootnote,
@@ -544,5 +544,66 @@ describe('RecentCompletionsPanel — Magic Move view-transition names (#2967)', 
     expect((row2 as HTMLElement).style.viewTransitionName).toBe(
       'agent-11223344-5566-7788-99aa-bbccddeeff00',
     );
+  });
+
+  // --- #3159 — clickable count opens the full-list dialog. The count
+  //             becomes a separate `<button>` badge in the header when
+  //             `onCountClick` is provided; the inline `(N)` parenthesised
+  //             rendering is preserved for back-compat when omitted.
+  describe('#3159 clickable count', () => {
+    it('renders inline `(N)` count and no clickable badge when onCountClick is omitted', () => {
+      render(
+        <RecentCompletionsPanel
+          completions={[completion({ agentId: 'a-1' })]}
+          nowMs={now}
+        />,
+      );
+      // Header text contains "(1)" — the legacy parenthesised count.
+      expect(
+        screen.getByRole('heading', { name: /recently completed \(1\)/i }),
+      ).toBeInTheDocument();
+      // No clickable badge.
+      expect(
+        screen.queryByTestId('recent-completions-count'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders clickable count badge when onCountClick is provided and fires the callback on click', () => {
+      const onCountClick = vi.fn();
+      render(
+        <RecentCompletionsPanel
+          completions={[
+            completion({ agentId: 'a-1' }),
+            completion({ agentId: 'a-2' }),
+          ]}
+          nowMs={now}
+          onCountClick={onCountClick}
+        />,
+      );
+      // Heading no longer carries the parenthesised count when the
+      // separate badge is shown — the count moves to the right side
+      // (matching QueuePanel's pattern).
+      expect(
+        screen.getByRole('heading', { name: /^recently completed$/i }),
+      ).toBeInTheDocument();
+      const badge = screen.getByTestId('recent-completions-count');
+      expect(badge.tagName).toBe('BUTTON');
+      expect(badge).toHaveTextContent('2');
+      fireEvent.click(badge);
+      expect(onCountClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('clickable badge has accessible aria-label that names the bucket', () => {
+      const onCountClick = vi.fn();
+      render(
+        <RecentCompletionsPanel
+          completions={[completion({ agentId: 'a-1' })]}
+          nowMs={now}
+          onCountClick={onCountClick}
+        />,
+      );
+      const badge = screen.getByTestId('recent-completions-count');
+      expect(badge.getAttribute('aria-label')).toMatch(/recent-completions/i);
+    });
   });
 });

--- a/packages/web/src/lib/apollo-client.ts
+++ b/packages/web/src/lib/apollo-client.ts
@@ -220,6 +220,14 @@ export function createApolloClient(): ApolloClient<unknown> {
         DispatcherConfigEntry: {
           keyFields: ['key'],
         },
+        // DispatcherQueueFull: full-list payload for the cockpit's
+        // expand-count dialog (issue #3159). One cache entry per kind
+        // bucket — `keyFields: ['kind']` keeps READY / BLOCKED /
+        // COMPLETED separate so opening a dialog after another doesn't
+        // get the previous bucket's cached payload.
+        DispatcherQueueFull: {
+          keyFields: ['kind'],
+        },
 
         // ---------------------------------------------------------------------
         // Types that intentionally do NOT need keyFields:

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -96,6 +96,51 @@ export const DISPATCHER_STATE_QUERY = gql`
   }
 `;
 
+/**
+ * Full-list payload for the cockpit's expand-count dialogs (issue #3159).
+ * Fired only on dialog open — NOT in the 2s `dispatcherState` poll path.
+ * The server resolves this from the same snapshot tables as the capped
+ * `DispatcherState` panels (`dispatcher.queue_snapshots` /
+ * `dispatcher.blocked_snapshots` / `dispatcher.agents`), so opening the
+ * dialog adds no GitHub API traffic.
+ *
+ * `kind` arg is required; the response echoes it back so Apollo can
+ * normalize the cache by bucket — see `apollo-client.ts` for the
+ * `keyFields: ['kind']` entry.
+ */
+export const DISPATCHER_QUEUE_FULL_QUERY = gql`
+  query DispatcherQueueFull($kind: DispatcherQueueKind!) {
+    dispatcherQueueFull(kind: $kind) {
+      kind
+      queueItems {
+        issueNumber
+        title
+        priority
+        labels
+        createdAt
+        blockedBy
+        cooldownSecondsRemaining
+      }
+      completions {
+        agentId
+        issueNumber
+        issueTitle
+        priority
+        status
+        endedAt
+        prNumber
+        totalTokens
+        totalCostUsd
+        failureSummary
+        mergedAt
+        verifiedAt
+        verifySkipReason
+        retroedAt
+      }
+    }
+  }
+`;
+
 export const DISPATCHER_CONTROL_MUTATION = gql`
   mutation DispatcherControl($command: DispatcherCommand!, $payload: JSON) {
     dispatcherControl(command: $command, payload: $payload) {
@@ -320,4 +365,25 @@ export interface DispatcherCommandResult {
 
 export interface DispatcherControlData {
   dispatcherControl: DispatcherCommandResult;
+}
+
+/**
+ * Bucket selector for `dispatcherQueueFull` (issue #3159). Mirrors the
+ * `DispatcherQueueKind` enum in the API schema.
+ */
+export type DispatcherQueueKind = 'READY' | 'BLOCKED' | 'COMPLETED';
+
+/**
+ * Result type for `dispatcherQueueFull` (issue #3159). Exactly one of
+ * `queueItems` (READY / BLOCKED) or `completions` (COMPLETED) is
+ * populated per request — the other is empty.
+ */
+export interface DispatcherQueueFull {
+  kind: DispatcherQueueKind;
+  queueItems: QueueItem[];
+  completions: RecentCompletion[];
+}
+
+export interface DispatcherQueueFullData {
+  dispatcherQueueFull: DispatcherQueueFull;
 }


### PR DESCRIPTION
## Summary

Make the three count badges on the dispatcher cockpit (Ready, Blocked, Recently Completed) clickable. Clicking any one opens a shared shadcn/ui Dialog that lists every item the daemon snapshot knows about — no 10-cap. Implemented via a new `dispatcherQueueFull(kind)` GraphQL query that reads the same snapshot tables the capped panels already read (no GitHub API calls, no extra load on the 2s `dispatcherState` poll). While in the area, fix two stale `schema.ts` docstrings that incorrectly described `queueReady` / `queueBlocked` as "joined with a GitHub API lookup."

Closes #3159

## Test plan

### Automated checks
- [x] Lint passes (`packages/web` next lint, `packages/api` eslint)
- [x] Format check passes (TypeScript — no separate format step)
- [x] Tests pass — `packages/web` 1392 tests pass; `packages/api` 259 unit + 27 dispatcher integration tests pass (incl. 7 new `dispatcherQueueFull` tests)
- [x] Web build passes (`npm run build`)
- [x] API build passes (`npm run build`)
- [x] CI green

### Post-deploy verification
- [ ] On `dev.judgemind.org/admin/dispatcher`, click each of the three count badges (Ready, Blocked, Recently Completed) and confirm the dialog opens with the full list (>10 items when queue depth >10). (Operator visual confirm pending — admin session required.)
- [x] Capture a `data-testid` query on the deployed page proving each count badge ships in the bundle. (`grep` against `dispatcher/page-1e4f3b94aa959bb3.js` returns all three count testids and all dialog testids — see issue evidence comment.)
- [x] Run `grep -n "GitHub API lookup" packages/api/src/graphql/dispatcher/schema.ts` against `main` post-merge — returns ZERO matches.
- [x] Verification evidence posted on issue #3159
