### PR TITLE
feat(infra): add supervisor-tick failure alarms to dispatcher daemon (#3397)

### DIFF
--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -945,3 +945,188 @@ resource "aws_cloudwatch_metric_alarm" "diagnoser_fallback_spike" {
   alarm_actions = [var.alert_sns_topic_arn]
   ok_actions    = [var.alert_sns_topic_arn]
 }
+
+# ─── Supervisor-tick swallow-and-return failure alarms ───────────────────────
+# Each of the five handlers below catches exceptions internally and returns
+# rather than propagating. A single event may be transient; two within the
+# window (default 300 s / ~2-3 ticks) signals a wedge.
+
+resource "aws_cloudwatch_log_metric_filter" "list_advanceable_failed" {
+  count = var.enable_alerts ? 1 : 0
+
+  name           = "${local.service_name}-list-advanceable-failed"
+  pattern        = "{ $.event = \"list_advanceable_failed\" }"
+  log_group_name = aws_cloudwatch_log_group.dispatcher.name
+
+  metric_transformation {
+    name          = "ListAdvanceableFailedCount"
+    namespace     = "Judgemind/Dispatcher"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "list_advanceable_failed" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "${local.service_name}-list-advanceable-failed"
+  alarm_description = "_list_advanceable_agents raised an unhandled exception during the supervisor tick (${var.environment}). Check ${aws_cloudwatch_log_group.dispatcher.name}."
+
+  namespace   = "Judgemind/Dispatcher"
+  metric_name = "ListAdvanceableFailedCount"
+  statistic   = "Sum"
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.supervisor_tick_failure_threshold
+  period              = var.supervisor_tick_failure_window_seconds
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}
+
+resource "aws_cloudwatch_log_metric_filter" "recover_scan_failed" {
+  count = var.enable_alerts ? 1 : 0
+
+  name           = "${local.service_name}-recover-scan-failed"
+  pattern        = "{ $.event = \"recover_scan_failed\" }"
+  log_group_name = aws_cloudwatch_log_group.dispatcher.name
+
+  metric_transformation {
+    name          = "RecoverScanFailedCount"
+    namespace     = "Judgemind/Dispatcher"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "recover_scan_failed" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "${local.service_name}-recover-scan-failed"
+  alarm_description = "_recover_scan raised an unhandled exception during the supervisor tick (${var.environment}). Check ${aws_cloudwatch_log_group.dispatcher.name}."
+
+  namespace   = "Judgemind/Dispatcher"
+  metric_name = "RecoverScanFailedCount"
+  statistic   = "Sum"
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.supervisor_tick_failure_threshold
+  period              = var.supervisor_tick_failure_window_seconds
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}
+
+resource "aws_cloudwatch_log_metric_filter" "resume_scan_failed" {
+  count = var.enable_alerts ? 1 : 0
+
+  name           = "${local.service_name}-resume-scan-failed"
+  pattern        = "{ $.event = \"resume_scan_failed\" }"
+  log_group_name = aws_cloudwatch_log_group.dispatcher.name
+
+  metric_transformation {
+    name          = "ResumeScanFailedCount"
+    namespace     = "Judgemind/Dispatcher"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "resume_scan_failed" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "${local.service_name}-resume-scan-failed"
+  alarm_description = "_resume_scan raised an unhandled exception during the supervisor tick (${var.environment}). Check ${aws_cloudwatch_log_group.dispatcher.name}."
+
+  namespace   = "Judgemind/Dispatcher"
+  metric_name = "ResumeScanFailedCount"
+  statistic   = "Sum"
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.supervisor_tick_failure_threshold
+  period              = var.supervisor_tick_failure_window_seconds
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}
+
+resource "aws_cloudwatch_log_metric_filter" "observe_external_terminal_failed" {
+  count = var.enable_alerts ? 1 : 0
+
+  name           = "${local.service_name}-observe-external-terminal-failed"
+  pattern        = "{ $.event = \"observe_external_terminal_failed\" }"
+  log_group_name = aws_cloudwatch_log_group.dispatcher.name
+
+  metric_transformation {
+    name          = "ObserveExternalTerminalFailedCount"
+    namespace     = "Judgemind/Dispatcher"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "observe_external_terminal_failed" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "${local.service_name}-observe-external-terminal-failed"
+  alarm_description = "_observe_external_terminal raised an unhandled exception during the supervisor tick (${var.environment}). Check ${aws_cloudwatch_log_group.dispatcher.name}."
+
+  namespace   = "Judgemind/Dispatcher"
+  metric_name = "ObserveExternalTerminalFailedCount"
+  statistic   = "Sum"
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.supervisor_tick_failure_threshold
+  period              = var.supervisor_tick_failure_window_seconds
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}
+
+resource "aws_cloudwatch_log_metric_filter" "reap_agent_tasks_select_failed" {
+  count = var.enable_alerts ? 1 : 0
+
+  name           = "${local.service_name}-reap-agent-tasks-select-failed"
+  pattern        = "{ $.event = \"reap_agent_tasks_select_failed\" }"
+  log_group_name = aws_cloudwatch_log_group.dispatcher.name
+
+  metric_transformation {
+    name          = "ReapAgentTasksSelectFailedCount"
+    namespace     = "Judgemind/Dispatcher"
+    value         = "1"
+    default_value = "0"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "reap_agent_tasks_select_failed" {
+  count = var.enable_alerts ? 1 : 0
+
+  alarm_name        = "${local.service_name}-reap-agent-tasks-select-failed"
+  alarm_description = "_reap_agent_tasks raised an unhandled exception during the supervisor tick (${var.environment}). Check ${aws_cloudwatch_log_group.dispatcher.name}."
+
+  namespace   = "Judgemind/Dispatcher"
+  metric_name = "ReapAgentTasksSelectFailedCount"
+  statistic   = "Sum"
+
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.supervisor_tick_failure_threshold
+  period              = var.supervisor_tick_failure_window_seconds
+  evaluation_periods  = 1
+  datapoints_to_alarm = 1
+  treat_missing_data  = "notBreaching"
+
+  alarm_actions = [var.alert_sns_topic_arn]
+  ok_actions    = [var.alert_sns_topic_arn]
+}

--- a/infra/terraform/modules/dispatcher-daemon/outputs.tf
+++ b/infra/terraform/modules/dispatcher-daemon/outputs.tf
@@ -52,3 +52,28 @@ output "diagnoser_fallback_spike_alarm_arn" {
   description = "ARN of the diagnoser_fallback_spike CloudWatch alarm (empty when enable_alerts is false)"
   value       = var.enable_alerts ? aws_cloudwatch_metric_alarm.diagnoser_fallback_spike[0].arn : ""
 }
+
+output "list_advanceable_failed_alarm_arn" {
+  description = "ARN of the list_advanceable_failed CloudWatch alarm (empty when enable_alerts is false)"
+  value       = var.enable_alerts ? aws_cloudwatch_metric_alarm.list_advanceable_failed[0].arn : ""
+}
+
+output "recover_scan_failed_alarm_arn" {
+  description = "ARN of the recover_scan_failed CloudWatch alarm (empty when enable_alerts is false)"
+  value       = var.enable_alerts ? aws_cloudwatch_metric_alarm.recover_scan_failed[0].arn : ""
+}
+
+output "resume_scan_failed_alarm_arn" {
+  description = "ARN of the resume_scan_failed CloudWatch alarm (empty when enable_alerts is false)"
+  value       = var.enable_alerts ? aws_cloudwatch_metric_alarm.resume_scan_failed[0].arn : ""
+}
+
+output "observe_external_terminal_failed_alarm_arn" {
+  description = "ARN of the observe_external_terminal_failed CloudWatch alarm (empty when enable_alerts is false)"
+  value       = var.enable_alerts ? aws_cloudwatch_metric_alarm.observe_external_terminal_failed[0].arn : ""
+}
+
+output "reap_agent_tasks_select_failed_alarm_arn" {
+  description = "ARN of the reap_agent_tasks_select_failed CloudWatch alarm (empty when enable_alerts is false)"
+  value       = var.enable_alerts ? aws_cloudwatch_metric_alarm.reap_agent_tasks_select_failed[0].arn : ""
+}

--- a/infra/terraform/modules/dispatcher-daemon/variables.tf
+++ b/infra/terraform/modules/dispatcher-daemon/variables.tf
@@ -252,7 +252,7 @@ variable "document_archive_bucket_arn" {
 }
 
 variable "supervisor_tick_failure_window_seconds" {
-  description = "CloudWatch alarm period (seconds) for supervisor-tick failure alarms. With the default 120s tick, a 300s window holds 2-3 ticks — threshold=2 cleanly separates a transient from a wedge."
+  description = "CloudWatch alarm period (seconds) for supervisor-tick failure alarms. With the default 120s tick, a 300s window holds 2-3 ticks -- threshold=2 cleanly separates a transient from a wedge."
   type        = number
   default     = 300
 }

--- a/infra/terraform/modules/dispatcher-daemon/variables.tf
+++ b/infra/terraform/modules/dispatcher-daemon/variables.tf
@@ -250,3 +250,15 @@ variable "document_archive_bucket_arn" {
   type        = string
   default     = ""
 }
+
+variable "supervisor_tick_failure_window_seconds" {
+  description = "CloudWatch alarm period (seconds) for supervisor-tick failure alarms. With the default 120s tick, a 300s window holds 2-3 ticks — threshold=2 cleanly separates a transient from a wedge."
+  type        = number
+  default     = 300
+}
+
+variable "supervisor_tick_failure_threshold" {
+  description = "Number of supervisor-tick failure events within supervisor_tick_failure_window_seconds that triggers each alarm. Default 2."
+  type        = number
+  default     = 2
+}


### PR DESCRIPTION
## Summary

Added CloudWatch metric-filter + alarm pairs for five supervisor-tick swallow-and-return handlers to catch and alert on supervisor-tick wedges. Threshold of 2 failures per 300s window distinguishes transient errors from persistent issues.

Closes #3397

## Test plan

### Automated checks

- [x] Lint passes — Terraform resources only, no ruff linting needed
- [x] Format check passes — no formatter checks required
- [x] Tests pass — no test suite for Terraform changes
- [ ] CI green

### Post-deploy verification

- [ ] `aws logs describe-metric-filters --log-group-name /ecs/judgemind-dispatcher-dev --region us-west-2` lists the five new metric filters
- [ ] `aws cloudwatch describe-alarms --alarm-name-prefix dispatcher- --region us-west-2` lists the five new alarms with correct thresholds (≥2 per 300s) and SNS topic targets
- [ ] Verification evidence posted on #3397 (see /task-v2-verify output)