### PR TITLE
fix(ci): guard against git -C self._repo_root() in daemon.py (#2829)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -551,6 +551,29 @@ if [ -n "$changed_dispatcher_deps" ]; then
 fi
 
 # -------------------------------------------------------------------
+# Dispatcher git-repo-root guard — run when daemon.py changes (#2829)
+# -------------------------------------------------------------------
+# Checks that no ``subprocess.run(["git", ...])`` call in daemon.py
+# anchors to ``self._repo_root()`` (which returns ``/app`` on Fargate —
+# no ``.git`` child). The correct anchor is ``self._git_parent_root()``.
+# Prevents the #2804/#2821 class of "not a git repository" runtime bug
+# from being re-introduced. Mirrors the CI step so the failure is caught
+# locally before the CI round trip.
+changed_daemon=$(echo "$changed_files" | grep -E '^scripts/dispatcher/daemon\.py$' || true)
+if [ -n "$changed_daemon" ]; then
+    echo "pre-push: checking no git -C self._repo_root() pattern in daemon.py..." >&2
+    if [ -x scripts/check-no-git-repo-root.py ]; then
+        if ! run_check "_" "scripts/check-no-git-repo-root.py" scripts/check-no-git-repo-root.py; then
+            echo "  A git subprocess in daemon.py anchors to self._repo_root() —" >&2
+            echo "  this is the #2804/#2821 class of bug. Use self._git_parent_root()." >&2
+            failures=$((failures + 1))
+        fi
+    else
+        echo "  WARNING: scripts/check-no-git-repo-root.py not found or not executable — skipping" >&2
+    fi
+fi
+
+# -------------------------------------------------------------------
 # Filename separator hygiene — always cheap, always run
 # -------------------------------------------------------------------
 # Flags same-directory filename pairs that differ only by `-` vs `_`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -628,6 +628,15 @@ jobs:
       # silent-ECS-agent-loss bug from creeping back in.
       - name: Verify every dispatcher.agents SQL site is execution_mode-aware
         run: scripts/check-dispatcher-execution-mode-aware.sh
+      # Issue #2829: prevent repeat of #2804/#2821 — ``self._repo_root()``
+      # returns ``/app`` on Fargate (no ``.git`` child), so any
+      # ``subprocess.run(["git", "-C", str(self._repo_root()), ...])`` in
+      # daemon.py fails with "not a git repository". The correct anchor is
+      # ``self._git_parent_root()`` which resolves to the baseline clone
+      # when ``baseline_repo_root`` is configured. AST-based so docstrings
+      # and comments are not false-positives.
+      - name: Verify daemon git subprocess calls anchor to git_parent_root
+        run: scripts/check-no-git-repo-root.py
       # Issue #3082: operator laptops run macOS's stock bash 3.2.
       # Shell scripts under scripts/**/*.sh must stick to the bash 3.2
       # subset — no mapfile, readarray, associative arrays, nameref,

--- a/scripts/check-no-git-repo-root.py
+++ b/scripts/check-no-git-repo-root.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Guard against ``git -C self._repo_root()`` in ``scripts/dispatcher/daemon.py``.
+
+Why this check exists
+---------------------
+Issues #2804 and #2821 traced two production failures to the same root cause:
+a ``subprocess.run(["git", "-C", str(self._repo_root()), ...])`` call in
+the daemon.  On the Fargate deployment, ``self._repo_root()`` returns ``/app``
+— the image's CWD — which has no ``.git`` child.  Every such ``git`` command
+fails with "not a git repository" and, in some cases, corrupted worktree
+state.  The correct anchor for git operations is ``self._git_parent_root()``
+(returns the baseline clone at ``/var/lib/dispatcher/judgemind`` when
+``DaemonConfig.baseline_repo_root`` is set, and falls back to ``_repo_root()``
+in local-dev mode where both happen to be the same path).
+
+The ``_repo_root()`` docstring already warns about this.  This guard makes the
+warning machine-enforceable: it fails CI / pre-push when any
+``subprocess.run(["git", ...])`` call site has ``self._repo_root()`` (or
+``str(self._repo_root())``) anywhere in its argv list.  Non-``git`` subprocess
+calls are out of scope (the bug class is git-worktree-specific per #2804/#2821).
+
+Rule
+----
+For every ``subprocess.run(...)`` call in ``scripts/dispatcher/daemon.py``
+whose first argv element is the string literal ``"git"``, NONE of the
+remaining argv elements may resolve to a ``self._repo_root()`` call (with or
+without an outer ``str()`` wrapping).
+
+Scope
+-----
+- Only scans daemon.py (the sole file with this pattern).  ``scripts/dispatcher/``
+  sibling modules have no ``self._repo_root()`` usages.
+- Only flags ``"git"`` subprocesses; ``"gh"`` subprocesses are out of scope.
+- AST-based to avoid false-positives from docstrings and comments.
+
+Usage
+-----
+    scripts/check-no-git-repo-root.py                         # scan daemon.py
+    scripts/check-no-git-repo-root.py [file]                  # scan a specific file
+
+Exit codes
+----------
+    0 — No violations found (or target file absent).
+    1 — One or more violations found.
+
+Ref: issues #2804, #2821, #2829.
+"""
+# permanent: true
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_TARGET = _REPO_ROOT / "scripts" / "dispatcher" / "daemon.py"
+
+
+def _is_repo_root_call(node: ast.expr) -> bool:
+    """Return True if ``node`` is ``self._repo_root()`` or ``str(self._repo_root())``.
+
+    Accepted shapes:
+        self._repo_root()
+        str(self._repo_root())
+    """
+    # Direct call: self._repo_root()
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_repo_root"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "self"
+    ):
+        return True
+
+    # str() wrapper: str(self._repo_root())
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "str"
+        and len(node.args) == 1
+        and not node.keywords
+    ):
+        return _is_repo_root_call(node.args[0])
+
+    return False
+
+
+def _first_argv_is_git(argv_node: ast.expr) -> bool:
+    """Return True if the first element of the argv list is the string ``"git"``."""
+    if not isinstance(argv_node, ast.List):
+        return False
+    if not argv_node.elts:
+        return False
+    first = argv_node.elts[0]
+    return isinstance(first, ast.Constant) and first.value == "git"
+
+
+def _argv_contains_repo_root(argv_node: ast.expr) -> int | None:
+    """Return the line number of the first offending element, or None.
+
+    Walks every element in the argv list (skipping the first ``"git"`` element)
+    and returns the line number of the first element that is a
+    ``self._repo_root()`` call (directly or wrapped in ``str()``).
+    """
+    if not isinstance(argv_node, ast.List):
+        return None
+    for elt in argv_node.elts[1:]:
+        if _is_repo_root_call(elt):
+            return elt.lineno
+    return None
+
+
+def find_violations(filepath: Path) -> list[tuple[int, str]]:
+    """Parse ``filepath`` and return ``(lineno, snippet)`` for each violation.
+
+    Walks every ``subprocess.run(...)`` call node.  For those whose first
+    positional argument is a list starting with ``"git"``, checks whether
+    any subsequent list element resolves to ``self._repo_root()``.
+
+    Returns an empty list on parse / IO errors (ruff/pytest will catch those).
+    """
+    try:
+        source = filepath.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+
+    try:
+        tree = ast.parse(source, filename=str(filepath))
+    except SyntaxError:
+        return []
+
+    source_lines = source.splitlines()
+    violations: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+
+        # Match ``subprocess.run(...)`` — both ``subprocess.run`` (Attribute)
+        # and bare ``run(...)`` (Name) shapes.
+        func = node.func
+        is_subprocess_run = (
+            isinstance(func, ast.Attribute)
+            and func.attr == "run"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "subprocess"
+        ) or (isinstance(func, ast.Name) and func.id == "run")
+
+        if not is_subprocess_run:
+            continue
+
+        # The argv list must be the first positional argument.
+        if not node.args:
+            continue
+        argv = node.args[0]
+
+        if not _first_argv_is_git(argv):
+            continue
+
+        offending_lineno = _argv_contains_repo_root(argv)
+        if offending_lineno is None:
+            continue
+
+        # Build a compact snippet from the offending source line.
+        snippet = ""
+        if 1 <= offending_lineno <= len(source_lines):
+            snippet = source_lines[offending_lineno - 1].strip()
+
+        violations.append((offending_lineno, snippet))
+
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    if argv:
+        target = Path(argv[0])
+    else:
+        target = _DEFAULT_TARGET
+
+    if not target.is_file():
+        print(
+            f"check-no-git-repo-root: no target file at {target} — nothing to check."
+        )
+        return 0
+
+    violations = find_violations(target)
+
+    if not violations:
+        print(
+            f"check-no-git-repo-root: {target} — no git subprocess "
+            "anchored to self._repo_root() found."
+        )
+        return 0
+
+    print("ERROR: git subprocess call(s) anchored to self._repo_root().", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(f"  Target: {target}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "  self._repo_root() returns os.getcwd() — on the Fargate deployment",
+        file=sys.stderr,
+    )
+    print(
+        "  that is /app, which has no .git child. Every `git -C /app ...`",
+        file=sys.stderr,
+    )
+    print(
+        '  fails with "not a git repository" (#2804, #2821).',
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    print("  Violations:", file=sys.stderr)
+    print("", file=sys.stderr)
+    for lineno, snippet in violations:
+        print(f"    {target}:{lineno}: {snippet}", file=sys.stderr)
+    print("", file=sys.stderr)
+    print(
+        "  Fix: replace self._repo_root() with self._git_parent_root() in",
+        file=sys.stderr,
+    )
+    print(
+        "  the git subprocess argv.  self._git_parent_root() returns the",
+        file=sys.stderr,
+    )
+    print(
+        "  baseline clone path when baseline_repo_root is configured, and",
+        file=sys.stderr,
+    )
+    print(
+        "  falls back to _repo_root() in local-dev / unit-test mode — so",
+        file=sys.stderr,
+    )
+    print(
+        "  the call is correct in both environments. See #2829.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/tests/test_check_no_git_repo_root.sh
+++ b/scripts/tests/test_check_no_git_repo_root.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# test_check_no_git_repo_root.sh — Tests for scripts/check-no-git-repo-root.py
+#
+# Verifies that the AST-based guard fails on synthetic daemon.py fixtures
+# that contain ``git`` subprocess calls anchored to ``self._repo_root()``,
+# and passes on the correct ``self._git_parent_root()`` form, non-git
+# usages of ``_repo_root()``, docstrings, and the real daemon.py.
+#
+# Usage:
+#   scripts/tests/test_check_no_git_repo_root.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-no-git-repo-root.py"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+write_file() {
+    # $1: file path (relative to TMPDIR_TEST)
+    # $2: contents (via stdin)
+    local path="$TMPDIR_TEST/$1"
+    mkdir -p "$(dirname "$path")"
+    cat > "$path"
+}
+
+assert_passes() {
+    local desc="$1"
+    local target="$2"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$target" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"
+    local target="$2"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$target" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+# ─── Test 1: FAIL — single-line git call with str(self._repo_root()) ────────
+write_file "bad_single_line.py" <<'EOF'
+import subprocess
+
+class Daemon:
+    def do_git(self):
+        subprocess.run(["git", "-C", str(self._repo_root()), "worktree", "add", "/tmp/x"], check=False)
+EOF
+assert_fails "FAIL: single-line git argv with str(self._repo_root())" \
+    "$TMPDIR_TEST/bad_single_line.py"
+
+# ─── Test 2: FAIL — multi-line argv list (the actual #2804/#2821 shape) ─────
+write_file "bad_multiline.py" <<'EOF'
+import subprocess
+
+class Daemon:
+    def create_worktree(self):
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(self._repo_root()),
+                "worktree",
+                "add",
+                "/tmp/worktrees/agent-abc",
+                "-b",
+                "agent/abc",
+                "origin/main",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+EOF
+assert_fails "FAIL: multi-line git argv with str(self._repo_root()) (the #2804/#2821 shape)" \
+    "$TMPDIR_TEST/bad_multiline.py"
+
+# ─── Test 3: FAIL — self._repo_root() without str() wrapping ────────────────
+write_file "bad_no_str.py" <<'EOF'
+import subprocess
+
+class Daemon:
+    def do_git(self):
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                self._repo_root(),
+                "fetch",
+                "origin",
+                "main",
+            ],
+            check=False,
+        )
+EOF
+assert_fails "FAIL: git argv with bare self._repo_root() (no str() wrap)" \
+    "$TMPDIR_TEST/bad_no_str.py"
+
+# ─── Test 4: PASS — correct form uses self._git_parent_root() ───────────────
+write_file "good_git_parent.py" <<'EOF'
+import subprocess
+
+class Daemon:
+    def create_worktree(self):
+        git_parent = self._git_parent_root()
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(git_parent),
+                "worktree",
+                "add",
+                "/tmp/worktrees/agent-abc",
+                "-b",
+                "agent/abc",
+                "origin/main",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+EOF
+assert_passes "PASS: git argv with self._git_parent_root() (the correct form)" \
+    "$TMPDIR_TEST/good_git_parent.py"
+
+# ─── Test 5: PASS — self._repo_root() used only for cleanup_script path ─────
+# (Mirrors daemon.py line 15497: ``repo_root = self._repo_root()`` followed by
+# ``cleanup_script = repo_root / "scripts" / "cleanup_worktree.sh"``.)
+write_file "good_non_git_path.py" <<'EOF'
+import subprocess
+from pathlib import Path
+
+class Daemon:
+    def drop_worktree(self, worktree_path):
+        repo_root = self._repo_root()
+        cleanup_script = repo_root / "scripts" / "cleanup_worktree.sh"
+        if cleanup_script.exists():
+            subprocess.run(
+                [str(cleanup_script), worktree_path],
+                check=False,
+            )
+EOF
+assert_passes "PASS: self._repo_root() used only for non-git script path" \
+    "$TMPDIR_TEST/good_non_git_path.py"
+
+# ─── Test 6: PASS — self._repo_root() used in tmp path (non-git usage) ──────
+# (Mirrors daemon.py line 18185 pattern: tmp_dir = self._repo_root() / "tmp" / ...)
+write_file "good_tmp_path.py" <<'EOF'
+import subprocess
+from pathlib import Path
+
+class Daemon:
+    def write_tmp(self):
+        tmp_dir = self._repo_root() / "tmp" / "worker-done.txt"
+        tmp_dir.parent.mkdir(parents=True, exist_ok=True)
+        tmp_dir.write_text("done")
+EOF
+assert_passes "PASS: self._repo_root() used in tmp path, no git subprocess" \
+    "$TMPDIR_TEST/good_tmp_path.py"
+
+# ─── Test 7: PASS — docstring mentioning self._repo_root() and git ───────────
+# (Mirrors daemon.py docstrings at lines 4432, 4453, 15462.)
+write_file "good_docstring.py" <<'EOF'
+class Daemon:
+    def _repo_root(self):
+        """Legacy repo-shaped directory.
+
+        Not the git parent for worktree ops. Phase 3A (#2783) originally
+        had ``_create_worktree`` run ``git -C <cwd> worktree add ...``, but
+        the container CWD has no ``.git`` child. Use self._git_parent_root()
+        for any git subprocess. self._repo_root() is only for non-git paths.
+        """
+        import os
+        from pathlib import Path
+        return Path(os.getcwd())
+EOF
+assert_passes "PASS: docstring mentioning self._repo_root() and git as prose" \
+    "$TMPDIR_TEST/good_docstring.py"
+
+# ─── Test 8: PASS — return self._repo_root() (not a subprocess call) ─────────
+# (Mirrors daemon.py line 4470: ``return self._repo_root()``.)
+write_file "good_return.py" <<'EOF'
+class Daemon:
+    def _git_parent_root(self):
+        if self._cfg.baseline_repo_root is not None:
+            return self._cfg.baseline_repo_root
+        return self._repo_root()
+EOF
+assert_passes "PASS: return self._repo_root() is not a git subprocess" \
+    "$TMPDIR_TEST/good_return.py"
+
+# ─── Test 9: PASS — gh subprocess using self._repo_root() (not git) ─────────
+write_file "good_gh_subprocess.py" <<'EOF'
+import subprocess
+
+class Daemon:
+    def run_gh(self):
+        subprocess.run(
+            [
+                "gh",
+                "--repo",
+                str(self._repo_root()),
+                "pr",
+                "list",
+            ],
+            check=False,
+        )
+EOF
+assert_passes "PASS: gh subprocess using self._repo_root() is out of scope" \
+    "$TMPDIR_TEST/good_gh_subprocess.py"
+
+# ─── Test 10: PASS — empty file ──────────────────────────────────────────────
+write_file "empty.py" <<'EOF'
+EOF
+assert_passes "PASS: empty file has nothing to check" \
+    "$TMPDIR_TEST/empty.py"
+
+# ─── Test 11: PASS — file without target class (no Daemon) ───────────────────
+write_file "no_class.py" <<'EOF'
+import subprocess
+
+def standalone_git():
+    subprocess.run(["git", "status"], check=False)
+EOF
+assert_passes "PASS: file without Daemon class, no self._repo_root() — passes" \
+    "$TMPDIR_TEST/no_class.py"
+
+# ─── Test 12: PASS — missing target file exits 0 (nothing to check) ─────────
+assert_passes "PASS: missing target file exits 0 (nothing to check)" \
+    "$TMPDIR_TEST/does_not_exist.py"
+
+# ─── Test 13: Regression — the real daemon.py passes ────────────────────────
+# This is the critical regression guard: the current (post-#2821)
+# scripts/dispatcher/daemon.py must pass the check — proving it has no
+# existing violations and that the check doesn't false-positive on real code.
+DAEMON_PATH="$REPO_ROOT/scripts/dispatcher/daemon.py"
+if [[ -f "$DAEMON_PATH" ]]; then
+    assert_passes "Regression: real scripts/dispatcher/daemon.py passes (no violations)" \
+        "$DAEMON_PATH"
+else
+    echo "SKIP: $DAEMON_PATH not present — skipping regression test"
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Added an AST-based guard `scripts/check-no-git-repo-root.py` that prevents the #2804/#2821 class of bug where a `git` subprocess is anchored to `self._repo_root()` (which returns `/app` on Fargate with no `.git` child). The check is wired into CI and the pre-push hook to catch violations before they reach main.

Closes #2829

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Verification

**AST-based guard (`scripts/check-no-git-repo-root.py`):**
- Parses daemon.py and walks all `subprocess.run(["git", ...])` calls
- Flags any argv element that resolves to `self._repo_root()` or `str(self._repo_root())`
- Exits 0 on clean scan, 1 on violations
- Handles edge cases: bare `_repo_root()` (no str() wrap), multi-line argv lists, non-git subprocesses (gh, etc.), docstrings

**CI integration:**
- New step in `.github/workflows/ci.yml` (scripts-tests job, line 638) runs the check
- No new paths filter needed — existing `scripts/**` filter covers daemon.py

**Pre-push integration:**
- New gated block in `.githooks/pre-push` (lines 553–575) runs check when daemon.py is in the push
- Integrated with existing pre-push failure tracking

**Peer test:**
- Test file `scripts/tests/test_check_no_git_repo_root.sh` (13 cases)
  - **FAIL fixtures (3):** single-line, multi-line argv, bare `self._repo_root()` (all correctly rejected)
  - **PASS fixtures (9):** `self._git_parent_root()` (correct form), `_repo_root()` in cleanup paths, tmp paths, docstrings, return statements, `gh` subprocesses
  - **Regression (1):** real daemon.py passes cleanly (no false-positives)

### Post-deploy verification

- [x] Guard is active and enforcing (CI and pre-push check successful)
- [x] Test coverage confirmed (13 test cases with clear pass/fail expectations)
- [x] Real daemon.py regression confirmed (no violations in current code)