### PR TITLE
feat(web): dispatcher Phase 2 polish — spacing, typography, blocker tooltip (#2812)

### DIFF
--- a/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
@@ -157,9 +157,6 @@ function ActiveAgentRow({
         >
           {agent.phase}
         </span>
-        <span className="w-16 flex-shrink-0 text-right font-mono text-xs text-muted-foreground">
-          {elapsed}
-        </span>
         <span className="flex-shrink-0 text-xs">
           {logsHref ? (
             <a
@@ -178,6 +175,9 @@ function ActiveAgentRow({
               {agent.worktreePath.split('/').pop() ?? agent.worktreePath}
             </span>
           )}
+        </span>
+        <span className="w-16 flex-shrink-0 text-right font-mono text-xs text-muted-foreground">
+          {elapsed}
         </span>
         <span className="flex flex-shrink-0 gap-1">
           <Button

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -17,6 +17,7 @@ import {
   type DispatcherSetConfigData,
   type DispatcherStateData,
 } from '@/lib/dispatcher-queries';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import { DispatcherHeader } from './DispatcherHeader';
 import { DispatcherControls } from './DispatcherControls';
 import { ActiveAgentsTable } from './ActiveAgentsTable';
@@ -26,6 +27,7 @@ import { RecentFailuresPanel } from './RecentFailuresPanel';
 import { ConfigPanel } from './ConfigPanel';
 import { ConfirmDialog, type ConfirmableCommand } from './ConfirmDialog';
 import { QueueFullDialog } from './QueueFullDialog';
+import { IssueLink } from './ui-primitives';
 
 /**
  * Polling interval for `dispatcherState`. Per spec §11, the daemon runs on
@@ -326,6 +328,7 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
   const showInitialLoad = (loading && !state) || (data !== undefined && !state);
 
   return (
+    <TooltipProvider>
     <div>
       <div className="mt-4 flex flex-wrap items-center justify-between gap-x-6 gap-y-2 border-b border-border pb-3 mb-4">
         <div className="flex flex-wrap items-baseline gap-x-4 gap-y-1">
@@ -387,7 +390,7 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
       ) : (
         <>
           <div
-            className="grid grid-cols-1 gap-x-6 gap-y-6 lg:grid-cols-2"
+            className="grid grid-cols-1 gap-x-6 gap-y-4 lg:grid-cols-2"
             data-testid="dispatcher-two-column-deck"
           >
             {/*
@@ -396,7 +399,7 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
              * transitions from "next" to "now". See file-level docstring
              * for the full state-flow rationale (#2823).
              */}
-            <div className="flex flex-col gap-6" data-testid="dispatcher-column-left">
+            <div className="flex flex-col gap-4" data-testid="dispatcher-column-left">
               <ActiveAgentsTable
                 agents={state?.activeAgents ?? []}
                 disabled={controlLoading}
@@ -417,7 +420,7 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
              * completed. Blocked sits bottom-right — adjacent to the flow
              * but not part of the active cycle.
              */}
-            <div className="flex flex-col gap-6" data-testid="dispatcher-column-right">
+            <div className="flex flex-col gap-4" data-testid="dispatcher-column-right">
               <RecentCompletionsPanel
                 completions={state?.recentCompletions ?? []}
                 total={state?.recentCompletionsCount}
@@ -440,20 +443,13 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
             busyKey={busyConfigKey}
           />
 
-          <div className="mt-6">
+          <div className="mt-4">
             <RecentFailuresPanel failures={state?.recentFailures ?? []} />
           </div>
 
           <p className="mt-4 text-xs text-muted-foreground">
             Daemon command handlers tracked in{' '}
-            <a
-              href="https://github.com/judgemind/judgemind/issues/2801"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-brand-accent dark:text-brand-accent-light underline-offset-2 hover:underline"
-            >
-              #2801
-            </a>
+            <IssueLink number={2801} />
             . Control buttons write to <code className="font-mono">dispatcher.commands</code>{' '}
             today; daemon-side handlers land with that issue.
           </p>
@@ -489,6 +485,7 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
         onClose={() => setFullDialogKind(null)}
       />
     </div>
+    </TooltipProvider>
   );
 }
 

--- a/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
@@ -3,6 +3,11 @@
 import type { CSSProperties } from 'react';
 import { SECTION_HEADING } from '@/lib/typography';
 import type { QueueItem } from '@/lib/dispatcher-queries';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { IssueLink, PriorityBadge } from './ui-primitives';
 
 interface QueuePanelProps {
@@ -318,13 +323,35 @@ export function QueueRow({
         </span>
       )}
       <div className="min-w-0 flex-1">
-        <span
-          className="block break-words text-foreground"
-          data-testid="queue-row-title"
-          title={item.title}
-        >
-          {item.title}
-        </span>
+        {item.blockedBy.length > 0 ? (
+          <Tooltip delayDuration={0}>
+            <TooltipTrigger asChild>
+              <span
+                className="block break-words text-foreground"
+                data-testid={`blocker-tooltip-trigger-${item.issueNumber}`}
+                title={item.title}
+              >
+                {item.title}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              <span className="flex flex-wrap items-center gap-1 text-xs">
+                Blocked by{' '}
+                {item.blockedBy.map((blockerNumber) => (
+                  <IssueLink key={blockerNumber} number={blockerNumber} />
+                ))}
+              </span>
+            </TooltipContent>
+          </Tooltip>
+        ) : (
+          <span
+            className="block break-words text-foreground"
+            data-testid="queue-row-title"
+            title={item.title}
+          >
+            {item.title}
+          </span>
+        )}
       </div>
     </li>
   );

--- a/packages/web/src/app/(main)/admin/dispatcher/RecentFailuresPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/RecentFailuresPanel.tsx
@@ -112,7 +112,7 @@ export function RecentFailuresPanel({ failures, nowMs }: RecentFailuresPanelProp
                       // (CloudWatch queries, SQL filters, copy-paste)
                       // while the visible pill text shows the
                       // operator-friendly `displayCategory` string.
-                      className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground"
+                      className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground"
                       title={group.category}
                       data-category={group.category}
                       data-testid={`failure-category-pill-${group.category}`}

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
@@ -747,6 +747,39 @@ describe('DispatcherDashboard — #3172 dialog title denominator', () => {
   });
 });
 
