### PR TITLE
refactor(dispatcher): materialize phase input files from DB at spawn time

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -2237,20 +2237,6 @@ class DispatcherDaemon:
         # boto3 clients are thread-safe; reuse across scheduler + reap
         # paths avoids redundant credential lookups.
         self._ecs_client: Any | None = None
-        # Phase 3A: within-tick handoff between phase helpers. Reset at
-        # the start of each orchestration run so a previous failure's
-        # partial state cannot leak into the next attempt.
-        self._agent_plan_output: dict[str, Any] | None = None
-        self._agent_ralph_output: dict[str, Any] | None = None
-        self._agent_summary_output: dict[str, Any] | None = None
-        #: Summary-phase ``unmet_criteria`` list. Populated by
-        #: :meth:`_run_summary_phase` when the summary skill flagged
-        #: criteria the ralph diff did not satisfy (#2856). When
-        #: non-empty, :meth:`_push_and_open_pr` opens a DRAFT PR with
-        #: the unmet list in the body and the agent terminates as
-        #: ``status='needs_review'`` rather than ``succeeded``. Reset
-        #: at the start of each orchestration run.
-        self._agent_unmet_criteria: list[str] | None = None
         # Phase 3C: GitHub rate-limit skip window. When set, ``now() <
         # self._gh_rate_skip_until`` → scheduler + supervisor ticks both
         # skip their hot paths. Cleared by
@@ -8950,14 +8936,6 @@ class DispatcherDaemon:
         the "3A's claim path catches it next tick" half of the retry
         loop — without this, the retrying row would sit idle forever.
         """
-        # Reset within-tick handoff so a prior run's partial state
-        # cannot leak into the next attempt (defense-in-depth; the
-        # scheduler only enters this path when no agent is active).
-        self._agent_plan_output = None
-        self._agent_ralph_output = None
-        self._agent_summary_output = None
-        self._agent_unmet_criteria = None
-
         # Phase 3C resume-retry path: pick up any retrying agent first.
         # If one exists, re-orchestrate it on a fresh worktree instead
         # of claiming a new issue. Returning after a resume means this
@@ -10173,24 +10151,6 @@ class DispatcherDaemon:
 
         return prior_output, prior_ts_str
 
-    def _materialize_plan_output(
-        self,
-        worktree: Path,
-        plan_output: dict[str, Any],
-    ) -> None:
-        """Write a reused plan to ``{worktree}/tmp/dispatcher-output/plan.json``.
-
-        Mirrors the artifact that the real plan subprocess produces so
-        any downstream code that reads the file directly (e.g. scripts,
-        admin tooling) sees an identical structure regardless of whether
-        the plan was freshly generated or reused from a prior agent's
-        run (#2937).
-        """
-        output_dir = worktree / "tmp" / "dispatcher-output"
-        output_dir.mkdir(parents=True, exist_ok=True)
-        output_path = output_dir / "plan.json"
-        output_path.write_text(json.dumps(plan_output, indent=2, default=str))
-
     def _fetch_prior_attempts(self, issue_number: int) -> list[dict[str, Any]]:
         """Return up to 3 prior non-infra-preempted failed agents for *issue_number*.
 
@@ -10494,7 +10454,6 @@ class DispatcherDaemon:
                 log_text="<reused from prior plan>",
                 usage=None,
             )
-            self._materialize_plan_output(worktree, reused)
             self._log.info(
                 "daemon.plan_reused",
                 extra={
@@ -10505,7 +10464,6 @@ class DispatcherDaemon:
                     "prior_plan_output_ts": prior_ts_str,
                 },
             )
-            self._agent_plan_output = reused
             return True
         # ── end plan-reuse ─────────────────────────────────────────────────
 
@@ -10629,8 +10587,6 @@ class DispatcherDaemon:
                 )
             return False
 
-        # Stash plan output on the agent for ralph + summary to reuse.
-        self._agent_plan_output = plan_output
         return True
 
     def _run_ralph_phase(
@@ -10692,7 +10648,7 @@ class DispatcherDaemon:
         )
         # ── end prior-attempt context ──────────────────────────────────────
 
-        plan_output = self._agent_plan_output or {}
+        plan_output = self._fetch_phase_output(agent_id, "plan") or {}
         ralph_input = {
             "agent_id": agent_id,
             "issue_number": issue_number,
@@ -10881,7 +10837,6 @@ class DispatcherDaemon:
         self._capture_and_persist_ralph_patch(agent_id, issue_number, worktree)
         # ── end SHIP patch persist ─────────────────────────────────────────
 
-        self._agent_ralph_output = ralph_output
         return True
 
     def _run_summary_phase(
@@ -10915,7 +10870,7 @@ class DispatcherDaemon:
         except Exception:  # pragma: no cover — defensive; not asserted in unit tests
             git_diff = ""
 
-        ralph_output = self._agent_ralph_output or {}
+        ralph_output = self._fetch_phase_output(agent_id, "ralph") or {}
         changed_files = ralph_output.get("changed_files", []) or []
         # Fall back to a git-state read if ralph didn't populate
         # changed_files (non-testable short-circuit path).
@@ -10961,7 +10916,7 @@ class DispatcherDaemon:
                 "parent_issue": None,
             }
 
-        plan_output = self._agent_plan_output or {}
+        plan_output = self._fetch_phase_output(agent_id, "plan") or {}
         # Branch name matches ``_create_worktree``'s naming convention.
         short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
         branch = f"agent/{short_id}"
@@ -11123,12 +11078,6 @@ class DispatcherDaemon:
                     "terminal_status": "needs_review",
                 },
             )
