### PR TITLE
chore(nlp): remove 5 unused runtime dependencies (#3296)

### DIFF
--- a/packages/nlp-pipeline/pyproject.toml
+++ b/packages/nlp-pipeline/pyproject.toml
@@ -13,15 +13,10 @@ requires-python = ">=3.12"
 license = "Apache-2.0"
 dependencies = [
     "anthropic>=0.21",
-    "openai>=1.12",
-    "redis>=5.0",
     "boto3>=1.34",
     "pydantic>=2.6",
     "structlog>=24.1",
-    "sqlalchemy>=2.0",
     "psycopg[binary]>=3.1",
-    "sentence-transformers>=2.5",
-    "qdrant-client>=1.8",
     "judgemind-config",
 ]
 


### PR DESCRIPTION
## Summary

Removed 5 unused runtime dependencies (openai, redis, sqlalchemy, sentence-transformers, qdrant-client) from `packages/nlp-pipeline/pyproject.toml`. These deps were never imported in the source code and unnecessarily bloated install time and Docker images. The 6 remaining dependencies satisfy all actual package functionality.

Closes #3296

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`) — 59 tests, 100% coverage
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (package metadata update only)