+// #2812: Phase 2 polish — vertical density + IssueLink for #2801.
+describe('DispatcherDashboard — #2812 Phase 2 polish', () => {
+  beforeEach(() => {
+    mockControlMutate.mockClear();
+    mockSetConfigMutate.mockClear();
+    mockRefetch.mockClear();
+    mockQueryData = { dispatcherState: { ...BASE_STATE } };
+  });
+
+  it('§2.1 — grid uses gap-y-4', () => {
+    renderDashboard();
+    const deck = screen.getByTestId('dispatcher-two-column-deck');
+    expect(deck.className).toMatch(/gap-x-6 gap-y-4/);
+  });
+
+  it('§2.1 — column wrappers use gap-4', () => {
+    renderDashboard();
+    const left = screen.getByTestId('dispatcher-column-left');
+    const right = screen.getByTestId('dispatcher-column-right');
+    expect(left.className).toMatch(/gap-4/);
+    expect(right.className).toMatch(/gap-4/);
+  });
+
+  it('§2.5 — #2801 issue reference is a hot link via IssueLink', () => {
+    renderDashboard();
+    expect(screen.getByTestId('issue-link-2801')).toBeInTheDocument();
+    expect(screen.getByTestId('issue-link-2801')).toHaveAttribute(
+      'href',
+      'https://github.com/judgemind/judgemind/issues/2801',
+    );
+  });
+});
+
 // #3206: Magic Move view-transition-names on cockpit panel rows must be
 // SUPPRESSED whenever any full-list dialog is open, otherwise the
 // browser's view-transition compositor layer paints over the Radix

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueuePanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueuePanel.test.tsx
@@ -1,10 +1,22 @@
 import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
-import { QueueBlockedPanel, QueuePanel, QueueReadyPanel } from '../QueuePanel';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { RenderOptions } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { QueueBlockedPanel, QueuePanel, QueueReadyPanel, QueueRow } from '../QueuePanel';
 import { formatCooldown } from '../QueuePanel';
 import type { QueueItem } from '@/lib/dispatcher-queries';
+import { TooltipProvider } from '@/components/ui/tooltip';
 
 const now = Date.parse('2026-04-18T12:00:00Z');
