### PR TITLE
fix(dispatcher): boto3 ECS timeouts + watchdog before initial tick (#3351)

### DIFF
--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -752,6 +752,17 @@ resource "aws_ecs_task_definition" "dispatcher" {
           "awslogs-group"         = aws_cloudwatch_log_group.dispatcher.name
           "awslogs-region"        = data.aws_region.current.id
           "awslogs-stream-prefix" = "dispatcher"
+          # #3351: switch the awslogs driver to non-blocking delivery
+          # so a CloudWatch slowdown cannot block the daemon's stdout
+          # (which would itself wedge the Python process — the same
+          # GIL-held / silent-for-30+-min failure mode observed in
+          # the 2026-04-25 cascade). With ``mode = non-blocking`` the
+          # driver buffers up to ``max-buffer-size`` and drops oldest
+          # events on overflow rather than back-pressuring the
+          # container. 4MB is the AWS-recommended floor — smaller
+          # values throttle awslogs internally.
+          "mode"            = "non-blocking"
+          "max-buffer-size" = "4m"
         }
       }
     }

--- a/scripts/check-dispatcher-image-deps.py
+++ b/scripts/check-dispatcher-image-deps.py
@@ -104,6 +104,14 @@ from pathlib import Path
 # ---------------------------------------------------------------------------
 IMPORT_TO_PACKAGE: dict[str, str] = {
     "boto3": "boto3",
+    # ``botocore`` is a hard transitive dependency of ``boto3`` — pip
+    # always installs it alongside ``boto3``, so mapping the import to
+    # the ``boto3`` pip name keeps the check honest without requiring a
+    # redundant ``botocore`` pip-install line in Dockerfile.dispatcher.
+    # The dispatcher daemon imports ``botocore.config`` lazily inside
+    # :meth:`DispatcherDaemon._make_ecs_client` to set explicit
+    # connect/read timeouts (#3351).
+    "botocore": "boto3",
     "psycopg": "psycopg",
     "yaml": "PyYAML",
 }

--- a/scripts/check-no-git-repo-root-anchor.sh
+++ b/scripts/check-no-git-repo-root-anchor.sh
@@ -76,8 +76,11 @@ try:
     source = path.read_text()
     tree = ast.parse(source)
 except SyntaxError as exc:
-    # Not valid Python — skip silently (the file may be a fixture
-    # or a stub the check doesn't need to flag).
+    # Not valid Python — skip silently. The file may be a fixture or
+    # a stub the check is not meant to flag. (Avoid apostrophes here:
+    # bash 3.2 mis-parses single quotes inside a $()-wrapped heredoc
+    # even when the heredoc terminator is itself single-quoted, which
+    # makes the wrapper script unrunnable on macOS. See #3351.)
     sys.exit(0)
 
 lines = source.splitlines()

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -183,6 +183,25 @@ DEFAULT_SCHEDULER_TICK_STALL_EXIT_SECONDS = 120
 #: change, not a config flip.
 WATCHDOG_POLL_INTERVAL_SECONDS = 30
 
+#: boto3 ECS client socket timeouts (#3351). Applied to every
+#: :meth:`DispatcherDaemon._make_ecs_client` invocation via a
+#: :class:`botocore.config.Config`. Without these the AWS SDK defaults
+#: leave ``read_timeout`` effectively unbounded (urllib3's socket
+#: ``recv()`` can block forever if the AWS API never ACKs); a hung
+#: ``ecs:DescribeTasks`` in the reaper would then wedge the scheduler
+#: thread, the GIL, and (because faulthandler runs from a separate
+#: signal-driven thread that depends on the same kernel-level call) the
+#: entire process — exactly the failure mode observed in the 2026-04-25
+#: cascade (#3344 / #3351, "no faulthandler dumps for 30+ minutes while
+#: the ECS task remained RUNNING"). With explicit timeouts a hung call
+#: raises :class:`botocore.exceptions.ReadTimeoutError` after ~25s
+#: worst-case (one retry × 10s read + 5s connect), the scheduler-tick
+#: exception handler catches it, and the watchdog only has to fire as
+#: the second-line defence.
+ECS_CLIENT_CONNECT_TIMEOUT_SECONDS = 5
+ECS_CLIENT_READ_TIMEOUT_SECONDS = 10
+ECS_CLIENT_MAX_ATTEMPTS = 2
+
 #: Max stack frames per thread emitted in the stall thread dump. Each
 #: frame renders as ``file:line (function)`` — ~60-120 chars per frame.
 #: With ~10 threads (main + scheduler + ralph head-watcher + CloudWatch
