### PR TITLE
fix(dx): make rebuild_db zero-pass silent failure loud (#2607)

### DIFF
--- a/packages/scraper-framework/tests/test_rebuild_db.py
+++ b/packages/scraper-framework/tests/test_rebuild_db.py
@@ -2457,6 +2457,250 @@ class TestClampConcurrencyToBudget:
         assert reason == "clamped_to_budget"
 
 
+class TestValidationSummary:
+    """Tests for _group_validation_reasons, _summarize_validation_results, and
+    main() integration of the post-rebuild validation summary (#2607)."""
+
+    # ------------------------------------------------------------------
+    # Pure-function tests
+    # ------------------------------------------------------------------
+
+    def test_group_validation_reasons_splits_concatenated_reasons(self) -> None:
+        """Reasons joined by '; ' are split and counted individually."""
+        rows = [
+            ("fail", "reason A; reason B"),
+            ("fail", "reason A"),
+        ]
+        result = rebuild_db._group_validation_reasons(rows)
+        assert result[0] == ("reason A", 2), f"expected reason A:2 first, got {result}"
+        assert result[1] == ("reason B", 1), f"expected reason B:1 second, got {result}"
+
+    def test_group_validation_reasons_only_buckets_fail_rows(self) -> None:
+        """pass, flag, and error rows must not contribute to the reason bucket."""
+        rows = [
+            ("pass", "should be ignored"),
+            ("flag", "also ignored"),
+            ("error", "error ignored"),
+            ("fail", "only this counts"),
+        ]
+        result = rebuild_db._group_validation_reasons(rows)
+        assert len(result) == 1
+        assert result[0][0] == "only this counts"
+
+    def test_group_validation_reasons_caps_top_3(self) -> None:
+        """Only the top 3 distinct reason fragments are returned."""
+        rows = [("fail", f"reason_{i}") for i in range(10)]
+        result = rebuild_db._group_validation_reasons(rows)
+        assert len(result) == 3, f"expected at most 3 reasons, got {len(result)}: {result}"
+
+    def test_group_validation_reasons_empty(self) -> None:
+        """Empty input returns an empty list without error."""
+        assert rebuild_db._group_validation_reasons([]) == []
+
+    def test_group_validation_reasons_no_fail_rows(self) -> None:
+        """When no fail rows exist, returns empty list."""
+        rows = [("pass", "all good"), ("flag", "minor issue")]
+        assert rebuild_db._group_validation_reasons(rows) == []
+
+    # ------------------------------------------------------------------
+    # DB-read helper tests
+    # ------------------------------------------------------------------
+
+    def test_summarize_validation_results_aggregates_counts_by_result(self) -> None:
+        """Returns correct accepted/flagged/rejected/errors counts from DB rows."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_cur.fetchall.return_value = [
+            ("pass", ""),
+            ("pass", ""),
+            ("flag", "minor"),
+            ("fail", "check_no_html_in_ruling_text"),
+            ("fail", "check_no_html_in_ruling_text; check_ruling_text_length"),
+            ("error", "exception"),
+        ]
+
+        from datetime import UTC, datetime
+
+        result = rebuild_db._summarize_validation_results(mock_conn, datetime.now(UTC))
+
+        assert result["accepted"] == 2
+        assert result["flagged"] == 1
+        assert result["rejected"] == 2
+        assert result["errors"] == 1
+        assert len(result["top_reasons"]) <= 3
+        # check_no_html_in_ruling_text appears in both fail rows → count 2
+        top_reason_names = [r for r, _ in result["top_reasons"]]
+        assert "check_no_html_in_ruling_text" in top_reason_names
+
+    def test_summarize_validation_results_returns_sentinel_on_failure(self) -> None:
+        """When the DB query raises, returns all-zero sentinel without raising."""
+        mock_conn = MagicMock()
+        mock_conn.cursor.side_effect = Exception("DB exploded")
+
+        from datetime import UTC, datetime
+
+        result = rebuild_db._summarize_validation_results(mock_conn, datetime.now(UTC))
+
+        assert result == {
+            "accepted": 0,
+            "flagged": 0,
+            "rejected": 0,
+            "errors": 0,
+            "top_reasons": [],
+        }
+
+    # ------------------------------------------------------------------
+    # main() integration tests
+    # ------------------------------------------------------------------
+
+    def _run_main_with_mocks(
+        self,
+        tmp_path: Any,
+        *,
+        county: str | None = None,
+        validation_summary: dict[str, Any],
+    ) -> tuple[MagicMock, SystemExit | None]:
+        """Run main() with controlled mocks and return (mock_logger, exit_exc).
+
+        Returns (logger_mock, None) if main() completed without sys.exit.
+        Returns (logger_mock, SystemExit_exc) if sys.exit was called.
+        """
+        import sys as _sys
+
+        # Create a minimal local cache with one HTML key.
+        key = "ca/orange/superior_court/raw/abc123.html"
+        html_dir = tmp_path / "cache" / "ca" / "orange" / "superior_court" / "raw"
+        html_dir.mkdir(parents=True)
+        (html_dir / "abc123.html").write_bytes(b"<html>Date: 03/15/2026 ruling text</html>")
+        cache_dir = str(tmp_path / "cache")
+
+        mock_future = MagicMock()
+        mock_future.result.return_value = {
+            "status": "ok",
+            "content_format": "html",
+            "had_hearing_date": True,
+            "hash_mismatch": False,
+        }
+
+        mock_pool = MagicMock()
+        mock_pool.__enter__ = MagicMock(return_value=mock_pool)
+        mock_pool.__exit__ = MagicMock(return_value=False)
+        mock_pool.submit.return_value = mock_future
+
+        mock_logger = MagicMock()
+
+        argv = ["rebuild_db.py"]
+        if county:
+            argv += ["--county", county]
+
+        exit_exc: SystemExit | None = None
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
+            patch("rebuild_db.list_local_keys", return_value=[key]),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db._fetch_rosters"),
+            patch(
+                "rebuild_db._summarize_validation_results",
+                return_value=validation_summary,
+            ),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                return_value=mock_pool,
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([mock_future]),
+            ),
+            patch.dict(
+                _sys.modules,
+                {},
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://test",
+                    "S3_CACHE_DIR": cache_dir,
+                },
+            ),
+            patch("sys.argv", argv),
+            patch.object(rebuild_db, "logger", mock_logger),
+        ):
+            try:
+                rebuild_db.main()
+            except SystemExit as exc:
+                exit_exc = exc
+
+        return mock_logger, exit_exc
+
+    def test_main_county_zero_accepted_exits_nonzero(self, tmp_path: Any) -> None:
+        """County-scoped run with 0 accepted + 0 flagged exits with code 3."""
+        vs = {
+            "accepted": 0,
+            "flagged": 0,
+            "rejected": 15,
+            "errors": 0,
+            "top_reasons": [("check_no_html", 15)],
+        }
+        mock_logger, exit_exc = self._run_main_with_mocks(
+            tmp_path, county="Orange", validation_summary=vs
+        )
+
+        assert exit_exc is not None, "expected sys.exit to be called"
+        assert exit_exc.code == 3, f"expected exit code 3, got {exit_exc.code!r}"
+
+        # The error-level log must include the reject hint
+        err_calls = mock_logger.error.call_args_list
+        summary_errors = [c for c in err_calls if c.args and c.args[0] == "Validation summary"]
+        assert len(summary_errors) == 1, (
+            f"expected 1 'Validation summary' error log, got: {err_calls}"
+        )
+        assert summary_errors[0].kwargs.get("rejected") == 15
+
+    def test_main_no_county_zero_accepted_does_not_exit_nonzero(self, tmp_path: Any) -> None:
+        """Full (non-county) rebuild with 0 accepted does NOT exit non-zero."""
+        vs = {"accepted": 0, "flagged": 0, "rejected": 100, "errors": 0, "top_reasons": []}
+        mock_logger, exit_exc = self._run_main_with_mocks(
+            tmp_path, county=None, validation_summary=vs
+        )
+
+        # Should complete without raising SystemExit (or exit 0 is fine)
+        assert exit_exc is None, (
+            f"non-county run with zero accepted must not exit non-zero, got {exit_exc!r}"
+        )
+
+    def test_main_county_with_accepted_exits_zero(self, tmp_path: Any) -> None:
+        """County run with accepted=10 must not raise and must log the summary."""
+        vs = {
+            "accepted": 10,
+            "flagged": 2,
+            "rejected": 2,
+            "errors": 0,
+            "top_reasons": [("check_x", 2)],
+        }
+        mock_logger, exit_exc = self._run_main_with_mocks(
+            tmp_path, county="Ventura", validation_summary=vs
+        )
+
+        assert exit_exc is None, f"expected clean exit, got {exit_exc!r}"
+
+        # Validation summary must have been logged (info or warning level)
+        all_info = mock_logger.info.call_args_list
+        all_warning = mock_logger.warning.call_args_list
+        summary_logs = [
+            c for c in all_info + all_warning if c.args and c.args[0] == "Validation summary"
+        ]
+        assert len(summary_logs) == 1, f"expected 1 Validation summary log, got: {summary_logs}"
+        kwargs = summary_logs[0].kwargs
+        assert "built" in kwargs
+        assert "accepted" in kwargs
+        assert "rejected" in kwargs
+        assert "top_reasons" in kwargs
+
+
 class TestQueryConnectionBudget:
     """Tests for _query_connection_budget() I/O wrapper."""
 

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -590,6 +590,80 @@ def _query_connection_budget(dsn: str) -> tuple[int, int]:
         return (0, 0)
 
 
+def _group_validation_reasons(rows: list[tuple[str, str]]) -> list[tuple[str, int]]:
+    """Group fail-result reason fragments and return the top-3 by count.
+
+    Each ``reason`` column from ``validation_results`` may contain multiple
+    rule names concatenated with ``'; '`` (the pattern used by the
+    deterministic-validation worker).  This pure function splits each reason,
+    counts occurrences of each fragment across all ``fail`` rows, and returns
+    up to 3 ``(fragment, count)`` pairs sorted by count descending.
+
+    Only ``result == 'fail'`` rows are bucketed — ``pass``, ``flag``, and
+    ``error`` rows are ignored.  Pure: no I/O, no side effects.
+    """
+    counts: dict[str, int] = {}
+    for result, reason in rows:
+        if result != "fail":
+            continue
+        for fragment in reason.split("; "):
+            fragment = fragment.strip()
+            if fragment:
+                counts[fragment] = counts.get(fragment, 0) + 1
+    return sorted(counts.items(), key=lambda x: x[1], reverse=True)[:3]
+
+
+def _summarize_validation_results(conn: Any, started_at: datetime) -> dict[str, Any]:
+    """Query validation_results written since *started_at* and return a summary dict.
+
+    Returns::
+
+        {
+            'accepted': int,   # result == 'pass'
+            'flagged':  int,   # result == 'flag'
+            'rejected': int,   # result == 'fail'
+            'errors':   int,   # result == 'error'
+            'top_reasons': [(reason_fragment, count), ...],  # up to 3
+        }
+
+    Returns all-zero sentinel on any DB or cursor failure so a connectivity
+    issue does not block the rebuild exit path.  Never raises.
+    """
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT result, reason FROM validation_results WHERE created_at >= %s",
+                (started_at,),
+            )
+            rows = cur.fetchall()
+        counts: dict[str, int] = {
+            "accepted": 0,
+            "flagged": 0,
+            "rejected": 0,
+            "errors": 0,
+        }
+        for result, reason in rows:
+            if result == "pass":
+                counts["accepted"] += 1
+            elif result == "flag":
+                counts["flagged"] += 1
+            elif result == "fail":
+                counts["rejected"] += 1
+            elif result == "error":
+                counts["errors"] += 1
+        top_reasons = _group_validation_reasons(rows)
+        return {**counts, "top_reasons": top_reasons}
+    except Exception:
+        logger.warning("Could not query validation_results — skipping summary")
+        return {
+            "accepted": 0,
+            "flagged": 0,
+            "rejected": 0,
+            "errors": 0,
+            "top_reasons": [],
+        }
+
+
 def _clamp_concurrency_to_budget(
     requested: int,
     max_connections: int,
@@ -1368,6 +1442,12 @@ def main() -> None:
     # rebuild raises before reaching the retry gate.  See #2572.
     retry_aborted_reason: str | None = None
 
+    # Initialize the validation-zero-pass reason outside the try block so it's
+    # always in scope for the post-finally exit check.  Mirrors
+    # retry_aborted_reason above.  Set when a county-scoped rebuild produces
+    # zero accepted/flagged validation results.
+    validation_zero_pass_reason: str | None = None
+
     # Wrap the rebuild in try/finally so the completion marker is always
     # written when --reset was used, even if the rebuild fails partway (#2222).
     try:
@@ -1471,6 +1551,13 @@ def main() -> None:
                 conn_used,
             )
         concurrency = clamped_concurrency
+
+        # Capture rebuild start time so the post-rebuild validation summary can
+        # scope its query to rows written during *this* run only.  Placed here
+        # (after seed_courts, after autoscale + connection-budget logging) so
+        # the timestamp covers all worker validation writes but excludes any
+        # earlier roster-fetch or reset activity.
+        rebuild_started_at = datetime.now(UTC)
 
         logger.info("Processing documents", concurrency=concurrency, total=len(keys))
 
@@ -1717,6 +1804,57 @@ def main() -> None:
                 hash_mismatch_warnings=hash_mismatch_warnings,
                 processed=processed,
             )
+
+        # Post-rebuild validation summary — queries validation_results for rows
+        # written since rebuild_started_at and emits a structured log so
+        # operators can quickly assess rule-failure rates without opening the
+        # DB.  Logged before conn.close() so we can reuse the open connection.
+        # The zero-pass county exit is deferred (mirroring retry_aborted_reason)
+        # until after conn.close() so the dev env returns to clean state first.
+        vs = _summarize_validation_results(conn, rebuild_started_at)
+        built = processed + errors
+        top_str = ", ".join(f"{r}: {c}" for r, c in vs["top_reasons"])
+        # Only consider zero-pass a hard failure when validation actually ran
+        # (i.e., at least one result row was written).  When the DB is
+        # unavailable or validation is not configured, all counts are zero —
+        # that is the sentinel path, not a real zero-pass.
+        validation_ran = (
+            vs["accepted"] + vs["flagged"] + vs["rejected"] + vs["errors"] > 0
+        )
+        if vs["accepted"] + vs["flagged"] == 0 and validation_ran and len(keys) > 0:
+            logger.error(
+                "Validation summary",
+                built=built,
+                accepted=vs["accepted"],
+                flagged=vs["flagged"],
+                rejected=vs["rejected"],
+                top_reasons=vs["top_reasons"],
+            )
+            if args.county:
+                validation_zero_pass_reason = (
+                    f"County-scoped rebuild produced 0 accepted/flagged rulings. "
+                    f"See telemetry.validation_results WHERE created_at >= "
+                    f"{rebuild_started_at.isoformat()} for details. "
+                    f"Top failure reasons: {top_str or 'none'}"
+                )
+        elif vs["rejected"] > 0:
+            logger.warning(
+                "Validation summary",
+                built=built,
+                accepted=vs["accepted"],
+                flagged=vs["flagged"],
+                rejected=vs["rejected"],
+                top_reasons=vs["top_reasons"],
+            )
+        else:
+            logger.info(
+                "Validation summary",
+                built=built,
+                accepted=vs["accepted"],
+                flagged=vs["flagged"],
+                rejected=vs["rejected"],
+                top_reasons=vs["top_reasons"],
+            )
     finally:
         # Clear the rebuild-in-progress marker so the data quality check
         # resumes normal P1 alerting.  Runs even if the rebuild fails
@@ -1737,6 +1875,21 @@ def main() -> None:
             retry_aborted_reason=retry_aborted_reason,
         )
         sys.exit(2)
+
+    # Propagate county-scoped zero-pass as a non-zero exit (code 3) so the
+    # ECS orchestrator surfaces the failure.  Deferred after conn.close() so
+    # the dev environment returns to a clean state before the task exits.
+    # Exit code 3 is distinct from 1 (missing DATABASE_URL / no keys) and
+    # 2 (retry-cap abort).  Only fires for county-scoped runs; a full rebuild
+    # with zero validation passes is unusual but not immediately actionable.
+    if validation_zero_pass_reason is not None:
+        logger.error(
+            "Exiting non-zero because county-scoped rebuild produced 0 "
+            "accepted/flagged rulings — see telemetry.validation_results for "
+            "details.",
+            validation_zero_pass_reason=validation_zero_pass_reason,
+        )
+        sys.exit(3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Added post-rebuild validation summary reporting to `scripts/rebuild_db.py`. When a county-scoped rebuild produces zero accepted/flagged rulings (all events fail validation), the script now exits with code 3 and logs a clear error message pointing to `telemetry.validation_results` for details. This eliminates the silent-failure mode that previously required manual DB queries to diagnose.

Closes #2607

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — 94/94 tests pass, 10 new tests in TestValidationSummary
- [x] CI green

### Post-deploy verification

- [ ] Run `scripts/rebuild_db.py --reset --county "San Diego"` on dev and confirm:
  - Validation summary logged with counts (accepted/flagged/rejected/errors)
  - If zero events pass validation, script exits with code 3 (not 0)
  - Error message references telemetry.validation_results for details
- [ ] Verification evidence posted on #2607 (see /task-v2-verify output)