### PR TITLE
feat(dispatcher): add dispatcher.config.max_turns_by_phase live-edit path (#2890)

### DIFF
--- a/packages/api/migrations/45_dispatcher-max-turns-by-phase.sql
+++ b/packages/api/migrations/45_dispatcher-max-turns-by-phase.sql
@@ -1,0 +1,54 @@
+-- Up Migration
+--
+-- Dispatcher v2 — seed per-phase max_turns overrides in
+-- ``dispatcher.config`` (#2890).
+--
+-- Context
+-- -------
+-- Issue #2890 adds a live-editable max_turns cap per phase so operators
+-- can raise (or lower) turn limits without a code deploy. This migration
+-- seeds the initial ``max_turns_by_phase`` row in ``dispatcher.config``
+-- with values matching the ``PHASE_MAX_TURNS`` module defaults established
+-- by #2885 (the 10× bump). After this migration, operators can tune any
+-- phase cap via the admin page; the config row wins over the module
+-- default in resolution order.
+--
+-- Design notes
+-- ------------
+-- - This migration writes the ``max_turns_by_phase`` JSONB row in
+--   ``dispatcher.config``, which ``_spawn_phase_subprocess`` reads once
+--   per spawn call via ``DispatcherDaemon._read_max_turns_overrides``.
+--   Any key present in the JSONB object wins over the ``PHASE_MAX_TURNS``
+--   module default (daemon.py). The row did NOT exist before this
+--   migration — fresh installs fell through to module defaults.
+--   Seeding the row here guarantees a consistent posture across all
+--   live environments.
+-- - ``ON CONFLICT (key) DO UPDATE`` is critical: on an install where
+--   an operator had already created the row by hand, this migration
+--   sets the value to match the current module defaults.
+-- - JSONB key names use hyphen form (``fix-ci``) matching the daemon's
+--   ``PHASE_MAX_TURNS`` dict keys. This intentionally differs from the
+--   underscore form used by ``stuck_timeout_s_by_phase`` (``fix_ci``).
+--   The hyphen/underscore drift is a known asymmetry (#2889): PHASE_MAX_TURNS
+--   and PHASE_MODELS use hyphen form because those keys come directly
+--   from the ``/task-v2-fix-ci`` skill invocation path. See daemon.py's
+--   ``PHASE_MAX_TURNS`` docstring.
+-- - ``updated_by='init-2890'`` distinguishes this migration's write
+--   from a manual operator edit. The admin page sets ``updated_by``
+--   to a GitHub login when operators tune the row.
+
+INSERT INTO dispatcher.config (key, value, updated_by) VALUES
+    ('max_turns_by_phase',
+     '{"plan":500,"ralph":5000,"summary":300,"fix-ci":1000,"verify":500,"retro":300}'::jsonb,
+     'init-2890')
+ON CONFLICT (key) DO UPDATE
+    SET value = EXCLUDED.value,
+        updated_by = EXCLUDED.updated_by,
+        updated_at = NOW();
+
+
+-- Down Migration
+--
+-- Down strategy: remove the row entirely. Reverting reinstates fall-
+-- through to ``PHASE_MAX_TURNS`` module defaults.
+DELETE FROM dispatcher.config WHERE key = 'max_turns_by_phase';

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -8297,7 +8297,8 @@ class DispatcherDaemon:
         :data:`POST_MERGE_PHASES_USING_BASELINE_CWD`; the spawn code
         below inherits the correct cwd automatically.
         """
-        max_turns = PHASE_MAX_TURNS[phase]
+        overrides = self._read_max_turns_overrides()
+        max_turns = self._max_turns_for_phase(phase, overrides=overrides)
         model = self._model_for_phase(phase, agent_id)
         log_path = worktree / "tmp" / f"claude-p-{phase}.log"
         stdout_path = worktree / "tmp" / f"claude-p-{phase}.stdout.json"
@@ -15112,6 +15113,74 @@ class DispatcherDaemon:
                 cur.execute(
                     "SELECT value FROM dispatcher.config WHERE key = %s",
                     ("stuck_timeout_s_by_phase",),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return {}
+        if row is None or row[0] is None:
+            return {}
+        raw = row[0]
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return {}
+        if not isinstance(raw, dict):
+            return {}
+        out: dict[str, int] = {}
+        for k, v in raw.items():
+            try:
+                out[str(k)] = int(v)
+            except (TypeError, ValueError):
+                continue
+        return out
+
+    def _max_turns_for_phase(
+        self, phase: str, *, overrides: dict[str, int] | None = None
+    ) -> int:
+        """Return the max_turns cap for a given phase.
+
+        Resolution order (first hit wins):
+
+        1. ``overrides`` argument (a pre-read JSONB object from
+           ``dispatcher.config.max_turns_by_phase`` — read once per
+           spawn call and passed in). Operators can live-edit any
+           phase's cap via this config row without a redeploy.
+        2. :data:`PHASE_MAX_TURNS` — module-level defaults.
+
+        Unknown phase raises ``KeyError`` (same contract as direct
+        ``PHASE_MAX_TURNS[phase]`` access — the dict is the source of
+        truth for valid phase names). Issue #2890.
+        """
+        key = (phase or "").strip()
+        if overrides and key and key in overrides:
+            try:
+                value = int(overrides[key])
+                if value > 0:
+                    return value
+            except (TypeError, ValueError):
+                pass
+        return PHASE_MAX_TURNS[key]
+
+    def _read_max_turns_overrides(self) -> dict[str, int]:
+        """Read the live ``max_turns_by_phase`` config override.
+
+        Returns an empty dict on missing row, malformed JSON, or any
+        read error — the caller's fallback chain
+        (:meth:`_max_turns_for_phase`) picks up the module defaults
+        cleanly in that case.
+        """
+        assert self._conn is not None, "connect() must run before config read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    ("max_turns_by_phase",),
                 )
                 row = cur.fetchone()
             self._conn.commit()

--- a/scripts/dispatcher/tests/test_daemon_merge_auto_unstick.py
+++ b/scripts/dispatcher/tests/test_daemon_merge_auto_unstick.py
@@ -650,9 +650,7 @@ class TestMigrationSmoke:
         Lookup is by suffix so a rebase-induced rename (#2916
         migration-number collision dance) doesn't break the test.
         """
-        migrations_dir = (
-            _SCRIPTS.parent / "packages" / "api" / "migrations"
-        )
+        migrations_dir = _SCRIPTS.parent / "packages" / "api" / "migrations"
         candidates = sorted(
             migrations_dir.glob("*_dispatcher-agent-merge-unstick-attempts.sql")
         )

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -1659,6 +1659,56 @@ class TestSpawnPhaseSubprocess:
                 f"phase={phase} cmd missing --dangerously-skip-permissions: {captured['cmd']}"
             )
 
+    def test_max_turns_override_wins_over_default(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Override from dispatcher.config takes precedence over PHASE_MAX_TURNS.
+
+        Issue #2890: when ``_read_max_turns_overrides`` returns a non-empty
+        dict with a key for the requested phase, ``_spawn_phase_subprocess``
+        must pass the override value to ``--max-turns`` instead of the
+        module default (500 for plan).
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        monkeypatch.setattr(d, "_read_max_turns_overrides", lambda: {"plan": 42})
+
+        captured: dict[str, Any] = {}
+
+        def on_start(cmd: list[str], _kwargs: dict[str, Any]) -> None:
+            captured["cmd"] = cmd
+
+        monkeypatch.setattr(subprocess, "Popen", make_popen_factory(on_start=on_start))
+        d._spawn_phase_subprocess("plan", tmp_path, "agent-uuid")
+        assert "42" in captured["cmd"], f"expected '42' in cmd: {captured['cmd']}"
+        assert "500" not in captured["cmd"], (
+            f"module default '500' should not appear when override is active: {captured['cmd']}"
+        )
+
+    def test_max_turns_falls_back_to_module_default_when_override_absent(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Empty overrides dict falls through to PHASE_MAX_TURNS module default.
+
+        Issue #2890: when ``_read_max_turns_overrides`` returns an empty dict
+        (e.g. row absent from dispatcher.config), the plan default of 500 is
+        used for ``--max-turns``.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        monkeypatch.setattr(d, "_read_max_turns_overrides", lambda: {})
+
+        captured: dict[str, Any] = {}
+
+        def on_start(cmd: list[str], _kwargs: dict[str, Any]) -> None:
+            captured["cmd"] = cmd
+
+        monkeypatch.setattr(subprocess, "Popen", make_popen_factory(on_start=on_start))
+        d._spawn_phase_subprocess("plan", tmp_path, "agent-uuid")
+        assert "500" in captured["cmd"], (
+            f"expected plan default '500' in cmd: {captured['cmd']}"
+        )
+
 
 # --------------------------------------------------------------------------
 # _run_subprocess_or_fail — timeout, non-zero exit, missing claude

--- a/scripts/dispatcher/tests/test_daemon_ralph_opus_final_attempt.py
+++ b/scripts/dispatcher/tests/test_daemon_ralph_opus_final_attempt.py
@@ -249,7 +249,9 @@ class TestRalphSpawnUsesAttemptAwareModel:
         d, conn, _handler = _make_daemon(tmp_path)
         # retries_used = MAX_RETRY_ATTEMPTS - 1 → 1-indexed attempt ==
         # MAX_RETRY_ATTEMPTS (the final budgeted attempt) → Opus.
-        conn.cursor_instance.fetch_queue = [(daemon.MAX_RETRY_ATTEMPTS - 1,)]
+        # None first: consumed by _read_max_turns_overrides() (returns {});
+        # the tuple is then read by _current_attempt_for().
+        conn.cursor_instance.fetch_queue = [None, (daemon.MAX_RETRY_ATTEMPTS - 1,)]
 
         captured: dict[str, Any] = {}
         _patch_popen_and_forwarder(monkeypatch, captured)
@@ -281,7 +283,9 @@ class TestRalphSpawnUsesAttemptAwareModel:
         default. A CloudWatch query over a retry stretch can therefore
         grep ``model = 'opus'`` to find final-attempt ralph runs."""
         d, conn, handler = _make_daemon(tmp_path)
-        conn.cursor_instance.fetch_queue = [(daemon.MAX_RETRY_ATTEMPTS - 1,)]
+        # None first: consumed by _read_max_turns_overrides() (returns {});
+        # the tuple is then read by _current_attempt_for().
+        conn.cursor_instance.fetch_queue = [None, (daemon.MAX_RETRY_ATTEMPTS - 1,)]
 
         _patch_popen_and_forwarder(monkeypatch)
         d._spawn_phase_subprocess("ralph", tmp_path, "agent-uuid")


### PR DESCRIPTION
## Summary

Adds a live-editable `max_turns_by_phase` override mechanism to the dispatcher daemon, enabling operators to tune per-phase turn limits without a code redeploy. Mirrors the existing `stuck_timeout_s_by_phase` config pattern: migration 45 seeds the initial values from `PHASE_MAX_TURNS` module defaults, and two new resolver methods (`_read_max_turns_overrides` and `_max_turns_for_phase`) implement config-first fallback semantics.

Closes #2890

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] AC1: Migration row created and seeded correctly
  - Verify: `SELECT value FROM dispatcher.config WHERE key = 'max_turns_by_phase'` on dev returns the expected JSONB with all phase keys (plan, ralph, summary, fix-ci, verify, retro) and matching values
- [ ] AC2: Resolver methods work correctly (will be covered by AC1 verification)
- [ ] AC3: Subprocess receives correct --max-turns arg (verified by unit tests in this PR; AC3-verify runs against deployed code via manual spawn test if needed)
- [ ] Verification evidence posted on #2890 (see /task-v2-verify output)