### PR TITLE
feat(web/admin): blocker-title tooltip on #NNNN links in Queue: Blocked panel (#2989)

### DIFF
--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -56,6 +56,14 @@ interface SnapshotIssueRecord {
   createdAt: string | null;
   /** Only populated for blocked snapshots (daemon omits on queue scan). */
   body?: string | null;
+  /**
+   * Enriched blocker refs written by the daemon's
+   * `_fetch_issue_titles_for_blockers` helper (issue #2989). Optional
+   * so that pre-#2989 snapshots (which only carried `body`) still
+   * parse cleanly via the backward-compat shim in
+   * `queueItemFromSnapshot`.
+   */
+  blockedBy?: Array<{ number: number; title: string | null }>;
 }
 
 // Minimal Context subset the dispatcher resolvers read.
@@ -435,8 +443,24 @@ function normalizeSnapshotJson(raw: unknown): SnapshotIssueRecord[] {
         : record.body === null
           ? null
           : undefined;
+    // Parse blockedBy: Array<{number, title}> defensively. Malformed
+    // entries (non-object, missing numeric `number`) are silently dropped
+    // so a corrupt snapshot row can't crash the resolver. Issue #2989.
+    let blockedBy: Array<{ number: number; title: string | null }> | undefined;
+    if (Array.isArray(record.blockedBy)) {
+      const parsedBlockers: Array<{ number: number; title: string | null }> = [];
+      for (const entry of record.blockedBy) {
+        if (!entry || typeof entry !== 'object') continue;
+        const e = entry as Record<string, unknown>;
+        if (typeof e.number !== 'number') continue;
+        const entryTitle = typeof e.title === 'string' ? e.title : null;
+        parsedBlockers.push({ number: e.number, title: entryTitle });
+      }
+      blockedBy = parsedBlockers;
+    }
     const out: SnapshotIssueRecord = { number, title, labels, createdAt };
     if (body !== undefined) out.body = body;
+    if (blockedBy !== undefined) out.blockedBy = blockedBy;
     result.push(out);
   }
   return result;
@@ -717,13 +741,35 @@ function queueItemFromSnapshot(
   includeBlockedBy: boolean,
   cooldownSecondsRemaining: number | null = null,
 ): Record<string, unknown> {
+  let blockedBy: Array<{ number: number; title: string | null }> = [];
+  if (includeBlockedBy) {
+    if (issue.blockedBy !== undefined) {
+      // Fast path: new daemon snapshot carries blockedBy: BlockerRef[].
+      // Back-compat shim: if the stored value is an array of plain
+      // numbers (pre-#2989 daemon write), wrap each as {number, title: null}.
+      blockedBy = (issue.blockedBy as Array<unknown>).map((entry) => {
+        if (typeof entry === 'number') {
+          return { number: entry, title: null };
+        }
+        // Already a {number, title} object (post-#2989 shape).
+        const e = entry as { number: number; title: string | null };
+        return { number: e.number, title: e.title ?? null };
+      });
+    } else {
+      // Legacy path: blockedBy not in snapshot → parse from body.
+      blockedBy = parseBlockedBy(issue.body).map((n) => ({
+        number: n,
+        title: null,
+      }));
+    }
+  }
   return {
     issueNumber: issue.number,
     title: issue.title,
     priority: extractPriority(issue.labels),
     labels: issue.labels,
     createdAt: issue.createdAt,
-    blockedBy: includeBlockedBy ? parseBlockedBy(issue.body) : [],
+    blockedBy,
     cooldownSecondsRemaining,
   };
 }

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -212,13 +212,27 @@ export const dispatcherTypeDefs = `#graphql
     modelUsed: String
   }
 
+  """A blocker reference — the issue number and optional title of an issue
+  that is blocking a \`status/blocked\` queue item. Title is populated by the
+  daemon's \`_fetch_issue_titles_for_blockers\` helper (issue #2989) and may
+  be null when the title fetch failed (404, rate-limit, etc.).
+  """
+  type BlockerRef {
+    """Issue number of the blocking issue."""
+    number: Int!
+    """Title of the blocking issue at snapshot time. Null when the daemon
+    could not fetch the title (transient fetch failure, issue deleted, etc.).
+    Clients should render just \`#N\` when this is null."""
+    title: String
+  }
+
   """One row in the queue side-panels (#2805 §1.3). Capped at 10 server-side.
 
   - \`queueReady\` entries are open issues labelled \`agent/ready\` + not
     assigned + not blocked. Sorted by priority asc then created_at asc.
   - \`queueBlocked\` entries are open issues labelled \`status/blocked\`.
     Sorted by created_at desc. \`blockedBy\` is parsed from the issue body's
-    \`Blocked by #N\` lines.
+    \`Blocked by #N\` lines plus the daemon-fetched blocker titles (issue #2989).
   """
   type QueueItem {
     issueNumber: Int!
@@ -228,9 +242,10 @@ export const dispatcherTypeDefs = `#graphql
     labels: [String!]!
     """Null when the daemon snapshot's upstream GitHub lookup was missing or malformed."""
     createdAt: DateTime
