### PR TITLE
chore(ci): add subprocess.run timeout hygiene check for scripts/**/*.py (#3213)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,6 +642,13 @@ jobs:
       # back in.
       - name: Verify every daemon git/gh subprocess site has retry or cold-path annotation
         run: scripts/check-git-gh-retries.sh
+      # Issue #3213: every ``subprocess.run(...)`` call site in
+      # ``scripts/**/*.py`` (excluding ``scripts/**/tests/**``) must have
+      # a ``timeout=`` kwarg or a ``**kwargs`` splat. An unbounded blocking
+      # subprocess.run was the prime hypothesis for the #3205 silent-daemon
+      # wedge class. This check prevents regression.
+      - name: Verify every subprocess.run call in scripts has timeout= or **kwargs
+        run: scripts/check-subprocess-timeouts.sh
       # Issue #3158: every ``UPDATE dispatcher.agents`` /
       # ``SELECT ... FROM dispatcher.agents`` line in
       # ``scripts/dispatcher/daemon.py`` must either mention

--- a/scripts/_unblock_dependents.py
+++ b/scripts/_unblock_dependents.py
@@ -17,7 +17,7 @@ import sys
 
 def gh(*args: str) -> str | None:
     """Run a gh CLI command and return stdout, or None on error."""
-    r = subprocess.run(["gh", *args], capture_output=True, text=True)  # noqa: S603, S607
+    r = subprocess.run(["gh", *args], capture_output=True, text=True, timeout=120)  # noqa: S603, S607
     if r.returncode != 0:
         print(f"  gh error: {r.stderr.strip()}", file=sys.stderr)
         return None
@@ -128,8 +128,15 @@ def main() -> None:
 
             # Update labels
             gh(
-                "issue", "edit", str(n), "--repo", repo,
-                "--remove-label", "status/blocked", "--add-label", "agent/ready",
+                "issue",
+                "edit",
+                str(n),
+                "--repo",
+                repo,
+                "--remove-label",
+                "status/blocked",
+                "--add-label",
+                "agent/ready",
             )
             print("  Labels updated: -status/blocked, +agent/ready.")
 
@@ -139,7 +146,9 @@ def main() -> None:
     # Summary
     print("---")
     if dry_run:
-        print(f"[DRY RUN] Would unblock {unblocked_count} issue(s), skipped {skipped_count}.")
+        print(
+            f"[DRY RUN] Would unblock {unblocked_count} issue(s), skipped {skipped_count}."
+        )
     else:
         print(f"Unblocked {unblocked_count} issue(s), skipped {skipped_count}.")
 

--- a/scripts/archive/run_judge_cleanup.py
+++ b/scripts/archive/run_judge_cleanup.py
@@ -71,7 +71,7 @@ def run_script(script_name: str, dry_run: bool) -> int:
         cmd.append("--dry-run")
 
     logger.info("Running: %s", " ".join(cmd))
-    result = subprocess.run(cmd, env=os.environ)
+    result = subprocess.run(cmd, env=os.environ, timeout=120)
     return result.returncode
 
 

--- a/scripts/audit_ci_health.py
+++ b/scripts/audit_ci_health.py
@@ -169,6 +169,7 @@ def fetch_runs_via_gh(limit: int) -> list[dict[str, Any]]:
         capture_output=True,
         text=True,
         check=True,
+        timeout=120,
     )
     runs_meta = json.loads(list_proc.stdout)
     results: list[dict[str, Any]] = []
@@ -188,6 +189,7 @@ def fetch_runs_via_gh(limit: int) -> list[dict[str, Any]]:
             capture_output=True,
             text=True,
             check=True,
