### PR TITLE
fix(dispatcher): ON CONFLICT on entrypoint phase_outputs INSERT (#3219)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -1684,6 +1684,33 @@ persist_phase_output() {
     # stay NULL here; Stage 2 wiring populates them once the daemon-
     # side log-capture path is in place.
     #
+    # #3219 — ON CONFLICT overwrite. The unique index
+    # ``idx_dispatcher_phase_outputs_agent_phase_attempt`` on
+    # ``(agent_id, phase, attempt)`` (migration 30) rejects a second
+    # INSERT on the same three-tuple. Re-entry to a phase is a legitimate
+    # case today — e.g. CI goes red, fix_ci patches, the entrypoint
+    # transitions back to ``awaiting_ci`` and calls persist_phase_output
+    # a second time with the same attempt (the entrypoint does not
+    # bump ``attempt``; retries_used / attempt increments are a daemon-
+    # side concern driven by ``_process_retry_markers``). Without the
+    # ON CONFLICT, the second INSERT raises a unique-constraint
+    # violation, psql exits 1, ``db_exec``'s ``-v ON_ERROR_STOP=1`` +
+    # ``set -euo pipefail`` kill the entrypoint, and the ECS task exits
+    # 1 → daemon marks the agent ``agent_task_stopped_unexpectedly`` →
+    # PR is stranded. The subprocess-mode daemon's
+    # ``_persist_phase_output`` already uses the same ON CONFLICT
+    # overwrite (see ``scripts/dispatcher/daemon.py`` ~line 5818), so
+    # this brings the entrypoint to parity.
+    #
+    # We intentionally overwrite rather than bumping ``attempt`` —
+    # the entrypoint has no access to the retry-counter state the
+    # daemon tracks, and a simple overwrite keeps re-entry idempotent
+    # without leaking any new semantics. The tradeoff is that fix_ci
+    # → awaiting_ci re-entry loses the prior awaiting_ci payload
+    # (typically a ``ci_red`` observation that prompted fix_ci); the
+    # ralph_patches table + the daemon-side fix_ci phase_output row
+    # preserve that history.
+    #
     # Default-substitute to an empty-object string if $2 is absent.
     # We spell the default in two stages rather than
     # ``${2:-{}}`` because bash's ``${param:-word}`` parser treats a
@@ -1697,7 +1724,10 @@ persist_phase_output() {
     fi
     _escaped=$(printf '%s' "$_output_json" | sed "s/'/''/g")
     db_exec "INSERT INTO dispatcher.phase_outputs (agent_id, phase, output_json)
-             VALUES ('$AGENT_ID', '$_phase', '$_escaped'::jsonb);"
+             VALUES ('$AGENT_ID', '$_phase', '$_escaped'::jsonb)
+             ON CONFLICT (agent_id, phase, attempt) DO UPDATE
+               SET output_json = EXCLUDED.output_json,
+                   ts = now();"
     log "phase_output_persisted" "phase=$_phase"
 }
 
@@ -2464,11 +2494,24 @@ agent_runner_reaped_failure() {
         "category=$_category" \
         "reason=$_reason"
     _escaped_reason=$(printf '%s' "$_reason" | sed "s/'/''/g")
+    # #3219 — ON CONFLICT overwrite. See persist_phase_output for the
+    # full rationale; the short version is that the unique index
+    # ``idx_dispatcher_phase_outputs_agent_phase_attempt`` rejects a
+    # second INSERT on the same (agent_id, phase, attempt) three-tuple.
+    # The failure path can legitimately be reached with an existing
+    # phase_outputs row (e.g. awaiting_ci observed ``ci_red`` then the
+    # reaper fires on an unrecoverable branch). The ``|| true`` below
+    # masked the crash already, but without ON CONFLICT the failure
+    # payload simply wasn't persisted — operators lost the reaper's
+    # category + reason context on re-entry.
     db_exec "INSERT INTO dispatcher.phase_outputs
                (agent_id, phase, output_json)
              VALUES
                ('$AGENT_ID', '$_term_phase',
-                '{\"category\": \"$_category\", \"reason\": \"$_escaped_reason\"}'::jsonb);" \
+                '{\"category\": \"$_category\", \"reason\": \"$_escaped_reason\"}'::jsonb)
+             ON CONFLICT (agent_id, phase, attempt) DO UPDATE
+               SET output_json = EXCLUDED.output_json,
+                   ts = now();" \
         >/dev/null 2>&1 || true
     db_exec "UPDATE dispatcher.agents
                 SET phase = '$_term_phase', status = 'failed'

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -652,6 +652,29 @@ else
     pass "phase_outputs INSERT omits nonexistent status column (#3115)"
 fi
 
+# #3219 regression guard — every INSERT into dispatcher.phase_outputs
+# must carry an ``ON CONFLICT (agent_id, phase, attempt) DO UPDATE``
+# clause so a legitimate re-entry (fix_ci → awaiting_ci is the
+# observed path from aa11f02a PR #3217 #2829) doesn't raise a
+# unique-constraint violation that propagates through db_exec's
+# ``-v ON_ERROR_STOP=1`` + ``set -euo pipefail`` and kills the
+# entrypoint (ECS exit 1 → daemon reaps as agent_task_stopped_
+# unexpectedly → PR stranded). The daemon's subprocess-mode
+# ``_persist_phase_output`` already writes the same ON CONFLICT
+# overwrite (daemon.py ~line 5818); this test keeps the entrypoint
+# at parity.
+insert_count=$(grep -c "INSERT INTO dispatcher.phase_outputs" "$INVOCATIONS_DIR/psql.log" 2>/dev/null || true)
+insert_count=${insert_count:-0}
+on_conflict_count=$(grep "INSERT INTO dispatcher.phase_outputs" "$INVOCATIONS_DIR/psql.log" \
+    | grep -c "ON CONFLICT (agent_id, phase, attempt) DO UPDATE" 2>/dev/null || true)
+on_conflict_count=${on_conflict_count:-0}
+if [[ "$insert_count" -gt 0 && "$insert_count" == "$on_conflict_count" ]]; then
+    pass "#3219 — every phase_outputs INSERT carries ON CONFLICT DO UPDATE (inserts=$insert_count)"
+else
+    fail "#3219 — every phase_outputs INSERT carries ON CONFLICT DO UPDATE" \
+         "inserts=$insert_count, with-on-conflict=$on_conflict_count. Sample: $(grep -m1 "INSERT INTO dispatcher.phase_outputs" "$INVOCATIONS_DIR/psql.log" | head -c 400)"
+fi
+
 # Verify ralph_patches was inserted on ralph SHIP.
 if grep -q "INSERT INTO dispatcher.ralph_patches" "$INVOCATIONS_DIR/psql.log"; then
     pass "inserts ralph_patches row on ralph SHIP"
@@ -3429,6 +3452,211 @@ if grep -q "SET phase = \\\\'merge\\\\'" "$INVOCATIONS_DIR/psql.log"; then
 else
     fail "#3200 T39 — fixture D advances to merge on already-merged short-circuit" \
          "psql log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 40: #3219 — persist_phase_output is idempotent on re-entry.
+#
+# Scenario under test: the daemon's subprocess-mode _persist_phase_output
+# uses ON CONFLICT (agent_id, phase, attempt) DO UPDATE, but the Stage 1b
+# entrypoint originally did a plain INSERT. When an ECS agent's CI went
+# red → fix_ci patched → re-entered awaiting_ci, the second
+# persist_phase_output call on the same (agent_id, phase, attempt)
+# tripped the idx_dispatcher_phase_outputs_agent_phase_attempt UNIQUE
+# index, psql exited 1, db_exec's ``-v ON_ERROR_STOP=1`` +
+# ``set -euo pipefail`` killed the entrypoint, ECS marked exit_code=1,
+# and the daemon reaped the agent as ``agent_task_stopped_unexpectedly``
+# with a stranded PR. Observed live on agent aa11f02a PR #3217 #2829
+# at 2026-04-24 14:26:52Z.
+#
+# This test isolates persist_phase_output by extracting just the
+# function definitions it needs (db_exec, log, persist_phase_output)
+# from the entrypoint via sed, then drives it with a psql stub that
+# enforces a real unique-constraint on (agent_id, phase, attempt).
+# If the INSERT lacks ON CONFLICT, the second call fails and
+# propagates exit 1. If ON CONFLICT is present, the second call
+# succeeds and the stored JSON is overwritten with EXCLUDED.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+
+# Extract the function definitions we need. Each function in the
+# entrypoint starts at ``<name>() {`` and ends at the first column-0
+# closing brace on its own line. We pull db_exec, log, and
+# persist_phase_output into a standalone fixture file so we can source
+# and invoke them without running the entrypoint's main loop.
+t40_funcs="$TEST_TMP/t40-funcs.sh"
+# Bootstrap: log() writes to fd 3 which the entrypoint's top-level wires
+# to stdout via ``exec 3>&1``. Reproduce that wiring here so the test
+# subshell doesn't hit "bad file descriptor" when persist_phase_output
+# calls log.
+printf 'exec 3>&1\n' > "$t40_funcs"
+
+# Extract `db_exec() { ... }` — the first brace-balanced block starting
+# at that token. Simple awk state machine: track brace depth from the
+# opening line, emit until depth returns to zero.
+awk '
+    /^db_exec\(\)/ { in_fn=1 }
+    in_fn { print }
+    in_fn && /^}$/ { exit }
+' "$ENTRYPOINT" >> "$t40_funcs"
+
+awk '
+    /^log\(\)/ { in_fn=1 }
+    in_fn { print }
+    in_fn && /^}$/ { exit }
+' "$ENTRYPOINT" >> "$t40_funcs"
+
+awk '
+    /^persist_phase_output\(\)/ { in_fn=1 }
+    in_fn { print }
+    in_fn && /^}$/ { exit }
+' "$ENTRYPOINT" >> "$t40_funcs"
+
+# Sanity: all three definitions extracted.
+for fn in db_exec log persist_phase_output; do
+    if grep -q "^${fn}()" "$t40_funcs"; then
+        pass "#3219 T40 — extracted ${fn} from entrypoint"
+    else
+        fail "#3219 T40 — extracted ${fn} from entrypoint" \
+             "fixture head: $(head -c 300 "$t40_funcs")"
+    fi
+done
+
+# Build a constraint-enforcing psql stub. Tracks (agent_id, phase, attempt)
+# tuples in a state file. Default attempt is 0 (schema default). On a
+# second INSERT for the same tuple:
+#   - If the query contains ``ON CONFLICT ... DO UPDATE``, overwrite the
+#     stored output_json and exit 0.
+#   - Otherwise, emit a realistic postgres unique-violation error and
+#     exit 1 (mirroring the real DB's behavior under
+#     ``-v ON_ERROR_STOP=1``).
+t40_state_dir="$TEST_TMP/t40-state"
+mkdir -p "$t40_state_dir"
+t40_stub_bin="$TEST_TMP/t40-bin"
+mkdir -p "$t40_stub_bin"
+
+cat > "$t40_stub_bin/psql" <<'T40PSQLEOF'
+#!/usr/bin/env bash
+set -u
+# Parse -c <query>.
+query=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -c) shift; query="$1" ;;
+    esac
+    shift || true
+done
+
+# Only phase_outputs INSERTs matter to this test — everything else is
+# a silent success.
+if [[ "$query" != *"INSERT INTO dispatcher.phase_outputs"* ]]; then
+    exit 0
+fi
+
+# Extract agent_id and phase from the query. The entrypoint formats
+# VALUES as ('<agent_id>', '<phase>', '<output>'::jsonb) — we grep the
+# first two single-quoted tokens after VALUES.
+agent_id=$(printf '%s' "$query" | sed -n "s/.*VALUES[[:space:]]*([[:space:]]*'\\([^']*\\)'.*/\\1/p")
+phase=$(printf '%s' "$query" | sed -n "s/.*VALUES[[:space:]]*('[^']*'[[:space:]]*,[[:space:]]*'\\([^']*\\)'.*/\\1/p")
+# Entrypoint always lets attempt default to 0.
+attempt=0
+key="${agent_id}__${phase}__${attempt}"
+state_file="${T40_STATE_DIR}/${key}.json"
+output_json=$(printf '%s' "$query" \
+    | sed -n "s/.*VALUES[[:space:]]*('[^']*'[[:space:]]*,[[:space:]]*'[^']*'[[:space:]]*,[[:space:]]*'\\(.*\\)'::jsonb.*/\\1/p")
+
+if [[ -f "$state_file" ]]; then
+    # Second INSERT on same (agent_id, phase, attempt). ON CONFLICT
+    # DO UPDATE is the only escape hatch.
+    if [[ "$query" == *"ON CONFLICT (agent_id, phase, attempt) DO UPDATE"* ]]; then
+        printf '%s' "$output_json" > "$state_file"
+        exit 0
+    fi
+    printf 'ERROR:  duplicate key value violates unique constraint "idx_dispatcher_phase_outputs_agent_phase_attempt"\n' >&2
+    printf 'DETAIL:  Key (agent_id, phase, attempt)=(%s, %s, %d) already exists.\n' \
+        "$agent_id" "$phase" "$attempt" >&2
+    exit 1
+fi
+printf '%s' "$output_json" > "$state_file"
+exit 0
+T40PSQLEOF
+chmod +x "$t40_stub_bin/psql"
+
+# Drive persist_phase_output twice on the same (agent_id, phase, attempt=0).
+# Subshell-isolate so `set -euo pipefail` (mirroring the entrypoint)
+# applies only to this test. Capture rc from the second call to prove
+# it did not propagate exit 1.
+set +e
+t40_out=$(T40_STATE_DIR="$t40_state_dir" \
+    PATH="$t40_stub_bin:$PATH" \
+    AGENT_ID="40404040-dead-beef-cafe-000000000001" \
+    DATABASE_URL="postgres://test" \
+    bash -c '
+        set -euo pipefail
+        # shellcheck disable=SC1090
+        . "'"$t40_funcs"'"
+        persist_phase_output "awaiting_ci" "{\"rollup_state\": \"red\", \"reason\": \"initial observation\"}"
+        persist_phase_output "awaiting_ci" "{\"rollup_state\": \"red\", \"reason\": \"re-entry after fix_ci\"}"
+        echo "second-call-rc=0"
+    ' 2>&1)
+t40_rc=$?
+set -e
+
+if [[ "$t40_rc" -eq 0 ]]; then
+    pass "#3219 T40 — persist_phase_output succeeds on second call with same (agent_id, phase, attempt)"
+else
+    fail "#3219 T40 — persist_phase_output succeeds on second call with same (agent_id, phase, attempt)" \
+         "rc=$t40_rc, output: $t40_out"
+fi
+
+if printf '%s' "$t40_out" | grep -q "second-call-rc=0"; then
+    pass "#3219 T40 — entrypoint reaches code after the second persist call (no set -e abort)"
+else
+    fail "#3219 T40 — entrypoint reaches code after the second persist call (no set -e abort)" \
+         "output: $t40_out"
+fi
+
+# Verify the stored row has the latest (second-call) output — ON CONFLICT
+# DO UPDATE SET output_json = EXCLUDED.output_json must have overwritten.
+t40_key="40404040-dead-beef-cafe-000000000001__awaiting_ci__0"
+t40_stored="$t40_state_dir/${t40_key}.json"
+if [[ -f "$t40_stored" ]] && grep -q "re-entry after fix_ci" "$t40_stored"; then
+    pass "#3219 T40 — stored phase_outputs row reflects the latest (second-call) payload"
+else
+    fail "#3219 T40 — stored phase_outputs row reflects the latest (second-call) payload" \
+         "stored=$(cat "$t40_stored" 2>/dev/null)"
+fi
+
+# Negative control: confirm the constraint-enforcing psql stub actually
+# rejects a second INSERT when ON CONFLICT is absent. Drives raw SQL
+# through db_exec to prove the stub catches the regression, not the
+# post-fix persist_phase_output implementation.
+t40_neg_state="$TEST_TMP/t40-neg-state"
+mkdir -p "$t40_neg_state"
+set +e
+t40_neg_out=$(T40_STATE_DIR="$t40_neg_state" \
+    PATH="$t40_stub_bin:$PATH" \
+    AGENT_ID="40404040-dead-beef-cafe-000000000002" \
+    DATABASE_URL="postgres://test" \
+    bash -c '
+        set -euo pipefail
+        # shellcheck disable=SC1090
+        . "'"$t40_funcs"'"
+        db_exec "INSERT INTO dispatcher.phase_outputs (agent_id, phase, output_json)
+                 VALUES ('\''40404040-dead-beef-cafe-000000000002'\'', '\''awaiting_ci'\'', '\''{}'\''::jsonb);"
+        db_exec "INSERT INTO dispatcher.phase_outputs (agent_id, phase, output_json)
+                 VALUES ('\''40404040-dead-beef-cafe-000000000002'\'', '\''awaiting_ci'\'', '\''{}'\''::jsonb);"
+        echo "neg-second-call-rc=0"
+    ' 2>&1)
+t40_neg_rc=$?
+set -e
+
+if [[ "$t40_neg_rc" -ne 0 ]]; then
+    pass "#3219 T40 — constraint-enforcing psql stub rejects duplicate INSERT without ON CONFLICT (negative control)"
+else
+    fail "#3219 T40 — constraint-enforcing psql stub rejects duplicate INSERT without ON CONFLICT (negative control)" \
+         "rc=$t40_neg_rc (expected non-zero), output: $t40_neg_out"
 fi
 
 # ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The ECS agent-runner entrypoint's `persist_phase_output` did a plain `INSERT INTO dispatcher.phase_outputs`, which trips the `idx_dispatcher_phase_outputs_agent_phase_attempt` UNIQUE index on re-entry to a phase (the observed path is `awaiting_ci` → `fix_ci` patches → re-enters `awaiting_ci`). psql exits 1, `db_exec`'s `-v ON_ERROR_STOP=1` + `set -euo pipefail` kill the entrypoint, ECS exits 1, daemon reaps the agent as `agent_task_stopped_unexpectedly`, PR is stranded.

Switch both entrypoint phase_outputs INSERTs to `ON CONFLICT (agent_id, phase, attempt) DO UPDATE SET output_json = EXCLUDED.output_json, ts = now()` — the same shape the subprocess-mode daemon's `_persist_phase_output` already uses at `daemon.py` L5818.

Observed live on agent `aa11f02a` (PR #3217, issue #2829) at 2026-04-24 14:26:52Z.

Closes #3219

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_agent_runner_entrypoint.sh` — 181/181)
- [x] CI green

### Post-deploy verification
- [x] New image digest recorded on issue via `deploy-agent-runner.yml` run URL (digest `sha256:bb53703d9c63198f83f41396f7cbb1264c5a25dbe5cac5d9a5fcecf7b92088bf`, tag `6ad38df`, run 24897778652)
- [x] Soak window: instrumented for next natural red-CI ECS agent on the new image; Test 40 + negative control provides mechanical coverage. No red-CI re-entry agents in flight at deploy time.
- [x] Verification evidence posted on issue (see A.8)
