### PR TITLE
feat(infra): grant dispatcher task s3:ListBucket on document-archive bucket (#3050)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -304,6 +304,11 @@ module "dispatcher_daemon" {
   # region or account-id segment, so hard-coding is safe here.
   oneshot_script_bucket_arn          = "arn:aws:s3:::judgemind-assets-dev"
   oneshot_ecr_scraper_repository_arn = module.ecr.repository_arn
+  # #3050 — grant the daemon's task role `s3:ListBucket` on the document-
+  # archive bucket so data-task agents can run pre/post rebuild census
+  # queries from the daemon context. The `iam_scraper` role already has
+  # ListBucket for in-task use; this wiring is for the daemon container.
+  document_archive_bucket_arn = module.document_archive.bucket_arn
 
   # Heartbeat alarm wired to the shared SNS topic once the daemon starts
   # emitting HeartbeatAge (Phase 2). Kept enabled in Phase 1 so the alarm

--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -435,6 +435,40 @@ resource "aws_iam_role_policy" "task_run_oneshot" {
   })
 }
 
+# ─── Document-archive S3 census access (#3050) ──────────────────────────────
+#
+# Grants `s3:ListBucket` on the document-archive bucket so the daemon
+# container can run pre-run/post-run census queries (e.g.
+# `aws s3api list-objects-v2 --bucket judgemind-document-archive-dev
+#   --prefix ca/santa_clara/ --query length(Contents)`).
+#
+# Note: the `iam_scraper` role already grants ListBucket for in-task use
+# (rebuild_db.py runs inside the oneshot ECS task under `iam_scraper`).
+# This policy is specifically for the daemon-container context — the
+# daemon is NOT the iam_scraper role, so it needs its own grant.
+#
+# Disabled (count=0) when `document_archive_bucket_arn` is empty — safe
+# for staging / throwaway stacks that don't provision the archive bucket.
+
+resource "aws_iam_role_policy" "task_s3_archive_list" {
+  count = var.document_archive_bucket_arn != "" ? 1 : 0
+
+  name = "${local.service_name}-task-s3-archive-list"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowListDocumentArchiveBucket"
+        Effect   = "Allow"
+        Action   = "s3:ListBucket"
+        Resource = var.document_archive_bucket_arn
+      },
+    ]
+  })
+}
+
 resource "aws_iam_role_policy" "task_ecs_exec_ssm" {
   name = "${local.service_name}-task-ecs-exec-ssm"
   role = aws_iam_role.task.id

--- a/infra/terraform/modules/dispatcher-daemon/variables.tf
+++ b/infra/terraform/modules/dispatcher-daemon/variables.tf
@@ -242,3 +242,11 @@ variable "agent_runner_security_group_id" {
   type        = string
   default     = ""
 }
+
+# ─── Document-archive S3 census access (#3050) ──────────────────────────────
+
+variable "document_archive_bucket_arn" {
+  description = "ARN of the document-archive S3 bucket. When set, the daemon task role is granted `s3:ListBucket` so data-task agents can run census queries (e.g. pre/post rebuild counts). Empty disables the policy — safe for staging / throwaway stacks."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Added `s3:ListBucket` IAM permission on `judgemind-document-archive-dev` to the dispatcher daemon task role. This enables backfill/rebuild agents to query document archive census (e.g. pre/post rebuild counts) from the daemon container context.

Introduced `document_archive_bucket_arn` variable to dispatcher-daemon Terraform module with count guard, and wired to `module.document_archive.bucket_arn` in dev environment.

Closes #3050

## Test plan

### Automated checks

- [x] Lint passes (`terraform fmt` / manual review)
- [x] Terraform init succeeds (`terraform init -lockfile=readonly`)
- [x] No syntax errors (Terraform plan validation)
- [x] CI green

### Post-deploy verification

- [ ] Dispatcher task role S3 ListBucket permission confirmed via `aws s3api list-objects-v2 --bucket judgemind-document-archive-dev --prefix ca/santa_clara/` from dispatcher container
- [ ] Issue #2630 rebuild (SC + OC) re-queued and `derived.documents` count for Santa Clara post-rebuild ≥ 1,651 baseline
- [ ] Verification evidence posted on #3050 (see /task-v2-verify output)