### PR TITLE
feat(infra): add check for unguarded compact([var.*]) in IAM Resource lists (#2741)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -440,6 +440,21 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         else
             echo "  WARNING: terraform not found — skipping fmt check" >&2
         fi
+
+        # Empty-resource risk check: IAM resources with compact([var.*])
+        # Resource lists that lack a count/for_each guard (#2739).
+        echo "pre-push: checking for unguarded compact([var.*]) Resource lists..." >&2
+        if [ -x scripts/check-terraform-empty-resource-risk.sh ]; then
+            if ! run_check "terraform" "check-terraform-empty-resource-risk" scripts/check-terraform-empty-resource-risk.sh; then
+                echo "  An IAM resource uses compact([var.*]) for a Resource list" >&2
+                echo "  without a count or for_each guard. See issue #2739." >&2
+                echo "  Fix or add a waiver to:" >&2
+                echo "    scripts/check-terraform-empty-resource-allowlist.txt" >&2
+                failures=$((failures + 1))
+            fi
+        else
+            echo "  WARNING: scripts/check-terraform-empty-resource-risk.sh not found or not executable — skipping" >&2
+        fi
     fi
 
 done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -963,6 +963,17 @@ jobs:
         run: scripts/check-hardcoded-models.sh
 
   # ---------------------------------------------------------------
+  # Terraform empty-resource risk guard: detect IAM resources with
+  # compact([var.*]) Resource lists that lack a count/for_each guard
+  # ---------------------------------------------------------------
+  terraform-empty-resource-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate IAM Resource compaction has count guard
+        run: scripts/check-terraform-empty-resource-risk.sh
+
+  # ---------------------------------------------------------------
   # Placeholder gates guard: prevent stub security gates
   # ---------------------------------------------------------------
   placeholder-gates-check:
@@ -1456,7 +1467,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-terraform-empty-resource-allowlist.txt
+++ b/scripts/check-terraform-empty-resource-allowlist.txt
@@ -1,0 +1,17 @@
+# check-terraform-empty-resource-allowlist.txt
+#
+# Temporary waivers for pre-existing compact([var.*]) Resource lists that lack
+# a count/for_each guard.  Each entry is:
+#
+#   <absolute-or-relative-path>:<resource_type>:<resource_name>  # issue #NNNN
+#
+# The path is compared against the scanned file path as reported by
+# check-terraform-empty-resource-risk.sh (absolute).  Use the absolute path
+# from the repo root as returned by the script's --list output.
+#
+# Add an entry here only while a fix is pending.  Remove the entry when the
+# corresponding issue is resolved.
+
+# Pre-existing latent #2739 pattern — fix tracked in follow-up issues
+infra/terraform/modules/api-service/main.tf:aws_iam_role_policy:api_secrets  # issue #2741 follow-up
+infra/terraform/modules/scraper-zero-record-check/main.tf:aws_iam_role_policy:execution_secrets  # issue #2741 follow-up

--- a/scripts/check-terraform-empty-resource-risk.sh
+++ b/scripts/check-terraform-empty-resource-risk.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# check-terraform-empty-resource-risk.sh — Detect Terraform resources with
+# compact([var.*]) Resource lists that lack a count or for_each guard.
+#
+# An IAM policy resource with:
+#   Resource = compact([var.some_arn, var.other_arn])
+# and no top-level `count = ...` or `for_each = ...` will silently create an
+# IAM policy with an empty Resource list when all input variables are "".
+# This is the #2739 shape.  The fix (#2740) is to add a count guard like:
+#   count = length(local.compacted_arns) > 0 ? 1 : 0
+#
+# Usage:
+#   scripts/check-terraform-empty-resource-risk.sh            # scan infra/
+#   scripts/check-terraform-empty-resource-risk.sh --list     # print scanned
+#                                                               files, exit 0
+#
+# Exit codes:
+#   0 — No violations found (or --list mode).
+#   1 — One or more unallowlisted violations found.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+ALLOWLIST="$REPO_ROOT/scripts/check-terraform-empty-resource-allowlist.txt"
+
+PYTHON="${PYTHON:-python3}"
+
+# ─── Directories to skip ────────────────────────────────────────────────────
+EXCLUDE_DIRS=(
+    ".git"
+    ".terraform"
+    ".venv"
+    "node_modules"
+    "__pycache__"
+)
+
+# ─── Parse arguments ─────────────────────────────────────────────────────────
+LIST_MODE=false
+if [[ "${1:-}" == "--list" ]]; then
+    LIST_MODE=true
+fi
+
+# ─── Collect .tf files to scan ───────────────────────────────────────────────
+# Scan every main.tf under infra/terraform/modules/**/ and
+# infra/terraform/environments/**/
+TF_FILES=()
+
+while IFS= read -r -d '' f; do
+    # Check against exclusion list
+    skip=false
+    for excl_dir in "${EXCLUDE_DIRS[@]}"; do
+        if [[ "$f" == *"/$excl_dir/"* ]]; then
+            skip=true
+            break
+        fi
+    done
+    if ! "$skip"; then
+        TF_FILES+=("$f")
+    fi
+done < <(find "$REPO_ROOT/infra/terraform" -name "main.tf" -print0 2>/dev/null)
+
+if [[ "$LIST_MODE" == true ]]; then
+    for f in "${TF_FILES[@]}"; do
+        echo "$f"
+    done
+    exit 0
+fi
+
+# ─── Run the check ───────────────────────────────────────────────────────────
+violations=0
+
+for f in "${TF_FILES[@]}"; do
+    # python3 exits 0 (clean) or 1 (violations found)
+    if ! output=$("$PYTHON" "$REPO_ROOT/scripts/check_tf_empty_resource.py" "$f" "$ALLOWLIST" 2>&1); then
+        echo "$output"
+        violations=$((violations + 1))
+    elif [[ -n "$output" ]]; then
+        echo "$output"
+        violations=$((violations + 1))
+    fi
+done
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "ERROR: Found $violations file(s) with IAM resources that use"
+    echo "       compact([var.*]) for a Resource list without a count or"
+    echo "       for_each guard.  When all input vars are \"\", the policy"
+    echo "       will be created with an empty Resource list — a silent"
+    echo "       misconfiguration (see issue #2739)."
+    echo ""
+    echo "  Fix: add a count or for_each guard, e.g.:"
+    echo "    locals {"
+    echo "      compacted_arns = compact([var.a_arn, var.b_arn])"
+    echo "    }"
+    echo "    resource \"aws_iam_role_policy\" \"example\" {"
+    echo "      count = length(local.compacted_arns) > 0 ? 1 : 0"
+    echo "      ..."
+    echo "      Resource = local.compacted_arns"
+    echo "    }"
+    echo ""
+    echo "  To add a temporary waiver while a fix is pending, add a line to:"
+    echo "    scripts/check-terraform-empty-resource-allowlist.txt"
+    echo "  Format: <path>:<resource_type>:<resource_name>  # issue #NNNN"
+    echo ""
+    echo "  See issue #2739 for background and issue #2740 for the fix pattern."
+    exit 1
+fi
+
+echo "All clean — no unguarded compact([var.*]) Resource lists found."
+exit 0

--- a/scripts/check_tf_empty_resource.py
+++ b/scripts/check_tf_empty_resource.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""
+check_tf_empty_resource.py — Detect IAM resources with compact([var.*]) Resource
+lists that lack a top-level count or for_each guard.
+
+Called by check-terraform-empty-resource-risk.sh for each .tf file.
+
+Usage:
+    python3 scripts/check_tf_empty_resource.py <path/to/file.tf> [<allowlist_file>]
+
+Exit codes:
+    0 — No violations found (or all violations are in the allowlist).
+    1 — One or more unallowlisted violations found.
+
+Output:
+    Lines of the form:
+        <path>:<line>: <resource_type> "<resource_name>" missing count guard for
+            compact([var.*]) Resource list
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def load_allowlist(allowlist_path: str | None) -> set[str]:
+    """Load allowlist entries, stripping comments and blank lines.
+
+    Each entry is of the form: <path>:<resource_type>:<resource_name>
+    Trailing comments (# ...) are stripped.
+    """
+    if not allowlist_path:
+        return set()
+    p = Path(allowlist_path)
+    if not p.is_file():
+        return set()
+    entries: set[str] = set()
+    for line in p.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Strip inline comment
+        line = line.split("#")[0].strip()
+        if line:
+            entries.add(line)
+    return entries
+
+
+def check_file(
+    tf_path: str, allowlist: set[str]
+) -> list[tuple[int, str, str]]:
+    """Return a list of (line_number, resource_type, resource_name) violations.
+
+    A violation is a resource block that:
+      - Contains a `Resource = compact([...])` (at any depth within the block)
+        where every argument inside compact() is a `var.<identifier>`
+        (with optional trailing comma), AND
+      - Does NOT have a top-level `count =` or `for_each =` at depth 1
+        (directly inside the resource block, not nested further).
+    """
+    text = Path(tf_path).read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    # Pattern to match the opening of a resource block:
+    #   resource "aws_iam_role_policy" "name" {
+    resource_header_re = re.compile(
+        r'^resource\s+"([^"]+)"\s+"([^"]+)"\s*\{'
+    )
+
+    # Pattern for top-level count / for_each (at depth 1 inside resource block)
+    count_re = re.compile(r'^\s*count\s*=')
+    for_each_re = re.compile(r'^\s*for_each\s*=')
+
+    # Pattern: Resource = compact([  — the start of the problematic pattern
+    # We scan for this at any depth within the resource block.
+    resource_compact_start_re = re.compile(
+        r'\bResource\s*=\s*compact\(\['
+    )
+
+    violations: list[tuple[int, str, str]] = []
+
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = resource_header_re.match(line.strip())
+        if not m:
+            i += 1
+            continue
+
+        resource_type = m.group(1)
+        resource_name = m.group(2)
+
+        # Walk the resource block, tracking brace depth.
+        # depth starts at 1 because we just consumed the opening {
+        depth = 1
+        i += 1
+
+        has_count_guard = False
+        compact_resource_lineno: int | None = None  # 1-based line of first match
+        compact_args_text = ""
+        collecting_compact = False
+        compact_bracket_depth = 0  # bracket depth inside compact([...])
+
+        while i < len(lines) and depth > 0:
+            ln = lines[i]
+            stripped = ln.strip()
+
+            # Increment depth BEFORE processing this line's content for
+            # count/for_each checks (so we know the depth at this line).
+            # We do NOT want to count braces from the current line before
+            # deciding if something is depth-1.
+            current_depth = depth
+
+            # Count braces to track depth changes
+            depth += stripped.count("{") - stripped.count("}")
+
+            if depth == 0:
+                # This line closes the resource block
+                i += 1
+                break
+
+            # Check for count/for_each at depth 1 (direct children of resource block)
+            if current_depth == 1:
+                if count_re.match(ln) or for_each_re.match(ln):
+                    has_count_guard = True
+
+            # Detect Resource = compact([  at ANY depth within the resource block
+            if not collecting_compact and compact_resource_lineno is None:
+                mc = resource_compact_start_re.search(ln)
+                if mc:
+                    compact_resource_lineno = i + 1  # 1-based
+                    # Collect from the [ after compact(
+                    bracket_pos = ln.index("[", mc.start())
+                    compact_args_text = ln[bracket_pos + 1:]
+                    collecting_compact = True
+                    compact_bracket_depth = 1
+                    # Check if compact() closes on the same line
+                    for ch in compact_args_text:
+                        if ch == "[":
+                            compact_bracket_depth += 1
+                        elif ch == "]":
+                            compact_bracket_depth -= 1
+                            if compact_bracket_depth == 0:
+                                collecting_compact = False
+                                break
+            elif collecting_compact:
+                # Continue collecting lines of the compact([...]) argument
+                compact_args_text += " " + stripped
+                for ch in stripped:
+                    if ch == "[":
+                        compact_bracket_depth += 1
+                    elif ch == "]":
+                        compact_bracket_depth -= 1
+                        if compact_bracket_depth == 0:
+                            collecting_compact = False
+                            break
+
+            i += 1
+
+        # Evaluate this resource
+        if compact_resource_lineno is not None:
+            # Check that every argument inside compact([...]) is var.<identifier>
+            # Strip trailing ] and optional ) from the collected text
+            args_raw = compact_args_text
+            # Remove everything from the closing ] onwards
+            close_bracket = args_raw.rfind("]")
+            if close_bracket != -1:
+                args_raw = args_raw[:close_bracket]
+
+            # Split by comma, trim whitespace
+            arg_tokens = [t.strip() for t in args_raw.split(",") if t.strip()]
+
+            # Every token must be var.<identifier>
+            var_only_re = re.compile(r'^var\.[a-zA-Z_][a-zA-Z0-9_]*$')
+            all_var = all(var_only_re.match(tok) for tok in arg_tokens)
+
+            if all_var and arg_tokens and not has_count_guard:
+                violations.append(
+                    (compact_resource_lineno, resource_type, resource_name)
+                )
+
+    # Filter against allowlist
+    # Allowlist entries may use either absolute paths or paths relative to
+    # the repo root (e.g. "infra/terraform/modules/api-service/main.tf:...").
+    # We match if the entry path equals the absolute path or is a suffix of it
+    # (preceded by a path separator).
+    tf_path_str = str(tf_path)
+    filtered: list[tuple[int, str, str]] = []
+    for lineno, rtype, rname in violations:
+        in_allowlist = False
+        for entry in allowlist:
+            parts = entry.split(":")
+            if len(parts) < 3:
+                continue
+            entry_path = parts[0]
+            entry_rtype = parts[1]
+            entry_rname = parts[2]
+            if entry_rtype != rtype or entry_rname != rname:
+                continue
+            # Match if the allowlist path is a suffix of the scanned path
+            if tf_path_str == entry_path or tf_path_str.endswith("/" + entry_path):
+                in_allowlist = True
+                break
+        if not in_allowlist:
+            filtered.append((lineno, rtype, rname))
+
+    return filtered
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(f"Usage: {sys.argv[0]} <file.tf> [allowlist_file]", file=sys.stderr)
+        return 2
+
+    tf_path = sys.argv[1]
+    allowlist_path = sys.argv[2] if len(sys.argv) > 2 else None
+
+    allowlist = load_allowlist(allowlist_path)
+    violations = check_file(tf_path, allowlist)
+
+    for lineno, rtype, rname in violations:
+        print(
+            f"{tf_path}:{lineno}: {rtype} \"{rname}\" "
+            f"missing count guard for compact([var.*]) Resource list"
+        )
+
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/fixtures/tf-empty-resource-bad.tf
+++ b/scripts/tests/fixtures/tf-empty-resource-bad.tf
@@ -1,0 +1,26 @@
+# tf-empty-resource-bad.tf — Fixture replicating the #2739 shape.
+#
+# An aws_iam_role_policy with Resource = compact([var.a_arn, var.b_arn]) and
+# no top-level count or for_each.  When all input vars are "", compact()
+# returns [] and the policy is created with an empty Resource list — silent
+# misconfiguration.
+
+resource "aws_iam_role_policy" "bad_secrets" {
+  name = "judgemind-bad-secrets"
+  role = "some-role"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadBadSecrets"
+        Effect = "Allow"
+        Action = "secretsmanager:GetSecretValue"
+        Resource = compact([
+          var.a_arn,
+          var.b_arn,
+        ])
+      }
+    ]
+  })
+}

