### PR TITLE
ci: add guard against git -C self._repo_root() in daemon.py (#2829)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -581,6 +581,23 @@ if [ -n "$changed_dispatcher_deps" ]; then
     else
         echo "  WARNING: scripts/check-dispatcher-image-deps.sh not found or not executable — skipping" >&2
     fi
+    # Issue #2829: git subprocesses in daemon.py must anchor at
+    # _git_parent_root(), not _repo_root() — the latter returns /app
+    # in Fargate (no .git directory). Mirrors the CI step so the
+    # failure is caught locally before the CI round trip.
+    if [ -x scripts/check-no-git-repo-root-anchor.sh ]; then
+        if ! run_check "_" "scripts/check-no-git-repo-root-anchor.sh" scripts/check-no-git-repo-root-anchor.sh; then
+            echo "  A git subprocess.run call in scripts/dispatcher/daemon.py" >&2
+            echo "  anchors at self._repo_root() instead of self._git_parent_root()." >&2
+            echo "  In Fargate mode, _repo_root() returns /app (no .git directory)." >&2
+            echo "" >&2
+            echo "  Fix: replace self._repo_root() with self._git_parent_root()" >&2
+            echo "  in the flagged git subprocess call. See issue #2829." >&2
+            failures=$((failures + 1))
+        fi
+    else
+        echo "  WARNING: scripts/check-no-git-repo-root-anchor.sh not found or not executable — skipping" >&2
+    fi
 fi
 
 # -------------------------------------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,6 +643,15 @@ jobs:
       # silent-ECS-agent-loss bug from creeping back in.
       - name: Verify every dispatcher.agents SQL site is execution_mode-aware
         run: scripts/check-dispatcher-execution-mode-aware.sh
+      # Issue #2829: every ``subprocess.run([... "git" ...])`` call site in
+      # ``scripts/dispatcher/daemon.py`` whose first positional arg resolves
+      # to a list literal beginning with ``"git"`` AND containing
+      # ``self._repo_root()`` is a bug — in Fargate mode, ``_repo_root()``
+      # returns ``/app`` (no ``.git`` directory). The correct anchor is
+      # ``_git_parent_root()``.
+      - name: Verify no git subprocess in daemon.py anchors at self._repo_root()
+        if: needs.detect-changes.outputs.scripts == 'true'
+        run: bash scripts/check-no-git-repo-root-anchor.sh
       # Issue #3082: operator laptops run macOS's stock bash 3.2.
       # Shell scripts under scripts/**/*.sh must stick to the bash 3.2
       # subset — no mapfile, readarray, associative arrays, nameref,

--- a/scripts/check-no-git-repo-root-anchor.sh
+++ b/scripts/check-no-git-repo-root-anchor.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# check-no-git-repo-root-anchor.sh — Every ``subprocess.run([... "git" ...])``
+# call site in ``scripts/dispatcher/daemon.py`` whose first positional arg
+# resolves to a list literal beginning with ``"git"`` AND containing
+# ``self._repo_root()`` (directly, wrapped in ``str()``, or ``Path()``)
+# is a bug: the correct anchor for git operations is
+# ``self._git_parent_root()``.
+#
+# Why this check exists
+# ---------------------
+# In Fargate mode, ``_repo_root()`` returns ``/app`` (the container image
+# mount), which has no ``.git`` directory. Any ``git -C <repo_root> ...``
+# subprocess silently fails or operates on the wrong repo. The right anchor
+# is ``_git_parent_root()``, which falls back to ``_repo_root()`` only in
+# local-dev / unit-test mode.
+#
+# Non-git subprocesses (cleanup-script lookups, tmp-dir construction)
+# legitimately use ``_repo_root()`` — this check only flags list literals
+# whose first element is ``"git"``.
+#
+# Issue: #2829.
+#
+# Rule
+# ----
+# Every ``subprocess.run(...)`` call site in ``scripts/dispatcher/daemon.py``
+# whose first positional arg resolves to a list literal that BOTH:
+#   (a) begins with ``"git"``, AND
+#   (b) contains ``self._repo_root()`` anywhere (directly or via str()/Path())
+# is a violation.
+#
+# Name-bound forms (``cmd = ["git", "-C", str(self._repo_root()), ...]``)
+# are also resolved and checked.
+#
+# Usage
+# -----
+#   scripts/check-no-git-repo-root-anchor.sh            # scan the real daemon.py
+#   scripts/check-no-git-repo-root-anchor.sh [file]     # scan a specific file (tests)
+#
+# Exit codes
+# ----------
+#   0 — No violations found.
+#   1 — At least one git subprocess anchors at self._repo_root().
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET_FILE="${1:-$REPO_ROOT/scripts/dispatcher/daemon.py}"
+
+# ─── Fast exit if the target file does not exist ─────────────────────────
+if [[ ! -f "$TARGET_FILE" ]]; then
+    echo "check-no-git-repo-root-anchor: no target file at $TARGET_FILE — nothing to check."
+    exit 0
+fi
+
+# ─── Locate violating call sites via embedded Python AST walker ──────────
+# The walker:
+#   1. Finds all subprocess.run(...) call nodes.
+#   2. Resolves the first positional arg: either a direct list literal, or
+#      a name-bound list literal from an Assign in the same function scope.
+#   3. Checks if the list's first element is "git".
+#   4. Checks if any element of the list calls self._repo_root() —
+#      directly (as an Attribute call on Self), or wrapped in str()/Path().
+#   5. Emits "<lineno>:<snippet>" for each violating call site.
+#
+# Docstrings and comments are excluded because AST parsing only sees
+# executable code — string literals not assigned or passed anywhere
+# are not visited as Call nodes.
+
+python_output="$(python3 - "$TARGET_FILE" <<'PYEOF'
+import ast
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+try:
+    source = path.read_text()
+    tree = ast.parse(source)
+except SyntaxError as exc:
+    # Not valid Python — skip silently (the file may be a fixture
+    # or a stub the check doesn't need to flag).
+    sys.exit(0)
+
+lines = source.splitlines()
+
+
+def _literal_str(node):
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _list_first_literal(node):
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return None
+    if not node.elts:
+        return None
+    return _literal_str(node.elts[0])
+
+
+def _enclosing_func(line_no):
+    best = None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.lineno <= line_no <= (node.end_lineno or node.lineno):
+                if best is None or node.lineno > best.lineno:
+                    best = node
+    return best
+
+
+def _resolve_name(name, before_line):
+    """Resolve ``name`` to its most recent list-literal Assign within
+    the enclosing function scope."""
+    scope = _enclosing_func(before_line)
+    if scope is None:
+        return None
+    best = None
+    for sub in ast.walk(scope):
+        if isinstance(sub, ast.Assign) and sub.lineno < before_line:
+            for target in sub.targets:
+                if isinstance(target, ast.Name) and target.id == name:
+                    if isinstance(sub.value, (ast.List, ast.Tuple)):
+                        best = sub.value
+    return best
+
+
+def _is_repo_root_call(node):
+    """Return True if ``node`` is self._repo_root(), str(self._repo_root()),
+    or Path(self._repo_root())."""
+    # Direct: self._repo_root()
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_repo_root"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "self"
+    ):
+        return True
+    # Wrapped: str(self._repo_root()) or Path(self._repo_root())
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in ("str", "Path")
+        and len(node.args) == 1
+    ):
+        inner = node.args[0]
+        if (
+            isinstance(inner, ast.Call)
+            and isinstance(inner.func, ast.Attribute)
+            and inner.func.attr == "_repo_root"
+            and isinstance(inner.func.value, ast.Name)
+            and inner.func.value.id == "self"
+        ):
+            return True
+    return False
+
+
+def _list_contains_repo_root(list_node):
+    """Return True if any element of the list literal is or wraps
+    self._repo_root()."""
+    for elt in list_node.elts:
+        if _is_repo_root_call(elt):
+            return True
+    return False
+
+
+for node in ast.walk(tree):
+    if not isinstance(node, ast.Call):
+        continue
+    func = node.func
+    if not (
+        isinstance(func, ast.Attribute)
+        and func.attr == "run"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "subprocess"
+    ):
+        continue
+    if not node.args:
+        continue
+    first = node.args[0]
+    cmd_list = None
+    if isinstance(first, (ast.List, ast.Tuple)):
+        cmd_list = first
+    elif isinstance(first, ast.Name):
+        resolved = _resolve_name(first.id, node.lineno)
+        if resolved is not None:
+            cmd_list = resolved
+
+    if cmd_list is None:
+        continue
+
+    # Only flag lists whose first element is the string "git"
+    if _list_first_literal(cmd_list) != "git":
+        continue
+
+    # Flag if any element is or wraps self._repo_root()
+    if _list_contains_repo_root(cmd_list):
+        snippet = lines[node.lineno - 1].strip() if node.lineno <= len(lines) else ""
+        print(f"{node.lineno}:{snippet}")
+PYEOF
+)"
+
+# ─── Report violations ───────────────────────────────────────────────────
+if [[ -z "${python_output// /}" ]]; then
+    exit 0
+fi
+
+violations=0
+while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    violations=$((violations + 1))
+done <<< "$python_output"
+
+if (( violations > 0 )); then
+    echo "ERROR: git subprocess.run call site(s) anchor at self._repo_root() in $TARGET_FILE."
+    echo ""
+    echo "  In Fargate mode, _repo_root() returns /app (no .git directory)."
+    echo "  Git operations must anchor at _git_parent_root() instead, which"
+    echo "  returns the correct baseline-clone path in production and falls"
+    echo "  back to _repo_root() in local-dev / unit-test mode."
+    echo ""
+    echo "  Fix: replace self._repo_root() with self._git_parent_root()"
+    echo "  (or a pre-bound local variable from self._git_parent_root())."
+    echo ""
+    echo "  See issue #2829 for context."
+    echo ""
+    echo "  Violating sites:"
+    echo ""
+    while IFS= read -r entry; do
+        [[ -z "$entry" ]] && continue
+        lineno="${entry%%:*}"
+        snippet="${entry#*:}"
+        echo "    $TARGET_FILE:${lineno}: ${snippet}"
+    done <<< "$python_output"
+    echo ""
+    exit 1
+fi
+
+exit 0

