### PR TITLE
feat(dispatcher): fetch + rebase before initial push in push_and_pr phase (#2964)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -333,6 +333,40 @@ Example hint:
 
 ---
 
+---
+
+## Per-category guidance — pre-push rebase conflict (issue #2964)
+
+### `merge_conflict_at_push` — daemon-side pre-push rebase hit a conflict
+
+This category is set by the daemon's `_push_and_open_pr` method when:
+
+1. `git fetch origin main` succeeded (or was skipped on network failure), AND
+2. `git rebase origin/main` returned a non-zero exit code (conflicts detected).
+
+The rebase was immediately aborted (`git rebase --abort`), leaving the worktree in its pre-rebase state. **No push was attempted. No PR exists.** The issue is still `status/in-progress`.
+
+**Context bundle extras.** In addition to the shared bundle shape, the `push_and_pr` phase_outputs row carries:
+
+- `conflict_files` (list of str) — paths with unresolved conflicts at abort time (from `git diff --name-only --diff-filter=U`).
+- `event` = `"merge_conflict_at_push"` — identifier for log queries.
+
+The `log_text` column contains the rebase stderr followed by `--- conflict files ---` and the newline-separated file paths.
+
+**Default action selection:**
+
+| Situation | Action | Why |
+|---|---|---|
+| Conflicting files suggest a **sibling PR landed** on main that overlaps with this agent's changes (parallel feature work, shared module refactor) | **`block_and_comment`** | Post a comment on the issue explaining the conflict files and the likely competing PR. Ask the operator to rebase manually or wait until the sibling PR is merged and re-queue. No auto-retry path exists yet. |
+| Conflicting files suggest a **structural dependency** — e.g. this PR depends on a schema or API contract that was changed on main without this agent's knowledge | **`file_prerequisite_task`** | The conflict signals that a prerequisite change must land on main first. File a blocking prerequisite issue; the operator can unblock once the dependency is resolved. |
+| Conflicting files look like **routine import / whitespace / trivial rebase noise** (e.g. only lock files or auto-generated code) | **`block_and_comment`** | Still no auto-retry, but a short comment indicating the conflict looks mechanical and should resolve with a fresh rebase is useful. |
+
+**There is NO auto-retry path for this category.** A mechanical retry would immediately hit the same conflict. The proper resolution path — LLM-assisted conflict resolution via `/task-v2-fix-conflict` — is a follow-up issue (#2964 notes). Until that path exists, the operator must rebase manually or the daemon must be extended.
+
+**Do NOT pick `retry` or `retry_with_hint` for this category.** A fresh agent starting from `origin/main` would not reproduce the conflict (it would already be on the updated base), but it would also lose the agent's implementation work. The correct resolution is to rebase the existing worktree branch, not spawn a new agent.
+
+**Do NOT pick `close` for this category** — a merge conflict is not evidence the issue is invalid.
+
 ## Per-category guidance — post-merge verify failure (issue #3071)
 
 ### `verify_failed_post_merge` — post-merge regression signal

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -11855,6 +11855,8 @@ class DispatcherDaemon:
         rebase_outcome: str = "skipped"
         conflict_paths: list[str] = []
         try:
+            # cold-path (#3089): non-blocking best-effort fetch; failure falls
+            # through to the push unchanged — no retry loop needed here.
             fetch_result = subprocess.run(
                 ["git", "-C", str(worktree), "fetch", "origin", "main"],
                 capture_output=True,
@@ -11878,6 +11880,8 @@ class DispatcherDaemon:
                 )
             else:
                 # Fetch succeeded; attempt the rebase.
+                # cold-path (#3089): local rebase op; conflicts abort cleanly;
+                # retry cannot resolve a conflict — outcome routes to failure.
                 rebase_result = subprocess.run(
                     ["git", "-C", str(worktree), "rebase", "origin/main"],
                     capture_output=True,
@@ -11901,6 +11905,8 @@ class DispatcherDaemon:
                     # Rebase conflict — capture conflicting files, abort,
                     # and fail the phase.
                     rebase_outcome = "conflict"
+                    # cold-path (#3089): local diff to enumerate conflict files;
+                    # no network; result used for diagnostics only.
                     diff_result = subprocess.run(
                         [
                             "git",
@@ -11918,6 +11924,8 @@ class DispatcherDaemon:
                     conflict_paths = [
                         p for p in diff_result.stdout.splitlines() if p.strip()
                     ]
+                    # cold-path (#3089): local cleanup (rebase --abort);
+                    # no network; idempotent — retry adds no value.
                     subprocess.run(
                         ["git", "-C", str(worktree), "rebase", "--abort"],
                         capture_output=True,

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -827,6 +827,13 @@ GH_AUTH_SETUP_GIT_TIMEOUT_SECONDS = 10
 #: timeout fallback of 30 min in :data:`STUCK_TIMEOUT_SECONDS`.
 GIT_PUSH_TIMEOUT_SECONDS = 1800
 
+#: Timeout for the pre-push ``git rebase origin/main`` inserted by
+#: :meth:`DispatcherDaemon._push_and_open_pr` (issue #2964). The rebase
+#: replays a small number of commits against a fast-forward base; 300 s
+#: (5 min) is clearly sufficient while still catching a genuinely-stuck
+#: rebase process.
+GIT_REBASE_TIMEOUT_SECONDS = 300
+
 #: Per-issue cooldown — skip an issue from candidate selection if its
 #: most recent ``dispatcher.agents`` row (any status) was created
 #: within this many seconds. Prevents a systemically-broken issue from
@@ -1228,6 +1235,11 @@ FAILURE_CATEGORY_MERGE_UNSTICK_EXHAUSTED = "merge_unstick_exhausted"
 #: rebase today — but when it is added it must route here.
 FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE = "conflict_unresolvable"
 
+#: daemon-side ``_push_and_open_pr`` pre-push rebase against ``origin/main``
+#: hit a conflict; rebase was aborted and worktree restored. No mechanical
+#: retry — proper LLM-resolution path is the follow-up issue. Tier-3.
+FAILURE_CATEGORY_MERGE_CONFLICT_AT_PUSH = "merge_conflict_at_push"
+
 #: GitHub's rejection stderr fragment when branch protection's
 #: statusCheckRollup evaluator still sees a stale FAILURE check_run
 #: from an earlier CI attempt even though the *latest* ci-passed
@@ -1502,6 +1514,11 @@ TIER_3_CATEGORIES: frozenset[str] = frozenset(
         # from the phase_outputs row and picks AC_INFEASIBLE vs
         # retry_with_hint based on the semantic-collision signal.
         FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE,
+        # #2964: pre-push rebase in _push_and_open_pr detected a conflict;
+        # rebase was aborted and the worktree was restored. No auto-retry
+        # path — the diagnoser picks block_and_comment or
+        # file_prerequisite_task based on the conflict files.
+        FAILURE_CATEGORY_MERGE_CONFLICT_AT_PUSH,
     }
 )
 
@@ -11809,9 +11826,178 @@ class DispatcherDaemon:
                 },
             )
 
-        # git push -u origin <branch>
+        # Compute branch name here so it is available for the pre-push
+        # rebase structured log (issue #2964) as well as the push command.
         short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
         branch = f"agent/{short_id}"
+
+        # Issue #2964: pre-push rebase — bring the branch up-to-date with
+        # origin/main before pushing, so a fast-forward push is possible
+        # and merge conflicts are caught locally (with a meaningful error)
+        # rather than manifesting as a CI failure or post-merge regression.
+        #
+        # Flow:
+        #   1. ``git fetch origin main`` — update the local tracking ref.
+        #      Non-blocking: fetch failure (network, DNS) is logged as a
+        #      warning and we fall through to the push unchanged.
+        #   2. ``git rebase origin/main`` — replay the agent's commits on
+        #      top of the updated main. Three outcomes:
+        #      a. rc==0 (clean or already-up-to-date): proceed to push.
+        #      b. rc!=0 (conflict): capture conflicting files, abort the
+        #         rebase, persist a phase_outputs row, call
+        #         ``_handle_agent_failure`` with
+        #         ``FAILURE_CATEGORY_MERGE_CONFLICT_AT_PUSH``, and return.
+        #         Push does NOT happen.
+        #   3. Always emit a ``daemon.push_and_pr_pre_push_rebase``
+        #      structured log event with ``fetch_ok``, ``rebase_outcome``,
+        #      and ``conflict_files_count`` for CloudWatch metric queries.
+        fetch_ok: bool = True
+        rebase_outcome: str = "skipped"
+        conflict_paths: list[str] = []
+        try:
+            fetch_result = subprocess.run(
+                ["git", "-C", str(worktree), "fetch", "origin", "main"],
+                capture_output=True,
+                text=True,
+                timeout=BASELINE_FETCH_TIMEOUT_SECONDS,
+                check=False,
+            )
+            if fetch_result.returncode != 0:
+                fetch_ok = False
+                self._log.warning(
+                    "daemon.push_and_pr_fetch_failed",
+                    extra={
+                        "event": "push_and_pr_fetch_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "issue_number": issue_number,
+                        "branch": branch,
+                        "exit_code": fetch_result.returncode,
+                        "stderr_tail": _stderr_tail(fetch_result.stderr),
+                    },
+                )
+            else:
+                # Fetch succeeded; attempt the rebase.
+                rebase_result = subprocess.run(
+                    ["git", "-C", str(worktree), "rebase", "origin/main"],
+                    capture_output=True,
+                    text=True,
+                    timeout=GIT_REBASE_TIMEOUT_SECONDS,
+                    check=False,
+                )
+                if rebase_result.returncode == 0:
+                    rebase_outcome = "clean"
+                    self._log.info(
+                        "daemon.push_and_pr_rebase_done",
+                        extra={
+                            "event": "push_and_pr_rebase_done",
+                            "run_id": self._run_id,
+                            "agent_id": agent_id,
+                            "issue_number": issue_number,
+                            "branch": branch,
+                        },
+                    )
+                else:
+                    # Rebase conflict — capture conflicting files, abort,
+                    # and fail the phase.
+                    rebase_outcome = "conflict"
+                    diff_result = subprocess.run(
+                        [
+                            "git",
+                            "-C",
+                            str(worktree),
+                            "diff",
+                            "--name-only",
+                            "--diff-filter=U",
+                        ],
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                        check=False,
+                    )
+                    conflict_paths = [
+                        p for p in diff_result.stdout.splitlines() if p.strip()
+                    ]
+                    subprocess.run(
+                        ["git", "-C", str(worktree), "rebase", "--abort"],
+                        capture_output=True,
+                        text=True,
+                        timeout=30,
+                        check=False,
+                    )
+                    log_text = (
+                        rebase_result.stderr
+                        + "\n--- conflict files ---\n"
+                        + "\n".join(conflict_paths)
+                    )
+                    self._persist_phase_output(
+                        agent_id,
+                        phase="push_and_pr",
+                        output_json={
+                            "event": "merge_conflict_at_push",
+                            "conflict_files": conflict_paths,
+                        },
+                        log_text=log_text,
+                    )
+                    # Emit the observability event before returning so the
+                    # CloudWatch filter can see both paths.
+                    self._log.info(
+                        "daemon.push_and_pr_pre_push_rebase",
+                        extra={
+                            "event": "push_and_pr_pre_push_rebase",
+                            "run_id": self._run_id,
+                            "agent_id": agent_id,
+                            "issue_number": issue_number,
+                            "branch": branch,
+                            "fetch_ok": fetch_ok,
+                            "rebase_outcome": rebase_outcome,
+                            "conflict_files_count": len(conflict_paths),
+                        },
+                    )
+                    self._handle_agent_failure(
+                        agent_id=agent_id,
+                        phase="push_and_pr",
+                        category=FAILURE_CATEGORY_MERGE_CONFLICT_AT_PUSH,
+                        stderr_tail=_stderr_tail(rebase_result.stderr),
+                        exit_code=rebase_result.returncode,
+                        details={
+                            "conflict_files": conflict_paths,
+                            "rebase_outcome": "conflict",
+                        },
+                        issue_number=issue_number,
+                    )
+                    return
+        except subprocess.TimeoutExpired:
+            fetch_ok = False
+            self._log.warning(
+                "daemon.push_and_pr_fetch_failed",
+                extra={
+                    "event": "push_and_pr_fetch_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "branch": branch,
+                    "exit_code": None,
+                    "stderr_tail": "TimeoutExpired",
+                },
+            )
+
+        # Always emit the observability event (non-conflict paths).
+        self._log.info(
+            "daemon.push_and_pr_pre_push_rebase",
+            extra={
+                "event": "push_and_pr_pre_push_rebase",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "branch": branch,
+                "fetch_ok": fetch_ok,
+                "rebase_outcome": rebase_outcome,
+                "conflict_files_count": len(conflict_paths),
+            },
+        )
+
+        # git push -u origin <branch>
         push_cmd = [
             "git",
             "-C",

--- a/scripts/dispatcher/tests/test_daemon_amend_commit.py
+++ b/scripts/dispatcher/tests/test_daemon_amend_commit.py
@@ -166,12 +166,24 @@ class TestPushAndOpenPrUsesAmend:
         rev_list_ahead = subprocess.CompletedProcess(
             args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
         )
+        # Issue #2964: pre-push fetch+rebase inserted before git push.
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=0,
+            stdout="Current branch is up to date.",
+            stderr="",
+        )
         with patch(
             "subprocess.run",
             side_effect=[
                 rev_list_ahead,
                 commit_ok,
                 git_show_empty,
+                fetch_ok,
+                rebase_ok,
                 push_ok,
                 pr_create_ok,
             ],
@@ -246,12 +258,24 @@ class TestPushAndOpenPrUsesAmend:
         rev_list_ahead = subprocess.CompletedProcess(
             args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
         )
+        # Issue #2964: pre-push fetch+rebase inserted before git push.
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=0,
+            stdout="Current branch is up to date.",
+            stderr="",
+        )
         with patch(
             "subprocess.run",
             side_effect=[
                 rev_list_ahead,
                 commit_ok,
                 git_show_empty,
+                fetch_ok,
+                rebase_ok,
                 push_ok,
                 pr_create_ok,
             ],
@@ -303,12 +327,24 @@ class TestPushAndOpenPrUsesAmend:
         rev_list_ahead = subprocess.CompletedProcess(
             args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
         )
+        # Issue #2964: pre-push fetch+rebase inserted before git push.
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=0,
+            stdout="Current branch is up to date.",
+            stderr="",
+        )
         with patch(
             "subprocess.run",
             side_effect=[
                 rev_list_ahead,
                 commit_ok,
                 git_show_empty,
+                fetch_ok,
+                rebase_ok,
                 push_ok,
                 pr_create_ok,
             ],

--- a/scripts/dispatcher/tests/test_daemon_milestone_columns.py
+++ b/scripts/dispatcher/tests/test_daemon_milestone_columns.py
@@ -407,9 +407,27 @@ class TestSelfDeployDetectionPrePush:
         rev_list_ahead = subprocess.CompletedProcess(
             args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
         )
+        # Issue #2964: pre-push fetch+rebase inserted before git push.
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=0,
+            stdout="Current branch is up to date.",
+            stderr="",
+        )
         with patch(
             "subprocess.run",
-            side_effect=[rev_list_ahead, commit_ok, git_show, push_ok, pr_create_ok],
+            side_effect=[
+                rev_list_ahead,
+                commit_ok,
+                git_show,
+                fetch_ok,
+                rebase_ok,
+                push_ok,
+                pr_create_ok,
+            ],
         ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=2953, worktree=worktree)
 
@@ -480,9 +498,27 @@ class TestSelfDeployDetectionPrePush:
         rev_list_ahead = subprocess.CompletedProcess(
             args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
         )
+        # Issue #2964: pre-push fetch+rebase inserted before git push.
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=0,
+            stdout="Current branch is up to date.",
+            stderr="",
+        )
         with patch(
             "subprocess.run",
-            side_effect=[rev_list_ahead, commit_ok, git_show, push_ok, pr_create_ok],
+            side_effect=[
+                rev_list_ahead,
+                commit_ok,
+                git_show,
+                fetch_ok,
+                rebase_ok,
+                push_ok,
+                pr_create_ok,
+            ],
         ):
             d._push_and_open_pr(agent_id=agent_id, issue_number=42, worktree=worktree)
 
@@ -541,12 +577,24 @@ class TestSelfDeployDetectionPrePush:
         rev_list_ahead = subprocess.CompletedProcess(
             args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
         )
+        # Issue #2964: pre-push fetch+rebase inserted before git push.
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=0,
+            stdout="Current branch is up to date.",
+            stderr="",
+        )
         with patch(
             "subprocess.run",
             side_effect=[
                 rev_list_ahead,
                 commit_ok,
                 git_show_fail,
+                fetch_ok,
+                rebase_ok,
                 push_ok,
                 pr_create_ok,
             ],

--- a/scripts/dispatcher/tests/test_daemon_push_and_pr_noop.py
+++ b/scripts/dispatcher/tests/test_daemon_push_and_pr_noop.py
@@ -326,6 +326,16 @@ class TestNormalShipPathUnaffected:
         git_show_empty = subprocess.CompletedProcess(
             args=["git", "show"], returncode=0, stdout="", stderr=""
         )
+        # Issue #2964: pre-push fetch+rebase inserted before git push.
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=0,
+            stdout="Current branch is up to date.",
+            stderr="",
+        )
         push_ok = subprocess.CompletedProcess(
             args=["git", "push"], returncode=0, stdout="", stderr=""
         )
@@ -342,6 +352,8 @@ class TestNormalShipPathUnaffected:
                 rev_list_ahead,
                 commit_ok,
                 git_show_empty,
+                fetch_ok,
+                rebase_ok,
                 push_ok,
                 pr_create_ok,
             ],
