### PR TITLE
feat(fix-ci): unconditional rebase at fix-ci entry, force-with-lease push, rebase_outcome observability (#2966)

### DIFF
--- a/.claude/skills/task-v2-fix-ci/SKILL.md
+++ b/.claude/skills/task-v2-fix-ci/SKILL.md
@@ -50,6 +50,7 @@ Write `{worktree}/tmp/dispatcher-output/fix-ci.json`:
   "agent_id": "<echo>",
   "pr_number": <int>,
   "verdict": "PATCHED" | "BLOCKED" | "FLAKY",
+  "rebase_outcome": "clean" | "resolved" | "conflict_unresolvable" | "skipped",
   "failure_category": "lint" | "format" | "type_error" | "test_failure" | "coverage_floor" |
                        "infra_external" | "missing_secret_or_config" | "build_failure" |
                        "markdown_links" | "hygiene_guard" | "ci_config" | "other",
@@ -65,7 +66,37 @@ Write `{worktree}/tmp/dispatcher-output/fix-ci.json`:
 - `BLOCKED` — the agent cannot fix this failure (missing secret, repo permissions, external infra beyond repo control, or fix-attempts exhausted). `block_reason` is populated with a concrete one-step human action. Daemon escalates to `status/needs-human` + `priority/p1`.
 - `FLAKY` — transient failure (intermittent timeout, AWS 5xx, etc.) with no code change needed. `flaky_evidence` explains. Daemon reruns the job once; second flaky → escalate.
 
+**`rebase_outcome` field** (required, enum): populated in Step 0 before the CI-fix logic runs. Values:
+
+- `"clean"` — rebase succeeded (possibly a no-op; branch was already up to date). Normal flow continues.
+- `"resolved"` — rebase encountered conflict markers; the skill resolved them semantically and ran `git rebase --continue`. Normal flow continues.
+- `"conflict_unresolvable"` — conflicts could not be resolved (semantic collision or turn budget exhausted). Skill ran `git rebase --abort` and returns verdict=`BLOCKED`.
+- `"skipped"` — reserved for input-JSON-missing or malformed; rebase step could not run.
+
+**Force-push semantics:** After a rebase (Step 0), the local branch's SHAs are rewritten. The daemon's `_apply_fix_ci_patch` push therefore uses `--force-with-lease` (never bare `--force`). `--force-with-lease` verifies the remote hasn't diverged since our last fetch — safe for a CI-fix branch that only the daemon writes.
+
+**`fix_ci_rebase_outcome` observability contract:** The skill emits `echo FIX_CI_REBASE_OUTCOME=<value>` to stdout immediately after Step 0 completes. The stream_forwarder tags this line in CloudWatch. The daemon re-emits it as a structured `daemon.fix_ci_rebase_outcome` log event (with `event="fix_ci_rebase_outcome"`, `run_id`, `agent_id`, `pr_number`, `rebase_outcome`) after parsing the output JSON, unconditionally — old-skill payloads that omit the field log `rebase_outcome=None` and are trivially spottable.
+
 Always exit 0. Verdict comes from the JSON, not the exit code.
+
+---
+
+## Step 0 — Rebase against origin/main (mandatory, unconditional)
+
+Before reading any failure logs, bring the branch up to date with `origin/main`. This ensures the CI fix applies cleanly on top of the current main and that the force-pushed commit is not based on a stale tree.
+
+```
+git -C <worktree_path> fetch origin main
+git -C <worktree_path> rebase origin/main
+```
+
+Three outcomes:
+
+**`clean`** — rebase succeeded (exit 0, no conflict markers). Set `rebase_outcome="clean"`. Emit `echo FIX_CI_REBASE_OUTCOME=clean`. Proceed to Step 1.
+
+**`resolved`** — rebase paused with conflict markers (exit non-zero, files contain `<<<<<<<`). Resolve conflicts semantically: read each conflicted file's markers; classify per the taxonomy in `.claude/skills/task-v2-fix-conflict/SKILL.md` §Step 2 (parallel edits / overlapping-compatible / semantic collision). For parallel-edits and overlapping-compatible conflicts: accept the merged result, run `git add <file>` per resolved file, then `git rebase --continue`. If all conflicts resolve: set `rebase_outcome="resolved"`. Emit `echo FIX_CI_REBASE_OUTCOME=resolved`. Proceed to Step 1. If turn budget is exhausted mid-rebase, escalate to `conflict_unresolvable`.
+
+**`conflict_unresolvable`** — classification returned semantic collision for any file, OR reconciliation loop exceeded turn budget. Run `git rebase --abort`. Set `rebase_outcome="conflict_unresolvable"`. Emit `echo FIX_CI_REBASE_OUTCOME=conflict_unresolvable`. Write output JSON with `verdict="BLOCKED"`, `block_reason` naming the conflicting file(s) and the colliding main commits (obtain via `git log --oneline origin/main ^HEAD~1 -- <file>`). Skip Steps 1–5 entirely.
 
 ---
 
@@ -168,6 +199,8 @@ For verdict=`FLAKY`:
 - **Attempt 1** — try to fix. Verdict=`PATCHED` if successful.
 - **Attempt 2** — if the first fix itself landed but didn't close all failures, try again. Same worktree.
 - **Attempt 3+** — if `previous_fix_attempts >= 2` and the same failure recurs, the pattern suggests a misdiagnosis. Return verdict=`BLOCKED` with `block_reason="CI failure persisted after <N> fix attempts; needs human diagnosis"` and let the daemon escalate.
+
+If `rebase_outcome="conflict_unresolvable"`, the shared `FIX_CI_MAX_RETRIES=3` budget still applies — a fresh attempt on the next retry will see a fresh `origin/main` tip and may succeed.
 
 ## Reminders
 

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -12961,6 +12961,17 @@ class DispatcherDaemon:
             log_text=self._read_full_phase_log(worktree, "fix-ci") or None,
             usage=self._parse_phase_usage(worktree, "fix-ci"),
         )
