### PR TITLE
fix(dx): clarify --force rule to permit --force-with-lease after rebase (#3298)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Shell-interactive prompt-prevention rules (`$()`, heredocs, inline `python -c`, 
 - Never create additional worktrees from inside a worktree via `git worktree add`. Fix bad state with `git checkout -- .` / `git clean -fd` rather than creating a new worktree.
 - Never close a task or remove a worktree without posting a verification evidence comment on the issue. See §A.8 Step 3.
 - Never merge user-visible affordances that haven't been exercised end-to-end. "The page renders" / "the service returns 200" is not evidence. Half-built behind a flag is fine; half-built and reachable by users is the bug.
-- Never bypass a safety check with `--force` or a manual workaround. When a check blocks you, trust it.
+- Never use `--force` (or `--force-with-lease`) to bypass a failing CI check or pre-push hook. `--force-with-lease` IS allowed after an intentional rebase of your own branch — see the `/task` skill A.4.
 - Never run `gh auth switch` without an explicit user instruction.
 
 ### ALWAYS — Before Acting


### PR DESCRIPTION
## Summary

Updated CLAUDE.md line 27 to clarify that `--force-with-lease` is permitted after an intentional rebase of your own branch, while still forbidding `--force` as a bypass of CI checks or pre-push hooks. The change explicitly references the `/task` skill A.4 as the canonical documentation, resolving the contradiction identified by the audit skill.

Closes #3298

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green
- [x] Markdown link check passes (`scripts/check-markdown-links.sh`)

### Post-deploy verification

- [x] N/A — docs only