### PR TITLE
feat(dispatcher): add CloudWatch alarm for scheduler_tick cadence slip (#2854)

### DIFF
--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -813,3 +813,38 @@ resource "aws_cloudwatch_metric_alarm" "heartbeat_stale" {
   alarm_actions = [var.alert_sns_topic_arn]
   ok_actions    = [var.alert_sns_topic_arn]
 }
+
+# ── scheduler tick cadence alarm (#2854) ──────────────────────────────────────
+#
+# Alarms when the p95 TickCadenceSeconds metric (emitted by the daemon just
+# before each scheduler_tick call) exceeds ``tick_cadence_slow_seconds``
+# over a 5-minute window.  Uses p95 so a single slow tick inside a healthy
+# window does not page; a persistently degraded loop will.
+#
+# ``treat_missing_data = "notBreaching"`` — the heartbeat alarm already
+# covers silence (daemon crashed / no metric at all).  This alarm
+# complements it: daemon is alive but ticking too slowly.
+
+resource "aws_cloudwatch_metric_alarm" "scheduler_tick_cadence_slow" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "${local.service_name}-scheduler-tick-cadence-slow"
+  alarm_description = "Dispatcher scheduler tick p95 cadence exceeded ${var.tick_cadence_slow_seconds}s over a 5-minute window (${var.environment}). The main loop is running slower than expected — check ${aws_cloudwatch_log_group.dispatcher.name} for daemon.tick_cadence_slip events. Issue #2854."
+
+  namespace   = "Judgemind/Dispatcher"
+  metric_name = "TickCadenceSeconds"
+  extended_statistic = "p95"
+  dimensions = {
+    Service = local.service_name
+  }
+
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = var.tick_cadence_slow_seconds
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}

--- a/infra/terraform/modules/dispatcher-daemon/outputs.tf
+++ b/infra/terraform/modules/dispatcher-daemon/outputs.tf
@@ -42,3 +42,8 @@ output "heartbeat_alarm_arn" {
   description = "ARN of the heartbeat staleness CloudWatch alarm (empty when enable_alerts is false)"
   value       = var.enable_alerts ? aws_cloudwatch_metric_alarm.heartbeat_stale[0].arn : ""
 }
+
+output "scheduler_tick_cadence_alarm_arn" {
+  description = "ARN of the scheduler tick cadence CloudWatch alarm (empty when enable_alerts is false)"
+  value       = var.enable_alerts ? aws_cloudwatch_metric_alarm.scheduler_tick_cadence_slow[0].arn : ""
+}

--- a/infra/terraform/modules/dispatcher-daemon/variables.tf
+++ b/infra/terraform/modules/dispatcher-daemon/variables.tf
@@ -140,6 +140,12 @@ variable "heartbeat_stale_seconds" {
   default     = 300
 }
 
+variable "tick_cadence_slow_seconds" {
+  description = "Threshold for the scheduler tick cadence alarm. When the p95 TickCadenceSeconds metric exceeds this value over a 5-minute window, the alarm fires. Default 90 (1.5× the 60s default cadence). See issue #2854."
+  type        = number
+  default     = 90
+}
+
 # ─── Oneshot task launcher (scripts/ecs-run-task.sh) ────────────────────────
 # When these ARNs are wired, the daemon's task role gets the permission set
 # required by `scripts/ecs-run-task.sh` so ralph phases can launch data

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -18874,6 +18874,86 @@ class DispatcherDaemon:
         )
         return True
 
