### PR TITLE
fix(api): add CI guard blocking GitHub fetches from packages/api/src/ (#2839)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,11 @@ jobs:
               - 'packages/judgemind-config/**'
             api:
               - 'packages/api/**'
+              # Include ci.yml so that edits to the no-api-github-fetch-check
+              # job are exercised on the PR that introduces them.
+              # Without this, the paths filter makes the job SKIP on its own
+              # PR — the #2410/#2505 footgun. See scripts/check-ci-job-skipped.py.
+              - '.github/workflows/ci.yml'
             web:
               - 'packages/web/**'
             infra:
@@ -952,6 +957,18 @@ jobs:
         run: scripts/check-no-test-database-url-fallback.sh
 
   # ---------------------------------------------------------------
+  # GitHub API call guard: api container src must not call GitHub (#2839)
+  # ---------------------------------------------------------------
+  no-api-github-fetch-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Enforce API container has no GitHub API calls
+        run: scripts/check-no-api-github-fetch.sh
+
+  # ---------------------------------------------------------------
   # Schema drift guard: schema.sql must match applied migrations
   # ---------------------------------------------------------------
   schema-drift-check:
@@ -1311,7 +1328,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check, no-api-github-fetch-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/docs/agent/unattended-patterns.md
+++ b/docs/agent/unattended-patterns.md
@@ -137,3 +137,7 @@ The GitHub API allows 5,000 requests per hour per authentication token. When mul
 
 - **Always use `--interval 60` with `gh run watch`.** The default poll interval is 3 seconds, which burns through API budget fast. Use `gh run watch <id> --repo judgemind/judgemind --interval 60 --exit-status --compact` as the standard CI/deploy watch command. This achieves the same rate savings as manual polling loops with simpler code.
 - **Never tight-loop on 403 errors.** If you get a rate limit response, always check the reset time via `gh api rate_limit` and sleep until it passes.
+
+## No API-side GitHub fetches
+
+`packages/api/src/` must not call GitHub's REST API directly. GitHub data enrichment belongs to the dispatcher daemon, which persists results to `dispatcher.*` tables for the API to read without burning the shared PAT budget. `GITHUB_TOKEN` has been removed from the API task-def (`infra/terraform/modules/api-service/main.tf`) — its absence is load-bearing. If a future feature needs GitHub data, the daemon is the only place that should be fetching it. Enforced by `scripts/check-no-api-github-fetch.sh` and the `no-api-github-fetch-check` CI job. See issue #2820.

--- a/scripts/check-no-api-github-fetch.sh
+++ b/scripts/check-no-api-github-fetch.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# check-no-api-github-fetch.sh — Forbid GitHub API calls from the API container.
+#
+# The API container (packages/api/src/) must not call GitHub's REST API
+# directly.  GitHub data enrichment belongs to the dispatcher daemon, which
+# persists results to dispatcher.* tables so the API can read them without
+# burning the shared PAT budget or having access to GITHUB_TOKEN.
+#
+# GITHUB_TOKEN has been removed from the API task-def (see
+# infra/terraform/modules/api-service/main.tf) — its absence is load-bearing.
+# If a future feature needs GitHub data, the daemon is the only place that
+# should be fetching it.  See issue #2820 and
+# docs/agent/unattended-patterns.md §No API-side GitHub fetches.
+#
+# Patterns scanned (each flagged independently; all matches collected before
+# failing):
+#   - Literal `api.github.com`      (fixed-string — direct GitHub REST host)
+#   - Literal `github.com/repos/`   (fixed-string — alternate URL shape)
+#   - Regex  `fetch\s*\(.*github`   (fetch call referencing github)
+#   - Regex  `https[^'"\s]*github`  (https URL with github in the host)
+#
+# Comment lines (first non-whitespace is //, /*, or *) are skipped so
+# JSDoc references to the removed github.ts module in parse-labels.ts and
+# resolvers.ts do not trip the guard.
+#
+# Usage:
+#   scripts/check-no-api-github-fetch.sh                # scan default dir
+#   scripts/check-no-api-github-fetch.sh [dir]          # scan a specific directory
+#
+# Exit codes:
+#   0 — No violations found.
+#   1 — One or more files contain a forbidden GitHub API reference.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-$REPO_ROOT/packages/api/src}"
+
+# ─── Directories to exclude from the scan ────────────────────────────────
+EXCLUDE_DIRS=(
+    ".git"
+    ".venv"
+    "node_modules"
+    "__pycache__"
+    "tmp"
+)
+
+# ─── Build common grep arguments ─────────────────────────────────────────
+exclude_args=()
+for dir in "${EXCLUDE_DIRS[@]}"; do
+    exclude_args+=("--exclude-dir=$dir")
+done
+
+# ─── Collect all matches across all patterns ─────────────────────────────
+violations=0
+
+run_check() {
+    local label="$1"
+    local flag="$2"     # -F or -E
+    local pattern="$3"
+
+    local raw_matches
+    raw_matches=$(grep -rn "$flag" "$pattern" "$SCAN_DIR" "${exclude_args[@]}" 2>/dev/null || true)
+
+    if [[ -z "$raw_matches" ]]; then
+        return
+    fi
+
+    while IFS= read -r line; do
+        # grep -rn output: <path>:<lineno>:<content>
+        file_path="${line%%:*}"
+        rest="${line#*:}"
+        content="${rest#*:}"
+
+        # Skip TS/JS comment lines (first non-whitespace is //, /*, or *).
+        if [[ "$content" =~ ^[[:space:]]*(//|\*|/\*) ]]; then
+            continue
+        fi
+
+        if [[ $violations -eq 0 ]]; then
+            echo "ERROR: Found forbidden GitHub API reference(s) in the API container source."
+            echo ""
+            echo "  packages/api/src/ must not call GitHub's REST API directly."
+            echo "  GitHub data enrichment belongs to the dispatcher daemon, which"
+            echo "  persists results to dispatcher.* tables for the API to read."
+            echo "  GITHUB_TOKEN has been removed from the API task-def — its"
+            echo "  absence is load-bearing.  See issue #2820."
+            echo ""
+        fi
+
+        echo "    [$label] $line"
+        violations=$((violations + 1))
+    done <<< "$raw_matches"
+}
+
+run_check "api.github.com"    -F "api.github.com"
+run_check "github.com/repos/" -F "github.com/repos/"
+run_check "fetch(..github..)" -E "fetch[[:space:]]*\(.*github"
+run_check "https://...github" -E "https[^'\"[:space:]]*github"
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "  Found $violations occurrence(s) of forbidden GitHub API reference(s)."
+    echo ""
+    echo "  Fix: move the GitHub fetch to the dispatcher daemon"
+    echo "  (packages/dispatcher/src/) and expose the result via dispatcher.*"
+    echo "  tables that the API reads.  If this is a comment referencing old code,"
+    echo "  the comment-line filter covers //, /*, and * prefixes."
+    echo ""
+    echo "  See docs/agent/unattended-patterns.md §No API-side GitHub fetches."
+    exit 1
+fi
+
+echo "All clean — no GitHub API references detected in packages/api/src/."
+exit 0

--- a/scripts/tests/test_check_no_api_github_fetch.sh
+++ b/scripts/tests/test_check_no_api_github_fetch.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# test_check_no_api_github_fetch.sh — Tests for
+# check-no-api-github-fetch.sh.
+#
+# Creates temporary files to verify that the checker correctly detects
+# forbidden GitHub API references while allowing comment-only references,
+# unrelated OAuth calls, JSDoc annotations, empty directories, and
+# excluded directories (.git, node_modules).
+#
+# Transitive-import note (test d): the guard catches GitHub API calls via
+# direct scan of every file under SCAN_DIR.  Since all relative imports
+# from packages/api/src/ resolve within packages/api/src/, a direct scan
+# catches any fetch anywhere in the API container code.  No AST walk is
+# performed — if a future refactor introduces packages/api/lib/ or similar,
+# extend the scan path then.
+#
+# Usage:
+#   scripts/tests/test_check_no_api_github_fetch.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-no-api-github-fetch.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo.
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test a: api.github.com literal in a .ts file should fail ────────────
+create_test_file "bad.ts" 'const url = "https://api.github.com/repos/judgemind/judgemind/issues";'
+assert_fails "api.github.com literal in a .ts file is detected"
+reset_tmpdir
+
+# ─── Test b: github.com/repos/ literal should fail ───────────────────────
+create_test_file "bad.ts" 'const endpoint = "https://github.com/repos/foo/bar/issues";'
+assert_fails "github.com/repos/ literal is detected"
+reset_tmpdir
+
+# ─── Test c: fetch('https://api.github.com/...') should fail ─────────────
+create_test_file "bad.ts" "const res = await fetch('https://api.github.com/repos/foo/bar/issues');"
+assert_fails "fetch('https://api.github.com/...') call is detected"
+reset_tmpdir
+
+# ─── Test d: Transitive — a.ts imports b.ts which contains api.github.com ─
+# The guard does a direct scan of every file under SCAN_DIR. Since b.ts
+# contains the forbidden literal, the scan catches it regardless of which
+# file imported it. No AST walk is needed — direct scan is sufficient.
+create_test_file "a.ts" "import { fetchIssues } from './b';"
+create_test_file "b.ts" 'const url = "https://api.github.com/repos/foo/bar/issues";'
+assert_fails "Transitive: b.ts with api.github.com is caught by direct scan"
+reset_tmpdir
+
+# ─── Test e: Comment-only reference should pass ───────────────────────────
+create_test_file "clean.ts" '// Do not call api.github.com from the API container.'
+assert_passes "// comment line with api.github.com is not flagged"
+reset_tmpdir
+
+# ─── Test f: JSDoc comment should pass ───────────────────────────────────
+create_test_file "clean.ts" ' * See github.ts for context on the removed fetch path.'
+assert_passes "JSDoc * comment line is not flagged"
+reset_tmpdir
+
+# ─── Test g: Unrelated oauth2.googleapis.com fetch call should pass ───────
+# This mirrors packages/api/src/graphql/auth-resolvers.ts:308 which uses
+# fetch for Google OAuth token exchange — not GitHub. The fetch(.*github)
+# regex only matches when the URL contains 'github', so googleapis.com
+# must not be flagged.
+create_test_file "clean.ts" "const tokenRes = await fetch('https://oauth2.googleapis.com/token', { method: 'POST' });"
+assert_passes "fetch to oauth2.googleapis.com is not flagged"
+reset_tmpdir
+
+# ─── Test h: Empty directory should pass ─────────────────────────────────
+assert_passes "Empty directory passes"
+
+# ─── Test i: .git and node_modules should be excluded ────────────────────
+mkdir -p "$TMPDIR_TEST/.git/objects"
+printf 'const url = "https://api.github.com/repos/foo/bar";\n' > "$TMPDIR_TEST/.git/objects/badfile"
+mkdir -p "$TMPDIR_TEST/node_modules/some-pkg"
+printf 'const url = "https://api.github.com/repos/foo/bar";\n' > "$TMPDIR_TEST/node_modules/some-pkg/index.js"
+assert_passes ".git and node_modules are excluded"
+reset_tmpdir
+
+# ─── Test j: No self-match on ci.yml step name ───────────────────────────
+# The step name in .github/workflows/ci.yml that runs this guard must
+# not itself contain the forbidden pattern.  If it does, the guard fails
+# on its first CI run (see issues #2541/#2542 for the class of bug).
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-no-api-github-fetch.sh" "yml"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Added `scripts/check-no-api-github-fetch.sh` guard that prevents the API container from calling GitHub's REST API directly. The guard greps for 4 patterns (literal `api.github.com` and `github.com/repos/`, regex `fetch(...github...)` and `https[...]github`), skips comment/JSDoc lines, and fails with a clear error message pointing to `docs/agent/unattended-patterns.md`. Comprehensive test suite with 10 fixture cases covers detection, exemptions (comments, unrelated OAuth), excluded directories, and self-match safety. CI job `no-api-github-fetch-check` wired into `.github/workflows/ci.yml` with path filter including `.github/workflows/ci.yml` to avoid the #2410/#2505 skip-on-own-PR footgun.

Closes #2839

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] CI job `no-api-github-fetch-check` runs and passes on this PR
- [ ] Verification: test PR adding `api.github.com` to `packages/api/src/graphql/dispatcher/resolvers.ts` causes CI to fail with the expected error
- [ ] Verification evidence posted on #2839 (see /task-v2-verify output)