### PR TITLE
feat(web): add ESLint rule to catch polled-query error guards that discard cached data (#2850)

### DIFF
--- a/docs/web-patterns.md
+++ b/docs/web-patterns.md
@@ -294,6 +294,31 @@ Shadcn's `TableRow` component applies `hover:bg-muted/50` by default, which make
 
 **Alternative:** for list pages where every column is informational (no checkboxes, no inline buttons), prefer the `<Link>`-wrapped row pattern used in `CasesList` and `RulingsFeed` — the entire row is a `<Link>` with `className="block ..."`. This gives native right-click / cmd-click behavior without needing `stopPropagation` plumbing. The `TableRow` + `onClick` pattern is appropriate when the row contains selection checkboxes or other interactive controls that cannot live inside an `<a>` tag.
 
+### Apollo Polling
+
+When a `useQuery` hook has a `pollInterval`, Apollo continues to re-run the query on a timer. On a poll failure the query returns a new `error` **alongside the stale `data`** from the last successful fetch. A bare `if (error) return <ErrorBanner/>` short-circuit discards that stale data and shows a blank or broken UI — even though the component could display the last-known values to the user.
+
+**Rule:** always guard the error short-circuit with `if (error && !data)` in polled queries. Show the error only when there is no data to fall back to.
+
+```tsx
+// Wrong — hides stale data on poll failures
+const { data, loading, error } = useQuery(QUERY, { pollInterval: 5000 });
+if (error) return <ErrorBanner error={error} />;
+
+// Correct — falls back to stale data when a subsequent poll errors
+const { data, loading, error } = useQuery(QUERY, { pollInterval: 5000 });
+if (error && !data) return <ErrorBanner error={error} />;
+```
+
+The same rule applies to renamed bindings:
+
+```tsx
+const { data: state, loading, error: queryError } = useQuery(QUERY, { pollInterval: 5000 });
+if (queryError && !state) return <ErrorBanner error={queryError} />;
+```
+
+**Enforcement:** an ESLint rule (`local/polled-query-error-guard`) flags any `useQuery` callsite with `pollInterval` where the destructured `error` binding is used in a bare `if (error)` that returns JSX. The rule emits an auto-fix rewriting the test to `error && !data`. See `packages/web/eslint-rules/polled-query-error-guard.js` and issue [#2850](https://github.com/judgemind/judgemind/issues/2850).
+
 ### Loading States
 
 - Skeleton loaders matching the shape of the content they replace

--- a/packages/web/.eslintrc.json
+++ b/packages/web/.eslintrc.json
@@ -20,7 +20,8 @@
     {
       "files": ["src/app/**/*.{ts,tsx}", "src/components/**/*.{ts,tsx}"],
       "rules": {
-        "local/clickable-table-row": "error"
+        "local/clickable-table-row": "error",
+        "local/polled-query-error-guard": "error"
       }
     },
     {

--- a/packages/web/eslint-plugin-local/index.js
+++ b/packages/web/eslint-plugin-local/index.js
@@ -5,6 +5,7 @@ module.exports = {
     'clickable-table-row': require('../eslint-rules/clickable-table-row'),
     'no-client-utility-import': require('../eslint-rules/no-client-utility-import'),
     'no-ssr-incompatible-import': require('../eslint-rules/no-ssr-incompatible-import'),
+    'polled-query-error-guard': require('../eslint-rules/polled-query-error-guard'),
     'prefer-path-alias': require('../eslint-rules/prefer-path-alias'),
   },
 };

--- a/packages/web/eslint-rules/polled-query-error-guard.js
+++ b/packages/web/eslint-rules/polled-query-error-guard.js
@@ -1,0 +1,243 @@
+/**
+ * ESLint rule: polled-query-error-guard
+ *
+ * Flags `useQuery(..., { pollInterval })` callsites where the destructured
+ * `error` is used in a bare `if (error) return <JSX/>` short-circuit.
+ *
+ * Why this matters: Apollo's `useQuery` with `pollInterval` will return a
+ * stale `data` value alongside a new `error` on subsequent poll failures.
+ * A bare `if (error) return <ErrorBanner/>` will hide the previously-loaded
+ * data, making the UI appear broken even though the last successful response
+ * is still available. The correct guard is `if (error && !data)` — show the
+ * error only when there is no data to fall back to.
+ *
+ * The approved pattern — documented in `docs/web-patterns.md` §Apollo
+ * Polling — is:
+ *
+ *   const { data, loading, error } = useQuery(QUERY, { pollInterval: 5000 });
+ *   if (error && !data) return <ErrorBanner error={error} />;
+ *
+ * Invalid:
+ *
+ *   const { data, loading, error } = useQuery(QUERY, { pollInterval: 5000 });
+ *   if (error) return <ErrorBanner error={error} />;
+ *
+ * @see https://github.com/judgemind/judgemind/issues/2850
+ */
+
+'use strict';
+
+/**
+ * Check whether an ObjectExpression contains a property with the given key
+ * name as a shorthand, identifier-valued, or computed property.
+ */
+function hasPropertyKey(objectExpression, keyName) {
+  if (!objectExpression || objectExpression.type !== 'ObjectExpression') return false;
+  for (const prop of objectExpression.properties) {
+    if (prop.type !== 'Property') continue;
+    if (prop.key && prop.key.type === 'Identifier' && prop.key.name === keyName) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Given an ObjectPattern (destructuring), extract the local binding name for
+ * a given source key. Handles renaming: `{ error: queryError }` returns
+ * `'queryError'` for key `'error'`. Returns null if the key is not present.
+ */
+function getDestructuredBinding(objectPattern, keyName) {
+  if (!objectPattern || objectPattern.type !== 'ObjectPattern') return null;
+  for (const prop of objectPattern.properties) {
+    if (prop.type !== 'Property') continue;
+    if (!prop.key || prop.key.type !== 'Identifier') continue;
+    if (prop.key.name !== keyName) continue;
+    // The local name is in the `value` (which may be renamed or an identifier).
+    if (prop.value && prop.value.type === 'Identifier') {
+      return prop.value.name;
+    }
+  }
+  return null;
+}
+
+/**
+ * Walk the statements in a function body (BlockStatement) for IfStatement
+ * nodes. Also descends into nested blocks, but NOT into nested function
+ * definitions (to avoid false positives from callbacks).
+ */
+function collectIfStatements(bodyNode, results) {
+  if (!bodyNode) return;
+  if (bodyNode.type === 'BlockStatement') {
+    for (const stmt of bodyNode.body) {
+      collectIfStatements(stmt, results);
+    }
+    return;
+  }
+  if (bodyNode.type === 'IfStatement') {
+    results.push(bodyNode);
+    // Also walk the branches for chained ifs.
+    collectIfStatements(bodyNode.consequent, results);
+    collectIfStatements(bodyNode.alternate, results);
+    return;
+  }
+  // Descend into try/catch, loops, etc. but not into nested functions.
+  if (
+    bodyNode.type === 'TryStatement' ||
+    bodyNode.type === 'WhileStatement' ||
+    bodyNode.type === 'ForStatement' ||
+    bodyNode.type === 'ForInStatement' ||
+    bodyNode.type === 'ForOfStatement'
+  ) {
+    if (bodyNode.block) collectIfStatements(bodyNode.block, results);
+    if (bodyNode.handler && bodyNode.handler.body) {
+      collectIfStatements(bodyNode.handler.body, results);
+    }
+    if (bodyNode.finalizer) collectIfStatements(bodyNode.finalizer, results);
+    if (bodyNode.body) collectIfStatements(bodyNode.body, results);
+  }
+}
+
+/**
+ * Check whether a statement (or block) contains a JSX return — i.e., a
+ * `return` whose argument is a JSXElement or JSXFragment.
+ */
+function consequentReturnsJsx(node) {
+  if (!node) return false;
+  // Direct return statement: `if (error) return <Foo/>;`
+  if (node.type === 'ReturnStatement') {
+    return isJsx(node.argument);
+  }
+  // Block: `if (error) { return <Foo/>; }`
+  if (node.type === 'BlockStatement') {
+    for (const stmt of node.body) {
+      if (stmt.type === 'ReturnStatement' && isJsx(stmt.argument)) {
+        return true;
+      }
+    }
+  }
+  // Expression statement with JSX (unusual but possible).
+  return false;
+}
+
+function isJsx(node) {
+  if (!node) return false;
+  return node.type === 'JSXElement' || node.type === 'JSXFragment';
+}
+
+/**
+ * Find the nearest enclosing function body for a given node using the
+ * ESLint ancestor stack (context.getAncestors()).
+ */
+function getEnclosingFunctionBody(ancestors) {
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    const anc = ancestors[i];
+    if (
+      anc.type === 'FunctionDeclaration' ||
+      anc.type === 'FunctionExpression' ||
+      anc.type === 'ArrowFunctionExpression'
+    ) {
+      return anc.body;
+    }
+  }
+  return null;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+    docs: {
+      description:
+        'Enforce that useQuery calls with pollInterval guard the error short-circuit as ' +
+        '`if (error && !data)` rather than bare `if (error)`. Polled queries retain ' +
+        'stale data after a poll failure; a bare `if (error)` discards it.',
+      recommended: false,
+    },
+    messages: {
+      bareErrorGuard:
+        'Polled useQuery: bare `if ({{errorBinding}})` hides stale data on poll failures. ' +
+        'Use `if ({{errorBinding}} && !{{dataBinding}})` instead. ' +
+        'See docs/web-patterns.md §Apollo Polling. ' +
+        'Tracked in https://github.com/judgemind/judgemind/issues/2850',
+      bareErrorGuardNoData:
+        'Polled useQuery: bare `if ({{errorBinding}})` hides stale data on poll failures. ' +
+        'Add a `data` binding and use `if ({{errorBinding}} && !data)` instead. ' +
+        'See docs/web-patterns.md §Apollo Polling. ' +
+        'Tracked in https://github.com/judgemind/judgemind/issues/2850',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      VariableDeclarator(node) {
+        // Must be: const { ... } = useQuery(QUERY, { pollInterval: ... })
+        const init = node.init;
+        if (!init || init.type !== 'CallExpression') return;
+
+        const callee = init.callee;
+        if (!callee || callee.type !== 'Identifier' || callee.name !== 'useQuery') return;
+
+        // Must have a second argument that is an object with pollInterval.
+        const args = init.arguments;
+        if (!args || args.length < 2) return;
+        const options = args[1];
+        if (!hasPropertyKey(options, 'pollInterval')) return;
+
+        // The declarator left side must be an ObjectPattern (destructuring).
+        const id = node.id;
+        if (!id || id.type !== 'ObjectPattern') return;
+
+        const errorBinding = getDestructuredBinding(id, 'error');
+        if (!errorBinding) return; // Not destructuring `error` — nothing to check.
+
+        const dataBinding = getDestructuredBinding(id, 'data');
+
+        // Walk the enclosing function body for bare IfStatements.
+        const ancestors = context.getAncestors();
+        const funcBody = getEnclosingFunctionBody(ancestors);
+        if (!funcBody) return;
+
+        const ifStatements = [];
+        collectIfStatements(funcBody, ifStatements);
+
+        for (const ifStmt of ifStatements) {
+          const test = ifStmt.test;
+
+          // Already guarded with a logical expression (e.g. `error && !data`,
+          // `error || loading`) — skip.
+          if (test.type === 'LogicalExpression') continue;
+
+          // Check for bare `if (errorBinding)`.
+          if (test.type !== 'Identifier') continue;
+          if (test.name !== errorBinding) continue;
+
+          // Consequent must return JSX.
+          if (!consequentReturnsJsx(ifStmt.consequent)) continue;
+
+          if (dataBinding) {
+            context.report({
+              node: ifStmt.test,
+              messageId: 'bareErrorGuard',
+              data: { errorBinding, dataBinding },
+              fix(fixer) {
+                return fixer.replaceText(
+                  ifStmt.test,
+                  `${errorBinding} && !${dataBinding}`,
+                );
+              },
+            });
+          } else {
+            context.report({
+              node: ifStmt.test,
+              messageId: 'bareErrorGuardNoData',
+              data: { errorBinding },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/web/tests/eslint-rules/polled-query-error-guard.test.ts
+++ b/packages/web/tests/eslint-rules/polled-query-error-guard.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+
+// Load the rule
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const rule = require('../../eslint-rules/polled-query-error-guard');
+
+// ---------------------------------------------------------------------------
+// Helper: lint JSX code with the rule using ESLint's Linter API
+//
+// The default espree parser supports JSX when ecmaFeatures.jsx is enabled.
+// We do not need @typescript-eslint/parser for the JS/JSX-level constructs
+// this rule inspects (destructuring pattern, IfStatement test, JSX returns).
+// ---------------------------------------------------------------------------
+
+function lintCode(code: string): Linter.LintMessage[] {
+  const linter = new Linter();
+  linter.defineRule('polled-query-error-guard', rule);
+  return linter.verify(
+    code,
+    {
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+      },
+      rules: { 'polled-query-error-guard': 'error' },
+    },
+    { filename: '/fake/src/app/admin/test-component.tsx' },
+  );
+}
+
+// Wrap a component snippet so the parser can handle it.
+// Uses plain JS/JSX syntax (no TypeScript annotations) because the Linter
+// is configured with espree + JSX — not @typescript-eslint/parser.
+function wrap(inner: string): string {
+  return [
+    `import React from 'react';`,
+    ``,
+    `function ErrorBanner(props) {`,
+    `  return <div>Error</div>;`,
+    `}`,
+    ``,
+    `export function Component() {`,
+    `${inner}`,
+    `}`,
+  ].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('polled-query-error-guard', () => {
+  // --- Valid cases (no errors expected) ---
+
+  it('allows useQuery without pollInterval', () => {
+    const messages = lintCode(
+      wrap(`
+  const { data, loading, error } = useQuery(QUERY);
+  if (error) return <ErrorBanner error={error} />;
+  return <div>{data}</div>;
+      `),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows useQuery with pollInterval and guarded if (error && !data)', () => {
+    const messages = lintCode(
+      wrap(`
+  const { data, loading, error } = useQuery(QUERY, { pollInterval: 5000 });
+  if (error && !data) return <ErrorBanner error={error} />;
+  return <div>{data}</div>;
+      `),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows renamed bindings with proper guard', () => {
+    const messages = lintCode(
+      wrap(`
+  const { data: state, loading, error: queryError } = useQuery(QUERY, { pollInterval: 5000 });
+  if (queryError && !state) return <ErrorBanner error={queryError} />;
+  return <div>{state}</div>;
+      `),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows if (error || loading) — logical expression is already guarded', () => {
+    const messages = lintCode(
+      wrap(`
+  const { data, loading, error } = useQuery(QUERY, { pollInterval: 5000 });
+  if (error || loading) return <ErrorBanner error={error} />;
+  return <div>{data}</div>;
+      `),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows polled useQuery when error is not destructured', () => {
+    const messages = lintCode(
+      wrap(`
+  const { data, loading } = useQuery(QUERY, { pollInterval: 5000 });
+  if (loading) return <div>Loading...</div>;
+  return <div>{data}</div>;
+      `),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows useQuery with pollInterval: 0 but error guard still valid', () => {
+    // pollInterval: 0 disables polling but we only care about whether it's
+    // present in the options object — the static check cannot evaluate it.
+    // If options has pollInterval key the rule fires, but if the consequent
+    // is already guarded it passes.
+    const messages = lintCode(
+      wrap(`
+  const { data, loading, error } = useQuery(QUERY, { pollInterval: 0 });
+  if (error && !data) return <ErrorBanner error={error} />;
+  return <div>{data}</div>;
+      `),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  it('allows if (error) when consequent does not return JSX', () => {
+    // Bare if (error) that does something other than return JSX should not fire.
+    const messages = lintCode(
+      wrap(`
+  const { data, loading, error } = useQuery(QUERY, { pollInterval: 5000 });
+  if (error) console.error(error);
+  return <div>{data}</div>;
+      `),
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  // --- Invalid cases (should produce errors) ---
+
+  it('reports error for bare if (error) with JSX return under polled query', () => {
+    const messages = lintCode(
+      wrap(`
+  const { data, loading, error } = useQuery(QUERY, { pollInterval: 5000 });
+  if (error) return <ErrorBanner error={error} />;
+  return <div>{data}</div>;
+      `),
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('error');
+    expect(messages[0].message).toContain('data');
+    expect(messages[0].message).toContain('docs/web-patterns.md');
+    expect(messages[0].message).toContain('2850');
+    expect(messages[0].severity).toBe(2); // error
+  });
+
+  it('reports error for bare if (error) with JSX in block statement', () => {
+    const messages = lintCode(
+      wrap(`
+  const { data, loading, error } = useQuery(QUERY, { pollInterval: 5000 });
+  if (error) {
+    return <ErrorBanner error={error} />;
+  }
+  return <div>{data}</div>;
+      `),
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('error');
+  });
+
+  it('reports error for renamed error binding', () => {
+    const messages = lintCode(
+      wrap(`
+  const { data: state, error: queryError } = useQuery(QUERY, { pollInterval: 5000 });
+  if (queryError) return <ErrorBanner error={queryError} />;
+  return <div>{state}</div>;
+      `),
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('queryError');
+    expect(messages[0].message).toContain('state');
+  });
+
+  it('error message references docs/web-patterns.md §Apollo Polling', () => {
+    const messages = lintCode(
+      wrap(`
+  const { data, loading, error } = useQuery(QUERY, { pollInterval: 5000 });
+  if (error) return <ErrorBanner error={error} />;
+  return <div>{data}</div>;
+      `),
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('docs/web-patterns.md');
+    expect(messages[0].message).toContain('Apollo Polling');
+    expect(messages[0].message).toContain('2850');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Regression fixtures: pre-#2842 vs post-#2842 DispatcherDashboard shape
+  //
+  // Before #2842 the DispatcherDashboard used:
+  //   const { data, loading, error, refetch } = useQuery(..., { pollInterval: ... });
+  //   if (error) return <ErrorBanner error={error} />;
+  //
+  // After #2842 it was fixed to:
+  //   const { data: state, loading, error, refetch } = useQuery(..., ...);
+  //   if (error && !state) return <ErrorBanner error={error} />;
+  // ---------------------------------------------------------------------------
+
+  it('fires on pre-#2842 DispatcherDashboard shape (polled query + bare if error)', () => {
+    const messages = lintCode(
+      wrap(`
+  const { data, loading, error, refetch } = useQuery(DISPATCHER_STATE_QUERY, {
+    skip: !authReady,
+    pollInterval: authReady ? 2000 : 0,
+    fetchPolicy: 'cache-and-network',
+  });
+  if (error) return <ErrorBanner error={error} />;
+  return <div>{data ? 'ok' : 'loading'}</div>;
+      `),
+    );
+    expect(messages).toHaveLength(1);
+    expect(messages[0].message).toContain('error');
+    expect(messages[0].message).toContain('data');
+  });
+
+  it('passes on post-#2842 DispatcherDashboard shape (guarded with error && !state)', () => {
+    const messages = lintCode(
+      wrap(`
+  const { data: state, loading, error, refetch } = useQuery(DISPATCHER_STATE_QUERY, {
+    skip: !authReady,
+    pollInterval: authReady ? 2000 : 0,
+    fetchPolicy: 'cache-and-network',
+  });
+  if (error && !state) return <ErrorBanner error={error} />;
+  return <div>{state ? 'ok' : 'loading'}</div>;
+      `),
+    );
+    expect(messages).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `local/polled-query-error-guard` ESLint rule to flag bare `if (error) return <JSX/>` short-circuits in `useQuery` calls with `pollInterval`. Apollo retains stale data on poll failures; a bare error guard hides that cached fallback and shows a broken UI. The rule auto-fixes to `if (error && !data)` and supports renamed bindings. Documented in `docs/web-patterns.md` § Apollo Polling.

Closes #2850

## Test plan

### Automated checks

- [x] Lint passes (`npm run lint`)
- [x] Tests pass (`npm test` — 1448 tests)
- [x] CI green (all pre-push gates)

### Post-deploy verification

- [ ] N/A — lint/test rule only, no deployed component