### PR TITLE
fix(web): skip root view-transition while cockpit dialog is open (#3220)

### DIFF
--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -141,6 +141,19 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
   // flows through the animation path without changing Apollo's cache
   // behaviour. On first paint we initialise synchronously — the very
   // first frame would have no "old" snapshot to animate from anyway.
+  //
+  // #3220: also bypass the wrapper while any cockpit dialog is open.
+  // #3206 stripped `viewTransitionName` from panel rows when a dialog is
+  // open, but `document.startViewTransition` *always* snapshots the root
+  // viewport into `::view-transition-*(root)` regardless of whether any
+  // named targets exist. Native scrollbars are browser UI — not DOM
+  // content — so they're not captured in the root snapshot and briefly
+  // disappear during the ~250ms cross-fade. On the dialog's
+  // `max-h-[60vh] overflow-y-auto` body, that produces a 2s on/off
+  // scrollbar flicker matching the poll cadence. Synchronous update
+  // while a dialog is open side-steps the root transition entirely.
+  // When the dialog closes, the next poll goes back through
+  // `startViewTransitionUpdate` and Magic Move resumes on the panels.
   const [renderedData, setRenderedData] = useState<DispatcherStateData | undefined>(
     data,
   );
@@ -151,13 +164,15 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
     if (data === lastAppliedDataRef.current) return;
     const hasPrior = lastAppliedDataRef.current !== undefined;
     lastAppliedDataRef.current = data;
-    if (!hasPrior) {
+    if (!hasPrior || fullDialogKind !== null) {
       // First successful fetch — no prior frame to transition from.
+      // Dialog open (#3220) — skip the root view-transition to avoid
+      // scrollbar flicker on the dialog's scroll container.
       setRenderedData(data);
       return;
     }
     startViewTransitionUpdate(() => setRenderedData(data));
-  }, [data, startViewTransitionUpdate]);
+  }, [data, fullDialogKind, startViewTransitionUpdate]);
 
   const [dispatcherControl, { loading: controlLoading }] =
     useMutation<DispatcherControlData>(DISPATCHER_CONTROL_MUTATION);

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
@@ -982,3 +982,189 @@ describe('DispatcherDashboard — DiagnoserEffectivenessPanel (#2800)', () => {
     ).toBeInTheDocument();
   });
 });
