### PR TITLE
fix(scraping): loosen Riverside regex and update courthouse label (#2603)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/pdf_link_scraper.py
+++ b/packages/scraper-framework/src/courts/ca/pdf_link_scraper.py
@@ -236,7 +236,7 @@ class PdfLinkScraper(BaseScraper):
         if m:
             gd = m.groupdict()
             department = gd.get("department", "").strip()
-            raw_name = gd.get("judge_name", "").strip()
+            raw_name = (gd.get("judge_name") or "").strip()
             # Normalize whitespace
             judge_name = " ".join(raw_name.split()) if raw_name else None
             if department and pc.courthouse_from_dept:

--- a/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/riverside_tentatives.py
@@ -8,6 +8,8 @@ Verified against live site 2026-03-02:
 Link text format: "Department {CODE} - Honorable {Firstname Lastname [Suffix]}"
   e.g. "Department PS1 - Honorable Arthur Hester III"
   e.g. "Department M205 - Honorable Belinda Handy"
+  e.g. "Department 01 - Assigned Judge"  (no Honorable prefix)
+  e.g. "Department 260"  (no judge suffix at all)
 
 PDF URL pattern: /system/files/{YYYY-MM}/{CODE}ruling{MMDDYY}.pdf
   Resolved against BASE_URL.
@@ -27,7 +29,7 @@ Ruling splitting:
 
 Courthouse mapping (best-effort — Riverside has many locations):
   PS*  → Palm Springs Courthouse
-  M*   → Murrieta Courthouse (mid-county)
+  M*   → Menifee Justice Center
   MV*  → Moreno Valley Courthouse
   C*   → Corona Courthouse
   01–15 (numbered) → Hall of Justice (Riverside)
@@ -51,9 +53,13 @@ logger = structlog.get_logger(__name__)
 INDEX_URL = "https://www.riverside.courts.ca.gov/online-services/tentative-rulings"
 BASE_URL = "https://www.riverside.courts.ca.gov"
 
-# Link text: "Department PS1 - Honorable Arthur Hester III"
+# Link text shapes (#2603 — judge suffix is optional):
+#   "Department PS1 - Honorable Arthur Hester III"  (standard)
+#   "Department 01 - Assigned Judge"                (no Honorable prefix)
+#   "Department 260"                                (no dash, no judge)
 _LINK_TEXT_RE = re.compile(
-    r"Department\s+(?P<department>\S+)\s*-\s*Honorable\s+(?P<judge_name>.+)",
+    r"Department\s+(?P<department>\S+)"
+    r"(?:\s*-\s*(?:Honorable\s+)?(?P<judge_name>.+))?",
     re.IGNORECASE,
 )
 
@@ -126,7 +132,7 @@ def _riv_courthouse(dept: str) -> str | None:
     if dept_upper.startswith("MV"):
         return "Moreno Valley Courthouse"
     if dept_upper.startswith("M"):
-        return "Murrieta Courthouse"
+        return "Menifee Justice Center"
     if dept_upper.startswith("C"):
         return "Corona Courthouse"
     # Numbered departments (01–15): Hall of Justice in Riverside

--- a/packages/scraper-framework/tests/courts/test_pdf_link_scraper.py
+++ b/packages/scraper-framework/tests/courts/test_pdf_link_scraper.py
@@ -51,9 +51,9 @@ pytestmark = pytest.mark.regression
 FIXTURES = Path(__file__).parent.parent / "fixtures"
 
 # Expected number of PDF links processed from riv_page.html after filtering.
-# The fixture has 17 links; 1 is excluded by ``link_text_re`` (#1845), leaving 16.
+# The fixture has 17 links; with the loosened regex (#2603), all 17 pass.
 # Mirrors _RIV_EXPECTED_PROCESSED_PDFS in test_riverside_tentatives.py — keep in sync.
-_RIV_EXPECTED_PROCESSED_PDFS = 16
+_RIV_EXPECTED_PROCESSED_PDFS = 17
 
 
 def _load_html(name: str) -> str:
@@ -255,9 +255,9 @@ def test_riv_courthouse_palm_springs() -> None:
     assert _riv_courthouse("PS2") == "Palm Springs Courthouse"
 
 
-def test_riv_courthouse_murrieta() -> None:
-    assert _riv_courthouse("M205") == "Murrieta Courthouse"
-    assert _riv_courthouse("M301") == "Murrieta Courthouse"
+def test_riv_courthouse_menifee() -> None:
+    assert _riv_courthouse("M205") == "Menifee Justice Center"
+    assert _riv_courthouse("M301") == "Menifee Justice Center"
 
 
 def test_riv_courthouse_moreno_valley() -> None:
@@ -527,13 +527,12 @@ def test_link_text_filter_logs_warning_for_skipped_links(caplog: pytest.LogCaptu
 
 
 @respx.mock
-def test_riv_filters_non_matching_dept_260_link() -> None:
-    """Riverside 'Department 260' link (no judge name) is filtered out (#1845).
+def test_riv_dept_260_no_judge_link_processed() -> None:
+    """Riverside 'Department 260' link (no judge) is now processed, not filtered (#2603).
 
-    The riv_page.html fixture contains 17 PDF links, but 'Department 260'
-    does not match the Riverside link_text_re pattern because it lacks
-    '- Honorable <name>'.  It should be skipped, leaving
-    ``_RIV_EXPECTED_PROCESSED_PDFS`` links.
+    The loosened link_text_re makes the judge-name suffix optional, so
+    'Department 260' (no dash, no judge name) is now included in the output.
+    The riv_page.html fixture has 17 links; all 17 should produce documents.
     """
     html = _load_html("riv_page.html")
     pdf_bytes = _load_bytes("riv_ps1.pdf")
@@ -546,11 +545,13 @@ def test_riv_filters_non_matching_dept_260_link() -> None:
     scraper = RiversideTentativeRulingsScraper(config=config)
     docs = scraper.fetch_documents()
 
-    # One document per PDF (no scraper-level splitting)
+    # All 17 PDF links should produce documents (no link_text_re filtering)
     assert len(docs) == _RIV_EXPECTED_PROCESSED_PDFS
-    # Verify no document has a null department (all matched the regex)
-    assert all(d.department is not None for d in docs)
-    assert all(d.department != "" for d in docs)
+    # Dept 260 document should be present with department set and no judge name
+    dept260_docs = [d for d in docs if d.department == "260"]
+    assert len(dept260_docs) == 1
+    assert dept260_docs[0].department == "260"
+    assert not dept260_docs[0].judge_name  # None or empty — judge-name suffix absent
 
 
 @respx.mock
@@ -585,6 +586,61 @@ def test_riv_escheat_style_link_filtered() -> None:
     assert len(docs) == 1  # 1 doc per PDF (no scraper-level splitting)
     assert all(d.department == "PS1" for d in docs)
     assert all("Hester" in (d.judge_name or "") for d in docs)
+
+
+# ---------------------------------------------------------------------------
+# _fetch_one_pdf — None judge_name does not raise AttributeError (#2603)
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_fetch_one_pdf_none_judge_name_no_error() -> None:
+    """When link_text_re matches but judge_name group is None, no AttributeError (#2603).
+
+    The loosened Riverside regex makes judge_name optional.  _fetch_one_pdf
+    must not call .strip() on None — it must use (value or '').strip().
+    """
+    import re
+
+    from courts.ca.pdf_link_scraper import PdfLinkConfig, PdfLinkScraper
+    from framework import ScraperConfig
+
+    # Regex where judge_name is optional (like the loosened Riverside regex)
+    loosened_re = re.compile(
+        r"Department\s+(?P<department>\S+)"
+        r"(?:\s*-\s*(?:Honorable\s+)?(?P<judge_name>.+))?",
+        re.IGNORECASE,
+    )
+
+    html = (
+        '<html><body><a href="/system/files/2023-10/260ruling.pdf">Department 260</a></body></html>'
+    )
+    pdf_bytes = b"%PDF-1.4 fake pdf bytes"
+
+    config = ScraperConfig(
+        scraper_id="test",
+        state="CA",
+        county="Test",
+        court="Superior Court",
+        target_urls=["http://example.com"],
+        request_delay_seconds=0,
+        s3_bucket="",
+    )
+    pdf_config = PdfLinkConfig(
+        index_url="http://example.com/rulings",
+        pdf_base_url="http://example.com/rulings",
+        link_text_re=loosened_re,
+    )
+    scraper = PdfLinkScraper(config=config, pdf_config=pdf_config)
+
+    respx.get("http://example.com/rulings").mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(return_value=httpx.Response(200, content=pdf_bytes))
+
+    # This must not raise AttributeError: 'NoneType' object has no attribute 'strip'
+    docs = scraper.fetch_documents()
+    assert len(docs) == 1
+    assert docs[0].department == "260"
+    assert docs[0].judge_name is None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/courts/test_riverside_tentatives.py
+++ b/packages/scraper-framework/tests/courts/test_riverside_tentatives.py
@@ -36,6 +36,7 @@ import respx
 from courts.ca.pdf_link_scraper import PdfLinkScraper, _extract_pdf_text
 from courts.ca.riverside_tentatives import (
     _CASE_NUMBER_RE,
+    _LINK_TEXT_RE,
     INDEX_URL,
     RiversideTentativeRulingsScraper,
     _is_no_tentative_rulings,
@@ -50,8 +51,9 @@ pytestmark = pytest.mark.regression
 FIXTURES = Path(__file__).parent.parent / "fixtures"
 
 # Expected number of PDF links processed from riv_page.html after filtering.
-# The fixture has 17 links; 1 is excluded by ``link_text_re`` (#1845), leaving 16.
-_RIV_EXPECTED_PROCESSED_PDFS = 16
+# The fixture has 17 links; with the loosened regex (#2603), all 17 pass
+# (Department 260 no longer filtered out).
+_RIV_EXPECTED_PROCESSED_PDFS = 17
 
 
 def _load_html(name: str) -> str:
@@ -207,7 +209,7 @@ def test_riv_courthouse_known_prefixes() -> None:
     """Known department prefixes map to correct courthouses."""
     assert _riv_courthouse("PS1") == "Palm Springs Courthouse"
     assert _riv_courthouse("MV1") == "Moreno Valley Courthouse"
-    assert _riv_courthouse("M205") == "Murrieta Courthouse"
+    assert _riv_courthouse("M205") == "Menifee Justice Center"
     assert _riv_courthouse("C1") == "Corona Courthouse"
     assert _riv_courthouse("05") == "Hall of Justice"
 
@@ -304,6 +306,98 @@ class TestCaseNumberRegexExpanded:
 
 
 # ---------------------------------------------------------------------------
+# _LINK_TEXT_RE — unit tests (#2603)
+# ---------------------------------------------------------------------------
+
+
+class TestLinkTextRe:
+    """Verify _LINK_TEXT_RE matches all three real-world link-text shapes."""
+
+    def test_standard_with_honorable(self) -> None:
+        """Standard form: 'Department 04 - Honorable Daniel A. Ottolia'."""
+        m = _LINK_TEXT_RE.search("Department 04 - Honorable Daniel A. Ottolia")
+        assert m is not None
+        assert m.group("department") == "04"
+        assert m.group("judge_name") == "Daniel A. Ottolia"
+
+    def test_without_honorable_prefix(self) -> None:
+        """Non-standard judge label without 'Honorable': 'Department 01 - Assigned Judge'."""
+        m = _LINK_TEXT_RE.search("Department 01 - Assigned Judge")
+        assert m is not None
+        assert m.group("department") == "01"
+        assert m.group("judge_name") == "Assigned Judge"
+
+    def test_no_dash_no_judge(self) -> None:
+        """No judge suffix at all: 'Department 260'."""
+        m = _LINK_TEXT_RE.search("Department 260")
+        assert m is not None
+        assert m.group("department") == "260"
+        assert m.group("judge_name") is None
+
+    def test_ps1_existing_passes(self) -> None:
+        """Existing PS1 format still matches after regex loosening."""
+        m = _LINK_TEXT_RE.search("Department PS1 - Honorable Arthur Hester III")
+        assert m is not None
+        assert m.group("department") == "PS1"
+        assert m.group("judge_name") == "Arthur Hester III"
+
+
+# ---------------------------------------------------------------------------
+# Regression test — all three link-text shapes flow through fetch_documents
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_riv_all_link_text_shapes_processed() -> None:
+    """Regression: all three link-text shapes produce documents (#2603).
+
+    Verifies:
+    - Standard form ('Department 04 - Honorable Daniel A. Ottolia') → judge populated
+    - No-Honorable form ('Department 01 - Assigned Judge') → judge populated
+    - No-dash form ('Department 260') → department='260', judge_name=None
+    """
+    html = (
+        "<html><body>"
+        '<a href="/system/files/2026-02/04ruling.pdf">'
+        "Department 04 - Honorable Daniel A. Ottolia</a>"
+        '<a href="/system/files/2026-02/01ruling.pdf">'
+        "Department 01 - Assigned Judge</a>"
+        '<a href="/system/files/2023-10/260ruling.pdf">'
+        "Department 260</a>"
+        "</body></html>"
+    )
+    pdf_bytes = _load_bytes("riv_ps1.pdf")
+
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+    respx.get(url__regex=r"\.pdf$").mock(return_value=httpx.Response(200, content=pdf_bytes))
+
+    config = riv_default_config()
+    config.request_delay_seconds = 0
+    scraper = RiversideTentativeRulingsScraper(config=config)
+
+    docs = scraper.fetch_documents()
+
+    # All three links should produce documents (no filtering)
+    assert len(docs) == 3
+
+    dept_map = {d.department: d for d in docs}
+
+    # Standard form — judge name populated from link text
+    assert "04" in dept_map
+    assert dept_map["04"].judge_name == "Daniel A. Ottolia"
+    assert dept_map["04"].courthouse == "Hall of Justice"
+
+    # No-Honorable form — judge name still populated
+    assert "01" in dept_map
+    assert dept_map["01"].judge_name == "Assigned Judge"
+
+    # No-dash form — department set, judge_name is None (fallback may fill later)
+    assert "260" in dept_map
+    assert dept_map["260"].department == "260"
+    assert dept_map["260"].judge_name is None or dept_map["260"].judge_name == ""
+
+
+# ---------------------------------------------------------------------------
 # Full scraper run — hearing_date populated
 # ---------------------------------------------------------------------------
 
@@ -374,7 +468,7 @@ def test_riv_run_returns_one_doc_per_pdf() -> None:
 
     docs = scraper.fetch_documents()
     # One doc per PDF link — no splitting
-    # (1 of 17 links filtered by link_text_re, #1845)
+    # (all 17 links pass with loosened link_text_re, #2603)
     assert len(docs) == _RIV_EXPECTED_PROCESSED_PDFS
 
     # Documents should NOT have pre_split flag (scraper does not split)
@@ -689,7 +783,7 @@ def test_riv_fetch_documents_pdf_extraction_failure() -> None:
 
     docs = scraper.fetch_documents()
     # Despite extraction failures, docs are still returned (one per PDF link)
-    # (1 of 17 links filtered by link_text_re, #1845)
+    # (all 17 links pass with loosened link_text_re, #2603)
     assert len(docs) == _RIV_EXPECTED_PROCESSED_PDFS
 
 


### PR DESCRIPTION
## Summary

Loosens `_LINK_TEXT_RE` in `riverside_tentatives.py` to make the judge-name suffix optional, correctly handling three real-world link-text shapes from the Riverside courts website. Fixes a shared bug in `pdf_link_scraper.py` that would raise AttributeError on None judge_name values. Updates the M* courthouse label from "Murrieta Courthouse" to "Menifee Justice Center" per the court's rebranding.

Closes #2603

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
- [x] CI green

### Post-deploy verification

- [ ] Verify `/spotcheck` run against live Riverside site captures Dept 01 and 260 documents with correct courthouse label
- [ ] Verify OpenSearch records for M* departments show "Menifee Justice Center"
- [ ] Verification evidence posted on #2603 (see /task-v2-verify output)