### PR TITLE
fix(dispatcher): propagate phase rename to remaining stub-terminals (#3300)

### DIFF
--- a/docs/specs/dispatcher-v2-spec.md
+++ b/docs/specs/dispatcher-v2-spec.md
@@ -316,7 +316,7 @@ Note: `enableExecuteCommand` only takes effect on freshly-launched tasks. Tasks 
 
 #### Known gaps
 
-- `daemon_restart_abandoned` is used by the entrypoint as a generic failed-terminal — it's a category error when the failure isn't actually from a daemon restart. Tracked as #3137.
+- ~~`daemon_restart_abandoned` is used by the entrypoint as a generic failed-terminal — it's a category error when the failure isn't actually from a daemon restart.~~ Resolved: PR #3277 + #3300 renamed the stub-terminal callsites to `agent_runner_route_stub`, closing #3137. Legitimate `daemon_restart_abandoned` references (restart-recovery path) remain unchanged.
 - No `launch-agent-runner-smoke.sh` DX helper yet — Stage 3 smokes were run by hand. Tracked as #3138.
 - ECS agent-runner has no equivalent of the daemon's `CLAUDE_P_SUBPROCESS_TIMEOUT_SECONDS`. If claude hangs inside a phase, the task runs indefinitely. Needs a wall-clock timeout per-phase or per-task.
 

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
@@ -379,6 +379,16 @@ describe('OutcomePill', () => {
       );
       expect(INFRA_PREEMPTED_CATEGORIES.has('paused_by_killswitch')).toBe(true);
     });
+
+    it('does NOT contain agent_runner_route_stub (#3300)', () => {
+      // agent_runner_route_stub is a phase terminal, not a failure
+      // category — it must NOT be in INFRA_PREEMPTED_CATEGORIES so
+      // the cockpit renders it as a red ✗ rather than a gray ↺.
+      // See phase_transitions.py:262–264 docstring.
+      expect(INFRA_PREEMPTED_CATEGORIES.has('agent_runner_route_stub')).toBe(
+        false,
+      );
+    });
   });
 
   // #2953: milestone-completeness glyph + colour logic. A merged row

--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -3948,7 +3948,7 @@ while true; do
                             advance_phase "$_bn"
                         else
                             log "ralph_baseline_transition_unrecognized" "action=$_ba"
-                            advance_phase "daemon_restart_abandoned" "crashed"
+                            advance_phase "agent_runner_route_stub" "crashed"
                         fi
                         continue
                     fi
@@ -4049,7 +4049,7 @@ while true; do
                     ;;
                 *)
                     log "push_and_pr_transition_unrecognized" "action=$_action"
-                    advance_phase "daemon_restart_abandoned" "crashed"
+                    advance_phase "agent_runner_route_stub" "crashed"
                     ;;
             esac
             ;;
@@ -4210,7 +4210,7 @@ while true; do
             ;;
         *)
             log "phase_unknown" "phase=$_current"
-            advance_phase "daemon_restart_abandoned" "crashed"
+            advance_phase "agent_runner_route_stub" "crashed"
             ;;
     esac
 done

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -984,6 +984,7 @@ STUCK_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
     "paused_by_killswitch": 60,  # 1 min — terminal phase, should be swept quickly
     "force_stopped": 60,  # 1 min — #2884 operator force_stop terminal phase
     "daemon_restart_abandoned": 60,  # 1 min — terminal phase from restart recovery
+    "agent_runner_route_stub": 60,  # 1 min — terminal phase from unrecognized route/transition
 }
 
 #: Terminal statuses on ``dispatcher.agents.status`` — the worker thread

--- a/scripts/dispatcher/tests/test_daemon_restart_cascade.py
+++ b/scripts/dispatcher/tests/test_daemon_restart_cascade.py
@@ -770,6 +770,8 @@ class TestPerPhaseStuckTimeout:
         # Restart-recovery "terminal" phases have a tight window so a
         # daemon that crashes mid-reclaim is picked up quickly.
         assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["daemon_restart_abandoned"] == 60
+        # Route-stub terminal phases also get a tight window (#3300).
+        assert daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE["agent_runner_route_stub"] == 60
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixed 3 remaining stub-terminal misuses of `daemon_restart_abandoned` in `agent-runner-entrypoint.sh` by renaming to `agent_runner_route_stub`, completing the partial rename from PR #3277. Added phase timeout config, TypeScript assertion test, and Python timeout test. Updated spec documentation.

Closes #3300

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green
- [x] Markdown links checked

### Post-deploy verification

- [ ] Insert synthetic dispatcher.agents row with `phase = 'agent_runner_route_stub'` on dev, load /admin/dispatcher, verify cockpit renders recognized label (not missing-key fallback)
- [ ] Verification evidence posted on #3300 (see /task-v2-verify output)