### PR TITLE
fix(dispatcher): bound every IO call site + add AST hygiene check (#3356)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -674,6 +674,16 @@ jobs:
       - name: Verify every subprocess.run call in scripts has timeout= or **kwargs
         if: matrix.shard == 'python'
         run: scripts/check-subprocess-timeouts.sh
+      # Issue #3356: every IO call site under scripts/dispatcher/
+      # (boto3.client, psycopg.connect, subprocess.run/Popen/check_*,
+      # requests.*, urllib.request.urlopen, socket.create_connection,
+      # http.client.HTTP{S,}Connection) must carry a bounded timeout.
+      # The 2026-04-25 cascade was caused by a single unbounded
+      # boto3.client("ecs", ...); PR #3353 fixed that one site. This
+      # AST-based check enforces the structural invariant going forward.
+      - name: Check no unbounded timeouts in dispatcher
+        if: matrix.shard == 'python'
+        run: scripts/check-no-unbounded-timeouts.py
       # Issue #3158: every ``UPDATE dispatcher.agents`` /
       # ``SELECT ... FROM dispatcher.agents`` line in
       # ``scripts/dispatcher/daemon.py`` must either mention

--- a/scripts/check-no-unbounded-timeouts.py
+++ b/scripts/check-no-unbounded-timeouts.py
@@ -1,0 +1,579 @@
+#!/usr/bin/env python3
+"""check-no-unbounded-timeouts.py — Fail if any IO call site under
+``scripts/dispatcher/`` (excluding ``scripts/dispatcher/tests/``) lacks
+a bounded timeout.
+
+Why this check exists
+---------------------
+The 2026-04-25 cascade was caused by a single ``boto3.client("ecs", ...)``
+call constructed without an explicit ``botocore.config.Config``. boto3's
+default ``read_timeout`` is effectively unbounded; a hung ``ecs:DescribeTasks``
+in the reaper held the GIL inside urllib3's blocking ``recv()`` for 30+
+minutes, silenced the entire Python process, and only recovered via
+manual ``aws ecs stop-task``. PR #3353 closed that one site (``_make_ecs_client``).
+This check enforces the structural invariant: every IO call site in the
+dispatcher daemon must have a bounded timeout.
+
+Rules enforced
+--------------
+For every ``ast.Call`` node under ``scripts/dispatcher/**/*.py`` (excluding
+``scripts/dispatcher/tests/**``):
+
+  1. ``boto3.client(...)`` -- must pass ``config=`` and the value must be
+     a ``Config(...)`` literal carrying both ``connect_timeout=`` and
+     ``read_timeout=`` kwargs.
+  2. ``psycopg.connect(...)`` -- must pass ``connect_timeout=`` AND must
+     pass ``options=`` whose value contains the substring
+     ``statement_timeout`` (the libpq server-side option form). The
+     daemon uses ``options="-c statement_timeout=30000"``; this rule
+     bounds both handshake and per-query wall clock.
+  3. ``subprocess.run(...)``, ``subprocess.check_output(...)``,
+     ``subprocess.check_call(...)`` -- must pass ``timeout=`` (kwarg) or
+     a ``**kwargs`` splat (``kw.arg is None``).
+  4. ``subprocess.Popen(...)`` -- allowed if the same enclosing function
+     contains a ``proc.wait(timeout=...)`` call AND a ``proc.kill()``
+     call inside an ``except subprocess.TimeoutExpired`` handler.
+  5. ``requests.get/post/put/delete/patch/head/request(...)`` -- must
+     pass ``timeout=`` (kwarg) or a ``**kwargs`` splat.
+  6. ``urllib.request.urlopen(...)`` (or imported as ``urlopen``) --
+     must pass ``timeout=`` or ``**kwargs`` splat.
+  7. ``socket.create_connection(...)`` -- must pass ``timeout=`` or
+     ``**kwargs`` splat.
+  8. ``http.client.HTTPConnection(...)`` /
+     ``http.client.HTTPSConnection(...)`` -- must pass ``timeout=`` or
+     ``**kwargs`` splat.
+
+Allowlist
+---------
+A call may be exempted by adding ``# noqa: timeout-required: <reason>``
+to the same source line as the call (or any line covered by the call's
+multi-line span). A bare ``# noqa`` does NOT exempt -- the rule name
+``timeout-required`` AND a non-empty reason are required.
+
+Output
+------
+On failure the script prints one line per offending call:
+``path:line: <call> -- missing: <thing>``
+
+Usage
+-----
+  scripts/check-no-unbounded-timeouts.py            # scan default tree
+  scripts/check-no-unbounded-timeouts.py [path...]  # scan specific files
+
+Exit codes
+----------
+  0 -- No violations.
+  1 -- At least one IO call site is missing its timeout constraint.
+
+Tracking: issue #3356.
+"""
+
+# venv: none
+# permanent: true
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+from typing import Iterator
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SCAN_ROOT = REPO_ROOT / "scripts" / "dispatcher"
+
+# requests methods that count as HTTP egress.
+REQUESTS_METHODS = frozenset(
+    {"get", "post", "put", "delete", "patch", "head", "request"}
+)
+
+# Allowlist marker -- see module docstring for the exact spelling. We
+# require the rule name AND a non-empty reason. Bare markers (no rule
+# name, or empty reason) are rejected -- see _line_is_allowlisted.
+_ALLOWLIST_RE = re.compile(r"#\s*noqa\s*:\s*timeout-required\s*:\s*\S+")
+
+
+# ---------------------------------------------------------------------------
+# AST predicates for each rule
+# ---------------------------------------------------------------------------
+
+
+def _is_attr_call(func: ast.expr, owner: str, attr: str) -> bool:
+    """Match ``owner.attr(...)`` -- e.g. ``boto3.client``."""
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr == attr
+        and isinstance(func.value, ast.Name)
+        and func.value.id == owner
+    )
+
+
+def _is_boto3_client(func: ast.expr) -> bool:
+    return _is_attr_call(func, "boto3", "client")
+
+
+def _is_psycopg_connect(func: ast.expr) -> bool:
+    return _is_attr_call(func, "psycopg", "connect")
+
+
+def _is_subprocess_simple(func: ast.expr) -> bool:
+    """Match ``subprocess.run/check_output/check_call`` (NOT Popen)."""
+    if not isinstance(func, ast.Attribute):
+        return False
+    if not (isinstance(func.value, ast.Name) and func.value.id == "subprocess"):
+        return False
+    return func.attr in ("run", "check_output", "check_call")
+
+
+def _is_subprocess_popen(func: ast.expr) -> bool:
+    return _is_attr_call(func, "subprocess", "Popen")
+
+
+def _is_requests_call(func: ast.expr) -> bool:
+    return (
+        isinstance(func, ast.Attribute)
+        and func.attr in REQUESTS_METHODS
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "requests"
+    )
+
+
+def _is_urlopen(func: ast.expr) -> bool:
+    # urllib.request.urlopen(...)
+    if (
+        isinstance(func, ast.Attribute)
+        and func.attr == "urlopen"
+        and isinstance(func.value, ast.Attribute)
+        and func.value.attr == "request"
+        and isinstance(func.value.value, ast.Name)
+        and func.value.value.id == "urllib"
+    ):
+        return True
+    # from urllib.request import urlopen; urlopen(...)
+    if isinstance(func, ast.Name) and func.id == "urlopen":
+        return True
+    return False
+
+
+def _is_socket_create_connection(func: ast.expr) -> bool:
+    return _is_attr_call(func, "socket", "create_connection")
+
+
+def _is_http_connection(func: ast.expr) -> bool:
+    """Match ``http.client.HTTPConnection`` and ``HTTPSConnection``."""
+    if (
+        isinstance(func, ast.Attribute)
+        and func.attr in ("HTTPConnection", "HTTPSConnection")
+        and isinstance(func.value, ast.Attribute)
+        and func.value.attr == "client"
+        and isinstance(func.value.value, ast.Name)
+        and func.value.value.id == "http"
+    ):
+        return True
+    # from http.client import HTTPConnection; HTTPConnection(...)
+    if isinstance(func, ast.Name) and func.id in (
+        "HTTPConnection",
+        "HTTPSConnection",
+    ):
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers for inspecting Call nodes
+# ---------------------------------------------------------------------------
+
+
+def _has_kwarg(call: ast.Call, name: str) -> bool:
+    """Return True if ``call`` passes ``name=...`` explicitly."""
+    return any(kw.arg == name for kw in call.keywords)
+
+
+def _has_kwargs_splat(call: ast.Call) -> bool:
+    """Return True if ``call`` passes ``**kwargs`` (kw.arg is None)."""
+    return any(kw.arg is None for kw in call.keywords)
+
+
+def _kwarg_value(call: ast.Call, name: str) -> ast.expr | None:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def _is_config_call(node: ast.expr) -> bool:
+    """Return True if ``node`` is a ``Config(...)`` call literal in any
+    of the canonical forms: ``Config(...)``, ``botocore.config.Config(...)``,
+    ``botocore.client.Config(...)``, ``config.Config(...)``."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name) and func.id == "Config":
+        return True
+    if isinstance(func, ast.Attribute) and func.attr == "Config":
+        return True
+    return False
+
+
+def _config_call_has(node: ast.expr, *required_kwargs: str) -> bool:
+    """If ``node`` is a ``Config(...)`` call literal, return True only if
+    every name in ``required_kwargs`` appears as a kwarg."""
+    if not _is_config_call(node):
+        return False
+    assert isinstance(node, ast.Call)
+    present = {kw.arg for kw in node.keywords if kw.arg is not None}
+    return all(req in present for req in required_kwargs)
+
+
+def _resolve_config_value(
+    tree: ast.AST,
+    call: ast.Call,
+    cfg_value: ast.expr,
+    *required_kwargs: str,
+) -> bool:
+    """Return True if ``cfg_value`` (the value of ``config=``) resolves
+    to a ``Config(...)`` literal carrying every name in ``required_kwargs``.
+
+    Two cases:
+      1. ``config=Config(...)`` -- inline literal; check directly.
+      2. ``config=cw_cfg`` -- Name reference; walk the enclosing function
+         for an ``Assign`` of ``cw_cfg = Config(...)`` and check that.
+
+    The Name-resolution path matches the daemon's preferred shape:
+    construct the Config in a local variable for readability, then pass
+    it into ``boto3.client(...)``.
+    """
+    if _is_config_call(cfg_value):
+        return _config_call_has(cfg_value, *required_kwargs)
+    if not isinstance(cfg_value, ast.Name):
+        return False
+    target_name = cfg_value.id
+    enclosing = _enclosing_function(tree, call)
+    search_root: ast.AST = enclosing if enclosing is not None else tree
+    for node in ast.walk(search_root):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == target_name:
+                    if _config_call_has(node.value, *required_kwargs):
+                        return True
+        if isinstance(node, ast.AnnAssign):
+            if (
+                isinstance(node.target, ast.Name)
+                and node.target.id == target_name
+                and node.value is not None
+                and _config_call_has(node.value, *required_kwargs)
+            ):
+                return True
+    return False
+
+
+def _options_value_has_substring(node: ast.expr | None, needle: str) -> bool:
+    """Return True if ``node`` is a string Constant containing ``needle``,
+    OR a Name reference (we conservatively trust named module-level
+    constants used by the daemon)."""
+    if node is None:
+        return False
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return needle in node.value
+    if isinstance(node, ast.Name):
+        # Name references resolve at runtime; trust the convention that
+        # the daemon's PSYCOPG_STATEMENT_TIMEOUT_OPTIONS constant is the
+        # only sanctioned source. The tests assert behaviour for both
+        # the literal and the named-constant form.
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Popen pairing detection: Popen(...) is allowed if the enclosing
+# function/method contains a ``proc.wait(timeout=...)`` AND a
+# ``proc.kill()`` inside an ``except subprocess.TimeoutExpired`` handler.
+# ---------------------------------------------------------------------------
+
+
+def _popen_has_pairing(tree: ast.AST, popen_node: ast.Call) -> bool:
+    """Heuristic: walk every enclosing function/method and look for the
+    canonical Popen + wait(timeout=...) + TimeoutExpired -> kill() shape.
+    Returns True if the pattern is present anywhere in the same function.
+
+    The check intentionally does not follow the actual data-flow (e.g.
+    confirm the wait() is called on the same Popen-returned name). The
+    daemon's two Popen sites (stream_subprocess_output_async wrapper
+    around claude -p, and the diagnoser subprocess) both follow the
+    canonical idiom -- a future contributor adding a Popen without that
+    idiom will get caught by Test (h) "Popen with timeout= in wait but
+    no kill() in TimeoutExpired" or Test (g) "Popen with no wait pairing".
+    """
+    enclosing = _enclosing_function(tree, popen_node)
+    if enclosing is None:
+        return False
+
+    has_wait_with_timeout = False
+    has_timeout_expired_kill = False
+
+    for node in ast.walk(enclosing):
+        # ``X.wait(timeout=...)`` anywhere in the same function.
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "wait"
+            and _has_kwarg(node, "timeout")
+        ):
+            has_wait_with_timeout = True
+        # ``except subprocess.TimeoutExpired:`` handler containing a
+        # ``X.kill()`` call.
+        if isinstance(node, ast.ExceptHandler) and _handler_matches_timeout_expired(
+            node
+        ):
+            for inner in ast.walk(node):
+                if (
+                    isinstance(inner, ast.Call)
+                    and isinstance(inner.func, ast.Attribute)
+                    and inner.func.attr == "kill"
+                ):
+                    has_timeout_expired_kill = True
+                    break
+
+    return has_wait_with_timeout and has_timeout_expired_kill
+
+
+def _handler_matches_timeout_expired(handler: ast.ExceptHandler) -> bool:
+    """Return True if the handler catches ``subprocess.TimeoutExpired``
+    (or bare ``TimeoutExpired``)."""
+    exc = handler.type
+    if exc is None:
+        return False
+    if isinstance(exc, ast.Attribute) and exc.attr == "TimeoutExpired":
+        return True
+    if isinstance(exc, ast.Name) and exc.id == "TimeoutExpired":
+        return True
+    # except (TimeoutExpired, OtherExc):
+    if isinstance(exc, ast.Tuple):
+        return any(_handler_matches_timeout_expired_expr(e) for e in exc.elts)
+    return False
+
+
+def _handler_matches_timeout_expired_expr(node: ast.expr) -> bool:
+    if isinstance(node, ast.Attribute) and node.attr == "TimeoutExpired":
+        return True
+    if isinstance(node, ast.Name) and node.id == "TimeoutExpired":
+        return True
+    return False
+
+
+def _enclosing_function(
+    tree: ast.AST, target: ast.AST
+) -> ast.FunctionDef | ast.AsyncFunctionDef | None:
+    """Return the innermost ``FunctionDef``/``AsyncFunctionDef`` ancestor
+    of ``target``, or None if ``target`` is at module top level.
+
+    We walk the tree explicitly because ``ast`` doesn't track parents.
+    """
+    candidate: ast.FunctionDef | ast.AsyncFunctionDef | None = None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if _node_contains(node, target):
+                candidate = node
+    return candidate
+
+
+def _node_contains(parent: ast.AST, child: ast.AST) -> bool:
+    """Return True if ``child`` is a descendant of ``parent`` (or the same
+    node). Linear in the size of the parent subtree."""
+    if parent is child:
+        return True
+    for node in ast.walk(parent):
+        if node is child:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Allowlist parsing
+# ---------------------------------------------------------------------------
+
+
+def _line_is_allowlisted(call: ast.Call, source_lines: list[str]) -> bool:
+    """Return True if any source line covered by ``call`` carries a
+    ``# noqa: timeout-required: <reason>`` comment."""
+    start = call.lineno
+    end = getattr(call, "end_lineno", None) or start
+    for lineno in range(start, end + 1):
+        idx = lineno - 1
+        if 0 <= idx < len(source_lines):
+            if _ALLOWLIST_RE.search(source_lines[idx]):
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Per-call rule application
+# ---------------------------------------------------------------------------
+
+
+def _check_call(
+    tree: ast.AST,
+    call: ast.Call,
+    source_lines: list[str],
+) -> tuple[str, str] | None:
+    """Apply every rule to ``call``. Return ``(call_label, missing_msg)``
+    on violation, or None if the call passes (or no rule applies).
+    """
+    func = call.func
+
+    # boto3.client(...): must have config=Config(connect_timeout=, read_timeout=)
+    if _is_boto3_client(func):
+        cfg = _kwarg_value(call, "config")
+        if cfg is None:
+            return ("boto3.client", "config=botocore.config.Config(...)")
+        if not _resolve_config_value(
+            tree, call, cfg, "connect_timeout", "read_timeout"
+        ):
+            return (
+                "boto3.client",
+                "config=Config(...) with both connect_timeout= and read_timeout=",
+            )
+        return None
+
+    # psycopg.connect(...): must have connect_timeout= AND options= containing
+    # statement_timeout.
+    if _is_psycopg_connect(func):
+        missing: list[str] = []
+        if not _has_kwarg(call, "connect_timeout"):
+            missing.append("connect_timeout=")
+        opts = _kwarg_value(call, "options")
+        if opts is None or not _options_value_has_substring(opts, "statement_timeout"):
+            missing.append("options=...statement_timeout...")
+        if missing:
+            return ("psycopg.connect", " AND ".join(missing))
+        return None
+
+    # subprocess.run/check_output/check_call: must have timeout= or **kwargs.
+    if _is_subprocess_simple(func):
+        if not (_has_kwarg(call, "timeout") or _has_kwargs_splat(call)):
+            attr = func.attr if isinstance(func, ast.Attribute) else "?"
+            return (f"subprocess.{attr}", "timeout=")
+        return None
+
+    # subprocess.Popen: allowed if the same function contains a paired
+    # wait(timeout=) + TimeoutExpired -> kill() block. Or, equivalently,
+    # if the call carries ``timeout=`` directly (some Python versions
+    # surface ``timeout=`` on Popen for read-side bounding).
+    if _is_subprocess_popen(func):
+        if _has_kwarg(call, "timeout") or _has_kwargs_splat(call):
+            return None
+        if _popen_has_pairing(tree, call):
+            return None
+        return (
+            "subprocess.Popen",
+            "timeout= OR a paired proc.wait(timeout=) + except TimeoutExpired -> proc.kill()",
+        )
+
+    # requests.<method>(...): must have timeout= or **kwargs.
+    if _is_requests_call(func):
+        if not (_has_kwarg(call, "timeout") or _has_kwargs_splat(call)):
+            attr = func.attr if isinstance(func, ast.Attribute) else "?"
+            return (f"requests.{attr}", "timeout=")
+        return None
+
+    # urllib.request.urlopen / urlopen: must have timeout= or **kwargs.
+    if _is_urlopen(func):
+        if not (_has_kwarg(call, "timeout") or _has_kwargs_splat(call)):
+            return ("urllib.request.urlopen", "timeout=")
+        return None
+
+    # socket.create_connection(...): must have timeout= or **kwargs.
+    if _is_socket_create_connection(func):
+        if not (_has_kwarg(call, "timeout") or _has_kwargs_splat(call)):
+            return ("socket.create_connection", "timeout=")
+        return None
+
+    # http.client.HTTP{S,}Connection(...): must have timeout= or **kwargs.
+    if _is_http_connection(func):
+        if not (_has_kwarg(call, "timeout") or _has_kwargs_splat(call)):
+            label = (
+                f"http.client.{func.attr}"
+                if isinstance(func, ast.Attribute)
+                else "http.client.HTTP[S]Connection"
+            )
+            return (label, "timeout=")
+        return None
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# File scanning
+# ---------------------------------------------------------------------------
+
+
+def _iter_python_files(roots: list[Path]) -> Iterator[Path]:
+    for root in roots:
+        if root.is_file() and root.suffix == ".py":
+            yield root
+            continue
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*.py")):
+            # Exclude scripts/dispatcher/tests/ — they may contain
+            # intentional unbounded fixtures.
+            if "/tests/" in str(path) or "\\tests\\" in str(path):
+                continue
+            if "/.venv/" in str(path) or "\\.venv\\" in str(path):
+                continue
+            yield path
+
+
+def scan_file(path: Path) -> list[str]:
+    """Return a list of violation lines for ``path``. Empty if clean."""
+    try:
+        source = path.read_text()
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    source_lines = source.splitlines()
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        result = _check_call(tree, node, source_lines)
+        if result is None:
+            continue
+        if _line_is_allowlisted(node, source_lines):
+            continue
+        label, missing = result
+        violations.append(f"{path}:{node.lineno}: {label} -- missing: {missing}")
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    if argv:
+        roots = [Path(a).resolve() for a in argv]
+    else:
+        roots = [DEFAULT_SCAN_ROOT]
+
+    all_violations: list[str] = []
+    for path in _iter_python_files(roots):
+        all_violations.extend(scan_file(path))
+
+    if all_violations:
+        sys.stderr.write("ERROR: unbounded IO call site(s) found in dispatcher.\n\n")
+        for line in all_violations:
+            sys.stderr.write(f"    {line}\n")
+        sys.stderr.write(
+            "\nFix: add the missing kwarg, or annotate the call with\n"
+            "    # noqa: timeout-required: <reason>\n"
+            "on the same line. See scripts/check-no-unbounded-timeouts.py\n"
+            "for the full rule table. Tracking: issue #3356.\n"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check-no-unbounded-timeouts.py
+++ b/scripts/check-no-unbounded-timeouts.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# venv: none
+# permanent: true
 """check-no-unbounded-timeouts.py — Fail if any IO call site under
 ``scripts/dispatcher/`` (excluding ``scripts/dispatcher/tests/``) lacks
 a bounded timeout.
@@ -67,9 +69,6 @@ Exit codes
 
 Tracking: issue #3356.
 """
-
-# venv: none
-# permanent: true
 
 from __future__ import annotations
 

--- a/scripts/check-oneshot-repo-paths.sh
+++ b/scripts/check-oneshot-repo-paths.sh
@@ -58,6 +58,7 @@ LOCAL_ONLY=(
     "check-aws-bool-flags.sh"
     "check-hardcoded-colors.sh"
     "check-migration-files.sh"
+    "check-no-unbounded-timeouts.py"
     # Developer/dispatcher tooling — only run locally
     "dispatcher-request.py"
     "phase_timer.py"

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -202,6 +202,26 @@ ECS_CLIENT_CONNECT_TIMEOUT_SECONDS = 5
 ECS_CLIENT_READ_TIMEOUT_SECONDS = 10
 ECS_CLIENT_MAX_ATTEMPTS = 2
 
+#: boto3 CloudWatch client socket timeouts (#3356). Same shape and
+#: rationale as the ECS_CLIENT_* constants above — a hung
+#: ``cloudwatch:PutMetricData`` from ``_emit_heartbeat_metric`` (called
+#: every supervisor tick, every ~120s) would otherwise wedge the
+#: scheduler thread the same way ``ecs:DescribeTasks`` did in the
+#: 2026-04-25 cascade. Values match the ECS budget so the worst-case
+#: total per call stays under the watchdog WARN tier.
+CLOUDWATCH_CLIENT_CONNECT_TIMEOUT_SECONDS = 5
+CLOUDWATCH_CLIENT_READ_TIMEOUT_SECONDS = 10
+CLOUDWATCH_CLIENT_MAX_ATTEMPTS = 2
+
+#: ``options`` payload for every ``psycopg.connect(...)`` site in the
+#: dispatcher (#3356). Bounds per-query wall clock at 30s — long enough
+#: for the daemon's heaviest analytics queries, short enough that a
+#: runaway lock or replica failover doesn't wedge the scheduler. The
+#: ``connect_timeout`` kwarg already bounds the libpq handshake; this
+#: bounds every query on the open connection. Format is the libpq
+#: server-side option string accepted by psycopg's ``options=`` kwarg.
+PSYCOPG_STATEMENT_TIMEOUT_OPTIONS = "-c statement_timeout=30000"
+
 #: Max stack frames per thread emitted in the stall thread dump. Each
 #: frame renders as ``file:line (function)`` — ~60-120 chars per frame.
 #: With ~10 threads (main + scheduler + ralph head-watcher + CloudWatch
@@ -2290,7 +2310,11 @@ class DispatcherDaemon:
                 "database_url_set": bool(self._cfg.database_url),
             },
         )