@@ -352,16 +364,16 @@ class TestNormalShipPathUnaffected:
                 worktree=worktree,
             )
 
-        # All five subprocess calls fired in order.
+        # All seven subprocess calls fired in order (fetch+rebase added by #2964).
         argvs = [call.args[0] for call in run_mock.call_args_list]
-        assert len(argvs) == 5, (
-            f"Expected 5 subprocess calls on normal SHIP; got {argvs}"
+        assert len(argvs) == 7, (
+            f"Expected 7 subprocess calls on normal SHIP; got {argvs}"
         )
         assert "rev-list" in argvs[0]
         assert "commit" in argvs[1] and "--amend" in argvs[1]
         assert "show" in argvs[2]
-        assert "push" in argvs[3]
-        assert argvs[4][:3] == ["gh", "pr", "create"]
+        assert "push" in argvs[5]
+        assert argvs[6][:3] == ["gh", "pr", "create"]
 
         # No push_and_pr_skipped_no_op event on the normal path.
         # (The method transitions to awaiting_ci via _mark_agent_terminal

--- a/scripts/dispatcher/tests/test_daemon_push_failed.py
+++ b/scripts/dispatcher/tests/test_daemon_push_failed.py
@@ -303,6 +303,16 @@ class TestGitPushFailedWritesFailureRow:
         git_show_empty = subprocess.CompletedProcess(
             args=["git", "show"], returncode=0, stdout="", stderr=""
         )
+        # Issue #2964: pre-push fetch+rebase inserted before git push.
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=0,
+            stdout="Current branch is up to date.",
+            stderr="",
+        )
         # Issue #3089: ``git push`` now routes through the shared
         # 3-attempt retry helper, so the failing push consumes 3
         # ``subprocess.run`` calls instead of 1. ``time.sleep`` is
