### PR TITLE
chore(docs): clarify dispatcher spike-0.5 artifact cleanup as no-op (#2692)

### DIFF
--- a/docs/investigations/dispatcher-v2-spike-0.5.md
+++ b/docs/investigations/dispatcher-v2-spike-0.5.md
@@ -160,11 +160,11 @@ Recommended spec edits are minor and included as a follow-up item rather than in
 
 ## Cleanup
 
-The throwaway `spike-hello` skill and its symlink are left in place as a reproducible artifact per the issue instructions. A follow-up issue will track their removal so this investigation note remains reproducible in the interim.
+The throwaway `spike-hello` skill (`.claude/skills/spike-hello/`) and its symlink (`.agents/skills/spike-hello`) were created inside the spike's worktree (`.claude/worktrees/agent-a78236f1`) and were never committed to `main`. No removal was needed: #2692 confirmed non-existence on `main` and closed as a no-op.
 
 ## Follow-ups
 
-See #2692 (cleanup issue filed as part of this investigation): remove `.claude/skills/spike-hello/` and the `.agents/skills/spike-hello` symlink.
+#2692 (cleanup issue filed as part of this investigation) was resolved as a no-op: the artifacts were never committed to `main`, so no files needed removal.
 
 Optional follow-ups to consider later (not filed as issues, for maintainer decision):
 


### PR DESCRIPTION
## Summary

Updated the Cleanup and Follow-ups sections in the dispatcher spike-0.5 investigation doc to clarify that the spike-hello artifacts were never committed to main. Scope check confirmed no spike-hello files exist in the git tree, so #2692 resolved as a no-op with only documentation updates required.

Closes #2692

## Test plan

### Automated checks

- [x] Lint passes (`scripts/check-markdown-links.sh`) — pre-push hook ran successfully
- [x] Tests pass — documentation-only change
- [x] CI green — markdown-link checks pass

### Post-deploy verification

- [ ] N/A — documentation-only change (investigation note)