### PR TITLE
feat(dispatcher): fix_conflict phase — claude-resolve rebase conflicts (#3225)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -290,6 +290,49 @@ Two categories land in this skill via the post-exit parse path added for #3010:
 
 ---
 
+## Per-category guidance — fix_conflict terminal (issue #3225)
+
+### `conflict_unresolvable` — fix_conflict skill couldn't resolve a rebase conflict
+
+This category is set by the agent-runner entrypoint when:
+
+1. The `/task-v2-fix-conflict` skill returned `verdict="unresolvable"` (semantic collision it couldn't reconcile), OR
+2. The per-agent `merge_conflict_attempts` budget was exhausted (default `FIX_CONFLICT_MAX_ATTEMPTS=2`). The synthetic output has `budget_exhausted=true`.
+
+The agent's pre-rebase ralph patch is still preserved in `dispatcher.ralph_patches` — the branch was never pushed, there is no PR. The issue is still `status/in-progress`; no PR exists.
+
+**Context bundle extras.** In addition to the shared bundle shape, the daemon's phase_outputs row for this agent (`phase='fix_conflict'`, attempt N) carries the skill's full output JSON. Read the `resolution_notes` field from `context.prior_failures[0].details.resolution_notes` (or re-fetch from `dispatcher.phase_outputs` if the daemon didn't inline it). Also inspect:
+
+- `conflict_files` (list of str) — paths that couldn't be reconciled.
+- `budget_exhausted` (bool) — `true` means the skill was never invoked on this attempt; the counter was already at the cap.
+- Main's recent commits on those files (same source as the skill's `main_commits_since_base` input — re-fetch via `git log origin/main`).
+
+**Default action selection:**
+
+| Situation (evidence in `resolution_notes`) | Action | Why |
+|---|---|---|
+| Notes indicate a **semantic collision** — e.g. `"function X was rewritten on main"`, `"main reverted the feature this PR depended on"`, `"signature changed and agent's call no longer type-checks"` | **`escalate`** (or `reissue` with a clarified `new_scope` if the AC itself needs rewriting) | Maps to the spec's `AC_INFEASIBLE` intent: the agent's original intent no longer fits on top of the new base. A fresh ralph with the same AC will hit the same wall. Needs human judgment on whether the AC still makes sense. Use `reissue` when a clarified AC on top of the updated main would unblock the work; otherwise `escalate`. |
+| Notes indicate a **routine parallel-edit conflict** — e.g. `"main landed a sibling feature with overlapping design; agent can re-attempt with updated context"`, `"main refactored imports; agent's additions still valid but need re-anchoring"` | **`retry_with_hint`** | A fresh agent starting from the updated main will produce a compatible implementation naturally. Write a `hint` that names the conflict files and the commits on main the next agent needs to read. Example: `"Previous attempt hit a rebase conflict against PR #<sibling> in <file>. Main has since landed <commit sha/subject>. Re-read <file> on main and re-apply the acceptance criteria against the updated shape."` |
+| `budget_exhausted=true` AND prior `fix_conflict` failures in the bundle each had `resolution_notes` that read like semantic collisions | **`escalate`** | Two rounds couldn't reconcile — the conflict is structural. Mark needs-human. |
+| `budget_exhausted=true` but no prior fix_conflict failures in the bundle (fresh agent, budget-gate fired on the first invocation — shouldn't happen under default cap=2 but is possible when an operator set `AGENT_RUNNER_FIX_CONFLICT_MAX_ATTEMPTS=0` for a test) | **`retry`** | Transient config issue — fresh agent with restored budget will succeed. |
+| `resolution_notes` is empty or missing (skill crashed before writing) | **`retry`** | Treat as a transient skill failure; the next agent will re-encounter the conflict and can either resolve or return a populated unresolvable. |
+
+**Do NOT pick `close` for this category** — the issue is still open and has a valid backlog item; a rebase conflict is not evidence the issue is invalid.
+
+**Do NOT pick `file_prerequisite_task`** unless the conflict's root cause is a fleet-wide pattern (e.g. multiple agents hitting the same class of conflict against the same sibling PR). The fix_conflict skill is the right layer for per-issue conflict resolution; filing a prerequisite task is a fallback for when the conflict is infrastructural (e.g. the baseline rebase keeps failing due to a branch-protection mis-config — which would surface differently anyway).
+
+**`hint` content for `retry_with_hint`.** Keep it concrete:
+
+- Name the conflict files.
+- Name the merging commit from `main_commits_since_base` (by subject if SHA is unwieldy).
+- Tell the next agent to re-read the updated main-side files before planning.
+
+Example hint:
+
+> Previous attempt hit a rebase conflict in `packages/web/app/(main)/admin/dispatcher/a.tsx` after PR #3218 landed. Main now has commit `feat(dispatcher-v2): UI polish phase 2` that refactored the same component. Re-read the current file on main before re-applying this issue's acceptance criteria.
+
+---
+
 ## Per-category guidance — post-merge verify failure (issue #3071)
 
 ### `verify_failed_post_merge` — post-merge regression signal

--- a/.claude/skills/task-v2-fix-conflict/SKILL.md
+++ b/.claude/skills/task-v2-fix-conflict/SKILL.md
@@ -1,0 +1,159 @@
+---
+description: Fix-conflict phase for the per-phase /task-v2 pipeline. Reads a rebase-conflict bundle, resolves conflicts semantically against updated origin/main content, and produces either a resolved-file set OR an unresolvable signal.
+argument-hint: "<agent-id>"
+maxTurns: 60
+model: haiku
+---
+
+# /task-v2-fix-conflict skill
+
+Fix-conflict phase for the dispatcher v2 per-phase task pipeline (`docs/specs/dispatcher-v2-spec.md` §6). Invoked by the agent-runner entrypoint when the pre-push rebase (in the `push_and_pr` phase) OR the start-of-ralph baseline rebase hits a conflict against `origin/main`. Reads the pre-rebase ralph patch, the set of conflicted files, the commits that landed on main since the agent's branch base, and the current main-branch content of each conflict file; then emits either a `resolved` verdict with the reconciled file contents OR an `unresolvable` verdict that routes the agent through the diagnoser toward a `conflict_unresolvable` terminal.
+
+**Prerequisites:** The agent-runner entrypoint has already (a) aborted the in-progress rebase (`git rebase --abort`), (b) incremented `dispatcher.agents.merge_conflict_attempts`, (c) written the input bundle to `{worktree}/tmp/dispatcher-input/fix-conflict.json`. The entrypoint owns all git operations after this skill returns — the skill does NOT run `git`, does NOT push, does NOT call `gh`.
+
+**Goal:** Produce `{worktree}/tmp/dispatcher-output/fix-conflict.json` with `verdict="resolved"` (conflict reconciled; `resolved_files[]` populated) OR `verdict="unresolvable"` (reasoned explanation in `resolution_notes`).
+
+**IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation. This subprocess is already a dispatcher-spawned background task.
+
+**IMPORTANT — No side effects on GitHub or the worktree.** This skill does NOT comment on issues, edit labels, close issues, edit PRs, write files directly into the worktree, run `git`, or invoke `gh`. The only write is the output JSON at the path above.
+
+**IMPORTANT — Smallest correct reconciliation.** Apply the smallest change that satisfies BOTH the agent's original intent (preserved in `original_patch`) AND the updated state of `origin/main` (in `main_files_content`). Do not refactor, do not rename, do not add defensive code unrelated to the conflict. The reconciled files accrete on top of main's latest — they are NOT replacements for the agent's ralph work, they are ralph's work re-applied on top of the new base.
+
+**IMPORTANT — Budget bounds.** The entrypoint bounds this skill at `FIX_CONFLICT_MAX_ATTEMPTS` invocations per agent lifetime (default 2). A second attempt is reasonable because main may advance again during the first resolution run. A third attempt is not: if two rounds of claude-resolution couldn't close the loop, the conflict is structurally adversarial and deserves `unresolvable`.
+
+---
+
+## Input contract
+
+Read `{worktree}/tmp/dispatcher-input/fix-conflict.json`. Required fields:
+
+- `agent_id` (str) — the failing agent's UUID.
+- `issue_number` (int) — the GitHub issue this agent is working on.
+- `issue_body` (str) — the original task description (so you can reason about what the agent was trying to do).
+- `original_patch` (str) — the pre-rebase unified diff of the agent's ralph output (from `dispatcher.ralph_patches` latest SHIP row, OR `git diff origin/main..HEAD` at the moment the rebase aborted — the entrypoint picks whichever is available). This is what the agent WANTED to ship before main advanced.
+- `conflict_files` (list of `{path, conflict_markers_text}`):
+  - `path` (str) — repo-relative path of each conflicted file.
+  - `conflict_markers_text` (str) — the file's on-disk content at the point `git rebase --abort` ran, INCLUDING the `<<<<<<<` / `=======` / `>>>>>>>` markers. This shows you exactly which hunks disagreed and what both sides looked like at the time of the conflict. Note: after `--abort`, the on-disk content should have NO markers (abort restores pre-rebase state); the entrypoint captures the markers BEFORE aborting and stashes them here.
+- `main_commits_since_base` (list of `{sha, author, subject, body, stat}`) — commits on `origin/main` that landed after the agent's branch-base. Usually 1–5 entries; ordered newest-first. `stat` is the `git show --stat` summary for each commit so you can see at a glance which files it touched.
+- `main_files_content` (list of `{path, content}`) — the CURRENT (post-rebase-target) content of each conflict-file as it exists on `origin/main`. This is the authoritative reference for the new base. When reconciling, the resolved file should fit on top of THIS content, not on top of the pre-rebase `HEAD`.
+- `worktree_path` (str) — absolute path of the agent's worktree (for context; do NOT write files here).
+- `repo_root` (str) — same as `worktree_path` for this pipeline.
+- `attempt_number` (int) — how many times this skill has already run for this agent (1 on first invocation, 2 on second). Defaults to 1 if absent.
+
+Optional:
+
+- `max_iterations` (int) — cap on internal claude iterations. Defaults to 1 (one resolve-and-return pass). Not a retry budget — the retry budget is `FIX_CONFLICT_MAX_ATTEMPTS` enforced by the entrypoint.
+
+If the file is missing or malformed, exit 0 with `verdict="unresolvable", resolution_notes="input JSON missing or malformed"`, and an empty `resolved_files` list.
+
+---
+
+## Output contract
+
+Write `{worktree}/tmp/dispatcher-output/fix-conflict.json`:
+
+```json
+{
+  "agent_id": "<echo>",
+  "verdict": "resolved" | "unresolvable",
+  "resolution_notes": "<short paragraph — what was reconciled or why not>",
+  "resolved_files": [
+    {"path": "...", "content": "..."}
+  ],
+  "conflict_files": ["<path>", ...],
+  "notes": "<optional prose for the retro phase>"
+}
+```
+
+- `verdict="resolved"` — the conflict has been semantically reconciled. `resolved_files` contains the **full new content** of every conflict-file (not a diff). The entrypoint will write each file to its path in the worktree, stage it, and create a single new commit with a conventional-commits message. The next pass of `push_and_pr` will re-fetch + rebase + push — and should succeed because the resolved content matches the new base.
+- `verdict="unresolvable"` — the conflict cannot be resolved without a human decision. `resolution_notes` MUST explain why (structural collision, semantic mismatch, AC conflict). `resolved_files` should be empty. The entrypoint routes the agent to the `conflict_unresolvable` terminal; the diagnoser picks it up and chooses between `AC_INFEASIBLE` (if `resolution_notes` indicates the original intent no longer applies) and `retry_with_hint` (if a fresh agent with a better mental model could succeed).
+
+Always exit 0. Verdict comes from the JSON, not the exit code.
+
+**`resolved_files` content rules:**
+
+- Each entry's `content` is the complete file body after reconciliation — NOT a diff, NOT a patch, NOT a hunk. The entrypoint writes `content` verbatim to `{worktree}/{path}`.
+- UTF-8 encoded. Preserve the file's line-ending style (trailing newline / no trailing newline) from the pre-conflict `main_files_content`. Never force CRLF.
+- Every file in `conflict_files` (input) MUST appear in `resolved_files` (output) on `resolved`, unless the reconciliation legitimately drops a file (rare — note in `resolution_notes`). Do NOT include files that were not in `conflict_files`.
+- Do NOT include conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in the content. If you can't reconcile a hunk without leaving markers, emit `unresolvable` for the whole file set — a half-resolved file is worse than an explicit failure.
+
+---
+
+## Step 1 — Read the bundle and understand the conflict
+
+1. Read `{worktree}/tmp/dispatcher-input/fix-conflict.json` with a helper script. Write the helper to `{worktree}/tmp/dispatcher-fix-conflict/read_input.py` first, then invoke it — no inline `python -c`.
+2. For each conflict file:
+   - Compare `conflict_markers_text` (what the two sides looked like at conflict time) against `main_files_content[].content` (the current main-side content).
+   - Extract from `original_patch` the hunks the agent applied to this file. These represent the agent's *intent*.
+3. Read the relevant commits in `main_commits_since_base` (subject + body + stat) to understand what changed on main.
+4. Form a hypothesis for each hunk: can the agent's intent be re-applied on top of main's new content, and if so, how?
+
+## Step 2 — Classify the conflict
+
+For each file (and its overall set), classify into one of three buckets:
+
+| Classification | Definition | Action |
+|---|---|---|
+| **Parallel edits** | Main and the agent edited different regions of the same file — the rebase tool flagged them because they were on the same blob, but the hunks don't overlap semantically. | Merge both edit sets on top of main. Straightforward — re-apply the agent's hunks against the new main content at the matching anchor. |
+| **Overlapping edits, compatible intent** | Both sides touched the same region but they're trying to achieve compatible things — e.g. main renamed `foo` → `bar`, agent added a call to `foo`. The agent's call must be updated to `bar`, but the intent survives. | Re-express the agent's hunk in the vocabulary of main's new content. Preserve the agent's *behavior*; adapt the *form*. |
+| **Semantic collision** | Both sides changed the same behavior incompatibly — e.g. main deleted the function the agent's PR relied on; main rewrote the function's signature in a way that changes its contract; main added a new acceptance criterion that the agent's implementation contradicts. | `unresolvable`. The agent's original intent no longer fits on top of the new base. Explain in `resolution_notes`. |
+
+**Classification heuristics:**
+
+- If main's commit stat shows `-50 lines` in a file the agent added `+5 lines` to, the deletion probably removed the exact region the agent was editing — check carefully.
+- If main's commit subject mentions "refactor", "rename", "delete", "revert" or "rewrite" on a file the agent also touched, the collision is more likely semantic than parallel.
+- If the file is a test fixture or a schema, parallel-edit resolution is usually safe. If it's a hot code path (a function body, a route handler), overlap-resolution requires more care.
+
+## Step 3 — Produce resolved content (on `resolved`) OR explain (on `unresolvable`)
+
+For `resolved`:
+
+1. For each file in `conflict_files`, build the complete resolved content:
+   - Start from `main_files_content[i].content`.
+   - Apply the agent's intent from `original_patch`, translated into main's vocabulary per §2.
+   - Verify no conflict markers remain.
+   - Verify the imports / top-level declarations make sense (e.g. if main dropped an import the agent needed, re-add it; if main renamed an import the agent used, update the usage).
+2. Populate `resolved_files` with one entry per conflict file.
+3. Set `resolution_notes` to a short paragraph: "Resolved N conflicts across M files. Main had landed commits A, B, C. Key translations: agent's call to `foo()` → `bar()` per commit B. Agent's addition to function `process_x` re-anchored on main's new line 42 signature."
+4. Verdict `resolved`.
+
+For `unresolvable`:
+
+1. Set `resolved_files: []`.
+2. Set `resolution_notes` to an honest paragraph explaining the collision:
+   - WHICH file's conflict couldn't be resolved.
+   - WHAT main changed that the agent's intent no longer fits.
+   - WHY a human decision is needed (AC changed? feature was removed? design diverged?).
+   - Use one of these phrasings to help the diagnoser classify:
+     - `"function X was rewritten on main — agent's addition no longer applies"` → diagnoser picks `AC_INFEASIBLE`.
+     - `"main landed a sibling feature with overlapping design; agent can re-attempt with updated context"` → diagnoser picks `retry_with_hint`.
+     - `"main reverted the feature this PR depended on"` → `AC_INFEASIBLE`.
+3. Verdict `unresolvable`.
+
+## Step 4 — Write the output JSON
+
+Write your helper to `{worktree}/tmp/dispatcher-fix-conflict/write_output.py` first (avoid inline `python -c`), then invoke it to serialize your final dict to `{worktree}/tmp/dispatcher-output/fix-conflict.json`.
+
+---
+
+## What this skill does NOT do
+
+- **Does not run `git`.** The entrypoint owns all git operations — rebase, abort, stage, commit, push.
+- **Does not call `gh`.** Reading the issue body is done from the input bundle (already fetched by the entrypoint).
+- **Does not write files into the worktree.** Only the output JSON is written. On `resolved`, the entrypoint applies `resolved_files[]` by reading the output and writing each file back itself.
+- **Does not retry itself.** If you can't resolve, return `unresolvable` — the entrypoint's budget machinery decides whether to retry on the next agent invocation.
+- **Does not touch acceptance criteria.** AC collisions are the diagnoser's domain, not the fix-conflict skill's.
+
+## Escalation policy
+
+- **Attempt 1** (`attempt_number=1`) — primary pass. Try hard to classify and reconcile.
+- **Attempt 2** (`attempt_number=2`) — only reached when main advanced AGAIN during attempt 1's resolution (rare but valid). Same procedure.
+- **Attempt 3+** — unreachable. `FIX_CONFLICT_MAX_ATTEMPTS=2` caps this. The entrypoint will not invoke you past 2.
+
+## Reminders
+
+- No `$()`, no heredocs, no `python -c`. See `CLAUDE.md` Critical Rules. Write helper scripts to `{worktree}/tmp/dispatcher-fix-conflict/` first.
+- All temp files go under `{worktree}/tmp/`, never `/tmp/`.
+- Prefer `Read` for files, not `cat`. Prefer `Edit` over `Write` when you're editing something that already exists — but note that in this skill the outputs live only in JSON, not in the worktree.
+- The `resolution_notes` paragraph surfaces directly in the diagnoser's context bundle. Write it for a reader who has the stderr but not the files.
+- When in doubt between `resolved` and `unresolvable`, pick `unresolvable` with a precise note. A wrong `resolved` produces a broken commit that the next push will reject; an explicit `unresolvable` routes through the diagnoser and preserves the agent's ralph work for a human or follow-up agent.

--- a/packages/api/migrations/44_dispatcher-agents-merge-conflict-attempts.sql
+++ b/packages/api/migrations/44_dispatcher-agents-merge-conflict-attempts.sql
@@ -1,0 +1,69 @@
+-- Up Migration
+--
+-- Dispatcher v2 — budget bookkeeping for the ``fix_conflict`` phase
+-- (issue #3225). Adds one column to ``dispatcher.agents`` so the
+-- agent-runner entrypoint can bound the "claude resolves a pre-push
+-- rebase conflict against origin/main" recovery loop to
+-- ``FIX_CONFLICT_MAX_ATTEMPTS`` (default 2) per agent lifetime.
+--
+-- Why a dedicated column (not ``retries_used`` or ``output_json``)
+-- ---------------------------------------------------------------
+-- * ``retries_used`` already counts fix-CI mechanical retries
+--   (``FIX_CI_MAX_RETRIES``). Overloading it with merge-conflict
+--   counts would conflate two independent budgets — one is a CI-side
+--   fix loop on a pushed PR, the other is a pre-push git-rebase
+--   recovery loop that never reaches CI — and would silently shrink
+--   the available fix-CI budget for any agent that also hit a
+--   rebase conflict.
+-- * ``merge_unstick_attempts`` (migration 43) tracks a different
+--   recovery: post-merge stale-rollup auto-unstick attempts. Same
+--   "agent-lifetime bounded retry" shape, different phase.
+-- * ``output_json`` is a per-phase-output JSONB on a different
+--   table (``dispatcher.phase_outputs``). Storing agent-lifetime
+--   bookkeeping there would split a single counter across many
+--   rows and complicate the "at most FIX_CONFLICT_MAX_ATTEMPTS
+--   attempts per agent" predicate.
+--
+-- Behaviour
+-- ---------
+-- * DEFAULT 0 — every existing row (including in-flight agents mid-
+--   pipeline) is backfilled to 0, i.e. "no fix_conflict invocation
+--   yet". Matches the issue's per-agent-lifetime retry budget: each
+--   invocation of ``handle_fix_conflict`` increments the column
+--   BEFORE invoking claude; when the current value is already
+--   >= FIX_CONFLICT_MAX_ATTEMPTS the handler skips to the
+--   ``conflict_unresolvable`` terminal without spending claude
+--   compute.
+-- * NOT NULL — the handler always reads an integer, never a NULL.
+-- * No index — this column is only read/written during the
+--   fix_conflict-phase handler (one agent at a time, already
+--   filtered by agent_id). Adding an index would be pure overhead.
+--
+-- Rollback
+-- --------
+-- Dropping the column is safe. The entrypoint tolerates its absence
+-- at runtime: ``read_merge_conflict_attempts`` degrades to returning
+-- 0 (so the budget never trips), and ``handle_fix_conflict``
+-- continues to emit its structured output via the skill. The worst-
+-- case behaviour on rollback is an unbounded retry loop — which the
+-- entrypoint's ``MAX_PHASE_ITERATIONS`` cap (40) still contains. This
+-- mirrors the merge_unstick_attempts / migration 43 rollback policy.
+
+ALTER TABLE dispatcher.agents
+    ADD COLUMN IF NOT EXISTS merge_conflict_attempts INT NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN dispatcher.agents.merge_conflict_attempts IS
+    'Count of fix_conflict-phase claude-resolution attempts for this '
+    'agent (#3225). Bounded at FIX_CONFLICT_MAX_ATTEMPTS (default 2) '
+    'per agent lifetime: each invocation of handle_fix_conflict '
+    'increments this column before spawning the claude skill; when '
+    'the value is already >= budget the handler advances to the '
+    'conflict_unresolvable terminal without spending compute. Covers '
+    'both the pre-push rebase-conflict path (push_and_pr) and the '
+    'start-of-ralph baseline rebase-conflict path (secondary '
+    'mitigation). See .claude/skills/task-v2-fix-conflict/SKILL.md.';
+
+
+-- Down Migration
+ALTER TABLE dispatcher.agents
+    DROP COLUMN IF EXISTS merge_conflict_attempts;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 43 migrations.
+-- Generated from 44 migrations.
 
 
 
@@ -367,7 +367,8 @@ CREATE TABLE dispatcher.agents (
     agent_task_arn text,
     execution_mode text DEFAULT 'subprocess'::text NOT NULL,
     ralph_iterations_observed integer DEFAULT 0 NOT NULL,
-    merge_unstick_attempts integer DEFAULT 0 NOT NULL
+    merge_unstick_attempts integer DEFAULT 0 NOT NULL,
+    merge_conflict_attempts integer DEFAULT 0 NOT NULL
 );
 
 
@@ -411,6 +412,9 @@ COMMENT ON COLUMN dispatcher.agents.ralph_iterations_observed IS 'Count of ralph
 
 
 COMMENT ON COLUMN dispatcher.agents.merge_unstick_attempts IS 'Count of stale-rollup merge-phase auto-unstick attempts for this agent (#2641). Bounded at 1 per agent lifetime: the first stale-rollup rejection (GitHub stderr "base branch policy prohibits the merge" while ci-passed on HEAD is SUCCESS) bumps this to 1 and the daemon pushes an empty commit to force a fresh rollup evaluation; a second rejection in the same agent''s lifetime routes through _handle_agent_failure with category merge_unstick_exhausted.';
+
+
+COMMENT ON COLUMN dispatcher.agents.merge_conflict_attempts IS 'Count of fix_conflict-phase claude-resolution attempts for this agent (#3225). Bounded at FIX_CONFLICT_MAX_ATTEMPTS (default 2) per agent lifetime: each invocation of handle_fix_conflict increments this column before spawning the claude skill; when the value is already >= budget the handler advances to the conflict_unresolvable terminal without spending compute. Covers both the pre-push rebase-conflict path (push_and_pr) and the start-of-ralph baseline rebase-conflict path (secondary mitigation). See .claude/skills/task-v2-fix-conflict/SKILL.md.';
 
 
 CREATE TABLE dispatcher.blocked_snapshots (

--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -1353,6 +1353,230 @@ def _build_retro_input(
     }
 
 
+def _build_fix_conflict_input(
+    agent_id: str,
+    issue_number: int,
+    repo_root: Path,
+    github_repo: str,
+) -> dict:
+    """Build the /task-v2-fix-conflict input bundle (#3225).
+
+    Reads artifacts the entrypoint stashed when the rebase conflict
+    was detected (``{AGENT_WORKSPACE}/fix-conflict/`` — see
+    ``handle_push_and_pr`` and the start-of-ralph baseline rebase
+    branch). Provides:
+
+    * ``issue_body`` — original task for context.
+    * ``original_patch`` — agent's pre-rebase diff (from the stashed
+      ``original-patch.diff``, or ralph_patches DB row as fallback).
+    * ``conflict_files`` — list of ``{path, conflict_markers_text}``.
+    * ``main_commits_since_base`` — ``git log``-derived commits on
+      origin/main since the stashed merge-base.
+    * ``main_files_content`` — each conflict file's current
+      ``origin/main`` content.
+
+    Every fetch is best-effort: a missing artifact returns an empty
+    string / empty list so the skill's own guard clauses produce a
+    structured ``unresolvable`` verdict rather than crashing.
+    """
+    import os as _os
+    import subprocess as _subprocess
+
+    bundle = _fetch_issue_bundle(github_repo, issue_number)
+    issue_body = bundle.get("issue_body", "")
+
+    workspace = Path(_os.environ.get("AGENT_WORKSPACE", "/tmp"))
+    stage = workspace / "fix-conflict"
+
+    # Conflict files list.
+    conflict_files_txt = stage / "conflict-files.txt"
+    conflict_paths: list[str] = []
+    if conflict_files_txt.is_file():
+        try:
+            conflict_paths = [
+                ln.strip()
+                for ln in conflict_files_txt.read_text(
+                    encoding="utf-8", errors="replace"
+                ).splitlines()
+                if ln.strip()
+            ]
+        except Exception:
+            conflict_paths = []
+
+    # Conflict markers per file — saved with slashes → "__".
+    markers_dir = stage / "conflict-markers"
+    conflict_files: list[dict] = []
+    for path in conflict_paths:
+        safe = path.replace("/", "__")
+        marker_file = markers_dir / safe
+        marker_text = ""
+        if marker_file.is_file():
+            try:
+                marker_text = marker_file.read_text(
+                    encoding="utf-8", errors="replace"
+                )
+            except Exception:
+                marker_text = ""
+        conflict_files.append(
+            {"path": path, "conflict_markers_text": marker_text}
+        )
+
+    # Original patch.
+    original_patch_file = stage / "original-patch.diff"
+    original_patch = ""
+    if original_patch_file.is_file():
+        try:
+            original_patch = original_patch_file.read_text(
+                encoding="utf-8", errors="replace"
+            )
+        except Exception:
+            original_patch = ""
+    # Fallback: latest SHIP ralph_patches row. Single-line SELECT.
+    if not original_patch:
+        ralph_row = _db_query_one(
+            "SELECT patch_content FROM dispatcher.ralph_patches "
+            f"WHERE agent_id = '{agent_id}' "
+            "ORDER BY iteration_n DESC LIMIT 1"
+        )
+        # db_query_one collapses newlines to '\t' — that's fine for
+        # a patch used as reference material (not re-applied). A
+        # follow-up could use a dedicated multiline fetch, but the
+        # DB copy is already redundant with the git diff above.
+        original_patch = ralph_row or ""
+
+    # main_commits_since_base — ``git log`` between stashed
+    # merge-base and origin/main, newest-first. Best-effort: if the
+    # merge-base file is missing, we scan the last 10 commits on
+    # origin/main as a fallback.
+    merge_base_file = stage / "merge-base.txt"
+    merge_base_sha = ""
+    if merge_base_file.is_file():
+        try:
+            merge_base_sha = merge_base_file.read_text(
+                encoding="utf-8", errors="replace"
+            ).strip()
+        except Exception:
+            merge_base_sha = ""
+    main_commits: list[dict] = []
+    log_range = (
+        f"{merge_base_sha}..origin/main" if merge_base_sha else "origin/main"
+    )
+    try:
+        proc = _subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_root),
+                "log",
+                "--max-count=20",
+                "--pretty=format:%H%x1f%an%x1f%s%x1f%b%x1e",
+                log_range,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if proc.returncode == 0:
+            records = [
+                r.strip()
+                for r in (proc.stdout or "").split("\x1e")
+                if r.strip()
+            ]
+            for rec in records:
+                parts = rec.split("\x1f")
+                if len(parts) < 4:
+                    continue
+                sha, author, subject, body = parts[0], parts[1], parts[2], parts[3]
+                # Per-commit stat — best-effort, skip on failure.
+                stat = ""
+                try:
+                    stat_proc = _subprocess.run(
+                        [
+                            "git",
+                            "-C",
+                            str(repo_root),
+                            "show",
+                            "--stat",
+                            "--format=",
+                            sha,
+                        ],
+                        capture_output=True,
+                        text=True,
+                        timeout=15,
+                        check=False,
+                    )
+                    if stat_proc.returncode == 0:
+                        stat = (stat_proc.stdout or "").strip()
+                except Exception:
+                    stat = ""
+                main_commits.append(
+                    {
+                        "sha": sha,
+                        "author": author,
+                        "subject": subject,
+                        "body": body,
+                        "stat": stat,
+                    }
+                )
+    except Exception:
+        pass
+
+    # main_files_content — current origin/main content of each
+    # conflict file. ``git show origin/main:<path>`` is the
+    # authoritative reference.
+    main_files_content: list[dict] = []
+    for path in conflict_paths:
+        content = ""
+        try:
+            show_proc = _subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(repo_root),
+                    "show",
+                    f"origin/main:{path}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+            if show_proc.returncode == 0:
+                content = show_proc.stdout or ""
+        except Exception:
+            content = ""
+        main_files_content.append({"path": path, "content": content})
+
+    # attempt_number = current merge_conflict_attempts (pre-
+    # increment). The entrypoint increments AFTER the budget gate,
+    # so when the skill reads the input the counter already reflects
+    # this attempt.
+    attempts_raw = _db_query_one(
+        "SELECT COALESCE(merge_conflict_attempts, 0) FROM dispatcher.agents "
+        f"WHERE agent_id = '{agent_id}' LIMIT 1"
+    )
+    try:
+        attempt_number = int(attempts_raw) if attempts_raw else 1
+    except (TypeError, ValueError):
+        attempt_number = 1
+    if attempt_number < 1:
+        attempt_number = 1
+
+    return {
+        "agent_id": agent_id,
+        "issue_number": issue_number,
+        "issue_body": issue_body,
+        "original_patch": original_patch,
+        "conflict_files": conflict_files,
+        "main_commits_since_base": main_commits,
+        "main_files_content": main_files_content,
+        "worktree_path": str(repo_root),
+        "repo_root": str(repo_root),
+        "attempt_number": attempt_number,
+    }
+
+
 def _build_input(
     phase: str,
     agent_id: str,
@@ -1382,6 +1606,10 @@ def _build_input(
         return _build_summary_input(agent_id, issue_number, repo_root, github_repo)
     if phase == "fix-ci":
         return _build_fix_ci_input(agent_id, issue_number, repo_root, github_repo)
+    if phase == "fix-conflict":
+        return _build_fix_conflict_input(
+            agent_id, issue_number, repo_root, github_repo
+        )
     if phase == "verify":
         return _build_verify_input(agent_id, issue_number, repo_root, github_repo)
     if phase == "retro":
@@ -1498,13 +1726,14 @@ phase_to_skill() {
     # $1 = phase name. Prints the matching skill suffix (no `task-v2-`
     # prefix) on stdout. die()s if no mapping exists.
     case "$1" in
-        planning)  printf 'plan' ;;
-        ralph)     printf 'ralph' ;;
-        summary)   printf 'summary' ;;
-        fix_ci)    printf 'fix-ci' ;;
-        verify)    printf 'verify' ;;
-        retro)     printf 'retro' ;;
-        *)         die "no_skill_mapping_for_phase=$1" ;;
+        planning)       printf 'plan' ;;
+        ralph)          printf 'ralph' ;;
+        summary)        printf 'summary' ;;
+        fix_ci)         printf 'fix-ci' ;;
+        fix_conflict)   printf 'fix-conflict' ;;  # #3225
+        verify)         printf 'verify' ;;
+        retro)          printf 'retro' ;;
+        *)              die "no_skill_mapping_for_phase=$1" ;;
     esac
 }
 
