### PR TITLE
feat(agent-runner): real awaiting_ci/merge/awaiting_deploy implementations (#3176)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -40,13 +40,16 @@
 #      immediately to `planning`. The daemon has already written the
 #      agent row by the time this task boots, so the claim step is
 #      nothing but a lifecycle marker.
-#   3. **Mechanical phases with side effects** — `push_and_pr` has a
-#      minimal in-process implementation (`handle_push_and_pr` ==
-#      `git push` + `gh pr create`). `awaiting_ci`, `merge`,
-#      `awaiting_deploy`, `retro`, and `setup` are stubbed: they
-#      advance to the documented "next" phase on the happy path so
-#      the smoke test can reach `done` without a full daemon
-#      integration. Stage 2 fleshes each stub out.
+#   3. **Mechanical phases with side effects** — `push_and_pr`,
+#      `awaiting_ci`, `merge`, and `awaiting_deploy` have in-process
+#      implementations mirroring the subprocess daemon's
+#      ``_push_and_open_pr`` / ``_advance_awaiting_ci`` /
+#      ``_merge_pr_and_advance`` / ``_advance_awaiting_deploy``. These
+#      are the critical post-ralph output-actions — without them an
+#      ECS agent opens a PR and then races through the remaining
+#      mechanical phases with stubs, abandoning the PR (see #3176).
+#      `retro` and `setup` remain stubbed on this path; Stage 3+
+#      wires them.
 #
 # The phase → skill-name mapping (`phase_to_skill`) is explicit and
 # dies on an unknown phase. Prior to #3117 the entrypoint constructed
@@ -1682,30 +1685,48 @@ persist_phase_output() {
 }
 
 handle_push_and_pr() {
-    # Mechanical implementation of the push_and_pr phase (#3117).
+    # Mechanical implementation of the push_and_pr phase (#3117, #3176).
     #
     # This phase is NOT claude-driven — the daemon handles push + PR
-    # creation inline today via `_handle_phase_push_and_pr` (daemon.py
-    # ~L10544). Prior to this fix the entrypoint's phase-dispatch case
-    # lumped `push_and_pr` in with the claude-driven branches and
-    # called `/task-v2-push_and_pr`, which returned "Unknown command"
-    # (the skill does not exist).
+    # creation inline today via ``_push_and_open_pr`` in daemon.py. This
+    # handler mirrors that flow for ECS-mode agents:
     #
-    # Stage 1b scope: the minimal viable push + PR, enough to get the
-    # smoke to exercise the phase boundary. Rich failure handling
-    # (commit --amend with the summary phase's commit_message, self-
-    # deploy detection, unmet-AC draft-PR, git_push_failed diagnoser
-    # routing) stays in the daemon's implementation and lands on the
-    # agent-runner side in a later Stage 2 PR.
+    #   1. #3039 no-op guardrail: if ``origin/main..HEAD`` is empty
+    #      (ralph SHIP with clean tree), emit ``{"no_op": true}`` and
+    #      let the transition shim flip the agent to ``succeeded``.
+    #   2. #3176 pre-push rebase: ``git fetch origin main`` then
+    #      ``git rebase origin/main`` so a stale branch tip doesn't
+    #      produce a CONFLICTING PR the moment main advances. Rebase
+    #      conflict → fail cleanly with ``push_failed: true`` so the
+    #      transition falls through to the unrecognized branch.
+    #   3. #3176 summary amend: read ``commit_message`` from
+    #      ``tmp/dispatcher-output/summary.json`` and
+    #      ``git commit --amend -F <file>`` to replace ralph's
+    #      placeholder ``"WIP: ralph output"`` commit with the
+    #      conventional-commits message produced by the summary skill.
+    #      Missing / unreadable summary output → fall through with the
+    #      existing ralph commit untouched (still produces a PR, just
+    #      without the rich title/body — subprocess mode raises this
+    #      as a PR_OUTPUT_MISSING failure; the entrypoint is intentionally
+    #      more tolerant so a partial summary doesn't abandon the PR).
+    #   4. Push the branch.
+    #   5. #3176 summary title/body: if ``summary.json`` provided
+    #      ``pr_title`` + ``pr_body_md``, pass them via
+    #      ``gh pr create --title "$T" --body-file <path>``. Otherwise
+    #      fall back to ``--fill`` (prior behaviour).
+    #   6. #3176 record pr_number: parse the PR number out of
+    #      ``gh pr create`` stdout and ``UPDATE dispatcher.agents
+    #      SET pr_number = $N`` so the green-counting audit sees the
+    #      PR linkage.
     #
     # Prints the phase-output JSON envelope on stdout so the caller
     # can persist it via persist_phase_output and drive the transition
-    # shim. Output shape matches `transition_from_push_and_pr`:
+    # shim. Output shape matches ``transition_from_push_and_pr``:
     #   {"no_op": true}   → terminal success (no commit to push)
     #   {"no_op": false}  → advance to awaiting_ci
     #
-    # Note: if `AGENT_RUNNER_DRY_RUN=1`, emit `{"no_op": true}` so the
-    # loop reaches a terminal phase without actually shelling out.
+    # Note: if ``AGENT_RUNNER_DRY_RUN=1``, emit ``{"no_op": true}`` so
+    # the loop reaches a terminal phase without actually shelling out.
 
     if [[ "$AGENT_RUNNER_DRY_RUN" == "1" ]]; then
         log "push_and_pr_dry_run"
@@ -1714,14 +1735,98 @@ handle_push_and_pr() {
     fi
 
     # Detect the #3039 no-op-SHIP guardrail: ralph's SHIP with a clean
-    # working tree means `origin/main..HEAD` is empty — there's nothing
-    # to push and no PR to open. Terminate as no_op so the transition
-    # shim flips the agent to `succeeded`.
+    # working tree means ``origin/main..HEAD`` is empty — there's
+    # nothing to push and no PR to open. Terminate as no_op so the
+    # transition shim flips the agent to ``succeeded``.
     _ahead_count=$(git -C "$REPO_ROOT" rev-list --count origin/main..HEAD 2>/dev/null || printf '0')
     if [[ "$_ahead_count" == "0" ]]; then
         log "push_and_pr_no_op" "reason=clean_worktree_on_ship"
         printf '{"no_op": true}'
         return 0
+    fi
+
+    # ── #3176: read summary skill output from dispatcher-output/ ──────
+    _summary_path="$REPO_ROOT/tmp/dispatcher-output/summary.json"
+    _pr_title=""
+    _pr_body_md=""
+    _commit_message=""
+    if [[ -s "$_summary_path" ]]; then
+        _pr_title=$(jq -r '.pr_title // ""' "$_summary_path" 2>/dev/null || printf '')
+        _pr_body_md=$(jq -r '.pr_body_md // ""' "$_summary_path" 2>/dev/null || printf '')
+        _commit_message=$(jq -r '.commit_message // ""' "$_summary_path" 2>/dev/null || printf '')
+        log "push_and_pr_summary_output_read" \
+            "has_title=$([[ -n "$_pr_title" ]] && printf 'true' || printf 'false')" \
+            "has_body=$([[ -n "$_pr_body_md" ]] && printf 'true' || printf 'false')" \
+            "has_commit=$([[ -n "$_commit_message" ]] && printf 'true' || printf 'false')"
+    else
+        log "push_and_pr_summary_output_missing" "path=$_summary_path"
+    fi
+
+    # ── #3176: amend ralph's placeholder commit with summary's
+    # conventional-commits message. Mirrors the daemon's
+    # ``git commit --amend -F <file>`` — see daemon.py ~L10914.
+    if [[ -n "$_commit_message" ]]; then
+        _commit_msg_path="$AGENT_WORKSPACE/commit_msg.txt"
+        printf '%s' "$_commit_message" > "$_commit_msg_path"
+        log "push_and_pr_commit_amend_begin"
+        set +e
+        git -C "$REPO_ROOT" commit --amend -F "$_commit_msg_path" \
+            > "$AGENT_WORKSPACE/git-commit-amend.stdout.log" \
+            2> "$AGENT_WORKSPACE/git-commit-amend.stderr.log"
+        _amend_rc=$?
+        set -e
+        log "push_and_pr_commit_amend_done" "exit_code=$_amend_rc"
+        if [[ "$_amend_rc" -ne 0 ]]; then
+            # Non-fatal: log + continue with ralph's original commit.
+            # A pre-push hook rejection is the common real-world
+            # failure here; proceeding with the unamended commit is
+            # a strictly better outcome than abandoning the PR.
+            log "push_and_pr_commit_amend_failed" "exit_code=$_amend_rc"
+        fi
+    fi
+
+    # ── #3176: pre-push rebase so we don't push a CONFLICTING branch.
+    # Mirrors the daemon-side behaviour (``git fetch origin main`` +
+    # ``git rebase origin/main``). On rebase conflict, abort and fail
+    # cleanly — the transition shim routes to the unrecognized branch
+    # and the agent terminates without opening an orphan PR.
+    log "push_and_pr_fetch_main_begin"
+    set +e
+    git -C "$REPO_ROOT" fetch origin main \
+        > "$AGENT_WORKSPACE/git-fetch-main.stdout.log" \
+        2> "$AGENT_WORKSPACE/git-fetch-main.stderr.log"
+    _fetch_rc=$?
+    set -e
+    log "push_and_pr_fetch_main_done" "exit_code=$_fetch_rc"
+    if [[ "$_fetch_rc" -eq 0 ]]; then
+        log "push_and_pr_rebase_begin"
+        set +e
+        git -C "$REPO_ROOT" rebase origin/main \
+            > "$AGENT_WORKSPACE/git-rebase.stdout.log" \
+            2> "$AGENT_WORKSPACE/git-rebase.stderr.log"
+        _rebase_rc=$?
+        set -e
+        log "push_and_pr_rebase_done" "exit_code=$_rebase_rc"
+        if [[ "$_rebase_rc" -ne 0 ]]; then
+            # Rebase conflict. Abort the in-progress rebase so the
+            # worktree returns to its pre-rebase state, log the
+            # failure, and emit the structured envelope.
+            set +e
+            git -C "$REPO_ROOT" rebase --abort \
+                > "$AGENT_WORKSPACE/git-rebase-abort.stdout.log" \
+                2> "$AGENT_WORKSPACE/git-rebase-abort.stderr.log"
+            set -e
+            log "push_and_pr_rebase_conflict" "exit_code=$_rebase_rc"
+            printf '{"no_op": false, "rebase_failed": true}'
+            return 0
+        fi
+    else
+        # Fetch failure is best-effort — the push below will fail with
+        # a network error we route through push_failed if it's a real
+        # network outage. A transient local-only fetch failure still
+        # lets the push succeed against whatever ``origin/main`` was
+        # at clone time.
+        log "push_and_pr_fetch_main_failed" "exit_code=$_fetch_rc"
     fi
 
     log "push_and_pr_push_begin" "branch=$BRANCH_NAME"
@@ -1740,20 +1845,33 @@ handle_push_and_pr() {
         return 0
     fi
 
-    # Open the PR against main. `gh pr create` auto-picks the current
-    # branch as head and --base main. The title comes from the last
-    # commit subject on the branch (Stage 2 will plumb the summary
-    # phase's pr_title through here; Stage 1b keeps it minimal).
+    # ── #3176: open the PR with summary's pr_title + pr_body_md when
+    # available. Fall back to ``--fill`` so a missing summary still
+    # produces a PR (degraded but not abandoned).
     log "push_and_pr_pr_create_begin"
+    _pr_body_path="$AGENT_WORKSPACE/pr_body.md"
     set +e
-    gh pr create \
-        --repo judgemind/judgemind \
-        --base main \
-        --head "$BRANCH_NAME" \
-        --fill \
-        > "$AGENT_WORKSPACE/gh-pr-create.stdout.log" \
-        2> "$AGENT_WORKSPACE/gh-pr-create.stderr.log"
-    _pr_rc=$?
+    if [[ -n "$_pr_title" && -n "$_pr_body_md" ]]; then
+        printf '%s' "$_pr_body_md" > "$_pr_body_path"
+        gh pr create \
+            --repo judgemind/judgemind \
+            --base main \
+            --head "$BRANCH_NAME" \
+            --title "$_pr_title" \
+            --body-file "$_pr_body_path" \
+            > "$AGENT_WORKSPACE/gh-pr-create.stdout.log" \
+            2> "$AGENT_WORKSPACE/gh-pr-create.stderr.log"
+        _pr_rc=$?
+    else
+        gh pr create \
+            --repo judgemind/judgemind \
+            --base main \
+            --head "$BRANCH_NAME" \
+            --fill \
+            > "$AGENT_WORKSPACE/gh-pr-create.stdout.log" \
+            2> "$AGENT_WORKSPACE/gh-pr-create.stderr.log"
+        _pr_rc=$?
+    fi
     set -e
     log "push_and_pr_pr_create_done" "exit_code=$_pr_rc"
     if [[ "$_pr_rc" -ne 0 ]]; then
@@ -1762,6 +1880,34 @@ handle_push_and_pr() {
         return 0
     fi
 
+    # ── #3176: parse PR number from ``gh pr create`` stdout and record
+    # on the agent row. ``gh pr create`` prints the PR URL on the last
+    # non-empty line: https://github.com/judgemind/judgemind/pull/<N>.
+    _pr_url=$(tail -n 20 "$AGENT_WORKSPACE/gh-pr-create.stdout.log" 2>/dev/null \
+        | grep -Eo 'https://github\.com/[^ ]+/pull/[0-9]+' \
+        | tail -n 1 \
+        || printf '')
+    _pr_number=""
+    if [[ -n "$_pr_url" ]]; then
+        _pr_number=$(printf '%s' "$_pr_url" | sed -E 's|.*/pull/([0-9]+).*|\1|')
+    fi
+    if [[ -n "$_pr_number" && "$_pr_number" =~ ^[0-9]+$ ]]; then
+        log "push_and_pr_pr_number_parsed" "pr_number=$_pr_number" "pr_url=$_pr_url"
+        # Best-effort — a DB failure here shouldn't abandon an
+        # already-opened PR. Mirrors daemon's pr_number write (daemon.py
+        # ~L11316, ``_mark_agent_terminal(..., pr_number=pr_number)``).
+        if ! db_exec "UPDATE dispatcher.agents
+                         SET pr_number = $_pr_number
+                       WHERE agent_id = '$AGENT_ID';" 2>/dev/null; then
+            log "push_and_pr_pr_number_persist_failed" "pr_number=$_pr_number"
+        else
+            log "push_and_pr_pr_number_persisted" "pr_number=$_pr_number"
+        fi
+        printf '{"no_op": false, "pr_number": %s}' "$_pr_number"
+        return 0
+    fi
+
+    log "push_and_pr_pr_number_parse_failed" "stdout_tail=$(tail -c 200 "$AGENT_WORKSPACE/gh-pr-create.stdout.log" 2>/dev/null | tr '\n' ' ')"
     printf '{"no_op": false}'
 }
 
@@ -2110,6 +2256,579 @@ mark_ended() {
     log "agent_ended"
 }
 
+# ── Post-PR mechanical phase handlers (#3176) ──────────────────────────────
+#
+# The subprocess-path daemon implements `awaiting_ci`, `merge`, and
+# `awaiting_deploy` inline via `_advance_awaiting_ci`,
+# `_merge_pr_and_advance`, and `_advance_awaiting_deploy` in daemon.py.
+# For ECS mode these were previously no-op stubs that raced through the
+# phase boundary in ~1s, producing orphan PRs. These handlers bring the
+# ECS entrypoint to parity: poll CI, merge on green, watch deploy
+# workflows, advance to verify.
+#
+# Design notes
+# ------------
+# * Each handler runs inside the per-agent Fargate task's ~2h wall
+#   time budget (``AGENT_RUNNER_*_TIMEOUT_SECONDS`` caps the polling so
+#   a stuck CI/deploy can't consume the whole budget).
+# * Polling uses foreground ``sleep`` (no backgrounded subshells) — the
+#   agent-runner container is single-purpose so blocking is fine.
+# * All polling intervals + timeouts are env-overridable so tests can
+#   run them with 0/1-second cadence against stubbed binaries.
+# * These handlers are distinct from the `run_claude_phase` flow; they
+#   do NOT call ``transition_for`` — the phase transition is
+#   hand-coded based on the observed outcome (green/red/merged/
+#   deploy_success/…) because `next_phase_from_verdict` is only wired
+#   for the verdict-driven (claude) phases, per phase_transitions.py
+#   comment "callers handle them explicitly because the input shape
+#   differs".
+
+# How often to re-poll PR status (CI + deploy). Defaults match the
+# subprocess daemon's supervisor tick (120s). Tests override to 0/1.
+CI_POLL_INTERVAL="${AGENT_RUNNER_CI_POLL_INTERVAL:-60}"
+DEPLOY_POLL_INTERVAL="${AGENT_RUNNER_DEPLOY_POLL_INTERVAL:-60}"
+
+# Hard timeouts. `awaiting_ci` = 60m matches the 60-min CI-watch ceiling
+# the subprocess daemon's scheduler enforces in practice. `awaiting_
+# deploy` = 30m matches deploy workflows' worst-case runtime.
+AWAITING_CI_TIMEOUT_SECONDS="${AGENT_RUNNER_AWAITING_CI_TIMEOUT_SECONDS:-3600}"
+AWAITING_DEPLOY_TIMEOUT_SECONDS="${AGENT_RUNNER_AWAITING_DEPLOY_TIMEOUT_SECONDS:-1800}"
+
+# Short grace period before declaring "no deploy workflows fired" on
+# the merge SHA. Deploy workflow triggers are eventually-consistent on
+# GitHub's side; a poll immediately after merge can see zero runs even
+# for a code PR that will deploy. Subprocess daemon works around this
+# by re-polling each supervisor tick; we mirror with a bounded grace.
+DEPLOY_GRACE_SECONDS="${AGENT_RUNNER_DEPLOY_GRACE_SECONDS:-90}"
+
+# Max attempts to auto-unstick a merge stale-rollup rejection (#3163).
+# Matches ``MERGE_UNSTICK_MAX_ATTEMPTS`` in daemon.py.
+MERGE_UNSTICK_MAX_ATTEMPTS="${AGENT_RUNNER_MERGE_UNSTICK_MAX_ATTEMPTS:-1}"
+
+# Stderr substring that indicates the #2641/#3163 stale-rollup branch-
+# protection rejection. Matches ``STALE_ROLLUP_STDERR_MARKER`` in
+# daemon.py.
+STALE_ROLLUP_MARKER="base branch policy prohibits the merge"
+
+# Deploy workflow filenames we watch on the merge SHA. Mirrors the
+# ``DEPLOY_WORKFLOW_NAMES`` frozenset in daemon.py (which reads
+# ``workflowName``); the entrypoint queries by workflow-file path
+# instead (``--workflow <file>.yml``) because bash stubs can match
+# file names more reliably than display names.
+DEPLOY_WORKFLOWS="${AGENT_RUNNER_DEPLOY_WORKFLOWS:-deploy-api.yml deploy-dispatcher.yml deploy-scraper.yml deploy-production.yml deploy-production-web.yml terraform.yml}"
+
+read_pr_number() {
+    # Query ``dispatcher.agents.pr_number`` for the current agent.
+    # Returns an empty string if NULL / missing (db_query_one emits
+    # the empty field for a NULL column with ``-At``).
+    db_query_one "SELECT pr_number
+                    FROM dispatcher.agents
+                   WHERE agent_id = '$AGENT_ID'
+                   LIMIT 1;"
+}
+
+classify_pr_rollup() {
+    # $1 = path to ``gh pr view --json ... ,statusCheckRollup,mergeable,
+    # mergeStateStatus`` stdout. Prints one of: green / red / pending /
+    # error. Mirrors ``_ci_rollup_state`` in phase_transitions.py so
+    # the ECS path uses the same merge gate as subprocess mode.
+    _status_file="$1"
+    if [[ ! -s "$_status_file" ]]; then
+        printf 'error'
+        return 0
+    fi
+    # Classify via a jq program rather than parsing in bash — keeps the
+    # logic declarative and bash-3.2 friendly.
+    _state=$(jq -r '
+        def classify:
+            (.statusCheckRollup // []) as $rollup
+            | ($rollup | map(select(type == "object"))) as $checks
+            | ([$checks[]
+                | (.status // "" | ascii_upcase) as $st
+                | (.conclusion // "" | ascii_upcase) as $co
+                | if $st == "COMPLETED" then
+                      if ($co == "FAILURE" or $co == "CANCELLED"
+                          or $co == "TIMED_OUT" or $co == "ACTION_REQUIRED"
+                          or $co == "STARTUP_FAILURE") then "red"
+                      elif ($co == "SUCCESS" or $co == "SKIPPED"
+                            or $co == "NEUTRAL" or $co == "STALE") then "ok"
+                      else "red" end
+                  else "pending" end]) as $outcomes
+            | if ($outcomes | index("red")) then "red"
+              elif ($outcomes | index("pending")) then "pending"
+              else
+                (.mergeable // "" | ascii_upcase) as $m
+                | (.mergeStateStatus // "" | ascii_upcase) as $ms
+                | if ($m == "MERGEABLE" and $ms == "CLEAN") then "green"
+                  else "pending" end
+              end;
+        classify
+    ' "$_status_file" 2>/dev/null || printf 'error')
+    if [[ -z "$_state" ]]; then
+        printf 'error'
+    else
+        printf '%s' "$_state"
+    fi
+}
+
+classify_deploy_runs() {
+    # $1 = path to ``gh run list --json status,conclusion,...`` stdout.
+    # Prints one of: success / failure / pending / none. Matches
+    # ``_classify_deploy_runs`` in daemon.py. ``none`` means no
+    # matching deploy runs — caller treats as "no deploy applicable".
+    _runs_file="$1"
+    if [[ ! -s "$_runs_file" ]]; then
+        printf 'none'
+        return 0
+    fi
+    _state=$(jq -r '
+        def classify:
+            if (type != "array" or length == 0) then "none"
+            else
+              ([.[]
+                | (.status // "" | ascii_upcase) as $st
+                | (.conclusion // "" | ascii_upcase) as $co
+                | if $st != "COMPLETED" then "pending"
+                  elif ($co == "SUCCESS" or $co == "SKIPPED" or $co == "NEUTRAL") then "ok"
+                  else "failure" end]) as $outcomes
+              | if ($outcomes | index("pending")) then "pending"
+                elif ($outcomes | index("failure")) then "failure"
+                else "success" end
+            end;
+        classify
+    ' "$_runs_file" 2>/dev/null || printf 'none')
+    if [[ -z "$_state" ]]; then
+        printf 'none'
+    else
+        printf '%s' "$_state"
+    fi
+}
+
+agent_runner_reaped_failure() {
+    # $1 = terminal phase (e.g. ``awaiting_ci_timeout``).
+    # $2 = category label (used only in the log line).
+    # $3 = stderr tail / reason (truncated to 200 chars).
+    #
+    # Mirrors the subprocess-daemon's ``_handle_agent_failure`` enough
+    # to drive an ECS agent to a terminal row: emit a structured log
+    # event, persist a phase_outputs row describing the failure, and
+    # UPDATE the agent row to ``status='failed' phase=$1``. Called
+    # from handle_awaiting_ci / handle_merge / handle_awaiting_deploy
+    # on their respective unrecoverable branches.
+    _term_phase="$1"
+    _category="$2"
+    _reason=$(printf '%s' "${3:-}" | head -c 200 | tr '\n' ' ')
+    log "agent_runner_reaped_failure" \
+        "terminal_phase=$_term_phase" \
+        "category=$_category" \
+        "reason=$_reason"
+    _escaped_reason=$(printf '%s' "$_reason" | sed "s/'/''/g")
+    db_exec "INSERT INTO dispatcher.phase_outputs
+               (agent_id, phase, output_json)
+             VALUES
+               ('$AGENT_ID', '$_term_phase',
+                '{\"category\": \"$_category\", \"reason\": \"$_escaped_reason\"}'::jsonb);" \
+        >/dev/null 2>&1 || true
+    db_exec "UPDATE dispatcher.agents
+                SET phase = '$_term_phase', status = 'failed'
+              WHERE agent_id = '$AGENT_ID';"
+    log "phase_advanced" "next_phase=$_term_phase" "status=failed"
+}
+
+fetch_pr_status() {
+    # $1 = pr_number. Writes the JSON response from
+    # ``gh pr view <N> --json statusCheckRollup,mergeable,
+    # mergeStateStatus,headRefOid,mergeCommit`` to
+    # ``$AGENT_WORKSPACE/pr-status.json`` and returns 0 on success,
+    # non-zero on gh failure. The caller reads the file.
+    _pr_num="$1"
+    _out_file="$AGENT_WORKSPACE/pr-status.json"
+    set +e
+    gh pr view "$_pr_num" \
+        --repo judgemind/judgemind \
+        --json statusCheckRollup,mergeable,mergeStateStatus,headRefOid,mergeCommit \
+        > "$_out_file" \
+        2> "$AGENT_WORKSPACE/gh-pr-view.stderr.log"
+    _gh_rc=$?
+    set -e
+    return $_gh_rc
+}
+
+handle_awaiting_ci() {
+    # Poll the PR's combined check rollup every CI_POLL_INTERVAL
+    # seconds until it classifies as green/red or the hard timeout
+    # elapses.
+    #
+    # Outcomes:
+    #   green → advance to ``merge`` (caller transitions).
+    #   red   → advance to ``fix_ci`` (Stage 2 will wire the fix-ci
+    #           skill; for now the dispatch case lets it route to the
+    #           claude-driven branch naturally).
+    #   timeout → agent_runner_reaped_failure + terminal
+    #             ``awaiting_ci_timeout``, agent exits.
+    log "awaiting_ci_begin"
+    _pr_number=$(read_pr_number)
+    log "awaiting_ci_pr_number_read" "pr_number=$_pr_number"
+    if [[ -z "$_pr_number" ]]; then
+        agent_runner_reaped_failure "awaiting_ci_failed" "missing_pr" "pr_number NULL on agent row"
+        printf '{"missing_pr": true}'
+        return 0
+    fi
+
+    _start_ts=$(date -u +%s)
+    _last_state=""
+    _poll_count=0
+    _max_polls="${AGENT_RUNNER_CI_MAX_POLLS:-100}"
+    while true; do
+        _poll_count=$((_poll_count + 1))
+        if [[ "$_poll_count" -gt "$_max_polls" ]]; then
+            log "awaiting_ci_max_polls_hit" "pr_number=$_pr_number" "poll_count=$_poll_count"
+            agent_runner_reaped_failure \
+                "awaiting_ci_timeout" \
+                "ci_max_polls" \
+                "pr=$_pr_number poll_count=$_poll_count last_state=$_last_state"
+            printf '{"timeout": true, "pr_number": %s, "max_polls": %s}' \
+                "$_pr_number" "$_poll_count"
+            return 0
+        fi
+        if fetch_pr_status "$_pr_number"; then
+            _state=$(classify_pr_rollup "$AGENT_WORKSPACE/pr-status.json")
+            _fetch_rc=0
+        else
+            _state="error"
+            _fetch_rc=1
+        fi
+        log "awaiting_ci_poll" "pr_number=$_pr_number" "rollup_state=$_state" "fetch_rc=$_fetch_rc"
+        if [[ "$_state" == "green" ]]; then
+            printf '{"rollup_state": "green", "pr_number": %s}' "$_pr_number"
+            return 0
+        fi
+        if [[ "$_state" == "red" ]]; then
+            printf '{"rollup_state": "red", "pr_number": %s}' "$_pr_number"
+            return 0
+        fi
+        # pending / error — keep polling until timeout.
+        _last_state="$_state"
+        _now_ts=$(date -u +%s)
+        _elapsed=$((_now_ts - _start_ts))
+        if [[ "$_elapsed" -ge "$AWAITING_CI_TIMEOUT_SECONDS" ]]; then
+            log "awaiting_ci_timeout" \
+                "pr_number=$_pr_number" \
+                "elapsed_s=$_elapsed" \
+                "last_state=$_last_state"
+            agent_runner_reaped_failure \
+                "awaiting_ci_timeout" \
+                "ci_timeout" \
+                "elapsed_s=$_elapsed last_state=$_last_state pr=$_pr_number"
+            printf '{"timeout": true, "pr_number": %s, "elapsed_s": %s}' \
+                "$_pr_number" "$_elapsed"
+            return 0
+        fi
+        sleep "$CI_POLL_INTERVAL"
+    done
+}
+
+extract_merge_sha() {
+    # Pull ``mergeCommit.oid`` from the current pr-status.json. Empty
+    # string if absent.
+    _status_file="$AGENT_WORKSPACE/pr-status.json"
+    if [[ ! -s "$_status_file" ]]; then
+        printf ''
+        return 0
+    fi
+    jq -r '.mergeCommit.oid // ""' "$_status_file" 2>/dev/null || printf ''
+}
+
+read_merge_unstick_attempts() {
+    # Column was added by the daemon's migration for #2641. Returns 0
+    # if the column is missing (older dev DB snapshots).
+    _val=$(db_query_one "SELECT COALESCE(merge_unstick_attempts, 0)
+                            FROM dispatcher.agents
+                           WHERE agent_id = '$AGENT_ID'
+                           LIMIT 1;" 2>/dev/null || printf '')
+    if [[ -z "$_val" ]] || ! [[ "$_val" =~ ^[0-9]+$ ]]; then
+        printf '0'
+    else
+        printf '%s' "$_val"
+    fi
+}
+
+increment_merge_unstick_attempts() {
+    # Best-effort; a lost increment at most burns one extra unstick
+    # before the daemon's ``FAILURE_CATEGORY_MERGE_UNSTICK_EXHAUSTED``
+    # path classifies the agent terminal.
+    db_exec "UPDATE dispatcher.agents
+                SET merge_unstick_attempts = COALESCE(merge_unstick_attempts, 0) + 1
+              WHERE agent_id = '$AGENT_ID';" \
+        >/dev/null 2>&1 || true
+}
+
+try_auto_unstick_merge() {
+    # Port of ``_try_auto_unstick_merge`` in daemon.py. Push an empty
+    # commit to the PR branch so GitHub re-evaluates the
+    # statusCheckRollup on a fresh SHA. Budget = MERGE_UNSTICK_MAX_
+    # ATTEMPTS. On exhaustion, route through agent_runner_reaped_
+    # failure and return 1 so the caller knows not to retry merge.
+    _pr_num="$1"
+    _attempts=$(read_merge_unstick_attempts)
+    log "merge_stale_rollup_detected" \
+        "pr_number=$_pr_num" \
+        "attempts_so_far=$_attempts"
+    if [[ "$_attempts" -ge "$MERGE_UNSTICK_MAX_ATTEMPTS" ]]; then
+        log "merge_unstick_exhausted" \
+            "pr_number=$_pr_num" \
+            "attempts_so_far=$_attempts"
+        agent_runner_reaped_failure \
+            "merge_failed" \
+            "merge_unstick_exhausted" \
+            "pr=$_pr_num attempts=$_attempts"
+        return 1
+    fi
+    log "merge_unstick_empty_commit_begin"
+    set +e
+    git -C "$REPO_ROOT" commit --allow-empty \
+        -m "ci: force fresh rollup evaluation (stale-ci-passed unstick, #2641)" \
+        > "$AGENT_WORKSPACE/merge-unstick-commit.stdout.log" \
+        2> "$AGENT_WORKSPACE/merge-unstick-commit.stderr.log"
+    _commit_rc=$?
+    set -e
+    if [[ "$_commit_rc" -ne 0 ]]; then
+        log "merge_unstick_commit_failed" "exit_code=$_commit_rc"
+        agent_runner_reaped_failure \
+            "merge_failed" \
+            "merge_unstick_exhausted" \
+            "pr=$_pr_num empty_commit_nonzero_exit=$_commit_rc"
+        return 1
+    fi
+    set +e
+    git -C "$REPO_ROOT" push origin "$BRANCH_NAME" \
+        > "$AGENT_WORKSPACE/merge-unstick-push.stdout.log" \
+        2> "$AGENT_WORKSPACE/merge-unstick-push.stderr.log"
+    _push_rc=$?
+    set -e
+    if [[ "$_push_rc" -ne 0 ]]; then
+        log "merge_unstick_push_failed" "exit_code=$_push_rc"
+        agent_runner_reaped_failure \
+            "merge_failed" \
+            "merge_unstick_exhausted" \
+            "pr=$_pr_num empty_commit_push_nonzero_exit=$_push_rc"
+        return 1
+    fi
+    increment_merge_unstick_attempts
+    log "merge_auto_unstick_empty_commit_pushed" \
+        "pr_number=$_pr_num" \
+        "new_attempts=$((_attempts + 1))"
+    return 0
+}
+
+handle_merge() {
+    # Squash-merge the PR with branch-delete. On stale-rollup stderr,
+    # attempt one auto-unstick (push empty commit, go back to
+    # awaiting_ci); on any other non-zero, route to
+    # agent_runner_reaped_failure. On success, record merge SHA and
+    # advance to awaiting_deploy.
+
+    _pr_number=$(read_pr_number)
+    if [[ -z "$_pr_number" ]]; then
+        agent_runner_reaped_failure "merge_failed" "missing_pr" "pr_number NULL on agent row"
+        printf '{"missing_pr": true}'
+        return 0
+    fi
+
+    log "merge_begin" "pr_number=$_pr_number"
+    set +e
+    gh pr merge "$_pr_number" \
+        --repo judgemind/judgemind \
+        --squash \
+        --delete-branch \
+        > "$AGENT_WORKSPACE/gh-pr-merge.stdout.log" \
+        2> "$AGENT_WORKSPACE/gh-pr-merge.stderr.log"
+    _merge_rc=$?
+    set -e
+    log "merge_done" "pr_number=$_pr_number" "exit_code=$_merge_rc"
+
+    if [[ "$_merge_rc" -eq 0 ]]; then
+        # Success — re-fetch PR status to extract the merge SHA.
+        if fetch_pr_status "$_pr_number"; then
+            _merge_sha=$(extract_merge_sha)
+        else
+            _merge_sha=""
+        fi
+        log "merge_succeeded" "pr_number=$_pr_number" "merge_sha=$_merge_sha"
+        printf '{"merged": true, "pr_number": %s, "merge_sha": "%s"}' \
+            "$_pr_number" "$_merge_sha"
+        return 0
+    fi
+
+    # Non-zero. Inspect stderr for the stale-rollup marker.
+    _stderr_text=""
+    if [[ -s "$AGENT_WORKSPACE/gh-pr-merge.stderr.log" ]]; then
+        _stderr_text=$(cat "$AGENT_WORKSPACE/gh-pr-merge.stderr.log" 2>/dev/null || printf '')
+    fi
+    # Case-insensitive match on the stale-rollup marker (gh output
+    # preserves case, but we compare lowercase for safety).
+    _stderr_lower=$(printf '%s' "$_stderr_text" | tr '[:upper:]' '[:lower:]')
+    if [[ "$_stderr_lower" == *"$STALE_ROLLUP_MARKER"* ]]; then
+        if try_auto_unstick_merge "$_pr_number"; then
+            # Budget left — go back to awaiting_ci for the next supervisor
+            # tick equivalent. Since we're inside one agent-runner
+            # process, advance the phase via the dispatch case's
+            # ``auto_unstick_retry`` signal.
+            printf '{"auto_unstick_retry": true, "pr_number": %s}' "$_pr_number"
+            return 0
+        fi
+        # try_auto_unstick_merge already called agent_runner_reaped_failure.
+        printf '{"merge_failed": true, "pr_number": %s}' "$_pr_number"
+        return 0
+    fi
+
+    # Any other non-zero exit — route to failure.
+    _stderr_tail=$(printf '%s' "$_stderr_text" | head -c 200 | tr '\n' ' ')
+    agent_runner_reaped_failure \
+        "merge_failed" \
+        "merge_nonzero_exit" \
+        "pr=$_pr_number exit=$_merge_rc stderr=$_stderr_tail"
+    printf '{"merge_failed": true, "pr_number": %s, "exit_code": %s}' \
+        "$_pr_number" "$_merge_rc"
+}
+
+find_deploy_runs() {
+    # $1 = merge SHA. Writes the JSON array response from
+    # ``gh run list --commit <sha> --workflow <w1> --workflow <w2> ...
+    # --json databaseId,workflowName,status,conclusion,createdAt``
+    # to ``$AGENT_WORKSPACE/deploy-runs.json``. On failure writes ``[]``.
+    _sha="$1"
+    _out_file="$AGENT_WORKSPACE/deploy-runs.json"
+    # Build the --workflow flag list from $DEPLOY_WORKFLOWS (space-
+    # separated file names). Bash 3.2: use positional args.
+    set --
+    for _w in $DEPLOY_WORKFLOWS; do
+        set -- "$@" --workflow "$_w"
+    done
+    set +e
+    gh run list \
+        --repo judgemind/judgemind \
+        --commit "$_sha" \
+        "$@" \
+        --json databaseId,workflowName,status,conclusion,createdAt \
+        --limit 20 \
+        > "$_out_file" \
+        2> "$AGENT_WORKSPACE/gh-run-list.stderr.log"
+    _gh_rc=$?
+    set -e
+    if [[ "$_gh_rc" -ne 0 ]]; then
+        printf '[]' > "$_out_file"
+    fi
+    return 0
+}
+
+handle_awaiting_deploy() {
+    # Poll the deploy-workflow runs for the merge SHA until at least
+    # one completes successfully, any fails, or the hard timeout
+    # elapses. If no deploy runs are observed within the short grace
+    # window, treat the PR as "no deploy applicable" (e.g. docs-only)
+    # and advance to verify. Mirrors daemon.py's
+    # ``_advance_awaiting_deploy``.
+    _pr_number=$(read_pr_number)
+    if [[ -z "$_pr_number" ]]; then
+        agent_runner_reaped_failure "awaiting_deploy_failed" "missing_pr" \
+            "pr_number NULL on agent row"
+        printf '{"missing_pr": true}'
+        return 0
+    fi
+
+    # Re-fetch PR status once to get the merge SHA.
+    if ! fetch_pr_status "$_pr_number"; then
+        # Treat as a transient GH failure — let the next supervisor
+        # tick equivalent try again. Since we're inside one process,
+        # sleep and retry the outer poll loop.
+        log "awaiting_deploy_pr_view_failed" "pr_number=$_pr_number"
+    fi
+    _merge_sha=$(extract_merge_sha)
+    if [[ -z "$_merge_sha" ]]; then
+        # A non-merged or still-propagating PR — treat as pending and
+        # poll-retry up to timeout.
+        log "awaiting_deploy_no_merge_sha" "pr_number=$_pr_number"
+    fi
+
+    _start_ts=$(date -u +%s)
+    _last_state=""
+    _poll_count=0
+    _max_polls="${AGENT_RUNNER_DEPLOY_MAX_POLLS:-60}"
+    while true; do
+        _poll_count=$((_poll_count + 1))
+        if [[ "$_poll_count" -gt "$_max_polls" ]]; then
+            log "awaiting_deploy_max_polls_hit" "pr_number=$_pr_number" "poll_count=$_poll_count"
+            agent_runner_reaped_failure \
+                "awaiting_deploy_timeout" \
+                "deploy_max_polls" \
+                "pr=$_pr_number poll_count=$_poll_count last_state=$_last_state"
+            printf '{"timeout": true, "pr_number": %s, "max_polls": %s}' \
+                "$_pr_number" "$_poll_count"
+            return 0
+        fi
+        if [[ -n "$_merge_sha" ]]; then
+            find_deploy_runs "$_merge_sha"
+            _state=$(classify_deploy_runs "$AGENT_WORKSPACE/deploy-runs.json")
+        else
+            _state="pending"
+        fi
+        log "awaiting_deploy_poll" \
+            "pr_number=$_pr_number" \
+            "merge_sha=$_merge_sha" \
+            "deploy_state=$_state"
+        if [[ "$_state" == "success" ]]; then
+            printf '{"deploy_state": "success", "merge_sha": "%s"}' "$_merge_sha"
+            return 0
+        fi
+        if [[ "$_state" == "failure" ]]; then
+            agent_runner_reaped_failure \
+                "awaiting_deploy_failed" \
+                "deploy_failed" \
+                "pr=$_pr_number sha=$_merge_sha"
+            printf '{"deploy_state": "failure", "merge_sha": "%s"}' "$_merge_sha"
+            return 0
+        fi
+        _now_ts=$(date -u +%s)
+        _elapsed=$((_now_ts - _start_ts))
+        # "No deploy runs" branch: once we're past the grace window
+        # and no matching run has appeared, treat as "no deploy
+        # applicable" and advance to verify.
+        if [[ "$_state" == "none" ]] && [[ "$_elapsed" -ge "$DEPLOY_GRACE_SECONDS" ]]; then
+            log "awaiting_deploy_no_runs" \
+                "pr_number=$_pr_number" \
+                "merge_sha=$_merge_sha" \
+                "grace_s=$DEPLOY_GRACE_SECONDS" \
+                "elapsed_s=$_elapsed"
+            printf '{"deploy_state": "none", "merge_sha": "%s", "elapsed_s": %s}' \
+                "$_merge_sha" "$_elapsed"
+            return 0
+        fi
+        _last_state="$_state"
+        if [[ "$_elapsed" -ge "$AWAITING_DEPLOY_TIMEOUT_SECONDS" ]]; then
+            log "awaiting_deploy_timeout" \
+                "pr_number=$_pr_number" \
+                "merge_sha=$_merge_sha" \
+                "elapsed_s=$_elapsed" \
+                "last_state=$_last_state"
+            agent_runner_reaped_failure \
+                "awaiting_deploy_timeout" \
+                "deploy_timeout" \
+                "pr=$_pr_number sha=$_merge_sha elapsed_s=$_elapsed"
+            printf '{"timeout": true, "merge_sha": "%s", "elapsed_s": %s}' \
+                "$_merge_sha" "$_elapsed"
+            return 0
+        fi
+        sleep "$DEPLOY_POLL_INTERVAL"
+        # Refresh merge SHA if we missed it the first time around.
+        if [[ -z "$_merge_sha" ]]; then
+            if fetch_pr_status "$_pr_number"; then
+                _merge_sha=$(extract_merge_sha)
+            fi
+        fi
+    done
+}
+
 # Check whether a phase is terminal per the shared Python module.
 # Uses a sibling one-line shim written alongside the transition shim
 # rather than an inline `python -c` heredoc (the preflight hook blocks
@@ -2306,16 +3025,94 @@ while true; do
                     ;;
             esac
             ;;
-        awaiting_ci|merge|awaiting_deploy|retro|setup)
-            # Mechanical phases the daemon handles inline today. Stage
-            # 1b stubs them: log + advance to the documented "next"
-            # phase on the happy path so the smoke test can reach
-            # `done` without a full daemon-integration.
+        awaiting_ci)
+            # #3176: real implementation — poll ``gh pr view`` rollup,
+            # advance to ``merge`` on green, ``fix_ci`` on red, exit
+            # with terminal failure on timeout.
+            _output=$(handle_awaiting_ci)
+            persist_phase_output "awaiting_ci" "$_output"
+            _rollup_state=$(printf '%s' "$_output" | jq -r '.rollup_state // ""' 2>/dev/null)
+            _timeout=$(printf '%s' "$_output" | jq -r '.timeout // false' 2>/dev/null)
+            if [[ "$_timeout" == "true" ]]; then
+                # agent_runner_reaped_failure already set the terminal
+                # phase + status in the DB; next tick will observe it
+                # as terminal and exit.
+                :
+            elif [[ "$_rollup_state" == "green" ]]; then
+                advance_phase "merge"
+            elif [[ "$_rollup_state" == "red" ]]; then
+                advance_phase "fix_ci"
+            else
+                # No recognizable state — shouldn't happen, but don't
+                # spin. Treat as failure to surface the bug.
+                log "awaiting_ci_unrecognized_output" "output=$_output"
+                agent_runner_reaped_failure \
+                    "awaiting_ci_failed" \
+                    "unrecognized_output" \
+                    "$_output"
+            fi
+            ;;
+        merge)
+            # #3176: real implementation — squash-merge with
+            # branch-delete, auto-unstick on stale-rollup (one-shot),
+            # terminal failure on other non-zero exits.
+            _output=$(handle_merge)
+            persist_phase_output "merge" "$_output"
+            _merged=$(printf '%s' "$_output" | jq -r '.merged // false' 2>/dev/null)
+            _auto_unstick=$(printf '%s' "$_output" | jq -r '.auto_unstick_retry // false' 2>/dev/null)
+            _merge_failed=$(printf '%s' "$_output" | jq -r '.merge_failed // false' 2>/dev/null)
+            if [[ "$_merged" == "true" ]]; then
+                # Mirror daemon's ``_merge_pr_and_advance``: flip
+                # status=succeeded the moment the squash-merge lands,
+                # advance phase to awaiting_deploy. A crash mid-write
+                # still leaves a ``status='succeeded' phase=merge``
+                # row recoverable by the next tick.
+                advance_phase "awaiting_deploy" "succeeded"
+            elif [[ "$_auto_unstick" == "true" ]]; then
+                # Go back to awaiting_ci so the next poll sees the
+                # post-empty-commit rollup.
+                advance_phase "awaiting_ci"
+            elif [[ "$_merge_failed" == "true" ]]; then
+                # agent_runner_reaped_failure already set terminal state.
+                :
+            else
+                log "merge_unrecognized_output" "output=$_output"
+                agent_runner_reaped_failure \
+                    "merge_failed" \
+                    "unrecognized_output" \
+                    "$_output"
+            fi
+            ;;
+        awaiting_deploy)
+            # #3176: real implementation — poll deploy workflows on
+            # the merge SHA, advance to verify on success / no-run
+            # grace, terminal failure on timeout / any deploy
+            # workflow failure.
+            _output=$(handle_awaiting_deploy)
+            persist_phase_output "awaiting_deploy" "$_output"
+            _deploy_state=$(printf '%s' "$_output" | jq -r '.deploy_state // ""' 2>/dev/null)
+            _timeout=$(printf '%s' "$_output" | jq -r '.timeout // false' 2>/dev/null)
+            if [[ "$_timeout" == "true" ]]; then
+                :
+            elif [[ "$_deploy_state" == "success" || "$_deploy_state" == "none" ]]; then
+                advance_phase "verify"
+            elif [[ "$_deploy_state" == "failure" ]]; then
+                :
+            else
+                log "awaiting_deploy_unrecognized_output" "output=$_output"
+                agent_runner_reaped_failure \
+                    "awaiting_deploy_failed" \
+                    "unrecognized_output" \
+                    "$_output"
+            fi
+            ;;
+        retro|setup)
+            # Remaining mechanical stubs — Stage 3+ will wire these to
+            # real implementations (retro posts the issue comment +
+            # closes the loop; setup is currently unreachable under the
+            # Stage 1b happy path).
             case "$_current" in
                 setup)            _next="ralph" ;;
-                awaiting_ci)      _next="merge" ;;
-                merge)            _next="awaiting_deploy" ;;
-                awaiting_deploy)  _next="verify" ;;
                 retro)            _next="retro_done" ;;
             esac
             log "mechanical_phase_stub" "phase=$_current" "next=$_next"

--- a/scripts/dispatcher/phase_transitions.py
+++ b/scripts/dispatcher/phase_transitions.py
@@ -175,6 +175,20 @@ PHASE_DAEMON_RESTART_ABANDONED = "daemon_restart_abandoned"
 #: Killswitch engaged terminal phase.
 PHASE_PAUSED_BY_KILLSWITCH = "paused_by_killswitch"
 
+#: Agent-runner (#3086 Stage 2+) post-ralph phase-failure terminals.
+#: Set by ``agent_runner_reaped_failure`` in
+#: ``scripts/dispatcher/agent-runner-entrypoint.sh`` when one of the
+#: post-PR mechanical phases exhausts its budget (#3176). The daemon's
+#: subprocess path routes these through ``_handle_agent_failure`` +
+#: diagnoser; the ECS path uses these as direct terminals so the
+#: per-agent Fargate task exits cleanly (the daemon's supervisor tick
+#: still picks up the row for diagnosis via ``_find_diagnoser_candidates``).
+PHASE_AWAITING_CI_FAILED = "awaiting_ci_failed"
+PHASE_AWAITING_CI_TIMEOUT = "awaiting_ci_timeout"
+PHASE_MERGE_FAILED = "merge_failed"
+PHASE_AWAITING_DEPLOY_FAILED = "awaiting_deploy_failed"
+PHASE_AWAITING_DEPLOY_TIMEOUT = "awaiting_deploy_timeout"
+
 # ---------------------------------------------------------------------------
 # Verdict constants — the string values produced by the phase-output JSONs.
 # ---------------------------------------------------------------------------
@@ -255,6 +269,12 @@ TERMINAL_PHASES: frozenset[str] = frozenset(
         PHASE_FORCE_STOPPED,
         PHASE_DAEMON_RESTART_ABANDONED,
         PHASE_PAUSED_BY_KILLSWITCH,
+        # #3176 — agent-runner post-ralph phase-failure terminals.
+        PHASE_AWAITING_CI_FAILED,
+        PHASE_AWAITING_CI_TIMEOUT,
+        PHASE_MERGE_FAILED,
+        PHASE_AWAITING_DEPLOY_FAILED,
+        PHASE_AWAITING_DEPLOY_TIMEOUT,
     }
 )
 
@@ -930,6 +950,11 @@ __all__ = [
     "PHASE_FORCE_STOPPED",
     "PHASE_DAEMON_RESTART_ABANDONED",
     "PHASE_PAUSED_BY_KILLSWITCH",
+    "PHASE_AWAITING_CI_FAILED",
+    "PHASE_AWAITING_CI_TIMEOUT",
+    "PHASE_MERGE_FAILED",
+    "PHASE_AWAITING_DEPLOY_FAILED",
+    "PHASE_AWAITING_DEPLOY_TIMEOUT",
     # Verdict constants
     "VERDICT_SHIP",
     "VERDICT_AC_INFEASIBLE",

--- a/scripts/dispatcher/tests/test_phase_transitions.py
+++ b/scripts/dispatcher/tests/test_phase_transitions.py
@@ -586,6 +586,16 @@ class TestTerminalPhaseAndStatus:
         assert pt.is_terminal_phase(pt.PHASE_DAEMON_RESTART_ABANDONED) is True
         assert pt.is_terminal_phase(pt.PHASE_PAUSED_BY_KILLSWITCH) is True
 
+    def test_is_terminal_phase_true_for_agent_runner_post_pr_terminals(
+        self,
+    ) -> None:
+        """#3176 — agent-runner post-ralph failure terminals."""
+        assert pt.is_terminal_phase(pt.PHASE_AWAITING_CI_FAILED) is True
+        assert pt.is_terminal_phase(pt.PHASE_AWAITING_CI_TIMEOUT) is True
+        assert pt.is_terminal_phase(pt.PHASE_MERGE_FAILED) is True
+        assert pt.is_terminal_phase(pt.PHASE_AWAITING_DEPLOY_FAILED) is True
+        assert pt.is_terminal_phase(pt.PHASE_AWAITING_DEPLOY_TIMEOUT) is True
+
     def test_is_terminal_phase_false_for_intermediate(self) -> None:
         assert pt.is_terminal_phase(pt.PHASE_PLANNING) is False
         assert pt.is_terminal_phase(pt.PHASE_RALPH) is False

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -132,6 +132,17 @@ case "$query" in
         fi
         exit 0
         ;;
+    *"SELECT pr_number"*"FROM dispatcher.agents"*)
+        # #3176 — post-PR handlers read pr_number from the agent row.
+        # Default 9999 matches the gh stub's canonical PR URL.
+        printf '%s\n' "${PR_NUMBER_FIXTURE:-9999}"
+        exit 0
+        ;;
+    *"SELECT COALESCE(merge_unstick_attempts"*|*"SELECT merge_unstick_attempts"*)
+        # #3176 — handle_merge's auto-unstick budget check.
+        printf '%s\n' "${MERGE_UNSTICK_ATTEMPTS_FIXTURE:-0}"
+        exit 0
+        ;;
     *"SELECT patch_content"*)
         if [[ -f "${PRIOR_PATCH_FIXTURE:-}" ]]; then
             cat "$PRIOR_PATCH_FIXTURE"
@@ -344,6 +355,25 @@ case "$subcommand" in
         # Honor GIT_PUSH_EXIT to simulate push failures.
         exit "${GIT_PUSH_EXIT:-0}"
         ;;
+    fetch)
+        # `git fetch origin main` — #3176 push_and_pr pre-push rebase.
+        exit "${GIT_FETCH_EXIT:-0}"
+        ;;
+    rebase)
+        # `git rebase origin/main` — #3176 push_and_pr pre-push rebase.
+        # `git rebase --abort` — #3176 conflict-abort on failed rebase.
+        for _arg in "$@"; do
+            if [[ "$_arg" == "--abort" ]]; then
+                exit 0
+            fi
+        done
+        exit "${GIT_REBASE_EXIT:-0}"
+        ;;
+    commit)
+        # `git commit --amend -F <file>` — #3176 summary amend.
+        # `git commit --allow-empty -m <msg>` — #3176 stale-rollup unstick.
+        exit "${GIT_COMMIT_EXIT:-0}"
+        ;;
     *)
         exit 0
         ;;
