### PR TITLE
docs(agent): add gap-state-probe guidance before issue filing (#3149)

### DIFF
--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -284,6 +284,35 @@ The adoption-to-merge path should be the common case when this check fires — i
 
 ---
 
+### Step 4b — Verify gap is real (current state probe)
+
+**Trigger condition:** Run this step when the issue title or body contains any of the following gap-assertion verbs — "enable", "add", "introduce", "expose", "document" — OR when the issue carries a `type/dx` or `type/infra` label. Issues with no gap-assertion signal (e.g. pure bug fixes, investigation tasks, refactoring) skip this step entirely.
+
+**What to do:** Pick the probe pattern that matches the issue's verb (see `docs/agent/issue-authoring.md §Verify the gap exists before filing` for the full probe catalog) and run it as a single tool call:
+
+- *"Enable AWS setting Y"* → `aws ecs describe-clusters --include SETTINGS` or grep `infra/terraform/` for the Terraform attribute.
+- *"Add metric / alarm"* → `aws cloudwatch list-metrics --namespace <ns>` / `aws cloudwatch describe-alarms --alarm-name-prefix <prefix>`.
+- *"Add / document X"* → `grep -r "X" docs/ .claude/skills/ CLAUDE.md` or `mcp__github__search_code` for the concept.
+- *"Fix code bug / introduce helper"* → grep for the function name or error-message string across `packages/`.
+
+**Decision tree:**
+
+- **Gap confirmed real** (the setting is off, the metric does not exist, the doc is absent, the bug is still present): continue to Path A / Path B as usual.
+- **Gap already satisfied** (probe output shows the state already matches the issue's goal): do NOT abandon the task. Post a comment on the issue quoting the probe output and proposing a reduced scope — typically a docs-only PR that documents the current state and cites the prior PR / Terraform attribute that already shipped it. Write the comment to `{worktree}/tmp/gap_probe_comment.txt`, post it, then continue with the reduced docs-only scope:
+  ```
+  gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/gap_probe_comment.txt
+  ```
+  The docs delta is worth producing — the AC's intent usually has a residual: "confirm and document that this already works." Complete that as a minimal PR before proceeding to merge.
+- **Probe ambiguous** (e.g. the AWS API returns unexpected output, the grep hits unrelated files, the state is partially configured): treat as "gap real" and continue to Path A.
+
+Exit codes:
+
+- **Gap real or ambiguous** → continue to Path A / Path B.
+- **Gap already satisfied** → post comment, pivot to reduced (docs-only) scope, continue as Path A with the reduced scope.
+
+---
+
+
 ### Path A: Implementation task (feature, bug fix, refactor)
 
 Follow the full PR Workflow defined in CLAUDE.md. **All commits must be on the worktree branch — never on `main`.** Summary of required substeps:

--- a/docs/agent/issue-authoring.md
+++ b/docs/agent/issue-authoring.md
@@ -31,6 +31,47 @@ Acceptance criteria must be concrete and machine-checkable wherever possible. Va
 
 Each criterion should have at least one `Verify:` line that an agent can execute to confirm the criterion is met. This applies to issues filed by both humans and agents. If a verification command is not possible (e.g., requires subjective judgment), note that explicitly so reviewers know it requires manual verification.
 
+## Verify the gap exists before filing
+
+Before filing a "does X" / "enable X" / "add X" issue, run a single command that verifies X is not already the case. This rule exists because an agent-runner cycle spent re-creating state that already exists is pure waste — the canonical example is #3146, where an issue was filed to "enable Container Insights on the ECS cluster" after the Terraform attribute `enable_container_insights = true` had already shipped in a prior PR. The agent spent a full cycle discovering, through probing, that there was nothing to do. A thirty-second check before filing would have surfaced that immediately. This is a sibling of the external-integration feasibility note in §Writing Acceptance Criteria (line 15): both rules say "verify the precondition before you ask an agent to build on top of it."
+
+**Probe patterns by verb:**
+
+- **"Enable AWS setting Y"** → check the live state and the Terraform source before filing.
+  ```
+  # Live state (example: ECS Container Insights)
+  aws ecs describe-clusters --clusters <cluster-name> --include SETTINGS \
+    --query 'clusters[0].settings'
+  # Terraform source
+  grep -r "enable_container_insights\|container_insights" infra/terraform/
+  ```
+  Already present if: live state shows `"value": "enabled"` OR Terraform already sets the attribute to `true`.
+
+- **"Add metric / alarm for X"** → check whether the metric namespace is already populated and the alarm already exists.
+  ```
+  aws cloudwatch list-metrics --namespace <namespace> --metric-name <MetricName>
+  aws cloudwatch describe-alarms --alarm-name-prefix <prefix>
+  ```
+  Already present if: `list-metrics` returns a non-empty `Metrics` array, or `describe-alarms` returns an existing alarm with the expected name prefix.
+
+- **"Add documentation for X"** → grep the docs tree before filing.
+  ```
+  grep -r "X" docs/
+  # or for agent-skill docs:
+  grep -r "X" .claude/skills/ CLAUDE.md
+  ```
+  Already present if: the concept is already explained at the relevant level of detail in an existing doc.
+
+- **"Fix code bug X" / "X throws an error"** → grep for the function name or error-message string; the bug may already be fixed in a prior PR the filer didn't see.
+  ```
+  grep -r "error_message_or_function_name" packages/
+  # Also check recent git log for the relevant area:
+  git log --oneline --all -- packages/<area>/
+  ```
+  Already fixed if: the offending code path no longer exists, or a recent commit message references the fix.
+
+**Decision after probing:** If the gap is genuinely absent (the feature/setting/doc does not yet exist), file the issue normally. If the gap is already satisfied, either close the draft or pivot scope to a doc-only update that confirms the current state (e.g., "document that Container Insights is enabled and cite the Terraform attribute"). If the probe is ambiguous, treat as real and file normally — agents can do their own probe at pickup time per Step 4b in `.claude/skills/task/SKILL.md`.
+
 ## Priority Framework
 
 Assign priority by urgency and workflow impact, not by user-visibility.


### PR DESCRIPTION
## Summary

Added lightweight "gap-state-probe" guidance to the issue-authoring workflow and task pickup flow to prevent wasted agent cycles on issues where the requested state already exists (e.g., #3146: Container Insights already enabled). The pattern: one grep / AWS describe / code search before filing or pickup can save a full implementation cycle.

Closes #3149

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] CI green
- [x] No tests required (documentation + workflow guidance)

### Post-deploy verification

- [x] N/A — no deployed component (documentation + agent skill guidance)