@@ -1856,16 +2085,80 @@ handle_push_and_pr() {
         set -e
         log "push_and_pr_rebase_done" "exit_code=$_rebase_rc"
         if [[ "$_rebase_rc" -ne 0 ]]; then
-            # Rebase conflict. Abort the in-progress rebase so the
-            # worktree returns to its pre-rebase state, log the
-            # failure, and emit the structured envelope.
+            # #3225: Before aborting, capture the conflict state so the
+            # fix_conflict phase can feed it to the claude skill without
+            # needing to replay the rebase. Capture three things:
+            #   1. Conflicted file paths (``git diff --name-only
+            #      --diff-filter=U``) — one path per line.
+            #   2. Per-file ``conflict_markers_text`` — the on-disk
+            #      content WITH the ``<<<<<<<``/``=======``/``>>>>>>>``
+            #      markers. After ``rebase --abort`` the markers are
+            #      gone, so this capture must happen BEFORE the abort.
+            # The files are staged under
+            # ``{AGENT_WORKSPACE}/fix-conflict/`` for the input-shim
+            # to consume when the fix_conflict phase starts.
+            _fix_conflict_stage="$AGENT_WORKSPACE/fix-conflict"
+            mkdir -p "$_fix_conflict_stage/conflict-markers"
+            set +e
+            git -C "$REPO_ROOT" diff --name-only --diff-filter=U \
+                > "$_fix_conflict_stage/conflict-files.txt" \
+                2> "$AGENT_WORKSPACE/git-diff-conflict-files.stderr.log"
+            set -e
+            while IFS= read -r _cfile; do
+                if [[ -z "$_cfile" ]]; then
+                    continue
+                fi
+                # Stash the path with slashes replaced so a flat dir
+                # works without pre-creating the tree.
+                _safe=$(printf '%s' "$_cfile" | tr '/' '__')
+                if [[ -f "$REPO_ROOT/$_cfile" ]]; then
+                    cp "$REPO_ROOT/$_cfile" \
+                        "$_fix_conflict_stage/conflict-markers/$_safe" \
+                        2>/dev/null || true
+                fi
+            done < "$_fix_conflict_stage/conflict-files.txt"
+            # Also capture the pre-rebase patch (git diff
+            # origin/main..HEAD AT THE ATTEMPTED REBASE-ROOT — i.e.
+            # the original base before the rebase started). During a
+            # rebase the index is in an in-progress state, so we can
+            # read ORIG_HEAD to find what HEAD used to be.
+            set +e
+            git -C "$REPO_ROOT" diff "$(git -C "$REPO_ROOT" merge-base ORIG_HEAD origin/main 2>/dev/null)..ORIG_HEAD" \
+                > "$_fix_conflict_stage/original-patch.diff" \
+                2> "$AGENT_WORKSPACE/git-diff-original-patch.stderr.log" || true
+            set -e
+            # Capture the merge-base and HEAD SHAs for the input shim's
+            # ``main_commits_since_base`` builder.
+            set +e
+            git -C "$REPO_ROOT" rev-parse ORIG_HEAD \
+                > "$_fix_conflict_stage/orig-head.txt" 2>/dev/null || true
+            git -C "$REPO_ROOT" merge-base ORIG_HEAD origin/main \
+                > "$_fix_conflict_stage/merge-base.txt" 2>/dev/null || true
+            set -e
+            # Build a compact JSON list of conflict files for the
+            # phase_output envelope — one array the transition shim
+            # can pass straight into context["conflict_files"].
+            _conflict_files_json="[]"
+            if [[ -s "$_fix_conflict_stage/conflict-files.txt" ]]; then
+                _conflict_files_json=$(jq -R -s -c \
+                    'split("\n") | map(select(length > 0))' \
+                    "$_fix_conflict_stage/conflict-files.txt" 2>/dev/null \
+                    || printf '[]')
+            fi
+            # Now abort the in-progress rebase so the worktree returns
+            # to its pre-rebase state, log the failure, and emit the
+            # structured envelope.
             set +e
             git -C "$REPO_ROOT" rebase --abort \
                 > "$AGENT_WORKSPACE/git-rebase-abort.stdout.log" \
                 2> "$AGENT_WORKSPACE/git-rebase-abort.stderr.log"
             set -e
-            log "push_and_pr_rebase_conflict" "exit_code=$_rebase_rc"
-            printf '{"no_op": false, "rebase_failed": true}'
+            log "push_and_pr_rebase_conflict" "exit_code=$_rebase_rc" \
+                "conflict_files_json=$_conflict_files_json"
+            # #3225: emit conflict_files so transition_from_push_and_pr
+            # routes to fix_conflict with the file list in context.
+            printf '{"no_op": false, "rebase_failed": true, "conflict_files": %s}' \
+                "$_conflict_files_json"
             return 0
         fi
     else
@@ -1957,6 +2250,282 @@ handle_push_and_pr() {
 
     log "push_and_pr_pr_number_parse_failed" "stdout_tail=$(tail -c 200 "$AGENT_WORKSPACE/gh-pr-create.stdout.log" 2>/dev/null | tr '\n' ' ')"
     printf '{"no_op": false}'
+}
+
+# ── fix_conflict helpers (#3225) ──────────────────────────────────────────
+#
+# The fix_conflict phase recovers from pre-push rebase conflicts
+# (and start-of-ralph baseline rebase conflicts) by claude-resolving
+# the conflict against updated origin/main content instead of
+# abandoning the agent's ralph work.
+#
+# Budget bookkeeping lives in ``dispatcher.agents.merge_conflict_
+# attempts`` (migration 44). Every invocation of
+# ``handle_fix_conflict`` increments the counter BEFORE spawning the
+# claude skill; when the current value is already >=
+# FIX_CONFLICT_MAX_ATTEMPTS the handler emits a synthetic
+# ``{"verdict": "unresolvable", "budget_exhausted": true}`` output
+# without spending compute. The transition shim sees that verdict and
+# advances to ``conflict_unresolvable`` (terminal).
+#
+# The applied-commit step (on verdict=resolved) writes each
+# ``resolved_files[].content`` to its path under REPO_ROOT, stages
+# everything, and creates ONE new commit with a conventional-commits
+# message. A new commit (not a rebase) keeps the history
+# straightforward for the retry — push_and_pr will re-fetch + rebase
+# + push on re-entry.
+
+read_merge_conflict_attempts() {
+    # Column added by migration 44. Returns 0 if the column is
+    # missing (older dev DB snapshots). Mirrors the
+    # read_merge_unstick_attempts helper pattern.
+    _val=$(db_query_one "SELECT COALESCE(merge_conflict_attempts, 0)
+                            FROM dispatcher.agents
+                           WHERE agent_id = '$AGENT_ID'
+                           LIMIT 1;" 2>/dev/null || printf '')
+    if [[ -z "$_val" ]] || ! [[ "$_val" =~ ^[0-9]+$ ]]; then
+        printf '0'
+    else
+        printf '%s' "$_val"
+    fi
+}
+
+increment_merge_conflict_attempts() {
+    # Best-effort — a lost increment at most burns one extra fix-
+    # conflict attempt before the budget gate trips. Mirrors the
+    # increment_merge_unstick_attempts helper pattern.
+    db_exec "UPDATE dispatcher.agents
+                SET merge_conflict_attempts = COALESCE(merge_conflict_attempts, 0) + 1
+              WHERE agent_id = '$AGENT_ID';" \
+        >/dev/null 2>&1 || true
+}
+
+apply_resolved_files() {
+    # $1 = path to fix-conflict.json (the skill's output).
+    # Reads ``resolved_files[]`` from the JSON and writes each
+    # ``{path, content}`` entry to its repo-relative location under
+    # REPO_ROOT, then stages + commits via ``git``. Prints the created
+    # commit SHA on success (or empty on failure) and returns 0 on
+    # success, non-zero on any error.
+    _out_json="$1"
+    if [[ ! -s "$_out_json" ]]; then
+        log "fix_conflict_apply_empty_output"
+        return 1
+    fi
+    # Write each resolved file via a small helper (avoids inline
+    # python -c). The helper returns the number of files written on
+    # stdout.
+    _apply_helper="$AGENT_WORKSPACE/fix-conflict-apply.py"
+    cat > "$_apply_helper" <<'APPLYPY'
+import json
+import os
+import sys
+from pathlib import Path
+
+if len(sys.argv) != 3:
+    print("usage: apply.py <out-json> <repo-root>", file=sys.stderr)
+    sys.exit(2)
+out_path = Path(sys.argv[1])
+repo_root = Path(sys.argv[2])
+try:
+    data = json.loads(out_path.read_text(encoding="utf-8"))
+except Exception as exc:
+    print(f"parse_error: {exc}", file=sys.stderr)
+    sys.exit(3)
+resolved = data.get("resolved_files") or []
+if not isinstance(resolved, list) or not resolved:
+    print("no_resolved_files", file=sys.stderr)
+    sys.exit(4)
+written = 0
+for entry in resolved:
+    if not isinstance(entry, dict):
+        continue
+    path = entry.get("path")
+    content = entry.get("content")
+    if not path or content is None:
+        continue
+    # Defensive: reject absolute or parent-traversing paths.
+    if path.startswith("/") or ".." in Path(path).parts:
+        print(f"reject_unsafe_path: {path}", file=sys.stderr)
+        continue
+    target = repo_root / path
+    target.parent.mkdir(parents=True, exist_ok=True)
+    # content is a string; write as UTF-8, preserving whatever
+    # trailing-newline convention the skill emitted.
+    target.write_text(content, encoding="utf-8")
+    written += 1
+print(written)
+APPLYPY
+    set +e
+    _written=$(python3 "$_apply_helper" "$_out_json" "$REPO_ROOT" \
+        2> "$AGENT_WORKSPACE/fix-conflict-apply.stderr.log")
+    _apply_rc=$?
+    set -e
+    log "fix_conflict_apply_done" "exit_code=$_apply_rc" "files_written=$_written"
+    if [[ "$_apply_rc" -ne 0 ]]; then
+        return 1
+    fi
+    # Stage every file listed in resolved_files (use the helper's
+    # stderr-safe path listing instead of ``git add -A`` to avoid
+    # accidentally staging test artifacts the skill left behind).
+    _stage_helper="$AGENT_WORKSPACE/fix-conflict-stage-list.py"
+    cat > "$_stage_helper" <<'STAGEPY'
+import json
+import sys
+from pathlib import Path
+
+out_path = Path(sys.argv[1])
+try:
+    data = json.loads(out_path.read_text(encoding="utf-8"))
+except Exception:
+    sys.exit(2)
+for entry in (data.get("resolved_files") or []):
+    if isinstance(entry, dict) and entry.get("path"):
+        print(entry["path"])
+STAGEPY
+    set +e
+    _paths_file="$AGENT_WORKSPACE/fix-conflict-stage-paths.txt"
+    python3 "$_stage_helper" "$_out_json" > "$_paths_file" \
+        2> "$AGENT_WORKSPACE/fix-conflict-stage-list.stderr.log"
+    _list_rc=$?
+    set -e
+    if [[ "$_list_rc" -ne 0 || ! -s "$_paths_file" ]]; then
+        log "fix_conflict_stage_list_failed" "exit_code=$_list_rc"
+        return 1
+    fi
+    # git add <file> for each staged path.
+    while IFS= read -r _sfile; do
+        if [[ -z "$_sfile" ]]; then
+            continue
+        fi
+        set +e
+        git -C "$REPO_ROOT" add -- "$_sfile" \
+            > /dev/null \
+            2>> "$AGENT_WORKSPACE/fix-conflict-add.stderr.log"
+        _add_rc=$?
+        set -e
+        if [[ "$_add_rc" -ne 0 ]]; then
+            log "fix_conflict_add_failed" "path=$_sfile" "exit_code=$_add_rc"
+            return 1
+        fi
+    done < "$_paths_file"
+    # Commit with a conventional-commits message.
+    _short_id=$(printf '%s' "$AGENT_ID" | tr -d '-' | cut -c1-8)
+    _commit_msg_path="$AGENT_WORKSPACE/fix-conflict-commit-msg.txt"
+    {
+        printf 'chore(agent): resolve rebase conflicts (#%s)\n\n' "${ISSUE_NUMBER:-0}"
+        printf 'fix_conflict skill reconciled conflicts against origin/main (#3225).\n'
+        printf 'agent=%s attempts=%s\n' "$_short_id" "$(read_merge_conflict_attempts)"
+    } > "$_commit_msg_path"
+    set +e
+    git -C "$REPO_ROOT" commit -F "$_commit_msg_path" \
+        > "$AGENT_WORKSPACE/fix-conflict-commit.stdout.log" \
+        2> "$AGENT_WORKSPACE/fix-conflict-commit.stderr.log"
+    _commit_rc=$?
+    set -e
+    log "fix_conflict_commit_done" "exit_code=$_commit_rc"
+    if [[ "$_commit_rc" -ne 0 ]]; then
+        log "fix_conflict_commit_failed" "exit_code=$_commit_rc" \
+            "stderr_tail=$(tail -c 200 "$AGENT_WORKSPACE/fix-conflict-commit.stderr.log" 2>/dev/null | tr '\n' ' ')"
+        return 1
+    fi
+    return 0
+}
+
+handle_fix_conflict() {
+    # Mechanical + claude-driven implementation of the fix_conflict
+    # phase (#3225).
+    #
+    # Flow:
+    #   1. Budget check — read merge_conflict_attempts; if already
+    #      >= FIX_CONFLICT_MAX_ATTEMPTS, emit the unresolvable +
+    #      budget_exhausted envelope without invoking claude.
+    #   2. Increment the counter before invoking claude (so a claude
+    #      crash still bumps the attempt count and a retry will hit
+    #      the budget gate if the skill is broken).
+    #   3. Invoke ``claude -p /task-v2-fix-conflict``. Input already
+    #      written by write_phase_input('fix-conflict'). Output read
+    #      from tmp/dispatcher-output/fix-conflict.json by
+    #      run_claude_phase.
+    #   4. On verdict=resolved: apply resolved_files as a new commit;
+    #      emit ``{"verdict": "resolved", ...}`` so the transition
+    #      shim re-enters push_and_pr.
+    #   5. On verdict=unresolvable (or any non-resolved output, or
+    #      an apply failure): emit the unresolvable envelope so the
+    #      transition shim advances to conflict_unresolvable.
+    #
+    # Prints the phase-output JSON on stdout for persist_phase_output
+    # + transition_for to consume. Always exits 0 — verdict-driven.
+
+    if [[ "$AGENT_RUNNER_DRY_RUN" == "1" ]]; then
+        log "fix_conflict_dry_run"
+        printf '{"verdict": "unresolvable", "resolution_notes": "dry-run: skill not invoked", "resolved_files": []}'
+        return 0
+    fi
+
+    # ── Budget gate ───────────────────────────────────────────────
+    _attempts=$(read_merge_conflict_attempts)
+    log "fix_conflict_budget_check" \
+        "attempts=$_attempts" \
+        "max=$FIX_CONFLICT_MAX_ATTEMPTS"
+    if [[ "$_attempts" -ge "$FIX_CONFLICT_MAX_ATTEMPTS" ]]; then
+        log "fix_conflict_budget_exhausted" \
+            "attempts=$_attempts" \
+            "max=$FIX_CONFLICT_MAX_ATTEMPTS"
+        # Emit the synthetic budget-exhausted envelope. The
+        # transition shim (transition_from_fix_conflict) sees
+        # verdict=unresolvable + budget_exhausted=true and routes to
+        # conflict_unresolvable via the diagnoser hint.
+        printf '{"verdict": "unresolvable", "budget_exhausted": true, "resolution_notes": "fix_conflict budget exhausted (attempts=%s, max=%s)", "resolved_files": []}' \
+            "$_attempts" "$FIX_CONFLICT_MAX_ATTEMPTS"
+        return 0
+    fi
+
+    # ── Increment BEFORE claude ──────────────────────────────────
+    # A claude crash still counts against the budget — otherwise a
+    # broken skill could spin forever.
+    increment_merge_conflict_attempts
+    _new_attempts=$(read_merge_conflict_attempts)
+    log "fix_conflict_attempts_incremented" "new_attempts=$_new_attempts"
+
+    # ── Invoke the claude skill ──────────────────────────────────
+    # run_claude_phase maps fix_conflict → fix-conflict and writes
+    # the input bundle via phase_input_shim.py.
+    _output=$(run_claude_phase "fix_conflict")
+    _verdict=$(printf '%s' "$_output" | jq -r '.verdict // ""' 2>/dev/null \
+        | tr '[:upper:]' '[:lower:]')
+    log "fix_conflict_skill_verdict" "verdict=$_verdict"
+
+    if [[ "$_verdict" == "resolved" ]]; then
+        # Apply resolved_files as a new commit. The output JSON on
+        # disk is the authoritative source; apply_resolved_files
+        # reads it directly.
+        _out_json_path="$REPO_ROOT/tmp/dispatcher-output/fix-conflict.json"
+        if apply_resolved_files "$_out_json_path"; then
+            log "fix_conflict_resolved_applied"
+            printf '%s' "$_output"
+            return 0
+        fi
+        # Apply failed → demote to unresolvable so we don't re-enter
+        # push_and_pr with a broken tree. Preserve the skill's notes
+        # for the diagnoser.
+        log "fix_conflict_apply_failed_demoting_to_unresolvable"
+        _notes=$(printf '%s' "$_output" | jq -r '.resolution_notes // ""' 2>/dev/null)
+        printf '{"verdict": "unresolvable", "apply_failed": true, "resolution_notes": %s, "resolved_files": []}' \
+            "$(printf '%s' "apply_resolved_files failed after skill returned resolved; original notes: $_notes" | jq -R -s .)"
+        return 0
+    fi
+
+    # Any non-resolved verdict (unresolvable, missing, malformed) —
+    # pass through so the transition shim routes to
+    # conflict_unresolvable.
+    log "fix_conflict_not_resolved" "verdict=$_verdict"
+    if [[ -n "$_output" && "$_output" != "{}" ]]; then
+        printf '%s' "$_output"
+    else
+        printf '{"verdict": "unresolvable", "resolution_notes": "skill returned empty / malformed output", "resolved_files": []}'
+    fi
+    return 0
 }
 
 # ── Ralph HEAD-watcher (#3144) ────────────────────────────────────────────
@@ -2352,6 +2921,15 @@ DEPLOY_GRACE_SECONDS="${AGENT_RUNNER_DEPLOY_GRACE_SECONDS:-90}"
 # Max attempts to auto-unstick a merge stale-rollup rejection (#3163).
 # Matches ``MERGE_UNSTICK_MAX_ATTEMPTS`` in daemon.py.
 MERGE_UNSTICK_MAX_ATTEMPTS="${AGENT_RUNNER_MERGE_UNSTICK_MAX_ATTEMPTS:-1}"
+
+# #3225: max invocations of the fix_conflict phase's claude skill per
+# agent lifetime. The first attempt handles the common "main advanced
+# during ralph" case; a second attempt covers the edge case where main
+# advances AGAIN during the first resolution. Three attempts starts
+# looking like a livelock — route cleanly to conflict_unresolvable.
+# Tests override to 0 (budget-exhausted on first call) or 1 (allows
+# exactly one attempt) via the env var.
+FIX_CONFLICT_MAX_ATTEMPTS="${AGENT_RUNNER_FIX_CONFLICT_MAX_ATTEMPTS:-2}"
 
 # Stderr substring that indicates the #2641/#3163 stale-rollup branch-
 # protection rejection. Matches ``STALE_ROLLUP_STDERR_MARKER`` in
@@ -3042,6 +3620,99 @@ while true; do
     # `/task-v2-push_and_pr` and got "Unknown command" back.
     case "$_current" in
         planning|ralph|summary|fix_ci|verify)
+            # #3225 secondary mitigation — run a baseline
+            # ``git fetch origin main && git rebase origin/main`` at
+            # the START of ralph (before any claude iterations). This
+            # cuts the conflict surface by the duration of ralph
+            # (~20-25 min) so the agent works against the latest main
+            # from the beginning. On conflict, short-circuit the
+            # claude invocation and emit the same rebase_failed
+            # envelope that push_and_pr emits — transition_from_ralph
+            # routes to fix_conflict.
+            if [[ "$_current" == "ralph" ]] && \
+               [[ "${AGENT_RUNNER_RALPH_BASELINE_REBASE:-1}" == "1" ]] && \
+               [[ "$AGENT_RUNNER_DRY_RUN" != "1" ]]; then
+                log "ralph_baseline_rebase_begin"
+                set +e
+                git -C "$REPO_ROOT" fetch origin main \
+                    > "$AGENT_WORKSPACE/ralph-baseline-fetch.stdout.log" \
+                    2> "$AGENT_WORKSPACE/ralph-baseline-fetch.stderr.log"
+                _baseline_fetch_rc=$?
+                set -e
+                log "ralph_baseline_fetch_done" "exit_code=$_baseline_fetch_rc"
+                if [[ "$_baseline_fetch_rc" -eq 0 ]]; then
+                    set +e
+                    git -C "$REPO_ROOT" rebase origin/main \
+                        > "$AGENT_WORKSPACE/ralph-baseline-rebase.stdout.log" \
+                        2> "$AGENT_WORKSPACE/ralph-baseline-rebase.stderr.log"
+                    _baseline_rebase_rc=$?
+                    set -e
+                    log "ralph_baseline_rebase_done" "exit_code=$_baseline_rebase_rc"
+                    if [[ "$_baseline_rebase_rc" -ne 0 ]]; then
+                        # Capture conflict files, stash markers, abort,
+                        # emit rebase_failed envelope. Same shape as
+                        # push_and_pr's conflict path so the
+                        # fix_conflict phase can consume either.
+                        _fix_conflict_stage="$AGENT_WORKSPACE/fix-conflict"
+                        mkdir -p "$_fix_conflict_stage/conflict-markers"
+                        set +e
+                        git -C "$REPO_ROOT" diff --name-only --diff-filter=U \
+                            > "$_fix_conflict_stage/conflict-files.txt" \
+                            2> "$AGENT_WORKSPACE/git-diff-conflict-files.stderr.log"
+                        set -e
+                        while IFS= read -r _cfile; do
+                            if [[ -z "$_cfile" ]]; then
+                                continue
+                            fi
+                            _safe=$(printf '%s' "$_cfile" | tr '/' '__')
+                            if [[ -f "$REPO_ROOT/$_cfile" ]]; then
+                                cp "$REPO_ROOT/$_cfile" \
+                                    "$_fix_conflict_stage/conflict-markers/$_safe" \
+                                    2>/dev/null || true
+                            fi
+                        done < "$_fix_conflict_stage/conflict-files.txt"
+                        set +e
+                        git -C "$REPO_ROOT" rev-parse ORIG_HEAD \
+                            > "$_fix_conflict_stage/orig-head.txt" 2>/dev/null || true
+                        git -C "$REPO_ROOT" merge-base ORIG_HEAD origin/main \
+                            > "$_fix_conflict_stage/merge-base.txt" 2>/dev/null || true
+                        git -C "$REPO_ROOT" rebase --abort \
+                            > "$AGENT_WORKSPACE/ralph-baseline-rebase-abort.stdout.log" \
+                            2> "$AGENT_WORKSPACE/ralph-baseline-rebase-abort.stderr.log"
+                        set -e
+                        _baseline_conflict_files_json="[]"
+                        if [[ -s "$_fix_conflict_stage/conflict-files.txt" ]]; then
+                            _baseline_conflict_files_json=$(jq -R -s -c \
+                                'split("\n") | map(select(length > 0))' \
+                                "$_fix_conflict_stage/conflict-files.txt" 2>/dev/null \
+                                || printf '[]')
+                        fi
+                        log "ralph_baseline_rebase_conflict" \
+                            "exit_code=$_baseline_rebase_rc" \
+                            "conflict_files_json=$_baseline_conflict_files_json"
+                        # Build a synthetic ralph-phase output with the
+                        # rebase_failed envelope. Persist + transition
+                        # via the normal shim path so the conflict
+                        # routes to fix_conflict.
+                        _ralph_baseline_output=$(printf '{"rebase_failed": true, "conflict_files": %s, "source_phase": "ralph"}' \
+                            "$_baseline_conflict_files_json")
+                        persist_phase_output "ralph" "$_ralph_baseline_output"
+                        _bt=$(transition_for "ralph" "$_ralph_baseline_output")
+                        _ba=$(printf '%s' "$_bt" | cut -f1)
+                        _bn=$(printf '%s' "$_bt" | cut -f2)
+                        if [[ "$_ba" == "advance" ]]; then
+                            advance_phase "$_bn"
+                        else
+                            log "ralph_baseline_transition_unrecognized" "action=$_ba"
+                            advance_phase "daemon_restart_abandoned" "crashed"
+                        fi
+                        continue
+                    fi
+                else
+                    log "ralph_baseline_fetch_failed_skipping" \
+                        "exit_code=$_baseline_fetch_rc"
+                fi
+            fi
             if [[ "$_current" == "ralph" ]]; then
                 # #3144: start the HEAD-watcher subshell so the long
                 # ralph phase emits per-iteration observability to
@@ -3077,12 +3748,22 @@ while true; do
                     advance_phase "$_next" "$_status"
                     ;;
                 route_to_diagnoser)
