### PR TITLE
fix(dispatcher): add deploy-agent-runner.yml to workflow configs (#3185)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -3185,7 +3185,7 @@ STALE_ROLLUP_MARKER="base branch policy prohibits the merge"
 # ``workflowName``); the entrypoint queries by workflow-file path
 # instead (``--workflow <file>.yml``) because bash stubs can match
 # file names more reliably than display names.
-DEPLOY_WORKFLOWS="${AGENT_RUNNER_DEPLOY_WORKFLOWS:-deploy-api.yml deploy-dispatcher.yml deploy-scraper.yml deploy-production.yml deploy-production-web.yml terraform.yml}"
+DEPLOY_WORKFLOWS="${AGENT_RUNNER_DEPLOY_WORKFLOWS:-deploy-api.yml deploy-dispatcher.yml deploy-scraper.yml deploy-production.yml deploy-production-web.yml terraform.yml deploy-agent-runner.yml}"
 
 read_pr_number() {
     # Query ``dispatcher.agents.pr_number`` for the current agent.

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -609,6 +609,7 @@ DEPLOY_WORKFLOW_NAMES = frozenset(
         "Deploy Production",
         "Deploy Production (Web)",
         "Terraform",
+        "Deploy Agent Runner",
     }
 )
 

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -268,6 +268,27 @@ class TestClassifyDeployRuns:
 
 
 # --------------------------------------------------------------------------
+# DEPLOY_WORKFLOW_NAMES contents — regression guard (#3185)
+# --------------------------------------------------------------------------
+
+
+class TestDeployWorkflowNamesContents:
+    def test_deploy_agent_runner_present(self) -> None:
+        assert "Deploy Agent Runner" in daemon.DEPLOY_WORKFLOW_NAMES
+
+    def test_existing_entries_present(self) -> None:
+        for name in (
+            "Deploy API",
+            "Deploy Dispatcher",
+            "Deploy Scraper",
+            "Deploy Production",
+            "Deploy Production (Web)",
+            "Terraform",
+        ):
+            assert name in daemon.DEPLOY_WORKFLOW_NAMES, f"{name!r} missing from DEPLOY_WORKFLOW_NAMES"
+
+
+# --------------------------------------------------------------------------
 # _extract_merge_sha
 # --------------------------------------------------------------------------
 

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -4632,6 +4632,17 @@ else
          "psql-log: $(cat "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null)"
 fi
 
+# ══════════════════════════════════════════════════════════════════════════
+# DEPLOY_WORKFLOWS default — static regression guard (#3185)
+# ══════════════════════════════════════════════════════════════════════════
+
+if grep -qE '^DEPLOY_WORKFLOWS=.*deploy-agent-runner\.yml' "$ENTRYPOINT"; then
+    pass "#3185 — DEPLOY_WORKFLOWS default includes deploy-agent-runner.yml"
+else
+    fail "#3185 — DEPLOY_WORKFLOWS default includes deploy-agent-runner.yml" \
+         "deploy-agent-runner.yml not found in DEPLOY_WORKFLOWS default in $ENTRYPOINT"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Added `deploy-agent-runner.yml` to the dispatcher's deploy-workflow tracking lists so the dispatcher correctly monitors and waits for agent-runner container deployments. This prevents premature phase advancement if a PR triggers only the agent-runner deployment workflow.

Closes #3185

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] N/A — no deployed component (configuration-only; dispatcher behavior is audited via dispatcher logs and CI test runs)