+        rebase_outcome = fix_ci_output.get("rebase_outcome")
+        self._log.info(
+            "daemon.fix_ci_rebase_outcome",
+            extra={
+                "event": "fix_ci_rebase_outcome",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "pr_number": pr_number,
+                "rebase_outcome": rebase_outcome,
+            },
+        )
         verdict = str(fix_ci_output.get("verdict") or "").upper()
 
         if verdict == "PATCHED":
@@ -13303,11 +13314,15 @@ class DispatcherDaemon:
         # Issue #3089: hot-path ``git push`` in fix-CI — retry
         # transient flakes before routing to the diagnoser. Same
         # rationale as ``_push_and_open_pr``'s push retry.
+        # Issue #2966: use --force-with-lease so post-rebase pushes
+        # succeed (rebase rewrites SHAs) while still guarding against
+        # concurrent remote writes.
         push_cmd = [
             "git",
             "-C",
             str(worktree),
             "push",
+            "--force-with-lease",
             "origin",
             branch,
         ]

--- a/scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py
+++ b/scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py
@@ -976,3 +976,193 @@ class TestVerifyFailedPostMergeCandidatePickup:
         assert cand["category"] == daemon.FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE
         assert cand["tier"] == 3
         assert cand["issue_number"] == 3071
+
+
+# ==========================================================================
+# #2966 — fix-ci force-with-lease and rebase_outcome log event
+# ==========================================================================
+
+
+class TestFixCiForceWithLease:
+    """Verify that ``_apply_fix_ci_patch`` pushes with ``--force-with-lease``.
+
+    After a rebase (Step 0 of the fix-ci skill), the branch's SHAs are
+    rewritten so a bare ``git push`` would be rejected. The daemon must
+    use ``--force-with-lease`` to allow the rebase-rewritten history
+    through while still guarding against concurrent remote writes.
+    """
+
+    def test_push_uses_force_with_lease(self, tmp_path: Path) -> None:
+        """The push command list in ``_apply_fix_ci_patch`` must include
+        ``--force-with-lease`` (AC2, issue #2966)."""
+        import subprocess as _subprocess  # noqa: PLC0415
+
+        d, _conn, _handler = _make_daemon(tmp_path, scope="fix_ci_fwl")
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        (worktree / "tmp").mkdir(parents=True, exist_ok=True)
+
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> Any:
+            captured_cmds.append(list(cmd))
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "ok"
+            result.stderr = ""
+            return result
+
+        orig_run = _subprocess.run
+
+        def fake_subprocess_with_retry(
+            cmd: list[str], *, event_name: str, **kwargs: Any
+        ) -> dict[str, Any]:
+            captured_cmds.append(list(cmd))
+            return {"ok": True}
+
+        d._subprocess_with_retry = fake_subprocess_with_retry  # type: ignore[method-assign]
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._increment_retries_used = MagicMock()  # type: ignore[method-assign]
+
+        try:
+            _subprocess.run = fake_run  # type: ignore[assignment]
+            agent = {
+                "agent_id": "agent-fwl-test",
+                "worktree_path": str(worktree),
+                "retries_used": 0,
+                "issue_number": 2966,
+                "pr_number": 9966,
+            }
+            fix_ci_output = {
+                "verdict": "PATCHED",
+                "commit_message": "fix(ci): test force-with-lease — CI (#9966)",
+                "changed_files": ["foo.py"],
+                "rebase_outcome": "clean",
+            }
+            d._apply_fix_ci_patch(agent, fix_ci_output)
+        finally:
+            _subprocess.run = orig_run  # type: ignore[assignment]
+
+        # The git push command must contain --force-with-lease
+        push_cmds = [cmd for cmd in captured_cmds if "push" in cmd]
+        assert push_cmds, "Expected at least one push command to be issued"
+        push_cmd = push_cmds[-1]  # last push is the actual remote push
+        assert "--force-with-lease" in push_cmd, (
+            f"Expected --force-with-lease in push cmd, got: {push_cmd}"
+        )
+        # Must NOT use bare --force
+        assert "--force" not in [
+            arg for arg in push_cmd if arg != "--force-with-lease"
+        ], "push cmd must not use bare --force"
+
+
+class TestFixCiRebaseOutcomeLogEvent:
+    """Verify ``_run_fix_ci`` emits a ``daemon.fix_ci_rebase_outcome`` log
+    event unconditionally after parsing the fix-ci output JSON (AC6, issue
+    #2966).
+
+    Three parametrized cases: clean / resolved / conflict_unresolvable.
+    Also covers the None case (old skill payload without rebase_outcome).
+    """
+
+    def _patch(
+        self,
+        d: "daemon.DispatcherDaemon",
+        *,
+        fix_ci_output: dict[str, Any],
+    ) -> None:
+        d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+        d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._read_phase_output = MagicMock(return_value=fix_ci_output)  # type: ignore[method-assign]
+        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+        d._extract_failing_jobs = MagicMock(return_value=[])  # type: ignore[method-assign]
+        d._fetch_pr_diff = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._apply_fix_ci_patch = MagicMock()  # type: ignore[method-assign]
+
+    def _run(
+        self, tmp_path: Path, *, scope: str, fix_ci_output: dict[str, Any]
+    ) -> "_CapturingLogHandler":
+        d, _conn, handler = _make_daemon(tmp_path, scope=scope)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        self._patch(d, fix_ci_output=fix_ci_output)
+        agent = {
+            "agent_id": f"agent-{scope}",
+            "pr_number": 9966,
+            "issue_number": 2966,
+            "worktree_path": str(worktree),
+            "retries_used": 0,
+        }
+        d._run_fix_ci(agent, {"statusCheckRollup": []})
+        return handler
+
+    def test_rebase_outcome_clean_logged(self, tmp_path: Path) -> None:
+        handler = self._run(
+            tmp_path,
+            scope="fci_ro_clean",
+            fix_ci_output={
+                "verdict": "PATCHED",
+                "commit_message": "fix(ci): clean rebase — CI (#9966)",
+                "changed_files": ["a.py"],
+                "rebase_outcome": "clean",
+            },
+        )
+        events = handler.events("fix_ci_rebase_outcome")
+        assert len(events) == 1, (
+            f"Expected 1 fix_ci_rebase_outcome event, got {len(events)}"
+        )
+        assert getattr(events[0], "rebase_outcome", None) == "clean"
+        assert getattr(events[0], "pr_number", None) == 9966
+
+    def test_rebase_outcome_resolved_logged(self, tmp_path: Path) -> None:
+        handler = self._run(
+            tmp_path,
+            scope="fci_ro_resolved",
+            fix_ci_output={
+                "verdict": "PATCHED",
+                "commit_message": "fix(ci): resolved rebase — CI (#9966)",
+                "changed_files": ["b.py"],
+                "rebase_outcome": "resolved",
+            },
+        )
+        events = handler.events("fix_ci_rebase_outcome")
+        assert len(events) == 1
+        assert getattr(events[0], "rebase_outcome", None) == "resolved"
+
+    def test_rebase_outcome_conflict_unresolvable_logged(self, tmp_path: Path) -> None:
+        handler = self._run(
+            tmp_path,
+            scope="fci_ro_unresolvable",
+            fix_ci_output={
+                "verdict": "BLOCKED",
+                "block_reason": "Semantic collision in foo.py vs main commit abc123",
+                "rebase_outcome": "conflict_unresolvable",
+                "changed_files": [],
+                "commit_message": "",
+            },
+        )
+        events = handler.events("fix_ci_rebase_outcome")
+        assert len(events) == 1
+        assert getattr(events[0], "rebase_outcome", None) == "conflict_unresolvable"
+
+    def test_rebase_outcome_none_logged_for_old_skills(self, tmp_path: Path) -> None:
+        """Old skill payloads without rebase_outcome log rebase_outcome=None —
+        they are trivially spottable in CloudWatch (issue #2966)."""
+        handler = self._run(
+            tmp_path,
+            scope="fci_ro_none",
+            fix_ci_output={
+                "verdict": "PATCHED",
+                "commit_message": "fix(ci): no rebase_outcome field — CI (#9966)",
+                "changed_files": ["c.py"],
+                # No rebase_outcome field
+            },
+        )
+        events = handler.events("fix_ci_rebase_outcome")
+        assert len(events) == 1
+        assert getattr(events[0], "rebase_outcome", "MISSING") is None