+    # ── tick cadence metric + slip warning (#2854) ────────────────────────
+
+    def _check_tick_cadence_slip(self, now: float, last_scheduler: float) -> None:
+        """Emit ``daemon.tick_cadence_slip`` WARNING when the scheduler
+        tick is more than 2× late.
+
+        No-ops on the bootstrap tick where ``last_scheduler == 0.0``.
+        No debounce — each late tick fires independently so CloudWatch
+        Insights can count occurrences and the operator can correlate with
+        other log events.
+
+        Args:
+            now: Current ``time.monotonic()`` value.
+            last_scheduler: ``time.monotonic()`` at the previous scheduler
+                tick.  ``0.0`` on the bootstrap tick (skip the check).
+        """
+        if last_scheduler == 0.0:
+            return
+        elapsed = now - last_scheduler
+        cadence = self._cfg.tick_scheduler_seconds
+        if elapsed > 2 * cadence:
+            self._log.warning(
+                "daemon.tick_cadence_slip",
+                extra={
+                    "event": "tick_cadence_slip",
+                    "run_id": self._run_id,
+                    "elapsed_seconds": round(elapsed, 3),
+                    "cadence_seconds": cadence,
+                    "slip_multiple": 2,
+                },
+            )
+
+    def _emit_tick_cadence_metric(self, elapsed_seconds: float) -> bool:
+        """Publish ``TickCadenceSeconds`` to the configured CloudWatch namespace.
+
+        Returns True on success, False on failure.  Mirrors
+        :meth:`_emit_heartbeat_metric` — same lazy boto3 client, same
+        namespace, same ``Service`` dimension, same failure → log + reset
+        policy so a transient CloudWatch outage does not poison the daemon.
+
+        Args:
+            elapsed_seconds: Wall-clock seconds since the previous scheduler
+                tick.  Passed in by ``run_forever`` which already computed
+                ``now - last_scheduler``.
+        """
+        service_dim = self._cfg.dispatcher_service_name or self._cfg.host
+
+        try:
+            if self._cloudwatch_client is None:
+                self._cloudwatch_client = self._make_cloudwatch_client()
+            self._cloudwatch_client.put_metric_data(
+                Namespace=self._cfg.heartbeat_metric_namespace,
+                MetricData=[
+                    {
+                        "MetricName": "TickCadenceSeconds",
+                        "Dimensions": [
+                            {"Name": "Service", "Value": service_dim},
+                        ],
+                        "Value": elapsed_seconds,
+                        "Unit": "Seconds",
+                    }
+                ],
+            )
+        except Exception as exc:
+            # Reset the client so the next tick re-creates it — mirrors
+            # the heartbeat metric error path.
+            self._cloudwatch_client = None
+            self._log.warning(
+                "daemon.tick_cadence_metric_failed",
+                extra={
+                    "event": "tick_cadence_metric_failed",
+                    "run_id": self._run_id,
+                    "namespace": self._cfg.heartbeat_metric_namespace,
+                    "detail": str(exc),
+                },
+            )
+            return False
+
+        return True
+
     # ── per-agent ECS launcher + reaper (#3091 Stage 2) ─────────────────
     #
     # These methods wire the daemon to the ``judgemind-dispatcher-agent-
@@ -20165,6 +20245,17 @@ class DispatcherDaemon:
             now = time.monotonic()
             try:
                 if now - last_scheduler >= self._cfg.tick_scheduler_seconds:
+                    # #2854: emit cadence metric + slip warning before the
+                    # tick body.  Skip on the bootstrap tick (last_scheduler
+                    # is only 0.0 when we reach this branch via the seeded
+                    # ``last_scheduler = time.monotonic()`` from the boot
+                    # block, so by the time the main loop fires for the
+                    # first time ``last_scheduler > 0.0`` — still correct
+                    # to guard on the 0.0 sentinel for safety).
+                    if last_scheduler > 0.0:
+                        elapsed = now - last_scheduler
+                        self._check_tick_cadence_slip(now, last_scheduler)
+                        self._emit_tick_cadence_metric(elapsed)
                     self.scheduler_tick()
                     last_scheduler = now
                 if now - last_supervisor >= self._cfg.tick_supervisor_seconds:

