### PR TITLE
polish(web/admin): dialog titles show only total, not {shown} / {total} (#3222)

### DIFF
--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -475,17 +475,19 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
        * X button) cancels future fetches until the operator clicks a
        * count again.
        *
-       * #3172: thread `shown` / `total` through so the dialog title
-       * carries the same `{shown} / {total}` denominator the badge
-       * displayed. `shown` is the panel's rendered list length (capped
-       * at 10 server-side); `total` comes from the matching depth field
-       * on `DispatcherState`. Both are scoped to the currently-open
-       * `kind` — when no dialog is open, both are undefined and the
-       * helper renders nothing (the dialog is unmounted anyway).
+       * #3172: thread `total` through so the dialog title reports the
+       * bucket size — `total` comes from the matching depth field on
+       * `DispatcherState`, scoped to the currently-open `kind`. When no
+       * dialog is open, `total` is undefined and the helper renders
+       * nothing (the dialog is unmounted anyway).
+       *
+       * #3222: the title now reads `{label} — {total}` only. The dialog
+       * shows every row (no 10-cap), so threading a `shown` numerator
+       * from the panel would be meaningless here — see `formatDialogTitle`
+       * docstring for the full rationale.
        */}
       <QueueFullDialog
         kind={fullDialogKind}
-        shown={shownForKind(fullDialogKind, state)}
         total={totalForKind(fullDialogKind, state)}
         onClose={() => setFullDialogKind(null)}
       />