-                    # Stage 1b does not have the diagnoser integration
-                    # wired in; route to a terminal failure phase so
-                    # the loop exits cleanly. Stage 2's daemon-side
-                    # failure router owns the real category mapping.
-                    log "diagnoser_route_stub" "hint=$_hint"
-                    advance_phase "daemon_restart_abandoned" "failed"
+                    # #3225: for the conflict_unresolvable hint, route
+                    # to the dedicated terminal so the diagnoser
+                    # supervisor sweep picks it up with the right
+                    # category. Other hints keep the Stage-1b stub
+                    # terminal (the daemon-side failure router owns
+                    # the real category mapping for those).
+                    if [[ "$_hint" == "conflict_unresolvable" ]]; then
+                        log "diagnoser_route_conflict_unresolvable" "hint=$_hint"
+                        agent_runner_reaped_failure \
+                            "conflict_unresolvable" \
+                            "conflict_unresolvable" \
+                            "fix_conflict skill returned unresolvable or budget exhausted"
+                    else
+                        log "diagnoser_route_stub" "hint=$_hint"
+                        advance_phase "daemon_restart_abandoned" "failed"
+                    fi
                     ;;
                 unrecognized|*)
                     log "transition_unrecognized" "phase=$_current" "action=$_action"
@@ -3125,6 +3806,48 @@ while true; do
                 *)
                     log "push_and_pr_transition_unrecognized" "action=$_action"
                     advance_phase "daemon_restart_abandoned" "crashed"