--- a/scripts/tests/test_check_no_git_repo_root_anchor.sh
+++ b/scripts/tests/test_check_no_git_repo_root_anchor.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# test_check_no_git_repo_root_anchor.sh — Tests for
+# scripts/check-no-git-repo-root-anchor.sh
+#
+# Verifies that the checker:
+#   - fails when a subprocess.run git list literal contains self._repo_root()
+#     inline or via a name-bound cmd variable
+#   - passes when the anchor is self._git_parent_root() (inline or
+#     name-bound)
+#   - passes on docstring prose that mentions _repo_root() (not real code)
+#   - passes on non-git subprocesses that legitimately use _repo_root()
+#   - passes on the real scripts/dispatcher/daemon.py
+#
+# Usage:
+#   scripts/tests/test_check_no_git_repo_root_anchor.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-no-git-repo-root-anchor.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+write_file() {
+    local path="$TMPDIR_TEST/$1"
+    mkdir -p "$(dirname "$path")"
+    cat > "$path"
+}
+
+# assert_passes <desc> [target]
+# When target is omitted the default is used for the self-match helper.
+assert_passes() {
+    local desc="$1"
+    local target="${2:-$TMPDIR_TEST/ci_step_names.yml}"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$target" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        "$CHECK_SCRIPT" "$target" 2>&1 | sed 's/^/    /'
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"
+    local target="$2"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$target" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: inline git list with self._repo_root() → FAIL ───────────────
+write_file "t1_inline_bad.py" <<'EOF'
+import subprocess
+
+class Daemon:
+    def _repo_root(self):
+        return "/app"
+    def do_git(self):
+        subprocess.run(
+            ["git", "-C", str(self._repo_root()), "status"],
+            check=True,
+        )
+EOF
+assert_fails "inline git list with str(self._repo_root()) is detected" \
+    "$TMPDIR_TEST/t1_inline_bad.py"
+
+# ─── Test 2: name-bound cmd list with self._repo_root() → FAIL ───────────
+write_file "t2_namebound_bad.py" <<'EOF'
+import subprocess
+
+class Daemon:
+    def _repo_root(self):
+        return "/app"
+    def do_git(self):
+        cmd = ["git", "-C", str(self._repo_root()), "worktree", "add", "path"]
+        subprocess.run(cmd, check=True)
+EOF
+assert_fails "name-bound cmd list with str(self._repo_root()) is detected" \
+    "$TMPDIR_TEST/t2_namebound_bad.py"
+
+# ─── Test 3: git list with self._git_parent_root() inline → PASS ─────────
+write_file "t3_good_inline.py" <<'EOF'
+import subprocess
+
+class Daemon:
+    def _git_parent_root(self):
+        return "/baseline"
+    def do_git(self):
+        subprocess.run(
+            ["git", "-C", str(self._git_parent_root()), "status"],
+            check=True,
+        )
+EOF
+assert_passes "inline git list with str(self._git_parent_root()) is allowed" \
+    "$TMPDIR_TEST/t3_good_inline.py"
+
+# ─── Test 4: name-bound cmd from self._git_parent_root() → PASS ──────────
+write_file "t4_good_namebound.py" <<'EOF'
+import subprocess
+
+class Daemon:
+    def _git_parent_root(self):
+        return "/baseline"
+    def do_git(self):
+        git_parent = self._git_parent_root()
+        cmd = ["git", "-C", str(git_parent), "worktree", "add", "path"]
+        subprocess.run(cmd, check=True)
+EOF
+assert_passes "name-bound cmd anchored at _git_parent_root() is allowed" \
+    "$TMPDIR_TEST/t4_good_namebound.py"
+
+# ─── Test 5: docstring prose mentioning self._repo_root() → PASS ─────────
+# Docstrings are string literals, not code; the AST walker does not visit
+# their textual content as a Call node.  Only executable list literals
+# inside subprocess.run calls are flagged.
+write_file "t5_docstring.py" <<'EOF'
+import subprocess
+
+class Daemon:
+    def do_git(self):
+        """Run git -C self._repo_root() status.
+
+        Note: legacy callers used self._repo_root() here; production now
+        requires self._git_parent_root().
+        """
+        pass
+EOF
+assert_passes "docstring prose mentioning self._repo_root() is ignored" \
+    "$TMPDIR_TEST/t5_docstring.py"
+
+# ─── Test 6: non-git subprocess using _repo_root() → PASS ────────────────
+# Cleanup-script lookups and tmp-dir paths legitimately use _repo_root().
+# The check only fires on list literals whose first element is "git".
+write_file "t6_nongit_subprocess.py" <<'EOF'
+import subprocess
+
+class Daemon:
+    def _repo_root(self):
+        return "/app"
+    def run_cleanup(self, cleanup_script):
+        subprocess.run(
+            [str(cleanup_script), str(self._repo_root())],
+            check=True,
+        )
+EOF
+assert_passes "non-git subprocess using _repo_root() is allowed" \
+    "$TMPDIR_TEST/t6_nongit_subprocess.py"
+
+# ─── Test 7: real scripts/dispatcher/daemon.py → PASS ────────────────────
+REAL_DAEMON="$REPO_ROOT/scripts/dispatcher/daemon.py"
+if [[ -f "$REAL_DAEMON" ]]; then
+    assert_passes "real scripts/dispatcher/daemon.py has no _repo_root() git anchors" \
+        "$REAL_DAEMON"
+fi
+
+# ─── Self-match assertion ─────────────────────────────────────────────────
+# The ci.yml step name that runs this guard must not itself contain the
+# forbidden Python pattern.  This assertion catches the class of failure
+# from #2541 / #2542.
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-no-git-repo-root-anchor.sh" "yml"
+
+# ─── Summary ─────────────────────────────────────────────────────────────
+echo ""
+if (( FAILURES > 0 )); then
+    echo "$FAILURES of $TESTS tests FAILED"
+    exit 1
+fi
+echo "all $TESTS tests passed"
+exit 0


### PR DESCRIPTION
## Summary

Adds a bash+Python3 AST-walker guard that detects subprocess.run git calls using self._repo_root() in daemon.py. In Fargate mode, _repo_root() returns /app (no .git directory), causing silent failures. The correct anchor is _git_parent_root(). Wired into CI workflow and pre-push hooks with developer-facing error messages.

Closes #2829

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green
- [x] Peer test covers 8 cases: fail paths (t1 direct str(), t2 name-bound), pass paths (t3/t4 _git_parent_root(), t5 docstring, t6 non-git, t7 real daemon.py), self-match assertion

### Post-deploy verification

- [ ] Introduce a git subprocess.run call anchored at self._repo_root() on a test branch and verify CI step fails (red)
- [ ] Revert the change and verify CI step passes (green)
- [ ] Verification evidence posted on #2829 (see /task-v2-verify output)