@@ -495,32 +497,12 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
 }
 
 /**
- * Compute the `shown` value to pass to `<QueueFullDialog>` so the
- * dialog title reads `{shown} / {total}` matching the badge that
- * opened it (issue #3172). `shown` is the count of items the panel was
- * rendering at click time — capped server-side at 10 for the queue
- * panels, capped at 10 by the `recentCompletions` resolver for the
- * Recently Completed panel.
- *
- * Returns `undefined` when no dialog is open or when `state` is not yet
- * loaded — `formatDialogTitle` falls back to a clean labelled title in
- * that case.
- */
-function shownForKind(
-  kind: DispatcherQueueKind | null,
-  state: DispatcherStateData['dispatcherState'] | undefined,
-): number | undefined {
-  if (kind === null || state === undefined) return undefined;
-  if (kind === 'READY') return state.queueReady.length;
-  if (kind === 'BLOCKED') return state.queueBlocked.length;
-  return state.recentCompletions.length;
-}
-
-/**
- * Companion to `shownForKind` — returns the matching depth field from
- * `DispatcherState` so the dialog title can render the `{shown} /
- * {total}` denominator. Returns `undefined` when no dialog is open or
- * when `state` is not loaded.
+ * Returns the matching depth field from `DispatcherState` so the dialog
+ * title can render the `{label} — {total}` count decoration. Returns
+ * `undefined` when no dialog is open or when `state` is not loaded.
+ * #3222 removed the companion `shownForKind` helper — the dialog title
+ * no longer carries a numerator because the dialog renders every row
+ * (no 10-cap), so a `shown` value would be meaningless there.
  */
 function totalForKind(
   kind: DispatcherQueueKind | null,

--- a/packages/web/src/app/(main)/admin/dispatcher/QueueFullDialog.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/QueueFullDialog.tsx
@@ -36,26 +36,20 @@ import { RecentCompletionRow } from './RecentCompletionsPanel';
  */
 export function QueueFullDialog({
   kind,
-  shown,
   total,
   onClose,
 }: {
   /** Open when not null — also drives which kind to fetch. */
   kind: DispatcherQueueKind | null;
   /**
-   * Number of rows the panel that opened this dialog was rendering at
-   * click time (capped at 10 server-side). Surfaced in the title's
-   * `{shown} / {total}` so the dialog title carries the same denominator
-   * as the badge the operator just clicked (issue #3172). Optional —
-   * when omitted the title falls back to bare `{label}` without a count
-   * decoration so existing test fixtures keep working.
-   */
-  shown?: number;
-  /**
    * Total count of rows in the bucket the panel knows about (sourced
    * from `DispatcherState.queueDepth` / `blockedDepth` /
-   * `recentCompletionsCount`). Same role as `shown` — surfaces the
-   * denominator. Optional for the same back-compat reason.
+   * `recentCompletionsCount`). Surfaced in the title as `{label} —
+   * {total}` so the dialog header reports the full bucket size (the
+   * dialog renders every row — no 10-cap — so the panel's `shown`
+   * numerator would be meaningless here; see #3222). Optional — when
+   * omitted the title falls back to bare `{label}` without a count
+   * decoration so initial-load and existing test fixtures stay clean.
    */
   total?: number;
   /** Called when the dialog closes (ESC, click outside, X button). */
@@ -80,7 +74,7 @@ export function QueueFullDialog({
   const queueItems = payload?.queueItems ?? [];
   const completions = payload?.completions ?? [];
 
-  const titleText = formatDialogTitle(kind, shown, total, loading);
+  const titleText = formatDialogTitle(kind, total, loading);
 
   return (
     <Dialog
@@ -232,29 +226,28 @@ function DialogList({
 
 /**
  * Format the dialog title — the heading text mirrors the panel heading
- * the operator just clicked, and the count decoration carries the same
- * `{shown} / {total}` denominator the badge displayed.
+ * the operator just clicked, and the count decoration reports the full
+ * bucket size.
  *
- * Issue #3172 made two changes vs. the original #3159 shape:
- *  1. Labels now match the panel headings exactly:
- *     - `READY`     → `Queue: Agent-ready`   (matches `QueuePanel.tsx`)
- *     - `BLOCKED`   → `Queue: Blocked`       (matches `QueuePanel.tsx`)
- *     - `COMPLETED` → `Recently completed`   (matches `RecentCompletionsPanel.tsx`)
- *     The original `Agent-ready queue (N)` / `Blocked queue (N)` strings
- *     inverted the noun/qualifier order vs. the panel headings, so the
- *     dialog visually disconnected from the badge that opened it.
- *  2. Count decoration is `{shown} / {total}` (em-dash separator), not
- *     `(N)`. When `shown` and `total` are both numbers, the title
- *     reads e.g. `Queue: Agent-ready — 10 / 50`. When either is
- *     undefined (back-compat / kind=null), the count decoration is
- *     dropped so the title stays clean.
+ * Labels match the panel headings exactly (#3172):
+ *  - `READY`     → `Queue: Agent-ready`   (matches `QueuePanel.tsx`)
+ *  - `BLOCKED`   → `Queue: Blocked`       (matches `QueuePanel.tsx`)
+ *  - `COMPLETED` → `Recently completed`   (matches `RecentCompletionsPanel.tsx`)
+ *
+ * Count decoration is `{label} — {total}` (em-dash separator). The
+ * dialog renders every row the daemon snapshot knows about (no 10-cap),
+ * so the panel's `shown` numerator is meaningless here — a denominator
+ * like `10 / 74` would actively mislead the operator into thinking they
+ * were looking at a 10-row slice (#3222). When `total` is undefined
+ * (initial load before `dispatcherState` resolves, or kind=null
+ * closed-dialog state), the count decoration is dropped so the title
+ * stays clean.
  *
  * Pure helper so the test can exercise the formatting without rendering
  * the dialog.
  */
 export function formatDialogTitle(
   kind: DispatcherQueueKind | null,
-  shown: number | undefined,
   total: number | undefined,
   loading: boolean,
 ): string {
@@ -266,8 +259,8 @@ export function formatDialogTitle(
         ? 'Queue: Blocked'
         : 'Recently completed';
   if (loading) return `${label} — loading…`;
-  if (typeof shown === 'number' && typeof total === 'number') {
-    return `${label} — ${shown} / ${total}`;
+  if (typeof total === 'number') {
+    return `${label} — ${total}`;
   }
   return label;
 }

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
@@ -635,9 +635,12 @@ describe('DispatcherDashboard — #3159 expand-count dialog wiring', () => {
   });
 });
 
-// #3172: dialog title carries the same {shown} / {total} denominator as
-// the badge that opened it, and labels match the panel headings exactly.
-describe('DispatcherDashboard — #3172 dialog title denominator', () => {
+// #3172 threaded `{shown} / {total}` into the dialog title; #3222
+// reverted the numerator because the dialog renders every row (no
+// 10-cap). These tests assert the bare-total shape while verifying the
+// panel badge keeps its `{shown} / {total}` format (still correct for
+// the 10-row-capped panel context).
+describe('DispatcherDashboard — #3222 dialog title (total only)', () => {
   beforeEach(() => {
     mockControlMutate.mockClear();
     mockSetConfigMutate.mockClear();
@@ -647,7 +650,7 @@ describe('DispatcherDashboard — #3172 dialog title denominator', () => {
     mockQueueFullData.COMPLETED = undefined;
   });
 
-  it('READY dialog title reads `Queue: Agent-ready — {shown} / {total}` matching the badge', async () => {
+  it('READY dialog title reads `Queue: Agent-ready — {total}` (panel badge still shows {shown} / {total})', async () => {
     // Panel renders 10 (capped); the daemon has scanned 50 ready issues.
     const items = Array.from({ length: 10 }, (_, i) => ({
       issueNumber: 8000 + i,
@@ -673,16 +676,18 @@ describe('DispatcherDashboard — #3172 dialog title denominator', () => {
       },
     };
     renderDashboard();
-    // Sanity: badge shows `10 / 50` (existing #2886 behaviour).
+    // Sanity: panel badge still shows `10 / 50` (existing #2886
+    // behaviour — the 10-row cap means the numerator is still
+    // meaningful in the panel context, unlike the dialog).
     expect(screen.getByTestId('queue-ready-count')).toHaveTextContent(
       '10 / 50',
     );
     fireEvent.click(screen.getByTestId('queue-ready-count'));
     const title = await screen.findByTestId('queue-full-dialog-title');
-    expect(title.textContent).toBe('Queue: Agent-ready — 10 / 50');
+    expect(title.textContent).toBe('Queue: Agent-ready — 50');
   });
 
-  it('BLOCKED dialog title reads `Queue: Blocked — {shown} / {total}`', async () => {
+  it('BLOCKED dialog title reads `Queue: Blocked — {total}`', async () => {
     const items = Array.from({ length: 4 }, (_, i) => ({
       issueNumber: 7000 + i,
       title: `blocked ${7000 + i}`,
@@ -712,10 +717,10 @@ describe('DispatcherDashboard — #3172 dialog title denominator', () => {
     );
     fireEvent.click(screen.getByTestId('queue-blocked-count'));
     const title = await screen.findByTestId('queue-full-dialog-title');
-    expect(title.textContent).toBe('Queue: Blocked — 4 / 12');
+    expect(title.textContent).toBe('Queue: Blocked — 12');
   });
 
-  it('COMPLETED dialog title reads `Recently completed — {shown} / {total}`', async () => {
+  it('COMPLETED dialog title reads `Recently completed — {total}`', async () => {
     const completions = Array.from({ length: 10 }, (_, i) => ({
       agentId: `aaaaaaaa-bbbb-cccc-dddd-${String(i).padStart(12, '0')}`,
       issueNumber: 6000 + i,
@@ -753,7 +758,7 @@ describe('DispatcherDashboard — #3172 dialog title denominator', () => {
     );
     fireEvent.click(screen.getByTestId('recent-completions-count'));
     const title = await screen.findByTestId('queue-full-dialog-title');
-    expect(title.textContent).toBe('Recently completed — 10 / 183');
+    expect(title.textContent).toBe('Recently completed — 183');
   });
 });
 

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueueFullDialog.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueueFullDialog.test.tsx
@@ -318,47 +318,48 @@ describe('QueueFullDialog — close handling', () => {
 
 describe('formatDialogTitle', () => {
   it('returns empty string for kind=null', () => {
-    expect(formatDialogTitle(null, 0, 0, false)).toBe('');
+    expect(formatDialogTitle(null, 0, false)).toBe('');
   });
 
-  // #3172: title labels match panel headings character-for-character
-  // and the count decoration becomes `{shown} / {total}`.
-  it('renders `Queue: Agent-ready — {shown} / {total}` for READY', () => {
-    expect(formatDialogTitle('READY', 10, 50, false)).toBe(
-      'Queue: Agent-ready — 10 / 50',
+  // #3222: title now reads `{label} — {total}` only. The dialog renders
+  // every row (no 10-cap), so a `shown` numerator would be meaningless
+  // and actively misleading — operators would think they were looking
+  // at a 10-row slice when in fact every row is visible.
+  it('renders `Queue: Agent-ready — {total}` for READY', () => {
+    expect(formatDialogTitle('READY', 50, false)).toBe(
+      'Queue: Agent-ready — 50',
     );
   });
 
-  it('renders `Queue: Blocked — {shown} / {total}` for BLOCKED', () => {
-    expect(formatDialogTitle('BLOCKED', 5, 12, false)).toBe(
-      'Queue: Blocked — 5 / 12',
+  it('renders `Queue: Blocked — {total}` for BLOCKED', () => {
+    expect(formatDialogTitle('BLOCKED', 12, false)).toBe(
+      'Queue: Blocked — 12',
     );
   });
 
-  it('renders `Recently completed — {shown} / {total}` for COMPLETED', () => {
-    expect(formatDialogTitle('COMPLETED', 10, 183, false)).toBe(
-      'Recently completed — 10 / 183',
+  it('renders `Recently completed — {total}` for COMPLETED', () => {
+    expect(formatDialogTitle('COMPLETED', 183, false)).toBe(
+      'Recently completed — 183',
     );
   });
 
   it('appends a — loading… marker while loading', () => {
-    expect(formatDialogTitle('READY', 0, 0, true)).toBe(
+    expect(formatDialogTitle('READY', 0, true)).toBe(
       'Queue: Agent-ready — loading…',
     );
   });
 
-  it('drops the count decoration when shown or total is undefined', () => {
-    // Back-compat fallback for callers that don't supply both numbers
-    // (e.g. existing test fixtures, or a future caller that hasn't yet
-    // wired up the depth fields).
-    expect(formatDialogTitle('READY', undefined, 50, false)).toBe(
+  it('drops the count decoration when total is undefined', () => {
+    // Initial-load fallback: before `dispatcherState` has resolved,
+    // `total` is undefined and the title renders as bare `{label}`.
+    expect(formatDialogTitle('READY', undefined, false)).toBe(
       'Queue: Agent-ready',
     );
-    expect(formatDialogTitle('READY', 10, undefined, false)).toBe(
-      'Queue: Agent-ready',
+    expect(formatDialogTitle('BLOCKED', undefined, false)).toBe(
+      'Queue: Blocked',
     );
-    expect(formatDialogTitle('READY', undefined, undefined, false)).toBe(
-      'Queue: Agent-ready',
+    expect(formatDialogTitle('COMPLETED', undefined, false)).toBe(
+      'Recently completed',
     );
   });
 
@@ -367,13 +368,13 @@ describe('formatDialogTitle', () => {
     // ("Agent-ready queue", "Blocked queue") inverted the noun/qualifier
     // order vs. the panel headings ("Queue: Agent-ready", "Queue: Blocked")
     // — operators saw two different strings for the same thing.
-    expect(formatDialogTitle('READY', undefined, undefined, false)).toBe(
+    expect(formatDialogTitle('READY', undefined, false)).toBe(
       'Queue: Agent-ready',
     );
-    expect(formatDialogTitle('BLOCKED', undefined, undefined, false)).toBe(
+    expect(formatDialogTitle('BLOCKED', undefined, false)).toBe(
       'Queue: Blocked',
     );
-    expect(formatDialogTitle('COMPLETED', undefined, undefined, false)).toBe(
+    expect(formatDialogTitle('COMPLETED', undefined, false)).toBe(
       'Recently completed',
     );
   });


### PR DESCRIPTION
## Summary

Correction to #3172 (PR #3178). The queue-full dialog renders every row the daemon snapshot knows about (no 10-cap), so the panel's `shown` numerator was actively misleading in the dialog title — operators seeing `Queue: Agent-ready — 10 / 74` could think they were looking at a 10-row slice when in fact every row was visible. Simplified `formatDialogTitle` to return `{label} — {total}` and cleaned up the now-dead `shown` / `shownForKind` plumbing. Panel badges keep `{shown} / {total}` (still correct for the 10-row-capped panel context).

Closes #3222

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] Open each of the three dialogs on `dev.judgemind.org/admin/dispatcher` (click the count badge on Queue: Agent-ready, Queue: Blocked, Recently completed) and confirm the header reads `{label} — {total}` (no `X / ` prefix) — verified via authenticated screenshots: `Queue: Agent-ready — 68`, `Queue: Blocked — 13`, `Recently completed — 206`.
- [x] Confirm the panel badges still render `{shown} / {total}` format — blocked-dialog screenshot shows the background panel badge still reads `10 / 13`.
- [x] Verification evidence posted on issue (see #3222 comments).
