### PR TITLE
docs: add capped-list convention to dispatcher-v2 spec (#2956)

### DIFF
--- a/docs/specs/dispatcher-v2-spec.md
+++ b/docs/specs/dispatcher-v2-spec.md
@@ -442,6 +442,8 @@ New route `packages/web/app/admin/dispatcher/`.
 - `query dispatcherAgent(agentId)` → full detail for one agent (phase transitions, failures, PR status).
 - `mutation dispatcherControl(command, payload)` → writes a row to `dispatcher.commands`.
 
+**Capped-list convention:** any admin-scoped list field with a server-side cap MUST be paired with a `{listName}Depth` or `{listName}Count` non-null integer field so the cockpit can render `{shown} / {total}`. Two precedents: `queueDepth`/`blockedDepth` (queue panels, #2886) and `recentCompletionsCount` (recently-completed panel, #3172). When adding a new capped list, replicate the `formatCountLabel` helper in `packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx` for consistent display.
+
 No subscriptions. Admin page uses Apollo `pollInterval: 2000` (2s). Dispatcher events happen on 30s/2min tick cadences, so a 2s polling delay is invisible — not worth the WebSocket infra.
 
 **UI sections:**


### PR DESCRIPTION
## Summary

Adds a capped-list convention paragraph to the dispatcher-v2 spec (§11 Admin Interface) requiring that any admin-scoped list field with a server-side cap must be paired with a non-null integer count/depth field. The convention codifies the pattern established in #2886 (queue panels) and #3172 (recent completions). Audit confirms all existing capped lists already have paired totals; no code changes were needed.

Closes #2956

## Test plan

### Automated checks

- [x] No tests required (documentation only)
- [ ] Lint passes (markdownlint)
- [ ] CI green

### Post-deploy verification

- [x] N/A — no deployed component (documentation only)