### PR TITLE
fix(dispatcher): handle untracked ARNs + tighten stall watchdog (#3344)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -141,32 +141,39 @@ DEFAULT_SUPERVISOR_TICK_SECONDS = 120
 #: heartbeat. Issue #2778 (closes the TODO in migration 24).
 DEFAULT_HOUSEKEEPING_TICK_SECONDS = 3600
 
-#: Scheduler-tick stall watchdog thresholds (#3097). The supervisor
-#: watchdog thread (:meth:`DispatcherDaemon._watchdog_loop`) observes
+#: Scheduler-tick stall watchdog thresholds (#3097, tightened in #3344).
+#: The supervisor watchdog thread
+#: (:meth:`DispatcherDaemon._watchdog_loop`) observes
 #: ``self._last_scheduler_tick_at`` and fires two tiers of alarm when
 #: the main scheduler loop goes silent:
 #:
-#: * ``DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS`` (300 = 5 min) —
-#:   WARNING ``scheduler_tick_stalled`` with a bounded thread dump.
-#:   This is ~10× the default scheduler cadence, so a transient GitHub
-#:   or DB slowdown does not trigger a false positive while a real
-#:   wedge (30+ min observed silence on #3097 reproductions) is
-#:   caught well before the exit threshold.
-#: * ``DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS`` (3000 = 50 min) —
-#:   ERROR ``scheduler_tick_stalled_exiting`` with a final thread dump
-#:   followed by ``os._exit(137)``. ECS restarts the task. 50 min is
-#:   the MTTR ceiling the issue targets (vs. ~30 min of operator-
-#:   notice + ~5 min of manual ``update-service --force-new-deployment``
-#:   today). Exit code 137 mirrors the kernel's 128+SIGKILL convention
-#:   for operator-legible logs.
+#: * ``DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS`` (60s) — WARNING
+#:   ``scheduler_tick_stalled`` with a bounded thread dump. Roughly 2×
+#:   the default scheduler cadence (30s), so a transient GitHub or DB
+#:   slowdown does not trigger a false positive while a real wedge is
+#:   surfaced loudly well before the exit threshold.
+#: * ``DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS`` (120s) — ERROR
+#:   ``scheduler_tick_stalled_exiting`` with a final thread dump followed
+#:   by ``os._exit(137)``. ECS restarts the task. 120s is the MTTR
+#:   ceiling the #3344 issue targets (vs. >12 min of operator-visible
+#:   silence observed on the 2026-04-25 wedge that exposed the
+#:   stale-ARN cascade). Exit code 137 mirrors the kernel's 128+SIGKILL
+#:   convention for operator-legible logs.
 #:
 #: Both thresholds are operator-tunable via
 #: ``dispatcher.config.scheduler_tick_stall_warn_seconds`` /
 #: ``scheduler_tick_stall_exit_seconds`` (read through
 #: :meth:`DispatcherDaemon._cb_config_int`, which fails closed to the
 #: default on any DB / parse error).
-DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS = 300
-DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS = 3000
+#:
+#: History: #3097 set these to 300 / 3000 (5 min WARN, 50 min EXIT).
+#: That EXIT ceiling failed to catch the 2026-04-25 reaper wedge — the
+#: daemon went >12 min silent and required manual force-redeploy. #3344
+#: drops EXIT to 120s and WARN to 60s so a recurrence auto-restarts in
+#: under 2 min and the WARN tier surfaces the wedge in CloudWatch
+#: Insights well before the EXIT path runs.
+DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS = 60
+DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS = 120
 
 #: Watchdog poll cadence. The watchdog thread wakes every 30s to check
 #: the elapsed-since-last-tick gap against the thresholds above. Small
@@ -195,11 +202,11 @@ WATCHDOG_THREAD_DUMP_MAX_FRAMES_PER_THREAD = 20
 #: ``daemon.scheduler_tick_slow_<step>`` WARNING with the measured
 #: elapsed seconds. Chosen to be comfortably above normal execution
 #: (single-digit ms for DB hits, low-hundreds-of-ms for ``gh`` calls)
-#: while still firing well before the #3097 watchdog's 300s wedge
-#: threshold — a 5s step repeated N times is the cheap path for us to
-#: pinpoint which helper owns the wedge BEFORE the main loop goes
-#: silent. Not operator-tunable today; flip to a config key if we end
-#: up needing per-environment overrides.
+#: while still firing well before the #3097 watchdog's wedge threshold
+#: (60s WARN / 120s EXIT post-#3344) — a 5s step repeated N times is
+#: the cheap path for us to pinpoint which helper owns the wedge
+#: BEFORE the main loop goes silent. Not operator-tunable today; flip
+#: to a config key if we end up needing per-environment overrides.
 SCHEDULER_TICK_SLOW_STEP_WARN_SECONDS = 5.0
 
 #: Periodic faulthandler stderr-dump cadence (#3205). At daemon startup
@@ -209,9 +216,13 @@ SCHEDULER_TICK_SLOW_STEP_WARN_SECONDS = 5.0
 #: state. This is the "nuclear option" — if the watchdog thread itself
 #: is wedged (e.g. GIL starved, psycopg-deadlocked), the faulthandler
 #: timer fires from the C-level SIGALRM handler and produces a stack
-#: dump anyway. Matches the #3097 watchdog's WARN threshold so the two
-#: reliability nets share the same "something is wrong" cadence. Can
-#: be disabled in tests / local dev via the
+#: dump anyway. Held at 300s as an independent diagnostic cadence —
+#: pre-#3344 this was tied to the watchdog WARN threshold (then 300s),
+#: but #3344 tightened WARN to 60s and coupling faulthandler to that
+#: would spray a dump every minute. The watchdog already produces its
+#: own thread dump on WARN/EXIT, so faulthandler exists only as the
+#: deeper safety net for the case where the Python-level watchdog is
+#: itself wedged. Can be disabled in tests / local dev via the
 #: ``JUDGEMIND_DISPATCHER_DISABLE_FAULTHANDLER_TIMER=1`` env var so a
 #: pytest run doesn't spray tracebacks at the terminal every 5 min.
 FAULTHANDLER_DUMP_INTERVAL_SECONDS = 300
@@ -2620,6 +2631,7 @@ class DispatcherDaemon:
             "reaped_success": 0,
             "reaped_failure": 0,
             "still_running": 0,
+            "reaped_untracked": 0,
         }
         try:
             reap_summary = self._reap_completed_agent_tasks()
