### PR TITLE
test(dispatcher): parametrized JSONB shape fixtures to catch wire-format drift (#2874)

### DIFF
--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -271,17 +271,36 @@ function diagnoserRowToGraphQL(row: DiagnoserEffectivenessRow): Record<string, u
   };
 }
 
+/**
+ * Normalise a raw JSONB scalar value that is expected to be a string.
+ *
+ * node-postgres (pg) unwraps JSONB scalars to native JS values by
+ * default: a JSONB string `"circuit_breaker"` becomes the JS string
+ * `'circuit_breaker'`; JSONB `null` becomes JS `null`. This helper
+ * accepts that unwrapped shape and returns `null` for any non-string
+ * (including `null`, `undefined`, numbers, booleans, and objects).
+ *
+ * It is the TS counterpart of the Python `isinstance(raw, str)` gate
+ * used in `_read_cap_flipped_by` and related daemon readers — see
+ * `daemon.py:16131–16140`.
+ *
+ * Note: `JSON.parse` sites in this file at `normalizeSnapshotJson`
+ * (line 393) and `dispatcherSetConfig` (line 1149) are NOT JSONB
+ * scalar reads — they parse user mutation input and a snapshot-fallback
+ * blob respectively; they are intentionally unchanged.
+ */
+export function normalizeJsonbString(raw: unknown): string | null {
+  return typeof raw === 'string' ? raw : null;
+}
+
 async function querySpawnFrozenUntil(pool: Pool): Promise<string | null> {
   const { rows } = await pool.query<{ value: unknown }>(
     `SELECT value FROM dispatcher.config WHERE key = 'spawn_frozen_until'`,
   );
   if (rows.length === 0) return null;
   const raw = rows[0].value;
-  // jsonb comes back as the native JSON value; wrap string vs null carefully.
-  if (raw === null || raw === undefined) return null;
-  // Expect either a string (ISO-8601) or a JSON string literal
-  if (typeof raw === 'string') return raw;
-  return null;
+  // re: psycopg JSONB unwrap — see normalizeJsonbString above.
+  return normalizeJsonbString(raw);
 }
 
 /**
@@ -297,11 +316,8 @@ async function queryCapFlippedBy(pool: Pool): Promise<string | null> {
   );
   if (rows.length === 0) return null;
   const raw = rows[0].value;
-  if (raw === null || raw === undefined) return null;
-  // pg's jsonb parser unwraps scalars: JSON `"circuit_breaker"` → the
-  // JS string `'circuit_breaker'`; JSON `null` → JS `null`.
-  if (typeof raw === 'string') return raw;
-  return null;
+  // re: psycopg JSONB unwrap — see normalizeJsonbString above.
+  return normalizeJsonbString(raw);
 }
 
 async function queryQueueDepth(pool: Pool): Promise<number> {

--- a/packages/api/tests/dispatcher-jsonb-normalize.unit.test.ts
+++ b/packages/api/tests/dispatcher-jsonb-normalize.unit.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for `normalizeJsonbString` — the shared JSONB scalar
+ * normaliser used by `querySpawnFrozenUntil` and `queryCapFlippedBy`
+ * (#2874).
+ *
+ * node-postgres unwraps JSONB scalars to native JS values by default
+ * (e.g. a JSONB string `"circuit_breaker"` becomes the JS string
+ * `'circuit_breaker'`). `normalizeJsonbString` accepts that unwrapped
+ * shape and returns `null` for any non-string value.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { normalizeJsonbString } from '../src/graphql/dispatcher/resolvers';
+
+describe('normalizeJsonbString — string inputs', () => {
+  it('returns the string unchanged for a non-empty string', () => {
+    expect(normalizeJsonbString('circuit_breaker')).toBe('circuit_breaker');
+  });
+
+  it('returns an empty string for an empty string input', () => {
+    // pg unwraps JSONB string "" to the JS empty string ''.
+    expect(normalizeJsonbString('')).toBe('');
+  });
+
+  it('returns an ISO-8601 timestamp string unchanged', () => {
+    const ts = '2026-04-24T12:00:00Z';
+    expect(normalizeJsonbString(ts)).toBe(ts);
+  });
+});
+
+describe('normalizeJsonbString — non-string inputs return null', () => {
+  it('returns null for null', () => {
+    expect(normalizeJsonbString(null)).toBeNull();
+  });
+
+  it('returns null for undefined', () => {
+    expect(normalizeJsonbString(undefined)).toBeNull();
+  });
+
+  it('returns null for a number', () => {
+    expect(normalizeJsonbString(42)).toBeNull();
+  });
+
+  it('returns null for a boolean true', () => {
+    expect(normalizeJsonbString(true)).toBeNull();
+  });
+
+  it('returns null for a boolean false', () => {
+    expect(normalizeJsonbString(false)).toBeNull();
+  });
+
+  it('returns null for an object', () => {
+    expect(normalizeJsonbString({ key: 'value' })).toBeNull();
+  });
+
+  it('returns null for an array', () => {
+    expect(normalizeJsonbString([1, 2, 3])).toBeNull();
+  });
+});

--- a/scripts/dispatcher/tests/_fixtures.py
+++ b/scripts/dispatcher/tests/_fixtures.py
@@ -1,0 +1,74 @@
+"""Shared JSONB test fixtures for dispatcher unit tests.
+
+Issue #2874: canonical helpers that model what psycopg3 hands back for
+a JSONB column vs what legacy fake-cursor tests may feed.
+
+**Production shape** (``psycopg_jsonb``):
+  psycopg3 decodes JSONB columns to their native Python equivalents
+  before returning rows.  A JSONB string ``"circuit_breaker"`` becomes
+  the Python string ``circuit_breaker`` (no surrounding quotes); JSONB
+  ``true`` becomes Python ``True``; JSONB number ``5`` becomes Python
+  ``int`` 5; JSONB ``null`` becomes Python ``None``.  The fixture
+  models this by returning the value unchanged — i.e. the identity
+  function — because callers should already be working with native
+  Python values when constructing ``fetch_queue`` entries.
+
+**Legacy shape** (``psycopg_jsonb_legacy``):
+  Some existing fake-cursor tests were written before psycopg3 and pass
+  the raw JSON-encoded wire bytes instead of the unwrapped Python
+  value.  For example, the JSON string ``"circuit_breaker"`` was stored
+  as the Python string ``'"circuit_breaker"'`` (with the JSON quotes).
+  This fixture models that legacy encoding via ``json.dumps``.  It
+  exists so tests can exercise the tolerant ``isinstance(raw, str) +
+  json.loads`` fallback branches that each JSONB reader still carries
+  for backwards compatibility with fake-cursor tests.
+
+Only ``psycopg_jsonb`` models what production callers see.
+``psycopg_jsonb_legacy`` is a test-infrastructure artefact — callers
+of the legacy shape produce the same reader output, confirming that the
+fallback gate works correctly, but the production code path is the
+identity form.
+
+See also: ``daemon.py::_read_cap_flipped_by`` docstring at line
+16131–16140 for the matching in-daemon rationale.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def psycopg_jsonb(value: Any) -> Any:
+    """Return *value* in the shape psycopg3 hands back for a JSONB column.
+
+    psycopg3 decodes JSONB scalars to their native Python equivalents
+    before returning rows, so this fixture is the identity function for
+    values that are already native Python objects.
+
+    Examples::
+
+        psycopg_jsonb("circuit_breaker")  # → "circuit_breaker"
+        psycopg_jsonb(True)               # → True
+        psycopg_jsonb(5)                  # → 5
+        psycopg_jsonb(None)               # → None
+    """
+    return value
+
+
+def psycopg_jsonb_legacy(value: Any) -> str:
+    """Return *value* encoded as a raw JSON string (legacy fake-cursor shape).
+
+    Some tests written before psycopg3 pass the raw JSONB wire bytes
+    instead of the unwrapped Python value.  This fixture models that
+    encoding via :func:`json.dumps` so the tolerant
+    ``isinstance(raw, str) + json.loads`` fallback branches in each
+    JSONB reader can be exercised.
+
+    Examples::
+
+        psycopg_jsonb_legacy("circuit_breaker")  # → '"circuit_breaker"'
+        psycopg_jsonb_legacy(True)               # → 'true'
+        psycopg_jsonb_legacy(5)                  # → '5'
+    """
+    return json.dumps(value)

--- a/scripts/dispatcher/tests/test_daemon_circuit_breaker.py
+++ b/scripts/dispatcher/tests/test_daemon_circuit_breaker.py
@@ -36,12 +36,15 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 # Make ``scripts`` importable without installing the repo as a package.
 _SCRIPTS = Path(__file__).resolve().parents[2]
 if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 from dispatcher import daemon  # noqa: E402
+from dispatcher.tests._fixtures import psycopg_jsonb, psycopg_jsonb_legacy  # noqa: E402
 
 
 # --------------------------------------------------------------------------
@@ -236,23 +239,42 @@ class TestWriteTerminalOutcome:
 
 
 class TestCBConfigReaders:
-    """The ``_cb_config_int``/``_cb_enabled`` helpers fall back to safe defaults."""
+    """The ``_cb_config_int``/``_cb_enabled`` helpers fall back to safe defaults.
+
+    Issue #2874: parametrized over both JSONB shapes — psycopg3 native
+    (production) and JSON-encoded string (legacy fake-cursor).
+    """
 
     def test_enabled_defaults_to_true_when_row_missing(self, tmp_path: Path) -> None:
         d, conn, _h = _make_daemon(tmp_path)
         conn.cursor_instance.fetch_queue = [None]
         assert d._cb_enabled() is True
 
-    def test_enabled_reads_bool_from_config(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "make_value",
+        [psycopg_jsonb, psycopg_jsonb_legacy],
+        ids=["psycopg3_native", "legacy_json_string"],
+    )
+    def test_enabled_reads_false_both_shapes(
+        self, tmp_path: Path, make_value: Any
+    ) -> None:
+        """Both JSONB shapes resolve to False for a stored 'false' value."""
         d, conn, _h = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [(False,)]
+        conn.cursor_instance.fetch_queue = [(make_value(False),)]
         assert d._cb_enabled() is False
 
-    def test_enabled_parses_json_string(self, tmp_path: Path) -> None:
-        """Stored as JSONB → driver may hand us the string ``"false"``."""
+    @pytest.mark.parametrize(
+        "make_value",
+        [psycopg_jsonb, psycopg_jsonb_legacy],
+        ids=["psycopg3_native", "legacy_json_string"],
+    )
+    def test_enabled_reads_true_both_shapes(
+        self, tmp_path: Path, make_value: Any
+    ) -> None:
+        """Both JSONB shapes resolve to True for a stored 'true' value."""
         d, conn, _h = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [("false",)]
-        assert d._cb_enabled() is False
+        conn.cursor_instance.fetch_queue = [(make_value(True),)]
+        assert d._cb_enabled() is True
 
     def test_enabled_defaults_to_true_on_malformed_json(self, tmp_path: Path) -> None:
         d, conn, _h = _make_daemon(tmp_path)
@@ -264,15 +286,17 @@ class TestCBConfigReaders:
         conn.cursor_instance.fetch_queue = [None]
         assert d._cb_config_int("circuit_breaker_window_minutes", 30) == 30
 
-    def test_config_int_reads_raw_int(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "make_value",
+        [psycopg_jsonb, psycopg_jsonb_legacy],
+        ids=["psycopg3_native", "legacy_json_string"],
+    )
+    def test_config_int_reads_int_both_shapes(
+        self, tmp_path: Path, make_value: Any
+    ) -> None:
+        """Both JSONB shapes resolve to the integer value."""
         d, conn, _h = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [(10,)]
-        assert d._cb_config_int("circuit_breaker_window_size", 10) == 10
-
-    def test_config_int_parses_json_string(self, tmp_path: Path) -> None:
-        """An integer stored as a JSON string ``"5"`` still parses."""
-        d, conn, _h = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [("5",)]
+        conn.cursor_instance.fetch_queue = [(make_value(5),)]
         assert d._cb_config_int("circuit_breaker_bad_outcome_threshold", 999) == 5
 
     def test_config_int_negative_falls_back_to_default(self, tmp_path: Path) -> None:
@@ -502,6 +526,9 @@ class TestReadCapFlippedBy:
     Python string ``"circuit_breaker"`` (no quotes). Test fake cursors
     may pass the pre-decode shape ``'"circuit_breaker"'``. Both must
     resolve identically.
+
+    Issue #2874: parametrized over both shapes so both rails are asserted
+    from the same test body.
     """
 
     def test_returns_none_when_row_absent(self, tmp_path: Path) -> None:
@@ -515,16 +542,17 @@ class TestReadCapFlippedBy:
         conn.cursor_instance.fetch_queue = [(None,)]
         assert d._read_cap_flipped_by() is None
 
-    def test_returns_unwrapped_string_production_shape(self, tmp_path: Path) -> None:
-        """psycopg3 production shape: JSONB string → Python string (no quotes)."""
+    @pytest.mark.parametrize(
+        "make_value",
+        [psycopg_jsonb, psycopg_jsonb_legacy],
+        ids=["psycopg3_native", "legacy_json_string"],
+    )
+    def test_returns_unwrapped_string_both_shapes(
+        self, tmp_path: Path, make_value: Any
+    ) -> None:
+        """Both JSONB shapes resolve to 'circuit_breaker' (no surrounding quotes)."""
         d, conn, _h = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [("circuit_breaker",)]
-        assert d._read_cap_flipped_by() == "circuit_breaker"
-
-    def test_returns_unwrapped_string_fake_cursor_shape(self, tmp_path: Path) -> None:
-        """Test fixtures may pass JSON-encoded bytes — accepted equivalently."""
-        d, conn, _h = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [('"circuit_breaker"',)]
+        conn.cursor_instance.fetch_queue = [(make_value("circuit_breaker"),)]
         assert d._read_cap_flipped_by() == "circuit_breaker"
 
     def test_returns_none_for_non_string_value(self, tmp_path: Path) -> None:

--- a/scripts/dispatcher/tests/test_daemon_commands.py
+++ b/scripts/dispatcher/tests/test_daemon_commands.py
@@ -36,6 +36,7 @@ if str(_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS))
 
 from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+from dispatcher.tests._fixtures import psycopg_jsonb, psycopg_jsonb_legacy  # noqa: E402
 
 
 # --------------------------------------------------------------------------
@@ -728,9 +729,47 @@ class TestClaimGateLegacyPausedKey:
     from dev-db-query still blocks new claims. These tests verify that
     escape hatch still works."""
 
+    @pytest.mark.parametrize(
+        "paused_value,shape_id",
+        [
+            (psycopg_jsonb(True), "psycopg3_native_bool"),
+            (psycopg_jsonb_legacy(True), "legacy_json_string"),
+        ],
+        ids=["psycopg3_native_bool", "legacy_json_string"],
+    )
+    def test_paused_via_is_paused_gate(self, paused_value: Any, shape_id: str) -> None:
+        """When paused=true in either JSONB shape, orchestration must not fire.
+
+        Issue #2874: psycopg3 native bool (production shape) and
+        JSON-encoded string (legacy fake-cursor shape) both block claims.
+        """
+        d, conn, _handler = _make_daemon_with_capture()
+        # SELECTs (in scheduler_tick order, cap>0 branch):
+        #   1. concurrency_cap = 1 (gate would normally proceed)
+        #   2. cap_flipped_by = None (overnight CB auto-close #2860; no-op)
+        #   3. _is_paused() = paused_value — the parametrized shape
+        conn.cursor_instance.fetch_queue = [(1,), None, (paused_value,)]
+        d._fetch_agent_ready_issues = lambda: []  # type: ignore[method-assign]
+        d._maybe_spawn_orchestration_thread = MagicMock(  # type: ignore[method-assign]
+            side_effect=AssertionError(
+                f"must not spawn when paused (shape={shape_id!r})"
+            )
+        )
+        d._consume_commands = lambda: 0  # type: ignore[method-assign]
+
+        summary = d.scheduler_tick()
+
+        # Orchestration was not attempted.
+        assert summary["orchestration_attempted"] == 0
+        assert d._maybe_spawn_orchestration_thread.call_count == 0  # type: ignore[attr-defined]
+
     def test_claim_gate_respects_paused_key(self) -> None:
         """When paused=true (manually inserted), orchestration must not
-        fire even if cap > 0."""
+        fire even if cap > 0.
+
+        Kept as a standalone regression guard; the parametrized
+        ``test_paused_via_is_paused_gate`` covers both shapes.
+        """
         d, conn, handler = _make_daemon_with_capture()
         # SELECTs (in scheduler_tick order, cap>0 branch):
         #   1. concurrency_cap = 1 (gate would normally proceed)

--- a/scripts/dispatcher/tests/test_daemon_phase3d.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3d.py
@@ -51,6 +51,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
 # Make ``scripts`` importable without installing the repo as a package.
 _SCRIPTS = Path(__file__).resolve().parents[2]
 if str(_SCRIPTS) not in sys.path:
@@ -58,6 +60,7 @@ if str(_SCRIPTS) not in sys.path:
 
 
 from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+from dispatcher.tests._fixtures import psycopg_jsonb, psycopg_jsonb_legacy  # noqa: E402
 from dispatcher.tests._popen_fake import make_popen_factory  # noqa: E402
 
 
@@ -213,25 +216,33 @@ class TestMigration26ConfigSeeds:
 
 
 class TestDiagnoserEnabled:
+    """Issue #2874: parametrized over both JSONB shapes (psycopg3 native + legacy)."""
+
     def test_default_true_when_row_missing(self, tmp_path: Path) -> None:
         d, conn, _handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetch_queue = [None]
         assert d._diagnoser_enabled() is True
 
-    def test_true_when_row_is_true(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "make_value",
+        [psycopg_jsonb, psycopg_jsonb_legacy],
+        ids=["psycopg3_native", "legacy_json_string"],
+    )
+    def test_true_both_shapes(self, tmp_path: Path, make_value: Any) -> None:
+        """Both JSONB shapes resolve to True for a stored 'true' value."""
         d, conn, _handler = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [(True,)]
+        conn.cursor_instance.fetch_queue = [(make_value(True),)]
         assert d._diagnoser_enabled() is True
 
-    def test_false_when_row_is_false(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "make_value",
+        [psycopg_jsonb, psycopg_jsonb_legacy],
+        ids=["psycopg3_native", "legacy_json_string"],
+    )
+    def test_false_both_shapes(self, tmp_path: Path, make_value: Any) -> None:
+        """Both JSONB shapes resolve to False for a stored 'false' value."""
         d, conn, _handler = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [(False,)]
-        assert d._diagnoser_enabled() is False
-
-    def test_false_when_row_is_json_string_false(self, tmp_path: Path) -> None:
-        # psycopg may hand us a raw JSON string when the column is JSONB.
-        d, conn, _handler = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [("false",)]
+        conn.cursor_instance.fetch_queue = [(make_value(False),)]
         assert d._diagnoser_enabled() is False
 
     def test_defaults_true_on_malformed(self, tmp_path: Path) -> None:
@@ -241,14 +252,28 @@ class TestDiagnoserEnabled:
 
 
 class TestFallbackThreshold:
-    def test_reads_float(self, tmp_path: Path) -> None:
+    """Issue #2874: parametrized over both JSONB shapes (psycopg3 native + legacy)."""
+
+    @pytest.mark.parametrize(
+        "make_value",
+        [psycopg_jsonb, psycopg_jsonb_legacy],
+        ids=["psycopg3_native", "legacy_json_string"],
+    )
+    def test_reads_float_both_shapes(self, tmp_path: Path, make_value: Any) -> None:
+        """Both JSONB shapes resolve to the correct float value."""
         d, conn, _handler = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [("0.50",)]
+        conn.cursor_instance.fetch_queue = [(make_value(0.50),)]
         assert d._diagnoser_fallback_threshold() == 0.50
 
-    def test_reads_number(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize(
+        "make_value",
+        [psycopg_jsonb, psycopg_jsonb_legacy],
+        ids=["psycopg3_native", "legacy_json_string"],
+    )
+    def test_reads_quarter_both_shapes(self, tmp_path: Path, make_value: Any) -> None:
+        """Both JSONB shapes resolve to 0.25."""
         d, conn, _handler = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [(0.25,)]
+        conn.cursor_instance.fetch_queue = [(make_value(0.25),)]
         assert d._diagnoser_fallback_threshold() == 0.25
 
     def test_default_when_row_missing(self, tmp_path: Path) -> None:

--- a/scripts/dispatcher/tests/test_fixtures.py
+++ b/scripts/dispatcher/tests/test_fixtures.py
@@ -1,0 +1,87 @@
+"""Round-trip tests for the ``_fixtures`` JSONB helper module.
+
+Issue #2874 — AC1 (helper exists) + AC4 (fixture round-trip).
+
+Tests confirm that:
+- ``psycopg_jsonb`` is the identity function for native Python values.
+- ``psycopg_jsonb_legacy`` returns the JSON-encoded string form.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from dispatcher.tests._fixtures import psycopg_jsonb, psycopg_jsonb_legacy  # noqa: E402
+
+
+class TestPsycopgJsonbIsIdentityForNativeValues:
+    """AC1 / AC4: ``psycopg_jsonb`` is the identity function."""
+
+    def test_string_round_trip(self) -> None:
+        assert psycopg_jsonb("circuit_breaker") == "circuit_breaker"
+
+    def test_bool_true_is_true(self) -> None:
+        assert psycopg_jsonb(True) is True
+
+    def test_bool_false_is_false(self) -> None:
+        assert psycopg_jsonb(False) is False
+
+    def test_int_round_trip(self) -> None:
+        assert psycopg_jsonb(5) == 5
+
+    def test_none_is_none(self) -> None:
+        assert psycopg_jsonb(None) is None
+
+    def test_float_round_trip(self) -> None:
+        assert psycopg_jsonb(0.30) == 0.30
+
+    def test_dict_round_trip(self) -> None:
+        d = {"action": "retry"}
+        assert psycopg_jsonb(d) is d
+
+    def test_list_round_trip(self) -> None:
+        lst = [1, 2, 3]
+        assert psycopg_jsonb(lst) is lst
+
+
+class TestPsycopgJsonbLegacyJsonEncodes:
+    """AC4: ``psycopg_jsonb_legacy`` returns the JSON-encoded wire shape."""
+
+    def test_string_is_json_quoted(self) -> None:
+        assert psycopg_jsonb_legacy("circuit_breaker") == '"circuit_breaker"'
+
+    def test_bool_true_is_lowercase_true(self) -> None:
+        assert psycopg_jsonb_legacy(True) == "true"
+
+    def test_bool_false_is_lowercase_false(self) -> None:
+        assert psycopg_jsonb_legacy(False) == "false"
+
+    def test_int_is_string(self) -> None:
+        assert psycopg_jsonb_legacy(5) == "5"
+
+    def test_none_is_null(self) -> None:
+        assert psycopg_jsonb_legacy(None) == "null"
+
+    def test_float_encodes(self) -> None:
+        assert psycopg_jsonb_legacy(0.30) == "0.3"
+
+
+class TestFixtureContrast:
+    """Contrast the two shapes to confirm they are distinct."""
+
+    def test_string_shapes_differ(self) -> None:
+        """psycopg_jsonb returns the bare string; legacy adds JSON quotes."""
+        assert psycopg_jsonb("circuit_breaker") != psycopg_jsonb_legacy(
+            "circuit_breaker"
+        )
+
+    def test_bool_shapes_differ(self) -> None:
+        """psycopg_jsonb returns Python bool; legacy returns a JSON string."""
+        assert type(psycopg_jsonb(True)) is bool
+        assert type(psycopg_jsonb_legacy(True)) is str


### PR DESCRIPTION
## Summary

Introduced shared JSONB test fixtures (`psycopg_jsonb` and `psycopg_jsonb_legacy`) to eliminate drift between production psycopg3 JSONB unwrap and unit-test fake cursors. Parametrized six daemon config readers to test both wire shapes equivalently; extracted `normalizeJsonbString` helper for API resolvers; ensured all `json.loads` gates wrapping JSONB reads have both-shape test coverage.

Closes #2874

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` for dispatcher; `npm test` for API resolvers)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (test-only, fixture module addition)

### Testing notes

**Fixture coverage:**
- `test_fixtures.py`: Round-trip tests for `psycopg_jsonb` (identity) and `psycopg_jsonb_legacy` (JSON-encodes).
- `test_daemon_circuit_breaker.py`: Six daemon readers parametrized over both shapes (TestCBConfigReaders, TestReadCapFlippedBy).
- `test_daemon_commands.py`: `test_paused_via_is_paused_gate` parametrized over both JSONB shapes.
- `test_daemon_phase3d.py`: TestDiagnoserEnabled and TestFallbackThreshold parametrized over both shapes.

**API resolvers:**
- Extracted `normalizeJsonbString` helper (exported from `resolvers.ts`).
- `querySpawnFrozenUntil` and `queryCapFlippedBy` refactored to use the helper.
- 10 unit tests in `dispatcher-jsonb-normalize.unit.test.ts` covering: strings, numbers, booleans, null, undefined, objects, arrays.

**Scope exclusions (verified unchanged):**
- `normalizeSnapshotJson` (line 397): parses defensive-fallback snapshot blob, not a JSONB read.
- `dispatcherSetConfig` (line 1149): parses user mutation input, not a JSONB read.