+
+// #3220: the root view-transition wrapper itself must be skipped while
+// any cockpit dialog is open. Even without named transition targets,
+// `document.startViewTransition` snapshots the entire viewport into
+// `::view-transition-*(root)` and cross-fades for ~250ms — during which
+// native scrollbars vanish and reappear, producing a 2s on/off flicker
+// on the dialog's scrollable body that matches the poll cadence.
+describe('DispatcherDashboard — #3220 root view-transition gate while dialog open', () => {
+  beforeEach(() => {
+    mockControlMutate.mockClear();
+    mockSetConfigMutate.mockClear();
+    mockRefetch.mockClear();
+    mockQueueFullData.READY = undefined;
+    mockQueueFullData.BLOCKED = undefined;
+    mockQueueFullData.COMPLETED = undefined;
+  });
+
+  function installViewTransitionStub(): {
+    startViewTransition: ReturnType<typeof vi.fn>;
+    restore: () => void;
+  } {
+    const startViewTransition = vi.fn((cb: () => void): unknown => {
+      // Run the callback so `setRenderedData` actually commits —
+      // otherwise subsequent rerenders see a stale mirror. The real
+      // API wraps this in `flushSync`, but for the purpose of
+      // asserting "was startViewTransition called?" we don't need to
+      // reproduce the snapshot semantics.
+      cb();
+      return { finished: Promise.resolve() };
+    });
+    (
+      document as unknown as {
+        startViewTransition?: (cb: () => void) => unknown;
+      }
+    ).startViewTransition = startViewTransition;
+
+    const originalMatchMedia = window.matchMedia;
+    (window as unknown as { matchMedia: typeof window.matchMedia }).matchMedia =
+      ((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      })) as typeof window.matchMedia;
+
+    return {
+      startViewTransition,
+      restore: () => {
+        delete (
+          document as unknown as {
+            startViewTransition?: (cb: () => void) => unknown;
+          }
+        ).startViewTransition;
+        (
+          window as unknown as { matchMedia: typeof window.matchMedia }
+        ).matchMedia = originalMatchMedia;
+      },
+    };
+  }
+
+  it('does NOT call startViewTransition on a poll-driven update while a dialog is open', async () => {
+    const { startViewTransition, restore } = installViewTransitionStub();
+    try {
+      // Initial frame — first render initialises the mirror synchronously.
+      mockQueryData = { dispatcherState: { ...BASE_STATE } };
+      mockQueueFullData.READY = {
+        dispatcherQueueFull: {
+          kind: 'READY',
+          queueItems: [],
+          completions: [],
+        },
+      };
+      const { rerender } = renderDashboard();
+      expect(startViewTransition).not.toHaveBeenCalled();
+
+      // Open the Ready dialog. Opening the dialog is itself a React
+      // state update (`setFullDialogKind('READY')`), and the effect
+      // that mirrors Apollo's `data` has `fullDialogKind` in its
+      // dependency list — but there's no new `data` reference yet, so
+      // the effect's early-returns (`data === lastAppliedDataRef.current`)
+      // short-circuit and no transition fires.
+      fireEvent.click(screen.getByTestId('queue-ready-count'));
+      await screen.findByTestId('queue-full-dialog');
+      expect(startViewTransition).not.toHaveBeenCalled();
+
+      // Now simulate a poll landing a *new* `data` reference while the
+      // dialog is open. With the #3220 gate in place, the effect takes
+      // the synchronous branch (`fullDialogKind !== null`) and never
+      // calls `startViewTransitionUpdate`.
+      mockQueryData = {
+        dispatcherState: {
+          ...BASE_STATE,
+          queueDepth: 42,
+        },
+      };
+      rerender(<DispatcherDashboard />);
+
+      // Give the effect a tick to run. `waitFor` will retry until the
+      // timeout; we expect it to *still* be zero at the end, so we
+      // just yield once and assert.
+      await waitFor(() => {
+        // The dialog is still open — sanity check.
+        expect(screen.queryByTestId('queue-full-dialog')).not.toBeNull();
+      });
+      expect(startViewTransition).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it('DOES call startViewTransition on a poll-driven update when no dialog is open (regression guard)', async () => {
+    const { startViewTransition, restore } = installViewTransitionStub();
+    try {
+      mockQueryData = { dispatcherState: { ...BASE_STATE } };
+      const { rerender } = renderDashboard();
+      expect(startViewTransition).not.toHaveBeenCalled();
+
+      // New data reference arrives — no dialog open, so the wrapper fires.
+      mockQueryData = {
+        dispatcherState: {
+          ...BASE_STATE,
+          queueDepth: 42,
+        },
+      };
+      rerender(<DispatcherDashboard />);
+
+      await waitFor(() => {
+        expect(startViewTransition).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('resumes wrapping poll updates in startViewTransition after the dialog closes', async () => {
+    const { startViewTransition, restore } = installViewTransitionStub();
+    try {
+      mockQueryData = { dispatcherState: { ...BASE_STATE } };
+      mockQueueFullData.READY = {
+        dispatcherQueueFull: {
+          kind: 'READY',
+          queueItems: [],
+          completions: [],
+        },
+      };
+      const { rerender } = renderDashboard();
+
+      // Open the dialog.
+      fireEvent.click(screen.getByTestId('queue-ready-count'));
+      await screen.findByTestId('queue-full-dialog');
+
+      // Poll lands while dialog is open — no transition.
+      mockQueryData = {
+        dispatcherState: { ...BASE_STATE, queueDepth: 1 },
+      };
+      rerender(<DispatcherDashboard />);
+      await waitFor(() => {
+        expect(screen.queryByTestId('queue-full-dialog')).not.toBeNull();
+      });
+      expect(startViewTransition).not.toHaveBeenCalled();
+
+      // Close the dialog — QueueFullDialog's `onClose` flips the kind
+      // to null. We trigger it by pressing Escape on the dialog, which
+      // Radix handles by firing onOpenChange(false).
+      fireEvent.keyDown(document.body, { key: 'Escape', code: 'Escape' });
+      await waitFor(() => {
+        expect(screen.queryByTestId('queue-full-dialog')).toBeNull();
+      });
+
+      // Next poll with a new data reference should now be wrapped.
+      mockQueryData = {
+        dispatcherState: { ...BASE_STATE, queueDepth: 2 },
+      };
+      rerender(<DispatcherDashboard />);
+      await waitFor(() => {
+        expect(startViewTransition).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      restore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Extends #3209's fix for cockpit dialog animation bleed-through. That PR suppressed named `viewTransitionName`s on panel rows while a `QueueFullDialog` is open, but `document.startViewTransition` still fired on every 2s poll and unconditionally snapshotted the root viewport — causing the dialog's native scrollbar to flicker on/off at poll cadence. Gate the wrapper on `fullDialogKind !== null` so dialog-open polls apply synchronously. Magic Move resumes on the next poll after the dialog closes.

Closes #3220

## Test plan

### Automated checks
- [x] Lint passes (`npm run lint` — clean)
- [x] Format check passes (ESLint + TS strict)
- [x] Tests pass (`npm run test` — 1431/1431 green, 3 new cases)
- [x] Build succeeds (`npm run build`)
- [x] CI green (web-tests, ci-passed, coverage-check all SUCCESS)

### Post-deploy verification
- [x] Screenshot sequence at varying `--click-wait` offsets (600, 1100, 1600, 2100, 2600, 3100, 4100 ms) on `https://dev.judgemind.org/admin/dispatcher` shows the dialog scrollbar is stable across poll boundaries (no on/off flicker)
- [x] Verification evidence posted on issue (see [comment](https://github.com/judgemind/judgemind/issues/3220#issuecomment-4314288378))
