### PR TITLE
fix(scripts): dev-db-query.sh must preserve SELECT rows, not just rowcount (#2862)

### DIFF
--- a/scripts/dev-db-query.sh
+++ b/scripts/dev-db-query.sh
@@ -15,10 +15,12 @@
 #   scripts/dev-db-query.sh "SELECT COUNT(*) FROM rulings"
 #   scripts/dev-db-query.sh "SELECT id, case_number FROM rulings LIMIT 5"
 #   scripts/dev-db-query.sh "SELECT * FROM courts WHERE state = 'CA'"
+#   scripts/dev-db-query.sh --file path/to/query.sql
 #
 # By default, the session is set to read-only mode (SET default_transaction_read_only = on)
 # so that only SELECT/EXPLAIN queries succeed. Use --rw to allow writes:
 #   scripts/dev-db-query.sh --rw "UPDATE rulings SET status = 'active' WHERE id = 1"
+#   scripts/dev-db-query.sh --rw --file path/to/update.sql
 
 set -euo pipefail
 
@@ -27,12 +29,113 @@ SERVICE="judgemind-ingestion-worker-dev"
 CONTAINER="ingestion-worker"
 REGION="us-west-2"
 
+usage() {
+    cat >&2 <<'USAGE'
+Usage: scripts/dev-db-query.sh [--rw] "SQL query"
+       scripts/dev-db-query.sh [--rw] --file <path.sql>
+
+Flags:
+  --rw              Allow writes (default: read-only session).
+  --file <path>     Read the SQL query from a file instead of the command line.
+
+Examples:
+  scripts/dev-db-query.sh "SELECT count(*) FROM derived.rulings"
+  scripts/dev-db-query.sh --file tmp/check.sql
+  scripts/dev-db-query.sh --rw --file tmp/update.sql
+USAGE
+}
+
 # ─── Parse flags ──────────────────────────────────────────────────────────────
 
 READ_ONLY=true
-if [[ "${1:-}" == "--rw" ]]; then
-    READ_ONLY=false
-    shift
+QUERY_FILE=""
+
+# Only leading args that exactly match a known flag are consumed. A raw SQL
+# query that happens to start with `-` (e.g. "-- a comment" or an EXPLAIN
+# variant) must still be accepted as the positional query. When unsure,
+# operators can pass `--` before the query to force positional parsing.
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --rw)
+            READ_ONLY=false
+            shift
+            ;;
+        --file)
+            if [[ $# -lt 2 || -z "${2:-}" ]]; then
+                echo "Error: --file requires a path argument." >&2
+                usage
+                exit 1
+            fi
+            QUERY_FILE="$2"
+            shift 2
+            ;;
+        --file=*)
+            QUERY_FILE="${1#--file=}"
+            if [[ -z "$QUERY_FILE" ]]; then
+                echo "Error: --file requires a path argument." >&2
+                usage
+                exit 1
+            fi
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            # Anything we don't recognise (including strings starting with `-`)
+            # is treated as the start of the positional query. This preserves
+            # support for quoted SQL that starts with a comment or operator.
+            break
+            ;;
+    esac
+done
+
+# ─── Resolve the query source ────────────────────────────────────────────────
+# Must happen before we hit AWS so bad invocations fail fast.
+
+if [[ -n "$QUERY_FILE" ]]; then
+    if [[ $# -gt 0 ]]; then
+        echo "Error: cannot combine --file with a positional query argument." >&2
+        usage
+        exit 1
+    fi
+    if [[ ! -f "$QUERY_FILE" ]]; then
+        echo "Error: SQL file not found: $QUERY_FILE" >&2
+        exit 1
+    fi
+    query="$(cat -- "$QUERY_FILE")"
+elif [[ $# -ge 1 ]]; then
+    query="$1"
+else
+    echo "Error: no SQL query provided." >&2
+    usage
+    exit 1
+fi
+
+# Reject queries that are empty or comment-only. Psycopg silently succeeds on
+# those with description=None and rowcount=-1, which used to leak out as a
+# misleading {"rowcount": -1} response (#2862).
+#
+# sed is invoked per-line so `--.*` safely matches to end-of-line without
+# needing `[^\n]` (which behaves differently on BSD/macOS sed). The second
+# expression strips single-line /* ... */ block comments; multi-line block
+# comments are not worth the portable-sed gymnastics — a query that consists
+# solely of a multi-line block comment will reach the Python runner, which has
+# its own (belt-and-suspenders) guard.
+stripped="$(
+    printf '%s\n' "$query" \
+        | sed -E 's|--.*||' \
+        | sed -E 's|/\*[^*]*\*+([^/*][^*]*\*+)*/||g' \
+        | tr -d '[:space:];'
+)"
+if [[ -z "$stripped" ]]; then
+    echo "Error: SQL query is empty or contains only comments." >&2
+    exit 1
 fi
 
 # ─── Resolve a running task ARN ──────────────────────────────────────────────
@@ -53,13 +156,6 @@ if [[ -z "$task_arn" || "$task_arn" == "None" ]]; then
 fi
 
 # ─── Build the command ───────────────────────────────────────────────────────
-
-if [[ $# -eq 0 ]]; then
-    echo "Usage: scripts/dev-db-query.sh [--rw] \"SELECT COUNT(*) FROM rulings\"" >&2
-    exit 1
-fi
-
-query="$1"
 
 echo "Running query on dev database via ECS Exec..." >&2
 echo "Task: $task_arn" >&2

--- a/scripts/dev_db_query_runner.py
+++ b/scripts/dev_db_query_runner.py
@@ -86,6 +86,17 @@ def run_query(query_b64: str, readonly_flag: str) -> None:
                 if cursor.description is not None:
                     rows = cursor.fetchall()
                     print(format_select_results(list(cursor.description), rows))
+                elif cursor.rowcount == -1:
+                    # No description AND no rowcount means nothing actually
+                    # executed — typically a comment-only or empty query slipped
+                    # past the caller-side guard. Fail loud instead of emitting
+                    # the misleading `{"rowcount": -1}` response (#2862).
+                    print(
+                        "Error: query produced no result set and no affected rows; "
+                        "did you pass an empty or comment-only statement?",
+                        file=sys.stderr,
+                    )
+                    sys.exit(1)
                 else:
                     print(format_non_select_result(cursor.rowcount))
 

--- a/scripts/tests/test_dev_db_query.sh
+++ b/scripts/tests/test_dev_db_query.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# test_dev_db_query.sh — Tests for dev-db-query.sh flag parsing (#2862).
+#
+# Focuses on the pre-AWS path: --file, --rw, usage errors, and the
+# comment-only query guard. Never reaches `aws ecs execute-command` because
+# the mock aws CLI returns an empty task list, causing the script to exit
+# with a "no running task" error — which still happens *after* the flag
+# parsing and query-source resolution we care about, so we assert on the
+# error message ordering to know which branch the script took.
+#
+# Some tests stub `aws` to return a fake task ARN *and* stub out `aws ecs
+# execute-command` as a no-op so we can observe the fully-assembled command.
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEV_DB_QUERY="$SCRIPT_DIR/dev-db-query.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+cleanup() {
+    set +e
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    echo "$dir"
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Mock aws CLI that returns "no tasks". Causes the real script to exit
+# after the query-source step with "no running task found" — lets us assert
+# the script got past flag parsing without actually talking to AWS.
+setup_mock_aws_no_tasks() {
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    local mock_bin="$tmpdir/bin"
+    mkdir -p "$mock_bin"
+
+    cat > "$mock_bin/aws" << 'MOCK_AWS'
+#!/usr/bin/env bash
+# No matter the args, return None so list-tasks reports no task.
+if [[ "${1:-}" == "ecs" && "${2:-}" == "list-tasks" ]]; then
+    echo "None"
+    exit 0
+fi
+echo "Mock aws: unexpected command: $*" >&2
+exit 1
+MOCK_AWS
+    chmod +x "$mock_bin/aws"
+    echo "$mock_bin"
+}
+
+run_script() {
+    # Args: <mock_bin> <args...>
+    local mock_bin="$1"
+    shift
+    PATH="$mock_bin:$PATH" "$DEV_DB_QUERY" "$@" 2>&1
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+test_no_args_shows_usage() {
+    local mock_bin
+    mock_bin=$(setup_mock_aws_no_tasks)
+    local output
+    output=$(run_script "$mock_bin" || true)
+
+    if [[ "$output" == *"no SQL query provided"* && "$output" == *"Usage:"* ]]; then
+        pass "no args prints usage"
+    else
+        fail "no args prints usage" "got: $output"
+    fi
+}
+
+test_help_flag_exits_zero() {
+    local mock_bin
+    mock_bin=$(setup_mock_aws_no_tasks)
+    local output
+    local rc=0
+    output=$(run_script "$mock_bin" --help) || rc=$?
+
+    if [[ $rc -eq 0 && "$output" == *"Usage:"* ]]; then
+        pass "--help exits 0 with usage"
+    else
+        fail "--help exits 0 with usage" "rc=$rc output=$output"
+    fi
+}
+
+test_leading_dash_query_accepted() {
+    # Queries starting with `-` (SQL comments, unusual EXPLAIN variants, etc.)
+    # must be treated as the positional query, not as an unknown flag. This
+    # is important for --rw use cases where an operator might paste a block
+    # that starts with a `--` comment header.
+    local mock_bin
+    mock_bin=$(setup_mock_aws_no_tasks)
+    local output
+    output=$(run_script "$mock_bin" "-- header
+SELECT 1;" || true)
+
+    if [[ "$output" == *"no running task found"* ]]; then
+        pass "query starting with comment reaches AWS stage"
+    else
+        fail "query starting with comment reaches AWS stage" "got: $output"
+    fi
+}
+
+test_file_requires_argument() {
+    local mock_bin
+    mock_bin=$(setup_mock_aws_no_tasks)
+    local output
+    output=$(run_script "$mock_bin" --file || true)
+
+    if [[ "$output" == *"--file requires a path argument"* ]]; then
+        pass "--file without path errors"
+    else
+        fail "--file without path errors" "got: $output"
+    fi
+}
+
+test_file_missing_path_errors() {
+    local mock_bin
+    mock_bin=$(setup_mock_aws_no_tasks)
+    local output
+    output=$(run_script "$mock_bin" --file /nonexistent/path/to/query.sql || true)
+
+    if [[ "$output" == *"SQL file not found"* ]]; then
+        pass "--file with missing file errors"
+    else
+        fail "--file with missing file errors" "got: $output"
+    fi
+}
+
+test_file_plus_positional_conflict() {
+    local mock_bin
+    mock_bin=$(setup_mock_aws_no_tasks)
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    local sql_file="$tmpdir/q.sql"
+    echo "SELECT 1" > "$sql_file"
+
+    local output
+    output=$(run_script "$mock_bin" --file "$sql_file" "SELECT 2" || true)
+
+    if [[ "$output" == *"cannot combine --file with a positional"* ]]; then
+        pass "--file + positional query conflict"
+    else
+        fail "--file + positional query conflict" "got: $output"
+    fi
+}
+
+test_comment_only_inline_query_rejected() {
+    # #2862 — psycopg silently succeeds on comment-only queries, which used
+    # to leak out as {"rowcount": -1}. The script should reject these before
+    # sending anything to AWS.
+    local mock_bin
+    mock_bin=$(setup_mock_aws_no_tasks)
+    local output
+    output=$(run_script "$mock_bin" "-- just a comment" || true)
+
+    if [[ "$output" == *"empty or contains only comments"* ]]; then
+        pass "comment-only inline query rejected"
+    else
+        fail "comment-only inline query rejected" "got: $output"
+    fi
+}
+
+test_block_comment_only_rejected() {
+    local mock_bin
+    mock_bin=$(setup_mock_aws_no_tasks)
+    local output
+    output=$(run_script "$mock_bin" "/* just a block */" || true)
+
+    if [[ "$output" == *"empty or contains only comments"* ]]; then
+        pass "block-comment-only query rejected"
+    else
+        fail "block-comment-only query rejected" "got: $output"
+    fi
+}
+
+test_whitespace_only_file_rejected() {
+    local mock_bin
+    mock_bin=$(setup_mock_aws_no_tasks)
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    local sql_file="$tmpdir/empty.sql"
+    printf '   \n\t\n;\n' > "$sql_file"
+
+    local output
+    output=$(run_script "$mock_bin" --file "$sql_file" || true)
+
+    if [[ "$output" == *"empty or contains only comments"* ]]; then
+        pass "whitespace-only file rejected"
+    else
+        fail "whitespace-only file rejected" "got: $output"
+    fi
+}
+
+test_file_with_select_reaches_aws() {
+    # Happy path: --file points to a valid SELECT; script should pass the
+    # query-source check and fail only at list-tasks (because our mock aws
+    # returns None).
+    local mock_bin
+    mock_bin=$(setup_mock_aws_no_tasks)
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    local sql_file="$tmpdir/q.sql"
+    echo "SELECT count(*) FROM derived.rulings;" > "$sql_file"
+
+    local output
+    output=$(run_script "$mock_bin" --file "$sql_file" || true)
+
+    if [[ "$output" == *"no running task found"* ]]; then
+        pass "--file with SELECT reaches AWS stage"
+    else
+        fail "--file with SELECT reaches AWS stage" "got: $output"
+    fi
+}
+
+test_file_equals_form_accepted() {
+    local mock_bin
+    mock_bin=$(setup_mock_aws_no_tasks)
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    local sql_file="$tmpdir/q.sql"
+    echo "SELECT 1;" > "$sql_file"
+
+    local output
+    output=$(run_script "$mock_bin" --file="$sql_file" || true)
+
+    if [[ "$output" == *"no running task found"* ]]; then
+        pass "--file=<path> form accepted"
+    else
+        fail "--file=<path> form accepted" "got: $output"
+    fi
+}
+
+test_rw_flag_still_works() {
+    local mock_bin
+    mock_bin=$(setup_mock_aws_no_tasks)
+    local output
+    output=$(run_script "$mock_bin" --rw "UPDATE derived.rulings SET status = 'x' WHERE id = 1;" || true)
+
+    if [[ "$output" == *"no running task found"* ]]; then
+        pass "--rw with positional query still works"
+    else
+        fail "--rw with positional query still works" "got: $output"
+    fi
+}
+
+test_rw_file_combo() {
+    local mock_bin
+    mock_bin=$(setup_mock_aws_no_tasks)
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    local sql_file="$tmpdir/upd.sql"
+    echo "UPDATE derived.rulings SET status = 'x' WHERE id = 1;" > "$sql_file"
+
+    local output
+    output=$(run_script "$mock_bin" --rw --file "$sql_file" || true)
+
+    if [[ "$output" == *"no running task found"* ]]; then
+        pass "--rw --file combo accepted"
+    else
+        fail "--rw --file combo accepted" "got: $output"
+    fi
+}
+
+# ── Run all ────────────────────────────────────────────────────────────────
+
+test_no_args_shows_usage
+test_help_flag_exits_zero
+test_leading_dash_query_accepted
+test_file_requires_argument
+test_file_missing_path_errors
+test_file_plus_positional_conflict
+test_comment_only_inline_query_rejected
+test_block_comment_only_rejected
+test_whitespace_only_file_rejected
+test_file_with_select_reaches_aws
+test_file_equals_form_accepted
+test_rw_flag_still_works
+test_rw_file_combo
+
+echo ""
+echo "────────────────────────────────────────────────"
+echo "Ran $TESTS tests, $FAILURES failed"
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi

--- a/scripts/tests/test_dev_db_query_runner.py
+++ b/scripts/tests/test_dev_db_query_runner.py
@@ -192,6 +192,56 @@ class TestRunQuery:
         result = json.loads(captured.out)
         assert result == {"rowcount": 5}
 
+    def test_comment_only_query_fails_loud(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """#2862 — psycopg returns description=None and rowcount=-1 for a
+        comment-only or empty query. Runner must fail loud instead of silently
+        printing the misleading ``{"rowcount": -1}`` response."""
+        query = "-- a comment"
+        query_b64 = base64.b64encode(query.encode()).decode()
+
+        mock_psycopg = self._make_mock_psycopg(
+            description=None,
+            rowcount=-1,
+        )
+
+        with patch.dict(sys.modules, {"psycopg": mock_psycopg}):
+            with patch.dict("os.environ", {"DATABASE_URL": "postgresql://test"}):
+                from dev_db_query_runner import run_query
+
+                with pytest.raises(SystemExit) as exc_info:
+                    run_query(query_b64, "0")
+                assert exc_info.value.code == 1
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "empty or comment-only" in captured.err
+
+    def test_ddl_zero_affected_still_emits_rowcount(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A legitimate DML that affects zero rows (rowcount=0, not -1) should
+        still emit a normal ``{"rowcount": 0}`` response — only rowcount == -1
+        indicates "nothing executed"."""
+        query = "UPDATE rulings SET status = 'active' WHERE id = -999"
+        query_b64 = base64.b64encode(query.encode()).decode()
+
+        mock_psycopg = self._make_mock_psycopg(
+            description=None,
+            rowcount=0,
+        )
+
+        with patch.dict(sys.modules, {"psycopg": mock_psycopg}):
+            with patch.dict("os.environ", {"DATABASE_URL": "postgresql://test"}):
+                from dev_db_query_runner import run_query
+
+                run_query(query_b64, "0")
+
+        captured = capsys.readouterr()
+        result = json.loads(captured.out)
+        assert result == {"rowcount": 0}
+
     def test_readonly_flag_sets_transaction_readonly(self) -> None:
         query = "SELECT 1"
         query_b64 = base64.b64encode(query.encode()).decode()


### PR DESCRIPTION
## Summary

Fixes the `scripts/dev-db-query.sh` bug where SELECT rows were silently
dropped and the script only printed `{"rowcount": -1}` — as reported in
#2862.

**Root cause:** the script did not implement the documented `--file
<path.sql>` flag. When an operator ran `--file tmp/query.sql`, `--file`
fell through as the literal query text. psycopg parsed `--file ...` as a
SQL line-comment (`--`), so the cursor came back with
`description=None` and `rowcount=-1`, and the runner printed
`{"rowcount": -1}`. Any comment-only or empty query hit the same silent
failure mode.

**Fix:**
- Add `--file <path>` (and `--file=<path>`) to `dev-db-query.sh`, plus
  `--help` and a conflict check so `--file` and a positional query can't
  be combined.
- Reject empty / comment-only queries in the shell before hitting AWS,
  with a clear error message.
- Belt-and-suspenders in the Python runner: if psycopg returns
  `description=None` AND `rowcount=-1`, exit 1 with an explanatory
  stderr message instead of printing `{"rowcount": -1}`.
- Keep leading-dash positional args (SQL comments at the top of a query,
  unusual EXPLAIN variants) as valid queries rather than treating them
  as unknown flags.

## Acceptance criteria mapping

- [x] `--file <path.sql>` returns formatted rows for SELECTs.
- [x] Multi-row SELECT prints all rows (verified with `SELECT * FROM
      dispatcher.agents LIMIT 2` — full row JSON emitted).
- [x] INSERT/UPDATE/DELETE still print `rowcount` (unchanged behavior,
      covered by the existing `test_non_select_query_prints_rowcount`
      test plus the new `test_ddl_zero_affected_still_emits_rowcount`).
- [x] EXPLAIN prints the plan (EXPLAIN emits a result set, so it hits
      the SELECT branch the same as before).
- [x] Special-char rows (jsonb columns, newlines) emit unambiguously —
      the runner already uses `json.dumps(..., default=str)`.

## Test plan

- [x] `pytest scripts/tests/test_dev_db_query_runner.py -v` — 23 passed,
      including 2 new cases for the fail-loud comment-only path and the
      rowcount=0 DML path.
- [x] `scripts/tests/test_dev_db_query.sh` — 13 shell tests passed
      covering `--file`, `--file=<path>`, `--rw`, `--help`, comment-only
      and block-comment rejection, leading-dash queries, flag conflicts,
      and missing-file errors (with a mock `aws` CLI — no real AWS
      traffic).
- [x] End-to-end against dev RDS:
  - `scripts/dev-db-query.sh --file tmp/check.sql` → `[{"n": 15702}]`
  - `scripts/dev-db-query.sh "SELECT 1 AS a, 2 AS b;"` →
    `[{"a": 1, "b": 2}]`
  - `scripts/dev-db-query.sh "SELECT * FROM dispatcher.agents LIMIT 2;"`
    → full multi-row JSON with jsonb-style embedded content.
  - `scripts/dev-db-query.sh "-- just a comment"` → `Error: SQL query is
    empty or contains only comments.` (exit 1).

## Files changed

- `scripts/dev-db-query.sh` — flag parser, `--file` support, comment-only
  guard, usage/help.
- `scripts/dev_db_query_runner.py` — fail-loud branch for
  `description=None AND rowcount=-1`.
- `scripts/tests/test_dev_db_query_runner.py` — 2 new cases.
- `scripts/tests/test_dev_db_query.sh` — new shell-level test file.

Closes #2862
