### PR TITLE
fix(dispatcher): ECS fix_ci stages+commits+pushes sonnet's patches (#3245)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -2528,6 +2528,250 @@ handle_fix_conflict() {
     return 0
 }
 
+# ── fix_ci handler (#3245) ────────────────────────────────────────────────
+#
+# ECS-mode equivalent of the subprocess daemon's ``_run_fix_ci`` +
+# ``_apply_fix_ci_patch`` (scripts/dispatcher/daemon.py ~line 12697 and
+# 12979). Before #3245 the entrypoint dispatched ``fix_ci`` through the
+# generic ``planning|ralph|summary|verify`` case — it called the skill,
+# persisted the phase_output, and routed via ``transition_for`` but
+# never staged / committed / pushed the working-tree changes the skill
+# had just produced. Result: every ECS agent with initially-red CI
+# looped 40 iterations of "sonnet patches the worktree → entrypoint
+# discards the patch → CI re-runs unchanged → red → fix_ci again,"
+# wasting ~75 min + 40 sonnet invocations per agent. See issue #3245
+# and the /task-v2-fix-ci SKILL.md (lines 64 + 160) which explicitly
+# defers git ops to "the daemon."
+#
+# The ``/task-v2-fix-ci`` skill writes a JSON envelope of shape:
+#
+#     {
+#       "verdict": "PATCHED" | "BLOCKED" | "FLAKY",
+#       "commit_message": "fix(area): desc — CI (#<PR>)",
+#       "changed_files": ["path1", "path2", ...],
+#       "block_reason": "<str>" | null,
+#       "flaky_evidence": "<str>" | null,
+#       ...
+#     }
+#
+# After ``run_claude_phase "fix_ci"`` returns, this handler:
+#
+#   * **PATCHED** — reads ``commit_message``, runs ``git add -A``,
+#     verifies ``git diff --cached`` has staged changes (empty-diff
+#     means the skill lied), runs ``git commit -m <msg>`` and
+#     ``git push origin <branch>``. On success leaves the agent in
+#     ``awaiting_ci`` so the next tick re-polls CI against the new
+#     commit. On any failure (missing commit_message, empty diff,
+#     git add/commit/push non-zero exit) advances to ``fix_ci_failed``
+#     terminal via ``agent_runner_reaped_failure``.
+#   * **FLAKY** — no code change; advance back to ``awaiting_ci`` so
+#     the next poll re-checks the rollup (GitHub may auto-retry a
+#     flaky job, or a manual nudge resolves eventually). Mirrors the
+#     daemon's FLAKY branch.
+#   * **BLOCKED** (or unrecognized verdict) — log and route to
+#     ``fix_ci_failed`` terminal. Same as daemon except the daemon's
+#     tier-3 failure-row + diagnoser routing is not mirrored here —
+#     the terminal signals "this agent is done, daemon supervisor
+#     picks it up from the failure_row category." (The daemon-side
+#     ``_handle_agent_failure`` would normally write the failure row;
+#     in ECS mode the supervisor's ``_find_diagnoser_candidates`` sweep
+#     picks up the agent by its terminal phase instead.)
+#
+# Log event names (``fix_ci_patch_pushed``, ``fix_ci_missing_commit_
+# message``, ``fix_ci_git_commit_failed``, ``fix_ci_git_push_failed``,
+# ``fix_ci_patch_empty``, ``fix_ci_flaky``, ``fix_ci_blocked``,
+# ``fix_ci_unrecognized_verdict``) mirror the daemon's names so
+# CloudWatch log-insights queries work across both paths.
+#
+# Prints the phase-output JSON on stdout (the same JSON that
+# ``run_claude_phase`` emitted, possibly re-wrapped) for
+# ``persist_phase_output`` in the caller. Always exits 0 — the
+# caller decides whether to advance or leave the terminal alone.
+#
+# Side effects (handler-owned, distinct from the ``run_claude_phase``
+# flow — so this handler does its own advance via
+# ``advance_phase`` / ``agent_runner_reaped_failure``):
+#
+#   * ``git -C "$REPO_ROOT" add -A`` (stage skill's edits).
+#   * ``git -C "$REPO_ROOT" diff --cached --quiet`` (empty-diff check).
+#   * ``git -C "$REPO_ROOT" commit -m "$commit_message"`` (commit).
+#   * ``git -C "$REPO_ROOT" push origin HEAD`` (push to PR branch).
+#
+# The caller (the fix_ci case arm) consumes the $_output envelope via
+# ``persist_phase_output`` but delegates transition to this handler
+# by reading the ``$_fix_ci_next_action`` global it writes before
+# returning. Pattern matches ``handle_awaiting_ci`` which also owns
+# its own advance decisions from within the handler via
+# ``advance_phase`` / ``agent_runner_reaped_failure`` calls.
+handle_fix_ci() {
+    # Invoke the /task-v2-fix-ci skill via run_claude_phase, parse
+    # the verdict, and stage+commit+push on PATCHED. Mirrors the
+    # daemon's ``_run_fix_ci`` + ``_apply_fix_ci_patch`` for the ECS
+    # path. Prints the skill's output JSON on stdout (so the caller
+    # can persist it into phase_outputs), advances the phase row
+    # internally via ``advance_phase`` / ``agent_runner_reaped_failure``,
+    # and always exits 0.
+    #
+    # Environment inputs:
+    #   REPO_ROOT       — per-agent clone root (contains the worktree
+    #                     changes written by the skill).
+    #   BRANCH_NAME     — the agent's branch name (e.g. agent/<shortid>).
+    #   AGENT_WORKSPACE — stderr/stdout log capture dir.
+
+    _output=$(run_claude_phase "fix_ci")
+    persist_phase_output "fix_ci" "$_output"
+
+    _verdict=$(printf '%s' "$_output" | jq -r '.verdict // "" | ascii_upcase' 2>/dev/null)
+    log "fix_ci_verdict" "verdict=$_verdict"
+
+    if [[ "$_verdict" == "PATCHED" ]]; then
+        # Parse commit_message from the skill output. The daemon
+        # treats a missing / empty commit_message as a hard failure
+        # via FAILURE_CATEGORY_FIX_CI_APPLY_FAILED + sub_reason=
+        # missing_commit_message. We terminal to fix_ci_failed.
+        _commit_msg=$(printf '%s' "$_output" | jq -r '.commit_message // ""' 2>/dev/null)
+        if [[ -z "$_commit_msg" ]]; then
+            log "fix_ci_missing_commit_message" "verdict=$_verdict"
+            agent_runner_reaped_failure \
+                "fix_ci_failed" \
+                "missing_commit_message" \
+                "fix_ci skill returned PATCHED with no commit_message"
+            return 0
+        fi
+
+        # Stage all worktree changes. ``git add -A`` mirrors the
+        # daemon (daemon.py line ~13039) — the skill may have
+        # created new files or deleted ones, so staging by
+        # changed_files list alone can miss deletions / renames.
+        set +e
+        git -C "$REPO_ROOT" add -A \
+            > "$AGENT_WORKSPACE/fix-ci-git-add.stdout.log" \
+            2> "$AGENT_WORKSPACE/fix-ci-git-add.stderr.log"
+        _add_rc=$?
+        set -e
+        if [[ "$_add_rc" -ne 0 ]]; then
+            _add_tail=$(tail -c 200 "$AGENT_WORKSPACE/fix-ci-git-add.stderr.log" \
+                2>/dev/null | tr '\n' ' ')
+            log "fix_ci_git_add_failed" \
+                "exit_code=$_add_rc" \
+                "stderr_tail=$_add_tail"
+            agent_runner_reaped_failure \
+                "fix_ci_failed" \
+                "git_add_failed" \
+                "git add -A exit=$_add_rc stderr=$_add_tail"
+            return 0
+        fi
+
+        # Empty-diff check (#3245): if the skill said PATCHED but
+        # wrote no changes to the working tree, ``git diff --cached
+        # --quiet`` exits 0 (nothing staged). Treat as BLOCKED — the
+        # skill's self-report was wrong and a plain ``git commit``
+        # would also fail non-zero downstream, but this explicit
+        # check gives a dedicated log event for CloudWatch.
+        set +e
+        git -C "$REPO_ROOT" diff --cached --quiet \
+            > /dev/null 2>&1
+        _diff_rc=$?
+        set -e
+        if [[ "$_diff_rc" -eq 0 ]]; then
+            # Exit 0 from ``diff --quiet`` = no staged changes.
+            log "fix_ci_patch_empty" \
+                "verdict=$_verdict" \
+                "commit_message=$_commit_msg"
+            agent_runner_reaped_failure \
+                "fix_ci_failed" \
+                "patch_empty" \
+                "fix_ci PATCHED but no changes staged after git add -A"
+            return 0
+        fi
+
+        # Commit. Write the message to a file so ``git commit -F`` gets
+        # the literal message verbatim — avoids any quoting / $-expansion
+        # hazards with multi-line or special-char commit messages.
+        _commit_msg_path="$AGENT_WORKSPACE/fix-ci-commit-msg.txt"
+        printf '%s' "$_commit_msg" > "$_commit_msg_path"
+        set +e
+        git -C "$REPO_ROOT" commit -F "$_commit_msg_path" \
+            > "$AGENT_WORKSPACE/fix-ci-git-commit.stdout.log" \
+            2> "$AGENT_WORKSPACE/fix-ci-git-commit.stderr.log"
+        _commit_rc=$?
+        set -e
+        if [[ "$_commit_rc" -ne 0 ]]; then
+            _commit_tail=$(tail -c 200 "$AGENT_WORKSPACE/fix-ci-git-commit.stderr.log" \
+                2>/dev/null | tr '\n' ' ')
+            log "fix_ci_git_commit_failed" \
+                "exit_code=$_commit_rc" \
+                "stderr_tail=$_commit_tail"
+            agent_runner_reaped_failure \
+                "fix_ci_failed" \
+                "git_commit_failed" \
+                "git commit exit=$_commit_rc stderr=$_commit_tail"
+            return 0
+        fi
+
+        # Push. The entrypoint uses the agent's named branch rather than
+        # ``HEAD`` so the push target is unambiguous even if a rebase or
+        # detached-HEAD state somehow snuck in — matches daemon.py line
+        # ~13166's ``push origin <branch>`` pattern.
+        set +e
+        git -C "$REPO_ROOT" push origin "$BRANCH_NAME" \
+            > "$AGENT_WORKSPACE/fix-ci-git-push.stdout.log" \
+            2> "$AGENT_WORKSPACE/fix-ci-git-push.stderr.log"
+        _push_rc=$?
+        set -e
+        if [[ "$_push_rc" -ne 0 ]]; then
+            _push_tail=$(tail -c 200 "$AGENT_WORKSPACE/fix-ci-git-push.stderr.log" \
+                2>/dev/null | tr '\n' ' ')
+            log "fix_ci_git_push_failed" \
+                "exit_code=$_push_rc" \
+                "stderr_tail=$_push_tail"
+            agent_runner_reaped_failure \
+                "fix_ci_failed" \
+                "git_push_failed" \
+                "git push exit=$_push_rc stderr=$_push_tail"
+            return 0
+        fi
+
+        log "fix_ci_patch_pushed" \
+            "branch=$BRANCH_NAME" \
+            "commit_message=$_commit_msg"
+        # Back to awaiting_ci so the next supervisor tick re-polls
+        # the rollup against the new push. Mirrors daemon behavior
+        # (daemon.py: fix_ci success leaves phase=awaiting_ci).
+        advance_phase "awaiting_ci"
+        printf '%s' "$_output"
+        return 0
+    fi
+
+    if [[ "$_verdict" == "FLAKY" ]]; then
+        _flaky_evidence=$(printf '%s' "$_output" | jq -r '.flaky_evidence // ""' 2>/dev/null)
+        log "fix_ci_flaky" "flaky_evidence=$_flaky_evidence"
+        # No code change. Next tick re-polls CI. GitHub may auto-retry
+        # the flaky job, or a manual nudge resolves eventually.
+        advance_phase "awaiting_ci"
+        printf '%s' "$_output"
+        return 0
+    fi
+
+    # BLOCKED or unrecognized verdict — terminal.
+    if [[ "$_verdict" == "BLOCKED" ]]; then
+        _block_reason=$(printf '%s' "$_output" | jq -r '.block_reason // ""' 2>/dev/null)
+        log "fix_ci_blocked" "block_reason=$_block_reason"
+        agent_runner_reaped_failure \
+            "fix_ci_failed" \
+            "fix_ci_blocked" \
+            "fix_ci skill returned BLOCKED: $_block_reason"
+    else
+        log "fix_ci_unrecognized_verdict" "verdict=$_verdict"
+        agent_runner_reaped_failure \
+            "fix_ci_failed" \
+            "unrecognized_verdict" \
+            "fix_ci skill returned unrecognized verdict: $_verdict"
+    fi
+    printf '%s' "$_output"
+    return 0
+}
+
 # ── Ralph HEAD-watcher (#3144) ────────────────────────────────────────────
 #
 # ECS-mode equivalent of the daemon's ``_start_ralph_head_watcher``