@@ -352,6 +382,20 @@ GITEOF
 chmod +x "$STUB_BIN/git"
 
 # ── gh stub ────────────────────────────────────────────────────────────────
+#
+# Supports the subcommands the entrypoint calls:
+#   * ``gh pr create`` — prints a PR URL, honours GH_PR_CREATE_EXIT.
+#   * ``gh pr view <N> --json ...`` — prints JSON from
+#     ``$GH_PR_VIEW_JSON_FIXTURE`` (defaults to a green rollup with a
+#     merged commit SHA of ``deadbeefcafe`` so the happy-path pipeline
+#     can merge + deploy without a fixture override).
+#   * ``gh pr merge`` — honours ``GH_PR_MERGE_EXIT`` (default 0). When
+#     ``GH_PR_MERGE_STDERR`` is non-empty, emits that text to stderr
+#     (used to simulate the #2641/#3163 stale-rollup rejection).
+#   * ``gh run list`` — prints the JSON array from
+#     ``$GH_RUN_LIST_JSON_FIXTURE`` (defaults to ``[]`` = no deploy
+#     workflows fired, so the entrypoint's awaiting_deploy "none"
+#     branch advances to verify).
 
 cat > "$STUB_BIN/gh" <<'GHEOF'
 #!/usr/bin/env bash