@@ -19544,10 +19563,34 @@ class DispatcherDaemon:
         tests that don't exercise the ECS launcher path do not have to
         install boto3. Region comes from :attr:`DaemonConfig.aws_region`
         which is already wired from ``AWS_REGION`` / ``AWS_DEFAULT_REGION``.
+
+        #3351: applies an explicit
+        :class:`botocore.config.Config` so a hung ``ecs:DescribeTasks``
+        cannot block the reaper indefinitely. boto3's defaults leave
+        ``read_timeout`` effectively unbounded; the 2026-04-25 cascade
+        showed that a single hung DescribeTasks call wedged the entire
+        Python process (GIL held in urllib3's blocking ``recv()``,
+        faulthandler unable to fire). The constants
+        :data:`ECS_CLIENT_CONNECT_TIMEOUT_SECONDS`,
+        :data:`ECS_CLIENT_READ_TIMEOUT_SECONDS`, and
+        :data:`ECS_CLIENT_MAX_ATTEMPTS` document the chosen budget.
         """
         import boto3  # noqa: PLC0415 — lazy import
+        import botocore.config  # noqa: PLC0415 — lazy import, mirrors boto3
 
-        return boto3.client("ecs", region_name=self._cfg.aws_region)
+        ecs_cfg = botocore.config.Config(
+            connect_timeout=ECS_CLIENT_CONNECT_TIMEOUT_SECONDS,
+            read_timeout=ECS_CLIENT_READ_TIMEOUT_SECONDS,
+            retries={
+                "max_attempts": ECS_CLIENT_MAX_ATTEMPTS,
+                "mode": "standard",
+            },
+        )
+        return boto3.client(
+            "ecs",
+            region_name=self._cfg.aws_region,
+            config=ecs_cfg,
+        )
 
     def _cb_config_str(self, key: str, default: str) -> str:
         """Read a string key from ``dispatcher.config`` with a fallback.
@@ -20998,11 +21041,14 @@ class DispatcherDaemon:
                     pass
 
     def _start_watchdog(self) -> None:
