### PR TITLE
fix(agent-runner): anchor claude -p cwd to $REPO_ROOT (#3190)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -1534,16 +1534,33 @@ run_claude_phase() {
     # rather than a null-deref.
     write_phase_input "$_skill" || true
 
-    log "claude_phase_begin" "phase=$_phase" "skill=$_skill"
     # Do NOT fail the script on a non-zero exit — parse the envelope
     # and let the caller decide. Redirect stderr to a sibling file for
     # triage parity with the daemon.
+    #
+    # #3190: explicitly anchor cwd to $REPO_ROOT for the `claude -p`
+    # invocation. The task-v2-* skills look up their input bundle via
+    # the RELATIVE path ``tmp/dispatcher-input/<phase>.json`` — if the
+    # child process inherits a cwd that isn't the repo root, the
+    # lookup silently misses and the skill emits a string-shaped FAILED
+    # verdict, which the daemon classifies as
+    # ``verify_infra_failure_post_merge`` (silent no-op verify). The
+    # entrypoint runs `cd "$REPO_ROOT"` once at line 190, but wrapping
+    # the claude invocation in an explicit subshell is belt-and-
+    # suspenders: it guarantees the child process cwd regardless of
+    # what any intervening phase handler may have done, AND it gives
+    # the ``cwd=`` field on ``claude_phase_begin`` (logged inside the
+    # subshell) as a self-diagnosing artifact for the next incident.
     set +e
-    claude -p "/task-v2-$_skill $AGENT_ID" \
-        --output-format json \
-        --dangerously-skip-permissions \
-        > "$_out_file" \
-        2> "$AGENT_WORKSPACE/claude-p-$_phase.stderr.log"
+    (
+        cd "$REPO_ROOT" || exit 127
+        log "claude_phase_begin" "phase=$_phase" "skill=$_skill" "cwd=$(pwd)"
+        claude -p "/task-v2-$_skill $AGENT_ID" \
+            --output-format json \
+            --dangerously-skip-permissions \
+            > "$_out_file" \
+            2> "$AGENT_WORKSPACE/claude-p-$_phase.stderr.log"
+    )
     _rc=$?
     set -e
     log "claude_phase_done" "phase=$_phase" "exit_code=$_rc"

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -224,6 +224,12 @@ for arg in "$@"; do
     esac
 done
 
+# #3190: record the effective cwd inherited by each `claude -p`
+# invocation so tests can assert the entrypoint anchors cwd to
+# $REPO_ROOT before the call. One line per invocation; skill name
+# precedes the pwd so tests can filter by phase.
+printf '%s\t%s\n' "${skill:-unknown}" "$(pwd)" >> "$INVOCATIONS_DIR/claude-cwd.log"
+
 # Allow tests to inject a non-object `.result` (e.g. a plain string
 # "Unknown command: /task-v2-foo") to exercise the defensive shim.
 # Set CLAUDE_RESULT_OVERRIDE to the exact JSON payload to emit. Set
@@ -493,6 +499,7 @@ setup_fixtures() {
     # Shared state across the test invocation. Each test resets them.
     : > "$INVOCATIONS_DIR/psql.log"
     : > "$INVOCATIONS_DIR/claude.log"
+    : > "$INVOCATIONS_DIR/claude-cwd.log"
     : > "$INVOCATIONS_DIR/git.log"
     : > "$INVOCATIONS_DIR/gh.log"
 }
@@ -713,6 +720,43 @@ if grep -F "/task-v2-push_and_pr" "$INVOCATIONS_DIR/claude.log" >/dev/null 2>&1;
          "Found /task-v2-push_and_pr in claude log."
 else
     pass "entrypoint does not invoke /task-v2-push_and_pr (mechanical phase)"
+fi
+
+# #3190: every claude -p invocation must run with cwd == $REPO_ROOT
+# so the task-v2-* skills can resolve their
+# ``tmp/dispatcher-input/<phase>.json`` input bundle via the relative
+# path they use internally. The claude stub records its pwd per-call
+# in $INVOCATIONS_DIR/claude-cwd.log (skill<TAB>pwd, one line per
+# invocation). REPO_ROOT = $AGENT_WORKSPACE/repo; the t2 happy path
+# invokes claude for plan, ralph, summary, verify — every row must
+# have pwd = $t2_workspace/repo.
+t2_expected_repo_root="$t2_workspace/repo"
+t2_cwd_total=$(wc -l < "$INVOCATIONS_DIR/claude-cwd.log" | tr -d ' ')
+# Count lines whose second field (tab-separated) is NOT the expected
+# REPO_ROOT. Use `set +e; grep ... ; set -e` so grep-exit-1-no-match
+# doesn't propagate through $(...); we want the printed count either
+# way.
+set +e
+t2_cwd_mismatches=$(grep -cvF "	${t2_expected_repo_root}" "$INVOCATIONS_DIR/claude-cwd.log" 2>/dev/null)
+set -e
+t2_cwd_mismatches="${t2_cwd_mismatches:-0}"
+if [[ "$t2_cwd_total" -ge 1 && "$t2_cwd_mismatches" -eq 0 ]]; then
+    pass "#3190 — every claude -p invocation runs with cwd == \$REPO_ROOT"
+else
+    fail "#3190 — every claude -p invocation runs with cwd == \$REPO_ROOT" \
+         "expected all lines to end with '<TAB>$t2_expected_repo_root', total_lines=$t2_cwd_total, mismatches=$t2_cwd_mismatches, log: $(cat "$INVOCATIONS_DIR/claude-cwd.log")"
+fi
+
+# #3190 AC #2: claude_phase_begin log event includes cwd= field so the
+# next incident is self-diagnosing without needing an in-model `pwd &&
+# ls` (which the preflight-bash hook blocks anyway). The log emitter
+# produces a JSON object with a ``"cwd": "..."`` field, so match that
+# shape explicitly instead of the raw key=value kwarg style.
+if printf '%s' "$out" | grep -qE "claude_phase_begin.*\"cwd\": \"${t2_expected_repo_root}\""; then
+    pass "#3190 AC #2 — claude_phase_begin log event includes cwd=\$REPO_ROOT"
+else
+    fail "#3190 AC #2 — claude_phase_begin log event includes cwd=\$REPO_ROOT" \
+         "expected a claude_phase_begin line carrying cwd=$t2_expected_repo_root, out tail: $(printf '%s' "$out" | grep claude_phase_begin | head -5)"
 fi
 
 # Verify final phase is done.


### PR DESCRIPTION
## Summary

ECS-mode agents' `verify` phase was silently no-oping because `claude -p` inherited a cwd other than `$REPO_ROOT`, so the `task-v2-*` skill's relative-path lookup of `tmp/dispatcher-input/<phase>.json` missed. Wrap the invocation in a `( cd "$REPO_ROOT" && ... )` subshell and log the effective `cwd=` on `claude_phase_begin` so the next incident is self-diagnosing.

Closes #3190

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (new `#3190` assertions cover cwd + log field; 165/165 locally)
- [x] CI green

### Post-deploy verification
- [x] `deploy-agent-runner.yml` workflow rebuilds the agent-runner ECR image (run `24885138182`, digest `sha256:7ca89366...`)
- [ ] Next natural ECS agent traverses `verify` cleanly — CloudWatch shows `claude_phase_begin phase=verify cwd=/.../repo` and a subsequent `phase_output_file_read` (no `phase_output_missing` / `verify_infra_failure_post_merge`). Monitoring; will follow up with evidence on #3190.
- [x] Verification evidence posted on issue (see §A.8)