@@ -359,20 +403,67 @@ set -u
 INVOCATIONS_DIR="${INVOCATIONS_DIR}"
 . "$(dirname "$0")/_record_invocation.sh" gh "$@"
 
-# Simulate `gh pr create` outcomes based on GH_PR_CREATE_EXIT.
+# Find the first two positional args (subcommand + verb, e.g. pr create).
 sub=""
+verb=""
 for arg in "$@"; do
-    if [[ "$sub" == "" && "$arg" != --* && "$arg" != -* ]]; then
+    case "$arg" in
+        --*|-*) continue ;;
+    esac
+    if [[ -z "$sub" ]]; then
         sub="$arg"
         continue
     fi
-    if [[ -n "$sub" && "$sub" == "pr" && "$arg" != --* && "$arg" != -* ]]; then
-        if [[ "$arg" == "create" ]]; then
-            printf 'https://github.com/judgemind/judgemind/pull/9999\n'
-            exit "${GH_PR_CREATE_EXIT:-0}"
-        fi
+    if [[ -z "$verb" ]]; then
+        verb="$arg"
+        break
     fi
 done
+
+case "$sub $verb" in
+    "pr create")
+        printf 'https://github.com/judgemind/judgemind/pull/9999\n'
+        exit "${GH_PR_CREATE_EXIT:-0}"
+        ;;
+    "pr view")
+        if [[ -n "${GH_PR_VIEW_JSON_FIXTURE:-}" && -f "${GH_PR_VIEW_JSON_FIXTURE:-}" ]]; then
+            cat "$GH_PR_VIEW_JSON_FIXTURE"
+        else
+            # Default: green rollup, mergeable, with a merge SHA so
+            # happy-path tests can traverse awaiting_ci → merge →
+            # awaiting_deploy without fixture overrides.
+            cat <<'JSONEOF'
+{
+  "statusCheckRollup": [
+    {"name": "ci-passed", "status": "COMPLETED", "conclusion": "SUCCESS"}
+  ],
+  "mergeable": "MERGEABLE",
+  "mergeStateStatus": "CLEAN",
+  "headRefOid": "deadbeefcafe",
+  "mergeCommit": {"oid": "deadbeefcafe"}
+}
+JSONEOF
+        fi
+        exit 0
+        ;;
+    "pr merge")
+        if [[ -n "${GH_PR_MERGE_STDERR:-}" ]]; then
+            printf '%s\n' "$GH_PR_MERGE_STDERR" >&2
+        fi
+        exit "${GH_PR_MERGE_EXIT:-0}"
+        ;;
+    "run list")
+        if [[ -n "${GH_RUN_LIST_JSON_FIXTURE:-}" && -f "${GH_RUN_LIST_JSON_FIXTURE:-}" ]]; then
+            cat "$GH_RUN_LIST_JSON_FIXTURE"
+        else
+            printf '[]\n'
+        fi
+        exit "${GH_RUN_LIST_EXIT:-0}"
+        ;;
+    "auth login"|"auth setup-git")
+        exit 0
+        ;;
+esac
 
 exit 0
 GHEOF
