### PR TITLE
polish(web/admin): cockpit dialog count, title, width follow-ups (#3172)

### DIFF
--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -448,6 +448,31 @@ async function queryRecentCompletions(pool: Pool, limit: number): Promise<Row[]>
   return rows;
 }
 
+/**
+ * Total count of terminal-status rows in `dispatcher.agents` — same
+ * filter as `queryRecentCompletions` so the admin-cockpit panel header
+ * can render `{shown} / {total}` for the Recently Completed panel
+ * (issue #3172). Mirrors the `queryQueueDepth` / `queryBlockedDepth`
+ * fall-back-to-0 contract: the GraphQL field is `Int!` (non-null), so
+ * a fresh deploy with no agent rows yet returns 0 rather than null.
+ *
+ * `dispatcher.agents` is NOT in `_HOUSEKEEPING_TARGETS`
+ * (`scripts/dispatcher/daemon.py`), so the count grows unboundedly. Today
+ * dev has ~180 rows — well within the 1000-row safety cap that
+ * `dispatcherQueueFull(kind: COMPLETED)` enforces.
+ */
+async function queryRecentCompletionsCount(pool: Pool): Promise<number> {
+  const { rows } = await pool.query<{ count: number | string }>(
+    `SELECT COUNT(*)::int AS count
+       FROM dispatcher.agents
+      WHERE status IN ('succeeded', 'failed', 'crashed', 'plan_blocked', 'needs_review')
+        AND ended_at IS NOT NULL`,
+  );
+  if (rows.length === 0) return 0;
+  const raw = rows[0].count;
+  return typeof raw === 'number' ? raw : Number(raw);
+}
+
 async function queryConfig(pool: Pool): Promise<Row[]> {
   const { rows } = await pool.query<Row>(
     `SELECT key, value, updated_at, updated_by
@@ -1141,6 +1166,15 @@ export const dispatcherResolvers = {
       requireDispatcherAdmin(user);
       const rows = await queryRecentCompletions(pool, 10);
       return recentCompletionsToGraphQL(rows);
+    },
+
+    recentCompletionsCount: async (
+      _: unknown,
+      __: unknown,
+      { pool, user }: DispatcherContext,
+    ) => {
+      requireDispatcherAdmin(user);
+      return queryRecentCompletionsCount(pool);
     },
 
     config: async (_: unknown, __: unknown, { pool, user }: DispatcherContext) => {

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -384,6 +384,16 @@ export const dispatcherTypeDefs = `#graphql
     ('succeeded','failed','crashed','plan_blocked','needs_review')
     ordered by \`ended_at\` DESC."""
     recentCompletions: [RecentCompletion!]!
+    """Total count of terminal-status rows in \`dispatcher.agents\`
+    (status IN \`('succeeded','failed','crashed','plan_blocked','needs_review')\`).
+    Same filter \`recentCompletions\` (and \`dispatcherQueueFull(kind: COMPLETED)\`)
+    use — paired with the capped \`recentCompletions\` list so the
+    admin-cockpit panel header can render \`{shown} / {total}\`,
+    matching the Ready/Blocked panels (issue #3172). \`dispatcher.agents\`
+    is not currently in the daemon's housekeeping target list, so this
+    grows unboundedly — well within the 1000-row dialog cap today
+    (~180 rows on dev). Returns 0 when the table is empty (fresh deploy)."""
+    recentCompletionsCount: Int!
     """All live-editable \`dispatcher.config\` entries (#2805 §1.6)."""
     config: [DispatcherConfigEntry!]!
     """\`dispatcher.config.value\` for \`spawn_frozen_until\` (§10), or null if not set."""

--- a/packages/api/tests/dispatcher.integration.test.ts
+++ b/packages/api/tests/dispatcher.integration.test.ts
@@ -337,6 +337,67 @@ describe('dispatcherState — admin', () => {
     // the inserted run in cleanup tears down the snapshot rows too.
   });
 
+  it('recentCompletionsCount equals SELECT COUNT(*) on terminal agent rows (#3172)', async () => {
+    // Seed three additional terminal-status agents and one running agent.
+    // recentCompletionsCount must include the three terminals (+ ended_at)
+    // and exclude the running one. We use COUNT(*) directly to compare
+    // rather than asserting a hard number, because earlier tests in this
+    // suite may have left other terminal rows behind that we should still
+    // pick up.
+    const runId = await insertRun();
+    const baseIssue = 999_300;
+    // Three terminals: succeeded / failed / plan_blocked, all with ended_at set.
+    const terminalStatuses = ['succeeded', 'failed', 'plan_blocked'];
+    for (let i = 0; i < terminalStatuses.length; i += 1) {
+      const { rows } = await pool.query<{ agent_id: string }>(
+        `INSERT INTO dispatcher.agents
+           (parent_run_id, kind, issue_number, worktree_path, phase, status,
+            started_at, ended_at)
+         VALUES ($1, 'task', $2, $3, 'retro', $4,
+                 now() - interval '1 hour',
+                 now() - interval '1 minute')
+         RETURNING agent_id`,
+        [
+          runId,
+          baseIssue + i,
+          `/tmp/${MARKER}/agent-count-${baseIssue + i}`,
+          terminalStatuses[i],
+        ],
+      );
+      insertedAgentIds.push(rows[0].agent_id);
+    }
+    // One running agent — must NOT count toward recentCompletionsCount.
+    await insertAgent({
+      runId,
+      issueNumber: baseIssue + 100,
+      status: 'running',
+      phase: 'ralph-worker',
+    });
+
+    const body = await gql(
+      `{ dispatcherState { recentCompletionsCount } }`,
+      undefined,
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const state = body.data?.dispatcherState as Record<string, unknown>;
+    expect(typeof state.recentCompletionsCount).toBe('number');
+
+    // Query the same filter directly to confirm the resolver's count
+    // matches `SELECT COUNT(*)` on the underlying table — same filter
+    // `queryRecentCompletions` uses.
+    const { rows: countRows } = await pool.query<{ count: number | string }>(
+      `SELECT COUNT(*)::int AS count
+         FROM dispatcher.agents
+        WHERE status IN ('succeeded', 'failed', 'crashed', 'plan_blocked', 'needs_review')
+          AND ended_at IS NOT NULL`,
+    );
+    const dbCount = Number(countRows[0].count);
+    expect(state.recentCompletionsCount).toBe(dbCount);
+    // Sanity: at least our 3 fresh terminals are counted.
+    expect(dbCount).toBeGreaterThanOrEqual(3);
+  });
+
   it('blockedDepth reflects the latest row in dispatcher.blocked_snapshots (#2886)', async () => {
     // Mirror the queueDepth test — seed two blocked snapshots and
     // confirm the resolver returns the latest-by-observed_at value.

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -418,6 +418,7 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
             <div className="flex flex-col gap-6" data-testid="dispatcher-column-right">
               <RecentCompletionsPanel
                 completions={state?.recentCompletions ?? []}
+                total={state?.recentCompletionsCount}
                 onCountClick={() => setFullDialogKind('COMPLETED')}
               />
               <QueueBlockedPanel
@@ -469,13 +470,61 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
        * `kind !== null`, so closing the dialog (ESC, click outside,
        * X button) cancels future fetches until the operator clicks a
        * count again.
+       *
+       * #3172: thread `shown` / `total` through so the dialog title
+       * carries the same `{shown} / {total}` denominator the badge
+       * displayed. `shown` is the panel's rendered list length (capped
+       * at 10 server-side); `total` comes from the matching depth field
+       * on `DispatcherState`. Both are scoped to the currently-open
+       * `kind` — when no dialog is open, both are undefined and the
+       * helper renders nothing (the dialog is unmounted anyway).
        */}
       <QueueFullDialog
         kind={fullDialogKind}
+        shown={shownForKind(fullDialogKind, state)}
+        total={totalForKind(fullDialogKind, state)}
         onClose={() => setFullDialogKind(null)}
       />
     </div>
   );
+}
+
+/**
+ * Compute the `shown` value to pass to `<QueueFullDialog>` so the
+ * dialog title reads `{shown} / {total}` matching the badge that
+ * opened it (issue #3172). `shown` is the count of items the panel was
+ * rendering at click time — capped server-side at 10 for the queue
+ * panels, capped at 10 by the `recentCompletions` resolver for the
+ * Recently Completed panel.
+ *
+ * Returns `undefined` when no dialog is open or when `state` is not yet
+ * loaded — `formatDialogTitle` falls back to a clean labelled title in
+ * that case.
+ */
+function shownForKind(
+  kind: DispatcherQueueKind | null,
+  state: DispatcherStateData['dispatcherState'] | undefined,
+): number | undefined {
+  if (kind === null || state === undefined) return undefined;
+  if (kind === 'READY') return state.queueReady.length;
+  if (kind === 'BLOCKED') return state.queueBlocked.length;
+  return state.recentCompletions.length;
+}
+
+/**
+ * Companion to `shownForKind` — returns the matching depth field from
+ * `DispatcherState` so the dialog title can render the `{shown} /
+ * {total}` denominator. Returns `undefined` when no dialog is open or
+ * when `state` is not loaded.
+ */
+function totalForKind(
+  kind: DispatcherQueueKind | null,
+  state: DispatcherStateData['dispatcherState'] | undefined,
+): number | undefined {
+  if (kind === null || state === undefined) return undefined;
+  if (kind === 'READY') return state.queueDepth;
+  if (kind === 'BLOCKED') return state.blockedDepth;
+  return state.recentCompletionsCount;
 }
 
 function parsePositiveInt(jsonValue: string): number | null {

--- a/packages/web/src/app/(main)/admin/dispatcher/QueueFullDialog.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/QueueFullDialog.tsx
@@ -36,10 +36,28 @@ import { RecentCompletionRow } from './RecentCompletionsPanel';
  */
 export function QueueFullDialog({
   kind,
+  shown,
+  total,
   onClose,
 }: {
   /** Open when not null — also drives which kind to fetch. */
   kind: DispatcherQueueKind | null;
+  /**
+   * Number of rows the panel that opened this dialog was rendering at
+   * click time (capped at 10 server-side). Surfaced in the title's
+   * `{shown} / {total}` so the dialog title carries the same denominator
+   * as the badge the operator just clicked (issue #3172). Optional —
+   * when omitted the title falls back to bare `{label}` without a count
+   * decoration so existing test fixtures keep working.
+   */
+  shown?: number;
+  /**
+   * Total count of rows in the bucket the panel knows about (sourced
+   * from `DispatcherState.queueDepth` / `blockedDepth` /
+   * `recentCompletionsCount`). Same role as `shown` — surfaces the
+   * denominator. Optional for the same back-compat reason.
+   */
+  total?: number;
   /** Called when the dialog closes (ESC, click outside, X button). */
   onClose: () => void;
 }) {
@@ -61,10 +79,8 @@ export function QueueFullDialog({
   const payload = data?.dispatcherQueueFull;
   const queueItems = payload?.queueItems ?? [];
   const completions = payload?.completions ?? [];
-  const totalCount =
-    kind === 'COMPLETED' ? completions.length : queueItems.length;
 
-  const titleText = formatDialogTitle(kind, totalCount, loading);
+  const titleText = formatDialogTitle(kind, shown, total, loading);
 
   return (
     <Dialog
@@ -74,7 +90,13 @@ export function QueueFullDialog({
       }}
     >
       <DialogContent
-        className="max-w-2xl"
+        // #3172: bumped from `max-w-2xl` (42rem / 672px) to `max-w-4xl`
+        // (56rem / 896px). The cockpit page is a wide 3-column layout
+        // and the previous width forced full issue rows (issue link +
+        // priority badge + PR link + title) to wrap awkwardly. `max-w-4xl`
+        // gives ~30% more horizontal room without crowding the page on
+        // common 1280px+ viewports.
+        className="max-w-4xl"
         data-testid="queue-full-dialog"
       >
         <DialogHeader>
@@ -209,22 +231,43 @@ function DialogList({
 }
 
 /**
- * Format the dialog title — the heading text mirrors which bucket the
- * operator opened. Pure helper so the test can exercise the formatting
- * without rendering the dialog. Issue #3159.
+ * Format the dialog title — the heading text mirrors the panel heading
+ * the operator just clicked, and the count decoration carries the same
+ * `{shown} / {total}` denominator the badge displayed.
+ *
+ * Issue #3172 made two changes vs. the original #3159 shape:
+ *  1. Labels now match the panel headings exactly:
+ *     - `READY`     → `Queue: Agent-ready`   (matches `QueuePanel.tsx`)
+ *     - `BLOCKED`   → `Queue: Blocked`       (matches `QueuePanel.tsx`)
+ *     - `COMPLETED` → `Recently completed`   (matches `RecentCompletionsPanel.tsx`)
+ *     The original `Agent-ready queue (N)` / `Blocked queue (N)` strings
+ *     inverted the noun/qualifier order vs. the panel headings, so the
+ *     dialog visually disconnected from the badge that opened it.
+ *  2. Count decoration is `{shown} / {total}` (em-dash separator), not
+ *     `(N)`. When `shown` and `total` are both numbers, the title
+ *     reads e.g. `Queue: Agent-ready — 10 / 50`. When either is
+ *     undefined (back-compat / kind=null), the count decoration is
+ *     dropped so the title stays clean.
+ *
+ * Pure helper so the test can exercise the formatting without rendering
+ * the dialog.
  */
 export function formatDialogTitle(
   kind: DispatcherQueueKind | null,
-  count: number,
+  shown: number | undefined,
+  total: number | undefined,
   loading: boolean,
 ): string {
   if (kind === null) return '';
   const label =
     kind === 'READY'
-      ? 'Agent-ready queue'
+      ? 'Queue: Agent-ready'
       : kind === 'BLOCKED'
-        ? 'Blocked queue'
+        ? 'Queue: Blocked'
         : 'Recently completed';
-  if (loading) return `${label} (loading…)`;
-  return `${label} (${count})`;
+  if (loading) return `${label} — loading…`;
+  if (typeof shown === 'number' && typeof total === 'number') {
+    return `${label} — ${shown} / ${total}`;
+  }
+  return label;
 }

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -16,6 +16,16 @@ interface RecentCompletionsPanelProps {
    */
   nowMs?: number;
   /**
+   * Total count of terminal-status rows in `dispatcher.agents`
+   * (sourced from `DispatcherState.recentCompletionsCount`). When
+   * provided, the panel header count badge renders `{shown} / {total}`
+   * to match the Ready/Blocked panels (issue #3172). When omitted, the
+   * count falls back to the bare `{shown}` value (back-compat for
+   * existing test fixtures and any caller that hasn't wired up the new
+   * field).
+   */
+  total?: number;
+  /**
    * When provided, the count label in the panel header becomes a
    * clickable button that triggers this callback. The cockpit
    * dashboard wires this to open the full-list dialog (issue #3159).
@@ -73,6 +83,7 @@ interface RecentCompletionsPanelProps {
 export function RecentCompletionsPanel({
   completions,
   nowMs,
+  total,
   onCountClick,
 }: RecentCompletionsPanelProps) {
   // #3159: when a click handler is provided, surface a separate
@@ -81,7 +92,12 @@ export function RecentCompletionsPanel({
   // bottom-row panels. The legacy inline `({n})` rendering is preserved
   // for back-compat when no handler is wired (existing test fixtures
   // and any non-cockpit caller).
-  const countText = String(completions.length);
+  //
+  // #3172: both code paths (clickable badge + inline parenthetical) now
+  // route through `formatCountLabel`. When `total` is provided we render
+  // `{shown} / {total}` exactly like Ready/Blocked; when it's omitted we
+  // fall back to `{shown}` so existing fixtures keep working.
+  const countText = formatRecentCompletionsCount(completions.length, total);
   return (
     <section aria-labelledby="recent-completions-heading">
       <div className="flex items-center justify-between border-b border-border pb-2 mb-2">
@@ -117,6 +133,27 @@ export function RecentCompletionsPanel({
       )}
     </section>
   );
+}
+
+/**
+ * Format the panel-header count badge. Matches the
+ * `formatCountLabel` shape from `QueuePanel.tsx` so all three
+ * bottom-row panels render `{shown} / {total}` consistently
+ * (issue #3172). When `total` is omitted, fall back to bare
+ * `{shown}` — preserves back-compat for tests and any caller that
+ * hasn't wired up `DispatcherState.recentCompletionsCount`.
+ *
+ * Edge case: when `total` is provided but `shown === 0`, render `0 / N`
+ * (never just `0`) — empty-panel UX stays obvious while still
+ * communicating the denominator. Mirrors the `0 / N` case the Ready
+ * and Blocked panels handle.
+ */
+function formatRecentCompletionsCount(
+  shown: number,
+  total: number | undefined,
+): string {
+  if (typeof total === 'number') return `${shown} / ${total}`;
+  return String(shown);
 }
 
 /**
@@ -403,4 +440,5 @@ export {
   formatRelativeTime,
   formatPacificDatetime,
   formatStartDurationEndTitle,
+  formatRecentCompletionsCount,
 };

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
@@ -128,6 +128,7 @@ const BASE_STATE = {
   queueReady: [],
   queueBlocked: [],
   recentCompletions: [],
+  recentCompletionsCount: 0,
   config: [
     {
       key: 'concurrency_cap',
@@ -553,7 +554,9 @@ describe('DispatcherDashboard — #3159 expand-count dialog wiring', () => {
     expect(screen.queryByTestId('queue-full-dialog')).not.toBeInTheDocument();
     fireEvent.click(screen.getByTestId('queue-ready-count'));
     const title = await screen.findByTestId('queue-full-dialog-title');
-    expect(title.textContent).toMatch(/agent-ready queue/i);
+    // #3172: title now matches the panel heading "Queue: Agent-ready"
+    // exactly (was "Agent-ready queue (N)" pre-#3172).
+    expect(title.textContent).toMatch(/queue: agent-ready/i);
   });
 
   it('clicking the Blocked count opens the dialog with the BLOCKED title', async () => {
@@ -567,7 +570,9 @@ describe('DispatcherDashboard — #3159 expand-count dialog wiring', () => {
     renderDashboard();
     fireEvent.click(screen.getByTestId('queue-blocked-count'));
     const title = await screen.findByTestId('queue-full-dialog-title');
-    expect(title.textContent).toMatch(/blocked queue/i);
+    // #3172: title now matches the panel heading "Queue: Blocked" exactly
+    // (was "Blocked queue (N)" pre-#3172).
+    expect(title.textContent).toMatch(/queue: blocked/i);
   });
 
   it('clicking the Recently Completed count opens the dialog with the COMPLETED title', async () => {
@@ -617,5 +622,127 @@ describe('DispatcherDashboard — #3159 expand-count dialog wiring', () => {
         screen.getByTestId(`issue-link-${it.issueNumber}`),
       ).toBeInTheDocument();
     }
+  });
+});
+
+// #3172: dialog title carries the same {shown} / {total} denominator as
+// the badge that opened it, and labels match the panel headings exactly.
+describe('DispatcherDashboard — #3172 dialog title denominator', () => {
+  beforeEach(() => {
+    mockControlMutate.mockClear();
+    mockSetConfigMutate.mockClear();
+    mockRefetch.mockClear();
+    mockQueueFullData.READY = undefined;
+    mockQueueFullData.BLOCKED = undefined;
+    mockQueueFullData.COMPLETED = undefined;
+  });
+
+  it('READY dialog title reads `Queue: Agent-ready — {shown} / {total}` matching the badge', async () => {
+    // Panel renders 10 (capped); the daemon has scanned 50 ready issues.
+    const items = Array.from({ length: 10 }, (_, i) => ({
+      issueNumber: 8000 + i,
+      title: `ready ${8000 + i}`,
+      priority: 'p2',
+      labels: ['priority/p2', 'agent/ready'],
+      createdAt: '2026-04-18T11:00:00Z',
+      blockedBy: [],
+      cooldownSecondsRemaining: null,
+    }));
+    mockQueryData = {
+      dispatcherState: {
+        ...BASE_STATE,
+        queueDepth: 50,
+        queueReady: items,
+      },
+    };
+    mockQueueFullData.READY = {
+      dispatcherQueueFull: {
+        kind: 'READY',
+        queueItems: items,
+        completions: [],
+      },
+    };
+    renderDashboard();
+    // Sanity: badge shows `10 / 50` (existing #2886 behaviour).
+    expect(screen.getByTestId('queue-ready-count')).toHaveTextContent(
+      '10 / 50',
+    );
+    fireEvent.click(screen.getByTestId('queue-ready-count'));
+    const title = await screen.findByTestId('queue-full-dialog-title');
+    expect(title.textContent).toBe('Queue: Agent-ready — 10 / 50');
+  });
+
+  it('BLOCKED dialog title reads `Queue: Blocked — {shown} / {total}`', async () => {
+    const items = Array.from({ length: 4 }, (_, i) => ({
+      issueNumber: 7000 + i,
+      title: `blocked ${7000 + i}`,
+      priority: 'p2',
+      labels: ['priority/p2', 'status/blocked'],
+      createdAt: '2026-04-18T11:00:00Z',
+      blockedBy: [42],
+      cooldownSecondsRemaining: null,
+    }));
+    mockQueryData = {
+      dispatcherState: {
+        ...BASE_STATE,
+        blockedDepth: 12,
+        queueBlocked: items,
+      },
+    };
+    mockQueueFullData.BLOCKED = {
+      dispatcherQueueFull: {
+        kind: 'BLOCKED',
+        queueItems: items,
+        completions: [],
+      },
+    };
+    renderDashboard();
+    expect(screen.getByTestId('queue-blocked-count')).toHaveTextContent(
+      '4 / 12',
+    );
+    fireEvent.click(screen.getByTestId('queue-blocked-count'));
+    const title = await screen.findByTestId('queue-full-dialog-title');
+    expect(title.textContent).toBe('Queue: Blocked — 4 / 12');
+  });
+
+  it('COMPLETED dialog title reads `Recently completed — {shown} / {total}`', async () => {
+    const completions = Array.from({ length: 10 }, (_, i) => ({
+      agentId: `aaaaaaaa-bbbb-cccc-dddd-${String(i).padStart(12, '0')}`,
+      issueNumber: 6000 + i,
+      issueTitle: `done ${6000 + i}`,
+      priority: 'p2',
+      status: 'succeeded',
+      startedAt: '2026-04-18T11:50:00Z',
+      endedAt: '2026-04-18T11:55:00Z',
+      prNumber: 7000 + i,
+      totalTokens: null,
+      totalCostUsd: null,
+      failureSummary: null,
+      mergedAt: '2026-04-18T11:50:00Z',
+      verifiedAt: '2026-04-18T11:53:00Z',
+      verifySkipReason: null,
+      retroedAt: '2026-04-18T11:55:00Z',
+    }));
+    mockQueryData = {
+      dispatcherState: {
+        ...BASE_STATE,
+        recentCompletions: completions,
+        recentCompletionsCount: 183,
+      },
+    };
+    mockQueueFullData.COMPLETED = {
+      dispatcherQueueFull: {
+        kind: 'COMPLETED',
+        queueItems: [],
+        completions,
+      },
+    };
+    renderDashboard();
+    expect(screen.getByTestId('recent-completions-count')).toHaveTextContent(
+      '10 / 183',
+    );
+    fireEvent.click(screen.getByTestId('recent-completions-count'));
+    const title = await screen.findByTestId('queue-full-dialog-title');
+    expect(title.textContent).toBe('Recently completed — 10 / 183');
   });
 });

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueueFullDialog.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueueFullDialog.test.tsx
@@ -318,28 +318,80 @@ describe('QueueFullDialog — close handling', () => {
 
 describe('formatDialogTitle', () => {
   it('returns empty string for kind=null', () => {
-    expect(formatDialogTitle(null, 0, false)).toBe('');
+    expect(formatDialogTitle(null, 0, 0, false)).toBe('');
   });
 
-  it('renders Agent-ready queue (N) for READY', () => {
-    expect(formatDialogTitle('READY', 12, false)).toBe(
-      'Agent-ready queue (12)',
+  // #3172: title labels match panel headings character-for-character
+  // and the count decoration becomes `{shown} / {total}`.
+  it('renders `Queue: Agent-ready — {shown} / {total}` for READY', () => {
+    expect(formatDialogTitle('READY', 10, 50, false)).toBe(
+      'Queue: Agent-ready — 10 / 50',
     );
   });
 
-  it('renders Blocked queue (N) for BLOCKED', () => {
-    expect(formatDialogTitle('BLOCKED', 5, false)).toBe('Blocked queue (5)');
-  });
-
-  it('renders Recently completed (N) for COMPLETED', () => {
-    expect(formatDialogTitle('COMPLETED', 7, false)).toBe(
-      'Recently completed (7)',
+  it('renders `Queue: Blocked — {shown} / {total}` for BLOCKED', () => {
+    expect(formatDialogTitle('BLOCKED', 5, 12, false)).toBe(
+      'Queue: Blocked — 5 / 12',
     );
   });
 
-  it('appends a (loading…) marker while loading', () => {
-    expect(formatDialogTitle('READY', 0, true)).toBe(
-      'Agent-ready queue (loading…)',
+  it('renders `Recently completed — {shown} / {total}` for COMPLETED', () => {
+    expect(formatDialogTitle('COMPLETED', 10, 183, false)).toBe(
+      'Recently completed — 10 / 183',
     );
+  });
+
+  it('appends a — loading… marker while loading', () => {
+    expect(formatDialogTitle('READY', 0, 0, true)).toBe(
+      'Queue: Agent-ready — loading…',
+    );
+  });
+
+  it('drops the count decoration when shown or total is undefined', () => {
+    // Back-compat fallback for callers that don't supply both numbers
+    // (e.g. existing test fixtures, or a future caller that hasn't yet
+    // wired up the depth fields).
+    expect(formatDialogTitle('READY', undefined, 50, false)).toBe(
+      'Queue: Agent-ready',
+    );
+    expect(formatDialogTitle('READY', 10, undefined, false)).toBe(
+      'Queue: Agent-ready',
+    );
+    expect(formatDialogTitle('READY', undefined, undefined, false)).toBe(
+      'Queue: Agent-ready',
+    );
+  });
+
+  it('label strings match the panel heading strings exactly', () => {
+    // Guards against the #3172 regression where the dialog's labels
+    // ("Agent-ready queue", "Blocked queue") inverted the noun/qualifier
+    // order vs. the panel headings ("Queue: Agent-ready", "Queue: Blocked")
+    // — operators saw two different strings for the same thing.
+    expect(formatDialogTitle('READY', undefined, undefined, false)).toBe(
+      'Queue: Agent-ready',
+    );
+    expect(formatDialogTitle('BLOCKED', undefined, undefined, false)).toBe(
+      'Queue: Blocked',
+    );
+    expect(formatDialogTitle('COMPLETED', undefined, undefined, false)).toBe(
+      'Recently completed',
+    );
+  });
+});
+
+describe('QueueFullDialog — #3172 width', () => {
+  it('uses max-w-4xl on DialogContent for the wide cockpit layout', () => {
+    resetMocks();
+    mockData.READY = {
+      dispatcherQueueFull: {
+        kind: 'READY',
+        queueItems: [],
+        completions: [],
+      },
+    };
+    render(<QueueFullDialog kind="READY" onClose={vi.fn()} />);
+    const content = screen.getByTestId('queue-full-dialog');
+    expect(content.className).toMatch(/\bmax-w-4xl\b/);
+    expect(content.className).not.toMatch(/\bmax-w-2xl\b/);
   });
 });

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
@@ -757,4 +757,74 @@ describe('RecentCompletionsPanel — Magic Move view-transition names (#2967)', 
       expect(badge.getAttribute('aria-label')).toMatch(/recent-completions/i);
     });
   });
+
+  // #3172: panel header now renders `{shown} / {total}` matching the
+  // Ready/Blocked panels. `total` comes from
+  // `DispatcherState.recentCompletionsCount`. Both code paths
+  // (clickable badge + inline parenthetical) route through the helper.
+  describe('#3172 {shown} / {total} count', () => {
+    it('clickable badge renders `{shown} / {total}` when total is provided', () => {
+      const onCountClick = vi.fn();
+      render(
+        <RecentCompletionsPanel
+          completions={[
+            completion({ agentId: 'a-1' }),
+            completion({ agentId: 'a-2' }),
+            completion({ agentId: 'a-3' }),
+          ]}
+          nowMs={now}
+          total={183}
+          onCountClick={onCountClick}
+        />,
+      );
+      const badge = screen.getByTestId('recent-completions-count');
+      expect(badge).toHaveTextContent('3 / 183');
+    });
+
+    it('inline parenthetical renders `({shown} / {total})` when onCountClick is omitted', () => {
+      render(
+        <RecentCompletionsPanel
+          completions={[
+            completion({ agentId: 'a-1' }),
+            completion({ agentId: 'a-2' }),
+          ]}
+          nowMs={now}
+          total={42}
+        />,
+      );
+      expect(
+        screen.getByRole('heading', {
+          name: /recently completed \(2 \/ 42\)/i,
+        }),
+      ).toBeInTheDocument();
+    });
+
+    it('falls back to `{shown}` when total is omitted (back-compat)', () => {
+      const onCountClick = vi.fn();
+      render(
+        <RecentCompletionsPanel
+          completions={[completion({ agentId: 'a-1' })]}
+          nowMs={now}
+          onCountClick={onCountClick}
+        />,
+      );
+      // No `total` prop — badge shows just the count, no slash.
+      const badge = screen.getByTestId('recent-completions-count');
+      expect(badge.textContent).toBe('1');
+    });
+
+    it('renders `0 / N` when there are no rows but total is provided', () => {
+      const onCountClick = vi.fn();
+      render(
+        <RecentCompletionsPanel
+          completions={[]}
+          nowMs={now}
+          total={5}
+          onCountClick={onCountClick}
+        />,
+      );
+      const badge = screen.getByTestId('recent-completions-count');
+      expect(badge).toHaveTextContent('0 / 5');
+    });
+  });
 });

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -84,6 +84,7 @@ export const DISPATCHER_STATE_QUERY = gql`
         verifySkipReason
         retroedAt
       }
+      recentCompletionsCount
       config {
         key
         value
@@ -326,6 +327,11 @@ export interface DispatcherState {
   queueReady: QueueItem[];
   queueBlocked: QueueItem[];
   recentCompletions: RecentCompletion[];
+  /** Total count of terminal-status rows in `dispatcher.agents` (#3172).
+   * Paired with `recentCompletions` (capped at 10 server-side) so the
+   * admin-cockpit panel header can render `{shown} / {total}`, matching
+   * the Ready/Blocked panels. Returns 0 when the table is empty. */
+  recentCompletionsCount: number;
   config: DispatcherConfigEntry[];
   spawnFrozenUntil: string | null;
   /** True when the circuit breaker is open (#2860). */


### PR DESCRIPTION
## Summary

Three small polish items on top of #3164 (full-list dialog work):

1. **`recentCompletionsCount: Int!` on `DispatcherState`** — same filter as `queryRecentCompletions`. Threaded into `RecentCompletionsPanel` so the header reads `{shown} / {total}` matching the Ready/Blocked panels (#2886). Both code paths (clickable badge + inline parenthetical) route through a new `formatRecentCompletionsCount` helper.
2. **Dialog titles match panel headings** — `formatDialogTitle` now returns `Queue: Agent-ready` / `Queue: Blocked` / `Recently completed` (character-for-character match), and the count decoration becomes `${label} — ${shown} / ${total}` (em-dash) instead of `${label} (${count})`. The dashboard threads `shown` (panel list length) and `total` (depth field) into the dialog so the title carries the same denominator as the badge that opened it. Loading state is `${label} — loading…`.
3. **Wider dialog** — `<DialogContent>` className bumped from `max-w-2xl` (672px) to `max-w-4xl` (896px). The cockpit page is a wide 3-column layout; the previous width forced full issue rows to wrap awkwardly.

Closes #3172

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (web 1412 + api 28 dispatcher integration + 260 unit — all green locally)
- [x] CI green

### Post-deploy verification
- [x] Open `/admin/dispatcher` on dev — Recently Completed header reads `10 / 182` matching DB count of 182
- [x] Click each of the three count badges; dialog titles read `Queue: Agent-ready — 10 / 77` / `Queue: Blocked — 10 / 13` / `Recently completed — 10 / 182` (matching the badges that opened them)
- [x] Dialog content area visibly wider than before — full issue rows don't wrap awkwardly at 1440px viewport
- [x] Verification evidence posted on issue (see comment thread on #3172)
