### PR TITLE
tune(dispatcher): fix_conflict skill → sonnet (#3250)

### DIFF
--- a/.claude/skills/task-v2-fix-conflict/SKILL.md
+++ b/.claude/skills/task-v2-fix-conflict/SKILL.md
@@ -2,7 +2,7 @@
 description: Fix-conflict phase for the per-phase /task-v2 pipeline. Reads a rebase-conflict bundle, resolves conflicts semantically against updated origin/main content, and produces either a resolved-file set OR an unresolvable signal.
 argument-hint: "<agent-id>"
 maxTurns: 60
-model: haiku
+model: sonnet
 ---
 
 # /task-v2-fix-conflict skill


### PR DESCRIPTION
## Summary

Bumps the `/task-v2-fix-conflict` skill frontmatter from `model: haiku` to `model: sonnet`. Semantic rebase-conflict resolution needs stronger judgment than haiku reliably gives; fix_ci already uses sonnet for the same reason.

**On the second acceptance criterion** (flip `AGENT_RUNNER_RALPH_BASELINE_REBASE` default `0` → `1`): investigation shows the default on `origin/main` is **already `1`** — it shipped that way in PR #3244 (line 3877 of `scripts/dispatcher/agent-runner-entrypoint.sh`). `git log -S 'AGENT_RUNNER_RALPH_BASELINE_REBASE:-0'` returns zero commits, confirming the `:-0` default the issue body describes was never in-tree. No code change was required. Full reasoning in the process-summary comment on #3250.

Diff is one line: `-model: haiku` / `+model: sonnet` in `.claude/skills/task-v2-fix-conflict/SKILL.md`.

Closes #3250

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] `deploy-agent-runner.yml` N/A — by design, the workflow's `paths:` filter does not include `.claude/skills/**` (skills are read at runtime from the daemon's baseline clone, not baked into the agent-runner image). Full deployment reasoning in the verification-evidence comment on #3250.
- [x] Verification evidence posted on issue #3250: https://github.com/judgemind/judgemind/issues/3250#issuecomment-4316443012
