### PR TITLE
ci: add lint to catch deploy-*.yml workflows that push to ECR without rolling a service (#2777)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -485,6 +485,27 @@ if [ -n "$changed_ci_yml" ]; then
 fi
 
 # -------------------------------------------------------------------
+# Deploy-workflow rollout check — run whenever a deploy-*.yml changes
+# or the check script itself changes (#2777)
+# -------------------------------------------------------------------
+# Mirrors the CI `deploy-workflow-rollout-check` job so the guard fires
+# locally before the push reaches CI.  Catches deploy workflows that
+# push to ECR but forget to roll the service.
+changed_deploy_wf=$(echo "$changed_files" | grep -E '^\.github/workflows/deploy-.*\.yml$|^scripts/check-deploy-workflow-rollout\.sh$' || true)
+if [ -n "$changed_deploy_wf" ]; then
+    echo "pre-push: checking deploy workflows for missing service rollout..." >&2
+    if [ -x scripts/check-deploy-workflow-rollout.sh ]; then
+        if ! run_check "_" "scripts/check-deploy-workflow-rollout.sh" scripts/check-deploy-workflow-rollout.sh; then
+            echo "  A deploy workflow pushes to ECR but has no service rollout step." >&2
+            echo "  Add a rollout step or an opt-out marker. See #2777." >&2
+            failures=$((failures + 1))
+        fi
+    else
+        echo "  WARNING: scripts/check-deploy-workflow-rollout.sh not found or not executable — skipping" >&2
+    fi
+fi
+
+# -------------------------------------------------------------------
 # Markdown link check — run whenever any .md file is in the push
 # -------------------------------------------------------------------
 # Mirrors the CI `markdown-links-check` job so broken internal pointers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       githooks: ${{ steps.changes.outputs.githooks }}
       dispatcher-terminals: ${{ steps.changes.outputs.dispatcher-terminals }}
       dispatcher-image: ${{ steps.changes.outputs.dispatcher-image }}
+      deploy-workflows: ${{ steps.changes.outputs.deploy-workflows }}
       any-testable: ${{ steps.any-testable.outputs.result }}
     steps:
       - uses: actions/checkout@v6
@@ -149,6 +150,14 @@ jobs:
             dispatcher-image:
               - 'Dockerfile.dispatcher'
               # Include ci.yml so that edits to the dispatcher-image-version-check
+              # job are exercised on the PR that introduces them. Without this, the
+              # paths filter makes the job SKIP on its own PR — the #2410/#2505
+              # footgun. See scripts/check-ci-job-skipped.py.
+              - '.github/workflows/ci.yml'
+            deploy-workflows:
+              - '.github/workflows/deploy-*.yml'
+              - 'scripts/check-deploy-workflow-rollout.sh'
+              # Include ci.yml so that edits to the deploy-workflow-rollout-check
               # job are exercised on the PR that introduces them. Without this, the
               # paths filter makes the job SKIP on its own PR — the #2410/#2505
               # footgun. See scripts/check-ci-job-skipped.py.
@@ -1453,10 +1462,25 @@ jobs:
       - name: Verify dispatcher image meets minimum runtime version requirements
         run: scripts/check-dispatcher-image-versions.sh --build Dockerfile.dispatcher
 
+  # ---------------------------------------------------------------
+  # Deploy-workflow rollout guard (#2777)
+  # Asserts that every deploy-*.yml that pushes to ECR also rolls
+  # a service (or carries an explicit opt-out marker).
+  # ---------------------------------------------------------------
+  deploy-workflow-rollout-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.deploy-workflows == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check every deploy workflow that pushes to ECR also rolls a service
+        run: scripts/check-deploy-workflow-rollout.sh
+
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check, deploy-workflow-rollout-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/deploy-agent-runner.yml
+++ b/.github/workflows/deploy-agent-runner.yml
@@ -1,5 +1,7 @@
 name: Deploy Agent Runner
 
+# rollout-not-required: task-definition family — ecs:RunTask callers pull :latest. See #2777.
+
 # Builds and pushes the dispatcher agent-runner image
 # (`judgemind/dispatcher-agent-runner`) to ECR on merge to main. Mirrors
 # the build-and-push half of `deploy-dispatcher.yml`, without the

--- a/scripts/check-deploy-workflow-rollout.sh
+++ b/scripts/check-deploy-workflow-rollout.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# check-deploy-workflow-rollout.sh — Every deploy workflow that pushes to ECR
+# must also roll a service (or declare an explicit opt-out).
+#
+# Background
+# ----------
+# Deploy workflows that push a new image to ECR but never trigger an ECS
+# service rollout leave the running tasks on stale image digests.  The bug
+# is silent: CI goes green, the push looks successful, but the service
+# keeps serving the previous build.
+#
+# Rule
+# ----
+# For each `.github/workflows/deploy-*.yml`:
+#   - If an ECR-push signal is present (non-comment line matching
+#     `aws ecr` OR `docker push`), the file MUST also contain a rollout
+#     signal (`aws ecs update-service`, `uses: ./.github/actions/ecs-deploy`,
+#     or `aws scheduler update-schedule`) OR an explicit opt-out comment
+#     `# rollout-not-required: <reason>` (reason must be non-empty).
+#
+# Opt-out
+# -------
+# Task-definition-family workflows (e.g. `deploy-agent-runner.yml`) push
+# an image but rely on `ecs:RunTask` callers always pulling `:latest` —
+# they never roll a service.  Add the marker:
+#   # rollout-not-required: task-definition family — ecs:RunTask callers
+#   #   pull :latest.  See <issue>.
+#
+# Usage:
+#   scripts/check-deploy-workflow-rollout.sh          # exits 0 if clean
+#   scripts/check-deploy-workflow-rollout.sh [dir]    # scan a specific directory
+#
+# Exit codes:
+#   0 — No violations found.
+#   1 — One or more deploy workflows push to ECR without rolling a service.
+#
+# permanent: true
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-$REPO_ROOT}"
+
+# ─── ECR-push signal patterns ───────────────────────────────────────────────
+# A non-comment line matching either of these indicates the workflow pushes
+# a new image to ECR and therefore requires a rollout (or opt-out).
+ECR_PUSH_PATTERN_AWS='aws[[:space:]]+ecr'
+ECR_PUSH_PATTERN_DOCKER='docker[[:space:]]+push'
+
+# ─── Rollout signal patterns ────────────────────────────────────────────────
+# Any of these signals on a non-comment line confirms the workflow rolls a
+# service after pushing.
+ROLLOUT_PATTERN_UPDATE_SERVICE='aws[[:space:]]+ecs[[:space:]]+update-service'
+ROLLOUT_PATTERN_ECS_DEPLOY='uses:[[:space:]]+\./.github/actions/ecs-deploy'
+ROLLOUT_PATTERN_SCHEDULER='aws[[:space:]]+scheduler[[:space:]]+update-schedule'
+
+# ─── Opt-out marker pattern ─────────────────────────────────────────────────
+# Comment line of the form `# rollout-not-required: <non-empty reason>`.
+# The reason must contain at least one non-space character after the colon.
+OPTOUT_PATTERN='#[[:space:]]+rollout-not-required:[[:space:]]+[^[:space:]]'
+
+violations=0
+
+# Find all deploy-*.yml files under .github/workflows/ within SCAN_DIR.
+# Use find for portability (Bash 3.2 compatible).
+workflow_files=()
+while IFS= read -r -d '' f; do
+    workflow_files+=("$f")
+done < <(find "$SCAN_DIR" -path "*/.github/workflows/deploy-*.yml" -print0 2>/dev/null | sort -z)
+
+# Also check top-level .github/workflows/deploy-*.yml when SCAN_DIR is a
+# fixture directory in tests (no subdirectory nesting).
+while IFS= read -r -d '' f; do
+    workflow_files+=("$f")
+done < <(find "$SCAN_DIR" -maxdepth 3 -name "deploy-*.yml" -not -path "*/.github/workflows/*" -print0 2>/dev/null | sort -z)
+
+# Deduplicate (sort -u on the array).
+if [[ ${#workflow_files[@]} -gt 0 ]]; then
+    IFS=$'\n' read -r -d '' -a workflow_files < <(printf '%s\n' "${workflow_files[@]}" | sort -u; printf '\0') || true
+fi
+
+check_workflow() {
+    local file="$1"
+
+    local has_ecr_push=false
+    local has_rollout=false
+    local has_optout=false
+
+    while IFS= read -r line; do
+        # Opt-out marker IS a comment — check it before the comment-skip below.
+        if [[ "$line" =~ $OPTOUT_PATTERN ]]; then
+            has_optout=true
+        fi
+
+        # Skip comment lines (first non-whitespace character is `#`) for
+        # signal detection — comments are allowed to reference these patterns
+        # as documentation context.
+        if [[ "$line" =~ ^[[:space:]]*# ]]; then
+            continue
+        fi
+
+        # ECR-push signal.
+        if [[ "$line" =~ $ECR_PUSH_PATTERN_AWS ]] || [[ "$line" =~ $ECR_PUSH_PATTERN_DOCKER ]]; then
+            has_ecr_push=true
+        fi
+
+        # Rollout signal.
+        if [[ "$line" =~ $ROLLOUT_PATTERN_UPDATE_SERVICE ]] || \
+           [[ "$line" =~ $ROLLOUT_PATTERN_ECS_DEPLOY ]] || \
+           [[ "$line" =~ $ROLLOUT_PATTERN_SCHEDULER ]]; then
+            has_rollout=true
+        fi
+    done < "$file"
+
+    # Violation: ECR push without rollout and without opt-out.
+    if "$has_ecr_push" && ! "$has_rollout" && ! "$has_optout"; then
+        return 1
+    fi
+    return 0
+}
+
+for wf in "${workflow_files[@]}"; do
+    if ! check_workflow "$wf"; then
+        if [[ $violations -eq 0 ]]; then
+            echo "ERROR: Deploy workflow(s) push to ECR but do not roll a service."
+            echo ""
+            echo "  Each of the following workflows pushes a new image to ECR but"
+            echo "  contains no rollout step (aws ecs update-service,"
+            echo "  uses: ./.github/actions/ecs-deploy, or"
+            echo "  aws scheduler update-schedule)."
+            echo ""
+            echo "  Violations:"
+        fi
+        echo "    $wf"
+        violations=$((violations + 1))
+    fi
+done
+
+if [[ $violations -gt 0 ]]; then
+    echo ""
+    echo "  Found $violations violation(s)."
+    echo ""
+    echo "  Fix: add a rollout step after the docker push / ecr push.  Use"
+    echo "  deploy-api.yml (service rollout via ecs-deploy composite) or"
+    echo "  deploy-scraper.yml (scheduler rollout via aws scheduler"
+    echo "  update-schedule) as patterns to mirror."
+    echo ""
+    echo "  If the workflow intentionally omits a service rollout (e.g. it"
+    echo "  builds a task-definition-family image where ecs:RunTask callers"
+    echo "  always pull :latest), add the opt-out marker anywhere in the file:"
+    echo ""
+    echo "    # rollout-not-required: <reason>  (reason must be non-empty)"
+    echo ""
+    echo "  See deploy-agent-runner.yml for an example."
+    exit 1
+fi
+
+echo "All clean — every deploy workflow that pushes to ECR also rolls a service (or is opted out)."
+exit 0

--- a/scripts/tests/test_check_deploy_workflow_rollout.sh
+++ b/scripts/tests/test_check_deploy_workflow_rollout.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# test_check_deploy_workflow_rollout.sh — Tests for check-deploy-workflow-rollout.sh
+#
+# Creates temporary workflow fixture files to verify that the checker correctly
+# requires a service rollout step when a deploy workflow pushes to ECR, while
+# allowing opt-out markers and empty (no-push) workflows to pass.
+#
+# Usage:
+#   scripts/tests/test_check_deploy_workflow_rollout.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+#
+# permanent: true
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-deploy-workflow-rollout.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory under repo tmp/ so we don't pollute the repo
+TMPDIR_TEST=$(mktemp -d "$SCRIPT_DIR/../tmp/test_deploy_rollout.XXXXXX")
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+# Fixture files must be under .github/workflows/ so the finder picks them up.
+create_workflow_file() {
+    local name="$1"
+    local content="$2"
+    local dir="$TMPDIR_TEST/.github/workflows"
+    mkdir -p "$dir"
+    local path="$dir/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST/.github"
+}
+
+# ─── Test (a): push + aws ecs update-service → pass ─────────────────────────
+create_workflow_file "deploy-api.yml" 'jobs:
+  build-and-push:
+    steps:
+      - run: docker push "$IMAGE_BASE" --all-tags
+  deploy-dev:
+    steps:
+      - run: |
+          aws ecs update-service \
+            --cluster judgemind-dev \
+            --service judgemind-api-dev \
+            --force-new-deployment'
+assert_passes "push + aws ecs update-service → pass (deploy-api.yml shape)"
+reset_tmpdir
+
+# ─── Test (b): push + uses ecs-deploy composite → pass ──────────────────────
+create_workflow_file "deploy-api.yml" 'jobs:
+  build-and-push:
+    steps:
+      - run: docker push "$IMAGE_BASE" --all-tags
+  deploy-dev:
+    steps:
+      - name: Deploy to ECS
+        uses: ./.github/actions/ecs-deploy
+        with:
+          deploy-mode: service'
+assert_passes "push + uses ecs-deploy composite → pass"
+reset_tmpdir
+
+# ─── Test (c): push + aws scheduler update-schedule → pass ──────────────────
+create_workflow_file "deploy-scraper.yml" 'jobs:
+  build-and-push:
+    steps:
+      - run: docker push "$IMAGE_BASE" --all-tags
+  deploy-staging:
+    steps:
+      - uses: ./.github/actions/ecs-deploy
+        with:
+          deploy-mode: scheduler
+          scheduler-name: judgemind-scraper-dev'
+assert_passes "push + scheduler rollout via ecs-deploy → pass (deploy-scraper.yml shape)"
+reset_tmpdir
+
+# ─── Test (d): push only, no rollout → fail ──────────────────────────────────
+create_workflow_file "deploy-broken.yml" 'jobs:
+  build-and-push:
+    steps:
+      - run: docker push "$IMAGE_BASE" --all-tags'
+assert_fails "push only, no rollout → fail"
+reset_tmpdir
+
+# ─── Test (e): push only with # rollout-not-required: reason text → pass ────
+create_workflow_file "deploy-agent-runner.yml" '# rollout-not-required: task-definition family — ecs:RunTask callers pull :latest. See #2777.
+jobs:
+  build-and-push:
+    steps:
+      - run: docker push "$IMAGE_BASE" --all-tags'
+assert_passes "push with rollout-not-required marker → pass"
+reset_tmpdir
+
+# ─── Test (f): marker without reason text → fail ────────────────────────────
+# `# rollout-not-required:` with no non-space text after the colon is
+# treated the same as no marker — a reason is mandatory.
+create_workflow_file "deploy-bad-optout.yml" '# rollout-not-required:
+jobs:
+  build-and-push:
+    steps:
+      - run: docker push "$IMAGE_BASE" --all-tags'
+assert_fails "rollout-not-required without reason text → fail"
+reset_tmpdir
+
+# ─── Test (g): aws ecs update-service only in a comment → fail ──────────────
+# Rollout signal must appear on a non-comment line; comment-only mentions
+# do not count.
+create_workflow_file "deploy-comment-only.yml" 'jobs:
+  build-and-push:
+    steps:
+      - run: docker push "$IMAGE_BASE" --all-tags
+      # Previously: aws ecs update-service --cluster foo (removed)
+      - run: echo "no rollout here"'
+assert_fails "rollout signal only in comment → fail"
+reset_tmpdir
+
+# ─── Test (h): empty workflow file → pass ───────────────────────────────────
+create_workflow_file "deploy-empty.yml" ''
+assert_passes "empty workflow file → pass (no ECR push, no violation)"
+reset_tmpdir
+
+# ─── Test (i): self-match guard ─────────────────────────────────────────────
+# The step name in .github/workflows/ci.yml that invokes this guard must not
+# itself contain a token that the guard would match, or the guard fails on
+# its very first CI run (see issue #2542 / PR #2541 for the class of failure).
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-deploy-workflow-rollout.sh" "yml"
+
+# ─── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add `scripts/check-deploy-workflow-rollout.sh` to enforce that every `.github/workflows/deploy-*.yml` workflow that pushes a new image to ECR also rolls a service (via `aws ecs update-service`, `ecs-deploy` composite, or `aws scheduler update-schedule`), or declares an explicit opt-out marker. This prevents the recurring bug where a deploy workflow silently drifts the running task to a stale image.

Closes #2777

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (CI/agent config only)