--- a/scripts/dispatcher/tests/test_skill_md_contracts.py
+++ b/scripts/dispatcher/tests/test_skill_md_contracts.py
@@ -510,3 +510,77 @@ class TestTaskV2RalphHeartbeats:
         so operators know where CloudWatch tagging happens."""
         content = _read(_TASK_V2_RALPH_SKILL)
         assert "stream_forwarder.py" in content or "stream-forwarder" in content
+
+
+# ------------------------------------------------------------------
+# Issue #2966 — task-v2-fix-ci: rebase-first step + force-with-lease
+# ------------------------------------------------------------------
+
+
+class TestTaskV2FixCiSkillContracts:
+    """Contract tests for ``.claude/skills/task-v2-fix-ci/SKILL.md``.
+
+    These grep-style assertions catch regressions where an edit removes
+    or renames a required marker introduced by issue #2966 (mandatory
+    rebase + force-with-lease push).
+    """
+
+    _SKILL_PATH = _REPO_ROOT / ".claude" / "skills" / "task-v2-fix-ci" / "SKILL.md"
+
+    def _content(self) -> str:
+        return _read(self._SKILL_PATH)
+
+    def test_rebase_first_step_present(self) -> None:
+        """Step 0 must document the mandatory fetch + rebase commands
+        (AC1, issue #2966).
+
+        The exact form is ``git -C <worktree_path> fetch origin main`` and
+        ``git -C <worktree_path> rebase origin/main`` — we check for the
+        distinctive ``fetch origin main`` and ``rebase origin/main``
+        substrings which are present in both the -C and plain forms.
+        """
+        content = self._content()
+        assert "fetch origin main" in content, (
+            "task-v2-fix-ci/SKILL.md must document a `fetch origin main` "
+            "command in Step 0 (issue #2966 AC1)"
+        )
+        assert "rebase origin/main" in content, (
+            "task-v2-fix-ci/SKILL.md must document a `rebase origin/main` "
+            "command in Step 0 (issue #2966 AC1)"
+        )
+
+    def test_force_with_lease_documented(self) -> None:
+        """The output contract must explain ``--force-with-lease`` semantics
+        (AC2, issue #2966)."""
+        content = self._content()
+        assert "--force-with-lease" in content, (
+            "task-v2-fix-ci/SKILL.md must document --force-with-lease "
+            "push semantics (issue #2966 AC2)"
+        )
+
+    def test_rebase_outcome_field_documented(self) -> None:
+        """The output contract must name the ``rebase_outcome`` field
+        (issue #2966)."""
+        content = self._content()
+        assert "rebase_outcome" in content, (
+            "task-v2-fix-ci/SKILL.md must document the rebase_outcome "
+            "output field (issue #2966)"
+        )
+
+    def test_conflict_unresolvable_enum_value_documented(self) -> None:
+        """The ``conflict_unresolvable`` enum value must appear in the
+        output contract (issue #2966)."""
+        content = self._content()
+        assert "conflict_unresolvable" in content, (
+            "task-v2-fix-ci/SKILL.md must document the conflict_unresolvable "
+            "rebase_outcome value (issue #2966)"
+        )
+
+    def test_fix_ci_rebase_outcome_heartbeat_documented(self) -> None:
+        """The skill must document the ``FIX_CI_REBASE_OUTCOME`` heartbeat
+        line (AC6 observability, issue #2966)."""
+        content = self._content()
+        assert "FIX_CI_REBASE_OUTCOME" in content, (
+            "task-v2-fix-ci/SKILL.md must document the FIX_CI_REBASE_OUTCOME "
+            "heartbeat echo line (issue #2966 AC6)"
+        )


### PR DESCRIPTION
## Summary

Fix-ci now unconditionally rebases against origin/main at Step 0, before reading any CI logs or attempting patches. This ensures the branch is up-to-date with the current main, preventing stale-base patches and unhandled merge conflicts. Rebase-induced SHA rewrites are pushed with `--force-with-lease` (not bare `--force`). A new `rebase_outcome` field captures outcomes (clean/resolved/conflict_unresolvable/skipped) and is emitted as a daemon.fix_ci_rebase_outcome log event unconditionally on every invocation, making it trivial to monitor conflict-resolution activity in CloudWatch.

Closes #2966

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 1506 tests including 10 new)
- [x] CI green

### Post-deploy verification

- [ ] CloudWatch Insights: `filter event="fix_ci_rebase_outcome"` shows non-zero `rebase_outcome=resolved` within a day of organic traffic (evidence conflict path works in prod)
- [ ] Manual smoke: on dev, checkout an older commit, make a change, push, wait for main to advance, then let fix-ci run → confirm rebase succeeds and PR proceeds
- [ ] Verification evidence posted on #2966 (see /task-v2-verify output)