### PR TITLE
test(dispatcher): cross-language contract fixture for priorityRank (#2848)

### DIFF
--- a/packages/api/src/graphql/dispatcher/parse-labels.ts
+++ b/packages/api/src/graphql/dispatcher/parse-labels.ts
@@ -92,6 +92,8 @@ export const PRIORITY_RANK_NO_LABEL = 4;
  * Tolerates non-array input (returns the no-label floor) and ignores
  * non-string entries, so a malformed ``issues_json`` row cannot crash
  * the sort.
+ *
+ * Cross-language contract: scripts/dispatcher/tests/fixtures/priority_rank_cases.json is the source of truth; Python mirror is _priority_rank in scripts/dispatcher/daemon.py.
  */
 export function priorityRank(labels: unknown): number {
   if (!Array.isArray(labels)) return PRIORITY_RANK_NO_LABEL;

--- a/packages/api/tests/dispatcher-enrichment.unit.test.ts
+++ b/packages/api/tests/dispatcher-enrichment.unit.test.ts
@@ -16,6 +16,9 @@
  *   - The ``parse-labels`` helpers remain pure — no fetch.
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
+
 import { describe, it, expect } from 'vitest';
 import {
   CATEGORY_DISPLAY_NAMES,
@@ -752,6 +755,31 @@ describe('priorityRank', () => {
     ];
     expect(ranks).toEqual([0, 1, 2, 3, PRIORITY_RANK_NO_LABEL]);
     expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
+  });
+
+  it('matches the shared cross-language fixture', () => {
+    // Cross-language contract: scripts/dispatcher/tests/fixtures/priority_rank_cases.json
+    // is the source of truth shared with the Python _priority_rank helper in
+    // scripts/dispatcher/daemon.py.  If either side drifts, this test (or its
+    // Python mirror) will fail on the drifted case.
+    //
+    // Resolution is explicit and relative to __dirname because no other test in
+    // packages/api/tests/ currently reads a JSON fixture from outside the package.
+    const fixturePath = path.resolve(
+      __dirname,
+      '../../../scripts/dispatcher/tests/fixtures/priority_rank_cases.json',
+    );
+    const cases = JSON.parse(fs.readFileSync(fixturePath, 'utf8')) as Array<{
+      name: string;
+      labels: unknown[];
+      expected_rank: number;
+    }>;
+
+    expect(cases.length).toBeGreaterThanOrEqual(8);
+
+    for (const c of cases) {
+      expect(priorityRank(c.labels), `case '${c.name}'`).toBe(c.expected_rank);
+    }
   });
 });
 

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1749,6 +1749,7 @@ def _extract_priority(labels: Any) -> str | None:
     return best
 
 
+# Cross-language contract: scripts/dispatcher/tests/fixtures/priority_rank_cases.json is the source of truth; TS mirror is priorityRank in packages/api/src/graphql/dispatcher/parse-labels.ts.
 def _priority_rank(labels: list[str] | Any) -> int:
     """Return the lowest (highest-priority) rank implied by ``labels``.
 

--- a/scripts/dispatcher/tests/fixtures/priority_rank_cases.json
+++ b/scripts/dispatcher/tests/fixtures/priority_rank_cases.json
@@ -1,0 +1,42 @@
+[
+  {
+    "name": "p0",
+    "labels": ["priority/p0"],
+    "expected_rank": 0
+  },
+  {
+    "name": "p1",
+    "labels": ["priority/p1"],
+    "expected_rank": 1
+  },
+  {
+    "name": "p2",
+    "labels": ["priority/p2"],
+    "expected_rank": 2
+  },
+  {
+    "name": "p3",
+    "labels": ["priority/p3"],
+    "expected_rank": 3
+  },
+  {
+    "name": "unlabelled",
+    "labels": ["area/devops", "type/bug"],
+    "expected_rank": 4
+  },
+  {
+    "name": "empty",
+    "labels": [],
+    "expected_rank": 4
+  },
+  {
+    "name": "multi_pick_lowest",
+    "labels": ["priority/p2", "priority/p0"],
+    "expected_rank": 0
+  },
+  {
+    "name": "non_string_entries_ignored",
+    "labels": [{"name": "priority/p0"}, 42, null],
+    "expected_rank": 4
+  }
+]

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -66,6 +66,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 # Make ``scripts`` importable without installing the repo as a package.
 _SCRIPTS = Path(__file__).resolve().parents[2]
 if str(_SCRIPTS) not in sys.path:
@@ -253,6 +255,15 @@ class TestFakeCursorDispatcher:
 # _priority_rank (issue #2835)
 # --------------------------------------------------------------------------
 
+# Cross-language contract: scripts/dispatcher/tests/fixtures/priority_rank_cases.json
+# is the shared source of truth for _priority_rank and its TS mirror priorityRank
+# in packages/api/src/graphql/dispatcher/parse-labels.ts.
+_PRIORITY_RANK_FIXTURE: list[dict] = json.loads(
+    (Path(__file__).parent / "fixtures" / "priority_rank_cases.json").read_text(
+        encoding="utf-8"
+    )
+)
+
 
 class TestPriorityRank:
     """``_priority_rank`` maps label lists to sort ranks (p0 → 0, ...)."""
@@ -307,6 +318,23 @@ class TestPriorityRank:
         ]
         assert ranks == sorted(ranks)
         assert ranks == [0, 1, 2, 3, daemon._PRIORITY_RANK_NO_LABEL]
+
+    @pytest.mark.parametrize(
+        "labels,expected_rank",
+        [(c["labels"], c["expected_rank"]) for c in _PRIORITY_RANK_FIXTURE],
+        ids=[c["name"] for c in _PRIORITY_RANK_FIXTURE],
+    )
+    def test_priority_rank_matches_shared_fixture(
+        self, labels: list, expected_rank: int
+    ) -> None:
+        """Shared cross-language fixture: if either side drifts, this test fails.
+
+        The fixture at scripts/dispatcher/tests/fixtures/priority_rank_cases.json
+        is the source of truth.  The TS mirror lives in
+        packages/api/tests/dispatcher-enrichment.unit.test.ts under
+        describe('priorityRank', ...).
+        """
+        assert daemon._priority_rank(labels) == expected_rank
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add a shared fixture asserting Python `_priority_rank` (daemon.py) and TypeScript `priorityRank` (parse-labels.ts) stay synchronized. Both implementations are duplicated across languages; the priority-rank drift in #2843 happened because the Python side shipped first and the TypeScript side drifted without test coverage.

Parametrized tests on both sides now load the fixture and assert output rank matches expected values for all 8 contract cases. Documented the fixture as source of truth in both helpers' docstrings.

Closes #2848

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`) — pre-push hook verified
- [x] CI green (will be verified on merge)

### Post-deploy verification

- [x] N/A — no deployed component (test fixture + tests only)