### PR TITLE
audit(dispatcher): execution_mode-aware paths for dispatcher.agents reads/writes (#3158)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -619,6 +619,15 @@ jobs:
       # back in.
       - name: Verify every daemon git/gh subprocess site has retry or cold-path annotation
         run: scripts/check-git-gh-retries.sh
+      # Issue #3158: every ``UPDATE dispatcher.agents`` /
+      # ``SELECT ... FROM dispatcher.agents`` line in
+      # ``scripts/dispatcher/daemon.py`` must either mention
+      # ``execution_mode`` / ``agent_task_arn`` within +/- 60 lines,
+      # OR carry an ``exec-mode-agnostic (#N): <reason>`` annotation
+      # nearby. Prevents the #3091-draft / #3128-era / #3152 class of
+      # silent-ECS-agent-loss bug from creeping back in.
+      - name: Verify every dispatcher.agents SQL site is execution_mode-aware
+        run: scripts/check-dispatcher-execution-mode-aware.sh
       # Issue #3082: operator laptops run macOS's stock bash 3.2.
       # Shell scripts under scripts/**/*.sh must stick to the bash 3.2
       # subset — no mapfile, readarray, associative arrays, nameref,

--- a/docs/investigations/dispatcher-execution-mode-audit-2026-04.md
+++ b/docs/investigations/dispatcher-execution-mode-audit-2026-04.md
@@ -1,0 +1,198 @@
+# Dispatcher `execution_mode` awareness audit — 2026-04
+
+**Scope.** Every SQL read or write of `dispatcher.agents` in
+`scripts/dispatcher/daemon.py` (as of commit pre-#3158). For each call
+site: is the code path execution-mode-aware, or does it carry
+subprocess-mode assumptions that silently mishandle ECS-mode agents?
+
+**Motivation.** Three Option A rollout bugs all had the same shape — a
+code path authored pre-ECS that assumed the agent was a local subprocess
+under the daemon:
+
+| # | Site | Bug |
+|---|------|-----|
+| #3091 | reap-tick path | early drafts routed STOPPED tasks through the subprocess crash handler; caught pre-merge |
+| #3128-era | `_persist_agent_task_arn` | ECS launch didn't flip `execution_mode`, producing reconciliation ambiguity after daemon restart |
+| #3152 | `recover_abandoned_agents` | startup sweep marked every in-flight ECS agent `daemon_restart_abandoned` on daemon redeploy |
+
+The forward-scan audit below enumerates every `dispatcher.agents`
+read/write and classifies each as **PASS** (mode-aware or
+fundamentally mode-independent), **CONCERN** (silently assumes
+subprocess semantics), or **BACKSTOP** (mode-agnostic by construction).
+
+## Classification summary
+
+- **PASS (mode-aware):** 4 sites — `recover_abandoned_agents`,
+  `_reap_completed_agent_tasks`, `_launch_agent_ecs_task`,
+  `_persist_agent_task_arn`.
+- **BACKSTOP (phase-driven, mode-independent by construction):** most
+  terminal writers (`_mark_agent_terminal`, `_write_merged_at`,
+  `_write_verified_at`, `_write_retroed_at`, `_write_failure_summary`,
+  `_restore_succeeded_and_advance_done`), phase read/write
+  (`_update_agent_phase`), status read (`_observe_external_terminal`,
+  `_read_agent_status_phase`, `_read_merged_at_and_verified_at`,
+  `_read_verify_skip_reason`), claim INSERT (`_atomic_claim`), run
+  counter (`_count_running_agents` / `_has_active_agent`), helper
+  lookups (`_lookup_active_owner_kind`, `_lookup_issue_number_by_agent`,
+  `_read_retries_used`), diagnoser context
+  (`_build_diagnoser_context`), housekeeping retention sweeps.
+- **CONCERN (this audit):** 3 sites fixed in this PR —
+  `_check_stuck_agents`, `_resume_retrying_agent`,
+  `_handle_force_stop` (per-agent branch).
+- **CONCERN (tracked as follow-ups):** 3 sites filed as issues —
+  diagnoser `_consume_action_*` family (terminal writes do not stop
+  ECS task), `_advance_awaiting_ci` / `_run_fix_ci` (uses
+  local worktree_path for fix-ci subprocess), agent-runner entrypoint
+  (no external-terminal signal observation mid-run).
+
+## Site-by-site table
+
+Line numbers are against `scripts/dispatcher/daemon.py` at the audit
+commit. "Fix" column: `pr-3158` = this PR, `follow-up #N` = filed as
+separate issue, `n/a` = no action needed.
+
+| Line | Call site | Code shape | Category | Disposition | Fix |
+|------|-----------|------------|----------|-------------|-----|
+| 2727 | `_handle_force_stop` SELECT `pid` | `SELECT pid FROM dispatcher.agents WHERE agent_id = %s` | CONCERN | For ECS agents `pid` is NULL on daemon host — the subsequent SIGKILL no-ops and the ECS task keeps running while the DB row reads `crashed`. | pr-3158 — stop the ECS task via `ecs:StopTask` before marking crashed |
+| 2738 | `_handle_force_stop` UPDATE crashed | UPDATE status=crashed, ended_at=now() | BACKSTOP | Phase-based terminal write, correct for both modes (both branches need the row flipped). | n/a |
+| 2814 | `_handle_retry` SELECT status | `SELECT status, retries_used FROM dispatcher.agents WHERE agent_id = %s` | BACKSTOP | Operator-initiated retry read. Mode-independent — operator decides which agents to retry. | n/a |
+| 2831 | `_handle_retry` UPDATE retrying | UPDATE status='retrying' | BACKSTOP | Sets the agent to the retrying lane. Same signal for both modes. | n/a |
+| 3411 | `_has_active_agent` SELECT 1 | `SELECT 1 FROM ... WHERE status = 'running'` | BACKSTOP | Concurrency cap predicate. `status='running'` covers both modes. | n/a |
+| 3890 | `_atomic_claim` INSERT | `INSERT ... execution_mode = %s` | PASS | Claim-time write persists the mode so every downstream branch can observe it. | n/a |
+| 4000 | `_lookup_active_owner_kind` SELECT kind | race-lost diagnostic | BACKSTOP | Daemon↔daemon race diagnostic, mode-independent. | n/a |
+| 4302 | `recover_abandoned_agents` SELECT execution_mode, agent_task_arn | daemon-restart reconciliation | PASS (#3152) | Branches on `execution_mode`. ECS → survival INFO event, no DB action. Subprocess → daemon_restart_abandoned + retry marker. | n/a |
+| 5476 | `_read_retries_used` SELECT retries_used | Ralph retry-context builder | BACKSTOP | Counter read; applies to both modes equally. | n/a |
+| 6599 | `_update_agent_phase` UPDATE phase | phase advance | BACKSTOP | Phase progression write. Daemon-side advances write the same value for either mode; agent-runner likewise writes through its own psql client but to the same column. | n/a |
+| 6651 | `_write_merged_at` UPDATE merged_at | merge-time flip | BACKSTOP | Merge event write. Daemon-side post-merge transition; mode-independent. | n/a |
+| 6741 | `_write_verified_at` UPDATE verified_at | post-verify stamp | BACKSTOP | Milestone stamp. Mode-independent. | n/a |
+| 6773 | `_write_verify_skip_reason` UPDATE verify_skip_reason | self-deploy PR | BACKSTOP | Pre-push self-deploy flag. Mode-independent. | n/a |
+| 6818 | `_read_merged_at_and_verified_at` SELECT | verify short-circuit | BACKSTOP | Milestone read. | n/a |
+| 6867 | `_restore_succeeded_and_advance_done` UPDATE | post-verify recovery | BACKSTOP | Post-merge state restore. | n/a |
+| 6895 | `_read_verify_skip_reason` SELECT | verify gate | BACKSTOP | Column read. | n/a |
+| 6931 | `_write_retroed_at` UPDATE retroed_at | milestone | BACKSTOP | Milestone stamp. | n/a |
+| 7403 | `_write_failure_summary` UPDATE failure_summary | admin-cockpit hint | BACKSTOP | Templated failure-one-liner. Mode-independent. | n/a |
+| 7478, 7488, 7496 | `_mark_agent_terminal` UPDATE | terminal state | BACKSTOP | Canonical terminal writer. Mode-independent by construction — the row transition is the contract; mode-specific teardown happens in the callers. | n/a (but callers must know to stop ECS tasks — see #3165) |
+| 7882 | `_lookup_issue_number_by_agent` SELECT issue_number | helper | BACKSTOP | Bare lookup. | n/a |
+| 8327 | `_observe_external_terminal` SELECT status | phase-boundary killswitch | BACKSTOP (subprocess-only observer) | Called by the subprocess worker thread between phases. ECS agent-runner does NOT invoke this — it has no equivalent. | #3166 (agent-runner lacks external-terminal observer) |
+| 8377 | `_resume_retrying_agent` SELECT retrying | retry pickup | CONCERN | Picks up `status='retrying'` agents **without filtering on execution_mode**; creates a local subprocess worktree, silently forking an ECS agent to subprocess mode. | pr-3158 — skip ECS rows; they must resume via the agent-runner launch path, not the subprocess lane |
+| 8417 | `_resume_retrying_agent` UPDATE running | retry status flip | CONCERN | Part of the same method — the flip precedes local worktree + subprocess. | pr-3158 — guarded by the execution_mode skip |
+| 9215 | `_list_active_agents_for_telegram` SELECT | admin read | BACKSTOP | Best-effort read for operator UX. | n/a |
+| 11211 | `_list_advanceable_agents` SELECT | scheduler queue | CONCERN | Picks up both subprocess AND ECS agents in post-ralph phases (awaiting_ci, awaiting_deploy, done, retro_done, retro_failed). For ECS agents, the agent-runner is still running and performs its own mechanical stubs for those phases; the daemon's advance handlers race with the agent-runner AND some use local `worktree_path` (which doesn't exist for ECS). See #3167. | #3167 |
+| 12279 | `_bump_retries_used` UPDATE retries_used | retry counter bump | BACKSTOP | Counter increment. | n/a |
+| 13374 | `_persist_phase_output_row` JOIN dispatcher.agents (for retries_used) | phase output persist | BACKSTOP | Metadata read. | n/a |
+| 14008 | `_check_stuck_agents` SELECT running | supervisor stuck-timeout scan | CONCERN | SELECTs **every** `status='running'` agent regardless of `execution_mode`. For an ECS agent in a long ralph (cap 15h under `STUCK_TIMEOUT_SECONDS_BY_PHASE`) that goes longer (or any ECS agent whose `phase_transitions.ts` MAX is stale because the agent-runner isn't writing one mid-ralph), the supervisor flips it to `crashed` + enqueues a retry marker — at which point `_resume_retrying_agent` would silently fork it to subprocess. | pr-3158 — filter out `execution_mode='ecs'`. ECS stuck detection belongs to the `_reap_completed_agent_tasks` path (STOPPED → route via `_handle_agent_failure`), not the per-phase timer. |
+| 14657, 14669 | `_process_retry_markers` JOIN dispatcher.agents (for worktree_path, issue_number) | retry drain | PASS (downstream CONCERN gated in `_resume_retrying_agent`) | The marker drain is mode-independent (drops worktree best-effort, flips status). The actual mode-fork happens in `_resume_retrying_agent` which we now guard. | pr-3158 (indirectly) |
+| 14768 | `_process_retry_markers` UPDATE retrying | retry reset | BACKSTOP | Same as above. | n/a |
+| 15153 | `_lookup_issue_number_by_agent_from_db` SELECT | helper | BACKSTOP | Bare lookup. | n/a |
+| 15791 | `_build_diagnoser_context` SELECT worktree_path | diagnoser context | BACKSTOP | Best-effort read of `ralph-done.txt` from the worktree. For ECS agents the path doesn't exist on the daemon, so `ralph_done_content` is empty — graceful degradation. | n/a (graceful) |
+| 15843, 16006, 16056 | `_build_diagnoser_context` / `_find_diagnoser_candidates` JOINs | diagnoser | BACKSTOP | Failure-table joins — mode-independent. | n/a |
+| 15923 | retry-marker history read | diagnoser | BACKSTOP | Marker history. | n/a |
+| 16647, 16657, 16683 | `_consume_action_*` `_mark_agent_terminal` + retry-marker inserts | diagnoser → terminal | CONCERN (terminal-only) | Marks the agent `failed` in the DB but does NOT stop a running ECS task. The ECS task keeps running until it writes its own status or is reaped. For tier-3 escalate / close / block this is a zombie risk. | #3165 (stop ECS task on diagnoser-forced terminal) |
+| 18179 | `_persist_agent_task_arn` UPDATE agent_task_arn, execution_mode | ECS launch | PASS | Authoritative mode flip — every downstream reader sees `execution_mode='ecs'`. | n/a |
+| 18252 | `_reap_completed_agent_tasks` SELECT agent_task_arn | ECS reap | PASS | Filters on `agent_task_arn IS NOT NULL`. | n/a |
+| 18417 | `_reap_completed_agent_tasks` `_handle_agent_failure` call | ECS reap → failure route | PASS | Unified failure route for ECS-specific `agent_task_stopped_unexpectedly` category. | n/a |
+| 18511 | `_read_agent_status_phase` SELECT status, phase | post-reap status read | BACKSTOP | Read-only for reap bookkeeping. | n/a |
+
+## Fixes landing in PR #3158 (this PR)
+
+### Fix 1 — `_check_stuck_agents` skips ECS agents
+
+**Before.** SELECT every `status='running'` agent → apply per-phase
+`STUCK_TIMEOUT_SECONDS_BY_PHASE` threshold → on timeout, mark
+`crashed` + enqueue retry marker.
+
+**After.** SELECT filter adds `AND execution_mode <> 'ecs'` (NULLs
+coerced to subprocess via `COALESCE`). ECS agents rely on
+`_reap_completed_agent_tasks` for liveness observation. An ECS task
+that actually hung will eventually be STOPPED by ECS (container health
+check, SIGKILL, OOM), at which point the reap path routes the failure
+via `_handle_agent_failure` with category
+`agent_task_stopped_unexpectedly`. No change for subprocess agents.
+
+### Fix 2 — `_resume_retrying_agent` skips ECS agents
+
+**Before.** Pick the oldest `status='retrying'` agent → create a new
+local worktree → call `_run_orchestration_phases` (subprocess pipeline).
+
+**After.** SELECT filter adds `AND execution_mode <> 'ecs'`. If an ECS
+agent ever lands in `status='retrying'` (e.g. operator-initiated
+`retry` command, or future bug), the subprocess lane skips it. An
+`agent_ecs_retry_not_supported` log event fires once per observation
+so the operator sees it; follow-up #4 tracks ECS retry support. The
+guard is strictly additive — subprocess retry behaviour is unchanged.
+
+### Fix 3 — `_handle_force_stop` per-agent branch calls `ecs:StopTask` first
+
+**Before.** SELECT `pid` → UPDATE status='crashed' → SIGKILL(pid).
+For ECS agents `pid` is NULL so the SIGKILL is a no-op; the Fargate
+task keeps running.
+
+**After.** SELECT `pid, execution_mode, agent_task_arn` → UPDATE
+status='crashed' → branch on `execution_mode`:
+- subprocess: SIGKILL(pid) as before.
+- ecs: `ecs:StopTask(cluster=cfg.ecs_cluster_arn, task=agent_task_arn,
+  reason='operator_force_stop')`. Best-effort; botocore errors log and
+  continue — the DB row is already flipped so the reap tick will
+  eventually catch up.
+
+### Fix 4 — CI hygiene check `scripts/check-dispatcher-execution-mode-aware.sh`
+
+Wired into `.github/workflows/ci.yml` dispatcher-tests job. Scans
+`scripts/dispatcher/daemon.py` for every `UPDATE dispatcher.agents`
+statement whose surrounding 30 lines (inclusive of the SQL string's
+docstring context) do not mention `execution_mode`, `agent_task_arn`,
+or a `# exec-mode-agnostic (#N):` annotation. Fails CI with the list
+of offending sites and a fix-shape hint. Pattern mirrors
+`check-terminal-routing-comments.sh` (#3062) and
+`check-git-gh-retries.sh` (#3089).
+
+## Follow-ups filed
+
+1. **#3165 (FOLLOW-1) — diagnoser-forced terminals must stop ECS tasks.**
+   `_consume_action_escalate` / `_close` / `_block_and_comment` /
+   `_file_prerequisite_task` / `_block_on_existing_task` write
+   `status='failed'` to the agent row but do not stop the underlying
+   ECS task. For an ECS agent, this produces a zombie (DB says failed,
+   task still running). Fix: after `_mark_agent_terminal` for an ECS
+   agent, call `ecs:StopTask` before the method returns. Add a shared
+   helper `_stop_ecs_task_if_ecs(agent_id)` and invoke from each of
+   the five consumers.
+2. **#3166 (FOLLOW-2) — agent-runner entrypoint has no external-terminal
+   observer.** The subprocess worker thread calls
+   `_observe_external_terminal` between phases so a diagnoser-written
+   `failed` aborts the worker. The Bash agent-runner entrypoint does
+   not — it runs each phase to completion and then reads the next
+   phase from `dispatcher.agents`. A diagnoser escalation during a
+   long ralph cannot preempt the ECS task. Fix: agent-runner polls
+   `SELECT status FROM dispatcher.agents` between phases and exits
+   non-zero if the row is terminal.
+3. **#3167 (FOLLOW-3) — `_advance_running_agents` post-ralph phase handlers
+   race with agent-runner mechanical stubs.** For ECS agents, both the
+   daemon's `_advance_awaiting_ci` / `_advance_awaiting_deploy` /
+   `_run_fix_ci` AND the agent-runner's mechanical-phase loop try to
+   advance the same row. Some advance handlers use local
+   `worktree_path` which doesn't exist for ECS. Fix shape: either (a)
+   the daemon owns the post-ralph pipeline and the agent-runner exits
+   after `push_and_pr`, OR (b) the agent-runner owns the full
+   pipeline and the daemon only reads state + reaps. Decide before
+   Stage 4 flips the default.
+4. **#3168 (FOLLOW-4) — `_resume_retrying_agent` has no ECS-side support.**
+   When fix 2 lands, an ECS agent flipped to `retrying` is skipped
+   with a warning. The ECS retry surface needs its own launcher
+   (reuse `_launch_agent_ecs_task` with a fresh agent-runner task).
+   Today the forked-to-subprocess path was silently "working" for
+   budgeted retries — the fork itself is the bug, even if the retry
+   eventually succeeded as a subprocess. Track the gap so the product
+   decision ("ECS retries relaunch the task" vs. "ECS retries
+   terminal-and-reclaim via the issue queue") is explicit.
+
+## Validation
+
+- Unit tests for the three fixes land in
+  `scripts/dispatcher/tests/test_daemon_execution_mode_audit.py`.
+- The CI hygiene check is exercised by
+  `scripts/dispatcher/tests/test_check_dispatcher_execution_mode_aware.py`
+  against synthetic pass/fail fixtures.
+- The existing `test_daemon_restart_cascade.py::
+  TestRecoverAbandonedAgentsEcsExecutionMode` suite keeps the #3152
+  fix pinned.

--- a/scripts/check-dispatcher-execution-mode-aware.sh
+++ b/scripts/check-dispatcher-execution-mode-aware.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# check-dispatcher-execution-mode-aware.sh — Every
+# ``UPDATE dispatcher.agents`` / ``SELECT ... FROM dispatcher.agents``
+# call site in ``scripts/dispatcher/daemon.py`` must either:
+#   (a) mention ``execution_mode`` (or ``agent_task_arn``) within a
+#       nearby window, OR
+#   (b) carry a nearby ``# exec-mode-agnostic (#N):`` annotation
+#       explaining why the call is mode-independent by construction
+#       (terminal writers, phase stamps, milestone columns, etc.).
+#
+# Why this check exists
+# ---------------------
+# Three Option A rollout bugs (#3091 draft, #3128-era, #3152) all had
+# the same shape: a code path authored pre-ECS that assumed the agent
+# was a local subprocess under the daemon. The #3158 audit
+# (``docs/investigations/dispatcher-execution-mode-audit-2026-04.md``)
+# classified every ``dispatcher.agents`` read/write and fixed three
+# sites (``_check_stuck_agents``, ``_resume_retrying_agent``,
+# ``_handle_force_stop``). This check prevents a fourth site from
+# being added silently — every new ``UPDATE dispatcher.agents`` /
+# ``SELECT ... dispatcher.agents`` line now either (a) observes the
+# mode flag, or (b) carries an inline audit stamp.
+#
+# Rule
+# ----
+# Every line in ``scripts/dispatcher/daemon.py`` matching
+# ``UPDATE dispatcher.agents`` or ``FROM dispatcher.agents`` (inside a
+# SQL string literal — matched by simple text pattern) MUST have at
+# least one of the following within ``EXEC_MODE_WINDOW_LINES`` lines
+# of surrounding code (window is symmetric: N lines above AND below
+# the SQL line, to cover both the docstring-before-method and
+# exception-handler-after-SQL shapes):
+#
+#   - the token ``execution_mode`` appears, OR
+#   - the token ``agent_task_arn`` appears, OR
+#   - the phrase ``exec-mode-agnostic (#<digits>)`` appears (typically
+#     as a ``# exec-mode-agnostic (#3158): <reason>`` inline comment
+#     OR as a docstring line beginning with
+#     ``exec-mode-agnostic (#3158): <reason>``).
+#
+# Tracking: issue #3158.
+#
+# Usage
+# -----
+#   scripts/check-dispatcher-execution-mode-aware.sh            # scan real daemon.py
+#   scripts/check-dispatcher-execution-mode-aware.sh [file]     # scan a specific file
+#
+# Exit codes
+# ----------
+#   0 — Every call site is covered.
+#   1 — At least one call site is missing nearby coverage.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_FILE="${1:-$REPO_ROOT/scripts/dispatcher/daemon.py}"
+
+# Symmetric window. 60 lines above AND below covers the typical
+# SQL-inside-method shape (docstring + SELECT/UPDATE + exception
+# handler + return). The #3158 audit measured the maximum
+# surrounding-text gap needed for a true-positive at ~55 lines (a
+# method with two SQL statements and a long docstring). 60 keeps
+# headroom for refactors that grow docstrings.
+: "${EXEC_MODE_WINDOW_LINES:=60}"
+
+if [[ ! -f "$TARGET_FILE" ]]; then
+    echo "check-dispatcher-execution-mode-aware: no target file at $TARGET_FILE — nothing to check."
+    exit 0
+fi
+
+# Lines that invoke the table (SELECT / UPDATE / DELETE, case-
+# insensitive SQL keywords inside Python string literals). We match
+# the literal ``dispatcher.agents`` anywhere on the line and filter
+# out obvious false positives: comments (``#`` or ``#:`` prefixed),
+# docstring prose, and JOIN clauses already covered by the same
+# method. Only lines whose content begins with a Python string
+# quote (double quote after whitespace) qualify as a real SQL site.
+target_lines=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && target_lines+=("$line")
+done < <(grep -nE '(UPDATE dispatcher\.agents|FROM dispatcher\.agents[^_])' "$TARGET_FILE" \
+    | grep -vE '^[0-9]+:[[:space:]]*#' \
+    | grep -E '^[0-9]+:[[:space:]]*"' \
+    | cut -d: -f1 || true)
+
+if [[ ${#target_lines[@]} -eq 0 ]]; then
+    echo "check-dispatcher-execution-mode-aware: no UPDATE/SELECT sites in $TARGET_FILE — nothing to check."
+    exit 0
+fi
+
+# Token lines: any line mentioning ``execution_mode`` or
+# ``agent_task_arn`` (anywhere — code, comment, docstring). Also:
+# lines matching the ``# exec-mode-agnostic (#<digits>)`` annotation.
+# We treat all three as coverage signals.
+coverage_lines=()
+while IFS= read -r line; do
+    [[ -n "$line" ]] && coverage_lines+=("$line")
+done < <(grep -nE '(execution_mode|agent_task_arn|exec-mode-agnostic \(#[0-9]+\))' "$TARGET_FILE" \
+    | cut -d: -f1 || true)
+
+violations=0
+missing=()
+
+for target_line in "${target_lines[@]}"; do
+    window_start=$((target_line - EXEC_MODE_WINDOW_LINES))
+    (( window_start < 1 )) && window_start=1
+    window_end=$((target_line + EXEC_MODE_WINDOW_LINES))
+
+    found=0
+    if [[ ${#coverage_lines[@]} -gt 0 ]]; then
+        for c in "${coverage_lines[@]}"; do
+            if (( c >= window_start && c <= window_end )); then
+                found=1
+                break
+            fi
+        done
+    fi
+
+    if (( found == 0 )); then
+        missing+=("$target_line")
+        violations=$((violations + 1))
+    fi
+done
+
+if (( violations > 0 )); then
+    echo "ERROR: dispatcher.agents SQL call site(s) missing nearby execution_mode awareness."
+    echo ""
+    echo "  Target: $TARGET_FILE"
+    echo "  Window: +/- ${EXEC_MODE_WINDOW_LINES} lines around each SQL line."
+    echo ""
+    echo "  Every UPDATE dispatcher.agents / SELECT ... FROM dispatcher.agents"
+    echo "  must have at least one of these within the window:"
+    echo ""
+    echo "    - the token execution_mode"
+    echo "    - the token agent_task_arn"
+    echo "    - the comment # exec-mode-agnostic (#N): <reason>"
+    echo ""
+    echo "  See the #3158 audit for the classification:"
+    echo "  docs/investigations/dispatcher-execution-mode-audit-2026-04.md"
+    echo ""
+    echo "  Sites missing coverage:"
+    echo ""
+    for line in "${missing[@]}"; do
+        snippet="$(sed -n "${line}p" "$TARGET_FILE")"
+        echo "    $TARGET_FILE:${line}: ${snippet}"
+    done
+    echo ""
+    echo "  Fix: add an execution_mode branch, OR annotate the site:"
+    echo ""
+    echo "    # exec-mode-agnostic (#3158): phase-driven terminal writer;"
+    echo "    # mode-specific teardown happens in the caller."
+    exit 1
+fi
+
+echo "check-dispatcher-execution-mode-aware: ${#target_lines[@]} dispatcher.agents SQL site(s) all covered within +/- ${EXEC_MODE_WINDOW_LINES} lines."
+exit 0

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -12205,6 +12205,9 @@ class DispatcherDaemon:
         supervisor tick re-attempts a second unstick instead of
         classifying as exhausted, which at most burns one extra empty
         commit before the real failure surfaces.
+
+        exec-mode-agnostic (#3158): merge-unstick counter bump;
+        mode-independent (merge is daemon-owned for both modes).
         """
         assert self._conn is not None, "connect() must run before update"
         try:

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -2748,17 +2748,29 @@ class DispatcherDaemon:
 
         - **Per-agent (``payload['agentId']`` present)** — kill just
           that agent: update its ``status`` to ``crashed``, set
-          ``ended_at`` to now(), and SIGKILL the pid if it is local.
-          Does NOT touch ``concurrency_cap`` or any global flag —
-          other in-flight agents and new claims are unaffected.
-          Replaces the former ``force_kill`` command.
+          ``ended_at`` to now(), and signal the underlying runtime:
+          for ``execution_mode='subprocess'`` agents SIGKILL the pid,
+          for ``execution_mode='ecs'`` agents call
+          ``ecs:StopTask(agent_task_arn)`` (#3158). Does NOT touch
+          ``concurrency_cap`` or any global flag — other in-flight
+          agents and new claims are unaffected. Replaces the former
+          ``force_kill`` command.
+
+          Pre-#3158 this method SIGKILLed ``pid`` unconditionally.
+          ECS agents have NULL ``pid`` on the daemon host so the
+          SIGKILL was a no-op and the Fargate task kept running while
+          the DB row read ``crashed`` — a zombie state that could
+          persist for hours until the natural task completion.
         """
         agent_id = payload.get("agentId")
 
         if agent_id:
             # Per-agent force_stop — narrow scope, no global effects.
+            # #3158: SELECT ``execution_mode`` + ``agent_task_arn`` so
+            # the signal-delivery branch below can dispatch on mode.
             cur.execute(
-                "SELECT pid FROM dispatcher.agents WHERE agent_id = %s",
+                "SELECT pid, execution_mode, agent_task_arn "
+                "FROM dispatcher.agents WHERE agent_id = %s",
                 (agent_id,),
             )
             row = cur.fetchone()
@@ -2767,6 +2779,14 @@ class DispatcherDaemon:
                     f"force_stop: agent {agent_id!r} not found in dispatcher.agents"
                 )
             pid = int(row[0]) if row[0] is not None else None
+            raw_mode = row[1] if len(row) > 1 else None
+            mode = (
+                str(raw_mode).lower()
+                if raw_mode is not None
+                else DEFAULT_AGENT_EXECUTION_MODE
+            )
+            raw_arn = row[2] if len(row) > 2 else None
+            task_arn = str(raw_arn) if raw_arn is not None else None
 
             cur.execute(
                 "UPDATE dispatcher.agents "
@@ -2775,7 +2795,16 @@ class DispatcherDaemon:
                 (agent_id,),
             )
 
-            if pid is not None:
+            # #3158: signal-delivery branches on execution_mode.
+            # Subprocess agents: SIGKILL the pid. ECS agents:
+            # ``ecs:StopTask`` the Fargate task. Both branches are
+            # best-effort — the DB row is already flipped, so a
+            # signal failure means the reap tick (_reap_completed_
+            # agent_tasks, or a stuck_timeout sweep post-fix) is the
+            # backstop.
+            if mode == "ecs":
+                self._force_stop_ecs_task(agent_id, task_arn)
+            elif pid is not None:
                 try:
                     os.kill(pid, signal.SIGKILL)
                     self._log.info(
@@ -2801,6 +2830,8 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "pid": pid,
+                    "execution_mode": mode,
+                    "agent_task_arn": task_arn,
                 },
             )
             return
@@ -2844,6 +2875,13 @@ class DispatcherDaemon:
         if not agent_id:
             raise CommandError("retry command missing required payload.agentId")
 
+        # exec-mode-agnostic (#3158): operator-initiated retry read —
+        # ``status/retries_used`` have identical semantics for both
+        # subprocess and ECS agents. Post-#3158 the actual
+        # subprocess-lane pickup (_resume_retrying_agent) filters
+        # execution_mode='ecs' out, so flipping an ECS agent to
+        # 'retrying' here just surfaces a WARNING log per
+        # _warn_on_ecs_retrying_rows until #3168 wires ECS retries.
         cur.execute(
             "SELECT status, retries_used FROM dispatcher.agents WHERE agent_id = %s",
             (agent_id,),
@@ -3441,6 +3479,9 @@ class DispatcherDaemon:
         assert self._conn is not None, "connect() must run before checking"
         try:
             with self._conn.cursor() as cur:
+                # exec-mode-agnostic (#3158): concurrency-cap predicate;
+                # ``status='running'`` counts equally for subprocess
+                # and ECS agents — they both consume one cap slot.
                 cur.execute(
                     "SELECT 1 FROM dispatcher.agents WHERE status = 'running' LIMIT 1",
                 )
@@ -4030,6 +4071,9 @@ class DispatcherDaemon:
         assert self._conn is not None, "connect() must run before reading"
         try:
             with self._conn.cursor() as cur:
+                # exec-mode-agnostic (#3158): race-lost diagnostic;
+                # both subprocess and ECS agents write ``kind='task'``
+                # and the race classification is identical.
                 cur.execute(
                     "SELECT kind FROM dispatcher.agents "
                     "WHERE issue_number = %s "
@@ -5506,6 +5550,9 @@ class DispatcherDaemon:
         assert self._conn is not None, "connect() must run before attempt read"
         try:
             with self._conn.cursor() as cur:
+                # exec-mode-agnostic (#3158): retry-counter read; both
+                # modes increment ``retries_used`` via the same
+                # :meth:`_process_retry_markers` path.
                 cur.execute(
                     "SELECT retries_used FROM dispatcher.agents WHERE agent_id = %s",
                     (agent_id,),
@@ -6625,7 +6672,12 @@ class DispatcherDaemon:
 
     def _update_agent_phase(self, agent_id: str, phase: str) -> None:
         """UPDATE ``dispatcher.agents.phase`` so the scheduler + admin
-        page see where the agent currently sits."""
+        page see where the agent currently sits.
+
+        exec-mode-agnostic (#3158): phase progression write. Daemon-
+        side advances call this; the agent-runner (ECS) writes phase
+        transitions via its own psql client to the same column.
+        """
         assert self._conn is not None, "connect() must run before update"
         try:
             with self._conn.cursor() as cur:
@@ -6677,6 +6729,11 @@ class DispatcherDaemon:
         for the ``succeeded`` branch (``ended_at``, ``failure_summary``
         cleanup, diagnosis outcome write-back, terminal-outcome circuit
         breaker feed) in one UPDATE so the admin row transitions atomically.
+
+        exec-mode-agnostic (#3158): merge-time stamp. PR merge is
+        observed by the daemon's awaiting_ci handler regardless of
+        how the agent wrote the phase; the ``status='succeeded'`` +
+        milestone columns are mode-independent.
         """
         assert self._conn is not None, "connect() must run before update"
         try:
@@ -6767,6 +6824,8 @@ class DispatcherDaemon:
         flipped it to ``succeeded`` at merge. The admin cockpit reads
         both columns and renders the pill color from their combined
         presence.
+
+        exec-mode-agnostic (#3158): milestone stamp; mode-independent.
         """
         assert self._conn is not None, "connect() must run before update"
         try:
@@ -6799,6 +6858,8 @@ class DispatcherDaemon:
         The verify phase later reads this column and no-ops if it's
         non-null, so the admin cockpit can distinguish "shipped + verify
         does not apply" from "shipped + verify failed to run".
+
+        exec-mode-agnostic (#3158): self-deploy flag; mode-independent.
         """
         assert self._conn is not None, "connect() must run before update"
         try:
@@ -6843,6 +6904,8 @@ class DispatcherDaemon:
         back to the pre-#3055 behaviour — the short-circuit is purely
         additive protection. A missing row also returns ``(False,
         False)``.
+
+        exec-mode-agnostic (#3158): milestone-read; mode-independent.
         """
         assert self._conn is not None, "connect() must run before read"
         try:
@@ -6893,6 +6956,9 @@ class DispatcherDaemon:
         state, but not a correctness bug (``merged_at`` is still set
         and the retro / cleanup state-machine can still drive the row
         to completion from there).
+
+        exec-mode-agnostic (#3158): post-merge state restore;
+        mode-independent.
         """
         assert self._conn is not None, "connect() must run before update"
         try:
@@ -6921,7 +6987,10 @@ class DispatcherDaemon:
                 pass
 
     def _read_verify_skip_reason(self, agent_id: str) -> str | None:
-        """Return the current ``verify_skip_reason`` for an agent, or None."""
+        """Return the current ``verify_skip_reason`` for an agent, or None.
+
+        exec-mode-agnostic (#3158): column read; mode-independent.
+        """
         assert self._conn is not None, "connect() must run before read"
         try:
             with self._conn.cursor() as cur:
@@ -6957,6 +7026,8 @@ class DispatcherDaemon:
         Issue #2953. Does NOT touch ``status`` or ``phase`` — those are
         handled by the existing ``_update_agent_phase(PHASE_RETRO_DONE)``
         call. Best-effort; a DB error here cannot unwind the retro work.
+
+        exec-mode-agnostic (#3158): milestone stamp; mode-independent.
         """
         assert self._conn is not None, "connect() must run before update"
         try:
@@ -7430,6 +7501,11 @@ class DispatcherDaemon:
         (written to the same column with richer LLM-authored prose).
         Best-effort — a write failure logs + rolls back but must not
         propagate; the terminal status was already committed.
+
+        exec-mode-agnostic (#3158): admin-cockpit hint write; the
+        same one-liner shape applies to subprocess and ECS agents
+        alike — the column is a pure render-hint derived from
+        ``status`` + ``phase`` + ``exit_code``.
         """
         assert self._conn is not None, "connect() must run before update"
         with self._conn.cursor() as cur:
@@ -7483,6 +7559,17 @@ class DispatcherDaemon:
         teardown, which is fine because those paths are rare edge cases
         and the DB row is already marked terminal (the authoritative
         interlock signal).
+
+        exec-mode-agnostic (#3158): canonical terminal writer — the
+        row transition is the contract. Mode-specific teardown
+        (SIGKILL pid for subprocess, ``ecs:StopTask`` for ECS) is the
+        caller's responsibility when the terminal write is
+        operator-initiated (see :meth:`_handle_force_stop` post-#3158)
+        or diagnoser-initiated (see #3165 follow-up). For
+        the natural-completion call sites (agent-runner writing its
+        own terminal before exit; daemon observing a completed merge),
+        there's nothing to stop — the underlying runtime is already
+        done.
         """
         assert self._conn is not None, "connect() must run before update"
         terminal = status in (
@@ -7906,6 +7993,8 @@ class DispatcherDaemon:
         structured-log ``issue_number`` field is simply serialized as
         JSON null so CloudWatch Log Insights can still filter by
         ``agent_id`` + ``phase``. Issue #3017.
+
+        exec-mode-agnostic (#3158): helper lookup; mode-independent.
         """
         conn = self._conn
         if conn is None:
@@ -8394,9 +8483,27 @@ class DispatcherDaemon:
         ``running``, creates a fresh worktree, and re-runs the
         plan → ralph → summary → PR pipeline.
 
-        Returns True when a retrying agent was picked up (the caller
-        must skip the new-claim path on the same tick). Returns False
-        when no retrying agent exists.
+        **Execution-mode filter (#3158).** The SELECT excludes
+        ``execution_mode = 'ecs'`` rows. The resume path creates a
+        *local* worktree on the daemon host and runs
+        :meth:`_run_orchestration_phases` in-process — the subprocess
+        lane. Pre-#3158 this method picked up ECS-mode rows whenever
+        any path (operator ``retry`` command, budgeted retry of a
+        stuck-timeout that was mis-fired at an ECS row) flipped them
+        to ``retrying``, silently forking the agent from ECS to
+        subprocess. NULL ``execution_mode`` (pre-#3091 migration 41
+        rows) defaults to subprocess via ``COALESCE``.
+
+        When an ECS row is observed in ``status='retrying'``, a
+        ``daemon.agent_ecs_retry_not_supported`` WARNING is emitted
+        once per observation so the operator sees it, and the row is
+        left in ``retrying`` (a follow-up sweep / the operator can
+        move it to terminal). Follow-up #3168 from the #3158 audit
+        tracks adding an ECS-native retry launcher.
+
+        Returns True when a subprocess-mode retrying agent was picked
+        up (the caller must skip the new-claim path on the same tick).
+        Returns False when no subprocess-mode retrying agent exists.
         """
         assert self._conn is not None, "connect() must run before resume"
 
@@ -8407,15 +8514,23 @@ class DispatcherDaemon:
                 # Oldest retrying agent first — FIFO fairness if multiple
                 # ever pile up (shouldn't at concurrency_cap=1 but cheap
                 # to order the right way anyway).
+                # #3158: ``COALESCE(execution_mode, 'subprocess') <> 'ecs'``
+                # excludes ECS-mode rows — see docstring.
                 cur.execute(
                     "SELECT agent_id, issue_number FROM dispatcher.agents "
                     "WHERE status = 'retrying' "
+                    "  AND COALESCE(execution_mode, 'subprocess') <> 'ecs' "
                     "ORDER BY started_at ASC "
                     "LIMIT 1",
                 )
                 row = cur.fetchone()
             self._conn.commit()
             if row is None:
+                # #3158: no subprocess-mode retrying agent. If there
+                # are ECS-mode retrying rows, log a warning so operators
+                # see them — they need manual attention until
+                # #3168 lands an ECS-native retry launcher.
+                self._warn_on_ecs_retrying_rows()
                 return False
             agent_id = str(row[0])
             issue_number = int(row[1]) if row[1] is not None else None
@@ -8515,6 +8630,58 @@ class DispatcherDaemon:
 
         self._run_orchestration_phases(agent_id, issue_number, worktree)
         return True
+
+    def _warn_on_ecs_retrying_rows(self) -> None:
+        """Log a WARNING for any ``status='retrying' execution_mode='ecs'`` rows.
+
+        #3158. The subprocess-lane resume path
+        (:meth:`_resume_retrying_agent`) filters these rows out so it
+        doesn't silently fork an ECS agent to subprocess mode. But the
+        rows still need operator visibility — the ECS retry surface is
+        not yet wired (see audit follow-up #3168), so an ECS row
+        stuck in ``retrying`` is invisible work that will never advance
+        without intervention.
+
+        Best-effort: a DB read failure here logs but does not propagate
+        — the scheduler tick must not stall on this diagnostic.
+        """
+        assert self._conn is not None, "connect() must run before ecs retry check"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT agent_id, issue_number "
+                    "FROM dispatcher.agents "
+                    "WHERE status = 'retrying' "
+                    "  AND execution_mode = 'ecs' "
+                    "LIMIT 5",
+                )
+                rows = cur.fetchall()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return
+        for row in rows or []:
+            self._log.warning(
+                "daemon.agent_ecs_retry_not_supported",
+                extra={
+                    "event": "agent_ecs_retry_not_supported",
+                    "run_id": self._run_id,
+                    "agent_id": str(row[0]),
+                    "issue_number": (int(row[1]) if row[1] is not None else None),
+                    "detail": (
+                        "ECS-mode agent in status='retrying'; the "
+                        "subprocess-lane resume path skips these rows "
+                        "(#3158) and the ECS-native retry launcher is "
+                        "not yet wired (audit follow-up #3168). "
+                        "Operator action required: either manually "
+                        "terminate (force_stop + agent/ready relabel) "
+                        "or wait for #3168."
+                    ),
+                },
+            )
 
     def _plan_blocked_comment_already_posted(self, issue_number: int) -> bool | None:
         """Return True if the plan-blocked sentinel comment is already on the issue.
@@ -9224,6 +9391,11 @@ class DispatcherDaemon:
         phase is NOT in :data:`_INFRA_PREEMPTION_CATEGORIES` (i.e. real
         budgeted retries: ``subprocess_crash``, ``stuck_timeout``,
         ``gh_rate_exhausted``, ``operator_retry``).
+
+        exec-mode-agnostic (#3158): failure-history read; the joined
+        ``phase_outputs`` rows are written by whichever runtime ran
+        the phase (daemon subprocess OR agent-runner), and the
+        terminal filter applies uniformly.
 
         Returns an empty list on any DB error (fail-open — the spawn
         continues without prior context).
@@ -11218,6 +11390,19 @@ class DispatcherDaemon:
 
         Cleanup_done / cleanup_blocked are deliberately excluded — they
         are terminal phases with no further advance to perform.
+
+        NOTE (#3158 audit follow-up #3167): this SELECT picks up
+        BOTH subprocess and ECS agents. For ECS agents the agent-
+        runner has its own mechanical stubs for these post-ralph
+        phases, so the daemon's advance handlers can race with the
+        agent-runner. Some advance handlers (``_run_fix_ci``) read
+        the local ``worktree_path`` which doesn't exist for ECS. The
+        fix shape is an architectural decision: either the daemon or
+        the agent-runner owns the post-ralph pipeline. Tracked in
+        #3167 from ``docs/investigations/
+        dispatcher-execution-mode-audit-2026-04.md``. Until then, the
+        race is observed-but-tolerable for the small number of ECS
+        agents in dev.
         """
         assert self._conn is not None, "connect() must run before reading"
 
@@ -11245,6 +11430,14 @@ class DispatcherDaemon:
                 # the other awaiting_* bookkeeping so the merge-phase
                 # handler has the counter in hand without a second
                 # round-trip. See ``_merge_pr_and_advance``.
+                #
+                # exec-mode-agnostic (#3158) — with a caveat: the
+                # SELECT matches BOTH subprocess and ECS agents. ECS
+                # agents in post-ralph phases are simultaneously
+                # advanced by the agent-runner's mechanical stubs,
+                # producing a daemon↔runner race. Tracked as
+                # #3167 in the #3158 audit (architectural decision
+                # needed: who owns the post-ralph pipeline).
                 cur.execute(
                     "SELECT agent_id, issue_number, phase, pr_number, "
                     "       worktree_path, retries_used, status, "
@@ -12618,7 +12811,11 @@ class DispatcherDaemon:
         )
 
     def _increment_retries_used(self, agent_id: str) -> None:
-        """UPDATE ``dispatcher.agents.retries_used = retries_used + 1``."""
+        """UPDATE ``dispatcher.agents.retries_used = retries_used + 1``.
+
+        exec-mode-agnostic (#3158): retry counter bump; both modes
+        track attempts via the same column.
+        """
         assert self._conn is not None, "connect() must run before update"
         try:
             with self._conn.cursor() as cur:
@@ -13712,7 +13909,11 @@ class DispatcherDaemon:
         return rows
 
     def _fetch_agent_total_duration_s(self, agent_id: str) -> int:
-        """Compute wall-clock seconds since the agent claimed."""
+        """Compute wall-clock seconds since the agent claimed.
+
+        exec-mode-agnostic (#3158): duration is started_at-relative;
+        claim-time stamp applies to both modes.
+        """
         assert self._conn is not None, "connect() must run before reading"
         try:
             with self._conn.cursor() as cur:
@@ -14332,16 +14533,39 @@ class DispatcherDaemon:
         (label-only /task coordination), so no kind-filter is needed
         — the #2903 task-skill guard has been removed.
 
+        **Execution-mode filter (#3158).** The SELECT excludes
+        ``execution_mode = 'ecs'`` rows. The per-phase stuck timer was
+        designed for subprocess-mode agents, whose
+        ``phase_transitions.ts`` is written by the daemon itself — so a
+        stuck subprocess always surfaces as an older MAX(ts). ECS
+        agents run the phase loop inside an independent Fargate task
+        whose lifecycle belongs to ECS, not to the daemon: a truly-hung
+        ECS task is caught by :meth:`_reap_completed_agent_tasks` when
+        ECS transitions the task to STOPPED (container health check,
+        SIGKILL, OOM) and routed via :meth:`_handle_agent_failure` with
+        category ``agent_task_stopped_unexpectedly``. Applying the
+        per-phase timer to an ECS agent is a silent-agent-loss risk:
+        (a) it flips the row to ``crashed`` while the Fargate task
+        keeps running (zombie state), (b) it enqueues a retry marker
+        which :meth:`_resume_retrying_agent` would pick up and
+        silently fork to subprocess mode. NULL ``execution_mode``
+        (pre-#3091 migration 41 rows) defaults to subprocess via
+        ``COALESCE``.
+
         Returns the number of stuck agents flagged this tick (for
         logging). Exceptions are caught per-agent + logged; one bad
         row cannot stall the scan.
         """
         assert self._conn is not None, "connect() must run before stuck check"
 
-        # Candidate rows: every running agent, regardless of elapsed
-        # time. The per-phase threshold comparison happens in Python
-        # so we can consult both the live config override and the
-        # module-level defaults without expressing them as SQL.
+        # Candidate rows: every running subprocess-mode agent,
+        # regardless of elapsed time. The per-phase threshold
+        # comparison happens in Python so we can consult both the live
+        # config override and the module-level defaults without
+        # expressing them as SQL.
+        #
+        # #3158: ``COALESCE(a.execution_mode, 'subprocess') <> 'ecs'``
+        # excludes ECS-mode agents — see method docstring for rationale.
         #
         # Fields: agent_id, issue_number, phase, elapsed_seconds.
         candidates: list[tuple[str, int | None, str | None, float]] = []
@@ -14358,7 +14582,8 @@ class DispatcherDaemon:
                     "    FROM dispatcher.phase_transitions "
                     "    WHERE agent_id = a.agent_id"
                     ") pt ON TRUE "
-                    "WHERE a.status = 'running'",
+                    "WHERE a.status = 'running' "
+                    "  AND COALESCE(a.execution_mode, 'subprocess') <> 'ecs'",
                 )
                 rows = cur.fetchall()
                 for row in rows:
@@ -15111,6 +15336,14 @@ class DispatcherDaemon:
                 # join) preserves the grep-ability of SQL statements
                 # in the daemon, which the fakes in
                 # ``test_daemon_phase3c.py`` rely on.
+                #
+                # exec-mode-agnostic (#3158): the reset itself is
+                # mode-independent — flip to retrying/claiming,
+                # increment counter. The MODE-FORK risk is downstream
+                # in :meth:`_resume_retrying_agent`, which was
+                # hardened in #3158 to filter out ``execution_mode =
+                # 'ecs'`` rows. So even if an ECS agent lands in
+                # retrying here, the subprocess lane won't pick it up.
                 reset_sql = (
                     "UPDATE dispatcher.agents "
                     "SET status = 'retrying', "
@@ -15493,6 +15726,9 @@ class DispatcherDaemon:
         time). Append-only: the ring-buffer semantics come from the
         rolling-window scan in :meth:`_evaluate_circuit_breaker`, not
         from deleting rows on write.
+
+        exec-mode-agnostic (#3158): circuit-breaker feed; a terminal
+        is a terminal regardless of which runtime produced it.
         """
         assert self._conn is not None, "connect() must run before outcome write"
         with self._conn.cursor() as cur:
@@ -16123,6 +16359,11 @@ class DispatcherDaemon:
         empty/null on failure — a stale or missing context is better
         than no diagnosis. The skill's decision-tree defaults to
         ``escalate`` on sparse context.
+
+        exec-mode-agnostic (#3158): diagnoser-context build; the
+        ``worktree_path`` field is read best-effort for the ralph-log
+        lookup, which gracefully degrades to empty string when the
+        path doesn't exist on the daemon host (ECS case).
         """
         assert self._conn is not None, "connect() must run before context build"
 
@@ -18544,6 +18785,80 @@ class DispatcherDaemon:
                 },
             )
 
+    def _force_stop_ecs_task(self, agent_id: str, task_arn: str | None) -> None:
+        """Best-effort ``ecs:StopTask`` for a per-agent Fargate task (#3158).
+
+        Called from :meth:`_handle_force_stop` when the agent has
+        ``execution_mode='ecs'``. Pre-#3158 the per-agent force_stop
+        only SIGKILLed the row's ``pid``, which for ECS agents is NULL
+        on the daemon host — the Fargate task kept running while the
+        DB row read ``crashed``. This helper closes the loop by
+        invoking ``ecs:StopTask`` on the recorded ``agent_task_arn``.
+
+        Best-effort by design:
+        - A missing ``task_arn`` (pre-launch crash, historical row)
+          logs and returns cleanly.
+        - A missing ``ecs_cluster_arn`` config (local dev / tests)
+          logs and returns cleanly.
+        - Any botocore exception (InvalidParameterException for an
+          already-STOPPED task, throttling, transient 5xx) is caught
+          and logged. The DB row is already flipped to ``crashed`` by
+          the caller, so the reap-tick loop (STOPPED →
+          :meth:`_handle_agent_failure`) is the backstop if the stop
+          call failed and the task is still running.
+        """
+        if not task_arn:
+            self._log.info(
+                "daemon.force_stop_ecs_task_no_arn",
+                extra={
+                    "event": "force_stop_ecs_task_no_arn",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            return
+        if not self._cfg.ecs_cluster_arn:
+            self._log.warning(
+                "daemon.force_stop_ecs_task_no_cluster",
+                extra={
+                    "event": "force_stop_ecs_task_no_cluster",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "task_arn": task_arn,
+                },
+            )
+            return
+        try:
+            if self._ecs_client is None:
+                self._ecs_client = self._make_ecs_client()
+            self._ecs_client.stop_task(
+                cluster=self._cfg.ecs_cluster_arn,
+                task=task_arn,
+                reason="operator_force_stop",
+            )
+            self._log.info(
+                "daemon.force_stop_ecs_task_sent",
+                extra={
+                    "event": "force_stop_ecs_task_sent",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "task_arn": task_arn,
+                },
+            )
+        except Exception as exc:  # noqa: BLE001 — log + swallow
+            # Reset the client so the next call picks up a fresh one.
+            self._ecs_client = None
+            self._log.warning(
+                "daemon.force_stop_ecs_task_failed",
+                extra={
+                    "event": "force_stop_ecs_task_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "task_arn": task_arn,
+                    "detail": str(exc),
+                },
+            )
+
     def _reap_completed_agent_tasks(self) -> dict[str, int]:
         """Observe lifecycle of active per-agent ECS tasks (#3091).
 
@@ -18850,6 +19165,10 @@ class DispatcherDaemon:
         "agent-runner already wrote terminal" from "container died
         before entrypoint finished". Returns ``(None, None)`` on DB
         error — the caller treats that as "assume non-terminal".
+
+        exec-mode-agnostic (#3158): status/phase columns are written
+        by either runtime (subprocess via daemon, ECS via agent-
+        runner); the read is uniform.
         """
         assert self._conn is not None, "connect() must run before read"
         try:

--- a/scripts/dispatcher/tests/test_daemon_execution_mode_audit.py
+++ b/scripts/dispatcher/tests/test_daemon_execution_mode_audit.py
@@ -1,0 +1,450 @@
+"""Unit tests for the #3158 ``execution_mode`` awareness audit fixes.
+
+Issue #3158. The audit
+(``docs/investigations/dispatcher-execution-mode-audit-2026-04.md``)
+classified every ``dispatcher.agents`` read/write in
+``scripts/dispatcher/daemon.py`` and fixed three sites that silently
+mishandled ECS-mode agents:
+
+* **Fix 1 — ``_check_stuck_agents``** — SELECT filter now excludes
+  ``execution_mode = 'ecs'`` rows so the per-phase stuck timer can
+  never flip an ECS agent to ``crashed`` (which pre-fix would enqueue
+  a retry marker and fork the agent to subprocess via
+  ``_resume_retrying_agent``).
+* **Fix 2 — ``_resume_retrying_agent``** — SELECT filter now excludes
+  ``execution_mode = 'ecs'`` rows so a retrying ECS agent is never
+  silently relaunched as a subprocess. Paired with a WARNING event
+  when an ECS-retrying row is observed (operator signal until
+  FOLLOW-4 wires ECS-native retry).
+* **Fix 3 — ``_handle_force_stop`` per-agent** — signal-delivery
+  branches on ``execution_mode``: subprocess → SIGKILL pid,
+  ECS → ``ecs:StopTask(agent_task_arn)``. Pre-fix the SIGKILL
+  no-oped for ECS agents because ``pid`` was NULL on the daemon host.
+
+All three fixes are strictly additive — subprocess-mode behaviour is
+unchanged. Tests below pin both the subprocess path (must not regress)
+and the ECS path (new behaviour).
+"""
+
+from __future__ import annotations
+
+import logging
+import signal
+import sys
+from pathlib import Path
+from typing import Any
+
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+from dispatcher import daemon  # noqa: E402 — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes (same shape as test_daemon_restart_cascade.py)
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+    ecs_cluster_arn: str | None = None,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.execution_mode_audit.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+        ecs_cluster_arn=ecs_cluster_arn,
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# Fix 1 — _check_stuck_agents filters execution_mode='ecs'
+# --------------------------------------------------------------------------
+
+
+class TestCheckStuckAgentsExecutionModeFilter:
+    """The supervisor stuck-timeout scan must not flag ECS-mode agents.
+
+    Pre-#3158, the SELECT returned every ``status='running'`` row and
+    applied the per-phase threshold uniformly. For a long ECS ralph
+    exceeding 15h the scan would flip the ECS row to ``crashed`` and
+    enqueue a retry marker — which (absent the #3158 fix in
+    :meth:`_resume_retrying_agent`) would silently fork the agent to
+    subprocess mode on the next scheduler tick.
+
+    Post-#3158, the SELECT carries
+    ``COALESCE(a.execution_mode, 'subprocess') <> 'ecs'`` so ECS rows
+    never reach the per-phase timer. An ECS task that's actually hung
+    is caught by :meth:`_reap_completed_agent_tasks` when ECS itself
+    stops it.
+    """
+
+    def test_select_filters_execution_mode_ecs(self, tmp_path: Path) -> None:
+        """The SELECT excludes ``execution_mode = 'ecs'`` via COALESCE."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue = [[]]
+
+        d._check_stuck_agents()
+
+        # The first SELECT is the candidate scan; later cursor.execute
+        # calls belong to the per-phase config read which may happen
+        # in the same tick.
+        selects = [
+            e
+            for e in conn.cursor_instance.executed
+            if "FROM dispatcher.agents a" in e[0]
+        ]
+        assert selects, "expected _check_stuck_agents to issue the SELECT"
+        sql, _params = selects[0]
+        assert "COALESCE(a.execution_mode, 'subprocess') <> 'ecs'" in sql, (
+            "_check_stuck_agents must filter out execution_mode='ecs' rows. "
+            "Actual SQL: " + sql
+        )
+
+    def test_subprocess_agent_still_flagged_on_timeout(self, tmp_path: Path) -> None:
+        """A subprocess-mode agent stuck past its threshold still flips crashed."""
+        d, conn, handler = _make_daemon(tmp_path)
+        # Override the config read so the per-phase overrides lookup
+        # returns an empty dict and we fall back to module defaults
+        # (``ralph`` = 54000s).
+        d._read_stuck_timeout_overrides = lambda: {}  # type: ignore[assignment]
+        # One subprocess agent stuck 60000s in ralph (exceeds 54000s).
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-sub", 2807, "ralph", 60000.0)],
+        ]
+        # Retry marker COUNT + backoff config reads that
+        # _write_failure / _create_retry_marker issue.
+        conn.cursor_instance.fetch_queue = [
+            (0,),
+            ("[60,300,900]",),
+        ]
+
+        flagged = d._check_stuck_agents()
+        assert flagged == 1
+
+        failure_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert len(failure_inserts) == 1
+        assert failure_inserts[0][1][1] == daemon.FAILURE_CATEGORY_STUCK_TIMEOUT
+        # Subprocess agent did get a retry marker and a crashed flip.
+        marker_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert len(marker_inserts) == 1
+
+
+# --------------------------------------------------------------------------
+# Fix 2 — _resume_retrying_agent filters execution_mode='ecs'
+# --------------------------------------------------------------------------
+
+
+class TestResumeRetryingAgentExecutionModeFilter:
+    """The subprocess-lane resume path must skip ECS-mode agents.
+
+    Pre-#3158 the SELECT matched any ``status='retrying'`` row and
+    called :meth:`_create_worktree` + :meth:`_run_orchestration_phases`,
+    silently forking an ECS agent to subprocess mode.
+
+    Post-#3158 the SELECT filters
+    ``COALESCE(execution_mode, 'subprocess') <> 'ecs'``. If no
+    subprocess-mode retrying agent exists, the method emits a
+    per-observation WARNING for each ECS-retrying row via
+    :meth:`_warn_on_ecs_retrying_rows`.
+    """
+
+    def test_select_filters_execution_mode_ecs(self, tmp_path: Path) -> None:
+        """The resume-scan SELECT excludes ``execution_mode = 'ecs'`` rows."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        # First SELECT returns no subprocess-mode retrying row.
+        # Second SELECT (in _warn_on_ecs_retrying_rows) returns no ECS rows.
+        conn.cursor_instance.fetchall_queue = [[]]
+        conn.cursor_instance.fetch_queue = [None]
+
+        assert d._resume_retrying_agent() is False
+
+        selects = [
+            e
+            for e in conn.cursor_instance.executed
+            if "status = 'retrying'" in e[0]
+            and "dispatcher.agents" in e[0]
+            and "execution_mode" in e[0]
+        ]
+        assert selects, (
+            "expected _resume_retrying_agent to issue a SELECT that "
+            "filters execution_mode"
+        )
+        sql, _params = selects[0]
+        assert "COALESCE(execution_mode, 'subprocess') <> 'ecs'" in sql, (
+            "_resume_retrying_agent must filter execution_mode='ecs'. "
+            "Actual SQL: " + sql
+        )
+
+    def test_ecs_retrying_row_logs_warning(self, tmp_path: Path) -> None:
+        """An ECS-mode retrying row produces an operator-visible WARNING."""
+        d, conn, handler = _make_daemon(tmp_path)
+        # _resume_retrying_agent issues a SELECT ... WHERE status =
+        # 'retrying' AND COALESCE(execution_mode,...) <> 'ecs' and
+        # reads via fetchone(). Queue None so the subprocess-lane
+        # pickup returns False.
+        conn.cursor_instance.fetch_queue = [None]
+        # _warn_on_ecs_retrying_rows then issues a second SELECT
+        # WHERE execution_mode='ecs' and reads via fetchall().
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-ecs-retry", 2671)],
+        ]
+
+        assert d._resume_retrying_agent() is False
+
+        warn_events = handler.events("agent_ecs_retry_not_supported")
+        assert len(warn_events) == 1
+        record = warn_events[0]
+        assert getattr(record, "agent_id") == "agent-ecs-retry"
+        assert getattr(record, "issue_number") == 2671
+
+    def test_subprocess_retrying_agent_still_resumes(self, tmp_path: Path) -> None:
+        """A subprocess-mode retrying agent is picked up and resumed."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        # Stub out the worktree + orchestration so we only exercise
+        # the SELECT + UPDATE path.
+        d._create_worktree = lambda _agent_id: tmp_path / "wt"  # type: ignore[assignment]
+        d._run_orchestration_phases = (  # type: ignore[assignment]
+            lambda _agent_id, _issue_number, _worktree: None
+        )
+        conn.cursor_instance.fetch_queue = [("agent-sub", 2807)]
+
+        assert d._resume_retrying_agent() is True
+
+        # Flip-to-running UPDATE issued — the SQL string contains
+        # ``'running'`` (literal, in the SET clause) + the agent_id
+        # param tuple.
+        updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and "'running'" in e[0]
+            and e[1] == ("agent-sub",)
+        ]
+        assert updates, (
+            f"expected flip-to-running UPDATE, saw: "
+            f"{[e[0][:80] for e in conn.cursor_instance.executed]}"
+        )
+
+
+# --------------------------------------------------------------------------
+# Fix 3 — _handle_force_stop branches on execution_mode for signal delivery
+# --------------------------------------------------------------------------
+
+
+class TestHandleForceStopExecutionModeBranch:
+    """Per-agent force_stop must stop the runtime for BOTH modes.
+
+    Pre-#3158 the method SIGKILLed ``pid`` unconditionally. For ECS
+    agents ``pid`` is NULL on the daemon host, so the SIGKILL was a
+    no-op while the Fargate task kept running — a zombie state.
+
+    Post-#3158, a ``SELECT pid, execution_mode, agent_task_arn``
+    drives the branch: subprocess → SIGKILL, ECS →
+    ``ecs:StopTask(agent_task_arn)`` via
+    :meth:`_force_stop_ecs_task`.
+    """
+
+    def test_subprocess_agent_sigkills_pid(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """Subprocess branch SIGKILLs the recorded pid."""
+        d, conn, handler = _make_daemon(tmp_path)
+        # Record SIGKILL targets.
+        killed: list[tuple[int, int]] = []
+
+        def fake_kill(pid: int, sig: int) -> None:
+            killed.append((pid, sig))
+
+        monkeypatch.setattr(daemon.os, "kill", fake_kill)
+        # Agent row: pid=12345, execution_mode='subprocess', arn=None.
+        conn.cursor_instance.fetch_queue = [(12345, "subprocess", None)]
+
+        d._handle_force_stop(conn.cursor_instance, {"agentId": "agent-sub"})
+
+        # UPDATE status='crashed' ran.
+        crashed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+        ]
+        assert crashed_updates
+        # SIGKILL delivered to pid 12345.
+        assert killed == [(12345, signal.SIGKILL)]
+
+    def test_ecs_agent_calls_stop_task(self, tmp_path: Path) -> None:
+        """ECS branch invokes ``ecs:StopTask`` with the task ARN."""
+        task_arn = (
+            "arn:aws:ecs:us-west-2:155326049300:task/"
+            "judgemind-dev/888fbe0274694bb2baaa8de21cdbe142"
+        )
+        d, conn, handler = _make_daemon(
+            tmp_path,
+            ecs_cluster_arn="arn:aws:ecs:us-west-2:155326049300:cluster/judgemind-dev",
+        )
+        # Stub the ECS client BEFORE the handler runs so
+        # _force_stop_ecs_task picks it up instead of calling
+        # _make_ecs_client.
+        stop_calls: list[dict[str, Any]] = []
+
+        class _FakeEcsClient:
+            def stop_task(self, **kwargs: Any) -> dict[str, Any]:
+                stop_calls.append(kwargs)
+                return {"task": {"taskArn": kwargs["task"]}}
+
+        d._ecs_client = _FakeEcsClient()
+
+        # Agent row: pid=None, execution_mode='ecs', arn populated.
+        conn.cursor_instance.fetch_queue = [(None, "ecs", task_arn)]
+
+        d._handle_force_stop(conn.cursor_instance, {"agentId": "agent-ecs"})
+
+        # ``ecs:StopTask`` called once with the cluster + task + reason.
+        assert len(stop_calls) == 1
+        assert stop_calls[0]["cluster"] == d._cfg.ecs_cluster_arn
+        assert stop_calls[0]["task"] == task_arn
+        assert stop_calls[0]["reason"] == "operator_force_stop"
+
+        # Structured-log event emitted for CloudWatch.
+        sent_events = handler.events("force_stop_ecs_task_sent")
+        assert len(sent_events) == 1
+
+    def test_ecs_agent_missing_arn_logs_and_returns(self, tmp_path: Path) -> None:
+        """An ECS agent with NULL ``agent_task_arn`` logs + returns cleanly."""
+        d, conn, handler = _make_daemon(
+            tmp_path,
+            ecs_cluster_arn="arn:aws:ecs:us-west-2:155326049300:cluster/judgemind-dev",
+        )
+        # pid=None, mode='ecs', arn=None (e.g. pre-launch crash).
+        conn.cursor_instance.fetch_queue = [(None, "ecs", None)]
+
+        d._handle_force_stop(conn.cursor_instance, {"agentId": "agent-ecs-no-arn"})
+
+        events = handler.events("force_stop_ecs_task_no_arn")
+        assert len(events) == 1
+
+    def test_ecs_agent_missing_cluster_config_logs(self, tmp_path: Path) -> None:
+        """An ECS agent with an ARN but no cluster config logs a warning."""
+        d, conn, handler = _make_daemon(
+            tmp_path,
+            ecs_cluster_arn=None,  # local dev / tests
+        )
+        conn.cursor_instance.fetch_queue = [
+            (None, "ecs", "arn:aws:ecs:us-west-2:1:task/x/y"),
+        ]
+
+        d._handle_force_stop(conn.cursor_instance, {"agentId": "agent-ecs-no-cluster"})
+
+        events = handler.events("force_stop_ecs_task_no_cluster")
+        assert len(events) == 1
+
+    def test_missing_agent_raises_command_error(self, tmp_path: Path) -> None:
+        """Unchanged behavior for missing agent_id — CommandError."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+
+        import pytest
+
+        with pytest.raises(daemon.CommandError):
+            d._handle_force_stop(conn.cursor_instance, {"agentId": "agent-missing"})
+
+    def test_select_includes_execution_mode_and_task_arn(self, tmp_path: Path) -> None:
+        """The SELECT must fetch mode + arn in a single round-trip."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(12345, "subprocess", None)]
+
+        d._handle_force_stop(conn.cursor_instance, {"agentId": "any"})
+
+        selects = [
+            e
+            for e in conn.cursor_instance.executed
+            if "SELECT pid" in e[0] and "dispatcher.agents" in e[0]
+        ]
+        assert selects, "expected SELECT pid, execution_mode, agent_task_arn"
+        sql, _params = selects[0]
+        assert "execution_mode" in sql
+        assert "agent_task_arn" in sql

--- a/scripts/tests/test_check_dispatcher_execution_mode_aware.sh
+++ b/scripts/tests/test_check_dispatcher_execution_mode_aware.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# test_check_dispatcher_execution_mode_aware.sh — Tests for
+# scripts/check-dispatcher-execution-mode-aware.sh
+#
+# Verifies that the checker:
+#   - passes on synthetic daemon.py contents with well-annotated SQL
+#     sites (inline ``# exec-mode-agnostic`` comment OR execution_mode
+#     branch nearby)
+#   - fails on unannotated ``UPDATE dispatcher.agents`` / ``FROM
+#     dispatcher.agents`` sites
+#   - ignores ``dispatcher.agents`` references inside Python comments
+#     and docstring prose
+#   - passes on the real ``scripts/dispatcher/daemon.py`` (#3158
+#     hardening landed with this test).
+#
+# Usage:
+#   scripts/tests/test_check_dispatcher_execution_mode_aware.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-dispatcher-execution-mode-aware.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+write_file() {
+    local path="$TMPDIR_TEST/$1"
+    mkdir -p "$(dirname "$path")"
+    cat > "$path"
+}
+
+assert_passes() {
+    local desc="$1"
+    local target="$2"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$target" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        "$CHECK_SCRIPT" "$target" 2>&1 | sed 's/^/    /'
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"
+    local target="$2"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$target" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+# ─── Test 1: UPDATE with nearby execution_mode branch passes ──────────────
+write_file "good_update_branch.py" <<'EOF'
+def handler(execution_mode):
+    if execution_mode == "ecs":
+        pass
+    cur.execute(
+        "UPDATE dispatcher.agents SET status = 'crashed' WHERE agent_id = %s",
+        (agent_id,),
+    )
+EOF
+assert_passes "UPDATE near execution_mode keyword" \
+    "$TMPDIR_TEST/good_update_branch.py"
+
+# ─── Test 2: UPDATE with nearby exec-mode-agnostic annotation passes ──────
+write_file "good_update_annotation.py" <<'EOF'
+def handler():
+    # exec-mode-agnostic (#3158): phase-driven write.
+    cur.execute(
+        "UPDATE dispatcher.agents SET phase = %s WHERE agent_id = %s",
+        (phase, agent_id),
+    )
+EOF
+assert_passes "UPDATE with nearby # exec-mode-agnostic annotation" \
+    "$TMPDIR_TEST/good_update_annotation.py"
+
+# ─── Test 3: UPDATE without any coverage fails ────────────────────────────
+write_file "bad_update_bare.py" <<'EOF'
+def handler():
+    cur.execute(
+        "UPDATE dispatcher.agents SET phase = %s WHERE agent_id = %s",
+        (phase, agent_id),
+    )
+EOF
+assert_fails "UPDATE without any mode awareness fails" \
+    "$TMPDIR_TEST/bad_update_bare.py"
+
+# ─── Test 4: SELECT FROM dispatcher.agents with annotation passes ─────────
+write_file "good_select.py" <<'EOF'
+def handler():
+    # exec-mode-agnostic (#3158): helper lookup.
+    cur.execute(
+        "SELECT issue_number FROM dispatcher.agents WHERE agent_id = %s",
+        (agent_id,),
+    )
+EOF
+assert_passes "SELECT with nearby # exec-mode-agnostic annotation" \
+    "$TMPDIR_TEST/good_select.py"
+
+# ─── Test 5: SELECT without coverage fails ────────────────────────────────
+write_file "bad_select.py" <<'EOF'
+def handler():
+    cur.execute(
+        "SELECT issue_number FROM dispatcher.agents WHERE agent_id = %s",
+        (agent_id,),
+    )
+EOF
+assert_fails "SELECT without any mode awareness fails" \
+    "$TMPDIR_TEST/bad_select.py"
+
+# ─── Test 6: docstring mention of dispatcher.agents is ignored ────────────
+# The SELECT/UPDATE pattern inside a docstring (comment or prose) is
+# not a real SQL site; the checker must skip it.
+write_file "docstring_mention.py" <<'EOF'
+#: Reads like ``SELECT count(*) FROM dispatcher.agents`` in the docs
+#: don't count as real call sites.
+CONSTANT = 1
+EOF
+assert_passes "docstring-prose mention of dispatcher.agents is ignored" \
+    "$TMPDIR_TEST/docstring_mention.py"
+
+# ─── Test 7: agent_task_arn keyword satisfies the check ───────────────────
+write_file "good_task_arn.py" <<'EOF'
+def handler(task_arn):
+    # the reap path tracks agent_task_arn for ECS rows.
+    cur.execute(
+        "SELECT status FROM dispatcher.agents WHERE agent_id = %s",
+        (agent_id,),
+    )
+EOF
+assert_passes "agent_task_arn keyword satisfies the check" \
+    "$TMPDIR_TEST/good_task_arn.py"
+
+# ─── Test 8: real daemon.py passes (the #3158 hardening landed) ───────────
+REAL_DAEMON="$REPO_ROOT/scripts/dispatcher/daemon.py"
+if [[ -f "$REAL_DAEMON" ]]; then
+    assert_passes "real scripts/dispatcher/daemon.py covers every site" \
+        "$REAL_DAEMON"
+fi
+
+echo ""
+if (( FAILURES > 0 )); then
+    echo "$FAILURES of $TESTS tests FAILED"
+    exit 1
+fi
+echo "all $TESTS tests passed"
+exit 0


### PR DESCRIPTION
## Summary

Forward-scan audit of every SQL call site that reads or writes
`dispatcher.agents` in `scripts/dispatcher/daemon.py`. Motivated by
three Option A rollout bugs (#3091 draft, #3128-era, #3152) that
all shared the same shape: a code path authored pre-ECS that
silently mishandled ECS-mode agents.

## Audit findings

Full site-by-site classification in
[`docs/investigations/dispatcher-execution-mode-audit-2026-04.md`](docs/investigations/dispatcher-execution-mode-audit-2026-04.md).

Summary:

| Verdict | Count | Disposition |
|---|---|---|
| PASS (mode-aware by design) | 4 | — |
| BACKSTOP (mode-agnostic by construction) | 29 | annotated `exec-mode-agnostic (#3158)` |
| CONCERN (fixed in this PR) | 3 | see below |
| CONCERN (filed as follow-ups) | 3 architectural items | #3165, #3166, #3167, #3168 |

## Fixes in this PR

### Fix 1 — `_check_stuck_agents` skips ECS agents

SELECT now filters `COALESCE(a.execution_mode, 'subprocess') <> 'ecs'`.
The per-phase stuck timer was authored for subprocess agents whose
`phase_transitions.ts` MAX is daemon-written; applying it to an ECS
agent in a long ralph would flip it to `crashed` and enqueue a retry
marker — which (pre-Fix 2 below) would have silently forked it to
subprocess. ECS liveness belongs to `_reap_completed_agent_tasks`.

### Fix 2 — `_resume_retrying_agent` skips ECS agents

SELECT now filters `execution_mode = 'ecs'`. This method creates a
local worktree and runs the subprocess pipeline — picking up an ECS
row here silently forked it to subprocess. New
`_warn_on_ecs_retrying_rows` helper emits an operator-visible
WARNING (`daemon.agent_ecs_retry_not_supported`) for any ECS row
that ends up in `status='retrying'` so the gap is audible until
#3168 wires the ECS retry launcher.

### Fix 3 — `_handle_force_stop` per-agent dispatches on execution_mode

Now `SELECT pid, execution_mode, agent_task_arn` and branches:
subprocess → SIGKILL(pid) as before; ECS → new `_force_stop_ecs_task`
helper calls `ecs:StopTask(agent_task_arn)` best-effort. Pre-fix the
SIGKILL no-oped for ECS agents (pid is NULL on the daemon host), so
a per-agent force_stop left the Fargate task running while the DB
read `crashed`.

## CI hygiene check

New `scripts/check-dispatcher-execution-mode-aware.sh` wired into
CI. Pattern mirrors `check-terminal-routing-comments.sh` (#3062)
and `check-git-gh-retries.sh` (#3089): every
`UPDATE dispatcher.agents` / `SELECT ... FROM dispatcher.agents`
line must either mention `execution_mode` / `agent_task_arn` within
+/- 60 lines, OR carry an `exec-mode-agnostic (#N): <reason>`
annotation. Prevents the fourth Option A bug of this class by
forcing the audit reasoning at author time.

All 36 existing SQL sites annotated accordingly.

## Test plan

- [x] `pytest scripts/dispatcher/tests/test_daemon_execution_mode_audit.py` — 11 new unit tests, all passing
- [x] `pytest scripts/dispatcher/tests/` — full 1277-test suite still green
- [x] `scripts/tests/test_check_dispatcher_execution_mode_aware.sh` — 8 shell tests (pass/fail fixtures + real daemon.py), all passing
- [x] `scripts/check-dispatcher-execution-mode-aware.sh` — 36 sites covered
- [x] `scripts/check-terminal-routing-comments.sh` — still green (28 sites)
- [x] `scripts/check-git-gh-retries.sh` — still green (27 sites)
- [x] `scripts/check-bash-compat.sh` — new shell script is bash 3.2 compatible
- [x] `ruff check` + `ruff format --check` — clean

Post-deploy verification:
- [ ] The live ECS agent 8cb229ac-22a5-4988-bfc8-0454bad5000b survives the daemon redeploy (#3152 is the pre-condition — this PR only adds filters, doesn't change reconciliation)
- [ ] CloudWatch shows no `daemon.agent_ecs_retry_not_supported` events in normal dev operation

## Follow-ups filed (not blockers for this PR)

- #3165 — diagnoser `_consume_action_*` must stop ECS tasks
- #3166 — agent-runner needs an external-terminal observer
- #3167 — resolve daemon vs agent-runner post-ralph phase ownership
- #3168 — wire an ECS-native retry launcher

Closes #3158

🤖 Generated with [Claude Code](https://claude.com/claude-code)
