### PR TITLE
fix(dispatcher): raise PhaseOutputFetchError on DB layer exceptions in _fetch_phase_output (#3385)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1046,6 +1046,22 @@ VERIFY_SKIP_REASON_SELF_DEPLOY = "self_deploy"
 #: issue lands.
 _SELF_DEPLOY_PATH_PREFIXES: tuple[str, ...] = ("scripts/dispatcher/",)
 
+
+class PhaseOutputFetchError(RuntimeError):
+    """Raised by :meth:`DispatcherDaemon._fetch_phase_output` when a psycopg
+    (or other DB-layer) exception prevents reading the
+    ``dispatcher.phase_outputs`` row.
+
+    The underlying exception is available as ``__cause__`` so callers can
+    include it in the ``stderr_tail`` passed to
+    :meth:`DispatcherDaemon._handle_agent_failure`.
+
+    Distinct from the "row not found" case (which still returns ``None``) —
+    this exception signals a transient infrastructure failure, not a missing
+    row. Issue #3385.
+    """
+
+
 #: Failure category written when the daemon restart-recovery sweep
 #: reclaims a ``status='running'`` agent left behind by the previous
 #: daemon run. Tier-1 mechanical retry category — the agent gets a
@@ -1158,6 +1174,20 @@ FAILURE_CATEGORY_GIT_PUSH_NETWORK = "git_push_network"
 #: or skill bug); hardcoded retry does not help.
 FAILURE_CATEGORY_PR_CREATE_FAILED = "pr_create_failed"
 FAILURE_CATEGORY_PHASE_OUTPUT_MISSING = "phase_output_missing"
+
+#: Tier-2 first-occurrence category from issue #3385 — a psycopg (or
+#: other DB-layer) exception prevented reading the
+#: ``dispatcher.phase_outputs`` row inside
+#: :meth:`DispatcherDaemon._fetch_phase_output`. The three hot-path call
+#: sites in ``_run_ralph_phase``, ``_run_summary_phase``, and
+#: ``_push_and_open_pr`` all raise :class:`PhaseOutputFetchError` on
+#: exception (pre-#3385 they silently returned ``None`` which let the
+#: ``or {}`` patterns propagate empty ``commit_message`` / ``pr_title``
+#: / ``unmet_criteria`` fields). The diagnoser picks ``retry`` /
+#: ``retry_with_hint`` / ``escalate`` based on the transient vs
+#: persistent nature of the failure. Mirrors the ``phase_output_missing``
+#: shape — same tier, same ``details`` schema, same routing.
+FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED = "phase_output_fetch_failed"
 
 #: Tier-2 first-occurrence category from issue #3067 — the daemon-side
 #: ``git commit --amend`` invoked by ``_push_and_open_pr`` after ralph
@@ -1515,6 +1545,7 @@ TIER_2_FIRST_OCCURRENCE_CATEGORIES: frozenset[str] = frozenset(
         FAILURE_CATEGORY_GIT_COMMIT_FAILED,  # #3067
         FAILURE_CATEGORY_FIX_CI_APPLY_FAILED,  # #3069
         FAILURE_CATEGORY_DEPLOY_FAILED,  # #3070
+        FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED,  # #3385
     }
 )
 
@@ -10675,7 +10706,23 @@ class DispatcherDaemon:
         )
         # ── end prior-attempt context ──────────────────────────────────────
 