@@ -311,6 +321,8 @@ class TestGitPushFailedWritesFailureRow:
             rev_list_ahead,
             commit_ok,
             git_show_empty,
+            fetch_ok,
+            rebase_ok,
             push_fail,
             push_fail,
             push_fail,
@@ -385,6 +397,16 @@ class TestGitPushFailedWritesFailureRow:
         git_show_empty = subprocess.CompletedProcess(
             args=["git", "show"], returncode=0, stdout="", stderr=""
         )
+        # Issue #2964: pre-push fetch+rebase inserted before git push.
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=0,
+            stdout="Current branch is up to date.",
+            stderr="",
+        )
         # Issue #3089: 3-attempt retry — 3 push_fail results needed.
         with (
             patch(
@@ -393,6 +415,8 @@ class TestGitPushFailedWritesFailureRow:
                     rev_list_ahead,
                     commit_ok,
                     git_show_empty,
+                    fetch_ok,
+                    rebase_ok,
                     push_fail,
                     push_fail,
                     push_fail,
@@ -459,6 +483,16 @@ class TestGitPushFailedWritesPhaseOutputRow:
         git_show_empty = subprocess.CompletedProcess(
             args=["git", "show"], returncode=0, stdout="", stderr=""
         )
+        # Issue #2964: pre-push fetch+rebase inserted before git push.
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=0,
+            stdout="Current branch is up to date.",
+            stderr="",
+        )
         # Issue #3089: 3-attempt retry — 3 push_fail results needed.
         with (
             patch(
@@ -467,6 +501,8 @@ class TestGitPushFailedWritesPhaseOutputRow:
                     rev_list_ahead,
                     commit_ok,
                     git_show_empty,
+                    fetch_ok,
+                    rebase_ok,
                     push_fail,
                     push_fail,
                     push_fail,

--- a/scripts/dispatcher/tests/test_daemon_push_failed.py
+++ b/scripts/dispatcher/tests/test_daemon_push_failed.py
@@ -43,8 +43,12 @@ from dispatcher import daemon  # noqa: E402  — sys.path mutation above
 from dispatcher.daemon import (  # noqa: E402
     AUTO_RETRY_CATEGORIES,
     FAILURE_CATEGORY_GIT_PUSH_NETWORK,
+    FAILURE_CATEGORY_MERGE_CONFLICT_AT_PUSH,
     FAILURE_CATEGORY_PRE_PUSH_HOOK_REJECTED,
     FAILURE_CATEGORY_PUSH_FAILED,
+    TIER_2_FIRST_OCCURRENCE_CATEGORIES,
+    TIER_2_RECURRENCE_CATEGORIES,
+    TIER_3_CATEGORIES,
     _classify_push_failure,
 )
 
@@ -608,4 +612,411 @@ class TestGitPushFailedSummaryTooltip:
         assert "(git push failed)" in summary, f"Unexpected summary: {summary!r}"
         assert "push_failed" not in summary, (
             f"Raw category token leaked into summary: {summary!r}"
+        )
+
+
+# --------------------------------------------------------------------------
+# Pre-push rebase block (issue #2964)
+# --------------------------------------------------------------------------
+
+
+def _make_push_and_pr_base(
+    tmp_path: Path,
+    *,
+    agent_id: str = "aaaabbbb-0000-0000-0000-000000000010",
+    worktree_name: str = "wt",
+) -> tuple[
+    daemon.DispatcherDaemon,
+    _FakeConnection,
+    _CapturingLogHandler,
+    Path,
+    str,
+]:
+    """Return a daemon + conn + handler + worktree + agent_id tuple.
+
+    The daemon's summary output and phase-update mocks are pre-wired for
+    the happy path.  Tests that need different setup override after calling
+    this helper.
+    """
+    d, conn, handler = _make_daemon(tmp_path)
+    worktree = tmp_path / worktree_name
+    worktree.mkdir()
+    (worktree / "tmp").mkdir()
+
+    d._agent_summary_output = {  # type: ignore[attr-defined]
+        "commit_message": "feat: test commit",
+        "pr_title": "Test PR",
+        "pr_body_md": "body",
+    }
+    d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+    d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+    d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+    d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
+    return d, conn, handler, worktree, agent_id
+
+
+class TestPrePushRebase:
+    """Issue #2964 — pre-push fetch+rebase block in _push_and_open_pr."""
+
+    def test_rebase_conflict_writes_failure_row_with_category(
+        self, tmp_path: Path
+    ) -> None:
+        """Rebase conflict writes a failures row with merge_conflict_at_push
+        category, does NOT call git push, and calls git rebase --abort."""
+        d, conn, _handler, worktree, agent_id = _make_push_and_pr_base(
+            tmp_path, worktree_name="wt_conflict"
+        )
+
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
+        )
+        git_show_empty = subprocess.CompletedProcess(
+            args=["git", "show"], returncode=0, stdout="", stderr=""
+        )
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_conflict = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=1,
+            stdout="",
+            stderr="CONFLICT (content): Merge conflict in packages/api/foo.py",
+        )
+        diff_conflict_files = subprocess.CompletedProcess(
+            args=["git", "diff"],
+            returncode=0,
+            stdout="packages/api/foo.py\n",
+            stderr="",
+        )
+        rebase_abort_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "--abort"], returncode=0, stdout="", stderr=""
+        )
+
+        run_side_effects = [
+            rev_list_ahead,
+            commit_ok,
+            git_show_empty,
+            fetch_ok,
+            rebase_conflict,
+            diff_conflict_files,
+            rebase_abort_ok,
+        ]
+        with patch("subprocess.run", side_effect=run_side_effects) as run_mock:
+            d._push_and_open_pr(
+                agent_id=agent_id,
+                issue_number=2964,
+                worktree=worktree,
+            )
+
+        # Assert: dispatcher.failures INSERT has category == merge_conflict_at_push.
+        failure_inserts = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "dispatcher.failures" in sql and "INSERT" in sql
+        ]
+        assert failure_inserts, (
+            f"Expected INSERT into dispatcher.failures; executed: {conn.cursor_instance.executed}"
+        )
+        _sql, params = failure_inserts[0]
+        assert params[1] == FAILURE_CATEGORY_MERGE_CONFLICT_AT_PUSH, (
+            f"Expected merge_conflict_at_push category; got {params[1]!r}"
+        )
+
+        # Assert: git push was NOT called.
+        all_argv = [call.args[0] for call in run_mock.call_args_list]
+        push_calls = [
+            argv for argv in all_argv if "push" in argv and "--abort" not in argv
+        ]
+        assert not push_calls, (
+            f"git push should NOT be called on conflict; calls: {push_calls}"
+        )
+
+        # Assert: git rebase --abort was called.
+        abort_calls = [
+            argv for argv in all_argv if "rebase" in argv and "--abort" in argv
+        ]
+        assert abort_calls, "git rebase --abort was not called"
+
+    def test_rebase_conflict_log_text_includes_conflict_files(
+        self, tmp_path: Path
+    ) -> None:
+        """The phase_outputs log_text contains the conflicting file paths."""
+        d, conn, _handler, worktree, agent_id = _make_push_and_pr_base(
+            tmp_path, worktree_name="wt_conflict2"
+        )
+
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
+        )
+        git_show_empty = subprocess.CompletedProcess(
+            args=["git", "show"], returncode=0, stdout="", stderr=""
+        )
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_conflict = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=1,
+            stdout="",
+            stderr="CONFLICT: merge conflict",
+        )
+        diff_conflict_files = subprocess.CompletedProcess(
+            args=["git", "diff"],
+            returncode=0,
+            stdout="packages/api/foo.py\npackages/web/bar.tsx\n",
+            stderr="",
+        )
+        rebase_abort_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "--abort"], returncode=0, stdout="", stderr=""
+        )
+
+        run_side_effects = [
+            rev_list_ahead,
+            commit_ok,
+            git_show_empty,
+            fetch_ok,
+            rebase_conflict,
+            diff_conflict_files,
+            rebase_abort_ok,
+        ]
+        with patch("subprocess.run", side_effect=run_side_effects):
+            d._push_and_open_pr(
+                agent_id=agent_id,
+                issue_number=2964,
+                worktree=worktree,
+            )
+
+        # Find the phase_outputs INSERT for push_and_pr.
+        phase_inserts = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if "dispatcher.phase_outputs" in sql and "INSERT" in sql
+        ]
+        assert phase_inserts, (
+            f"Expected INSERT into dispatcher.phase_outputs; executed: {conn.cursor_instance.executed}"
+        )
+        _sql, params = phase_inserts[0]
+        assert params[1] == "push_and_pr"
+        log_text = params[3]
+        assert "packages/api/foo.py" in log_text, (
+            f"log_text missing packages/api/foo.py: {log_text!r}"
+        )
+        assert "packages/web/bar.tsx" in log_text, (
+            f"log_text missing packages/web/bar.tsx: {log_text!r}"
+        )
+
+    def test_fetch_failure_does_not_block_push(self, tmp_path: Path) -> None:
+        """Fetch returning non-zero rc is non-blocking — push still proceeds."""
+        d, conn, handler, worktree, agent_id = _make_push_and_pr_base(
+            tmp_path, worktree_name="wt_fetch_fail"
+        )
+
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
+        )
+        git_show_empty = subprocess.CompletedProcess(
+            args=["git", "show"], returncode=0, stdout="", stderr=""
+        )
+        fetch_fail = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"],
+            returncode=128,
+            stdout="",
+            stderr="fatal: Could not resolve host: github.com",
+        )
+        push_ok = subprocess.CompletedProcess(
+            args=["git", "push"], returncode=0, stdout="", stderr=""
+        )
+        pr_create_ok = subprocess.CompletedProcess(
+            args=["gh", "pr", "create"],
+            returncode=0,
+            stdout="https://github.com/x/y/pull/2964\n",
+            stderr="",
+        )
+
+        run_side_effects = [
+            rev_list_ahead,
+            commit_ok,
+            git_show_empty,
+            fetch_fail,
+            push_ok,
+            pr_create_ok,
+        ]
+        with patch("subprocess.run", side_effect=run_side_effects) as run_mock:
+            d._push_and_open_pr(
+                agent_id=agent_id,
+                issue_number=2964,
+                worktree=worktree,
+            )
+
+        # Assert: git push WAS called downstream.
+        all_argv = [call.args[0] for call in run_mock.call_args_list]
+        push_calls = [
+            argv for argv in all_argv if "push" in argv and "--abort" not in argv
+        ]
+        assert push_calls, (
+            f"git push should be called after fetch failure; calls: {all_argv}"
+        )
+
+        # Assert: structured log event has fetch_ok=False, rebase_outcome="skipped".
+        rebase_events = handler.events("push_and_pr_pre_push_rebase")
+        assert rebase_events, "Expected push_and_pr_pre_push_rebase event"
+        ev = rebase_events[0]
+        assert ev.fetch_ok is False, f"Expected fetch_ok=False; got {ev.fetch_ok!r}"
+        assert ev.rebase_outcome == "skipped", (
+            f"Expected rebase_outcome='skipped'; got {ev.rebase_outcome!r}"
+        )
+
+    def test_fetch_timeout_does_not_block_push(self, tmp_path: Path) -> None:
+        """Fetch raising TimeoutExpired is non-blocking — push still proceeds."""
+        d, conn, handler, worktree, agent_id = _make_push_and_pr_base(
+            tmp_path, worktree_name="wt_fetch_timeout"
+        )
+
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
+        )
+        git_show_empty = subprocess.CompletedProcess(
+            args=["git", "show"], returncode=0, stdout="", stderr=""
+        )
+        push_ok = subprocess.CompletedProcess(
+            args=["git", "push"], returncode=0, stdout="", stderr=""
+        )
+        pr_create_ok = subprocess.CompletedProcess(
+            args=["gh", "pr", "create"],
+            returncode=0,
+            stdout="https://github.com/x/y/pull/2964\n",
+            stderr="",
+        )
+
+        remaining = [rev_list_ahead, commit_ok, git_show_empty, push_ok, pr_create_ok]
+        fetch_raised = [False]
+
+        def ordered_side_effect(
+            *args: Any, **kwargs: Any
+        ) -> subprocess.CompletedProcess:  # type: ignore[type-arg]
+            argv = args[0] if args else []
+            if "fetch" in argv and not fetch_raised[0]:
+                fetch_raised[0] = True
+                raise subprocess.TimeoutExpired(cmd=argv, timeout=120)
+            return remaining.pop(0)
+
+        with patch("subprocess.run", side_effect=ordered_side_effect) as run_mock:
+            d._push_and_open_pr(
+                agent_id=agent_id,
+                issue_number=2964,
+                worktree=worktree,
+            )
+
+        # Assert: git push WAS called downstream.
+        all_argv = [call.args[0] for call in run_mock.call_args_list]
+        push_calls = [
+            argv for argv in all_argv if "push" in argv and "--abort" not in argv
+        ]
+        assert push_calls, (
+            f"git push should be called after fetch timeout; calls: {all_argv}"
+        )
+
+        # Assert: structured log event has fetch_ok=False.
+        rebase_events = handler.events("push_and_pr_pre_push_rebase")
+        assert rebase_events, "Expected push_and_pr_pre_push_rebase event"
+        ev = rebase_events[0]
+        assert ev.fetch_ok is False, f"Expected fetch_ok=False; got {ev.fetch_ok!r}"
+
+    def test_clean_rebase_emits_observability_log(self, tmp_path: Path) -> None:
+        """Happy path: clean rebase emits push_and_pr_pre_push_rebase with
+        fetch_ok=True, rebase_outcome='clean'."""
+        d, _conn, handler, worktree, agent_id = _make_push_and_pr_base(
+            tmp_path, worktree_name="wt_clean"
+        )
+
+        rev_list_ahead = subprocess.CompletedProcess(
+            args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
+        )
+        commit_ok = subprocess.CompletedProcess(
+            args=["git", "commit", "--amend"], returncode=0, stdout="", stderr=""
+        )
+        git_show_empty = subprocess.CompletedProcess(
+            args=["git", "show"], returncode=0, stdout="", stderr=""
+        )
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=0,
+            stdout="Current branch is up to date.",
+            stderr="",
+        )
+        push_ok = subprocess.CompletedProcess(
+            args=["git", "push"], returncode=0, stdout="", stderr=""
+        )
+        pr_create_ok = subprocess.CompletedProcess(
+            args=["gh", "pr", "create"],
+            returncode=0,
+            stdout="https://github.com/x/y/pull/2964\n",
+            stderr="",
+        )
+
+        run_side_effects = [
+            rev_list_ahead,
+            commit_ok,
+            git_show_empty,
+            fetch_ok,
+            rebase_ok,
+            push_ok,
+            pr_create_ok,
+        ]
+        with patch("subprocess.run", side_effect=run_side_effects):
+            d._push_and_open_pr(
+                agent_id=agent_id,
+                issue_number=2964,
+                worktree=worktree,
+            )
+
+        # Assert: push_and_pr_pre_push_rebase event has fetch_ok=True,
+        # rebase_outcome='clean'.
+        rebase_events = handler.events("push_and_pr_pre_push_rebase")
+        assert rebase_events, "Expected push_and_pr_pre_push_rebase event"
+        ev = rebase_events[0]
+        assert ev.fetch_ok is True, f"Expected fetch_ok=True; got {ev.fetch_ok!r}"
+        assert ev.rebase_outcome == "clean", (
+            f"Expected rebase_outcome='clean'; got {ev.rebase_outcome!r}"
+        )
+
+
+# --------------------------------------------------------------------------
+# FAILURE_CATEGORY_MERGE_CONFLICT_AT_PUSH category wiring (issue #2964)
+# --------------------------------------------------------------------------
+
+
+class TestMergeConflictCategoryWiring:
+    """AC#4 — category membership assertions for merge_conflict_at_push."""
+
+    def test_in_tier3(self) -> None:
+        assert FAILURE_CATEGORY_MERGE_CONFLICT_AT_PUSH in TIER_3_CATEGORIES
+
+    def test_not_in_auto_retry(self) -> None:
+        assert FAILURE_CATEGORY_MERGE_CONFLICT_AT_PUSH not in AUTO_RETRY_CATEGORIES
+
+    def test_not_in_tier2_first_occurrence(self) -> None:
+        assert (
+            FAILURE_CATEGORY_MERGE_CONFLICT_AT_PUSH
+            not in TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        )
+
+    def test_not_in_tier2_recurrence(self) -> None:
+        assert (
+            FAILURE_CATEGORY_MERGE_CONFLICT_AT_PUSH not in TIER_2_RECURRENCE_CATEGORIES
         )