@@ -1530,20 +1621,34 @@ else
          "expected file not found: $SHIM_PY"
 fi
 
-# Extend the gh stub with richer routes for the Stage 2 fetches:
+# Extend the gh stub with richer routes for the Stage 2 fetches and the
+# #3176 post-PR mechanical phases:
 #   * ``gh issue view <N> --json ...``    → read $GH_ISSUE_FIXTURE
-#   * ``gh pr view <N> --json ...``       → read $GH_PR_FIXTURE
+#   * ``gh pr view <N> --json ...``       → read $GH_PR_FIXTURE (shim
+#                                           tests) OR #3176
+#                                           $GH_PR_VIEW_JSON_FIXTURE
+#                                           (post-PR tests) — falls
+#                                           back to a canonical green
+#                                           rollup when neither is set.
 #   * ``gh pr diff <N>``                  → read $GH_PR_DIFF_FIXTURE
+#   * ``gh pr create``                    → honour GH_PR_CREATE_EXIT
+#                                           (defaults to 0, printing a
+#                                           canonical PR URL).
+#   * ``gh pr merge``                     → honour GH_PR_MERGE_EXIT +
+#                                           GH_PR_MERGE_STDERR (#3176).
 #   * ``gh run view --log-failed --job``  → read $GH_RUN_LOG_FIXTURE
 #   * ``gh run list --commit <sha>``      → read $GH_RUN_LIST_FIXTURE
