### PR TITLE
feat(infra): terraform precondition on dispatcher-daemon secret ARNs when desired_count > 0 (#2838)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -51,6 +51,13 @@ jobs:
           terraform -chdir=infra/terraform/environments/production init -backend=false
           terraform -chdir=infra/terraform/environments/production validate
 
+      # Precondition fixture test: verifies that the dispatcher-daemon module
+      # raises a plan-time error when desired_count > 0 and required secret
+      # ARNs are empty. Uses fake AWS credentials so no real API calls are made.
+      - name: Dispatcher precondition check
+        if: ${{ env.AWS_ACCESS_KEY_ID != '' }}
+        run: bash infra/terraform/modules/dispatcher-daemon/tests/preconditions/check.sh
+
       # Plan requires AWS credentials (stored as GitHub Actions secrets).
       # The plan confirms the module is deployable and shows exactly what
       # resources will be created or modified.

--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -722,6 +722,17 @@ resource "aws_ecs_task_definition" "dispatcher" {
       }
     }
   ])
+
+  lifecycle {
+    precondition {
+      condition     = var.desired_count == 0 || var.anthropic_api_key_secret_arn != ""
+      error_message = "dispatcher-daemon: anthropic_api_key_secret_arn must be set when desired_count > 0 (phase 2+ needs anthropic_api_key to spawn claude -p)."
+    }
+    precondition {
+      condition     = var.desired_count == 0 || var.db_connection_secret_arn != ""
+      error_message = "dispatcher-daemon: db_connection_secret_arn must be set when desired_count > 0 (phase 2+ needs database_url to persist dispatcher.runs / dispatcher.queue_snapshots)."
+    }
+  }
 }
 
 # ─── ECS Service ────────────────────────────────────────────────────────────

--- a/infra/terraform/modules/dispatcher-daemon/tests/preconditions/check.sh
+++ b/infra/terraform/modules/dispatcher-daemon/tests/preconditions/check.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verifies that the dispatcher-daemon module's preconditions fire correctly
+# when desired_count > 0 but required secret ARNs are empty.
+# Expected behaviour: `terraform plan` exits non-zero with the precondition
+# error text in its output.
+
+FIXTURE_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_REGION=us-west-2
+
+echo "==> Initialising terraform fixture..."
+terraform -chdir="$FIXTURE_DIR" init -backend=false -input=false -no-color
+
+echo "==> Running terraform plan (expecting precondition failure)..."
+set +e
+plan_output=$(terraform -chdir="$FIXTURE_DIR" plan -input=false -no-color 2>&1)
+plan_exit=$?
+set -e
+
+echo "$plan_output"
+
+if [ "$plan_exit" -eq 0 ]; then
+  echo "FAIL: terraform plan exited 0 — precondition did not fire." >&2
+  exit 1
+fi
+
+if echo "$plan_output" | grep -q "anthropic_api_key_secret_arn must be set"; then
+  echo "PASS: anthropic_api_key_secret_arn precondition fired as expected."
+else
+  echo "FAIL: expected 'anthropic_api_key_secret_arn must be set' in plan output." >&2
+  exit 1
+fi
+
+if echo "$plan_output" | grep -q "db_connection_secret_arn must be set"; then
+  echo "PASS: db_connection_secret_arn precondition fired as expected."
+else
+  echo "FAIL: expected 'db_connection_secret_arn must be set' in plan output." >&2
+  exit 1
+fi
+
+echo "==> All precondition checks passed."

--- a/infra/terraform/modules/dispatcher-daemon/tests/preconditions/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/tests/preconditions/main.tf
@@ -1,0 +1,36 @@
+# Negative-case fixture for dispatcher-daemon precondition checks.
+# Running `terraform plan` here must fail with a precondition error because
+# desired_count = 1 but both secret ARNs are empty.
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-west-2"
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+  skip_metadata_api_check     = true
+  access_key                  = "test"
+  secret_key                  = "test"
+}
+
+module "dispatcher_daemon" {
+  source = "../../"
+
+  environment        = "dev"
+  vpc_id             = "vpc-00000000000000000"
+  private_subnet_ids = ["subnet-00000000000000001", "subnet-00000000000000002"]
+  ecs_cluster_arn    = "arn:aws:ecs:us-west-2:123456789012:cluster/judgemind-dev"
+  ecr_repository_url = "123456789012.dkr.ecr.us-west-2.amazonaws.com/judgemind-dispatcher"
+
+  # These are intentionally empty to trigger the precondition.
+  desired_count                = 1
+  anthropic_api_key_secret_arn = ""
+  db_connection_secret_arn     = ""
+}


### PR DESCRIPTION
## Summary

Adds lifecycle preconditions to the dispatcher-daemon Terraform module that validate required secret ARNs (`anthropic_api_key_secret_arn`, `db_connection_secret_arn`) are set when `desired_count > 0`. This prevents the #2834 failure mode where secrets are omitted during terraform apply but the daemon silently runs without credentials at runtime, surfacing errors only downstream. The precondition catches the mistake at `terraform plan` time — the same check operators run manually before apply and the same check the dispatcher's automated dev-apply runs in CI.

Closes #2838

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`) — N/A for Terraform; covered by terraform validate
- [x] CI green — includes new "Dispatcher precondition check" step that runs negative-case fixture

### Post-deploy verification

- [ ] Dispatcher dev-apply (CI job on next main push) runs terraform plan with real AWS credentials; if preconditions were broken, plan step would fail. Verify CI step "Dispatcher precondition check" runs and passes (tests failure case with fake credentials), then normal terraform plan steps succeed (tests success case with real secrets).
- [ ] Manual verification (optional): `terraform -chdir=infra/terraform/modules/dispatcher-daemon/tests/preconditions plan -input=false` with fake AWS credentials should exit non-zero with both precondition error messages.

**Note:** Two acceptance criteria (AC3, AC4) are marked "not met — shape mismatch" because the test fixture covers only the failure case (desired_count=1, secrets empty). The positive cases (desired_count=0 with empty secrets; desired_count=1 with secrets wired) are guaranteed by the precondition logic but are not explicitly tested in the diff. The normal terraform plan job in CI implicitly tests these when running against environments/dev, but explicit positive-case tests (terraform plan with desired_count=0; or a second fixture with secrets wired) are not in the diff and may be desirable for test completeness.