### PR TITLE
fix(scraping): raise DEFAULT_STREAM_MAXLEN to reduce orphan rate (#3096)

### DIFF
--- a/packages/scraper-framework/src/framework/events.py
+++ b/packages/scraper-framework/src/framework/events.py
@@ -15,10 +15,12 @@ logger = logging.getLogger(__name__)
 STREAM_DOCUMENT_CAPTURED = "document.captured"
 STREAM_SCRAPER_HEALTH = "scraper.health"
 
-#: Default maximum stream length.  Each event is ~2–5 KB, so 10 000 entries
-#: ≈ 20–50 MB — well within the 512 MB available on cache.t4g.micro.
+#: Default maximum stream length.  At ~5 KB/event, 50 000 entries ≈ 250 MB —
+#: well within the 512 MB available on cache.t4g.micro.  Raised from 10 000 to
+#: provide ~5× burst headroom for re-run scenarios (e.g. Santa Clara / Orange
+#: simultaneous re-ingestion; see docs/investigations/correctly-labeled-s3-orphans-2026-04.md).
 #: Override at runtime with the ``STREAM_MAXLEN`` environment variable.
-DEFAULT_STREAM_MAXLEN = 10_000
+DEFAULT_STREAM_MAXLEN = 50_000
 
 
 def _stream_maxlen() -> int:

--- a/packages/scraper-framework/tests/test_event_bus.py
+++ b/packages/scraper-framework/tests/test_event_bus.py
@@ -373,5 +373,5 @@ class TestStreamMaxlen:
         assert call_args.kwargs["maxlen"] == 5000
 
     def test_default_stream_maxlen_value(self) -> None:
-        """The default MAXLEN should be 10_000."""
-        assert DEFAULT_STREAM_MAXLEN == 10_000
+        """The default MAXLEN should be 50_000."""
+        assert DEFAULT_STREAM_MAXLEN == 50_000


### PR DESCRIPTION
## Summary

Raised DEFAULT_STREAM_MAXLEN from 10,000 to 50,000 entries to reduce correctly-labeled S3 orphans during scraper burst runs. Updated docstring with memory math (~250 MB at 50k entries, providing ~5x burst headroom) and updated pin test. All tests pass with 96% coverage.

Closes #3096

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 6564 tests, 96% coverage)
- [x] CI green

### Post-deploy verification

- [ ] N/A — no deployed component (configuration constant change verified pre-merge)