@@ -2835,6 +2847,11 @@ class DispatcherDaemon:
                 "reap_success": reap_summary["reaped_success"],
                 "reap_failure": reap_summary["reaped_failure"],
                 "reap_still_running": reap_summary["still_running"],
+                # #3344: count of rows finalized via the untracked-ARN
+                # branch (DescribeTasks returned no entry, or returned an
+                # entry with empty lastStatus). Non-zero on the recovery
+                # tick after a redeploy when the stale-ARN backlog drains.
+                "reap_untracked": reap_summary.get("reaped_untracked", 0),
                 # #3199: concurrency-cap gate denominator so CloudWatch
                 # Insights can self-diagnose "why didn't the daemon
                 # spawn a second agent when cap=2?". ``None`` on ticks
@@ -2876,6 +2893,8 @@ class DispatcherDaemon:
             "reap_success": reap_summary["reaped_success"],
             "reap_failure": reap_summary["reaped_failure"],
             "reap_still_running": reap_summary["still_running"],
+            # #3344 — untracked-ARN counter.
+            "reap_untracked": reap_summary.get("reaped_untracked", 0),
         }
 
     # ── command consumption (#2801) ────────────────────────────────────
@@ -20017,6 +20036,7 @@ class DispatcherDaemon:
                 "reaped_success": 0,
                 "reaped_failure": 0,
                 "still_running": 0,
+                "reaped_untracked": 0,
             }
 
         if not rows:
@@ -20025,6 +20045,7 @@ class DispatcherDaemon:
                 "reaped_success": 0,
                 "reaped_failure": 0,
                 "still_running": 0,
+                "reaped_untracked": 0,
             }
 
         # Can't reap without cluster + ECS client. The wiring may be
@@ -20044,6 +20065,7 @@ class DispatcherDaemon:
                 "reaped_success": 0,
                 "reaped_failure": 0,
                 "still_running": 0,
+                "reaped_untracked": 0,
             }
 
         arns = [row[2] for row in rows if row[2]]
@@ -20073,12 +20095,71 @@ class DispatcherDaemon:
                 "reaped_success": 0,
                 "reaped_failure": 0,
                 "still_running": 0,
+                "reaped_untracked": 0,
             }
 
         tasks = response.get("tasks") or []
         reaped_success = 0
         reaped_failure = 0
         still_running = 0