-        plan_output = self._fetch_phase_output(agent_id, "plan") or {}
+        # Issue #3385: catch PhaseOutputFetchError so a transient DB
+        # hiccup does not silently propagate an empty plan dict into
+        # the ralph input bundle. The diagnoser picks retry vs escalate.
+        try:
+            plan_output = self._fetch_phase_output(agent_id, "plan") or {}
+        except PhaseOutputFetchError as _fetch_exc:
+            self._handle_agent_failure(
+                agent_id=agent_id,
+                phase="ralph",
+                category=FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED,
+                stderr_tail=str(_fetch_exc.__cause__)[:512],
+                exit_code=None,
+                details={"fetch_phase": "plan", "issue_number": issue_number},
+                issue_number=issue_number,
+            )
+            return False
+
         ralph_input = {
             "agent_id": agent_id,
             "issue_number": issue_number,
@@ -10897,7 +10944,24 @@ class DispatcherDaemon:
         except Exception:  # pragma: no cover — defensive; not asserted in unit tests
             git_diff = ""
 
-        ralph_output = self._fetch_phase_output(agent_id, "ralph") or {}
+        # Issue #3385: catch PhaseOutputFetchError so a transient DB error
+        # in either the ralph or plan fetch does not silently produce an
+        # empty summary input bundle. Both fetches share one handler since
+        # they feed the same input file and have the same failure action.
+        try:
+            ralph_output = self._fetch_phase_output(agent_id, "ralph") or {}
+        except PhaseOutputFetchError as _fetch_exc:
+            self._handle_agent_failure(
+                agent_id=agent_id,
+                phase="summary",
+                category=FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED,
+                stderr_tail=str(_fetch_exc.__cause__)[:512],
+                exit_code=None,
+                details={"fetch_phase": "ralph", "issue_number": issue_number},
+                issue_number=issue_number,
+            )
+            return False
+
         changed_files = ralph_output.get("changed_files", []) or []
         # Fall back to a git-state read if ralph didn't populate
         # changed_files (non-testable short-circuit path).
@@ -10943,7 +11007,22 @@ class DispatcherDaemon:
                 "parent_issue": None,
             }
 
-        plan_output = self._fetch_phase_output(agent_id, "plan") or {}
+        # Issue #3385: plan fetch shares the same failure action — route
+        # through _handle_agent_failure if the DB is unavailable.
+        try:
+            plan_output = self._fetch_phase_output(agent_id, "plan") or {}
+        except PhaseOutputFetchError as _fetch_exc:
+            self._handle_agent_failure(
+                agent_id=agent_id,
+                phase="summary",
+                category=FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED,
+                stderr_tail=str(_fetch_exc.__cause__)[:512],
+                exit_code=None,
+                details={"fetch_phase": "plan", "issue_number": issue_number},
+                issue_number=issue_number,
+            )
+            return False
+
         # Branch name matches ``_create_worktree``'s naming convention.
         short_id = agent_id.replace("-", "")[:AGENT_SHORT_ID_HEX_CHARS]
         branch = f"agent/{short_id}"
@@ -11812,7 +11891,25 @@ class DispatcherDaemon:
             )
             return
 
-        summary_output = self._fetch_phase_output(agent_id, "summary") or {}
+        # Issue #3385: catch PhaseOutputFetchError so a transient DB error
+        # does not silently produce an empty commit_message / pr_title /
+        # unmet_criteria — which would either open a garbage PR or silently
+        # fall through to the summary_output_incomplete branch with no
+        # failure row. The diagnoser picks retry vs escalate.
+        try:
+            summary_output = self._fetch_phase_output(agent_id, "summary") or {}
+        except PhaseOutputFetchError as _fetch_exc:
+            self._handle_agent_failure(
+                agent_id=agent_id,
+                phase="push_and_pr",
+                category=FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED,
+                stderr_tail=str(_fetch_exc.__cause__)[:512],
+                exit_code=None,
+                details={"fetch_phase": "summary", "issue_number": issue_number},
+                issue_number=issue_number,
+            )
+            return
+
         unmet_criteria = [str(u) for u in (summary_output.get("unmet_criteria") or [])]
         is_needs_review = bool(unmet_criteria)
         commit_message = summary_output.get("commit_message") or ""
@@ -15321,7 +15418,14 @@ class DispatcherDaemon:
         return int(row[0])
 
     def _fetch_phase_output(self, agent_id: str, phase: str) -> dict[str, Any] | None:
-        """SELECT a single ``dispatcher.phase_outputs`` row JSON, or None."""
+        """SELECT a single ``dispatcher.phase_outputs`` row JSON, or None.
+
+        Returns ``None`` when the row does not exist yet (normal "not ready"
+        case). Raises :class:`PhaseOutputFetchError` on any DB-layer
+        exception so callers can route the failure through
+        :meth:`_handle_agent_failure` instead of silently propagating an
+        empty ``{}`` payload. Issue #3385.
+        """
         assert self._conn is not None, "connect() must run before reading"
         try:
             with self._conn.cursor() as cur:
@@ -15332,7 +15436,7 @@ class DispatcherDaemon:
                 )
                 row = cur.fetchone()
             self._conn.commit()
-        except Exception:
+        except Exception as exc:
             self._log.exception(
                 "daemon.fetch_phase_output_failed",
                 extra={
@@ -15346,7 +15450,9 @@ class DispatcherDaemon:
                 self._conn.rollback()
             except Exception:  # pragma: no cover
                 pass
-            return None
+            raise PhaseOutputFetchError(
+                f"DB error fetching phase_outputs for agent={agent_id} phase={phase}"
+            ) from exc
         if row is None:
             return None
         raw = row[0]

--- a/scripts/dispatcher/tests/test_daemon_diagnoser_routing.py
+++ b/scripts/dispatcher/tests/test_daemon_diagnoser_routing.py
@@ -182,6 +182,16 @@ class TestTierSetsIncludeNewCategories:
             FAILURE_CATEGORY_PHASE_OUTPUT_MISSING in TIER_2_FIRST_OCCURRENCE_CATEGORIES
         )
 
+    def test_phase_output_fetch_failed_in_tier2_first_occurrence(self) -> None:
+        """#3385 — DB-layer fetch errors route through the diagnoser on first
+        occurrence so the diagnoser can pick retry vs escalate based on
+        whether the failure is transient or persistent.
+        """
+        assert (
+            daemon.FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED
+            in TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        )
+
     def test_regression_ac_infeasible_categories_still_tier3(self) -> None:
         assert FAILURE_CATEGORY_RALPH_AC_INFEASIBLE in TIER_3_CATEGORIES
         assert FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE in TIER_3_CATEGORIES

--- a/scripts/dispatcher/tests/test_phase_output_db_failure.py
+++ b/scripts/dispatcher/tests/test_phase_output_db_failure.py
@@ -1,0 +1,485 @@
+"""Unit tests for issue #3385 — _fetch_phase_output raises PhaseOutputFetchError
+on psycopg exceptions instead of silently returning None.
+
+Covers:
+- ``test_summary_fetch_psycopg_error_routes_through_handle_agent_failure`` —
+  single OperationalError from ``_fetch_phase_output(phase="summary")`` inside
+  ``_push_and_open_pr`` routes through ``_handle_agent_failure`` with
+  ``category=phase_output_fetch_failed``, no PR opened, no commit amended.
+- ``test_persistent_fetch_failure_does_not_open_pr`` —
+  three consecutive raises across three ``_push_and_open_pr`` calls all route
+  through ``_handle_agent_failure``; no ``git commit --amend`` or ``gh pr create``.
+- ``test_run_summary_phase_fetch_psycopg_error_routes_through_handle_agent_failure`` —
+  mirror for ``_run_summary_phase``'s ralph + plan fetches.
+- ``test_run_ralph_phase_fetch_psycopg_error_routes_through_handle_agent_failure`` —
+  mirror for ``_run_ralph_phase``'s plan fetch.
+- ``test_happy_path_fetch_phase_output_returns_dict`` —
+  sanity: normal cursor returns a dict, no raise.
+- ``test_fetch_phase_output_row_none_returns_none`` —
+  row not found (no DB error) still returns None.
+- ``test_fetch_phase_output_raises_phase_output_fetch_error_on_exception`` —
+  real DB exception → PhaseOutputFetchError, not None.
+
+All external calls (subprocesses, real psycopg, network) are mocked.
+Mirrors test_daemon_summary_output_incomplete.py style.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from dispatcher import daemon  # noqa: E402 — sys.path mutation above
+from dispatcher.daemon import (  # noqa: E402
+    FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED,
+    PhaseOutputFetchError,
+    TIER_2_FIRST_OCCURRENCE_CATEGORIES,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fakes (mirror test_daemon_summary_output_incomplete.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> "_FakeCursor":
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> "_FakeCursor":
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(
+        f"dispatcher.test.phase_output_db_failure.{id(tmp_path)}"
+    )
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+def _patch_push_and_open_pr_helpers(
+    d: daemon.DispatcherDaemon,
+    *,
+    fetch_side_effect: Any,
+) -> None:
+    """Stub helpers for ``_push_and_open_pr`` so DB/subprocess are not needed.
+
+    Sets ``_fetch_phase_output`` to raise (or return) according to
+    ``fetch_side_effect``. ``_handle_agent_failure`` is captured for assertions.
+    """
+    d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+    d._is_noop_ship = MagicMock(return_value=False)  # type: ignore[method-assign]
+    d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+    d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+    d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+        side_effect=fetch_side_effect
+    )
+
+
+def _patch_run_summary_phase_helpers(
+    d: daemon.DispatcherDaemon,
+    *,
+    fetch_side_effect: Any,
+) -> None:
+    """Stub helpers for ``_run_summary_phase``."""
+    d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+    d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+    d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+    d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+    d._read_phase_output = MagicMock(  # type: ignore[method-assign]
+        return_value={
+            "commit_message": "feat(foo): bar (#3385)",
+            "pr_title": "feat(foo): bar (#3385)",
+            "pr_body_md": "## Summary\n\nBar.\n\nCloses #3385",
+        }
+    )
+    d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+    d._extract_log_preview = MagicMock(return_value="")  # type: ignore[method-assign]
+    d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
+    d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+    d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+    d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
+        return_value={
+            "issue_number": 3385,
+            "issue_title": "Test issue",
+            "issue_body": "Body",
+            "issue_comments": [],
+            "issue_labels": [],
+            "blocked_by": [],
+            "parent_issue": None,
+        }
+    )
+    d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+        side_effect=fetch_side_effect
+    )
+
+
+def _patch_run_ralph_phase_helpers(
+    d: daemon.DispatcherDaemon,
+    *,
+    fetch_side_effect: Any,
+) -> None:
+    """Stub helpers for ``_run_ralph_phase``."""
+    d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+    d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+    d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+    d._apply_prior_ralph_patch = MagicMock(return_value=None)  # type: ignore[method-assign]
+    d._materialize_prior_attempts = MagicMock(return_value=0)  # type: ignore[method-assign]
+    d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
+    d._read_phase_output = MagicMock(  # type: ignore[method-assign]
+        return_value={
+            "ship": True,
+            "summary": "Implemented the fix",
+            "changed_files": ["scripts/dispatcher/daemon.py"],
+        }
+    )
+    d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+    d._extract_log_preview = MagicMock(return_value="")  # type: ignore[method-assign]
+    d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
+    d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+    d._write_phase_input = MagicMock()  # type: ignore[method-assign]
+    d._store_ralph_patch = MagicMock()  # type: ignore[method-assign]
+    d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
+        side_effect=fetch_side_effect
+    )
+
+
+# ---------------------------------------------------------------------------
+# _fetch_phase_output unit tests (low-level)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPhaseOutputDirectly:
+    """Tests that directly drive _fetch_phase_output to verify the raise path."""
+
+    def test_fetch_phase_output_raises_phase_output_fetch_error_on_exception(
+        self, tmp_path: Path
+    ) -> None:
+        """A psycopg (or any) exception inside _fetch_phase_output must raise
+        PhaseOutputFetchError — not return None.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        # Make cursor().execute() raise to simulate a psycopg OperationalError.
+        class _FakePsycopgError(Exception):
+            pass
+
+        class _ExplodingCursor:
+            def __enter__(self) -> "_ExplodingCursor":
+                return self
+
+            def __exit__(self, *_exc: Any) -> None:
+                return None
+
+            def execute(self, *_a: Any, **_kw: Any) -> None:
+                raise _FakePsycopgError("connection lost")
+
+        class _ExplodingConn:
+            commits = 0
+            rollbacks = 0
+
+            def cursor(self) -> "_ExplodingCursor":
+                return _ExplodingCursor()
+
+            def commit(self) -> None:
+                self.commits += 1
+
+            def rollback(self) -> None:
+                self.rollbacks += 1
+
+        d._conn = _ExplodingConn()  # type: ignore[assignment]
+
+        with pytest.raises(PhaseOutputFetchError) as exc_info:
+            d._fetch_phase_output("agent-abc", "summary")
+
+        # __cause__ must be the original psycopg exception.
+        assert isinstance(exc_info.value.__cause__, _FakePsycopgError)
+
+    def test_fetch_phase_output_row_none_returns_none(self, tmp_path: Path) -> None:
+        """Row not found (no DB error) still returns None — no regression."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        # _FakeConnection's cursor fetchone() returns None by default.
+        result = d._fetch_phase_output("agent-abc", "plan")
+        assert result is None
+
+    def test_happy_path_fetch_phase_output_returns_dict(self, tmp_path: Path) -> None:
+        """Normal path: row present with a dict JSONB → dict returned, no raise."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue.append(({"commit_message": "feat: x"},))
+        result = d._fetch_phase_output("agent-abc", "summary")
+        assert result == {"commit_message": "feat: x"}
+
+
+# ---------------------------------------------------------------------------
+# _push_and_open_pr DB-failure routing tests
+# ---------------------------------------------------------------------------
+
+
+class TestPushAndOpenPrDbFailureRouting:
+    def test_summary_fetch_psycopg_error_routes_through_handle_agent_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """Single PhaseOutputFetchError from ``_fetch_phase_output(phase='summary')``
+        inside ``_push_and_open_pr`` must route through ``_handle_agent_failure``
+        with ``category=phase_output_fetch_failed``, and must NOT open a PR or
+        amend a commit.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        cause = Exception("connection lost")
+        err = PhaseOutputFetchError("DB error fetching summary")
+        err.__cause__ = cause
+
+        _patch_push_and_open_pr_helpers(
+            d,
+            fetch_side_effect=err,
+        )
+
+        d._push_and_open_pr("agent-db-fail", 3385, worktree)
+
+        # _handle_agent_failure called once with the right category.
+        d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
+        kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["agent_id"] == "agent-db-fail"
+        assert kwargs["category"] == FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED
+        assert kwargs["issue_number"] == 3385
+
+        # No terminal was called directly — the unified handler owns that.
+        d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
+
+    def test_persistent_fetch_failure_does_not_open_pr(self, tmp_path: Path) -> None:
+        """Three consecutive PhaseOutputFetchError raises across three
+        ``_push_and_open_pr`` calls must all route through
+        ``_handle_agent_failure``; no ``git commit --amend`` or ``gh pr create``.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        # Build a factory that always produces a fresh PhaseOutputFetchError.
+        def _make_err() -> PhaseOutputFetchError:
+            cause = Exception("db unavailable")
+            err = PhaseOutputFetchError("fetch failed")
+            err.__cause__ = cause
+            return err
+
+        _patch_push_and_open_pr_helpers(
+            d,
+            fetch_side_effect=[_make_err(), _make_err(), _make_err()],
+        )
+
+        # Drive three consecutive calls.
+        d._push_and_open_pr("agent-persistent", 3385, worktree)
+        d._push_and_open_pr("agent-persistent", 3385, worktree)
+        d._push_and_open_pr("agent-persistent", 3385, worktree)
+
+        # All three routed through _handle_agent_failure.
+        assert d._handle_agent_failure.call_count == 3  # type: ignore[union-attr]
+        for call in d._handle_agent_failure.call_args_list:  # type: ignore[union-attr]
+            assert call.kwargs["category"] == FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED
+
+        # No direct terminal call.
+        d._mark_agent_terminal.assert_not_called()  # type: ignore[union-attr]
+
+
+# ---------------------------------------------------------------------------
+# _run_summary_phase DB-failure routing tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunSummaryPhaseDbFailureRouting:
+    def test_run_summary_phase_ralph_fetch_psycopg_error_routes_through_handle_agent_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """PhaseOutputFetchError from the ralph fetch inside ``_run_summary_phase``
+        routes through ``_handle_agent_failure`` with
+        ``category=phase_output_fetch_failed`` and returns False.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        cause = Exception("connection lost")
+        err = PhaseOutputFetchError("DB error fetching ralph output")
+        err.__cause__ = cause
+
+        # First (ralph) fetch raises; return value is never reached.
+        _patch_run_summary_phase_helpers(
+            d,
+            fetch_side_effect=err,
+        )
+
+        result = d._run_summary_phase("agent-db-fail-summary", 3385, worktree)
+
+        assert result is False
+        d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
+        kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["agent_id"] == "agent-db-fail-summary"
+        assert kwargs["category"] == FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED
+        assert kwargs["issue_number"] == 3385
+
+    def test_run_summary_phase_plan_fetch_psycopg_error_routes_through_handle_agent_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """PhaseOutputFetchError from the plan fetch inside ``_run_summary_phase``
+        (after the ralph fetch succeeds) routes through ``_handle_agent_failure``
+        with ``category=phase_output_fetch_failed`` and returns False.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        # First call (ralph fetch) returns a valid dict; second call (plan fetch) raises.
+        ralph_dict = {"changed_files": ["scripts/dispatcher/daemon.py"], "summary": "x"}
+        cause = Exception("db gone away")
+        plan_err = PhaseOutputFetchError("DB error fetching plan output")
+        plan_err.__cause__ = cause
+
+        _patch_run_summary_phase_helpers(
+            d,
+            fetch_side_effect=[ralph_dict, plan_err],
+        )
+
+        result = d._run_summary_phase("agent-db-fail-plan", 3385, worktree)
+
+        assert result is False
+        d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
+        kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["agent_id"] == "agent-db-fail-plan"
+        assert kwargs["category"] == FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED
+        assert kwargs["issue_number"] == 3385
+
+
+# ---------------------------------------------------------------------------
+# _run_ralph_phase DB-failure routing tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunRalphPhaseDbFailureRouting:
+    def test_run_ralph_phase_fetch_psycopg_error_routes_through_handle_agent_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """PhaseOutputFetchError from ``_fetch_phase_output(phase='plan')`` inside
+        ``_run_ralph_phase`` routes through ``_handle_agent_failure`` with
+        ``category=phase_output_fetch_failed`` and returns False.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        cause = Exception("connection lost")
+        err = PhaseOutputFetchError("DB error fetching plan output")
+        err.__cause__ = cause
+
+        _patch_run_ralph_phase_helpers(
+            d,
+            fetch_side_effect=err,
+        )
+
+        result = d._run_ralph_phase("agent-db-fail-ralph", 3385, worktree)
+
+        assert result is False
+        d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
+        kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
+        assert kwargs["agent_id"] == "agent-db-fail-ralph"
+        assert kwargs["category"] == FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED
+        assert kwargs["issue_number"] == 3385
+
+
+# ---------------------------------------------------------------------------
+# Tier classification regression guard
+# ---------------------------------------------------------------------------
+
+
+class TestTierClassification:
+    def test_phase_output_fetch_failed_in_tier2_first_occurrence(self) -> None:
+        """The new category must diagnose on first occurrence so the diagnoser
+        can pick retry vs escalate — mirror the phase_output_missing assertion.
+        """
+        assert (
+            FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED
+            in TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        )


### PR DESCRIPTION
## Summary

Fixed `_fetch_phase_output` to raise `PhaseOutputFetchError` on psycopg/DB-layer exceptions instead of silently returning `None`. This prevents transient DB errors from producing empty `commit_message`/`pr_title`/`unmet_criteria` payloads that would garbage-ify commits, PRs, or wedge downstream phases.

Added the new exception class and `FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED` constant to tier-2 first-occurrence categories. Wrapped hot-path call sites in `_run_ralph_phase`, `_run_summary_phase`, and `_push_and_open_pr` to catch the exception and route through `_handle_agent_failure` so the diagnoser can pick `retry` vs `escalate` based on whether the failure is transient or persistent.

Closes #3385

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`) — pre-PR checks passed
- [x] Format check passes (`ruff format --check` / prettier) — pre-PR checks passed
- [x] Tests pass (`pytest` / `npm test`) — 1699 tests pass with 100% diff coverage
- [x] CI green — awaiting merge

### Post-deploy verification

- [x] N/A — no deployed component (internal daemon error handling, no user-visible affordance change)