### PR TITLE
fix(infra): revert dispatcher-daemon awslogs to blocking once #3356 lands

### DIFF
--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -746,23 +746,22 @@ resource "aws_ecs_task_definition" "dispatcher" {
         ] : [],
       )
 
+      # #3357 (reverts #3351): drop the awslogs async-drop delivery options
+      # (``mode = "non-blocking"`` and ``max-buffer-size``) and revert to the
+      # driver default (synchronous / blocking delivery). The revert is safe
+      # because #3356 (commit ceed892) bounded every IO call site in the daemon
+      # with per-call timeouts, eliminating the back-pressure-wedge surface that
+      # motivated the async-drop switch. Blocking awslogs is safe ONLY while
+      # that invariant holds — any future unbounded IO path on the daemon's main
+      # thread re-justifies switching back. Cost recovered: the 4 MB async-drop
+      # buffer was silently discarding ``scheduler_tick`` events under the
+      # daemon's 5 s cadence, causing operator-triage confusion (2026-04-25).
       logConfiguration = {
         logDriver = "awslogs"
         options = {
           "awslogs-group"         = aws_cloudwatch_log_group.dispatcher.name
           "awslogs-region"        = data.aws_region.current.id
           "awslogs-stream-prefix" = "dispatcher"
-          # #3351: switch the awslogs driver to non-blocking delivery
-          # so a CloudWatch slowdown cannot block the daemon's stdout
-          # (which would itself wedge the Python process — the same
-          # GIL-held / silent-for-30+-min failure mode observed in
-          # the 2026-04-25 cascade). With ``mode = non-blocking`` the
-          # driver buffers up to ``max-buffer-size`` and drops oldest
-          # events on overflow rather than back-pressuring the
-          # container. 4MB is the AWS-recommended floor — smaller
-          # values throttle awslogs internally.
-          "mode"            = "non-blocking"
-          "max-buffer-size" = "4m"
         }
       }
     }


### PR DESCRIPTION
## Summary

Removed `mode = "non-blocking"` and `max-buffer-size = "4m"` from the dispatcher container's awslogs logConfiguration, reverting to the default synchronous/blocking delivery. Added a comment block above the logConfiguration referencing #3357 and #3356: #3356 bounded all IO call sites eliminating the back-pressure-wedge surface, and the async-drop buffer was silently discarding scheduler_tick events under the 5s cadence.

Closes #3357

## Test plan

### Automated checks

- [x] Lint passes (N/A — Terraform only)
- [x] Format check passes (`terraform fmt -check -recursive infra/terraform/` passed on pre-push)
- [x] Tests pass (`terraform validate` passed on pre-push)
- [x] CI green

### Post-deploy verification

- [ ] 30-min CloudWatch sample shows scheduler_tick events at expected rate (10-12/min)
- [ ] No new scheduler_tick_stalled or watchdog_stopped events in the same window
- [ ] Verification evidence posted on #3357 (see /task-v2-verify output)