### PR TITLE
obs(dispatcher): diagnoser metering to phase_outputs table (#2881)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -5907,6 +5907,84 @@ class DispatcherDaemon:
             except Exception:  # pragma: no cover
                 pass
 
+    def _persist_diagnoser_phase_output(
+        self,
+        agent_id: str,
+        diagnosis_id: int,
+        usage: dict[str, Any] | None,
+        log_text: str | None,
+    ) -> None:
+        """INSERT a ``dispatcher.phase_outputs`` row for a diagnoser run.
+
+        Mirrors :meth:`_persist_phase_output` but:
+
+        * Uses a constant ``phase='diagnose'`` — the diagnoser is not
+          part of the orchestration phase sequence.
+        * Sets ``output_json={"diagnosis_id": diagnosis_id}`` so
+          admin-page queries can JOIN back to ``dispatcher.diagnoses``.
+        * Does **not** write a ``dispatcher.phase_transitions`` row —
+          the diagnoser fires on already-failed agents and keeping the
+          transitions sequence clean preserves the dispatcher-v2 spec
+          invariant that transitions trace the orchestration flow.
+
+        Uses ``ON CONFLICT (agent_id, phase, attempt) DO UPDATE`` so a
+        second diagnosis on the same agent at the same ``retries_used``
+        count overwrites the earlier row (rare, cost telemetry is
+        aggregated, not per-row). Issue #2881.
+        """
+        assert self._conn is not None, "connect() must run before persisting"
+        attempt = self._current_attempt_for(agent_id)
+        u = usage or {}
+        output_json = json.dumps({"diagnosis_id": diagnosis_id}, default=str)
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO dispatcher.phase_outputs "
+                    "    (agent_id, phase, output_json, log_text, attempt, "
+                    "     tokens_input, tokens_output, tokens_cache_read, "
+                    "     tokens_cache_write, cost_usd, model_used) "
+                    "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s) "
+                    "ON CONFLICT (agent_id, phase, attempt) DO UPDATE SET "
+                    "    output_json         = EXCLUDED.output_json, "
+                    "    log_text            = EXCLUDED.log_text, "
+                    "    tokens_input        = EXCLUDED.tokens_input, "
+                    "    tokens_output       = EXCLUDED.tokens_output, "
+                    "    tokens_cache_read   = EXCLUDED.tokens_cache_read, "
+                    "    tokens_cache_write  = EXCLUDED.tokens_cache_write, "
+                    "    cost_usd            = EXCLUDED.cost_usd, "
+                    "    model_used          = EXCLUDED.model_used, "
+                    "    ts                  = now()",
+                    (
+                        agent_id,
+                        "diagnose",
+                        output_json,
+                        log_text,
+                        attempt,
+                        u.get("tokens_input"),
+                        u.get("tokens_output"),
+                        u.get("tokens_cache_read"),
+                        u.get("tokens_cache_write"),
+                        u.get("cost_usd"),
+                        u.get("model_used"),
+                    ),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.persist_diagnoser_phase_output_failed",
+                extra={
+                    "event": "persist_diagnoser_phase_output_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "diagnosis_id": diagnosis_id,
+                    "attempt": attempt,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+
     def _current_attempt_for(self, agent_id: str) -> int:
         """Return the current retry attempt number for an agent.
 
@@ -8431,27 +8509,28 @@ class DispatcherDaemon:
         except Exception:  # pragma: no cover — defensive
             return
 
-    def _parse_phase_usage(self, worktree: Path, phase: str) -> dict[str, Any] | None:
-        """Parse the ``claude -p --output-format json`` usage envelope.
+    def _parse_usage_envelope(
+        self, stdout_path: Path, fallback_model: str | None
+    ) -> dict[str, Any] | None:
+        """Parse a ``claude -p --output-format json`` stdout file.
 
-        Reads ``{worktree}/tmp/claude-p-<phase>.stdout.json`` — the
-        single JSON object Claude Code writes to stdout when
-        ``--output-format json`` is passed. Extracts the fields we
-        persist on ``dispatcher.phase_outputs``:
+        Shared inner helper used by both :meth:`_parse_phase_usage` and
+        :meth:`_parse_diagnoser_usage`. Reads the JSON envelope at
+        *stdout_path*, validates the structure, and returns the
+        normalised usage dict:
 
         - ``tokens_input`` ← ``usage.input_tokens``
         - ``tokens_output`` ← ``usage.output_tokens``
         - ``tokens_cache_read`` ← ``usage.cache_read_input_tokens``
         - ``tokens_cache_write`` ← ``usage.cache_creation_input_tokens``
         - ``cost_usd`` ← ``total_cost_usd``
-        - ``model_used`` ← ``model`` (falls back to ``PHASE_MODELS[phase]``)
+        - ``model_used`` ← ``model`` (falls back to *fallback_model*)
 
-        Returns ``None`` on any error — the stdout file is missing,
-        empty, not JSON, or the envelope has no ``usage`` block. The
-        caller treats ``None`` the same as "no metering signal": the
-        new columns stay NULL, the row still inserts. Issue #2869.
+        Returns ``None`` on any error — the file is missing, empty, not
+        JSON, or the envelope has no ``usage`` block. The caller treats
+        ``None`` as "no metering signal": the new columns stay NULL and
+        the INSERT still runs. Issue #2869.
         """
-        stdout_path = worktree / "tmp" / f"claude-p-{phase}.stdout.json"
         if not stdout_path.exists():
             return None
         try:
@@ -8478,7 +8557,7 @@ class DispatcherDaemon:
             cost_usd = None
         model_used = envelope.get("model")
         if not isinstance(model_used, str) or not model_used:
-            model_used = PHASE_MODELS.get(phase)
+            model_used = fallback_model
 
         def _int_or_none(v: Any) -> int | None:
             try:
@@ -8496,6 +8575,39 @@ class DispatcherDaemon:
             "cost_usd": cost_usd,
             "model_used": model_used,
         }
+
+    def _parse_phase_usage(self, worktree: Path, phase: str) -> dict[str, Any] | None:
+        """Parse the ``claude -p --output-format json`` usage envelope.
+
+        Thin wrapper around :meth:`_parse_usage_envelope` that computes
+        the stdout path from the worktree + phase name and supplies
+        ``PHASE_MODELS[phase]`` as the model fallback.
+
+        Reads ``{worktree}/tmp/claude-p-<phase>.stdout.json``. Returns
+        ``None`` on any error — the stdout file is missing, empty, not
+        JSON, or the envelope has no ``usage`` block. The caller treats
+        ``None`` the same as "no metering signal": the new columns stay
+        NULL, the row still inserts. Issue #2869.
+        """
+        stdout_path = worktree / "tmp" / f"claude-p-{phase}.stdout.json"
+        return self._parse_usage_envelope(stdout_path, PHASE_MODELS.get(phase))
+
+    def _parse_diagnoser_usage(self, diagnosis_id: int) -> dict[str, Any] | None:
+        """Parse token usage from a diagnoser subprocess stdout file.
+
+        Thin wrapper around :meth:`_parse_usage_envelope` that computes
+        the stdout path for a diagnoser run — stored under
+        ``{repo_root}/tmp/claude-p-diagnose-<diagnosis_id>.stdout.json``
+        — and supplies ``DIAGNOSER_MODEL`` as the model fallback.
+
+        Returns ``None`` on any error (same semantics as
+        :meth:`_parse_phase_usage`). Issue #2881.
+        """
+        repo_root = self._repo_root_for_notify_script()
+        stdout_path = (
+            repo_root / "tmp" / f"claude-p-diagnose-{diagnosis_id}.stdout.json"
+        )
+        return self._parse_usage_envelope(stdout_path, DIAGNOSER_MODEL)
 
     def _claim_and_orchestrate_one(self) -> None:
         """Claim one issue and run the plan → ralph → summary → PR flow.
@@ -17400,6 +17512,8 @@ class DispatcherDaemon:
             str(DIAGNOSER_MAX_TURNS),
             "--model",
             DIAGNOSER_MODEL,
+            "--output-format",
+            "json",
             # See ``_spawn_phase_subprocess`` for the full rationale on
             # why the Fargate dispatcher runs subagents with
             # ``--dangerously-skip-permissions``. Same reasoning applies
@@ -17414,8 +17528,11 @@ class DispatcherDaemon:
         jsonl_path = (
             repo_root / "tmp" / ".dispatcher" / f"diagnose-{diagnosis_id}.jsonl"
         )
+        stdout_path = (
+            repo_root / "tmp" / f"claude-p-diagnose-{diagnosis_id}.stdout.json"
+        )
+        stdout_path.parent.mkdir(parents=True, exist_ok=True)
         stderr_buf: list[str] = []
-        stdout_buf: list[str] = []
 
         class _ListSink:
             """File-like sink that appends each write to ``buf``."""
@@ -17442,6 +17559,7 @@ class DispatcherDaemon:
         except FileNotFoundError:
             return None, "claude binary not found"
 
+        stdout_file = stdout_path.open("w", encoding="utf-8")
         threads = stream_subprocess_output_async(
             proc,
             agent_id=f"diagnose-{diagnosis_id}",
@@ -17449,7 +17567,7 @@ class DispatcherDaemon:
             phase="diagnose",
             logger=self._log,
             jsonl_path=jsonl_path,
-            stdout_sink=_ListSink(stdout_buf),
+            stdout_sink=stdout_file,
             stderr_sink=_ListSink(stderr_buf),
         )
         try:
@@ -17461,10 +17579,14 @@ class DispatcherDaemon:
             except subprocess.TimeoutExpired:  # pragma: no cover
                 pass
             threads.join(timeout=10)
+            stdout_file.flush()
+            stdout_file.close()
             tail = ("".join(stderr_buf))[-500:]
             return None, tail
 
         threads.join(timeout=10)
+        stdout_file.flush()
+        stdout_file.close()
         stderr_tail = ("".join(stderr_buf))[-500:]
         return returncode, stderr_tail
 
@@ -18648,11 +18770,24 @@ class DispatcherDaemon:
                         "agent_id": candidate["agent_id"],
                         "category": candidate["category"],
                         "tier": candidate["tier"],
+                        "output_format": "json",
                     },
                 )
 
                 exit_code, stderr_tail = self._spawn_diagnoser_subprocess(diagnosis_id)
                 ran += 1
+
+                # Parse + persist metering before any branch — records
+                # cost even when the diagnoser timed out or exited
+                # non-zero (that's when opus-cost-vs-savings matters
+                # most). Issue #2881.
+                diag_usage = self._parse_diagnoser_usage(diagnosis_id)
+                self._persist_diagnoser_phase_output(
+                    agent_id=candidate["agent_id"],
+                    diagnosis_id=diagnosis_id,
+                    usage=diag_usage,
+                    log_text=stderr_tail if stderr_tail else None,
+                )
 
                 if exit_code is None:
                     # Timeout or subprocess could not be launched.

--- a/scripts/dispatcher/tests/test_daemon_diagnoser_metering.py
+++ b/scripts/dispatcher/tests/test_daemon_diagnoser_metering.py
@@ -1,0 +1,503 @@
+"""Unit tests for diagnoser token + cost metering (#2881).
+
+Covers the diagnoser-specific metering path introduced in issue #2881:
+
+* :meth:`daemon.DispatcherDaemon._spawn_diagnoser_subprocess` — adds
+  ``--output-format json`` and writes stdout to
+  ``{repo_root}/tmp/claude-p-diagnose-<id>.stdout.json``.
+* :meth:`daemon.DispatcherDaemon._parse_diagnoser_usage` — thin wrapper
+  around ``_parse_usage_envelope`` that computes the diagnoser stdout
+  path and supplies ``DIAGNOSER_MODEL`` as the fallback model.
+* :meth:`daemon.DispatcherDaemon._persist_diagnoser_phase_output` —
+  inserts one ``dispatcher.phase_outputs`` row with ``phase='diagnose'``
+  and the six metering columns.
+* :meth:`daemon.DispatcherDaemon._run_diagnoser_pass` — parses usage and
+  persists on every exit branch (timeout, non-zero, exit 0).
+
+Same mocking strategy as :mod:`test_daemon_token_metering` — ``psycopg``
+is stubbed before the daemon import so the test runner never needs a real
+DB or the ``psycopg`` wheel. No ``claude`` / ``gh`` / ``git``
+subprocesses run.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+from dispatcher.tests._popen_fake import make_popen_factory  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — mirror test_daemon_token_metering's lightweight DB doubles.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.diagnoser_metering.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+        baseline_repo_root=tmp_path,
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# _spawn_diagnoser_subprocess — --output-format json flag
+# --------------------------------------------------------------------------
+
+
+class TestSpawnDiagnoserAddsOutputFormatJsonFlag:
+    """``_spawn_diagnoser_subprocess`` must include ``--output-format json``
+    so the stdout stream is a parseable JSON envelope for metering."""
+
+    def test_command_includes_output_format_json(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        captured: dict[str, Any] = {}
+
+        def on_start(cmd: list[str], _kwargs: dict[str, Any]) -> None:
+            captured["cmd"] = cmd
+
+        monkeypatch.setattr(subprocess, "Popen", make_popen_factory(on_start=on_start))
+        d._spawn_diagnoser_subprocess(42)
+
+        cmd = captured["cmd"]
+        assert "--output-format" in cmd, cmd
+        i = cmd.index("--output-format")
+        assert cmd[i + 1] == "json"
+
+
+# --------------------------------------------------------------------------
+# _spawn_diagnoser_subprocess — stdout file written to repo_root/tmp/
+# --------------------------------------------------------------------------
+
+
+class TestSpawnDiagnoserWritesStdoutFile:
+    """``_spawn_diagnoser_subprocess`` must write the diagnoser stdout to
+    ``{repo_root}/tmp/claude-p-diagnose-<id>.stdout.json``."""
+
+    def test_stdout_file_written_to_repo_root_tmp(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        stdout_payload = '{"usage":{"input_tokens":10},"total_cost_usd":0.01}\n'
+        monkeypatch.setattr(
+            subprocess,
+            "Popen",
+            make_popen_factory(stdout_chunks=[stdout_payload]),
+        )
+        d._spawn_diagnoser_subprocess(99)
+
+        stdout_path = tmp_path / "tmp" / "claude-p-diagnose-99.stdout.json"
+        assert stdout_path.exists(), f"Expected stdout file at {stdout_path}"
+        content = stdout_path.read_text(encoding="utf-8")
+        assert '"input_tokens"' in content
+
+
+# --------------------------------------------------------------------------
+# _parse_diagnoser_usage
+# --------------------------------------------------------------------------
+
+
+class TestParseDiagnoserUsage:
+    """``_parse_diagnoser_usage`` is a thin wrapper around
+    ``_parse_usage_envelope`` that resolves the diagnoser stdout path and
+    supplies ``DIAGNOSER_MODEL`` as the model fallback."""
+
+    def _write_stdout(self, tmp_path: Path, diagnosis_id: int, payload: str) -> None:
+        path = tmp_path / "tmp" / f"claude-p-diagnose-{diagnosis_id}.stdout.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(payload, encoding="utf-8")
+
+    def test_parses_full_usage_envelope(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        envelope = {
+            "result": "...",
+            "usage": {
+                "input_tokens": 1234,
+                "output_tokens": 567,
+                "cache_creation_input_tokens": 8901,
+                "cache_read_input_tokens": 23456,
+            },
+            "total_cost_usd": 0.5678,
+            "model": "claude-opus-4-5-20250929",
+        }
+        self._write_stdout(tmp_path, 7, json.dumps(envelope))
+
+        usage = d._parse_diagnoser_usage(7)
+        assert usage is not None
+        assert usage["tokens_input"] == 1234
+        assert usage["tokens_output"] == 567
+        assert usage["tokens_cache_write"] == 8901
+        assert usage["tokens_cache_read"] == 23456
+        assert usage["cost_usd"] == 0.5678
+        assert usage["model_used"] == "claude-opus-4-5-20250929"
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        assert d._parse_diagnoser_usage(999) is None
+
+    def test_empty_file_returns_none(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        self._write_stdout(tmp_path, 1, "")
+        assert d._parse_diagnoser_usage(1) is None
+
+    def test_malformed_json_returns_none(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        self._write_stdout(tmp_path, 2, "not json at all")
+        assert d._parse_diagnoser_usage(2) is None
+
+    def test_envelope_without_usage_block_returns_none(self, tmp_path: Path) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        self._write_stdout(tmp_path, 3, json.dumps({"result": "hi"}))
+        assert d._parse_diagnoser_usage(3) is None
+
+    def test_partial_usage_falls_back_to_diagnoser_model(self, tmp_path: Path) -> None:
+        """A partial usage block (model absent) falls back to DIAGNOSER_MODEL."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        envelope = {
+            "usage": {"input_tokens": 100},
+            "total_cost_usd": None,
+        }
+        self._write_stdout(tmp_path, 4, json.dumps(envelope))
+
+        usage = d._parse_diagnoser_usage(4)
+        assert usage is not None
+        assert usage["tokens_input"] == 100
+        assert usage["tokens_output"] is None
+        assert usage["tokens_cache_read"] is None
+        assert usage["tokens_cache_write"] is None
+        assert usage["cost_usd"] is None
+        # Model falls back to DIAGNOSER_MODEL.
+        assert usage["model_used"] == daemon.DIAGNOSER_MODEL
+
+
+# --------------------------------------------------------------------------
+# _persist_diagnoser_phase_output
+# --------------------------------------------------------------------------
+
+
+class TestPersistDiagnoserPhaseOutput:
+    """``_persist_diagnoser_phase_output`` inserts into
+    ``dispatcher.phase_outputs`` with ``phase='diagnose'``."""
+
+    def test_writes_phase_outputs_row_with_phase_diagnose(self, tmp_path: Path) -> None:
+        """11-param INSERT with phase='diagnose', agent_id bound to the
+        failing-agent UUID, and all six metering columns populated."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        # Migration-30 contract: _current_attempt_for reads retries_used first.
+        conn.cursor_instance.fetch_queue = [(0,)]
+
+        usage = {
+            "tokens_input": 1000,
+            "tokens_output": 500,
+            "tokens_cache_read": 2000,
+            "tokens_cache_write": 3000,
+            "cost_usd": 0.0742,
+            "model_used": "claude-opus-4-5",
+        }
+        d._persist_diagnoser_phase_output(
+            agent_id="agent-failing-uuid",
+            diagnosis_id=77,
+            usage=usage,
+            log_text="stderr tail here",
+        )
+
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_outputs" in e[0]
+        ]
+        assert len(inserts) == 1
+        sql, params = inserts[0]
+        # 11 bind params: 5 original + 6 metering.
+        assert len(params) == 11
+        assert params[0] == "agent-failing-uuid"  # agent_id
+        assert params[1] == "diagnose"  # phase constant
+        # output_json contains the diagnosis_id for join-back
+        output = json.loads(params[2])
+        assert output["diagnosis_id"] == 77
+        assert params[3] == "stderr tail here"  # log_text
+        assert params[5] == 1000  # tokens_input
+        assert params[6] == 500  # tokens_output
+        assert params[7] == 2000  # tokens_cache_read
+        assert params[8] == 3000  # tokens_cache_write
+        assert params[9] == 0.0742  # cost_usd
+        assert params[10] == "claude-opus-4-5"  # model_used
+        # SQL references every metering column name.
+        assert "tokens_input" in sql
+        assert "tokens_output" in sql
+        assert "tokens_cache_read" in sql
+        assert "tokens_cache_write" in sql
+        assert "cost_usd" in sql
+        assert "model_used" in sql
+
+    def test_no_usage_signal_still_inserts_with_nulls(self, tmp_path: Path) -> None:
+        """``usage=None`` path must still insert — metering columns become NULL."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+
+        d._persist_diagnoser_phase_output(
+            agent_id="agent-no-signal",
+            diagnosis_id=88,
+            usage=None,
+            log_text=None,
+        )
+
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_outputs" in e[0]
+        ]
+        assert len(inserts) == 1
+        _sql, params = inserts[0]
+        # All six metering columns must be None.
+        for idx in range(5, 11):
+            assert params[idx] is None, f"param idx={idx} should be None"
+
+    def test_does_not_write_phase_transitions_row(self, tmp_path: Path) -> None:
+        """The diagnoser is not an orchestration phase — no
+        ``dispatcher.phase_transitions`` row should be inserted."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+
+        d._persist_diagnoser_phase_output(
+            agent_id="agent-transitions-check",
+            diagnosis_id=55,
+            usage=None,
+            log_text=None,
+        )
+
+        all_sql = [e[0] for e in conn.cursor_instance.executed]
+        transitions_inserts = [
+            s for s in all_sql if "INSERT INTO dispatcher.phase_transitions" in s
+        ]
+        assert transitions_inserts == [], (
+            "No phase_transitions INSERT expected for diagnose phase, "
+            f"but found: {transitions_inserts}"
+        )
+        # But the phase_outputs INSERT must have happened.
+        phase_output_inserts = [
+            s for s in all_sql if "INSERT INTO dispatcher.phase_outputs" in s
+        ]
+        assert len(phase_output_inserts) == 1
+
+
+# --------------------------------------------------------------------------
+# _run_diagnoser_pass — metering persisted on every exit branch
+# --------------------------------------------------------------------------
+
+
+_FAKE_CANDIDATE = {
+    "failure_id": 101,
+    "agent_id": "agent-failing-for-diagnoser",
+    "category": "subprocess_crash",
+    "tier": 2,
+}
+
+
+def _setup_run_diagnoser_pass(
+    d: daemon.DispatcherDaemon,
+    conn: _FakeConnection,
+    diagnosis_id: int = 42,
+) -> None:
+    """Wire the daemon so ``_run_diagnoser_pass`` can run a single candidate."""
+    # diagnoser_enabled: reads one config row
+    # _find_diagnoser_candidates: returns our fake candidate
+    # _build_diagnoser_context: returns empty dict
+    # _insert_pending_diagnosis: returns our diagnosis_id
+    # _current_attempt_for (inside _persist_diagnoser_phase_output):
+    #   reads retries_used from agents table
+    # _mark_diagnosis_failed / _apply_mechanical_escalation need conn too
+    pass  # monkeypatching done inline in each test
+
+
+class TestRunDiagnoserPassPersistsOnTimeout:
+    """When ``_spawn_diagnoser_subprocess`` returns ``(None, tail)`` (timeout),
+    the persist path must still fire."""
+
+    def test_persist_called_on_timeout(self, monkeypatch: Any, tmp_path: Path) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        # Pre-write a stdout file so _parse_diagnoser_usage can succeed.
+        stdout_path = tmp_path / "tmp" / "claude-p-diagnose-42.stdout.json"
+        stdout_path.parent.mkdir(parents=True, exist_ok=True)
+        stdout_path.write_text(
+            json.dumps({"usage": {"input_tokens": 50}, "total_cost_usd": 0.005}),
+            encoding="utf-8",
+        )
+
+        persisted: list[dict[str, Any]] = []
+
+        def fake_persist(
+            agent_id: str,
+            diagnosis_id: int,
+            usage: dict[str, Any] | None,
+            log_text: str | None,
+        ) -> None:
+            persisted.append(
+                {
+                    "agent_id": agent_id,
+                    "diagnosis_id": diagnosis_id,
+                    "usage": usage,
+                }
+            )
+
+        monkeypatch.setattr(d, "_diagnoser_enabled", lambda: True)
+        monkeypatch.setattr(
+            d, "_find_diagnoser_candidates", lambda: [dict(_FAKE_CANDIDATE)]
+        )
+        monkeypatch.setattr(d, "_build_diagnoser_context", lambda c: {})
+        monkeypatch.setattr(d, "_insert_pending_diagnosis", lambda **_kw: 42)
+        # Simulate timeout: exit_code=None
+        monkeypatch.setattr(
+            d,
+            "_spawn_diagnoser_subprocess",
+            lambda _id: (None, "timeout-tail"),
+        )
+        monkeypatch.setattr(d, "_persist_diagnoser_phase_output", fake_persist)
+        monkeypatch.setattr(d, "_mark_diagnosis_failed", lambda *_a, **_kw: None)
+        monkeypatch.setattr(d, "_apply_mechanical_escalation", lambda *_a: None)
+
+        ran = d._run_diagnoser_pass()
+
+        assert ran == 1
+        assert len(persisted) == 1, "persist must fire even on timeout"
+        assert persisted[0]["diagnosis_id"] == 42
+        assert persisted[0]["agent_id"] == _FAKE_CANDIDATE["agent_id"]
+
+
+class TestRunDiagnoserPassPersistsOnNonzeroExit:
+    """When ``_spawn_diagnoser_subprocess`` returns non-zero exit code,
+    the persist path must still fire."""
+
+    def test_persist_called_on_nonzero_exit(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, _handler = _make_daemon(tmp_path)
+
+        # Pre-write a stdout file (diagnoser may emit partial JSON even on
+        # non-zero exit).
+        stdout_path = tmp_path / "tmp" / "claude-p-diagnose-43.stdout.json"
+        stdout_path.parent.mkdir(parents=True, exist_ok=True)
+        stdout_path.write_text(
+            json.dumps({"usage": {"input_tokens": 20}, "total_cost_usd": 0.002}),
+            encoding="utf-8",
+        )
+
+        persisted: list[dict[str, Any]] = []
+
+        def fake_persist(
+            agent_id: str,
+            diagnosis_id: int,
+            usage: dict[str, Any] | None,
+            log_text: str | None,
+        ) -> None:
+            persisted.append({"diagnosis_id": diagnosis_id})
+
+        monkeypatch.setattr(d, "_diagnoser_enabled", lambda: True)
+        monkeypatch.setattr(
+            d, "_find_diagnoser_candidates", lambda: [dict(_FAKE_CANDIDATE)]
+        )
+        monkeypatch.setattr(d, "_build_diagnoser_context", lambda c: {})
+        monkeypatch.setattr(d, "_insert_pending_diagnosis", lambda **_kw: 43)
+        # Simulate non-zero exit.
+        monkeypatch.setattr(
+            d,
+            "_spawn_diagnoser_subprocess",
+            lambda _id: (1, "error-tail"),
+        )
+        monkeypatch.setattr(d, "_persist_diagnoser_phase_output", fake_persist)
+        monkeypatch.setattr(d, "_mark_diagnosis_failed", lambda *_a, **_kw: None)
+        monkeypatch.setattr(d, "_apply_mechanical_escalation", lambda *_a: None)
+
+        ran = d._run_diagnoser_pass()
+
+        assert ran == 1
+        assert len(persisted) == 1, "persist must fire even on non-zero exit"
+        assert persisted[0]["diagnosis_id"] == 43


### PR DESCRIPTION
## Summary

Extends the metering infrastructure from orchestration phases (plan/ralph/summary/fix-ci/verify/retro) to the diagnoser subprocess, making diagnoser cost visible in the cost-by-phase dashboards. Diagnoser invocations now record token usage and cost even on failure (timeout or non-zero exit), enabling cost-vs-savings tuning decisions.

Closes #2881

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — 13 new tests in `test_daemon_diagnoser_metering.py`; all pass; no regressions in existing 16 token metering tests
- [x] CI green

### Post-deploy verification

- [ ] CloudWatch logs show `phase_started event=diagnoser_started output_format=json` when diagnoser runs
- [ ] Dashboard query returns non-null metering: `SELECT * FROM dispatcher.phase_outputs WHERE phase='diagnose' ORDER BY ts DESC LIMIT 5`
- [ ] Verification evidence posted on #2881 (see /task-v2-verify output)