-        self._conn = psycopg.connect(self._cfg.database_url, connect_timeout=10)
+        self._conn = psycopg.connect(
+            self._cfg.database_url,
+            connect_timeout=10,
+            options=PSYCOPG_STATEMENT_TIMEOUT_OPTIONS,
+        )
         # Autocommit off — every daemon step is one small transaction.
         self._conn.autocommit = False
 
@@ -3484,7 +3508,11 @@ class DispatcherDaemon:
 
         worker_conn: Connection[Any] | None = None
         try:
-            worker_conn = psycopg.connect(self._cfg.database_url, connect_timeout=10)
+            worker_conn = psycopg.connect(
+                self._cfg.database_url,
+                connect_timeout=10,
+                options=PSYCOPG_STATEMENT_TIMEOUT_OPTIONS,
+            )
             worker_conn.autocommit = False
             self._thread_state.conn = worker_conn
             self._claim_and_orchestrate_one()
@@ -6914,7 +6942,9 @@ class DispatcherDaemon:
         try:
             try:
                 watcher_conn = psycopg.connect(
-                    self._cfg.database_url, connect_timeout=10
+                    self._cfg.database_url,
+                    connect_timeout=10,
+                    options=PSYCOPG_STATEMENT_TIMEOUT_OPTIONS,
                 )
                 watcher_conn.autocommit = False
             except Exception as exc:
