### PR TITLE
fix(scraping): align reingest_from_s3.py --department-in SQL semantics with help text

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -2132,13 +2132,35 @@ class TestBuildFilters:
         assert params == []
 
     def test_department_in_adds_clause(self) -> None:
-        """Passing a non-empty department_in list emits the EXISTS subquery and
-        appends the list as the corresponding param."""
+        """Passing a non-empty department_in list emits the EXISTS subquery for
+        the any-ruling semantic and appends the list as the corresponding param."""
         depts = ["C32", "C11"]
         clauses, params = reingest._build_filters(None, None, None, department_in=depts)
         assert "AND EXISTS" in clauses
         assert "r.department = ANY(%s)" in clauses
         assert depts in params
+
+    def test_department_in_uses_any_ruling_semantic_not_latest(self) -> None:
+        """The --department-in filter uses an EXISTS subquery that matches a
+        document if *any* of its rulings has the given department — not just
+        the latest ruling.  The SQL must contain EXISTS and r.department =
+        ANY(%s), and must NOT use LATERAL or ORDER BY ruled_on DESC (which
+        would imply a latest-ruling join)."""
+        depts = ["C11"]
+        clauses, params = reingest._build_filters(None, None, None, department_in=depts)
+        # Confirm the any-ruling shape is present
+        assert "EXISTS" in clauses
+        assert "r.department = ANY(%s)" in clauses
+        # Confirm no latest-ruling join is used
+        assert "LATERAL" not in clauses
+        assert "ORDER BY ruled_on DESC" not in clauses
+        # A second selector value produces the same clause shape
+        depts2 = ["C99"]
+        clauses2, params2 = reingest._build_filters(None, None, None, department_in=depts2)
+        assert "EXISTS" in clauses2
+        assert "r.department = ANY(%s)" in clauses2
+        assert "LATERAL" not in clauses2
+        assert "ORDER BY ruled_on DESC" not in clauses2
 
     def test_department_in_none_no_clause(self) -> None:
         """Passing department_in=None emits no clause."""

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -3698,10 +3698,10 @@ def main() -> None:
         default=None,
         dest="department_in",
         help=(
-            "Only re-ingest documents whose latest ruling has a department "
-            "matching one of these values. Values must match rulings.department "
-            "exactly (case-sensitive). Useful for targeting specific courtrooms "
-            "without processing the entire county, e.g. "
+            "Only re-ingest documents that have at least one ruling whose "
+            "department matches one of these values. Values must match "
+            "rulings.department exactly (case-sensitive). Useful for targeting "
+            "specific courtrooms without processing the entire county, e.g. "
             "--department-in C11 C20 C32. Applies an EXISTS subquery against "
             "the rulings table."
         ),


### PR DESCRIPTION
## Summary

Fixed mismatched semantics in `--department-in` flag: help text now accurately describes the existing SQL behavior (ANY ruling, not latest ruling). Added regression test locking in the ANY-ruling semantic via SQL clause structure assertions.

Closes #3301

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 6 department_in tests all green, pre-push hook clean)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (script-only, help text + test)