-    """Issue numbers this issue is blocked by (from the 'Blocked by #N' lines
-    in the body). Empty for queueReady items."""
-    blockedBy: [Int!]!
+    """Blocker references for this issue (from the 'Blocked by #N' lines in the
+    body, enriched with titles fetched by the daemon at snapshot time — issue
+    #2989). Empty for queueReady items. Title may be null when the fetch failed."""
+    blockedBy: [BlockerRef!]!
     """Seconds left before this issue is eligible for the scheduler to pick up
     again after a recent failure. Null when no prior \`dispatcher.agents\` row
     exists or when cooldown has elapsed (0 = expired, positive = still cooling,

--- a/packages/api/tests/dispatcher-enrichment.unit.test.ts
+++ b/packages/api/tests/dispatcher-enrichment.unit.test.ts
@@ -20,6 +20,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { describe, it, expect } from 'vitest';
+import { buildSchema } from 'graphql';
 import {
   CATEGORY_DISPLAY_NAMES,
   coerceNullableNumber,
@@ -36,6 +37,7 @@ import {
   type DiagnoserEffectivenessRow,
   type SnapshotIssueRecord,
 } from '../src/graphql/dispatcher/resolvers';
+import { dispatcherTypeDefs } from '../src/graphql/dispatcher/schema';
 import {
   extractPriority,
   parseBlockedBy,
@@ -174,13 +176,18 @@ describe('queueItemFromSnapshot', () => {
     });
   });
 
-  it('parses blockedBy from the body when requested', () => {
+  it('parses blockedBy from the body when requested (legacy body-only path wraps to BlockerRef[])', () => {
+    // Issue #2989: body-only legacy path (no blockedBy field in snapshot)
+    // wraps each parsed number as {number, title: null}.
     const withBody: SnapshotIssueRecord = {
       ...base,
       body: 'Some context.\n\nBlocked by #42\nBlocked by #100\n',
     };
     const result = queueItemFromSnapshot(withBody, true);
-    expect(result.blockedBy).toEqual([42, 100]);
+    expect(result.blockedBy).toEqual([
+      { number: 42, title: null },
+      { number: 100, title: null },
+    ]);
   });
 
   it('handles missing priority label', () => {
@@ -1500,5 +1507,180 @@ describe('diagnoserRowToGraphQL', () => {
     // The DateTime scalar serializes to a string; the raw value is passed
     // through so the DateTimeScalar.serialize function handles formatting.
     expect(out.day).toBe(isoDay);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #2989 — BlockerRef type in GraphQL schema + resolver back-compat
+// ---------------------------------------------------------------------------
+
+describe('GraphQL schema — BlockerRef type (issue #2989)', () => {
+  it('AC2: schema parses cleanly with BlockerRef type defined', () => {
+    // buildSchema will throw if the schema string has syntax errors or
+    // references an undefined type. This confirms BlockerRef is defined and
+    // QueueItem.blockedBy references it correctly.
+    //
+    // dispatcherTypeDefs uses `extend type Query/Mutation` — wrap in a
+    // base schema to satisfy buildSchema's requirement for root types.
+    const baseSchema = `
+      type Query { _noop: Boolean }
+      type Mutation { _noop: Boolean }
+    `;
+    expect(() => buildSchema(baseSchema + dispatcherTypeDefs)).not.toThrow();
+  });
+
+  it('AC2: QueueItem.blockedBy is typed [BlockerRef!]! in the schema', () => {
+    const baseSchema = `
+      type Query { _noop: Boolean }
+      type Mutation { _noop: Boolean }
+    `;
+    const schema = buildSchema(baseSchema + dispatcherTypeDefs);
+    const queueItemType = schema.getType('QueueItem') as import('graphql').GraphQLObjectType;
+    expect(queueItemType).toBeTruthy();
+    const blockedByField = queueItemType.getFields()['blockedBy'];
+    expect(blockedByField).toBeTruthy();
+    // Should be [BlockerRef!]! — inspect the type string
+    expect(blockedByField.type.toString()).toBe('[BlockerRef!]!');
+  });
+
+  it('AC2: BlockerRef type has number (Int!) and title (String) fields', () => {
+    const baseSchema = `
+      type Query { _noop: Boolean }
+      type Mutation { _noop: Boolean }
+    `;
+    const schema = buildSchema(baseSchema + dispatcherTypeDefs);
+    const blockerRefType = schema.getType('BlockerRef') as import('graphql').GraphQLObjectType;
+    expect(blockerRefType).toBeTruthy();
+    const fields = blockerRefType.getFields();
+    expect(fields['number'].type.toString()).toBe('Int!');
+    expect(fields['title'].type.toString()).toBe('String');
+  });
+});
+
+describe('queueItemFromSnapshot — BlockerRef shape (issue #2989)', () => {
+  it('AC3: legacy row with blockedBy=number[] wraps to [{number, title: null}]', () => {
+    // Pre-migration snapshot: daemon wrote blockedBy as number[] or body-only.
+    // The resolver back-compat shim must map this to BlockerRef[] without crash.
+    const legacyWithNumberArray: SnapshotIssueRecord & { blockedBy?: unknown } = {
+      number: 500,
+      title: 'Blocked issue',
+      labels: ['status/blocked'],
+      createdAt: '2026-04-18T12:00:00Z',
+      body: 'Blocked by #42\n',
+      blockedBy: [42, 100],  // legacy int[] shape
+    };
+    const result = queueItemFromSnapshot(legacyWithNumberArray as SnapshotIssueRecord, true);
+    // Back-compat: when blockedBy is number[], wrap each as {number, title: null}.
+    expect(result.blockedBy).toEqual([
+      { number: 42, title: null },
+      { number: 100, title: null },
+    ]);
+  });
+
+  it('uses new BlockerRef[] when present in snapshot', () => {
+    const newShape: SnapshotIssueRecord = {
+      number: 500,
+      title: 'Blocked issue',
+      labels: ['status/blocked'],
+      createdAt: '2026-04-18T12:00:00Z',
+      body: 'Blocked by #42\n',
+      blockedBy: [{ number: 42, title: 'The blocker title' }],
+    };
+    const result = queueItemFromSnapshot(newShape, true);
+    expect(result.blockedBy).toEqual([
+      { number: 42, title: 'The blocker title' },
+    ]);
+  });
+
+  it('falls back to body-parse when blockedBy is absent and includeBlockedBy=true', () => {
+    // Body-only legacy path (pre-#2989 daemon wrote body but no blockedBy field).
+    const bodyOnly: SnapshotIssueRecord = {
+      number: 501,
+      title: 'Body only',
+      labels: ['status/blocked'],
+      createdAt: '2026-04-18T12:00:00Z',
+      body: 'Blocked by #42\nBlocked by #100\n',
+    };
+    const result = queueItemFromSnapshot(bodyOnly, true);
+    expect(result.blockedBy).toEqual([
+      { number: 42, title: null },
+      { number: 100, title: null },
+    ]);
+  });
+
+  it('returns empty blockedBy when includeBlockedBy=false (ready panel)', () => {
+    // AC7: ready rows have no blockers — blockedBy should always be empty.
+    const readyIssue: SnapshotIssueRecord = {
+      number: 200,
+      title: 'Ready issue',
+      labels: ['agent/ready'],
+      createdAt: '2026-04-18T12:00:00Z',
+    };
+    const result = queueItemFromSnapshot(readyIssue, false);
+    expect(result.blockedBy).toEqual([]);
+  });
+
+  it('handles null title in BlockerRef gracefully', () => {
+    const withNullTitle: SnapshotIssueRecord = {
+      number: 502,
+      title: 'Blocked with null title',
+      labels: ['status/blocked'],
+      createdAt: '2026-04-18T12:00:00Z',
+      blockedBy: [{ number: 99, title: null }],
+    };
+    const result = queueItemFromSnapshot(withNullTitle, true);
+    expect(result.blockedBy).toEqual([{ number: 99, title: null }]);
+  });
+});
+
+describe('normalizeSnapshotJson — blockedBy field (issue #2989)', () => {
+  it('parses blockedBy: BlockerRef[] from the snapshot', () => {
+    const raw = [
+      {
+        number: 500,
+        title: 'Blocked',
+        labels: ['status/blocked'],
+        createdAt: '2026-04-18T12:00:00Z',
+        body: 'Blocked by #42\n',
+        blockedBy: [{ number: 42, title: 'Blocker title' }],
+      },
+    ];
+    const result = normalizeSnapshotJson(raw);
+    expect(result[0].blockedBy).toEqual([{ number: 42, title: 'Blocker title' }]);
+  });
+
+  it('drops malformed blockedBy entries (non-object or missing number)', () => {
+    const raw = [
+      {
+        number: 500,
+        title: 'Blocked',
+        labels: [],
+        createdAt: '',
+        blockedBy: [
+          { number: 42, title: 'Good' },
+          'bad_string',
+          { title: 'no-number' },
+          { number: 'not-int', title: 'bad-type' },
+          null,
+        ],
+      },
+    ];
+    const result = normalizeSnapshotJson(raw);
+    // Only the well-formed entry {number: 42, title: 'Good'} survives.
+    expect(result[0].blockedBy).toEqual([{ number: 42, title: 'Good' }]);
+  });
+
+  it('omits blockedBy field entirely when not present (queue snapshot shape)', () => {
+    // Ready-queue snapshots don't carry blockedBy.
+    const raw = [
+      {
+        number: 100,
+        title: 'Ready',
+        labels: ['agent/ready'],
+        createdAt: '2026-04-18T12:00:00Z',
+      },
+    ];
+    const result = normalizeSnapshotJson(raw);
+    expect('blockedBy' in result[0]).toBe(false);
   });
 });

--- a/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/QueuePanel.tsx
@@ -2,12 +2,7 @@
 
 import type { CSSProperties } from 'react';
 import { SECTION_HEADING } from '@/lib/typography';
-import type { QueueItem } from '@/lib/dispatcher-queries';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
+import type { BlockerRef, QueueItem } from '@/lib/dispatcher-queries';
 import { IssueLink, PriorityBadge } from './ui-primitives';
 
 interface QueuePanelProps {
@@ -269,6 +264,54 @@ export function formatCooldown(seconds: number): string {
 }
 
 /**
+ * Build the native `title` tooltip string for the `#NNNN` IssueLink on a
+ * blocked queue row. Issue #2989.
+ *
+ * Format:
+ * ```
+ * Blocked by:
+ *   #42 The blocker title
+ *   #100 Another blocker
+ *   (+M more)
+ * ```
+ *
+ * Rules:
+ * - Header line is always `Blocked by:`.
+ * - Each blocker gets its own line: `#N title` when title is known, or
+ *   `#N` alone when `title` is null.
+ * - Individual titles are capped at 80 characters with a `…` ellipsis.
+ * - At most 6 entries are shown; when truncated, a `(+M more)` line is
+ *   appended.
+ * - Entries are separated by `\n` — modern browsers render newlines in
+ *   native `title` attributes.
+ *
+ * Pure function — safe to call during render.
+ */
+export function formatBlockerTooltip(refs: BlockerRef[]): string {
+  const MAX_ENTRIES = 6;
+  const MAX_TITLE_CHARS = 80;
+
+  const lines: string[] = ['Blocked by:'];
+  const visible = refs.slice(0, MAX_ENTRIES);
+  for (const ref of visible) {
+    if (ref.title !== null && ref.title !== undefined) {
+      const truncated =
+        ref.title.length > MAX_TITLE_CHARS
+          ? `${ref.title.slice(0, MAX_TITLE_CHARS)}\u2026`
+          : ref.title;
+      lines.push(`  #${ref.number} ${truncated}`);
+    } else {
+      lines.push(`  #${ref.number}`);
+    }
+  }
+  const remaining = refs.length - MAX_ENTRIES;
+  if (remaining > 0) {
+    lines.push(`  (+${remaining} more)`);
+  }
+  return lines.join('\n');
+}
+
+/**
  * One row in the queue panel. Exported so the full-list dialog
  * (`QueueFullDialog`, issue #3159) can render the same row layout
  * without duplicating the markup.
@@ -308,7 +351,14 @@ export function QueueRow({
       data-testid={animated ? `queue-row-${item.issueNumber}` : undefined}
     >
       <div className="flex-shrink-0 pt-0.5">
-        <IssueLink number={item.issueNumber} />
+        <IssueLink
+          number={item.issueNumber}
+          title={
+            item.blockedBy.length > 0
+              ? formatBlockerTooltip(item.blockedBy)
+              : undefined
+          }
+        />
       </div>
       <div className="flex-shrink-0 pt-0.5">
         <PriorityBadge priority={item.priority} />
@@ -323,35 +373,13 @@ export function QueueRow({
         </span>
       )}
       <div className="min-w-0 flex-1">
-        {item.blockedBy.length > 0 ? (
-          <Tooltip delayDuration={0}>
-            <TooltipTrigger asChild>
-              <span
-                className="block break-words text-foreground"
-                data-testid={`blocker-tooltip-trigger-${item.issueNumber}`}
-                title={item.title}
-              >
-                {item.title}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent>
-              <span className="flex flex-wrap items-center gap-1 text-xs">
-                Blocked by{' '}
-                {item.blockedBy.map((blockerNumber) => (
-                  <IssueLink key={blockerNumber} number={blockerNumber} />
-                ))}
-              </span>
-            </TooltipContent>
-          </Tooltip>
-        ) : (
-          <span
-            className="block break-words text-foreground"
-            data-testid="queue-row-title"
-            title={item.title}
-          >
-            {item.title}
-          </span>
-        )}
+        <span
+          className="block break-words text-foreground"
+          data-testid="queue-row-title"
+          title={item.title}
+        >
+          {item.title}
+        </span>
       </div>
     </li>
   );

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueuePanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/QueuePanel.test.tsx
@@ -2,9 +2,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { RenderOptions } from '@testing-library/react';
 import type { ReactElement } from 'react';
-import { QueueBlockedPanel, QueuePanel, QueueReadyPanel, QueueRow } from '../QueuePanel';
+import { QueueBlockedPanel, QueuePanel, QueueReadyPanel, QueueRow, formatBlockerTooltip } from '../QueuePanel';
 import { formatCooldown } from '../QueuePanel';
 import type { QueueItem } from '@/lib/dispatcher-queries';
+import type { BlockerRef } from '@/lib/dispatcher-queries';
 import { TooltipProvider } from '@/components/ui/tooltip';
 
 const now = Date.parse('2026-04-18T12:00:00Z');
@@ -29,6 +30,11 @@ function item(overrides: Partial<QueueItem>): QueueItem {
     cooldownSecondsRemaining: null,
     ...overrides,
   };
+}
+
+/** Build a BlockerRef for tests. */
+function blocker(number: number, title: string | null = null): BlockerRef {
+  return { number, title };
 }
 
 describe('QueuePanel', () => {
@@ -59,7 +65,7 @@ describe('QueuePanel', () => {
 
   it('renders blocked rows with the issue link and title only', () => {
     const blocked = [
-      item({ issueNumber: 2500, title: 'blocked issue', blockedBy: [2500, 2600] }),
+      item({ issueNumber: 2500, title: 'blocked issue', blockedBy: [blocker(2500), blocker(2600)] }),
     ];
     renderWithTooltip(<QueuePanel queueReady={[]} queueBlocked={blocked} nowMs={now} />);
     expect(screen.getByTestId('issue-link-2500')).toBeInTheDocument();
@@ -80,7 +86,7 @@ describe('QueuePanel', () => {
 
   it('#2818: strips the [N] blocked-by count column from the blocked side', () => {
     const blocked = [
-      item({ issueNumber: 2500, title: 'blocked issue', blockedBy: [2500, 2600] }),
+      item({ issueNumber: 2500, title: 'blocked issue', blockedBy: [blocker(2500), blocker(2600)] }),
     ];
     renderWithTooltip(<QueuePanel queueReady={[]} queueBlocked={blocked} nowMs={now} />);
     expect(screen.queryByText('[2]')).not.toBeInTheDocument();
@@ -135,7 +141,7 @@ describe('QueuePanel', () => {
 
   it('#2886: blocked panel header renders `{shown} / {total}` when total provided', () => {
     const blocked = [
-      item({ issueNumber: 2500, title: 'blocked issue', blockedBy: [2500, 2600] }),
+      item({ issueNumber: 2500, title: 'blocked issue', blockedBy: [blocker(2500), blocker(2600)] }),
     ];
     renderWithTooltip(
       <QueuePanel
@@ -342,16 +348,21 @@ describe('QueuePanel — #3159 clickable count', () => {
   });
 });
 
-// --- #2812 — blocker tooltip hot links on blocked rows.
-describe('QueuePanel — #2812 blocker tooltip', () => {
-  it('renders blocker numbers as hot links inside the blocked-row tooltip', async () => {
+// --- #2989 — native title tooltip on IssueLink for blocked rows.
+// Replaces the #2812 Radix Tooltip approach. The tooltip is now a native
+// browser `title` attribute on the `#NNNN` IssueLink.
+describe('QueuePanel — #2989 blocker native title tooltip', () => {
+  it('AC5: IssueLink for a blocked row carries a title starting with "Blocked by:"', () => {
     const blockedItem: QueueItem = {
       issueNumber: 9001,
       title: 'blocked issue with two blockers',
       priority: 'p2',
       labels: ['priority/p2', 'status/blocked'],
       createdAt: '2026-04-18T11:00:00Z',
-      blockedBy: [2500, 2600],
+      blockedBy: [
+        blocker(2500, 'The first blocker'),
+        blocker(2600, 'The second blocker'),
+      ],
       cooldownSecondsRemaining: null,
     };
     render(
@@ -359,37 +370,62 @@ describe('QueuePanel — #2812 blocker tooltip', () => {
         <QueueRow item={blockedItem} />
       </TooltipProvider>,
     );
-    // The tooltip trigger should be present for rows with blockers.
-    const trigger = screen.getByTestId('blocker-tooltip-trigger-9001');
-    expect(trigger).toBeInTheDocument();
-    // Fire pointerMove to begin the tooltip open sequence (Radix opens on
-    // pointerMove). Then advance all timers (even delayDuration=0 uses setTimeout).
-    vi.useFakeTimers();
-    try {
-      act(() => {
-        fireEvent.pointerMove(trigger);
-        vi.runAllTimers();
-      });
-    } finally {
-      vi.useRealTimers();
-    }
-    // Tooltip content renders the blocker links.
-    const link2500 = screen.getAllByTestId('issue-link-2500')[0];
-    const link2600 = screen.getAllByTestId('issue-link-2600')[0];
-    expect(link2500).toBeInTheDocument();
-    expect(link2600).toBeInTheDocument();
-    // Check the links have the correct hrefs.
-    expect(link2500).toHaveAttribute(
-      'href',
-      'https://github.com/judgemind/judgemind/issues/2500',
-    );
-    expect(link2600).toHaveAttribute(
-      'href',
-      'https://github.com/judgemind/judgemind/issues/2600',
-    );
+    const link = screen.getByTestId('issue-link-9001');
+    const titleAttr = link.getAttribute('title');
+    expect(titleAttr).toBeTruthy();
+    expect(titleAttr).toMatch(/^Blocked by:/);
   });
 
-  it('suppresses the blocker tooltip when blockedBy is empty', () => {
+  it('AC5: tooltip includes both blocker numbers and titles', () => {
+    const blockedItem: QueueItem = {
+      issueNumber: 9001,
+      title: 'blocked issue',
+      priority: 'p2',
+      labels: ['priority/p2', 'status/blocked'],
+      createdAt: '2026-04-18T11:00:00Z',
+      blockedBy: [
+        blocker(2500, 'The first blocker'),
+        blocker(2600, 'The second blocker'),
+      ],
+      cooldownSecondsRemaining: null,
+    };
+    render(
+      <TooltipProvider>
+        <QueueRow item={blockedItem} />
+      </TooltipProvider>,
+    );
+    const link = screen.getByTestId('issue-link-9001');
+    const titleAttr = link.getAttribute('title') ?? '';
+    expect(titleAttr).toContain('2500');
+    expect(titleAttr).toContain('The first blocker');
+    expect(titleAttr).toContain('2600');
+    expect(titleAttr).toContain('The second blocker');
+  });
+
+  it('AC6: tooltip falls back to #N alone when a blocker title is null', () => {
+    const blockedItem: QueueItem = {
+      issueNumber: 9003,
+      title: 'blocked issue with null title',
+      priority: 'p2',
+      labels: ['priority/p2', 'status/blocked'],
+      createdAt: '2026-04-18T11:00:00Z',
+      blockedBy: [blocker(42, null)],
+      cooldownSecondsRemaining: null,
+    };
+    render(
+      <TooltipProvider>
+        <QueueRow item={blockedItem} />
+      </TooltipProvider>,
+    );
+    const link = screen.getByTestId('issue-link-9003');
+    const titleAttr = link.getAttribute('title') ?? '';
+    // For null title the line must be "#42" only (no extra text after it).
+    expect(titleAttr).toContain('#42');
+    // Must NOT contain stray "null" string.
+    expect(titleAttr).not.toContain('null');
+  });
+
+  it('AC7: ready row IssueLink has no title attribute (no blockers)', () => {
     const readyItem: QueueItem = {
       issueNumber: 9002,
       title: 'ready issue no blockers',
@@ -404,8 +440,28 @@ describe('QueuePanel — #2812 blocker tooltip', () => {
         <QueueRow item={readyItem} />
       </TooltipProvider>,
     );
-    // No tooltip trigger for rows without blockers.
-    expect(screen.queryByTestId('blocker-tooltip-trigger-9002')).toBeNull();
+    const link = screen.getByTestId('issue-link-9002');
+    // Ready rows have no blocker tooltip.
+    expect(link.getAttribute('title')).toBeNull();
+  });
+
+  it('no Radix blocker-tooltip-trigger on blocked rows (replaced by native title)', () => {
+    const blockedItem: QueueItem = {
+      issueNumber: 9004,
+      title: 'blocked issue',
+      priority: 'p2',
+      labels: ['priority/p2', 'status/blocked'],
+      createdAt: '2026-04-18T11:00:00Z',
+      blockedBy: [blocker(42, 'Some title')],
+      cooldownSecondsRemaining: null,
+    };
+    render(
+      <TooltipProvider>
+        <QueueRow item={blockedItem} />
+      </TooltipProvider>,
+    );
+    // The old Radix trigger testid must be gone — replaced by native title.
+    expect(screen.queryByTestId('blocker-tooltip-trigger-9004')).toBeNull();
   });
 });
 
@@ -421,5 +477,80 @@ describe('formatCooldown', () => {
     expect(formatCooldown(300)).toBe('5m');
     expect(formatCooldown(3540)).toBe('59m');
     expect(formatCooldown(3600)).toBe('60m');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatBlockerTooltip — pure helper (issue #2989)
+// ---------------------------------------------------------------------------
+describe('formatBlockerTooltip', () => {
+  it('returns a string starting with "Blocked by:"', () => {
+    const refs: BlockerRef[] = [blocker(42, 'Do the thing')];
+    expect(formatBlockerTooltip(refs)).toMatch(/^Blocked by:/);
+  });
+
+  it('renders each blocker on its own line with "#N title"', () => {
+    const refs: BlockerRef[] = [
+      blocker(42, 'First blocker'),
+      blocker(100, 'Second blocker'),
+    ];
+    const result = formatBlockerTooltip(refs);
+    const lines = result.split('\n');
+    // First line is "Blocked by:"
+    expect(lines[0]).toBe('Blocked by:');
+    expect(lines).toContainEqual(expect.stringContaining('#42'));
+    expect(lines).toContainEqual(expect.stringContaining('First blocker'));
+    expect(lines).toContainEqual(expect.stringContaining('#100'));
+    expect(lines).toContainEqual(expect.stringContaining('Second blocker'));
+  });
+
+  it('AC6: null title renders as "#N" only with no stray "null"', () => {
+    const refs: BlockerRef[] = [blocker(42, null)];
+    const result = formatBlockerTooltip(refs);
+    expect(result).toContain('#42');
+    expect(result).not.toContain('null');
+  });
+
+  it('truncates at 6 entries and appends "(+M more)"', () => {
+    const refs: BlockerRef[] = Array.from({ length: 9 }, (_, i) =>
+      blocker(100 + i, `Title ${i}`),
+    );
+    const result = formatBlockerTooltip(refs);
+    // 9 blockers → show 6, append "(+3 more)"
+    expect(result).toContain('(+3 more)');
+    // Entries 7-9 (numbers 106-108) must NOT appear.
+    expect(result).not.toContain('#106');
+    expect(result).not.toContain('#107');
+    expect(result).not.toContain('#108');
+  });
+
+  it('does NOT append "(+M more)" when 6 or fewer', () => {
+    const refs: BlockerRef[] = Array.from({ length: 6 }, (_, i) =>
+      blocker(100 + i, `Title ${i}`),
+    );
+    const result = formatBlockerTooltip(refs);
+    expect(result).not.toContain('more');
+  });
+
+  it('caps individual title at ~80 chars with ellipsis', () => {
+    const longTitle = 'A'.repeat(90);
+    const refs: BlockerRef[] = [blocker(42, longTitle)];
+    const result = formatBlockerTooltip(refs);
+    // Title must be truncated; ellipsis appended.
+    expect(result).toContain('\u2026');
+    // The line with the blocker must not contain the full 90-char title.
+    const lines = result.split('\n');
+    const blockerLine = lines.find((l) => l.includes('#42')) ?? '';
+    // Line format: "  #42 <title>" — check that the title portion is capped.
+    // Strip leading spaces and "#42 " to isolate the title portion.
+    const titlePart = blockerLine.trimStart().replace(/^#\d+\s/, '');
+    // Title should be at most 81 chars (80 + ellipsis).
+    expect(titlePart.length).toBeLessThanOrEqual(81);
+    // Must not contain the full 90-char title.
+    expect(titlePart).not.toBe(longTitle);
+  });
+
+  it('returns just "Blocked by:" header for empty input', () => {
+    expect(formatBlockerTooltip([])).toBe('Blocked by:');
   });
 });

--- a/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
@@ -48,8 +48,14 @@ const REPO = 'judgemind/judgemind';
 const BRAND_LINK_CLASSES =
   'font-mono text-brand-accent dark:text-brand-accent-light underline-offset-2 hover:underline';
 
-/** Hot link to a GitHub issue. Opens in a new tab. */
-export function IssueLink({ number, className }: { number: number; className?: string }) {
+/** Hot link to a GitHub issue. Opens in a new tab.
+ *
+ * Optional `title` prop is forwarded to the anchor's native `title`
+ * attribute for a browser tooltip — used by `QueueRow` to surface
+ * blocker details on the `#NNNN` link in the Queue: Blocked panel
+ * (issue #2989). Pass `undefined` (or omit) for no tooltip.
+ */
+export function IssueLink({ number, className, title }: { number: number; className?: string; title?: string }) {
   const href = `https://github.com/${REPO}/issues/${number}`;
   return (
     <a
@@ -58,6 +64,7 @@ export function IssueLink({ number, className }: { number: number; className?: s
       rel="noopener noreferrer"
       className={`${BRAND_LINK_CLASSES} ${className ?? ''}`}
       data-testid={`issue-link-${number}`}
+      title={title}
     >
       #{number}
     </a>

--- a/packages/web/src/lib/apollo-client.ts
+++ b/packages/web/src/lib/apollo-client.ts
@@ -234,6 +234,12 @@ export function createApolloClient(): ApolloClient<unknown> {
         // here. Cache as literal array items; the query is not in the 2s
         // poll path so stale merging is not a concern.
         DiagnoserEffectivenessRow: { keyFields: false },
+        // BlockerRef: inline type inside QueueItem.blockedBy (issue #2989).
+        // Uses issue `number` as the identity key — blocker refs with the
+        // same number (same blocking issue) are the same object.
+        BlockerRef: {
+          keyFields: ['number'],
+        },
 
         // ---------------------------------------------------------------------
         // Types that intentionally do NOT need keyFields:

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -56,7 +56,10 @@ export const DISPATCHER_STATE_QUERY = gql`
         priority
         labels
         createdAt
-        blockedBy
+        blockedBy {
+          number
+          title
+        }
         cooldownSecondsRemaining
       }
       queueBlocked {
@@ -65,7 +68,10 @@ export const DISPATCHER_STATE_QUERY = gql`
         priority
         labels
         createdAt
-        blockedBy
+        blockedBy {
+          number
+          title
+        }
       }
       recentCompletions {
         agentId
@@ -120,7 +126,10 @@ export const DISPATCHER_QUEUE_FULL_QUERY = gql`
         priority
         labels
         createdAt
-        blockedBy
+        blockedBy {
+          number
+          title
+        }
         cooldownSecondsRemaining
       }
       completions {
@@ -232,13 +241,31 @@ export interface DispatcherFailure {
   issueNumber: number | null;
 }
 
+/**
+ * A blocker reference — the issue number and optional title of an issue
+ * that is blocking a `status/blocked` queue item. Title is populated by the
+ * daemon's `_fetch_issue_titles_for_blockers` helper (issue #2989) and may
+ * be null when the title fetch failed (404, rate-limit, etc.).
+ *
+ * Apollo `keyFields: ['number']` is registered in `apollo-client.ts` so
+ * Apollo normalises distinct BlockerRef entries correctly.
+ */
+export interface BlockerRef {
+  number: number;
+  title: string | null;
+}
+
 export interface QueueItem {
   issueNumber: number;
   title: string;
   priority: string | null;
   labels: string[];
   createdAt: string | null;
-  blockedBy: number[];
+  /** Blocker references for this issue. Issue #2989: now `BlockerRef[]`
+   * instead of `number[]`. Each entry carries the blocker issue number
+   * and optional title (null when the daemon's title fetch failed).
+   * Empty for queueReady items. */
+  blockedBy: BlockerRef[];
   /** Seconds left in the post-failure cooldown window. Null when no prior
    * attempt exists (never attempted) or when cooldown has elapsed.
    * Positive when the issue is still cooling down after a recent failure.

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -282,6 +282,12 @@ BLOCKED_SCAN_EVERY_N_TICKS = 4
 #: ``QUEUE_SCAN_PAGE_LIMIT`` so a single ``gh`` call always suffices.
 BLOCKED_SCAN_PAGE_LIMIT = 200
 
+#: Maximum number of unique blocker-issue numbers for which we fetch titles in a
+#: single scan tick. Numbers beyond this cap receive ``title=None`` silently.
+#: Guards against O(N × timeout) latency in ``_fetch_issue_titles_for_blockers``
+#: when GitHub is rate-limited and N is large (issue #2989).
+MAX_BLOCKER_TITLE_FETCH = 20
+
 #: Default CloudWatch metric namespace. Matches the terraform module's
 #: ``task_put_metric`` policy condition
 #: (``cloudwatch:namespace = Judgemind/Dispatcher``).
@@ -1870,6 +1876,7 @@ def _normalize_issue_enrichment(
     issue: dict[str, Any],
     *,
     include_body: bool = False,
+    blocker_title_lookup: dict[int, str | None] | None = None,
 ) -> dict[str, Any]:
     """Project a ``gh issue list``-shaped dict into the enrichment record.
 