+#                                           (shim tests) OR #3176
+#                                           $GH_RUN_LIST_JSON_FIXTURE
+#                                           (post-PR tests) — falls
+#                                           back to ``[]``.
 cat > "$STUB_BIN/gh" <<'GHEOF'
 #!/usr/bin/env bash
 set -u
 INVOCATIONS_DIR="${INVOCATIONS_DIR}"
 . "$(dirname "$0")/_record_invocation.sh" gh "$@"
 
-# Parse subcommand chain: ``gh issue view`` or ``gh pr view`` or
-# ``gh run view`` / ``gh run list`` — anything else is a no-op success.
+# Parse subcommand chain.
 if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
     if [[ -n "${GH_ISSUE_FIXTURE:-}" && -f "$GH_ISSUE_FIXTURE" ]]; then
         cat "$GH_ISSUE_FIXTURE"
@@ -1553,11 +1658,30 @@ if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
 fi
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+    # Shim-test fixture (Stage 2) first, then #3176 post-PR fixture,
+    # then a canonical green-rollup fallback so happy-path tests can
+    # traverse awaiting_ci → merge → awaiting_deploy without setting
+    # any fixture at all.
     if [[ -n "${GH_PR_FIXTURE:-}" && -f "$GH_PR_FIXTURE" ]]; then
         cat "$GH_PR_FIXTURE"
         exit 0
     fi
