### PR TITLE
refactor(dispatcher): consolidate terminal agent status constants (#2863)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -969,6 +969,18 @@ jobs:
         run: scripts/check-no-api-github-fetch.sh
 
   # ---------------------------------------------------------------
+  # Dispatcher terminal-status sync guard (#2863)
+  # ---------------------------------------------------------------
+  dispatcher-terminal-statuses-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.scripts == 'true' || needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Assert Python and TypeScript terminal-status lists match
+        run: scripts/check-dispatcher-terminal-statuses.sh
+
+  # ---------------------------------------------------------------
   # Schema drift guard: schema.sql must match applied migrations
   # ---------------------------------------------------------------
   schema-drift-check:

--- a/packages/api/src/graphql/dispatcher/constants.test.ts
+++ b/packages/api/src/graphql/dispatcher/constants.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit tests for the dispatcher terminal-status constants (issue #2863).
+ *
+ * Guards against accidental deletion, reordering, or drift of the
+ * `TERMINAL_AGENT_STATUSES` export.  Adding a new terminal status requires
+ * updating this test — that friction is intentional: the list must also be
+ * updated in `scripts/dispatcher/daemon.py` and
+ * `packages/web/.../ui-primitives.tsx`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { TERMINAL_AGENT_STATUSES } from './constants';
+import type { TerminalAgentStatus } from './constants';
+
+describe('TERMINAL_AGENT_STATUSES', () => {
+  it('contains exactly the expected five terminal statuses', () => {
+    const expected = new Set([
+      'succeeded',
+      'failed',
+      'crashed',
+      'plan_blocked',
+      'needs_review',
+    ]);
+    expect(new Set(TERMINAL_AGENT_STATUSES)).toEqual(expected);
+  });
+
+  it('has exactly 5 entries', () => {
+    expect(TERMINAL_AGENT_STATUSES).toHaveLength(5);
+  });
+
+  it('is a readonly tuple (as const)', () => {
+    // Verify the array is non-empty and every element is a non-empty string.
+    for (const status of TERMINAL_AGENT_STATUSES) {
+      expect(typeof status).toBe('string');
+      expect(status.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('TerminalAgentStatus type', () => {
+  it('accepts all valid terminal statuses at compile time', () => {
+    // If the type is wrong these assignments would fail tsc (--noEmit).
+    const s1: TerminalAgentStatus = 'succeeded';
+    const s2: TerminalAgentStatus = 'failed';
+    const s3: TerminalAgentStatus = 'crashed';
+    const s4: TerminalAgentStatus = 'plan_blocked';
+    const s5: TerminalAgentStatus = 'needs_review';
+    // Use the variables so tsc doesn't prune them.
+    expect([s1, s2, s3, s4, s5]).toHaveLength(5);
+  });
+});

--- a/packages/api/src/graphql/dispatcher/constants.ts
+++ b/packages/api/src/graphql/dispatcher/constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Canonical terminal-status constants for the dispatcher agent state machine.
+ *
+ * Authoritative twin (Python): scripts/dispatcher/daemon.py::TERMINAL_AGENT_STATUSES
+ *
+ * A CI check (`scripts/check-dispatcher-terminal-statuses.sh`) asserts that
+ * this list stays in sync with the Python frozenset. When adding a new
+ * terminal status, update BOTH lists and the OUTCOME_STYLES map in
+ * `packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx`.
+ */
+
+export const TERMINAL_AGENT_STATUSES = [
+  'succeeded',
+  'failed',
+  'crashed',
+  'plan_blocked',
+  'needs_review',
+] as const;
+
+export type TerminalAgentStatus = (typeof TERMINAL_AGENT_STATUSES)[number];

--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -17,6 +17,7 @@ import { GraphQLError, GraphQLScalarType, Kind } from 'graphql';
 import type { AuthUser } from '../../auth';
 import { requireDispatcherAdmin } from './auth';
 import { extractPriority, parseBlockedBy, priorityRank } from './parse-labels';
+import { TERMINAL_AGENT_STATUSES } from './constants';
 
 /**
  * Cooldown window in seconds — mirrors `FAILED_AGENT_COOLDOWN_SECONDS` in
@@ -478,11 +479,11 @@ async function queryRecentCompletions(pool: Pool, limit: number): Promise<Row[]>
            FROM dispatcher.phase_outputs
           GROUP BY agent_id
        ) po ON po.agent_id = a.agent_id
-      WHERE a.status IN ('succeeded', 'failed', 'crashed', 'plan_blocked', 'needs_review')
+      WHERE a.status = ANY($2::text[])
         AND a.ended_at IS NOT NULL
       ORDER BY a.ended_at DESC
       LIMIT $1`,
-    [limit],
+    [limit, [...TERMINAL_AGENT_STATUSES]],
   );
   return rows;
 }
@@ -504,8 +505,9 @@ async function queryRecentCompletionsCount(pool: Pool): Promise<number> {
   const { rows } = await pool.query<{ count: number | string }>(
     `SELECT COUNT(*)::int AS count
        FROM dispatcher.agents
-      WHERE status IN ('succeeded', 'failed', 'crashed', 'plan_blocked', 'needs_review')
+      WHERE status = ANY($1::text[])
         AND ended_at IS NOT NULL`,
+    [[...TERMINAL_AGENT_STATUSES]],
   );
   if (rows.length === 0) return 0;
   const raw = rows[0].count;

--- a/packages/web/package-lock.json
+++ b/packages/web/package-lock.json
@@ -79,7 +79,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1089,7 +1088,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1100,7 +1098,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1110,14 +1107,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1301,7 +1296,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1315,7 +1309,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1325,7 +1318,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -3152,14 +3144,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3170,7 +3162,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -4018,14 +4010,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4039,7 +4029,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -4364,7 +4353,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4388,7 +4376,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4516,7 +4503,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4595,7 +4581,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -4620,7 +4605,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4696,7 +4680,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4755,7 +4738,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -4792,7 +4774,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -5095,7 +5077,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/diff-sequences": {
@@ -5112,7 +5093,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -5950,7 +5930,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -5967,7 +5946,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -5994,7 +5972,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -6017,7 +5994,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6123,7 +6099,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6138,7 +6113,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6315,7 +6289,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -6518,7 +6491,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6749,7 +6721,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -6802,7 +6773,6 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -6853,7 +6823,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6909,7 +6878,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -6948,7 +6916,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -7332,7 +7299,6 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -7495,7 +7461,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -7508,7 +7473,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/local-pkg": {
@@ -7664,7 +7628,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -7674,7 +7637,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -7770,7 +7732,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -7937,7 +7898,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7985,7 +7945,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -8269,7 +8228,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -8316,7 +8274,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -8329,7 +8286,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8339,7 +8295,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -8378,7 +8333,6 @@
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
       "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8407,7 +8361,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -8425,7 +8378,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8451,7 +8403,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8494,7 +8445,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8520,7 +8470,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8534,7 +8483,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -8606,7 +8554,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8750,7 +8697,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -8760,7 +8706,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -8909,7 +8854,6 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -8950,7 +8894,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -9045,7 +8988,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9680,7 +9622,6 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -9716,7 +9657,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9754,7 +9694,6 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -9845,7 +9784,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -9855,7 +9793,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -9881,7 +9818,6 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -9898,7 +9834,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -9916,7 +9851,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9967,7 +9901,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -10017,7 +9950,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/ts-invariant": {
@@ -10353,7 +10285,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/victory-vendor": {

--- a/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
@@ -204,12 +204,25 @@ export const INFRA_PREEMPTED_CHIP_CLASSES =
 /** Shared ↺ glyph (U+21BA, ANTICLOCKWISE OPEN CIRCLE ARROW). Issue #2947. */
 export const INFRA_PREEMPTED_GLYPH = '\u21BA';
 
-type OutcomeStatus =
-  | 'succeeded'
-  | 'failed'
-  | 'crashed'
-  | 'plan_blocked'
-  | 'needs_review';
+/**
+ * Canonical terminal-status list — mirrors
+ * `packages/api/src/graphql/dispatcher/constants.ts::TERMINAL_AGENT_STATUSES`
+ * and `scripts/dispatcher/daemon.py::TERMINAL_AGENT_STATUSES`.
+ *
+ * Kept as a local const (not a cross-package import) because `packages/web`
+ * does not depend on `packages/api` at runtime. The CI check
+ * `scripts/check-dispatcher-terminal-statuses.sh` asserts that all three
+ * copies stay in sync — update them together when adding a new status.
+ */
+const TERMINAL_AGENT_STATUSES = [
+  'succeeded',
+  'failed',
+  'crashed',
+  'plan_blocked',
+  'needs_review',
+] as const;
+
+type OutcomeStatus = (typeof TERMINAL_AGENT_STATUSES)[number];
 
 /** Amber ✓ chip — shipped but post-merge bookkeeping incomplete.
  *

--- a/scripts/check-dispatcher-terminal-statuses.sh
+++ b/scripts/check-dispatcher-terminal-statuses.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# check-dispatcher-terminal-statuses.sh — Assert that the terminal-status
+# lists in Python and TypeScript stay in sync.
+#
+# Three canonical copies of the terminal-status list must always agree:
+#   1. scripts/dispatcher/daemon.py::TERMINAL_AGENT_STATUSES (frozenset)
+#   2. packages/api/src/graphql/dispatcher/constants.ts (TERMINAL_AGENT_STATUSES array)
+#   3. packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
+#      (TERMINAL_AGENT_STATUSES array)
+#
+# The script extracts the status token strings from each location, sorts
+# them, and fails if any copy diverges from the others.  This guards against
+# the accidental pattern of adding a new terminal status in Python without
+# updating the TypeScript side (or vice versa).
+#
+# Usage:
+#   scripts/check-dispatcher-terminal-statuses.sh
+#
+# Exit codes:
+#   0 — All three copies are identical.
+#   1 — One or more copies differ; details printed to stderr.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+DAEMON_PY="$REPO_ROOT/scripts/dispatcher/daemon.py"
+CONSTANTS_TS="$REPO_ROOT/packages/api/src/graphql/dispatcher/constants.ts"
+UI_PRIMITIVES_TSX="$REPO_ROOT/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx"
+
+# ─── Extraction helpers ───────────────────────────────────────────────────
+# Extract status tokens from the Python frozenset literal:
+#   TERMINAL_AGENT_STATUSES: frozenset[str] = frozenset(
+#       {"succeeded", "failed", ...}
+#   )
+# We grab the block between the first { after the frozenset( call and the
+# matching }, then strip down to bare word tokens.
+extract_python() {
+    local file="$1"
+    # Grab the frozenset literal block (single or multi-line).
+    # awk: print lines from 'TERMINAL_AGENT_STATUSES.*frozenset' to the
+    # closing ')' of the outer frozenset() call.
+    awk '/^TERMINAL_AGENT_STATUSES.*frozenset/{p=1} p{print; if(/\)/) {p=0; exit}}' "$file" \
+        | grep -oE '"[a-z_]+"' \
+        | tr -d '"' \
+        | sort
+}
+
+# Extract status tokens from a TS/TSX const array:
+#   const TERMINAL_AGENT_STATUSES = [
+#     'succeeded', 'failed', ...
+#   ] as const;
+# We grab the block between the [ and ] for the TERMINAL_AGENT_STATUSES array.
+extract_ts() {
+    local file="$1"
+    awk '/const TERMINAL_AGENT_STATUSES[[:space:]]*=[[:space:]]*\[/{p=1} p{print; if(/\] as const/) {p=0; exit}}' "$file" \
+        | grep -oE "'[a-z_]+'" \
+        | tr -d "'" \
+        | sort
+}
+
+# ─── Extract all three lists ──────────────────────────────────────────────
+py_list=$(extract_python "$DAEMON_PY")
+api_ts_list=$(extract_ts "$CONSTANTS_TS")
+web_tsx_list=$(extract_ts "$UI_PRIMITIVES_TSX")
+
+if [[ -z "$py_list" ]]; then
+    echo "ERROR: Could not extract TERMINAL_AGENT_STATUSES from $DAEMON_PY" >&2
+    exit 1
+fi
+if [[ -z "$api_ts_list" ]]; then
+    echo "ERROR: Could not extract TERMINAL_AGENT_STATUSES from $CONSTANTS_TS" >&2
+    exit 1
+fi
+if [[ -z "$web_tsx_list" ]]; then
+    echo "ERROR: Could not extract TERMINAL_AGENT_STATUSES from $UI_PRIMITIVES_TSX" >&2
+    exit 1
+fi
+
+# ─── Compare ─────────────────────────────────────────────────────────────
+failures=0
+
+if [[ "$py_list" != "$api_ts_list" ]]; then
+    echo "ERROR: Terminal-status list mismatch between daemon.py and constants.ts" >&2
+    echo "" >&2
+    echo "  daemon.py:      $(echo "$py_list" | tr '\n' ' ')" >&2
+    echo "  constants.ts:   $(echo "$api_ts_list" | tr '\n' ' ')" >&2
+    echo "" >&2
+    failures=$((failures + 1))
+fi
+
+if [[ "$py_list" != "$web_tsx_list" ]]; then
+    echo "ERROR: Terminal-status list mismatch between daemon.py and ui-primitives.tsx" >&2
+    echo "" >&2
+    echo "  daemon.py:          $(echo "$py_list" | tr '\n' ' ')" >&2
+    echo "  ui-primitives.tsx:  $(echo "$web_tsx_list" | tr '\n' ' ')" >&2
+    echo "" >&2
+    failures=$((failures + 1))
+fi
+
+if [[ $failures -gt 0 ]]; then
+    echo "  Fix: update all three copies together." >&2
+    echo "  Files:" >&2
+    echo "    $DAEMON_PY" >&2
+    echo "    $CONSTANTS_TS" >&2
+    echo "    $UI_PRIMITIVES_TSX" >&2
+    exit 1
+fi
+
+echo "All three terminal-status lists match: $(echo "$py_list" | tr '\n' ' ')"
+exit 0

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -896,6 +896,19 @@ TERMINAL_AGENT_STATUSES: frozenset[str] = frozenset(
     {"succeeded", "failed", "crashed", "plan_blocked", "needs_review"}
 )
 
+#: Subset of :data:`TERMINAL_AGENT_STATUSES` that count as a
+#: *correct* outcome for retry-effectiveness classification written to
+#: ``dispatcher.diagnoses.outcome``.  A retry that resolves to one of
+#: these is recorded as ``retry_outcome='succeeded'`` — meaning the
+#: diagnoser's recommendation led to a desired end-state, regardless of
+#: whether a PR shipped (``succeeded``) or the plan was intentionally
+#: declined (``plan_blocked``) or flagged for operator review
+#: (``needs_review``).  The complement — any terminal status not in
+#: this set — is recorded as ``retry_outcome='failed'``.
+CORRECT_OUTCOME_TERMINAL_STATUSES: frozenset[str] = frozenset(
+    {"succeeded", "plan_blocked", "needs_review"}
+)
+
 # --------------------------------------------------------------------------
 # Milestone columns on ``dispatcher.agents`` — split the single
 # ``status='succeeded'`` terminal write into four independently-stamped
@@ -7905,13 +7918,12 @@ class DispatcherDaemon:
         done.
         """
         assert self._conn is not None, "connect() must run before update"
-        terminal = status in (
-            "succeeded",
-            "failed",
-            "crashed",
-            "plan_blocked",
-            "needs_review",
-        )
+        if status != "running" and status not in TERMINAL_AGENT_STATUSES:
+            raise AssertionError(
+                f"_mark_agent_terminal got unknown status={status!r}; "
+                f"must be 'running' or in TERMINAL_AGENT_STATUSES"
+            )
+        terminal = status in TERMINAL_AGENT_STATUSES
         # Issue #2913: clear ``failure_summary`` on correct-outcome
         # terminals so a row that previously held a crash message from
         # an earlier iteration (crashed → retry_reset → succeeded) does
@@ -14743,7 +14755,7 @@ class DispatcherDaemon:
         # decisions against the retry-success rate.
         retry_outcome = (
             "succeeded"
-            if final_status in ("succeeded", "plan_blocked", "needs_review")
+            if final_status in CORRECT_OUTCOME_TERMINAL_STATUSES
             else "failed"
         )
         outcome = {

--- a/scripts/dispatcher/tests/test_daemon_terminal_statuses.py
+++ b/scripts/dispatcher/tests/test_daemon_terminal_statuses.py
@@ -1,0 +1,169 @@
+"""Unit tests for TERMINAL_AGENT_STATUSES constant usage in daemon.py.
+
+Covers two contract properties introduced by issue #2863:
+
+1. ``_mark_agent_terminal`` raises ``AssertionError`` when given a status
+   that is neither ``'running'`` nor a member of ``TERMINAL_AGENT_STATUSES``.
+   This guards against typos or the incremental-status-addition mistake where
+   the daemon writes an unknown status to ``dispatcher.agents``.
+
+2. Each valid status — ``TERMINAL_AGENT_STATUSES`` ∪ {``'running'``} — is
+   accepted without raising.  Accepted means the method reaches the SQL
+   execution path (i.e. the guard passes, and the DB cursor receives at
+   least one ``execute`` call).
+
+All external calls (psycopg) are mocked.  Uses the same ``_make_daemon``
+fixture shape as ``test_daemon_phase3e.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — minimal subset needed for _mark_agent_terminal.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        return None
+
+    def fetchall(self) -> list[Any]:
+        return []
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection]:
+    logger = logging.getLogger(f"dispatcher.test.terminal_statuses.{id(tmp_path)}")
+    logger.handlers = []
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+
+def test_mark_agent_terminal_rejects_unknown_status(tmp_path: Path) -> None:
+    """_mark_agent_terminal raises AssertionError for an unknown status."""
+    d, conn = _make_daemon(tmp_path)
+    with pytest.raises(AssertionError, match="unknown status"):
+        d._mark_agent_terminal(
+            agent_id="agent-bogus",
+            status="bogus",
+            phase="some_phase",
+        )
+    # No SQL must have been issued — the guard fires before any DB call.
+    assert conn.cursor_instance.executed == []
+
+
+def test_mark_agent_terminal_rejects_empty_status(tmp_path: Path) -> None:
+    """_mark_agent_terminal raises AssertionError for an empty string status."""
+    d, conn = _make_daemon(tmp_path)
+    with pytest.raises(AssertionError, match="unknown status"):
+        d._mark_agent_terminal(
+            agent_id="agent-empty",
+            status="",
+            phase="some_phase",
+        )
+    assert conn.cursor_instance.executed == []
+
+
+def test_mark_agent_terminal_accepts_all_valid_statuses(tmp_path: Path) -> None:
+    """Every value in TERMINAL_AGENT_STATUSES ∪ {'running'} is accepted."""
+    valid_statuses = daemon.TERMINAL_AGENT_STATUSES | {"running"}
+    for status in sorted(valid_statuses):
+        d, conn = _make_daemon(tmp_path)
+        # Should not raise — the guard passes and the method attempts SQL.
+        try:
+            d._mark_agent_terminal(
+                agent_id=f"agent-{status}",
+                status=status,
+                phase="some_phase",
+            )
+        except AssertionError as exc:
+            pytest.fail(
+                f"_mark_agent_terminal raised AssertionError for valid status={status!r}: {exc}"
+            )
+        # At least one SQL statement must have been issued.
+        assert conn.cursor_instance.executed, (
+            f"Expected at least one SQL call for status={status!r}, got none"
+        )
+
+
+def test_terminal_agent_statuses_constant_contents() -> None:
+    """TERMINAL_AGENT_STATUSES contains exactly the expected five values."""
+    expected = frozenset(
+        {"succeeded", "failed", "crashed", "plan_blocked", "needs_review"}
+    )
+    assert daemon.TERMINAL_AGENT_STATUSES == expected
+
+
+def test_correct_outcome_terminal_statuses_constant_contents() -> None:
+    """CORRECT_OUTCOME_TERMINAL_STATUSES contains exactly the expected three values."""
+    expected = frozenset({"succeeded", "plan_blocked", "needs_review"})
+    assert daemon.CORRECT_OUTCOME_TERMINAL_STATUSES == expected
+
+
+def test_correct_outcome_is_subset_of_terminal() -> None:
+    """CORRECT_OUTCOME_TERMINAL_STATUSES must be a subset of TERMINAL_AGENT_STATUSES."""
+    assert daemon.CORRECT_OUTCOME_TERMINAL_STATUSES <= daemon.TERMINAL_AGENT_STATUSES


### PR DESCRIPTION
## Summary

Consolidated terminal-status constants across daemon.py, resolvers.ts, and ui-primitives.tsx: added CORRECT_OUTCOME_TERMINAL_STATUSES to daemon.py and replaced all hardcoded inline tuples with references to module-level constants; created packages/api/src/graphql/dispatcher/constants.ts exporting TERMINAL_AGENT_STATUSES and TerminalAgentStatus; updated SQL queries in resolvers.ts to use = ANY($N::text[]); derived OutcomeStatus in ui-primitives.tsx from a local const; added AssertionError guard in _mark_agent_terminal for unknown statuses; wired scripts/check-dispatcher-terminal-statuses.sh into CI to enforce cross-language sync.

Closes #2863

## Test plan

### Automated checks

- [ ] Lint passes (`ruff check` / `npm run lint`)
- [ ] Format check passes (`ruff format --check` / prettier)
- [ ] Tests pass (`pytest` / `npm test`)
- [ ] CI green

### Post-deploy verification

- [ ] Recent completions panel renders all terminal statuses
- [ ] Terminal status sync check passes in CI
- [ ] Verification evidence posted on #2863