--- a/scripts/tests/fixtures/tf-empty-resource-good.tf
+++ b/scripts/tests/fixtures/tf-empty-resource-good.tf
@@ -1,0 +1,51 @@
+# tf-empty-resource-good.tf — Fixture showing the #2740 fix pattern.
+#
+# Two variants:
+#   1. count guard using length(local.compacted_arns) > 0 ? 1 : 0
+#   2. for_each guard
+#
+# Both are correctly guarded and should not be flagged by the check.
+
+# Variant 1: count guard
+locals {
+  compacted_arns = compact([var.a_arn, var.b_arn])
+}
+
+resource "aws_iam_role_policy" "good_secrets_count" {
+  count = length(local.compacted_arns) > 0 ? 1 : 0
+
+  name = "judgemind-good-secrets"
+  role = "some-role"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadGoodSecrets"
+        Effect = "Allow"
+        Action = "secretsmanager:GetSecretValue"
+        Resource = local.compacted_arns
+      }
+    ]
+  })
+}
+
+# Variant 2: for_each guard
+resource "aws_iam_role_policy" "good_secrets_foreach" {
+  for_each = toset(compact([var.c_arn, var.d_arn]))
+
+  name = "judgemind-good-secrets-${each.key}"
+  role = "some-role"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadGoodSecretsForEach"
+        Effect = "Allow"
+        Action = "secretsmanager:GetSecretValue"
+        Resource = [each.value]
+      }
+    ]
+  })
+}

