### PR TITLE
feat(dispatcher): flip agent_execution_mode default to ecs (#3093)

### DIFF
--- a/docs/specs/dispatcher-v2-spec.md
+++ b/docs/specs/dispatcher-v2-spec.md
@@ -242,8 +242,8 @@ Model selection at the CLI: Claude uses `--model <alias\|id>` (aliases `opus`/`s
 
 `dispatcher.config.agent_execution_mode` controls how the daemon spawns agents, orthogonal to runner choice (§6b):
 
-- `'subprocess'` (historical default): daemon forks the runner (e.g. `claude -p /task-v2-<phase>`) as a child process inside its own ECS task. Each daemon redeploy SIGKILLs all child processes, abandoning in-flight agents.
-- `'ecs'` (Option A, #3086/#3078): daemon calls `ecs:RunTask` to launch a dedicated per-agent task from the `judgemind-dispatcher-agent-runner-dev` task-definition family. The agent-runner task is independent of the daemon task — daemon redeploys no longer kill agents.
+- `'subprocess'` (legacy fallback): daemon forks the runner (e.g. `claude -p /task-v2-<phase>`) as a child process inside its own ECS task. Each daemon redeploy SIGKILLs all child processes, abandoning in-flight agents. Reachable via an explicit `dispatcher.config.agent_execution_mode = 'subprocess'` row.
+- `'ecs'` (**default since #3093**, Option A, #3086/#3078): daemon calls `ecs:RunTask` to launch a dedicated per-agent task from the `judgemind-dispatcher-agent-runner-dev` task-definition family. The agent-runner task is independent of the daemon task — daemon redeploys no longer kill agents.
 
 The config flag is stored on the agent row at claim-time (`dispatcher.agents.execution_mode`) and is immutable for that agent's lifetime.
 

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -364,6 +364,13 @@ module "dispatcher_agent_runner" {
 
   github_repo = "judgemind/judgemind"
   repo_url    = "https://github.com/judgemind/judgemind.git"
+
+  # Error alarm wired to the shared SNS topic (same as the daemon and
+  # scraper modules). Stage 4 (#3093) — fires on any ERROR/FATAL log
+  # event emitted by an agent-runner task before the daemon reap pass
+  # observes the STOPPED state.
+  enable_alerts       = true
+  alert_sns_topic_arn = module.compute.alerts_topic_arn
 }
 
 output "ecr_repository_url" {

--- a/infra/terraform/modules/dispatcher-agent-runner/main.tf
+++ b/infra/terraform/modules/dispatcher-agent-runner/main.tf
@@ -329,3 +329,53 @@ resource "aws_ecs_task_definition" "agent_runner" {
     }
   ])
 }
+
+# ── Agent-runner error alarm (#3093) ─────────────────────────────────────────
+# Fires when any ERROR or FATAL structured-log event is emitted by an
+# agent-runner task. A single unhandled exception inside a phase
+# (unrecognized exit code, missing env var, AWS throttle) appears here
+# before the daemon reap pass has a chance to notice the STOPPED task,
+# giving operators an early signal.
+#
+# Gated behind enable_alerts (default false) so non-prod environments
+# stay quiet. Wire enable_alerts = true in the dev module block once
+# the SNS topic ARN is available (mirrors the dispatcher-daemon pattern).
+#
+# Mirrors the filter/alarm shape at
+# infra/terraform/modules/dispatcher-daemon/main.tf (stuck_timeout_repeated).
+
+resource "aws_cloudwatch_log_metric_filter" "agent_runner_errors" {
+  count = var.enable_alerts ? 1 : 0
+
+  name           = "${local.task_family}-errors"
+  pattern        = "{ $.level = \"ERROR\" || $.level = \"FATAL\" }"
+  log_group_name = aws_cloudwatch_log_group.agent_runner.name
+
+  metric_transformation {
+    name          = "AgentRunnerErrorCount"
+    namespace     = "Judgemind/AgentRunner"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "agent_runner_errors" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "${local.task_family}-errors"
+  alarm_description = "An agent-runner task emitted an ERROR or FATAL log event (${var.environment}). A phase may have crashed before the daemon reap pass observed a STOPPED task — check ${aws_cloudwatch_log_group.agent_runner.name}."
+
+  namespace   = "Judgemind/AgentRunner"
+  metric_name = "AgentRunnerErrorCount"
+  statistic   = "Sum"
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = 1
+  period              = 300
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}

--- a/infra/terraform/modules/dispatcher-agent-runner/variables.tf
+++ b/infra/terraform/modules/dispatcher-agent-runner/variables.tf
@@ -91,3 +91,17 @@ variable "repo_url" {
   type        = string
   default     = "https://github.com/judgemind/judgemind.git"
 }
+
+# ─── Alerts ──────────────────────────────────────────────────────────────
+
+variable "enable_alerts" {
+  description = "Whether to create CloudWatch metric filter and alarm for agent-runner error events. Set false until an SNS topic is available. Mirrors the dispatcher-daemon enable_alerts flag (#3093)."
+  type        = bool
+  default     = false
+}
+
+variable "alert_sns_topic_arn" {
+  description = "ARN of the SNS topic for alarm notifications. Required when enable_alerts is true."
+  type        = string
+  default     = ""
+}

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -349,12 +349,12 @@ DEFAULT_HEARTBEAT_METRIC_NAMESPACE = "Judgemind/Dispatcher"
 DEFAULT_AWS_REGION = "us-west-2"
 
 #: Default value for ``dispatcher.config.agent_execution_mode`` when the
-#: row is missing or malformed. ``'subprocess'`` keeps the pre-#3091
-#: behaviour — the daemon spawns per-phase ``claude -p`` subprocesses
-#: inside its own container — and is the safe default until Stage 3
-#: smoke (#3092) confirms the ECS path end-to-end and Stage 4 (#3093)
-#: flips this default.
-DEFAULT_AGENT_EXECUTION_MODE = "subprocess"
+#: row is missing or malformed. Flipped to ``'ecs'`` by Stage 4 (#3093)
+#: after Stage 3 smoke (#3092) confirmed the ECS path end-to-end. New
+#: agents claim with ``execution_mode='ecs'`` (per-agent Fargate task via
+#: ``ecs:RunTask``) unless overridden via ``dispatcher.config``. The
+#: subprocess code path remains reachable via an explicit config row.
+DEFAULT_AGENT_EXECUTION_MODE = "ecs"
 
 #: Valid values for ``dispatcher.config.agent_execution_mode``. Anything
 #: outside this set falls back to :data:`DEFAULT_AGENT_EXECUTION_MODE`
@@ -4944,10 +4944,14 @@ class DispatcherDaemon:
                 )
                 for row in cur.fetchall():
                     raw_mode = row[3] if len(row) > 3 else None
+                    # NULL execution_mode means a pre-migration-41 row —
+                    # it was always a subprocess agent. Explicitly default
+                    # to 'subprocess' here (not DEFAULT_AGENT_EXECUTION_MODE)
+                    # so new rows that happen to be NULL (migration hiccup,
+                    # hand-edit) still take the legacy abandon path rather
+                    # than the ECS-survival path. See #3152 / #3093.
                     mode = (
-                        str(raw_mode).lower()
-                        if raw_mode is not None
-                        else DEFAULT_AGENT_EXECUTION_MODE
+                        str(raw_mode).lower() if raw_mode is not None else "subprocess"
                     )
                     raw_arn = row[4] if len(row) > 4 else None
                     task_arn = str(raw_arn) if raw_arn is not None else None
@@ -12447,12 +12451,14 @@ class DispatcherDaemon:
                                 if len(row) > 7 and row[7] is not None
                                 else 0
                             ),
-                            # #3196: default to 'subprocess' if COALESCE
+                            # #3196: fall back to 'subprocess' if COALESCE
                             # in the SELECT is stripped by a fake cursor
-                            # in tests. Also defaults to 'subprocess'
-                            # when the column is absent (pre-#3091
-                            # migration rows); the subprocess lane is
-                            # the legacy/safe default.
+                            # in tests, or when the column is absent on
+                            # pre-#3091 migration rows. Those rows were
+                            # claimed under subprocess mode — preserving
+                            # 'subprocess' here keeps them on the legacy
+                            # lane for their lifetime. New agents use
+                            # DEFAULT_AGENT_EXECUTION_MODE ('ecs', #3093).
                             "execution_mode": (
                                 str(row[8]) if len(row) > 8 and row[8] else "subprocess"
                             ),

--- a/scripts/dispatcher/tests/test_daemon_execution_mode_flag.py
+++ b/scripts/dispatcher/tests/test_daemon_execution_mode_flag.py
@@ -131,6 +131,10 @@ class TestReadAgentExecutionMode:
         d = _make_daemon(value="ecs")
         assert d._read_agent_execution_mode() == "ecs"
 
+    def test_recognizes_subprocess(self) -> None:
+        d = _make_daemon(value="subprocess")
+        assert d._read_agent_execution_mode() == "subprocess"
+
     def test_unrecognized_falls_back_with_warning(self, caplog: Any) -> None:
         d = _make_daemon(value="docker")
         caplog.set_level(logging.WARNING, logger="test.daemon_execution_mode")

--- a/scripts/dispatcher/tests/test_daemon_execution_mode_flag.py
+++ b/scripts/dispatcher/tests/test_daemon_execution_mode_flag.py
@@ -8,7 +8,7 @@ Coverage:
 * ``_read_agent_execution_mode`` returns the stored value when it's
   one of the recognized modes (``'subprocess'`` / ``'ecs'``), falls
   back to the default with a warning on an unrecognized value, and
-  defaults to ``'subprocess'`` when the row is missing.
+  defaults to ``'ecs'`` when the row is missing.
 * Claim-time dispatch branches on the read mode: ``'ecs'`` calls
   ``_launch_agent_ecs_task`` and skips ``_run_orchestration_phases``;
   ``'subprocess'`` takes the legacy path.
@@ -123,9 +123,9 @@ class TestCBConfigStr:
 
 
 class TestReadAgentExecutionMode:
-    def test_default_is_subprocess(self) -> None:
+    def test_default_is_ecs(self) -> None:
         d = _make_daemon(value=_MISSING)
-        assert d._read_agent_execution_mode() == "subprocess"
+        assert d._read_agent_execution_mode() == "ecs"
 
     def test_recognizes_ecs(self) -> None:
         d = _make_daemon(value="ecs")
@@ -134,7 +134,7 @@ class TestReadAgentExecutionMode:
     def test_unrecognized_falls_back_with_warning(self, caplog: Any) -> None:
         d = _make_daemon(value="docker")
         caplog.set_level(logging.WARNING, logger="test.daemon_execution_mode")
-        assert d._read_agent_execution_mode() == "subprocess"
+        assert d._read_agent_execution_mode() == "ecs"
         events = [getattr(r, "event", None) for r in caplog.records]
         assert "agent_execution_mode_unrecognized" in events
 
@@ -274,9 +274,9 @@ class TestExecutionModePersistenceAtomicClaim:
         # The last param should be 'ecs'.
         assert params[-1] == "ecs"
 
-    def test_atomic_claim_default_mode_is_subprocess(self) -> None:
+    def test_atomic_claim_default_mode_is_ecs(self) -> None:
         """Callers that don't pass execution_mode get the module-level
-        default — preserving pre-#3091 behaviour.
+        default — now 'ecs' since Stage 4 (#3093).
         """
         d = _make_daemon()
         with patch.object(d, "_gh_issue_add_labels"):
@@ -286,4 +286,4 @@ class TestExecutionModePersistenceAtomicClaim:
                 worktree_path="/tmp/wt",
             )
         _sql, params = d._main_conn.cursor_obj.executed[0]  # type: ignore[attr-defined]
-        assert params[-1] == "subprocess"
+        assert params[-1] == "ecs"

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -1190,10 +1190,10 @@ class TestAtomicClaim:
             if "INSERT INTO dispatcher.agents" in e[0]
         ]
         _sql, params = inserts[0]
-        # Priority = NULL (second-to-last); execution_mode = 'subprocess'
-        # (last, migration 41 / #3091 default).
+        # Priority = NULL (second-to-last); execution_mode = 'ecs'
+        # (last, DEFAULT_AGENT_EXECUTION_MODE flipped to 'ecs' by #3093).
         assert params[-2] is None
-        assert params[-1] == "subprocess"
+        assert params[-1] == "ecs"
 
     def test_unique_violation_returns_false(self, tmp_path: Path) -> None:
         d, conn, handler = _make_daemon(tmp_path)
@@ -1960,6 +1960,9 @@ class TestHappyPathOrchestration:
             return 0, 0.1
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        # Force subprocess mode so this legacy-path test exercises the
+        # subprocess lane regardless of DEFAULT_AGENT_EXECUTION_MODE (#3093).
+        monkeypatch.setattr(d, "_read_agent_execution_mode", lambda: "subprocess")
 
         # Run orchestration.
         d._claim_and_orchestrate_one()
@@ -2110,6 +2113,7 @@ class TestPlanGoFalse:
             return 0, 0.1
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_read_agent_execution_mode", lambda: "subprocess")
 
         d._claim_and_orchestrate_one()
 
@@ -2203,6 +2207,7 @@ class TestPlanGoFalse:
             return 0, 0.1
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_read_agent_execution_mode", lambda: "subprocess")
 
         d._claim_and_orchestrate_one()
 
@@ -2739,6 +2744,7 @@ class TestPlanBlockedHandler:
             return 0, 0.1
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_read_agent_execution_mode", lambda: "subprocess")
 
         d._claim_and_orchestrate_one()
 
@@ -2820,6 +2826,7 @@ class TestRalphBlocked:
             return 0, 0.1
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_read_agent_execution_mode", lambda: "subprocess")
 
         d._claim_and_orchestrate_one()
 
@@ -2891,6 +2898,7 @@ class TestSubprocessNonZeroExit:
             return 1, 0.1
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_read_agent_execution_mode", lambda: "subprocess")
 
         d._claim_and_orchestrate_one()
 
@@ -3446,6 +3454,7 @@ class TestNeedsReviewOrchestration:
             return 0, 0.1
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_read_agent_execution_mode", lambda: "subprocess")
 
         d._claim_and_orchestrate_one()
 
@@ -3578,6 +3587,7 @@ class TestNeedsReviewOrchestration:
             return 0, 0.1
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_read_agent_execution_mode", lambda: "subprocess")
 
         d._claim_and_orchestrate_one()
 

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -285,7 +285,9 @@ class TestDeployWorkflowNamesContents:
             "Deploy Production (Web)",
             "Terraform",
         ):
-            assert name in daemon.DEPLOY_WORKFLOW_NAMES, f"{name!r} missing from DEPLOY_WORKFLOW_NAMES"
+            assert name in daemon.DEPLOY_WORKFLOW_NAMES, (
+                f"{name!r} missing from DEPLOY_WORKFLOW_NAMES"
+            )
 
 
 # --------------------------------------------------------------------------

--- a/scripts/dispatcher/tests/test_daemon_skeleton.py
+++ b/scripts/dispatcher/tests/test_daemon_skeleton.py
@@ -204,17 +204,17 @@ class TestSchedulerTick:
         # Config SELECT fired (step 2 of scheduler_tick).
         # The SQL reads "SELECT value FROM dispatcher.config WHERE key = %s"
         # with ("concurrency_cap",) as the bound parameter.
-        assert any(
-            "FROM dispatcher.config" in sql for sql, _ in executed
-        ), "config SELECT (dispatcher.config) must fire"
+        assert any("FROM dispatcher.config" in sql for sql, _ in executed), (
+            "config SELECT (dispatcher.config) must fire"
+        )
         # Infra-preemption retry-marker SELECT fired (#2949 pre-scan drain).
-        assert any(
-            "FROM dispatcher.retry_markers" in sql for sql, _ in executed
-        ), "retry_markers SELECT must fire before queue scan"
+        assert any("FROM dispatcher.retry_markers" in sql for sql, _ in executed), (
+            "retry_markers SELECT must fire before queue scan"
+        )
         # Per-agent ECS reap SELECT fired (#3091).
-        assert any(
-            "agent_task_arn IS NOT NULL" in sql for sql, _ in executed
-        ), "ECS reap SELECT (agent_task_arn) must fire"
+        assert any("agent_task_arn IS NOT NULL" in sql for sql, _ in executed), (
+            "ECS reap SELECT (agent_task_arn) must fire"
+        )
         # queue_snapshots INSERT fired (Phase 2 addition, #2768).
         assert any(
             "INSERT INTO dispatcher.queue_snapshots" in sql for sql, _ in executed


### PR DESCRIPTION
## Summary

Flips `DEFAULT_AGENT_EXECUTION_MODE` from `'subprocess'` to `'ecs'` in daemon.py, enabling the Stage 4 cutover after Stage 3 smoke validation (#3092). New agents claim with ECS-based execution by default, allowing daemon redeploys to proceed without killing in-flight work. Subprocess mode remains reachable via explicit config override for fallback.

Closes #3093

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — all 1564 tests)
- [x] CI green

### Post-deploy verification

- [ ] AC1: New agents default to `execution_mode='ecs'` — `SELECT execution_mode, count(*) FROM dispatcher.agents WHERE created_at > now() - interval '1 hour' GROUP BY 1` shows `ecs` dominant
- [ ] AC2: 10 consecutive daemon redeploys on dev with active agents produce 0 `daemon_restart_abandoned` failures — CloudWatch query `event=daemon_restart_abandoned` count over the sweep window
- [ ] AC3: Subprocess fallback works — one-shot smoke with explicit subprocess override
- [ ] Verification evidence posted on #3093 (see /task-v2-verify output)