+                    ;;
+            esac
+            ;;
+        fix_conflict)
+            # #3225: fix_conflict phase. Budget-gated claude-resolution
+            # of rebase conflicts. handle_fix_conflict enforces the
+            # per-agent FIX_CONFLICT_MAX_ATTEMPTS budget, invokes the
+            # claude skill, applies resolved_files as a new commit on
+            # verdict=resolved, and emits the output envelope the
+            # transition shim uses to advance.
+            _output=$(handle_fix_conflict)
+            persist_phase_output "fix_conflict" "$_output"
+            _transition=$(transition_for "fix_conflict" "$_output")
+            _action=$(printf '%s' "$_transition" | cut -f1)
+            _next=$(printf '%s' "$_transition" | cut -f2)
+            _status=$(printf '%s' "$_transition" | cut -f3)
+            _hint=$(printf '%s' "$_transition" | cut -f4)
+            case "$_action" in
+                advance)
+                    advance_phase "$_next"
+                    ;;
+                advance_with_status)
+                    advance_phase "$_next" "$_status"
+                    ;;
+                route_to_diagnoser)
+                    # conflict_unresolvable is the only hint we expect
+                    # here. Route to the dedicated terminal via
+                    # agent_runner_reaped_failure so the row carries
+                    # ``category=conflict_unresolvable`` for the
+                    # diagnoser sweep.
+                    log "fix_conflict_route_to_diagnoser" "hint=$_hint"
+                    agent_runner_reaped_failure \
+                        "conflict_unresolvable" \
+                        "conflict_unresolvable" \
+                        "fix_conflict skill returned unresolvable or budget exhausted"
+                    ;;
+                *)
+                    log "fix_conflict_transition_unrecognized" "action=$_action"
+                    agent_runner_reaped_failure \
+                        "conflict_unresolvable" \
+                        "unrecognized_output" \
+                        "fix_conflict transition shim returned $_action"
                     ;;
             esac
             ;;

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1113,6 +1113,19 @@ FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE = "verify_failed_post_merge"
 #: not a mechanical retry.
 FAILURE_CATEGORY_MERGE_UNSTICK_EXHAUSTED = "merge_unstick_exhausted"
 
