### PR TITLE
chore(lint): add placeholder security gates check (#2894)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -920,6 +920,16 @@ jobs:
         run: scripts/check-hardcoded-models.sh
 
   # ---------------------------------------------------------------
+  # Placeholder gates guard: prevent stub security gates
+  # ---------------------------------------------------------------
+  placeholder-gates-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run placeholder gates check
+        run: scripts/check-placeholder-gates.sh
+
+  # ---------------------------------------------------------------
   # Hardcoded color guard: enforce semantic design tokens in TSX
   # ---------------------------------------------------------------
   hardcoded-colors-check:

--- a/scripts/check-placeholder-gates.sh
+++ b/scripts/check-placeholder-gates.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# check-placeholder-gates.sh — Detect placeholder security gates.
+#
+# permanent: true
+#
+# Flags patterns that indicate a security gate (MFA, auth, rate-limit, etc.)
+# has been left as a placeholder stub rather than a real implementation.
+# Catches regressions of the class documented in #2884.
+#
+# Flagged patterns:
+#   1. "accept(ed)? any non-empty" within ±3 lines of MFA|gate|auth|security|
+#      rate.?limit|token (same-line match or proximity match)
+#   2. "TODO.*Phase [0-9]+.*placeholder"
+#   3. "placeholder.*(MFA|gate|auth|security).*(accept|pass)"
+#
+# Excluded by design:
+#   - Lines that reference #2884 (intentional historical regression markers)
+#   - docs/ directory
+#   - Test paths (**/tests/**, *.test.*, *_test.*)
+#   - This script and its tests
+#
+# Usage:
+#   scripts/check-placeholder-gates.sh          # exits 0 if clean, 1 if violations
+#   scripts/check-placeholder-gates.sh [dir]    # scan a specific directory
+#
+# Exit codes:
+#   0 — No placeholder security gates found.
+#   1 — One or more files contain placeholder gate patterns.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-$REPO_ROOT}"
+
+# ─── Directories to exclude from scanning ─────────────────────────────
+EXCLUDE_DIRS=(
+    ".git"
+    ".venv"
+    "node_modules"
+    ".next"
+    "__pycache__"
+    ".claude"
+    ".vite"
+    "docs"
+)
+
+# ─── Files to exclude (relative to repo root) ─────────────────────────
+EXCLUDE_FILES=(
+    "scripts/check-placeholder-gates.sh"
+    "scripts/tests/test_check_placeholder_gates.sh"
+)
+
+# ─── Path patterns to exclude ──────────────────────────────────────────
+# Test directories and test files are allowed to reference these patterns.
+EXCLUDE_PATH_PATTERNS=(
+    "*/tests/*"
+    "*_test.*"
+    "*.test.*"
+)
+
+# ─── Build grep exclude arguments ────────────────────────────────────
+exclude_args=()
+for dir in "${EXCLUDE_DIRS[@]}"; do
+    exclude_args+=("--exclude-dir=$dir")
+done
+
+# ─── Determine scan targets ───────────────────────────────────────────
+scan_targets=()
+if [[ "$SCAN_DIR" == "$REPO_ROOT" ]]; then
+    for pkg_src in "$REPO_ROOT"/packages/*/src/; do
+        [[ -d "$pkg_src" ]] && scan_targets+=("$pkg_src")
+    done
+    scan_targets+=("$REPO_ROOT/scripts/")
+else
+    scan_targets+=("$SCAN_DIR")
+fi
+
+# ─── Helper: check if a grep output line should be skipped ───────────
+should_skip() {
+    local line="$1"
+
+    # Exempt lines referencing #2884
+    if [[ "$line" == *"#2884"* ]]; then
+        return 0
+    fi
+
+    # Check excluded files
+    for excl in "${EXCLUDE_FILES[@]}"; do
+        if [[ "$line" == *"$excl"* ]]; then
+            return 0
+        fi
+    done
+
+    # Check excluded path patterns
+    for pat in "${EXCLUDE_PATH_PATTERNS[@]}"; do
+        # shellcheck disable=SC2254
+        case "$line" in
+            *$pat*) return 0 ;;
+        esac
+    done
+
+    return 1
+}
+
+emit_header() {
+    echo "ERROR: Found placeholder security gate pattern(s) in the codebase."
+    echo ""
+    echo "  These patterns indicate a security gate was left as a stub."
+    echo "  See #2884 for the canonical incident and remediation guide."
+    echo ""
+    echo "  To suppress a known-intentional stub, add a reference to #2884"
+    echo "  on the same line (e.g. as a comment)."
+    echo ""
+    echo "  Violations:"
+    echo ""
+}
+
+violations=0
+
+# ─── Pattern 1: "accept(ed)? any non-empty" near security keywords ────
+# Grep for the base phrase, then verify a security keyword appears
+# within ±3 lines of each hit.
+
+PAT1='accept(ed)? any non-empty'
+SECURITY_KW='(MFA|gate|auth|security|rate.?limit|token)'
+
+pat1_matches=$(grep -rnE "$PAT1" "${scan_targets[@]}" "${exclude_args[@]}" 2>/dev/null || true)
+
+if [[ -n "$pat1_matches" ]]; then
+    while IFS= read -r match_line; do
+        should_skip "$match_line" && continue
+
+        # Extract filepath and line number (grep format: path:lineno:content)
+        filepath="${match_line%%:*}"
+        rest="${match_line#*:}"
+        lineno="${rest%%:*}"
+
+        # Read ±3 lines around the match from the file to check for security kw
+        start=$(( lineno - 3 ))
+        (( start < 1 )) && start=1
+        end=$(( lineno + 3 ))
+
+        context_block=""
+        if [[ -f "$filepath" ]]; then
+            context_block=$(sed -n "${start},${end}p" "$filepath" 2>/dev/null || true)
+        fi
+
+        # Skip if #2884 appears anywhere in the surrounding context block
+        # (the marker may be on a preceding comment line, not the match line itself)
+        if echo "$context_block" | grep -q '#2884' 2>/dev/null; then
+            continue
+        fi
+
+        if echo "$context_block" | grep -qE "$SECURITY_KW" 2>/dev/null; then
+            [[ $violations -eq 0 ]] && emit_header
+            echo "    $match_line"
+            violations=$((violations + 1))
+        fi
+    done <<< "$pat1_matches"
+fi
+
+# ─── Pattern 2: TODO.*Phase [0-9]+.*placeholder ───────────────────────
+PAT2='TODO.*Phase [0-9]+.*placeholder'
+
+pat2_matches=$(grep -rnE "$PAT2" "${scan_targets[@]}" "${exclude_args[@]}" 2>/dev/null || true)
+
+if [[ -n "$pat2_matches" ]]; then
+    while IFS= read -r line; do
+        should_skip "$line" && continue
+        [[ $violations -eq 0 ]] && emit_header
+        echo "    $line"
+        violations=$((violations + 1))
+    done <<< "$pat2_matches"
+fi
+
+# ─── Pattern 3: placeholder.*(MFA|gate|auth|security).*(accept|pass) ──
+PAT3='placeholder.*(MFA|gate|auth|security).*(accept|pass)'
+
+pat3_matches=$(grep -rnE "$PAT3" "${scan_targets[@]}" "${exclude_args[@]}" 2>/dev/null || true)
+
+if [[ -n "$pat3_matches" ]]; then
+    while IFS= read -r line; do
+        should_skip "$line" && continue
+        [[ $violations -eq 0 ]] && emit_header
+        echo "    $line"
+        violations=$((violations + 1))
+    done <<< "$pat3_matches"
+fi
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "  Found $violations occurrence(s) of placeholder security gate patterns."
+    echo ""
+    echo "  Fix: Implement the real gate, or add '#2884' to the line if the stub"
+    echo "  is an intentional regression marker reviewed in that issue."
+    echo ""
+    exit 1
+fi
+
+echo "All clean — no placeholder security gates found."
+exit 0

--- a/scripts/tests/test_check_placeholder_gates.sh
+++ b/scripts/tests/test_check_placeholder_gates.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# test_check_placeholder_gates.sh — Tests for check-placeholder-gates.sh
+#
+# Creates temporary files to verify that the checker correctly detects
+# placeholder security gate patterns while allowing legitimate uses
+# (#2884 markers, test paths, innocuous placeholder text).
+#
+# Usage:
+#   scripts/tests/test_check_placeholder_gates.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-placeholder-gates.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    printf '%s\n' "$content" > "$TMPDIR_TEST/$name"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+}
+
+# ─── Test 1: Bare "accept any non-empty MFA header" in TS source fails ─
+create_test_file "middleware.ts" '// accept any non-empty MFA header'
+assert_fails "accept any non-empty near MFA keyword is detected"
+reset_tmpdir
+
+# ─── Test 2: Same line with #2884 reference is exempted ───────────────
+create_test_file "middleware.ts" '// accept any non-empty MFA header // see #2884'
+assert_passes "accept any non-empty MFA line with #2884 ref is allowed"
+reset_tmpdir
+
+# ─── Test 3: Matching line under tests/ directory is exempted ──────────
+mkdir -p "$TMPDIR_TEST/tests"
+printf '%s\n' '// accept any non-empty MFA header' > "$TMPDIR_TEST/tests/middleware.test.ts"
+assert_passes "Matching line under tests/ directory is allowed"
+reset_tmpdir
+
+# ─── Test 4: TODO Phase N placeholder fails ───────────────────────────
+create_test_file "auth.ts" '// TODO: Phase 2 placeholder -- real auth gate lands in sub-task E'
+assert_fails "TODO Phase N placeholder is detected"
+reset_tmpdir
+
+# ─── Test 5: Innocuous UI placeholder attribute passes ────────────────
+create_test_file "form.tsx" '<input placeholder="Enter your name" />'
+assert_passes "Innocuous UI placeholder attribute is allowed"
+reset_tmpdir
+
+# ─── Test 6: Innocuous em-dash placeholder for null display passes ─────
+create_test_file "display.ts" '// em-dash placeholder for null display'
+assert_passes "Innocuous em-dash placeholder for null display is allowed"
+reset_tmpdir
+
+# ─── Summary ───────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a new linting script and CI job to detect placeholder security gates—stub checks, trivially-satisfiable auth patterns, and phase-N placeholders left as "future hardening." Fixes the structural gap exposed by the #2884 incident by automating detection of this class of footgun. Script validates against three patterns and exempts known-intentional #2884 regression markers.

Closes #2894

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`scripts/tests/test_check_placeholder_gates.sh` — 6/6 cases pass)
- [x] CI green

### Post-deploy verification

- [x] N/A — CI/linting rule only (no deployed runtime change)