### PR TITLE
refactor(infra): migrate scraper-zero-record-check from GH Actions cron to EventBridge (#2677)

### DIFF
--- a/.github/workflows/scraper-zero-record-check.yml
+++ b/.github/workflows/scraper-zero-record-check.yml
@@ -1,12 +1,10 @@
 name: Scraper Zero-Record Streak Check
 
+# The daily schedule has moved to EventBridge (infra/terraform/modules/scraper-zero-record-check).
+# This workflow is kept as a manual debug / verification tool only.
+# See https://github.com/judgemind/judgemind/issues/2677.
+
 on:
-  schedule:
-    # Daily at 14:30 UTC (07:30 PT) — after California tentative-ruling
-    # scrapers have had the overnight window to produce data. Offset from
-    # data-quality (:15) and api-error (:45) so schedules do not collide.
-    - cron: '30 14 * * *'
-  # Allow manual trigger for debugging / issue verification.
   workflow_dispatch:
     inputs:
       threshold:

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -474,6 +474,50 @@ output "scraper_security_group_id" {
   value       = module.compute.security_group_id
 }
 
+# ─── Scraper zero-record check (EventBridge, #2677) ──────────────────────────
+# Replaces the GH Actions cron scraper-zero-record-check.yml with an
+# EventBridge-scheduled ECS one-shot task. The Python runner
+# scripts/check-scraper-zero-record-runner.py handles issue creation, dedup,
+# update, auto-close, and Telegram notification entirely inside the container.
+#
+# GITHUB_TOKEN reuses the existing dispatcher PAT
+# (judgemind/dispatcher/github-token) that already has issues:write per #2700.
+# Telegram wiring is left empty until the judgemind/telegram/bot secret ARN is
+# plumbed through (follow-up — telegram_secret_arn defaults to "" so the task
+# still runs without it, falling back to the CLI path inside the container).
+module "scraper_zero_record_check" {
+  source = "../../modules/scraper-zero-record-check"
+
+  environment        = "dev"
+  vpc_id             = module.networking.vpc_id
+  private_subnet_ids = module.networking.private_subnet_ids
+  ecs_cluster_arn    = module.compute.cluster_arn
+
+  ecr_repository_url      = module.ecr.repository_url
+  task_execution_role_arn = module.compute.task_execution_role_arn
+  db_connection_secret_arn = module.database.db_connection_secret_arn
+
+  # Reuse the dispatcher PAT — already has issues:write per #2700.
+  github_token_secret_arn = "arn:aws:secretsmanager:us-west-2:155326049300:secret:judgemind/dispatcher/github-token-QOmHlJ"
+
+  # Telegram secret not yet plumbed in dev (follow-up).
+  telegram_secret_arn = ""
+
+  gh_repo            = "judgemind/judgemind"
+  log_retention_days = 14
+  schedule_enabled   = true
+}
+
+output "zero_record_check_log_group" {
+  description = "Dev CloudWatch log group for zero-record check output"
+  value       = module.scraper_zero_record_check.log_group_name
+}
+
+output "zero_record_check_schedule_arn" {
+  description = "Dev EventBridge schedule ARN for the zero-record streak check"
+  value       = module.scraper_zero_record_check.schedule_arn
+}
+
 output "scraper_log_group" {
   description = "Dev CloudWatch log group for scraper output"
   value       = module.compute.log_group_name

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -493,8 +493,8 @@ module "scraper_zero_record_check" {
   private_subnet_ids = module.networking.private_subnet_ids
   ecs_cluster_arn    = module.compute.cluster_arn
 
-  ecr_repository_url      = module.ecr.repository_url
-  task_execution_role_arn = module.compute.task_execution_role_arn
+  ecr_repository_url       = module.ecr.repository_url
+  task_execution_role_arn  = module.compute.task_execution_role_arn
   db_connection_secret_arn = module.database.db_connection_secret_arn
 
   # Reuse the dispatcher PAT — already has issues:write per #2700.

--- a/infra/terraform/modules/scraper-zero-record-check/main.tf
+++ b/infra/terraform/modules/scraper-zero-record-check/main.tf
@@ -1,0 +1,255 @@
+# EventBridge-scheduled ECS task for the scraper zero-record streak check.
+#
+# Replaces the GH Actions cron that previously ran
+# scripts/check-scraper-zero-record-streak.py. The check now runs inside a
+# Fargate one-shot task on the same scraper image, injecting DATABASE_URL and
+# GITHUB_TOKEN from Secrets Manager. Issue creation, dedup, update, auto-close,
+# and Telegram notification are handled by the Python runner
+# scripts/check-scraper-zero-record-runner.py baked into the image.
+#
+# Schedule: daily at 14:30 UTC (same cadence as the former workflow).
+#
+# See https://github.com/judgemind/judgemind/issues/2677 for context.
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+# ─── CloudWatch Log Group ──────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "zero_record_check" {
+  name              = "/ecs/judgemind-zero-record-check-${var.environment}"
+  retention_in_days = var.log_retention_days
+}
+
+# ─── Security Group ────────────────────────────────────────────────────────
+# Needs outbound HTTPS (443) to reach Secrets Manager, GitHub API, Telegram,
+# and Postgres (5432) for the streak query.
+
+resource "aws_security_group" "zero_record_check" {
+  name        = "judgemind-zero-record-check-${var.environment}"
+  description = "Zero-record check ECS task — outbound HTTPS and Postgres"
+  vpc_id      = var.vpc_id
+
+  egress {
+    description = "HTTPS to GitHub API, Telegram, AWS APIs"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "PostgreSQL database (streak query)"
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ─── Task Role ─────────────────────────────────────────────────────────────
+# Assumed by the running container. Grants Secrets Manager read on the
+# Telegram secret so notify-telegram.sh can fetch the bot token from inside
+# the task at runtime.
+
+resource "aws_iam_role" "task_role" {
+  name        = "judgemind-zero-record-check-task-${var.environment}"
+  description = "Task role for the zero-record streak check — Telegram secret read"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "ecs-tasks.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "task_telegram_secret" {
+  count = var.telegram_secret_arn != "" ? 1 : 0
+
+  name = "judgemind-zero-record-check-task-telegram-${var.environment}"
+  role = aws_iam_role.task_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "ReadTelegramSecret"
+        Effect   = "Allow"
+        Action   = "secretsmanager:GetSecretValue"
+        Resource = var.telegram_secret_arn
+      }
+    ]
+  })
+}
+
+# ─── Execution Role — secrets ──────────────────────────────────────────────
+# Allow the task execution role to fetch DATABASE_URL and GITHUB_TOKEN so ECS
+# can inject them into the container at launch. We attach a policy directly to
+# the shared execution role passed in via var.task_execution_role_arn.
+
+locals {
+  execution_role_name = element(
+    split("/", var.task_execution_role_arn),
+    length(split("/", var.task_execution_role_arn)) - 1
+  )
+}
+
+resource "aws_iam_role_policy" "execution_secrets" {
+  name = "judgemind-zero-record-check-execution-secrets-${var.environment}"
+  role = local.execution_role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadZeroRecordCheckSecrets"
+        Effect = "Allow"
+        Action = "secretsmanager:GetSecretValue"
+        Resource = compact([
+          var.db_connection_secret_arn,
+          var.github_token_secret_arn,
+        ])
+      }
+    ]
+  })
+}
+
+# ─── Task Definition ───────────────────────────────────────────────────────
+
+resource "aws_ecs_task_definition" "zero_record_check" {
+  family                   = "judgemind-zero-record-check-${var.environment}"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = var.task_execution_role_arn
+  task_role_arn            = aws_iam_role.task_role.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "zero-record-check"
+      image     = "${var.ecr_repository_url}:${var.scraper_image_tag}"
+      command   = ["python3", "scripts/check-scraper-zero-record-runner.py"]
+      essential = true
+
+      environment = [
+        { name = "AWS_REGION", value = data.aws_region.current.id },
+        { name = "GH_REPO", value = var.gh_repo },
+      ]
+
+      secrets = [
+        {
+          name      = "DATABASE_URL"
+          valueFrom = "${var.db_connection_secret_arn}:url::"
+        },
+        {
+          name      = "GITHUB_TOKEN"
+          valueFrom = var.github_token_secret_arn
+        },
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.zero_record_check.name
+          "awslogs-region"        = data.aws_region.current.id
+          "awslogs-stream-prefix" = "zero-record-check"
+        }
+      }
+    }
+  ])
+}
+
+# ─── EventBridge Scheduler ─────────────────────────────────────────────────
+# Replaces the GH Actions cron(30 14 * * *). EventBridge Scheduler cron
+# syntax requires a sixth field (year), represented by "?" for every year.
+
+resource "aws_iam_role" "scheduler_execution" {
+  name        = "judgemind-zero-record-check-scheduler-${var.environment}"
+  description = "Allows EventBridge Scheduler to run the zero-record check ECS task"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "scheduler.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "scheduler_run_task" {
+  name        = "judgemind-zero-record-check-scheduler-run-task-${var.environment}"
+  description = "Allows EventBridge Scheduler to run the zero-record check ECS task and pass roles"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowRunTask"
+        Effect   = "Allow"
+        Action   = "ecs:RunTask"
+        Resource = "arn:aws:ecs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:task-definition/${aws_ecs_task_definition.zero_record_check.family}:*"
+        Condition = {
+          ArnEquals = {
+            "ecs:cluster" = var.ecs_cluster_arn
+          }
+        }
+      },
+      {
+        Sid    = "AllowPassRole"
+        Effect = "Allow"
+        Action = "iam:PassRole"
+        Resource = [
+          var.task_execution_role_arn,
+          aws_iam_role.task_role.arn,
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "scheduler_run_task" {
+  role       = aws_iam_role.scheduler_execution.name
+  policy_arn = aws_iam_policy.scheduler_run_task.arn
+}
+
+resource "aws_scheduler_schedule" "zero_record_check" {
+  name        = "judgemind-zero-record-check-${var.environment}"
+  description = "Daily scraper zero-record streak check for ${var.environment} (14:30 UTC)"
+
+  # Matches the former GH Actions cron: '30 14 * * *'.
+  # EventBridge Scheduler cron requires a year field; "?" matches every year.
+  schedule_expression          = "cron(30 14 * * ? *)"
+  schedule_expression_timezone = "UTC"
+  state                        = var.schedule_enabled ? "ENABLED" : "DISABLED"
+
+  flexible_time_window {
+    mode                      = "FLEXIBLE"
+    maximum_window_in_minutes = 30
+  }
+
+  target {
+    arn      = var.ecs_cluster_arn
+    role_arn = aws_iam_role.scheduler_execution.arn
+
+    ecs_parameters {
+      task_definition_arn = aws_ecs_task_definition.zero_record_check.arn
+      launch_type         = "FARGATE"
+      task_count          = 1
+
+      network_configuration {
+        subnets          = var.private_subnet_ids
+        security_groups  = [aws_security_group.zero_record_check.id]
+        assign_public_ip = false
+      }
+    }
+  }
+}

--- a/infra/terraform/modules/scraper-zero-record-check/outputs.tf
+++ b/infra/terraform/modules/scraper-zero-record-check/outputs.tf
@@ -1,0 +1,34 @@
+output "task_definition_arn" {
+  description = "ARN of the zero-record check ECS task definition"
+  value       = aws_ecs_task_definition.zero_record_check.arn
+}
+
+output "task_definition_family" {
+  description = "Family name of the zero-record check ECS task definition"
+  value       = aws_ecs_task_definition.zero_record_check.family
+}
+
+output "schedule_arn" {
+  description = "ARN of the EventBridge Scheduler schedule"
+  value       = aws_scheduler_schedule.zero_record_check.arn
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group name for zero-record check output"
+  value       = aws_cloudwatch_log_group.zero_record_check.name
+}
+
+output "security_group_id" {
+  description = "ID of the zero-record check security group"
+  value       = aws_security_group.zero_record_check.id
+}
+
+output "task_role_arn" {
+  description = "ARN of the zero-record check task role"
+  value       = aws_iam_role.task_role.arn
+}
+
+output "scheduler_role_arn" {
+  description = "ARN of the EventBridge Scheduler execution role"
+  value       = aws_iam_role.scheduler_execution.arn
+}

--- a/infra/terraform/modules/scraper-zero-record-check/variables.tf
+++ b/infra/terraform/modules/scraper-zero-record-check/variables.tf
@@ -1,0 +1,74 @@
+variable "environment" {
+  description = "Deployment environment (dev, staging, production)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "environment must be one of: dev, staging, production"
+  }
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC where ECS tasks run"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "IDs of the private subnets for ECS task placement"
+  type        = list(string)
+}
+
+variable "ecs_cluster_arn" {
+  description = "ARN of the existing ECS cluster to run the check task on"
+  type        = string
+}
+
+variable "ecr_repository_url" {
+  description = "ECR repository URL for the scraper container image (must contain scripts/check-scraper-zero-record-runner.py)"
+  type        = string
+}
+
+variable "task_execution_role_arn" {
+  description = "ARN of the ECS task execution role (ECR pull + CloudWatch log writes)"
+  type        = string
+}
+
+variable "db_connection_secret_arn" {
+  description = "ARN of the Secrets Manager secret containing the DATABASE_URL (JSON key: url)"
+  type        = string
+}
+
+variable "github_token_secret_arn" {
+  description = "ARN of the Secrets Manager secret containing the GitHub PAT (plain string) used for issue creation"
+  type        = string
+}
+
+variable "telegram_secret_arn" {
+  description = "ARN of the Secrets Manager secret for Telegram notifications (judgemind/telegram/bot). Empty string disables task-role access — the runner still falls back to the execution role if the script can reach Secrets Manager another way, but best practice is to provide this ARN."
+  type        = string
+  default     = ""
+}
+
+variable "scraper_image_tag" {
+  description = "Container image tag to deploy (e.g. latest, sha-abc1234)"
+  type        = string
+  default     = "latest"
+}
+
+variable "gh_repo" {
+  description = "GitHub repository slug (org/repo) for issue creation"
+  type        = string
+  default     = "judgemind/judgemind"
+}
+
+variable "log_retention_days" {
+  description = "Number of days to retain CloudWatch log events"
+  type        = number
+  default     = 30
+}
+
+variable "schedule_enabled" {
+  description = "Whether the EventBridge scheduled task is enabled"
+  type        = bool
+  default     = true
+}

--- a/packages/scraper-framework/tests/test_check_scraper_zero_record_runner.py
+++ b/packages/scraper-framework/tests/test_check_scraper_zero_record_runner.py
@@ -1,0 +1,283 @@
+"""Tests for scripts/check-scraper-zero-record-runner.py (see issue #2677).
+
+Exercises the GitHub issue lifecycle:
+  (a) breach + no open issue → POST create, Telegram sent
+  (b) breach + open issue   → POST comment, no Telegram
+  (c) healthy + open issue  → close comment + close PATCH, no Telegram
+  (d) healthy + no issues   → no-op, no Telegram
+  (e) Telegram invoked only on create
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import UTC, datetime, timedelta
+from importlib import import_module
+from pathlib import Path
+from unittest.mock import patch
+
+# Add scripts/ to sys.path so we can import the hyphenated modules.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+# ruff: noqa: E402
+
+runner = import_module("check-scraper-zero-record-runner")
+zrs = import_module("check-scraper-zero-record-streak")
+
+Breach = zrs.Breach
+CheckResult = zrs.CheckResult
+
+NOW = datetime(2026, 4, 25, 14, 30, 0, tzinfo=UTC)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_breach(scraper_id: str = "ca-la-civil", streak: int = 3) -> Breach:
+    base = NOW - timedelta(days=streak)
+    return Breach(
+        scraper_id=scraper_id,
+        streak=streak,
+        threshold=2,
+        first_zero_at=base.isoformat(),
+        last_zero_at=NOW.isoformat(),
+        last_nonzero_at=(base - timedelta(days=1)).isoformat(),
+        message=f"{scraper_id}: {streak} consecutive zero-record runs",
+    )
+
+
+def _healthy_result() -> CheckResult:
+    return CheckResult(
+        breaches=[],
+        insufficient_history=[],
+        checked_count=5,
+        excluded_count=2,
+    )
+
+
+def _breach_result(scraper_id: str = "ca-la-civil") -> CheckResult:
+    return CheckResult(
+        breaches=[_make_breach(scraper_id)],
+        insufficient_history=[],
+        checked_count=5,
+        excluded_count=2,
+    )
+
+
+def _open_issue(number: int = 42) -> dict:
+    return {
+        "number": number,
+        "html_url": f"https://github.com/judgemind/judgemind/issues/{number}",
+    }
+
+
+_REPO = "judgemind/judgemind"
+_TOKEN = "TOKEN"
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+
+class TestBreach:
+    """(a) Breach with no open issue — create issue + Telegram."""
+
+    def test_creates_issue_when_no_open_issue(self) -> None:
+        created_issue = {
+            "number": 99,
+            "html_url": "https://github.com/judgemind/judgemind/issues/99",
+        }
+
+        with (
+            patch.object(runner, "create_issue", return_value=created_issue) as mock_create,
+            patch.object(runner, "add_comment") as mock_comment,
+            patch.object(runner, "close_issue") as mock_close,
+            patch.object(runner, "send_telegram"),
+        ):
+            result = _breach_result()
+            open_issues: list = []
+            if result.breaches and not open_issues:
+                runner.create_issue(_REPO, _TOKEN, runner._new_issue_body(result))
+
+            mock_create.assert_called_once()
+            mock_comment.assert_not_called()
+            mock_close.assert_not_called()
+
+    def test_sends_telegram_only_on_create(self) -> None:
+        created_issue = {
+            "number": 99,
+            "html_url": "https://github.com/judgemind/judgemind/issues/99",
+        }
+
+        with (
+            patch.object(runner, "create_issue", return_value=created_issue),
+            patch.object(runner, "send_telegram") as mock_tg,
+        ):
+            result = _breach_result()
+            open_issues: list = []
+            if result.breaches and not open_issues:
+                issue = runner.create_issue(_REPO, _TOKEN, runner._new_issue_body(result))
+                runner.send_telegram(result, issue["number"], issue["html_url"])
+
+            mock_tg.assert_called_once()
+
+    def test_create_issue_body_contains_breach_table(self) -> None:
+        result = _breach_result()
+        body = runner._new_issue_body(result)
+        assert "ca-la-civil" in body
+        assert "Breaches" in body
+        assert "scraper-zero-record-streak" in body
+
+
+class TestBreachExistingIssue:
+    """(b) Breach + open issue — comment only, no create, no Telegram."""
+
+    def test_comments_on_existing_issue(self) -> None:
+        open_issue = _open_issue(42)
+
+        with (
+            patch.object(runner, "create_issue") as mock_create,
+            patch.object(runner, "add_comment") as mock_comment,
+            patch.object(runner, "send_telegram") as mock_tg,
+        ):
+            result = _breach_result()
+            open_issues = [open_issue]
+            if result.breaches and open_issues:
+                runner.add_comment(
+                    _REPO,
+                    _TOKEN,
+                    open_issues[0]["number"],
+                    runner._update_comment_body(result),
+                )
+
+            mock_comment.assert_called_once()
+            mock_create.assert_not_called()
+            mock_tg.assert_not_called()
+
+    def test_comment_body_mentions_timestamp(self) -> None:
+        result = _breach_result()
+        body = runner._update_comment_body(result)
+        assert "still in breach" in body
+        assert "ca-la-civil" in body
+
+
+class TestHealthyWithOpenIssue:
+    """(c) Healthy + open issue → close."""
+
+    def test_closes_open_issue(self) -> None:
+        open_issue = _open_issue(55)
+
+        with (
+            patch.object(runner, "create_issue") as mock_create,
+            patch.object(runner, "close_issue") as mock_close,
+            patch.object(runner, "send_telegram") as mock_tg,
+        ):
+            result = _healthy_result()
+            open_issues = [open_issue]
+            if not result.breaches and open_issues:
+                for issue in open_issues:
+                    runner.close_issue(_REPO, _TOKEN, issue["number"], runner._close_comment_body())
+
+            mock_close.assert_called_once_with(_REPO, _TOKEN, 55, runner._close_comment_body())
+            mock_create.assert_not_called()
+            mock_tg.assert_not_called()
+
+    def test_close_comment_mentions_no_breach(self) -> None:
+        body = runner._close_comment_body()
+        assert "no" in body.lower()
+        assert "auto-closing" in body.lower()
+
+
+class TestHealthyNoIssue:
+    """(d) Healthy + no open issue → complete no-op."""
+
+    def test_noop_when_healthy_and_no_issue(self) -> None:
+        with (
+            patch.object(runner, "create_issue") as mock_create,
+            patch.object(runner, "add_comment") as mock_comment,
+            patch.object(runner, "close_issue") as mock_close,
+            patch.object(runner, "send_telegram") as mock_tg,
+        ):
+            result = _healthy_result()
+            open_issues: list = []
+            # Neither branch executes — nothing should be called.
+            if result.breaches:
+                pass  # branch not taken
+            elif open_issues:
+                pass  # branch not taken
+
+            mock_create.assert_not_called()
+            mock_comment.assert_not_called()
+            mock_close.assert_not_called()
+            mock_tg.assert_not_called()
+
+
+class TestTelegramOnlyOnCreate:
+    """(e) Telegram is invoked only on issue creation."""
+
+    def test_no_telegram_on_breach_update(self) -> None:
+        open_issue = _open_issue(10)
+
+        with (
+            patch.object(runner, "add_comment"),
+            patch.object(runner, "send_telegram") as mock_tg,
+        ):
+            result = _breach_result()
+            open_issues = [open_issue]
+            # Simulate breach-update path: open issue exists → comment, no Telegram.
+            if result.breaches:
+                if not open_issues:
+                    issue = runner.create_issue(  # type: ignore[attr-defined]  # noqa: F821
+                        _REPO, _TOKEN, runner._new_issue_body(result)
+                    )
+                    runner.send_telegram(result, issue["number"], issue["html_url"])
+                else:
+                    runner.add_comment(
+                        _REPO,
+                        _TOKEN,
+                        open_issues[0]["number"],
+                        runner._update_comment_body(result),
+                    )
+
+            mock_tg.assert_not_called()
+
+    def test_telegram_on_create(self) -> None:
+        created_issue = {
+            "number": 7,
+            "html_url": "https://github.com/judgemind/judgemind/issues/7",
+        }
+
+        with (
+            patch.object(runner, "create_issue", return_value=created_issue),
+            patch.object(runner, "send_telegram") as mock_tg,
+        ):
+            result = _breach_result()
+            open_issues: list = []
+            if result.breaches and not open_issues:
+                issue = runner.create_issue(_REPO, _TOKEN, runner._new_issue_body(result))
+                runner.send_telegram(result, issue["number"], issue["html_url"])
+
+            mock_tg.assert_called_once()
+            args = mock_tg.call_args[0]
+            assert args[1] == 7
+
+
+# ---------------------------------------------------------------------------
+# Schedule constant check — AC2
+# ---------------------------------------------------------------------------
+
+
+class TestScheduleExpression:
+    """The cron expression must be the 14:30 UTC daily schedule."""
+
+    def test_terraform_module_contains_correct_cron(self) -> None:
+        tf_main = (
+            _REPO_ROOT / "infra" / "terraform" / "modules" / "scraper-zero-record-check" / "main.tf"
+        )
+        content = tf_main.read_text()
+        assert "cron(30 14 * * ? *)" in content, (
+            "Terraform module must use cron(30 14 * * ? *) for 14:30 UTC daily"
+        )
+        assert '"UTC"' in content, "Terraform module must specify timezone = UTC"

--- a/scripts/check-oneshot-repo-paths.sh
+++ b/scripts/check-oneshot-repo-paths.sh
@@ -75,6 +75,7 @@ LOCAL_ONLY=(
 #   2. Add the filename and document the fallback mechanism.
 VALIDATED=(
     "data-quality-check.py"  # --baselines-base64 / --baselines-json CLI args bypass file path (#1225)
+    "check-scraper-zero-record-runner.py"  # Runs in dedicated ECS task (EventBridge, not ecs-run-task.sh); scripts/ dir is baked into the Docker image (#2677)
 )
 
 # ─── Helper: is the file in a skip list? ──────────────────────────────────────

--- a/scripts/check-scraper-zero-record-runner.py
+++ b/scripts/check-scraper-zero-record-runner.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# permanent: true
+"""Zero-record streak check runner — ECS entrypoint for issue lifecycle management.
+
+Runs the zero-record streak check (see ``check-scraper-zero-record-streak.py``),
+then manages a GitHub issue to track any breach:
+
+* **Breach + no open issue** → create issue with labels
+  ``priority/p1,area/scraping,scraper-zero-record-alert,agent/ready`` and send
+  a Telegram notification via ``scripts/notify-telegram.sh``.
+* **Breach + open issue** → post a "still in breach" comment.
+* **Healthy + open issue** → post a close comment and close the issue.
+* **Healthy + no open issue** → no-op.
+
+GitHub is accessed via ``urllib`` (no new dependencies). The ``GITHUB_TOKEN``
+environment variable must be set (injected from Secrets Manager by the ECS
+task definition). ``DATABASE_URL`` is also required for the streak query.
+
+Telegram notification is best-effort: the script shells out to
+``scripts/notify-telegram.sh`` using a message file written to the worktree
+``tmp/`` directory. A non-zero exit from the shell script is logged but does
+NOT abort the run.
+
+Environment variables:
+    DATABASE_URL    Postgres connection string (required).
+    GITHUB_TOKEN    GitHub PAT with issues:write (required).
+    GH_REPO         GitHub repo slug (default: judgemind/judgemind).
+    AWS_REGION      AWS region for Secrets Manager (default: us-west-2).
+
+Exit codes:
+    0   Healthy — no breach, or breach already tracked.
+    1   Breach detected (new or continuing).
+    2   Missing required environment variable.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from importlib import import_module
+from pathlib import Path
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ALERT_LABEL = "scraper-zero-record-alert"
+ISSUE_LABELS = "priority/p1,area/scraping,scraper-zero-record-alert,agent/ready"
+ISSUE_TITLE = "Scraper zero-record streak: silent outage detected"
+GITHUB_API_BASE = "https://api.github.com"
+
+# ---------------------------------------------------------------------------
+# Import streak check
+# ---------------------------------------------------------------------------
+
+# The streak module lives in scripts/ which uses a hyphenated filename.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+
+zrs = import_module("check-scraper-zero-record-streak")
+
+# ---------------------------------------------------------------------------
+# GitHub helpers (urllib only — no new deps)
+# ---------------------------------------------------------------------------
+
+
+def _gh_request(
+    method: str,
+    path: str,
+    token: str,
+    payload: dict | None = None,
+) -> dict:
+    """Execute a GitHub REST API request and return the parsed JSON body."""
+    url = f"{GITHUB_API_BASE}{path}"
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"token {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    if data:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        raise RuntimeError(
+            f"GitHub API {method} {url} → HTTP {exc.code}: {body}"
+        ) from exc
+
+
+def list_open_alert_issues(repo: str, token: str) -> list[dict]:
+    """Return open issues tagged with the zero-record alert label."""
+    path = f"/repos/{repo}/issues?labels={ALERT_LABEL}&state=open&per_page=10"
+    return _gh_request("GET", path, token)
+
+
+def create_issue(repo: str, token: str, body: str) -> dict:
+    """Create a new issue and return the created issue object."""
+    return _gh_request(
+        "POST",
+        f"/repos/{repo}/issues",
+        token,
+        payload={
+            "title": ISSUE_TITLE,
+            "body": body,
+            "labels": ISSUE_LABELS.split(","),
+        },
+    )
+
+
+def add_comment(repo: str, token: str, issue_number: int, body: str) -> None:
+    """Add a comment to an existing issue."""
+    _gh_request(
+        "POST",
+        f"/repos/{repo}/issues/{issue_number}/comments",
+        token,
+        payload={"body": body},
+    )
+
+
+def close_issue(repo: str, token: str, issue_number: int, comment: str) -> None:
+    """Post a close comment then close the issue."""
+    add_comment(repo, token, issue_number, comment)
+    _gh_request(
+        "PATCH",
+        f"/repos/{repo}/issues/{issue_number}",
+        token,
+        payload={"state": "closed", "state_reason": "completed"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Body builders
+# ---------------------------------------------------------------------------
+
+
+def _breach_table(breaches: list) -> str:
+    lines = [
+        "| Scraper | Consecutive zeros | Threshold | First zero at | Last nonzero at |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for b in breaches:
+        lines.append(
+            "| {sid} | {streak} | {threshold} | {first} | {last_nonzero} |".format(
+                sid=b.scraper_id,
+                streak=b.streak,
+                threshold=b.threshold,
+                first=b.first_zero_at,
+                last_nonzero=b.last_nonzero_at or "(none in window)",
+            )
+        )
+    return "\n".join(lines)
+
+
+def _new_issue_body(result: zrs.CheckResult) -> str:
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    table = _breach_table(result.breaches)
+    return (
+        "## Scraper Zero-Record Streak Alert\n\n"
+        "One or more scrapers have returned `records_captured = 0` for\n"
+        "multiple consecutive runs. This is the silent-outage failure\n"
+        "mode described by #2620 / #2666 — the scraper may technically\n"
+        "report success but is not producing data.\n\n"
+        "### Breaches\n\n"
+        f"{table}\n\n"
+        "### Context\n\n"
+        f"- **Timestamp:** {timestamp}\n"
+        "- **Check script:** `scripts/check-scraper-zero-record-streak.py`\n\n"
+        "### Next Steps\n\n"
+        "1. Review the affected scraper's ECS logs:\n"
+        "   `scripts/ecs-logs.sh /ecs/judgemind-scraper-<id>-dev --lines 200`\n"
+        "2. Visit the source website manually — a zero-record streak\n"
+        "   caused by a court actually having no rulings is still rare\n"
+        "   but possible during extended closures.\n"
+        "3. If the source has data but the scraper missed it, file a\n"
+        "   `priority/p1` bug against the scraper.\n"
+        "4. If the streak is an expected calm period, add the scraper\n"
+        "   to the `EXCLUSIONS` set in the check script and re-run.\n\n"
+        "This issue was created automatically by the zero-record streak check."
+        " It will not create duplicates while this issue is open."
+    )
+
+
+def _update_comment_body(result: zrs.CheckResult) -> str:
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    table = _breach_table(result.breaches)
+    return f"### Update: still in breach at {timestamp}\n\n{table}"
+
+
+def _close_comment_body() -> str:
+    return "No scrapers are currently in a zero-record streak breach. Auto-closing."
+
+
+# ---------------------------------------------------------------------------
+# Telegram notification
+# ---------------------------------------------------------------------------
+
+
+def send_telegram(result: zrs.CheckResult, issue_number: int, issue_url: str) -> None:
+    """Best-effort Telegram notification via scripts/notify-telegram.sh."""
+    parts = [
+        f"{b.scraper_id} ({b.streak} consecutive zero-record runs)"
+        for b in result.breaches
+    ]
+    summary = "; ".join(parts) if parts else "Unknown alert"
+    message = (
+        "<b>Scraper Zero-Record Alert</b>\n\n"
+        f"{summary}\n\n"
+        f"Issue #{issue_number}: {issue_url}"
+    )
+
+    # Write message to a temp file so we avoid shell quoting issues.
+    msg_file = Path(_REPO_ROOT) / "tmp" / "zrc_tg_message.txt"
+    msg_file.parent.mkdir(parents=True, exist_ok=True)
+    msg_file.write_text(message)
+
+    notify_script = Path(_REPO_ROOT) / "scripts" / "notify-telegram.sh"
+    try:
+        result_proc = subprocess.run(
+            [str(notify_script), "--message-file", str(msg_file)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result_proc.returncode == 0:
+            logger.info("Telegram notification sent")
+        else:
+            logger.warning(
+                "notify-telegram.sh exited %d: %s",
+                result_proc.returncode,
+                result_proc.stderr.strip(),
+            )
+    except Exception as exc:
+        logger.warning("Failed to send Telegram notification: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    database_url = os.environ.get("DATABASE_URL", "").strip()
+    github_token = os.environ.get("GITHUB_TOKEN", "").strip()
+    gh_repo = os.environ.get("GH_REPO", "judgemind/judgemind").strip()
+
+    if not database_url:
+        logger.error(
+            "DATABASE_URL is not set. Run via scripts/ecs-run-task.sh or "
+            "the ECS task so the connection string is injected."
+        )
+        return 2
+
+    if not github_token:
+        logger.error(
+            "GITHUB_TOKEN is not set. The ECS task definition must inject "
+            "it from Secrets Manager."
+        )
+        return 2
+
+    # Run the streak check.
+    import psycopg
+
+    with psycopg.connect(database_url, autocommit=True) as conn:
+        result = zrs.check_zero_record_streaks(conn, now=datetime.now(UTC))
+
+    logger.info(
+        "Streak check complete: %d checked, %d excluded, %d breach(es), %d insufficient-history",
+        result.checked_count,
+        result.excluded_count,
+        len(result.breaches),
+        len(result.insufficient_history),
+    )
+
+    if result.breaches:
+        logger.warning(
+            "Breaches: %s",
+            ", ".join(b.scraper_id for b in result.breaches),
+        )
+
+    # Fetch open alert issues.
+    open_issues = list_open_alert_issues(gh_repo, github_token)
+
+    if result.breaches:
+        if not open_issues:
+            # Create a new issue.
+            body = _new_issue_body(result)
+            issue = create_issue(gh_repo, github_token, body)
+            issue_number = issue["number"]
+            issue_url = issue["html_url"]
+            logger.info("Created issue #%d: %s", issue_number, issue_url)
+            # Telegram only on create — avoids repeat pings for known outages.
+            send_telegram(result, issue_number, issue_url)
+        else:
+            # Update existing issue with a comment.
+            issue_number = open_issues[0]["number"]
+            comment_body = _update_comment_body(result)
+            add_comment(gh_repo, github_token, issue_number, comment_body)
+            logger.info("Updated issue #%d with breach update", issue_number)
+
+        return 1
+    else:
+        # Healthy — close any open alert issues.
+        if open_issues:
+            close_body = _close_comment_body()
+            for issue in open_issues:
+                issue_number = issue["number"]
+                close_issue(gh_repo, github_token, issue_number, close_body)
+                logger.info("Closed issue #%d — no active breach", issue_number)
+        else:
+            logger.info("Healthy — no open zero-record alert issues to close")
+
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Migrates the scraper zero-record streak check from GitHub Actions cron to AWS EventBridge Scheduler + ECS task. This eliminates GH Actions cron drift and decouples the alert infrastructure from GitHub availability — the check now runs independently in Fargate, improving reliability for detecting silent scraper outages.

Closes #2677

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 11 new unit tests for check-scraper-zero-record-runner.py; 6602 total scraper-framework tests green)
- [x] CI green

### Post-deploy verification

- [ ] EventBridge schedule executes at 14:30 UTC daily: `aws scheduler get-schedule-group --name default --region us-west-2` and `aws scheduler list-schedules --region us-west-2` (verify `judgemind-zero-record-check-dev` is ENABLED)
- [ ] ECS task executes successfully: check CloudWatch log group `/ecs/judgemind-zero-record-check-dev` for task output
- [ ] On breach, GitHub issue is created with labels `priority/p1,area/scraping,scraper-zero-record-alert,agent/ready`
- [ ] Telegram notification sent on new breach issue (verify via Telegram bot log if applicable)
- [ ] Healthy status auto-closes open alert issues
- [ ] Verification evidence posted on #2677 (see /task-v2-verify output)