+#: #3225 — fix_conflict terminal category. Set by the agent-runner
+#: entrypoint (``agent_runner_reaped_failure``) when
+#: ``handle_fix_conflict`` either exhausts the per-agent
+#: ``merge_conflict_attempts`` budget OR the claude skill returns
+#: ``verdict='unresolvable'``. The diagnoser (``/diagnose-failure``)
+#: routes these to ``AC_INFEASIBLE`` when the ``resolution_notes`` in
+#: phase_outputs indicate a semantic collision (function rewritten,
+#: feature reverted) or to ``retry_with_hint`` when the collision
+#: looks like a routine sibling-PR timing issue. The subprocess path
+#: currently has no equivalent — daemon.py doesn't run a pre-push
+#: rebase today — but when it is added it must route here.
+FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE = "conflict_unresolvable"
+
 #: GitHub's rejection stderr fragment when branch protection's
 #: statusCheckRollup evaluator still sees a stale FAILURE check_run
 #: from an earlier CI attempt even though the *latest* ci-passed
@@ -1382,6 +1395,11 @@ TIER_3_CATEGORIES: frozenset[str] = frozenset(
         FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,  # #3071
         # #2641: merge-phase auto-unstick budget exhausted.
         FAILURE_CATEGORY_MERGE_UNSTICK_EXHAUSTED,
+        # #3225: fix_conflict budget exhausted OR skill returned
+        # verdict=unresolvable. The diagnoser reads resolution_notes
+        # from the phase_outputs row and picks AC_INFEASIBLE vs
+        # retry_with_hint based on the semantic-collision signal.
+        FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE,
     }
 )
 

--- a/scripts/dispatcher/phase_transitions.py
+++ b/scripts/dispatcher/phase_transitions.py
@@ -126,6 +126,15 @@ PHASE_AWAITING_CI = "awaiting_ci"
 #: Fix-CI retry skill (``/task-v2-fix-ci``). Runs on red CI.
 PHASE_FIX_CI = "fix_ci"
 
+#: Fix-conflict skill (``/task-v2-fix-conflict``). Runs when
+#: ``push_and_pr``'s pre-push rebase — or the start-of-ralph baseline
+#: rebase — hits a merge conflict against ``origin/main``. The skill
+#: semantically resolves the conflict against updated main-branch
+#: content and returns ``resolved`` with a new file set (entrypoint
+#: commits + re-enters push_and_pr) or ``unresolvable`` (entrypoint
+#: routes to the ``conflict_unresolvable`` terminal). See #3225.
+PHASE_FIX_CONFLICT = "fix_conflict"
+
 #: Merge step. Squash-merge the PR.
 PHASE_MERGE = "merge"
 
@@ -189,6 +198,13 @@ PHASE_MERGE_FAILED = "merge_failed"
 PHASE_AWAITING_DEPLOY_FAILED = "awaiting_deploy_failed"
 PHASE_AWAITING_DEPLOY_TIMEOUT = "awaiting_deploy_timeout"
 
+#: #3225 — fix_conflict terminal. Set when the fix_conflict skill
+#: returns ``verdict='unresolvable'`` or when ``merge_conflict_attempts
+#: >= FIX_CONFLICT_MAX_ATTEMPTS``. Routed through the diagnoser (via the
+#: supervisor tick's ``_find_diagnoser_candidates`` sweep) under
+#: ``FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE``.
+PHASE_CONFLICT_UNRESOLVABLE = "conflict_unresolvable"
+
 # ---------------------------------------------------------------------------
 # Verdict constants — the string values produced by the phase-output JSONs.
 # ---------------------------------------------------------------------------
@@ -216,6 +232,15 @@ VERDICT_FAILED = "FAILED"
 #: Verify passed / skipped cleanly.
 VERDICT_VERIFIED = "VERIFIED"
 VERDICT_SKIPPED = "SKIPPED"
+
+#: Fix-conflict skill verdicts (#3225). Lower-case to match the skill's
+#: on-disk contract (``.claude/skills/task-v2-fix-conflict/SKILL.md``).
+#: The skill writes verdict in lower-case so an operator scanning the
+#: output JSON sees "resolved"/"unresolvable" rather than SHOUTED
+#: UPPERCASE. The transition function upper-cases for comparison, so
+#: callers can emit either.
+VERDICT_RESOLVED = "RESOLVED"
+VERDICT_UNRESOLVABLE = "UNRESOLVABLE"
 
 # ---------------------------------------------------------------------------
 # Terminal-status enumeration. Mirrors ``TERMINAL_AGENT_STATUSES`` in
@@ -275,6 +300,8 @@ TERMINAL_PHASES: frozenset[str] = frozenset(
         PHASE_MERGE_FAILED,
         PHASE_AWAITING_DEPLOY_FAILED,
         PHASE_AWAITING_DEPLOY_TIMEOUT,
+        # #3225 — fix_conflict terminal.
+        PHASE_CONFLICT_UNRESOLVABLE,
     }
 )
 
@@ -347,6 +374,11 @@ FAILURE_HINT_VERIFY_FAILED_POST_MERGE = "verify_failed_post_merge"
 
 #: Plan phase returned BLOCKED. Terminal (``status='plan_blocked'``).
 FAILURE_HINT_PLAN_BLOCKED = "plan_blocked"
+
+#: Fix-conflict skill emitted ``verdict='unresolvable'`` OR the
+#: per-agent ``merge_conflict_attempts`` budget is exhausted. Maps to
+#: ``FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE`` in daemon.py. See #3225.
+FAILURE_HINT_CONFLICT_UNRESOLVABLE = "conflict_unresolvable"
 
 
 # ---------------------------------------------------------------------------
@@ -456,7 +488,31 @@ def transition_from_ralph(output: Mapping[str, Any] | None) -> PhaseTransition:
     * anything else (``REVISE``-exhausted, worker-STUCK twice) —
       non-SHIP terminal per #3054. Route through
       :func:`FAILURE_HINT_RALPH_NOT_SHIP`.
+
+    #3225 secondary mitigation — the entrypoint runs
+    ``git fetch origin main && git rebase origin/main`` at the START
+    of ralph (before any claude iterations) so the agent works
+    against the latest main from the beginning rather than
+    discovering the conflict after ~25 min of ralph work. When that
+    baseline rebase conflicts, the entrypoint emits
+    ``{"rebase_failed": true, "conflict_files": [...]}`` as the
+    ralph phase output — same envelope shape as push_and_pr — and
+    this function advances to ``fix_conflict``. The start-of-ralph
+    path takes precedence over verdict parsing because no claude
+    skill has run yet.
     """
+    # #3225: start-of-ralph baseline rebase conflict. Short-circuits
+    # the verdict check because the claude skill never ran.
+    if output and output.get("rebase_failed"):
+        return PhaseTransition(
+            action=TransitionAction.ADVANCE,
+            next_phase=PHASE_FIX_CONFLICT,
+            reason="ralph baseline rebase conflict — routing to fix_conflict (#3225)",
+            context={
+                "conflict_files": output.get("conflict_files") or [],
+                "source_phase": "ralph",
+            },
+        )
     verdict = _verdict(output)
     if verdict == VERDICT_SHIP:
         return PhaseTransition(
@@ -526,6 +582,11 @@ def transition_from_push_and_pr(
     * ``no_op=True`` — ralph's #3039 no-op-SHIP guardrail fired; the
       working tree was clean on SHIP. Terminal success with phase
       ``no_op``, status ``succeeded``. No PR, no CI, no merge.
+    * ``rebase_failed=True`` (#3225) — the pre-push
+      ``git rebase origin/main`` hit a conflict. Advance to the
+      ``fix_conflict`` phase, where a claude skill semantically
+      resolves the conflict and either re-enters push_and_pr or
+      routes to ``conflict_unresolvable``.
     * otherwise — PR was opened; advance to ``awaiting_ci``.
     """
     if output and output.get("no_op"):
