### PR TITLE
feat(dx): make preflight helpers callable without source (#2711)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,13 +42,12 @@ Shell-interactive prompt-prevention rules (`$()`, heredocs, inline `python -c`, 
 The PreToolUse hook (`.claude/hooks/preflight-bash.sh`) and `scripts/preflight.sh` enforce the Critical Rules above. See `docs/agent/interactive-shell-rules.md` for the full operator-laptop vs. Fargate-runtime scope split.
 
 ```bash
-source scripts/preflight.sh
-preflight_in_worktree       # Fail if pwd is main repo, not a worktree
-preflight_not_on_main       # Fail if on main/master branch
-preflight_branch_fresh      # Fail if behind origin/main (add --fetch to fetch first)
-preflight_venv_local        # Fail if .venv is missing or is a symlink
-preflight_no_duplicate_pr N # Check if open PR already exists for issue #N
-preflight_rate_budget       # Warn if GitHub API rate budget < 100 remaining
+scripts/preflight/in-worktree.sh       # Fail if pwd is main repo, not a worktree
+scripts/preflight/not-on-main.sh       # Fail if on main/master branch
+scripts/preflight/branch-fresh.sh      # Fail if behind origin/main (pass --fetch to fetch first)
+scripts/preflight/venv-local.sh        # Fail if .venv is missing or is a symlink
+scripts/preflight/no-duplicate-pr.sh N # Check if open PR already exists for issue #N
+scripts/preflight/rate-budget.sh       # Warn if GitHub API rate budget < 100 remaining
 ```
 
 ## Project Context

--- a/docs/preflight-checklist.md
+++ b/docs/preflight-checklist.md
@@ -4,15 +4,15 @@ Machine-readable checklist of rules extracted from CLAUDE.md. Agents should vali
 
 ## Enforced Rules (hook + scripts/preflight.sh)
 
-| ID | Rule | Enforcement | Script Function |
-|----|------|-------------|-----------------|
-| E-01 | No `$()`, heredocs, or backtick expansion | PreToolUse hook blocks | `preflight_no_forbidden_syntax` |
-| E-02 | Fetch/rebase before analyzing code | Manual / script check | `preflight_branch_fresh --fetch` |
-| E-03 | Must be in a worktree during task work | Manual / script check | `preflight_in_worktree` |
-| E-04 | Venv must be local to worktree | Manual / script check | `preflight_venv_local` |
-| E-05 | Never push to main/master | PreToolUse hook blocks | `preflight_not_on_main` |
-| E-06 | No `git worktree add` inside worktrees | PreToolUse hook blocks | — |
-| E-07 | No bare `git stash pop` / `git stash apply` (#2749) | PreToolUse hook blocks | — |
+| ID | Rule | Enforcement | Standalone Script | Script Function |
+|----|------|-------------|-------------------|-----------------|
+| E-01 | No `$()`, heredocs, or backtick expansion | PreToolUse hook blocks | `scripts/preflight/no-forbidden-syntax.sh` | `preflight_no_forbidden_syntax` |
+| E-02 | Fetch/rebase before analyzing code | Manual / script check | `scripts/preflight/branch-fresh.sh --fetch` | `preflight_branch_fresh --fetch` |
+| E-03 | Must be in a worktree during task work | Manual / script check | `scripts/preflight/in-worktree.sh` | `preflight_in_worktree` |
+| E-04 | Venv must be local to worktree | Manual / script check | `scripts/preflight/venv-local.sh` | `preflight_venv_local` |
+| E-05 | Never push to main/master | PreToolUse hook blocks | `scripts/preflight/not-on-main.sh` | `preflight_not_on_main` |
+| E-06 | No `git worktree add` inside worktrees | PreToolUse hook blocks | — | — |
+| E-07 | No bare `git stash pop` / `git stash apply` (#2749) | PreToolUse hook blocks | — | — |
 
 ## Shell Command Rules
 

--- a/scripts/preflight/branch-fresh.sh
+++ b/scripts/preflight/branch-fresh.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# scripts/preflight/branch-fresh.sh — Standalone wrapper around preflight_branch_fresh.
+#
+# Verifies the current branch is not behind origin/main. Catches the common
+# mistake of analyzing or modifying stale code.
+#
+# This wrapper exists because calling the underlying function in a single Bash
+# tool invocation requires `source scripts/preflight.sh && preflight_branch_fresh`,
+# which the preflight hook blocks (quoted strings combined with `&&`).
+# A standalone script under scripts/preflight/ is covered by the `Bash(scripts/*)`
+# permission and runs without prompts.
+#
+# Usage:
+#   scripts/preflight/branch-fresh.sh            # check only (no fetch)
+#   scripts/preflight/branch-fresh.sh --fetch    # fetch origin main first, then check
+#
+# Exit codes (pass-through from preflight_branch_fresh):
+#   0 — Branch is at or ahead of origin/main. Safe to proceed.
+#   1 — Branch is behind origin/main. PREFLIGHT FAIL is printed to stderr
+#       with the commit-count gap. Caller should rebase.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=../preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+
+exit_code=0
+preflight_branch_fresh "$@" || exit_code=$?
+
+exit "$exit_code"

--- a/scripts/preflight/in-worktree.sh
+++ b/scripts/preflight/in-worktree.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# scripts/preflight/in-worktree.sh — Standalone wrapper around preflight_in_worktree.
+#
+# Verifies that the current directory is inside a git worktree, not the main
+# repo checkout. Prevents agents from accidentally modifying the shared main
+# checkout or using its venv.
+#
+# This wrapper exists because calling the underlying function in a single Bash
+# tool invocation requires `source scripts/preflight.sh && preflight_in_worktree`,
+# which the preflight hook blocks (quoted strings combined with `&&`).
+# A standalone script under scripts/preflight/ is covered by the `Bash(scripts/*)`
+# permission and runs without prompts.
+#
+# Usage:
+#   scripts/preflight/in-worktree.sh
+#
+# Exit codes (pass-through from preflight_in_worktree):
+#   0 — Current directory is inside a worktree. Safe to proceed.
+#   1 — Not in a worktree (main repo checkout or outside git). PREFLIGHT FAIL
+#       is printed to stderr.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=../preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+
+exit_code=0
+preflight_in_worktree "$@" || exit_code=$?
+
+exit "$exit_code"

--- a/scripts/preflight/no-duplicate-pr.sh
+++ b/scripts/preflight/no-duplicate-pr.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# scripts/preflight/no-duplicate-pr.sh — Standalone wrapper around preflight_no_duplicate_pr.
+#
+# Checks whether an open PR already exists for the given issue number. Prevents
+# duplicate PRs when a session loses context (e.g. after context compaction) or
+# when multiple agents pick up the same issue.
+#
+# This wrapper exists because calling the underlying function in a single Bash
+# tool invocation requires `source scripts/preflight.sh && preflight_no_duplicate_pr N`,
+# which the preflight hook blocks (quoted strings combined with `&&`).
+# A standalone script under scripts/preflight/ is covered by the `Bash(scripts/*)`
+# permission and runs without prompts.
+#
+# Usage:
+#   scripts/preflight/no-duplicate-pr.sh 42   # check issue #42 (bare PR number
+#                                             # printed to stdout if duplicate found)
+#   scripts/preflight/no-duplicate-pr.sh '#42' # leading # is stripped automatically
+#
+# Exit codes (pass-through from preflight_no_duplicate_pr):
+#   0 — Duplicate PR exists. Existing PR number is printed to stdout. Caller
+#       should adopt the existing PR instead of creating a new one.
+#   1 — No duplicate found. Safe to create a new PR.
+#   2 — Error (missing argument, gh CLI unavailable, or API failure). A
+#       PREFLIGHT WARN line is printed to stderr.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=../preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+
+exit_code=0
+preflight_no_duplicate_pr "$@" || exit_code=$?
+
+exit "$exit_code"

--- a/scripts/preflight/no-forbidden-syntax.sh
+++ b/scripts/preflight/no-forbidden-syntax.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# scripts/preflight/no-forbidden-syntax.sh — Standalone wrapper around preflight_no_forbidden_syntax.
+#
+# Checks a command string for forbidden shell patterns ($() substitution,
+# heredocs, inline python -c). Mirrors the checks in .claude/hooks/preflight-bash.sh
+# but can be called from scripts.
+#
+# This wrapper exists because calling the underlying function in a single Bash
+# tool invocation requires `source scripts/preflight.sh && preflight_no_forbidden_syntax`,
+# which the preflight hook blocks (quoted strings combined with `&&`).
+# A standalone script under scripts/preflight/ is covered by the `Bash(scripts/*)`
+# permission and runs without prompts.
+#
+# Usage:
+#   scripts/preflight/no-forbidden-syntax.sh 'git status'
+#   scripts/preflight/no-forbidden-syntax.sh 'echo $(whoami)'
+#
+# Exit codes (pass-through from preflight_no_forbidden_syntax):
+#   0 — Command string contains no forbidden patterns. Safe to proceed.
+#   1 — Command string contains a forbidden pattern ($(), heredoc, or python -c).
+#       PREFLIGHT FAIL is printed to stderr identifying the pattern.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=../preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+
+exit_code=0
+preflight_no_forbidden_syntax "$@" || exit_code=$?
+
+exit "$exit_code"

--- a/scripts/preflight/not-on-main.sh
+++ b/scripts/preflight/not-on-main.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# scripts/preflight/not-on-main.sh — Standalone wrapper around preflight_not_on_main.
+#
+# Verifies the current branch is not main/master. Prevents accidental commits
+# or pushes to the default branch during task work.
+#
+# This wrapper exists because calling the underlying function in a single Bash
+# tool invocation requires `source scripts/preflight.sh && preflight_not_on_main`,
+# which the preflight hook blocks (quoted strings combined with `&&`).
+# A standalone script under scripts/preflight/ is covered by the `Bash(scripts/*)`
+# permission and runs without prompts.
+#
+# Usage:
+#   scripts/preflight/not-on-main.sh
+#
+# Exit codes (pass-through from preflight_not_on_main):
+#   0 — On a non-main/master branch. Safe to proceed.
+#   1 — On main or master branch (or detached HEAD). PREFLIGHT FAIL is printed
+#       to stderr.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=../preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+
+exit_code=0
+preflight_not_on_main "$@" || exit_code=$?
+
+exit "$exit_code"

--- a/scripts/preflight/rate-budget.sh
+++ b/scripts/preflight/rate-budget.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# scripts/preflight/rate-budget.sh — Standalone wrapper around preflight_rate_budget.
+#
+# Checks the GitHub API rate limit and warns if remaining requests are below
+# the given threshold (default: 100). Useful before expensive polling operations
+# like `gh run watch`.
+#
+# This wrapper exists because calling the underlying function in a single Bash
+# tool invocation requires `source scripts/preflight.sh && preflight_rate_budget`,
+# which the preflight hook blocks (quoted strings combined with `&&`).
+# A standalone script under scripts/preflight/ is covered by the `Bash(scripts/*)`
+# permission and runs without prompts.
+#
+# Usage:
+#   scripts/preflight/rate-budget.sh           # warn if < 100 requests remaining
+#   scripts/preflight/rate-budget.sh 200       # warn if < 200 requests remaining
+#
+# Exit codes (pass-through from preflight_rate_budget):
+#   0 — Rate budget sufficient (remaining >= threshold).
+#   1 — Rate budget low (remaining < threshold). PREFLIGHT WARN printed to stderr.
+#   2 — Error (gh CLI unavailable or API unreachable). PREFLIGHT WARN printed
+#       to stderr.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=../preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+
+exit_code=0
+preflight_rate_budget "$@" || exit_code=$?
+
+exit "$exit_code"

--- a/scripts/preflight/tf-not-root.sh
+++ b/scripts/preflight/tf-not-root.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# scripts/preflight/tf-not-root.sh — Standalone wrapper around preflight_tf_not_root.
+#
+# Verifies that a terraform apply/destroy is not being run from the root
+# infra/terraform/ directory. The root config has its own state backend and
+# running apply from it creates duplicate resources that collide with the real
+# ones in environments/<env>/.
+#
+# This wrapper exists because calling the underlying function in a single Bash
+# tool invocation requires `source scripts/preflight.sh && preflight_tf_not_root`,
+# which the preflight hook blocks (quoted strings combined with `&&`).
+# A standalone script under scripts/preflight/ is covered by the `Bash(scripts/*)`
+# permission and runs without prompts.
+#
+# Usage:
+#   scripts/preflight/tf-not-root.sh                                  # checks pwd
+#   scripts/preflight/tf-not-root.sh infra/terraform/environments/dev # checks path
+#
+# Exit codes (pass-through from preflight_tf_not_root):
+#   0 — Path is an environment-specific directory. Safe to proceed.
+#   1 — Path is the root infra/terraform/ directory. PREFLIGHT FAIL is printed
+#       to stderr with guidance on which environment path to use instead.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=../preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+
+exit_code=0
+preflight_tf_not_root "$@" || exit_code=$?
+
+exit "$exit_code"

--- a/scripts/preflight/venv-local.sh
+++ b/scripts/preflight/venv-local.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# scripts/preflight/venv-local.sh — Standalone wrapper around preflight_venv_local.
+#
+# Verifies that a .venv directory exists in the given path (default: pwd) and
+# that it is NOT a symlink to another worktree's venv.
+#
+# This wrapper exists because calling the underlying function in a single Bash
+# tool invocation requires `source scripts/preflight.sh && preflight_venv_local`,
+# which the preflight hook blocks (quoted strings combined with `&&`).
+# A standalone script under scripts/preflight/ is covered by the `Bash(scripts/*)`
+# permission and runs without prompts.
+#
+# Usage:
+#   scripts/preflight/venv-local.sh              # checks .venv in current directory
+#   scripts/preflight/venv-local.sh /path/to/pkg # checks .venv at the given path
+#
+# Exit codes (pass-through from preflight_venv_local):
+#   0 — .venv exists and is a real directory (not a symlink). Safe to proceed.
+#   1 — .venv is missing or is a symlink. PREFLIGHT FAIL is printed to stderr.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=../preflight.sh
+source "$SCRIPT_DIR/preflight.sh"
+
+exit_code=0
+preflight_venv_local "$@" || exit_code=$?
+
+exit "$exit_code"

--- a/scripts/tests/test_preflight_wrappers.sh
+++ b/scripts/tests/test_preflight_wrappers.sh
@@ -1,0 +1,458 @@
+#!/usr/bin/env bash
+# test_preflight_wrappers.sh — Tests for scripts/preflight/ standalone wrappers
+#
+# Exercises every wrapper under scripts/preflight/ and asserts the 0/1/2 exit
+# codes match the underlying function in scripts/preflight.sh.
+#
+# Covers:
+#   in-worktree.sh      — exit 0 in a worktree, exit 1 in a main repo / outside git
+#   not-on-main.sh      — exit 0 on a feature branch, exit 1 on main/master/detached
+#   branch-fresh.sh     — exit 0 when up-to-date, exit 1 when behind origin/main
+#   venv-local.sh       — exit 0 with real .venv, exit 1 when missing or symlinked
+#   tf-not-root.sh      — exit 0 for env path, exit 1 for root infra/terraform/
+#   no-duplicate-pr.sh  — exit 2 with no argument; exit 0/1 with mock-gh
+#   rate-budget.sh      — exit 0/1/2 with mock-gh
+#   no-forbidden-syntax.sh — exit 1 for forbidden patterns, exit 0 for safe commands
+#
+# Usage:
+#   scripts/tests/test_preflight_wrappers.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PREFLIGHT_DIR="$SCRIPT_DIR/preflight"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+cleanup() {
+    set +e
+    for d in "${TEMP_DIRS[@]}"; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            if git -C "$d" rev-parse --git-dir > /dev/null 2>&1; then
+                git -C "$d" worktree list --porcelain 2>/dev/null \
+                    | awk '/^worktree / { print $2 }' \
+                    | while read -r wt; do
+                        [[ "$wt" == "$d" ]] && continue
+                        git -C "$d" worktree remove "$wt" --force 2>/dev/null || true
+                    done
+            fi
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+make_temp_repo() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    git -C "$dir" init --initial-branch main -q
+    git -C "$dir" config user.email "test@example.com"
+    git -C "$dir" config user.name "Test"
+    touch "$dir/README.md"
+    git -C "$dir" add README.md
+    git -C "$dir" commit -m "init" -q
+    echo "$dir"
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Precondition: all 8 wrappers exist and are executable ──────────────────
+
+WRAPPERS=(
+    in-worktree.sh
+    not-on-main.sh
+    branch-fresh.sh
+    venv-local.sh
+    tf-not-root.sh
+    no-duplicate-pr.sh
+    rate-budget.sh
+    no-forbidden-syntax.sh
+)
+
+for wrapper in "${WRAPPERS[@]}"; do
+    path="$PREFLIGHT_DIR/$wrapper"
+    if [[ -x "$path" ]]; then
+        pass "wrapper exists and is executable: $wrapper"
+    else
+        fail "wrapper exists and is executable: $wrapper" "$path is missing or not executable"
+    fi
+done
+
+# ══════════════════════════════════════════════════════════════════════════
+# in-worktree.sh
+# ══════════════════════════════════════════════════════════════════════════
+
+REPO1=$(make_temp_repo)
+
+# Test: Fails in main repo (not a worktree)
+exit_code=0
+(cd "$REPO1" && "$PREFLIGHT_DIR/in-worktree.sh") > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "in-worktree.sh exits non-zero in main repo"
+else
+    fail "in-worktree.sh exits non-zero in main repo" "expected non-zero exit"
+fi
+
+# Test: Succeeds inside a worktree
+git -C "$REPO1" worktree add "$REPO1/wt1" -b feat-wt HEAD -q
+exit_code=0
+(cd "$REPO1/wt1" && "$PREFLIGHT_DIR/in-worktree.sh") > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "in-worktree.sh exits 0 inside a worktree"
+else
+    fail "in-worktree.sh exits 0 inside a worktree" "exit code: $exit_code"
+fi
+
+# Test: Fails outside any git repo
+TEMP_NO_GIT=$(mktemp -d)
+TEMP_DIRS+=("$TEMP_NO_GIT")
+exit_code=0
+(cd "$TEMP_NO_GIT" && "$PREFLIGHT_DIR/in-worktree.sh") > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "in-worktree.sh exits non-zero outside git repo"
+else
+    fail "in-worktree.sh exits non-zero outside git repo" "expected non-zero exit"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# not-on-main.sh
+# ══════════════════════════════════════════════════════════════════════════
+
+REPO2=$(make_temp_repo)
+
+# Test: Fails on main branch
+exit_code=0
+(cd "$REPO2" && "$PREFLIGHT_DIR/not-on-main.sh") > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "not-on-main.sh exits non-zero on main branch"
+else
+    fail "not-on-main.sh exits non-zero on main branch" "expected non-zero exit"
+fi
+
+# Test: Succeeds on feature branch
+git -C "$REPO2" checkout -b feature-test -q
+exit_code=0
+(cd "$REPO2" && "$PREFLIGHT_DIR/not-on-main.sh") > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "not-on-main.sh exits 0 on feature branch"
+else
+    fail "not-on-main.sh exits 0 on feature branch" "exit code: $exit_code"
+fi
+
+# Test: Fails on master branch
+git -C "$REPO2" checkout -b master -q
+exit_code=0
+(cd "$REPO2" && "$PREFLIGHT_DIR/not-on-main.sh") > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "not-on-main.sh exits non-zero on master branch"
+else
+    fail "not-on-main.sh exits non-zero on master branch" "expected non-zero exit"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# branch-fresh.sh
+# ══════════════════════════════════════════════════════════════════════════
+
+REPO3=$(make_temp_repo)
+git -C "$REPO3" remote add origin "$REPO3"
+git -C "$REPO3" fetch origin main -q 2>/dev/null
+git -C "$REPO3" checkout -b feature-fresh -q
+
+# Test: Succeeds when branch is up-to-date
+exit_code=0
+(cd "$REPO3" && "$PREFLIGHT_DIR/branch-fresh.sh") > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "branch-fresh.sh exits 0 when up-to-date with origin/main"
+else
+    fail "branch-fresh.sh exits 0 when up-to-date with origin/main" "exit code: $exit_code"
+fi
+
+# Test: Fails when behind origin/main
+git -C "$REPO3" checkout main -q
+touch "$REPO3/newfile.txt"
+git -C "$REPO3" add newfile.txt
+git -C "$REPO3" commit -m "advance main" -q
+git -C "$REPO3" fetch origin main -q 2>/dev/null
+git -C "$REPO3" checkout feature-fresh -q
+
+exit_code=0
+(cd "$REPO3" && "$PREFLIGHT_DIR/branch-fresh.sh") > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "branch-fresh.sh exits non-zero when behind origin/main"
+else
+    fail "branch-fresh.sh exits non-zero when behind origin/main" "expected non-zero exit"
+fi
+
+# Test: --fetch flag is accepted without error
+exit_code=0
+(cd "$REPO3" && "$PREFLIGHT_DIR/branch-fresh.sh" --fetch) > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "--fetch flag accepted (still behind, non-zero exit expected)"
+else
+    fail "--fetch flag accepted" "expected non-zero exit because still behind"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# venv-local.sh
+# ══════════════════════════════════════════════════════════════════════════
+
+VENV_DIR=$(mktemp -d)
+TEMP_DIRS+=("$VENV_DIR")
+
+# Test: Fails when .venv does not exist
+exit_code=0
+"$PREFLIGHT_DIR/venv-local.sh" "$VENV_DIR" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "venv-local.sh exits non-zero when .venv missing"
+else
+    fail "venv-local.sh exits non-zero when .venv missing" "expected non-zero exit"
+fi
+
+# Test: Succeeds when .venv is a real directory
+mkdir -p "$VENV_DIR/.venv"
+exit_code=0
+"$PREFLIGHT_DIR/venv-local.sh" "$VENV_DIR" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "venv-local.sh exits 0 with real .venv directory"
+else
+    fail "venv-local.sh exits 0 with real .venv directory" "exit code: $exit_code"
+fi
+
+# Test: Fails when .venv is a symlink
+rm -rf "$VENV_DIR/.venv"
+OTHER_VENV=$(mktemp -d)
+TEMP_DIRS+=("$OTHER_VENV")
+mkdir -p "$OTHER_VENV/.venv"
+ln -s "$OTHER_VENV/.venv" "$VENV_DIR/.venv"
+exit_code=0
+"$PREFLIGHT_DIR/venv-local.sh" "$VENV_DIR" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "venv-local.sh exits non-zero when .venv is a symlink"
+else
+    fail "venv-local.sh exits non-zero when .venv is a symlink" "expected non-zero exit"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# tf-not-root.sh
+# ══════════════════════════════════════════════════════════════════════════
+
+TF_DIR=$(mktemp -d)
+TEMP_DIRS+=("$TF_DIR")
+
+# Test: Fails for root infra/terraform/ path
+mkdir -p "$TF_DIR/infra/terraform"
+exit_code=0
+"$PREFLIGHT_DIR/tf-not-root.sh" "$TF_DIR/infra/terraform" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "tf-not-root.sh exits non-zero for root infra/terraform/"
+else
+    fail "tf-not-root.sh exits non-zero for root infra/terraform/" "expected non-zero exit"
+fi
+
+# Test: Succeeds for environment-specific path
+mkdir -p "$TF_DIR/infra/terraform/environments/dev"
+exit_code=0
+"$PREFLIGHT_DIR/tf-not-root.sh" "$TF_DIR/infra/terraform/environments/dev" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "tf-not-root.sh exits 0 for environments/dev path"
+else
+    fail "tf-not-root.sh exits 0 for environments/dev path" "exit code: $exit_code"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# no-duplicate-pr.sh (argument validation + mock-gh)
+# ══════════════════════════════════════════════════════════════════════════
+
+# Test: Exits 2 with no argument
+exit_code=0
+"$PREFLIGHT_DIR/no-duplicate-pr.sh" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "no-duplicate-pr.sh exits 2 with no argument"
+else
+    fail "no-duplicate-pr.sh exits 2 with no argument" "expected exit 2, got $exit_code"
+fi
+
+# Test with mock-gh: exits 1 when no duplicate found
+MOCK_BIN_DIR=$(mktemp -d)
+TEMP_DIRS+=("$MOCK_BIN_DIR")
+ORIG_PATH_SAVE="$PATH"
+
+# Mock gh: returns empty PR list and empty branch PR list
+# The function checks both title-search and head-branch — we need to respond
+# to both `gh pr list --search` and `gh pr list --head`.
+cat > "$MOCK_BIN_DIR/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+# Return an empty JSON array for all pr list calls
+if [[ "$*" == *"pr list"* ]]; then
+    echo "[]"
+    exit 0
+fi
+exit 1
+MOCKGH
+chmod +x "$MOCK_BIN_DIR/gh"
+export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
+
+exit_code=0
+"$PREFLIGHT_DIR/no-duplicate-pr.sh" 9999 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "no-duplicate-pr.sh exits 1 when no duplicate found (mock-gh)"
+else
+    fail "no-duplicate-pr.sh exits 1 when no duplicate found (mock-gh)" "expected exit 1, got $exit_code"
+fi
+
+# Restore PATH
+export PATH="$ORIG_PATH_SAVE"
+
+# ══════════════════════════════════════════════════════════════════════════
+# rate-budget.sh (with mock-gh)
+# ══════════════════════════════════════════════════════════════════════════
+
+MOCK_BIN_DIR2=$(mktemp -d)
+TEMP_DIRS+=("$MOCK_BIN_DIR2")
+ORIG_PATH_SAVE2="$PATH"
+
+# Test: Returns 0 when budget is sufficient
+cat > "$MOCK_BIN_DIR2/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+echo "4500 9999999999 5000"
+exit 0
+MOCKGH
+chmod +x "$MOCK_BIN_DIR2/gh"
+export PATH="$MOCK_BIN_DIR2:$ORIG_PATH_SAVE2"
+
+exit_code=0
+"$PREFLIGHT_DIR/rate-budget.sh" 100 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "rate-budget.sh exits 0 when budget sufficient (mock-gh)"
+else
+    fail "rate-budget.sh exits 0 when budget sufficient (mock-gh)" "exit code: $exit_code"
+fi
+
+# Test: Returns 1 when budget is low
+cat > "$MOCK_BIN_DIR2/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+echo "50 9999999999 5000"
+exit 0
+MOCKGH
+chmod +x "$MOCK_BIN_DIR2/gh"
+
+exit_code=0
+"$PREFLIGHT_DIR/rate-budget.sh" 100 > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "rate-budget.sh exits 1 when budget low (mock-gh)"
+else
+    fail "rate-budget.sh exits 1 when budget low (mock-gh)" "expected exit 1, got $exit_code"
+fi
+
+# Test: Returns 2 when gh api fails
+cat > "$MOCK_BIN_DIR2/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+exit 1
+MOCKGH
+chmod +x "$MOCK_BIN_DIR2/gh"
+
+exit_code=0
+"$PREFLIGHT_DIR/rate-budget.sh" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+    pass "rate-budget.sh exits 2 when gh api fails (mock-gh)"
+else
+    fail "rate-budget.sh exits 2 when gh api fails (mock-gh)" "expected exit 2, got $exit_code"
+fi
+
+# Test: Uses default threshold of 100
+cat > "$MOCK_BIN_DIR2/gh" << 'MOCKGH'
+#!/usr/bin/env bash
+echo "99 9999999999 5000"
+exit 0
+MOCKGH
+chmod +x "$MOCK_BIN_DIR2/gh"
+
+exit_code=0
+"$PREFLIGHT_DIR/rate-budget.sh" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "rate-budget.sh uses default threshold of 100 (mock-gh)"
+else
+    fail "rate-budget.sh uses default threshold of 100 (mock-gh)" "expected exit 1, got $exit_code"
+fi
+
+# Restore PATH
+export PATH="$ORIG_PATH_SAVE2"
+
+# ══════════════════════════════════════════════════════════════════════════
+# no-forbidden-syntax.sh
+# ══════════════════════════════════════════════════════════════════════════
+
+# Test: Detects $() substitution
+exit_code=0
+"$PREFLIGHT_DIR/no-forbidden-syntax.sh" 'echo $(whoami)' > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "no-forbidden-syntax.sh detects \$() substitution"
+else
+    fail "no-forbidden-syntax.sh detects \$() substitution" "expected non-zero exit"
+fi
+
+# Test: Detects heredoc
+exit_code=0
+"$PREFLIGHT_DIR/no-forbidden-syntax.sh" 'cat <<EOF' > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "no-forbidden-syntax.sh detects heredoc"
+else
+    fail "no-forbidden-syntax.sh detects heredoc" "expected non-zero exit"
+fi
+
+# Test: Detects python -c
+exit_code=0
+"$PREFLIGHT_DIR/no-forbidden-syntax.sh" 'python3 -c "print(1)"' > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -ne 0 ]]; then
+    pass "no-forbidden-syntax.sh detects python -c"
+else
+    fail "no-forbidden-syntax.sh detects python -c" "expected non-zero exit"
+fi
+
+# Test: Allows safe commands
+exit_code=0
+"$PREFLIGHT_DIR/no-forbidden-syntax.sh" 'git status' > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "no-forbidden-syntax.sh exits 0 for safe command"
+else
+    fail "no-forbidden-syntax.sh exits 0 for safe command" "exit code: $exit_code"
+fi
+
+# Test: Allows $HOME (not a substitution)
+exit_code=0
+"$PREFLIGHT_DIR/no-forbidden-syntax.sh" 'echo $HOME' > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "no-forbidden-syntax.sh exits 0 for \$HOME (not substitution)"
+else
+    fail "no-forbidden-syntax.sh exits 0 for \$HOME (not substitution)" "exit code: $exit_code"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Created 8 standalone wrapper scripts under `scripts/preflight/` so preflight helper functions can be invoked directly without `source`, removing friction from the agent task pipeline. Removed the dependency on shell-state-preservation workarounds (e.g., `gh pr list --search` as a fallback) that agents currently use when hitting the quoted-strings-with-`;` hook block. Updated documentation in `CLAUDE.md` and `docs/preflight-checklist.md` to show the new direct-script form as the recommended agent invocation.

Closes #2711

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] Interactive shell test: `source scripts/preflight.sh && preflight_no_duplicate_pr 2680` returns 0/1/2 as expected (shell function invocation still works)
- [ ] Verification evidence posted on #2711 (see /task-v2-verify output)