+
+/**
+ * Render wrapper that includes `TooltipProvider` — required because `QueueRow`
+ * uses Radix `<Tooltip>` on blocked rows (#2812) and Radix requires the
+ * provider in the tree.
+ */
+function renderWithTooltip(ui: ReactElement, options?: RenderOptions) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>, options);
+}
 
 function item(overrides: Partial<QueueItem>): QueueItem {
   return {
@@ -21,7 +33,7 @@ function item(overrides: Partial<QueueItem>): QueueItem {
 
 describe('QueuePanel', () => {
   it('renders empty states for both panels when no items', () => {
-    render(<QueuePanel queueReady={[]} queueBlocked={[]} nowMs={now} />);
+    renderWithTooltip(<QueuePanel queueReady={[]} queueBlocked={[]} nowMs={now} />);
     expect(screen.getByText(/queue empty/i)).toBeInTheDocument();
     expect(screen.getByText(/no blocked issues/i)).toBeInTheDocument();
   });
@@ -31,7 +43,7 @@ describe('QueuePanel', () => {
       item({ issueNumber: 2801, title: 'wire dispatcherControl through to daemon' }),
       item({ issueNumber: 2802, title: 'recently completed panel', priority: 'p2' }),
     ];
-    render(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
+    renderWithTooltip(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
     expect(screen.getByTestId('issue-link-2801')).toHaveAttribute(
       'href',
       'https://github.com/judgemind/judgemind/issues/2801',
@@ -49,7 +61,7 @@ describe('QueuePanel', () => {
     const blocked = [
       item({ issueNumber: 2500, title: 'blocked issue', blockedBy: [2500, 2600] }),
     ];
-    render(<QueuePanel queueReady={[]} queueBlocked={blocked} nowMs={now} />);
+    renderWithTooltip(<QueuePanel queueReady={[]} queueBlocked={blocked} nowMs={now} />);
     expect(screen.getByTestId('issue-link-2500')).toBeInTheDocument();
     expect(screen.getByText('blocked issue')).toBeInTheDocument();
   });
@@ -60,7 +72,7 @@ describe('QueuePanel', () => {
       item({ issueNumber: 2801, title: 'first' }),
       item({ issueNumber: 2802, title: 'second' }),
     ];
-    render(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
+    renderWithTooltip(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
     expect(screen.queryByText('#1')).not.toBeInTheDocument();
     expect(screen.queryByText('#2')).not.toBeInTheDocument();
     expect(screen.queryAllByTestId('queue-row-slot')).toHaveLength(0);
@@ -70,7 +82,7 @@ describe('QueuePanel', () => {
     const blocked = [
       item({ issueNumber: 2500, title: 'blocked issue', blockedBy: [2500, 2600] }),
     ];
-    render(<QueuePanel queueReady={[]} queueBlocked={blocked} nowMs={now} />);
+    renderWithTooltip(<QueuePanel queueReady={[]} queueBlocked={blocked} nowMs={now} />);
     expect(screen.queryByText('[2]')).not.toBeInTheDocument();
   });
 
@@ -82,7 +94,7 @@ describe('QueuePanel', () => {
         createdAt: '2026-04-16T11:00:00Z', // 2 d ago from the fixed `now`
       }),
     ];
-    render(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
+    renderWithTooltip(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
     expect(screen.queryByText(/\bago\b/i)).not.toBeInTheDocument();
   });
 
@@ -90,7 +102,7 @@ describe('QueuePanel', () => {
     const longTitle =
       'fix(admin-dispatcher): (title unavailable) everywhere + 20562-day-ago timestamps + strip wasteful columns';
     const items = [item({ issueNumber: 2818, title: longTitle })];
-    render(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
+    renderWithTooltip(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
     const titleEl = screen.getByText(longTitle);
     // Title cell uses `break-words` (soft wrap) rather than `truncate`.
     expect(titleEl.className).toMatch(/break-words/);
@@ -105,7 +117,7 @@ describe('QueuePanel', () => {
       item({ issueNumber: 2801, title: 'first' }),
       item({ issueNumber: 2802, title: 'second' }),
     ];
-    render(
+    renderWithTooltip(
       <QueuePanel
         queueReady={items}
         queueBlocked={[]}
@@ -125,7 +137,7 @@ describe('QueuePanel', () => {
     const blocked = [
       item({ issueNumber: 2500, title: 'blocked issue', blockedBy: [2500, 2600] }),
     ];
-    render(
+    renderWithTooltip(
       <QueuePanel
         queueReady={[]}
         queueBlocked={blocked}
@@ -142,7 +154,7 @@ describe('QueuePanel', () => {
     // total>0 always yields at least 1 shown), but the blocked-panel
     // empty-with-total-nonzero case is explicitly called out in the
     // issue. The component MUST still render `0 / N`, never "0 shown".
-    render(
+    renderWithTooltip(
       <QueuePanel
         queueReady={[]}
         queueBlocked={[]}
@@ -161,7 +173,7 @@ describe('QueuePanel', () => {
     // have a total is strictly safer than guessing — total === shown
     // would be a lie when the tail is capped.
     const items = [item({ issueNumber: 2801, title: 'first' })];
-    render(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
+    renderWithTooltip(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
     expect(screen.getByTestId('queue-ready-count')).toHaveTextContent('1 shown');
     expect(screen.getByTestId('queue-blocked-count')).toHaveTextContent('0 shown');
   });
@@ -176,7 +188,7 @@ describe('QueuePanel', () => {
       item({ issueNumber: 2801, title: 'first' }),
       item({ issueNumber: 2802, title: 'second' }),
     ];
-    render(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
+    renderWithTooltip(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
     const row1 = screen.getByTestId('queue-row-2801');
     const row2 = screen.getByTestId('queue-row-2802');
     expect((row1 as HTMLElement).style.viewTransitionName).toBe('issue-2801');
@@ -187,7 +199,7 @@ describe('QueuePanel', () => {
     const blocked = [
       item({ issueNumber: 2500, title: 'blocked issue' }),
     ];
-    render(<QueuePanel queueReady={[]} queueBlocked={blocked} nowMs={now} />);
+    renderWithTooltip(<QueuePanel queueReady={[]} queueBlocked={blocked} nowMs={now} />);
     // Blocked rows are intentionally not animated — they don't show up
     // in the Queue → Active → Completed flow, and giving them the same
     // `issue-<N>` name as a ready row of the same issue number would
@@ -211,7 +223,7 @@ describe('QueuePanel', () => {
       item({ issueNumber: 3151, title: 'first' }),
       item({ issueNumber: 3152, title: 'second' }),
     ];
-    render(<QueueReadyPanel items={items} total={50} dialogOpen />);
+    renderWithTooltip(<QueueReadyPanel items={items} total={50} dialogOpen />);
     // Rows still render — only the animation hook is suppressed.
     expect(screen.getByText('first')).toBeInTheDocument();
     expect(screen.getByText('second')).toBeInTheDocument();
@@ -223,14 +235,14 @@ describe('QueuePanel', () => {
 
   it('#3206: ready rows KEEP view-transition-name when dialogOpen=false (default)', () => {
     const items = [item({ issueNumber: 3151, title: 'first' })];
-    render(<QueueReadyPanel items={items} total={50} />);
+    renderWithTooltip(<QueueReadyPanel items={items} total={50} />);
     const row = screen.getByTestId('queue-row-3151');
     expect((row as HTMLElement).style.viewTransitionName).toBe('issue-3151');
   });
 
   it('#3206: dialogOpen=true also strips view-transition-name when explicit', () => {
     const items = [item({ issueNumber: 3151, title: 'first' })];
-    render(<QueueReadyPanel items={items} total={50} dialogOpen={true} />);
+    renderWithTooltip(<QueueReadyPanel items={items} total={50} dialogOpen={true} />);
     // No queue-row-<N> testid → no view-transition-name in style.
     expect(screen.queryByTestId('queue-row-3151')).toBeNull();
   });
@@ -240,7 +252,7 @@ describe('QueuePanel', () => {
     const items = [
       item({ issueNumber: 3001, title: 'cooled down issue', cooldownSecondsRemaining: 1800 }),
     ];
-    render(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
+    renderWithTooltip(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
     const badge = screen.getByTestId('cooldown-badge-3001');
     expect(badge).toBeInTheDocument();
     // 1800s → 30m
@@ -251,7 +263,7 @@ describe('QueuePanel', () => {
     const items = [
       item({ issueNumber: 3002, title: 'fresh issue', cooldownSecondsRemaining: null }),
     ];
-    render(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
+    renderWithTooltip(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
     expect(screen.queryByTestId('cooldown-badge-3002')).toBeNull();
   });
 
@@ -259,7 +271,7 @@ describe('QueuePanel', () => {
     const items = [
       item({ issueNumber: 3003, title: 'expired cooldown', cooldownSecondsRemaining: 0 }),
     ];
-    render(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
+    renderWithTooltip(<QueuePanel queueReady={items} queueBlocked={[]} nowMs={now} />);
     expect(screen.queryByTestId('cooldown-badge-3003')).toBeNull();
   });
 });
@@ -274,14 +286,14 @@ describe('QueuePanel — #3159 clickable count', () => {
   ];
 
   it('ready: count renders as a span when onCountClick is omitted (back-compat)', () => {
-    render(<QueueReadyPanel items={items} total={50} />);
+    renderWithTooltip(<QueueReadyPanel items={items} total={50} />);
     const count = screen.getByTestId('queue-ready-count');
     expect(count.tagName).toBe('SPAN');
   });
 
   it('ready: count renders as a button and fires onCountClick when provided', () => {
     const onCountClick = vi.fn();
-    render(
+    renderWithTooltip(
       <QueueReadyPanel
         items={items}
         total={50}
@@ -296,14 +308,14 @@ describe('QueuePanel — #3159 clickable count', () => {
   });
 
   it('blocked: count renders as a span when onCountClick is omitted (back-compat)', () => {
-    render(<QueueBlockedPanel items={[]} total={5} />);
+    renderWithTooltip(<QueueBlockedPanel items={[]} total={5} />);
     const count = screen.getByTestId('queue-blocked-count');
     expect(count.tagName).toBe('SPAN');
   });
 
   it('blocked: count renders as a button and fires onCountClick when provided', () => {
     const onCountClick = vi.fn();
-    render(
+    renderWithTooltip(
       <QueueBlockedPanel
         items={items}
         total={50}
@@ -318,7 +330,7 @@ describe('QueuePanel — #3159 clickable count', () => {
 
   it('button has accessible aria-label that names the bucket', () => {
     const onCountClick = vi.fn();
-    render(
+    renderWithTooltip(
       <QueueReadyPanel
         items={items}
         total={50}
@@ -327,6 +339,73 @@ describe('QueuePanel — #3159 clickable count', () => {
     );
     const count = screen.getByTestId('queue-ready-count');
     expect(count.getAttribute('aria-label')).toMatch(/agent-ready/i);
+  });
+});
+
+// --- #2812 — blocker tooltip hot links on blocked rows.
+describe('QueuePanel — #2812 blocker tooltip', () => {
+  it('renders blocker numbers as hot links inside the blocked-row tooltip', async () => {
+    const blockedItem: QueueItem = {
+      issueNumber: 9001,
+      title: 'blocked issue with two blockers',
+      priority: 'p2',
+      labels: ['priority/p2', 'status/blocked'],
+      createdAt: '2026-04-18T11:00:00Z',
+      blockedBy: [2500, 2600],
+      cooldownSecondsRemaining: null,
+    };
+    render(
+      <TooltipProvider>
+        <QueueRow item={blockedItem} />
+      </TooltipProvider>,
+    );
+    // The tooltip trigger should be present for rows with blockers.
+    const trigger = screen.getByTestId('blocker-tooltip-trigger-9001');
+    expect(trigger).toBeInTheDocument();
+    // Fire pointerMove to begin the tooltip open sequence (Radix opens on
+    // pointerMove). Then advance all timers (even delayDuration=0 uses setTimeout).
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        fireEvent.pointerMove(trigger);
+        vi.runAllTimers();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+    // Tooltip content renders the blocker links.
+    const link2500 = screen.getAllByTestId('issue-link-2500')[0];
+    const link2600 = screen.getAllByTestId('issue-link-2600')[0];
+    expect(link2500).toBeInTheDocument();
+    expect(link2600).toBeInTheDocument();
+    // Check the links have the correct hrefs.
+    expect(link2500).toHaveAttribute(
+      'href',
+      'https://github.com/judgemind/judgemind/issues/2500',
+    );
+    expect(link2600).toHaveAttribute(
+      'href',
+      'https://github.com/judgemind/judgemind/issues/2600',
+    );
+  });
+
+  it('suppresses the blocker tooltip when blockedBy is empty', () => {
+    const readyItem: QueueItem = {
+      issueNumber: 9002,
+      title: 'ready issue no blockers',
+      priority: 'p2',
+      labels: ['priority/p2', 'agent/ready'],
+      createdAt: '2026-04-18T11:00:00Z',
+      blockedBy: [],
+      cooldownSecondsRemaining: null,
+    };
+    render(
+      <TooltipProvider>
+        <QueueRow item={readyItem} />
+      </TooltipProvider>,
+    );
+    // No tooltip trigger for rows without blockers.
+    expect(screen.queryByTestId('blocker-tooltip-trigger-9002')).toBeNull();
   });
 });
 

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentFailuresPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentFailuresPanel.test.tsx
@@ -169,6 +169,18 @@ describe('RecentFailuresPanel', () => {
     });
   });
 
+  // #2812: §2.2 — category pill is font-mono.
+  it('§2.2 — category pill is font-mono', () => {
+    render(
+      <RecentFailuresPanel
+        failures={[makeFailure({ category: 'subprocess_crash', displayCategory: 'subprocess crashed' })]}
+        nowMs={NOW_MS}
+      />,
+    );
+    const pill = screen.getByTestId('failure-category-pill-subprocess_crash');
+    expect(pill.className).toContain('font-mono');
+  });
+
   // #2948: the Category column renders the operator-friendly
   // `displayCategory` string instead of the raw category token,
   // matching the Recently Completed tooltip rephrasing from #2935.

--- a/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
@@ -11,6 +11,34 @@
  * file-per-component would dilute the density-first design.
  */
 
+// ---------------------------------------------------------------------------
+// Amber / yellow usage allow-list (#2812 AC3)
+//
+// All amber/yellow Tailwind classes in the dispatcher UI are SEMANTIC — they
+// encode outcome or status, not decoration. The approved uses are:
+//
+//   amber — p1 PriorityBadge (time-sensitive priority indicator)
+//           OutcomePill `crashed` variant (amber ⚠ — non-fatal agent failure)
+//           OutcomePill `shipped_incomplete` variant (amber ✓ — merged but
+//             post-merge bookkeeping not finished; #2953)
+//           INCOMPLETE_SUCCESS_CLASSES (same as above)
+//           Stale-data indicator in DispatcherDashboard (yellow-700/300 text
+//             + yellow-500 pulse dot — indicates last poll failed, cached state)
+//
+//   yellow — OutcomePill `needs_review` variant (yellow ◐ — ralph SHIP'd but
+//              operator review needed; #2856)
+//            Daemon paused-status pill in DispatcherHeader (if applicable)
+//
+// Hot links use `text-brand-accent` / `text-brand-accent-light` (the brand
+// amber token defined in tailwind.config.ts — see docs/BRAND.md §Tailwind
+// Token Mapping). This is NOT Tailwind's built-in `amber` scale — it maps
+// to the design-token alias and is also an approved use.
+//
+// Any new amber/yellow use MUST be added here with a rationale. The
+// absence of a use from this list is a signal to challenge it in review.
+// Audit: grep -n 'amber\|yellow' packages/web/src/app/(main)/admin/dispatcher/*.tsx
+// ---------------------------------------------------------------------------
+
 const REPO = 'judgemind/judgemind';
 
 // Brand amber token for hot links. Note: `text-accent` is shadcn's


### PR DESCRIPTION
## Summary

Dispatcher UI Phase 2 refinement per #2805: reduced vertical spacing (gap-y-6→4, mt-6→4) for 20% denser layout, added Radix Tooltip on blocked queue rows showing blocker issues as hot links, added font-mono to category pills, reordered metadata columns for visual consistency, and consolidated GitHub links through IssueLink component. Includes comprehensive amber/yellow allow-list comment to prevent future accent-color drift.

Closes #2812

## Test plan

### Automated checks

- [x] Lint passes (`npm run lint`)
- [x] Format check passes (`prettier`)
- [x] Tests pass (`npm test`) — 1428/1428 pass, 6 new tests added
- [x] CI green

### Post-deploy verification

- [ ] Row height is 20% denser compared to baseline (screenshot comparison on dev)
- [ ] All system-identifier text (agent id, sha, pr #, issue #, phase, category) is monospace (grep audit on dev)
- [ ] Every row in Queue / Active / Completed / Failures follows consistent [glyph/id] [text] [metadata] [timestamp] order (manual visual audit at 1920px)
- [ ] Verification evidence posted on #2812 (see /task-v2-verify output)