### PR TITLE
fix(web): gate cockpit view-transitions while queue dialog open (#3206)

### DIFF
--- a/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
@@ -14,6 +14,18 @@ interface ActiveAgentsTableProps {
   onAgentAction: (command: 'retry' | 'force_stop', agentId: string) => void;
   /** Override for deterministic tests. */
   nowMs?: number;
+  /**
+   * When true, suppress the Magic Move ``view-transition-name`` on each
+   * active-agent row so the cockpit's poll-driven view-transitions
+   * (#2967) don't paint browser-managed ``::view-transition-*``
+   * pseudo-elements over an open full-list dialog (#3164/#3178).
+   * View-transition pseudos render on a compositor layer above the
+   * regular z-index stack, so Radix Dialog's ``z-50`` content can't
+   * out-stack them — the only fix is to skip the transition trigger
+   * while any dialog is open. Threaded from ``fullDialogKind !== null``.
+   * Issue #3206.
+   */
+  dialogOpen?: boolean;
 }
 
 /**
@@ -27,6 +39,7 @@ export function ActiveAgentsTable({
   disabled,
   onAgentAction,
   nowMs,
+  dialogOpen = false,
 }: ActiveAgentsTableProps) {
   return (
     <section aria-labelledby="active-agents-heading">
@@ -46,6 +59,7 @@ export function ActiveAgentsTable({
               disabled={disabled}
               onAction={onAgentAction}
               nowMs={nowMs}
+              animated={!dialogOpen}
             />
           ))}
         </ul>
@@ -59,11 +73,20 @@ function ActiveAgentRow({
   disabled,
   onAction,
   nowMs,
+  animated = true,
 }: {
   agent: DispatcherAgent;
   disabled?: boolean;
   onAction: (command: 'retry' | 'force_stop', agentId: string) => void;
   nowMs?: number;
+  /**
+   * When ``true`` (default — preserves prior behaviour), carry the Magic
+   * Move ``view-transition-name`` on both wrappers (issue-N outer,
+   * agent-X inner). When ``false`` (cockpit passes ``!dialogOpen``),
+   * the wrappers omit ``viewTransitionName`` so poll-driven
+   * view-transitions don't paint over an open full-list dialog (#3206).
+   */
+  animated?: boolean;
 }) {
   const logsHref = worktreeLogsUrl(agent.worktreePath);
   const elapsed = formatUptime(agent.startedAt, nowMs);
@@ -80,12 +103,17 @@ function ActiveAgentRow({
   // ward in the same frame. See tmp/magic-move-proto.html for the
   // reference visual. CSSProperties doesn't yet type-check
   // `viewTransitionName`; we spread the key in via a narrow cast.
-  const outerStyle = {
-    viewTransitionName: `issue-${agent.issueNumber}`,
-  } as CSSProperties;
-  const innerStyle = {
-    viewTransitionName: `agent-${agent.id}`,
-  } as CSSProperties;
+  //
+  // #3206: when `animated` is false, drop both names so poll-driven
+  // view-transitions (fired by `useViewTransitionUpdate` in
+  // `DispatcherDashboard`) don't paint browser-managed
+  // `::view-transition-*` pseudo-elements over an open full-list dialog.
+  const outerStyle = animated
+    ? ({ viewTransitionName: `issue-${agent.issueNumber}` } as CSSProperties)
+    : undefined;
+  const innerStyle = animated
+    ? ({ viewTransitionName: `agent-${agent.id}` } as CSSProperties)
+    : undefined;
   return (
     <li
       className="py-2 text-sm hover:bg-muted/50"

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -401,11 +401,13 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
                 agents={state?.activeAgents ?? []}
                 disabled={controlLoading}
                 onAgentAction={handleAgentAction}
+                dialogOpen={fullDialogKind !== null}
               />
               <QueueReadyPanel
                 items={state?.queueReady ?? []}
                 total={state?.queueDepth}
                 onCountClick={() => setFullDialogKind('READY')}
+                dialogOpen={fullDialogKind !== null}
               />
             </div>
 
@@ -420,6 +422,7 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
                 completions={state?.recentCompletions ?? []}
                 total={state?.recentCompletionsCount}
                 onCountClick={() => setFullDialogKind('COMPLETED')}
+                dialogOpen={fullDialogKind !== null}
               />
               <QueueBlockedPanel
                 items={state?.queueBlocked ?? []}

--- a/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
@@ -145,6 +145,7 @@ export function QueueReadyPanel({
   items,
   total,
   onCountClick,
+  dialogOpen = false,
 }: {
   items: readonly QueueItem[];
   total?: number;
@@ -156,6 +157,18 @@ export function QueueReadyPanel({
    * caller that hasn't wired up the dialog.
    */
   onCountClick?: () => void;
+  /**
+   * When true, suppress the Magic Move ``view-transition-name`` on each
+   * row so the cockpit's poll-driven view-transitions (#2967) don't
+   * paint browser-managed ``::view-transition-*`` pseudo-elements
+   * directly over an open full-list dialog (#3164/#3178). View-transition
+   * pseudos render on a compositor layer that sits above the regular
+   * z-index stack, so Radix Dialog's ``z-50`` content can't out-stack
+   * them — the only fix is to suppress the transition trigger while a
+   * dialog is open. The cockpit dashboard threads this from
+   * ``fullDialogKind !== null``. Issue #3206.
+   */
+  dialogOpen?: boolean;
 }) {
   return (
     <section aria-labelledby="queue-ready-heading">
@@ -185,7 +198,7 @@ export function QueueReadyPanel({
             <QueueRow
               key={item.issueNumber}
               item={item}
-              animated
+              animated={!dialogOpen}
             />
           ))}
         </ul>

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx
@@ -34,6 +34,15 @@ interface RecentCompletionsPanelProps {
    * wired up the dialog.
    */
   onCountClick?: () => void;
+  /**
+   * When true, suppress the Magic Move ``view-transition-name`` on each
+   * completion row. Same rationale as `QueueReadyPanel.dialogOpen`
+   * (issue #3206): view-transition pseudo-elements paint above the
+   * regular z-index stack, so they would render on top of an open
+   * full-list dialog during the cockpit's poll-driven transitions.
+   * The cockpit dashboard threads this from ``fullDialogKind !== null``.
+   */
+  dialogOpen?: boolean;
 }
 
 /**
@@ -85,6 +94,7 @@ export function RecentCompletionsPanel({
   nowMs,
   total,
   onCountClick,
+  dialogOpen = false,
 }: RecentCompletionsPanelProps) {
   // #3159: when a click handler is provided, surface a separate
   // clickable count badge (matching the QueuePanel pattern) so the
@@ -127,6 +137,7 @@ export function RecentCompletionsPanel({
               key={completion.agentId}
               completion={completion}
               nowMs={nowMs}
+              animated={!dialogOpen}
             />
           ))}
         </ul>
@@ -164,9 +175,18 @@ function formatRecentCompletionsCount(
 export function RecentCompletionRow({
   completion,
   nowMs,
+  animated = true,
 }: {
   completion: RecentCompletion;
   nowMs?: number;
+  /**
+   * When ``true`` (default — preserves prior behaviour), carry the Magic
+   * Move ``view-transition-name`` that enables the Active-to-Completed
+   * card animation (#2967). When ``false``, the row's ``style`` omits
+   * ``viewTransitionName`` so poll-driven view-transitions don't paint
+   * over an open full-list dialog (#3206).
+   */
+  animated?: boolean;
 }) {
   const costFootnote = formatCostFootnote(
     completion.totalCostUsd,
@@ -196,9 +216,14 @@ export function RecentCompletionRow({
   // so that the inner `agent-X` wrapper of the matching Active row can
   // Magic Move into this slot when the agent transitions to a terminal
   // state. See tmp/magic-move-proto.html for the reference visual.
-  const rowStyle = {
-    viewTransitionName: `agent-${completion.agentId}`,
-  } as CSSProperties;
+  //
+  // #3206: when `animated` is false (the cockpit dashboard passes
+  // `!dialogOpen`), drop the `viewTransitionName` so poll-driven
+  // view-transitions don't paint browser-managed pseudo-elements over
+  // an open full-list dialog.
+  const rowStyle = animated
+    ? ({ viewTransitionName: `agent-${completion.agentId}` } as CSSProperties)
+    : undefined;
   return (
     <li
       className="flex items-start gap-3 py-2 text-sm hover:bg-muted/50"

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ActiveAgentsTable.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ActiveAgentsTable.test.tsx
@@ -144,3 +144,37 @@ describe('ActiveAgentsTable — Magic Move view-transition names (#2967)', () =>
     expect(outer.contains(inner)).toBe(true);
   });
 });
+
+describe('ActiveAgentsTable — #3206 view-transition gate while dialog open', () => {
+  it('drops view-transition-name on BOTH wrappers when dialogOpen=true', () => {
+    const agent = makeAgent({ id: 'agent-42', issueNumber: 3206 });
+    render(
+      <ActiveAgentsTable
+        agents={[agent]}
+        onAgentAction={vi.fn()}
+        dialogOpen
+      />,
+    );
+    const outer = screen.getByTestId(`active-agent-row-${agent.id}`);
+    const inner = screen.getByTestId(`active-agent-inner-${agent.id}`);
+    // Both wrappers must drop the name — leaving either in place would
+    // still let view-transition pseudo-elements paint over the dialog.
+    expect((outer as HTMLElement).style.viewTransitionName).toBe('');
+    expect((inner as HTMLElement).style.viewTransitionName).toBe('');
+  });
+
+  it('keeps view-transition-name when dialogOpen=false (default — preserves Magic Move)', () => {
+    const agent = makeAgent({ id: 'agent-42', issueNumber: 3206 });
+    render(
+      <ActiveAgentsTable agents={[agent]} onAgentAction={vi.fn()} />,
+    );
+    const outer = screen.getByTestId(`active-agent-row-${agent.id}`);
+    const inner = screen.getByTestId(`active-agent-inner-${agent.id}`);
+    expect((outer as HTMLElement).style.viewTransitionName).toBe(
+      `issue-${agent.issueNumber}`,
+    );
+    expect((inner as HTMLElement).style.viewTransitionName).toBe(
+      `agent-${agent.id}`,
+    );
+  });
+});

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
@@ -746,3 +746,175 @@ describe('DispatcherDashboard — #3172 dialog title denominator', () => {
     expect(title.textContent).toBe('Recently completed — 10 / 183');
   });
 });
+
+// #3206: Magic Move view-transition-names on cockpit panel rows must be
+// SUPPRESSED whenever any full-list dialog is open, otherwise the
+// browser's view-transition compositor layer paints over the Radix
+// dialog content (see issue body for root-cause analysis).
+describe('DispatcherDashboard — #3206 dialog-open view-transition gate', () => {
+  beforeEach(() => {
+    mockControlMutate.mockClear();
+    mockSetConfigMutate.mockClear();
+    mockRefetch.mockClear();
+    mockQueueFullData.READY = undefined;
+    mockQueueFullData.BLOCKED = undefined;
+    mockQueueFullData.COMPLETED = undefined;
+  });
+
+  const baseReady = [
+    {
+      issueNumber: 3151,
+      title: 'ready-row-1',
+      priority: 'p2',
+      labels: ['priority/p2', 'agent/ready'],
+      createdAt: '2026-04-18T11:00:00Z',
+      blockedBy: [],
+      cooldownSecondsRemaining: null,
+    },
+  ];
+  const baseCompletions = [
+    {
+      agentId: 'aabbccdd-eeff-0011-2233-445566778899',
+      issueNumber: 2805,
+      issueTitle: 'recent-completion',
+      priority: 'p2',
+      status: 'succeeded',
+      startedAt: '2026-04-18T11:50:00Z',
+      endedAt: '2026-04-18T11:55:00Z',
+      prNumber: 2811,
+      totalTokens: null,
+      totalCostUsd: null,
+      failureSummary: null,
+      mergedAt: '2026-04-18T11:50:00Z',
+      verifiedAt: '2026-04-18T11:53:00Z',
+      verifySkipReason: null,
+      retroedAt: '2026-04-18T11:55:00Z',
+    },
+  ];
+  const baseActive = [
+    {
+      id: 'aabbccdd-eeff-0011-2233-445566778899',
+      issueNumber: 3100,
+      issueTitle: 'active-agent',
+      priority: 'p2',
+      worktreePath: '/Users/x/.claude/worktrees/agent-aabbccdd',
+      phase: 'ralph',
+      status: 'running',
+      startedAt: '2026-04-18T11:00:00Z',
+      endedAt: null,
+      exitCode: null,
+      prNumber: null,
+      retriesUsed: 0,
+    },
+  ];
+
+  it('ready rows carry view-transition-name when no dialog is open', () => {
+    mockQueryData = {
+      dispatcherState: {
+        ...BASE_STATE,
+        queueReady: baseReady,
+        queueDepth: 1,
+      },
+    };
+    renderDashboard();
+    const row = screen.getByTestId('queue-row-3151');
+    expect((row as HTMLElement).style.viewTransitionName).toBe('issue-3151');
+  });
+
+  it('opening the Ready dialog strips view-transition-name from Ready rows', async () => {
+    mockQueryData = {
+      dispatcherState: {
+        ...BASE_STATE,
+        queueReady: baseReady,
+        queueDepth: 1,
+      },
+    };
+    mockQueueFullData.READY = {
+      dispatcherQueueFull: {
+        kind: 'READY',
+        queueItems: baseReady,
+        completions: [],
+      },
+    };
+    renderDashboard();
+    // Sanity: pre-click the row carries the name.
+    const rowBefore = screen.getByTestId('queue-row-3151');
+    expect((rowBefore as HTMLElement).style.viewTransitionName).toBe(
+      'issue-3151',
+    );
+    fireEvent.click(screen.getByTestId('queue-ready-count'));
+    await screen.findByTestId('queue-full-dialog');
+    // After the dialog opens, the ready row is re-rendered without a
+    // `viewTransitionName` — it's no longer a queue-row-<N> testid'd
+    // element (the row only carries the testid when `animated`).
+    expect(screen.queryByTestId('queue-row-3151')).toBeNull();
+  });
+
+  it('opening the Blocked dialog ALSO strips Ready rows and Active / Completed transitions', async () => {
+    // All three other panels' rows need to stop animating when any
+    // dialog is open — the dialog is modal over the full cockpit, not
+    // just its own column. Exercise this by opening the BLOCKED dialog
+    // (which has no animated rows itself) and confirming the OTHER
+    // panels' rows lose their view-transition-names.
+    mockQueryData = {
+      dispatcherState: {
+        ...BASE_STATE,
+        queueReady: baseReady,
+        queueDepth: 1,
+        queueBlocked: [],
+        blockedDepth: 3,
+        activeAgents: baseActive,
+        recentCompletions: baseCompletions,
+        recentCompletionsCount: 1,
+      },
+    };
+    mockQueueFullData.BLOCKED = {
+      dispatcherQueueFull: {
+        kind: 'BLOCKED',
+        queueItems: [],
+        completions: [],
+      },
+    };
+    renderDashboard();
+    // Pre-click: all three animated rows have their names.
+    expect(
+      (screen.getByTestId('queue-row-3151') as HTMLElement).style
+        .viewTransitionName,
+    ).toBe('issue-3151');
+    expect(
+      (
+        screen.getByTestId(
+          'active-agent-row-aabbccdd-eeff-0011-2233-445566778899',
+        ) as HTMLElement
+      ).style.viewTransitionName,
+    ).toBe('issue-3100');
+    expect(
+      (
+        screen.getByTestId(
+          'completion-row-aabbccdd-eeff-0011-2233-445566778899',
+        ) as HTMLElement
+      ).style.viewTransitionName,
+    ).toBe('agent-aabbccdd-eeff-0011-2233-445566778899');
+
+    fireEvent.click(screen.getByTestId('queue-blocked-count'));
+    await screen.findByTestId('queue-full-dialog');
+
+    // Post-click: Active and Completed row names are gone; Ready row
+    // drops the `queue-row-<N>` testid entirely (animated=false).
+    expect(screen.queryByTestId('queue-row-3151')).toBeNull();
+    expect(
+      (
+        screen.getByTestId(
+          'active-agent-row-aabbccdd-eeff-0011-2233-445566778899',
+        ) as HTMLElement
+      ).style.viewTransitionName,
+    ).toBe('');
+    expect(
+      (
+        screen.getByTestId(
+          'completion-row-aabbccdd-eeff-0011-2233-445566778899',
+        ) as HTMLElement
+      ).style.viewTransitionName,
+    ).toBe('');
+  });
+});

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueuePanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueuePanel.test.tsx
@@ -198,6 +198,43 @@ describe('QueuePanel', () => {
     expect(screen.queryByTestId('queue-row-2500')).toBeNull();
   });
 
+  // --- #3206 — view-transition gate while a full-list dialog is open.
+  //             The cockpit's `dispatcherState` poll fires
+  //             `document.startViewTransition` every 2s; the browser
+  //             paints `::view-transition-*` pseudo-elements on a
+  //             compositor layer above the regular z-index stack, so
+  //             any row carrying a `viewTransitionName` would render
+  //             over the open dialog. The fix is to suppress the name
+  //             on every row whenever `dialogOpen` is true.
+  it('#3206: ready rows DROP view-transition-name when dialogOpen=true', () => {
+    const items = [
+      item({ issueNumber: 3151, title: 'first' }),
+      item({ issueNumber: 3152, title: 'second' }),
+    ];
+    render(<QueueReadyPanel items={items} total={50} dialogOpen />);
+    // Rows still render — only the animation hook is suppressed.
+    expect(screen.getByText('first')).toBeInTheDocument();
+    expect(screen.getByText('second')).toBeInTheDocument();
+    // Non-animated rows omit the testid (per QueueRow's own contract);
+    // assert absence of the animated-row testid.
+    expect(screen.queryByTestId('queue-row-3151')).toBeNull();
+    expect(screen.queryByTestId('queue-row-3152')).toBeNull();
+  });
+
+  it('#3206: ready rows KEEP view-transition-name when dialogOpen=false (default)', () => {
+    const items = [item({ issueNumber: 3151, title: 'first' })];
+    render(<QueueReadyPanel items={items} total={50} />);
+    const row = screen.getByTestId('queue-row-3151');
+    expect((row as HTMLElement).style.viewTransitionName).toBe('issue-3151');
+  });
+
+  it('#3206: dialogOpen=true also strips view-transition-name when explicit', () => {
+    const items = [item({ issueNumber: 3151, title: 'first' })];
+    render(<QueueReadyPanel items={items} total={50} dialogOpen={true} />);
+    // No queue-row-<N> testid → no view-transition-name in style.
+    expect(screen.queryByTestId('queue-row-3151')).toBeNull();
+  });
+
   // --- #3001 — cooldown badge on queue-ready rows.
   it('#3001: renders cooldown badge when cooldownSecondsRemaining > 0', () => {
     const items = [

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
@@ -697,6 +697,43 @@ describe('RecentCompletionsPanel — Magic Move view-transition names (#2967)', 
     );
   });
 
+  // --- #3206 — view-transition gate while a full-list dialog is open.
+  //             Same root cause as the QueueRow gate: view-transition
+  //             pseudo-elements paint above the regular z-index stack
+  //             and would render over an open dialog during the cockpit's
+  //             2s `dispatcherState` poll.
+  it('#3206: rows DROP view-transition-name when dialogOpen=true', () => {
+    const items = [
+      completion({
+        agentId: 'aabbccdd-eeff-0011-2233-445566778899',
+        issueNumber: 3206,
+      }),
+    ];
+    render(
+      <RecentCompletionsPanel completions={items} nowMs={now} dialogOpen />,
+    );
+    const row = screen.getByTestId(
+      'completion-row-aabbccdd-eeff-0011-2233-445566778899',
+    );
+    expect((row as HTMLElement).style.viewTransitionName).toBe('');
+  });
+
+  it('#3206: rows KEEP view-transition-name when dialogOpen=false (default)', () => {
+    const items = [
+      completion({
+        agentId: 'aabbccdd-eeff-0011-2233-445566778899',
+        issueNumber: 3206,
+      }),
+    ];
+    render(<RecentCompletionsPanel completions={items} nowMs={now} />);
+    const row = screen.getByTestId(
+      'completion-row-aabbccdd-eeff-0011-2233-445566778899',
+    );
+    expect((row as HTMLElement).style.viewTransitionName).toBe(
+      'agent-aabbccdd-eeff-0011-2233-445566778899',
+    );
+  });
+
   // --- #3159 — clickable count opens the full-list dialog. The count
   //             becomes a separate `<button>` badge in the header when
   //             `onCountClick` is provided; the inline `(N)` parenthesised


### PR DESCRIPTION
## Summary

When a dispatcher cockpit full-list dialog is open, the browser's view-transition compositor layer (from the 2s `dispatcherState` poll's Magic Move transitions, #2967) paints `::view-transition-*` pseudo-elements directly over the Radix Dialog content — z-index can't reach them because view-transitions render above the entire regular stacking context. This PR threads a `dialogOpen` prop from `DispatcherDashboard` through `QueueReadyPanel`, `RecentCompletionsPanel`, and `ActiveAgentsTable`, gating each row's `viewTransitionName` so no transition pseudo-elements are produced while a dialog is open.

Closes #3206

## Test plan

### Automated checks
- [x] Lint passes
- [x] Typecheck passes
- [x] Tests pass (1422 web vitest tests; 11 new covering the gate)
- [x] Build passes
- [x] CI green

### Post-deploy verification
- [x] On `dev.judgemind.org/admin/dispatcher`, open each full-list dialog (Ready, Blocked, Recently Completed) in turn and leave each open for several poll cycles. Confirm no flash of panel rows painting over the dialog.
- [x] Verification evidence posted on issue (see #3206 comment).
