### PR TITLE
fix(ingestion): protect dedup supersede operations with savepoints (#2660)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -1760,6 +1760,9 @@ def insert_ruling(
         # Fetch county and s3_key for the loser so we can emit a
         # per-county telemetry metric and a structured WARN log.  Best-
         # effort — failure to fetch doesn't prevent the supersede.
+        # Savepoint-protected so a transient error doesn't abort the outer
+        # transaction (mirrors the zero_ruling_metric pattern in worker.py).
+        cur.execute("SAVEPOINT supersede_ctx")
         try:
             cur.execute(
                 "SELECT c.county, d.s3_key FROM documents d "
@@ -1771,8 +1774,9 @@ def insert_ruling(
             if ctx_row is not None:
                 county_for_metric = ctx_row[0]
                 s3_key_for_log = ctx_row[1]
+            cur.execute("RELEASE SAVEPOINT supersede_ctx")
         except Exception:  # noqa: BLE001 — telemetry lookup is best-effort
-            pass
+            cur.execute("ROLLBACK TO SAVEPOINT supersede_ctx")
 
         cur.execute(
             "DELETE FROM rulings WHERE document_id = %s::uuid",
@@ -1806,7 +1810,10 @@ def insert_ruling(
         # (e.g. the document row doesn't exist yet in this transaction's
         # visible snapshot), skip — we don't want a telemetry write to
         # break the primary supersede path.
+        # Savepoint-protected so a transient error doesn't abort the outer
+        # transaction (mirrors the zero_ruling_metric pattern in worker.py).
         if county_for_metric is not None:
+            cur.execute("SAVEPOINT supersede_metric")
             try:
                 cur.execute(
                     """
@@ -1829,8 +1836,9 @@ def insert_ruling(
                         ),
                     ),
                 )
+                cur.execute("RELEASE SAVEPOINT supersede_metric")
             except Exception:  # noqa: BLE001 — telemetry is best-effort
-                pass
+                cur.execute("ROLLBACK TO SAVEPOINT supersede_metric")
 
     logger.warning(
         "insert_ruling: content-hash dedup — superseded losing document",

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -2084,6 +2084,110 @@ class TestInsertRulingContentDedup:
         assert "SAVEPOINT ruling_insert" in sql_stmts
         assert "RELEASE SAVEPOINT ruling_insert" in sql_stmts
 
+    def test_supersede_context_select_failure_does_not_abort_supersede(self) -> None:
+        """A failing context SELECT must not abort the supersede — SAVEPOINT protects it.
+
+        When ``cur.execute`` raises on the context lookup, the primary supersede
+        (DELETE FROM rulings + UPDATE documents) must still run, and
+        ``ROLLBACK TO SAVEPOINT supersede_ctx`` must have been issued.
+        """
+        import psycopg.errors
+
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        unique_exc = psycopg.errors.UniqueViolation(
+            "duplicate key value violates unique constraint"
+        )
+        context_exc = psycopg.errors.QueryCanceled("query was canceled")
+
+        def side_effect_execute(sql: str, params: tuple | None = None) -> None:
+            if "INSERT INTO rulings" in sql:
+                raise unique_exc
+            if "SELECT c.county" in sql:
+                raise context_exc
+
+        cur.execute = MagicMock(side_effect=side_effect_execute)
+        # Winner lookup returns a row; context lookup raises (never reaches fetchone).
+        cur.fetchone = MagicMock(return_value=("winner-doc-id",))
+
+        insert_ruling(
+            conn,
+            document_id="losing-doc",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+        )
+
+        execute_calls = cur.execute.call_args_list
+        sql_stmts = [call[0][0] for call in execute_calls]
+
+        # SAVEPOINT was issued before the context SELECT.
+        assert "SAVEPOINT supersede_ctx" in sql_stmts
+        # ROLLBACK was issued because the SELECT raised.
+        assert "ROLLBACK TO SAVEPOINT supersede_ctx" in sql_stmts
+        # Primary supersede still ran.
+        assert any("DELETE FROM rulings" in s for s in sql_stmts), (
+            "DELETE FROM rulings must run even when context SELECT raises."
+        )
+        assert any("UPDATE documents" in s and "superseded" in s for s in sql_stmts), (
+            "UPDATE documents … superseded must run even when context SELECT raises."
+        )
+
+    def test_supersede_metric_insert_failure_does_not_abort_supersede(self) -> None:
+        """A failing metric INSERT must not abort the supersede — SAVEPOINT protects it.
+
+        When ``cur.execute`` raises on the ``data_quality_metrics`` INSERT, the
+        outer UPDATE documents must already have run (it precedes the metric write),
+        and ``ROLLBACK TO SAVEPOINT supersede_metric`` must have been issued.
+        """
+        import psycopg.errors
+
+        conn = _mock_conn()
+        cur = conn.cursor.return_value.__enter__.return_value
+        unique_exc = psycopg.errors.UniqueViolation(
+            "duplicate key value violates unique constraint"
+        )
+        metric_exc = Exception("metric insert failure")
+
+        def side_effect_execute(sql: str, params: tuple | None = None) -> None:
+            if "INSERT INTO rulings" in sql:
+                raise unique_exc
+            if "INSERT INTO data_quality_metrics" in sql:
+                raise metric_exc
+
+        cur.execute = MagicMock(side_effect=side_effect_execute)
+        # Winner lookup returns a row; county lookup returns a county.
+        cur.fetchone = MagicMock(
+            side_effect=[
+                ("winner-doc-id",),
+                ("Contra Costa", "ca-contra_costa/some.pdf"),
+            ]
+        )
+
+        insert_ruling(
+            conn,
+            document_id="losing-doc",
+            case_id="case-1",
+            court_id="court-1",
+            hearing_date=date(2026, 3, 5),
+            ruling_text="Motion GRANTED",
+            department="Dept. 1",
+        )
+
+        execute_calls = cur.execute.call_args_list
+        sql_stmts = [call[0][0] for call in execute_calls]
+
+        # SAVEPOINT was issued before the metric INSERT.
+        assert "SAVEPOINT supersede_metric" in sql_stmts
+        # ROLLBACK was issued because the INSERT raised.
+        assert "ROLLBACK TO SAVEPOINT supersede_metric" in sql_stmts
+        # Primary supersede UPDATE ran (precedes metric write).
+        assert any("UPDATE documents" in s and "superseded" in s for s in sql_stmts), (
+            "UPDATE documents … superseded must have run before metric INSERT attempted."
+        )
+
 
 # ---------------------------------------------------------------------------
 # _is_all_caps_title


### PR DESCRIPTION
## Summary

Wrapped the best-effort context SELECT and data_quality_metrics INSERT in insert_ruling's supersede path with SAVEPOINT/ROLLBACK TO SAVEPOINT pairs (supersede_ctx and supersede_metric), mirroring the zero_ruling_metric pattern from worker.py. Added two regression tests asserting that failures in each block do not abort the outer transaction.

Closes #2660

## Test plan

### Automated checks

- [ ] Lint passes (`ruff check`)
- [ ] Format check passes (`ruff format --check`)
- [ ] Tests pass (`pytest`)
- [ ] CI green

### Post-deploy verification

- [ ] Verify via `/task-v2-verify` post-deploy on dev environment