### PR TITLE
feat(dx): add dedup/orphan rate observability query (#2654)

### DIFF
--- a/docs/agent/observability.md
+++ b/docs/agent/observability.md
@@ -1,0 +1,53 @@
+# Ingestion Pipeline Observability
+
+Agent reference for spot-checking pipeline health signals via
+`telemetry.data_quality_metrics`.
+
+## Canonical dedup and orphan metrics
+
+Two metrics track the most common silent-failure modes in the ingestion pipeline:
+
+| `metric_name` | What it counts | Emitter |
+|---|---|---|
+| `content_hash_dedup_supersede` | Documents deduplicated by content hash (re-captures of an already-stored ruling) | `packages/scraper-framework/src/ingestion/db.py:1819` |
+| `zero_ruling_extraction` | Documents processed by the LLM that returned zero rulings | `packages/scraper-framework/src/ingestion/worker.py:2620` |
+
+Both metrics write one row per event to `telemetry.data_quality_metrics` with
+`metric_value = 1` and a `metadata` JSONB blob containing `county`, `scraper_id`,
+and the document's S3 key.
+
+See `packages/scraper-framework/src/telemetry/README.md` for the full telemetry
+event catalog.
+
+## Running the 30-day dedup/orphan rate query
+
+```bash
+scripts/dev-db-query.sh --file scripts/dq_queries/dedup_orphan_rate_30d.sql
+```
+
+Returns per-county, per-day event counts and `metric_value` sums for the two
+metrics above, over the last 30 days.
+
+**Reading the output:**
+
+- **Zero rows** is acceptable for very new metric names; a healthy dev instance
+  should have at least one row within a week of deploy.
+- **Rising `event_count` on `content_hash_dedup_supersede`** means dedup is
+  firing more often — normal during re-capture backfills or after a scraper
+  produces duplicates. Sustained rises on a single county without a known
+  backfill are worth investigating.
+- **Rising `event_count` on `zero_ruling_extraction`** means more documents are
+  being processed without extracting any rulings. Investigate if the trend
+  persists over multiple days — likely causes are a new non-ruling PDF type
+  slipping past capture-side filters, or an LLM regression.
+
+## Related resources
+
+- `docs/runbooks/data-quality-monitoring.md` — operational runbook for the
+  hourly data quality check and the `/admin/data-quality` dashboard.
+- `packages/scraper-framework/src/telemetry/README.md` — full catalog of
+  structured telemetry events and their `telemetry.data_quality_metrics` shapes.
+- `packages/api/migrations/6_data-quality-metrics.sql` — table definition.
+- `packages/api/migrations/15_schema-reorganization.sql` — moved the table to
+  the `telemetry` schema; `search_path` includes `telemetry` so unqualified
+  references still resolve.

--- a/scripts/dq_queries/dedup_orphan_rate_30d.sql
+++ b/scripts/dq_queries/dedup_orphan_rate_30d.sql
@@ -1,0 +1,36 @@
+-- dedup_orphan_rate_30d.sql
+-- Per-county, per-day counts of dedup and orphan events for the last 30 days.
+--
+-- Issue: https://github.com/judgemind/judgemind/issues/2654
+-- Parent: https://github.com/judgemind/judgemind/issues/2569
+--
+-- Metric emitters:
+--   content_hash_dedup_supersede  — packages/scraper-framework/src/ingestion/db.py:1819
+--   zero_ruling_extraction        — packages/scraper-framework/src/ingestion/worker.py:2620
+--
+-- Run via:
+--   scripts/dev-db-query.sh --file scripts/dq_queries/dedup_orphan_rate_30d.sql
+--
+-- Reading the output:
+--   Zero rows is acceptable for very new metrics; a healthy dev instance
+--   should have at least one row within a week of deploy.
+--   Rising event_count on content_hash_dedup_supersede means dedup is firing
+--   more often (normal steady-state or a burst of re-captures).
+--   Rising event_count on zero_ruling_extraction means more documents are
+--   being processed without extracting any rulings (possible scraper or
+--   LLM regression — investigate if trend persists over multiple days).
+
+SELECT
+    county,
+    metric_name,
+    DATE_TRUNC('day', recorded_at AT TIME ZONE 'UTC')::date AS day,
+    COUNT(*)                                                 AS event_count,
+    SUM(metric_value)                                        AS metric_value_sum
+FROM telemetry.data_quality_metrics
+WHERE metric_name IN (
+    'content_hash_dedup_supersede',
+    'zero_ruling_extraction'
+)
+  AND recorded_at >= NOW() - INTERVAL '30 days'
+GROUP BY county, metric_name, DATE_TRUNC('day', recorded_at AT TIME ZONE 'UTC')::date
+ORDER BY day DESC, county, metric_name;


### PR DESCRIPTION
## Summary

Added a canned SQL query (`scripts/dq_queries/dedup_orphan_rate_30d.sql`) that reports per-county, per-day counts of `content_hash_dedup_supersede` and `zero_ruling_extraction` telemetry events over the last 30 days, with documentation in `docs/agent/observability.md` to guide agents on invocation, output interpretation, and pipeline health assessment.

Closes #2654

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] Query returns rows when run via `scripts/dev-db-query.sh --file scripts/dq_queries/dedup_orphan_rate_30d.sql` (acceptable to have zero rows for very new metrics; a healthy dev has at least one row within a week of deploy)
- [ ] Verification evidence posted on #2654 (see /task-v2-verify output)