@@ -534,6 +595,21 @@ def transition_from_push_and_pr(
             next_phase=PHASE_NO_OP,
             terminal_status=AgentStatus.SUCCEEDED.value,
             reason="push_and_pr no-op SHIP (#3039)",
+        )
+    # #3225: pre-push rebase conflict. The entrypoint emits
+    # ``{"rebase_failed": true, "conflict_files": [...]}`` when
+    # ``git rebase origin/main`` hits a conflict. Route to
+    # fix_conflict instead of letting the agent fall through to
+    # awaiting_ci with missing_pr.
+    if output and output.get("rebase_failed"):
+        return PhaseTransition(
+            action=TransitionAction.ADVANCE,
+            next_phase=PHASE_FIX_CONFLICT,
+            reason="push_and_pr rebase conflict — routing to fix_conflict (#3225)",
+            context={
+                "conflict_files": output.get("conflict_files") or [],
+                "source_phase": "push_and_pr",
+            },
         )
     return PhaseTransition(
         action=TransitionAction.ADVANCE,
@@ -615,6 +691,67 @@ def transition_from_fix_ci(output: Mapping[str, Any] | None) -> PhaseTransition:
         context={
             "verdict": verdict,
             "block_reason": (output or {}).get("block_reason"),
+        },
+    )
+
+
+def transition_from_fix_conflict(
+    output: Mapping[str, Any] | None,
+) -> PhaseTransition:
+    """Return the phase transition after ``/task-v2-fix-conflict`` runs.
+
+    Added by #3225. The fix_conflict phase recovers from pre-push
+    rebase conflicts (and, in the secondary-mitigation path, from
+    start-of-ralph baseline rebase conflicts) by claude-resolving the
+    conflict against updated ``origin/main`` content instead of
+    abandoning the agent's ralph work.
+
+    The skill's output JSON carries a ``verdict`` field (``resolved``
+    or ``unresolvable``). The entrypoint is responsible for:
+
+    * **Budget gate.** Before invoking the skill, it checks
+      ``dispatcher.agents.merge_conflict_attempts`` against
+      ``FIX_CONFLICT_MAX_ATTEMPTS`` (2 per agent lifetime). A budget
+      exhaustion surfaces here as a synthetic
+      ``verdict='unresolvable', budget_exhausted=true`` output so this
+      pure function can stay I/O-free.
+    * **Apply the resolution.** On ``verdict='resolved'``, the
+      entrypoint writes ``resolved_files[]`` back into the worktree
+      as a new commit on the agent branch, then re-enters
+      ``push_and_pr`` — which will re-fetch + rebase + push.
+    * **Route to terminal.** On ``verdict='unresolvable'``, the
+      entrypoint advances to ``conflict_unresolvable`` and lets the
+      supervisor tick's ``_find_diagnoser_candidates`` sweep pick it
+      up for a diagnoser recommendation.
+
+    Verdicts:
+
+    * ``RESOLVED`` — conflict resolved, re-enter ``push_and_pr``.
+    * ``UNRESOLVABLE`` (or unrecognized / missing) — route to
+      diagnoser with ``FAILURE_HINT_CONFLICT_UNRESOLVABLE``.
+    """
+    verdict = _verdict(output)
+    if verdict == VERDICT_RESOLVED:
+        return PhaseTransition(
+            action=TransitionAction.ADVANCE,
+            next_phase=PHASE_PUSH_AND_PR,
+            reason="fix_conflict RESOLVED",
+            context={
+                "resolution_notes": (output or {}).get("resolution_notes"),
+                "resolved_files_count": len((output or {}).get("resolved_files") or []),
+            },
+        )
+    # UNRESOLVABLE, budget_exhausted, or any unrecognized verdict —
+    # route to the diagnoser for retry_with_hint / AC_INFEASIBLE.
+    return PhaseTransition(
+        action=TransitionAction.ROUTE_TO_DIAGNOSER,
+        failure_hint=FAILURE_HINT_CONFLICT_UNRESOLVABLE,
+        reason=f"fix_conflict non-resolved verdict: {verdict or '(missing)'}",
+        context={
+            "verdict": verdict,
+            "resolution_notes": (output or {}).get("resolution_notes"),
+            "budget_exhausted": bool((output or {}).get("budget_exhausted")),
+            "conflict_files": (output or {}).get("conflict_files") or [],
         },
     )
 
@@ -866,6 +1003,7 @@ _VERDICT_DRIVEN_TRANSITIONS: dict[
     PHASE_SUMMARY: transition_from_summary,
     PHASE_PUSH_AND_PR: transition_from_push_and_pr,
     PHASE_FIX_CI: transition_from_fix_ci,
+    PHASE_FIX_CONFLICT: transition_from_fix_conflict,
     PHASE_VERIFY: transition_from_verify,
 }
 
