### PR TITLE
fix(scraping): pre-flight DB connection budget in rebuild_db.py (#2575)

### DIFF
--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -446,7 +446,7 @@ Best practices:
 1. Never launch a rebuild while another rebuild or large backfill is already running against dev. Check first — preferred path: `mcp__awslabs_ecs-mcp-server__ecs_resource_management` with `api_operation: "ListTasks"`, `api_params: {"cluster": "judgemind-dev", "desiredStatus": "RUNNING"}`. CLI fallback: `aws ecs list-tasks --cluster judgemind-dev --desired-status RUNNING`. (See `docs/agent/aws-api-access.md`.)
 2. If you see `rds_reserved` errors, first check for runaway oneshot tasks (preferred: MCP `ListTasks` + `DescribeTasks` as above; CLI: `aws ecs list-tasks` then `aws ecs describe-tasks`) and stop any that are stuck retrying — each zombie task holds N connections until it exits.
 3. When iterating locally, prefer `scripts/rebuild_db.sh` against the Docker Compose Postgres rather than dev.
-4. If you *must* run rebuild with aggressive concurrency on dev, drop `--concurrency` to match the headroom (e.g. `--concurrency 32` leaves ~100 connections free for other callers).
+4. If you *must* run rebuild with aggressive concurrency on dev, drop `--concurrency` to match the headroom (e.g. `--concurrency 32` leaves ~100 connections free for other callers). Note: as of #2575, `rebuild_db.py` queries `max_connections` and `pg_stat_activity` at startup and self-clamps `--concurrency` to stay within the 80% connection headroom — manual tuning is a fallback, not a requirement.
 
 **History.** The instance was bumped from `db.t4g.micro` (max_connections ≈ 84) to `db.t4g.small` in #2549 after rebuild + backfill contention reliably triggered connection-slot exhaustion.
 

--- a/packages/scraper-framework/tests/test_rebuild_db.py
+++ b/packages/scraper-framework/tests/test_rebuild_db.py
@@ -568,6 +568,7 @@ class TestMainSummary:
         with (
             patch("rebuild_db.make_s3_client", return_value=MagicMock()),
             patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
             patch(
                 "rebuild_db.list_local_keys",
                 return_value=[
@@ -1054,6 +1055,7 @@ class TestMainPerCountyResetDispatch:
         with (
             patch("rebuild_db.make_s3_client", return_value=MagicMock()),
             patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
             patch(
                 "rebuild_db.list_local_keys",
                 return_value=["ca/santa_clara/superior_court/raw/abc123.html"],
@@ -1099,6 +1101,7 @@ class TestMainPerCountyResetDispatch:
         with (
             patch("rebuild_db.make_s3_client", return_value=MagicMock()),
             patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
             patch(
                 "rebuild_db.list_local_keys",
                 return_value=["ca/santa_clara/superior_court/raw/abc123.html"],
@@ -1166,6 +1169,7 @@ class TestMainPerCountyResetDispatch:
         with (
             patch("rebuild_db.make_s3_client", return_value=MagicMock()),
             patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
             patch(
                 "rebuild_db.list_local_keys",
                 return_value=["ca/santa_clara/superior_court/raw/abc123.html"],
@@ -1201,6 +1205,7 @@ class TestMainPerCountyResetDispatch:
         with (
             patch("rebuild_db.make_s3_client", return_value=MagicMock()),
             patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
             patch(
                 "rebuild_db.list_local_keys",
                 return_value=["ca/santa_clara/superior_court/raw/abc123.html"],
@@ -1411,6 +1416,7 @@ class TestForceSplitChildLossDeprecated:
         with (
             patch("rebuild_db.make_s3_client", return_value=MagicMock()),
             patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
             patch(
                 "rebuild_db.list_local_keys",
                 return_value=["ca/santa_clara/superior_court/raw/abc123.html"],
@@ -1501,6 +1507,7 @@ class TestRebuildSummaryHashMismatchCounter:
         with (
             patch("rebuild_db.make_s3_client", return_value=MagicMock()),
             patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
             patch(
                 "rebuild_db.list_local_keys",
                 return_value=[
@@ -1703,6 +1710,7 @@ class TestAutoscaleLogging:
         with (
             patch("rebuild_db.make_s3_client", return_value=MagicMock()),
             patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
             patch("rebuild_db.list_local_keys", return_value=keys),
             patch("rebuild_db.seed_courts", return_value={}),
             patch("rebuild_db._fetch_rosters"),
@@ -1962,6 +1970,7 @@ class TestMainPoolBreakHandling:
         with (
             patch("rebuild_db.make_s3_client", return_value=MagicMock()),
             patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
             patch(
                 "rebuild_db.list_local_keys",
                 return_value=keys,
@@ -2067,6 +2076,7 @@ class TestMainPoolBreakHandling:
         with (
             patch("rebuild_db.make_s3_client", return_value=MagicMock()),
             patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
             patch(
                 "rebuild_db.list_local_keys",
                 return_value=keys,
@@ -2160,6 +2170,7 @@ class TestMaxWorkerMemoryCLI:
         with (
             patch("rebuild_db.make_s3_client", return_value=MagicMock()),
             patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
             patch(
                 "rebuild_db.list_local_keys",
                 return_value=keys,
@@ -2236,6 +2247,7 @@ class TestMaxWorkerMemoryCLI:
         with (
             patch("rebuild_db.make_s3_client", return_value=MagicMock()),
             patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
             patch(
                 "rebuild_db.list_local_keys",
                 return_value=keys,
@@ -2309,6 +2321,7 @@ class TestMaxWorkerMemoryCLI:
         with (
             patch("rebuild_db.make_s3_client", return_value=MagicMock()),
             patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
             patch(
                 "rebuild_db.list_local_keys",
                 return_value=keys,
@@ -2347,3 +2360,143 @@ class TestMaxWorkerMemoryCLI:
             rebuild_db.main()
 
         assert captured_max_workers[0] == 4
+
+
+# ---------------------------------------------------------------------------
+# Connection-budget pre-flight — #2575
+# ---------------------------------------------------------------------------
+
+
+class TestClampConcurrencyToBudget:
+    """Tests for _clamp_concurrency_to_budget() pure function."""
+
+    def test_budget_ok_when_plentiful(self) -> None:
+        """172 max_connections, 5 used, 64 requested → no clamp (budget_ok).
+
+        available = int((172-5) * 0.8) = int(133.6) = 133
+        133 >= 64 + 1 = 65 → no clamp
+        """
+        effective, reason = rebuild_db._clamp_concurrency_to_budget(
+            requested=64, max_connections=172, used=5
+        )
+        assert effective == 64
+        assert reason == "budget_ok"
+
+    def test_clamps_when_budget_tight(self) -> None:
+        """20 max_connections, 2 used, 64 requested → clamp to 13.
+
+        available = int((20-2) * 0.8) = int(14.4) = 14
+        14 < 64 + 1 = 65 → clamp to max(4, 14-1) = 13
+        """
+        effective, reason = rebuild_db._clamp_concurrency_to_budget(
+            requested=64, max_connections=20, used=2
+        )
+        assert effective == 13
+        assert reason == "clamped_to_budget"
+
+    def test_floor_of_four(self) -> None:
+        """20 max_connections, 18 used, 64 requested → floor clamps to 4.
+
+        available = int((20-18) * 0.8) = int(1.6) = 1
+        1 < 65 → clamp to max(4, 1-1) = max(4, 0) = 4
+        """
+        effective, reason = rebuild_db._clamp_concurrency_to_budget(
+            requested=64, max_connections=20, used=18
+        )
+        assert effective == 4
+        assert reason == "clamped_to_budget"
+
+    def test_max_connections_zero_returns_budget_unknown(self) -> None:
+        """max_connections=0 → (requested, budget_unknown) — skip clamping."""
+        effective, reason = rebuild_db._clamp_concurrency_to_budget(
+            requested=64, max_connections=0, used=0
+        )
+        assert effective == 64
+        assert reason == "budget_unknown"
+
+    def test_max_connections_negative_returns_budget_unknown(self) -> None:
+        """Negative max_connections also returns budget_unknown."""
+        effective, reason = rebuild_db._clamp_concurrency_to_budget(
+            requested=64, max_connections=-1, used=0
+        )
+        assert effective == 64
+        assert reason == "budget_unknown"
+
+    def test_no_clamp_at_boundary(self) -> None:
+        """Clamp triggers only when available < requested + 1.
+
+        When available == requested + 1, the condition is false → budget_ok.
+        Example: max=100, used=0, headroom_pct=0.0 →
+          available = int((100-0)*(1-0.0)) = 100
+          requested = 99 → 100 >= 99+1=100 → not clamped
+        """
+        effective, reason = rebuild_db._clamp_concurrency_to_budget(
+            requested=99, max_connections=100, used=0, headroom_pct=0.0
+        )
+        assert effective == 99
+        assert reason == "budget_ok"
+
+    def test_clamp_at_exact_boundary(self) -> None:
+        """When available == requested, the condition fires → clamped.
+
+        available = int((100-0)*(1-0.0)) = 100
+        requested = 100 → 100 < 100+1=101 → clamped to max(4, 100-1)=99
+        """
+        effective, reason = rebuild_db._clamp_concurrency_to_budget(
+            requested=100, max_connections=100, used=0, headroom_pct=0.0
+        )
+        assert effective == 99
+        assert reason == "clamped_to_budget"
+
+    def test_custom_floor(self) -> None:
+        """floor parameter overrides the default of 4."""
+        effective, reason = rebuild_db._clamp_concurrency_to_budget(
+            requested=64, max_connections=20, used=18, floor=2
+        )
+        assert effective == 2
+        assert reason == "clamped_to_budget"
+
+
+class TestQueryConnectionBudget:
+    """Tests for _query_connection_budget() I/O wrapper."""
+
+    def test_issues_expected_sql(self) -> None:
+        """Issues the two expected SQL queries and returns (max, used) tuple."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+        mock_conn.__exit__ = MagicMock(return_value=False)
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        # fetchone() is called twice: once for max_connections, once for used
+        mock_cur.fetchone.side_effect = [(172,), (5,)]
+
+        with patch("psycopg.connect", return_value=mock_conn):
+            result = rebuild_db._query_connection_budget("postgres://test")
+
+        assert result == (172, 5)
+        # Verify both SQL strings were issued
+        execute_calls = [call[0][0] for call in mock_cur.execute.call_args_list]
+        assert any("max_connections" in sql for sql in execute_calls), (
+            f"expected max_connections query in {execute_calls!r}"
+        )
+        assert any("pg_stat_activity" in sql for sql in execute_calls), (
+            f"expected pg_stat_activity query in {execute_calls!r}"
+        )
+
+    def test_failure_returns_zero_zero_and_logs_warning(self) -> None:
+        """Connection failure returns (0, 0) and logs a warning — does not raise."""
+        mock_logger = MagicMock()
+
+        with (
+            patch("psycopg.connect", side_effect=Exception("connection refused")),
+            patch.object(rebuild_db, "logger", mock_logger),
+        ):
+            result = rebuild_db._query_connection_budget("postgres://test")
+
+        assert result == (0, 0)
+        # Must have logged a warning — not raised
+        calls = mock_logger.warning.call_args_list
+        assert mock_logger.warning.called, (
+            f"expected warning log on connection failure; got {calls!r}"
+        )

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -555,6 +555,71 @@ def _autoscale_concurrency(
     )
 
 
+def _query_connection_budget(dsn: str) -> tuple[int, int]:
+    """Return (max_connections, currently_used) from the target database.
+
+    Opens a short-lived connection, runs two queries:
+    - ``SELECT setting::int FROM pg_settings WHERE name='max_connections'``
+    - ``SELECT count(*) FROM pg_stat_activity``
+
+    Returns ``(0, 0)`` on any failure so a permission or connectivity issue
+    does not block the rebuild — the caller treats ``(0, 0)`` as
+    "budget unknown" and skips clamping.  Never raises.
+    """
+    import psycopg
+
+    try:
+        with psycopg.connect(dsn) as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT setting::int FROM pg_settings WHERE name='max_connections'"
+                )
+                row = cur.fetchone()
+                max_connections = int(row[0]) if row else 0
+
+                cur.execute("SELECT count(*) FROM pg_stat_activity")
+                row = cur.fetchone()
+                used = int(row[0]) if row else 0
+
+        return (max_connections, used)
+    except Exception:
+        logger.warning(
+            "Could not query connection budget — skipping clamp",
+            dsn=dsn,
+        )
+        return (0, 0)
+
+
+def _clamp_concurrency_to_budget(
+    requested: int,
+    max_connections: int,
+    used: int,
+    headroom_pct: float = 0.20,
+    floor: int = 4,
+) -> tuple[int, str]:
+    """Clamp ``requested`` concurrency to the database connection budget.
+
+    Computes ``available = int((max_connections - used) * (1 - headroom_pct))``.
+    Returns a ``(effective, reason)`` tuple:
+
+    - If ``max_connections <= 0``: ``(requested, "budget_unknown")`` — the
+      I/O layer failed, skip clamping.
+    - If ``available < requested + 1``: ``(max(floor, available - 1),
+      "clamped_to_budget")`` — too few slots, apply the floor.
+    - Otherwise: ``(requested, "budget_ok")`` — budget is plentiful.
+
+    The floor (default 4) ensures the rebuild always makes forward progress
+    even when the DB is nearly saturated.  Pure function — no I/O.
+    """
+    if max_connections <= 0:
+        return (requested, "budget_unknown")
+
+    available = int((max_connections - used) * (1 - headroom_pct))
+    if available < requested + 1:
+        return (max(floor, available - 1), "clamped_to_budget")
+    return (requested, "budget_ok")
+
+
 def _should_abort_retry_pass(
     crashed_count: int,
     total_count: int,
@@ -1380,6 +1445,33 @@ def main() -> None:
                 requested_concurrency=concurrency_requested,
                 effective_concurrency=concurrency,
             )
+
+        # Connection-budget pre-flight: clamp the autoscaled concurrency so we
+        # never exhaust the DB connection pool (#2575).  Runs after autoscale so
+        # both memory and connection budgets compose (the tighter limit wins).
+        max_conn, conn_used = _query_connection_budget(database_url)
+        clamped_concurrency, budget_reason = _clamp_concurrency_to_budget(
+            concurrency, max_conn, conn_used
+        )
+        logger.info(
+            "Connection budget decision",
+            max_connections=max_conn,
+            currently_used=conn_used,
+            requested=concurrency,
+            effective=clamped_concurrency,
+            reason=budget_reason,
+        )
+        if budget_reason == "clamped_to_budget":
+            logger.warning(
+                "Clamping --concurrency from %d to %d "
+                "(max_connections=%d, currently_used=%d)",
+                concurrency,
+                clamped_concurrency,
+                max_conn,
+                conn_used,
+            )
+        concurrency = clamped_concurrency
+
         logger.info("Processing documents", concurrency=concurrency, total=len(keys))
 
         # Step 4: Process documents concurrently using processes (not threads).


### PR DESCRIPTION
## Summary

Adds automatic connection-budget pre-flighting to `rebuild_db.py` to prevent exhausting the database connection pool. The script now queries `max_connections` and `pg_stat_activity` at startup and clamps `--concurrency` to stay within an 80% headroom (4-worker floor). Failure to query the budget returns (0,0) so connectivity issues never block the rebuild.

Closes #2575

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — all 84 tests pass (10 new tests added)
- [x] CI green

### Post-deploy verification

- [ ] N/A — no deployed component (script change only, fully tested via unit tests with mocked psycopg)