-        """Spawn the supervisor watchdog thread (#3097).
+        """Spawn the supervisor watchdog thread (#3097, #3351).
 
         Idempotent — a second call while the thread is alive is a no-op.
-        Called from :meth:`run_forever` after the initial tick so the
-        watchdog starts only when the daemon is fully up.
+        Called from :meth:`run_forever` BEFORE the initial scheduler
+        tick (#3351) so an initial-tick wedge is still observable by
+        the watchdog. The baseline timestamp is seeded at boot in
+        :meth:`__init__` so the first observation has a valid reference
+        even before the first tick fires.
         """
         if self._watchdog_thread is not None and self._watchdog_thread.is_alive():
             return
@@ -21038,6 +21084,21 @@ class DispatcherDaemon:
         last_scheduler = 0.0
         last_supervisor = 0.0
         last_housekeeping = 0.0
+
+        # #3351: spawn the stall-watchdog BEFORE the first scheduler /
+        # supervisor tick so an initial-tick wedge (e.g. a hung
+        # ``ecs:DescribeTasks`` in the reaper) is still observed by the
+        # watchdog and force-exits the process at the EXIT threshold.
+        # Pre-#3351 the watchdog started AFTER the initial tick, so a
+        # boto3 client created during that first reap could block the
+        # daemon forever with no recourse — exactly the failure mode
+        # observed in the 2026-04-25 cascade. The watchdog's baseline
+        # is ``_last_scheduler_tick_at``, seeded at boot in
+        # :meth:`__init__`, so observation has a valid reference even
+        # before the first tick fires. See :meth:`_watchdog_loop` for
+        # the WARN/EXIT tier semantics.
+        self._start_watchdog()
+
         # Tick once on boot so the first scheduler/supervisor cycle is
         # observable immediately in logs + DB, rather than after the
         # first full cadence elapses. Housekeeping is NOT fired on boot
@@ -21054,11 +21115,6 @@ class DispatcherDaemon:
         except Exception:
             self._log.exception("daemon.initial_tick_failed")
             return 1
-
-        # #3097: spawn the stall-watchdog thread after the initial tick
-        # so it begins observing from a known-fresh baseline. See
-        # :meth:`_watchdog_loop` for the WARN/EXIT tier semantics.
-        self._start_watchdog()
 
         # Poll the stop flag in 1-second slices so SIGTERM lands promptly.
         while not self._stop.is_set():

--- a/scripts/dispatcher/tests/test_daemon_ecs_client_timeout.py
+++ b/scripts/dispatcher/tests/test_daemon_ecs_client_timeout.py
@@ -1,0 +1,219 @@
+"""Unit tests for the boto3 ECS client timeout config (#3351).
+
+The 2026-04-25 cascade revealed that boto3's default ``read_timeout``
+on an ECS client is effectively unbounded: a hung ``ecs:DescribeTasks``
+call inside the reaper would block the scheduler thread, hold the GIL
+through urllib3's blocking ``recv()``, and (because faulthandler runs
+from a separate signal-driven thread depending on the same kernel-level
+call) silence the entire Python process for 30+ minutes while the ECS
+task itself remained RUNNING.
+
+Fix: :meth:`DispatcherDaemon._make_ecs_client` now constructs the boto3
+client with an explicit :class:`botocore.config.Config` carrying a
+small connect-timeout, a small read-timeout, and a bounded retry
+policy. Worst-case wall-clock for a hung DescribeTasks is now
+~25 seconds (one retry × 10s read + 5s connect) instead of indefinite.
+
+Tests below assert the constants are sane AND that
+:meth:`_make_ecs_client` actually wires them onto the boto3 client's
+``meta.config`` object.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _make_daemon() -> daemon.DispatcherDaemon:
+    """Build a minimal daemon instance for client-construction tests.
+
+    We bypass the normal ctor (and its DB / arg parsing) by using
+    ``__new__`` and seeding only the fields :meth:`_make_ecs_client`
+    reads — currently just ``self._cfg.aws_region``.
+    """
+    d = daemon.DispatcherDaemon.__new__(daemon.DispatcherDaemon)
+    d._thread_state = threading.local()  # type: ignore[attr-defined]
+    d._cfg = MagicMock(aws_region="us-west-2")  # type: ignore[attr-defined]
+    d._log = logging.getLogger("test.daemon_ecs_client_timeout")  # type: ignore[attr-defined]
+    return d
+
+
+# --------------------------------------------------------------------------
+# Module constants
+# --------------------------------------------------------------------------
+
+
+class TestModuleConstants:
+    def test_connect_timeout_default(self) -> None:
+        # 5s is generous for AWS API connect — a healthy connect lands
+        # in <50ms, so 5s is 100× the normal budget but still well below
+        # the watchdog WARN tier.
+        assert daemon.ECS_CLIENT_CONNECT_TIMEOUT_SECONDS == 5
+
+    def test_read_timeout_default(self) -> None:
+        # 10s read keeps total worst-case (one retry) at ~25s, comfortably
+        # below the 60s watchdog WARN tier and the 120s EXIT tier.
+        assert daemon.ECS_CLIENT_READ_TIMEOUT_SECONDS == 10
+
+    def test_max_attempts_default(self) -> None:
+        # max_attempts=2 means at most one retry. Three or more would
+        # push worst-case past the WARN tier and we lose the early signal.
+        assert daemon.ECS_CLIENT_MAX_ATTEMPTS == 2
+
+    def test_timeouts_below_watchdog_warn(self) -> None:
+        """The total ECS-client budget must fit inside the watchdog WARN
+        threshold so a hung call surfaces as ``ReadTimeoutError`` BEFORE
+        the watchdog stack-dumps the process. Worst-case is one retry,
+        so total ≈ max_attempts × (connect + read)."""
+        worst_case = daemon.ECS_CLIENT_MAX_ATTEMPTS * (
+            daemon.ECS_CLIENT_CONNECT_TIMEOUT_SECONDS
+            + daemon.ECS_CLIENT_READ_TIMEOUT_SECONDS
+        )
+        assert worst_case < daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS, (
+            f"ECS client worst-case {worst_case}s must be < watchdog WARN "
+            f"{daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS}s so a hung "
+            f"DescribeTasks raises ReadTimeoutError before the watchdog fires."
+        )
+
+
+# --------------------------------------------------------------------------
+# _make_ecs_client wires botocore.config.Config onto the client
+# --------------------------------------------------------------------------
+
+
+class TestMakeEcsClientConfig:
+    """Assert ``_make_ecs_client`` constructs a boto3 client with the
+    expected ``botocore.config.Config`` parameters.
+
+    We assert on the Config object passed to ``boto3.client(...)`` rather
+    than on ``client.meta.config`` because the latter is the *merged*
+    config that boto3 builds from session defaults + env vars + our
+    Config. AWS env vars (``AWS_MAX_ATTEMPTS`` etc.) on the test runner
+    can override fields in the merged view, which is fine at runtime
+    but makes for flaky asserts. Our durable contract is "we pass these
+    values to boto3"; what boto3 then merges is its concern.
+    """
+
+    def _capture_config(self, monkeypatch: Any) -> tuple[Any, list[Any]]:
+        """Patch ``boto3.client`` to record (a snapshot of) the kwargs.
+
+        Returns a (daemon, captured-list) tuple. ``captured`` is a list
+        of dicts with the kwargs from each ``boto3.client`` call.
+
+        Important: boto3's ``client()`` mutates the ``Config`` object
+        in place (it normalises ``max_attempts`` into ``total_max_attempts``
+        and merges in session/env defaults), so we snapshot the raw
+        ``connect_timeout`` / ``read_timeout`` / ``retries`` values
+        BEFORE delegating to the real ``client()``. The snapshot is
+        what tests assert against.
+        """
+        import boto3  # local import so the test is skipped on a venv
+        # without boto3 (the dispatcher venv always has it).
+
+        captured: list[dict[str, Any]] = []
+        real_client = boto3.client
+
+        def recording_client(*args: Any, **kwargs: Any) -> Any:
+            cfg = kwargs.get("config")
+            snapshot = {
+                "args": args,
+                "kwargs": dict(kwargs),
+                "config_snapshot": (
+                    {
+                        "connect_timeout": getattr(cfg, "connect_timeout", None),
+                        "read_timeout": getattr(cfg, "read_timeout", None),
+                        # ``retries`` is a dict; copy so a later boto3
+                        # mutation can't poison the assertion.
+                        "retries": dict(cfg.retries) if cfg and cfg.retries else {},
+                    }
+                    if cfg is not None
+                    else None
+                ),
+            }
+            captured.append(snapshot)
+            return real_client(*args, **kwargs)
+
+        monkeypatch.setattr(boto3, "client", recording_client)
+        d = _make_daemon()
+        return d, captured
+
+    def test_make_ecs_client_passes_read_timeout_to_boto3(
+        self, monkeypatch: Any
+    ) -> None:
+        """The boto3 client constructed in ``_make_ecs_client`` must
+        receive a ``Config`` with the configured ``read_timeout`` so a
+        hung ``ecs:DescribeTasks`` raises rather than blocks forever."""
+        d, captured = self._capture_config(monkeypatch)
+
+        d._make_ecs_client()
+
+        assert len(captured) == 1, captured
+        snap = captured[0]["config_snapshot"]
+        assert snap is not None, "_make_ecs_client must pass a config="
+        assert snap["read_timeout"] == daemon.ECS_CLIENT_READ_TIMEOUT_SECONDS, (
+            f"expected read_timeout={daemon.ECS_CLIENT_READ_TIMEOUT_SECONDS}, "
+            f"got {snap['read_timeout']}"
+        )
+
+    def test_make_ecs_client_passes_connect_timeout_to_boto3(
+        self, monkeypatch: Any
+    ) -> None:
+        """Connect timeout must also be bounded — a TCP SYN black-hole
+        would otherwise hang forever in ``urllib3.HTTPConnection.connect``."""
+        d, captured = self._capture_config(monkeypatch)
+
+        d._make_ecs_client()
+
+        snap = captured[0]["config_snapshot"]
+        assert snap is not None
+        assert snap["connect_timeout"] == daemon.ECS_CLIENT_CONNECT_TIMEOUT_SECONDS, (
+            f"expected connect_timeout={daemon.ECS_CLIENT_CONNECT_TIMEOUT_SECONDS}, "
+            f"got {snap['connect_timeout']}"
+        )
+
+    def test_make_ecs_client_passes_retries_to_boto3(self, monkeypatch: Any) -> None:
+        """The retries config must cap attempts at the configured max so a
+        single transient hang triggers exactly one retry before raising."""
+        d, captured = self._capture_config(monkeypatch)
+
+        d._make_ecs_client()
+
+        snap = captured[0]["config_snapshot"]
+        assert snap is not None
+        retries = snap["retries"]
+        assert retries.get("max_attempts") == daemon.ECS_CLIENT_MAX_ATTEMPTS, (
+            f"expected retries.max_attempts={daemon.ECS_CLIENT_MAX_ATTEMPTS}, "
+            f"got {retries}"
+        )
+        # ``standard`` mode is the modern boto3 retry algorithm — the
+        # legacy mode would silently re-add network round-trips on
+        # throttling that push us past the watchdog WARN.
+        assert retries.get("mode") == "standard", retries
+
+    def test_make_ecs_client_uses_configured_region(self) -> None:
+        """Sanity: the daemon's ``aws_region`` is wired to the boto3
+        client. Regression guard for a refactor that drops the kwarg."""
+        d = _make_daemon()
+        d._cfg.aws_region = "us-east-1"  # type: ignore[attr-defined]
+
+        client = d._make_ecs_client()
+
+        assert client.meta.region_name == "us-east-1"

--- a/scripts/dispatcher/tests/test_daemon_watchdog.py
+++ b/scripts/dispatcher/tests/test_daemon_watchdog.py
@@ -719,3 +719,128 @@ class TestStartWatchdog:
             d._watchdog_stop.set()
             if d._watchdog_thread is not None:
                 d._watchdog_thread.join(timeout=2.0)
+
+
+# --------------------------------------------------------------------------
+# #3351 — watchdog starts BEFORE the first scheduler tick
+#
+# Pre-#3351 the watchdog was started AFTER ``self.scheduler_tick()`` in
+# ``run_forever``, so an initial-tick wedge (e.g. a hung
+# ``ecs:DescribeTasks`` in the reaper) blocked the daemon forever with
+# no observer running. The fix moves ``_start_watchdog`` ahead of the
+# initial tick so even a boot-time wedge triggers the EXIT path.
+# --------------------------------------------------------------------------
+
+
+class TestWatchdogStartsBeforeFirstTick:
+    """Regression guard for #3351 — the watchdog must observe the first
+    scheduler tick, not just subsequent ones."""
+
+    def test_run_forever_starts_watchdog_before_initial_tick(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """Capture the order in which ``_start_watchdog`` and the first
+        ``scheduler_tick`` fire inside ``run_forever``. Pre-#3351 the
+        watchdog came second; post-#3351 it must come first so an
+        initial-tick wedge is observable."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        # _stop set immediately so run_forever exits after the initial
+        # tick pair without the polling loop running.
+        d._stop.set()
+
+        order: list[str] = []
+
+        def stub_scheduler_tick() -> None:
+            order.append("scheduler_tick")
+
+        def stub_supervisor_tick() -> None:
+            order.append("supervisor_tick")
+
+        def stub_start_watchdog() -> None:
+            order.append("start_watchdog")
+
+        monkeypatch.setattr(d, "scheduler_tick", stub_scheduler_tick)
+        monkeypatch.setattr(d, "supervisor_tick", stub_supervisor_tick)
+        monkeypatch.setattr(d, "_start_watchdog", stub_start_watchdog)
+
+        exit_code = d.run_forever()
+
+        assert exit_code == 0
+        # The fix's invariant: watchdog spins up FIRST.
+        assert order, "expected at least one event to fire"
+        assert order[0] == "start_watchdog", (
+            f"watchdog must start before any tick (got order={order!r}); "
+            "pre-#3351 the watchdog was started AFTER the initial tick, "
+            "so a wedge inside the first reap was unobservable."
+        )
+        assert "scheduler_tick" in order
+        assert "supervisor_tick" in order
+
+
+# --------------------------------------------------------------------------
+# #3351 — _emit_scheduler_stall_exit calls os._exit (not sys.exit)
+#
+# os._exit is uncatchable; sys.exit raises SystemExit which can be
+# swallowed by ``try/except`` in main loops or held up by GIL contention.
+# This test belt-and-suspenders the existing exit-path coverage by
+# explicitly asserting we did NOT use sys.exit.
+# --------------------------------------------------------------------------
+
+
+class TestExitUsesOsExitNotSysExit:
+    def test_emit_exit_uses_os_exit_not_sys_exit(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """Patch BOTH ``os._exit`` and ``sys.exit``; confirm only
+        ``os._exit`` is invoked. ``sys.exit`` raises ``SystemExit``
+        which the watchdog's defensive ``except Exception`` could
+        swallow during a wedge — exactly the hit-rate-25% behaviour
+        observed in production before #3351."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        os_exit_calls: list[int] = []
+        sys_exit_calls: list[int] = []
+
+        def fake_os_exit(code: int) -> None:
+            os_exit_calls.append(code)
+            raise _ExitCalled(code)
+
+        def fake_sys_exit(code: int = 0) -> None:
+            sys_exit_calls.append(int(code))
+            # Mirror SystemExit semantics so the test fails loudly if
+            # we accidentally invoke it.
+            raise SystemExit(code)
+
+        monkeypatch.setattr(daemon.os, "_exit", fake_os_exit)
+        monkeypatch.setattr(daemon.sys, "exit", fake_sys_exit)
+
+        with pytest.raises(_ExitCalled):
+            d._emit_scheduler_stall_exit(elapsed_seconds=200.0)
+
+        assert os_exit_calls == [137], (
+            f"expected exactly one os._exit(137); got {os_exit_calls!r}"
+        )
+        assert sys_exit_calls == [], (
+            f"sys.exit must NEVER be called from the watchdog exit path "
+            f"(SystemExit can be swallowed); got {sys_exit_calls!r}"
+        )
+
+    def test_emit_exit_called_with_code_137(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """Sanity: the watchdog uses 128+SIGKILL (137) so ECS console
+        and operator runbooks can recognise it as a forced kill."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        recorded: list[int] = []
+
+        def fake_exit(code: int) -> None:
+            recorded.append(code)
+            raise _ExitCalled(code)
+
+        monkeypatch.setattr(daemon.os, "_exit", fake_exit)
+
+        with pytest.raises(_ExitCalled):
+            d._emit_scheduler_stall_exit(elapsed_seconds=999.0)
+
+        assert recorded == [137]


### PR DESCRIPTION
## Summary

Closes #3351. The 2026-04-25 daemon-wedge cascade (7 wedges in 4 hours, watchdog hit-rate ~25%) had two root causes the original PR #3348 didn't fully cover:

- **boto3 ECS client had no read timeout.** A hung `ecs:DescribeTasks` in the reaper would block the scheduler thread, hold the GIL through urllib3's blocking `recv()`, and silence the entire process for 30+ minutes while the ECS task remained RUNNING.
- **The supervisor watchdog started AFTER the initial scheduler tick** in `run_forever`, so an initial-tick wedge was unobservable. When the wedge happened during the first reap (before the watchdog spun up), no observer existed to fire `os._exit`.

## Changes

1. **`_make_ecs_client`** now constructs the boto3 client with an explicit `botocore.config.Config(connect_timeout=5, read_timeout=10, retries={"max_attempts": 2, "mode": "standard"})`. Worst-case wall-clock for a hung DescribeTasks is ~25s (one retry × 10s read + 5s connect), comfortably below the 60s watchdog WARN tier.
2. **`_start_watchdog()` now fires BEFORE the initial `scheduler_tick()`** in `run_forever`. The watchdog's baseline (`_last_scheduler_tick_at`) is seeded at boot in `__init__`, so the first observation has a valid reference even before the first tick fires.
3. **awslogs driver** now uses `mode = "non-blocking"` + `max-buffer-size = "4m"` so a CloudWatch slowdown can't back-pressure the daemon's stdout (a separate path to the same kernel-level wedge).
4. **DX:** Added `botocore` → `boto3` mapping in `check-dispatcher-image-deps.py` (botocore ships with boto3 — no separate pip line needed). Fixed a bash 3.2 heredoc parse error in `check-no-git-repo-root-anchor.sh` so the operator-laptop pre-push hook actually runs.

The watchdog already used `os._exit(137)` (not `sys.exit`) — added explicit regression tests asserting that, in case of future refactors.

## Test plan

- [x] `pytest scripts/dispatcher/tests/` — 1549 passed, 1 skipped
- [x] `ruff check` + `ruff format --check` clean
- [x] `terraform validate` clean on dev environment
- [x] New `test_daemon_ecs_client_timeout.py`: 8 tests covering module constants and boto3 Config wiring
- [x] Extended `test_daemon_watchdog.py`: regression test that `run_forever` calls `_start_watchdog` BEFORE either initial tick fires + explicit assertion that EXIT path uses `os._exit(137)` and NOT `sys.exit`
- [x] Companion shell tests for both check scripts pass
- [ ] Post-deploy: 30-min sustained scheduler-tick output with no wedges OR a single wedge that auto-recovers within 2 min via watchdog
- [ ] CloudWatch confirms `read_timeout` config landing — DescribeTasks call latencies bounded by 25s

🤖 Generated with [Claude Code](https://claude.com/claude-code)
