### PR TITLE
feat(dispatcher): launch-agent-runner-smoke.sh helper for ECS debugging (#3138)

### DIFF
--- a/scripts/dispatcher/launch-agent-runner-smoke.sh
+++ b/scripts/dispatcher/launch-agent-runner-smoke.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# venv: none
+# permanent: true
+#
+# launch-agent-runner-smoke.sh — Operator script to manually fire an
+# agent-runner ECS task for a given agent-id.
+#
+# Background
+# ----------
+# The dispatcher daemon normally calls ecs:RunTask on behalf of each
+# agent via _launch_agent_ecs_task (#3091 Stage 2). This script exposes
+# the same launch path as a one-liner for operators who need to:
+#   - Smoke-test the agent-runner task def after a Terraform deploy
+#     (related: #3086, #3090, #3091).
+#   - Re-launch a specific agent manually during an incident (#3131/#3133
+#     debugging context where the daemon has already claimed the issue
+#     but the ECS task exited before the phase pipeline ran).
+#   - Verify network / IAM wiring without modifying the daemon.
+#
+# Usage
+# -----
+#   scripts/dispatcher/launch-agent-runner-smoke.sh <agent-id> [issue-number]
+#   scripts/dispatcher/launch-agent-runner-smoke.sh --watch <agent-id> [issue-number]
+#
+# Options
+#   --watch   Tail CloudWatch logs via scripts/ecs-logs.sh until the
+#             task stops (polls ecs:DescribeTasks between log batches).
+#   --help    Print this help message.
+#
+# Environment variables (all optional; dev defaults shown)
+#   ECS_CLUSTER                        (default: judgemind-dev)
+#   AGENT_RUNNER_TASK_DEFINITION_FAMILY (default: judgemind-dispatcher-agent-runner-dev)
+#   AGENT_RUNNER_SUBNET_IDS            (default: resolved from judgemind-dispatcher-dev service)
+#   AGENT_RUNNER_SECURITY_GROUP_ID     (default: resolved from judgemind-dispatcher-dev service)
+#   REGION                             (default: us-west-2)
+#
+# Examples
+#   scripts/dispatcher/launch-agent-runner-smoke.sh 550e8400-e29b-41d4-a716-446655440000
+#   scripts/dispatcher/launch-agent-runner-smoke.sh 550e8400-e29b-41d4-a716-446655440000 3138
+#   scripts/dispatcher/launch-agent-runner-smoke.sh --watch 550e8400-e29b-41d4-a716-446655440000 3138
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+
+CLUSTER="${ECS_CLUSTER:-judgemind-dev}"
+TASK_DEF_FAMILY="${AGENT_RUNNER_TASK_DEFINITION_FAMILY:-judgemind-dispatcher-agent-runner-dev}"
+SUBNET_IDS="${AGENT_RUNNER_SUBNET_IDS:-}"
+SG_ID="${AGENT_RUNNER_SECURITY_GROUP_ID:-}"
+REGION="${REGION:-us-west-2}"
+WATCH=false
+
+# ── Usage ─────────────────────────────────────────────────────────────────────
+
+usage() {
+    cat >&2 <<'USAGE'
+Usage: scripts/dispatcher/launch-agent-runner-smoke.sh [--watch] <agent-id> [issue-number]
+
+Arguments:
+  <agent-id>       UUID of the agent to launch (required).
+  [issue-number]   GitHub issue number to assign to the agent (optional).
+
+Options:
+  --watch          Tail CloudWatch logs until the task stops.
+  --help           Show this help message.
+
+Environment variables:
+  ECS_CLUSTER                         ECS cluster name (default: judgemind-dev)
+  AGENT_RUNNER_TASK_DEFINITION_FAMILY Task def family (default: judgemind-dispatcher-agent-runner-dev)
+  AGENT_RUNNER_SUBNET_IDS             Comma-separated subnet IDs (resolved from dispatcher service if unset)
+  AGENT_RUNNER_SECURITY_GROUP_ID      Security group ID (resolved from dispatcher service if unset)
+  REGION                              AWS region (default: us-west-2)
+
+Examples:
+  scripts/dispatcher/launch-agent-runner-smoke.sh 550e8400-e29b-41d4-a716-446655440000
+  scripts/dispatcher/launch-agent-runner-smoke.sh 550e8400-e29b-41d4-a716-446655440000 3138
+  scripts/dispatcher/launch-agent-runner-smoke.sh --watch 550e8400-e29b-41d4-a716-446655440000 3138
+USAGE
+}
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+AGENT_ID=""
+ISSUE_NUMBER=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --watch|-w)
+            WATCH=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            echo "Error: unknown option '$1'" >&2
+            usage
+            exit 1
+            ;;
+        *)
+            if [[ -z "$AGENT_ID" ]]; then
+                AGENT_ID="$1"
+            elif [[ -z "$ISSUE_NUMBER" ]]; then
+                ISSUE_NUMBER="$1"
+            else
+                echo "Error: unexpected argument '$1'" >&2
+                usage
+                exit 1
+            fi
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$AGENT_ID" ]]; then
+    echo "Error: <agent-id> is required." >&2
+    usage
+    exit 1
+fi
+
+# ── Resolve ECS wiring from environment or dispatcher service ─────────────────
+#
+# When AGENT_RUNNER_SUBNET_IDS / AGENT_RUNNER_SECURITY_GROUP_ID are unset,
+# resolve them once from the running dispatcher daemon service — the same
+# resolution pattern used in scripts/ecs-run-task.sh (lines 708-723).
+# This means an operator can export just ECS_CLUSTER and REGION and get
+# everything else for free.
+
+if [[ -z "$SUBNET_IDS" || -z "$SG_ID" ]]; then
+    echo "Resolving network wiring from judgemind-dispatcher-dev service..." >&2
+    NETWORK_CONFIG=$(aws ecs describe-services \
+        --cluster "$CLUSTER" \
+        --services "judgemind-dispatcher-dev" \
+        --region "$REGION" \
+        --output json \
+        --no-cli-pager \
+        --query 'services[0].networkConfiguration.awsvpcConfiguration')
+
+    if [[ -z "$NETWORK_CONFIG" || "$NETWORK_CONFIG" == "null" ]]; then
+        echo "Error: could not resolve networking from judgemind-dispatcher-dev service." >&2
+        echo "Set AGENT_RUNNER_SUBNET_IDS and AGENT_RUNNER_SECURITY_GROUP_ID explicitly." >&2
+        exit 1
+    fi
+
+    if [[ -z "$SUBNET_IDS" ]]; then
+        SUBNET_IDS=$(python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(','.join(d['subnets']))" <<< "$NETWORK_CONFIG")
+    fi
+    if [[ -z "$SG_ID" ]]; then
+        SG_ID=$(python3 -c "import sys,json; d=json.loads(sys.stdin.read()); print(d['securityGroups'][0])" <<< "$NETWORK_CONFIG")
+    fi
+
+    echo "Resolved subnets:         $SUBNET_IDS" >&2
+    echo "Resolved security group:  $SG_ID" >&2
+fi
+
+# ── Seed dispatcher.agents row (SELECT then INSERT if absent) ─────────────────
+#
+# The agent row must exist before the ECS task starts — the entrypoint reads
+# its own agent_id from the row on startup. If a row already exists (re-run
+# with the same agent-id) we skip the INSERT to keep the operation idempotent.
+
+echo "Checking dispatcher.agents for agent_id=$AGENT_ID..." >&2
+
+EXISTING=$("$REPO_ROOT/scripts/dev-db-query.sh" "SELECT 1 FROM dispatcher.agents WHERE agent_id = '$AGENT_ID' LIMIT 1")
+
+if [[ -z "$EXISTING" || "$EXISTING" == "None" ]]; then
+    echo "No row found — seeding dispatcher.agents..." >&2
+    WORKTREE_PATH="/tmp/agent-runner-smoke/${AGENT_ID}"
+    ISSUE_COL="${ISSUE_NUMBER:-0}"
+
+    "$REPO_ROOT/scripts/dev-db-query.sh" --rw \
+        "INSERT INTO dispatcher.agents (agent_id, issue_number, worktree_path, kind, phase, status, execution_mode) VALUES ('${AGENT_ID}', ${ISSUE_COL}, '${WORKTREE_PATH}', 'task', 'claiming', 'running', 'ecs') ON CONFLICT (agent_id) DO NOTHING"
+
+    echo "Row seeded." >&2
+else
+    echo "Row already exists — skipping INSERT." >&2
+fi
+
+# ── Build container overrides ─────────────────────────────────────────────────
+
+ISSUE_VALUE="${ISSUE_NUMBER:-}"
+
+# Build JSON overrides inline — avoids heredocs and subshell quoting
+# nightmares while staying readable. Single quotes around values are safe
+# because agent UUIDs and issue numbers contain no special characters.
+OVERRIDES='{"containerOverrides":[{"name":"agent-runner","environment":[{"name":"AGENT_ID","value":"'"$AGENT_ID"'"},{"name":"ISSUE_NUMBER","value":"'"$ISSUE_VALUE"'"}]}]}'
+
+# ── Run the ECS task ──────────────────────────────────────────────────────────
+
+echo "" >&2
+echo "Launching agent-runner task..." >&2
+echo "  Cluster:    $CLUSTER" >&2
+echo "  Task def:   $TASK_DEF_FAMILY" >&2
+echo "  Agent ID:   $AGENT_ID" >&2
+echo "  Issue:      ${ISSUE_NUMBER:-(none)}" >&2
+echo "" >&2
+
+RUN_OUTPUT=$(aws ecs run-task \
+    --cluster "$CLUSTER" \
+    --task-definition "$TASK_DEF_FAMILY" \
+    --launch-type FARGATE \
+    --enable-execute-command \
+    --region "$REGION" \
+    --output json \
+    --no-cli-pager \
+    --network-configuration "awsvpcConfiguration={subnets=[${SUBNET_IDS}],securityGroups=[${SG_ID}],assignPublicIp=DISABLED}" \
+    --overrides "$OVERRIDES")
+
+TASK_ARN=$(python3 -c "import sys,json; tasks=json.loads(sys.stdin.read()).get('tasks',[]); print(tasks[0]['taskArn'] if tasks else '')" <<< "$RUN_OUTPUT")
+
+if [[ -z "$TASK_ARN" ]]; then
+    echo "Error: ecs:RunTask returned no task ARN." >&2
+    FAILURES=$(python3 -c "import sys,json; fs=json.loads(sys.stdin.read()).get('failures',[]); [print(x.get('reason','unknown')) for x in fs]" <<< "$RUN_OUTPUT")
+    if [[ -n "$FAILURES" ]]; then
+        echo "Failures:" >&2
+        echo "$FAILURES" >&2
+    fi
+    exit 1
+fi
+
+TASK_ID=$(echo "$TASK_ARN" | rev | cut -d'/' -f1 | rev)
+
+# Print task ARN to stdout (so callers can capture it).
+echo "$TASK_ARN"
+
+# Print log location and watch hint to stderr.
+LOG_GROUP="/ecs/judgemind-dispatcher-agent-runner-dev"
+LOG_STREAM="agent-runner/agent-runner/${TASK_ID}"
+echo "" >&2
+echo "Task launched successfully." >&2
+echo "  Task ARN:   $TASK_ARN" >&2
+echo "  Task ID:    $TASK_ID" >&2
+echo "  Log group:  $LOG_GROUP" >&2
+echo "  Log stream: $LOG_STREAM" >&2
+echo "  Tail logs:  scripts/ecs-logs.sh $LOG_GROUP --task $TASK_ID --follow" >&2
+echo "" >&2
+
+# ── Watch mode: poll task status + tail logs ──────────────────────────────────
+
+if [[ "$WATCH" == true ]]; then
+    echo "Watching task (Ctrl+C to stop)..." >&2
+    "$REPO_ROOT/scripts/ecs-logs.sh" "$LOG_GROUP" --task "$TASK_ID" --follow &
+    LOGS_PID=$!
+
+    while true; do
+        sleep 10
+        STATUS=$(aws ecs describe-tasks \
+            --cluster "$CLUSTER" \
+            --tasks "$TASK_ARN" \
+            --region "$REGION" \
+            --no-cli-pager \
+            --output json 2>/dev/null \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['tasks'][0]['lastStatus'] if d.get('tasks') else 'UNKNOWN')" \
+            || echo "UNKNOWN")
+
+        if [[ "$STATUS" == "STOPPED" ]]; then
+            echo "" >&2
+            echo "Task stopped." >&2
+            kill "$LOGS_PID" 2>/dev/null || true
+            wait "$LOGS_PID" 2>/dev/null || true
+            break
+        fi
+        echo "Task status: $STATUS" >&2
+    done
+fi

--- a/scripts/tests/test_launch_agent_runner_smoke.sh
+++ b/scripts/tests/test_launch_agent_runner_smoke.sh
@@ -1,0 +1,502 @@
+#!/usr/bin/env bash
+# test_launch_agent_runner_smoke.sh — Tests for
+# scripts/dispatcher/launch-agent-runner-smoke.sh (#3138).
+#
+# Exercises the script with stubbed `aws` and `psql`-via-dev-db-query.sh
+# PATH shims so no real AWS calls or database connections are made.
+#
+# Test cases:
+#   1. Fresh agent_id — one INSERT recorded, one ecs:RunTask, exit 0, taskArn
+#      on stdout.
+#   2. Re-run with existing agent_id — zero INSERTs, one ecs:RunTask.
+#   3. Missing AGENT_ID arg — exit != 0 with usage message.
+#   4. Wiring env unset — ecs:describe-services called once (internal
+#      resolution), one ecs:RunTask recorded.
+#
+# Usage:
+#   scripts/tests/test_launch_agent_runner_smoke.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/dispatcher/launch-agent-runner-smoke.sh"
+
+FAILURES=0
+TESTS=0
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Temp dir lifecycle ────────────────────────────────────────────────────────
+
+TEST_TMP=""
+cleanup() {
+    set +eu
+    if [[ "${TEST_LAUNCH_AGENT_RUNNER_KEEP_TMP:-0}" == "1" ]]; then
+        echo "TEST_LAUNCH_AGENT_RUNNER_KEEP_TMP=1 — keeping $TEST_TMP for inspection"
+        return
+    fi
+    if [[ -n "$TEST_TMP" && -d "$TEST_TMP" ]]; then
+        rm -rf "$TEST_TMP"
+    fi
+}
+trap cleanup EXIT
+
+TEST_TMP=$(mktemp -d)
+
+# ── Build a stub-bin directory on PATH ────────────────────────────────────────
+#
+# Every stub writes its argv (one arg per line) to a per-binary log file
+# under $TEST_TMP/invocations/, so tests can count and grep specific calls.
+
+STUB_BIN="$TEST_TMP/bin-stubs"
+INVOCATIONS_DIR="$TEST_TMP/invocations"
+mkdir -p "$STUB_BIN" "$INVOCATIONS_DIR"
+
+# Shared stub utility — each stub sources this to record its invocation.
+cat > "$STUB_BIN/_record_invocation.sh" << 'RECORDEOF'
+# Source this to record argv into $INVOCATIONS_DIR/<tool>.log, one
+# invocation per line starting with a count marker.
+TOOL_NAME="$1"
+shift
+INVOCATIONS_LOG="${INVOCATIONS_DIR:-/tmp}/${TOOL_NAME}.log"
+{
+    printf 'CALL '
+    for arg in "$@"; do
+        printf '%q ' "$arg"
+    done
+    printf '\n'
+} >> "$INVOCATIONS_LOG"
+RECORDEOF
+
+# ── aws stub ─────────────────────────────────────────────────────────────────
+# Routes on subcommand:
+#   ecs describe-services → returns fake subnet + SG JSON
+#   ecs run-task          → returns fake taskArn JSON
+#   ecs describe-tasks    → returns fake STOPPED status
+
+cat > "$STUB_BIN/aws" << 'AWSEOF'
+#!/usr/bin/env bash
+set -u
+INVOCATIONS_DIR="${INVOCATIONS_DIR}"
+# shellcheck disable=SC1091
+. "$(dirname "$0")/_record_invocation.sh" aws "$@"
+
+# Walk to the service subcommand.
+service="${1:-}"
+shift || true
+subcommand="${1:-}"
+shift || true
+
+case "$service" in
+    ecs)
+        case "$subcommand" in
+            describe-services)
+                cat << 'JSON'
+{
+    "subnets": ["subnet-aaa111", "subnet-bbb222"],
+    "securityGroups": ["sg-deadbeef"],
+    "assignPublicIp": "DISABLED"
+}
+JSON
+                exit 0
+                ;;
+            run-task)
+                cat << 'JSON'
+{
+    "tasks": [
+        {
+            "taskArn": "arn:aws:ecs:us-west-2:155326049300:task/judgemind-dev/fake-task-id-001"
+        }
+    ],
+    "failures": []
+}
+JSON
+                exit 0
+                ;;
+            describe-tasks)
+                cat << 'JSON'
+{
+    "tasks": [
+        {
+            "lastStatus": "STOPPED",
+            "taskArn": "arn:aws:ecs:us-west-2:155326049300:task/judgemind-dev/fake-task-id-001"
+        }
+    ]
+}
+JSON
+                exit 0
+                ;;
+            *)
+                echo "aws-stub: unhandled ecs subcommand: $subcommand" >&2
+                exit 0
+                ;;
+        esac
+        ;;
+    *)
+        echo "aws-stub: unhandled service: $service" >&2
+        exit 0
+        ;;
+esac
+AWSEOF
+chmod +x "$STUB_BIN/aws"
+
+# ── dev-db-query.sh stub ──────────────────────────────────────────────────────
+# Stubs the wrapper script that the smoke script calls. Routes on query
+# content:
+#   SELECT 1 FROM dispatcher.agents → empty (no row) unless AGENT_ROW_EXISTS=1
+#   INSERT INTO dispatcher.agents   → success (records to invocations/insert.log)
+
+mkdir -p "$STUB_BIN/scripts"
+cat > "$STUB_BIN/scripts/dev-db-query.sh" << 'DBEOF'
+#!/usr/bin/env bash
+set -u
+INVOCATIONS_DIR="${INVOCATIONS_DIR}"
+
+# Record full argv.
+{
+    printf 'CALL '
+    for arg in "$@"; do
+        printf '%q ' "$arg"
+    done
+    printf '\n'
+} >> "$INVOCATIONS_DIR/dev-db-query.log"
+
+# Consume flags to find the SQL query.
+rw_mode=false
+query=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --rw)
+            rw_mode=true
+            shift
+            ;;
+        *)
+            query="$1"
+            shift
+            ;;
+    esac
+done
+
+case "$query" in
+    *"SELECT 1 FROM dispatcher.agents"*)
+        if [[ "${AGENT_ROW_EXISTS:-0}" == "1" ]]; then
+            printf '1\n'
+        fi
+        exit 0
+        ;;
+    *"INSERT INTO dispatcher.agents"*)
+        {
+            printf 'CALL '
+            printf '%q ' "$query"
+            printf '\n'
+        } >> "$INVOCATIONS_DIR/insert.log"
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+DBEOF
+chmod +x "$STUB_BIN/scripts/dev-db-query.sh"
+
+# Make the scripts/ wrapper visible as scripts/dev-db-query.sh relative to the
+# repo root by symlinking into a path the script resolves via $REPO_ROOT.
+# The smoke script calls: "$REPO_ROOT/scripts/dev-db-query.sh"
+# We intercept by prepending the stub to PATH and using a wrapper that
+# matches the absolute path the smoke script constructs.
+#
+# Strategy: create a shim at the same absolute path used by the script, which
+# is $REPO_ROOT/scripts/dev-db-query.sh. Since we can't replace that file,
+# we instead set REPO_ROOT to our stub tree so the script resolves to our stub.
+#
+# We set STUB_REPO_ROOT below to point the smoke script at our stubs.
+
+STUB_REPO_ROOT="$TEST_TMP/fake-repo"
+mkdir -p "$STUB_REPO_ROOT/scripts"
+cp "$STUB_BIN/scripts/dev-db-query.sh" "$STUB_REPO_ROOT/scripts/dev-db-query.sh"
+
+# ── Count helper ──────────────────────────────────────────────────────────────
+
+count_invocations() {
+    local log="$INVOCATIONS_DIR/${1}.log"
+    if [[ ! -f "$log" ]]; then
+        echo 0
+        return
+    fi
+    grep -c '^CALL' "$log" || true
+}
+
+count_insert_calls() {
+    local log="$INVOCATIONS_DIR/insert.log"
+    if [[ ! -f "$log" ]]; then
+        echo 0
+        return
+    fi
+    grep -c '^CALL' "$log" || true
+}
+
+count_aws_subcommand() {
+    # Count CALL lines in aws.log that contain the given subcommand string.
+    local log="$INVOCATIONS_DIR/aws.log"
+    local pattern="$1"
+    if [[ ! -f "$log" ]]; then
+        echo 0
+        return
+    fi
+    grep -c "$pattern" "$log" || true
+}
+
+# ── Reset invocations between tests ──────────────────────────────────────────
+
+reset_invocations() {
+    rm -f "$INVOCATIONS_DIR"/*.log
+}
+
+# ── Precondition: script exists and is executable ────────────────────────────
+
+if [[ ! -f "$SCRIPT" ]]; then
+    echo "FAIL: script not found: $SCRIPT"
+    exit 1
+fi
+if [[ ! -x "$SCRIPT" ]]; then
+    echo "FAIL: script is not executable: $SCRIPT"
+    exit 1
+fi
+
+# Assert headers are present.
+if ! grep -q '# venv: none' "$SCRIPT"; then
+    fail "script has # venv: none header" "header not found in $SCRIPT"
+else
+    pass "script has # venv: none header"
+fi
+
+if ! grep -q '# permanent: true' "$SCRIPT"; then
+    fail "script has # permanent: true header" "header not found in $SCRIPT"
+else
+    pass "script has # permanent: true header"
+fi
+
+# ── Test 1: Fresh agent_id → INSERT + RunTask + taskArn on stdout ─────────────
+
+reset_invocations
+AGENT_ID_1="aaaaaaaa-0001-0001-0001-000000000001"
+
+# Override REPO_ROOT so dev-db-query.sh resolves to our stub.
+output=$(
+    PATH="$STUB_BIN:$PATH" \
+    INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+    ECS_CLUSTER="judgemind-dev" \
+    AGENT_RUNNER_TASK_DEFINITION_FAMILY="judgemind-dispatcher-agent-runner-dev" \
+    AGENT_RUNNER_SUBNET_IDS="subnet-aaa111,subnet-bbb222" \
+    AGENT_RUNNER_SECURITY_GROUP_ID="sg-deadbeef" \
+    REGION="us-west-2" \
+    AGENT_ROW_EXISTS="0" \
+    bash -c "
+        # Patch REPO_ROOT inside the script by wrapping dev-db-query.sh.
+        # The smoke script sources SCRIPT_DIR/../.. for REPO_ROOT.
+        # We copy the script to a wrapper that sets the right path.
+        export TEST_TMP='$TEST_TMP'
+        export STUB_BIN='$STUB_BIN'
+
+        # Run the script but with the real script pointing at our stub.
+        # Since REPO_ROOT is computed from BASH_SOURCE[0] inside the
+        # script, we need to inject a replacement. We do that by placing
+        # our stub dev-db-query.sh at the path the script will compute.
+        # Temporarily symlink:
+        TMP_SCRIPTS='$TEST_TMP/repo$$/scripts'
+        mkdir -p \"\$TMP_SCRIPTS\"
+        cp '$STUB_BIN/scripts/dev-db-query.sh' \"\$TMP_SCRIPTS/dev-db-query.sh\"
+
+        # We can't override REPO_ROOT from outside easily since the script
+        # computes it from BASH_SOURCE[0]. Instead we wrap dev-db-query.sh
+        # via a PATH-visible wrapper that intercepts the absolute-path call.
+        # The smoke script calls: \"\$REPO_ROOT/scripts/dev-db-query.sh\"
+        # We shadow it with a function export trick.
+        '$SCRIPT' '$AGENT_ID_1' 2>/dev/null
+    "
+) || true
+
+# The output capture approach above has a limitation: we can't intercept
+# absolute path calls via PATH. Let's use a different approach: copy the
+# smoke script to a temp location with REPO_ROOT forced.
+
+reset_invocations
+
+# Approach: create a thin wrapper that sets REPO_ROOT before calling the
+# real script's body. We do this by creating a shim that exports
+# REPO_ROOT pointing to our stub tree, then sources the real script.
+# The real script re-defines REPO_ROOT at startup from BASH_SOURCE[0],
+# so we need to use a copy with the REPO_ROOT override baked in.
+
+PATCHED_SCRIPT="$TEST_TMP/launch-agent-runner-smoke-patched.sh"
+# Read the script and patch the REPO_ROOT line.
+sed 's|REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"|REPO_ROOT="'"$TEST_TMP"'/fake-repo"|' \
+    "$SCRIPT" > "$PATCHED_SCRIPT"
+chmod +x "$PATCHED_SCRIPT"
+
+output=$(
+    PATH="$STUB_BIN:$PATH" \
+    INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+    ECS_CLUSTER="judgemind-dev" \
+    AGENT_RUNNER_TASK_DEFINITION_FAMILY="judgemind-dispatcher-agent-runner-dev" \
+    AGENT_RUNNER_SUBNET_IDS="subnet-aaa111,subnet-bbb222" \
+    AGENT_RUNNER_SECURITY_GROUP_ID="sg-deadbeef" \
+    REGION="us-west-2" \
+    AGENT_ROW_EXISTS="0" \
+    "$PATCHED_SCRIPT" "$AGENT_ID_1" 2>/dev/null
+)
+exit_code=$?
+
+if [[ $exit_code -eq 0 ]]; then
+    pass "test1: fresh agent-id exits 0"
+else
+    fail "test1: fresh agent-id exits 0" "exit code was $exit_code"
+fi
+
+if echo "$output" | grep -q "arn:aws:ecs:"; then
+    pass "test1: taskArn on stdout"
+else
+    fail "test1: taskArn on stdout" "stdout was: $output"
+fi
+
+insert_count=$(count_insert_calls)
+if [[ "$insert_count" -eq 1 ]]; then
+    pass "test1: exactly one INSERT for fresh agent-id"
+else
+    fail "test1: exactly one INSERT for fresh agent-id" "insert count was $insert_count"
+fi
+
+run_task_count=$(count_aws_subcommand "run-task")
+if [[ "$run_task_count" -eq 1 ]]; then
+    pass "test1: exactly one ecs:RunTask"
+else
+    fail "test1: exactly one ecs:RunTask" "run-task count was $run_task_count"
+fi
+
+# ── Test 2: Re-run with existing agent_id → zero INSERTs, one RunTask ─────────
+
+reset_invocations
+
+output2=$(
+    PATH="$STUB_BIN:$PATH" \
+    INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+    ECS_CLUSTER="judgemind-dev" \
+    AGENT_RUNNER_TASK_DEFINITION_FAMILY="judgemind-dispatcher-agent-runner-dev" \
+    AGENT_RUNNER_SUBNET_IDS="subnet-aaa111,subnet-bbb222" \
+    AGENT_RUNNER_SECURITY_GROUP_ID="sg-deadbeef" \
+    REGION="us-west-2" \
+    AGENT_ROW_EXISTS="1" \
+    "$PATCHED_SCRIPT" "$AGENT_ID_1" 2>/dev/null
+)
+exit_code2=$?
+
+if [[ $exit_code2 -eq 0 ]]; then
+    pass "test2: existing agent-id exits 0"
+else
+    fail "test2: existing agent-id exits 0" "exit code was $exit_code2"
+fi
+
+insert_count2=$(count_insert_calls)
+if [[ "$insert_count2" -eq 0 ]]; then
+    pass "test2: zero INSERTs for existing agent-id"
+else
+    fail "test2: zero INSERTs for existing agent-id" "insert count was $insert_count2"
+fi
+
+run_task_count2=$(count_aws_subcommand "run-task")
+if [[ "$run_task_count2" -eq 1 ]]; then
+    pass "test2: exactly one ecs:RunTask for existing agent-id"
+else
+    fail "test2: exactly one ecs:RunTask for existing agent-id" "run-task count was $run_task_count2"
+fi
+
+# ── Test 3: Missing AGENT_ID arg → exit != 0 with usage message ───────────────
+
+reset_invocations
+
+stderr3=$("$PATCHED_SCRIPT" 2>&1 || true)
+exit_code3=$("$PATCHED_SCRIPT" 2>/dev/null; echo $?) || true
+# Re-run to capture exit code properly.
+set +e
+"$PATCHED_SCRIPT" > /dev/null 2>&1
+exit_code3=$?
+set -e
+
+if [[ $exit_code3 -ne 0 ]]; then
+    pass "test3: missing agent-id exits non-zero"
+else
+    fail "test3: missing agent-id exits non-zero" "exit code was $exit_code3"
+fi
+
+if echo "$stderr3" | grep -qi "usage\|agent-id\|required"; then
+    pass "test3: usage message on stderr"
+else
+    fail "test3: usage message on stderr" "stderr was: $stderr3"
+fi
+
+# ── Test 4: Wiring env unset → describe-services called once ─────────────────
+#
+# When AGENT_RUNNER_SUBNET_IDS and AGENT_RUNNER_SECURITY_GROUP_ID are unset,
+# the script must call ecs:describe-services once to resolve the wiring.
+
+reset_invocations
+AGENT_ID_4="dddddddd-0004-0004-0004-000000000004"
+
+output4=$(
+    PATH="$STUB_BIN:$PATH" \
+    INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+    ECS_CLUSTER="judgemind-dev" \
+    AGENT_RUNNER_TASK_DEFINITION_FAMILY="judgemind-dispatcher-agent-runner-dev" \
+    REGION="us-west-2" \
+    AGENT_ROW_EXISTS="0" \
+    "$PATCHED_SCRIPT" "$AGENT_ID_4" 2>/dev/null
+)
+exit_code4=$?
+
+if [[ $exit_code4 -eq 0 ]]; then
+    pass "test4: wiring-env-unset run exits 0"
+else
+    fail "test4: wiring-env-unset run exits 0" "exit code was $exit_code4"
+fi
+
+describe_count=$(count_aws_subcommand "describe-services")
+if [[ "$describe_count" -eq 1 ]]; then
+    pass "test4: exactly one ecs:describe-services call for wiring resolution"
+else
+    fail "test4: exactly one ecs:describe-services call for wiring resolution" "describe-services count was $describe_count"
+fi
+
+run_task_count4=$(count_aws_subcommand "run-task")
+if [[ "$run_task_count4" -eq 1 ]]; then
+    pass "test4: exactly one ecs:RunTask after wiring resolution"
+else
+    fail "test4: exactly one ecs:RunTask after wiring resolution" "run-task count was $run_task_count4"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed. $FAILURES failed."
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Created `scripts/dispatcher/launch-agent-runner-smoke.sh` — an operator helper for manually launching agent-runner ECS tasks with idempotent dispatcher.agents seeding and automatic resolution of ECS networking. This eliminates ~30 minutes of manual AWS CLI composition per smoke debug iteration by automating cluster lookup, task-definition resolution, subnet/security-group discovery, dispatcher.agents seeding, and optional log-stream tailing.

Closes #3138

## Test plan

### Automated checks

- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/tests/test_launch_agent_runner_smoke.sh` — 14 test cases, all green)
- [x] CI green

### Post-deploy verification

- [ ] `scripts/dispatcher/launch-agent-runner-smoke.sh --help` shows usage
- [ ] `scripts/dispatcher/launch-agent-runner-smoke.sh <test-agent-id>` successfully launches a task on dev
- [ ] Re-run with same agent-id doesn't create duplicate `dispatcher.agents` rows
- [ ] Test suite appears in `scripts/run-scripts-tests.sh` output