+        reaped_untracked = 0
+
+        # Issue #3344: any ARN we sent that ECS does NOT return is a
+        # "terminal-untrackable" row — the task left the Fargate stopped-
+        # task retention window (~1h) and DescribeTasks no longer has
+        # metadata for it. Pre-#3344 those rows stayed in the SELECT
+        # forever (zero forward progress every tick) and eventually
+        # wedged the daemon. We treat them as terminal: run the same
+        # finalize sequence (label strip + merged_at stamp + ARN clear)
+        # so the row drops out of the next tick's SELECT. ARNs returned
+        # WITH metadata (any non-empty lastStatus) follow the regular
+        # STOPPED / RUNNING / etc. branches below; ARNs returned with an
+        # EMPTY lastStatus are also treated as untracked because Fargate
+        # occasionally returns a stub entry that conveys no useful state.
+        returned_arns_with_status: set[str] = set()
+        returned_arns_empty_status: set[str] = set()
+        for task in tasks:
+            task_arn = task.get("taskArn", "")
+            if not task_arn:
+                continue
+            if task.get("lastStatus"):
+                returned_arns_with_status.add(task_arn)
+            else:
+                returned_arns_empty_status.add(task_arn)
+
+        sent_arns: set[str] = set(arns)
+        # Untracked = sent but missing from response, OR returned with
+        # no usable lastStatus.
+        untracked_arns = (
+            sent_arns - returned_arns_with_status
+        ) | returned_arns_empty_status
+        for untracked_arn in untracked_arns:
+            row = arn_to_row.get(untracked_arn)
+            if row is None:
+                continue
+            u_agent_id, u_issue_number, _u_arn, _u_phase, _u_status = row
+            self._log.info(
+                "daemon.agent_runner_reaped_arn_untracked",
+                extra={
+                    "event": "agent_runner_reaped_arn_untracked",
+                    "run_id": self._run_id,
+                    "agent_id": u_agent_id,
+                    "issue_number": u_issue_number,
+                    "task_arn": untracked_arn,
+                    "reason": (
+                        "empty_last_status"
+                        if untracked_arn in returned_arns_empty_status
+                        else "not_in_describe_tasks_response"
+                    ),
+                },
+            )
+            # Reuse the success-branch finalize: label strip (best-effort),
+            # merged_at stamp (idempotent + gated by pr_number IS NOT NULL),
+            # agent_task_arn clear. The merged_at WHERE filter handles the
+            # no-PR case naturally — the UPDATE is a no-op when there is
+            # no PR row.
+            self._reap_finalize_ecs_success(u_agent_id, u_issue_number)
+            reaped_untracked += 1
 
         for task in tasks:
             task_arn = task.get("taskArn", "")
@@ -20091,6 +20172,12 @@ class DispatcherDaemon:
             ]
             row = arn_to_row.get(task_arn)
             if row is None:
+                continue
+            # Issue #3344: rows with empty lastStatus were already
+            # finalized as untracked above — skip the regular branches
+            # so we don't double-count or fight ourselves on idempotent
+            # SQL.
+            if not last_status:
                 continue
             agent_id, issue_number, _arn, phase, status = row
 
@@ -20301,6 +20388,7 @@ class DispatcherDaemon:
             "reaped_success": reaped_success,
             "reaped_failure": reaped_failure,
             "still_running": still_running,
+            "reaped_untracked": reaped_untracked,
         }
 
     def _reap_finalize_ecs_success(

--- a/scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py
+++ b/scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py
@@ -159,6 +159,7 @@ class TestReapCompletedAgentTasks:
             "reaped_success": 1,
             "reaped_failure": 0,
             "still_running": 0,
+            "reaped_untracked": 0,
         }
         events = [getattr(r, "event", None) for r in caplog.records]
         assert "agent_runner_reaped_success" in events
@@ -438,6 +439,7 @@ class TestReapCompletedAgentTasks:
             "reaped_success": 0,
             "reaped_failure": 0,
             "still_running": 1,
+            "reaped_untracked": 0,
         }
 
 
@@ -511,6 +513,7 @@ class TestReapGuards:
             "reaped_success": 0,
             "reaped_failure": 0,
             "still_running": 0,
+            "reaped_untracked": 0,
         }
 
     def test_missing_cluster_logs_and_returns(self, caplog: Any) -> None:
@@ -757,9 +760,268 @@ class TestReapArnClearIdempotence:
             "reaped_success": 0,
             "reaped_failure": 0,
             "still_running": 0,
+            "reaped_untracked": 0,
         }
         # The SELECT ran exactly once with the post-#3329 WHERE shape.
         assert len(select_cur.executed) == 1
         sql, _params = select_cur.executed[0]
         assert "agent_task_arn IS NOT NULL" in sql
         assert "status IN" not in sql