@@ -940,6 +1078,7 @@ ACTIVE_PHASES: frozenset[str] = frozenset(
         PHASE_PUSH_AND_PR,
         PHASE_AWAITING_CI,
         PHASE_FIX_CI,
+        PHASE_FIX_CONFLICT,
         PHASE_MERGE,
         PHASE_AWAITING_DEPLOY,
         PHASE_VERIFY,
@@ -967,6 +1106,7 @@ __all__ = [
     "PHASE_PUSH_AND_PR",
     "PHASE_AWAITING_CI",
     "PHASE_FIX_CI",
+    "PHASE_FIX_CONFLICT",
     "PHASE_MERGE",
     "PHASE_AWAITING_DEPLOY",
     "PHASE_VERIFY",
@@ -986,6 +1126,7 @@ __all__ = [
     "PHASE_MERGE_FAILED",
     "PHASE_AWAITING_DEPLOY_FAILED",
     "PHASE_AWAITING_DEPLOY_TIMEOUT",
+    "PHASE_CONFLICT_UNRESOLVABLE",
     # Verdict constants
     "VERDICT_SHIP",
     "VERDICT_AC_INFEASIBLE",
@@ -995,6 +1136,8 @@ __all__ = [
     "VERDICT_FAILED",
     "VERDICT_VERIFIED",
     "VERDICT_SKIPPED",
+    "VERDICT_RESOLVED",
+    "VERDICT_UNRESOLVABLE",
     # Status
     "AgentStatus",
     "TERMINAL_STATUSES",
@@ -1007,6 +1150,7 @@ __all__ = [
     "FAILURE_HINT_FIX_CI_BLOCKED",
     "FAILURE_HINT_VERIFY_FAILED_POST_MERGE",
     "FAILURE_HINT_PLAN_BLOCKED",
+    "FAILURE_HINT_CONFLICT_UNRESOLVABLE",
     # Transition dataclass + enum
     "PhaseTransition",
     "TransitionAction",
@@ -1017,6 +1161,7 @@ __all__ = [
     "transition_from_push_and_pr",
     "transition_from_awaiting_ci",
     "transition_from_fix_ci",
+    "transition_from_fix_conflict",
     "transition_from_merge",
     "transition_from_awaiting_deploy",
     "transition_from_verify",

--- a/scripts/dispatcher/tests/test_daemon_diagnoser_routing.py
+++ b/scripts/dispatcher/tests/test_daemon_diagnoser_routing.py
@@ -186,6 +186,16 @@ class TestTierSetsIncludeNewCategories:
         assert FAILURE_CATEGORY_RALPH_AC_INFEASIBLE in TIER_3_CATEGORIES
         assert FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE in TIER_3_CATEGORIES
 
+    def test_conflict_unresolvable_in_tier3(self) -> None:
+        """#3225 — fix_conflict terminal routes through the diagnoser."""
+        assert daemon.FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE in TIER_3_CATEGORIES
+        # Not in tier-1 auto-retry (we don't want the mechanical retry
+        # path to swallow it — diagnoser picks AC_INFEASIBLE /
+        # retry_with_hint based on resolution_notes).
+        assert (
+            daemon.FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE not in AUTO_RETRY_CATEGORIES
+        )
+
     def test_regression_subprocess_crash_still_tier2_recurrence(self) -> None:
         assert FAILURE_CATEGORY_SUBPROCESS_CRASH in TIER_2_RECURRENCE_CATEGORIES
 

--- a/scripts/dispatcher/tests/test_phase_transitions.py
+++ b/scripts/dispatcher/tests/test_phase_transitions.py
@@ -529,6 +529,163 @@ class TestTransitionFromFixCi:
 
 
 # --------------------------------------------------------------------------
+# transition_from_fix_conflict (#3225)
+# --------------------------------------------------------------------------
+
+
+class TestTransitionFromFixConflict:
+    """Fix-conflict transitions (#3225): RESOLVED re-enters push_and_pr, UNRESOLVABLE routes to diagnoser."""
+
+    def test_resolved_advances_to_push_and_pr(self) -> None:
+        result = pt.transition_from_fix_conflict(
+            {
+                "verdict": "resolved",
+                "resolution_notes": "reconciled 2 hunks against main's refactor",
+                "resolved_files": [
+                    {"path": "packages/web/app/a.tsx", "content": "..."},
+                    {"path": "packages/web/app/b.tsx", "content": "..."},
+                ],
+            }
+        )
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_PUSH_AND_PR
+        assert result.context["resolved_files_count"] == 2
+        assert (
+            result.context["resolution_notes"]
+            == "reconciled 2 hunks against main's refactor"
+        )
+
+    def test_resolved_uppercase_still_matches(self) -> None:
+        # Verdict matching is case-insensitive via str.upper() — skill
+        # emits lowercase, daemon constants are upper.
+        result = pt.transition_from_fix_conflict({"verdict": "RESOLVED"})
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_PUSH_AND_PR
+
+    def test_unresolvable_routes_to_diagnoser(self) -> None:
+        result = pt.transition_from_fix_conflict(
+            {
+                "verdict": "unresolvable",
+                "resolution_notes": "function X was rewritten on main",
+                "conflict_files": ["packages/api/src/x.py"],
+            }
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_CONFLICT_UNRESOLVABLE
+        assert result.context["verdict"] == "UNRESOLVABLE"
+        assert result.context["resolution_notes"] == "function X was rewritten on main"
+        assert result.context["conflict_files"] == ["packages/api/src/x.py"]
+        assert result.context["budget_exhausted"] is False
+
+    def test_budget_exhausted_routes_to_diagnoser(self) -> None:
+        # Entrypoint emits this shape when merge_conflict_attempts >=
+        # FIX_CONFLICT_MAX_ATTEMPTS — no claude was invoked. The
+        # transition still routes to diagnoser; the budget_exhausted
+        # flag propagates via context so the diagnoser can distinguish
+        # "we never tried" from "we tried and failed semantically".
+        result = pt.transition_from_fix_conflict(
+            {
+                "verdict": "unresolvable",
+                "resolution_notes": "budget exhausted after 2 attempts",
+                "budget_exhausted": True,
+            }
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_CONFLICT_UNRESOLVABLE
+        assert result.context["budget_exhausted"] is True
+
+    def test_missing_verdict_routes_to_diagnoser(self) -> None:
+        result = pt.transition_from_fix_conflict({})
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_CONFLICT_UNRESOLVABLE
+        assert result.context["verdict"] == ""
+
+    def test_none_output_routes_to_diagnoser(self) -> None:
+        result = pt.transition_from_fix_conflict(None)
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_CONFLICT_UNRESOLVABLE
+
+
+# --------------------------------------------------------------------------
+# transition_from_push_and_pr — rebase_failed branch (#3225)
+# --------------------------------------------------------------------------
+
+
+class TestTransitionFromPushAndPrRebaseConflict:
+    """#3225: push_and_pr emits rebase_failed → advance to fix_conflict."""
+
+    def test_rebase_failed_advances_to_fix_conflict(self) -> None:
+        result = pt.transition_from_push_and_pr(
+            {
+                "rebase_failed": True,
+                "conflict_files": [
+                    "packages/web/app/(main)/admin/dispatcher/a.tsx",
+                    "packages/web/app/(main)/admin/dispatcher/b.tsx",
+                ],
+            }
+        )
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_FIX_CONFLICT
+        assert result.context["conflict_files"] == [
+            "packages/web/app/(main)/admin/dispatcher/a.tsx",
+            "packages/web/app/(main)/admin/dispatcher/b.tsx",
+        ]
+        assert result.context["source_phase"] == "push_and_pr"
+
+    def test_rebase_failed_takes_precedence_over_no_op(self) -> None:
+        # Defensive — if the entrypoint somehow emits both (shouldn't
+        # happen, but paranoia is cheap here), the no-op SHIP terminal
+        # wins because it signals "ralph had no changes" which is
+        # incompatible with "rebase conflicted on changes".
+        result = pt.transition_from_push_and_pr({"rebase_failed": True, "no_op": True})
+        # no_op wins (ordered check).
+        assert result.action == pt.TransitionAction.ADVANCE_WITH_STATUS
+        assert result.next_phase == pt.PHASE_NO_OP
+
+    def test_missing_rebase_failed_advances_normally(self) -> None:
+        result = pt.transition_from_push_and_pr({"pr_number": 4242})
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_AWAITING_CI
+
+
+# --------------------------------------------------------------------------
+# transition_from_ralph — rebase_failed branch (#3225 secondary mitigation)
+# --------------------------------------------------------------------------
+
+
+class TestTransitionFromRalphBaselineRebaseConflict:
+    """#3225: start-of-ralph baseline rebase failure → fix_conflict."""
+
+    def test_rebase_failed_short_circuits_verdict_check(self) -> None:
+        # The entrypoint emits rebase_failed BEFORE any claude
+        # iterations ran, so there is no verdict field yet. Transition
+        # must still advance to fix_conflict rather than falling into
+        # the RALPH_NOT_SHIP diagnoser branch.
+        result = pt.transition_from_ralph(
+            {"rebase_failed": True, "conflict_files": ["x.py", "y.py"]}
+        )
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_FIX_CONFLICT
+        assert result.context["conflict_files"] == ["x.py", "y.py"]
+        assert result.context["source_phase"] == "ralph"
+
+    def test_rebase_failed_beats_verdict(self) -> None:
+        # Even if a verdict is somehow present alongside rebase_failed,
+        # the rebase-failure takes precedence — the claude iterations
+        # never actually executed, so any verdict would be stale.
+        result = pt.transition_from_ralph({"rebase_failed": True, "verdict": "SHIP"})
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_FIX_CONFLICT
+
+    def test_no_rebase_failed_advances_via_verdict(self) -> None:
+        # Sanity check: pre-existing SHIP behaviour is preserved when
+        # rebase_failed is absent.
+        result = pt.transition_from_ralph({"verdict": "SHIP"})
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_SUMMARY
+
+
+# --------------------------------------------------------------------------
 # transition_from_merge
 # --------------------------------------------------------------------------
 
@@ -674,6 +831,22 @@ class TestNextPhaseFromVerdict:
         result = pt.next_phase_from_verdict(pt.PHASE_FIX_CI, {"verdict": "PATCHED"})
         assert result.next_phase == pt.PHASE_AWAITING_CI
 
+    def test_dispatches_fix_conflict_correctly(self) -> None:
+        """#3225 — fix_conflict is dispatch-table wired for RESOLVED."""
+        result = pt.next_phase_from_verdict(
+            pt.PHASE_FIX_CONFLICT, {"verdict": "resolved"}
+        )
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_PUSH_AND_PR
+
+    def test_dispatches_fix_conflict_unresolvable(self) -> None:
+        result = pt.next_phase_from_verdict(
+            pt.PHASE_FIX_CONFLICT,
+            {"verdict": "unresolvable", "resolution_notes": "reason"},
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_CONFLICT_UNRESOLVABLE
+
     def test_dispatches_verify_correctly(self) -> None:
         result = pt.next_phase_from_verdict(pt.PHASE_VERIFY, {"verdict": "VERIFIED"})
         assert result.next_phase == pt.PHASE_DONE
@@ -716,6 +889,14 @@ class TestTerminalPhaseAndStatus:
         assert pt.is_terminal_phase(pt.PHASE_AWAITING_DEPLOY_FAILED) is True
         assert pt.is_terminal_phase(pt.PHASE_AWAITING_DEPLOY_TIMEOUT) is True
 
+    def test_is_terminal_phase_true_for_conflict_unresolvable(self) -> None:
+        """#3225 — fix_conflict budget-exhausted / unresolvable terminal."""
+        assert pt.is_terminal_phase(pt.PHASE_CONFLICT_UNRESOLVABLE) is True
+
+    def test_fix_conflict_is_intermediate_not_terminal(self) -> None:
+        """#3225 — fix_conflict is active, not terminal (it advances)."""
+        assert pt.is_terminal_phase(pt.PHASE_FIX_CONFLICT) is False
+
     def test_is_terminal_phase_false_for_intermediate(self) -> None:
         assert pt.is_terminal_phase(pt.PHASE_PLANNING) is False
         assert pt.is_terminal_phase(pt.PHASE_RALPH) is False
@@ -755,6 +936,7 @@ class TestTerminalPhaseAndStatus:
             pt.PHASE_PUSH_AND_PR,
             pt.PHASE_AWAITING_CI,
             pt.PHASE_FIX_CI,
+            pt.PHASE_FIX_CONFLICT,  # #3225
             pt.PHASE_MERGE,
             pt.PHASE_AWAITING_DEPLOY,
             pt.PHASE_VERIFY,
@@ -762,6 +944,7 @@ class TestTerminalPhaseAndStatus:
             pt.PHASE_DONE,
             pt.PHASE_RETRO_DONE,
             pt.PHASE_PLAN_BLOCKED,
+            pt.PHASE_CONFLICT_UNRESOLVABLE,  # #3225
         ):
             assert pt.is_known_phase(phase), f"{phase!r} should be known"
 

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -3659,6 +3659,499 @@ else
          "rc=$t40_neg_rc (expected non-zero), output: $t40_neg_out"
 fi
 
+# ══════════════════════════════════════════════════════════════════════════
+# Test 41: #3225 — handle_fix_conflict happy path (verdict=resolved).
+#
+# Scenario: dispatcher.agents.merge_conflict_attempts is 0, the
+# fix_conflict skill returns verdict=resolved with resolved_files
+# populated. Expected behaviour:
+#   1. The budget gate passes (0 < FIX_CONFLICT_MAX_ATTEMPTS=2).
+#   2. merge_conflict_attempts is incremented (UPDATE on the agent row).
+#   3. The claude skill is invoked with /task-v2-fix-conflict.
+#   4. handle_fix_conflict reads the output, applies resolved_files as
+#      a new commit, and prints the pass-through envelope.
+#   5. The loop advances to push_and_pr.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+
+# Isolate the function definitions needed. Reuse the same awk-based
+# extraction as T40 so the test exercises the REAL entrypoint code.
+t41_funcs="$TEST_TMP/t41-funcs.sh"
+printf 'exec 3>&1\n' > "$t41_funcs"
+
+for fn in db_exec db_query_one log persist_phase_output \
+          read_merge_conflict_attempts \
+          increment_merge_conflict_attempts \
+          apply_resolved_files \
+          run_claude_phase \
+          write_phase_input \
+          phase_to_skill \
+          read_phase_output \
+          handle_fix_conflict; do
+    awk -v FN="^${fn}\\\\(\\\\)" '
+        $0 ~ FN { in_fn=1 }
+        in_fn { print }
+        in_fn && /^}$/ { exit }
+    ' "$ENTRYPOINT" >> "$t41_funcs"
+done
+
+# Sanity: handle_fix_conflict was extracted.
+if grep -q "^handle_fix_conflict()" "$t41_funcs"; then
+    pass "#3225 T41 — extracted handle_fix_conflict from entrypoint"
+else
+    fail "#3225 T41 — extracted handle_fix_conflict from entrypoint" \
+         "fixture head: $(head -c 400 "$t41_funcs")"
+fi
+
+# Build a minimal per-test workspace and stub binaries. The stubs track
+# the key observations: psql read/write, git invocations, and claude
+# output.
+t41_workspace="$TEST_TMP/t41-workspace"
+t41_repo_root="$TEST_TMP/t41-repo"
+t41_state_dir="$TEST_TMP/t41-state"
+t41_stub_bin="$TEST_TMP/t41-bin"
+mkdir -p "$t41_workspace" "$t41_repo_root" "$t41_state_dir" "$t41_stub_bin"
+
+# Pre-create tmp/dispatcher-output/ with the "resolved" skill output.
+mkdir -p "$t41_repo_root/tmp/dispatcher-output"
+cat > "$t41_repo_root/tmp/dispatcher-output/fix-conflict.json" <<'T41OUTJSON'
+{
+  "agent_id": "41414141-dead-beef-cafe-000000000001",
+  "verdict": "resolved",
+  "resolution_notes": "reconciled 1 hunk against main's refactor",
+  "resolved_files": [
+    {"path": "packages/web/a.tsx", "content": "resolved-a\n"}
+  ],
+  "conflict_files": ["packages/web/a.tsx"]
+}
+T41OUTJSON
+
+# Seed the pre-conflict file so apply_resolved_files has a parent
+# dir to write into.
+mkdir -p "$t41_repo_root/packages/web"
+printf 'original-a\n' > "$t41_repo_root/packages/web/a.tsx"
+
+# psql stub — reads merge_conflict_attempts from a state file, and
+# records any UPDATE that touches the column.
+cat > "$t41_stub_bin/psql" <<'T41PSQLEOF'
+#!/usr/bin/env bash
+set -u
+query=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -c) shift; query="$1" ;;
+    esac
+    shift || true
+done
+state_file="${T41_STATE_DIR}/merge_conflict_attempts.txt"
+if [[ ! -f "$state_file" ]]; then
+    printf '0\n' > "$state_file"
+fi
+if [[ "$query" == *"SELECT COALESCE(merge_conflict_attempts"* ]]; then
+    cat "$state_file"
+    exit 0
+fi
+if [[ "$query" == *"SET merge_conflict_attempts"* ]]; then
+    _cur=$(cat "$state_file")
+    printf '%s\n' "$((_cur + 1))" > "$state_file"
+    printf 'UPDATE_MCA\n' >> "${T41_STATE_DIR}/update-log.txt"
+    exit 0
+fi
+# Everything else — silent success.
+exit 0
+T41PSQLEOF
+chmod +x "$t41_stub_bin/psql"
+
+# claude stub — prints a minimal envelope to stdout (not used by the
+# entrypoint since it reads the dispatcher-output file, but invoked).
+cat > "$t41_stub_bin/claude" <<'T41CLAUDEEOF'
+#!/usr/bin/env bash
+printf '{"result": "claude invoked"}\n'
+printf 'CLAUDE_INVOKED\n' >> "${T41_STATE_DIR}/claude-log.txt"
+exit 0
+T41CLAUDEEOF
+chmod +x "$t41_stub_bin/claude"
+
+# git stub — minimal: we need ``git add`` and ``git commit`` to succeed.
+# Fall through everything else to a no-op success.
+cat > "$t41_stub_bin/git" <<'T41GITEOF'
+#!/usr/bin/env bash
+printf 'git %s\n' "$*" >> "${T41_STATE_DIR}/git-log.txt"
+exit 0
+T41GITEOF
+chmod +x "$t41_stub_bin/git"
+
+# jq stub: we need the real jq. Symlink it in.
+if command -v jq >/dev/null 2>&1; then
+    ln -sf "$(command -v jq)" "$t41_stub_bin/jq"
+fi
+# python3 too
+if command -v python3 >/dev/null 2>&1; then
+    ln -sf "$(command -v python3)" "$t41_stub_bin/python3"
+fi
+
+# Phase input shim — write an empty fix-conflict.json so
+# write_phase_input succeeds.
+mkdir -p "$t41_repo_root/tmp/dispatcher-input"
+cat > "$t41_repo_root/tmp/dispatcher-input/fix-conflict.json" <<'T41INPUTEOF'
+{"agent_id": "41414141-dead-beef-cafe-000000000001", "conflict_files": []}
+T41INPUTEOF
+
+# Stub phase_input_shim.py — minimal no-op so write_phase_input's
+# python3 invocation succeeds.
+t41_shim="$TEST_TMP/t41-phase-input-shim.py"
+cat > "$t41_shim" <<'T41SHIMEOF'
+import sys
+print(sys.argv)
+sys.exit(0)
+T41SHIMEOF
+
+# Drive handle_fix_conflict. Subshell-isolate with set -euo pipefail
+# mirroring the entrypoint.
+set +e
+t41_out=$(T41_STATE_DIR="$t41_state_dir" \
+    PATH="$t41_stub_bin:$PATH" \
+    AGENT_ID="41414141-dead-beef-cafe-000000000001" \
+    ISSUE_NUMBER="3225" \
+    AGENT_WORKSPACE="$t41_workspace" \
+    REPO_ROOT="$t41_repo_root" \
+    DATABASE_URL="postgres://test" \
+    AGENT_RUNNER_DRY_RUN="0" \
+    AGENT_RUNNER_FIX_CONFLICT_MAX_ATTEMPTS="2" \
+    AGENT_RUNNER_PHASE_INPUT_SHIM="$t41_shim" \
+    PHASE_INPUT_SHIM="$t41_shim" \
+    FIX_CONFLICT_MAX_ATTEMPTS="2" \
+    bash -c '
+        set -euo pipefail
+        # shellcheck disable=SC1090
+        . "'"$t41_funcs"'"
+        handle_fix_conflict
+    ' 2>&1)
+t41_rc=$?
+set -e
+
+# Expectations:
+# 1. handle_fix_conflict exits 0.
+if [[ "$t41_rc" -eq 0 ]]; then
+    pass "#3225 T41 — handle_fix_conflict exits 0 on resolved"
+else
+    fail "#3225 T41 — handle_fix_conflict exits 0 on resolved" \
+         "rc=$t41_rc, output: $t41_out"
+fi
+
+# 2. Output contains verdict=resolved.
+if printf '%s' "$t41_out" | grep -q '"verdict".*"resolved"'; then
+    pass "#3225 T41 — handle_fix_conflict prints verdict=resolved envelope"
+else
+    fail "#3225 T41 — handle_fix_conflict prints verdict=resolved envelope" \
+         "output: $t41_out"
+fi
+
+# 3. merge_conflict_attempts was incremented (UPDATE log has an entry).
+if [[ -s "$t41_state_dir/update-log.txt" ]]; then
+    pass "#3225 T41 — merge_conflict_attempts was incremented"
+else
+    fail "#3225 T41 — merge_conflict_attempts was incremented" \
+         "update-log.txt empty or missing"
+fi
+
+# 4. claude was invoked.
+if [[ -s "$t41_state_dir/claude-log.txt" ]]; then
+    pass "#3225 T41 — claude -p fix-conflict was invoked"
+else
+    fail "#3225 T41 — claude -p fix-conflict was invoked" \
+         "claude-log.txt empty"
+fi
+
+# 5. git add + git commit were run (apply_resolved_files staged + committed).
+# The git stub logs `git <argv>` (without the binary name); the
+# entrypoint invokes ``git -C <repo> add`` and ``git -C <repo> commit``.
+if grep -q " add " "$t41_state_dir/git-log.txt" 2>/dev/null; then
+    pass "#3225 T41 — apply_resolved_files ran git add"
+else
+    fail "#3225 T41 — apply_resolved_files ran git add" \
+         "git-log.txt: $(cat "$t41_state_dir/git-log.txt" 2>/dev/null)"
+fi
+if grep -q " commit " "$t41_state_dir/git-log.txt" 2>/dev/null; then
+    pass "#3225 T41 — apply_resolved_files ran git commit"
+else
+    fail "#3225 T41 — apply_resolved_files ran git commit" \
+         "git-log.txt: $(cat "$t41_state_dir/git-log.txt" 2>/dev/null)"
+fi
+
+# 6. The resolved file's content matches the skill's output on disk.
+if [[ -f "$t41_repo_root/packages/web/a.tsx" ]] && \
+   grep -q "resolved-a" "$t41_repo_root/packages/web/a.tsx"; then
+    pass "#3225 T41 — resolved_files content written to repo path"
+else
+    fail "#3225 T41 — resolved_files content written to repo path" \
+         "file contents: $(cat "$t41_repo_root/packages/web/a.tsx" 2>/dev/null)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 42: #3225 — handle_fix_conflict unresolvable case.
+#
+# Scenario: budget is fine (0 < 2), but the skill returns
+# verdict=unresolvable. handle_fix_conflict must:
+#   1. Still increment the counter (the skill WAS invoked).
+#   2. NOT apply any resolved_files (none were provided).
+#   3. Emit the unresolvable envelope so the transition shim routes
+#      to conflict_unresolvable.
+# ══════════════════════════════════════════════════════════════════════════
+
+t42_workspace="$TEST_TMP/t42-workspace"
+t42_repo_root="$TEST_TMP/t42-repo"
+t42_state_dir="$TEST_TMP/t42-state"
+t42_stub_bin="$TEST_TMP/t42-bin"
+mkdir -p "$t42_workspace" "$t42_repo_root" "$t42_state_dir" "$t42_stub_bin"
+
+mkdir -p "$t42_repo_root/tmp/dispatcher-output"
+cat > "$t42_repo_root/tmp/dispatcher-output/fix-conflict.json" <<'T42OUTJSON'
+{
+  "agent_id": "42424242-dead-beef-cafe-000000000002",
+  "verdict": "unresolvable",
+  "resolution_notes": "function X was rewritten on main — agent's addition no longer applies",
+  "resolved_files": [],
+  "conflict_files": ["packages/api/src/x.py"]
+}
+T42OUTJSON
+
+mkdir -p "$t42_repo_root/tmp/dispatcher-input"
+printf '{}' > "$t42_repo_root/tmp/dispatcher-input/fix-conflict.json"
+
+# Reuse the same psql/claude/git stub pattern — cheap to duplicate here
+# so each test is independently inspectable.
+cat > "$t42_stub_bin/psql" <<'T42PSQLEOF'
+#!/usr/bin/env bash
+set -u
+query=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -c) shift; query="$1" ;;
+    esac
+    shift || true
+done
+state_file="${T42_STATE_DIR}/merge_conflict_attempts.txt"
+if [[ ! -f "$state_file" ]]; then
+    printf '0\n' > "$state_file"
+fi
+if [[ "$query" == *"SELECT COALESCE(merge_conflict_attempts"* ]]; then
+    cat "$state_file"
+    exit 0
+fi
+if [[ "$query" == *"SET merge_conflict_attempts"* ]]; then
+    _cur=$(cat "$state_file")
+    printf '%s\n' "$((_cur + 1))" > "$state_file"
+    printf 'UPDATE_MCA\n' >> "${T42_STATE_DIR}/update-log.txt"
+    exit 0
+fi
+exit 0
+T42PSQLEOF
+chmod +x "$t42_stub_bin/psql"
+
+cat > "$t42_stub_bin/claude" <<'T42CLAUDEEOF'
+#!/usr/bin/env bash
+printf '{"result": "claude invoked"}\n'
+printf 'CLAUDE_INVOKED\n' >> "${T42_STATE_DIR}/claude-log.txt"
+exit 0
+T42CLAUDEEOF
+chmod +x "$t42_stub_bin/claude"
+
+cat > "$t42_stub_bin/git" <<'T42GITEOF'
+#!/usr/bin/env bash
+printf 'git %s\n' "$*" >> "${T42_STATE_DIR}/git-log.txt"
+exit 0
+T42GITEOF
+chmod +x "$t42_stub_bin/git"
+
+if command -v jq >/dev/null 2>&1; then
+    ln -sf "$(command -v jq)" "$t42_stub_bin/jq"
+fi
+if command -v python3 >/dev/null 2>&1; then
+    ln -sf "$(command -v python3)" "$t42_stub_bin/python3"
+fi
+
+t42_shim="$TEST_TMP/t42-phase-input-shim.py"
+cat > "$t42_shim" <<'T42SHIMEOF'
+import sys
+sys.exit(0)
+T42SHIMEOF
+
+set +e
+t42_out=$(T42_STATE_DIR="$t42_state_dir" \
+    PATH="$t42_stub_bin:$PATH" \
+    AGENT_ID="42424242-dead-beef-cafe-000000000002" \
+    ISSUE_NUMBER="3225" \
+    AGENT_WORKSPACE="$t42_workspace" \
+    REPO_ROOT="$t42_repo_root" \
+    DATABASE_URL="postgres://test" \
+    AGENT_RUNNER_DRY_RUN="0" \
+    AGENT_RUNNER_FIX_CONFLICT_MAX_ATTEMPTS="2" \
+    AGENT_RUNNER_PHASE_INPUT_SHIM="$t42_shim" \
+    PHASE_INPUT_SHIM="$t42_shim" \
+    FIX_CONFLICT_MAX_ATTEMPTS="2" \
+    bash -c '
+        set -euo pipefail
+        # shellcheck disable=SC1090
+        . "'"$t41_funcs"'"
+        handle_fix_conflict
+    ' 2>&1)
+t42_rc=$?
+set -e
+
+if [[ "$t42_rc" -eq 0 ]]; then
+    pass "#3225 T42 — handle_fix_conflict exits 0 on unresolvable"
+else
+    fail "#3225 T42 — handle_fix_conflict exits 0 on unresolvable" \
+         "rc=$t42_rc, output: $t42_out"
+fi
+
+if printf '%s' "$t42_out" | grep -q '"verdict".*"unresolvable"'; then
+    pass "#3225 T42 — handle_fix_conflict prints verdict=unresolvable envelope"
+else
+    fail "#3225 T42 — handle_fix_conflict prints verdict=unresolvable envelope" \
+         "output: $t42_out"
+fi
+
+# merge_conflict_attempts was still incremented (the skill WAS invoked).
+if [[ -s "$t42_state_dir/update-log.txt" ]]; then
+    pass "#3225 T42 — merge_conflict_attempts incremented even on unresolvable"
+else
+    fail "#3225 T42 — merge_conflict_attempts incremented even on unresolvable" \
+         "update-log.txt empty"
+fi
+
+# No git commit was attempted (no resolved_files to apply).
+if ! grep -q " commit " "$t42_state_dir/git-log.txt" 2>/dev/null; then
+    pass "#3225 T42 — no git commit attempted on unresolvable"
+else
+    fail "#3225 T42 — no git commit attempted on unresolvable" \
+         "git-log.txt: $(cat "$t42_state_dir/git-log.txt" 2>/dev/null)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 43: #3225 — handle_fix_conflict budget-exhausted case.
+#
+# Scenario: merge_conflict_attempts is already 2 (equal to the budget
+# cap FIX_CONFLICT_MAX_ATTEMPTS). handle_fix_conflict must:
+#   1. Skip the claude invocation (budget gate fires first).
+#   2. NOT increment the counter (we didn't run the skill).
+#   3. Emit the synthetic unresolvable + budget_exhausted envelope.
+# ══════════════════════════════════════════════════════════════════════════
+
+t43_workspace="$TEST_TMP/t43-workspace"
+t43_repo_root="$TEST_TMP/t43-repo"
+t43_state_dir="$TEST_TMP/t43-state"
+t43_stub_bin="$TEST_TMP/t43-bin"
+mkdir -p "$t43_workspace" "$t43_repo_root" "$t43_state_dir" "$t43_stub_bin"
+
+# Seed the state file with 2 (at the budget cap).
+printf '2\n' > "$t43_state_dir/merge_conflict_attempts.txt"
+
+# Same psql stub shape, different state dir.
+cat > "$t43_stub_bin/psql" <<'T43PSQLEOF'
+#!/usr/bin/env bash
+set -u
+query=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -c) shift; query="$1" ;;
+    esac
+    shift || true
+done
+state_file="${T43_STATE_DIR}/merge_conflict_attempts.txt"
+if [[ ! -f "$state_file" ]]; then
+    printf '0\n' > "$state_file"
+fi
+if [[ "$query" == *"SELECT COALESCE(merge_conflict_attempts"* ]]; then
+    cat "$state_file"
+    exit 0
+fi
+if [[ "$query" == *"SET merge_conflict_attempts"* ]]; then
+    _cur=$(cat "$state_file")
+    printf '%s\n' "$((_cur + 1))" > "$state_file"
+    printf 'UPDATE_MCA\n' >> "${T43_STATE_DIR}/update-log.txt"
+    exit 0
+fi
+exit 0
+T43PSQLEOF
+chmod +x "$t43_stub_bin/psql"
+
+# claude stub that records ANY invocation — if it runs, T43 has failed.
+cat > "$t43_stub_bin/claude" <<'T43CLAUDEEOF'
+#!/usr/bin/env bash
+printf 'CLAUDE_INVOKED\n' >> "${T43_STATE_DIR}/claude-log.txt"
+printf '{"result": "should-not-happen"}\n'
+exit 0
+T43CLAUDEEOF
+chmod +x "$t43_stub_bin/claude"
+
+cat > "$t43_stub_bin/git" <<'T43GITEOF'
+#!/usr/bin/env bash
+printf 'git %s\n' "$*" >> "${T43_STATE_DIR}/git-log.txt"
+exit 0
+T43GITEOF
+chmod +x "$t43_stub_bin/git"
+
+if command -v jq >/dev/null 2>&1; then
+    ln -sf "$(command -v jq)" "$t43_stub_bin/jq"
+fi
+if command -v python3 >/dev/null 2>&1; then
+    ln -sf "$(command -v python3)" "$t43_stub_bin/python3"
+fi
+
+set +e
+t43_out=$(T43_STATE_DIR="$t43_state_dir" \
+    PATH="$t43_stub_bin:$PATH" \
+    AGENT_ID="43434343-dead-beef-cafe-000000000003" \
+    ISSUE_NUMBER="3225" \
+    AGENT_WORKSPACE="$t43_workspace" \
+    REPO_ROOT="$t43_repo_root" \
+    DATABASE_URL="postgres://test" \
+    AGENT_RUNNER_DRY_RUN="0" \
+    AGENT_RUNNER_FIX_CONFLICT_MAX_ATTEMPTS="2" \
+    FIX_CONFLICT_MAX_ATTEMPTS="2" \
+    bash -c '
+        set -euo pipefail
+        # shellcheck disable=SC1090
+        . "'"$t41_funcs"'"
+        handle_fix_conflict
+    ' 2>&1)
+t43_rc=$?
+set -e
+
+if [[ "$t43_rc" -eq 0 ]]; then
+    pass "#3225 T43 — handle_fix_conflict exits 0 on budget exhaustion"
+else
+    fail "#3225 T43 — handle_fix_conflict exits 0 on budget exhaustion" \
+         "rc=$t43_rc, output: $t43_out"
+fi
+
+# claude was NOT invoked (budget gate short-circuited).
+if [[ ! -s "$t43_state_dir/claude-log.txt" ]]; then
+    pass "#3225 T43 — claude skipped on budget exhaustion"
+else
+    fail "#3225 T43 — claude skipped on budget exhaustion" \
+         "claude-log: $(cat "$t43_state_dir/claude-log.txt" 2>/dev/null)"
+fi
+
+# Envelope carries verdict=unresolvable + budget_exhausted=true.
+if printf '%s' "$t43_out" | grep -q '"budget_exhausted":[[:space:]]*true'; then
+    pass "#3225 T43 — envelope carries budget_exhausted=true"
+else
+    fail "#3225 T43 — envelope carries budget_exhausted=true" \
+         "output: $t43_out"
+fi
+
+# No increment (we skipped the skill, so the counter stays at 2).
+if [[ ! -s "$t43_state_dir/update-log.txt" ]]; then
+    pass "#3225 T43 — merge_conflict_attempts NOT incremented on budget exhaustion"
+else
+    fail "#3225 T43 — merge_conflict_attempts NOT incremented on budget exhaustion" \
+         "update-log: $(cat "$t43_state_dir/update-log.txt" 2>/dev/null)"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Adds a new `fix_conflict` phase to the dispatcher-v2 pipeline — parallel in shape to `fix_ci` — that resolves pre-push rebase conflicts (and start-of-ralph baseline rebase conflicts) semantically via a haiku-tier claude skill, instead of abandoning the agent's ralph work. Budget-gated at `FIX_CONFLICT_MAX_ATTEMPTS=2` per agent lifetime; on exhaustion or `verdict="unresolvable"` the agent terminates at the new `conflict_unresolvable` terminal and the diagnoser picks `AC_INFEASIBLE` vs `retry_with_hint` based on the skill's `resolution_notes`.

Closes #3225

## Test plan

### Automated checks
- [x] Lint passes (ruff check on changed Python files)
- [x] Format check passes (ruff format --check)
- [x] Tests pass — 1438 dispatcher pytest + 197 entrypoint tests (15 new assertions + T41/T42/T43 for resolved/unresolvable/budget-exhausted + `test_conflict_unresolvable_in_tier3`)
- [x] CI green

### Post-deploy verification
- [x] `deploy-dispatcher.yml` + `deploy-agent-runner.yml` both complete (see evidence comment for run IDs + deployed-SHA verification)
- [x] Migration 44 applied to dev (confirmed via `scripts/dev-db-query.sh` — `merge_conflict_attempts` column present)
- [x] Post-merge comment on #3225 with deploy run IDs + migration confirmation + soak instrumentation note
- [ ] **Smoke (AC#9, manual procedure — optional automation):** file two sibling-design tasks touching the same file; when the second's pre-push rebase conflicts, observe in CloudWatch the sequence `agent_runner.fix_conflict_budget_check` → `agent_runner.fix_conflict_attempts_incremented` → `agent_runner.claude_phase_begin phase=fix_conflict` → `agent_runner.fix_conflict_resolved_applied` (on resolve) OR `agent_runner.fix_conflict_not_resolved` → `agent_runner.agent_runner_reaped_failure terminal_phase=conflict_unresolvable` (on unresolvable). Deferred to natural occurrence per the issue scope.
- [x] Verification evidence posted on #3225