+            timeout=120,
         )
         detail = json.loads(view_proc.stdout)
         results.append(

--- a/scripts/check-ci-job-skipped.py
+++ b/scripts/check-ci-job-skipped.py
@@ -140,7 +140,9 @@ class Job:
     name: str
     start_line: int  # 1-indexed, line of the `<name>:` header
     end_line: int  # 1-indexed, last line of the job body
-    if_gate_filter: str | None  # e.g. "scripts" if gated on detect-changes.outputs.scripts
+    if_gate_filter: (
+        str | None
+    )  # e.g. "scripts" if gated on detect-changes.outputs.scripts
 
 
 @dataclass
@@ -288,14 +290,10 @@ def _extract_filters(lines: list[str], jobs: list[Job]) -> dict[str, list[str]]:
     if filter_name_indent is None:
         return {}
 
-    filter_name_re = re.compile(
-        rf"^ {{{filter_name_indent}}}([A-Za-z0-9_\-]+):\s*$"
-    )
+    filter_name_re = re.compile(rf"^ {{{filter_name_indent}}}([A-Za-z0-9_\-]+):\s*$")
     # Glob entries are lines more deeply indented than the filter name,
     # starting with `- '...'`.
-    glob_entry_re = re.compile(
-        rf"^ {{{filter_name_indent + 2},}}-\s*(.+?)\s*$"
-    )
+    glob_entry_re = re.compile(rf"^ {{{filter_name_indent + 2},}}-\s*(.+?)\s*$")
 
     filters: dict[str, list[str]] = {}
     current_filter: str | None = None
@@ -457,6 +455,7 @@ def get_diff_from_git(base_ref: str, repo_root: Path) -> str:
         ["git", "-C", str(repo_root), "merge-base", "HEAD", base_ref],
         capture_output=True,
         text=True,
+        timeout=30,
     )
     if mb.returncode == 0 and mb.stdout.strip():
         base = mb.stdout.strip()
@@ -467,6 +466,7 @@ def get_diff_from_git(base_ref: str, repo_root: Path) -> str:
         ["git", "-C", str(repo_root), "diff", f"{base}...HEAD", "--unified=3"],
         capture_output=True,
         text=True,
+        timeout=30,
     )
     if result.returncode != 0:
         raise RuntimeError(
@@ -596,6 +596,7 @@ def main() -> int:
                 capture_output=True,
                 text=True,
                 check=True,
+                timeout=30,
             )
             repo_root = Path(r.stdout.strip())
         except (subprocess.CalledProcessError, FileNotFoundError) as exc:

--- a/scripts/check-migration-number-collision.py
+++ b/scripts/check-migration-number-collision.py
@@ -245,12 +245,14 @@ def get_diff_from_git(base_ref: str, repo_root: Path) -> str:
         ["git", "-C", str(repo_root), "merge-base", "HEAD", base_ref],
         capture_output=True,
         text=True,
+        timeout=30,
     )
     base = mb.stdout.strip() if (mb.returncode == 0 and mb.stdout.strip()) else base_ref
     result = subprocess.run(
         ["git", "-C", str(repo_root), "diff", f"{base}...HEAD", "--unified=0"],
         capture_output=True,
         text=True,
+        timeout=30,
     )
     if result.returncode != 0:
         raise RuntimeError(
@@ -274,6 +276,7 @@ def get_latest_migration_number_on_base(base_ref: str, repo_root: Path) -> int |
         ],
         capture_output=True,
         text=True,
+        timeout=30,
     )
     if result.returncode != 0:
         return None
@@ -305,7 +308,7 @@ def get_open_prs_via_gh(repo: str | None) -> str:
     ]
     if repo:
         cmd += ["--repo", repo]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
     if result.returncode != 0:
         raise RuntimeError(
             f"gh pr list failed (exit {result.returncode}): {result.stderr.strip()}"
@@ -334,6 +337,7 @@ def detect_current_pr_number(repo_root: Path) -> int | None:
             capture_output=True,
             text=True,
             cwd=str(repo_root),
+            timeout=30,
         )
     except FileNotFoundError:
         return None
@@ -431,6 +435,7 @@ def main() -> int:
                 capture_output=True,
                 text=True,
                 check=True,
+                timeout=30,
             )
             repo_root = Path(r.stdout.strip())
         except (subprocess.CalledProcessError, FileNotFoundError) as exc:

--- a/scripts/check-subprocess-timeouts.sh
+++ b/scripts/check-subprocess-timeouts.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# check-subprocess-timeouts.sh — Every ``subprocess.run(...)`` call site in
+# ``scripts/**/*.py`` (excluding any path with a ``tests/`` segment) must
+# have either a ``timeout=`` keyword argument OR a ``**kwargs`` splat
+# (treated as a transparent pass-through that delegates timeout
+# responsibility to the caller).
+#
+# Why this check exists
+# ---------------------
+# An unbounded ``subprocess.run`` on the MainThread of a long-lived process
+# can wedge the process silently forever — confirmed as the prime hypothesis
+# for the #3205 dispatcher silent-wedge class. Issue #3213 audited all
+# scripts/*.py call sites and fixed the 13 violations; this check prevents
+# the invariant from regressing.
+#
+# Rule
+# ----
+# Every ``subprocess.run(...)`` call in ``scripts/**/*.py`` (excluding
+# ``scripts/**/tests/**``) must pass:
+#   (a) ``timeout=<value>`` as an explicit keyword argument, OR
+#   (b) ``**kwargs`` (``kw.arg is None``) as a keyword splat — the wrapper
+#       itself is expected to set the timeout and this tool cannot verify the
+#       chain statically.
+#
+# ``subprocess.Popen`` is out of scope: the daemon already pairs every Popen
+# with a subsequent ``proc.wait(timeout=...)`` call. A follow-up issue will
+# extend this check to the Popen-pairing invariant.
+#
+# Tracking: issue #3213.
+#
+# Usage
+# -----
+#   scripts/check-subprocess-timeouts.sh            # scan all scripts/**/*.py
+#   scripts/check-subprocess-timeouts.sh [file]     # scan a specific file (tests)
+#
+# Exit codes
+# ----------
+#   0 — Every subprocess.run call site has a timeout= kwarg or **kwargs splat.
+#   1 — At least one call site is missing a timeout constraint.
+
+# venv: none
+# permanent: true
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ─── Build the list of files to scan ─────────────────────────────────────────
+# If a specific file was passed as $1, scan only that file.
+# Otherwise walk every *.py under scripts/ excluding any path containing /tests/.
+
+if [[ $# -gt 0 ]]; then
+    TARGET_FILE="$1"
+    if [[ ! -f "$TARGET_FILE" ]]; then
+        echo "check-subprocess-timeouts: no target file at $TARGET_FILE — nothing to check."
+        exit 0
+    fi
+    # Run python helper on a single file and capture output.
+    python_output="$(python3 - "$TARGET_FILE" <<'PYEOF'
+import ast
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+source = path.read_text()
+try:
+    tree = ast.parse(source)
+except SyntaxError as exc:
+    print(f"SYNTAX_ERROR:{exc}", file=sys.stderr)
+    sys.exit(0)
+
+for node in ast.walk(tree):
+    if not isinstance(node, ast.Call):
+        continue
+    func = node.func
+    if not (
+        isinstance(func, ast.Attribute)
+        and func.attr == "run"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "subprocess"
+    ):
+        continue
+    # Check for timeout= kwarg or **kwargs splat (kw.arg is None).
+    has_timeout = any(
+        kw.arg == "timeout" or kw.arg is None
+        for kw in node.keywords
+    )
+    if not has_timeout:
+        # Print file:line: source_snippet
+        snippet = source.splitlines()[node.lineno - 1].strip()
+        print(f"{path}:{node.lineno}: {snippet}")
+PYEOF
+)"
+
+    if [[ -z "${python_output// /}" ]]; then
+        echo "check-subprocess-timeouts: $TARGET_FILE — OK (all subprocess.run calls have timeout= or **kwargs)"
+        exit 0
+    fi
+    echo "ERROR: subprocess.run call(s) missing timeout= kwarg or **kwargs splat."
+    echo ""
+    echo "  Violations:"
+    echo ""
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        echo "    $line"
+    done <<< "$python_output"
+    echo ""
+    echo "  Fix: add timeout=<seconds> to each call. Choose a value appropriate"
+    echo "  to the operation (e.g. timeout=30 for local git ops, timeout=120 for"
+    echo "  network gh calls)."
+    echo ""
+    echo "  See #3213 for the full audit and rationale."
+    exit 1
+fi
+
+# ─── Multi-file scan mode ─────────────────────────────────────────────────────
+# Collect all *.py files under scripts/, excluding any path with /tests/ in it.
+mapfile_compat() {
+    # bash 3.2 compat: read into array without mapfile/readarray.
+    # Usage: mapfile_compat varname command [args...]
+    # We use a temp file instead of process substitution + readarray.
+    local _varname="$1"
+    shift
+    local _tmpfile
+    _tmpfile="$(mktemp)"
+    "$@" > "$_tmpfile" 2>/dev/null || true
+    # Read lines into positional params then copy to named array via eval.
+    # Portable: bash 3.2+.
+    local _line
+    local _arr=()
+    while IFS= read -r _line; do
+        _arr+=("$_line")
+    done < "$_tmpfile"
+    rm -f "$_tmpfile"
+    eval "${_varname}=(\"\${_arr[@]}\")"
+}
+
+# Collect candidate files using find (no mapfile needed if we process inline).
+violations_total=0
+files_scanned=0
+violation_lines=()
+
+while IFS= read -r -d '' py_file; do
+    # Exclude any path containing /tests/ or /.venv/ segment.
+    if [[ "$py_file" == */tests/* ]]; then
+        continue
+    fi
+    if [[ "$py_file" == */.venv/* ]]; then
+        continue
+    fi
+    files_scanned=$((files_scanned + 1))
+
+    # Run the AST checker on this file.
+    file_output="$(python3 - "$py_file" <<'PYEOF'
+import ast
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+source = path.read_text()
+try:
+    tree = ast.parse(source)
+except SyntaxError:
+    sys.exit(0)
+
+for node in ast.walk(tree):
+    if not isinstance(node, ast.Call):
+        continue
+    func = node.func
+    if not (
+        isinstance(func, ast.Attribute)
+        and func.attr == "run"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "subprocess"
+    ):
+        continue
+    has_timeout = any(
+        kw.arg == "timeout" or kw.arg is None
+        for kw in node.keywords
+    )
+    if not has_timeout:
+        snippet = source.splitlines()[node.lineno - 1].strip()
+        print(f"{path}:{node.lineno}: {snippet}")
+PYEOF
+)"
+
+    if [[ -n "${file_output// /}" ]]; then
+        while IFS= read -r vline; do
+            [[ -z "$vline" ]] && continue
+            violation_lines+=("$vline")
+            violations_total=$((violations_total + 1))
+        done <<< "$file_output"
+    fi
+done < <(find "$REPO_ROOT/scripts" -name "*.py" -print0 | sort -z)
+
+if (( violations_total > 0 )); then
+    echo "ERROR: subprocess.run call(s) missing timeout= kwarg or **kwargs splat."
+    echo ""
+    echo "  Violations:"
+    echo ""
+    for vline in "${violation_lines[@]}"; do
+        echo "    $vline"
+    done
+    echo ""
+    echo "  Fix: add timeout=<seconds> to each call. Choose a value appropriate"
+    echo "  to the operation (e.g. timeout=30 for local git ops, timeout=120 for"
+    echo "  network gh calls)."
+    echo ""
+    echo "  See #3213 for the full audit and rationale."
+    exit 1
+fi
+
+echo "check-subprocess-timeouts: ${files_scanned} file(s) scanned — all subprocess.run calls have timeout= or **kwargs."
+exit 0

--- a/scripts/dispatcher/tests/test_daemon_scheduler_tick_instrumentation.py
+++ b/scripts/dispatcher/tests/test_daemon_scheduler_tick_instrumentation.py
@@ -2,11 +2,6 @@
 
 Covers the diagnostic-first changes added to :mod:`scripts.dispatcher.daemon`:
 
-* Every ``subprocess.run`` / ``subprocess.Popen`` call site in
-  ``daemon.py`` uses a ``timeout=`` kwarg (AST-level scan). An unbounded
-  ``gh`` / ``git`` subprocess was the prime hypothesis for the #3205
-  silent-daemon wedge; this test locks in the no-unbounded-subprocess
-  invariant for future edits.
 * The per-step instrumentation inside :meth:`scheduler_tick` emits
   ``daemon.scheduler_tick_slow_<step>`` WARNING events when a
   sub-step's elapsed wall-clock exceeds
@@ -17,12 +12,16 @@ Covers the diagnostic-first changes added to :mod:`scripts.dispatcher.daemon`:
   multiple times, and honours the
   ``JUDGEMIND_DISPATCHER_DISABLE_FAULTHANDLER_TIMER`` opt-out.
 
+Note: AST-level coverage of ``subprocess.run`` timeout kwargs (formerly
+``TestSubprocessTimeoutCoverage``) has been moved to the
+``scripts/check-subprocess-timeouts.sh`` hygiene guard (#3213), which
+covers all of ``scripts/**/*.py`` rather than just ``daemon.py``.
+
 No real subprocess is spawned. No real CloudWatch / ECS is reached.
 """
 
 from __future__ import annotations
 
-import ast
 import logging
 import sys
 import time
@@ -38,9 +37,6 @@ if str(_SCRIPTS) not in sys.path:
 
 
 from dispatcher import daemon  # noqa: E402  — sys.path mutation above
-
-
-DAEMON_PATH = Path(daemon.__file__)
 
 
 # --------------------------------------------------------------------------
@@ -133,70 +129,16 @@ def _make_daemon(
 
 
 # --------------------------------------------------------------------------
-# AC #1 — every ``subprocess.run`` / ``subprocess.Popen`` call site in
-# daemon.py uses a ``timeout=`` kwarg.
+# AC #1 — ``QUEUE_SCAN_SUBPROCESS_TIMEOUT_SECONDS`` is sane.
 #
-# An unbounded ``gh`` / ``git`` subprocess call in the scheduler_tick
-# reachable path was the prime hypothesis for the #3205 silent wedge
-# (issue body §Hypothesis). This AST-level scan locks in the invariant
-# for the whole module — any future addition that forgets ``timeout=``
-# fails this test at author time rather than wedging the daemon in
-# production.
+# The AST-level scan that verified every ``subprocess.run`` call site in
+# daemon.py has a ``timeout=`` kwarg has been moved to the broader
+# ``scripts/check-subprocess-timeouts.sh`` hygiene guard (#3213), which
+# covers all of ``scripts/**/*.py`` rather than just ``daemon.py``.
 # --------------------------------------------------------------------------
 
 
-def _collect_subprocess_run_sites() -> list[tuple[int, bool]]:
-    """Return (lineno, has_timeout_kw) for every ``subprocess.run`` call.
-
-    Walks ``daemon.py`` at parse time. ``subprocess.Popen`` calls are
-    deliberately excluded — ``Popen`` itself returns immediately, and
-    the daemon bounds Popen-based subprocesses via a subsequent
-    ``proc.wait(timeout=...)`` call (see the ``claude -p`` orchestration
-    spawn at line ~8252 and the diagnoser spawn at line ~17320). The
-    scheduler_tick wedge class the #3205 instrumentation targets is
-    specifically an unbounded blocking ``subprocess.run`` — those are
-    the calls that tie up the MainThread indefinitely.
-
-    ``has_timeout_kw`` is True iff the call passes ``timeout=...`` —
-    either inline or via ``**kwargs`` (we treat ``**kwargs`` as a
-    pass-through and accept it, relying on the wrapper's own check).
-    """
-    source = DAEMON_PATH.read_text()
-    tree = ast.parse(source)
-    sites: list[tuple[int, bool]] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        if not isinstance(func, ast.Attribute):
-            continue
-        if not (
-            isinstance(func.value, ast.Name)
-            and func.value.id == "subprocess"
-            and func.attr == "run"
-        ):
-            continue
-        has_timeout = any(
-            kw.arg == "timeout" or kw.arg is None  # kw.arg None == **kwargs splat
-            for kw in node.keywords
-        )
-        sites.append((node.lineno, has_timeout))
-    return sites
-
-
 class TestSubprocessTimeoutCoverage:
-    def test_every_subprocess_run_call_has_timeout_kwarg(self) -> None:
-        sites = _collect_subprocess_run_sites()
-        assert sites, "expected at least one subprocess.run call site in daemon.py"
-        missing = [lineno for lineno, ok in sites if not ok]
-        assert missing == [], (
-            "subprocess.run call sites without ``timeout=`` kwarg (daemon.py "
-            f"line numbers): {missing!r}. Every blocking subprocess.run in the "
-            "scheduler_tick-reachable path must be bounded to avoid the #3205 "
-            "silent-daemon wedge class. If you need an unbounded subprocess, "
-            "use subprocess.Popen + proc.wait(timeout=...) instead."
-        )
-
     def test_queue_scan_timeout_constant_is_bounded(self) -> None:
         """The shared ``QUEUE_SCAN_SUBPROCESS_TIMEOUT_SECONDS`` drives
         the hot-path ``gh issue list`` calls. Keep it well below the

--- a/scripts/tests/test_check_subprocess_timeouts.sh
+++ b/scripts/tests/test_check_subprocess_timeouts.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# test_check_subprocess_timeouts.sh — Tests for
+# scripts/check-subprocess-timeouts.sh
+#
+# Verifies that the checker:
+#   (a) passes on a file where subprocess.run has an explicit timeout= kwarg
+#   (b) fails on a file where subprocess.run has no timeout= kwarg
+#   (c) passes on a file where subprocess.run uses a **kwargs splat
+#   (d) ignores subprocess.Popen calls (out of scope)
+#   (e) passes on the real scripts/dispatcher/daemon.py
+#   (f) passes on the whole scripts/ tree after the #3213 fix
+#
+# Usage:
+#   scripts/tests/test_check_subprocess_timeouts.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-subprocess-timeouts.sh"
+FAILURES=0
+TESTS=0
+
+TMPDIR_TEST="$(mktemp -d)"
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+write_file() {
+    local path="$TMPDIR_TEST/$1"
+    mkdir -p "$(dirname "$path")"
+    cat > "$path"
+}
+
+assert_passes() {
+    local desc="$1"
+    local target="$2"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$target" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        "$CHECK_SCRIPT" "$target" 2>&1 | sed 's/^/    /'
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_fails() {
+    local desc="$1"
+    local target="$2"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$target" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+# ─── Test (a): file with timeout= passes ─────────────────────────────────────
+write_file "good_timeout.py" <<'EOF'
+import subprocess
+
+def run_git():
+    result = subprocess.run(
+        ["git", "status"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    return result.returncode
+EOF
+assert_passes "file with explicit timeout= kwarg passes" \
+    "$TMPDIR_TEST/good_timeout.py"
+
+# ─── Test (b): file without timeout= fails ───────────────────────────────────
+write_file "bad_no_timeout.py" <<'EOF'
+import subprocess
+
+def run_git():
+    result = subprocess.run(
+        ["git", "status"],
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode
+EOF
+assert_fails "file with subprocess.run missing timeout= fails" \
+    "$TMPDIR_TEST/bad_no_timeout.py"
+
+# ─── Test (c): file with **kwargs splat passes ────────────────────────────────
+# The checker treats **kwargs as a pass-through — the wrapper is expected
+# to carry a timeout= kwarg from the call site above.
+write_file "good_kwargs_splat.py" <<'EOF'
+import subprocess
+from typing import Any
+
+def _run_helper(cmd: list, **kwargs: Any):
+    return subprocess.run(cmd, **kwargs)
+EOF
+assert_passes "file with **kwargs splat passes (timeout delegated to caller)" \
+    "$TMPDIR_TEST/good_kwargs_splat.py"
+
+# ─── Test (d): subprocess.Popen is ignored ───────────────────────────────────
+# Popen + proc.wait(timeout=...) is the out-of-scope pattern per #3213
+# plan. The checker must NOT flag Popen calls — they are not subprocess.run.
+write_file "popen_ignored.py" <<'EOF'
+import subprocess
+
+def spawn_child():
+    proc = subprocess.Popen(
+        ["long-running-process"],
+        stdout=subprocess.PIPE,
+    )
+    proc.wait(timeout=60)
+    return proc.returncode
+EOF
+assert_passes "subprocess.Popen calls are ignored (out of scope per #3213)" \
+    "$TMPDIR_TEST/popen_ignored.py"
+
+# ─── Test (e): real scripts/dispatcher/daemon.py passes ──────────────────────
+# Regression gate: daemon.py has always had timeout= on every subprocess.run.
+# If a future author adds a new unbounded subprocess.run, this test catches it.
+assert_passes "real scripts/dispatcher/daemon.py passes" \
+    "$REPO_ROOT/scripts/dispatcher/daemon.py"
+
+# ─── Test (f): whole scripts/ tree post-#3213 fix passes ─────────────────────
+# The full-tree scan (no argument) must exit 0 after the 13 violation
+# sites are fixed in #3213.
+TESTS=$((TESTS + 1))
+if "$CHECK_SCRIPT" > /dev/null 2>&1; then
+    echo "PASS: whole scripts/ tree passes after #3213 fix"
+else
+    echo "FAIL: whole scripts/ tree has remaining violations (expected all fixed by #3213)"
+    "$CHECK_SCRIPT" 2>&1 | sed 's/^/    /'
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "$TESTS tests run, $FAILURES failed"
+if (( FAILURES > 0 )); then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Promotes an AST-level subprocess.run timeout check from a single pytest into a standalone hygiene guard (`scripts/check-subprocess-timeouts.sh`) that validates every `subprocess.run(…)` call in `scripts/**/*.py` (excluding test paths) has either a `timeout=` kwarg or a `**kwargs` splat.

The change fixes all 13 existing violation sites (30s for git ops, 120s for gh calls), deletes the now-redundant test, and wires the check into the `scripts-tests` CI job.

Closes #3213

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [x] Hygiene check passes on all current scripts/**/*.py files
- [x] New test suite (scripts/tests/test_check_subprocess_timeouts.sh) validates:
  - Check passes on file with explicit `timeout=`
  - Check fails on file without timeout (regression detection)
  - Check passes on file with `**kwargs` splat
  - Check ignores subprocess.Popen (out of scope)
  - Real daemon.py passes regression gate
  - Whole scripts/ tree passes post-fix

See #3213 for verification evidence.