-            # Coerce to list[str] so downstream rendering is total on
-            # malformed skill output (non-string entries get stringified
-            # rather than crashing the orchestration).
-            self._agent_unmet_criteria = [str(u) for u in unmet]
-
-        self._agent_summary_output = summary_output
         return True
 
     def _run_subprocess_or_fail(
@@ -11763,17 +11712,17 @@ class DispatcherDaemon:
         success (criteria all met), ``phase='awaiting_ci'`` so Phase 3B
         knows where to pick up, and ``status`` stays ``running``.
 
-        **needs_review branch (#2856):** when
-        :attr:`_agent_unmet_criteria` is non-empty (set by
-        :meth:`_run_summary_phase`), the PR is opened as a DRAFT with
-        an ``⚠️ Unmet acceptance criteria`` section appended to the
-        body, an issue comment is posted linking the draft + listing
-        the unmet criteria, and the agent terminates as
-        ``status='needs_review', phase='needs_review'`` with
-        ``ended_at`` set. The draft PR is NOT picked up by Phase 3B
-        (``needs_review`` is outside the ``_list_advanceable_agents``
-        SELECT), so auto-merge cannot touch it — the operator reviews,
-        marks ready + merges, or closes.
+        **needs_review branch (#2856):** when the summary phase's
+        ``unmet_criteria`` list is non-empty (fetched from
+        ``dispatcher.phase_outputs`` via :meth:`_fetch_phase_output`),
+        the PR is opened as a DRAFT with an ``⚠️ Unmet acceptance
+        criteria`` section appended to the body, an issue comment is
+        posted linking the draft + listing the unmet criteria, and the
+        agent terminates as ``status='needs_review',
+        phase='needs_review'`` with ``ended_at`` set. The draft PR is
+        NOT picked up by Phase 3B (``needs_review`` is outside the
+        ``_list_advanceable_agents`` SELECT), so auto-merge cannot touch
+        it — the operator reviews, marks ready + merges, or closes.
         """
         self._update_agent_phase(agent_id, "push_and_pr")
 
@@ -11836,10 +11785,9 @@ class DispatcherDaemon:
             )
             return
 
-        unmet_criteria = self._agent_unmet_criteria or []
+        summary_output = self._fetch_phase_output(agent_id, "summary") or {}
+        unmet_criteria = [str(u) for u in (summary_output.get("unmet_criteria") or [])]
         is_needs_review = bool(unmet_criteria)
-
-        summary_output = self._agent_summary_output or {}
         commit_message = summary_output.get("commit_message") or ""
         pr_title = summary_output.get("pr_title") or ""
         pr_body_md = summary_output.get("pr_body_md") or ""

--- a/scripts/dispatcher/tests/test_daemon_amend_commit.py
+++ b/scripts/dispatcher/tests/test_daemon_amend_commit.py
@@ -116,14 +116,20 @@ def _make_daemon(tmp_path: Path) -> tuple[daemon.DispatcherDaemon, _FakeConnecti
     return d, conn
 
 
+_SUMMARY_OUTPUT_FOR_PUSH = {
+    "commit_message": "feat(dispatcher): ralph-commits-daemon-amends (#2971)",
+    "pr_title": "feat(dispatcher): ralph-commits-daemon-amends (#2971)",
+    "pr_body_md": "body",
+    "unmet_criteria": [],
+}
+
+
 def _prep_daemon_for_push(d: daemon.DispatcherDaemon) -> None:
     """Stub the DB methods ``_push_and_open_pr`` calls into no-ops."""
-    d._agent_summary_output = {  # type: ignore[attr-defined]
-        "commit_message": "feat(dispatcher): ralph-commits-daemon-amends (#2971)",
-        "pr_title": "feat(dispatcher): ralph-commits-daemon-amends (#2971)",
-        "pr_body_md": "body",
-    }
-    d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+    # _push_and_open_pr reads summary output from DB via _fetch_phase_output (#2975).
+    d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+        return_value=_SUMMARY_OUTPUT_FOR_PUSH
+    )
     d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
     d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
     d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
@@ -302,7 +308,7 @@ class TestPushAndOpenPrUsesAmend:
         write to the rewritten commit."""
         d, _conn = _make_daemon(tmp_path)
         _prep_daemon_for_push(d)
-        expected_msg = d._agent_summary_output["commit_message"]  # type: ignore[index]
+        expected_msg = _SUMMARY_OUTPUT_FOR_PUSH["commit_message"]
 
         worktree = tmp_path / "worktree"
         worktree.mkdir()

--- a/scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py
+++ b/scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py
@@ -207,8 +207,13 @@ class TestGitCommitFailedRouting:
         d._is_noop_ship = MagicMock(return_value=False)  # type: ignore[method-assign]
         d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
-        d._agent_summary_output = summary_output
-        d._agent_unmet_criteria = []
+        # _push_and_open_pr reads summary output from DB via _fetch_phase_output.
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                **summary_output,
+                "unmet_criteria": summary_output.get("unmet_criteria", []),
+            }
+        )
 
         import subprocess  # noqa: PLC0415
 
@@ -247,12 +252,14 @@ class TestGitCommitFailedRouting:
         d._is_noop_ship = MagicMock(return_value=False)  # type: ignore[method-assign]
         d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
-        d._agent_summary_output = {
-            "commit_message": "feat(foo): bar (#3067)",
-            "pr_title": "feat(foo): bar (#3067)",
-            "pr_body_md": "## Summary\n\nBaz.\n\nCloses #3067",
-        }
-        d._agent_unmet_criteria = []
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "commit_message": "feat(foo): bar (#3067)",
+                "pr_title": "feat(foo): bar (#3067)",
+                "pr_body_md": "## Summary\n\nBaz.\n\nCloses #3067",
+                "unmet_criteria": [],
+            }
+        )
 
         d._push_and_open_pr("agent-commit-exc", 3067, worktree)
 