+
+
+# --------------------------------------------------------------------------
+# Issue #3344 — untracked-ARN handling.
+#
+# After #3329 the SELECT picks up every row with a non-NULL ARN. But ECS
+# Fargate retains stopped-task metadata for ~1h; rows older than that
+# return NO entry from DescribeTasks (or return one with empty
+# lastStatus). Pre-#3344 those rows stayed in the SELECT forever (zero
+# forward progress per tick) and eventually wedged the daemon.
+#
+# The fix: detect ARNs we sent vs ARNs returned with usable metadata,
+# and run the same finalize sequence (label strip + merged_at stamp +
+# ARN clear) on the difference. Verified by:
+# - 5 sent, 2 returned -> 3 untracked finalize sequences fire.
+# - 1 returned with empty lastStatus -> treated as untracked.
+# - re-running with all rows ARN-cleared -> SELECT empty, zero work.
+# --------------------------------------------------------------------------
+
+
+class TestReapUntrackedArns:
+    """Stale-ARN cascade fix (#3344)."""
+
+    def _queue_per_row_finalize_cursors(
+        self, conn: _FakeConn, rows_count: int
+    ) -> list[_FakeCursor]:
+        """Per untracked row, ``_reap_finalize_ecs_success`` issues two
+        UPDATEs (merged_at gated, then ARN clear). Queue the cursors so
+        the test can assert on each.
+        """
+        cursors: list[_FakeCursor] = []
+        for _ in range(rows_count):
+            merged_at_cur = _FakeCursor()
+            arn_clear_cur = _FakeCursor()
+            conn.queue_cursor(merged_at_cur)
+            conn.queue_cursor(arn_clear_cur)
+            cursors.extend([merged_at_cur, arn_clear_cur])
+        return cursors
+
+    def test_three_of_five_arns_missing_runs_untracked_finalize(
+        self, caplog: Any
+    ) -> None:
+        """SELECT returns 5 ARNs; DescribeTasks returns only 2.
+
+        The 3 missing rows must:
+        - emit ``agent_runner_reaped_arn_untracked`` (one per row).
+        - run the finalize sequence (label strip + merged_at stamp gated
+          by ``pr_number IS NOT NULL`` + ``agent_task_arn = NULL``).
+        - drop out of the next tick's SELECT (verified by the ARN-clear
+          UPDATE).
+        - increment ``reaped_untracked``; not ``still_running``.
+
+        The 2 returned rows follow the regular STOPPED-success path.
+        """
+        d, conn = _make_daemon()
+        caplog.set_level(logging.INFO, logger="test.daemon_reap")
+
+        all_arns = [f"arn:aws:ecs:us-west-2:123:task/jm/{i}" for i in range(5)]
+        rows = [
+            (f"agent-{i}", 1000 + i, all_arns[i], "done", "succeeded") for i in range(5)
+        ]
+        select_cur = _FakeCursor(rows=rows)
+        conn.queue_cursor(select_cur)
+
+        # ECS retention has dropped the first 3 ARNs entirely; only the
+        # last 2 come back in the response.
+        returned_arns = all_arns[3:]
+        missing_arns = all_arns[:3]
+
+        # Per untracked row: 2 cursors (merged_at + ARN clear).
+        untracked_cursors = self._queue_per_row_finalize_cursors(
+            conn, rows_count=len(missing_arns)
+        )
+
+        # The 2 returned rows take the STOPPED-success-already-terminal
+        # path. Each needs: status read, finalize merged_at, ARN clear.
+        for i in range(3, 5):
+            status_cur = _FakeCursor()
+            status_cur.fetchone_queue = [("succeeded", "done")]
+            conn.queue_cursor(status_cur)
+            finalize_cur = _FakeCursor()
+            conn.queue_cursor(finalize_cur)
+            arn_clear_cur = _FakeCursor()
+            conn.queue_cursor(arn_clear_cur)
+
+        fake_client = MagicMock()
+        fake_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": arn,
+                    "lastStatus": "STOPPED",
+                    "stopCode": "EssentialContainerExited",
+                    "containers": [{"exitCode": 0}],
+                }
+                for arn in returned_arns
+            ]
+        }
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch.object(d, "_gh_issue_remove_labels") as remove_labels_mock,
+        ):
+            summary = d._reap_completed_agent_tasks()
+
+        assert summary["active"] == 5
+        assert summary["reaped_untracked"] == 3
+        # The 2 returned rows ran the success-already-terminal path.
+        assert summary["reaped_success"] == 2
+        assert summary["reaped_failure"] == 0
+        assert summary["still_running"] == 0
+
+        # Three untracked-ARN events, one per missing row.
+        events = [getattr(r, "event", None) for r in caplog.records]
+        untracked_events = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "agent_runner_reaped_arn_untracked"
+        ]
+        assert len(untracked_events) == 3
+        # Each event names the untracked ARN + agent_id + issue_number.
+        evt_arns = {getattr(r, "task_arn", None) for r in untracked_events}
+        assert evt_arns == set(missing_arns)
+        evt_agents = {getattr(r, "agent_id", None) for r in untracked_events}
+        assert evt_agents == {f"agent-{i}" for i in range(3)}
+        evt_issues = {getattr(r, "issue_number", None) for r in untracked_events}
+        assert evt_issues == {1000, 1001, 1002}
+        # Reason indicates the missing-from-response cause.
+        assert all(
+            getattr(r, "reason", None) == "not_in_describe_tasks_response"
+            for r in untracked_events
+        )
+
+        # Label strip called for the 3 untracked + 2 returned = 5 total.
+        # Each call uses STATUS_IN_PROGRESS_LABEL.
+        assert remove_labels_mock.call_count == 5
+        all_label_args = [c.args[1] for c in remove_labels_mock.call_args_list]
+        assert all(args == [daemon.STATUS_IN_PROGRESS_LABEL] for args in all_label_args)
+
+        # All three untracked rows issued a merged_at UPDATE (gated by
+        # ``pr_number IS NOT NULL`` so it's a no-op when no PR exists)
+        # AND an ARN-clear UPDATE. The cursor ordering interleaves
+        # (merged_at, arn_clear, merged_at, arn_clear, merged_at,
+        # arn_clear) per row.
+        for i in range(3):
+            merged_cur = untracked_cursors[i * 2]
+            arn_cur = untracked_cursors[i * 2 + 1]
+            merged_sqls = [s for s, _ in merged_cur.executed]
+            assert any("merged_at" in s for s in merged_sqls), merged_sqls
+            assert any("merged_at IS NULL" in s for s in merged_sqls)
+            assert any("pr_number IS NOT NULL" in s for s in merged_sqls)
+            arn_sqls = [s for s, _ in arn_cur.executed]
+            assert any("SET agent_task_arn = NULL" in s for s in arn_sqls), arn_sqls
+
+        # ``still_running`` did not absorb any of the untracked rows —
+        # this is the regression bar pre-#3344 was missing.
+        assert "agent_runner_reaped_arn_untracked" in events
+
+    def test_empty_last_status_treated_as_untracked(self, caplog: Any) -> None:
+        """Fargate occasionally returns an entry with empty lastStatus
+        — it counts as no usable metadata, same as missing entirely.
+
+        SELECT returns 1 ARN; DescribeTasks returns it but with
+        ``lastStatus`` empty. The row must be reaped via the untracked
+        path (label strip + merged_at + ARN clear), NOT carried as
+        ``still_running``.
+        """
+        d, conn = _make_daemon()
+        caplog.set_level(logging.INFO, logger="test.daemon_reap")
+
+        arn = "arn:aws:ecs:us-west-2:123:task/jm/empty-status"
+        select_cur = _FakeCursor(rows=[("agent-empty", 4242, arn, "done", "succeeded")])
+        conn.queue_cursor(select_cur)
+        # Per-untracked finalize cursors.
+        merged_cur = _FakeCursor()
+        arn_clear_cur = _FakeCursor()
+        conn.queue_cursor(merged_cur)
+        conn.queue_cursor(arn_clear_cur)
+
+        fake_client = MagicMock()
+        fake_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    # Returned, but ``lastStatus`` empty — Fargate stub
+                    # response shape that conveys no useful state.
+                    "taskArn": arn,
+                    "lastStatus": "",
+                }
+            ]
+        }
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch.object(d, "_gh_issue_remove_labels") as remove_labels_mock,
+            patch.object(d, "_handle_agent_failure") as fail_mock,
+            patch.object(d, "_mark_agent_terminal") as mark_mock,
+        ):
+            summary = d._reap_completed_agent_tasks()
+
+        assert summary["reaped_untracked"] == 1
+        assert summary["still_running"] == 0
+        assert summary["reaped_success"] == 0
+        assert summary["reaped_failure"] == 0
+        # Untracked path does not route via _handle_agent_failure or
+        # _mark_agent_terminal — it relies on the agent-runner having
+        # already written its terminal row (or accepts the row as gone).
+        fail_mock.assert_not_called()
+        mark_mock.assert_not_called()
+        # Label stripped, merged_at gated, ARN cleared.
+        remove_labels_mock.assert_called_once_with(
+            4242, [daemon.STATUS_IN_PROGRESS_LABEL]
+        )
+        merged_sqls = [s for s, _ in merged_cur.executed]
+        assert any("merged_at" in s for s in merged_sqls)
+        arn_sqls = [s for s, _ in arn_clear_cur.executed]
+        assert any("SET agent_task_arn = NULL" in s for s in arn_sqls)
+        # Event reason should indicate empty lastStatus.
+        evts = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "agent_runner_reaped_arn_untracked"
+        ]
+        assert len(evts) == 1
+        assert getattr(evts[0], "reason", None) == "empty_last_status"
+
+    def test_idempotence_after_arn_clear_select_empty(self) -> None:
+        """After a tick clears all 5 ARNs via the untracked path, the
+        next reaper tick's SELECT (gated by ``agent_task_arn IS NOT
+        NULL``) returns zero rows — no ECS calls, no UPDATEs, no log
+        spam.
+
+        This pins the cascade exit: an empty result set is the desired
+        steady state once the stale-ARN backlog drains.
+        """
+        d, conn = _make_daemon()
+        # Empty result set models the post-clear DB state — every row
+        # the previous tick finalized via untracked has ``agent_task_arn
+        # = NULL`` and is excluded from the WHERE clause.
+        select_cur = _FakeCursor(rows=[])
+        conn.queue_cursor(select_cur)
+
+        with (
+            patch.object(d, "_make_ecs_client") as mock_make_client,
+            patch.object(d, "_gh_issue_remove_labels") as remove_labels_mock,
+            patch.object(d, "_mark_agent_terminal") as mark_mock,
+            patch.object(d, "_handle_agent_failure") as fail_mock,
+        ):
+            summary = d._reap_completed_agent_tasks()
+
+        # Zero-work early return — same shape as TestReapArnClearIdempotence.
+        mock_make_client.assert_not_called()
+        remove_labels_mock.assert_not_called()
+        mark_mock.assert_not_called()
+        fail_mock.assert_not_called()
+        assert summary == {
+            "active": 0,
+            "reaped_success": 0,
+            "reaped_failure": 0,
+            "still_running": 0,
+            "reaped_untracked": 0,
+        }

