### PR TITLE
polish(web): relabel spawn-frozen field, hide when inactive, remove stale footnote (#2990)

### DIFF
--- a/packages/web/src/app/(main)/admin/dispatcher/ConfigPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ConfigPanel.tsx
@@ -29,7 +29,15 @@ interface ConfigPanelProps {
  * Compact editable config strip (#2805 §1.6). Replaces the two-column
  * `<dl>` with a single horizontal row:
  *
- *   cap [ 1 ]   backoff [ 300s ]   idle [ on ▾ ]   spawn frozen: —
+ *   cap [ 1 ]   backoff [ 300s ]
+ *
+ * When the spawn-frozen back-pressure gate is active:
+ *
+ *   cap [ 1 ]   backoff [ 300s ]   new agents paused for ~N min
+ *   cap [ 1 ]   backoff [ 300s ]   new agents paused until H:MM AM/PM PT
+ *
+ * The freeze label is structurally hidden when inactive (not visibility:hidden
+ * or opacity:0 — it is simply not rendered). See #2990.
  *
  * Borderless. Sits beneath the main two-column grid.
  *
@@ -39,7 +47,7 @@ interface ConfigPanelProps {
  *     ConfirmDialog for destructive transitions).
  *   - Escape → cancel.
  *
- * Non-editable display-only: `spawn_frozen_until` (monospace timestamp).
+ * Non-editable display-only: `spawn_frozen_until` (when active).
  */
 export function ConfigPanel({
   entries,
@@ -49,6 +57,7 @@ export function ConfigPanel({
   busyKey,
 }: ConfigPanelProps) {
   const entryByKey = new Map(entries.map((e) => [e.key, e] as const));
+  const freezeLabel = buildFreezeLabel(spawnFrozenUntil);
 
   return (
     <section
@@ -74,13 +83,17 @@ export function ConfigPanel({
           busy={busyKey === 'backoff_seconds'}
           onCommit={(value) => onCommitEdit('backoff_seconds', value)}
         />
-        <span aria-hidden="true" className="text-muted-foreground">&middot;</span>
-        <span className="text-muted-foreground">
-          spawn frozen:{' '}
-          <span className="text-foreground" title={spawnFrozenUntil ?? ''}>
-            {spawnFrozenUntil ?? '—'}
-          </span>
-        </span>
+        {freezeLabel !== null && (
+          <>
+            <span aria-hidden="true" className="text-muted-foreground">&middot;</span>
+            <span
+              className="text-foreground"
+              title={freezeLabel.tooltip}
+            >
+              {freezeLabel.text}
+            </span>
+          </>
+        )}
       </div>
       {errorMessage && (
         <p
@@ -93,6 +106,59 @@ export function ConfigPanel({
       )}
     </section>
   );
+}
+
+/**
+ * Formats a Pacific Time clock string from a Date, e.g. "9:42 PM PT".
+ */
+function formatPacificTime(date: Date): string {
+  return (
+    new Intl.DateTimeFormat('en-US', {
+      timeZone: 'America/Los_Angeles',
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    }).format(date) + ' PT'
+  );
+}
+
+/**
+ * Computes the display text and tooltip for the spawn-frozen label.
+ * Returns null when the freeze is inactive (null or in the past).
+ *
+ * - ≤15 min remaining → `new agents paused for ~N min`
+ * - >15 min remaining → `new agents paused until H:MM AM/PM PT`
+ *
+ * Tooltip: `Resumes {H:MM AM/PM PT}.`
+ */
+function buildFreezeLabel(
+  spawnFrozenUntil: string | null,
+): { text: string; tooltip: string } | null {
+  if (spawnFrozenUntil === null) return null;
+
+  const until = new Date(spawnFrozenUntil);
+  const now = Date.now();
+  const remainingMs = until.getTime() - now;
+
+  // Past or exactly now → hide.
+  if (remainingMs <= 0) return null;
+
+  const resumeTime = formatPacificTime(until);
+  const tooltip = `Resumes ${resumeTime}.`;
+
+  const remainingMinutes = Math.max(1, Math.round(remainingMs / 60_000));
+
+  if (remainingMinutes <= 15) {
+    return {
+      text: `new agents paused for ~${remainingMinutes} min`,
+      tooltip,
+    };
+  }
+
+  return {
+    text: `new agents paused until ${resumeTime}`,
+    tooltip,
+  };
 }
 
 interface EditableNumberFieldProps {

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -28,7 +28,6 @@ import { DiagnoserEffectivenessPanel } from './DiagnoserEffectivenessPanel';
 import { ConfigPanel } from './ConfigPanel';
 import { ConfirmDialog, type ConfirmableCommand } from './ConfirmDialog';
 import { QueueFullDialog } from './QueueFullDialog';
-import { IssueLink } from './ui-primitives';
 
 /**
  * Polling interval for `dispatcherState`. Per spec §11, the daemon runs on
@@ -467,12 +466,6 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
             <DiagnoserEffectivenessPanel />
           </div>
 
-          <p className="mt-4 text-xs text-muted-foreground">
-            Daemon command handlers tracked in{' '}
-            <IssueLink number={2801} />
-            . Control buttons write to <code className="font-mono">dispatcher.commands</code>{' '}
-            today; daemon-side handlers land with that issue.
-          </p>
         </>
       )}
 

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ConfigPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ConfigPanel.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Tests for ConfigPanel's spawn-frozen field display logic (#2990).
+ *
+ * Acceptance criteria:
+ *   - null spawnFrozenUntil → field hidden entirely
+ *   - past spawnFrozenUntil → field hidden
+ *   - ≤15 min remaining → "new agents paused for ~N min"
+ *   - >15 min remaining → "new agents paused until H:MM AM/PM PT"
+ *   - title tooltip contains "Resumes"
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ConfigPanel } from '../ConfigPanel';
+
+const NOOP_COMMIT = vi.fn().mockResolvedValue(undefined);
+
+function renderConfigPanel(spawnFrozenUntil: string | null) {
+  return render(
+    <ConfigPanel
+      entries={[]}
+      spawnFrozenUntil={spawnFrozenUntil}
+      onCommitEdit={NOOP_COMMIT}
+    />,
+  );
+}
+
+describe('ConfigPanel — spawn frozen field (#2990)', () => {
+  it('renders nothing paused-related when spawnFrozenUntil is null', () => {
+    renderConfigPanel(null);
+    expect(screen.queryByText(/paused/i)).toBeNull();
+  });
+
+  it('renders nothing paused-related when spawnFrozenUntil is 1 minute in the past', () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    renderConfigPanel(past);
+    expect(screen.queryByText(/paused/i)).toBeNull();
+  });
+
+  it('renders nothing paused-related when spawnFrozenUntil is exactly now', () => {
+    // Exactly now counts as "past" (not strictly future).
+    const now = new Date(Date.now()).toISOString();
+    renderConfigPanel(now);
+    expect(screen.queryByText(/paused/i)).toBeNull();
+  });
+
+  it('renders "new agents paused for ~7 min" when 7 minutes remain', () => {
+    const future = new Date(Date.now() + 7 * 60_000).toISOString();
+    renderConfigPanel(future);
+    expect(screen.getByText(/new agents paused for ~7 min/i)).toBeInTheDocument();
+  });
+
+  it('renders "new agents paused for ~1 min" when 30 seconds remain (floor at 1)', () => {
+    const future = new Date(Date.now() + 30_000).toISOString();
+    renderConfigPanel(future);
+    expect(screen.getByText(/new agents paused for ~1 min/i)).toBeInTheDocument();
+  });
+
+  it('renders "new agents paused for ~15 min" when exactly 15 minutes remain', () => {
+    // 15 min is still the "short" branch (≤15 min).
+    const future = new Date(Date.now() + 15 * 60_000).toISOString();
+    renderConfigPanel(future);
+    expect(screen.getByText(/new agents paused for ~15 min/i)).toBeInTheDocument();
+  });
+
+  it('renders "new agents paused until ... PT" when 20 minutes remain', () => {
+    const future = new Date(Date.now() + 20 * 60_000).toISOString();
+    renderConfigPanel(future);
+    // The "until" variant uses Pacific Time clock.
+    expect(screen.getByText(/new agents paused until .+ PT/i)).toBeInTheDocument();
+    // Does NOT say "for ~N min".
+    expect(screen.queryByText(/for ~\d+ min/i)).toBeNull();
+  });
+
+  it('title tooltip on the freeze label contains "Resumes"', () => {
+    const future = new Date(Date.now() + 7 * 60_000).toISOString();
+    renderConfigPanel(future);
+    const label = screen.getByText(/new agents paused/i).closest('[title]') as HTMLElement | null;
+    expect(label).not.toBeNull();
+    expect(label!.getAttribute('title')).toContain('Resumes');
+  });
+
+  it('title tooltip on the "until" variant also contains "Resumes"', () => {
+    const future = new Date(Date.now() + 20 * 60_000).toISOString();
+    renderConfigPanel(future);
+    const label = screen.getByText(/new agents paused until/i).closest('[title]') as HTMLElement | null;
+    expect(label).not.toBeNull();
+    expect(label!.getAttribute('title')).toContain('Resumes');
+  });
+
+  it('freeze label is not rendered (structurally absent) when inactive', () => {
+    renderConfigPanel(null);
+    // The config strip is still present for the editable fields.
+    expect(screen.getByTestId('config-strip')).toBeInTheDocument();
+    // But no separator or freeze text.
+    expect(screen.queryByText(/spawn frozen/i)).toBeNull();
+  });
+});

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
@@ -785,13 +785,13 @@ describe('DispatcherDashboard — #2812 Phase 2 polish', () => {
     expect(right.className).toMatch(/gap-4/);
   });
 
-  it('§2.5 — #2801 issue reference is a hot link via IssueLink', () => {
+  it('§2.5 — #2990: stale #2801 footnote has been removed', () => {
+    // The footnote "Daemon command handlers tracked in #2801…" was removed
+    // in #2990 because #2801 closed on 2026-04-19 when PR #2858 landed
+    // the daemon-side handlers. The disclaimer was wrong and misleading.
     renderDashboard();
-    expect(screen.getByTestId('issue-link-2801')).toBeInTheDocument();
-    expect(screen.getByTestId('issue-link-2801')).toHaveAttribute(
-      'href',
-      'https://github.com/judgemind/judgemind/issues/2801',
-    );
+    expect(screen.queryByTestId('issue-link-2801')).toBeNull();
+    expect(screen.queryByText(/daemon command handlers/i)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Polished the admin dispatcher cockpit for clarity: relabeled the cryptic "spawn frozen: —" field to human-legible copy that adapts to the freeze state, hidden it entirely when inactive, and removed the obsolete #2801 footnote about daemon handlers (shipped in #2858). All 1458 tests pass with lint and typecheck green.

Closes #2990

## Test plan

### Automated checks

- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (10 new ConfigPanel tests + 1 updated DispatcherDashboard test; all 1458 pass)
- [x] CI green

### Post-deploy verification

- [ ] Navigate to `/admin/dispatcher` on dev and verify:
  - When dispatcher is healthy (no freeze), the config bar shows `cap [ 1 ] · backoff [ 300s ]` with no freeze label
  - When a freeze is active, the label reads either "new agents paused for ~N min" or "new agents paused until H:MM AM/PM PT" depending on duration
  - Hover over the freeze label and verify the `title` tooltip shows "Resumes H:MM AM/PM PT." with the accurate resume time
- [ ] Verification evidence posted on #2990 (see /task-v2-verify output)