@@ -3619,7 +3863,7 @@ while true; do
     # Stage 1b dispatch, which called `/task-v2-claiming` /
     # `/task-v2-push_and_pr` and got "Unknown command" back.
     case "$_current" in
-        planning|ralph|summary|fix_ci|verify)
+        planning|ralph|summary|verify)
             # #3225 secondary mitigation — run a baseline
             # ``git fetch origin main && git rebase origin/main`` at
             # the START of ralph (before any claude iterations). This
@@ -3850,6 +4094,25 @@ while true; do
                         "fix_conflict transition shim returned $_action"
                     ;;
             esac
+            ;;
+        fix_ci)
+            # #3245: fix_ci phase. Split out of the generic Claude-phase
+            # case because — unlike planning/ralph/summary/verify — the
+            # /task-v2-fix-ci skill explicitly defers git ops to "the
+            # daemon" (SKILL.md lines 64 + 160). Before #3245 the ECS
+            # entrypoint ran fix_ci through the generic arm and never
+            # staged / committed / pushed the skill's patch; every agent
+            # with initially-red CI looped 40 iterations without adding
+            # a single commit. handle_fix_ci mirrors the subprocess
+            # daemon's ``_run_fix_ci`` + ``_apply_fix_ci_patch`` (daemon.py
+            # ~line 12697 / 12979): PATCHED → stage + commit + push +
+            # back to awaiting_ci; FLAKY → back to awaiting_ci without
+            # commit; BLOCKED / unrecognized → fix_ci_failed terminal.
+            # handle_fix_ci owns its own advance_phase /
+            # agent_runner_reaped_failure calls so the dispatch case
+            # just invokes the handler and lets the next loop tick
+            # observe the new phase row.
+            handle_fix_ci >/dev/null
             ;;
         awaiting_ci)
             # #3176: real implementation — poll ``gh pr view`` rollup,