--- a/scripts/dispatcher/tests/test_daemon_scheduler_tick_instrumentation.py
+++ b/scripts/dispatcher/tests/test_daemon_scheduler_tick_instrumentation.py
@@ -385,12 +385,23 @@ class TestModuleConstants:
             < daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS
         )
 
-    def test_faulthandler_interval_matches_watchdog_warn(self) -> None:
-        """The faulthandler periodic stderr dump uses the same cadence
-        as the #3097 watchdog so both reliability nets share the same
-        'something is wrong' threshold."""
+    def test_faulthandler_interval_is_a_diagnostic_cadence(self) -> None:
+        """The faulthandler periodic stderr dump is a fixed-interval
+        observability tool — independent of the #3097 watchdog WARN
+        threshold.
+
+        Pre-#3344 the two were bound to the same value (300s). #3344
+        tightened the watchdog WARN to 60s; coupling faulthandler to
+        that new cadence would spray a full thread dump to stderr every
+        60s, which is too noisy. Faulthandler stays at its independent
+        cadence (300s — operator-tunable in the constants module if
+        needed). The bound to enforce here is just "positive and not
+        smaller than the EXIT threshold" — by the time EXIT fires the
+        watchdog has already produced a dump, so faulthandler is the
+        deeper-cadence safety net only.
+        """
         assert daemon.FAULTHANDLER_DUMP_INTERVAL_SECONDS > 0
         assert (
             daemon.FAULTHANDLER_DUMP_INTERVAL_SECONDS
-            == daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS
+            >= daemon.DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS
         )

