### PR TITLE
fix(dx): update dispatcher terminal-status check to extract from frozenset literal (#2870)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -584,6 +584,35 @@ if [ -n "$changed_dispatcher_deps" ]; then
 fi
 
 # -------------------------------------------------------------------
+# Dispatcher terminal-status consistency drift — run when daemon or
+# API/web dispatcher files change (#2870)
+# -------------------------------------------------------------------
+# Cross-checks the five terminal-status literals (succeeded / failed /
+# crashed / plan_blocked / needs_review) across daemon.py, the GraphQL
+# schema, the SQL resolver, ui-primitives.tsx, and
+# RecentCompletionsPanel.tsx. Mirrors the CI step so drift is caught
+# locally before the CI round trip.
+changed_dispatcher_terminals=$(echo "$changed_files" \
+    | grep -E '^(scripts/dispatcher/daemon\.py|packages/api/src/graphql/dispatcher/|packages/web/src/app/.*/admin/dispatcher/)' || true)
+if [ -n "$changed_dispatcher_terminals" ]; then
+    echo "pre-push: checking dispatcher terminal-status consistency..." >&2
+    if [ -x scripts/check-dispatcher-terminals-consistent.sh ]; then
+        if ! run_check "_" "scripts/check-dispatcher-terminals-consistent.sh" scripts/check-dispatcher-terminals-consistent.sh; then
+            echo "  The dispatcher terminal-status set is out of sync across" >&2
+            echo "  daemon.py, schema.ts, resolvers.ts, ui-primitives.tsx," >&2
+            echo "  or RecentCompletionsPanel.tsx." >&2
+            echo "" >&2
+            echo "  Fix: update every flagged location to match the canonical" >&2
+            echo "  set. The canonical source is _mark_agent_terminal in" >&2
+            echo "  scripts/dispatcher/daemon.py." >&2
+            failures=$((failures + 1))
+        fi
+    else
+        echo "  WARNING: scripts/check-dispatcher-terminals-consistent.sh not found or not executable — skipping" >&2
+    fi
+fi
+
+# -------------------------------------------------------------------
 # Filename separator hygiene — always cheap, always run
 # -------------------------------------------------------------------
 # Flags same-directory filename pairs that differ only by `-` vs `_`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       schema: ${{ steps.changes.outputs.schema }}
       hooks: ${{ steps.changes.outputs.hooks }}
       githooks: ${{ steps.changes.outputs.githooks }}
+      dispatcher-terminals: ${{ steps.changes.outputs.dispatcher-terminals }}
       any-testable: ${{ steps.any-testable.outputs.result }}
     steps:
       - uses: actions/checkout@v6
@@ -134,6 +135,15 @@ jobs:
             githooks:
               - '.githooks/**'
               - 'scripts/tests/test_pre_push.sh'
+              - '.github/workflows/ci.yml'
+            dispatcher-terminals:
+              - 'scripts/dispatcher/daemon.py'
+              - 'packages/api/src/graphql/dispatcher/**'
+              - 'packages/web/src/app/**/admin/dispatcher/**'
+              # Include ci.yml so that edits to the dispatcher-terminal-consistency-check
+              # job are exercised on the PR that introduces them. Without this, the
+              # paths filter makes the job SKIP on its own PR — the #2410/#2505
+              # footgun. See scripts/check-ci-job-skipped.py.
               - '.github/workflows/ci.yml'
       - name: Check if any coverage-producing package changed
         id: any-testable
@@ -1262,6 +1272,22 @@ jobs:
         run: scripts/tests/test_pre_push.sh
 
   # ---------------------------------------------------------------
+  # Dispatcher terminal-status consistency guard: verifies the five
+  # terminal-status literals (issue #2870) match across daemon.py,
+  # schema.ts, resolvers.ts, ui-primitives.tsx, and
+  # RecentCompletionsPanel.tsx. Runs when any of the three source
+  # areas changes (daemon, API GraphQL layer, web admin dispatcher).
+  # ---------------------------------------------------------------
+  dispatcher-terminal-consistency-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.dispatcher-terminals == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Verify dispatcher terminal-status set is aligned across daemon API and web
+        run: scripts/check-dispatcher-terminals-consistent.sh
+
+  # ---------------------------------------------------------------
   # ECS oneshot Docker integration test: run scripts in a container
   # ---------------------------------------------------------------
   ecs-oneshot-test:
@@ -1340,7 +1366,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check, no-api-github-fetch-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-dispatcher-terminals-consistent.sh
+++ b/scripts/check-dispatcher-terminals-consistent.sh
@@ -20,8 +20,9 @@
 #
 # Rule
 # ----
-# 1. Parse the canonical set from ``terminal = status in (...)`` inside
-#    ``_mark_agent_terminal`` in ``scripts/dispatcher/daemon.py``.
+# 1. Parse the canonical set from the module-level
+#    ``TERMINAL_AGENT_STATUSES: frozenset[str] = frozenset({...})``
+#    constant in ``scripts/dispatcher/daemon.py``.
 #
 # 2. Check SET EQUALITY against:
 #      a. ``packages/api/src/graphql/dispatcher/schema.ts``
@@ -141,32 +142,21 @@ extract_quoted_tokens() {
 }
 
 # ─── Step 1: Extract canonical set from daemon.py ─────────────────────────
-# Find the ``terminal = status in (...)`` block inside _mark_agent_terminal.
-# Uses awk to scan the file in one pass.
-# POSIX awk: extract the quoted token on each line inside the block using
-# sub() to consume the leading portion, then print what's left between quotes.
-canonical_raw="$(awk '
-    /terminal = status in \(/ { in_block=1; next }
-    in_block && /^[[:space:]]*\)/ { exit }
-    in_block {
-        line = $0
-        # Try double-quoted token
-        if (sub(/^[^"]*"/, "", line)) {
-            sub(/".*/, "", line)
-            if (length(line) > 0) { print line; next }
-        }
-        # Reset line and try single-quoted token
-        line = $0
-        if (sub(/^[^'"'"']*'"'"'/, "", line)) {
-            sub(/'"'"'.*/, "", line)
-            if (length(line) > 0) { print line }
-        }
-    }
-' "$DAEMON_FILE" | tr '\n' ' ' | sed 's/ $//')"
+# Extract from the module-level frozenset literal:
+#   TERMINAL_AGENT_STATUSES: frozenset[str] = frozenset(
+#       {"succeeded", "failed", ...}
+#   )
+# Model: scripts/check-dispatcher-terminal-statuses.sh extract_python().
+canonical_raw="$(awk '/^TERMINAL_AGENT_STATUSES.*frozenset/{p=1} p{print; if(/\)/) {p=0; exit}}' "$DAEMON_FILE" \
+    | grep -oE '"[a-z_]+"' \
+    | tr -d '"' \
+    | sort \
+    | tr '\n' ' ' \
+    | sed 's/ $//')"
 
 if [[ -z "$canonical_raw" ]]; then
     echo "ERROR: check-dispatcher-terminals-consistent: could not extract canonical terminal set from $DAEMON_FILE"
-    echo "  Expected to find:  terminal = status in (...)"
+    echo "  Expected to find:  TERMINAL_AGENT_STATUSES: frozenset[str] = frozenset({...})"
     exit 1
 fi
 
@@ -199,6 +189,9 @@ if ! check_equality "schema.ts (docstrings)" "$schema_raw" "$CANONICAL"; then
 fi
 
 # ─── Step 2b: resolvers.ts — SQL IN lists ─────────────────────────────────
+# Only validates hardcoded inline SQL `status IN (...)` lists.  When resolvers.ts
+# uses a constant (e.g. `[...TERMINAL_AGENT_STATUSES]`) there are no inline lists
+# to check — empty result means no drift risk; skip equality check.
 if [[ ! -f "$RESOLVERS_FILE" ]]; then
     echo "check-dispatcher-terminals-consistent: no resolvers file at $RESOLVERS_FILE — nothing to check."
     exit 0
@@ -208,11 +201,13 @@ location_count=$((location_count + 1))
 resolvers_raw="$(grep -iE "status IN \(" "$RESOLVERS_FILE" \
     | tr "'" ' ' | tr ',' ' ' | tr '(' ' ' | tr ')' ' ' \
     | grep -oE '(succeeded|failed|crashed|plan_blocked|needs_review)' \
-    | sort -u | tr '\n' ' ' | sed 's/ $//')"
+    | sort -u | tr '\n' ' ' | sed 's/ $//' || true)"
 
-if ! check_equality "resolvers.ts (SQL IN lists)" "$resolvers_raw" "$CANONICAL"; then
-    failures=$((failures + 1))
-    echo "  File: $RESOLVERS_FILE"
+if [[ -n "$resolvers_raw" ]]; then
+    if ! check_equality "resolvers.ts (SQL IN lists)" "$resolvers_raw" "$CANONICAL"; then
+        failures=$((failures + 1))
+        echo "  File: $RESOLVERS_FILE"
+    fi
 fi
 
 # ─── Step 2c: ui-primitives.tsx — OutcomeStatus union AND OUTCOME_STYLES ──
@@ -222,25 +217,16 @@ if [[ ! -f "$UI_PRIM_FILE" ]]; then
 fi
 location_count=$((location_count + 1))
 
-# Extract OutcomeStatus union members using POSIX awk.
-# Terminated by the first line that ends with ';' after the opening line.
-union_raw="$(awk '
-    /^type OutcomeStatus[[:space:]]*=/ { in_union=1; next }
-    in_union {
-        line = $0
-        # Extract single-quoted token
-        if (sub(/^[^'"'"']*'"'"'/, "", line)) {
-            sub(/'"'"'.*/, "", line)
-            if (length(line) > 0) { print line }
-        }
-        # End: line ends with ;
-        if ($0 ~ /;[[:space:]]*$/) { exit }
-    }
-' "$UI_PRIM_FILE" \
-    | grep -E '^(succeeded|failed|crashed|plan_blocked|needs_review)$' \
-    | sort -u | tr '\n' ' ' | sed 's/ $//')"
+# Extract TERMINAL_AGENT_STATUSES array from ui-primitives.tsx.
+# OutcomeStatus is a derived type `(typeof TERMINAL_AGENT_STATUSES)[number]`
+# so the array is the actual source of truth; same awk pattern as
+# scripts/check-dispatcher-terminal-statuses.sh::extract_ts().
+union_raw="$(awk '/const TERMINAL_AGENT_STATUSES[[:space:]]*=[[:space:]]*\[/{p=1} p{print; if(/\] as const/) {p=0; exit}}' "$UI_PRIM_FILE" \
+    | grep -oE "'[a-z_]+'" \
+    | tr -d "'" \
+    | sort -u | tr '\n' ' ' | sed 's/ $//' || true)"
 
-if ! check_equality "ui-primitives.tsx (OutcomeStatus union)" "$union_raw" "$CANONICAL"; then
+if ! check_equality "ui-primitives.tsx (TERMINAL_AGENT_STATUSES array)" "$union_raw" "$CANONICAL"; then
     failures=$((failures + 1))
     echo "  File: $UI_PRIM_FILE"
 fi
@@ -395,10 +381,10 @@ if (( failures > 0 )); then
     echo ""
     echo "  Canonical set ($CANONICAL_COUNT terminals): $CANONICAL"
     echo "  Source: $DAEMON_FILE"
-    echo "         _mark_agent_terminal — terminal = status in (...)"
+    echo "         TERMINAL_AGENT_STATUSES: frozenset[str] = frozenset({...})"
     echo ""
     echo "  Fix: update every flagged location to match the canonical set."
-    echo "  The canonical source is the tuple in _mark_agent_terminal."
+    echo "  The canonical source is TERMINAL_AGENT_STATUSES in daemon.py."
     exit 1
 fi
 

--- a/scripts/check-dispatcher-terminals-consistent.sh
+++ b/scripts/check-dispatcher-terminals-consistent.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+# check-dispatcher-terminals-consistent.sh — Verify that the canonical
+# set of dispatcher terminal-status strings defined in
+# ``_mark_agent_terminal`` (``scripts/dispatcher/daemon.py``) matches
+# every consumer location in the API and web packages, and that every
+# canonical terminal is classified inside ``_write_diagnosis_outcome_for_agent``.
+#
+# Why this check exists
+# ---------------------
+# The five terminal-status strings
+# (succeeded / failed / crashed / plan_blocked / needs_review) are
+# hard-coded as literals in seven places spread across the Python daemon,
+# the GraphQL schema, the SQL query resolver, two TypeScript UI constructs,
+# and a JSDoc comment. A contributor adding a sixth terminal status must
+# update all seven locations — no compiler or type system enforces this
+# across the language boundary.
+#
+# This check was motivated by issue #2870 (dispatcher terminal-status
+# drift across daemon / API / web).
+#
+# Rule
+# ----
+# 1. Parse the canonical set from ``terminal = status in (...)`` inside
+#    ``_mark_agent_terminal`` in ``scripts/dispatcher/daemon.py``.
+#
+# 2. Check SET EQUALITY against:
+#      a. ``packages/api/src/graphql/dispatcher/schema.ts``
+#         — three docstring occurrences
+#           (DispatcherAgent.status, RecentCompletion.status,
+#            DispatcherState.recentCompletions + DispatcherQueueKind.COMPLETED).
+#      b. ``packages/api/src/graphql/dispatcher/resolvers.ts``
+#         — two SQL ``status IN (...)`` lists.
+#      c. ``packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx``
+#         — ``type OutcomeStatus = ...`` union lines AND keys of
+#           ``OUTCOME_STYLES``.
+#      d. ``packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx``
+#         — the JSDoc phrase listing terminal statuses.
+#
+# 3. Check SUBSET: the explicit correct-outcome tuple in
+#    ``_write_diagnosis_outcome_for_agent`` must only reference terminals
+#    that exist in the canonical set (no phantom terminals).
+#
+# 4. Check ACTIVE_AGENT_STATUSES validity: every element must be either
+#    ``running``, ``retrying``, or a member of the canonical set.
+#
+# On failure: print the canonical set, the drifting location, the
+# extracted set, and the symmetric set-diff.  Exit 1.
+# On success: print a summary line and exit 0.
+#
+# Usage
+# -----
+#   scripts/check-dispatcher-terminals-consistent.sh
+#   scripts/check-dispatcher-terminals-consistent.sh \
+#       [daemon.py] [schema.ts] [resolvers.ts] [ui-primitives.tsx] \
+#       [RecentCompletionsPanel.tsx]
+#
+# Exit codes
+# ----------
+#   0 — All locations carry the canonical set.
+#   1 — At least one location is inconsistent with the canonical set.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+DAEMON_FILE="${1:-$REPO_ROOT/scripts/dispatcher/daemon.py}"
+SCHEMA_FILE="${2:-$REPO_ROOT/packages/api/src/graphql/dispatcher/schema.ts}"
+RESOLVERS_FILE="${3:-$REPO_ROOT/packages/api/src/graphql/dispatcher/resolvers.ts}"
+UI_PRIM_FILE="${4:-$REPO_ROOT/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx}"
+COMPLETIONS_FILE="${5:-$REPO_ROOT/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx}"
+
+# ─── Fast exit if the daemon file is missing ──────────────────────────────
+if [[ ! -f "$DAEMON_FILE" ]]; then
+    echo "check-dispatcher-terminals-consistent: no daemon file at $DAEMON_FILE — nothing to check."
+    exit 0
+fi
+
+# ─── Helper: print symmetric diff with labels ─────────────────────────────
+print_diff() {
+    local label_a="$1"
+    local label_b="$2"
+    local tokens_a="$3"
+    local tokens_b="$4"
+
+    local only_a=""
+    for tok in $tokens_a; do
+        found=0
+        for chk in $tokens_b; do
+            if [[ "$tok" = "$chk" ]]; then found=1; break; fi
+        done
+        if (( found == 0 )); then
+            only_a="$only_a $tok"
+        fi
+    done
+    local only_b=""
+    for tok in $tokens_b; do
+        found=0
+        for chk in $tokens_a; do
+            if [[ "$tok" = "$chk" ]]; then found=1; break; fi
+        done
+        if (( found == 0 )); then
+            only_b="$only_b $tok"
+        fi
+    done
+
+    if [[ -n "$only_a" ]]; then
+        echo "  In $label_a but NOT $label_b:$only_a"
+    fi
+    if [[ -n "$only_b" ]]; then
+        echo "  In $label_b but NOT $label_a:$only_b"
+    fi
+}
+
+# ─── Helper: check set equality, print error on mismatch ──────────────────
+check_equality() {
+    local label="$1"
+    local loc_tokens="$2"
+    local canonical="$3"
+
+    local sorted_loc
+    sorted_loc="$(echo "$loc_tokens" | tr ' ' '\n' | grep -v '^$' | sort | tr '\n' ' ' | sed 's/ $//')"
+    local sorted_can
+    sorted_can="$(echo "$canonical" | tr ' ' '\n' | grep -v '^$' | sort | tr '\n' ' ' | sed 's/ $//')"
+
+    if [[ "$sorted_loc" != "$sorted_can" ]]; then
+        echo ""
+        echo "  DRIFT at $label"
+        echo "  Canonical set: $canonical"
+        echo "  Extracted set: $loc_tokens"
+        print_diff "canonical" "$label" "$canonical" "$loc_tokens"
+        return 1
+    fi
+    return 0
+}
+
+# ─── extract_quoted_tokens <file> — print all quoted strings (one/line) ──
+# Extracts every double-quoted or single-quoted string literal from stdin.
+# POSIX-compatible sed approach — no gawk match() with array required.
+extract_quoted_tokens() {
+    sed -n 's/.*"\([^"]*\)".*/\1/p; s/.*'"'"'\([^'"'"']*\)'"'"'.*/\1/p'
+}
+
+# ─── Step 1: Extract canonical set from daemon.py ─────────────────────────
+# Find the ``terminal = status in (...)`` block inside _mark_agent_terminal.
+# Uses awk to scan the file in one pass.
+# POSIX awk: extract the quoted token on each line inside the block using
+# sub() to consume the leading portion, then print what's left between quotes.
+canonical_raw="$(awk '
+    /terminal = status in \(/ { in_block=1; next }
+    in_block && /^[[:space:]]*\)/ { exit }
+    in_block {
+        line = $0
+        # Try double-quoted token
+        if (sub(/^[^"]*"/, "", line)) {
+            sub(/".*/, "", line)
+            if (length(line) > 0) { print line; next }
+        }
+        # Reset line and try single-quoted token
+        line = $0
+        if (sub(/^[^'"'"']*'"'"'/, "", line)) {
+            sub(/'"'"'.*/, "", line)
+            if (length(line) > 0) { print line }
+        }
+    }
+' "$DAEMON_FILE" | tr '\n' ' ' | sed 's/ $//')"
+
+if [[ -z "$canonical_raw" ]]; then
+    echo "ERROR: check-dispatcher-terminals-consistent: could not extract canonical terminal set from $DAEMON_FILE"
+    echo "  Expected to find:  terminal = status in (...)"
+    exit 1
+fi
+
+# Sort canonical set
+CANONICAL="$(echo "$canonical_raw" | tr ' ' '\n' | sort | tr '\n' ' ' | sed 's/ $//')"
+CANONICAL_COUNT="$(echo "$CANONICAL" | tr ' ' '\n' | grep -c -v '^$')"
+
+failures=0
+location_count=0
+
+# ─── Step 2a: schema.ts — check docstring occurrences ────────────────────
+# Extracts the union of all terminal strings appearing in pipe-separated
+# status-listing docstrings.
+if [[ ! -f "$SCHEMA_FILE" ]]; then
+    echo "check-dispatcher-terminals-consistent: no schema file at $SCHEMA_FILE — nothing to check."
+    exit 0
+fi
+location_count=$((location_count + 1))
+
+schema_raw="$(grep -E \
+    "(succeeded|failed|crashed|plan_blocked|needs_review).*\|.*(succeeded|failed|crashed|plan_blocked|needs_review)" \
+    "$SCHEMA_FILE" \
+    | tr '|' ' ' | tr "'" ' ' | tr '`' ' ' \
+    | grep -oE '(succeeded|failed|crashed|plan_blocked|needs_review)' \
+    | sort -u | tr '\n' ' ' | sed 's/ $//')"
+
+if ! check_equality "schema.ts (docstrings)" "$schema_raw" "$CANONICAL"; then
+    failures=$((failures + 1))
+    echo "  File: $SCHEMA_FILE"
+fi
+
+# ─── Step 2b: resolvers.ts — SQL IN lists ─────────────────────────────────
+if [[ ! -f "$RESOLVERS_FILE" ]]; then
+    echo "check-dispatcher-terminals-consistent: no resolvers file at $RESOLVERS_FILE — nothing to check."
+    exit 0
+fi
+location_count=$((location_count + 1))
+
+resolvers_raw="$(grep -iE "status IN \(" "$RESOLVERS_FILE" \
+    | tr "'" ' ' | tr ',' ' ' | tr '(' ' ' | tr ')' ' ' \
+    | grep -oE '(succeeded|failed|crashed|plan_blocked|needs_review)' \
+    | sort -u | tr '\n' ' ' | sed 's/ $//')"
+
+if ! check_equality "resolvers.ts (SQL IN lists)" "$resolvers_raw" "$CANONICAL"; then
+    failures=$((failures + 1))
+    echo "  File: $RESOLVERS_FILE"
+fi
+
+# ─── Step 2c: ui-primitives.tsx — OutcomeStatus union AND OUTCOME_STYLES ──
+if [[ ! -f "$UI_PRIM_FILE" ]]; then
+    echo "check-dispatcher-terminals-consistent: no ui-primitives file at $UI_PRIM_FILE — nothing to check."
+    exit 0
+fi
+location_count=$((location_count + 1))
+
+# Extract OutcomeStatus union members using POSIX awk.
+# Terminated by the first line that ends with ';' after the opening line.
+union_raw="$(awk '
+    /^type OutcomeStatus[[:space:]]*=/ { in_union=1; next }
+    in_union {
+        line = $0
+        # Extract single-quoted token
+        if (sub(/^[^'"'"']*'"'"'/, "", line)) {
+            sub(/'"'"'.*/, "", line)
+            if (length(line) > 0) { print line }
+        }
+        # End: line ends with ;
+        if ($0 ~ /;[[:space:]]*$/) { exit }
+    }
+' "$UI_PRIM_FILE" \
+    | grep -E '^(succeeded|failed|crashed|plan_blocked|needs_review)$' \
+    | sort -u | tr '\n' ' ' | sed 's/ $//')"
+
+if ! check_equality "ui-primitives.tsx (OutcomeStatus union)" "$union_raw" "$CANONICAL"; then
+    failures=$((failures + 1))
+    echo "  File: $UI_PRIM_FILE"
+fi
+
+# Extract OUTCOME_STYLES keys using POSIX awk.
+# Keys are identifiers followed by ':' at first non-space position in the block.
+styles_raw="$(awk '
+    /^const OUTCOME_STYLES/ { in_styles=1; next }
+    in_styles && /^\}/ { exit }
+    in_styles {
+        line = $0
+        # Strip leading whitespace
+        sub(/^[[:space:]]+/, "", line)
+        # Extract identifier before ':'
+        id = line
+        sub(/:.*/, "", id)
+        # Only print identifiers that match lowercase + underscore
+        if (id ~ /^[a-z_]+$/ && length(id) > 0) { print id }
+    }
+' "$UI_PRIM_FILE" \
+    | grep -E '^(succeeded|failed|crashed|plan_blocked|needs_review)$' \
+    | sort -u | tr '\n' ' ' | sed 's/ $//')"
+
+if ! check_equality "ui-primitives.tsx (OUTCOME_STYLES keys)" "$styles_raw" "$CANONICAL"; then
+    failures=$((failures + 1))
+    echo "  File: $UI_PRIM_FILE (OUTCOME_STYLES)"
+fi
+
+# ─── Step 2d: RecentCompletionsPanel.tsx — JSDoc list ─────────────────────
+if [[ ! -f "$COMPLETIONS_FILE" ]]; then
+    echo "check-dispatcher-terminals-consistent: no completions panel file at $COMPLETIONS_FILE — nothing to check."
+    exit 0
+fi
+location_count=$((location_count + 1))
+
+completions_raw="$(grep -E \
+    "(succeeded|failed|crashed|plan_blocked|needs_review).*/.*(succeeded|failed|crashed|plan_blocked|needs_review)" \
+    "$COMPLETIONS_FILE" \
+    | tr '/' ' ' \
+    | grep -oE '(succeeded|failed|crashed|plan_blocked|needs_review)' \
+    | sort -u | tr '\n' ' ' | sed 's/ $//')"
+
+if ! check_equality "RecentCompletionsPanel.tsx (JSDoc)" "$completions_raw" "$CANONICAL"; then
+    failures=$((failures + 1))
+    echo "  File: $COMPLETIONS_FILE"
+fi
+
+# ─── Step 3: Subset check — _write_diagnosis_outcome_for_agent ────────────
+# The explicit correct-outcome tuple inside _write_diagnosis_outcome_for_agent
+# (the ``final_status in (...)`` expression) must only reference terminals
+# that exist in the canonical set.  Catches stale phantom terminals left in
+# the classifier after being removed from the canonical set.
+location_count=$((location_count + 1))
+
+# Use POSIX awk: enter the function body, find the final_status in (...) tuple,
+# extract ALL double-quoted strings from it.  sub() iteratively strips the
+# first "..." token on each pass to handle multiple tokens per line.
+diag_outcome_raw="$(awk '
+    /^    def _write_diagnosis_outcome_for_agent\(/ { in_func=1; next }
+    in_func && /^    def [a-z_]+\(/ { exit }
+    in_func && /final_status in \(/ { in_tuple=1 }
+    in_func && in_tuple {
+        line = $0
+        while (1) {
+            # Try to extract a double-quoted token
+            if (!sub(/^[^"]*"/, "", line)) break
+            tok = line
+            sub(/".*/, "", tok)
+            if (length(tok) > 0) { print tok }
+            sub(/^[^"]*"/, "", line)
+        }
+        # End: closing paren on its own line OR inline single-line form
+        if ($0 ~ /^[[:space:]]*\)/ || ($0 ~ /final_status in \(/ && $0 ~ /\)/)) {
+            in_tuple=0
+        }
+    }
+' "$DAEMON_FILE" | sort -u | tr '\n' ' ' | sed 's/ $//')"
+
+if [[ -n "$diag_outcome_raw" ]]; then
+    phantom_in_diag=""
+    for terminal in $diag_outcome_raw; do
+        found=0
+        for canonical in $CANONICAL; do
+            if [[ "$terminal" = "$canonical" ]]; then found=1; break; fi
+        done
+        if (( found == 0 )); then
+            if [[ -z "$phantom_in_diag" ]]; then
+                phantom_in_diag="$terminal"
+            else
+                phantom_in_diag="$phantom_in_diag $terminal"
+            fi
+        fi
+    done
+    if [[ -n "$phantom_in_diag" ]]; then
+        echo ""
+        echo "  DRIFT: _write_diagnosis_outcome_for_agent correct-outcome tuple contains"
+        echo "  terminal(s) not in the canonical set: $phantom_in_diag"
+        echo "  File: $DAEMON_FILE"
+        echo "  The correct-outcome tuple must only reference terminals from"
+        echo "  the canonical set defined in _mark_agent_terminal."
+        failures=$((failures + 1))
+    fi
+fi
+
+# ─── Step 4: ACTIVE_AGENT_STATUSES validity ───────────────────────────────
+# Every element of ACTIVE_AGENT_STATUSES must be "running", "retrying",
+# or a member of the canonical set.
+location_count=$((location_count + 1))
+
+active_raw="$(grep -E '^ACTIVE_AGENT_STATUSES[[:space:]]*=' "$DAEMON_FILE" \
+    | tr "'" '"' \
+    | grep -oE '"[a-z_]+"' \
+    | tr -d '"' \
+    | sort -u | tr '\n' ' ' | sed 's/ $//')"
+
+if [[ -n "$active_raw" ]]; then
+    bad_active=""
+    for tok in $active_raw; do
+        valid=0
+        if [[ "$tok" = "running" || "$tok" = "retrying" ]]; then
+            valid=1
+        else
+            for canonical in $CANONICAL; do
+                if [[ "$tok" = "$canonical" ]]; then
+                    valid=1
+                    break
+                fi
+            done
+        fi
+        if (( valid == 0 )); then
+            if [[ -z "$bad_active" ]]; then
+                bad_active="$tok"
+            else
+                bad_active="$bad_active $tok"
+            fi
+        fi
+    done
+    if [[ -n "$bad_active" ]]; then
+        echo ""
+        echo "  DRIFT: ACTIVE_AGENT_STATUSES contains unknown status(es): $bad_active"
+        echo "  Each element must be 'running', 'retrying', or a member of the"
+        echo "  canonical terminal set ($CANONICAL)."
+        echo "  File: $DAEMON_FILE"
+        failures=$((failures + 1))
+    fi
+fi
+
+# ─── Final verdict ────────────────────────────────────────────────────────
+if (( failures > 0 )); then
+    echo ""
+    echo "ERROR: check-dispatcher-terminals-consistent: $failures location(s) are out of sync."
+    echo ""
+    echo "  Canonical set ($CANONICAL_COUNT terminals): $CANONICAL"
+    echo "  Source: $DAEMON_FILE"
+    echo "         _mark_agent_terminal — terminal = status in (...)"
+    echo ""
+    echo "  Fix: update every flagged location to match the canonical set."
+    echo "  The canonical source is the tuple in _mark_agent_terminal."
+    exit 1
+fi
+
+echo "check-dispatcher-terminals-consistent: $CANONICAL_COUNT terminal(s) aligned across $location_count location(s)."
+exit 0

--- a/scripts/tests/test_check_dispatcher_terminals_consistent.sh
+++ b/scripts/tests/test_check_dispatcher_terminals_consistent.sh
@@ -1,0 +1,539 @@
+#!/usr/bin/env bash
+# test_check_dispatcher_terminals_consistent.sh — Tests for
+# scripts/check-dispatcher-terminals-consistent.sh
+#
+# Verifies that the checker:
+#   (1) passes when all seven locations carry the canonical terminal set
+#   (2) fails when any of the four cross-language locations has a drift
+#       (schema.ts, resolvers.ts, ui-primitives.tsx, RecentCompletionsPanel.tsx)
+#   (3) fails when daemon.py's _write_diagnosis_outcome_for_agent
+#       correct-outcome tuple references a non-canonical terminal
+#   (4) passes on the real repo files
+#   (5) the guard's own CI step name does not contain a literal terminal string
+#
+# Usage:
+#   scripts/tests/test_check_dispatcher_terminals_consistent.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-dispatcher-terminals-consistent.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+write_file() {
+    local path="$TMPDIR_TEST/$1"
+    mkdir -p "$(dirname "$path")"
+    cat > "$path"
+}
+
+# assert_passes_files — run the guard with 5 explicit file paths.
+# Usage: assert_passes_files "description" daemon schema resolvers ui_prim completions
+assert_passes_files() {
+    local desc="$1"
+    local d="$2" s="$3" r="$4" u="$5" c="$6"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$d" "$s" "$r" "$u" "$c" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        "$CHECK_SCRIPT" "$d" "$s" "$r" "$u" "$c" 2>&1 | sed 's/^/    /'
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# assert_fails_files — run the guard with 5 explicit file paths.
+# Usage: assert_fails_files "description" daemon schema resolvers ui_prim completions
+assert_fails_files() {
+    local desc="$1"
+    local d="$2" s="$3" r="$4" u="$5" c="$6"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$d" "$s" "$r" "$u" "$c" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+# assert_passes / assert_fails — run the guard with TMPDIR_TEST as the daemon
+# file argument.  Used by the self-match helper which calls assert_passes with
+# only a description.  The guard exits 0 when the daemon file is missing
+# (fast skip), so using a non-existent path from TMPDIR_TEST is fine here.
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    # Pass a non-existent daemon path so the guard fast-exits 0.
+    # The self-match helper only needs assert_passes to not fail —
+    # the guard does not scan ci.yml step names for terminal strings.
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST/__nofile__.py" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        "$CHECK_SCRIPT" "$TMPDIR_TEST/__nofile__.py" 2>&1 | sed 's/^/    /'
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST/__nofile__.py" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Synthetic fixture helpers ────────────────────────────────────────────
+
+# Write a canonical daemon.py fixture with all 5 terminals in both
+# _mark_agent_terminal and _write_diagnosis_outcome_for_agent.
+write_daemon() {
+    write_file "daemon.py" <<'EOF'
+class Dispatcher:
+    def _mark_agent_terminal(self, agent_id, status):
+        """Mark an agent as terminal."""
+        terminal = status in (
+            "succeeded",
+            "failed",
+            "crashed",
+            "plan_blocked",
+            "needs_review",
+        )
+        return terminal
+
+    def _write_diagnosis_outcome_for_agent(self, agent_id, final_status):
+        """Write back the resolved outcome to pending diagnoser rows.
+
+        Updates dispatcher.diagnoses.outcome with shape:
+            {"retry_outcome": "succeeded" | "failed", "final_status": ...}
+        """
+        # plan_blocked and needs_review are correct-outcome terminals.
+        retry_outcome = (
+            "succeeded"
+            if final_status in ("succeeded", "plan_blocked", "needs_review")
+            else "failed"
+        )
+        return retry_outcome
+
+ACTIVE_AGENT_STATUSES = ("running", "retrying", "succeeded", "needs_review")
+EOF
+}
+
+# Write a canonical schema.ts fixture.
+write_schema() {
+    write_file "schema.ts" <<'EOF'
+"""
+DispatcherAgent.status field.
+One of running | succeeded | failed | retrying | crashed | plan_blocked | needs_review.
+"""
+const schemaA = true;
+
+"""
+RecentCompletion.status field.
+One of succeeded | failed | crashed | plan_blocked | needs_review.
+See DispatcherAgent.status for semantics.
+"""
+const schemaB = true;
+
+"""
+Rows from dispatcher.agents where status IN
+('succeeded','failed','crashed','plan_blocked','needs_review')
+ordered by ended_at DESC.
+"""
+const schemaC = true;
+
+"""
+Recently terminal agents (succeeded | failed | crashed | plan_blocked | needs_review)
+fetched from dispatcher.agents.
+"""
+const schemaD = true;
+EOF
+}
+
+# Write a canonical resolvers.ts fixture.
+write_resolvers() {
+    write_file "resolvers.ts" <<'EOF'
+async function queryRecentCompletions(pool) {
+  const { rows } = await pool.query(
+    `SELECT * FROM dispatcher.agents
+      WHERE a.status IN ('succeeded', 'failed', 'crashed', 'plan_blocked', 'needs_review')
+        AND a.ended_at IS NOT NULL`
+  );
+  return rows;
+}
+
+async function queryRecentCompletionsCount(pool) {
+  const { rows } = await pool.query(
+    `SELECT COUNT(*) FROM dispatcher.agents
+      WHERE status IN ('succeeded', 'failed', 'crashed', 'plan_blocked', 'needs_review')
+        AND ended_at IS NOT NULL`
+  );
+  return rows;
+}
+EOF
+}
+
+# Write a canonical ui-primitives.tsx fixture.
+write_ui_prim() {
+    write_file "ui-primitives.tsx" <<'EOF'
+type OutcomeStatus =
+  | 'succeeded'
+  | 'failed'
+  | 'crashed'
+  | 'plan_blocked'
+  | 'needs_review';
+
+const OUTCOME_STYLES: Record<
+  OutcomeStatus,
+  { glyph: string; className: string; label: string }
+> = {
+  succeeded: {
+    glyph: '\u2713',
+    className: 'bg-green-100',
+    label: 'succeeded',
+  },
+  failed: {
+    glyph: '\u2717',
+    className: 'bg-red-100',
+    label: 'failed',
+  },
+  crashed: {
+    glyph: '\u26A0',
+    className: 'bg-amber-100',
+    label: 'crashed',
+  },
+  plan_blocked: {
+    glyph: '\u2298',
+    className: 'bg-muted',
+    label: 'plan blocked',
+  },
+  needs_review: {
+    glyph: '\u25D0',
+    className: 'bg-yellow-100',
+    label: 'needs review',
+  },
+};
+EOF
+}
+
+# Write a canonical RecentCompletionsPanel.tsx fixture.
+write_completions() {
+    write_file "completions.tsx" <<'EOF'
+/**
+ * The "Recently completed" panel. Newest terminal-state agents
+ * (succeeded / failed / crashed / plan_blocked / needs_review) in
+ * the operator's recent history.
+ */
+export function RecentCompletionsPanel() {
+  return null;
+}
+EOF
+}
+
+# ─── Test 1: Happy path — all canonical fixtures pass ────────────────────
+write_daemon
+write_schema
+write_resolvers
+write_ui_prim
+write_completions
+assert_passes_files "Happy path: all locations canonical" \
+    "$TMPDIR_TEST/daemon.py" \
+    "$TMPDIR_TEST/schema.ts" \
+    "$TMPDIR_TEST/resolvers.ts" \
+    "$TMPDIR_TEST/ui-primitives.tsx" \
+    "$TMPDIR_TEST/completions.tsx"
+reset_tmpdir
+
+# ─── Test 2: schema.ts drift — remove a terminal from docstrings ─────────
+write_daemon
+write_schema
+write_resolvers
+write_ui_prim
+write_completions
+# Overwrite schema.ts with a version missing 'crashed'
+write_file "schema.ts" <<'EOF'
+"""
+One of running | succeeded | failed | retrying | plan_blocked | needs_review.
+"""
+const schemaA = true;
+
+"""
+One of succeeded | failed | plan_blocked | needs_review.
+"""
+const schemaB = true;
+
+"""
+status IN ('succeeded','failed','plan_blocked','needs_review')
+"""
+const schemaC = true;
+
+"""
+terminal agents (succeeded | failed | plan_blocked | needs_review)
+"""
+const schemaD = true;
+EOF
+assert_fails_files "schema.ts drift: missing a terminal from docstrings fails" \
+    "$TMPDIR_TEST/daemon.py" \
+    "$TMPDIR_TEST/schema.ts" \
+    "$TMPDIR_TEST/resolvers.ts" \
+    "$TMPDIR_TEST/ui-primitives.tsx" \
+    "$TMPDIR_TEST/completions.tsx"
+reset_tmpdir
+
+# ─── Test 3: resolvers.ts drift — remove a terminal from SQL IN list ─────
+write_daemon
+write_schema
+write_resolvers
+write_ui_prim
+write_completions
+# Overwrite resolvers.ts missing 'plan_blocked' from the SQL IN clause
+write_file "resolvers.ts" <<'EOF'
+async function queryRecentCompletions(pool) {
+  const { rows } = await pool.query(
+    `SELECT * FROM dispatcher.agents
+      WHERE a.status IN ('succeeded', 'failed', 'crashed', 'needs_review')
+        AND a.ended_at IS NOT NULL`
+  );
+  return rows;
+}
+
+async function queryRecentCompletionsCount(pool) {
+  const { rows } = await pool.query(
+    `SELECT COUNT(*) FROM dispatcher.agents
+      WHERE status IN ('succeeded', 'failed', 'crashed', 'needs_review')
+        AND ended_at IS NOT NULL`
+  );
+  return rows;
+}
+EOF
+assert_fails_files "resolvers.ts drift: missing terminal from SQL IN list fails" \
+    "$TMPDIR_TEST/daemon.py" \
+    "$TMPDIR_TEST/schema.ts" \
+    "$TMPDIR_TEST/resolvers.ts" \
+    "$TMPDIR_TEST/ui-primitives.tsx" \
+    "$TMPDIR_TEST/completions.tsx"
+reset_tmpdir
+
+# ─── Test 4: ui-primitives.tsx drift — remove a terminal from OutcomeStatus ──
+write_daemon
+write_schema
+write_resolvers
+write_ui_prim
+write_completions
+# Overwrite ui-primitives.tsx missing 'needs_review' from OutcomeStatus union
+write_file "ui-primitives.tsx" <<'EOF'
+type OutcomeStatus =
+  | 'succeeded'
+  | 'failed'
+  | 'crashed'
+  | 'plan_blocked';
+
+const OUTCOME_STYLES: Record<
+  OutcomeStatus,
+  { glyph: string; className: string; label: string }
+> = {
+  succeeded: {
+    glyph: '\u2713',
+    className: 'bg-green-100',
+    label: 'succeeded',
+  },
+  failed: {
+    glyph: '\u2717',
+    className: 'bg-red-100',
+    label: 'failed',
+  },
+  crashed: {
+    glyph: '\u26A0',
+    className: 'bg-amber-100',
+    label: 'crashed',
+  },
+  plan_blocked: {
+    glyph: '\u2298',
+    className: 'bg-muted',
+    label: 'plan blocked',
+  },
+};
+EOF
+assert_fails_files "ui-primitives.tsx drift: missing terminal from OutcomeStatus fails" \
+    "$TMPDIR_TEST/daemon.py" \
+    "$TMPDIR_TEST/schema.ts" \
+    "$TMPDIR_TEST/resolvers.ts" \
+    "$TMPDIR_TEST/ui-primitives.tsx" \
+    "$TMPDIR_TEST/completions.tsx"
+reset_tmpdir
+
+# ─── Test 5: RecentCompletionsPanel.tsx drift — remove terminal from JSDoc ──
+write_daemon
+write_schema
+write_resolvers
+write_ui_prim
+write_completions
+# Overwrite completions.tsx missing 'failed' from JSDoc status list
+write_file "completions.tsx" <<'EOF'
+/**
+ * The "Recently completed" panel. Newest terminal-state agents
+ * (succeeded / crashed / plan_blocked / needs_review) in
+ * the operator's recent history.
+ */
+export function RecentCompletionsPanel() {
+  return null;
+}
+EOF
+assert_fails_files "RecentCompletionsPanel.tsx drift: missing terminal from JSDoc fails" \
+    "$TMPDIR_TEST/daemon.py" \
+    "$TMPDIR_TEST/schema.ts" \
+    "$TMPDIR_TEST/resolvers.ts" \
+    "$TMPDIR_TEST/ui-primitives.tsx" \
+    "$TMPDIR_TEST/completions.tsx"
+reset_tmpdir
+
+# ─── Test 6: _write_diagnosis_outcome_for_agent has a non-canonical terminal ──
+# If a terminal that was removed from _mark_agent_terminal is still in
+# the correct-outcome tuple of _write_diagnosis_outcome_for_agent, the check
+# should fail (phantom terminal in the classifier).
+write_schema
+write_resolvers
+write_ui_prim
+write_completions
+# Write daemon.py with 5 canonical terminals in _mark_agent_terminal,
+# but _write_diagnosis_outcome_for_agent has a stale "timed_out" terminal
+# in the correct-outcome tuple that does NOT exist in canonical.
+write_file "daemon.py" <<'EOF'
+class Dispatcher:
+    def _mark_agent_terminal(self, agent_id, status):
+        """Mark an agent as terminal."""
+        terminal = status in (
+            "succeeded",
+            "failed",
+            "crashed",
+            "plan_blocked",
+            "needs_review",
+        )
+        return terminal
+
+    def _write_diagnosis_outcome_for_agent(self, agent_id, final_status):
+        """Write back the resolved outcome.
+
+        {"retry_outcome": "succeeded" | "failed", "final_status": ...}
+        """
+        # timed_out was once a correct-outcome terminal but was removed
+        # from the canonical set — this tuple is now stale.
+        retry_outcome = (
+            "succeeded"
+            if final_status in ("succeeded", "plan_blocked", "needs_review", "timed_out")
+            else "failed"
+        )
+        return retry_outcome
+
+ACTIVE_AGENT_STATUSES = ("running", "retrying", "succeeded", "needs_review")
+EOF
+assert_fails_files "Non-canonical terminal in _write_diagnosis_outcome_for_agent fails" \
+    "$TMPDIR_TEST/daemon.py" \
+    "$TMPDIR_TEST/schema.ts" \
+    "$TMPDIR_TEST/resolvers.ts" \
+    "$TMPDIR_TEST/ui-primitives.tsx" \
+    "$TMPDIR_TEST/completions.tsx"
+reset_tmpdir
+
+# ─── Test 7: ACTIVE_AGENT_STATUSES contains an unknown status ────────────
+write_schema
+write_resolvers
+write_ui_prim
+write_completions
+# Write daemon.py with a stray/unknown status in ACTIVE_AGENT_STATUSES
+write_file "daemon.py" <<'EOF'
+class Dispatcher:
+    def _mark_agent_terminal(self, agent_id, status):
+        """Mark an agent as terminal."""
+        terminal = status in (
+            "succeeded",
+            "failed",
+            "crashed",
+            "plan_blocked",
+            "needs_review",
+        )
+        return terminal
+
+    def _write_diagnosis_outcome_for_agent(self, agent_id, final_status):
+        """Write back the resolved outcome.
+
+        {"retry_outcome": "succeeded" | "failed", "final_status": ...}
+        """
+        retry_outcome = (
+            "succeeded"
+            if final_status in ("succeeded", "plan_blocked", "needs_review")
+            else "failed"
+        )
+        return retry_outcome
+
+ACTIVE_AGENT_STATUSES = ("running", "retrying", "succeeded", "needs_review", "pending")
+EOF
+assert_fails_files "ACTIVE_AGENT_STATUSES with unknown status fails" \
+    "$TMPDIR_TEST/daemon.py" \
+    "$TMPDIR_TEST/schema.ts" \
+    "$TMPDIR_TEST/resolvers.ts" \
+    "$TMPDIR_TEST/ui-primitives.tsx" \
+    "$TMPDIR_TEST/completions.tsx"
+reset_tmpdir
+
+# ─── Test 8: Missing daemon file exits 0 (nothing to check) ──────────────
+write_schema
+write_resolvers
+write_ui_prim
+write_completions
+# Pass a non-existent daemon path — guard should exit 0 (fast skip).
+assert_passes_files "Missing daemon.py exits 0 cleanly" \
+    "$TMPDIR_TEST/does_not_exist.py" \
+    "$TMPDIR_TEST/schema.ts" \
+    "$TMPDIR_TEST/resolvers.ts" \
+    "$TMPDIR_TEST/ui-primitives.tsx" \
+    "$TMPDIR_TEST/completions.tsx"
+reset_tmpdir
+
+# ─── Test 9: Real repo files pass ────────────────────────────────────────
+REAL_DAEMON="$REPO_ROOT/scripts/dispatcher/daemon.py"
+REAL_SCHEMA="$REPO_ROOT/packages/api/src/graphql/dispatcher/schema.ts"
+REAL_RESOLVERS="$REPO_ROOT/packages/api/src/graphql/dispatcher/resolvers.ts"
+REAL_UI_PRIM="$REPO_ROOT/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx"
+REAL_COMPLETIONS="$REPO_ROOT/packages/web/src/app/(main)/admin/dispatcher/RecentCompletionsPanel.tsx"
+if [[ -f "$REAL_DAEMON" && -f "$REAL_SCHEMA" && -f "$REAL_RESOLVERS" && -f "$REAL_UI_PRIM" && -f "$REAL_COMPLETIONS" ]]; then
+    assert_passes_files "Real repo files: all locations consistent" \
+        "$REAL_DAEMON" "$REAL_SCHEMA" "$REAL_RESOLVERS" "$REAL_UI_PRIM" "$REAL_COMPLETIONS"
+fi
+
+# ─── Test 10: No self-match on ci.yml step name ──────────────────────────
+# The step name in .github/workflows/ci.yml that runs this guard must
+# not itself contain the terminal string literals (succeeded / failed /
+# crashed / plan_blocked / needs_review) which would trip the guard.
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-dispatcher-terminals-consistent.sh" "yml"
+
+# ─── Summary ──────────────────────────────────────────────────────────────
+echo ""
+if (( FAILURES > 0 )); then
+    echo "$FAILURES of $TESTS tests FAILED"
+    exit 1
+fi
+echo "all $TESTS tests passed"
+exit 0

--- a/scripts/tests/test_check_dispatcher_terminals_consistent.sh
+++ b/scripts/tests/test_check_dispatcher_terminals_consistent.sh
@@ -108,16 +108,14 @@ reset_tmpdir() {
 # _mark_agent_terminal and _write_diagnosis_outcome_for_agent.
 write_daemon() {
     write_file "daemon.py" <<'EOF'
+TERMINAL_AGENT_STATUSES: frozenset[str] = frozenset(
+    {"succeeded", "failed", "crashed", "plan_blocked", "needs_review"}
+)
+
 class Dispatcher:
     def _mark_agent_terminal(self, agent_id, status):
         """Mark an agent as terminal."""
-        terminal = status in (
-            "succeeded",
-            "failed",
-            "crashed",
-            "plan_blocked",
-            "needs_review",
-        )
+        terminal = status in TERMINAL_AGENT_STATUSES
         return terminal
 
     def _write_diagnosis_outcome_for_agent(self, agent_id, final_status):
@@ -193,14 +191,18 @@ EOF
 }
 
 # Write a canonical ui-primitives.tsx fixture.
+# Uses the real pattern: TERMINAL_AGENT_STATUSES array + derived OutcomeStatus type.
 write_ui_prim() {
     write_file "ui-primitives.tsx" <<'EOF'
-type OutcomeStatus =
-  | 'succeeded'
-  | 'failed'
-  | 'crashed'
-  | 'plan_blocked'
-  | 'needs_review';
+const TERMINAL_AGENT_STATUSES = [
+  'succeeded',
+  'failed',
+  'crashed',
+  'plan_blocked',
+  'needs_review',
+] as const;
+
+type OutcomeStatus = (typeof TERMINAL_AGENT_STATUSES)[number];
 
 const OUTCOME_STYLES: Record<
   OutcomeStatus,
@@ -333,19 +335,22 @@ assert_fails_files "resolvers.ts drift: missing terminal from SQL IN list fails"
     "$TMPDIR_TEST/completions.tsx"
 reset_tmpdir
 
-# ─── Test 4: ui-primitives.tsx drift — remove a terminal from OutcomeStatus ──
+# ─── Test 4: ui-primitives.tsx drift — remove a terminal from TERMINAL_AGENT_STATUSES ──
 write_daemon
 write_schema
 write_resolvers
 write_ui_prim
 write_completions
-# Overwrite ui-primitives.tsx missing 'needs_review' from OutcomeStatus union
+# Overwrite ui-primitives.tsx missing 'needs_review' from TERMINAL_AGENT_STATUSES array
 write_file "ui-primitives.tsx" <<'EOF'
-type OutcomeStatus =
-  | 'succeeded'
-  | 'failed'
-  | 'crashed'
-  | 'plan_blocked';
+const TERMINAL_AGENT_STATUSES = [
+  'succeeded',
+  'failed',
+  'crashed',
+  'plan_blocked',
+] as const;
+
+type OutcomeStatus = (typeof TERMINAL_AGENT_STATUSES)[number];
 
 const OUTCOME_STYLES: Record<
   OutcomeStatus,
@@ -418,16 +423,14 @@ write_completions
 # but _write_diagnosis_outcome_for_agent has a stale "timed_out" terminal
 # in the correct-outcome tuple that does NOT exist in canonical.
 write_file "daemon.py" <<'EOF'
+TERMINAL_AGENT_STATUSES: frozenset[str] = frozenset(
+    {"succeeded", "failed", "crashed", "plan_blocked", "needs_review"}
+)
+
 class Dispatcher:
     def _mark_agent_terminal(self, agent_id, status):
         """Mark an agent as terminal."""
-        terminal = status in (
-            "succeeded",
-            "failed",
-            "crashed",
-            "plan_blocked",
-            "needs_review",
-        )
+        terminal = status in TERMINAL_AGENT_STATUSES
         return terminal
 
     def _write_diagnosis_outcome_for_agent(self, agent_id, final_status):
@@ -461,16 +464,14 @@ write_ui_prim
 write_completions
 # Write daemon.py with a stray/unknown status in ACTIVE_AGENT_STATUSES
 write_file "daemon.py" <<'EOF'
+TERMINAL_AGENT_STATUSES: frozenset[str] = frozenset(
+    {"succeeded", "failed", "crashed", "plan_blocked", "needs_review"}
+)
+
 class Dispatcher:
     def _mark_agent_terminal(self, agent_id, status):
         """Mark an agent as terminal."""
-        terminal = status in (
-            "succeeded",
-            "failed",
-            "crashed",
-            "plan_blocked",
-            "needs_review",
-        )
+        terminal = status in TERMINAL_AGENT_STATUSES
         return terminal
 
     def _write_diagnosis_outcome_for_agent(self, agent_id, final_status):


### PR DESCRIPTION
## Summary

Fixed the canonical-set extractor in `check-dispatcher-terminals-consistent.sh` to read from the real `TERMINAL_AGENT_STATUSES: frozenset[str]` pattern instead of the legacy tuple form. Updated test fixtures to match, fixed graceful skipping for constant-based SQL resolvers, and updated the ui-primitives check to extract from the array. All tests pass on the current codebase.

Closes #2870

## Test plan

### Automated checks

- [ ] Lint passes (`ruff check` / `npm run lint`)
- [ ] Format check passes (`ruff format --check` / prettier)
- [ ] Tests pass (`pytest` / `npm test`)
- [ ] CI green

### Post-deploy verification

- [ ] N/A — no deployed component (scripts / CI tooling / dx only)