### PR TITLE
fix(dispatcher): allow NULL issue_number on scheduled-skill agents (#3380)

### DIFF
--- a/packages/api/migrations/49_dispatcher-agents-issue-number-nullable.sql
+++ b/packages/api/migrations/49_dispatcher-agents-issue-number-nullable.sql
@@ -1,0 +1,54 @@
+-- Up Migration
+--
+-- Dispatcher v2 — drop NOT NULL on ``dispatcher.agents.issue_number``
+-- (issue #3380, follow-up to #3374).
+--
+-- Why
+-- ---
+-- The generalized scheduled-skills mechanism (#3374) introduces
+-- synthetic agents with ``kind='scheduled_skill'`` for periodic skills
+-- like ``/audit`` and ``/spotcheck``. These agents legitimately have
+-- no issue — the skill itself decides what to act on (e.g. ``/audit``
+-- reads recent merged PRs from GitHub).
+--
+-- The original schema (migration 21) declared ``issue_number INT NOT
+-- NULL`` because every pre-#3374 agent was issue-driven. The
+-- ``_spawn_scheduled_skill_agent`` path INSERTs ``NULL`` for
+-- ``issue_number`` and trips the constraint, so the daemon's spawn
+-- pass fails with::
+--
+--     psycopg.errors.NotNullViolation: null value in column
+--     "issue_number" of relation "agents" violates not-null constraint
+--
+-- Dropping the constraint is the minimal change. Existing call sites
+-- that read ``issue_number`` already tolerate ``NULL`` (the daemon's
+-- ``_agent_issue_number`` returns ``int | None``); the only new path
+-- where ``NULL`` shows up is the synthetic scheduled-skill agents,
+-- which never enter the issue-driven plan→ralph→PR pipeline.
+--
+-- Rollback
+-- --------
+-- The DOWN migration re-adds the constraint, but only after replacing
+-- existing NULL values with 0 (the synthetic agents would otherwise
+-- block the constraint add). The ``UPDATE ... WHERE issue_number IS
+-- NULL`` is idempotent — re-running it is a no-op once all rows have
+-- a non-NULL value.
+
+ALTER TABLE dispatcher.agents
+    ALTER COLUMN issue_number DROP NOT NULL;
+
+COMMENT ON COLUMN dispatcher.agents.issue_number IS
+    'GitHub issue number for issue-driven agents. NULL for synthetic '
+    'agents (kind=''scheduled_skill'') that have no issue context — '
+    'the skill itself decides what to act on. See #3374 / #3380.';
+
+
+-- Down Migration
+--
+-- Replace any NULL values with 0 (sentinel) before re-adding the
+-- constraint. Synthetic scheduled-skill agents inserted under #3374
+-- would otherwise block the ALTER.
+UPDATE dispatcher.agents SET issue_number = 0 WHERE issue_number IS NULL;
+
+ALTER TABLE dispatcher.agents
+    ALTER COLUMN issue_number SET NOT NULL;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 48 migrations.
+-- Generated from 49 migrations.
 
 
 
@@ -345,7 +345,7 @@ CREATE TABLE dispatcher.agents (
     agent_id uuid DEFAULT gen_random_uuid() NOT NULL,
     parent_run_id uuid,
     kind text DEFAULT 'task'::text NOT NULL,
-    issue_number integer NOT NULL,
+    issue_number integer,
     worktree_path text NOT NULL,
     phase text DEFAULT 'claiming'::text NOT NULL,
     status text DEFAULT 'running'::text NOT NULL,
@@ -373,6 +373,9 @@ CREATE TABLE dispatcher.agents (
 
 
 COMMENT ON TABLE dispatcher.agents IS 'One row per /task (or audit/spotcheck/security-review) agent invocation.';
+
+
+COMMENT ON COLUMN dispatcher.agents.issue_number IS 'GitHub issue number for issue-driven agents. NULL for synthetic agents (kind=''scheduled_skill'') that have no issue context — the skill itself decides what to act on. See #3374 / #3380.';
 
 
 COMMENT ON COLUMN dispatcher.agents.runner_override IS 'Per-agent override of dispatcher.config.runner_by_phase; NULL = use config default.';

--- a/scripts/dispatcher/tests/test_agents_issue_number_nullable_migration.py
+++ b/scripts/dispatcher/tests/test_agents_issue_number_nullable_migration.py
@@ -1,0 +1,69 @@
+"""Schema test for migration 49 — drop NOT NULL on agents.issue_number.
+
+Issue #3380 (follow-up to #3374). Synthetic scheduled-skill agents
+INSERT a row with ``issue_number IS NULL``; the original
+NOT NULL constraint blocked the spawn path.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "packages"
+    / "api"
+    / "migrations"
+    / "49_dispatcher-agents-issue-number-nullable.sql"
+)
+SCHEMA_SQL = (
+    Path(__file__).resolve().parents[3]
+    / "packages"
+    / "api"
+    / "src"
+    / "data-access"
+    / "schema.sql"
+)
+
+
+def test_migration_file_exists() -> None:
+    assert MIGRATION_PATH.is_file(), f"missing: {MIGRATION_PATH}"
+
+
+def test_up_drops_not_null() -> None:
+    text = MIGRATION_PATH.read_text()
+    up = text.split("-- Down Migration")[0]
+    assert re.search(r"ALTER COLUMN issue_number\s+DROP NOT NULL", up, re.IGNORECASE), (
+        "Up section must DROP NOT NULL on issue_number"
+    )
+
+
+def test_down_restores_not_null() -> None:
+    text = MIGRATION_PATH.read_text()
+    down = text.split("-- Down Migration")[1]
+    assert re.search(
+        r"ALTER COLUMN issue_number\s+SET NOT NULL", down, re.IGNORECASE
+    ), "Down section must restore NOT NULL on issue_number"
+    # Down also must coerce NULLs to 0 first to avoid constraint
+    # violation on synthetic-skill rows.
+    assert re.search(
+        r"UPDATE dispatcher\.agents.*WHERE issue_number IS NULL",
+        down,
+        re.IGNORECASE | re.DOTALL,
+    ), "Down section must UPDATE NULLs to 0 before re-adding constraint"
+
+
+def test_schema_sql_reflects_nullable() -> None:
+    """schema.sql snapshot must show issue_number without NOT NULL."""
+    text = SCHEMA_SQL.read_text()
+    # Find the dispatcher.agents CREATE TABLE block.
+    m = re.search(r"CREATE TABLE dispatcher\.agents\s*\((.*?)\);", text, re.DOTALL)
+    assert m, "missing CREATE TABLE dispatcher.agents in schema.sql"
+    body = m.group(1)
+    # Find the issue_number line; it should NOT contain "NOT NULL".
+    line_match = re.search(r"^\s*issue_number\s+[^\n,]*", body, re.MULTILINE)
+    assert line_match, "issue_number column not declared in schema.sql"
+    assert "NOT NULL" not in line_match.group(0), (
+        f"issue_number must be nullable post-migration 49; got: {line_match.group(0)!r}"
+    )


### PR DESCRIPTION
## Summary

- Migration 49 drops `NOT NULL` on `dispatcher.agents.issue_number` so synthetic scheduled-skill agents (#3374, `kind='scheduled_skill'`) can spawn without tripping a constraint violation.
- DOWN migration coerces existing NULL → 0 before re-adding `NOT NULL` so a rollback doesn't block on synthetic-skill rows.

## Background

#3374 introduced `dispatcher.scheduled_skills` and `_spawn_scheduled_skill_agent`, which INSERTs an agent row with `issue_number=NULL` (synthetic skills have no issue — the skill itself decides what to act on). The pre-#3374 schema declared `issue_number INT NOT NULL`, so the spawn fails with:

```
psycopg.errors.NotNullViolation: null value in column "issue_number"
  of relation "agents" violates not-null constraint
```

Captured in dev daemon logs after #3374 deploy.

Closes #3380

## Test plan

- [x] `ruff check` + format clean
- [x] New schema test passes
- [ ] CI green
- [ ] Post-merge: re-run #3374 verification (set audit `trigger_value=2`, observe synthetic agent spawn) — log evidence comment on #3374

🤖 Generated with [Claude Code](https://claude.com/claude-code)