--- a/scripts/dispatcher/tests/test_daemon_tick_cadence_slip.py
+++ b/scripts/dispatcher/tests/test_daemon_tick_cadence_slip.py
@@ -1,0 +1,230 @@
+"""Unit tests for #2854 — scheduler tick cadence monitoring.
+
+Covers the two helpers added to :mod:`scripts.dispatcher.daemon`:
+
+* :meth:`DispatcherDaemon._check_tick_cadence_slip` — emits a WARNING
+  ``daemon.tick_cadence_slip`` event when ``now - last_scheduler`` is
+  more than 2× the configured cadence.  Silent on boot tick
+  (``last_scheduler == 0.0``) and on ticks that arrive on time.
+
+* :meth:`DispatcherDaemon._emit_tick_cadence_metric` — posts
+  ``TickCadenceSeconds`` to CloudWatch under the ``Judgemind/Dispatcher``
+  namespace with a ``Service`` dimension.  Swallows boto3 errors and
+  resets the client for the next tick.
+
+No real CloudWatch / ECS is reached.  No real Postgres is used.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# Make ``scripts`` importable without installing the repo as a package —
+# mirrors the preamble in the other ``test_daemon_*.py`` modules.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes (local copies so this test file stays self-contained —
+# the established convention in this test suite).
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.cadence.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+    d._scan_blocked_and_snapshot = lambda: 0  # type: ignore[method-assign]
+    d._maybe_spawn_orchestration_thread = MagicMock(return_value=False)  # type: ignore[method-assign]
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# _check_tick_cadence_slip
+# --------------------------------------------------------------------------
+
+
+class TestCheckTickCadenceSlip:
+    def test_slip_above_2x_cadence_emits_warning(self, tmp_path: Path) -> None:
+        """Elapsed > 2*cadence must fire a WARNING with the expected fields."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        cadence = d._cfg.tick_scheduler_seconds
+        # Simulate: last tick was (2*cadence + 0.1) seconds ago.
+        last_scheduler = 1000.0
+        now = last_scheduler + 2 * cadence + 0.1
+        d._check_tick_cadence_slip(now, last_scheduler)
+
+        events = handler.events("tick_cadence_slip")
+        assert len(events) == 1, (
+            f"expected 1 tick_cadence_slip event, got {len(events)}"
+        )
+        rec = events[0]
+        assert rec.levelno == logging.WARNING
+        assert getattr(rec, "slip_multiple", None) == 2
+        assert getattr(rec, "cadence_seconds", None) == cadence
+        elapsed = getattr(rec, "elapsed_seconds", None)
+        assert isinstance(elapsed, float)
+        assert elapsed > 2 * cadence
+
+    def test_slip_exactly_2x_does_not_emit(self, tmp_path: Path) -> None:
+        """The check is strict (>), so exactly 2× cadence must NOT fire."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        cadence = d._cfg.tick_scheduler_seconds
+        last_scheduler = 1000.0
+        # Exactly 2*cadence — must not trip the guard (strict >).
+        now = last_scheduler + 2 * cadence
+        d._check_tick_cadence_slip(now, last_scheduler)
+        assert handler.events("tick_cadence_slip") == []
+
+    def test_fast_tick_does_not_emit(self, tmp_path: Path) -> None:
+        """A tick that arrives roughly on time must not fire."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        cadence = d._cfg.tick_scheduler_seconds
+        last_scheduler = 1000.0
+        # Simulate a tick that arrived 1× cadence late (on time).
+        now = last_scheduler + cadence
+        d._check_tick_cadence_slip(now, last_scheduler)
+        assert handler.events("tick_cadence_slip") == []
+
+    def test_first_tick_never_emits(self, tmp_path: Path) -> None:
+        """Bootstrap tick (last_scheduler == 0.0) must always be silent."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        # last_scheduler is 0.0 — the sentinel for "no prior tick".
+        # Even with a very large 'now' the check must be a no-op.
+        d._check_tick_cadence_slip(999999.0, 0.0)
+        assert handler.events("tick_cadence_slip") == []
+
+
+# --------------------------------------------------------------------------
+# _emit_tick_cadence_metric
+# --------------------------------------------------------------------------
+
+
+class TestEmitTickCadenceMetric:
+    def test_emit_tick_cadence_metric_posts_to_cloudwatch(self, tmp_path: Path) -> None:
+        """On success, put_metric_data is called with the correct payload."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        fake_client = MagicMock()
+        d._cloudwatch_client = fake_client
+
+        elapsed = 65.0
+        result = d._emit_tick_cadence_metric(elapsed)
+
+        assert result is True
+        fake_client.put_metric_data.assert_called_once()
+        call_kwargs = fake_client.put_metric_data.call_args[1]
+        assert call_kwargs["Namespace"] == d._cfg.heartbeat_metric_namespace
+        metric = call_kwargs["MetricData"][0]
+        assert metric["MetricName"] == "TickCadenceSeconds"
+        assert metric["Unit"] == "Seconds"
+        assert metric["Value"] == elapsed
+        assert metric["Dimensions"] == [
+            {"Name": "Service", "Value": "judgemind-dispatcher-test"}
+        ]
+
+    def test_emit_tick_cadence_metric_swallows_boto_errors(
+        self, tmp_path: Path
+    ) -> None:
+        """A boto3 exception must return False and reset the client."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        fake_client = MagicMock()
+        fake_client.put_metric_data.side_effect = RuntimeError("boto3 boom")
+        d._cloudwatch_client = fake_client
+
+        result = d._emit_tick_cadence_metric(72.5)
+
+        assert result is False
+        # Client is reset so the next tick recreates it.
+        assert d._cloudwatch_client is None
+        # A warning event is logged.
+        events = handler.events("tick_cadence_metric_failed")
+        assert len(events) == 1
+        assert events[0].levelno == logging.WARNING
+
+        # Confirm that a subsequent call attempts to recreate the client.
+        new_fake_client = MagicMock()
+        with patch.object(d, "_make_cloudwatch_client", return_value=new_fake_client):
+            result2 = d._emit_tick_cadence_metric(70.0)
+        assert result2 is True
+        assert d._cloudwatch_client is new_fake_client


### PR DESCRIPTION
## Summary

Added scheduler tick cadence monitoring to detect when the dispatcher daemon's main loop slows down. The daemon now emits a `TickCadenceSeconds` CloudWatch metric and a `daemon.tick_cadence_slip` WARNING log event when the inter-tick interval exceeds 2× the configured cadence. A new Terraform alarm triggers when the p95 cadence metric exceeds 90 seconds over a 5-minute window, surfacing architectural invariant violations that would otherwise go unnoticed (as happened during #2847).

Closes #2854

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` on `scripts/dispatcher/` and `infra/terraform/`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest scripts/dispatcher/tests/test_daemon_tick_cadence_slip.py` — 6 new tests)
- [x] CI green

### Post-deploy verification

- [ ] Run `terraform apply -auto-approve` on dev; verify `aws_cloudwatch_metric_alarm.scheduler-tick-cadence-slow` exists
- [ ] Confirm alarm is in OK state during normal daemon operation (cadence stable at ~30s)
- [ ] Verification evidence posted on #2854 (see /task-v2-verify output)