### PR TITLE
feat(admin-cockpit): surface final-attempt Opus-ralph marker in agent table (#3021)

### DIFF
--- a/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { SECTION_HEADING } from '@/lib/typography';
 import type { DispatcherAgent } from '@/lib/dispatcher-queries';
 import { tooltipText } from '@/lib/dispatcher-phase-flow';
+import { isFinalRalphAttempt } from '@/lib/dispatcher-ralph-model';
 import { formatUptime, shortAgentId, worktreeLogsUrl } from './format-helpers';
 import { IssueLink, PriorityBadge } from './ui-primitives';
 
@@ -92,7 +93,16 @@ function ActiveAgentRow({
   const elapsed = formatUptime(agent.startedAt, nowMs);
   // Build the phase tooltip from the shared canonical constant so
   // future phase additions propagate automatically (#2899).
-  const phaseTooltip = tooltipText(agent.phase);
+  let phaseTooltip = tooltipText(agent.phase);
+  // Final-attempt Opus escalation marker (#3021 / #2955): when the agent
+  // is on a ralph phase AND has exhausted all-but-last retries, annotate
+  // the chip text and tooltip so operators know this is the Opus run.
+  const isFinalOpusRalph =
+    agent.phase === 'ralph' && isFinalRalphAttempt(agent.retriesUsed);
+  if (isFinalOpusRalph) {
+    phaseTooltip += '\n\nFinal attempt — Opus escalation (#2955)';
+  }
+  const phaseChipText = isFinalOpusRalph ? 'ralph (opus)' : agent.phase;
   // Magic Move wiring (#2967). The outer <li> carries the issue identity
   // (`issue-N`) so the row Magic Moves between Queue and Active when the
   // agent is claimed, retried, or released. The inner wrapper carries
@@ -155,7 +165,7 @@ function ActiveAgentRow({
           data-testid={`active-agent-phase-${agent.id}`}
           title={phaseTooltip}
         >
-          {agent.phase}
+          {phaseChipText}
         </span>
         <span className="flex-shrink-0 text-xs">
           {logsHref ? (

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ActiveAgentsTable.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ActiveAgentsTable.test.tsx
@@ -145,6 +145,37 @@ describe('ActiveAgentsTable — Magic Move view-transition names (#2967)', () =>
   });
 });
 
+describe('ActiveAgentsTable — final-attempt Opus marker (#3021)', () => {
+  it('renders (opus) in chip text and Final attempt in tooltip when retriesUsed=2 and phase=ralph', () => {
+    const agent = makeAgent({ phase: 'ralph', retriesUsed: 2 });
+    render(
+      <ActiveAgentsTable agents={[agent]} onAgentAction={vi.fn()} />,
+    );
+    const chip = screen.getByTestId(`active-agent-phase-${agent.id}`);
+    expect(chip.textContent).toContain('(opus)');
+    expect(chip.getAttribute('title')).toContain('Final attempt');
+  });
+
+  it('does NOT render (opus) when retriesUsed=0 and phase=ralph', () => {
+    const agent = makeAgent({ phase: 'ralph', retriesUsed: 0 });
+    render(
+      <ActiveAgentsTable agents={[agent]} onAgentAction={vi.fn()} />,
+    );
+    const chip = screen.getByTestId(`active-agent-phase-${agent.id}`);
+    expect(chip.textContent).toBe('ralph');
+    expect(chip.getAttribute('title')).not.toContain('Final attempt');
+  });
+
+  it('does NOT render (opus) on a non-ralph phase even when retriesUsed=2', () => {
+    const agent = makeAgent({ phase: 'planning', retriesUsed: 2 });
+    render(
+      <ActiveAgentsTable agents={[agent]} onAgentAction={vi.fn()} />,
+    );
+    const chip = screen.getByTestId(`active-agent-phase-${agent.id}`);
+    expect(chip.textContent).toBe('planning');
+  });
+});
+
 describe('ActiveAgentsTable — #3206 view-transition gate while dialog open', () => {
   it('drops view-transition-name on BOTH wrappers when dialogOpen=true', () => {
     const agent = makeAgent({ id: 'agent-42', issueNumber: 3206 });

--- a/packages/web/src/lib/__tests__/dispatcher-ralph-model.test.ts
+++ b/packages/web/src/lib/__tests__/dispatcher-ralph-model.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for the dispatcher ralph-model helpers (#3021) plus a parity
+ * check against `scripts/dispatcher/daemon.py`.
+ *
+ * Why the parity check
+ * --------------------
+ * The admin cockpit's final-attempt Opus marker reads
+ * `MAX_RETRY_ATTEMPTS` from the TS constant in
+ * `../dispatcher-ralph-model.ts`, but the canonical value lives in
+ * `scripts/dispatcher/daemon.py` (the daemon is the source of truth
+ * for retry budget). Without a parity check the two could drift — e.g.
+ * a future PR bumps `MAX_RETRY_ATTEMPTS` in the daemon but forgets the
+ * TS mirror, and the cockpit marks the wrong attempt as final.
+ *
+ * The parity check reads the Python source file as text, extracts the
+ * `MAX_RETRY_ATTEMPTS = N` line via a simple regex (no Python interpreter
+ * needed — the JS test runner already has file I/O), and asserts numeric
+ * equality. A mismatch fails CI with a descriptive error message.
+ *
+ * Same pattern as `dispatcher-phase-flow.test.ts`.
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_RETRY_ATTEMPTS,
+  isFinalRalphAttempt,
+  ralphModelForAttempt,
+} from '../dispatcher-ralph-model';
+
+// ---------------------------------------------------------------------------
+// Parity test — TS constant MUST match the Python source
+// ---------------------------------------------------------------------------
+
+describe('dispatcher-ralph-model parity with scripts/dispatcher/daemon.py', () => {
+  it('TS MAX_RETRY_ATTEMPTS matches the Python MAX_RETRY_ATTEMPTS', () => {
+    // Resolve repo root by climbing from this test file. Four levels:
+    // __tests__ → lib → src → packages/web → repo root.
+    const repoRoot = join(__dirname, '..', '..', '..', '..', '..');
+    const daemonPath = join(repoRoot, 'scripts', 'dispatcher', 'daemon.py');
+    const daemonSource = readFileSync(daemonPath, 'utf8');
+
+    const match = daemonSource.match(/^MAX_RETRY_ATTEMPTS\s*=\s*(\d+)/m);
+    if (!match) {
+      throw new Error(
+        'daemon.py is missing the `MAX_RETRY_ATTEMPTS = N` assignment — ' +
+          'the parity test parser expects that exact shape.',
+      );
+    }
+    const pythonValue = parseInt(match[1], 10);
+    expect(MAX_RETRY_ATTEMPTS).toBe(pythonValue);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ralphModelForAttempt — attempt-number to model name
+// ---------------------------------------------------------------------------
+
+describe('ralphModelForAttempt', () => {
+  it('returns sonnet for attempts 1 through MAX_RETRY_ATTEMPTS-1', () => {
+    for (let attempt = 1; attempt < MAX_RETRY_ATTEMPTS; attempt++) {
+      expect(ralphModelForAttempt(attempt)).toBe('sonnet');
+    }
+  });
+
+  it('returns opus for the final attempt (MAX_RETRY_ATTEMPTS)', () => {
+    expect(ralphModelForAttempt(MAX_RETRY_ATTEMPTS)).toBe('opus');
+  });
+
+  it('returns opus defensively for attempts past the cap', () => {
+    expect(ralphModelForAttempt(MAX_RETRY_ATTEMPTS + 1)).toBe('opus');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isFinalRalphAttempt — truth table over retriesUsed
+// ---------------------------------------------------------------------------
+
+describe('isFinalRalphAttempt', () => {
+  it('returns false when retriesUsed=0 (first attempt, not final)', () => {
+    expect(isFinalRalphAttempt(0)).toBe(false);
+  });
+
+  it('returns false when retriesUsed=1 (second attempt, not yet final)', () => {
+    expect(isFinalRalphAttempt(1)).toBe(false);
+  });
+
+  it('returns true when retriesUsed=2 (third attempt = MAX_RETRY_ATTEMPTS)', () => {
+    // retriesUsed=2 means attempt_n = 3 = MAX_RETRY_ATTEMPTS → final
+    expect(isFinalRalphAttempt(2)).toBe(true);
+  });
+
+  it('returns true when retriesUsed=3 (past cap — defensive)', () => {
+    expect(isFinalRalphAttempt(3)).toBe(true);
+  });
+});

--- a/packages/web/src/lib/dispatcher-ralph-model.ts
+++ b/packages/web/src/lib/dispatcher-ralph-model.ts
@@ -1,0 +1,58 @@
+/**
+ * Ralph model-selection constants and helpers for the admin cockpit (#3021).
+ *
+ * This is a TS mirror of the relevant constants in
+ * `scripts/dispatcher/daemon.py`. A parity test in
+ * `__tests__/dispatcher-ralph-model.test.ts` reads the Python source
+ * and asserts the two values stay in sync — when the cap changes,
+ * update both files in the same PR. CI catches drift.
+ *
+ * Why two copies instead of a GraphQL field?
+ * ------------------------------------------
+ * `MAX_RETRY_ATTEMPTS` almost never changes. Plumbing it through the
+ * GraphQL schema would add a server round-trip on every admin-page
+ * render for data that would be identical 99.9% of the time; the
+ * parity test gives us the "single source of truth" guarantee at
+ * build time at zero runtime cost.
+ *
+ * Same design rationale as `dispatcher-phase-flow.ts`.
+ */
+
+/**
+ * Hard cap on auto-retry attempts per agent+reason. Mirrors
+ * `MAX_RETRY_ATTEMPTS` in `scripts/dispatcher/daemon.py:1024`.
+ *
+ * On the final attempt (attempt N = MAX_RETRY_ATTEMPTS) the daemon
+ * escalates ralph from Sonnet to Opus (#2955). This constant drives
+ * the cockpit's final-attempt Opus marker without a server round-trip.
+ */
+export const MAX_RETRY_ATTEMPTS = 3;
+
+/**
+ * Return the model name for a given ralph attempt number, mirroring
+ * `_ralph_model_for_attempt` in `scripts/dispatcher/daemon.py:562-587`.
+ *
+ * `attemptN` is 1-indexed: the first run is attempt 1 and the final
+ * budgeted retry is {@link MAX_RETRY_ATTEMPTS}. On the final attempt
+ * the model upgrades from `'sonnet'` to `'opus'`. Defensive: attempts
+ * numerically past {@link MAX_RETRY_ATTEMPTS} stay on Opus rather than
+ * silently downgrading.
+ */
+export function ralphModelForAttempt(attemptN: number): 'sonnet' | 'opus' {
+  if (attemptN >= MAX_RETRY_ATTEMPTS) {
+    return 'opus';
+  }
+  return 'sonnet';
+}
+
+/**
+ * Convenience predicate: returns `true` when the agent is on its final
+ * budgeted ralph attempt, meaning `retriesUsed + 1 >= MAX_RETRY_ATTEMPTS`.
+ *
+ * `retriesUsed` is the 0-based count of retries already consumed
+ * (`DispatcherAgent.retriesUsed`). Adding 1 gives the 1-indexed current
+ * attempt number, which is then compared to {@link MAX_RETRY_ATTEMPTS}.
+ */
+export function isFinalRalphAttempt(retriesUsed: number): boolean {
+  return retriesUsed + 1 >= MAX_RETRY_ATTEMPTS;
+}


### PR DESCRIPTION
## Summary

Surface the final-attempt Opus escalation to operators without a DB query. Added a new dispatcher-ralph-model.ts utility library exporting MAX_RETRY_ATTEMPTS (=3) and helper functions to compute whether a given agent is on its final ralph attempt. Modified ActiveAgentsTable to render 'ralph (opus)' when the agent reaches retries_used=2 (final attempt on a ralph phase), with a tooltip explaining the Opus escalation.

Closes #3021

## Test plan

### Automated checks

- [x] Lint passes (`npm run lint`) ✓
- [x] Typecheck passes (`npm run typecheck`) ✓
- [x] Tests pass (`npm test`) — 22 tests pass including 3 new ActiveAgentsTable final-attempt tests and 8 dispatcher-ralph-model tests ✓
- [x] CI green ✓

### Post-deploy verification

- [ ] Admin cockpit screenshot: navigate to dev.judgemind.org/admin/dispatcher, verify agent with retries_used=2 and phase='ralph' renders chip text 'ralph (opus)' with tooltip 'Final attempt — Opus escalation (#2955)'
- [ ] Verify evidence posted on #3021 (see /task-v2-verify output)