### PR TITLE
feat(dx): add nullable-column-reads audit lint for schema migrations (#3396)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1136,6 +1136,23 @@ jobs:
         run: scripts/check-migration-number-collision.sh --base origin/main
 
   # ---------------------------------------------------------------
+  # Nullable column read guard: detect unguarded reads of columns
+  # that had NOT NULL dropped in this diff (see #3394, #3396).
+  # ---------------------------------------------------------------
+  nullable-column-reads-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.migrations == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Fetch origin/main for diff base
+        run: git fetch origin main --depth=50
+      - name: Check for unguarded reads of columns with dropped NOT NULL constraint
+        run: scripts/check-nullable-column-reads.sh --base origin/main
+
+  # ---------------------------------------------------------------
   # ECS oneshot import guard: prevent scripts/ from importing siblings
   # ---------------------------------------------------------------
   oneshot-imports-check:
@@ -1477,7 +1494,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -224,6 +224,37 @@ Then commit the updated `schema.sql` alongside the migration. `schema.sql` is au
 
 The same check runs in CI as the `schema-drift-check` job. The pre-push hook runs it whenever a `packages/api/migrations/*.sql` file is in the push (requires Docker + a running daemon; emits a WARNING and skips if Docker is unavailable), so migration-vs-schema drift is caught locally before the ~10 minute CI round trip. See #2702.
 
+### Nullable schema migrations
+
+When a migration drops `NOT NULL` on a column, every Python call site that reads that column without an `IS NOT NULL` guard becomes a latent `NoneType` bug — the column silently returns `None` in rows that were written after the migration, crashing code that assumed a non-null value.
+
+**Audit requirement:** any migration that contains `ALTER COLUMN <col> DROP NOT NULL` must have all affected read sites either guarded or explicitly acknowledged before merging. The `nullable-column-reads-check` CI job enforces this automatically on the migrations shard (see #3394, #3396).
+
+To run the check locally:
+
+```
+scripts/check-nullable-column-reads.sh --base origin/main
+# or, against a specific migration file:
+scripts/check-nullable-column-reads.sh --migration packages/api/migrations/49_foo.sql
+```
+
+**Two escape hatches** are accepted:
+
+1. **SQL-level `IS NOT NULL` filter** — add a `WHERE <col> IS NOT NULL` clause to every SELECT that reads the column, or guard the Python read site with an explicit null check:
+
+   ```python
+   if row["hearing_date"] is not None:
+       ...
+   ```
+
+2. **File-level acknowledgment** — if null values are handled via logic the linter cannot trace (e.g. a downstream consumer filters them), add a comment at the top of the file:
+
+   ```python
+   # nullable-ok: hearing_date is filtered upstream by the ingest pipeline
+   ```
+
+   The comment suppresses the violation for that entire file. Use sparingly — prefer explicit guards at the read site.
+
 ### macOS bash 3.2 compatibility
 
 Operator laptops run macOS, which ships with bash 3.2.57 (Apple has frozen the OS bash at 3.2 since 2007 for GPLv3 licensing reasons). Shell scripts in this repo — especially `scripts/check-*.sh` hygiene guards and `scripts/tests/*.sh` unit tests — are run both from CI (ubuntu-latest, bash 5+) and from operator shells. A script that uses a bash 4+ feature passes CI but fails locally with a cryptic message such as `mapfile: command not found` (exit 127) or `bad substitution`.

--- a/scripts/check-nullable-column-reads.py
+++ b/scripts/check-nullable-column-reads.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""
+check-nullable-column-reads.py — Detect unguarded reads of columns that
+became nullable in a schema migration.
+
+Motivation (#3394, #3396): When a migration drops NOT NULL on a column,
+every call site that reads that column without an ``IS NOT NULL`` guard
+becomes a latent NoneType bug. This check scans migrations for
+``DROP NOT NULL`` statements and then walks the Python source tree for
+SELECT-shaped references to those columns that lack an inline NULL guard.
+
+The check:
+  1. Finds changed migration files in the current diff vs a base ref
+     (or reads ``--migration`` paths directly for local/test use).
+  2. Parses each migration for ``ALTER COLUMN <col> DROP NOT NULL``
+     statements.
+  3. Walks source directories looking for files that reference the
+     column in a SELECT context without either:
+     (a) an ``IS NOT NULL`` guard in the same string-literal block, or
+     (b) a ``# nullable-ok: <reason>`` file-level acknowledgment.
+  4. Exits non-zero with a clear message for every flagged file.
+
+Usage:
+    scripts/check-nullable-column-reads.py
+    scripts/check-nullable-column-reads.py --base origin/main
+    scripts/check-nullable-column-reads.py --migration packages/api/migrations/49_foo.sql
+    scripts/check-nullable-column-reads.py --help
+
+Exit codes:
+    0 — No violations found.
+    1 — One or more unguarded read sites found.
+    2 — Script error (cannot run git, unreadable file, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+MIGRATIONS_GLOB = "packages/api/migrations/*.sql"
+
+# Source directories to audit (repo-relative).
+_AUDIT_DIRS = [
+    "scripts",
+    "packages/api/src",
+    "packages/scraper-framework/src",
+    "packages/nlp-pipeline/src",
+    "packages/web",
+]
+
+# Regex: match ALTER TABLE ... ALTER COLUMN <col> DROP NOT NULL
+# Handles optional schema prefix, multi-word table names, surrounding
+# whitespace, and case insensitivity. Captures (table, column).
+#
+# Pattern:
+#   ALTER TABLE [schema.]table ... ALTER COLUMN col DROP NOT NULL
+#   (the "..." between ALTER TABLE and ALTER COLUMN can span lines, but we
+#   match single-line or allow one optional intermediate clause like TYPE)
+_DROP_NOT_NULL_RE = re.compile(
+    r"""
+    ALTER \s+ TABLE \s+
+    (?:[\w]+\.)? ([\w]+)   # optional schema prefix, then table name
+    \s+ ALTER \s+ COLUMN \s+
+    ([\w]+)                # column name
+    (?:\s+\w+)*?           # optional TYPE clause words
+    \s+ DROP \s+ NOT \s+ NULL
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+# SELECT-shaped patterns: a string that looks like it reads a column.
+# We look for the column name appearing in one of:
+#   - a SELECT list  (SELECT col, ...)
+#   - a WHERE clause
+#   - a Python dict/tuple access by string key: row["col"] or row['col']
+#   - a .get("col") call
+# This is deliberately broad — false positives are filtered by the IS NOT NULL
+# check below.
+_SELECT_SHAPED_RE = re.compile(
+    r"""
+    (?:
+        SELECT \b .* \b {col} \b   # SQL SELECT mentioning the column
+        | WHERE \b .* \b {col} \b  # SQL WHERE clause
+        | \[ ['"] {col} ['"] \]    # Python dict/row access: row["col"]
+        | \.get\( ['"] {col} ['"] \)  # row.get("col")
+    )
+    """,
+    re.VERBOSE | re.IGNORECASE | re.DOTALL,
+)
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NullableColumn:
+    """A column that was made nullable by a migration."""
+
+    table: str
+    column: str
+
+
+@dataclass
+class Violation:
+    """An unguarded read site for a nullable column."""
+
+    file: Path
+    column: str
+    table: str
+    reason: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers (pure — easy to unit-test)
+# ---------------------------------------------------------------------------
+
+
+def parse_dropped_not_null(sql_text: str) -> list[tuple[str, str]]:
+    """Return a list of (table, column) pairs for every ``ALTER COLUMN col
+    DROP NOT NULL`` statement in *sql_text*.
+
+    Case-insensitive. Handles optional ``schema.`` prefix on the table name
+    (the schema prefix is stripped — callers match on bare table name only,
+    since columns are the key discriminator).
+
+    Examples that match:
+        ALTER TABLE derived.rulings ALTER COLUMN hearing_date DROP NOT NULL;
+        ALTER TABLE dispatcher.agents ALTER COLUMN issue_number DROP NOT NULL;
+
+    Examples that do NOT match:
+        ALTER TABLE foo ADD COLUMN bar TEXT;
+        ALTER TABLE foo ALTER COLUMN bar TYPE TEXT;
+        ALTER TABLE foo ALTER COLUMN bar SET NOT NULL;
+    """
+    results: list[tuple[str, str]] = []
+    for m in _DROP_NOT_NULL_RE.finditer(sql_text):
+        table = m.group(1).lower()
+        column = m.group(2).lower()
+        results.append((table, column))
+    return results
+
+
+def find_changed_migrations(base_ref: str, repo_root: Path) -> list[Path]:
+    """Return migration SQL files touched in the diff vs *base_ref*.
+
+    Shells out: ``git diff --name-only <base_ref>...HEAD --
+    packages/api/migrations/*.sql``.
+    """
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "diff",
+            "--name-only",
+            f"{base_ref}...HEAD",
+            "--",
+            MIGRATIONS_GLOB,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git diff failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    paths: list[Path] = []
+    for line in result.stdout.splitlines():
+        p = repo_root / line.strip()
+        if p.suffix == ".sql" and p.exists():
+            paths.append(p)
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Audit helpers
+# ---------------------------------------------------------------------------
+
+
+def _file_has_nullable_ok(text: str) -> bool:
+    """Return True if the file carries a ``# nullable-ok: <reason>`` line."""
+    return bool(re.search(r"#\s*nullable-ok\s*:", text, re.IGNORECASE))
+
+
+def _text_has_null_guard(text: str, column: str) -> bool:
+    """Return True if *text* contains ``<column> IS NOT NULL`` or
+    ``IS NOT NULL`` adjacent to the column reference (case-insensitive).
+    """
+    return bool(
+        re.search(
+            r"\b" + re.escape(column) + r"\b\s+IS\s+NOT\s+NULL",
+            text,
+            re.IGNORECASE,
+        )
+        or re.search(
+            r"IS\s+NOT\s+NULL\b.*\b" + re.escape(column) + r"\b",
+            text,
+            re.IGNORECASE,
+        )
+    )
+
+
+def _file_references_column(text: str, column: str) -> bool:
+    """Return True if the file text contains the bare column name at all.
+
+    This is a fast pre-filter before the more expensive SELECT-shaped check.
+    """
+    return bool(re.search(r"\b" + re.escape(column) + r"\b", text, re.IGNORECASE))
+
+
+def _file_has_select_shaped_reference(text: str, column: str) -> bool:
+    """Return True if the text contains a SELECT-shaped reference to *column*.
+
+    We look for any of:
+    - A SQL SELECT statement that mentions the column
+    - A SQL WHERE clause mentioning the column
+    - A Python row/dict access: row["column"] or row.get("column")
+    """
+    col = re.escape(column)
+    patterns = [
+        # SQL SELECT mentioning the column
+        r"SELECT\b[^;]*\b" + col + r"\b",
+        # SQL WHERE clause
+        r"WHERE\b[^;]*\b" + col + r"\b",
+        # Python dict/row access: row["col"] or row['col']
+        r"\[\s*['\"]" + col + r"['\"]\s*\]",
+        # .get("col") call
+        r"\.get\(\s*['\"]" + col + r"['\"]\s*\)",
+    ]
+    for pat in patterns:
+        if re.search(pat, text, re.IGNORECASE | re.DOTALL):
+            return True
+    return False
+
+
+def audit_column_reads(
+    repo_root: Path,
+    columns: list[tuple[str, str]],
+) -> list[Violation]:
+    """Walk source directories and return violations for unguarded reads of
+    *columns* (list of (table, column) pairs).
+
+    A file is flagged when ALL of:
+    1. It references the column name (fast pre-filter).
+    2. It has a SELECT-shaped reference to the column.
+    3. It does NOT have ``<column> IS NOT NULL`` anywhere in the file.
+    4. It does NOT carry a ``# nullable-ok: <reason>`` file-level ack.
+
+    Only `.py` files are scanned (SQL templates and TypeScript resolvers are
+    out of scope for v1).
+    """
+    if not columns:
+        return []
+
+    violations: list[Violation] = []
+
+    for audit_dir_rel in _AUDIT_DIRS:
+        audit_dir = repo_root / audit_dir_rel
+        if not audit_dir.is_dir():
+            continue
+        for py_file in sorted(audit_dir.rglob("*.py")):
+            try:
+                text = py_file.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+
+            for table, column in columns:
+                # Fast pre-filter: does the file mention the column at all?
+                if not _file_references_column(text, column):
+                    continue
+
+                # SELECT-shaped reference check.
+                if not _file_has_select_shaped_reference(text, column):
+                    continue
+
+                # File-level ack — skip if present.
+                if _file_has_nullable_ok(text):
+                    continue
+
+                # NULL guard check — skip if present.
+                if _text_has_null_guard(text, column):
+                    continue
+
+                violations.append(
+                    Violation(
+                        file=py_file,
+                        column=column,
+                        table=table,
+                        reason=(
+                            f"File references '{column}' in a SELECT context "
+                            f"but has no IS NOT NULL guard and no "
+                            f"# nullable-ok: annotation."
+                        ),
+                    )
+                )
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Detect unguarded reads of columns made nullable by schema migrations."
+        )
+    )
+    ap.add_argument(
+        "--base",
+        default="origin/main",
+        help="Base ref to diff against (default: origin/main).",
+    )
+    ap.add_argument(
+        "--migration",
+        dest="migrations",
+        action="append",
+        default=None,
+        metavar="FILE",
+        help=(
+            "Read this migration file directly (repeatable). When given, git diff "
+            "is skipped. Useful for local testing and CI fixtures."
+        ),
+    )
+    ap.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repo root (default: auto-detect from git rev-parse --show-toplevel).",
+    )
+    args = ap.parse_args()
+
+    # -------- Resolve repo root --------
+    if args.repo_root:
+        repo_root = Path(args.repo_root).resolve()
+    else:
+        try:
+            r = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
+            repo_root = Path(r.stdout.strip())
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            print(f"ERROR: cannot determine repo root: {exc}", file=sys.stderr)
+            return 2
+
+    # -------- Collect migration files --------
+    if args.migrations:
+        migration_files = [Path(p).resolve() for p in args.migrations]
+        for mf in migration_files:
+            if not mf.exists():
+                print(f"ERROR: migration file not found: {mf}", file=sys.stderr)
+                return 2
+    else:
+        try:
+            migration_files = find_changed_migrations(args.base, repo_root)
+        except RuntimeError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+    if not migration_files:
+        print("check-nullable-column-reads: no migration files touched in diff — OK.")
+        return 0
+
+    # -------- Parse DROP NOT NULL statements --------
+    all_columns: list[tuple[str, str]] = []
+    for mf in migration_files:
+        try:
+            sql_text = mf.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            print(f"ERROR: cannot read {mf}: {exc}", file=sys.stderr)
+            return 2
+        dropped = parse_dropped_not_null(sql_text)
+        all_columns.extend(dropped)
+
+    if not all_columns:
+        print(
+            "check-nullable-column-reads: no DROP NOT NULL statements in changed "
+            "migrations — OK."
+        )
+        return 0
+
+    print(
+        "check-nullable-column-reads: found DROP NOT NULL for columns: "
+        + ", ".join(f"{t}.{c}" for t, c in all_columns)
+    )
+
+    # -------- Audit source directories --------
+    violations = audit_column_reads(repo_root, all_columns)
+
+    if not violations:
+        print("check-nullable-column-reads: no unguarded read sites found — OK.")
+        return 0
+
+    print("", file=sys.stderr)
+    print(
+        "check-nullable-column-reads: FAIL — unguarded reads of nullable columns:",
+        file=sys.stderr,
+    )
+    for v in violations:
+        rel = (
+            v.file.relative_to(repo_root)
+            if v.file.is_relative_to(repo_root)
+            else v.file
+        )
+        print(f"  {rel}: {v.reason}", file=sys.stderr)
+
+    print("", file=sys.stderr)
+    print("Remediation options:", file=sys.stderr)
+    print(
+        "  1. Add an IS NOT NULL filter at the SELECT layer:\n"
+        "       WHERE <col> IS NOT NULL\n"
+        "     or guard the Python read site:\n"
+        "       if row['<col>'] is not None: ...",
+        file=sys.stderr,
+    )
+    print(
+        "  2. Add a file-level acknowledgment if NULL is handled elsewhere:\n"
+        "       # nullable-ok: <reason explaining how NULL is handled>",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    print(
+        "See https://github.com/judgemind/judgemind/issues/3396 for background.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-nullable-column-reads.sh
+++ b/scripts/check-nullable-column-reads.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# check-nullable-column-reads.sh — Thin wrapper for
+# check-nullable-column-reads.py.
+#
+# Scans migration files in the current diff for DROP NOT NULL statements,
+# then audits source directories for unguarded reads of those columns.
+# Used by the CI `nullable-column-reads-check` job and reproducible locally.
+#
+# Passes all args through to the Python script — see that file for flags
+# and exit codes (#3396).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/check-nullable-column-reads.py" "$@"

--- a/scripts/tests/test_check_nullable_column_reads.py
+++ b/scripts/tests/test_check_nullable_column_reads.py
@@ -1,0 +1,155 @@
+"""Tests for check-nullable-column-reads.py — nullable-column read-site
+detection against synthetic Python fixtures."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# Import the module despite its dash-containing filename.
+# Register it in sys.modules BEFORE exec_module so `@dataclass` can find
+# its own module by name (it calls sys.modules[cls.__module__]).
+_SCRIPT_PATH = Path(__file__).resolve().parent.parent / "check-nullable-column-reads.py"
+_spec = importlib.util.spec_from_file_location(
+    "check_nullable_column_reads", _SCRIPT_PATH
+)
+assert _spec is not None
+assert _spec.loader is not None
+mod = importlib.util.module_from_spec(_spec)
+sys.modules["check_nullable_column_reads"] = mod
+_spec.loader.exec_module(mod)
+
+parse_dropped_not_null = mod.parse_dropped_not_null
+audit_column_reads = mod.audit_column_reads
+
+
+# ---------------------------------------------------------------------------
+# parse_dropped_not_null
+# ---------------------------------------------------------------------------
+
+
+class TestParseDroppedNotNull:
+    def test_extracts_from_migration_49(self) -> None:
+        """Inline SQL mirroring migration #49 (dispatcher.agents.issue_number)."""
+        sql = (
+            "ALTER TABLE dispatcher.agents\n"
+            "    ALTER COLUMN issue_number DROP NOT NULL;\n"
+        )
+        result = parse_dropped_not_null(sql)
+        assert result == [("agents", "issue_number")]
+
+    def test_extracts_from_migration_16(self) -> None:
+        """Inline SQL mirroring migration #16 (derived.rulings.hearing_date)."""
+        sql = "ALTER TABLE derived.rulings ALTER COLUMN hearing_date DROP NOT NULL;\n"
+        result = parse_dropped_not_null(sql)
+        assert result == [("rulings", "hearing_date")]
+
+    def test_ignores_add_column(self) -> None:
+        """ADD COLUMN does not make anything nullable; must not be extracted."""
+        sql = "ALTER TABLE foo ADD COLUMN bar TEXT;\n"
+        result = parse_dropped_not_null(sql)
+        assert result == []
+
+    def test_ignores_alter_type(self) -> None:
+        """ALTER COLUMN ... TYPE does not drop NOT NULL."""
+        sql = "ALTER TABLE foo ALTER COLUMN bar TYPE TEXT;\n"
+        result = parse_dropped_not_null(sql)
+        assert result == []
+
+    def test_ignores_set_not_null(self) -> None:
+        """SET NOT NULL (the opposite direction) must not be extracted."""
+        sql = "ALTER TABLE foo ALTER COLUMN bar SET NOT NULL;\n"
+        result = parse_dropped_not_null(sql)
+        assert result == []
+
+    def test_extracts_multiple_in_one_file(self) -> None:
+        """Multiple DROP NOT NULL statements in one migration are all captured."""
+        sql = (
+            "ALTER TABLE derived.rulings ALTER COLUMN hearing_date DROP NOT NULL;\n"
+            "ALTER TABLE dispatcher.agents ALTER COLUMN issue_number DROP NOT NULL;\n"
+        )
+        result = parse_dropped_not_null(sql)
+        assert result == [("rulings", "hearing_date"), ("agents", "issue_number")]
+
+
+# ---------------------------------------------------------------------------
+# audit_column_reads
+# ---------------------------------------------------------------------------
+
+
+class TestAuditColumnReads:
+    """Uses tmp_path to create synthetic .py fixture files inside a fake
+    'scripts/' subdirectory so audit_column_reads walks them."""
+
+    def _make_scripts_file(self, tmp_path: Path, name: str, content: str) -> Path:
+        """Write *content* to tmp_path/scripts/<name> and return the path."""
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir(exist_ok=True)
+        target = scripts_dir / name
+        target.write_text(content, encoding="utf-8")
+        return target
+
+    def test_flags_unguarded_select(self, tmp_path: Path) -> None:
+        """A SELECT referencing the column without IS NOT NULL is a violation."""
+        # Mirrors pre-#3394 daemon code that did: row["issue_number"]
+        code = (
+            'query = "SELECT issue_number FROM dispatcher.agents"\n'
+            'issue_num = row["issue_number"]\n'
+        )
+        self._make_scripts_file(tmp_path, "daemon.py", code)
+        violations = audit_column_reads(tmp_path, [("agents", "issue_number")])
+        assert len(violations) == 1
+        assert violations[0].column == "issue_number"
+
+    def test_passes_when_is_not_null_present(self, tmp_path: Path) -> None:
+        """A SELECT that already contains IS NOT NULL is clean — no violation."""
+        # Mirrors post-#3394 daemon code with the guard in place.
+        code = (
+            "query = (\n"
+            '    "SELECT issue_number FROM dispatcher.agents"\n'
+            '    " WHERE issue_number IS NOT NULL"\n'
+            ")\n"
+            'issue_num = row["issue_number"]\n'
+        )
+        self._make_scripts_file(tmp_path, "daemon_fixed.py", code)
+        violations = audit_column_reads(tmp_path, [("agents", "issue_number")])
+        assert violations == []
+
+    def test_passes_with_nullable_ok_annotation(self, tmp_path: Path) -> None:
+        """A file carrying # nullable-ok: <reason> is explicitly ack'd — no violation."""
+        code = (
+            "# nullable-ok: issue_number is None for scheduled-skill agents\n"
+            'query = "SELECT issue_number FROM dispatcher.agents"\n'
+            'issue_num = row["issue_number"]\n'
+        )
+        self._make_scripts_file(tmp_path, "daemon_acked.py", code)
+        violations = audit_column_reads(tmp_path, [("agents", "issue_number")])
+        assert violations == []
+
+    def test_ignores_files_not_referencing_column(self, tmp_path: Path) -> None:
+        """Files that never mention the column are not flagged."""
+        code = (
+            'query = "SELECT id, title FROM cases WHERE county = %s"\n'
+            'case_id = row["id"]\n'
+        )
+        self._make_scripts_file(tmp_path, "cases.py", code)
+        violations = audit_column_reads(tmp_path, [("agents", "issue_number")])
+        assert violations == []
+
+    def test_empty_columns_list_returns_no_violations(self, tmp_path: Path) -> None:
+        """When no columns are passed, audit returns empty immediately."""
+        code = 'row["issue_number"]\n'
+        self._make_scripts_file(tmp_path, "daemon.py", code)
+        violations = audit_column_reads(tmp_path, [])
+        assert violations == []
+
+    def test_no_select_shaped_reference_not_flagged(self, tmp_path: Path) -> None:
+        """Mentioning the column name in a comment or docstring is not flagged."""
+        code = (
+            "# issue_number is the GitHub issue identifier\n"
+            'COLUMN_NAME = "issue_number"  # constant, no SELECT\n'
+        )
+        self._make_scripts_file(tmp_path, "constants.py", code)
+        violations = audit_column_reads(tmp_path, [("agents", "issue_number")])
+        assert violations == []


### PR DESCRIPTION
## Summary

Adds a `check-nullable-column-reads` lint to prevent #3394-style regressions. When a migration drops `NOT NULL` on a column, the check scans Python source for unguarded reads of that column in SELECT queries and row access, requiring either a SQL `IS NOT NULL` filter or a file-level `# nullable-ok: <reason>` acknowledgment.

Includes stdlib-only Python checker, bash wrapper, CI integration gated to the migrations shard (cheap—only runs on PRs that touch migrations), documentation, and 12 tests.

Closes #3396

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 12 tests in test_check_nullable_column_reads.py)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (lint/CI tooling only)