--- a/scripts/dispatcher/tests/test_daemon_watchdog.py
+++ b/scripts/dispatcher/tests/test_daemon_watchdog.py
@@ -5,12 +5,14 @@ that records ``time.monotonic()`` of each ``scheduler_tick`` entry to
 ``self._last_scheduler_tick_at`` and fires two tiers of alarm when the
 gap exceeds configurable thresholds:
 
-* ``SCHEDULER_TICK_STALL_WARN_SECONDS`` (default 300s) — WARNING
-  ``scheduler_tick_stalled`` with a bounded thread dump. Debounced so
-  duplicate warnings don't spam CloudWatch while the stall persists.
-* ``SCHEDULER_TICK_STALL_EXIT_SECONDS`` (default 3000s) — ERROR
-  ``scheduler_tick_stalled_exiting`` with a final thread dump followed
-  by ``os._exit(137)`` so ECS restarts the task.
+* ``SCHEDULER_TICK_STALL_WARN_SECONDS`` (default 60s, post-#3344) —
+  WARNING ``scheduler_tick_stalled`` with a bounded thread dump.
+  Debounced so duplicate warnings don't spam CloudWatch while the stall
+  persists.
+* ``SCHEDULER_TICK_STALL_EXIT_SECONDS`` (default 120s, post-#3344) —
+  ERROR ``scheduler_tick_stalled_exiting`` with a final thread dump
+  followed by ``os._exit(137)`` so ECS restarts the task. The MTTR
+  ceiling matches the #3344 target — under 2 min from wedge to restart.
 
 Tests cover:
 
@@ -156,19 +158,31 @@ def _make_daemon(
 
 
 class TestModuleConstants:
-    def test_warn_default_is_300(self) -> None:
-        assert daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS == 300
+    def test_warn_default_is_60(self) -> None:
+        # #3344 — tightened from 300s to 60s so a wedge surfaces in
+        # CloudWatch Insights within ~1-2 poll cycles instead of 5 min.
+        assert daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS == 60
 
-    def test_exit_default_is_3000(self) -> None:
-        assert daemon.DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS == 3000
+    def test_exit_default_is_120(self) -> None:
+        # #3344 — tightened from 3000s (50 min) to 120s. The 2026-04-25
+        # reaper wedge ran >12 min silent under the old 50 min ceiling
+        # before manual force-redeploy. New ceiling is the MTTR target.
+        assert daemon.DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS == 120
 
-    def test_exit_is_10x_warn(self) -> None:
-        """#3097 design — exit threshold is 10× warn so a transient
-        slowdown is caught loudly (WARN) but not escalated to a
-        process restart until the gap becomes catastrophic."""
+    def test_exit_within_2min_target(self) -> None:
+        """#3344 design — EXIT threshold must be ≤120s so a wedged
+        daemon auto-restarts in ECS in under 2 min instead of waiting
+        for an operator to notice and force-redeploy.
+
+        The original #3097 design set EXIT = 10× WARN; #3344 trades that
+        ratio for the tighter MTTR target. WARN remains < EXIT so the
+        WARN tier still fires first, but the multiplier is now 2× rather
+        than 10×.
+        """
+        assert daemon.DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS <= 120
         assert (
-            daemon.DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS
-            == 10 * daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS
+            daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS
+            < daemon.DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS
         )
 
     def test_poll_interval_is_positive(self) -> None:
@@ -416,16 +430,21 @@ class TestWatchdogLoopBehaviour:
     def test_warning_fires_when_elapsed_exceeds_warn_threshold(
         self, tmp_path: Path, monkeypatch: Any, psycopg_stub: Any
     ) -> None:
-        """AC #2 — a mocked monotonic that simulates a 301s stall
-        against a 300s threshold triggers exactly one WARNING."""
+        """AC #2 — a stall above WARN but below EXIT triggers exactly
+        one WARNING (no os._exit)."""
         d, conn, handler = _make_daemon(tmp_path)
 
         # Shrink poll interval so the loop spins fast.
         monkeypatch.setattr(daemon, "WATCHDOG_POLL_INTERVAL_SECONDS", 0)
 
-        # Control time. Start at 1000.0; tick was at 1000.0. Then
-        # advance to 1301.0 so elapsed = 301 > 300 (warn) but
-        # < 3000 (exit).
+        # Control time. Start at 1000.0; tick was at 1000.0. Then advance
+        # to a value > WARN but < EXIT so only the WARN tier fires. With
+        # the post-#3344 defaults that's WARN=60s, EXIT=120s — pick 90s.
+        warn_s = daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS
+        exit_s = daemon.DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS
+        elapsed = (warn_s + exit_s) / 2.0  # midway between WARN and EXIT
+        assert warn_s < elapsed < exit_s, (warn_s, elapsed, exit_s)
+
         clock = _TickClock(start=1000.0)
         d._last_scheduler_tick_at = 1000.0
         monkeypatch.setattr(daemon.time, "monotonic", clock)
@@ -441,13 +460,16 @@ class TestWatchdogLoopBehaviour:
         # Stub psycopg.connect so the watchdog's DB setup path is inert.
         psycopg_stub.connect = MagicMock(return_value=_FakeConnection())
 
-        clock.advance(301.0)
+        clock.advance(elapsed)
         t = self._run_loop_in_thread(d)
         try:
             rec = self._wait_for_event(handler, "scheduler_tick_stalled")
             assert rec is not None, "expected a scheduler_tick_stalled WARNING"
             assert rec.levelno == logging.WARNING
-            assert getattr(rec, "elapsed_seconds", 0) >= 300
+            assert getattr(rec, "elapsed_seconds", 0) >= warn_s
+            # Must NOT have escalated to EXIT — elapsed is below the
+            # exit threshold.
+            assert handler.events("scheduler_tick_stalled_exiting") == []
         finally:
             d._watchdog_stop.set()
             t.join(timeout=2.0)
@@ -457,8 +479,8 @@ class TestWatchdogLoopBehaviour:
     def test_exit_fires_when_elapsed_exceeds_exit_threshold(
         self, tmp_path: Path, monkeypatch: Any, psycopg_stub: Any
     ) -> None:
-        """AC #3 — a 3001s stall against a 3000s threshold triggers
-        ``os._exit(137)`` with an ERROR log.
+        """AC #3 — a stall above EXIT triggers ``os._exit(137)`` with
+        an ERROR log.
 
         The fake ``os._exit`` raises ``_ExitCalled`` (a BaseException
         subclass) from the watchdog thread — pytest captures that as
@@ -468,6 +490,9 @@ class TestWatchdogLoopBehaviour:
         """
         d, conn, handler = _make_daemon(tmp_path)
         monkeypatch.setattr(daemon, "WATCHDOG_POLL_INTERVAL_SECONDS", 0)
+
+        exit_s = daemon.DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS
+        elapsed = exit_s + 1.0  # one second past EXIT — minimum trigger.
 
         clock = _TickClock(start=5000.0)
         d._last_scheduler_tick_at = 5000.0
@@ -488,7 +513,7 @@ class TestWatchdogLoopBehaviour:
 
         monkeypatch.setattr(daemon.os, "_exit", fake_exit)
 
-        clock.advance(3001.0)
+        clock.advance(elapsed)
         t = self._run_loop_in_thread(d)
         try:
             rec = self._wait_for_event(handler, "scheduler_tick_stalled_exiting")
@@ -521,8 +546,9 @@ class TestWatchdogLoopBehaviour:
         )
         psycopg_stub.connect = MagicMock(return_value=_FakeConnection())
 
-        # Only advance 30s — well below the 300s WARN threshold.
-        clock.advance(30.0)
+        # Advance to half the WARN threshold — well below it.
+        warn_s = daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS
+        clock.advance(warn_s / 2.0)
         t = self._run_loop_in_thread(d)
         try:
             # Let the loop run a few polls.
@@ -551,8 +577,12 @@ class TestWatchdogLoopBehaviour:
         )
         psycopg_stub.connect = MagicMock(return_value=_FakeConnection())
 
-        # Advance into the WARN zone but not the EXIT zone.
-        clock.advance(500.0)
+        # Advance into the WARN zone but not the EXIT zone — pick the
+        # midpoint so the test is robust to threshold tuning.
+        warn_s = daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS
+        exit_s = daemon.DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS
+        elapsed = (warn_s + exit_s) / 2.0
+        clock.advance(elapsed)
         t = self._run_loop_in_thread(d)
         try:
             rec = self._wait_for_event(handler, "scheduler_tick_stalled")
@@ -583,8 +613,15 @@ class TestWatchdogLoopBehaviour:
         )
         psycopg_stub.connect = MagicMock(return_value=_FakeConnection())
 
+        # Both stalls land between WARN and EXIT so we exercise WARN
+        # debounce/rearm without escalating to EXIT (which would kill
+        # the process under test).
+        warn_s = daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS
+        exit_s = daemon.DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS
+        warn_zone_elapsed = (warn_s + exit_s) / 2.0
+
         # Step 1: stall → WARN.
-        clock.advance(500.0)
+        clock.advance(warn_zone_elapsed)
         t = self._run_loop_in_thread(d)
         try:
             rec1 = self._wait_for_event(handler, "scheduler_tick_stalled")
@@ -600,8 +637,8 @@ class TestWatchdogLoopBehaviour:
                 time.sleep(0.01)
             assert not d._watchdog_warn_emitted_for_gap
 
-            # Step 3: stall again.
-            clock.advance(500.0)
+            # Step 3: stall again — advance again into WARN zone.
+            clock.advance(warn_zone_elapsed)
             deadline = time.monotonic() + 2.0
             while (
                 len(handler.events("scheduler_tick_stalled")) < 2


### PR DESCRIPTION
## Summary

Fixes the post-#3329 reaper wedge (#3344). Two compounding issues caused the daemon to hang twice on 2026-04-25 (>12 min silent each before manual force-redeploy):

- **Untracked-ARN cascade.** The post-#3329 reaper SELECT picks up every row with a non-NULL `agent_task_arn`. ECS Fargate stopped-task retention is ~1h; older ARNs no longer return metadata from `DescribeTasks`. Pre-#3344 those rows stayed in the SELECT forever (zero progress per tick) and eventually hung the daemon. Fix: detect ARNs we sent vs ARNs returned with usable `lastStatus`, run the same finalize sequence (label strip + `merged_at` gated by `pr_number IS NOT NULL` + `agent_task_arn = NULL`) on the difference. Logs `agent_runner_reaped_arn_untracked` per row.

- **Stall-watchdog ceiling too generous.** #3097 set EXIT=3000s (50 min) and WARN=300s (5 min). The wedge ran 12+ min silent under that ceiling. New defaults: WARN=60s, EXIT=120s. ECS auto-restart now happens in under 2 min instead of waiting for an operator. Faulthandler periodic stderr dump decoupled from WARN (held at 300s) so the tighter watchdog doesn't spray dumps every minute.

## Acceptance criteria mapping (#3344)

- [x] AC1: untracked-ARN handling in `_reap_completed_agent_tasks` — finalize sequence + new event.
- [x] AC2: watchdog runs in sidecar daemon thread (already true — confirmed); EXIT threshold dropped to 120s with `os._exit(137)`.
- [x] AC3: tests for 5-sent/2-returned, empty-lastStatus, post-clear idempotence; watchdog test uses fake clock.
- AC4 (one-shot cleanup script): out-of-scope per the parent issue note ("Already done manually for the 29 issues hit today.")

## Test plan

- [x] `pytest scripts/dispatcher/tests/` — 1538 passed, 1 skipped.
- [x] `ruff check` + `ruff format --check` — clean.
- [ ] After merge + dispatcher redeploy: observe `agent_runner_reaped_arn_untracked` events fire on the next 1–2 ticks; observe `reap_active` declining tick-over-tick; observe a clean 5-min stretch with the watchdog active. Post evidence on #3344.

Closes #3344
