### PR TITLE
fix(dispatcher): rename daemon_restart_abandoned stub terminal to agent_runner_route_stub (#3137)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -4006,12 +4006,12 @@ while true; do
                             "fix_conflict skill returned unresolvable or budget exhausted"
                     else
                         log "diagnoser_route_stub" "hint=$_hint"
-                        advance_phase "daemon_restart_abandoned" "failed"
+                        advance_phase "agent_runner_route_stub" "failed"
                     fi
                     ;;
                 unrecognized|*)
                     log "transition_unrecognized" "phase=$_current" "action=$_action"
-                    advance_phase "daemon_restart_abandoned" "crashed"
+                    advance_phase "agent_runner_route_stub" "crashed"
                     ;;
             esac
             ;;

--- a/scripts/dispatcher/phase_transitions.py
+++ b/scripts/dispatcher/phase_transitions.py
@@ -255,6 +255,17 @@ PHASE_FIX_CI_FAILED = "fix_ci_failed"
 #: ``FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE``.
 PHASE_CONFLICT_UNRESOLVABLE = "conflict_unresolvable"
 
+#: #3137 — Stage 1b stub terminal set by the agent-runner entrypoint when
+#: the phase-transition shim routes to diagnoser or returns an unrecognized
+#: action (the ``diagnoser_route_stub`` and ``transition_unrecognized``
+#: branches inside the main claude-phase dispatch case). Represents a real
+#: failure (ralph REVISE-exhausted, worker-STUCK) — intentionally NOT added
+#: to INFRA_PREEMPTED_CATEGORIES so it counts toward the circuit breaker and
+#: renders as a red ✗ in the admin cockpit. Stage 2 (#3091) will replace
+#: this stub with real diagnoser routing writing to dispatcher.failures and
+#: advancing to the appropriate diagnoser-decided terminal phase.
+PHASE_AGENT_RUNNER_ROUTE_STUB = "agent_runner_route_stub"
+
 # ---------------------------------------------------------------------------
 # Verdict constants — the string values produced by the phase-output JSONs.
 # ---------------------------------------------------------------------------
@@ -354,6 +365,8 @@ TERMINAL_PHASES: frozenset[str] = frozenset(
         PHASE_CONFLICT_UNRESOLVABLE,
         # #3245 — fix_ci terminal for the ECS agent-runner path.
         PHASE_FIX_CI_FAILED,
+        # #3137 — agent-runner route stub terminal (Stage 1b).
+        PHASE_AGENT_RUNNER_ROUTE_STUB,
     }
 )
 
@@ -1180,6 +1193,7 @@ __all__ = [
     "PHASE_AWAITING_DEPLOY_TIMEOUT",
     "PHASE_CONFLICT_UNRESOLVABLE",
     "PHASE_FIX_CI_FAILED",
+    "PHASE_AGENT_RUNNER_ROUTE_STUB",
     # Verdict constants
     "VERDICT_SHIP",
     "VERDICT_AC_INFEASIBLE",

--- a/scripts/dispatcher/tests/test_phase_transitions.py
+++ b/scripts/dispatcher/tests/test_phase_transitions.py
@@ -893,6 +893,10 @@ class TestTerminalPhaseAndStatus:
         """#3225 — fix_conflict budget-exhausted / unresolvable terminal."""
         assert pt.is_terminal_phase(pt.PHASE_CONFLICT_UNRESOLVABLE) is True
 
+    def test_is_terminal_phase_true_for_agent_runner_route_stub(self) -> None:
+        """#3137 — agent-runner route stub terminal (Stage 1b)."""
+        assert pt.is_terminal_phase(pt.PHASE_AGENT_RUNNER_ROUTE_STUB) is True
+
     def test_fix_conflict_is_intermediate_not_terminal(self) -> None:
         """#3225 — fix_conflict is active, not terminal (it advances)."""
         assert pt.is_terminal_phase(pt.PHASE_FIX_CONFLICT) is False


### PR DESCRIPTION
## Summary

Renamed the agent-runner entrypoint's stub-terminal phase from `daemon_restart_abandoned` to `agent_runner_route_stub` to accurately categorize route-to-diagnoser failures (ralph non-SHIP verdicts, worker stuck). Updated phase_transitions.py registry and added unit test.

Closes #3137

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 97 phase_transitions tests all pass)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (dispatcher infrastructure refactor; agent-runner runs in ECS with the updated shell script)

### Migration note

The rename is prospective-only. The three in-flight agents with `phase='daemon_restart_abandoned'` from the smoke window (2026-04-23 22:50-22:57Z) stay as-is — they're already terminal, already historical. New ECS agents going forward will log the new phase name and it will render correctly in the admin cockpit circuit breaker and phase-terminal checks.

Stage 2 (#3091) will replace this stub entirely with real diagnoser integration, writing to `dispatcher.failures` and advancing to the appropriate diagnoser-decided terminal phase.