--- a/scripts/dispatcher/tests/test_daemon_ralph_patches.py
+++ b/scripts/dispatcher/tests/test_daemon_ralph_patches.py
@@ -839,12 +839,24 @@ class TestPushAndOpenPrDeletesRalphPatch:
         rev_list_ahead = subprocess.CompletedProcess(
             args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
         )
+        # Issue #2964: pre-push fetch+rebase inserted before git push.
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=0,
+            stdout="Current branch is up to date.",
+            stderr="",
+        )
         with patch(
             "subprocess.run",
             side_effect=[
                 rev_list_ahead,
                 commit_ok,
                 git_show_empty,
+                fetch_ok,
+                rebase_ok,
                 push_ok,
                 pr_create_ok,
             ],
@@ -898,6 +910,16 @@ class TestPushAndOpenPrDeletesRalphPatch:
         rev_list_ahead = subprocess.CompletedProcess(
             args=["git", "rev-list"], returncode=0, stdout="1\n", stderr=""
         )
+        # Issue #2964: pre-push fetch+rebase inserted before git push.
+        fetch_ok = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin", "main"], returncode=0, stdout="", stderr=""
+        )
+        rebase_ok = subprocess.CompletedProcess(
+            args=["git", "rebase", "origin/main"],
+            returncode=0,
+            stdout="Current branch is up to date.",
+            stderr="",
+        )
         # Issue #3089: ``git push`` now retries 3 times before falling
         # through to ``_handle_agent_failure``. Provide three push_fail
         # results and stub ``time.sleep`` to keep the test fast.
@@ -908,6 +930,8 @@ class TestPushAndOpenPrDeletesRalphPatch:
                     rev_list_ahead,
                     commit_ok,
                     git_show_empty,
+                    fetch_ok,
+                    rebase_ok,
                     push_fail,
                     push_fail,
                     push_fail,


### PR DESCRIPTION
## Summary

Adds pre-push fetch+rebase block in daemon's `_push_and_open_pr` phase to ensure agent branch is up-to-date with origin/main before pushing. Detects merge conflicts locally, fails with new `merge_conflict_at_push` Tier-3 category, and includes detailed conflict file list. Fetch failures are non-blocking.

Closes #2964

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`) — 73 tests including 9 new tests for pre-push rebase
- [x] CI green

### Post-deploy verification

- [ ] Monitor CloudWatch Logs Insights for `daemon.push_and_pr_pre_push_rebase` events with `fetch_ok=true` and `rebase_outcome=clean` on next few agent runs
- [ ] Verify no `merge_conflict_at_push` failures appear (expected: none until main legitimately conflicts with agent work)
- [ ] Verification evidence posted on #2964 (see /task-v2-verify output)