@@ -290,12 +297,14 @@ class TestGitCommitFailedRouting:
         d._is_noop_ship = MagicMock(return_value=False)  # type: ignore[method-assign]
         d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
-        d._agent_summary_output = {
-            "commit_message": "feat(foo): bar (#3067)",
-            "pr_title": "feat(foo): bar (#3067)",
-            "pr_body_md": "## Summary\n\nBaz.\n\nCloses #3067",
-        }
-        d._agent_unmet_criteria = []
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "commit_message": "feat(foo): bar (#3067)",
+                "pr_title": "feat(foo): bar (#3067)",
+                "pr_body_md": "## Summary\n\nBaz.\n\nCloses #3067",
+                "unmet_criteria": [],
+            }
+        )
 
         d._push_and_open_pr("agent-commit-nonzero", 3067, worktree)
 

--- a/scripts/dispatcher/tests/test_daemon_call_site_audit.py
+++ b/scripts/dispatcher/tests/test_daemon_call_site_audit.py
@@ -189,6 +189,38 @@ class DispatcherDaemon:
         )
 
 
+# ---------------------------------------------------------------------------
+# AC #2 of #2975: in-memory phase-output instance vars must be absent
+# ---------------------------------------------------------------------------
+
+_REMOVED_INSTANCE_VARS = [
+    "_agent_plan_output",
+    "_agent_ralph_output",
+    "_agent_summary_output",
+    "_agent_unmet_criteria",
+    "_materialize_plan_output",
+]
+
+
+@pytest.mark.parametrize("var_name", _REMOVED_INSTANCE_VARS)
+class TestRemovedPhaseOutputInstanceVarsAbsent:
+    """#2975 AC #2 — the in-memory phase-output instance variables that were
+    replaced by unconditional DB reads must not appear anywhere in daemon.py.
+
+    Absence here guarantees no spawn site can accidentally fall back to an
+    in-memory cache instead of reading from ``dispatcher.phase_outputs``.
+    """
+
+    def test_instance_var_not_present_in_daemon_source(self, var_name: str) -> None:
+        daemon_source_file = inspect.getsourcefile(daemon)
+        assert daemon_source_file is not None, "Could not resolve daemon.py path"
+        source = Path(daemon_source_file).read_text(encoding="utf-8")
+        assert var_name not in source, (
+            f"Removed instance var {var_name!r} still appears in daemon.py. "
+            "All phase-output reads must go through _fetch_phase_output(agent_id, phase)."
+        )
+
+
 @pytest.mark.parametrize("method_name", _HOT_PATH_METHODS)
 class TestMarkAgentTerminalIssueNumberAudit:
     """AC #2 + AC #5: one test per hot-path method, all green on current main.

--- a/scripts/dispatcher/tests/test_daemon_milestone_columns.py
+++ b/scripts/dispatcher/tests/test_daemon_milestone_columns.py
@@ -362,12 +362,14 @@ class TestSelfDeployDetectionPrePush:
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
 
-        d._agent_summary_output = {  # type: ignore[attr-defined]
-            "commit_message": "feat(dispatcher): split terminal success (#2953)",
-            "pr_title": "feat(dispatcher): split terminal success",
-            "pr_body_md": "body",
-        }
-        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "commit_message": "feat(dispatcher): split terminal success (#2953)",
+                "pr_title": "feat(dispatcher): split terminal success",
+                "pr_body_md": "body",
+                "unmet_criteria": [],
+            }
+        )
 
         worktree = tmp_path / "worktree"
         worktree.mkdir()
@@ -460,12 +462,14 @@ class TestSelfDeployDetectionPrePush:
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
 
-        d._agent_summary_output = {  # type: ignore[attr-defined]
-            "commit_message": "feat(web): new feature",
-            "pr_title": "feat(web): new feature",
-            "pr_body_md": "body",
-        }
-        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "commit_message": "feat(web): new feature",
+                "pr_title": "feat(web): new feature",
+                "pr_body_md": "body",
+                "unmet_criteria": [],
+            }
+        )
 
         worktree = tmp_path / "worktree"
         worktree.mkdir()
@@ -538,12 +542,14 @@ class TestSelfDeployDetectionPrePush:
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
 
-        d._agent_summary_output = {  # type: ignore[attr-defined]
-            "commit_message": "x",
-            "pr_title": "x",
-            "pr_body_md": "x",
-        }
-        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "commit_message": "x",
+                "pr_title": "x",
+                "pr_body_md": "x",
+                "unmet_criteria": [],
+            }
+        )
 
         worktree = tmp_path / "worktree"
         worktree.mkdir()

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -1964,6 +1964,14 @@ class TestHappyPathOrchestration:
         # subprocess lane regardless of DEFAULT_AGENT_EXECUTION_MODE (#3093).
         monkeypatch.setattr(d, "_read_agent_execution_mode", lambda: "subprocess")
 
+        # _fetch_phase_output (#2975): spawn sites read from DB unconditionally.
+        # The fake cursor's fetchone() can't distinguish between phase args,
+        # so mock _fetch_phase_output to return the right fixture per phase.
+        def fake_fetch_phase_output(agent_id: str, phase: str) -> dict[str, Any] | None:
+            return phase_outputs.get(phase)
+
+        monkeypatch.setattr(d, "_fetch_phase_output", fake_fetch_phase_output)
+
         # Run orchestration.
         d._claim_and_orchestrate_one()
 
@@ -3456,6 +3464,14 @@ class TestNeedsReviewOrchestration:
         monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
         monkeypatch.setattr(d, "_read_agent_execution_mode", lambda: "subprocess")
 
+        # _fetch_phase_output (#2975): return the right fixture per phase.
+        def fake_fetch_phase_output_unmet(
+            agent_id: str, phase: str
+        ) -> dict[str, Any] | None:
+            return phase_outputs.get(phase)
+
+        monkeypatch.setattr(d, "_fetch_phase_output", fake_fetch_phase_output_unmet)
+
         d._claim_and_orchestrate_one()
 
         # --- AC1: draft flag present on gh pr create ---
@@ -3588,6 +3604,16 @@ class TestNeedsReviewOrchestration:
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
         monkeypatch.setattr(d, "_read_agent_execution_mode", lambda: "subprocess")
+
+        # _fetch_phase_output (#2975): return the right fixture per phase.
+        def fake_fetch_phase_output_comment_fail(
+            agent_id: str, phase: str
+        ) -> dict[str, Any] | None:
+            return phase_outputs.get(phase)
+
+        monkeypatch.setattr(
+            d, "_fetch_phase_output", fake_fetch_phase_output_comment_fail
+        )
 
         d._claim_and_orchestrate_one()
 

--- a/scripts/dispatcher/tests/test_daemon_phase_failure_preview.py
+++ b/scripts/dispatcher/tests/test_daemon_phase_failure_preview.py
@@ -267,6 +267,10 @@ class TestPhaseOutputMissingPreview:
         d._read_phase_output = MagicMock(return_value=None)  # type: ignore[method-assign]
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._apply_prior_ralph_patch = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._materialize_prior_attempts = MagicMock(return_value=0)  # type: ignore[method-assign]
+        # _run_ralph_phase fetches plan output from DB (#2975).
+        d._fetch_phase_output = MagicMock(return_value={})  # type: ignore[method-assign]
 
         d._run_ralph_phase("agent-123", 1, worktree)
 
@@ -298,7 +302,13 @@ class TestPhaseOutputMissingPreview:
                 "parent_issue": None,
             }
         )
-        d._agent_ralph_output = {"summary": "", "changed_files": []}
+        # _run_summary_phase fetches ralph and plan outputs from DB (#2975).
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            side_effect=lambda agent_id, phase: {
+                "ralph": {"summary": "", "changed_files": []},
+                "plan": {"acceptance_criteria": [], "scope_check": []},
+            }.get(phase)
+        )
 
         d._run_summary_phase("agent-123", 1, worktree)
 

--- a/scripts/dispatcher/tests/test_daemon_plan_reuse.py
+++ b/scripts/dispatcher/tests/test_daemon_plan_reuse.py
@@ -11,8 +11,6 @@ Covers:
   helper: None when no qualifying row exists, None when go=False, None
   when the issue was edited after the prior plan ran, and the parsed
   output_json dict on a valid hit.
-* :meth:`daemon.DispatcherDaemon._materialize_plan_output` — writes
-  ``{worktree}/tmp/dispatcher-output/plan.json``.
 * :meth:`daemon.DispatcherDaemon._run_plan_phase` — the short-circuit
   branch: subprocess NOT spawned when a reusable plan exists (AC #1),
   subprocess IS spawned when no prior plan exists (AC #2), subprocess IS
@@ -21,6 +19,10 @@ Covers:
   ``issue_number`` (AC #4).
 * Cost impact: ``_persist_phase_output`` called with ``usage=None`` so
   no Opus cost entry is written for the reused copy (AC #5).
+* DB-source-of-truth: ``_run_ralph_phase`` fetches plan output from DB
+  via ``_fetch_phase_output`` rather than an in-memory instance var,
+  so a daemon restart between plan and ralph resumes cleanly (AC #4 of
+  #2975).
 """
 
 from __future__ import annotations