@@ -19468,10 +19498,34 @@ class DispatcherDaemon:
 
         Lazy import of boto3 mirrors psycopg — tests that do not exercise
         the heartbeat path should not have to install boto3.
+
+        #3356: applies an explicit :class:`botocore.config.Config` so a
+        hung ``cloudwatch:PutMetricData`` from ``_emit_heartbeat_metric``
+        cannot block the supervisor thread indefinitely. boto3's defaults
+        leave ``read_timeout`` effectively unbounded; a hung call would
+        wedge the GIL via urllib3's blocking ``recv()`` the same way the
+        2026-04-25 cascade demonstrated for the ECS client (#3351). The
+        constants :data:`CLOUDWATCH_CLIENT_CONNECT_TIMEOUT_SECONDS`,
+        :data:`CLOUDWATCH_CLIENT_READ_TIMEOUT_SECONDS`, and
+        :data:`CLOUDWATCH_CLIENT_MAX_ATTEMPTS` document the chosen
+        budget — same values as the ECS client.
         """
         import boto3  # noqa: PLC0415  — lazy import
+        import botocore.config  # noqa: PLC0415 — lazy import, mirrors boto3
 
-        return boto3.client("cloudwatch", region_name=self._cfg.aws_region)
+        cw_cfg = botocore.config.Config(
+            connect_timeout=CLOUDWATCH_CLIENT_CONNECT_TIMEOUT_SECONDS,
+            read_timeout=CLOUDWATCH_CLIENT_READ_TIMEOUT_SECONDS,
+            retries={
+                "max_attempts": CLOUDWATCH_CLIENT_MAX_ATTEMPTS,
+                "mode": "standard",
+            },
+        )
+        return boto3.client(
+            "cloudwatch",
+            region_name=self._cfg.aws_region,
+            config=cw_cfg,
+        )
 
     def _emit_heartbeat_metric(self) -> bool:
         """Publish ``HeartbeatAge=0`` to the configured CloudWatch namespace.
@@ -20953,7 +21007,11 @@ class DispatcherDaemon:
 
         watcher_conn: Connection[Any] | None = None
         try:
-            watcher_conn = psycopg.connect(self._cfg.database_url, connect_timeout=10)
+            watcher_conn = psycopg.connect(
+                self._cfg.database_url,
+                connect_timeout=10,
+                options=PSYCOPG_STATEMENT_TIMEOUT_OPTIONS,
+            )
             watcher_conn.autocommit = False
             self._thread_state.conn = watcher_conn
         except Exception as exc:

--- a/scripts/dispatcher/emit_failure.py
+++ b/scripts/dispatcher/emit_failure.py
@@ -127,7 +127,15 @@ def _insert(
     """Run the single INSERT. Psycopg is imported lazily."""
     import psycopg
 
-    with psycopg.connect(database_url, connect_timeout=10) as conn:
+    # #3356: bound per-query wall clock at 30s in addition to
+    # ``connect_timeout`` so a runaway lock or replica failover can't
+    # wedge the agent-runner-entrypoint subprocess. Mirror constant from
+    # daemon.py inline so this module stays import-free of daemon.py.
+    with psycopg.connect(
+        database_url,
+        connect_timeout=10,
+        options="-c statement_timeout=30000",
+    ) as conn:
         with conn.cursor() as cur:
             cur.execute(
                 f"INSERT INTO {table} "

--- a/scripts/dispatcher/tests/test_daemon_cloudwatch_client_timeout.py
+++ b/scripts/dispatcher/tests/test_daemon_cloudwatch_client_timeout.py
@@ -1,0 +1,223 @@
+"""Unit tests for the boto3 CloudWatch client timeout config (#3356).
+
+Mirror of :mod:`test_daemon_ecs_client_timeout` for the CloudWatch client.
+
+Why this test exists
+--------------------
+The 2026-04-25 cascade revealed that boto3's default ``read_timeout``
+on the dispatcher's ECS client was effectively unbounded; PR #3353
+fixed the ECS site. The same defect was present on the CloudWatch
+client (used every supervisor tick to emit ``HeartbeatAge=0``): a hung
+``cloudwatch:PutMetricData`` would have wedged the supervisor thread
+the same way a hung ``ecs:DescribeTasks`` wedged the scheduler.
+
+Fix: :meth:`DispatcherDaemon._make_cloudwatch_client` now constructs
+the boto3 client with an explicit :class:`botocore.config.Config`
+carrying a small connect-timeout, a small read-timeout, and a bounded
+retry policy. Worst-case wall-clock for a hung PutMetricData is now
+~25 seconds (one retry x 10s read + 5s connect) instead of indefinite.
+
+Tests below assert the constants are sane AND that
+:meth:`_make_cloudwatch_client` actually wires them onto the boto3
+client's ``meta.config`` object.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+from dispatcher import daemon  # noqa: E402  -- sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+
+def _make_daemon() -> daemon.DispatcherDaemon:
+    """Build a minimal daemon instance for client-construction tests.
+
+    Bypasses the normal ctor (and its DB / arg parsing) by using
+    ``__new__`` and seeding only the fields ``_make_cloudwatch_client``
+    reads -- currently just ``self._cfg.aws_region``.
+    """
+    d = daemon.DispatcherDaemon.__new__(daemon.DispatcherDaemon)
+    d._thread_state = threading.local()  # type: ignore[attr-defined]
+    d._cfg = MagicMock(aws_region="us-west-2")  # type: ignore[attr-defined]
+    d._log = logging.getLogger("test.daemon_cloudwatch_client_timeout")  # type: ignore[attr-defined]
+    return d
+
+
+# --------------------------------------------------------------------------
+# Module constants
+# --------------------------------------------------------------------------
+
+
+class TestModuleConstants:
+    def test_connect_timeout_default(self) -> None:
+        # Match the ECS client budget -- hung CloudWatch and hung ECS
+        # have the same wedge mechanism (urllib3 blocking ``recv()``
+        # holding the GIL), so the timeout shape should be identical.
+        assert daemon.CLOUDWATCH_CLIENT_CONNECT_TIMEOUT_SECONDS == 5
+
+    def test_read_timeout_default(self) -> None:
+        assert daemon.CLOUDWATCH_CLIENT_READ_TIMEOUT_SECONDS == 10
+
+    def test_max_attempts_default(self) -> None:
+        assert daemon.CLOUDWATCH_CLIENT_MAX_ATTEMPTS == 2
+
+    def test_timeouts_below_watchdog_warn(self) -> None:
+        """The total CloudWatch-client budget must fit inside the
+        watchdog WARN threshold so a hung call surfaces as
+        ``ReadTimeoutError`` BEFORE the watchdog stack-dumps the
+        process. Worst-case is one retry, so total approx
+        max_attempts x (connect + read).
+        """
+        worst_case = daemon.CLOUDWATCH_CLIENT_MAX_ATTEMPTS * (
+            daemon.CLOUDWATCH_CLIENT_CONNECT_TIMEOUT_SECONDS
+            + daemon.CLOUDWATCH_CLIENT_READ_TIMEOUT_SECONDS
+        )
+        assert worst_case < daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS, (
+            f"CloudWatch client worst-case {worst_case}s must be < watchdog "
+            f"WARN {daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS}s so a "
+            f"hung PutMetricData raises ReadTimeoutError before the watchdog fires."
+        )
+
+    def test_matches_ecs_client_budget(self) -> None:
+        """CloudWatch and ECS share the same wedge mechanism -- their
+        timeout budgets should match. If they ever diverge, this test
+        will surface the question 'why?' explicitly."""
+        assert (
+            daemon.CLOUDWATCH_CLIENT_CONNECT_TIMEOUT_SECONDS
+            == daemon.ECS_CLIENT_CONNECT_TIMEOUT_SECONDS
+        )
+        assert (
+            daemon.CLOUDWATCH_CLIENT_READ_TIMEOUT_SECONDS
+            == daemon.ECS_CLIENT_READ_TIMEOUT_SECONDS
+        )
+        assert daemon.CLOUDWATCH_CLIENT_MAX_ATTEMPTS == daemon.ECS_CLIENT_MAX_ATTEMPTS
+
+
+# --------------------------------------------------------------------------
+# _make_cloudwatch_client wires botocore.config.Config onto the client
+# --------------------------------------------------------------------------
+
+
+class TestMakeCloudwatchClientConfig:
+    """Assert ``_make_cloudwatch_client`` constructs a boto3 client with
+    the expected ``botocore.config.Config`` parameters.
+
+    Mirrors the structure of ``TestMakeEcsClientConfig`` -- assert on
+    the Config object passed to ``boto3.client(...)`` rather than on
+    ``client.meta.config``, because the latter is the merged config
+    that boto3 builds from session defaults + env vars + our Config.
+    """
+
+    def _capture_config(self, monkeypatch: Any) -> tuple[Any, list[Any]]:
+        """Patch ``boto3.client`` to record (a snapshot of) the kwargs."""
+        import boto3  # local import so the test is skipped on a venv
+        # without boto3 (the dispatcher venv always has it).
+
+        captured: list[dict[str, Any]] = []
+        real_client = boto3.client
+
+        def recording_client(*args: Any, **kwargs: Any) -> Any:
+            cfg = kwargs.get("config")
+            snapshot = {
+                "args": args,
+                "kwargs": dict(kwargs),
+                "config_snapshot": (
+                    {
+                        "connect_timeout": getattr(cfg, "connect_timeout", None),
+                        "read_timeout": getattr(cfg, "read_timeout", None),
+                        "retries": dict(cfg.retries) if cfg and cfg.retries else {},
+                    }
+                    if cfg is not None
+                    else None
+                ),
+            }
+            captured.append(snapshot)
+            return real_client(*args, **kwargs)
+
+        monkeypatch.setattr(boto3, "client", recording_client)
+        d = _make_daemon()
+        return d, captured
+
+    def test_make_cloudwatch_client_passes_read_timeout_to_boto3(
+        self, monkeypatch: Any
+    ) -> None:
+        """The boto3 client constructed in ``_make_cloudwatch_client``
+        must receive a ``Config`` with the configured ``read_timeout``
+        so a hung ``cloudwatch:PutMetricData`` raises rather than
+        blocks forever."""
+        d, captured = self._capture_config(monkeypatch)
+
+        d._make_cloudwatch_client()
+
+        assert len(captured) == 1, captured
+        snap = captured[0]["config_snapshot"]
+        assert snap is not None, "_make_cloudwatch_client must pass a config="
+        assert snap["read_timeout"] == daemon.CLOUDWATCH_CLIENT_READ_TIMEOUT_SECONDS, (
+            f"expected read_timeout={daemon.CLOUDWATCH_CLIENT_READ_TIMEOUT_SECONDS},"
+            f" got {snap['read_timeout']}"
+        )
+
+    def test_make_cloudwatch_client_passes_connect_timeout_to_boto3(
+        self, monkeypatch: Any
+    ) -> None:
+        """Connect timeout must also be bounded -- a TCP SYN black-hole
+        would otherwise hang forever in
+        ``urllib3.HTTPConnection.connect``."""
+        d, captured = self._capture_config(monkeypatch)
+
+        d._make_cloudwatch_client()
+
+        snap = captured[0]["config_snapshot"]
+        assert snap is not None
+        assert (
+            snap["connect_timeout"] == daemon.CLOUDWATCH_CLIENT_CONNECT_TIMEOUT_SECONDS
+        ), (
+            f"expected connect_timeout="
+            f"{daemon.CLOUDWATCH_CLIENT_CONNECT_TIMEOUT_SECONDS}, "
+            f"got {snap['connect_timeout']}"
+        )
+
+    def test_make_cloudwatch_client_passes_retries_to_boto3(
+        self, monkeypatch: Any
+    ) -> None:
+        """The retries config must cap attempts at the configured max so
+        a single transient hang triggers exactly one retry before
+        raising."""
+        d, captured = self._capture_config(monkeypatch)
+
+        d._make_cloudwatch_client()
+
+        snap = captured[0]["config_snapshot"]
+        assert snap is not None
+        retries = snap["retries"]
+        assert retries.get("max_attempts") == daemon.CLOUDWATCH_CLIENT_MAX_ATTEMPTS, (
+            f"expected retries.max_attempts="
+            f"{daemon.CLOUDWATCH_CLIENT_MAX_ATTEMPTS}, got {retries}"
+        )
+        assert retries.get("mode") == "standard", retries
+
+    def test_make_cloudwatch_client_uses_configured_region(self) -> None:
+        """Sanity: the daemon's ``aws_region`` is wired to the boto3
+        client. Regression guard for a refactor that drops the kwarg."""
+        d = _make_daemon()
+        d._cfg.aws_region = "us-east-1"  # type: ignore[attr-defined]
+
+        client = d._make_cloudwatch_client()
+
+        assert client.meta.region_name == "us-east-1"

--- a/scripts/tests/test_check_no_unbounded_timeouts.py
+++ b/scripts/tests/test_check_no_unbounded_timeouts.py
@@ -1,0 +1,426 @@
+"""Tests for scripts/check-no-unbounded-timeouts.py.
+
+Covers one positive (clean) and one negative (offending) fixture per
+rule, plus the allowlist behaviour. Tracking: issue #3356.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module loader (the check script has dashes in the filename, so we have
+# to load it via importlib rather than ``import``).
+# ---------------------------------------------------------------------------
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_SCRIPT_PATH = _REPO_ROOT / "scripts" / "check-no-unbounded-timeouts.py"
+_spec = importlib.util.spec_from_file_location(
+    "check_no_unbounded_timeouts", _SCRIPT_PATH
+)
+assert _spec is not None
+assert _spec.loader is not None
+check_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(check_mod)
+
+
+# ---------------------------------------------------------------------------
+# Fixture helper: write a Python source string to a temp file, then run
+# scan_file on it and return the violation list.
+# ---------------------------------------------------------------------------
+
+
+def _scan(tmp_path: Path, source: str, name: str = "fixture.py") -> list[str]:
+    path = tmp_path / name
+    path.write_text(source)
+    return check_mod.scan_file(path)
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: boto3.client(...)
+# ---------------------------------------------------------------------------
+
+
+class TestBoto3Client:
+    def test_inline_config_literal_passes(self, tmp_path: Path) -> None:
+        source = (
+            "import boto3\n"
+            "import botocore.config\n"
+            "boto3.client(\n"
+            "    'ecs',\n"
+            "    config=botocore.config.Config(\n"
+            "        connect_timeout=5, read_timeout=10,\n"
+            "        retries={'max_attempts': 2},\n"
+            "    ),\n"
+            ")\n"
+        )
+        assert _scan(tmp_path, source) == []
+
+    def test_named_config_local_variable_passes(self, tmp_path: Path) -> None:
+        """Daemon's preferred shape: build Config(...) into a local then
+        pass the local. The check resolves the Name back to its
+        assignment in the same function."""
+        source = (
+            "import boto3\n"
+            "import botocore.config\n"
+            "def make_client():\n"
+            "    cfg = botocore.config.Config(connect_timeout=5, read_timeout=10)\n"
+            "    return boto3.client('ecs', config=cfg)\n"
+        )
+        assert _scan(tmp_path, source) == []
+
+    def test_no_config_kwarg_fails(self, tmp_path: Path) -> None:
+        source = "import boto3\nboto3.client('ecs', region_name='us-west-2')\n"
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+        assert "boto3.client" in violations[0]
+
+    def test_config_missing_read_timeout_fails(self, tmp_path: Path) -> None:
+        source = (
+            "import boto3\n"
+            "import botocore.config\n"
+            "boto3.client('ecs', config=botocore.config.Config(connect_timeout=5))\n"
+        )
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+        assert "read_timeout" in violations[0]
+
+    def test_config_missing_connect_timeout_fails(self, tmp_path: Path) -> None:
+        source = (
+            "import boto3\n"
+            "import botocore.config\n"
+            "boto3.client('ecs', config=botocore.config.Config(read_timeout=10))\n"
+        )
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+        assert "connect_timeout" in violations[0]
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: psycopg.connect(...)
+# ---------------------------------------------------------------------------
+
+
+class TestPsycopgConnect:
+    def test_options_with_statement_timeout_passes(self, tmp_path: Path) -> None:
+        source = (
+            "import psycopg\n"
+            "psycopg.connect(\n"
+            "    'postgres://x',\n"
+            "    connect_timeout=10,\n"
+            "    options='-c statement_timeout=30000',\n"
+            ")\n"
+        )
+        assert _scan(tmp_path, source) == []
+
+    def test_named_options_constant_passes(self, tmp_path: Path) -> None:
+        """A Name reference for ``options=`` is trusted: the daemon uses
+        ``options=PSYCOPG_STATEMENT_TIMEOUT_OPTIONS``."""
+        source = (
+            "import psycopg\n"
+            "PSYCOPG_STATEMENT_TIMEOUT_OPTIONS = '-c statement_timeout=30000'\n"
+            "psycopg.connect(\n"
+            "    'postgres://x',\n"
+            "    connect_timeout=10,\n"
+            "    options=PSYCOPG_STATEMENT_TIMEOUT_OPTIONS,\n"
+            ")\n"
+        )
+        assert _scan(tmp_path, source) == []
+
+    def test_missing_options_fails(self, tmp_path: Path) -> None:
+        source = "import psycopg\npsycopg.connect('postgres://x', connect_timeout=10)\n"
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+        assert "statement_timeout" in violations[0]
+        assert "psycopg.connect" in violations[0]
+
+    def test_options_without_statement_timeout_fails(self, tmp_path: Path) -> None:
+        source = (
+            "import psycopg\n"
+            "psycopg.connect('postgres://x', connect_timeout=10, options='-c x=y')\n"
+        )
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+        assert "statement_timeout" in violations[0]
+
+    def test_missing_connect_timeout_fails(self, tmp_path: Path) -> None:
+        source = (
+            "import psycopg\n"
+            "psycopg.connect(\n"
+            "    'postgres://x',\n"
+            "    options='-c statement_timeout=30000',\n"
+            ")\n"
+        )
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+        assert "connect_timeout" in violations[0]
+
+
+# ---------------------------------------------------------------------------
+# Rule 3: subprocess.run / check_output / check_call
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessSimple:
+    @pytest.mark.parametrize("call", ["run", "check_output", "check_call"])
+    def test_with_timeout_passes(self, tmp_path: Path, call: str) -> None:
+        source = f"import subprocess\nsubprocess.{call}(['ls'], timeout=30)\n"
+        assert _scan(tmp_path, source) == []
+
+    @pytest.mark.parametrize("call", ["run", "check_output", "check_call"])
+    def test_without_timeout_fails(self, tmp_path: Path, call: str) -> None:
+        source = f"import subprocess\nsubprocess.{call}(['ls'])\n"
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+        assert f"subprocess.{call}" in violations[0]
+
+    def test_kwargs_splat_passes(self, tmp_path: Path) -> None:
+        source = (
+            "import subprocess\n"
+            "def run_helper(cmd, **kw):\n"
+            "    return subprocess.run(cmd, **kw)\n"
+        )
+        assert _scan(tmp_path, source) == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 4: subprocess.Popen with paired wait(timeout=) + TimeoutExpired -> kill()
+# ---------------------------------------------------------------------------
+
+
+class TestSubprocessPopen:
+    def test_popen_with_paired_wait_and_kill_passes(self, tmp_path: Path) -> None:
+        """The two daemon Popen sites both follow this canonical shape."""
+        source = (
+            "import subprocess\n"
+            "def spawn():\n"
+            "    proc = subprocess.Popen(['x'], stdout=subprocess.PIPE)\n"
+            "    try:\n"
+            "        proc.wait(timeout=60)\n"
+            "    except subprocess.TimeoutExpired:\n"
+            "        proc.kill()\n"
+            "        proc.wait(timeout=10)\n"
+        )
+        assert _scan(tmp_path, source) == []
+
+    def test_popen_without_pairing_fails(self, tmp_path: Path) -> None:
+        source = (
+            "import subprocess\n"
+            "def spawn():\n"
+            "    proc = subprocess.Popen(['x'])\n"
+            "    proc.wait()\n"
+        )
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+        assert "subprocess.Popen" in violations[0]
+
+    def test_popen_with_wait_but_no_kill_fails(self, tmp_path: Path) -> None:
+        """Catching TimeoutExpired without ``proc.kill()`` would leak the
+        zombie child — must fail."""
+        source = (
+            "import subprocess\n"
+            "def spawn():\n"
+            "    proc = subprocess.Popen(['x'])\n"
+            "    try:\n"
+            "        proc.wait(timeout=10)\n"
+            "    except subprocess.TimeoutExpired:\n"
+            "        pass\n"
+        )
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+
+    def test_popen_with_explicit_timeout_passes(self, tmp_path: Path) -> None:
+        """Some Python versions surface ``timeout=`` directly on Popen
+        for read-side bounding; allow that shape too."""
+        source = "import subprocess\nsubprocess.Popen(['x'], timeout=30)\n"
+        assert _scan(tmp_path, source) == []
+
+
+# ---------------------------------------------------------------------------
+# Rule 5: requests.<method>(...)
+# ---------------------------------------------------------------------------
+
+
+class TestRequests:
+    @pytest.mark.parametrize(
+        "method", ["get", "post", "put", "delete", "patch", "head", "request"]
+    )
+    def test_with_timeout_passes(self, tmp_path: Path, method: str) -> None:
+        source = (
+            f"import requests\nrequests.{method}('https://example.com', timeout=10)\n"
+        )
+        assert _scan(tmp_path, source) == []
+
+    @pytest.mark.parametrize(
+        "method", ["get", "post", "put", "delete", "patch", "head", "request"]
+    )
+    def test_without_timeout_fails(self, tmp_path: Path, method: str) -> None:
+        source = f"import requests\nrequests.{method}('https://example.com')\n"
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+        assert f"requests.{method}" in violations[0]
+
+
+# ---------------------------------------------------------------------------
+# Rule 6: urllib.request.urlopen
+# ---------------------------------------------------------------------------
+
+
+class TestUrlopen:
+    def test_dotted_with_timeout_passes(self, tmp_path: Path) -> None:
+        source = (
+            "import urllib.request\n"
+            "urllib.request.urlopen('https://example.com', timeout=30)\n"
+        )
+        assert _scan(tmp_path, source) == []
+
+    def test_dotted_without_timeout_fails(self, tmp_path: Path) -> None:
+        source = (
+            "import urllib.request\nurllib.request.urlopen('https://example.com')\n"
+        )
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+        assert "urlopen" in violations[0]
+
+    def test_from_import_with_timeout_passes(self, tmp_path: Path) -> None:
+        source = (
+            "from urllib.request import urlopen\n"
+            "urlopen('https://example.com', timeout=30)\n"
+        )
+        assert _scan(tmp_path, source) == []
+
+    def test_from_import_without_timeout_fails(self, tmp_path: Path) -> None:
+        source = "from urllib.request import urlopen\nurlopen('https://example.com')\n"
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Rule 7: socket.create_connection
+# ---------------------------------------------------------------------------
+
+
+class TestSocketCreateConnection:
+    def test_with_timeout_passes(self, tmp_path: Path) -> None:
+        source = "import socket\nsocket.create_connection(('host', 443), timeout=10)\n"
+        assert _scan(tmp_path, source) == []
+
+    def test_without_timeout_fails(self, tmp_path: Path) -> None:
+        source = "import socket\nsocket.create_connection(('host', 443))\n"
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+        assert "socket.create_connection" in violations[0]
+
+
+# ---------------------------------------------------------------------------
+# Rule 8: http.client.HTTP{S,}Connection
+# ---------------------------------------------------------------------------
+
+
+class TestHttpClientConnection:
+    @pytest.mark.parametrize("cls", ["HTTPConnection", "HTTPSConnection"])
+    def test_dotted_with_timeout_passes(self, tmp_path: Path, cls: str) -> None:
+        source = f"import http.client\nhttp.client.{cls}('host', timeout=10)\n"
+        assert _scan(tmp_path, source) == []
+
+    @pytest.mark.parametrize("cls", ["HTTPConnection", "HTTPSConnection"])
+    def test_dotted_without_timeout_fails(self, tmp_path: Path, cls: str) -> None:
+        source = f"import http.client\nhttp.client.{cls}('host')\n"
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+        assert cls in violations[0]
+
+    def test_from_import_without_timeout_fails(self, tmp_path: Path) -> None:
+        source = "from http.client import HTTPConnection\nHTTPConnection('host')\n"
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+
+
+# ---------------------------------------------------------------------------
+# Allowlist behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlist:
+    def test_allowlist_with_reason_exempts(self, tmp_path: Path) -> None:
+        source = (
+            "import requests\n"
+            "requests.get('https://example.com')  # noqa: timeout-required: test fixture\n"
+        )
+        assert _scan(tmp_path, source) == []
+
+    def test_bare_noqa_does_not_exempt(self, tmp_path: Path) -> None:
+        """A bare ``# noqa`` (no rule name, no reason) must NOT exempt."""
+        source = "import requests\nrequests.get('https://example.com')  # noqa\n"
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+
+    def test_noqa_rule_only_does_not_exempt(self, tmp_path: Path) -> None:
+        """``# noqa: timeout-required`` without a colon-reason must NOT
+        exempt — the rule requires a non-empty justification."""
+        source = (
+            "import requests\n"
+            "requests.get('https://example.com')  # noqa: timeout-required\n"
+        )
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+
+    def test_noqa_empty_reason_does_not_exempt(self, tmp_path: Path) -> None:
+        """``# noqa: timeout-required:`` (colon present, reason empty)
+        must NOT exempt."""
+        source = (
+            "import requests\n"
+            "requests.get('https://example.com')  # noqa: timeout-required: \n"
+        )
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+
+    def test_allowlist_inside_multiline_call_exempts(self, tmp_path: Path) -> None:
+        """A noqa marker on any line covered by the call's span exempts."""
+        source = (
+            "import requests\n"
+            "requests.get(\n"
+            "    'https://example.com',  # noqa: timeout-required: legacy\n"
+            ")\n"
+        )
+        assert _scan(tmp_path, source) == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the real scripts/dispatcher tree must scan clean.
+# ---------------------------------------------------------------------------
+
+
+class TestRealDispatcherTree:
+    def test_dispatcher_tree_scans_clean(self) -> None:
+        """The post-fix dispatcher must scan clean — this is the primary
+        regression gate."""
+        rc = check_mod.main([])
+        assert rc == 0, "scripts/dispatcher/ has unbounded IO call(s)"
+
+
+# ---------------------------------------------------------------------------
+# tests/ directory exclusion
+# ---------------------------------------------------------------------------
+
+
+class TestPathExclusion:
+    def test_tests_directory_skipped(self, tmp_path: Path) -> None:
+        """A file under a ``tests/`` segment must be skipped even if it
+        contains an unbounded call."""
+        bad_file = tmp_path / "tests" / "fixture.py"
+        bad_file.parent.mkdir(parents=True)
+        bad_file.write_text("import requests\nrequests.get('https://example.com')\n")
+        rc = check_mod.main([str(tmp_path)])
+        assert rc == 0
+
+    def test_non_tests_path_scanned(self, tmp_path: Path) -> None:
+        bad_file = tmp_path / "fixture.py"
+        bad_file.write_text("import requests\nrequests.get('https://example.com')\n")
+        rc = check_mod.main([str(tmp_path)])
+        assert rc == 1


### PR DESCRIPTION
## Summary

The 2026-04-25 cascade was caused by a single unbounded `boto3.client("ecs", ...)`. PR #3353 fixed that one site. This PR closes the six remaining unbounded IO sites in `scripts/dispatcher/` and ships an AST-based regression guard so the class can't re-enter.

### Repairs (6 call sites)

- **`_make_cloudwatch_client`** (daemon.py): now passes `botocore.config.Config(connect_timeout=5, read_timeout=10, retries={max_attempts: 2, mode: "standard"})` -- mirrors `_make_ecs_client`. New `CLOUDWATCH_CLIENT_*` constants document the budget.
- **5 `psycopg.connect(...)` sites**: main `self._conn`, orchestration `worker_conn`, ralph head `watcher_conn`, watchdog `watcher_conn`, and the standalone `emit_failure.py`. All now pass `options="-c statement_timeout=30000"` in addition to `connect_timeout=10`. Bounds per-query wall clock at 30s. `daemon.py` uses the new `PSYCOPG_STATEMENT_TIMEOUT_OPTIONS` constant; `emit_failure.py` inlines the literal to stay import-free of `daemon.py`.

### AST hygiene check

New `scripts/check-no-unbounded-timeouts.py` (Python `ast`, not regex) enforces all 7 patterns from the issue table:
- `boto3.client(...)` -- requires `config=` resolving to a `Config(...)` literal carrying both `connect_timeout=` and `read_timeout=`. Resolves Name references back to local-variable assignments in the same enclosing function (matches the daemon's preferred shape).
- `psycopg.connect(...)` -- requires `connect_timeout=` AND `options=` containing the substring `statement_timeout`.
- `subprocess.run/check_output/check_call(...)` -- requires `timeout=` or `**kwargs` splat.
- `subprocess.Popen(...)` -- allowed if the enclosing function pairs `proc.wait(timeout=)` with a `proc.kill()` inside an `except subprocess.TimeoutExpired` handler. Matches the daemon's two existing Popen sites without forcing an out-of-scope refactor.
- `requests.get/post/put/delete/patch/head/request(...)`, `urllib.request.urlopen(...)`, `socket.create_connection(...)`, `http.client.HTTP{S,}Connection(...)` -- all require `timeout=` or `**kwargs` splat.

Allowlist via `# noqa: timeout-required: <reason>` on any line covered by the call's span. Bare `# noqa`, rule-name-only, and empty-reason variants do NOT exempt.

### Tests

- `scripts/tests/test_check_no_unbounded_timeouts.py` (54 tests): one positive + one negative fixture per rule, plus allowlist behaviour and `tests/` directory exclusion. Includes an end-to-end gate that the real `scripts/dispatcher/` tree scans clean.
- `scripts/dispatcher/tests/test_daemon_cloudwatch_client_timeout.py` (9 tests): mirrors `test_daemon_ecs_client_timeout.py` for the new CloudWatch constants and `_make_cloudwatch_client` wiring.
- All 1554 dispatcher tests still pass after these changes.

### CI wiring

New "Check no unbounded timeouts in dispatcher" step added to the `python` shard of `.github/workflows/ci.yml`, mirroring the pattern of the other hygiene checks. Step name follows the hygiene-naming rule (no quoted forbidden literal in the `name:` field).

## Test plan

- [x] `scripts/check-no-unbounded-timeouts.py` exits 0 on the post-fix dispatcher tree
- [x] All 54 tests in `scripts/tests/test_check_no_unbounded_timeouts.py` pass
- [x] All 9 tests in `scripts/dispatcher/tests/test_daemon_cloudwatch_client_timeout.py` pass
- [x] All 1554 dispatcher tests still pass
- [x] `ruff check` clean on touched files
- [x] `ruff format --check` clean on touched files
- [ ] CI green (full ci.yml run)
- [ ] Post-deploy: 30-min CloudWatch query for new daemon `run_id` shows zero ERROR events from `cloudwatch` or `psycopg` paths
- [ ] Post-deploy: `supervisor_tick` logs continue to show `heartbeat_metric_emitted: true`
- [ ] Post-deploy: `scheduler_tick` events fire at expected cadence (~12/min)

Closes #3356.

Unblocks #3357 (revert awslogs `mode=non-blocking`).
