### PR TITLE
obs(dispatcher): CloudWatch alarms for stuck_timeout + diagnoser_fallback (#2878)

### DIFF
--- a/docs/specs/dispatcher-v2-spec.md
+++ b/docs/specs/dispatcher-v2-spec.md
@@ -31,7 +31,7 @@
 3. **Runtime signals over post-hoc classification.** Failures are labeled by cheap deterministic signals (hooks, exit codes, timeouts). Weekly summaries are SQL aggregations, not LLM transcript reviews.
 4. **Retry markers, not retry RPCs.** Hooks and sub-subprocesses signal the daemon by writing rows (`dispatcher.failures`, `dispatcher.retry_markers`), never by calling back. Survives any crash.
 5. **Fail to escalate, not to silent drop.** After the retry budget is exhausted, the task gets `status/needs-human` and a Telegram message with the issue URL. Nothing quietly vanishes.
-6. **No LLM subprocess spans more than one workflow phase.** Each `claude -p` invocation runs one tightly-scoped phase (plan, implement, summarize, verify, etc.) with fresh context. Inter-phase handoff is strictly via `dispatcher.*` + small file artifacts the next phase reads. This is what lets us live without auto-compact in print mode (see §17 Risk 4b) and keeps every leaf LLM call small, reproducible, and replayable.
+6. **No LLM subprocess spans more than one workflow phase.** Each `claude -p` invocation runs one tightly-scoped phase (plan, implement, summarize, verify, etc.) with fresh context. Inter-phase handoff is strictly via `dispatcher.*` + small file artifacts the next phase reads. This is what lets us live without auto-compact in print mode (see §18 Risk 4b) and keeps every leaf LLM call small, reproducible, and replayable.
 
 ## 4. Architecture Overview
 
@@ -153,7 +153,7 @@ Every step is a single SQL transaction or idempotent git/gh call. Crash at any p
 
 ### 6a. Per-phase skills (`/task-v2-*`)
 
-New skills in .claude/skills/task-v2-\*/SKILL.md, each narrowly scoped to one phase. The original `/task` skill is unchanged and remains the laptop-dispatcher's execution path. Cutover and eventual deletion of `/task` is a manual follow-up after v2 proves itself (same pattern as `/dispatcher` — see §15).
+New skills in .claude/skills/task-v2-\*/SKILL.md, each narrowly scoped to one phase. The original `/task` skill is unchanged and remains the laptop-dispatcher's execution path. Cutover and eventual deletion of `/task` is a manual follow-up after v2 proves itself (same pattern as `/dispatcher` — see §16).
 
 | Skill | Input | Output | Typical context budget |
 |---|---|---|---|
@@ -487,7 +487,7 @@ Rationale: MCP tools are a Claude Code feature — they exist inside an active C
 
 Any new escalation path added later MUST extend the table in (A) with its own issue/PR URL — "something needs human attention" and "no link to act on" are incompatible.
 
-**Implementation:** ~20 lines of `httpx.post("https://api.telegram.org/bot<TOKEN>/sendMessage", json={...})`. Chat ID stored in `dispatcher.config.telegram_chat_id`. Bot token from Secrets Manager. Send failures are logged and swallowed — Telegram outages must never block the scheduler. Messages are persisted to `dispatcher.notifications` (schema TBD in §18) so we can reconstruct the escalation history even when Telegram is down.
+**Implementation:** ~20 lines of `httpx.post("https://api.telegram.org/bot<TOKEN>/sendMessage", json={...})`. Chat ID stored in `dispatcher.config.telegram_chat_id`. Bot token from Secrets Manager. Send failures are logged and swallowed — Telegram outages must never block the scheduler. Messages are persisted to `dispatcher.notifications` (schema TBD in §19) so we can reconstruct the escalation history even when Telegram is down.
 
 **If interactive chat becomes useful later:** the user opens a Claude Code session locally, points it at the same GraphQL, and reasons about state naturally. No always-on Claude process required, no MCP-in-container puzzle, no per-message LLM spend.
 
@@ -512,11 +512,49 @@ Terraform module `infra/terraform/modules/dispatcher-daemon/`:
 
 Prod deployment is out of scope for v1 — dev daemon handles both repos (same dev DB, same worktrees) until we prove stability.
 
-## 15. Migration Plan
+## 15. Observability
 
-**Throughout migration: both the laptop `/dispatcher` skill AND the original `/task` skill stay untouched.** They are the rollback target for every phase. Do not mark either deprecated, do not remove them from the skills index, do not rewrite CLAUDE.md to remove references. The new per-phase skills are created alongside under new names (`/task-v2-plan`, `/task-v2-ralph`, etc.) so the existing interactive loop continues working unchanged while v2 is brought up. Once v2 has proven itself in full production (post-Phase 4, measured against §16), the operator deletes the old skills manually as a standalone follow-up — not as part of these migration PRs.
+Three CloudWatch alarms are wired in `infra/terraform/modules/dispatcher-daemon/main.tf`, all gated on `var.enable_alerts` and routed to `var.alert_sns_topic_arn` (email + Telegram).
 
-**Phase 0 outcome — all 7 spikes returned GO.** The Phase 0 spikes ran in parallel over ~1 week and together de-risked the full architecture; every reasoned-but-untested claim in §4, §6, §7, §9, §14, and §17 now has empirical or analytical backing. The verdicts:
+### 15.1 Heartbeat staleness (see §14)
+
+| Field | Value |
+|---|---|
+| Metric | `HeartbeatAge` (Maximum) in `Judgemind/Dispatcher` |
+| Window / period | 60s × 5 consecutive evaluations |
+| Threshold | > `var.heartbeat_stale_seconds` (default 300 s) |
+| `treat_missing_data` | `notBreaching` — silence does not alarm during Phase 1 (daemon off) |
+
+Source: daemon emits `HeartbeatAge` via `_emit_heartbeat_metric` every supervisor tick.
+
+### 15.2 Stuck-timeout repeated
+
+| Field | Value |
+|---|---|
+| Metric | `StuckTimeoutRepeatedCount` (Sum) in `Judgemind/Dispatcher` |
+| Window / period | `var.stuck_timeout_repeated_window_seconds` (default 600 s) |
+| Threshold | ≥ 1 |
+| `treat_missing_data` | `notBreaching` |
+
+**Why a daemon-side signal, not a raw metric filter on `failure_detected`.**
+CloudWatch metric filters cannot express "same `agent_id`, count ≥ 2 in 10 min" without per-dimension math alarms (which require a static dimension set). Instead, the daemon's `_flag_stuck_agents` calls `_has_prior_stuck_timeout_in_window` after each `stuck_timeout` write; if a prior failure exists within 600 s it emits a dedicated `{ "event": "stuck_timeout_repeated", ... }` structured-log line. The metric filter counts those directly. Future editors: do not replace this with a filter on `failure_detected` — the per-agent check is load-bearing.
+
+### 15.3 Diagnoser fallback spike
+
+| Field | Value |
+|---|---|
+| Metric | `DiagnoserFallbackCount` (Sum) in `Judgemind/Dispatcher` |
+| Window / period | `var.diagnoser_fallback_window_seconds` (default 1800 s) |
+| Threshold | ≥ `var.diagnoser_fallback_threshold` (default 2) |
+| `treat_missing_data` | `notBreaching` |
+
+Source: daemon emits `{ "event": "diagnoser_fallback", ... }` whenever the diagnoser subprocess times out, returns non-zero, or produces malformed JSON and the mechanical escalation fallback fires instead. An isolated fallback is expected (transient timeout, model hiccup); ≥ 2 in 30 min indicates a systematic problem.
+
+## 16. Migration Plan
+
+**Throughout migration: both the laptop `/dispatcher` skill AND the original `/task` skill stay untouched.** They are the rollback target for every phase. Do not mark either deprecated, do not remove them from the skills index, do not rewrite CLAUDE.md to remove references. The new per-phase skills are created alongside under new names (`/task-v2-plan`, `/task-v2-ralph`, etc.) so the existing interactive loop continues working unchanged while v2 is brought up. Once v2 has proven itself in full production (post-Phase 4, measured against §17), the operator deletes the old skills manually as a standalone follow-up — not as part of these migration PRs.
+
+**Phase 0 outcome — all 7 spikes returned GO.** The Phase 0 spikes ran in parallel over ~1 week and together de-risked the full architecture; every reasoned-but-untested claim in §4, §6, §7, §9, §14, and §18 now has empirical or analytical backing. The verdicts:
 
 - **0.1 — `claude -p` end-to-end on Fargate: GO** (`docs/investigations/dispatcher-v2-spike-0.1.md`, #2683). All 4 scenarios (success, turn-limit, auth-fail, mcp-probe) booted and ran on Fargate in ~60s wall-clock; MCP tools propagate via explicit `--mcp-config`; one caveat (exit code 1 is ambiguous between auth-fail and turn-limit) folded into §8 as the tiered classifier.
 - **0.2 — Hook → Postgres from a `claude -p` subprocess: GO** (`docs/investigations/dispatcher-v2-spike-0.2.md`, #2684). `emit_failure.py` direct-insert design validated at p50=179 ms / p95=200 ms / max=202 ms across 20 cold-connection hook fires; zero failed inserts; graceful fail-mode when DB is unreachable.
@@ -526,7 +564,7 @@ Prod deployment is out of scope for v1 — dev daemon handles both repos (same d
 - **0.6 — Worktree footprint at peak concurrency: GO** (`docs/investigations/dispatcher-v2-spike-0.6.md`, #2688). Typical 5-worktree Python load is ~3.4 GB; realistic mixed peak is ~10 GB; adversarial worst case 19.6 GB. 50 GB ephemeral storage (already budgeted in §14) gives 5× headroom on the realistic peak. No EFS, no shared venvs, no change from spec.
 - **0.7 — Git + GitHub auth from Fargate: GO** (`docs/investigations/dispatcher-v2-spike-0.7.md`, #2689). Scoped PAT in Secrets Manager → `GITHUB_TOKEN` env var → `gh auth setup-git` → `git push` / `gh pr create` / `gh pr close` / `scripts/check-issue-author.sh` all succeed from inside the container. No GitHub App registration required for v1.
 
-Phase 1 can begin without revisiting any Phase 0 question; the remaining §17 Open Questions are non-blocking (cost projection, diagnoser effectiveness — both measurable only post-launch).
+Phase 1 can begin without revisiting any Phase 0 question; the remaining §18 Open Questions are non-blocking (cost projection, diagnoser effectiveness — both measurable only post-launch).
 
 **Phase 0: Spikes (parallel PRs, ~1 week).** Seven time-boxed experiments that verify the spec's reasoned-but-untested claims before any scaffolding lands. Failures here reshape the design, not just the schedule.
 
@@ -545,11 +583,11 @@ Sequence: 0.1 → 0.2 → 0.3 in series (each gates the next). 0.4–0.7 can run
 **Deferred spikes** (not blocking Phase 1):
 - Cursor `-p` hang-bug repro — only matters if/when we add a Cursor runner.
 - OpenCode hook DB-connection spike — only matters if/when we add an OpenCode runner.
-- Diagnoser effectiveness measurement — can only be measured post-launch over weeks (already Open Question 5 in §17).
+- Diagnoser effectiveness measurement — can only be measured post-launch over weeks (already Open Question 5 in §18).
 - Admin-page GraphQL authz — piggybacks on existing web app auth; no novel surface.
-- Cost projection — covered as Open Question 4 in §17; informational, not a design gate.
+- Cost projection — covered as Open Question 4 in §18; informational, not a design gate.
 
-Phase 0 does not require its own infrastructure — spikes run in the existing dev account using throwaway Fargate tasks, throwaway schema (`dispatcher_spike.*`), and a single test issue labeled `type/spike`. Every spike produces either a "go" note on the corresponding §17 Open Question or a design-change proposal.
+Phase 0 does not require its own infrastructure — spikes run in the existing dev account using throwaway Fargate tasks, throwaway schema (`dispatcher_spike.*`), and a single test issue labeled `type/spike`. Every spike produces either a "go" note on the corresponding §18 Open Question or a design-change proposal.
 
 **Phase 1: Scaffolding (1 PR, or a small series).**
 - New `dispatcher.*` schema via migration.
@@ -579,7 +617,7 @@ Gate: ≥10 successful task completions via the daemon; zero stuck agents; all r
 
 Rollback plan: any phase can revert by scaling ECS to 0 and invoking laptop `/dispatcher` + original `/task` as normal. State in `dispatcher.*` is read-only in that mode.
 
-## 16. Success Criteria
+## 17. Success Criteria
 
 - Daemon runs ≥14 days with no human intervention. Any intervention is a bug.
 - Retries resolve ≥80% of transient failures (stuck, 529, cwd drift) without human touch.
@@ -587,7 +625,7 @@ Rollback plan: any phase can revert by scaling ECS to 0 and invoking laptop `/di
 - Admin page answers "what is the dispatcher doing right now" in under 2s.
 - Weekly SQL-based summary produced reliably for ≥4 consecutive weeks; the operator can spot the top 3 failure categories at a glance.
 
-## 17. Risks & Open Questions (adversarial-review bait)
+## 18. Risks & Open Questions (adversarial-review bait)
 
 ### Risks
 
@@ -619,7 +657,7 @@ Rollback plan: any phase can revert by scaling ECS to 0 and invoking laptop `/di
 
 5. **Diagnoser net benefit — tiered version.** The tiered diagnoser (§8: mechanical first, diagnose only on recurrence or Tier 3) should see far fewer invocations than the always-diagnose original. Projected: ~2-3 invocations/week. At that volume, the effectiveness bar is low — we mainly need to verify the diagnoser doesn't make things worse than immediate human escalation. **Action:** first month of operation, dump every `dispatcher.diagnoses.recommendation` + its `outcome` weekly. If the diagnoser's recommendation was "retry" and the retry succeeded, that's net-positive latency savings; if it escalated, the human got a pre-analyzed failure; if it was wrong, measure the added-damage rate.
 
-## 18. Appendix — Schema DDL sketch
+## 19. Appendix — Schema DDL sketch
 
 ```sql
 CREATE SCHEMA dispatcher;
@@ -755,4 +793,4 @@ INSERT INTO dispatcher.config (key, value, updated_by) VALUES
 
 ---
 
-**Next step:** adversarial review. I'll spawn (or you spawn) a reviewer with this file as input and a specific brief to attack the design (not accept it) — look for correctness bugs, race conditions, operational traps, and cost blow-ups. Anything in §17 is fair game; anything not yet listed is bonus.
+**Next step:** adversarial review. I'll spawn (or you spawn) a reviewer with this file as input and a specific brief to attack the design (not accept it) — look for correctness bugs, race conditions, operational traps, and cost blow-ups. Anything in §18 is fair game; anything not yet listed is bonus.

--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -813,3 +813,91 @@ resource "aws_cloudwatch_metric_alarm" "heartbeat_stale" {
   alarm_actions = [var.alert_sns_topic_arn]
   ok_actions    = [var.alert_sns_topic_arn]
 }
+
+# ── Stuck-timeout repeated alarm (#2878) ─────────────────────────────────────
+# Fires when the same agent hits stuck_timeout twice within 10 minutes.
+# A single stuck_timeout is expected (the mechanical retry path handles it);
+# two in quick succession indicate a thrash loop that will exhaust the
+# retry budget before a human notices.  The daemon emits a dedicated
+# ``stuck_timeout_repeated`` structured-log event (distinct from the raw
+# ``failure_detected`` event) because CloudWatch metric filters cannot
+# express "same agent_id, count ≥ 2 in 10 min" alone — the daemon-side
+# helper does the per-agent check and writes the signal.
+
+resource "aws_cloudwatch_log_metric_filter" "stuck_timeout_repeated" {
+  count = var.enable_alerts ? 1 : 0
+
+  name           = "${local.service_name}-stuck-timeout-repeated"
+  pattern        = "{ $.event = \"stuck_timeout_repeated\" }"
+  log_group_name = aws_cloudwatch_log_group.dispatcher.name
+
+  metric_transformation {
+    name          = "StuckTimeoutRepeatedCount"
+    namespace     = "Judgemind/Dispatcher"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "stuck_timeout_repeated" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "${local.service_name}-stuck-timeout-repeated"
+  alarm_description = "An agent hit stuck_timeout twice within ${var.stuck_timeout_repeated_window_seconds}s (${var.environment}). The retry budget may be exhausted before the diagnoser fires — check ${aws_cloudwatch_log_group.dispatcher.name}."
+
+  namespace   = "Judgemind/Dispatcher"
+  metric_name = "StuckTimeoutRepeatedCount"
+  statistic   = "Sum"
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 1
+  period              = var.stuck_timeout_repeated_window_seconds
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}
+
+# ── Diagnoser fallback spike alarm (#2878) ────────────────────────────────────
+# Fires when the diagnoser falls back to mechanical escalation multiple
+# times in a short window.  Isolated fallbacks are normal (transient
+# timeout, malformed JSON) but a spike indicates a systematic problem with
+# the diagnoser skill or its input context.
+
+resource "aws_cloudwatch_log_metric_filter" "diagnoser_fallback" {
+  count = var.enable_alerts ? 1 : 0
+
+  name           = "${local.service_name}-diagnoser-fallback"
+  pattern        = "{ $.event = \"diagnoser_fallback\" }"
+  log_group_name = aws_cloudwatch_log_group.dispatcher.name
+
+  metric_transformation {
+    name          = "DiagnoserFallbackCount"
+    namespace     = "Judgemind/Dispatcher"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "diagnoser_fallback_spike" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "${local.service_name}-diagnoser-fallback-spike"
+  alarm_description = "Diagnoser fell back to mechanical escalation >= ${var.diagnoser_fallback_threshold} times in ${var.diagnoser_fallback_window_seconds}s (${var.environment}). Check ${aws_cloudwatch_log_group.dispatcher.name} for diagnoser timeout or malformed output."
+
+  namespace   = "Judgemind/Dispatcher"
+  metric_name = "DiagnoserFallbackCount"
+  statistic   = "Sum"
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.diagnoser_fallback_threshold
+  period              = var.diagnoser_fallback_window_seconds
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}

--- a/infra/terraform/modules/dispatcher-daemon/outputs.tf
+++ b/infra/terraform/modules/dispatcher-daemon/outputs.tf
@@ -42,3 +42,13 @@ output "heartbeat_alarm_arn" {
   description = "ARN of the heartbeat staleness CloudWatch alarm (empty when enable_alerts is false)"
   value       = var.enable_alerts ? aws_cloudwatch_metric_alarm.heartbeat_stale[0].arn : ""
 }
+
+output "stuck_timeout_repeated_alarm_arn" {
+  description = "ARN of the stuck_timeout_repeated CloudWatch alarm (empty when enable_alerts is false)"
+  value       = var.enable_alerts ? aws_cloudwatch_metric_alarm.stuck_timeout_repeated[0].arn : ""
+}
+
+output "diagnoser_fallback_spike_alarm_arn" {
+  description = "ARN of the diagnoser_fallback_spike CloudWatch alarm (empty when enable_alerts is false)"
+  value       = var.enable_alerts ? aws_cloudwatch_metric_alarm.diagnoser_fallback_spike[0].arn : ""
+}

--- a/infra/terraform/modules/dispatcher-daemon/variables.tf
+++ b/infra/terraform/modules/dispatcher-daemon/variables.tf
@@ -140,6 +140,24 @@ variable "heartbeat_stale_seconds" {
   default     = 300
 }
 
+variable "stuck_timeout_repeated_window_seconds" {
+  description = "CloudWatch alarm period (seconds) for the stuck_timeout_repeated alarm. The alarm fires when at least one stuck_timeout_repeated event is observed in this window. Default 600 (10 min) per §15 of the spec."
+  type        = number
+  default     = 600
+}
+
+variable "diagnoser_fallback_window_seconds" {
+  description = "CloudWatch alarm period (seconds) for the diagnoser_fallback_spike alarm. Default 1800 (30 min)."
+  type        = number
+  default     = 1800
+}
+
+variable "diagnoser_fallback_threshold" {
+  description = "Number of diagnoser_fallback events within diagnoser_fallback_window_seconds that triggers the alarm. Default 2."
+  type        = number
+  default     = 2
+}
+
 # ─── Oneshot task launcher (scripts/ecs-run-task.sh) ────────────────────────
 # When these ARNs are wired, the daemon's task role gets the permission set
 # required by `scripts/ecs-run-task.sh` so ralph phases can launch data

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -21,8 +21,8 @@ belong to 3B-3E.
 
 Spec: ``docs/specs/dispatcher-v2-spec.md`` §6 (scheduler loop), §6a
 (per-phase skill contracts), §7 (supervisor loop), §14 (deployment),
-§15 (Phase 2 definition + gate), §17 Risk 2 (double-daemon race),
-§17 Risk 4a (subprocess timeout), §18 (schema DDL). Issues #2768
+§16 (Phase 2 definition + gate), §18 Risk 2 (double-daemon race),
+§18 Risk 4a (subprocess timeout), §19 (schema DDL). Issues #2768
 (Phase 2), #2783 (Phase 3A).
 
 Structured logging is JSON-per-line to stdout so CloudWatch Logs
@@ -114,7 +114,7 @@ from .stream_forwarder import stream_subprocess_output_async  # noqa: E402
 DISPATCHER_SCHEMA = "dispatcher"
 
 #: Lease window — another running daemon whose heartbeat is newer than
-#: this many seconds blocks this one from spawning (§17 Risk 2). 60 s is
+#: this many seconds blocks this one from spawning (§18 Risk 2). 60 s is
 #: 2× the scheduler tick, so a healthy peer is always seen as active.
 LEASE_HEARTBEAT_WINDOW_SECONDS = 60
 
@@ -368,7 +368,7 @@ ORCHESTRATION_JOIN_TIMEOUT_SECONDS = 10
 
 #: Hard wall-clock timeout for each ``claude -p`` subprocess spawned
 #: from the orchestration path. Matches the 180-minute ceiling from
-#: spec §17 Risk 4a and the ``dispatcher.config.subprocess_timeout_s``
+#: spec §18 Risk 4a and the ``dispatcher.config.subprocess_timeout_s``
 #: seed value (10800s). Enforced via ``subprocess.run(..., timeout=...)``.
 CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS = 180 * 60
 
@@ -738,7 +738,7 @@ GIT_PUSH_TIMEOUT_SECONDS = 1800
 #: burning through the candidate queue in a failure loop when paired
 #: with the partial UNIQUE INDEX (which only blocks re-claim for
 #: ``running``/``retrying``, not ``failed``/``crashed`` — see spec
-#: §17 Risk 2 and issue #2804). 3600s (60 min) gives the diagnoser a
+#: §18 Risk 2 and issue #2804). 3600s (60 min) gives the diagnoser a
 #: clear window to file a follow-up or un-fail the agent before the
 #: scheduler retries. Tuned for the cap=1 cutover; a higher cap may
 #: want a shorter cooldown to avoid starving the queue on transient
@@ -1409,6 +1409,14 @@ TIER_3_CATEGORIES: frozenset[str] = frozenset(
 #: again in the afternoon) while not re-triggering on unrelated failures
 #: weeks later.
 TIER_2_RECURRENCE_WINDOW_SECONDS = 24 * 60 * 60
+
+#: Window used by :meth:`DispatcherDaemon._has_prior_stuck_timeout_in_window`
+#: to decide whether a stuck_timeout is a repeat (two occurrences in 10 min
+#: on the same agent) worth paging on. Distinct from
+#: :data:`TIER_2_RECURRENCE_WINDOW_SECONDS` (24 h) which controls the
+#: diagnoser trigger — 10 min is short enough to catch a thrash loop
+#: without false-positives from same-day but unrelated retries.
+STUCK_TIMEOUT_ALERT_WINDOW_SECONDS = 600
 
 #: Hard wall-clock timeout for the ``/diagnose-failure`` subprocess
 #: (``claude -p``). Matches spec §8 "5-min hard wall-clock timeout".
@@ -2195,7 +2203,7 @@ class DispatcherDaemon:
 
         # Under SERIALIZABLE we would be free of races here, but the
         # check + insert happens fast enough that two daemons booting
-        # simultaneously during a rolling deploy (§17 Risk 2) still race
+        # simultaneously during a rolling deploy (§18 Risk 2) still race
         # on the millisecond window. That is acceptable: the second
         # daemon's supervisor tick will observe the first one's heartbeat
         # within the next 120s and can be watchdog-killed. The lease
@@ -2556,7 +2564,7 @@ class DispatcherDaemon:
         #
         # Failures here (rate limit, network, auth) log + return -1 but
         # do NOT raise — the daemon must survive GitHub API hiccups,
-        # and the next tick will try again (§15).
+        # and the next tick will try again (§16).
         queue_depth = self._scan_queue_and_snapshot()
         t_step = self._record_scheduler_step("scan_queue", t_step)
 
@@ -3512,7 +3520,7 @@ class DispatcherDaemon:
         try:
             issues = self._fetch_agent_ready_issues()
         except RuntimeError as exc:
-            # Daemon must survive GitHub API hiccups (§15). Log + return
+            # Daemon must survive GitHub API hiccups (§16). Log + return
             # -1 so the caller knows the scan failed without crashing.
             self._log.warning(
                 "daemon.queue_scan_failed",
@@ -4508,7 +4516,7 @@ class DispatcherDaemon:
         ``dispatcher.agents.worktree_path`` row points at the same
         directory the supervisor / cleanup code later looks for
         (otherwise the worktree is "orphaned from the DB's perspective"
-        — see spec §17 Risk 1).
+        — see spec §18 Risk 1).
 
         When ``baseline_repo_root`` is set, the worktree lives in the
         sibling ``worktrees/`` directory next to the baseline clone
@@ -10682,7 +10690,7 @@ class DispatcherDaemon:
                 phase, worktree, agent_id
             )
         except subprocess.TimeoutExpired:
-            # Timeout = subprocess runaway (spec §17 Risk 4). Treat as
+            # Timeout = subprocess runaway (spec §18 Risk 4). Treat as
             # a generic ``subprocess_crash`` — the subprocess didn't
             # actually crash but the next retry needs a fresh worktree
             # just the same. Capture the log tail for triage — a runaway
@@ -14844,14 +14852,16 @@ class DispatcherDaemon:
         category: str,
         detected_by: str,
         details: dict[str, Any],
-    ) -> None:
-        """INSERT one row into ``dispatcher.failures``.
+    ) -> int | None:
+        """INSERT one row into ``dispatcher.failures`` and return the new ``failure_id``.
+
+        Returns ``None`` on DB error (best-effort: a DB hiccup logs +
+        rolls back but does not propagate, mirroring the hook-side
+        behaviour in ``emit_failure.py`` (§9)).
 
         ``agent_id=None`` is permitted (the schema allows it) and used by
         the GitHub rate-limit guard which is a daemon-level signal not
-        attributable to any single agent. Failures here are best-effort:
-        a DB hiccup logs + rolls back but does not propagate, mirroring
-        the hook-side behaviour in ``emit_failure.py`` (§9).
+        attributable to any single agent.
         """
         assert self._conn is not None, "connect() must run before failure write"
         try:
@@ -14859,9 +14869,11 @@ class DispatcherDaemon:
                 cur.execute(
                     "INSERT INTO dispatcher.failures "
                     "    (agent_id, category, detected_by, details) "
-                    "VALUES (%s, %s, %s, %s)",
+                    "VALUES (%s, %s, %s, %s) "
+                    "RETURNING failure_id",
                     (agent_id, category, detected_by, json.dumps(details, default=str)),
                 )
+                row = cur.fetchone()
             self._conn.commit()
         except Exception:
             self._log.exception(
@@ -14877,6 +14889,8 @@ class DispatcherDaemon:
                 self._conn.rollback()
             except Exception:  # pragma: no cover — best-effort
                 pass
+            return None
+        return int(row[0]) if row is not None else None
 
     @staticmethod
     def _classify_subprocess_failure(
@@ -15096,7 +15110,7 @@ class DispatcherDaemon:
             if elapsed_seconds < threshold:
                 continue
             try:
-                self._write_failure(
+                failure_id = self._write_failure(
                     agent_id=agent_id,
                     category=FAILURE_CATEGORY_STUCK_TIMEOUT,
                     detected_by="supervisor",
@@ -15133,6 +15147,27 @@ class DispatcherDaemon:
                         "threshold_seconds": threshold,
                     },
                 )
+                # Emit alert signal for CloudWatch alarm (#2878): if this
+                # agent had a prior stuck_timeout within the alert window,
+                # log a distinct event so the metric filter can count it.
+                # Pure signal — no change to retry/diagnose routing.
+                if failure_id is not None:
+                    prior_failure_id = self._has_prior_stuck_timeout_in_window(
+                        agent_id=agent_id,
+                        before_failure_id=failure_id,
+                        window_seconds=STUCK_TIMEOUT_ALERT_WINDOW_SECONDS,
+                    )
+                    if prior_failure_id is not None:
+                        self._log.warning(
+                            "daemon.stuck_timeout_repeated",
+                            extra={
+                                "event": "stuck_timeout_repeated",
+                                "agent_id": agent_id,
+                                "issue_number": issue_number,
+                                "window_seconds": STUCK_TIMEOUT_ALERT_WINDOW_SECONDS,
+                                "prior_failure_id": prior_failure_id,
+                            },
+                        )
                 # Enqueue the tier-1 retry marker. The processor picks
                 # it up on the next supervisor tick once the backoff
                 # window elapses.
@@ -16821,6 +16856,51 @@ class DispatcherDaemon:
                 pass
             return False
         return row is not None
+
+    def _has_prior_stuck_timeout_in_window(
+        self, *, agent_id: str, before_failure_id: int, window_seconds: int
+    ) -> int | None:
+        """Return the ``failure_id`` of the most-recent prior ``stuck_timeout``
+        for ``agent_id`` within the last ``window_seconds``, or ``None`` if
+        no such row exists.
+
+        Used by :meth:`_flag_stuck_agents` to decide whether to emit the
+        ``stuck_timeout_repeated`` alert event.  A plain metric filter on
+        ``failure_detected`` cannot express "same agent, count ≥ 2 in
+        10 min" — this daemon-side check writes a distinct log event so
+        the CloudWatch alarm can count directly.
+
+        Mirrors :meth:`_has_prior_same_category_failure` but is
+        parameterised on ``window_seconds`` (not the tier-2 24 h window)
+        and returns the prior row's ID instead of a boolean.
+        """
+        assert self._conn is not None, "connect() must run before recurrence check"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT failure_id FROM dispatcher.failures "
+                    "WHERE agent_id = %s "
+                    "  AND category = %s "
+                    "  AND failure_id < %s "
+                    "  AND ts > now() - make_interval(secs => %s) "
+                    "ORDER BY failure_id DESC "
+                    "LIMIT 1",
+                    (
+                        agent_id,
+                        FAILURE_CATEGORY_STUCK_TIMEOUT,
+                        before_failure_id,
+                        window_seconds,
+                    ),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return None
+        return int(row[0]) if row is not None else None
 
     def _build_diagnoser_context(self, candidate: dict[str, Any]) -> dict[str, Any]:
         """Assemble the JSONB context bundle passed to ``/diagnose-failure``.

--- a/scripts/dispatcher/tests/test_daemon_execution_mode_audit.py
+++ b/scripts/dispatcher/tests/test_daemon_execution_mode_audit.py
@@ -188,11 +188,14 @@ class TestCheckStuckAgentsExecutionModeFilter:
         conn.cursor_instance.fetchall_queue = [
             [("agent-sub", 2807, "ralph", 60000.0)],
         ]
-        # Retry marker COUNT + backoff config reads that
-        # _write_failure / _create_retry_marker issue.
+        # Per _flag_stuck_agents path: failure_id RETURNING from
+        # _write_failure, prior stuck check (no prior), retry marker
+        # COUNT, backoff config.
         conn.cursor_instance.fetch_queue = [
-            (0,),
-            ("[60,300,900]",),
+            (42,),  # failure_id RETURNING from _write_failure
+            None,  # _has_prior_stuck_timeout_in_window — no prior
+            (0,),  # prior retry marker count
+            ("[60,300,900]",),  # backoff config
         ]
 
         flagged = d._check_stuck_agents()

--- a/scripts/dispatcher/tests/test_daemon_phase3c.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3c.py
@@ -224,12 +224,17 @@ class TestCheckStuckAgents:
         # Order inside _check_stuck_agents + _create_retry_marker:
         # (1) stuck_timeout_s_by_phase override read (returns None → fall
         # through to module defaults),
-        # (2) COUNT prior markers in _create_retry_marker,
-        # (3) read backoff_seconds config.
+        # (2) RETURNING failure_id from _write_failure INSERT,
+        # (3) _has_prior_stuck_timeout_in_window SELECT (returns None →
+        #     first occurrence, no repeated event),
+        # (4) COUNT prior markers in _create_retry_marker,
+        # (5) read backoff_seconds config.
         # Post-#2927 the #2903 _lookup_agent_kind defensive fetch is
         # gone — no task-skill rows exist to guard against.
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            (42,),  # failure_id from _write_failure RETURNING
+            None,  # _has_prior_stuck_timeout_in_window — no prior
             (0,),  # prior retry marker count
             ("[60,300,900]",),  # backoff schedule
         ]
@@ -305,14 +310,19 @@ class TestCheckStuckAgents:
             ],
         ]
         # Queue: (1) stuck_timeout_s_by_phase override (unset),
-        # then for each agent: (1) prior marker count, (2) backoff config.
+        # then for each agent: failure_id RETURNING, prior_stuck check,
+        # prior marker count, backoff config.
         # Post-#2927 the #2903 _lookup_agent_kind fetch is gone.
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase — unset
+            (42,),  # failure_id RETURNING for agent-1
+            None,  # _has_prior_stuck_timeout_in_window for agent-1 — no prior
             (0,),  # prior marker count for agent-1
-            ("[60,300,900]",),  # backoff
+            ("[60,300,900]",),  # backoff for agent-1
+            (43,),  # failure_id RETURNING for agent-2
+            None,  # _has_prior_stuck_timeout_in_window for agent-2 — no prior
             (0,),  # prior marker count for agent-2
-            ("[60,300,900]",),  # backoff
+            ("[60,300,900]",),  # backoff for agent-2
         ]
         assert d._check_stuck_agents() == 2
         detected = handler.events("failure_detected")

--- a/scripts/dispatcher/tests/test_daemon_restart_cascade.py
+++ b/scripts/dispatcher/tests/test_daemon_restart_cascade.py
@@ -713,6 +713,8 @@ class TestPerPhaseStuckTimeout:
         ]
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            (42,),  # failure_id RETURNING from _write_failure
+            None,  # _has_prior_stuck_timeout_in_window — no prior
             (0,),  # prior retry marker count
             ("[60,300,900]",),  # backoff
         ]
@@ -732,6 +734,8 @@ class TestPerPhaseStuckTimeout:
         ]
         conn.cursor_instance.fetch_queue = [
             ('{"claiming": 300}',),  # operator override
+            (42,),  # failure_id RETURNING from _write_failure
+            None,  # _has_prior_stuck_timeout_in_window — no prior
             (0,),  # prior marker count
             ("[60,300,900]",),
         ]
@@ -746,6 +750,8 @@ class TestPerPhaseStuckTimeout:
         ]
         conn.cursor_instance.fetch_queue = [
             None,  # no override
+            (42,),  # failure_id RETURNING from _write_failure
+            None,  # _has_prior_stuck_timeout_in_window — no prior
             (0,),  # prior marker count
             ("[60,300,900]",),
         ]

--- a/scripts/dispatcher/tests/test_daemon_retry_loop.py
+++ b/scripts/dispatcher/tests/test_daemon_retry_loop.py
@@ -148,10 +148,14 @@ class TestRetryLoopEndToEnd:
         ]
         # Per _check_stuck_agents + _create_retry_marker call order:
         # (1) stuck_timeout_s_by_phase config override (unset → None),
-        # (2) COUNT prior retry markers (0 → first attempt),
-        # (3) backoff schedule.
+        # (2) RETURNING failure_id from _write_failure INSERT,
+        # (3) _has_prior_stuck_timeout_in_window (no prior → None),
+        # (4) COUNT prior retry markers (0 → first attempt),
+        # (5) backoff schedule.
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            (42,),  # failure_id RETURNING from _write_failure
+            None,  # _has_prior_stuck_timeout_in_window — no prior
             (0,),  # prior retry marker count
             ("[60,300,900]",),  # backoff schedule
         ]

--- a/scripts/dispatcher/tests/test_daemon_stuck_timeout_repeated.py
+++ b/scripts/dispatcher/tests/test_daemon_stuck_timeout_repeated.py
@@ -1,0 +1,207 @@
+"""Regression tests for the stuck_timeout_repeated alert signal (#2878).
+
+The daemon emits ``daemon.stuck_timeout_repeated`` only when the same
+agent fires ``stuck_timeout`` twice within ``STUCK_TIMEOUT_ALERT_WINDOW_SECONDS``
+(10 min).  A plain CloudWatch metric filter on ``failure_detected`` cannot
+express "same agent_id, count >= 2 in N seconds" — the daemon does the
+per-agent DB check and writes a distinct structured-log event so the alarm
+can count it directly.
+
+Two test cases:
+- First occurrence → only ``failure_detected`` emitted, NOT
+  ``stuck_timeout_repeated``.
+- Second occurrence on the same agent within the window → BOTH
+  ``failure_detected`` AND ``stuck_timeout_repeated`` emitted.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+from dispatcher import daemon  # noqa: E402 — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes (mirrors test_daemon_restart_cascade.py)
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.stuck_repeated.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    # Stub out the complex sub-calls that consume additional DB fetchones
+    # and are tested in their own dedicated test files.  This isolates the
+    # stuck_timeout_repeated signal logic from the retry/terminal machinery.
+    d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+    d._create_retry_marker = MagicMock()  # type: ignore[method-assign]
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+
+class TestStuckTimeoutRepeated:
+    def test_first_stuck_timeout_no_repeated_event(self, tmp_path: Path) -> None:
+        """First stuck_timeout for an agent emits only ``failure_detected``.
+
+        The ``_has_prior_stuck_timeout_in_window`` DB query returns no row
+        (this is the first occurrence) so ``stuck_timeout_repeated`` must
+        NOT be emitted.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-first", 101, "ralph", 57600.0)],  # 16 hr > 54000s threshold
+        ]
+        # Fetch order with _mark_agent_terminal / _create_retry_marker stubbed:
+        # (1) stuck_timeout_s_by_phase config override (unset → None),
+        # (2) RETURNING failure_id from _write_failure INSERT = 10,
+        # (3) _has_prior_stuck_timeout_in_window → None (no prior row).
+        conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase override — unset
+            (10,),  # failure_id RETURNING from _write_failure
+            None,  # _has_prior_stuck_timeout_in_window — no prior
+        ]
+
+        flagged = d._check_stuck_agents()
+        assert flagged == 1
+
+        # failure_detected emitted exactly once.
+        detected = handler.events("failure_detected")
+        assert len(detected) == 1
+        assert detected[0].category == daemon.FAILURE_CATEGORY_STUCK_TIMEOUT  # type: ignore[attr-defined]
+
+        # stuck_timeout_repeated must NOT be emitted on the first occurrence.
+        repeated = handler.events("stuck_timeout_repeated")
+        assert len(repeated) == 0
+
+    def test_second_stuck_timeout_within_window_emits_repeated_event(
+        self, tmp_path: Path
+    ) -> None:
+        """Second stuck_timeout on the same agent within the alert window emits both events.
+
+        When ``_has_prior_stuck_timeout_in_window`` finds a prior row
+        (simulated by returning ``(9,)`` — failure_id 9 preceding the
+        current failure_id 10), the daemon must emit ``stuck_timeout_repeated``
+        in addition to ``failure_detected``.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-repeat", 202, "ralph", 57600.0)],
+        ]
+        # Fetch order with _mark_agent_terminal / _create_retry_marker stubbed:
+        # (1) stuck_timeout_s_by_phase override — unset,
+        # (2) RETURNING failure_id = 10 (current failure),
+        # (3) _has_prior_stuck_timeout_in_window → (9,) (prior row exists).
+        conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase override — unset
+            (10,),  # failure_id RETURNING (current failure)
+            (9,),  # prior failure_id within window
+        ]
+
+        flagged = d._check_stuck_agents()
+        assert flagged == 1
+
+        # failure_detected emitted.
+        detected = handler.events("failure_detected")
+        assert len(detected) == 1
+
+        # stuck_timeout_repeated MUST be emitted on the second occurrence.
+        repeated = handler.events("stuck_timeout_repeated")
+        assert len(repeated) == 1
+
+        rec = repeated[0]
+        assert rec.agent_id == "agent-repeat"  # type: ignore[attr-defined]
+        assert rec.issue_number == 202  # type: ignore[attr-defined]
+        assert rec.window_seconds == daemon.STUCK_TIMEOUT_ALERT_WINDOW_SECONDS  # type: ignore[attr-defined]
+        assert rec.prior_failure_id == 9  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Added CloudWatch alarms to detect repeated stuck_timeout and diagnoser_fallback patterns in the dispatcher, providing early warning of cascading failures like the 2026-04-19 incident (#2872).

Closes #2878

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
- [x] CI green

### Post-deploy verification

- [ ] Manually verify alarms fire by simulating stuck_timeout conditions on dev
- [ ] Confirm Telegram notifications route correctly when thresholds exceeded
- [ ] Verify alarm thresholds documented in spec match code implementation
- [ ] Verification evidence posted on #2878 (see /task-v2-verify output)