-    exit 1
+    if [[ -n "${GH_PR_VIEW_JSON_FIXTURE:-}" && -f "$GH_PR_VIEW_JSON_FIXTURE" ]]; then
+        cat "$GH_PR_VIEW_JSON_FIXTURE"
+        exit 0
+    fi
+    cat <<'JSONEOF'
+{
+  "statusCheckRollup": [
+    {"name": "ci-passed", "status": "COMPLETED", "conclusion": "SUCCESS"}
+  ],
+  "mergeable": "MERGEABLE",
+  "mergeStateStatus": "CLEAN",
+  "headRefOid": "deadbeefcafe",
+  "mergeCommit": {"oid": "deadbeefcafe"}
+}
+JSONEOF
+    exit 0
 fi
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "diff" ]]; then
@@ -1566,6 +1690,14 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "diff" ]]; then
         exit 0
     fi
     exit 1
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "merge" ]]; then
+    # #3176: handle_merge calls ``gh pr merge <N> --squash --delete-branch``.
+    if [[ -n "${GH_PR_MERGE_STDERR:-}" ]]; then
+        printf '%s\n' "$GH_PR_MERGE_STDERR" >&2
+    fi
+    exit "${GH_PR_MERGE_EXIT:-0}"
 fi
 
 if [[ "${1:-}" == "run" && "${2:-}" == "view" ]]; then
@@ -1577,11 +1709,19 @@ if [[ "${1:-}" == "run" && "${2:-}" == "view" ]]; then
 fi
 
 if [[ "${1:-}" == "run" && "${2:-}" == "list" ]]; then
+    # Shim-test fixture (Stage 2) first, then #3176 post-PR fixture,
+    # then empty array fallback so awaiting_deploy's "no runs → verify"
+    # branch lights up without fixture setup.
     if [[ -n "${GH_RUN_LIST_FIXTURE:-}" && -f "$GH_RUN_LIST_FIXTURE" ]]; then
         cat "$GH_RUN_LIST_FIXTURE"
         exit 0
     fi
-    exit 1
+    if [[ -n "${GH_RUN_LIST_JSON_FIXTURE:-}" && -f "$GH_RUN_LIST_JSON_FIXTURE" ]]; then
+        cat "$GH_RUN_LIST_JSON_FIXTURE"
+        exit 0
+    fi
+    printf '[]\n'
+    exit "${GH_RUN_LIST_EXIT:-0}"
 fi
 
 # Legacy route kept for push_and_pr tests.
@@ -1629,6 +1769,16 @@ case "$query" in
         if [[ -f "${PHASE_FIXTURE_FILE:-}" ]]; then
             head -n 1 "$PHASE_FIXTURE_FILE"
         fi
+        exit 0
+        ;;
+    *"SELECT pr_number"*"FROM dispatcher.agents"*)
+        # #3176 — post-PR handlers read pr_number from the agent row.
+        printf '%s\n' "${PR_NUMBER_FIXTURE:-9999}"
+        exit 0
+        ;;
+    *"SELECT COALESCE(merge_unstick_attempts"*|*"SELECT merge_unstick_attempts"*)
+        # #3176 — handle_merge's auto-unstick budget check.
+        printf '%s\n' "${MERGE_UNSTICK_ATTEMPTS_FIXTURE:-0}"
         exit 0
         ;;
     *"SELECT COALESCE(pr_number"*"FROM dispatcher.agents"*)