@@ -260,36 +262,6 @@ class TestTryReusePriorPlan:
 
 
 # --------------------------------------------------------------------------
-# _materialize_plan_output — writes plan.json to the worktree
-# --------------------------------------------------------------------------
-
-
-class TestMaterializePlanOutput:
-    def test_writes_plan_json_to_dispatcher_output_dir(self, tmp_path: Path) -> None:
-        d, _conn, _handler = _make_daemon(tmp_path)
-        worktree = tmp_path / "worktree"
-        worktree.mkdir()
-
-        d._materialize_plan_output(worktree, _GOOD_PLAN_OUTPUT)
-
-        plan_path = worktree / "tmp" / "dispatcher-output" / "plan.json"
-        assert plan_path.exists(), "plan.json must be written to dispatcher-output/"
-        written = json.loads(plan_path.read_text())
-        assert written["go"] is True
-        assert written["plan"] == "Implement feature X"
-
-    def test_creates_parent_dirs(self, tmp_path: Path) -> None:
-        d, _conn, _handler = _make_daemon(tmp_path)
-        worktree = tmp_path / "worktree"
-        # Do NOT mkdir worktree — _materialize_plan_output must create dirs.
-
-        d._materialize_plan_output(worktree, _GOOD_PLAN_OUTPUT)
-
-        plan_path = worktree / "tmp" / "dispatcher-output" / "plan.json"
-        assert plan_path.exists()
-
-
-# --------------------------------------------------------------------------
 # _run_plan_phase integration — subprocess short-circuit
 # --------------------------------------------------------------------------
 
