### PR TITLE
fix(dispatcher): drop status filter from ECS reaper SELECT; clear agent_task_arn after finalize (#3329)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -19918,9 +19918,8 @@ class DispatcherDaemon:
         """Observe lifecycle of active per-agent ECS tasks (#3091).
 
         Runs on every :meth:`scheduler_tick`. Fetches every
-        ``dispatcher.agents`` row where ``agent_task_arn IS NOT NULL``
-        and ``status IN ('running', 'retrying')``, calls
-        ``ecs:DescribeTasks`` once for up to 100 ARNs (the ECS
+        ``dispatcher.agents`` row where ``agent_task_arn IS NOT NULL``,
+        calls ``ecs:DescribeTasks`` once for up to 100 ARNs (the ECS
         page-size cap — more than we'll ever reap in one tick on a
         concurrency_cap<=5 cluster), and acts on the returned
         ``lastStatus``:
@@ -19961,6 +19960,21 @@ class DispatcherDaemon:
         # matches the ECS ``DescribeTasks`` page-size cap. For
         # concurrency_cap<=5 dev this is always one call; a future
         # production cap>5 would need pagination here.
+        #
+        # Issue #3329: the SELECT used to filter on
+        # ``status IN ('running', 'retrying')`` but the agent-runner
+        # entrypoint (#3158) writes its own terminal status row BEFORE
+        # the ECS task transitions to STOPPED. That ordering meant rows
+        # were excluded from this SELECT before the daemon ever called
+        # ``ecs:DescribeTasks``, so the success/failure already-terminal
+        # branches below were unreachable in production — leaking the
+        # ``status/in-progress`` label and skipping the ``merged_at``
+        # stamp. We now key off ``agent_task_arn IS NOT NULL`` alone,
+        # and the success/failure finalize paths CLEAR ``agent_task_arn``
+        # to mark the row as no-longer-needing-ECS-observation. The
+        # column is the canonical "this row still owes an ECS reap"
+        # signal — pre-#3091 rows never set it, so dropping the status
+        # filter does not pull in legacy work.
         try:
             with self._conn.cursor() as cur:
                 cur.execute(
@@ -19968,7 +19982,6 @@ class DispatcherDaemon:
                     "       phase, status "
                     "FROM dispatcher.agents "
                     "WHERE agent_task_arn IS NOT NULL "
-                    "  AND status IN ('running', 'retrying') "
                     "LIMIT 100"
                 )
                 rows = cur.fetchall()
@@ -20201,6 +20214,35 @@ class DispatcherDaemon:
                                     "branch": "failure_already_terminal",
                                 },
                             )
+                    # Issue #3329: clear ``agent_task_arn`` so the
+                    # next reaper tick excludes this row. Mirror of
+                    # the success-path clear in
+                    # ``_reap_finalize_ecs_success`` — same rationale,
+                    # same idempotence story.
+                    try:
+                        with self._conn.cursor() as cur:
+                            cur.execute(
+                                "UPDATE dispatcher.agents "
+                                "SET agent_task_arn = NULL "
+                                "WHERE agent_id = %s",
+                                (agent_id,),
+                            )
+                        self._conn.commit()
+                    except Exception:
+                        self._log.exception(
+                            "daemon.agent_runner_reaped_arn_clear_failed",
+                            extra={
+                                "event": "agent_runner_reaped_arn_clear_failed",
+                                "run_id": self._run_id,
+                                "agent_id": agent_id,
+                                "issue_number": issue_number,
+                                "branch": "failure_already_terminal",
+                            },
+                        )
+                        try:
+                            self._conn.rollback()
+                        except Exception:  # pragma: no cover — defensive
+                            pass
                     reaped_failure += 1
                     continue
                 # Real failure — agent-runner died before it could write
@@ -20319,6 +20361,38 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                     "agent_id": agent_id,
                     "issue_number": issue_number,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — defensive
+                pass
+        # Issue #3329: clear ``agent_task_arn`` so the next reaper tick
+        # excludes this row from the SELECT. Without this clear, the
+        # SELECT (now keyed solely on ``agent_task_arn IS NOT NULL``)
+        # would re-observe the same already-finalized row forever and
+        # the daemon would re-call ``ecs:DescribeTasks`` for it on
+        # every tick. Idempotent — if the column is already NULL the
+        # UPDATE is a no-op. Best-effort: a DB hiccup here just defers
+        # the cleanup to the next successful tick.
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.agents "
+                    "SET agent_task_arn = NULL "
+                    "WHERE agent_id = %s",
+                    (agent_id,),
+                )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.agent_runner_reaped_arn_clear_failed",
+                extra={
+                    "event": "agent_runner_reaped_arn_clear_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "branch": "success_already_terminal",
                 },
             )
             try:

--- a/scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py
+++ b/scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py
@@ -132,6 +132,10 @@ class TestReapCompletedAgentTasks:
         # Third cursor: _reap_finalize_ecs_success merged_at UPDATE.
         finalize_cur = _FakeCursor()
         conn.queue_cursor(finalize_cur)
+        # Fourth cursor: _reap_finalize_ecs_success agent_task_arn UPDATE
+        # (Issue #3329 — clear the ARN so the next tick excludes the row).
+        arn_clear_cur = _FakeCursor()
+        conn.queue_cursor(arn_clear_cur)
 
         fake_client = MagicMock()
         fake_client.describe_tasks.return_value = {
@@ -173,6 +177,12 @@ class TestReapCompletedAgentTasks:
         assert "pr_number IS NOT NULL" in merged_at_sql
         params = [params for _, params in finalize_cur.executed]
         assert params == [("agent-ok",)]
+        # Issue #3329: success path must also clear ``agent_task_arn``
+        # so the next reaper tick's SELECT (now keyed solely on
+        # ``agent_task_arn IS NOT NULL``) skips this row.
+        arn_sqls = [sql for sql, _ in arn_clear_cur.executed]
+        assert any("SET agent_task_arn = NULL" in sql for sql in arn_sqls), arn_sqls
+        assert [params for _, params in arn_clear_cur.executed] == [("agent-ok",)]
 
     def test_stopped_success_already_terminal_idempotent_re_reap(
         self, caplog: Any
@@ -204,6 +214,8 @@ class TestReapCompletedAgentTasks:
         conn.queue_cursor(status_cur)
         finalize_cur = _FakeCursor()
         conn.queue_cursor(finalize_cur)
+        arn_clear_cur = _FakeCursor()
+        conn.queue_cursor(arn_clear_cur)
 
         fake_client = MagicMock()
         fake_client.describe_tasks.return_value = {
@@ -222,16 +234,14 @@ class TestReapCompletedAgentTasks:
         ):
             d._reap_completed_agent_tasks()
 
-        # Exactly one UPDATE issued. The WHERE filter (asserted above)
-        # makes the SQL itself a no-op when merged_at is already set —
-        # the DB does the idempotence; the helper just always issues
-        # the same statement.
-        update_sqls = [
-            sql for sql, _ in finalize_cur.executed if "UPDATE dispatcher.agents" in sql
-        ]
-        assert len(update_sqls) == 1, update_sqls
-        assert "merged_at IS NULL" in update_sqls[0]
-        assert "pr_number IS NOT NULL" in update_sqls[0]
+        # Exactly one merged_at UPDATE issued. The WHERE filter
+        # (asserted above) makes the SQL itself a no-op when merged_at
+        # is already set — the DB does the idempotence; the helper just
+        # always issues the same statement.
+        merged_at_sqls = [sql for sql, _ in finalize_cur.executed if "merged_at" in sql]
+        assert len(merged_at_sqls) == 1, merged_at_sqls
+        assert "merged_at IS NULL" in merged_at_sqls[0]
+        assert "pr_number IS NOT NULL" in merged_at_sqls[0]
 
     def test_stopped_success_row_gap_marks_succeeded(self, caplog: Any) -> None:
         """Container exited 0 but DB row still ``running`` -> daemon closes the gap."""
@@ -349,6 +359,11 @@ class TestReapCompletedAgentTasks:
         # Agent-runner wrote ``failed`` before exiting.
         status_cur.fetchone_queue = [("failed", "ralph")]
         conn.queue_cursor(status_cur)
+        # Issue #3329: failure-already-terminal branch also issues the
+        # ``agent_task_arn = NULL`` UPDATE to take the row out of the
+        # next reaper SELECT.
+        arn_clear_cur = _FakeCursor()
+        conn.queue_cursor(arn_clear_cur)
 
         fake_client = MagicMock()
         fake_client.describe_tasks.return_value = {
@@ -377,6 +392,12 @@ class TestReapCompletedAgentTasks:
         remove_labels_mock.assert_called_once_with(
             300, [daemon.STATUS_IN_PROGRESS_LABEL]
         )
+        # Issue #3329: ``agent_task_arn`` must be cleared on the
+        # failure path too, otherwise the row stays in the SELECT
+        # forever now that the status filter is gone.
+        arn_sqls = [sql for sql, _ in arn_clear_cur.executed]
+        assert any("SET agent_task_arn = NULL" in sql for sql in arn_sqls), arn_sqls
+        assert [params for _, params in arn_clear_cur.executed] == [("agent-done",)]
 
     def test_running_task_is_noop(self) -> None:
         d, conn = _make_daemon()
@@ -527,3 +548,218 @@ class TestReapGuards:
         assert summary["reaped_success"] == 0
         events = [getattr(r, "event", None) for r in caplog.records]
         assert "reap_agent_tasks_describe_failed" in events
+
+
+# --------------------------------------------------------------------------
+# Issue #3329 — SELECT must NOT filter on ``status`` (the agent-runner
+# entrypoint writes its terminal status BEFORE ECS marks the task STOPPED,
+# so a status filter excludes every real ECS-mode terminal). The fix:
+# - drop the ``status IN ('running', 'retrying')`` filter from the SELECT,
+# - clear ``agent_task_arn`` after success/failure finalize so the next
+#   tick excludes the row instead.
+# --------------------------------------------------------------------------
+
+
+class TestReapSelectScope:
+    def test_select_query_does_not_filter_by_status(self) -> None:
+        """The SELECT must key on ``agent_task_arn IS NOT NULL`` alone.
+
+        Pre-fix the WHERE clause had ``AND status IN ('running',
+        'retrying')``. The agent-runner (#3158) writes its own terminal
+        ``status='succeeded'`` row before exit, which transitions out of
+        the filter window before the ECS task transitions to STOPPED —
+        so the rows were excluded and the success/failure already-
+        terminal branches never fired in production. This test pins
+        the SELECT shape against regression.
+        """
+        d, conn = _make_daemon()
+        select_cur = _FakeCursor(rows=[])
+        conn.queue_cursor(select_cur)
+        with patch.object(d, "_make_ecs_client"):
+            d._reap_completed_agent_tasks()
+
+        assert len(select_cur.executed) == 1
+        sql, _params = select_cur.executed[0]
+        assert "FROM dispatcher.agents" in sql
+        assert "agent_task_arn IS NOT NULL" in sql
+        # Regression guard: the status filter must stay gone (#3329).
+        assert "status IN" not in sql, sql
+        assert "running" not in sql, sql
+        assert "retrying" not in sql, sql
+
+    def test_terminal_status_row_is_still_reaped(self, caplog: Any) -> None:
+        """A row whose ``status`` is already terminal but still has
+        ``agent_task_arn`` set MUST be picked up by the reaper. This is
+        the production-realistic shape — the agent-runner writes
+        ``status='succeeded'`` before the ECS task STOPS, so the row is
+        ALREADY terminal by the time the daemon's reaper SELECTs it.
+
+        Pre-fix this row was excluded by the ``status IN ('running',
+        'retrying')`` filter. Post-fix the daemon describes the task,
+        sees STOPPED+exit0, and runs the success-already-terminal
+        finalize branch (label strip + merged_at + agent_task_arn
+        clear).
+        """
+        d, conn = _make_daemon()
+        caplog.set_level(logging.INFO, logger="test.daemon_reap")
+        select_cur = _FakeCursor(
+            rows=[
+                (
+                    "agent-already-succeeded",
+                    501,
+                    "arn:aws:ecs:us-west-2:123:task/jm/already",
+                    "done",
+                    # Production-realistic: status is already terminal
+                    # by the time this SELECT runs.
+                    "succeeded",
+                ),
+            ]
+        )
+        conn.queue_cursor(select_cur)
+        status_cur = _FakeCursor()
+        status_cur.fetchone_queue = [("succeeded", "done")]
+        conn.queue_cursor(status_cur)
+        finalize_cur = _FakeCursor()
+        conn.queue_cursor(finalize_cur)
+        arn_clear_cur = _FakeCursor()
+        conn.queue_cursor(arn_clear_cur)
+
+        fake_client = MagicMock()
+        fake_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": "arn:aws:ecs:us-west-2:123:task/jm/already",
+                    "lastStatus": "STOPPED",
+                    "stopCode": "EssentialContainerExited",
+                    "containers": [{"exitCode": 0}],
+                }
+            ]
+        }
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch.object(d, "_gh_issue_remove_labels") as remove_labels_mock,
+        ):
+            summary = d._reap_completed_agent_tasks()
+
+        assert summary["reaped_success"] == 1
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_reaped_success" in events
+        # Label stripped, merged_at stamped, agent_task_arn cleared.
+        remove_labels_mock.assert_called_once_with(
+            501, [daemon.STATUS_IN_PROGRESS_LABEL]
+        )
+        merged_sqls = [sql for sql, _ in finalize_cur.executed if "merged_at" in sql]
+        assert merged_sqls and "merged_at IS NULL" in merged_sqls[0]
+        arn_sqls = [sql for sql, _ in arn_clear_cur.executed]
+        assert any("SET agent_task_arn = NULL" in sql for sql in arn_sqls), arn_sqls
+
+    def test_failed_status_row_is_still_reaped(self, caplog: Any) -> None:
+        """Mirror of the success case for the failure path.
+
+        A row already in ``status='failed'`` but with ``agent_task_arn``
+        still set must be picked up; the reaper should strip the label
+        and clear ``agent_task_arn``. No ``merged_at`` stamp on the
+        failure path.
+        """
+        d, conn = _make_daemon()
+        caplog.set_level(logging.INFO, logger="test.daemon_reap")
+        select_cur = _FakeCursor(
+            rows=[
+                (
+                    "agent-already-failed",
+                    777,
+                    "arn:aws:ecs:us-west-2:123:task/jm/failterm",
+                    "ralph",
+                    # Production-realistic: status is already terminal.
+                    "failed",
+                ),
+            ]
+        )
+        conn.queue_cursor(select_cur)
+        status_cur = _FakeCursor()
+        status_cur.fetchone_queue = [("failed", "ralph")]
+        conn.queue_cursor(status_cur)
+        arn_clear_cur = _FakeCursor()
+        conn.queue_cursor(arn_clear_cur)
+
+        fake_client = MagicMock()
+        fake_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": "arn:aws:ecs:us-west-2:123:task/jm/failterm",
+                    # Issue scenario in the spec writeup:
+                    # ECS reports STOPPED+exit0 even though the agent
+                    # row is ``failed``. The exit-code-zero +
+                    # status-is-terminal combination is treated as a
+                    # success-already-terminal in the reaper logic
+                    # (the agent-runner wrote its own terminal). This
+                    # variant uses a non-zero stop_code to force the
+                    # failure branch instead.
+                    "lastStatus": "STOPPED",
+                    "stopCode": "EssentialContainerExited",
+                    "containers": [{"exitCode": 1}],  # non-zero → failure path
+                }
+            ]
+        }
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch.object(d, "_handle_agent_failure") as fail_mock,
+            patch.object(d, "_gh_issue_remove_labels") as remove_labels_mock,
+        ):
+            summary = d._reap_completed_agent_tasks()
+
+        assert summary["reaped_failure"] == 1
+        # Already-terminal branch — must NOT route through
+        # _handle_agent_failure (would double-insert a failures row).
+        fail_mock.assert_not_called()
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_reaped_failure_already_terminal" in events
+        remove_labels_mock.assert_called_once_with(
+            777, [daemon.STATUS_IN_PROGRESS_LABEL]
+        )
+        arn_sqls = [sql for sql, _ in arn_clear_cur.executed]
+        assert any("SET agent_task_arn = NULL" in sql for sql in arn_sqls), arn_sqls
+        assert [params for _, params in arn_clear_cur.executed] == [
+            ("agent-already-failed",)
+        ]
+
+
+class TestReapArnClearIdempotence:
+    def test_arn_null_row_is_not_reselected(self) -> None:
+        """After finalize clears ``agent_task_arn``, the next reaper tick
+        must skip the row entirely — no ECS DescribeTasks call, no
+        UPDATEs, no log spam. The SELECT's ``agent_task_arn IS NOT NULL``
+        clause is the gate, so an empty fetchall() simulates the
+        post-finalize state.
+        """
+        d, conn = _make_daemon()
+        # Empty result set models the post-clear DB state for any agent
+        # already finalized: ``agent_task_arn IS NOT NULL`` excludes it.
+        select_cur = _FakeCursor(rows=[])
+        conn.queue_cursor(select_cur)
+
+        with (
+            patch.object(d, "_make_ecs_client") as mock_make_client,
+            patch.object(d, "_gh_issue_remove_labels") as remove_labels_mock,
+            patch.object(d, "_mark_agent_terminal") as mark_mock,
+            patch.object(d, "_handle_agent_failure") as fail_mock,
+        ):
+            summary = d._reap_completed_agent_tasks()
+
+        # Zero-work early return: no ECS client built, no GH calls,
+        # no terminal-marking, no failure routing.
+        mock_make_client.assert_not_called()
+        remove_labels_mock.assert_not_called()
+        mark_mock.assert_not_called()
+        fail_mock.assert_not_called()
+        assert summary == {
+            "active": 0,
+            "reaped_success": 0,
+            "reaped_failure": 0,
+            "still_running": 0,
+        }
+        # The SELECT ran exactly once with the post-#3329 WHERE shape.
+        assert len(select_cur.executed) == 1
+        sql, _params = select_cur.executed[0]
+        assert "agent_task_arn IS NOT NULL" in sql
+        assert "status IN" not in sql


### PR DESCRIPTION
## Summary

Closes #3329. Fix the unreachable bookkeeping branches PR #3325 added to `_reap_completed_agent_tasks`.

PR #3325 wired `_reap_finalize_ecs_success` (label strip + `merged_at` stamp) and the failure-already-terminal label strip into the ECS reaper, but the reaper's SELECT filtered on `status IN ('running', 'retrying')`. The agent-runner entrypoint (#3158) writes its terminal status row BEFORE the ECS task transitions to STOPPED, so the rows were excluded from the SELECT before the daemon ever called `ecs:DescribeTasks` — both finalize branches were dead code in production.

Symptoms:
- `status/in-progress` label leaks on every ECS terminal (verified across many closed issues from the last 24h).
- `dispatcher.agents.merged_at` stays NULL on every ECS green; `fleet-status.sh --since 30m` queries `WHERE merged_at IS NOT NULL` and reports `0 of 0 greens` even when greens exist.
- 0 occurrences of `agent_runner_reaped*` events in 3.5h of production daemon logs covering many ECS terminals.

## Changes

- `scripts/dispatcher/daemon.py`:
  - Reaper SELECT now keys on `agent_task_arn IS NOT NULL` alone — the status filter is gone.
  - `_reap_finalize_ecs_success` (success path) issues `UPDATE dispatcher.agents SET agent_task_arn = NULL WHERE agent_id = %s` after the merged_at stamp. This is the canonical "row no longer needs ECS observation" signal.
  - The failure-already-terminal branch issues the same `agent_task_arn = NULL` clear after the label strip.
  - Both clears are idempotent — re-running on a NULL row is a no-op.
- `scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py`:
  - 4 new tests under `TestReapSelectScope` and `TestReapArnClearIdempotence` covering the SELECT shape, the production-realistic terminal-status rows on both success and failure paths, and the "post-clear row is excluded" idempotence path.
  - Existing happy-path / failure-already-terminal tests updated to assert the new `SET agent_task_arn = NULL` UPDATE fires.

Single-issue PR. No scheduler / launcher / claim path edits. Out of scope per the issue: backfill of stale rows from before this deploys.

## Backfill note (go-forward only)

Issues closed during the bug window keep their `status/in-progress` label and `merged_at IS NULL`. Their rows have terminal `status` AND `agent_task_arn` was never going to be cleared by the old code, so the new SELECT won't pick them up either. Examples from the last ~24h:
- #3302, #3301, #3299, #3296, #3309, #3307, #3271, #3228, #3254, #3213, #3203, #3149, #3138, #3137, #3096, #3050, #2989, #3009.

A separate cleanup pass would be needed if we want to retroactively strip `status/in-progress` and stamp `merged_at` for those — that's out of scope for this PR.

## Test plan

- [x] `pytest scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py -v` — 14/14 pass locally.
- [x] `pytest scripts/dispatcher/tests/ -m "not integration"` — 1525 passed, 1 skipped.
- [x] `ruff check scripts/dispatcher/daemon.py …test…` — clean.
- [x] `ruff format --check` — clean.
- [ ] CI green (watch on push).
- [ ] Post-deploy verification (next ECS-mode green):
  - [ ] `gh issue view <N> --json labels` shows NO `status/in-progress`.
  - [ ] CloudWatch query shows `agent_runner_reaped_success` / `agent_runner_reaped_failure_already_terminal` event firing.
  - [ ] `dev-db-query.sh "SELECT merged_at, agent_task_arn FROM dispatcher.agents WHERE pr_number = <PR#>"` → `merged_at IS NOT NULL`, `agent_task_arn IS NULL`.
  - [ ] `scripts/dispatcher/helpers/fleet-status.sh --since 30m` shows the agent under `daemon-shipped greens`.

Generated with Claude Code.
