### PR TITLE
fix(infra): replace em-dash in tf descriptions; add hygiene check (#3321)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Terraform Format Check
         run: terraform fmt -check -recursive infra/terraform/
 
+      # Hygiene check: AWS rejects non-ASCII bytes in `description` fields
+      # for several resource types (security groups, IAM roles, IAM policies)
+      # at apply time. terraform validate does NOT catch this. See #3321.
+      - name: Check no non-ASCII in tf descriptions
+        run: scripts/check-no-nonascii-tf-descriptions.sh
+
       # Validate each environment. Uses -backend=false so no AWS credentials
       # are required for syntax and config validation.
       - name: Validate dev

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -388,7 +388,7 @@ output "dispatcher_agent_runner_log_group" {
 }
 
 output "dispatcher_agent_runner_task_role_arn" {
-  description = "Dev dispatcher agent-runner task role ARN (narrow: DB + PAT secret read, log-group scoped log writes — no RunTask, no ECS Exec)"
+  description = "Dev dispatcher agent-runner task role ARN (narrow: DB + PAT secret read, log-group scoped log writes -- no RunTask, no ECS Exec)"
   value       = module.dispatcher_agent_runner.task_role_arn
 }
 
@@ -438,7 +438,7 @@ output "ses_notifications_topic_arn" {
 }
 
 output "ses_dkim_tokens" {
-  description = "Dev DKIM CNAME tokens — add each as <token>._domainkey.judgemind.org CNAME <token>.dkim.amazonses.com"
+  description = "Dev DKIM CNAME tokens -- add each as <token>._domainkey.judgemind.org CNAME <token>.dkim.amazonses.com"
   value       = module.ses.dkim_tokens
 }
 
@@ -458,7 +458,7 @@ output "scraper_role_arn" {
 }
 
 output "agent_role_arn" {
-  description = "Dev agent IAM role ARN — copy into ~/.aws/config as role_arn for the judgemind-agent profile"
+  description = "Dev agent IAM role ARN -- copy into ~/.aws/config as role_arn for the judgemind-agent profile"
   value       = module.iam_agent.role_arn
 }
 
@@ -607,7 +607,7 @@ output "api_log_group" {
 }
 
 output "api_acm_validation" {
-  description = "Dev API ACM certificate DNS validation records — create these in Cloudflare"
+  description = "Dev API ACM certificate DNS validation records -- create these in Cloudflare"
   value       = module.api_service.acm_domain_validation_options
 }
 

--- a/infra/terraform/environments/production/main.tf
+++ b/infra/terraform/environments/production/main.tf
@@ -143,7 +143,7 @@ output "ses_notifications_topic_arn" {
 }
 
 output "ses_dkim_tokens" {
-  description = "Production DKIM CNAME tokens — add each as <token>._domainkey.judgemind.org CNAME <token>.dkim.amazonses.com"
+  description = "Production DKIM CNAME tokens -- add each as <token>._domainkey.judgemind.org CNAME <token>.dkim.amazonses.com"
   value       = module.ses.dkim_tokens
 }
 

--- a/infra/terraform/modules/cache/outputs.tf
+++ b/infra/terraform/modules/cache/outputs.tf
@@ -9,6 +9,6 @@ output "redis_port" {
 }
 
 output "security_group_id" {
-  description = "Security group ID — grant ingress from other resources that need Redis access"
+  description = "Security group ID -- grant ingress from other resources that need Redis access"
   value       = aws_security_group.redis.id
 }

--- a/infra/terraform/modules/compute/variables.tf
+++ b/infra/terraform/modules/compute/variables.tf
@@ -47,7 +47,7 @@ variable "task_memory" {
 }
 
 variable "schedule_expression" {
-  description = "EventBridge schedule expression — rate (e.g. rate(1 day)) or cron (e.g. cron(15 6,18 * * ? *) for 6:15 AM/PM PT)"
+  description = "EventBridge schedule expression -- rate (e.g. rate(1 day)) or cron (e.g. cron(15 6,18 * * ? *) for 6:15 AM/PM PT)"
   type        = string
   default     = "rate(1 day)"
 }

--- a/infra/terraform/modules/database/main.tf
+++ b/infra/terraform/modules/database/main.tf
@@ -165,7 +165,7 @@ output "db_port" {
 }
 
 output "db_security_group_id" {
-  description = "Security group ID — grant ingress from other resources that need DB access"
+  description = "Security group ID -- grant ingress from other resources that need DB access"
   value       = aws_security_group.db.id
 }
 

--- a/infra/terraform/modules/dispatcher-agent-runner/variables.tf
+++ b/infra/terraform/modules/dispatcher-agent-runner/variables.tf
@@ -24,19 +24,19 @@ variable "ecr_repository_url" {
 }
 
 variable "image_tag" {
-  description = "Container image tag to run. Safe to leave at `latest` for Stage 1b — daemon picks the pinned SHA at RunTask time in Stage 2."
+  description = "Container image tag to run. Safe to leave at `latest` for Stage 1b -- daemon picks the pinned SHA at RunTask time in Stage 2."
   type        = string
   default     = "latest"
 }
 
 variable "task_cpu" {
-  description = "CPU units for the Fargate task (256 = 0.25 vCPU, 512 = 0.5 vCPU, 1024 = 1 vCPU, 4096 = 4 vCPU). Default is 4096 to match the subprocess-daemon envelope — ralph workload under the 512-baseline saturated CPU at 509/512 for extended bursts (#3153)."
+  description = "CPU units for the Fargate task (256 = 0.25 vCPU, 512 = 0.5 vCPU, 1024 = 1 vCPU, 4096 = 4 vCPU). Default is 4096 to match the subprocess-daemon envelope -- ralph workload under the 512-baseline saturated CPU at 509/512 for extended bursts (#3153)."
   type        = number
   default     = 4096
 }
 
 variable "task_memory" {
-  description = "Memory (MiB) for the Fargate task. Default is 16384 (16 GiB) to match the subprocess-daemon envelope — ralph pegged memory at 1022/1024 MB for hours under the 1024-baseline (#3153). Fargate valid pair: 4096 CPU / 16384 MB."
+  description = "Memory (MiB) for the Fargate task. Default is 16384 (16 GiB) to match the subprocess-daemon envelope -- ralph pegged memory at 1022/1024 MB for hours under the 1024-baseline (#3153). Fargate valid pair: 4096 CPU / 16384 MB."
   type        = number
   default     = 16384
 }

--- a/infra/terraform/modules/dispatcher-daemon/outputs.tf
+++ b/infra/terraform/modules/dispatcher-daemon/outputs.tf
@@ -29,7 +29,7 @@ output "execution_role_arn" {
 }
 
 output "task_role_arn" {
-  description = "ARN of the dispatcher task role (assumed by the container at runtime — grants ecs:RunTask self-invocation, ECS Exec SSM, and cloudwatch:PutMetricData)"
+  description = "ARN of the dispatcher task role (assumed by the container at runtime -- grants ecs:RunTask self-invocation, ECS Exec SSM, and cloudwatch:PutMetricData)"
   value       = aws_iam_role.task.arn
 }
 

--- a/infra/terraform/modules/dispatcher-daemon/variables.tf
+++ b/infra/terraform/modules/dispatcher-daemon/variables.tf
@@ -24,7 +24,7 @@ variable "ecs_cluster_arn" {
 }
 
 variable "ecr_repository_url" {
-  description = "ECR repository URL that will host the dispatcher image (populated by sub-task C, #2729). Placeholder until then — the service runs at desired_count=0 so the image tag is not resolved."
+  description = "ECR repository URL that will host the dispatcher image (populated by sub-task C, #2729). Placeholder until then -- the service runs at desired_count=0 so the image tag is not resolved."
   type        = string
 }
 
@@ -35,7 +35,7 @@ variable "image_tag" {
 }
 
 variable "desired_count" {
-  description = "Number of dispatcher task replicas. Phase 1 keeps this at 0 (inert); Phase 2 flips to 1 (shadow mode); never >1 (the dispatcher is a singleton — overlapping instances would double-spawn agents)."
+  description = "Number of dispatcher task replicas. Phase 1 keeps this at 0 (inert); Phase 2 flips to 1 (shadow mode); never >1 (the dispatcher is a singleton -- overlapping instances would double-spawn agents)."
   type        = number
   default     = 0
 
@@ -46,19 +46,19 @@ variable "desired_count" {
 }
 
 variable "task_cpu" {
-  description = "CPU units for the Fargate task (1024 = 1 vCPU, per §14 of the spec)"
+  description = "CPU units for the Fargate task (1024 = 1 vCPU, per Section 14 of the spec)"
   type        = number
   default     = 1024
 }
 
 variable "task_memory" {
-  description = "Memory (MiB) for the Fargate task (2048 = 2 GB, per §14 of the spec)"
+  description = "Memory (MiB) for the Fargate task (2048 = 2 GB, per Section 14 of the spec)"
   type        = number
   default     = 2048
 }
 
 variable "ephemeral_storage_gib" {
-  description = "Ephemeral storage (GiB) for the Fargate task. 50 GiB per spike 0.6 findings (docs/investigations/dispatcher-v2-spike-0.6.md): realistic 5-concurrent-worktree peak is ~10 GB, so 50 GiB gives 5× headroom."
+  description = "Ephemeral storage (GiB) for the Fargate task. 50 GiB per spike 0.6 findings (docs/investigations/dispatcher-v2-spike-0.6.md): realistic 5-concurrent-worktree peak is ~10 GB, so 50 GiB gives 5x headroom."
   type        = number
   default     = 50
 
@@ -89,7 +89,7 @@ variable "anthropic_api_key_secret_arn" {
 }
 
 variable "db_connection_secret_arn" {
-  description = "Secrets Manager ARN for the dispatcher-role DATABASE_URL (JSON key: url). Sub-task A (#2727) creates the `judgemind_dispatcher` role and its connection secret; until A merges, callers can pass the main `judgemind` role secret — safe while desired_count=0."
+  description = "Secrets Manager ARN for the dispatcher-role DATABASE_URL (JSON key: url). Sub-task A (#2727) creates the `judgemind_dispatcher` role and its connection secret; until A merges, callers can pass the main `judgemind` role secret -- safe while desired_count=0."
   type        = string
   default     = ""
 }
@@ -107,7 +107,7 @@ variable "telegram_bot_token_secret_arn" {
 }
 
 variable "gemini_api_key_secret_arn" {
-  description = "Secrets Manager ARN for GEMINI_API_KEY. Only required if `runner_by_phase` / `runner_shadow` routes to the Gemini runner (see spec §14 / spike 0.4)."
+  description = "Secrets Manager ARN for GEMINI_API_KEY. Only required if `runner_by_phase` / `runner_shadow` routes to the Gemini runner (see spec Section 14 / spike 0.4)."
   type        = string
   default     = ""
 }
@@ -135,13 +135,13 @@ variable "alert_sns_topic_arn" {
 }
 
 variable "heartbeat_stale_seconds" {
-  description = "Threshold for the heartbeat staleness alarm. Per §14, default 300 (5 min)."
+  description = "Threshold for the heartbeat staleness alarm. Per Section 14, default 300 (5 min)."
   type        = number
   default     = 300
 }
 
 variable "stuck_timeout_repeated_window_seconds" {
-  description = "CloudWatch alarm period (seconds) for the stuck_timeout_repeated alarm. The alarm fires when at least one stuck_timeout_repeated event is observed in this window. Default 600 (10 min) per §15 of the spec."
+  description = "CloudWatch alarm period (seconds) for the stuck_timeout_repeated alarm. The alarm fires when at least one stuck_timeout_repeated event is observed in this window. Default 600 (10 min) per Section 15 of the spec."
   type        = number
   default     = 600
 }
@@ -189,13 +189,13 @@ variable "oneshot_maintenance_task_role_arn" {
 }
 
 variable "oneshot_script_bucket_arn" {
-  description = "ARN of the S3 bucket where scripts/ecs-run-task.sh uploads scripts larger than the 8KB command-override limit (typically judgemind-assets-<env>). When set, the daemon task role is granted PutObject/DeleteObject under oneshot-scripts/*. Empty disables S3 uploads — scripts under ~6KB still work inline."
+  description = "ARN of the S3 bucket where scripts/ecs-run-task.sh uploads scripts larger than the 8KB command-override limit (typically judgemind-assets-<env>). When set, the daemon task role is granted PutObject/DeleteObject under oneshot-scripts/*. Empty disables S3 uploads -- scripts under ~6KB still work inline."
   type        = string
   default     = ""
 }
 
 variable "oneshot_ecr_scraper_repository_arn" {
-  description = "ARN of the ECR repository that hosts the scraper/ingestion-worker image (used by scripts/ecs-run-task.sh to resolve image digests). When set, the daemon task role is granted ecr:DescribeImages on that repo. Empty disables — ecs-run-task.sh still works using the service image without the digest-check step."
+  description = "ARN of the ECR repository that hosts the scraper/ingestion-worker image (used by scripts/ecs-run-task.sh to resolve image digests). When set, the daemon task role is granted ecr:DescribeImages on that repo. Empty disables -- ecs-run-task.sh still works using the service image without the digest-check step."
   type        = string
   default     = ""
 }
@@ -214,7 +214,7 @@ variable "oneshot_ecr_scraper_repository_arn" {
 # inert behind the `agent_execution_mode='subprocess'` default.
 
 variable "agent_runner_task_definition_family" {
-  description = "Family name of the dispatcher-agent-runner task definition (e.g. `judgemind-dispatcher-agent-runner-<env>`). Wired from the dispatcher-agent-runner module's `task_definition_family` output. When set alongside the two role ARNs below, the daemon's task role gains ecs:RunTask / ecs:DescribeTasks / ecs:StopTask scoped to this family. Empty disables — Stage 2 launcher falls back to the subprocess path."
+  description = "Family name of the dispatcher-agent-runner task definition (e.g. `judgemind-dispatcher-agent-runner-<env>`). Wired from the dispatcher-agent-runner module's `task_definition_family` output. When set alongside the two role ARNs below, the daemon's task role gains ecs:RunTask / ecs:DescribeTasks / ecs:StopTask scoped to this family. Empty disables -- Stage 2 launcher falls back to the subprocess path."
   type        = string
   default     = ""
 }
@@ -232,7 +232,7 @@ variable "agent_runner_task_role_arn" {
 }
 
 variable "agent_runner_subnet_ids" {
-  description = "Private subnet IDs the agent-runner tasks launch into. Typically the same list as the daemon's `private_subnet_ids`. Threaded into the dispatcher container as AGENT_RUNNER_SUBNET_IDS (comma-separated) for the Stage 2 launcher's network_configuration. Empty list disables the env var — daemon falls back to subprocess mode."
+  description = "Private subnet IDs the agent-runner tasks launch into. Typically the same list as the daemon's `private_subnet_ids`. Threaded into the dispatcher container as AGENT_RUNNER_SUBNET_IDS (comma-separated) for the Stage 2 launcher's network_configuration. Empty list disables the env var -- daemon falls back to subprocess mode."
   type        = list(string)
   default     = []
 }
@@ -246,7 +246,7 @@ variable "agent_runner_security_group_id" {
 # ─── Document-archive S3 census access (#3050) ──────────────────────────────
 
 variable "document_archive_bucket_arn" {
-  description = "ARN of the document-archive S3 bucket. When set, the daemon task role is granted `s3:ListBucket` so data-task agents can run census queries (e.g. pre/post rebuild counts). Empty disables the policy — safe for staging / throwaway stacks."
+  description = "ARN of the document-archive S3 bucket. When set, the daemon task role is granted `s3:ListBucket` so data-task agents can run census queries (e.g. pre/post rebuild counts). Empty disables the policy -- safe for staging / throwaway stacks."
   type        = string
   default     = ""
 }

--- a/infra/terraform/modules/dns/variables.tf
+++ b/infra/terraform/modules/dns/variables.tf
@@ -11,7 +11,7 @@ variable "ses_verification_token" {
 }
 
 variable "ses_dkim_tokens" {
-  description = "SES DKIM CNAME tokens — list of 3 (from ses module output)"
+  description = "SES DKIM CNAME tokens -- list of 3 (from ses module output)"
   type        = list(string)
   default     = []
 }

--- a/infra/terraform/modules/iam_agent/variables.tf
+++ b/infra/terraform/modules/iam_agent/variables.tf
@@ -1,5 +1,5 @@
 variable "environment" {
-  description = "Deployment environment — agent role is dev-only (staging and production are human-operated)"
+  description = "Deployment environment -- agent role is dev-only (staging and production are human-operated)"
   type        = string
 
   validation {
@@ -14,18 +14,18 @@ variable "document_archive_bucket_arn" {
 }
 
 variable "scraper_role_arn" {
-  description = "ARN of the scraper IAM role — the agent may pass this role when launching ECS tasks"
+  description = "ARN of the scraper IAM role -- the agent may pass this role when launching ECS tasks"
   type        = string
 }
 
 variable "maintenance_role_arn" {
-  description = "ARN of the maintenance IAM role — if non-empty, the agent may also pass this role when launching ECS tasks"
+  description = "ARN of the maintenance IAM role -- if non-empty, the agent may also pass this role when launching ECS tasks"
   type        = string
   default     = ""
 }
 
 variable "dev_account_id" {
-  description = "AWS account ID for the dev environment — used to construct scoped resource ARNs"
+  description = "AWS account ID for the dev environment -- used to construct scoped resource ARNs"
   type        = string
   default     = "155326049300"
 }

--- a/infra/terraform/modules/scraper-zero-record-check/main.tf
+++ b/infra/terraform/modules/scraper-zero-record-check/main.tf
@@ -27,7 +27,7 @@ resource "aws_cloudwatch_log_group" "zero_record_check" {
 
 resource "aws_security_group" "zero_record_check" {
   name        = "judgemind-zero-record-check-${var.environment}"
-  description = "Zero-record check ECS task — outbound HTTPS and Postgres"
+  description = "Zero-record check ECS task -- outbound HTTPS and Postgres"
   vpc_id      = var.vpc_id
 
   egress {
@@ -54,7 +54,7 @@ resource "aws_security_group" "zero_record_check" {
 
 resource "aws_iam_role" "task_role" {
   name        = "judgemind-zero-record-check-task-${var.environment}"
-  description = "Task role for the zero-record streak check — Telegram secret read"
+  description = "Task role for the zero-record streak check -- Telegram secret read"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/infra/terraform/modules/scraper-zero-record-check/variables.tf
+++ b/infra/terraform/modules/scraper-zero-record-check/variables.tf
@@ -44,7 +44,7 @@ variable "github_token_secret_arn" {
 }
 
 variable "telegram_secret_arn" {
-  description = "ARN of the Secrets Manager secret for Telegram notifications (judgemind/telegram/bot). Empty string disables task-role access — the runner still falls back to the execution role if the script can reach Secrets Manager another way, but best practice is to provide this ARN."
+  description = "ARN of the Secrets Manager secret for Telegram notifications (judgemind/telegram/bot). Empty string disables task-role access -- the runner still falls back to the execution role if the script can reach Secrets Manager another way, but best practice is to provide this ARN."
   type        = string
   default     = ""
 }

--- a/infra/terraform/modules/search/outputs.tf
+++ b/infra/terraform/modules/search/outputs.tf
@@ -9,7 +9,7 @@ output "domain_arn" {
 }
 
 output "security_group_id" {
-  description = "Security group ID — grant ingress from other resources that need OpenSearch access"
+  description = "Security group ID -- grant ingress from other resources that need OpenSearch access"
   value       = aws_security_group.opensearch.id
 }
 

--- a/infra/terraform/modules/vercel-web/variables.tf
+++ b/infra/terraform/modules/vercel-web/variables.tf
@@ -25,6 +25,6 @@ variable "graphql_url" {
 }
 
 variable "site_url" {
-  description = "Value for NEXT_PUBLIC_SITE_URL — used as metadataBase for OG image URLs (e.g. https://dev.judgemind.org)"
+  description = "Value for NEXT_PUBLIC_SITE_URL -- used as metadataBase for OG image URLs (e.g. https://dev.judgemind.org)"
   type        = string
 }

--- a/scripts/check-no-nonascii-tf-descriptions.sh
+++ b/scripts/check-no-nonascii-tf-descriptions.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# check-no-nonascii-tf-descriptions.sh -- Fail if any Terraform `description`
+# argument in `infra/terraform/**/*.tf` contains a non-ASCII byte.
+#
+# Why this check exists
+# ---------------------
+# AWS rejects non-ASCII characters in `description` fields for several
+# resource types (security groups, IAM roles, IAM policies, etc.) at apply
+# time. This is a class of bug that:
+#   - Passes `terraform validate` (the AWS provider does not validate
+#     description content client-side).
+#   - Passes `terraform plan` if the resource does not exist yet (the
+#     AWS API is only called at apply time for create operations).
+#   - Fails `terraform apply` with an opaque
+#     "Character sets beyond ASCII are not supported" or
+#     "Member must satisfy regular expression pattern: [\t\n\r -~]*" error.
+#
+# Three consecutive `terraform.yml / Apply dev` runs on `main` were broken
+# by an em-dash (U+2014) in two `description` fields in
+# `infra/terraform/modules/scraper-zero-record-check/main.tf` (issue #3321).
+# This check prevents that class of failure structurally.
+#
+# Rule
+# ----
+# Every `description = "..."` argument under `infra/terraform/**/*.tf` must
+# be strict 7-bit ASCII (bytes 0x09, 0x0A, 0x0D, or 0x20-0x7E). Any byte
+# outside that set is a violation.
+#
+# Usage
+# -----
+#   scripts/check-no-nonascii-tf-descriptions.sh
+#
+# Exit codes
+# ----------
+#   0 -- No violations found.
+#   1 -- At least one description argument contains a non-ASCII byte.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TF_DIR="${REPO_ROOT}/infra/terraform"
+
+if [[ ! -d "$TF_DIR" ]]; then
+    echo "check-no-nonascii-tf-descriptions: no infra/terraform/ -- nothing to check."
+    exit 0
+fi
+
+# Use Python for a precise byte-level scan. BSD grep on macOS lacks
+# Perl-compatible regex (`-P`), so a portable shell-only solution is
+# fragile. Python is available everywhere we run CI (GHA and operator
+# laptops).
+python_output="$(python3 - "$TF_DIR" <<'PYEOF'
+import re
+import sys
+from pathlib import Path
+
+tf_root = Path(sys.argv[1])
+
+# Match any line where the first non-whitespace token is `description`
+# followed by `=`. Captures both top-level resource arguments and nested
+# block arguments (e.g. inside an `egress` block).
+DESC_RE = re.compile(r"^[ \t]*description[ \t]*=")
+
+violations = []
+for tf_file in sorted(tf_root.rglob("*.tf")):
+    # Read as bytes so we can detect any byte > 0x7E without locale
+    # interference.
+    raw = tf_file.read_bytes()
+    # Split on universal newlines so line numbers match editor display.
+    lines = raw.split(b"\n")
+    for lineno, line in enumerate(lines, start=1):
+        try:
+            decoded = line.decode("utf-8")
+        except UnicodeDecodeError:
+            # Non-UTF-8 bytes anywhere on the line -- definite violation
+            # if the line is a description argument.
+            decoded = line.decode("latin-1")
+        if not DESC_RE.match(decoded):
+            continue
+        # Allowed bytes: tab (0x09), CR (0x0D), and printable ASCII
+        # (0x20-0x7E). LF would have been split out already.
+        bad_bytes = [b for b in line if b not in (0x09, 0x0D) and not (0x20 <= b <= 0x7E)]
+        if bad_bytes:
+            rel = tf_file.relative_to(tf_root.parent)
+            # Show the offending line, replacing non-ASCII bytes with
+            # `<U+XXXX>` markers for clarity.
+            display = decoded.encode("ascii", errors="backslashreplace").decode("ascii")
+            print(f"{rel}:{lineno}: {display.rstrip()}")
+            violations.append((rel, lineno))
+
+sys.exit(1 if violations else 0)
+PYEOF
+)" && rc=0 || rc=$?
+
+if (( rc == 0 )); then
+    exit 0
+fi
+
+echo "ERROR: non-ASCII byte(s) found in Terraform 'description' argument(s)."
+echo ""
+echo "  AWS rejects non-ASCII characters in description fields for several"
+echo "  resource types (security groups, IAM roles, IAM policies, etc.) at"
+echo "  apply time. terraform plan does NOT catch this -- the AWS API is"
+echo "  only called when the resource is actually created."
+echo ""
+echo "  Fix: replace the non-ASCII byte(s) with 7-bit ASCII equivalents."
+echo "  Common offender: em-dash U+2014 ('--' or '-' is the safe replacement)."
+echo ""
+echo "  See issue #3321 for context."
+echo ""
+echo "  Violating lines:"
+echo ""
+while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    echo "    $entry"
+done <<< "$python_output"
+echo ""
+exit 1


### PR DESCRIPTION
## Summary

- Replace non-ASCII bytes in Terraform `description = "..."` arguments with ASCII equivalents. Two of these (em-dashes in `infra/terraform/modules/scraper-zero-record-check/main.tf` lines 30 and 56) were the root cause of three consecutive failing `terraform.yml / Apply dev` runs on `main` since 800089b6 (2026-04-25T08:19Z).
- Add `scripts/check-no-nonascii-tf-descriptions.sh` to enforce strict 7-bit ASCII on every `description = "..."` argument under `infra/terraform/`. Wired into `.github/workflows/terraform.yml` as a fast-running step right after the format check.
- Verified locally with `terraform plan` against `infra/terraform/environments/dev`: 6 to add, 1 to change, 0 to destroy. Both target descriptions now read clean ASCII in the plan output.

## Why

AWS rejects non-ASCII characters in `description` fields for several resource types (security groups via `CreateSecurityGroup`, IAM roles via `CreateRole`, IAM policies, etc.) at apply time. `terraform validate` does NOT catch this -- the AWS API is only called when the resource is actually created. The dispatcher's `awaiting_deploy` phase correctly caught the failure for PR #3319 post-merge, but the source bug was still in the tree.

## Scope note

The hygiene check found genuine non-ASCII bytes in `description` arguments across 13 other tf files (variable declarations, outputs, env-level `output` blocks). Most of those are HCL metadata that never reaches the AWS API, so they would not have failed `apply`. But a uniform 7-bit ASCII rule is simpler than a per-resource-type rule and prevents anyone from accidentally copying a non-ASCII description from a variable into an AWS resource. All 13 files fixed in this PR with mechanical replacements (em-dash → `--`, `§` → `Section `, `×` → `x`).

## Verification (pre-merge, local)

- `scripts/check-no-nonascii-tf-descriptions.sh` exits 0 on this branch.
- `terraform fmt -check -recursive infra/terraform/` clean.
- `terraform -chdir=infra/terraform/environments/dev validate` clean.
- `terraform -chdir=infra/terraform/environments/production validate` clean.
- `terraform -chdir=infra/terraform/environments/dev plan` clean: 6 to add, 1 to change, 0 to destroy. Plan output shows the two target descriptions as ASCII (`Zero-record check ECS task -- outbound HTTPS and Postgres` and `Task role for the zero-record streak check -- Telegram secret read`).

## Test plan

- [ ] CI `Terraform / Validate and Plan` job is green.
- [ ] Hygiene step (`Check no non-ASCII in tf descriptions`) runs and passes on this PR.
- [ ] Post-merge: `Terraform / Apply dev` job on `main` is green -- this is the actual fix-validation step (links the failing `CreateSecurityGroup` and `CreateRole` calls to a successful create).

Closes #3321