@@ -341,9 +313,6 @@ class TestPlanReuse:
         # Capture _persist_phase_output calls.
         d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
 
-        # Capture _materialize_plan_output calls.
-        d._materialize_plan_output = MagicMock()  # type: ignore[method-assign]
-
         # Subprocess spawn should NOT be called.
         d._run_subprocess_or_fail = MagicMock(  # type: ignore[method-assign]
             return_value=0
@@ -368,11 +337,15 @@ class TestPlanReuse:
         log_text_arg = call_kwargs[1].get("log_text") or call_kwargs[0][3]
         assert "reused" in str(log_text_arg)
 
-        # _materialize_plan_output was called.
-        d._materialize_plan_output.assert_called_once_with(worktree, _GOOD_PLAN_OUTPUT)
-
-        # _agent_plan_output is set from the reused plan.
-        assert d._agent_plan_output == _GOOD_PLAN_OUTPUT
+        # _persist_phase_output was called with the new agent_id (AC #4 of #2975:
+        # the DB row is the authoritative source for downstream phases).
+        d._persist_phase_output.assert_called_once_with(
+            "agent-new",
+            "plan",
+            _GOOD_PLAN_OUTPUT,
+            log_text="<reused from prior plan>",
+            usage=None,
+        )
 
         # Observability: daemon.plan_reused event logged (AC #4).
         reused_events = handler.events("plan_reused")
@@ -600,3 +573,68 @@ class TestTryReusePriorPlanTimestampEdgeCases:
         assert plan_output["go"] is True
         # Datetime was converted to ISO string.
         assert "2026-04-19" in prior_ts_str
+
+
+# --------------------------------------------------------------------------
+# AC #4 of #2975: _run_ralph_phase reads plan output from DB unconditionally
+# --------------------------------------------------------------------------
+
+
+class TestPhaseInputBuiltFromDbRow:
+    """_run_ralph_phase must fetch plan output from dispatcher.phase_outputs,
+    not from an in-memory instance variable (#2975 AC #4).
+
+    Simulates a daemon restart between plan and ralph: there is no in-memory
+    state at all, but the DB has a ``phase_outputs`` row for the plan phase.
+    The ralph spawn's input bundle must carry the plan content from the DB.
+    """
+
+    def test_ralph_spawn_input_built_from_db_row_not_instance_var(
+        self, tmp_path: Path
+    ) -> None:
+        """_fetch_phase_output("plan") drives ralph's input, not an instance var."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        # Simulate DB returning the plan row.
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value=_GOOD_PLAN_OUTPUT
+        )
+
+        # Capture the input written to ralph.
+        written_inputs: list[dict] = []
+
+        def _capture_write(wt: Path, phase: str, data: dict) -> None:  # type: ignore[override]
+            if phase == "ralph":
+                written_inputs.append(data)
+
+        d._write_phase_input = _capture_write  # type: ignore[method-assign]
+
+        # Stub all other helpers so _run_ralph_phase runs its full flow.
+        ralph_output = {"verdict": "SHIP", "summary": "done", "changed_files": []}
+        d._apply_prior_ralph_patch = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._materialize_prior_attempts = MagicMock(return_value=0)  # type: ignore[method-assign]
+        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+        d._read_phase_output = MagicMock(return_value=ralph_output)  # type: ignore[method-assign]
+        d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+        d._capture_and_persist_ralph_patch = MagicMock()  # type: ignore[method-assign]
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+
+        ok = d._run_ralph_phase("agent-abc", 42, worktree)
+
+        assert ok is True
+        # _fetch_phase_output was called for the "plan" phase.
+        d._fetch_phase_output.assert_any_call("agent-abc", "plan")
+
+        # The ralph input bundle carries the plan content from the DB row.
+        assert written_inputs, "ralph input must have been written"
+        ralph_input = written_inputs[0]
+        assert ralph_input["plan"] == _GOOD_PLAN_OUTPUT, (
+            "ralph input 'plan' key must equal the DB-fetched plan output"
+        )
+        assert ralph_input["dependencies_installed"] == [], (
+            "dependencies_installed must be derived from the DB-fetched plan"
+        )

--- a/scripts/dispatcher/tests/test_daemon_push_and_pr_noop.py
+++ b/scripts/dispatcher/tests/test_daemon_push_and_pr_noop.py
@@ -141,12 +141,15 @@ def _make_daemon(
     # Supply the summary output so the non-no-op path has everything it
     # needs to run (defensive — individual tests only exercise the no-op
     # path where this data is never read).
-    d._agent_summary_output = {  # type: ignore[attr-defined]
-        "commit_message": "feat(dispatcher): test (#3039)",
-        "pr_title": "feat(dispatcher): test (#3039)",
-        "pr_body_md": "body",
-    }
-    d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+    # _push_and_open_pr reads summary output from DB via _fetch_phase_output.
+    d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+        return_value={
+            "commit_message": "feat(dispatcher): test (#3039)",
+            "pr_title": "feat(dispatcher): test (#3039)",
+            "pr_body_md": "body",
+            "unmet_criteria": [],
+        }
+    )
     d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
     d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
     d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]

--- a/scripts/dispatcher/tests/test_daemon_push_failed.py
+++ b/scripts/dispatcher/tests/test_daemon_push_failed.py
@@ -272,13 +272,15 @@ class TestGitPushFailedWritesFailureRow:
             stderr="pre-push: ruff check failed — 1 error",
         )
 
-        # _push_and_open_pr reads _agent_summary_output and _agent_unmet_criteria.
-        d._agent_summary_output = {  # type: ignore[attr-defined]
-            "commit_message": "feat: test commit",
-            "pr_title": "Test PR",
-            "pr_body_md": "body",
-        }
-        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+        # _push_and_open_pr reads summary output from DB via _fetch_phase_output.
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "commit_message": "feat: test commit",
+                "pr_title": "Test PR",
+                "pr_body_md": "body",
+                "unmet_criteria": [],
+            }
+        )
 
         # _update_agent_phase and _mark_agent_terminal do DB writes we don't
         # need to actually run in this test — stub them out.
@@ -377,12 +379,14 @@ class TestGitPushFailedWritesFailureRow:
             stderr="fatal: unable to access 'https://github.com/': Could not resolve host: github.com",
         )
 
-        d._agent_summary_output = {
-            "commit_message": "c",
-            "pr_title": "t",
-            "pr_body_md": "b",
-        }  # type: ignore[attr-defined]
-        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "commit_message": "c",
+                "pr_title": "t",
+                "pr_body_md": "b",
+                "unmet_criteria": [],
+            }
+        )
         d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
@@ -463,12 +467,14 @@ class TestGitPushFailedWritesPhaseOutputRow:
         )
         push_fail = _make_push_result(returncode=1, stderr=long_stderr)
 
-        d._agent_summary_output = {
-            "commit_message": "c",
-            "pr_title": "t",
-            "pr_body_md": "b",
-        }  # type: ignore[attr-defined]
-        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "commit_message": "c",
+                "pr_title": "t",
+                "pr_body_md": "b",
+                "unmet_criteria": [],
+            }
+        )
         d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]

--- a/scripts/dispatcher/tests/test_daemon_push_failed.py
+++ b/scripts/dispatcher/tests/test_daemon_push_failed.py
@@ -643,12 +643,16 @@ def _make_push_and_pr_base(
     worktree.mkdir()
     (worktree / "tmp").mkdir()
 
-    d._agent_summary_output = {  # type: ignore[attr-defined]
-        "commit_message": "feat: test commit",
-        "pr_title": "Test PR",
-        "pr_body_md": "body",
-    }
-    d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+    # _push_and_open_pr now reads summary output from DB via _fetch_phase_output (#2975).
+    d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+        return_value={
+            "commit_message": "feat: test commit",
+            "pr_title": "Test PR",
+            "pr_body_md": "body",
+            "unmet_criteria": [],
+        }
+    )
+    d._materialize_phase_output = MagicMock()  # type: ignore[method-assign]
     d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
     d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
     d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]

--- a/scripts/dispatcher/tests/test_daemon_ralph_ac_infeasible.py
+++ b/scripts/dispatcher/tests/test_daemon_ralph_ac_infeasible.py
@@ -127,6 +127,7 @@ def _patch_ralph_helpers(
     real subprocesses, DB, or filesystem state."""
     d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
     d._materialize_prior_attempts = MagicMock(return_value=0)  # type: ignore[method-assign]
+    d._apply_prior_ralph_patch = MagicMock(return_value=None)  # type: ignore[method-assign]
     d._write_phase_input = MagicMock()  # type: ignore[method-assign]
     d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
     d._read_phase_output = MagicMock(return_value=ralph_output)  # type: ignore[method-assign]
@@ -135,6 +136,8 @@ def _patch_ralph_helpers(
     d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
     d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
     d._write_failure = MagicMock()  # type: ignore[method-assign]
+    # _fetch_phase_output is called to read plan output from DB (#2975).
+    d._fetch_phase_output = MagicMock(return_value={})  # type: ignore[method-assign]
 
 
 # --------------------------------------------------------------------------
@@ -254,9 +257,11 @@ class TestRunRalphPhaseAcInfeasible:
         # No failure row written, no terminal mark.
         d._write_failure.assert_not_called()  # type: ignore[union-attr]
         d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
-        # Ralph output stashed for summary phase.
-        assert d._agent_ralph_output is not None
-        assert d._agent_ralph_output.get("verdict") == "SHIP"
+        # SHIP path persists ralph output to DB for summary to fetch.
+        d._persist_phase_output.assert_called_once()  # type: ignore[union-attr]
+        persisted_args = d._persist_phase_output.call_args.args  # type: ignore[union-attr]
+        assert persisted_args[1] == "ralph"
+        assert persisted_args[2].get("verdict") == "SHIP"
 
     def test_blocked_verdict_does_not_write_ac_infeasible_failure(
         self, tmp_path: Path

--- a/scripts/dispatcher/tests/test_daemon_ralph_not_ship.py
+++ b/scripts/dispatcher/tests/test_daemon_ralph_not_ship.py
@@ -133,6 +133,7 @@ def _patch_ralph_helpers(
     real subprocesses, DB, or filesystem state."""
     d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
     d._materialize_prior_attempts = MagicMock(return_value=0)  # type: ignore[method-assign]
+    d._apply_prior_ralph_patch = MagicMock(return_value=None)  # type: ignore[method-assign]
     d._write_phase_input = MagicMock()  # type: ignore[method-assign]
     d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
     d._read_phase_output = MagicMock(return_value=ralph_output)  # type: ignore[method-assign]
@@ -146,6 +147,9 @@ def _patch_ralph_helpers(
     # (SHIP, AC_INFEASIBLE) can still be asserted.
     d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
     d._write_failure = MagicMock()  # type: ignore[method-assign]
+    # _fetch_phase_output is called at the start of _run_ralph_phase to
+    # read the plan output from DB (#2975: DB-source-of-truth).
+    d._fetch_phase_output = MagicMock(return_value={})  # type: ignore[method-assign]
 
 
 # --------------------------------------------------------------------------
@@ -358,9 +362,11 @@ class TestRegressionGuards:
         d._handle_agent_failure.assert_not_called()  # type: ignore[union-attr]
         d._write_failure.assert_not_called()  # type: ignore[union-attr]
         d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
-        # SHIP path stashes output for summary.
-        assert d._agent_ralph_output is not None
-        assert d._agent_ralph_output.get("verdict") == "SHIP"
+        # SHIP path persists ralph output to DB for summary to fetch.
+        d._persist_phase_output.assert_called_once()  # type: ignore[union-attr]
+        persisted_args = d._persist_phase_output.call_args.args  # type: ignore[union-attr]
+        assert persisted_args[1] == "ralph"
+        assert persisted_args[2].get("verdict") == "SHIP"
 
     def test_ac_infeasible_verdict_still_uses_ac_infeasible_path(
         self, tmp_path: Path

--- a/scripts/dispatcher/tests/test_daemon_ralph_patches.py
+++ b/scripts/dispatcher/tests/test_daemon_ralph_patches.py
@@ -803,12 +803,14 @@ class TestPushAndOpenPrDeletesRalphPatch:
         agent_id = "aaaabbbb-0000-0000-0000-000000000111"
 
         # Stub the DB methods _push_and_open_pr touches.
-        d._agent_summary_output = {  # type: ignore[attr-defined]
-            "commit_message": "feat(dispatcher): ralph patches (#3012)",
-            "pr_title": "feat(dispatcher): ralph patches (#3012)",
-            "pr_body_md": "body",
-        }
-        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "commit_message": "feat(dispatcher): ralph patches (#3012)",
+                "pr_title": "feat(dispatcher): ralph patches (#3012)",
+                "pr_body_md": "body",
+                "unmet_criteria": [],
+            }
+        )
         d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]
@@ -877,12 +879,14 @@ class TestPushAndOpenPrDeletesRalphPatch:
         d, _conn, _handler = _make_daemon(tmp_path)
         agent_id = "aaaabbbb-0000-0000-0000-000000000222"
 
-        d._agent_summary_output = {  # type: ignore[attr-defined]
-            "commit_message": "c",
-            "pr_title": "t",
-            "pr_body_md": "b",
-        }
-        d._agent_unmet_criteria = []  # type: ignore[attr-defined]
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            return_value={
+                "commit_message": "c",
+                "pr_title": "t",
+                "pr_body_md": "b",
+                "unmet_criteria": [],
+            }
+        )
         d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._current_attempt_for = MagicMock(return_value=0)  # type: ignore[method-assign]

--- a/scripts/dispatcher/tests/test_daemon_summary_ac_infeasible.py
+++ b/scripts/dispatcher/tests/test_daemon_summary_ac_infeasible.py
@@ -117,9 +117,9 @@ def _patch_summary_helpers(
     d: daemon.DispatcherDaemon, *, summary_output: dict[str, Any]
 ) -> None:
     """Stub the helpers _run_summary_phase relies on so the test doesn't
-    need a real subprocess or issue-bundle fetch. The ralph-side output
-    stash (``_agent_ralph_output``) is set to a minimal SHIP dict so
-    the summary phase sees the expected predecessor state."""
+    need a real subprocess or issue-bundle fetch. ``_fetch_phase_output``
+    is mocked to return the predecessor phase outputs the summary phase
+    fetches from DB (ralph output and plan output)."""
     d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
     d._write_phase_input = MagicMock()  # type: ignore[method-assign]
     d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
@@ -129,15 +129,23 @@ def _patch_summary_helpers(
     d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
     d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
     d._write_failure = MagicMock()  # type: ignore[method-assign]
-    # Pretend ralph shipped so the summary phase has the expected
-    # precursor state. The real summary_input build reads
-    # ``_agent_ralph_output.summary`` and ``changed_files`` from here.
-    d._agent_ralph_output = {
+    # Mock _fetch_phase_output to return the DB-backed predecessor outputs
+    # that _run_summary_phase reads for ralph and plan phases.
+    _ralph_db_output = {
         "verdict": "SHIP",
         "summary": "ralph shipped something",
         "changed_files": ["scripts/foo.py"],
     }
-    d._agent_plan_output = {"acceptance_criteria": [], "scope_check": []}
+    _plan_db_output: dict[str, Any] = {"acceptance_criteria": [], "scope_check": []}
+
+    def _fake_fetch_phase_output(agent_id: str, phase: str) -> dict[str, Any] | None:
+        if phase == "ralph":
+            return _ralph_db_output
+        if phase == "plan":
+            return _plan_db_output
+        return None
+
+    d._fetch_phase_output = _fake_fetch_phase_output  # type: ignore[method-assign]
     # Issue bundle fetch — short-circuit.
     d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
         return_value={
@@ -300,8 +308,8 @@ class TestRunSummaryPhaseAcInfeasible:
         assert ok is True
         d._write_failure.assert_not_called()  # type: ignore[union-attr]
         d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
-        assert d._agent_summary_output is not None
-        assert str(d._agent_summary_output.get("verdict")).upper() == "OK"
+        # summary phase returned True — the output was persisted to DB
+        d._persist_phase_output.assert_called_once()  # type: ignore[union-attr]
 
     def test_ok_with_unmet_takes_needs_review_path_not_ac_infeasible(
         self, tmp_path: Path
@@ -334,7 +342,10 @@ class TestRunSummaryPhaseAcInfeasible:
         # (the draft-PR flow).
         assert ok is True
         d._write_failure.assert_not_called()  # type: ignore[union-attr]
-        assert d._agent_unmet_criteria == ["shape-mismatch AC"]
+        # unmet_criteria comes from the summary output — _run_summary_phase
+        # no longer stashes it on an instance var; _push_and_open_pr reads
+        # it from the DB-fetched summary output instead.
+        d._persist_phase_output.assert_called_once()  # type: ignore[union-attr]
 
     def test_build_diagnoser_context_bundles_summary_extras(
         self, tmp_path: Path

--- a/scripts/dispatcher/tests/test_daemon_summary_deferred_acs.py
+++ b/scripts/dispatcher/tests/test_daemon_summary_deferred_acs.py
@@ -161,12 +161,17 @@ class TestSummaryDeferredAcsPersisted:
         d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._write_failure = MagicMock()  # type: ignore[method-assign]
-        d._agent_ralph_output = {
-            "verdict": "SHIP",
-            "summary": "…",
-            "changed_files": ["scripts/foo.py"],
-        }
-        d._agent_plan_output = {"acceptance_criteria": [], "scope_check": []}
+        # Mock _fetch_phase_output to return DB-backed predecessor outputs.
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            side_effect=lambda agent_id, phase: {
+                "ralph": {
+                    "verdict": "SHIP",
+                    "summary": "…",
+                    "changed_files": ["scripts/foo.py"],
+                },
+                "plan": {"acceptance_criteria": [], "scope_check": []},
+            }.get(phase)
+        )
         d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
             return_value={
                 "issue_number": 3010,
@@ -225,12 +230,13 @@ class TestSummaryDeferredAcsPersisted:
         d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
         d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
         d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
-        d._agent_ralph_output = {
-            "verdict": "SHIP",
-            "summary": "",
-            "changed_files": [],
-        }
-        d._agent_plan_output = {"acceptance_criteria": [], "scope_check": []}
+        # Mock _fetch_phase_output to return DB-backed predecessor outputs.
+        d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+            side_effect=lambda agent_id, phase: {
+                "ralph": {"verdict": "SHIP", "summary": "", "changed_files": []},
+                "plan": {"acceptance_criteria": [], "scope_check": []},
+            }.get(phase)
+        )
         d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
             return_value={
                 "issue_number": 3010,

--- a/scripts/dispatcher/tests/test_daemon_summary_output_incomplete.py
+++ b/scripts/dispatcher/tests/test_daemon_summary_output_incomplete.py
@@ -139,10 +139,14 @@ def _patch_push_and_open_pr_helpers(
     d._is_noop_ship = MagicMock(return_value=is_noop)  # type: ignore[method-assign]
     d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
     d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
-    # Stash the summary output the caller wants ``_push_and_open_pr`` to
-    # see (normally written by ``_run_summary_phase``).
-    d._agent_summary_output = summary_output
-    d._agent_unmet_criteria = []
+    # _push_and_open_pr reads summary output from DB via _fetch_phase_output (#2975).
+    # Include unmet_criteria so the DB-fetched shape is complete.
+    d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+        return_value={
+            **summary_output,
+            "unmet_criteria": summary_output.get("unmet_criteria", []),
+        }
+    )
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Refactored dispatcher to make the database the single source of truth for phase outputs. Removed in-memory instance variables from daemon.py and replaced all spawn-site reads with unconditional DB materialization. Deleted conditional plan-restore logic; materialize-on-spawn is now standard, simplifying boot-recovery.

Closes #2975

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — 1567 tests pass, all green
- [x] CI green

### Post-deploy verification

- [ ] One successful end-to-end daemon run where daemon restarts mid-pipeline; next phase resumes cleanly without phase_output_missing
- [ ] Verification evidence posted on #2975 (see /task-v2-verify output)