### PR TITLE
fix(dispatcher): count-vs-cap scheduler_tick gate so concurrency_cap>1 claims (#3199)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -2498,13 +2498,17 @@ class DispatcherDaemon:
         # 4. Phase 3A orchestration gate (#2783) — threaded spawn (#2847).
         #
         # Only enter the claim + orchestrate path when (a) the live
-        # ``concurrency_cap`` is >0 AND (b) no agent is currently in
-        # flight for this daemon run AND (c) Phase 3C's GitHub
-        # rate-limit skip flag is not active AND (d) no orchestration
-        # worker thread from a prior tick is still alive. Phase 3 runs
-        # at ``concurrency_cap=1`` (one subprocess at a time); Phase 3E
-        # flips the value from 0 to 1. Until then the gate stays
-        # closed and this branch is a no-op.
+        # ``concurrency_cap`` is >0 AND (b) the current count of
+        # ``status='running'`` agents is strictly less than that cap
+        # AND (c) Phase 3C's GitHub rate-limit skip flag is not active
+        # AND (d) no orchestration worker thread from a prior tick is
+        # still alive. The pre-#3199 gate was a single-slot binary
+        # check (``not _has_active_agent()``) which silently clamped
+        # ``cap > 1`` to one concurrent agent — see #3199 for the
+        # Phase 4 ECS incident. ``_active_agent_count()`` reads the
+        # actual denominator so ``cap == 2`` claims a second slot
+        # after the first agent's ECS task is launched and the
+        # orchestration thread exits.
         #
         # Orchestration runs on a dedicated worker thread so this tick
         # returns quickly (spawn + return = ~ms) and the main run loop
@@ -2515,18 +2519,38 @@ class DispatcherDaemon:
         # phase boundary (≤60s for plan; worst-case ~one ralph
         # iteration for ralph).
         #
+        # ``_maybe_spawn_orchestration_thread`` serializes spawns
+        # per-tick via its own thread-alive guard — at most one new
+        # orchestration thread is spawned per tick even when the gate
+        # opens. Under ECS mode that is fine: the prior tick's
+        # orchestration exits in seconds after launching its Fargate
+        # task, so the next tick can spawn the second agent's
+        # orchestration thread. Under subprocess mode the fix is a
+        # no-op at ``cap == 1`` (``0 < 1`` opens the gate on empty,
+        # ``1 < 1`` closes it once one agent runs — identical to the
+        # old boolean); at ``cap > 1`` subprocess threads contend for
+        # the same orchestration slot across ticks but that is
+        # intentional — an operator opting into ``cap > 1`` on
+        # subprocess accepts the per-tick spawn rate (#3199).
+        #
         # Exceptions here are caught + logged but not re-raised — the
         # scheduler tick must survive any spawn failure so the next
         # tick can try again. Worker-thread exceptions are caught in
         # ``_orchestration_worker_entry``.
         orchestration_attempted = False
-        # #3184 — capture the result of ``_has_active_agent`` when we
-        # call it inside the claim gate so the supervisor orphan check
-        # below can reuse it without a second DB round-trip. ``None``
-        # here means "not checked this tick" (rate-skipped or paused
-        # branches), which is also the signal for the orphan check to
-        # skip this tick and reset the counter.
+        # #3199 — capture the running-agent count once inside the
+        # claim gate so the cap comparison and the scheduler_tick log
+        # event share a single DB round-trip. ``None`` here means
+        # "not checked this tick" (rate-skipped or paused branches);
+        # the supervisor orphan check below and the log event both
+        # interpret ``None`` as "no evidence" rather than "zero".
+        active_agent_count: int | None = None
+        # #3184 — the supervisor orphan detector below needs a
+        # boolean "did we observe 'no active agent' this tick" signal.
+        # Derived from ``active_agent_count`` so the semantics stay
+        # identical to the pre-#3199 ``_has_active_agent()`` call.
         has_active_agent_this_tick: bool | None = None
+        gate_blocked_on_cap: bool | None = None
         rate_skip_active = self._gh_rate_skip_active()
         if rate_skip_active:
             self._log.info(
@@ -2544,8 +2568,10 @@ class DispatcherDaemon:
             and concurrency_cap > 0
             and not self._is_paused()
         ):
-            has_active_agent_this_tick = self._has_active_agent()
-            if not has_active_agent_this_tick:
+            active_agent_count = self._active_agent_count()
+            has_active_agent_this_tick = active_agent_count > 0
+            gate_blocked_on_cap = active_agent_count >= concurrency_cap
+            if active_agent_count < concurrency_cap:
                 try:
                     orchestration_attempted = self._maybe_spawn_orchestration_thread()
                 except Exception:
@@ -2635,6 +2661,13 @@ class DispatcherDaemon:
                 "reap_success": reap_summary["reaped_success"],
                 "reap_failure": reap_summary["reaped_failure"],
                 "reap_still_running": reap_summary["still_running"],
+                # #3199: concurrency-cap gate denominator so CloudWatch
+                # Insights can self-diagnose "why didn't the daemon
+                # spawn a second agent when cap=2?". ``None`` on ticks
+                # that skipped the gate (rate-limited or paused) —
+                # those ticks never read the count from the DB.
+                "active_agent_count": active_agent_count,
+                "gate_blocked_on_cap": gate_blocked_on_cap,
             },
         )
         return {
@@ -2643,6 +2676,15 @@ class DispatcherDaemon:
             "queue_depth": queue_depth,
             "blocked_depth": blocked_depth,
             "orchestration_attempted": 1 if orchestration_attempted else 0,
+            # #3199 observability — concurrency-cap gate diagnostics.
+            # ``-1`` means "not checked this tick" (rate-skipped or
+            # paused branches); a real zero means "no running agents."
+            "active_agent_count": (
+                -1 if active_agent_count is None else active_agent_count
+            ),
+            "gate_blocked_on_cap": (
+                -1 if gate_blocked_on_cap is None else (1 if gate_blocked_on_cap else 0)
+            ),
             # #2847 observability fields for tests and CloudWatch.
             "orchestration_thread_alive": 1 if orchestration_thread_alive else 0,
             "pause_requested": 1 if pause_requested else 0,
@@ -3644,6 +3686,13 @@ class DispatcherDaemon:
         — no ``kind`` filter needed. Historical ``kind='task-skill'``
         rows the /task skill wrote pre-#2927 were cleaned up at
         deploy time (see #2927 cleanup commit).
+
+        **Callers.** Used by the supervisor orphan-detection guard in
+        :meth:`scheduler_tick` (boolean "thread alive but no active
+        agent" mismatch — see #3184) where only the presence/absence
+        signal matters. The concurrency-cap gate itself uses
+        :meth:`_active_agent_count` so ``concurrency_cap > 1`` can
+        actually claim more than one slot (#3199).
         """
         assert self._conn is not None, "connect() must run before checking"
         try:
@@ -3672,6 +3721,58 @@ class DispatcherDaemon:
             # rather than double-spawn on a confused DB state.
             return True
         return row is not None
+
+    def _active_agent_count(self) -> int:
+        """Return the number of agent rows currently ``status='running'``.
+
+        Counterpart to :meth:`_has_active_agent`. The concurrency-cap
+        gate in :meth:`scheduler_tick` compares this count against
+        ``concurrency_cap`` so ``cap > 1`` actually claims extra slots
+        instead of being silently clamped to 1 by the old boolean gate
+        (#3199). Keeps the same ``status='running'`` predicate as
+        :meth:`_has_active_agent` — subprocess and ECS agents both
+        count as one slot.
+
+        Fail-closed semantics match :meth:`_has_active_agent`: a DB
+        error returns a "cap is full" sentinel (``INT_MAX``-equivalent)
+        so the next tick skips spawning rather than double-claiming on
+        a confused DB state. Mapped as a large integer rather than a
+        symbolic sentinel so the ``< concurrency_cap`` gate naturally
+        evaluates False without special-casing.
+        """
+        assert self._conn is not None, "connect() must run before checking"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT COUNT(*) FROM dispatcher.agents WHERE status = 'running'",
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.active_agent_count_failed",
+                extra={
+                    "event": "active_agent_count_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            # Fail-closed — a sentinel that is always >= any realistic
+            # ``concurrency_cap`` so the gate evaluates False and we
+            # skip this tick rather than double-spawn on a confused
+            # DB state. Mirrors :meth:`_has_active_agent`'s fail-closed
+            # behaviour (returns True on error).
+            return 1_000_000
+        if row is None:
+            return 0
+        try:
+            return int(row[0])
+        except (TypeError, ValueError, IndexError):
+            # Defensive: malformed cursor row shouldn't crash the tick.
+            return 1_000_000
 
     def _latest_queue_snapshot_issues(self) -> list[int]:
         """Return issue numbers from the most recent queue snapshot, priority-sorted.

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -499,6 +499,267 @@ class TestHasActiveAgent:
 
 
 # --------------------------------------------------------------------------
+# _active_agent_count (#3199)
+# --------------------------------------------------------------------------
+
+
+class TestActiveAgentCount:
+    """``_active_agent_count`` returns the concurrency-cap gate denominator.
+
+    Pre-#3199 the gate was a binary ``_has_active_agent()`` check which
+    silently clamped ``concurrency_cap > 1`` to one concurrent agent.
+    The new helper returns the actual running-agent count so the
+    scheduler gate can compare ``count < cap``.
+    """
+
+    def test_no_running_rows_returns_zero(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+        assert d._active_agent_count() == 0
+
+    def test_one_running_row_returns_one(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(1,)]
+        assert d._active_agent_count() == 1
+
+    def test_two_running_rows_returns_two(self, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(2,)]
+        assert d._active_agent_count() == 2
+
+    def test_no_row_returns_zero(self, tmp_path: Path) -> None:
+        """Defensive: missing cursor row (None) is treated as zero, not fail-closed.
+
+        ``COUNT(*)`` should always return a row, but if the stub or a
+        malformed DB response returns ``None`` from ``fetchone()``, we
+        treat that as "zero running" rather than the fail-closed
+        sentinel — otherwise every tick after a single malformed read
+        would refuse to spawn.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [None]
+        assert d._active_agent_count() == 0
+
+    def test_db_error_fails_closed(self, tmp_path: Path) -> None:
+        """Fail-closed on DB error: return a sentinel ≥ any realistic cap."""
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        def boom(sql: str, params: Any = None) -> None:
+            raise RuntimeError("connection lost")
+
+        conn.cursor_instance.execute = boom  # type: ignore[method-assign]
+        # Sentinel is large enough that ``count < cap`` is always False
+        # for any realistic concurrency_cap.
+        count = d._active_agent_count()
+        assert count >= 1_000
+        assert conn.rollbacks >= 1
+
+    def test_sql_uses_count_star_and_running_filter(self, tmp_path: Path) -> None:
+        """Lock in the SELECT shape so future refactors don't silently change semantics."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+        d._active_agent_count()
+
+        counts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "COUNT(*)" in e[0] and "dispatcher.agents" in e[0]
+        ]
+        assert counts, "expected _active_agent_count to issue a COUNT(*) SELECT"
+        sql, _params = counts[0]
+        assert "status = 'running'" in sql
+        assert "kind" not in sql, (
+            "_active_agent_count must not carry a kind filter — every row "
+            "is daemon-owned post-#2927. Actual SQL: " + sql
+        )
+
+
+# --------------------------------------------------------------------------
+# scheduler_tick concurrency_cap > 1 gate (#3199)
+# --------------------------------------------------------------------------
+
+
+class TestSchedulerGateCapGreaterThanOne:
+    """The ``scheduler_tick`` gate compares running-agent count to ``concurrency_cap``.
+
+    Pre-#3199 the gate used ``not self._has_active_agent()`` — a
+    binary single-slot check that silently clamped ``cap > 1`` to one
+    concurrent agent. Post-#3199 the gate is
+    ``self._active_agent_count() < concurrency_cap`` so a second slot
+    opens when the first agent's orchestration thread has exited but
+    its ``status='running'`` row is still alive (ECS mode, see #3199).
+    """
+
+    # Cursor fetch sequence per scheduler_tick (all via fetchone; the
+    # fetchall-based SELECTs for commands / retry markers / reap pass
+    # do NOT consume positional slots here):
+    #   0: config SELECT ``concurrency_cap`` → wants ``(cap,)``
+    #   1: config SELECT ``cap_flipped_by``  → wants ``None``
+    #      (via ``_check_circuit_breaker_auto_close`` — cap≥1 only)
+    #   2: config SELECT ``paused``          → wants ``None``
+    #      (via ``_is_paused`` before the gate proper)
+    #   3: COUNT(*) ``dispatcher.agents``    → wants ``(count,)``
+    #      (via ``_active_agent_count`` — the #3199 gate denominator)
+    def test_cap_two_with_zero_running_attempts_spawn(self, tmp_path: Path) -> None:
+        """cap=2, count=0 → gate open, spawn attempted."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(2,), None, None, (0,)]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            return_value=True,
+        )
+        summary = d.scheduler_tick()
+        assert summary["orchestration_attempted"] == 1
+        assert summary["active_agent_count"] == 0
+        assert summary["gate_blocked_on_cap"] == 0
+        assert d._maybe_spawn_orchestration_thread.call_count == 1  # type: ignore[attr-defined]
+
+    def test_cap_two_with_one_running_still_spawns(self, tmp_path: Path) -> None:
+        """cap=2, count=1 → 1 < 2 so the gate is OPEN — this is the #3199 fix.
+
+        Pre-#3199 the gate closed on ANY active agent; with cap=2 this
+        meant the second slot was never claimed. Post-#3199 the gate
+        opens because ``1 < 2`` is True.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(2,), None, None, (1,)]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            return_value=True,
+        )
+        summary = d.scheduler_tick()
+        assert summary["orchestration_attempted"] == 1
+        assert summary["active_agent_count"] == 1
+        assert summary["gate_blocked_on_cap"] == 0
+
+    def test_cap_two_with_two_running_closes_gate(self, tmp_path: Path) -> None:
+        """cap=2, count=2 → 2 < 2 is False, gate closed, no spawn."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(2,), None, None, (2,)]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            side_effect=AssertionError("must not spawn when count == cap")
+        )
+        summary = d.scheduler_tick()
+        assert summary["orchestration_attempted"] == 0
+        assert summary["active_agent_count"] == 2
+        assert summary["gate_blocked_on_cap"] == 1
+
+    def test_three_tick_sequence_cap_two_count_zero_one_two(
+        self, tmp_path: Path
+    ) -> None:
+        """Three consecutive ticks at cap=2 with active_agent_count going 0→1→2.
+
+        This is the AC #3 regression: stub ``_active_agent_count`` to
+        return 0, 1, 2 over three ticks with cap=2 and assert
+        ``orchestration_attempted`` is True on ticks 1 and 2 (count
+        strictly less than cap) and False on tick 3 (count == cap).
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+
+        counts = iter([0, 1, 2])
+        d._active_agent_count = lambda: next(counts)  # type: ignore[method-assign]
+        spawn_mock = MagicMock(return_value=True)
+        d._maybe_spawn_orchestration_thread = spawn_mock  # type: ignore[method-assign]
+
+        results: list[dict[str, Any]] = []
+        for _ in range(3):
+            # Per-tick fetch_queue: config cap=2, cap_flipped_by None,
+            # _is_paused None. ``_active_agent_count`` is stubbed above
+            # so we don't feed a COUNT(*) response through fetch_queue.
+            conn.cursor_instance.fetch_queue = [(2,), None, None]
+            results.append(d.scheduler_tick())
+
+        assert results[0]["orchestration_attempted"] == 1
+        assert results[0]["active_agent_count"] == 0
+        assert results[1]["orchestration_attempted"] == 1
+        assert results[1]["active_agent_count"] == 1
+        assert results[2]["orchestration_attempted"] == 0
+        assert results[2]["active_agent_count"] == 2
+        assert results[2]["gate_blocked_on_cap"] == 1
+        # ``_maybe_spawn_orchestration_thread`` called on ticks 1 and
+        # 2 only — not on the tick that hit the cap.
+        assert spawn_mock.call_count == 2
+
+    def test_cap_one_regression_count_zero_spawns(self, tmp_path: Path) -> None:
+        """Regression: cap=1 behaviour unchanged from pre-#3199.
+
+        ``0 < 1`` is True → spawn attempted — identical to the old
+        ``not _has_active_agent()`` check when no agents are running.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(1,), None, None, (0,)]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            return_value=True,
+        )
+        summary = d.scheduler_tick()
+        assert summary["orchestration_attempted"] == 1
+        assert summary["active_agent_count"] == 0
+
+    def test_cap_one_regression_count_one_closes_gate(self, tmp_path: Path) -> None:
+        """Regression: cap=1, count=1 → gate closed (pre-#3199 parity).
+
+        ``1 < 1`` is False — identical semantics to the old binary
+        ``_has_active_agent()`` check.
+        """
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(1,), None, None, (1,)]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            side_effect=AssertionError("must not spawn when count == cap=1")
+        )
+        summary = d.scheduler_tick()
+        assert summary["orchestration_attempted"] == 0
+        assert summary["active_agent_count"] == 1
+        assert summary["gate_blocked_on_cap"] == 1
+
+    def test_log_event_includes_active_agent_count(self, tmp_path: Path) -> None:
+        """``scheduler_tick`` log event carries ``active_agent_count``.
+
+        AC #2 — CloudWatch Insights can self-diagnose the gate decision
+        without inspecting the DB.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(2,), None, None, (1,)]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            return_value=True,
+        )
+        d.scheduler_tick()
+
+        events = handler.events("scheduler_tick")
+        assert events, "expected a scheduler_tick log event"
+        record = events[-1]
+        assert getattr(record, "active_agent_count", "MISSING") == 1
+        assert getattr(record, "gate_blocked_on_cap", "MISSING") is False
+
+    def test_log_event_active_count_none_when_rate_skipped(
+        self, tmp_path: Path
+    ) -> None:
+        """Rate-skipped tick logs ``active_agent_count=None`` — gate never read the DB."""
+        d, conn, handler = _make_daemon(tmp_path)
+        # Mark the GH rate-limit skip flag as active so the claim gate
+        # short-circuits before reading the agent count.
+        d._gh_rate_skip_active = lambda: True  # type: ignore[method-assign]
+        # config cap=2 + cap_flipped_by None (circuit-breaker auto-close
+        # check still fires ahead of the rate-skip branch).
+        conn.cursor_instance.fetch_queue = [(2,), None]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            side_effect=AssertionError("must not spawn when rate-skipped")
+        )
+        d.scheduler_tick()
+
+        events = handler.events("scheduler_tick")
+        assert events
+        record = events[-1]
+        assert getattr(record, "active_agent_count", "MISSING") is None
+        assert getattr(record, "gate_blocked_on_cap", "MISSING") is None
+
+
+# --------------------------------------------------------------------------
 # _latest_queue_snapshot_issues
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Replaces the single-slot `not _has_active_agent()` orchestration gate in `scheduler_tick` with a count-vs-cap comparison (`_active_agent_count() < concurrency_cap`) so `concurrency_cap > 1` actually claims a second ECS slot. Pre-fix the daemon silently clamped every configuration to cap=1 — Phase 4 ECS parallelism was a config-surface-only feature with no effect. Adds `active_agent_count` + `gate_blocked_on_cap` to the `scheduler_tick` structured log event and return summary for CloudWatch self-diagnosis. `_has_active_agent()` stays — still used by the #3184 supervisor orphan-detection guard.

Closes #3199

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `deploy-dispatcher.yml` completes successfully; verify the new daemon image is running via `scripts/verify-pr-in-deployed-sha.sh <pr>`
- [x] With `dispatcher.config.concurrency_cap=2` in place, observe 2 concurrent `status='running'` rows in `dispatcher.agents` within 2 scheduler ticks (~60s) of the new daemon coming up, while `queue_depth > 0`
- [x] CloudWatch Insights query confirms `active_agent_count` and `gate_blocked_on_cap` fields appear in `scheduler_tick` log events
- [x] Verification evidence posted on issue (see A.8)
