### PR TITLE
feat(infra): twice-daily scraper schedule and dashboard thresholds (#2980)

### DIFF
--- a/docs/runbooks/scraper-operations.md
+++ b/docs/runbooks/scraper-operations.md
@@ -9,7 +9,7 @@ running on AWS ECS Fargate.
 | ------------------ | --------------------------------------------------------- |
 | ECS Cluster        | `judgemind-{env}`                                         |
 | Task Definition    | `judgemind-scraper-{env}`                                 |
-| EventBridge Sched. | `judgemind-scraper-{env}` (daily at 6 AM PT)              |
+| EventBridge Sched. | `judgemind-scraper-{env}` (twice daily at 6:15 AM/PM PT)  |
 | CloudWatch Logs    | `/ecs/judgemind-scraper-{env}`                            |
 | S3 Archive         | `judgemind-document-archive-{env}`                        |
 | SNS Alerts         | `judgemind-scraper-alerts-{env}`                          |
@@ -205,7 +205,7 @@ Disable the schedule immediately:
 aws scheduler update-schedule \
   --name judgemind-scraper-dev \
   --state DISABLED \
-  --schedule-expression "cron(0 6 * * ? *)" \
+  --schedule-expression "cron(15 6,18 * * ? *)" \
   --schedule-expression-timezone "America/Los_Angeles" \
   --flexible-time-window '{"Mode":"FLEXIBLE","MaximumWindowInMinutes":30}' \
   --target '{}' \
@@ -218,7 +218,7 @@ Re-enable:
 aws scheduler update-schedule \
   --name judgemind-scraper-dev \
   --state ENABLED \
-  --schedule-expression "cron(0 6 * * ? *)" \
+  --schedule-expression "cron(15 6,18 * * ? *)" \
   --schedule-expression-timezone "America/Los_Angeles" \
   --flexible-time-window '{"Mode":"FLEXIBLE","MaximumWindowInMinutes":30}' \
   --target '{}' \

--- a/docs/specs/architecture-spec-v1.md
+++ b/docs/specs/architecture-spec-v1.md
@@ -131,6 +131,8 @@ These mechanisms catch scraper *failures* well (crashes, staleness, missing fiel
 
 **Scraper health model.** Operational status is tracked via `scraper_runs` records (success/failure, response time, records captured). Output quality is tracked via hourly data quality checks. CloudWatch alarms fire if no successful scraper run occurs within 24 hours. The admin data quality dashboard shows per-county health tiles (green/yellow/red) based on ruling count, field completeness, and scraper freshness.
 
+**Scraper cadence.** The EventBridge Scheduler fires twice daily at 6:15 AM and 6:15 PM PT (`cron(15 6,18 * * ? *)`). Fire times are deliberately outside typical business hours so admin and clerk staff are off-clock when any transient scraper errors surface. The 12-hour cadence doubles capture opportunities versus the previous once-daily schedule, reducing the maximum window during which a newly posted tentative ruling could go uncaptured. Dashboard and alerter thresholds are aligned to this cadence: the scraper freshness field turns yellow at 13 hours (12h cadence + 1h slack for `FlexibleTimeWindow` and runtime) and red at 25 hours (two missed cycles + 1h slack). Per-scraper cadence overrides and threshold tuning are tracked at #2981.
+
 ## 3.2 Data Store
 
 Judgemind uses three complementary storage systems, each optimized for a specific access pattern.

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -118,13 +118,13 @@ module "compute" {
   courtlistener_api_token_secret_arn = data.aws_secretsmanager_secret.courtlistener_api_token.arn
   capsolver_api_key_secret_arn       = data.aws_secretsmanager_secret.capsolver_api_key.arn
 
-  # Dev: 1 vCPU, 2 GB RAM, daily schedule at 6 AM PT
+  # Dev: 1 vCPU, 2 GB RAM, twice-daily schedule at 6:15 AM and 6:15 PM PT
   # Matches production to prevent OOM kills during the full 17-scraper run.
   # See #2349 — 0.5 vCPU / 1 GB was insufficient and caused the task to be
   # killed before completing all scrapers.
   task_cpu            = 1024
   task_memory         = 2048
-  schedule_expression = "cron(0 6 * * ? *)"
+  schedule_expression = "cron(15 6,18 * * ? *)"
   schedule_timezone   = "America/Los_Angeles"
   schedule_enabled    = true
   log_retention_days  = 14

--- a/infra/terraform/environments/production/main.tf
+++ b/infra/terraform/environments/production/main.tf
@@ -3,8 +3,8 @@
 # Manages networking, storage, IAM, compute, and email for the production
 # environment.
 #
-# The compute schedule is enabled. The EventBridge Scheduler triggers a daily
-# scraper run at 6 AM PT.
+# The compute schedule is enabled. The EventBridge Scheduler triggers a
+# twice-daily scraper run at 6:15 AM and 6:15 PM PT.
 
 # Look up secrets so we can pass their ARNs to the compute module
 # without hardcoding the random Secrets Manager suffix.
@@ -72,10 +72,10 @@ module "compute" {
   courtlistener_api_token_secret_arn = data.aws_secretsmanager_secret.courtlistener_api_token.arn
   capsolver_api_key_secret_arn       = data.aws_secretsmanager_secret.capsolver_api_key.arn
 
-  # Production: 1 vCPU, 2 GB RAM, daily schedule at 6 AM PT
+  # Production: 1 vCPU, 2 GB RAM, twice-daily schedule at 6:15 AM and 6:15 PM PT
   task_cpu            = 1024
   task_memory         = 2048
-  schedule_expression = "cron(0 6 * * ? *)"
+  schedule_expression = "cron(15 6,18 * * ? *)"
   schedule_timezone   = "America/Los_Angeles"
   schedule_enabled    = true
   log_retention_days  = 30

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -199,7 +199,7 @@ resource "aws_ecs_task_definition" "scraper" {
 }
 
 # ─── EventBridge Scheduler ──────────────────────────────────────────────────
-# Runs the scraper task on a daily schedule. EventBridge Scheduler replaces
+# Runs the scraper task on a twice-daily schedule. EventBridge Scheduler replaces
 # the legacy CloudWatch Events / EventBridge Rules pattern and supports
 # native ECS RunTask targets without a Lambda intermediary.
 

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -47,7 +47,7 @@ variable "task_memory" {
 }
 
 variable "schedule_expression" {
-  description = "EventBridge schedule expression — rate (e.g. rate(1 day)) or cron (e.g. cron(0 13 * * ? *) for 6 AM PT)"
+  description = "EventBridge schedule expression — rate (e.g. rate(1 day)) or cron (e.g. cron(15 6,18 * * ? *) for 6:15 AM/PM PT)"
   type        = string
   default     = "rate(1 day)"
 }

--- a/packages/api/src/graphql/data-quality.ts
+++ b/packages/api/src/graphql/data-quality.ts
@@ -67,10 +67,13 @@ interface CountyMetrics {
 /**
  * Compute health status from the latest metrics for a county.
  *
+ * Thresholds are calibrated against the twice-daily scraper schedule (6:15 AM
+ * and 6:15 PM PT) plus a 1-hour slack for FlexibleTimeWindow and runtime:
+ *
  * - Green: ruling_count_24h > 0 AND field_completeness_pct >= 90
- *          AND scraper_last_success_age_hours < 6
- * - Yellow: any metric slightly degraded (completeness 70-90%, scraper age 6-24h)
- * - Red: scraper down > 24h OR completeness < 70% OR zero rulings when expected
+ *          AND scraper_last_success_age_hours < 13
+ * - Yellow: any metric slightly degraded (completeness 70-90%, scraper age 13-25h)
+ * - Red: scraper down > 25h OR completeness < 70% OR zero rulings when expected
  */
 export function computeHealthStatus(metrics: CountyMetrics): string {
   const { rulingCount24h, fieldCompletenessPct, scraperLastSuccessAgeHours } = metrics;
@@ -81,19 +84,19 @@ export function computeHealthStatus(metrics: CountyMetrics): string {
   }
 
   // Check for red conditions
-  if (scraperLastSuccessAgeHours !== null && scraperLastSuccessAgeHours > 24) return 'red';
+  if (scraperLastSuccessAgeHours !== null && scraperLastSuccessAgeHours > 25) return 'red';
   if (fieldCompletenessPct !== null && fieldCompletenessPct < 70) return 'red';
   if (rulingCount24h !== null && rulingCount24h === 0) return 'red';
 
   // Check for yellow conditions
   if (fieldCompletenessPct !== null && fieldCompletenessPct < 90) return 'yellow';
-  if (scraperLastSuccessAgeHours !== null && scraperLastSuccessAgeHours >= 6) return 'yellow';
+  if (scraperLastSuccessAgeHours !== null && scraperLastSuccessAgeHours >= 13) return 'yellow';
 
   // Check for green: all available metrics look good
   const isGreen =
     (rulingCount24h === null || rulingCount24h > 0) &&
     (fieldCompletenessPct === null || fieldCompletenessPct >= 90) &&
-    (scraperLastSuccessAgeHours === null || scraperLastSuccessAgeHours < 6);
+    (scraperLastSuccessAgeHours === null || scraperLastSuccessAgeHours < 13);
 
   return isGreen ? 'green' : 'yellow';
 }

--- a/packages/api/tests/data-quality.unit.test.ts
+++ b/packages/api/tests/data-quality.unit.test.ts
@@ -72,12 +72,34 @@ describe('computeHealthStatus', () => {
     expect(computeHealthStatus(metrics)).toBe('yellow');
   });
 
-  it('returns yellow when scraper age is 6-24h', () => {
+  it('returns green when scraper age is 12h (below 13h yellow threshold)', () => {
     const metrics: CountyMetrics = {
       county: 'Los Angeles',
       rulingCount24h: 10,
       fieldCompletenessPct: 95,
       scraperLastSuccessAgeHours: 12,
+      lastUpdated: '2026-03-01T00:00:00Z',
+    };
+    expect(computeHealthStatus(metrics)).toBe('green');
+  });
+
+  it('returns yellow when scraper age is 13h (at yellow threshold)', () => {
+    const metrics: CountyMetrics = {
+      county: 'Los Angeles',
+      rulingCount24h: 10,
+      fieldCompletenessPct: 95,
+      scraperLastSuccessAgeHours: 13,
+      lastUpdated: '2026-03-01T00:00:00Z',
+    };
+    expect(computeHealthStatus(metrics)).toBe('yellow');
+  });
+
+  it('returns yellow when scraper age is 13-25h', () => {
+    const metrics: CountyMetrics = {
+      county: 'Los Angeles',
+      rulingCount24h: 10,
+      fieldCompletenessPct: 95,
+      scraperLastSuccessAgeHours: 20,
       lastUpdated: '2026-03-01T00:00:00Z',
     };
     expect(computeHealthStatus(metrics)).toBe('yellow');
@@ -116,26 +138,37 @@ describe('computeHealthStatus', () => {
     expect(computeHealthStatus(metrics)).toBe('green');
   });
 
-  it('returns yellow at boundary: scraper age exactly 6h', () => {
+  it('returns yellow at boundary: scraper age exactly 13h', () => {
     const metrics: CountyMetrics = {
       county: 'Los Angeles',
       rulingCount24h: 10,
       fieldCompletenessPct: 95,
-      scraperLastSuccessAgeHours: 6,
+      scraperLastSuccessAgeHours: 13,
       lastUpdated: '2026-03-01T00:00:00Z',
     };
     expect(computeHealthStatus(metrics)).toBe('yellow');
   });
 
-  it('returns red at boundary: scraper age exactly 24h (> 24 check)', () => {
+  it('returns red at boundary: scraper age exactly 26h (> 25 check)', () => {
     const metrics: CountyMetrics = {
       county: 'Los Angeles',
       rulingCount24h: 10,
       fieldCompletenessPct: 95,
-      scraperLastSuccessAgeHours: 24,
+      scraperLastSuccessAgeHours: 26,
       lastUpdated: '2026-03-01T00:00:00Z',
     };
-    // 24 is not > 24 so it's yellow, not red
+    expect(computeHealthStatus(metrics)).toBe('red');
+  });
+
+  it('returns red at boundary: scraper age exactly 25h (> 25 check — 25 is not > 25 so yellow)', () => {
+    const metrics: CountyMetrics = {
+      county: 'Los Angeles',
+      rulingCount24h: 10,
+      fieldCompletenessPct: 95,
+      scraperLastSuccessAgeHours: 25,
+      lastUpdated: '2026-03-01T00:00:00Z',
+    };
+    // 25 is not > 25 so it's yellow, not red
     expect(computeHealthStatus(metrics)).toBe('yellow');
   });
 });


### PR DESCRIPTION
## Summary

Scheduler now fires at 6:15 AM and 6:15 PM PT (twice daily) in both dev and production Terraform. Dashboard thresholds (`computeHealthStatus`) recalibrated from 6h/24h to 13h/25h, matching the new 12-hour cadence plus 1-hour slack for EventBridge FlexibleTimeWindow and scraper runtime.

Closes #2980

## Test plan

### Automated checks

- [x] Lint passes (ruff/prettier)
- [x] Format passes
- [x] Tests pass (unit tests for 12h→green, 13h→yellow, 26h→red boundaries)
- [ ] CI green

### Post-deploy verification

- [ ] Dev: `aws scheduler get-schedule --region us-west-2 --name judgemind-scraper-dev` shows `cron(15 6,18 * * ? *)` in `America/Los_Angeles`
- [ ] After next 6:15 AM PT scraper run on dev, `/admin/data-quality` shows all counties green (excluding pre-existing San Diego issue)
- [ ] Verification evidence posted on #2980 (see /task-v2-verify output)