--- a/scripts/dispatcher/phase_transitions.py
+++ b/scripts/dispatcher/phase_transitions.py
@@ -198,6 +198,21 @@ PHASE_MERGE_FAILED = "merge_failed"
 PHASE_AWAITING_DEPLOY_FAILED = "awaiting_deploy_failed"
 PHASE_AWAITING_DEPLOY_TIMEOUT = "awaiting_deploy_timeout"
 
+#: #3245 — fix_ci terminal for the agent-runner (ECS) path. Set when
+#: the fix_ci skill returned ``verdict=BLOCKED`` (or unrecognized) OR
+#: when the entrypoint's local git stage/commit/push of the skill's
+#: patch failed (missing commit_message, empty diff, git add/commit/push
+#: non-zero exit). The daemon-side path handles these cases in
+#: ``_run_fix_ci`` / ``_apply_fix_ci_patch`` via
+#: ``_handle_agent_failure`` with tier-3 ``FAILURE_CATEGORY_FIX_CI_BLOCKED``
+#: / tier-2 ``FAILURE_CATEGORY_FIX_CI_APPLY_FAILED``; the ECS path
+#: uses this direct terminal so the per-agent Fargate task exits
+#: cleanly (the daemon's supervisor tick still picks up the row for
+#: diagnosis via ``_find_diagnoser_candidates``). Matches the existing
+#: ECS-terminal pattern established by #3176 for awaiting_ci /
+#: merge / awaiting_deploy.
+PHASE_FIX_CI_FAILED = "fix_ci_failed"
+
 #: #3225 — fix_conflict terminal. Set when the fix_conflict skill
 #: returns ``verdict='unresolvable'`` or when ``merge_conflict_attempts
 #: >= FIX_CONFLICT_MAX_ATTEMPTS``. Routed through the diagnoser (via the
