### PR TITLE
feat(dx): add --click flag to screenshot script for dialog/modal capture (#3175)

### DIFF
--- a/.claude/skills/screenshot/SKILL.md
+++ b/.claude/skills/screenshot/SKILL.md
@@ -64,6 +64,17 @@ The `--auth` flag fetches admin credentials from AWS Secrets Manager (`judgemind
 
 The `agent-admin` account on dev has `users.role = 'admin'`, so both admin dashboards (`/admin/data-quality`, `/admin/dispatcher`) render with full admin content. To add a new admin-gated page, gate on `user.role === 'admin'` and `--auth` will Just Work.
 
+**Capture state behind a single click (modal, dropdown, popover):**
+```
+scripts/run-py.sh scripts/screenshot.py --auth /admin/dispatcher \
+    --click '[data-testid="queue-ready-count"]' \
+    --output tmp/ready_dialog.png
+```
+
+The `--click <selector>` flag performs one `page.click(selector)` after the existing `--wait` and before the screenshot, so the captured image shows the post-click state. Pair with `--click-wait <ms>` (default 500) so animated UIs (Radix Dialog, etc.) finish rendering before the snapshot — set `--click-wait 0` to capture a mid-animation frame, or bump it higher for slow transitions.
+
+If the selector matches nothing, the script exits non-zero with `Click target not found: <selector>` rather than letting Playwright time out. Multi-step flows (open menu, then click item, then type) are out of scope — write a one-off Playwright script for those.
+
 ### Options
 
 | Flag | Default | Description |
@@ -75,6 +86,8 @@ The `agent-admin` account on dev has `users.role = 'admin'`, so both admin dashb
 | `--height` | 720 | Viewport height in pixels |
 | `--wait` | 3000 | Wait time in ms after page load for JS rendering |
 | `--auth` | off | Log in as admin before taking the screenshot. Fetches credentials from AWS Secrets Manager (`judgemind/dev/agent-admin`, a `role='admin'` user on dev). Required for admin pages. |
+| `--click` | none | CSS selector to click after the `--wait` and before the screenshot. Use to capture modals/dropdowns/popovers behind a single interaction. Exits non-zero if the selector matches nothing. |
+| `--click-wait` | 500 | Wait time in ms after `--click` for animations (Radix Dialog ~200ms etc.) to settle before the screenshot. |
 
 ---
 

--- a/scripts/screenshot.py
+++ b/scripts/screenshot.py
@@ -11,6 +11,7 @@ Usage:
     scripts/run-py.sh scripts/screenshot.py /rulings --width 1280 --height 720
     scripts/run-py.sh scripts/screenshot.py /rulings --wait 5000
     scripts/run-py.sh scripts/screenshot.py --auth /admin/data-quality --output tmp/dq.png
+    scripts/run-py.sh scripts/screenshot.py --auth /admin/dispatcher --click '[data-testid="queue-ready-count"]' --output tmp/ready_dialog.png
 
 Requires the scraper-framework venv (which includes playwright). Run via
 scripts/run-py.sh, which reads the ``# venv:`` header and activates the
@@ -149,6 +150,16 @@ def main() -> None:
         action="store_true",
         help="Log in as admin before taking the screenshot (fetches credentials from AWS Secrets Manager)",
     )
+    parser.add_argument(
+        "--click",
+        help="CSS selector to click after navigation (for capturing modal/dialog state)",
+    )
+    parser.add_argument(
+        "--click-wait",
+        type=int,
+        default=500,
+        help="Wait time in ms after the --click for animations to settle (default: 500)",
+    )
     args = parser.parse_args()
 
     url = validate_url(args.path)
@@ -181,6 +192,20 @@ def main() -> None:
         # Extra wait for client-side JS rendering (React hydration, data fetching)
         if args.wait > 0:
             page.wait_for_timeout(args.wait)
+
+        # Optional click to surface state behind a single interaction (modals,
+        # dropdowns, popovers). Use query_selector + element.click so a missing
+        # target produces a clear, fail-fast error rather than a Playwright
+        # timeout from page.click.
+        if args.click:
+            click_target = page.query_selector(args.click)
+            if click_target is None:
+                print(f"Click target not found: {args.click}", file=sys.stderr)
+                browser.close()
+                sys.exit(1)
+            click_target.click()
+            if args.click_wait > 0:
+                page.wait_for_timeout(args.click_wait)
 
         if args.selector:
             element = page.query_selector(args.selector)

--- a/scripts/tests/test_screenshot.py
+++ b/scripts/tests/test_screenshot.py
@@ -251,3 +251,199 @@ class TestMainAuthIntegration:
         # The target URL navigation happens after login
         target_goto = mock_page.goto.call_args_list[0]
         assert "admin/data-quality" in target_goto[0][0]
+
+
+class TestClickFlag:
+    """Tests for the --click and --click-wait flags.
+
+    Mirrors the patching pattern used by TestMainAuthIntegration so the lazy
+    ``from playwright.sync_api import sync_playwright`` inside ``main()``
+    works without playwright installed.
+    """
+
+    def _patch_modules(self, mock_sync_pw_fn: MagicMock) -> dict[str, MagicMock]:
+        mock_sync_api = MagicMock()
+        mock_sync_api.sync_playwright = mock_sync_pw_fn
+        mock_pw_pkg = MagicMock()
+        return {"playwright": mock_pw_pkg, "playwright.sync_api": mock_sync_api}
+
+    def test_click_invokes_query_selector_then_click(self) -> None:
+        """--click <sel> calls query_selector(sel) and then .click() on the result."""
+        from screenshot import main
+
+        test_args = [
+            "screenshot.py",
+            "/rulings",
+            "--click",
+            '[data-testid="queue-ready-count"]',
+        ]
+        mock_sync_pw_fn, mock_page, _mock_browser = _make_mock_playwright()
+
+        mock_click_target = MagicMock()
+        mock_page.query_selector.return_value = mock_click_target
+
+        with (
+            patch("sys.argv", test_args),
+            patch.dict("sys.modules", self._patch_modules(mock_sync_pw_fn)),
+        ):
+            main()
+
+        mock_page.query_selector.assert_called_once_with(
+            '[data-testid="queue-ready-count"]'
+        )
+        mock_click_target.click.assert_called_once_with()
+
+    def test_click_default_wait_is_500_ms(self) -> None:
+        """Default --click-wait is 500ms; called via page.wait_for_timeout after click."""
+        from screenshot import main
+
+        test_args = ["screenshot.py", "/rulings", "--click", ".btn"]
+        mock_sync_pw_fn, mock_page, _mock_browser = _make_mock_playwright()
+        mock_page.query_selector.return_value = MagicMock()
+
+        with (
+            patch("sys.argv", test_args),
+            patch.dict("sys.modules", self._patch_modules(mock_sync_pw_fn)),
+        ):
+            main()
+
+        # The default --wait is 3000ms (the existing post-load wait), then 500ms
+        # after the click — both go through page.wait_for_timeout.
+        wait_calls = [c.args[0] for c in mock_page.wait_for_timeout.call_args_list]
+        assert 500 in wait_calls
+
+    def test_click_wait_zero_skips_post_click_wait(self) -> None:
+        """--click-wait 0 must not invoke wait_for_timeout(0) after the click."""
+        from screenshot import main
+
+        test_args = [
+            "screenshot.py",
+            "/rulings",
+            "--click",
+            ".btn",
+            "--click-wait",
+            "0",
+            "--wait",
+            "0",
+        ]
+        mock_sync_pw_fn, mock_page, _mock_browser = _make_mock_playwright()
+        mock_page.query_selector.return_value = MagicMock()
+
+        with (
+            patch("sys.argv", test_args),
+            patch.dict("sys.modules", self._patch_modules(mock_sync_pw_fn)),
+        ):
+            main()
+
+        # With both --wait 0 and --click-wait 0, no timeout calls fire at all.
+        mock_page.wait_for_timeout.assert_not_called()
+
+    def test_click_wait_custom_value(self) -> None:
+        """--click-wait <N> passes N to page.wait_for_timeout."""
+        from screenshot import main
+
+        test_args = [
+            "screenshot.py",
+            "/rulings",
+            "--click",
+            ".btn",
+            "--click-wait",
+            "1500",
+            "--wait",
+            "0",
+        ]
+        mock_sync_pw_fn, mock_page, _mock_browser = _make_mock_playwright()
+        mock_page.query_selector.return_value = MagicMock()
+
+        with (
+            patch("sys.argv", test_args),
+            patch.dict("sys.modules", self._patch_modules(mock_sync_pw_fn)),
+        ):
+            main()
+
+        wait_calls = [c.args[0] for c in mock_page.wait_for_timeout.call_args_list]
+        assert wait_calls == [1500]
+
+    def test_click_missing_selector_exits_with_clear_error(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """If the click target is not found, exit non-zero with a one-line error."""
+        from screenshot import main
+
+        test_args = [
+            "screenshot.py",
+            "/rulings",
+            "--click",
+            '[data-testid="does-not-exist"]',
+        ]
+        mock_sync_pw_fn, mock_page, _mock_browser = _make_mock_playwright()
+        mock_page.query_selector.return_value = None
+
+        with (
+            patch("sys.argv", test_args),
+            patch.dict("sys.modules", self._patch_modules(mock_sync_pw_fn)),
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert 'Click target not found: [data-testid="does-not-exist"]' in captured.err
+
+    def test_no_click_flag_skips_click_entirely(self) -> None:
+        """Without --click, neither query_selector nor an extra wait fires."""
+        from screenshot import main
+
+        test_args = ["screenshot.py", "/rulings", "--wait", "0"]
+        mock_sync_pw_fn, mock_page, _mock_browser = _make_mock_playwright()
+
+        with (
+            patch("sys.argv", test_args),
+            patch.dict("sys.modules", self._patch_modules(mock_sync_pw_fn)),
+        ):
+            main()
+
+        # No click means no query_selector for a click target. (--selector
+        # would also call query_selector, but we did not pass it here.)
+        mock_page.query_selector.assert_not_called()
+        # No --click and --wait 0 means no wait_for_timeout calls at all.
+        mock_page.wait_for_timeout.assert_not_called()
+
+    def test_click_runs_after_wait_and_before_screenshot(self) -> None:
+        """Order must be: goto → wait_for_timeout (page wait) → click → wait_for_timeout (click wait) → screenshot."""
+        from screenshot import main
+
+        test_args = ["screenshot.py", "/rulings", "--click", ".btn"]
+        mock_sync_pw_fn, mock_page, _mock_browser = _make_mock_playwright()
+
+        # Build a single mock that records every relevant call so we can
+        # inspect ordering.
+        mock_click_target = MagicMock()
+        mock_page.query_selector.return_value = mock_click_target
+
+        # Use a parent MagicMock to record order across attributes.
+        ordered = MagicMock()
+        ordered.attach_mock(mock_page.goto, "goto")
+        ordered.attach_mock(mock_page.wait_for_timeout, "wait_for_timeout")
+        ordered.attach_mock(mock_page.query_selector, "query_selector")
+        ordered.attach_mock(mock_click_target.click, "click")
+        ordered.attach_mock(mock_page.screenshot, "screenshot")
+
+        with (
+            patch("sys.argv", test_args),
+            patch.dict("sys.modules", self._patch_modules(mock_sync_pw_fn)),
+        ):
+            main()
+
+        names = [c[0] for c in ordered.mock_calls]
+        # Expected sequence (using default --wait 3000 and --click-wait 500):
+        # goto, wait_for_timeout(3000), query_selector(.btn), click(),
+        # wait_for_timeout(500), screenshot(...)
+        assert names == [
+            "goto",
+            "wait_for_timeout",
+            "query_selector",
+            "click",
+            "wait_for_timeout",
+            "screenshot",
+        ]


### PR DESCRIPTION
## Summary

Add `--click <selector>` and `--click-wait <ms>` (default 500) to `scripts/screenshot.py` so the screenshot workflow can capture UI state behind a single click — modals, dropdowns, popovers, tooltips. Use `query_selector` + `element.click()` instead of `page.click(selector)` so a missing target fails fast with `Click target not found: <selector>` and exits non-zero rather than waiting on a Playwright timeout. Updates `.claude/skills/screenshot/SKILL.md` with a worked example against `/admin/dispatcher` and table rows for both flags.

Closes #3175

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (7 new `TestClickFlag` cases + 13 existing — all 20 green locally)
- [x] CI green

### Post-deploy verification
- [x] DX/tooling — exercised the new flag against `https://dev.judgemind.org/admin/dispatcher`. With `--click 'button[aria-label="User menu"]'` the captured image shows the user-menu dropdown panel rendered, which is only visible after the click. The bad-selector path also verified end-to-end (`Click target not found: ...` on stderr, exit 1).
- [x] Verification evidence posted on issue (https://github.com/judgemind/judgemind/issues/3175#issuecomment-4310819724)
