### PR TITLE
fix(ingestion): per-court rebuild_db reset with OS delete (#3014)

### DIFF
--- a/packages/scraper-framework/tests/test_rebuild_db.py
+++ b/packages/scraper-framework/tests/test_rebuild_db.py
@@ -2744,3 +2744,445 @@ class TestQueryConnectionBudget:
         assert mock_logger.warning.called, (
             f"expected warning log on connection failure; got {calls!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Per-court reset tests (#3014)
+# ---------------------------------------------------------------------------
+
+
+def _build_per_court_mock_conn(
+    court_id: str,
+    court_row: tuple[str, str, str, str] | None = None,
+    counts: dict[str, int] | None = None,
+) -> tuple[MagicMock, MagicMock]:
+    """Build a mock psycopg connection + cursor for per-court reset tests.
+
+    The cursor is driven by a scripted ``execute``/``fetchone``/``fetchall``
+    sequence so each DELETE/COUNT call returns deterministic data.  Returns
+    ``(mock_conn, mock_cur)`` so tests can inspect call history.
+
+    court_row is (id, state, county, court_name).
+    """
+    counts = counts or {}
+    mock_conn = MagicMock()
+    mock_cur = MagicMock()
+    mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+    # First fetchone(): _resolve_court_code_to_id → SELECT id FROM derived.courts
+    # Returns (uuid,) tuple.
+    # Subsequent fetchone() calls are COUNT(*) results.
+    count_sequence = [
+        (court_id,),  # resolve lookup
+        (counts.get("case_judges", 0),),
+        (counts.get("case_parties", 0),),
+        (counts.get("case_attorneys", 0),),
+        (counts.get("documents", 0),),
+        (counts.get("rulings", 0),),
+        (counts.get("cases", 0),),
+        (counts.get("judges", 0),),
+    ]
+    mock_cur.fetchone.side_effect = count_sequence
+    return mock_conn, mock_cur
+
+
+class TestResolveCourtCodeToId:
+    """Tests for _resolve_court_code_to_id()."""
+
+    def test_returns_court_id_string(self) -> None:
+        """Returns a single string UUID from derived.courts matching court_code."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_cur.fetchone.return_value = ("00000000-0000-0000-0000-000000000001",)
+
+        result = rebuild_db._resolve_court_code_to_id(mock_conn, "ca-orange")
+
+        assert result == "00000000-0000-0000-0000-000000000001"
+        sql, params = mock_cur.execute.call_args[0]
+        assert "LOWER(court_code)" in sql
+        assert params == ("ca-orange",)
+
+    def test_raises_when_court_code_not_found(self) -> None:
+        """Unknown court_code raises ValueError — fail loud, not silent no-op."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_cur.fetchone.return_value = None
+
+        try:
+            rebuild_db._resolve_court_code_to_id(mock_conn, "ca-nonexistent")
+        except ValueError as exc:
+            assert "ca-nonexistent" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+
+class TestDeleteOpensearchDocsForCourt:
+    """Tests for delete_opensearch_docs_for_court() (#3014).
+
+    The global ``tentative_rulings_v1`` index cannot be reset under
+    ``--reset --court`` because that would wipe docs for every other court.
+    Since ``court`` is not unique across counties, the filter must use the
+    (state, county, court) triple so the delete-by-query scopes exactly to
+    the target court.
+    """
+
+    def test_issues_delete_by_query_filtered_on_state_county_court_triple(self) -> None:
+        """Calls _delete_by_query on tentative_rulings_v1 filtered on (state, county, court)."""
+        mock_client = MagicMock()
+        mock_client.indices.exists.return_value = True
+        mock_client.delete_by_query.return_value = {"deleted": 17}
+
+        with patch("opensearchpy.OpenSearch", return_value=mock_client):
+            result = rebuild_db.delete_opensearch_docs_for_court(
+                "http://os", "ca", "Orange", "Superior Court"
+            )
+
+        assert result == 17
+        mock_client.delete_by_query.assert_called_once()
+        kwargs = mock_client.delete_by_query.call_args.kwargs
+        assert kwargs["index"] == "tentative_rulings_v1"
+        assert kwargs["body"] == {
+            "query": {
+                "bool": {
+                    "must": [
+                        {"term": {"state": "ca"}},
+                        {"term": {"county": "Orange"}},
+                        {"term": {"court": "Superior Court"}},
+                    ]
+                }
+            }
+        }
+        assert kwargs["refresh"] is True
+        assert kwargs["conflicts"] == "proceed"
+
+    def test_no_op_when_index_missing(self) -> None:
+        """Returns 0 without calling delete_by_query if the index is missing."""
+        mock_client = MagicMock()
+        mock_client.indices.exists.return_value = False
+
+        with patch("opensearchpy.OpenSearch", return_value=mock_client):
+            result = rebuild_db.delete_opensearch_docs_for_court(
+                "http://os", "ca", "Orange", "Superior Court"
+            )
+
+        assert result == 0
+        mock_client.delete_by_query.assert_not_called()
+
+    def test_uses_basic_auth_when_credentials_set(self) -> None:
+        """OPENSEARCH_USERNAME/PASSWORD env vars feed http_auth tuple."""
+        mock_client = MagicMock()
+        mock_client.indices.exists.return_value = True
+        mock_client.delete_by_query.return_value = {"deleted": 0}
+
+        with (
+            patch("opensearchpy.OpenSearch", return_value=mock_client) as mock_ctor,
+            patch.dict(
+                os.environ,
+                {
+                    "OPENSEARCH_USERNAME": "admin",
+                    "OPENSEARCH_PASSWORD": "s3cret",
+                },
+                clear=False,
+            ),
+        ):
+            rebuild_db.delete_opensearch_docs_for_court(
+                "http://os", "ca", "Orange", "Superior Court"
+            )
+
+        kwargs = mock_ctor.call_args.kwargs
+        assert kwargs["hosts"] == ["http://os"]
+        assert kwargs["timeout"] == 30
+        assert kwargs["max_retries"] == 3
+        assert kwargs["retry_on_timeout"] is True
+        assert kwargs["http_auth"] == ("admin", "s3cret")
+
+    def test_no_auth_when_credentials_unset(self) -> None:
+        """Missing env vars → http_auth not passed to the client ctor."""
+        mock_client = MagicMock()
+        mock_client.indices.exists.return_value = True
+        mock_client.delete_by_query.return_value = {"deleted": 0}
+
+        env = {k: v for k, v in os.environ.items()}
+        env.pop("OPENSEARCH_USERNAME", None)
+        env.pop("OPENSEARCH_PASSWORD", None)
+
+        with (
+            patch("opensearchpy.OpenSearch", return_value=mock_client) as mock_ctor,
+            patch.dict(os.environ, env, clear=True),
+        ):
+            rebuild_db.delete_opensearch_docs_for_court(
+                "http://os", "ca", "Orange", "Superior Court"
+            )
+
+        kwargs = mock_ctor.call_args.kwargs
+        assert "http_auth" not in kwargs
+
+
+class TestResetDerivedTablesForCourt:
+    """Tests for reset_derived_tables_for_court() (#3014)."""
+
+    def test_raises_when_court_code_not_found(self) -> None:
+        """Unknown court_code raises ValueError, not a silent no-op."""
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_cur.fetchone.return_value = None
+
+        try:
+            rebuild_db.reset_derived_tables_for_court(mock_conn, "ca-nonexistent")
+        except ValueError as exc:
+            assert "ca-nonexistent" in str(exc)
+        else:
+            raise AssertionError("expected ValueError")
+
+        mock_conn.commit.assert_not_called()
+
+    def test_deletes_per_court_and_returns_counts(self) -> None:
+        """Resolves court, deletes in dependency order, returns row-count summary."""
+        court_id = "00000000-0000-0000-0000-000000000001"
+        counts = {
+            "case_judges": 50,
+            "case_parties": 80,
+            "case_attorneys": 20,
+            "documents": 2000,
+            "rulings": 150,
+            "cases": 300,
+            "judges": 10,
+        }
+        mock_conn, mock_cur = _build_per_court_mock_conn(court_id, counts=counts)
+
+        result = rebuild_db.reset_derived_tables_for_court(mock_conn, "ca-orange")
+
+        assert result == counts
+        mock_conn.commit.assert_called_once()
+
+        all_sql = [call[0][0] for call in mock_cur.execute.call_args_list]
+        joined = "\n".join(all_sql)
+        for table in (
+            "case_judges",
+            "case_parties",
+            "case_attorneys",
+            "documents",
+            "rulings",
+            "cases",
+            "judges",
+        ):
+            assert f"DELETE FROM derived.{table}" in joined, (
+                f"expected DELETE FROM derived.{table} in emitted SQL"
+            )
+
+        assert "TRUNCATE" not in joined
+        assert "DELETE FROM derived.courts" not in joined
+
+    def test_delete_order_rulings_before_cases(self) -> None:
+        """Must delete rulings before cases (FK: rulings.case_id → cases.id)."""
+        court_id = "00000000-0000-0000-0000-000000000001"
+        counts = dict.fromkeys(
+            (
+                "case_judges",
+                "case_parties",
+                "case_attorneys",
+                "documents",
+                "rulings",
+                "cases",
+                "judges",
+            ),
+            1,
+        )
+        mock_conn, mock_cur = _build_per_court_mock_conn(court_id, counts=counts)
+
+        rebuild_db.reset_derived_tables_for_court(mock_conn, "ca-orange")
+
+        delete_sql = [
+            call[0][0]
+            for call in mock_cur.execute.call_args_list
+            if "DELETE FROM derived." in call[0][0]
+        ]
+
+        def _find(sub: str) -> int:
+            for i, s in enumerate(delete_sql):
+                if f"DELETE FROM derived.{sub}" in s and ("case_id IN" not in s):
+                    return i
+            return -1
+
+        rulings_idx = _find("rulings")
+        cases_idx = _find("cases")
+        documents_idx = _find("documents")
+        judges_idx = _find("judges")
+
+        assert rulings_idx != -1, "rulings DELETE not emitted"
+        assert cases_idx != -1, "cases DELETE not emitted"
+        assert documents_idx != -1, "documents DELETE not emitted"
+        assert judges_idx != -1, "judges DELETE not emitted"
+        assert rulings_idx < cases_idx
+        assert documents_idx < cases_idx
+        assert rulings_idx < judges_idx
+
+
+class TestMainPerCourtResetDispatch:
+    """Tests for main()'s dispatch for --reset --court (#3014)."""
+
+    def _common_patches(
+        self,
+        tmp_path: Any,
+        argv: list[str],
+    ) -> dict[str, Any]:
+        """Set up common patches used by per-court dispatch tests."""
+        cache_dir = str(tmp_path / "cache")
+        (tmp_path / "cache").mkdir()
+        key_dir = tmp_path / "cache" / "ca" / "orange" / "superior_court" / "raw"
+        key_dir.mkdir(parents=True)
+        (key_dir / "abc123.html").write_bytes(b"<html>x</html>")
+
+        mock_pool = MagicMock()
+        mock_pool.__enter__ = MagicMock(return_value=mock_pool)
+        mock_pool.__exit__ = MagicMock(return_value=False)
+        mock_future = MagicMock()
+        mock_future.result.return_value = {
+            "status": "ok",
+            "content_format": "html",
+            "had_hearing_date": False,
+        }
+        mock_pool.submit.return_value = mock_future
+
+        return {
+            "cache_dir": cache_dir,
+            "argv": argv,
+            "mock_pool": mock_pool,
+            "mock_future": mock_future,
+        }
+
+    def test_reset_with_court_uses_per_court_reset(self, tmp_path: Any) -> None:
+        """``--reset --court ca-orange`` → per-court delete + OS delete, not global.
+
+        Also verifies OS delete runs BEFORE the DB reset.
+        """
+        ctx = self._common_patches(tmp_path, ["rebuild_db.py", "--reset", "--court", "ca-orange"])
+        parent = MagicMock()
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=["ca/orange/superior_court/raw/abc123.html"],
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db.reset_derived_tables") as mock_global_reset,
+            patch("rebuild_db.reset_derived_tables_for_county") as mock_per_county_reset,
+            patch("rebuild_db.reset_derived_tables_for_court") as mock_per_court_reset,
+            patch("rebuild_db.reset_opensearch_index") as mock_os_reset,
+            patch("rebuild_db.delete_opensearch_docs_for_county") as mock_os_delete_county,
+            patch("rebuild_db.delete_opensearch_docs_for_court") as mock_os_delete_court,
+            patch(
+                "rebuild_db._resolve_court_for_reset",
+                return_value=(
+                    "00000000-0000-0000-0000-000000000001",
+                    "ca",
+                    "Orange",
+                    "Superior Court",
+                ),
+            ),
+            patch("rebuild_db._fetch_rosters"),
+            patch("rebuild_db._write_rebuild_marker"),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                return_value=ctx["mock_pool"],
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([ctx["mock_future"]]),
+            ),
+            patch.dict(
+                os.environ,
+                {
+                    "DATABASE_URL": "postgres://test",
+                    "S3_CACHE_DIR": ctx["cache_dir"],
+                    "OPENSEARCH_URL": "http://opensearch:9200",
+                },
+                clear=False,
+            ),
+            patch("sys.argv", ctx["argv"]),
+        ):
+            parent.attach_mock(mock_os_delete_court, "os_delete_court")
+            parent.attach_mock(mock_per_court_reset, "per_court_reset")
+            rebuild_db.main()
+
+        mock_global_reset.assert_not_called()
+        mock_per_county_reset.assert_not_called()
+        mock_os_reset.assert_not_called()
+        mock_os_delete_county.assert_not_called()
+        mock_per_court_reset.assert_called_once()
+        mock_os_delete_court.assert_called_once_with(
+            "http://opensearch:9200", "ca", "Orange", "Superior Court"
+        )
+        # OS delete must run BEFORE the DB reset.
+        method_names = [name for name, _, _ in parent.mock_calls]
+        os_idx = method_names.index("os_delete_court")
+        db_idx = method_names.index("per_court_reset")
+        assert os_idx < db_idx
+
+    def test_per_court_reset_skips_os_delete_when_url_unset(self, tmp_path: Any) -> None:
+        """Without OPENSEARCH_URL, per-court DB reset still runs; OS delete skipped."""
+        ctx = self._common_patches(tmp_path, ["rebuild_db.py", "--reset", "--court", "ca-orange"])
+        env = {k: v for k, v in os.environ.items()}
+        env.pop("OPENSEARCH_URL", None)
+        env["DATABASE_URL"] = "postgres://test"
+        env["S3_CACHE_DIR"] = ctx["cache_dir"]
+
+        with (
+            patch("rebuild_db.make_s3_client", return_value=MagicMock()),
+            patch("psycopg.connect", return_value=MagicMock()),
+            patch("rebuild_db._query_connection_budget", return_value=(0, 0)),
+            patch(
+                "rebuild_db.list_local_keys",
+                return_value=["ca/orange/superior_court/raw/abc123.html"],
+            ),
+            patch("rebuild_db.seed_courts", return_value={}),
+            patch("rebuild_db.reset_derived_tables") as mock_global_reset,
+            patch("rebuild_db.reset_derived_tables_for_court") as mock_per_court_reset,
+            patch("rebuild_db.delete_opensearch_docs_for_court") as mock_os_delete_court,
+            patch(
+                "rebuild_db._resolve_court_for_reset",
+                return_value=(
+                    "00000000-0000-0000-0000-000000000001",
+                    "ca",
+                    "Orange",
+                    "Superior Court",
+                ),
+            ),
+            patch("rebuild_db._fetch_rosters"),
+            patch("rebuild_db._write_rebuild_marker"),
+            patch(
+                "concurrent.futures.ProcessPoolExecutor",
+                return_value=ctx["mock_pool"],
+            ),
+            patch(
+                "concurrent.futures.as_completed",
+                return_value=iter([ctx["mock_future"]]),
+            ),
+            patch.dict(os.environ, env, clear=True),
+            patch("sys.argv", ctx["argv"]),
+        ):
+            rebuild_db.main()
+
+        mock_global_reset.assert_not_called()
+        mock_per_court_reset.assert_called_once()
+        mock_os_delete_court.assert_not_called()
+
+    def test_court_and_county_are_mutually_exclusive(self) -> None:
+        """``--reset --court X --county Y`` must cause argparse SystemExit."""
+        argv = ["rebuild_db.py", "--reset", "--court", "ca-orange", "--county", "Orange"]
+        with patch("sys.argv", argv):
+            try:
+                rebuild_db.main()
+            except SystemExit:
+                pass  # expected — argparse rejects mutually exclusive args
+            else:
+                raise AssertionError("expected SystemExit from argparse mutual exclusion")

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -991,6 +991,67 @@ def _resolve_county_court_ids(
         return [str(row[0]) for row in cur.fetchall()]
 
 
+def _resolve_court_code_to_id(
+    conn: psycopg.Connection,
+    court_code: str,
+) -> str:
+    """Look up ``derived.courts.id`` for a given court_code.
+
+    Match is case-insensitive on the stored ``court_code`` column so
+    "CA-Orange" and "ca-orange" both resolve.
+
+    Raises:
+        ValueError: if no court matches ``court_code``.  A typo must not
+            silently resolve to nothing and then delete nothing.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id
+              FROM derived.courts
+             WHERE LOWER(court_code) = LOWER(%s)
+            """,
+            (court_code,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise ValueError(
+            f"No court found in derived.courts for court_code={court_code!r}. "
+            "Refusing to reset to avoid silently deleting nothing."
+        )
+    return str(row[0])
+
+
+def _resolve_court_for_reset(
+    conn: psycopg.Connection,
+    court_code: str,
+) -> tuple[str, str, str, str]:
+    """Resolve court_code to (id, state, county, court_name) for the reset path.
+
+    Returns the four-tuple needed to scope both the DB reset and the
+    OpenSearch delete-by-query.
+
+    Raises:
+        ValueError: if court_code is not found in derived.courts.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, state, county, court_name
+              FROM derived.courts
+             WHERE LOWER(court_code) = LOWER(%s)
+            """,
+            (court_code,),
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise ValueError(
+            f"No court found in derived.courts for court_code={court_code!r}. "
+            "Refusing to reset to avoid silently deleting nothing."
+        )
+    return str(row[0]), str(row[1]), str(row[2]), str(row[3])
+
+
 def reset_derived_tables_for_county(
     conn: psycopg.Connection,
     state: str,
@@ -1142,6 +1203,136 @@ def reset_derived_tables_for_county(
     return deleted
 
 
+def reset_derived_tables_for_court(
+    conn: psycopg.Connection,
+    court_code: str,
+) -> dict[str, int]:
+    """Delete per-court rows from derived tables without touching other courts.
+
+    Scoped reset used when ``--reset`` is combined with ``--court <court_code>``.
+    See #3014.
+
+    Behaviour:
+    * Resolves the single ``derived.courts.id`` for ``court_code``.
+    * Logs a pre-delete row count for every affected table so operators can
+      eyeball the scope before DELETEs fire.
+    * Deletes in one transaction.  Join tables (``case_judges``,
+      ``case_parties``, ``case_attorneys``) are deleted first via
+      ``case_id IN (SELECT id FROM cases WHERE court_id = %s)`` so their
+      parent ``cases`` rows can be removed without relying on cascade.
+    * Then deletes rows keyed directly by ``court_id`` from ``documents``,
+      ``rulings``, ``cases``, and ``judges``.
+    * Does **not** touch ``derived.courts`` — the rebuild reseeds on
+      ``ON CONFLICT (court_code)`` and preserving these rows keeps UUIDs
+      stable for cross-schema references like ``telemetry.scraper_runs``.
+    * Does **not** touch county-agnostic entity tables (``attorneys``,
+      ``parties``, ``judge_aliases``, ``attorney_aliases``, ``party_aliases``).
+
+    Raises:
+        ValueError: if no court matches ``court_code``.  Silently
+            matching zero rows would let a typo nuke nothing and rebuild
+            nothing, which is worse than a hard error.
+
+    Returns:
+        ``{table_name: rows_deleted}`` for logging / test assertions.
+    """
+    court_id = _resolve_court_code_to_id(conn, court_code)
+
+    logger.info(
+        "Per-court reset — resolved court",
+        court_code=court_code,
+        court_id=court_id,
+    )
+
+    deleted: dict[str, int] = {}
+    # Wrap the reset in a single transaction: psycopg with ``autocommit=False``
+    # treats the whole block as one transaction and commits at the end.  A
+    # mid-DELETE failure rolls everything back so we can't land in a
+    # half-reset state.
+    with conn.cursor() as cur:
+        # Pre-delete row counts (what we're about to remove).
+        for table in _PER_COUNTY_CASE_JOIN_TABLES:
+            cur.execute(
+                f"""
+                SELECT COUNT(*)
+                  FROM derived.{table} jt
+                  JOIN derived.cases c ON jt.case_id = c.id
+                 WHERE c.court_id = %s::uuid
+                """,
+                (court_id,),
+            )
+            count = cur.fetchone()[0]
+            deleted[table] = count
+            logger.info(
+                "Pre-delete row count",
+                table=f"derived.{table}",
+                rows=count,
+                court_id=court_id,
+            )
+
+        for table in _PER_COUNTY_COURT_ID_TABLES:
+            cur.execute(
+                f"SELECT COUNT(*) FROM derived.{table} WHERE court_id = %s::uuid",
+                (court_id,),
+            )
+            count = cur.fetchone()[0]
+            deleted[table] = count
+            logger.info(
+                "Pre-delete row count",
+                table=f"derived.{table}",
+                rows=count,
+                court_id=court_id,
+            )
+
+        # Actual deletes.  Order: join tables first (case-scoped), then
+        # court-scoped tables from most dependent to least dependent.
+        # ``rulings`` references ``documents`` AND ``cases`` AND ``judges``,
+        # so it must be deleted before any of those.
+        for table in _PER_COUNTY_CASE_JOIN_TABLES:
+            logger.info(
+                "Deleting rows",
+                table=f"derived.{table}",
+                rows=deleted[table],
+                court_id=court_id,
+            )
+            cur.execute(
+                f"""
+                DELETE FROM derived.{table}
+                 WHERE case_id IN (
+                    SELECT id FROM derived.cases WHERE court_id = %s::uuid
+                 )
+                """,
+                (court_id,),
+            )
+
+        # Order among the court-id-keyed tables:
+        #   rulings  → references documents, cases, judges
+        #   documents → references cases
+        #   cases    → referenced by rulings, documents, join tables
+        #   judges   → referenced by rulings (nullable FK) and case_judges
+        # We delete rulings first, then documents, then cases, then judges.
+        for table in ("rulings", "documents", "cases", "judges"):
+            logger.info(
+                "Deleting rows",
+                table=f"derived.{table}",
+                rows=deleted[table],
+                court_id=court_id,
+            )
+            cur.execute(
+                f"DELETE FROM derived.{table} WHERE court_id = %s::uuid",
+                (court_id,),
+            )
+
+    conn.commit()
+    logger.info(
+        "Per-court reset complete",
+        court_code=court_code,
+        court_id=court_id,
+        deleted=deleted,
+    )
+    return deleted
+
+
 def reset_opensearch_index(os_url: str) -> None:
     """Delete the OpenSearch tentative_rulings index so it's rebuilt from scratch."""
     from opensearchpy import OpenSearch
@@ -1214,6 +1405,79 @@ def delete_opensearch_docs_for_county(os_url: str, county: str) -> int:
         "Deleted per-county OpenSearch docs",
         index=index_name,
         county=county,
+        deleted=deleted,
+    )
+    return deleted
+
+
+def delete_opensearch_docs_for_court(
+    os_url: str,
+    state: str,
+    county: str,
+    court_name: str,
+) -> int:
+    """Delete OS docs for one court before per-court DB rebuild.
+
+    Pairs with reset_derived_tables_for_court(): the global OS index can't
+    be reset (would wipe other courts), and upsert-by-ruling_id only
+    refreshes content for ruling_ids that survive the rebuild.  Without
+    this, rulings dropped during rebuild remain as orphans in OS.  See #3014.
+
+    The filter uses the (state, county, court) triple because ``court`` is
+    not unique across counties — e.g. "Superior Court" appears in every
+    county.  The OS mapping has ``state``, ``county``, and ``court`` keyword
+    fields; there is no ``court_id`` field in the index.  See #3014.
+
+    Returns the number of OS docs deleted (0 if index missing).
+    """
+    from opensearchpy import OpenSearch
+
+    os_kwargs: dict = {
+        "hosts": [os_url],
+        "timeout": 30,
+        "max_retries": 3,
+        "retry_on_timeout": True,
+    }
+    os_user = os.environ.get("OPENSEARCH_USERNAME", "")
+    os_pass = os.environ.get("OPENSEARCH_PASSWORD", "")
+    if os_user and os_pass:
+        os_kwargs["http_auth"] = (os_user, os_pass)
+    client = OpenSearch(**os_kwargs)
+
+    index_name = "tentative_rulings_v1"
+    if not client.indices.exists(index=index_name):
+        logger.info(
+            "OpenSearch index does not exist, nothing to delete",
+            index=index_name,
+            state=state,
+            county=county,
+            court=court_name,
+        )
+        return 0
+
+    response = client.delete_by_query(
+        index=index_name,
+        body={
+            "query": {
+                "bool": {
+                    "must": [
+                        {"term": {"state": state}},
+                        {"term": {"county": county}},
+                        {"term": {"court": court_name}},
+                    ]
+                }
+            }
+        },
+        refresh=True,
+        conflicts="proceed",
+    )
+    deleted = int(response.get("deleted", 0)) if isinstance(response, dict) else 0
+    logger.info(
+        "Deleted per-court OpenSearch docs",
+        index=index_name,
+        state=state,
+        county=county,
+        court=court_name,
         deleted=deleted,
     )
     return deleted
@@ -1337,11 +1601,22 @@ def main() -> None:
         action="store_true",
         help="Truncate all derived tables and delete OpenSearch index before rebuilding",
     )
-    parser.add_argument(
+    _scope_group = parser.add_mutually_exclusive_group()
+    _scope_group.add_argument(
         "--county",
         type=str,
         default=None,
         help="Only process documents from this county (e.g. 'Ventura', 'Los Angeles')",
+    )
+    _scope_group.add_argument(
+        "--court",
+        type=str,
+        default=None,
+        help=(
+            "Only process documents from this court, identified by its court_code "
+            "(e.g. 'ca-orange').  Mutually exclusive with --county.  The court_code "
+            "is the operator-friendly slug stored in derived.courts.court_code."
+        ),
     )
     parser.add_argument(
         "--state",
@@ -1414,7 +1689,25 @@ def main() -> None:
     # path, so ``--reset --county`` on multi-case-PDF counties (Santa Clara,
     # Orange, Riverside, Fresno) is safe.
     if args.reset:
-        if args.county:
+        if args.court:
+            # Resolve the court row first so we can scope the OS delete by
+            # (state, county, court_name).  Delete OS docs FIRST — same
+            # fail-safe rationale as per-county: a delete-by-query failure
+            # aborts before we reset the DB and leave stale OS orphans.  See #3014.
+            _court_id, _court_state, _court_county, _court_name = (
+                _resolve_court_for_reset(conn, args.court)
+            )
+            if os_url:
+                delete_opensearch_docs_for_court(
+                    os_url, _court_state, _court_county, _court_name
+                )
+            else:
+                logger.info(
+                    "OPENSEARCH_URL not set — skipping per-court "
+                    "OpenSearch delete-by-query"
+                )
+            reset_derived_tables_for_court(conn, args.court)
+        elif args.county:
             # Delete the county's OS docs FIRST so a failure there aborts
             # before we reset the DB — otherwise we'd be left with a fresh
             # DB and stale OS orphans.  See #2568.
@@ -1464,10 +1757,23 @@ def main() -> None:
             )
 
         # Step 1: Discover keys (local cache or S3)
-        # Build S3 prefix — default "ca/", narrowed by --county if given.
+        # Build S3 prefix — default "ca/", narrowed by --county or --court if given.
+        # For --court, we derive the (state, county) from the resolved court row.
+        # Today every county has exactly one court_code, so the per-court prefix is
+        # identical to the per-county prefix.  When multi-court-per-county S3 paths
+        # are introduced, this will need a per-court sub-prefix.  See #3014.
         s3_prefix = f"{sluggify(args.state)}/"
         if args.county:
             s3_prefix = f"{sluggify(args.state)}/{sluggify(args.county)}/"
+        elif args.court:
+            # Resolve state+county from the court row to scope the S3 prefix.
+            # _resolve_court_for_reset was already called above (in the reset path);
+            # we call it again here because the reset branch may not have run
+            # (--court without --reset is valid for a scoped non-reset rebuild).
+            _c_id, _c_state, _c_county, _c_name = _resolve_court_for_reset(
+                conn, args.court
+            )
+            s3_prefix = f"{sluggify(_c_state)}/{sluggify(_c_county)}/"
         logger.info("Discovering S3 objects...", prefix=s3_prefix)
         if cache_dir:
             keys = list_local_keys(Path(cache_dir), prefix=s3_prefix)


### PR DESCRIPTION
## Summary

Implemented per-court reset path for `scripts/rebuild_db.py` alongside the existing per-county variant. Adds `--court <court_code>` flag (mutually exclusive with `--county`), resolves the court metadata via `_resolve_court_for_reset()`, and deletes OpenSearch docs filtered on the (state, county, court) triple BEFORE the DB reset. Same OS-delete-first fail-safe as per-county: a delete-by-query failure aborts before the DB reset to prevent stale orphans.

Closes #3014

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`) — all 106 tests green; 12 new per-court tests added
- [x] CI green

### Post-deploy verification

- [ ] Run `scripts/ecs-run-task.sh scripts/rebuild_db.py -- --reset --court <id>` on dev for a representative court
- [ ] Compare OS doc count against derived.rulings count for that court; counts must match
- [ ] Verification evidence posted on #3014 (see /task-v2-verify output)