@@ -302,6 +317,8 @@ TERMINAL_PHASES: frozenset[str] = frozenset(
         PHASE_AWAITING_DEPLOY_TIMEOUT,
         # #3225 — fix_conflict terminal.
         PHASE_CONFLICT_UNRESOLVABLE,
+        # #3245 — fix_ci terminal for the ECS agent-runner path.
+        PHASE_FIX_CI_FAILED,
     }
 )
 
@@ -1127,6 +1144,7 @@ __all__ = [
     "PHASE_AWAITING_DEPLOY_FAILED",
     "PHASE_AWAITING_DEPLOY_TIMEOUT",
     "PHASE_CONFLICT_UNRESOLVABLE",
+    "PHASE_FIX_CI_FAILED",
     # Verdict constants
     "VERDICT_SHIP",
     "VERDICT_AC_INFEASIBLE",

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -4152,6 +4152,486 @@ else
          "update-log: $(cat "$t43_state_dir/update-log.txt" 2>/dev/null)"
 fi
 
+# ══════════════════════════════════════════════════════════════════════════
+# Tests T44–T49: #3245 — handle_fix_ci stages, commits, and pushes the
+# /task-v2-fix-ci skill's patches. Before #3245 the ECS entrypoint
+# dispatched ``fix_ci`` through the generic Claude-phase case — it
+# invoked the skill, persisted the phase_output, and advanced via
+# ``transition_for``, but NEVER staged / committed / pushed the working-
+# tree changes that /task-v2-fix-ci actually produced. Every ECS agent
+# with initially-red CI looped 40 fix_ci iterations adding zero commits.
+#
+# These tests extract ``handle_fix_ci`` from the entrypoint and drive
+# it directly with stubbed git/psql/claude, asserting that:
+#
+#   T44 — PATCHED verdict → git add + commit + push invoked, advance to
+#         awaiting_ci, ``fix_ci_patch_pushed`` log event emitted.
+#   T45 — BLOCKED verdict → no commit attempted, ``fix_ci_blocked`` event,
+#         advance to terminal ``fix_ci_failed``.
+#   T46 — PATCHED with empty commit_message → treated as BLOCKED,
+#         ``fix_ci_missing_commit_message`` event, terminal.
+#   T47 — PATCHED with stub that stages nothing (empty diff) → treated
+#         as BLOCKED, ``fix_ci_patch_empty`` event, terminal.
+#   T48 — PATCHED but ``git push`` fails → ``fix_ci_git_push_failed``
+#         event, terminal.
+#   T49 — FLAKY verdict → advance to awaiting_ci, no commit attempted.
+# ══════════════════════════════════════════════════════════════════════════
+
+# Common helper: extract the handler + its dependencies from the real
+# entrypoint so each test exercises the production code path, not a
+# vendored copy.
+t44_funcs="$TEST_TMP/t44-funcs.sh"
+printf 'exec 3>&1\n' > "$t44_funcs"
+
+for fn in db_exec db_query_one log persist_phase_output \
+          phase_to_skill \
+          read_phase_output \
+          write_phase_input \
+          run_claude_phase \
+          advance_phase \
+          agent_runner_reaped_failure \
+          handle_fix_ci; do
+    awk -v FN="^${fn}\\\\(\\\\)" '
+        $0 ~ FN { in_fn=1 }
+        in_fn { print }
+        in_fn && /^}$/ { exit }
+    ' "$ENTRYPOINT" >> "$t44_funcs"
+done
+
+# Sanity: handle_fix_ci and its dependencies were extracted.
+if grep -q "^handle_fix_ci()" "$t44_funcs"; then
+    pass "#3245 T44 setup — extracted handle_fix_ci from entrypoint"
+else
+    fail "#3245 T44 setup — extracted handle_fix_ci from entrypoint" \
+         "fixture head: $(head -c 400 "$t44_funcs")"
+fi
+
+# Shared stub-builder helper: generates stubs into $1 (bin dir) that log
+# all invocations to $2 (state dir). Defaults: git/gh/psql/claude all
+# exit 0; set GIT_PUSH_EXIT=N in the test env to simulate a push
+# failure, GIT_DIFF_CACHED_EXIT=0 to simulate an empty staged diff.
+make_fix_ci_stubs() {
+    _stub_bin="$1"
+    _state_dir="$2"
+
+    cat > "$_stub_bin/git" <<'T44GITEOF'
+#!/usr/bin/env bash
+set -u
+# Log argv (one arg per line for easy parsing).
+printf '%s\n' "CALL $*" >> "${T_STATE_DIR}/git-log.txt"
+
+# Skip any `-C <dir>` prefix to find the subcommand.
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -C) shift 2 || true; continue ;;
+        *) break ;;
+    esac
+done
+
+sub="${1:-}"
+case "$sub" in
+    add)
+        exit "${GIT_ADD_EXIT:-0}"
+        ;;
+    diff)
+        # ``git diff --cached --quiet`` — exit 0 = no changes, 1 = changes.
+        # Tests that want to simulate "skill lied, nothing staged" set
+        # GIT_DIFF_CACHED_EXIT=0. Default is 1 (there ARE staged changes).
+        exit "${GIT_DIFF_CACHED_EXIT:-1}"
+        ;;
+    commit)
+        exit "${GIT_COMMIT_EXIT:-0}"
+        ;;
+    push)
+        exit "${GIT_PUSH_EXIT:-0}"
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+T44GITEOF
+    chmod +x "$_stub_bin/git"
+
+    cat > "$_stub_bin/psql" <<'T44PSQLEOF'
+#!/usr/bin/env bash
+set -u
+query=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -c) shift; query="$1" ;;
+    esac
+    shift || true
+done
+printf 'CALL %s\n' "$query" >> "${T_STATE_DIR}/psql-log.txt"
+exit 0
+T44PSQLEOF
+    chmod +x "$_stub_bin/psql"
+
+    # claude stub — the handler's run_claude_phase reads its output from
+    # $REPO_ROOT/tmp/dispatcher-output/fix-ci.json (see read_phase_output),
+    # so this stub just logs the invocation and exits 0; the per-test
+    # fix-ci.json fixture seeded under $T_REPO_ROOT is the actual source
+    # of truth for the verdict.
+    cat > "$_stub_bin/claude" <<'T44CLAUDEEOF'
+#!/usr/bin/env bash
+printf 'CLAUDE_INVOKED %s\n' "$*" >> "${T_STATE_DIR}/claude-log.txt"
+# Emit a minimal envelope on stdout — ignored by the handler because
+# read_phase_output reads the tmp/dispatcher-output/fix-ci.json file
+# first and returns 0 when it parses as JSON.
+printf '{"result": {"verdict": "PATCHED"}}\n'
+exit 0
+T44CLAUDEEOF
+    chmod +x "$_stub_bin/claude"
+
+    if command -v jq >/dev/null 2>&1; then
+        ln -sf "$(command -v jq)" "$_stub_bin/jq"
+    fi
+    if command -v python3 >/dev/null 2>&1; then
+        ln -sf "$(command -v python3)" "$_stub_bin/python3"
+    fi
+}
+
+# Per-test runner: isolates env, drives handle_fix_ci, returns rc + output.
+# Usage: run_fix_ci_test <test-id> <fix-ci-output-json> [extra env var=value ...]
+run_fix_ci_test() {
+    _test_id="$1"
+    shift
+    _fixci_json="$1"
+    shift
+
+    _tworkspace="$TEST_TMP/${_test_id}-workspace"
+    _trepo="$TEST_TMP/${_test_id}-repo"
+    _tstate="$TEST_TMP/${_test_id}-state"
+    _tbin="$TEST_TMP/${_test_id}-bin"
+    mkdir -p "$_tworkspace" "$_trepo" "$_tstate" "$_tbin"
+    mkdir -p "$_trepo/tmp/dispatcher-output" "$_trepo/tmp/dispatcher-input"
+
+    # Seed the dispatcher-output/fix-ci.json with the test's JSON fixture.
+    printf '%s' "$_fixci_json" > "$_trepo/tmp/dispatcher-output/fix-ci.json"
+    # Seed a minimal dispatcher-input/fix-ci.json so write_phase_input's
+    # python3 shim has a directory to write to.
+    printf '{}' > "$_trepo/tmp/dispatcher-input/fix-ci.json"
+
+    # Phase-input shim no-op.
+    _tshim="$TEST_TMP/${_test_id}-phase-input-shim.py"
+    cat > "$_tshim" <<'T44SHIMEOF'
+import sys
+sys.exit(0)
+T44SHIMEOF
+
+    make_fix_ci_stubs "$_tbin" "$_tstate"
+
+    set +e
+    # Extra env vars come in as "$@" (e.g. GIT_PUSH_EXIT=128). Bash's
+    # VAR=value prefix only works as a single compound command; here the
+    # compound starts with a ``$()``-captured subshell which resets the
+    # prefix semantics, so we route the extras through ``env -S`` instead.
+    _tout=$(env \
+        T_STATE_DIR="$_tstate" \
+        T_REPO_ROOT="$_trepo" \
+        PATH="$_tbin:$PATH" \
+        AGENT_ID="${_test_id}-dead-beef-cafe-000000000099" \
+        ISSUE_NUMBER="3245" \
+        AGENT_WORKSPACE="$_tworkspace" \
+        REPO_ROOT="$_trepo" \
+        BRANCH_NAME="agent/${_test_id}abcd" \
+        DATABASE_URL="postgres://test" \
+        AGENT_RUNNER_DRY_RUN="0" \
+        AGENT_RUNNER_PHASE_INPUT_SHIM="$_tshim" \
+        PHASE_INPUT_SHIM="$_tshim" \
+        "$@" \
+        bash -c '
+            set -uo pipefail
+            # shellcheck disable=SC1090
+            . "'"$t44_funcs"'"
+            handle_fix_ci
+        ' 2>&1)
+    _trc=$?
+    set -e
+
+    # Make the state dir + rc + output available to the caller via
+    # globals (bash 3.2 — no nameref / assoc-array returns).
+    FIXCI_TEST_RC="$_trc"
+    FIXCI_TEST_OUT="$_tout"
+    FIXCI_TEST_STATE="$_tstate"
+    FIXCI_TEST_REPO="$_trepo"
+}
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test T44: PATCHED verdict → git add + commit + push + advance awaiting_ci
+# ══════════════════════════════════════════════════════════════════════════
+
+t44_json='{"verdict": "PATCHED", "commit_message": "fix(scraping): lint E501 — CI (#9999)", "changed_files": ["a.py", "b.py"]}'
+run_fix_ci_test "t44" "$t44_json"
+
+if [[ "$FIXCI_TEST_RC" -eq 0 ]]; then
+    pass "#3245 T44 — handle_fix_ci exits 0 on PATCHED"
+else
+    fail "#3245 T44 — handle_fix_ci exits 0 on PATCHED" \
+         "rc=$FIXCI_TEST_RC, output: $FIXCI_TEST_OUT"
+fi
+
+# git add was invoked.
+if grep -qE "CALL .*\\badd\\b" "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3245 T44 — git add invoked on PATCHED"
+else
+    fail "#3245 T44 — git add invoked on PATCHED" \
+         "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+
+# git commit was invoked.
+if grep -qE "CALL .*\\bcommit\\b" "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3245 T44 — git commit invoked on PATCHED"
+else
+    fail "#3245 T44 — git commit invoked on PATCHED" \
+         "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+
+# git push was invoked with the branch name.
+if grep -qE "CALL .*\\bpush\\b.*agent/t44abcd" "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3245 T44 — git push origin <branch> invoked on PATCHED"
+else
+    fail "#3245 T44 — git push origin <branch> invoked on PATCHED" \
+         "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+
+# Success log event emitted.
+if printf '%s' "$FIXCI_TEST_OUT" | grep -q "fix_ci_patch_pushed"; then
+    pass "#3245 T44 — fix_ci_patch_pushed log event emitted"
+else
+    fail "#3245 T44 — fix_ci_patch_pushed log event emitted" \
+         "output: $FIXCI_TEST_OUT"
+fi
+
+# Phase advanced to awaiting_ci. advance_phase runs a DB UPDATE via psql.
+if grep -q "SET phase = 'awaiting_ci'" "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null; then
+    pass "#3245 T44 — advance_phase awaiting_ci executed on PATCHED"
+else
+    fail "#3245 T44 — advance_phase awaiting_ci executed on PATCHED" \
+         "psql-log: $(cat "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test T45: BLOCKED verdict → no commit, advance to fix_ci_failed terminal
+# ══════════════════════════════════════════════════════════════════════════
+
+t45_json='{"verdict": "BLOCKED", "block_reason": "secret AWS_SECRET not set in CI environment — ops must provision"}'
+run_fix_ci_test "t45" "$t45_json"
+
+if [[ "$FIXCI_TEST_RC" -eq 0 ]]; then
+    pass "#3245 T45 — handle_fix_ci exits 0 on BLOCKED"
+else
+    fail "#3245 T45 — handle_fix_ci exits 0 on BLOCKED" \
+         "rc=$FIXCI_TEST_RC, output: $FIXCI_TEST_OUT"
+fi
+
+# No git commit attempted (and no git add, no push).
+if ! grep -qE "CALL .*\\bcommit\\b" "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3245 T45 — no git commit attempted on BLOCKED"
+else
+    fail "#3245 T45 — no git commit attempted on BLOCKED" \
+         "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+if ! grep -qE "CALL .*\\bpush\\b" "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3245 T45 — no git push attempted on BLOCKED"
+else
+    fail "#3245 T45 — no git push attempted on BLOCKED" \
+         "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+
+# fix_ci_blocked log event emitted.
+if printf '%s' "$FIXCI_TEST_OUT" | grep -q "fix_ci_blocked"; then
+    pass "#3245 T45 — fix_ci_blocked log event emitted"
+else
+    fail "#3245 T45 — fix_ci_blocked log event emitted" \
+         "output: $FIXCI_TEST_OUT"
+fi
+
+# Routed to fix_ci_failed terminal — agent_runner_reaped_failure runs
+# an UPDATE setting phase='fix_ci_failed' status='failed'.
+if grep -q "phase = 'fix_ci_failed'" "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null; then
+    pass "#3245 T45 — advances to fix_ci_failed terminal on BLOCKED"
+else
+    fail "#3245 T45 — advances to fix_ci_failed terminal on BLOCKED" \
+         "psql-log: $(cat "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test T46: PATCHED with empty commit_message → treated as BLOCKED
+# (fix_ci_missing_commit_message event, terminal fix_ci_failed).
+# ══════════════════════════════════════════════════════════════════════════
+
+t46_json='{"verdict": "PATCHED", "commit_message": "", "changed_files": ["a.py"]}'
+run_fix_ci_test "t46" "$t46_json"
+
+if [[ "$FIXCI_TEST_RC" -eq 0 ]]; then
+    pass "#3245 T46 — handle_fix_ci exits 0 on PATCHED+empty-commit-message"
+else
+    fail "#3245 T46 — handle_fix_ci exits 0 on PATCHED+empty-commit-message" \
+         "rc=$FIXCI_TEST_RC, output: $FIXCI_TEST_OUT"
+fi
+
+# Diagnostic log event emitted.
+if printf '%s' "$FIXCI_TEST_OUT" | grep -q "fix_ci_missing_commit_message"; then
+    pass "#3245 T46 — fix_ci_missing_commit_message log event emitted"
+else
+    fail "#3245 T46 — fix_ci_missing_commit_message log event emitted" \
+         "output: $FIXCI_TEST_OUT"
+fi
+
+# No git commit attempted.
+if ! grep -qE "CALL .*\\bcommit\\b" "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3245 T46 — no git commit attempted on empty commit_message"
+else
+    fail "#3245 T46 — no git commit attempted on empty commit_message" \
+         "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+
+# Routed to fix_ci_failed terminal.
+if grep -q "phase = 'fix_ci_failed'" "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null; then
+    pass "#3245 T46 — advances to fix_ci_failed terminal on empty commit_message"
+else
+    fail "#3245 T46 — advances to fix_ci_failed terminal on empty commit_message" \
+         "psql-log: $(cat "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test T47: PATCHED but ``git diff --cached --quiet`` returns 0
+# (no staged changes) → treated as BLOCKED via fix_ci_patch_empty event.
+# ══════════════════════════════════════════════════════════════════════════
+
+t47_json='{"verdict": "PATCHED", "commit_message": "fix(area): thing — CI (#9999)", "changed_files": []}'
+run_fix_ci_test "t47" "$t47_json" GIT_DIFF_CACHED_EXIT=0
+
+if [[ "$FIXCI_TEST_RC" -eq 0 ]]; then
+    pass "#3245 T47 — handle_fix_ci exits 0 on PATCHED+empty-diff"
+else
+    fail "#3245 T47 — handle_fix_ci exits 0 on PATCHED+empty-diff" \
+         "rc=$FIXCI_TEST_RC, output: $FIXCI_TEST_OUT"
+fi
+
+# Diagnostic log event emitted.
+if printf '%s' "$FIXCI_TEST_OUT" | grep -q "fix_ci_patch_empty"; then
+    pass "#3245 T47 — fix_ci_patch_empty log event emitted"
+else
+    fail "#3245 T47 — fix_ci_patch_empty log event emitted" \
+         "output: $FIXCI_TEST_OUT"
+fi
+
+# git add ran (the stub succeeds), but no commit / push.
+if grep -qE "CALL .*\\badd\\b" "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3245 T47 — git add ran (before empty-diff detection)"
+else
+    fail "#3245 T47 — git add ran (before empty-diff detection)" \
+         "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+if ! grep -qE "CALL .*\\bcommit\\b" "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3245 T47 — no git commit attempted after empty-diff detection"
+else
+    fail "#3245 T47 — no git commit attempted after empty-diff detection" \
+         "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+
+# Terminal fix_ci_failed.
+if grep -q "phase = 'fix_ci_failed'" "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null; then
+    pass "#3245 T47 — advances to fix_ci_failed terminal on empty-diff"
+else
+    fail "#3245 T47 — advances to fix_ci_failed terminal on empty-diff" \
+         "psql-log: $(cat "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test T48: PATCHED but ``git push`` exits non-zero →
+# fix_ci_git_push_failed log event, terminal fix_ci_failed.
+# ══════════════════════════════════════════════════════════════════════════
+
+t48_json='{"verdict": "PATCHED", "commit_message": "fix(scraping): foo — CI (#9999)", "changed_files": ["a.py"]}'
+run_fix_ci_test "t48" "$t48_json" GIT_PUSH_EXIT=128
+
+if [[ "$FIXCI_TEST_RC" -eq 0 ]]; then
+    pass "#3245 T48 — handle_fix_ci exits 0 on PATCHED+push-failure"
+else
+    fail "#3245 T48 — handle_fix_ci exits 0 on PATCHED+push-failure" \
+         "rc=$FIXCI_TEST_RC, output: $FIXCI_TEST_OUT"
+fi
+
+# Push was attempted (commit succeeded first).
+if grep -qE "CALL .*\\bpush\\b" "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3245 T48 — git push attempted on PATCHED"
+else
+    fail "#3245 T48 — git push attempted on PATCHED" \
+         "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+
+# Diagnostic log event emitted.
+if printf '%s' "$FIXCI_TEST_OUT" | grep -q "fix_ci_git_push_failed"; then
+    pass "#3245 T48 — fix_ci_git_push_failed log event emitted"
+else
+    fail "#3245 T48 — fix_ci_git_push_failed log event emitted" \
+         "output: $FIXCI_TEST_OUT"
+fi
+
+# Terminal fix_ci_failed (not awaiting_ci — push failure is fatal).
+if grep -q "phase = 'fix_ci_failed'" "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null; then
+    pass "#3245 T48 — advances to fix_ci_failed terminal on push failure"
+else
+    fail "#3245 T48 — advances to fix_ci_failed terminal on push failure" \
+         "psql-log: $(cat "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null)"
+fi
+# Negative: must NOT have advanced to awaiting_ci (that would let the
+# supervisor re-enter a broken push loop).
+if ! grep -q "SET phase = 'awaiting_ci'" "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null; then
+    pass "#3245 T48 — does not advance to awaiting_ci on push failure"
+else
+    fail "#3245 T48 — does not advance to awaiting_ci on push failure" \
+         "psql-log: $(cat "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test T49: FLAKY verdict → advance to awaiting_ci, no commit, no push.
+# ══════════════════════════════════════════════════════════════════════════
+
+t49_json='{"verdict": "FLAKY", "flaky_evidence": "httpx.TimeoutError to api.anthropic.com in packages/api tests — intermittent"}'
+run_fix_ci_test "t49" "$t49_json"
+
+if [[ "$FIXCI_TEST_RC" -eq 0 ]]; then
+    pass "#3245 T49 — handle_fix_ci exits 0 on FLAKY"
+else
+    fail "#3245 T49 — handle_fix_ci exits 0 on FLAKY" \
+         "rc=$FIXCI_TEST_RC, output: $FIXCI_TEST_OUT"
+fi
+
+# fix_ci_flaky log event emitted.
+if printf '%s' "$FIXCI_TEST_OUT" | grep -q "fix_ci_flaky"; then
+    pass "#3245 T49 — fix_ci_flaky log event emitted"
+else
+    fail "#3245 T49 — fix_ci_flaky log event emitted" \
+         "output: $FIXCI_TEST_OUT"
+fi
+
+# No git add / commit / push attempted on FLAKY.
+if ! grep -qE "CALL .*\\badd\\b|CALL .*\\bcommit\\b|CALL .*\\bpush\\b" \
+    "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3245 T49 — no git add/commit/push on FLAKY"
+else
+    fail "#3245 T49 — no git add/commit/push on FLAKY" \
+         "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+
+# Advanced to awaiting_ci (not fix_ci_failed).
+if grep -q "SET phase = 'awaiting_ci'" "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null; then
+    pass "#3245 T49 — advances to awaiting_ci on FLAKY (re-poll)"
+else
+    fail "#3245 T49 — advances to awaiting_ci on FLAKY (re-poll)" \
+         "psql-log: $(cat "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null)"
+fi
+if ! grep -q "phase = 'fix_ci_failed'" "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null; then
+    pass "#3245 T49 — does NOT advance to fix_ci_failed on FLAKY"
+else
+    fail "#3245 T49 — does NOT advance to fix_ci_failed on FLAKY" \
+         "psql-log: $(cat "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null)"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Fixes the P0 bug where the ECS agent-runner entrypoint dispatched `fix_ci` through the generic Claude-phase case and never staged/committed/pushed the working-tree changes the `/task-v2-fix-ci` skill produced. Every ECS agent with initially-red CI looped 40 iterations adding zero commits, wasting ~75 min + 40 sonnet invocations per agent.

Splits `fix_ci` out into a dedicated `handle_fix_ci` function that mirrors the subprocess daemon's `_run_fix_ci` + `_apply_fix_ci_patch` — stages (`git add -A`), validates non-empty diff, commits, and pushes on PATCHED; advances to `fix_ci_failed` terminal on BLOCKED / empty commit_message / empty diff / push failure; advances to `awaiting_ci` without commit on FLAKY.

Closes #3245

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (228/228 `scripts/tests/test_agent_runner_entrypoint.sh`; 1471 dispatcher pytest tests)
- [x] CI green

### Post-deploy verification
- [x] `deploy-agent-runner.yml` ships the new image digest to dev (run 24910987049 SUCCESS, digest `sha256:c653339b…c1f2880`, tag `f95e991`)
- [ ] Next natural red-CI ECS agent produces a commit after fix_ci (log line `fix_ci_patch_pushed` + PR commit-count delta 1→2+ within the first few iterations) — *deferred, post-merge observational*
- [ ] 40-iteration cap signature disappears for non-legitimate BLOCKED failures — *deferred, post-merge observational*
- [x] Verification evidence posted on #3245 ([comment 4316267605](https://github.com/judgemind/judgemind/issues/3245#issuecomment-4316267605))