--- a/scripts/tests/test_check_terraform_empty_resource.sh
+++ b/scripts/tests/test_check_terraform_empty_resource.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# test_check_terraform_empty_resource.sh — Tests for check-terraform-empty-resource-risk.sh
+#
+# Creates temporary .tf files to verify that the checker correctly detects
+# compact([var.*]) Resource lists without count/for_each guards.
+#
+# Usage:
+#   scripts/tests/test_check_terraform_empty_resource.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-terraform-empty-resource-risk.sh"
+PYTHON_HELPER="$SCRIPT_DIR/check_tf_empty_resource.py"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+# Create a minimal directory structure that mirrors infra/terraform so
+# check-terraform-empty-resource-risk.sh --list picks up our test files.
+# Tests that drive the Python helper directly use TMPDIR_TEST files directly.
+TF_DIR="$TMPDIR_TEST/infra/terraform/modules/test-module"
+mkdir -p "$TF_DIR"
+
+create_main_tf() {
+    local content="$1"
+    printf '%s\n' "$content" > "$TF_DIR/main.tf"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# Python-level assert helpers (drive the helper directly on a specific file)
+# These use if/then/else to be safe under set -e (the if condition is not
+# subject to set -e exit).
+assert_py_fails() {
+    local desc="$1"
+    local tf_file="$2"
+    local allowlist="${3:-}"
+    TESTS=$((TESTS + 1))
+    local passed=false
+    if [[ -n "$allowlist" ]]; then
+        if python3 "$PYTHON_HELPER" "$tf_file" "$allowlist" > /dev/null 2>&1; then
+            passed=true
+        fi
+    else
+        if python3 "$PYTHON_HELPER" "$tf_file" > /dev/null 2>&1; then
+            passed=true
+        fi
+    fi
+    if "$passed"; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_py_passes() {
+    local desc="$1"
+    local tf_file="$2"
+    local allowlist="${3:-}"
+    TESTS=$((TESTS + 1))
+    local passed=false
+    if [[ -n "$allowlist" ]]; then
+        if python3 "$PYTHON_HELPER" "$tf_file" "$allowlist" > /dev/null 2>&1; then
+            passed=true
+        fi
+    else
+        if python3 "$PYTHON_HELPER" "$tf_file" > /dev/null 2>&1; then
+            passed=true
+        fi
+    fi
+    if "$passed"; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+assert_py_output_contains() {
+    local desc="$1"
+    local tf_file="$2"
+    local pattern="$3"
+    TESTS=$((TESTS + 1))
+    local out
+    out=$(python3 "$PYTHON_HELPER" "$tf_file" 2>&1 || true)
+    if echo "$out" | grep -qE "$pattern"; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (pattern '$pattern' not found in output: $out)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TF_DIR"
+    mkdir -p "$TF_DIR"
+}
+
+# ─── Test 1: Bad fixture (the #2739 shape) should be flagged ──────────────────
+# Inline TF: resource with Resource = compact([var.*]) and no count/for_each
+FIXTURES_DIR="$SCRIPT_DIR/tests/fixtures"
+assert_py_fails "bad fixture exits non-zero" "$FIXTURES_DIR/tf-empty-resource-bad.tf"
+reset_tmpdir
+
+# ─── Test 2: Bad fixture output includes line number and resource info ────────
+assert_py_output_contains \
+    "bad fixture output contains path:line format" \
+    "$FIXTURES_DIR/tf-empty-resource-bad.tf" \
+    ":[0-9]+:"
+reset_tmpdir
+
+# ─── Test 3: Good fixture (the #2740 fix — count + locals) should pass ───────
+assert_py_passes "good fixture exits 0" "$FIXTURES_DIR/tf-empty-resource-good.tf"
+reset_tmpdir
+
+# ─── Test 4: Resource with count guard passes ─────────────────────────────────
+cat > "$TMPDIR_TEST/with_count.tf" << 'TFEOF'
+resource "aws_iam_role_policy" "guarded" {
+  count = length(local.arns) > 0 ? 1 : 0
+  name  = "guarded"
+  role  = "some-role"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "secretsmanager:GetSecretValue"
+      Resource = compact([var.a_arn, var.b_arn])
+    }]
+  })
+}
+TFEOF
+assert_py_passes "resource with count guard passes" "$TMPDIR_TEST/with_count.tf"
+
+# ─── Test 5: Resource with for_each guard passes ──────────────────────────────
+cat > "$TMPDIR_TEST/with_foreach.tf" << 'TFEOF'
+resource "aws_iam_role_policy" "guarded_fe" {
+  for_each = toset(local.arns)
+  name     = "guarded-${each.key}"
+  role     = "some-role"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "secretsmanager:GetSecretValue"
+      Resource = compact([var.a_arn])
+    }]
+  })
+}
+TFEOF
+assert_py_passes "resource with for_each guard passes" "$TMPDIR_TEST/with_foreach.tf"
+
+# ─── Test 6: Mixed compact() args (one literal) — not flagged ────────────────
+# When any compact() arg is not a var.*, it's not the #2739 pattern
+cat > "$TMPDIR_TEST/mixed_args.tf" << 'TFEOF'
+resource "aws_iam_role_policy" "mixed" {
+  name = "mixed"
+  role = "some-role"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "secretsmanager:GetSecretValue"
+      Resource = compact([var.a_arn, "arn:aws:iam::123456789012:root"])
+    }]
+  })
+}
+TFEOF
+assert_py_passes "compact() with literal arg is not flagged" "$TMPDIR_TEST/mixed_args.tf"
+
+# ─── Test 7: compact() inside jsonencode nested (depth > 1) is not flagged ───
+# The Resource = compact([...]) is nested inside jsonencode, not at depth 1
+# of the resource block.  The check looks at depth 1 only, so a compact()
+# that appears only inside jsonencode({...}) won't trigger unless it also
+# appears at depth 1.
+cat > "$TMPDIR_TEST/nested_only.tf" << 'TFEOF'
+resource "aws_iam_role_policy" "nested" {
+  name = "nested"
+  role = "some-role"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "secretsmanager:GetSecretValue"
+      Resource = compact([var.a_arn, var.b_arn])
+    }]
+  })
+}
+TFEOF
+# This IS the bad pattern (compact([var.*]) without count) — should fail
+assert_py_fails "nested compact([var.*]) without count is flagged" "$TMPDIR_TEST/nested_only.tf"
+
+# ─── Test 8: Allowlist suppression works ─────────────────────────────────────
+cat > "$TMPDIR_TEST/bad_for_allowlist.tf" << 'TFEOF'
+resource "aws_iam_role_policy" "suppress_me" {
+  name = "suppress-me"
+  role = "some-role"
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "secretsmanager:GetSecretValue"
+      Resource = compact([var.a_arn, var.b_arn])
+    }]
+  })
+}
+TFEOF
+ALLOWLIST_FILE="$TMPDIR_TEST/test_allowlist.txt"
+printf '%s\n' "$TMPDIR_TEST/bad_for_allowlist.tf:aws_iam_role_policy:suppress_me" > "$ALLOWLIST_FILE"
+TESTS=$((TESTS + 1))
+if python3 "$PYTHON_HELPER" "$TMPDIR_TEST/bad_for_allowlist.tf" "$ALLOWLIST_FILE" > /dev/null 2>&1; then
+    echo "PASS: allowlist suppression works"
+else
+    echo "FAIL: allowlist suppression works (allowlisted violation still flagged)"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 9: --list flag prints expected paths and exits 0 ────────────────────
+# Point the script at a directory with a known .tf file
+# We need the script to look in a known location — use REPO_ROOT override
+# by creating a minimal structure
+TF_LIST_DIR="$TMPDIR_TEST/list_test/infra/terraform/modules/mymodule"
+mkdir -p "$TF_LIST_DIR"
+printf 'resource "aws_s3_bucket" "b" { bucket = "b" }\n' > "$TF_LIST_DIR/main.tf"
+# We can't easily override REPO_ROOT inside the shell script, so test --list
+# against the real repo.
+TESTS=$((TESTS + 1))
+list_output=$("$CHECK_SCRIPT" --list 2>&1 || true)
+if echo "$list_output" | grep -q "main.tf"; then
+    echo "PASS: --list flag prints .tf files and exits 0"
+else
+    echo "FAIL: --list flag did not print any main.tf files (output: $list_output)"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 10: --list includes modules and environments paths ──────────────────
+TESTS=$((TESTS + 1))
+if echo "$list_output" | grep -q "infra/terraform/modules" && echo "$list_output" | grep -q "infra/terraform/environments"; then
+    echo "PASS: --list includes both modules/ and environments/ paths"
+else
+    echo "FAIL: --list missing modules or environments path"
+    echo "  Output was: $list_output"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 11: No violations in real repo (allowlisted violations excluded) ────
+TESTS=$((TESTS + 1))
+if "$CHECK_SCRIPT" > /dev/null 2>&1; then
+    echo "PASS: real repo scan exits 0 with allowlisted violations excluded"
+else
+    echo "FAIL: real repo scan exits non-zero — allowlist may be incomplete"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 12: No self-match on ci.yml step name ──────────────────────────────
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-terraform-empty-resource-risk.sh" "yml"
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Added static check to detect Terraform IAM resources with `Resource = compact([var.*])` lacking a `count`/`for_each` guard. This pattern silently creates invalid (empty) Resource lists when all input variables are "", which IAM rejects at `terraform apply` time with `MalformedPolicyDocument`. The check catches this at PR/push time instead.

Includes:
- Bash wrapper `scripts/check-terraform-empty-resource-risk.sh` and Python analyzer `scripts/check_tf_empty_resource.py`
- Synthetic good/bad fixtures and 12-test peer suite
- Integration into CI job `terraform-empty-resource-check` and `.githooks/pre-push`
- Allowlist for two pre-existing violations (api-service, scraper-zero-record-check) pending follow-up fixes

Closes #2741

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (CI/local tooling only)