### PR TITLE
fix(dispatcher): classify StatusContext + early-exit merged PRs in awaiting_ci (#3200)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -2349,6 +2349,18 @@ classify_pr_rollup() {
     # mergeStateStatus`` stdout. Prints one of: green / red / pending /
     # error. Mirrors ``_ci_rollup_state`` in phase_transitions.py so
     # the ECS path uses the same merge gate as subprocess mode.
+    #
+    # statusCheckRollup is a heterogeneous list:
+    #   * CheckRun entries have ``.status`` + ``.conclusion`` (GitHub
+    #     Actions, container-based check runs).
+    #   * StatusContext entries have ``.state`` only (commit-status API,
+    #     third-party integrations like Vercel).
+    #
+    # We branch on ``.__typename`` so Vercel-style StatusContext entries
+    # classify correctly. Before #3200 the jq program only looked at
+    # ``.status`` + ``.conclusion`` and fell through to "pending" for
+    # any StatusContext entry — so every PR that exposed a Vercel
+    # status stayed pending forever and every ECS agent timed out.
     _status_file="$1"
     if [[ ! -s "$_status_file" ]]; then
         printf 'error'
@@ -2361,16 +2373,28 @@ classify_pr_rollup() {
             (.statusCheckRollup // []) as $rollup
             | ($rollup | map(select(type == "object"))) as $checks
             | ([$checks[]
-                | (.status // "" | ascii_upcase) as $st
-                | (.conclusion // "" | ascii_upcase) as $co
-                | if $st == "COMPLETED" then
-                      if ($co == "FAILURE" or $co == "CANCELLED"
-                          or $co == "TIMED_OUT" or $co == "ACTION_REQUIRED"
-                          or $co == "STARTUP_FAILURE") then "red"
-                      elif ($co == "SUCCESS" or $co == "SKIPPED"
-                            or $co == "NEUTRAL" or $co == "STALE") then "ok"
-                      else "red" end
-                  else "pending" end]) as $outcomes
+                | (.__typename // "" | ascii_upcase) as $tn
+                | if $tn == "STATUSCONTEXT" then
+                      # Commit-status API entries (Vercel, etc.): only
+                      # ``.state`` is populated. State vocabulary:
+                      # EXPECTED / PENDING / SUCCESS / FAILURE / ERROR.
+                      (.state // "" | ascii_upcase) as $cs
+                      | if ($cs == "FAILURE" or $cs == "ERROR") then "red"
+                        elif ($cs == "SUCCESS" or $cs == "NEUTRAL") then "ok"
+                        else "pending" end
+                  else
+                      # CheckRun (default) — the pre-#3200 code path.
+                      (.status // "" | ascii_upcase) as $st
+                      | (.conclusion // "" | ascii_upcase) as $co
+                      | if $st == "COMPLETED" then
+                            if ($co == "FAILURE" or $co == "CANCELLED"
+                                or $co == "TIMED_OUT" or $co == "ACTION_REQUIRED"
+                                or $co == "STARTUP_FAILURE") then "red"
+                            elif ($co == "SUCCESS" or $co == "SKIPPED"
+                                  or $co == "NEUTRAL" or $co == "STALE") then "ok"
+                            else "red" end
+                        else "pending" end
+                  end]) as $outcomes
             | if ($outcomes | index("red")) then "red"
               elif ($outcomes | index("pending")) then "pending"
               else
@@ -2509,6 +2533,23 @@ handle_awaiting_ci() {
             return 0
         fi
         if fetch_pr_status "$_pr_number"; then
+            # #3200 early-exit — after the PR is merged, ``mergeable``
+            # and ``mergeStateStatus`` both flip to ``UNKNOWN`` while
+            # ``mergeCommit.oid`` is populated with the squash SHA. The
+            # rollup classifier cannot distinguish "pending + UNKNOWN"
+            # from "merged + UNKNOWN" from the rollup alone, so short-
+            # circuit the poll on merge-commit presence.
+            _merge_oid_check=$(jq -r '.mergeCommit.oid // ""' \
+                "$AGENT_WORKSPACE/pr-status.json" 2>/dev/null || printf '')
+            if [[ -n "$_merge_oid_check" ]]; then
+                log "awaiting_ci_already_merged" \
+                    "pr_number=$_pr_number" \
+                    "merge_sha=$_merge_oid_check" \
+                    "rollup_state=green"
+                printf '{"rollup_state": "green", "pr_number": %s, "already_merged": true}' \
+                    "$_pr_number"
+                return 0
+            fi
             _state=$(classify_pr_rollup "$AGENT_WORKSPACE/pr-status.json")
             _fetch_rc=0
         else

--- a/scripts/dispatcher/phase_transitions.py
+++ b/scripts/dispatcher/phase_transitions.py
@@ -760,6 +760,12 @@ _CI_FAILURE_CONCLUSIONS: frozenset[str] = frozenset(
 #: Check-run conclusions that count as green.
 _CI_SUCCESS_CONCLUSIONS: frozenset[str] = frozenset({"SUCCESS", "SKIPPED", "NEUTRAL"})
 
+#: StatusContext (commit-status API, e.g. Vercel) states that count as red.
+_CI_STATUSCONTEXT_FAILURE_STATES: frozenset[str] = frozenset({"FAILURE", "ERROR"})
+
+#: StatusContext states that count as green.
+_CI_STATUSCONTEXT_SUCCESS_STATES: frozenset[str] = frozenset({"SUCCESS", "NEUTRAL"})
+
 
 def _ci_rollup_state(pr_status: Mapping[str, Any] | None) -> str:
     """Classify a ``gh pr view --json`` rollup as green / red / pending.
@@ -769,12 +775,25 @@ def _ci_rollup_state(pr_status: Mapping[str, Any] | None) -> str:
     the agent-runner can use it identically without duplicating the
     check-run conclusion constants.
 
+    statusCheckRollup is a heterogeneous list:
+
+    * ``CheckRun`` entries have ``.status`` + ``.conclusion`` (GitHub
+      Actions, container-based check runs).
+    * ``StatusContext`` entries have ``.state`` only (commit-status
+      API, third-party integrations like Vercel). Before #3200 this
+      function only inspected ``.status`` + ``.conclusion`` and fell
+      through to "pending" for any StatusContext entry — so every PR
+      that exposed a Vercel status stayed pending forever.
+
     Rules (short-circuit ordering):
 
-    1. If any check has a RED conclusion (FAILURE / CANCELLED /
-       TIMED_OUT / ACTION_REQUIRED / STARTUP_FAILURE) → red.
-    2. If any check is not yet COMPLETED (status in_progress /
-       queued / pending) → pending.
+    1. If any check has a RED outcome (CheckRun conclusion in
+       FAILURE / CANCELLED / TIMED_OUT / ACTION_REQUIRED /
+       STARTUP_FAILURE, or StatusContext state in FAILURE / ERROR)
+       → red.
+    2. If any check is not yet complete (CheckRun status
+       in_progress / queued / pending, or StatusContext state
+       EXPECTED / PENDING) → pending.
     3. If mergeable is not ``MERGEABLE`` or mergeStateStatus is not
        ``CLEAN`` → pending (the merge-conflict polling path; we
        treat it as "not ready yet" rather than red).
@@ -791,6 +810,18 @@ def _ci_rollup_state(pr_status: Mapping[str, Any] | None) -> str:
     for check in rollup:
         if not isinstance(check, dict):
             continue
+        typename = str(check.get("__typename") or "").upper()
+        if typename == "STATUSCONTEXT":
+            state = str(check.get("state") or "").upper()
+            if state in _CI_STATUSCONTEXT_FAILURE_STATES:
+                return "red"
+            if state in _CI_STATUSCONTEXT_SUCCESS_STATES:
+                continue
+            # EXPECTED / PENDING / unknown / "" → not yet done.
+            any_pending = True
+            continue
+
+        # CheckRun (default) — pre-#3200 code path.
         status = str(check.get("status") or "").upper()
         conclusion = str(check.get("conclusion") or "").upper()
         if status == "COMPLETED":

--- a/scripts/dispatcher/tests/test_phase_transitions.py
+++ b/scripts/dispatcher/tests/test_phase_transitions.py
@@ -366,6 +366,126 @@ class TestTransitionFromAwaitingCi:
         result = pt.transition_from_awaiting_ci(status)
         assert result.next_phase == pt.PHASE_MERGE
 
+    # ----- #3200 StatusContext coverage ------------------------------------
+
+    def test_statuscontext_success_counts_as_green(self) -> None:
+        # Regression for #3200 — the live-reproducible bug: Vercel-
+        # style StatusContext entries have no ``.status``/``.conclusion``,
+        # only ``.state``. Pre-fix the classifier fell through to
+        # "pending" so every PR with a Vercel status was stuck.
+        status = self._make_status(
+            [
+                {
+                    "__typename": "CheckRun",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "name": "lint",
+                },
+                {
+                    "__typename": "StatusContext",
+                    "context": "Vercel",
+                    "state": "SUCCESS",
+                },
+            ]
+        )
+        result = pt.transition_from_awaiting_ci(status)
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_MERGE
+
+    def test_statuscontext_failure_counts_as_red(self) -> None:
+        status = self._make_status(
+            [
+                {
+                    "__typename": "StatusContext",
+                    "context": "Vercel",
+                    "state": "FAILURE",
+                },
+            ]
+        )
+        result = pt.transition_from_awaiting_ci(status)
+        assert result.next_phase == pt.PHASE_FIX_CI
+
+    def test_statuscontext_error_counts_as_red(self) -> None:
+        status = self._make_status(
+            [
+                {
+                    "__typename": "StatusContext",
+                    "context": "build",
+                    "state": "ERROR",
+                },
+            ]
+        )
+        result = pt.transition_from_awaiting_ci(status)
+        assert result.next_phase == pt.PHASE_FIX_CI
+
+    def test_statuscontext_pending_stays_pending(self) -> None:
+        # PENDING / EXPECTED state — StatusContext entry hasn't
+        # completed; must stay in awaiting_ci rather than returning
+        # green.
+        status = self._make_status(
+            [
+                {
+                    "__typename": "CheckRun",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "name": "lint",
+                },
+                {
+                    "__typename": "StatusContext",
+                    "context": "Vercel",
+                    "state": "PENDING",
+                },
+            ]
+        )
+        result = pt.transition_from_awaiting_ci(status)
+        assert result.next_phase == pt.PHASE_AWAITING_CI
+
+    def test_statuscontext_expected_stays_pending(self) -> None:
+        status = self._make_status(
+            [
+                {
+                    "__typename": "StatusContext",
+                    "context": "Vercel",
+                    "state": "EXPECTED",
+                },
+            ]
+        )
+        result = pt.transition_from_awaiting_ci(status)
+        assert result.next_phase == pt.PHASE_AWAITING_CI
+
+    def test_mixed_checkrun_and_statuscontext_all_green(self) -> None:
+        # Real PR #3198 shape — 3 CheckRuns + 1 Vercel StatusContext,
+        # all success, MERGEABLE + CLEAN.
+        status = self._make_status(
+            [
+                {
+                    "__typename": "CheckRun",
+                    "status": "COMPLETED",
+                    "conclusion": "SUCCESS",
+                    "name": "lint",
+                },
+                {
+                    "__typename": "CheckRun",
+                    "status": "COMPLETED",
+                    "conclusion": "SKIPPED",
+                    "name": "build",
+                },
+                {
+                    "__typename": "CheckRun",
+                    "status": "COMPLETED",
+                    "conclusion": "NEUTRAL",
+                    "name": "codecov",
+                },
+                {
+                    "__typename": "StatusContext",
+                    "context": "Vercel",
+                    "state": "SUCCESS",
+                },
+            ]
+        )
+        result = pt.transition_from_awaiting_ci(status)
+        assert result.next_phase == pt.PHASE_MERGE
+
 
 # --------------------------------------------------------------------------
 # transition_from_fix_ci

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -3229,6 +3229,208 @@ else
          "git log: $(cat "$INVOCATIONS_DIR/git.log")"
 fi
 
+# ══════════════════════════════════════════════════════════════════════════
+# #3200 — classify_pr_rollup must handle StatusContext entries (Vercel,
+# third-party commit-status API) as well as CheckRun entries, and
+# handle_awaiting_ci must early-exit when the PR is already merged.
+#
+# Fixtures drive `awaiting_ci` through one poll iteration. A "green"
+# rollup advances the phase to `merge`; a "red" rollup advances to
+# `fix_ci`. An already-merged PR short-circuits to green immediately.
+# ══════════════════════════════════════════════════════════════════════════
+
+# ── Test 36: Fixture A — CheckRuns only, all SUCCESS + CLEAN → green ──────
+# (Regression guard for the pre-#3200 happy path. Mirrors T28 but with
+# an explicit fixture so the assertions don't depend on the default
+# stub output.)
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t36.txt"
+printf 'awaiting_ci\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t36_pr_view="$TEST_TMP/t36-pr-view.json"
+cat > "$t36_pr_view" <<'EOF'
+{
+  "statusCheckRollup": [
+    {"__typename": "CheckRun", "name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+    {"__typename": "CheckRun", "name": "test", "status": "COMPLETED", "conclusion": "SUCCESS"},
+    {"__typename": "CheckRun", "name": "build", "status": "COMPLETED", "conclusion": "SKIPPED"}
+  ],
+  "mergeable": "MERGEABLE",
+  "mergeStateStatus": "CLEAN",
+  "headRefOid": "deadbeefcafe",
+  "mergeCommit": null
+}
+EOF
+
+t36_workspace="$TEST_TMP/t36-workspace"
+set +e
+t36_out=$(run_post_pr_phase "awaiting_ci" "$t36_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_PR_VIEW_JSON_FIXTURE=$t36_pr_view" \
+    "CLAUDE_VERDICT_FIXTURE=")
+set -e
+
+if printf '%s' "$t36_out" | grep -q '"rollup_state": "green"'; then
+    pass "#3200 T36 — fixture A (CheckRun-only, all SUCCESS + CLEAN) → green"
+else
+    fail "#3200 T36 — fixture A (CheckRun-only, all SUCCESS + CLEAN) → green" \
+         "out tail: $(printf '%s' "$t36_out" | tail -c 500)"
+fi
+
+# ── Test 37: Fixture B — StatusContext SUCCESS + CheckRuns SUCCESS + CLEAN → green
+# (This is the live-reproducible bug: PR #3198 shape. Pre-#3200 the
+# StatusContext entry fell through to "pending" so the function never
+# returned green and every ECS agent hit the 60min timeout.)
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t37.txt"
+printf 'awaiting_ci\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t37_pr_view="$TEST_TMP/t37-pr-view.json"
+cat > "$t37_pr_view" <<'EOF'
+{
+  "statusCheckRollup": [
+    {"__typename": "CheckRun", "name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+    {"__typename": "CheckRun", "name": "test", "status": "COMPLETED", "conclusion": "SUCCESS"},
+    {"__typename": "CheckRun", "name": "build", "status": "COMPLETED", "conclusion": "SKIPPED"},
+    {"__typename": "StatusContext", "context": "Vercel", "state": "SUCCESS"}
+  ],
+  "mergeable": "MERGEABLE",
+  "mergeStateStatus": "CLEAN",
+  "headRefOid": "deadbeefcafe",
+  "mergeCommit": null
+}
+EOF
+
+t37_workspace="$TEST_TMP/t37-workspace"
+set +e
+t37_out=$(run_post_pr_phase "awaiting_ci" "$t37_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_PR_VIEW_JSON_FIXTURE=$t37_pr_view" \
+    "CLAUDE_VERDICT_FIXTURE=")
+set -e
+
+if printf '%s' "$t37_out" | grep -q '"rollup_state": "green"'; then
+    pass "#3200 T37 — fixture B (StatusContext SUCCESS + CheckRuns + CLEAN) → green"
+else
+    fail "#3200 T37 — fixture B (StatusContext SUCCESS + CheckRuns + CLEAN) → green" \
+         "out tail: $(printf '%s' "$t37_out" | tail -c 500)"
+fi
+
+# Phase advances past awaiting_ci to merge → the classifier returned green.
+if grep -q "SET phase = \\\\'merge\\\\'" "$INVOCATIONS_DIR/psql.log"; then
+    pass "#3200 T37 — fixture B advances to merge on green"
+else
+    fail "#3200 T37 — fixture B advances to merge on green" \
+         "psql log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
+fi
+
+# ── Test 38: Fixture C — StatusContext FAILURE → red → advances to fix_ci
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t38.txt"
+printf 'awaiting_ci\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t38_pr_view="$TEST_TMP/t38-pr-view.json"
+cat > "$t38_pr_view" <<'EOF'
+{
+  "statusCheckRollup": [
+    {"__typename": "CheckRun", "name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"},
+    {"__typename": "StatusContext", "context": "Vercel", "state": "FAILURE"}
+  ],
+  "mergeable": "MERGEABLE",
+  "mergeStateStatus": "CLEAN",
+  "headRefOid": "deadbeefcafe",
+  "mergeCommit": null
+}
+EOF
+
+t38_workspace="$TEST_TMP/t38-workspace"
+set +e
+t38_out=$(run_post_pr_phase "awaiting_ci" "$t38_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_PR_VIEW_JSON_FIXTURE=$t38_pr_view" \
+    "CLAUDE_VERDICT_FIXTURE=")
+set -e
+
+if printf '%s' "$t38_out" | grep -q '"rollup_state": "red"'; then
+    pass "#3200 T38 — fixture C (StatusContext FAILURE) → red"
+else
+    fail "#3200 T38 — fixture C (StatusContext FAILURE) → red" \
+         "out tail: $(printf '%s' "$t38_out" | tail -c 500)"
+fi
+
+if grep -q "SET phase = \\\\'fix_ci\\\\'" "$INVOCATIONS_DIR/psql.log"; then
+    pass "#3200 T38 — fixture C advances to fix_ci on red"
+else
+    fail "#3200 T38 — fixture C advances to fix_ci on red" \
+         "psql log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
+fi
+
+# ── Test 39: Fixture D — already-merged PR (mergeCommit.oid set,
+# mergeStateStatus=UNKNOWN) → handle_awaiting_ci short-circuits to green
+# without even looking at the rollup classifier.
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t39.txt"
+printf 'awaiting_ci\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t39_pr_view="$TEST_TMP/t39-pr-view.json"
+cat > "$t39_pr_view" <<'EOF'
+{
+  "statusCheckRollup": [
+    {"__typename": "CheckRun", "name": "lint", "status": "COMPLETED", "conclusion": "SUCCESS"}
+  ],
+  "mergeable": "UNKNOWN",
+  "mergeStateStatus": "UNKNOWN",
+  "headRefOid": "deadbeefcafe",
+  "mergeCommit": {"oid": "a300318bd5b1813da8dea78a28eb5b37c0d427ac"}
+}
+EOF
+
+t39_workspace="$TEST_TMP/t39-workspace"
+set +e
+t39_out=$(run_post_pr_phase "awaiting_ci" "$t39_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_PR_VIEW_JSON_FIXTURE=$t39_pr_view" \
+    "CLAUDE_VERDICT_FIXTURE=")
+set -e
+
+if printf '%s' "$t39_out" | grep -q "awaiting_ci_already_merged"; then
+    pass "#3200 T39 — fixture D (merged PR) emits awaiting_ci_already_merged"
+else
+    fail "#3200 T39 — fixture D (merged PR) emits awaiting_ci_already_merged" \
+         "out tail: $(printf '%s' "$t39_out" | tail -c 500)"
+fi
+
+# handle_awaiting_ci's JSON payload is captured by the caller into
+# $_output and then INSERTed into dispatcher.phase_outputs — so the
+# already_merged flag surfaces in the psql invocation log, not in the
+# entrypoint's stdout.
+if grep -F "already_merged" "$INVOCATIONS_DIR/psql.log" >/dev/null 2>&1; then
+    pass "#3200 T39 — fixture D short-circuits with already_merged payload (persisted to phase_outputs)"
+else
+    fail "#3200 T39 — fixture D short-circuits with already_merged payload (persisted to phase_outputs)" \
+         "psql log tail: $(tail -c 800 "$INVOCATIONS_DIR/psql.log")"
+fi
+
+# Merged PR still advances to merge (caller transitions green → merge).
+if grep -q "SET phase = \\\\'merge\\\\'" "$INVOCATIONS_DIR/psql.log"; then
+    pass "#3200 T39 — fixture D advances to merge on already-merged short-circuit"
+else
+    fail "#3200 T39 — fixture D advances to merge on already-merged short-circuit" \
+         "psql log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Fixes P0 bug #3200. `classify_pr_rollup` (shell, agent-runner) and `_ci_rollup_state` (Python, phase_transitions) both only looked at CheckRun fields — so any PR with a Vercel/third-party `StatusContext` entry in its rollup fell through to "pending" forever and every ECS agent hit the 60-min `awaiting_ci_timeout`. Live-reproduced on PR #3198 (50 SUCCESS + 35 SKIPPED CheckRuns + 1 Vercel StatusContext SUCCESS, MERGEABLE+CLEAN, classified as "pending").

Compounding fix: once a PR is merged, `mergeable` and `mergeStateStatus` flip to `UNKNOWN`. The classifier can't distinguish "merged + UNKNOWN" from "pending + UNKNOWN", so the polling loop burned the timeout on already-merged PRs. `handle_awaiting_ci` now early-exits to `rollup_state=green` when `mergeCommit.oid` is non-empty.

Changes:
- `scripts/dispatcher/agent-runner-entrypoint.sh::classify_pr_rollup` — jq program now branches on `.__typename`. `StatusContext`: `.state` SUCCESS/NEUTRAL → ok, FAILURE/ERROR → red, else pending. `CheckRun` (default) keeps pre-#3200 behaviour.
- `scripts/dispatcher/agent-runner-entrypoint.sh::handle_awaiting_ci` — short-circuits to `green` when `mergeCommit.oid` is populated; logs `awaiting_ci_already_merged` with `rollup_state=green` + `merge_sha` for CloudWatch parity.
- `scripts/dispatcher/phase_transitions.py::_ci_rollup_state` — same `__typename` branch, new `_CI_STATUSCONTEXT_*` constant sets.
- Tests: 4 new shell fixtures (T36-T39) exercising CheckRun-only green, mixed StatusContext+CheckRun green (the live bug), StatusContext FAILURE, and the already-merged short-circuit. 6 new Python tests covering StatusContext SUCCESS/FAILURE/ERROR/PENDING/EXPECTED paths and the mixed-rollup happy path.

Scope guard: did not touch `_advance_running_agents` or anything #3196 touched. The daemon's own `_classify_check_rollup` (daemon.py:~12022) already handles the legacy commit-status path — `phase_transitions._ci_rollup_state` was the drift.

## Local repro

```
$ jq -r -f tmp/classify_current.jq tmp/pr3198.json   # pre-fix
pending
$ jq -r -f tmp/classify_fixed.jq tmp/pr3198.json     # post-fix
green
```

## Test plan

- [x] `scripts/tests/test_agent_runner_entrypoint.sh` → 173/173 pass (4 new T36-T39 cover fixtures A-D).
- [x] `pytest scripts/dispatcher/tests/test_phase_transitions.py` → 80/80 pass (6 new StatusContext tests).
- [x] `ruff check` + `ruff format --check` on changed Python files → clean.
- [x] `scripts/check-bash-compat.sh` on changed shell scripts → clean.
- [ ] Post-merge: deploy-agent-runner.yml fires; flip `dispatcher.config.agent_execution_mode` from `subprocess` back to `ecs`; next natural ECS claim smoke-tests the fix.

Closes #3200
