### PR TITLE
feat(scraping): LLM prompt should return empty ruling_text for empty OC tentative-ruling cells

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -267,14 +267,19 @@ PDF_PER_PAGE_PROMPT = (
     "procedural background, legal standard, analysis, discussion, "
     "conclusion, disposition, orders, and any other content the "
     "judge wrote about this case. Do not summarize or omit anything. "
-    "Empty string if not visible.\n\n"
+    "**If the row's tentative-ruling column/cell is visibly empty (the "
+    "column is present but the body cell is blank), return "
+    '`ruling_text=""`. Do NOT substitute the case caption, motion '
+    "label, case number, or any other nearby text. Emit empty string.**\n\n"
     "## How to handle different page layouts\n\n"
     "California courts use many different PDF formats. Identify which "
     "layout this page uses and extract accordingly:\n\n"
     "**Tables** (columns separated by vertical lines): "
     "Return one object per table row. The narrow column(s) have the "
     "entry number and/or case info; the wide column has the ruling "
-    "text.\n\n"
+    "text. **When a row's ruling-text column is empty/blank, emit "
+    '`ruling_text=""` for that row even though entry_number / '
+    "case_number / case_title are filled.**\n\n"
     "**Bordered boxes** (each case in a rectangular border): "
     "Return one object per box. The box header has the item number, "
     "time, case number, and case name. The ruling text is everything "
@@ -299,6 +304,12 @@ PDF_PER_PAGE_PROMPT = (
     "procedures — no actual case rulings): Return an empty rulings "
     "array. Still extract page_header if the department, judge, or "
     "hearing date is visible.\n\n"
+    "**Calendar listings without a ruling column** (rows that show "
+    "only entry number and case name with no dedicated ruling-body "
+    "column — e.g. a pure calendar agenda): Return one object per row "
+    "with entry_number / case_number / case_title populated and "
+    '`ruling_text=""`. Downstream filters will drop these rows; do '
+    "NOT copy the case caption or motion label into ruling_text.\n\n"
     "## Formatting rules\n\n"
     "- Transcribe ruling_text as **Markdown** preserving formatting:\n"
     "  - Use **bold** for bold text and headings\n"
@@ -335,6 +346,18 @@ PDF_PER_PAGE_PROMPT = (
     '      "case_number": "",\n'
     '      "case_title": "",\n'
     '      "ruling_text": "continuation from previous page..."\n'
+    "    },\n"
+    "    {\n"
+    '      "entry_number": "5",\n'
+    '      "case_number": "2025-00912345",\n'
+    '      "case_title": "Malki vs. Acme Corp.",\n'
+    '      "ruling_text": ""\n'
+    "    },\n"
+    "    {\n"
+    '      "entry_number": "6",\n'
+    '      "case_number": "2025-00956789",\n'
+    '      "case_title": "Johnson vs. Smith — Motion to Compel",\n'
+    '      "ruling_text": ""\n'
     "    }\n"
     "  ]\n"
     "}"

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -2995,6 +2995,35 @@ class TestPerPagePrompt:
         assert "Continuation pages" in PDF_PER_PAGE_PROMPT
         assert "Boilerplate-only pages" in PDF_PER_PAGE_PROMPT
 
+    def test_per_page_prompt_instructs_empty_cell_behavior(self) -> None:
+        """The prompt tells the LLM to emit ruling_text="" when the cell is empty."""
+        from framework.llm_extractor import PDF_PER_PAGE_PROMPT
+
+        # The ruling_text field description must contain the empty-cell instruction.
+        ruling_text_section = PDF_PER_PAGE_PROMPT[PDF_PER_PAGE_PROMPT.index("ruling_text") :]
+        assert "empty" in ruling_text_section
+        # The LLM must not substitute nearby text.
+        assert "Do NOT substitute" in PDF_PER_PAGE_PROMPT
+        # Explicit empty-string directive.
+        assert 'ruling_text=""' in PDF_PER_PAGE_PROMPT
+
+    def test_per_page_prompt_describes_calendar_listing_rows(self) -> None:
+        """The prompt has a Calendar listings layout section."""
+        from framework.llm_extractor import PDF_PER_PAGE_PROMPT
+
+        assert "Calendar listings" in PDF_PER_PAGE_PROMPT
+        # The section must instruct the LLM to emit empty ruling_text.
+        cal_section = PDF_PER_PAGE_PROMPT[PDF_PER_PAGE_PROMPT.index("Calendar listings") :]
+        assert "ruling_text" in cal_section
+
+    def test_per_page_prompt_includes_empty_cell_example(self) -> None:
+        """The example output section includes at least one entry with ruling_text=""."""
+        from framework.llm_extractor import PDF_PER_PAGE_PROMPT
+
+        example_section = PDF_PER_PAGE_PROMPT[PDF_PER_PAGE_PROMPT.index("## Example output") :]
+        # The example must show ruling_text as the empty string.
+        assert '"ruling_text": ""' in example_section
+
 
 # ---------------------------------------------------------------------------
 # Cross-reference resolution tests (#2317)


### PR DESCRIPTION
## Summary

Updated PDF_PER_PAGE_PROMPT in llm_extractor.py with explicit 'empty cell → ruling_text=""' guidance in the ruling_text field description, extended the Tables layout paragraph with the same instruction, added a new 'Calendar listings without a ruling column' layout paragraph, and included two distinct example entries (empty table cell vs. calendar listing with motion label) so the LLM sees both variants. Added 3 new tests to TestPerPagePrompt asserting the prompt content changes. All pre-push checks passed: ruff, pytest (6564 passed, 2 skipped), coverage floor (96% package), diff coverage, filename-separator collisions; OC regression suite test_oc_tentatives.py 7/7 passing.

Closes #2672

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 6564 passed, 2 skipped)
- [x] Diff coverage ≥ 90% (96% package)
- [x] CI green

### Post-deploy verification

The following acceptance criteria require live environment verification:
- [ ] Re-ingest OC Dept W8 (Hon. Recio) PDF and verify Malki row emitted with ruling_text="" (check S3 LLM cache entry)
- [ ] Query dev database for OC rulings <100 chars + NULL motion + NULL outcome; count should be 0 after rebuild_db run
- [ ] Verification evidence posted on #2672 (see /task-v2-verify output)