@@ -1893,11 +1900,20 @@ def _normalize_issue_enrichment(
           "body":      <str | null>,    # so the API can parse
                                         # ``Blocked by #N`` without a
                                         # GitHub call
+          # when include_body=True AND blocker_title_lookup provided:
+          "blockedBy": [{"number": int, "title": str | null}, ...],
+                                        # enriched blocker refs (issue #2989)
         }
 
     ``gh`` sometimes omits keys on error responses; callers should
     already have filtered to dict-shaped entries before calling this.
+
+    ``blocker_title_lookup`` is injected by ``_scan_blocked_and_snapshot``
+    so this function stays pure — the lookup is built one level up and
+    shared across all issues in the tick (issue #2989).
     """
+    import re  # noqa: PLC0415 — lazy import
+
     number = issue.get("number")
     title = issue.get("title") if isinstance(issue.get("title"), str) else ""
     created_at = (
@@ -1922,6 +1938,17 @@ def _normalize_issue_enrichment(
     if include_body:
         body = issue.get("body")
         record["body"] = body if isinstance(body, str) else None
+        # Build blockedBy when a lookup is provided (issue #2989).
+        if blocker_title_lookup is not None:
+            body_str = body if isinstance(body, str) else ""
+            blocker_numbers = [
+                int(m)
+                for m in re.findall(r"(?im)^\s*blocked by\s+#(\d+)\s*$", body_str)
+            ]
+            record["blockedBy"] = [
+                {"number": n, "title": blocker_title_lookup.get(n)}
+                for n in blocker_numbers
+            ]
     return record
 
 
@@ -3740,6 +3767,27 @@ class DispatcherDaemon:
             )
             return -1
 
+        # Collect all unique blocker numbers across the whole tick so we can
+        # fetch titles in one deduped pass (issue #2989).
+        all_blocker_numbers: set[int] = set()
+        for issue in issues:
+            body = issue.get("body") or ""
+            all_blocker_numbers.update(self._parse_blocked_by(body))
+
+        try:
+            blocker_title_lookup = self._fetch_issue_titles_for_blockers(
+                all_blocker_numbers
+            )
+        except Exception:
+            self._log.exception(
+                "daemon.blocker_title_fetch_unexpected_error",
+                extra={
+                    "event": "blocker_title_fetch_unexpected_error",
+                    "run_id": self._run_id,
+                },
+            )
+            blocker_title_lookup = {}
+
         issue_numbers: list[int] = []
         issues_enriched: list[dict[str, Any]] = []
         for issue in issues:
@@ -3748,7 +3796,11 @@ class DispatcherDaemon:
                 continue
             issue_numbers.append(number)
             issues_enriched.append(
-                _normalize_issue_enrichment(issue, include_body=True)
+                _normalize_issue_enrichment(
+                    issue,
+                    include_body=True,
+                    blocker_title_lookup=blocker_title_lookup,
+                )
             )
         blocked_depth = len(issue_numbers)
 
@@ -5821,6 +5873,61 @@ class DispatcherDaemon:
 
         matches = re.findall(r"(?im)^\s*blocked by\s+#(\d+)\s*$", body)
         return [int(m) for m in matches]
+
+    def _fetch_issue_titles_for_blockers(
+        self, numbers: set[int]
+    ) -> dict[int, str | None]:
+        """Fetch issue titles for a set of blocker issue numbers.
+
+        One ``gh issue view <N> --json number,title`` call per unique number,
+        routed through ``_subprocess_with_retry`` with
+        ``event_name='blocker_title_fetch'``. Returns ``{number: title}`` with
+        ``None`` on per-issue failure (404, closed, rate-limit).
+
+        Single-tick scope — no cross-tick caching. Issue #2989.
+
+        Caps the number of lookups at ``MAX_BLOCKER_TITLE_FETCH`` to bound
+        worst-case latency when GitHub is rate-limited (issue #2989).
+        """
+        result: dict[int, str | None] = {}
+        capped = set(list(numbers)[:MAX_BLOCKER_TITLE_FETCH])
+        for number in capped:
+            cmd = [
+                "gh",
+                "issue",
+                "view",
+                str(number),
+                "--repo",
+                self._cfg.github_repo,
+                "--json",
+                "number,title",
+            ]
+            outcome = self._subprocess_with_retry(
+                cmd,
+                event_name="blocker_title_fetch",
+                timeout=30,
+                extra_log_fields={"blocker_number": number},
+            )
+            if not outcome["ok"]:
+                self._log.warning(
+                    "daemon.blocker_title_fetch_exhausted for #%d",
+                    number,
+                    extra={
+                        "event": "blocker_title_fetch_exhausted",
+                        "run_id": self._run_id,
+                        "blocker_number": number,
+                        "reason": outcome.get("reason"),
+                    },
+                )
+                result[number] = None
+                continue
+            try:
+                payload = json.loads(outcome["result"].stdout or "{}")
+                title = payload.get("title")
+                result[number] = title if isinstance(title, str) else None
+            except (json.JSONDecodeError, AttributeError):
+                result[number] = None
+        return result
 
     @staticmethod
     def _parse_parent_issue(body: str) -> int | None:

--- a/scripts/dispatcher/tests/test_daemon_enrichment.py
+++ b/scripts/dispatcher/tests/test_daemon_enrichment.py
@@ -935,7 +935,7 @@ class TestFetchIssuesTitleCap:
     def test_cap_limits_gh_calls(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """When >MAX_BLOCKER_TITLE_FETCH unique blockers are passed, only the
         first MAX_BLOCKER_TITLE_FETCH are fetched; the rest are absent."""
-        from scripts.dispatcher.daemon import MAX_BLOCKER_TITLE_FETCH
+        from dispatcher.daemon import MAX_BLOCKER_TITLE_FETCH
 
         d, _conn, _handler = _make_daemon_with_capture()
 

--- a/scripts/dispatcher/tests/test_daemon_enrichment.py
+++ b/scripts/dispatcher/tests/test_daemon_enrichment.py
@@ -298,6 +298,10 @@ class TestScanBlockedAndSnapshot:
                 "body": None,
             },
         ]
+        # Issue #2989: mock title lookup so the test is deterministic.
+        d._fetch_issue_titles_for_blockers = lambda numbers: {  # type: ignore[method-assign]
+            n: f"Title for #{n}" for n in numbers
+        }
 
         depth = d._scan_blocked_and_snapshot()
 
@@ -320,8 +324,10 @@ class TestScanBlockedAndSnapshot:
             "labels": ["status/blocked"],
             "createdAt": "2026-04-18T12:00:00Z",
             "body": "Blocked by #42\n",
+            "blockedBy": [{"number": 42, "title": "Title for #42"}],
         }
         assert enriched[1]["body"] is None
+        assert enriched[1]["blockedBy"] == []  # no blocked-by lines in body=None
         assert params[3] == "test-run-id"
         assert conn.commits == 1
 
@@ -360,6 +366,8 @@ class TestScanBlockedAndSnapshot:
                 "body": None,
             },
         ]
+        # body=None → empty blocker set → no gh calls needed; still mock for safety.
+        d._fetch_issue_titles_for_blockers = lambda numbers: {}  # type: ignore[method-assign]
 
         original_execute = conn.cursor_instance.execute
 
@@ -565,6 +573,8 @@ class TestSchedulerTickBlockedWiring:
                 "body": None,
             },
         ]
+        # body=None → empty blocker set → no gh calls; mock for determinism (#2989).
+        d._fetch_issue_titles_for_blockers = lambda numbers: {}  # type: ignore[method-assign]
 
         summary = d.scheduler_tick()
         assert summary["blocked_depth"] == 1
@@ -596,3 +606,368 @@ class TestSchedulerTickBlockedWiring:
         # Sentinel is emitted in the scheduler_tick log.
         ticks = handler.events("scheduler_tick")
         assert ticks[0].blocked_depth == -1
+
+
+# --------------------------------------------------------------------------
+# _fetch_issue_titles_for_blockers — new helper (issue #2989)
+# --------------------------------------------------------------------------
+
+
+class TestFetchIssueTitlesForBlockers:
+    """New helper that batch-fetches blocker titles from ``gh issue view``."""
+
+    def test_returns_title_for_each_number(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        d, _conn, _handler = _make_daemon_with_capture()
+
+        call_log: list[list[str]] = []
+
+        def fake_retry(
+            cmd: list[str],
+            *,
+            event_name: str,
+            timeout: float,
+            extra_log_fields: dict | None = None,
+        ) -> dict:
+            call_log.append(cmd)
+            number_str = cmd[cmd.index("view") + 1]
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = json.dumps(
+                {"number": int(number_str), "title": f"Title for #{number_str}"}
+            )
+            return {"ok": True, "result": result, "attempts": 1}
+
+        monkeypatch.setattr(d, "_subprocess_with_retry", fake_retry)
+
+        titles = d._fetch_issue_titles_for_blockers({42, 100})
+
+        assert titles[42] == "Title for #42"
+        assert titles[100] == "Title for #100"
+        # One gh call per unique number.
+        assert len(call_log) == 2
+
+    def test_returns_none_on_subprocess_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        d, _conn, handler = _make_daemon_with_capture()
+
+        def fake_retry(
+            cmd: list[str],
+            *,
+            event_name: str,
+            timeout: float,
+            extra_log_fields: dict | None = None,
+        ) -> dict:
+            return {
+                "ok": False,
+                "reason": "nonzero_exit",
+                "stderr_tail": "404",
+                "exit_code": 1,
+                "attempts": 3,
+            }
+
+        monkeypatch.setattr(d, "_subprocess_with_retry", fake_retry)
+
+        titles = d._fetch_issue_titles_for_blockers({99})
+        assert titles[99] is None
+        # Warning logged at WARNING level.
+        warn_events = [
+            r
+            for r in handler.records
+            if r.levelno == logging.WARNING
+            and getattr(r, "event", None) == "blocker_title_fetch_exhausted"
+        ]
+        assert len(warn_events) == 1
+
+    def test_empty_set_returns_empty_dict(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        d, _conn, _handler = _make_daemon_with_capture()
+        calls: list = []
+
+        def fake_retry(*_a: object, **_kw: object) -> dict:  # pragma: no cover
+            calls.append(1)
+            return {"ok": True, "result": MagicMock(), "attempts": 1}
+
+        monkeypatch.setattr(d, "_subprocess_with_retry", fake_retry)
+
+        titles = d._fetch_issue_titles_for_blockers(set())
+        assert titles == {}
+        assert calls == []
+
+    def test_deduplicates_blocker_numbers_within_tick(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One gh issue view per distinct blocker number across the whole tick."""
+        d, _conn, _handler = _make_daemon_with_capture()
+
+        call_log: list[str] = []
+
+        def fake_retry(
+            cmd: list[str],
+            *,
+            event_name: str,
+            timeout: float,
+            extra_log_fields: dict | None = None,
+        ) -> dict:
+            number_str = cmd[cmd.index("view") + 1]
+            call_log.append(number_str)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = json.dumps(
+                {"number": int(number_str), "title": f"T#{number_str}"}
+            )
+            return {"ok": True, "result": result, "attempts": 1}
+
+        monkeypatch.setattr(d, "_subprocess_with_retry", fake_retry)
+
+        # Pass a set — duplicates are already deduplicated by set semantics.
+        # This verifies we only make one call even when the same number
+        # appears in multiple blocked issues' bodies.
+        titles = d._fetch_issue_titles_for_blockers({42, 42, 100})
+        # Set deduplicated to {42, 100} — only 2 calls.
+        assert len(call_log) == 2
+        assert sorted(call_log) == ["100", "42"]
+        assert titles[42] == "T#42"
+
+
+# --------------------------------------------------------------------------
+# _normalize_issue_enrichment with blocker_title_lookup (issue #2989)
+# --------------------------------------------------------------------------
+
+
+class TestNormalizeIssueEnrichmentWithBlockers:
+    """blockedBy field is populated from the lookup dict when include_body=True."""
+
+    def test_populate_blocker_refs_from_lookup(self) -> None:
+        raw = {
+            "number": 500,
+            "title": "Blocked A",
+            "labels": [{"name": "status/blocked"}],
+            "createdAt": "2026-04-18T12:00:00Z",
+            "body": "Some context.\nBlocked by #42\nBlocked by #100\n",
+        }
+        lookup = {42: "The forty-two issue", 100: None}
+        result = daemon._normalize_issue_enrichment(
+            raw, include_body=True, blocker_title_lookup=lookup
+        )
+        assert result["blockedBy"] == [
+            {"number": 42, "title": "The forty-two issue"},
+            {"number": 100, "title": None},
+        ]
+
+    def test_no_lookup_omits_blockedby(self) -> None:
+        """Without a lookup the field is absent (backward-compat path)."""
+        raw = {
+            "number": 500,
+            "title": "Blocked A",
+            "labels": [],
+            "createdAt": "",
+            "body": "Blocked by #42\n",
+        }
+        result = daemon._normalize_issue_enrichment(raw, include_body=True)
+        assert "blockedBy" not in result
+
+    def test_blockedby_absent_when_body_has_no_blocked_lines(self) -> None:
+        raw = {
+            "number": 501,
+            "title": "Blocked B",
+            "labels": [],
+            "createdAt": "",
+            "body": "No blocked lines here.",
+        }
+        lookup: dict[int, str | None] = {}
+        result = daemon._normalize_issue_enrichment(
+            raw, include_body=True, blocker_title_lookup=lookup
+        )
+        assert result["blockedBy"] == []
+
+    def test_blockedby_not_present_when_include_body_false(self) -> None:
+        raw = {
+            "number": 501,
+            "title": "Ready issue",
+            "labels": [],
+            "createdAt": "",
+        }
+        lookup = {42: "Title"}
+        result = daemon._normalize_issue_enrichment(
+            raw, include_body=False, blocker_title_lookup=lookup
+        )
+        # include_body=False → no blockedBy even if a lookup was passed.
+        assert "blockedBy" not in result
+
+
+# --------------------------------------------------------------------------
+# _scan_blocked_and_snapshot with blocker-title enrichment (issue #2989)
+# --------------------------------------------------------------------------
+
+
+class TestScanBlockedAndSnapshotWithTitles:
+    """Verifies dedup and None-fallthrough in the full scan path."""
+
+    def test_blocker_title_fetch_dedupes_within_tick(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC1: one gh issue view per distinct blocker number, regardless of
+        how many blocked issues share that blocker."""
+        d, conn, _handler = _make_daemon_with_capture()
+
+        d._fetch_blocked_issues = lambda: [  # type: ignore[method-assign]
+            {
+                "number": 500,
+                "title": "Blocked A",
+                "labels": [{"name": "status/blocked"}],
+                "createdAt": "2026-04-18T12:00:00Z",
+                "body": "Blocked by #42\n",
+            },
+            {
+                "number": 501,
+                "title": "Blocked B",
+                "labels": [{"name": "status/blocked"}],
+                "createdAt": "2026-04-18T13:00:00Z",
+                "body": "Blocked by #42\nBlocked by #100\n",
+            },
+        ]
+
+        fetch_calls: list[int] = []
+
+        def fake_fetch_titles(numbers: set[int]) -> dict[int, str | None]:
+            fetch_calls.extend(sorted(numbers))
+            return {n: f"Title for #{n}" for n in numbers}
+
+        monkeypatch.setattr(d, "_fetch_issue_titles_for_blockers", fake_fetch_titles)
+
+        depth = d._scan_blocked_and_snapshot()
+        assert depth == 2
+
+        # The deduped set {42, 100} was passed to the fetcher exactly once.
+        assert sorted(fetch_calls) == [42, 100]
+
+        # Check persisted JSON includes blockedBy.
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.blocked_snapshots" in e[0]
+        ]
+        assert len(inserts) == 1
+        enriched = json.loads(inserts[0][1][2])
+        # Issue 500: only blocked by #42.
+        assert enriched[0]["blockedBy"] == [{"number": 42, "title": "Title for #42"}]
+        # Issue 501: blocked by #42 and #100.
+        assert enriched[1]["blockedBy"] == [
+            {"number": 42, "title": "Title for #42"},
+            {"number": 100, "title": "Title for #100"},
+        ]
+
+    def test_null_title_fallthrough_on_subprocess_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC: when the title fetch fails for a blocker, title=None, no crash."""
+        d, conn, _handler = _make_daemon_with_capture()
+
+        d._fetch_blocked_issues = lambda: [  # type: ignore[method-assign]
+            {
+                "number": 500,
+                "title": "Blocked A",
+                "labels": [],
+                "createdAt": "",
+                "body": "Blocked by #42\n",
+            },
+        ]
+
+        def fake_fetch_titles(numbers: set[int]) -> dict[int, str | None]:
+            # Simulate failure → title is None.
+            return {n: None for n in numbers}
+
+        monkeypatch.setattr(d, "_fetch_issue_titles_for_blockers", fake_fetch_titles)
+
+        depth = d._scan_blocked_and_snapshot()
+        assert depth == 1
+
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.blocked_snapshots" in e[0]
+        ]
+        enriched = json.loads(inserts[0][1][2])
+        assert enriched[0]["blockedBy"] == [{"number": 42, "title": None}]
+
+    def test_blocker_title_fetch_exception_falls_back_to_empty_lookup(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Exception in _fetch_issue_titles_for_blockers must not propagate;
+        _scan_blocked_and_snapshot should still succeed with title=None."""
+        d, conn, _handler = _make_daemon_with_capture()
+
+        d._fetch_blocked_issues = lambda: [  # type: ignore[method-assign]
+            {
+                "number": 500,
+                "title": "Blocked A",
+                "labels": [],
+                "createdAt": "",
+                "body": "Blocked by #42\n",
+            },
+        ]
+
+        def raising_fetch(numbers: set[int]) -> dict[int, str | None]:
+            raise RuntimeError("unexpected internal error")
+
+        monkeypatch.setattr(d, "_fetch_issue_titles_for_blockers", raising_fetch)
+
+        depth = d._scan_blocked_and_snapshot()
+        assert depth == 1
+
+        inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.blocked_snapshots" in e[0]
+        ]
+        enriched = json.loads(inserts[0][1][2])
+        # title is None because the lookup fell back to {}
+        assert enriched[0]["blockedBy"] == [{"number": 42, "title": None}]
+
+
+class TestFetchIssuesTitleCap:
+    """MAX_BLOCKER_TITLE_FETCH cap bounds the number of gh calls."""
+
+    def test_cap_limits_gh_calls(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When >MAX_BLOCKER_TITLE_FETCH unique blockers are passed, only the
+        first MAX_BLOCKER_TITLE_FETCH are fetched; the rest are absent."""
+        from scripts.dispatcher.daemon import MAX_BLOCKER_TITLE_FETCH
+
+        d, _conn, _handler = _make_daemon_with_capture()
+
+        call_count = 0
+
+        def fake_subprocess_with_retry(
+            cmd: list[str],
+            event_name: str,
+            timeout: int = 30,
+            extra_log_fields: dict | None = None,
+        ) -> dict:
+            nonlocal call_count
+            call_count += 1
+            # cmd = ["gh", "issue", "view", "<N>", "--repo", ...]
+            number = int(cmd[3])
+            return {
+                "ok": True,
+                "result": type(
+                    "CP",
+                    (),
+                    {"stdout": f'{{"number": {number}, "title": "T{number}"}}'},
+                )(),
+            }
+
+        # Build a set with MAX_BLOCKER_TITLE_FETCH + 5 unique numbers.
+        big_set: set[int] = set(range(1, MAX_BLOCKER_TITLE_FETCH + 6))
+
+        monkeypatch.setattr(d, "_subprocess_with_retry", fake_subprocess_with_retry)
+        result = d._fetch_issue_titles_for_blockers(big_set)
+
+        # Only MAX_BLOCKER_TITLE_FETCH calls should have been made.
+        assert call_count == MAX_BLOCKER_TITLE_FETCH
+        # All fetched numbers have a title.
+        assert len(result) == MAX_BLOCKER_TITLE_FETCH
+        assert all(v is not None for v in result.values())

--- a/scripts/dispatcher/tests/test_daemon_terminal_lifecycle.py
+++ b/scripts/dispatcher/tests/test_daemon_terminal_lifecycle.py
@@ -129,7 +129,9 @@ def _make_daemon(
 _SENTINEL = object()  # used to detect "no change" vs None
 
 
-def _apply_executed_to_row(row: dict[str, Any], executed: list[tuple[str, Any]]) -> None:
+def _apply_executed_to_row(
+    row: dict[str, Any], executed: list[tuple[str, Any]]
+) -> None:
     """Walk ``cursor.executed`` in order and apply each recognized UPDATE shape.
 
     Mutates ``row`` in place.  Unrecognized SQL is silently ignored (e.g.
@@ -260,8 +262,12 @@ class TestRetryRecoveryLifecycleFinalRowState:
         _apply_executed_to_row(row, executed_before_reset)
 
         # Intermediate: row should be crashed with failure_summary populated
-        assert row["status"] == "crashed", f"Expected crashed after first terminal, got {row['status']}"
-        assert row["ended_at"] is not None, "ended_at must be set after crashed terminal"
+        assert row["status"] == "crashed", (
+            f"Expected crashed after first terminal, got {row['status']}"
+        )
+        assert row["ended_at"] is not None, (
+            "ended_at must be set after crashed terminal"
+        )
         assert row["failure_summary"] is not None, (
             "failure_summary must be populated after crashed terminal"
         )
@@ -281,7 +287,9 @@ class TestRetryRecoveryLifecycleFinalRowState:
         conn.cursor_instance.execute(reset_sql, ("agent-lifecycle",))
         _apply_executed_to_row(row, conn.cursor_instance.executed[pos_before_reset:])
 
-        assert row["status"] == "retrying", f"Expected retrying after reset, got {row['status']}"
+        assert row["status"] == "retrying", (
+            f"Expected retrying after reset, got {row['status']}"
+        )
         assert row["exit_code"] is None, "exit_code must be cleared by retry-reset"
         assert row["ended_at"] is None, "ended_at must be cleared by retry-reset"
         # failure_summary is NOT cleared by retry-reset (that's the succeeded terminal's job)
@@ -299,9 +307,13 @@ class TestRetryRecoveryLifecycleFinalRowState:
         )
         _apply_executed_to_row(row, conn.cursor_instance.executed[pos_before_running:])
 
-        assert row["status"] == "running", f"Expected running after non-terminal, got {row['status']}"
+        assert row["status"] == "running", (
+            f"Expected running after non-terminal, got {row['status']}"
+        )
         assert row["phase"] == "awaiting_ci"
-        assert row["pr_number"] == 9999, "pr_number must be set via COALESCE on non-terminal"
+        assert row["pr_number"] == 9999, (
+            "pr_number must be set via COALESCE on non-terminal"
+        )
         assert row["ended_at"] is None, "Non-terminal must NOT set ended_at"
         # failure_summary must still be untouched by non-terminal UPDATE
         assert row["failure_summary"] is not None, (
@@ -317,7 +329,9 @@ class TestRetryRecoveryLifecycleFinalRowState:
             exit_code=0,
             pr_number=9999,
         )
-        _apply_executed_to_row(row, conn.cursor_instance.executed[pos_before_succeeded:])
+        _apply_executed_to_row(
+            row, conn.cursor_instance.executed[pos_before_succeeded:]
+        )
 
         # ── Step 6: final row assertions (AC-1 verify-line) ──────────────
         assert row["status"] == "succeeded", (


### PR DESCRIPTION
## Summary

Operators using the Queue: Blocked panel on `/admin/dispatcher` can now hover over blocker issue numbers (`#NNNN`) to see their titles — previously they had to open GitHub to see what was holding up an issue.

The daemon now fetches blocker titles during queue scans (one `gh issue view` per unique blocker, capped at 20 per tick). The API wraps the number+title shape as a new `BlockerRef` GraphQL type with backward-compatible handling for legacy snapshots. The frontend renders a native `title` attribute tooltip formatted as:

```
Blocked by:
  #2980 twice-daily scraper schedule…
  #2981 per-scraper cadence config
```

Closes #2989

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
  - 34 daemon tests green
  - 293 API tests green (including BlockerRef schema + resolver tests)
  - 1458 web tests green (including formatBlockerTooltip + QueuePanel tooltip tests)
- [x] CI green

### Post-deploy verification

- [ ] Navigate to `/admin/dispatcher` and verify Queue: Blocked panel loads
- [ ] Hover over a `#NNNN` link in a blocked row; native browser tooltip appears with "Blocked by: #N title, …"
- [ ] Test with a blocker having `title: null`; tooltip shows `#N` without "null" string
- [ ] Verification evidence posted on #2989