### PR TITLE
fix(dispatcher): kill orphan diagnoser PIDs on daemon restart (#3384)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -20266,6 +20266,47 @@ class DispatcherDaemon:
             return True
         return True
 
+    @staticmethod
+    def _diagnoser_cmdline_matches(pid: int) -> bool | None:
+        """Return True if ``pid`` is a ``claude -p /diagnose-failure`` process.
+
+        Reads ``/proc/<pid>/cmdline`` (NUL-separated argv on Linux) and
+        checks that argv[0] ends with ``claude`` AND one of the subsequent
+        tokens starts with ``/diagnose-failure``.
+
+        Returns:
+          * ``True``  — cmdline read and matches the expected diagnoser argv.
+          * ``False`` — cmdline read but does NOT match (recycled PID running
+            a different process).
+          * ``None``  — ``/proc/<pid>/cmdline`` could not be read (race
+            condition where the process exited between the liveness check
+            and the cmdline read, or non-Linux platform). Callers should
+            treat ``None`` conservatively (do not signal).
+
+        This is a boot-time-only helper (#3384) — the in-session reaper
+        (:meth:`_reap_diagnoser_subprocesses`) already owns the PID it
+        spawned, so it has no recycled-PID risk and does not need this
+        check.
+        """
+        try:
+            cmdline_bytes = Path(f"/proc/{pid}/cmdline").read_bytes()
+        except OSError:
+            return None
+        if not cmdline_bytes:
+            return None
+        argv = cmdline_bytes.rstrip(b"\x00").split(b"\x00")
+        if not argv:
+            return None
+        # argv[0] must end with 'claude' (covers /usr/bin/claude, .venv/bin/claude, etc.)
+        executable = argv[0].decode("utf-8", errors="replace")
+        if not (executable == "claude" or executable.endswith("/claude")):
+            return False
+        # One of the remaining tokens must start with '/diagnose-failure'
+        rest = [tok.decode("utf-8", errors="replace") for tok in argv[1:]]
+        if any(tok.startswith("/diagnose-failure") for tok in rest):
+            return True
+        return False
+
     def _kill_diagnoser_process(self, pid: int) -> None:
         """Send SIGTERM, then SIGKILL after a short grace period (#3376).
 
@@ -20472,32 +20513,52 @@ class DispatcherDaemon:
         return max(0.0, (now - started_at).total_seconds())
 
     def _reap_orphaned_diagnoses_on_boot(self) -> int:
-        """Reap diagnoses orphaned by a daemon restart (#3376).
+        """Reap diagnoses orphaned by a daemon restart (#3376, #3384).
 
         Called once at daemon startup, after :meth:`recover_abandoned_agents`.
-        Iterates rows with ``status='pending' AND subprocess_pid IS
-        NOT NULL`` left behind by a previous daemon. For each:
+        Iterates ``dispatcher.diagnoses`` rows with ``status='pending'``
+        whose ``started_at`` predates this run's ``started_at``, which means
+        they were spawned by a *previous* daemon that crashed or restarted.
 
-          * If the PID is still alive AND ``started_at`` predates
-            the current daemon's run-registration timestamp — the
-            diagnoser process is unrelated to the new daemon's
-            spawn (the previous daemon's PID has been recycled by
-            the OS). Mark ``failed`` with reason
-            ``diagnoser_orphaned_by_daemon_restart`` (does NOT
-            kill the process — the new daemon doesn't own it).
-          * If the PID is dead — mark ``failed`` for the same
-            reason. The recommendation + directive may still be
-            on-disk but we don't trust it: the previous daemon
-            crashed mid-consume, so consuming now would be a race
-            against the corrupt state.
+        For each orphan row the method branches on PID liveness and cmdline
+        identity (via :meth:`_diagnoser_cmdline_matches`) BEFORE marking the
+        row terminal:
 
-        Plus orphans without PIDs: pending rows whose ``started_at``
-        predates the current daemon (i.e. their parent daemon
-        crashed before the PID UPDATE landed). Same treatment.
+          * **No PID** (``subprocess_pid IS NULL``) — the previous daemon
+            crashed before the PID UPDATE landed.  Log
+            ``diagnoser_orphan_pid_dead`` (no kill possible), mark failed.
+          * **PID dead** (``_process_alive`` returns ``False``) — the
+            diagnoser process has already exited.  Log
+            ``diagnoser_orphan_pid_dead``, mark failed.
+          * **PID alive, cmdline matches** (``_diagnoser_cmdline_matches``
+            returns ``True``) — the previous daemon's diagnoser subprocess
+            is still running and IS confirmed to be a ``claude -p
+            /diagnose-failure`` invocation.  The new daemon shares the same
+            DB row and GitHub credentials so it IS responsible for this
+            process.  Log ``diagnoser_orphan_killed``, call
+            :meth:`_kill_diagnoser_process` (SIGTERM → grace →
+            SIGKILL), then mark failed.
+          * **PID alive, cmdline mismatched / unreadable** (``False`` or
+            ``None``) — the OS has recycled the old PID and the slot now
+            belongs to an unrelated process.  Log
+            ``diagnoser_orphan_pid_recycled``, do NOT signal the unrelated
+            process, mark failed.
 
-        Returns the number of orphans reaped. Always non-fatal —
-        DB errors are logged and the daemon continues. The supervisor
-        tick's reaper is the backstop for any orphans this misses.
+        **Rationale for killing (#3384).** The prior design said "do NOT
+        kill — the new daemon doesn't own it."  That was correct for the
+        recycled-PID case but wrong for the still-running-diagnoser case.
+        A diagnoser that survived the previous daemon crash continues to
+        hold the ``diagnosis_id`` DB row in ``status='pending'`` and may
+        still be writing to GitHub/disk using shared credentials.  Killing
+        it (with cmdline verification) is the safe path — the row will be
+        marked failed and the task's failure will be re-evaluated on the
+        next supervisor tick.  The ``DIAGNOSER_REAP_GRACE_SECONDS`` constant
+        governs the SIGTERM grace window (same as the supervisor-tick reaper,
+        PR #3378 lineage).
+
+        Returns the number of orphans reaped.  Always non-fatal — DB errors
+        are logged and the daemon continues.  The supervisor tick's reaper is
+        the backstop for any orphans this misses.
         """
         assert self._conn is not None, "connect() must run before orphan reap"
         assert self._run_id is not None, "register run before orphan reap"
@@ -20568,17 +20629,57 @@ class DispatcherDaemon:
             orphan_started_at = orphan_row[2]
             pid = int(pid_raw) if pid_raw is not None else None
 
-            self._log.warning(
-                "daemon.diagnoser_orphaned_by_daemon_restart",
-                extra={
-                    "event": "diagnoser_orphaned_by_daemon_restart",
-                    "run_id": self._run_id,
-                    "diagnosis_id": diagnosis_id,
-                    "subprocess_pid": pid,
-                    "orphan_started_at": str(orphan_started_at),
-                    "this_run_started_at": str(run_started_at),
-                },
-            )
+            if pid is None:
+                # No PID — parent crashed before the PID UPDATE landed.
+                self._log.warning(
+                    "daemon.diagnoser_orphan_pid_dead",
+                    extra={
+                        "event": "diagnoser_orphan_pid_dead",
+                        "run_id": self._run_id,
+                        "diagnosis_id": diagnosis_id,
+                        "subprocess_pid": None,
+                        "orphan_started_at": str(orphan_started_at),
+                    },
+                )
+            elif self._process_alive(pid) is False:
+                # PID is already gone — nothing to kill.
+                self._log.warning(
+                    "daemon.diagnoser_orphan_pid_dead",
+                    extra={
+                        "event": "diagnoser_orphan_pid_dead",
+                        "run_id": self._run_id,
+                        "diagnosis_id": diagnosis_id,
+                        "subprocess_pid": pid,
+                        "orphan_started_at": str(orphan_started_at),
+                    },
+                )
+            elif self._diagnoser_cmdline_matches(pid) is True:
+                # Alive AND confirmed to be a diagnoser — kill it (#3384).
+                self._log.warning(
+                    "daemon.diagnoser_orphan_killed",
+                    extra={
+                        "event": "diagnoser_orphan_killed",
+                        "run_id": self._run_id,
+                        "diagnosis_id": diagnosis_id,
+                        "subprocess_pid": pid,
+                        "orphan_started_at": str(orphan_started_at),
+                    },
+                )
+                self._kill_diagnoser_process(pid)
+            else:
+                # Alive but cmdline does not match — recycled PID.
+                # Do NOT signal the unrelated process.
+                self._log.warning(
+                    "daemon.diagnoser_orphan_pid_recycled",
+                    extra={
+                        "event": "diagnoser_orphan_pid_recycled",
+                        "run_id": self._run_id,
+                        "diagnosis_id": diagnosis_id,
+                        "subprocess_pid": pid,
+                        "orphan_started_at": str(orphan_started_at),
+                    },
+                )
+
             try:
                 self._mark_diagnosis_failed(
                     diagnosis_id,

--- a/scripts/dispatcher/tests/test_daemon_boot_orphan_diagnoser_cleanup.py
+++ b/scripts/dispatcher/tests/test_daemon_boot_orphan_diagnoser_cleanup.py
@@ -1,4 +1,4 @@
-"""Daemon-boot reap of orphaned async diagnoses (#3376).
+"""Daemon-boot reap of orphaned async diagnoses (#3376, #3384).
 
 When the previous daemon crashed (watchdog kill, panic, etc.) leaving
 ``dispatcher.diagnoses`` rows at ``status='pending'``, the new daemon's
@@ -6,19 +6,28 @@ boot path must:
 
   1. Read its own ``dispatcher.runs.started_at``.
   2. Find pending rows whose ``started_at`` predates that timestamp.
-  3. Mark them ``status='failed'`` with reason
-     ``diagnoser_orphaned_by_daemon_restart``.
-  4. NOT signal any subprocess — PIDs from a prior boot may have been
-     recycled by the OS, signalling them is dangerous.
+  3. For each orphan row, branch on PID liveness and cmdline identity:
 
-Today's three observed kills 20:14–20:34Z (diagnoses #22, #23, #24)
-are exactly this case — the supervisor's reaper backstop should
-catch them on first boot post-deploy.
+     * No PID (crashed before PID UPDATE) → log ``diagnoser_orphan_pid_dead``,
+       mark failed.
+     * PID dead → log ``diagnoser_orphan_pid_dead``, mark failed.
+     * PID alive AND cmdline matches ``claude -p /diagnose-failure`` →
+       log ``diagnoser_orphan_killed``, KILL the process (SIGTERM →
+       grace → SIGKILL), mark failed.
+     * PID alive but cmdline mismatched (recycled PID) → log
+       ``diagnoser_orphan_pid_recycled``, do NOT signal, mark failed.
+
+  4. Return count of rows marked failed.
+
+The cmdline-verification step (#3384) is the safe path: it confirms the
+alive PID actually belongs to a prior-daemon diagnoser before signalling,
+preventing accidental kill of an unrelated OS process that recycled the PID.
 """
 
 from __future__ import annotations
 
 import logging
+import signal
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -96,6 +105,7 @@ def _make_daemon(tmp_path: Path) -> daemon.DispatcherDaemon:
 
 class TestOrphanReap:
     def test_marks_orphan_rows_failed(self, monkeypatch: Any, tmp_path: Path) -> None:
+        """All orphan rows are marked failed; alive+matching PID gets SIGTERM."""
         d = _make_daemon(tmp_path)
         conn = d._conn  # type: ignore[assignment]
         run_started = datetime.now(daemon.UTC)
@@ -118,17 +128,46 @@ class TestOrphanReap:
 
         monkeypatch.setattr(d, "_mark_diagnosis_failed", fake_mark_failed)
 
-        # Critical: must NOT call os.kill — those PIDs may be recycled.
+        # Make PID 11111 alive+matching, PID 33333 dead.
+        def fake_process_alive(pid: int) -> bool:
+            return pid == 11111
+
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_process_alive",
+            staticmethod(fake_process_alive),
+        )
+
+        def fake_cmdline_matches(pid: int) -> bool | None:
+            if pid == 11111:
+                return True
+            return False
+
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_diagnoser_cmdline_matches",
+            staticmethod(fake_cmdline_matches),
+        )
+
         kills: list[Any] = []
         monkeypatch.setattr(daemon.os, "kill", lambda *a, **_kw: kills.append(a))
+        monkeypatch.setattr(daemon.time, "sleep", lambda _s: None)
 
         reaped = d._reap_orphaned_diagnoses_on_boot()
         assert reaped == 3
         assert {m["id"] for m in marked} == {22, 23, 24}
         for m in marked:
             assert m["reason"] == "diagnoser_orphaned_by_daemon_restart"
-        # No signals sent — orphan reap never tries to kill.
-        assert kills == []
+        # PID 11111 is alive+matching — must have been signalled (SIGTERM at minimum).
+        sigtermed_pids = [a[0] for a in kills if len(a) > 1 and a[1] == signal.SIGTERM]
+        assert 11111 in sigtermed_pids, (
+            f"expected SIGTERM to alive+matching PID 11111; kills={kills}"
+        )
+        # PID 33333 is dead — must NOT have been signalled.
+        killed_pids = {a[0] for a in kills}
+        assert 33333 not in killed_pids, (
+            f"dead PID 33333 should not be signalled; kills={kills}"
+        )
 
     def test_no_orphans_returns_zero(self, monkeypatch: Any, tmp_path: Path) -> None:
         d = _make_daemon(tmp_path)
@@ -159,15 +198,21 @@ class TestOrphanReap:
             [(99, 4444, old)]
         ]
         monkeypatch.setattr(d, "_mark_diagnosis_failed", lambda *_a, **_kw: None)
+        # PID 4444 is dead.
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_process_alive",
+            staticmethod(lambda _pid: False),
+        )
 
         d._reap_orphaned_diagnoses_on_boot()
 
         events = [
             r
             for r in records
-            if getattr(r, "event", None) == "diagnoser_orphaned_by_daemon_restart"
+            if getattr(r, "event", None) == "diagnoser_orphan_pid_dead"
         ]
-        assert events, "expected daemon.diagnoser_orphaned_by_daemon_restart log"
+        assert events, "expected daemon.diagnoser_orphan_pid_dead log"
 
     def test_query_filters_by_started_at(self, tmp_path: Path) -> None:
         """The orphan-scan SELECT joins by ``started_at < this_run.started_at``
@@ -188,3 +233,262 @@ class TestOrphanReap:
         assert any(
             "status = 'pending'" in sql and "started_at <" in sql for sql in scan_sql
         )
+
+    # ── AC1: alive + matching cmdline → SIGTERM sent ─────────────────────
+
+    def test_orphan_alive_matching_cmdline_killed(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Alive PID + matching cmdline → SIGTERM sent, row marked failed,
+        ``diagnoser_orphan_killed`` event emitted."""
+        d = _make_daemon(tmp_path)
+        conn = d._conn  # type: ignore[assignment]
+
+        run_started = datetime.now(daemon.UTC)
+        old = run_started - timedelta(minutes=10)
+        conn.cursor_instance.fetch_queue = [(run_started,)]  # type: ignore[union-attr]
+        conn.cursor_instance.fetchall_queue = [[(55, 77777, old)]]  # type: ignore[union-attr]
+
+        marked: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            d,
+            "_mark_diagnosis_failed",
+            lambda diagnosis_id, reason: marked.append(
+                {"id": diagnosis_id, "reason": reason}
+            ),
+        )
+
+        # PID 77777 is alive and cmdline matches.
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_process_alive",
+            staticmethod(lambda _pid: True),
+        )
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_diagnoser_cmdline_matches",
+            staticmethod(lambda _pid: True),
+        )
+
+        signals_sent: list[tuple[int, int]] = []
+
+        def fake_kill(pid: int, sig: int) -> None:
+            signals_sent.append((pid, sig))
+
+        monkeypatch.setattr(daemon.os, "kill", fake_kill)
+        monkeypatch.setattr(daemon.time, "sleep", lambda _s: None)
+
+        # Capture log records to verify event name.
+        records: list[logging.LogRecord] = []
+
+        class _Handler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        d._log.addHandler(_Handler(level=logging.DEBUG))
+        d._log.setLevel(logging.DEBUG)
+
+        reaped = d._reap_orphaned_diagnoses_on_boot()
+
+        assert reaped == 1
+        assert marked == [{"id": 55, "reason": "diagnoser_orphaned_by_daemon_restart"}]
+        # SIGTERM must have been sent to PID 77777.
+        assert (77777, signal.SIGTERM) in signals_sent, (
+            f"expected SIGTERM to 77777; signals={signals_sent}"
+        )
+        # Event log must say diagnoser_orphan_killed.
+        kill_events = [
+            r for r in records if getattr(r, "event", None) == "diagnoser_orphan_killed"
+        ]
+        assert kill_events, "expected diagnoser_orphan_killed log event"
+
+    # ── AC2: alive + recycled PID → no signal ────────────────────────────
+
+    def test_orphan_alive_recycled_pid_not_killed(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Alive PID + mismatched cmdline → no signal sent, row marked failed,
+        ``diagnoser_orphan_pid_recycled`` event emitted."""
+        d = _make_daemon(tmp_path)
+        conn = d._conn  # type: ignore[assignment]
+
+        run_started = datetime.now(daemon.UTC)
+        old = run_started - timedelta(minutes=5)
+        conn.cursor_instance.fetch_queue = [(run_started,)]  # type: ignore[union-attr]
+        conn.cursor_instance.fetchall_queue = [[(66, 88888, old)]]  # type: ignore[union-attr]
+
+        marked: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            d,
+            "_mark_diagnosis_failed",
+            lambda diagnosis_id, reason: marked.append(
+                {"id": diagnosis_id, "reason": reason}
+            ),
+        )
+
+        # PID 88888 is alive but cmdline is `cat` — mismatched (recycled).
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_process_alive",
+            staticmethod(lambda _pid: True),
+        )
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_diagnoser_cmdline_matches",
+            staticmethod(lambda _pid: False),
+        )
+
+        signals_sent: list[tuple[int, int]] = []
+        monkeypatch.setattr(
+            daemon.os,
+            "kill",
+            lambda pid, sig: signals_sent.append((pid, sig)),
+        )
+        monkeypatch.setattr(daemon.time, "sleep", lambda _s: None)
+
+        records: list[logging.LogRecord] = []
+
+        class _Handler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        d._log.addHandler(_Handler(level=logging.DEBUG))
+        d._log.setLevel(logging.DEBUG)
+
+        reaped = d._reap_orphaned_diagnoses_on_boot()
+
+        assert reaped == 1
+        assert marked == [{"id": 66, "reason": "diagnoser_orphaned_by_daemon_restart"}]
+        # No signal must have been sent to PID 88888.
+        signalled_pids = {pid for pid, _sig in signals_sent}
+        assert 88888 not in signalled_pids, (
+            f"recycled PID 88888 must NOT be signalled; signals={signals_sent}"
+        )
+        # Event must say recycled.
+        recycled_events = [
+            r
+            for r in records
+            if getattr(r, "event", None) == "diagnoser_orphan_pid_recycled"
+        ]
+        assert recycled_events, "expected diagnoser_orphan_pid_recycled log event"
+
+    # ── AC3: dead PID → logged distinctly ────────────────────────────────
+
+    def test_orphan_dead_pid_logged_distinctly(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Dead PID → no signal, row marked failed, ``diagnoser_orphan_pid_dead``
+        event emitted."""
+        d = _make_daemon(tmp_path)
+        conn = d._conn  # type: ignore[assignment]
+
+        run_started = datetime.now(daemon.UTC)
+        old = run_started - timedelta(minutes=8)
+        conn.cursor_instance.fetch_queue = [(run_started,)]  # type: ignore[union-attr]
+        conn.cursor_instance.fetchall_queue = [[(77, 99999, old)]]  # type: ignore[union-attr]
+
+        marked: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            d,
+            "_mark_diagnosis_failed",
+            lambda diagnosis_id, reason: marked.append(
+                {"id": diagnosis_id, "reason": reason}
+            ),
+        )
+
+        # PID 99999 is dead.
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon,
+            "_process_alive",
+            staticmethod(lambda _pid: False),
+        )
+
+        signals_sent: list[tuple[int, int]] = []
+        monkeypatch.setattr(
+            daemon.os,
+            "kill",
+            lambda pid, sig: signals_sent.append((pid, sig)),
+        )
+
+        records: list[logging.LogRecord] = []
+
+        class _Handler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        d._log.addHandler(_Handler(level=logging.DEBUG))
+        d._log.setLevel(logging.DEBUG)
+
+        reaped = d._reap_orphaned_diagnoses_on_boot()
+
+        assert reaped == 1
+        assert marked == [{"id": 77, "reason": "diagnoser_orphaned_by_daemon_restart"}]
+        # No signal sent (PID is dead).
+        assert signals_sent == [], (
+            f"dead PID 99999 must not be signalled; signals={signals_sent}"
+        )
+        # Event must say pid_dead.
+        dead_events = [
+            r
+            for r in records
+            if getattr(r, "event", None) == "diagnoser_orphan_pid_dead"
+        ]
+        assert dead_events, "expected diagnoser_orphan_pid_dead log event"
+        # The log record must carry subprocess_pid=99999.
+        assert any(getattr(r, "subprocess_pid", None) == 99999 for r in dead_events), (
+            "diagnoser_orphan_pid_dead should include subprocess_pid=99999"
+        )
+
+    # ── Null-PID path: pre-PID-UPDATE crash ──────────────────────────────
+
+    def test_orphan_null_pid_path(self, monkeypatch: Any, tmp_path: Path) -> None:
+        """Null subprocess_pid → no kill attempted, row marked failed,
+        ``diagnoser_orphan_pid_dead`` event emitted (no PID to check)."""
+        d = _make_daemon(tmp_path)
+        conn = d._conn  # type: ignore[assignment]
+
+        run_started = datetime.now(daemon.UTC)
+        old = run_started - timedelta(minutes=12)
+        conn.cursor_instance.fetch_queue = [(run_started,)]  # type: ignore[union-attr]
+        # subprocess_pid is None.
+        conn.cursor_instance.fetchall_queue = [[(88, None, old)]]  # type: ignore[union-attr]
+
+        marked: list[dict[str, Any]] = []
+        monkeypatch.setattr(
+            d,
+            "_mark_diagnosis_failed",
+            lambda diagnosis_id, reason: marked.append(
+                {"id": diagnosis_id, "reason": reason}
+            ),
+        )
+
+        signals_sent: list[tuple[int, int]] = []
+        monkeypatch.setattr(
+            daemon.os,
+            "kill",
+            lambda pid, sig: signals_sent.append((pid, sig)),
+        )
+
+        records: list[logging.LogRecord] = []
+
+        class _Handler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        d._log.addHandler(_Handler(level=logging.DEBUG))
+        d._log.setLevel(logging.DEBUG)
+
+        reaped = d._reap_orphaned_diagnoses_on_boot()
+
+        assert reaped == 1
+        assert marked == [{"id": 88, "reason": "diagnoser_orphaned_by_daemon_restart"}]
+        assert signals_sent == [], f"no PID → no signal; got signals={signals_sent}"
+        dead_events = [
+            r
+            for r in records
+            if getattr(r, "event", None) == "diagnoser_orphan_pid_dead"
+        ]
+        assert dead_events, "expected diagnoser_orphan_pid_dead log for null-PID orphan"
+        assert any(
+            getattr(r, "subprocess_pid", "MISSING") is None for r in dead_events
+        ), "subprocess_pid should be None in the log record"


### PR DESCRIPTION
## Summary

Fix a safety issue in daemon boot-time orphan reaping: previously, orphaned diagnoser PIDs were never signaled even when still alive and confirmed to be diagnoser subprocesses. This exposed a race where a live diagnoser from a crashed previous daemon could continue running, holding the same `dispatcher.diagnoses` row, and potentially corrupt state by racing the new daemon to write `recommendation` / `next_directive` columns.

This PR adds `_diagnoser_cmdline_matches` to distinguish true diagnosers from recycled OS PIDs, then branches the reap logic to kill alive+matching PIDs, while safely skipping recycled/dead ones. All three scenarios are now logged distinctly and covered by tests.

Closes #3384

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — all 1689 tests pass, including 5 new/updated tests in `test_daemon_boot_orphan_diagnoser_cleanup.py`
- [x] CI green

### Test coverage

New tests added:
- `test_orphan_alive_matching_cmdline_killed` — alive+matching PID is killed with SIGTERM, `diagnoser_orphan_killed` event logged
- `test_orphan_alive_recycled_pid_not_killed` — alive but mismatched cmdline PID is NOT signaled, `diagnoser_orphan_pid_recycled` event logged
- `test_orphan_dead_pid_logged_distinctly` — dead PID is not signaled, `diagnoser_orphan_pid_dead` event logged with subprocess_pid
- `test_orphan_null_pid_path` — null subprocess_pid (pre-PID-UPDATE crash) is handled safely, `diagnoser_orphan_pid_dead` event logged
- Updated `test_marks_orphan_rows_failed` to verify the new kill-on-match behavior