@@ -2592,6 +2742,444 @@ if grep -q "INSERT INTO dispatcher.ralph_patches" "$INVOCATIONS_DIR/psql.log"; t
          "psql log: $(cat "$INVOCATIONS_DIR/psql.log")"
 else
     pass "#3144 T27 — no INSERT when SELECT-exists guard fires"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# #3176 — real implementations for awaiting_ci / merge / awaiting_deploy.
+# Each test starts at the phase under test and drives one iteration.
+#
+# Shared helper — runs the entrypoint with the env vars the post-PR
+# handlers need (0-second polls so timeouts + happy-paths finish
+# instantly against the stubbed gh/psql).
+# ══════════════════════════════════════════════════════════════════════════
+
+run_post_pr_phase() {
+    # $1 = starting phase (awaiting_ci | merge | awaiting_deploy)
+    # $2 = workspace dir
+    # Remaining args are `VAR=VAL` tokens exported for the run.
+    _rpp_start_phase="$1"
+    _rpp_workspace="$2"
+    shift 2
+    mkdir -p "$_rpp_workspace"
+
+    set +e
+    (
+        export AGENT_ID="fe28f05f-0000-0000-0000-000000003176"
+        export ISSUE_NUMBER="3176"
+        export DATABASE_URL="postgres://test"
+        export GITHUB_TOKEN=""
+        export AGENT_WORKSPACE="$_rpp_workspace"
+        export REPO_URL="https://example.invalid/repo.git"
+        export PATH="$STUB_BIN:$PATH"
+        export INVOCATIONS_DIR="$INVOCATIONS_DIR"
+        export PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher"
+        export PHASE_TRANSITIONS_PARENT="$REPO_ROOT"
+        export AGENT_RUNNER_MAX_PHASE_ITERATIONS=10
+        # Poll every 0 seconds so any while-loop exits immediately;
+        # timeouts are 0 too so tests can drive the timeout branch.
+        export AGENT_RUNNER_CI_POLL_INTERVAL=0
+        export AGENT_RUNNER_DEPLOY_POLL_INTERVAL=0
+        export AGENT_RUNNER_DEPLOY_GRACE_SECONDS="${AGENT_RUNNER_DEPLOY_GRACE_SECONDS:-0}"
+        for _tok in "$@"; do
+            export "$_tok"
+        done
+        bash "$ENTRYPOINT" 2>&1
+    )
+    _rpp_rc=$?
+    set -e
+    return $_rpp_rc
+}
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 28: awaiting_ci + green rollup → advances to merge.
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t28.txt"
+printf 'awaiting_ci\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t28_workspace="$TEST_TMP/t28-workspace"
+set +e
+t28_out=$(run_post_pr_phase "awaiting_ci" "$t28_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999")
+set -e
+
+if printf '%s' "$t28_out" | grep -q '"rollup_state": "green"'; then
+    pass "#3176 T28 — awaiting_ci green rollup classified"
+else
+    fail "#3176 T28 — awaiting_ci green rollup classified" \
+         "out tail: $(printf '%s' "$t28_out" | tail -c 500)"
+fi
+
+# awaiting_ci green → advances to merge, which then runs (loop) to
+# awaiting_deploy. We assert SET phase = 'merge' appears.
+if grep -q "SET phase = \\\\'merge\\\\'" "$INVOCATIONS_DIR/psql.log"; then
+    pass "#3176 T28 — awaiting_ci advances to merge on green"
+else
+    fail "#3176 T28 — awaiting_ci advances to merge on green" \
+         "psql log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 29: awaiting_ci + red rollup → advances to fix_ci (NOT merge).
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t29.txt"
+printf 'awaiting_ci\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+# Write a red-rollup fixture.
+t29_pr_view="$TEST_TMP/t29-pr-view.json"
+cat > "$t29_pr_view" <<'EOF'
+{
+  "statusCheckRollup": [
+    {"name": "ci-passed", "status": "COMPLETED", "conclusion": "FAILURE"}
+  ],
+  "mergeable": "MERGEABLE",
+  "mergeStateStatus": "CLEAN",
+  "headRefOid": "deadbeefcafe",
+  "mergeCommit": null
+}
+EOF
+
+t29_workspace="$TEST_TMP/t29-workspace"
+set +e
+t29_out=$(run_post_pr_phase "awaiting_ci" "$t29_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_PR_VIEW_JSON_FIXTURE=$t29_pr_view" \
+    "CLAUDE_VERDICT_FIXTURE=")
+set -e
+
+if printf '%s' "$t29_out" | grep -q '"rollup_state": "red"'; then
+    pass "#3176 T29 — awaiting_ci red rollup classified"
+else
+    fail "#3176 T29 — awaiting_ci red rollup classified" \
+         "out tail: $(printf '%s' "$t29_out" | tail -c 500)"
+fi
+
+if grep -q "SET phase = \\\\'fix_ci\\\\'" "$INVOCATIONS_DIR/psql.log"; then
+    pass "#3176 T29 — awaiting_ci advances to fix_ci on red"
+else
+    fail "#3176 T29 — awaiting_ci advances to fix_ci on red" \
+         "psql log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
+fi
+
+# Verify merge was NOT invoked — red rollup must not trigger a merge.
+# We filter the gh log for lines containing `pr merge`.
+if grep -F "pr merge" "$INVOCATIONS_DIR/gh.log" >/dev/null 2>&1; then
+    fail "#3176 T29 — no gh pr merge invoked on red CI" \
+         "gh log: $(cat "$INVOCATIONS_DIR/gh.log")"
+else
+    pass "#3176 T29 — no gh pr merge invoked on red CI"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 30: merge stale-rollup → auto-unstick (empty commit + push) and
+# phase stays at awaiting_ci for next poll.
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t30.txt"
+printf 'merge\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t30_workspace="$TEST_TMP/t30-workspace"
+set +e
+t30_out=$(run_post_pr_phase "merge" "$t30_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "MERGE_UNSTICK_ATTEMPTS_FIXTURE=0" \
+    "GH_PR_MERGE_EXIT=1" \
+    "GH_PR_MERGE_STDERR=error: base branch policy prohibits the merge" \
+    "GIT_REV_LIST_COUNT=1")
+set -e
+
+if printf '%s' "$t30_out" | grep -q "merge_stale_rollup_detected"; then
+    pass "#3176 T30 — merge stale-rollup detected"
+else
+    fail "#3176 T30 — merge stale-rollup detected" \
+         "out tail: $(printf '%s' "$t30_out" | tail -c 500)"
+fi
+
+if printf '%s' "$t30_out" | grep -q "merge_auto_unstick_empty_commit_pushed"; then
+    pass "#3176 T30 — auto-unstick empty-commit push succeeded"
+else
+    fail "#3176 T30 — auto-unstick empty-commit push succeeded" \
+         "out tail: $(printf '%s' "$t30_out" | tail -c 500)"
+fi
+
+# Phase bounces back to awaiting_ci for the next poll.
+if grep -q "SET phase = \\\\'awaiting_ci\\\\'" "$INVOCATIONS_DIR/psql.log"; then
+    pass "#3176 T30 — stale-rollup unstick returns phase to awaiting_ci"
+else
+    fail "#3176 T30 — stale-rollup unstick returns phase to awaiting_ci" \
+         "psql log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 31: merge stale-rollup with budget exhausted → terminal failure,
+# no additional empty commit attempted.
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t31.txt"
+printf 'merge\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t31_workspace="$TEST_TMP/t31-workspace"
+set +e
+t31_out=$(run_post_pr_phase "merge" "$t31_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "MERGE_UNSTICK_ATTEMPTS_FIXTURE=1" \
+    "GH_PR_MERGE_EXIT=1" \
+    "GH_PR_MERGE_STDERR=error: base branch policy prohibits the merge")
+set -e
+
+if printf '%s' "$t31_out" | grep -q "merge_unstick_exhausted"; then
+    pass "#3176 T31 — merge unstick exhausted logged"
+else
+    fail "#3176 T31 — merge unstick exhausted logged" \
+         "out tail: $(printf '%s' "$t31_out" | tail -c 500)"
+fi
+
+if printf '%s' "$t31_out" | grep -q "agent_runner_reaped_failure"; then
+    pass "#3176 T31 — agent_runner_reaped_failure emitted"
+else
+    fail "#3176 T31 — agent_runner_reaped_failure emitted" \
+         "out tail: $(printf '%s' "$t31_out" | tail -c 500)"
+fi
+
+# Phase advances to merge_failed (terminal).
+_t31_final=$(cat "$PHASE_FIXTURE_FILE" 2>/dev/null || printf '')
+if [[ "$_t31_final" == "merge_failed" ]]; then
+    pass "#3176 T31 — phase terminates at merge_failed"
+else
+    fail "#3176 T31 — phase terminates at merge_failed" \
+         "actual final phase: $_t31_final"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 32: awaiting_deploy with no deploy workflows fired → short-grace
+# advance to verify.
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t32.txt"
+printf 'awaiting_deploy\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+# Empty runs list → classify as "none" → awaiting_deploy advances to
+# verify after the grace window elapses. Grace window set to 0 so we
+# don't need to wait.
+t32_runs="$TEST_TMP/t32-runs.json"
+printf '[]\n' > "$t32_runs"
+
+t32_workspace="$TEST_TMP/t32-workspace"
+set +e
+t32_out=$(run_post_pr_phase "awaiting_deploy" "$t32_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_RUN_LIST_JSON_FIXTURE=$t32_runs" \
+    "AGENT_RUNNER_DEPLOY_GRACE_SECONDS=0")
+set -e
+
+if printf '%s' "$t32_out" | grep -q "awaiting_deploy_no_runs"; then
+    pass "#3176 T32 — awaiting_deploy no-runs branch hit"
+else
+    fail "#3176 T32 — awaiting_deploy no-runs branch hit" \
+         "out tail: $(printf '%s' "$t32_out" | tail -c 500)"
+fi
+
+if grep -q "SET phase = \\\\'verify\\\\'" "$INVOCATIONS_DIR/psql.log"; then
+    pass "#3176 T32 — awaiting_deploy no-runs advances to verify"
+else
+    fail "#3176 T32 — awaiting_deploy no-runs advances to verify" \
+         "psql log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 33: awaiting_deploy timeout → terminal failure.
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t33.txt"
+printf 'awaiting_deploy\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+# Pending runs → classify as "pending" forever. Timeout=0 forces the
+# first-tick timeout branch.
+t33_runs="$TEST_TMP/t33-runs.json"
+cat > "$t33_runs" <<'EOF'
+[
+  {"databaseId": 1, "workflowName": "Deploy Dispatcher", "status": "IN_PROGRESS", "conclusion": null, "createdAt": "2026-04-23T00:00:00Z"}
+]
+EOF
+
+t33_workspace="$TEST_TMP/t33-workspace"
+set +e
+t33_out=$(run_post_pr_phase "awaiting_deploy" "$t33_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_RUN_LIST_JSON_FIXTURE=$t33_runs" \
+    "AGENT_RUNNER_AWAITING_DEPLOY_TIMEOUT_SECONDS=0" \
+    "AGENT_RUNNER_DEPLOY_GRACE_SECONDS=9999")
+set -e
+
+if printf '%s' "$t33_out" | grep -q "awaiting_deploy_timeout"; then
+    pass "#3176 T33 — awaiting_deploy timeout logged"
+else
+    fail "#3176 T33 — awaiting_deploy timeout logged" \
+         "out tail: $(printf '%s' "$t33_out" | tail -c 500)"
+fi
+
+_t33_final=$(cat "$PHASE_FIXTURE_FILE" 2>/dev/null || printf '')
+if [[ "$_t33_final" == "awaiting_deploy_timeout" ]]; then
+    pass "#3176 T33 — phase terminates at awaiting_deploy_timeout"
+else
+    fail "#3176 T33 — phase terminates at awaiting_deploy_timeout" \
+         "actual final phase: $_t33_final"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 34: push_and_pr reads summary.json for pr_title/pr_body_md and
+# commit_message; persists pr_number after successful PR create.
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t34.txt"
+printf 'push_and_pr\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t34_workspace="$TEST_TMP/t34-workspace"
+mkdir -p "$t34_workspace/repo/tmp/dispatcher-output"
+cat > "$t34_workspace/repo/tmp/dispatcher-output/summary.json" <<'EOF'
+{
+  "commit_message": "feat(agent-runner): real post-PR handlers (#3176)\n\nCloses #3176",
+  "pr_title": "feat(agent-runner): real post-PR handlers (#3176)",
+  "pr_body_md": "## Summary\nReal impls of awaiting_ci / merge / awaiting_deploy.\n\n## Test plan\n- [x] unit tests\n"
+}
+EOF
+
+set +e
+t34_out=$(run_post_pr_phase "push_and_pr" "$t34_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GIT_REV_LIST_COUNT=1" \
+    "CLAUDE_VERDICT_FIXTURE=")
+set -e
+
+# Summary output was read.
+if printf '%s' "$t34_out" | grep -q "push_and_pr_summary_output_read"; then
+    pass "#3176 T34 — push_and_pr reads tmp/dispatcher-output/summary.json"
+else
+    fail "#3176 T34 — push_and_pr reads tmp/dispatcher-output/summary.json" \
+         "out tail: $(printf '%s' "$t34_out" | tail -c 500)"
+fi
+
+# git commit --amend was invoked with -F.
+if grep -F "commit --amend -F" "$INVOCATIONS_DIR/git.log" >/dev/null 2>&1 \
+   || grep -F "commit" "$INVOCATIONS_DIR/git.log" | grep -F "amend" >/dev/null 2>&1; then
+    pass "#3176 T34 — push_and_pr amends commit with summary's commit_message"
+else
+    fail "#3176 T34 — push_and_pr amends commit with summary's commit_message" \
+         "git log: $(cat "$INVOCATIONS_DIR/git.log")"
+fi
+
+# git fetch origin main was invoked (pre-push rebase).
+if grep -F "fetch" "$INVOCATIONS_DIR/git.log" | grep -F "origin" | grep -F "main" >/dev/null 2>&1; then
+    pass "#3176 T34 — push_and_pr fetches origin/main pre-push"
+else
+    fail "#3176 T34 — push_and_pr fetches origin/main pre-push" \
+         "git log: $(cat "$INVOCATIONS_DIR/git.log")"
+fi
+
+# git rebase origin/main was invoked.
+if grep -F "rebase" "$INVOCATIONS_DIR/git.log" | grep -F "origin/main" >/dev/null 2>&1; then
+    pass "#3176 T34 — push_and_pr rebases on origin/main pre-push"
+else
+    fail "#3176 T34 — push_and_pr rebases on origin/main pre-push" \
+         "git log: $(cat "$INVOCATIONS_DIR/git.log")"
+fi
+
+# gh pr create was invoked with --title + --body-file, NOT --fill.
+if grep -F "pr" "$INVOCATIONS_DIR/gh.log" | grep -F "create" | grep -F -- "--title" >/dev/null 2>&1; then
+    pass "#3176 T34 — push_and_pr passes --title to gh pr create"
+else
+    fail "#3176 T34 — push_and_pr passes --title to gh pr create" \
+         "gh log: $(cat "$INVOCATIONS_DIR/gh.log")"
+fi
+
+if grep -F "pr" "$INVOCATIONS_DIR/gh.log" | grep -F "create" | grep -F -- "--body-file" >/dev/null 2>&1; then
+    pass "#3176 T34 — push_and_pr passes --body-file to gh pr create"
+else
+    fail "#3176 T34 — push_and_pr passes --body-file to gh pr create" \
+         "gh log: $(cat "$INVOCATIONS_DIR/gh.log")"
+fi
+
+# pr_number parsed + UPDATEd on the agent row.
+if printf '%s' "$t34_out" | grep -q "push_and_pr_pr_number_persisted"; then
+    pass "#3176 T34 — push_and_pr persists pr_number on the agent row"
+else
+    fail "#3176 T34 — push_and_pr persists pr_number on the agent row" \
+         "out tail: $(printf '%s' "$t34_out" | tail -c 500)"
+fi
+
+if grep -F "SET pr_number = 9999" "$INVOCATIONS_DIR/psql.log" >/dev/null 2>&1; then
+    pass "#3176 T34 — psql UPDATE dispatcher.agents SET pr_number = 9999"
+else
+    fail "#3176 T34 — psql UPDATE dispatcher.agents SET pr_number = 9999" \
+         "psql log sample: $(grep -m1 "SET pr_number" "$INVOCATIONS_DIR/psql.log" | head -c 200)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 35: push_and_pr rebase conflict → fail cleanly, no push attempted.
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t35.txt"
+printf 'push_and_pr\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t35_workspace="$TEST_TMP/t35-workspace"
+mkdir -p "$t35_workspace"
+
+# The git stub needs to return non-zero on rebase. The only way to
+# condition the stub is via env var — add GIT_REBASE_EXIT.
+set +e
+t35_out=$(run_post_pr_phase "push_and_pr" "$t35_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GIT_REV_LIST_COUNT=1" \
+    "GIT_REBASE_EXIT=1" \
+    "CLAUDE_VERDICT_FIXTURE=")
+set -e
+
+if printf '%s' "$t35_out" | grep -q "push_and_pr_rebase_conflict"; then
+    pass "#3176 T35 — rebase conflict emits push_and_pr_rebase_conflict"
+else
+    fail "#3176 T35 — rebase conflict emits push_and_pr_rebase_conflict" \
+         "out tail: $(printf '%s' "$t35_out" | tail -c 500)"
+fi
+
+# No push attempted.
+if grep -F "push" "$INVOCATIONS_DIR/git.log" | grep -F "origin" | grep -v "fetch" | grep -v "rebase" >/dev/null 2>&1; then
+    fail "#3176 T35 — no push attempted on rebase conflict" \
+         "git log: $(cat "$INVOCATIONS_DIR/git.log")"
+else
+    pass "#3176 T35 — no push attempted on rebase conflict"
+fi
+
+# git rebase --abort was invoked to restore the worktree.
+if grep -F "rebase" "$INVOCATIONS_DIR/git.log" | grep -F "abort" >/dev/null 2>&1; then
+    pass "#3176 T35 — rebase conflict triggers git rebase --abort"
+else
+    fail "#3176 T35 — rebase conflict triggers git rebase --abort" \
+         "git log: $(cat "$INVOCATIONS_DIR/git.log")"
 fi
 
 # ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replaces the no-op stubs for `awaiting_ci`, `merge`, and
  `awaiting_deploy` phases in `scripts/dispatcher/agent-runner-entrypoint.sh`
  with real implementations that mirror the subprocess daemon's
  `_advance_awaiting_ci`, `_merge_pr_and_advance`, and
  `_advance_awaiting_deploy`. Before this change every ECS-mode agent
  raced through the three post-push_and_pr phases with
  `mechanical_phase_stub` events in ~1 second, abandoning the PR
  without ever merging (incident: agent `fe28f05f` on #2825 opened
  PR #3174 and "succeeded" without a merge).
- Fixes the secondary push_and_pr bugs documented in #3176: wires
  `tmp/dispatcher-output/summary.json` into `gh pr create --title/--body-file`,
  `git commit --amend -F` with the summary's `commit_message`,
  pre-push `git fetch origin main && git rebase origin/main` (+ clean
  abort on conflict), and `UPDATE dispatcher.agents SET pr_number = $N`
  after successful PR create.
- Adds five new terminal phase constants to `phase_transitions.py` so
  the per-agent Fargate task exits cleanly on timeout / budget-
  exhaustion paths: `awaiting_ci_failed`, `awaiting_ci_timeout`,
  `merge_failed`, `awaiting_deploy_failed`, `awaiting_deploy_timeout`.

## Acceptance criteria (from #3176)

1. ✅ `handle_awaiting_ci` / `handle_merge` / `handle_awaiting_deploy`
   are real implementations — no more `mechanical_phase_stub` events
   for these three phases.
2. ✅ `dispatcher.agents.pr_number` is recorded during `push_and_pr`.
3. ✅ `gh pr create` uses `pr_title` + `pr_body_md` from
   `tmp/dispatcher-output/summary.json` when available.
4. ✅ `git fetch origin main` + `git rebase origin/main` runs before
   `git push`; rebase conflicts abort cleanly.
5. ✅ Unit tests in `scripts/tests/test_agent_runner_entrypoint.sh`
   cover each new phase handler with stubbed `gh`/`git`/`psql`
   binaries (T28-T35, 33 new assertions).
6. ⏳ End-to-end smoke verification — operator will re-enable
   `agent_execution_mode='ecs'` after merge + deploy and observe a
   real agent through the full pipeline; evidence will be posted on
   #3176 as a verification comment.
7. ✅ No daemon.py regressions — subprocess-path handlers untouched.

## Test plan

- [x] `scripts/tests/test_agent_runner_entrypoint.sh` — 163/163
      passing (added 9 new scenarios, 33 new assertions for #3176).
- [x] `scripts/dispatcher/tests/test_phase_transitions.py` — 74/74
      passing (added 1 new test for the new terminal-phase constants).
- [x] `scripts/check-bash-compat.sh` — 126/126 scripts clean.
- [ ] Post-merge smoke: flip `dispatcher.config.agent_execution_mode='ecs'`
      and observe one real agent through `plan → ralph → summary → push_and_pr
      → awaiting_ci → merge → awaiting_deploy → verify → retro → done`
      with `pr_number` populated and the PR actually merged. Evidence
      will be posted on #3176.

Closes #3176

🤖 Generated with [Claude Code](https://claude.com/claude-code)
