### PR TITLE
fix(dispatcher): resurrect orphaned-but-mergeable daemon PRs (#3399)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -78,7 +78,7 @@ import threading
 import time
 import uuid
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -1319,6 +1319,32 @@ STALE_ROLLUP_STDERR_MARKER = "base branch policy prohibits the merge"
 #: under :data:`FAILURE_CATEGORY_MERGE_UNSTICK_EXHAUSTED`. 1 matches
 #: the spec: "at most one auto-unstick attempt per agent lifetime".
 MERGE_UNSTICK_MAX_ATTEMPTS = 1
+
+#: How far back the orphan-PR resurrection sweep looks for failed
+#: agents whose PR may have become mergeable since the agent died
+#: (#3399). Agents whose ``ended_at`` is older than this window are
+#: skipped — operator-attention territory; a 2-day-old failed agent
+#: with a still-open PR is unlikely to be a transient flake. 24h
+#: matches the spec; tune via the constant rather than per-call.
+ORPHAN_PR_RESURRECTION_LOOKBACK = timedelta(hours=24)
+
+#: How many times the orphan-PR sweep will resurrect the same
+#: ``agent_id`` (#3399). Bound prevents an infinite loop where a
+#: resurrected agent keeps going green-then-red-then-green and we
+#: keep flipping it back to ``running`` forever. Counted by reading
+#: ``dispatcher.phase_transitions`` rows whose phase is
+#: :data:`PHASE_RESURRECTED_FOR_ORPHAN_PR`. 3 matches the issue's
+#: "don't resurrect more than 2-3 times per agent_id" guidance.
+ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS = 3
+
+#: Phase-transition marker the resurrection sweep writes when it
+#: flips a ``status='failed'`` agent back to ``status='running' AND
+#: phase='awaiting_ci'`` (#3399). Stored as a free-form
+#: ``dispatcher.phase_transitions`` row keyed by ``agent_id`` so the
+#: sweep can count past resurrections without a schema migration.
+#: NOT in the canonical phase progression — exists purely as an
+#: append-only audit + bookkeeping marker.
+PHASE_RESURRECTED_FOR_ORPHAN_PR = "resurrected_for_orphan_pr"
 
 #: Which failure categories auto-create a retry marker (tier 1 per
 #: spec §8 table). ``subprocess_turn_limit`` (tier 2) and
@@ -12652,6 +12678,325 @@ class DispatcherDaemon:
     # unhandled exceptions flip the agent to ``status='crashed'`` and
     # the supervisor tick continues with the next agent.
 
+    def _resurrect_orphan_pr_agents(self) -> int:
+        """Resurrect ``status='failed'`` agents whose PR is now mergeable.
+
+        Issue #3399. When a daemon-spawned agent dies after creating a
+        PR — e.g. ``status='failed' phase='fix_ci_failed'`` from a
+        transient CI flake or a since-resolved migration collision —
+        the PR remains open. CI may go green later (the flake clears,
+        sibling PRs land, the operator re-runs the failed jobs), making
+        the PR mergeable. But ``_list_advanceable_agents`` only picks
+        up ``status='running'`` (or ``'succeeded'`` for retro paths)
+        rows — failed agents are excluded, so the PR sits stuck.
+        Re-adding ``agent/ready`` to the issue spawns a NEW agent that
+        runs ralph from scratch on a fresh branch and doesn't reuse the
+        existing PR (and often dies on the same root cause).
+
+        This sweep, run once per supervisor tick BEFORE
+        :meth:`_advance_running_agents`, looks for ``status='failed'
+        AND pr_number IS NOT NULL AND ended_at >
+        now() - ORPHAN_PR_RESURRECTION_LOOKBACK`` rows. For each, it
+        fetches the PR's combined check rollup + merge state via
+        :meth:`_fetch_pr_status` and runs the same classifier
+        (:meth:`_classify_check_rollup`) the awaiting_ci handler uses.
+        Only when the classifier says ``'green'`` (open + mergeable +
+        all checks SUCCESS/SKIPPED + ``mergeStateStatus=CLEAN``) does
+        the sweep flip the row back to ``status='running' AND
+        phase='awaiting_ci'`` so the next tick's
+        :meth:`_advance_awaiting_ci` handler can drive the
+        ``gh pr merge`` path.
+
+        Bounds:
+
+        * **Recency:** :data:`ORPHAN_PR_RESURRECTION_LOOKBACK` (24h
+          default). Older failures are operator territory — not the
+          autonomous sweep's job.
+        * **Resurrection budget per agent_id:**
+          :data:`ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS` (3 default),
+          counted by reading
+          ``dispatcher.phase_transitions`` rows whose phase is
+          :data:`PHASE_RESURRECTED_FOR_ORPHAN_PR`. After the budget is
+          exhausted the row stays ``status='failed'`` and the
+          ``orphan_pr_resurrection_skipped`` event records the skip
+          reason.
+        * **PR-state guard:** the classifier's ``'green'`` predicate
+          rejects closed/merged PRs (``mergeable != 'MERGEABLE'``),
+          dirty PRs (``mergeStateStatus != 'CLEAN'``), and
+          still-pending CI. Skips emit ``orphan_pr_resurrection_skipped``
+          with a ``reason`` tag for CloudWatch grep.
+
+        On resurrection the row is also forced to
+        ``execution_mode='subprocess'``. The sweep is a daemon-owned
+        recovery path — the worktree is gone (cleaned up at terminal
+        time), the original agent's ECS Fargate task is gone, and the
+        ``_advance_awaiting_ci`` handler only needs the PR number to
+        merge. Forcing subprocess mode prevents
+        :meth:`_advance_running_agents`'s ECS short-circuit from
+        skipping the resurrected row.
+
+        Returns the number of agents this tick resurrected (for the
+        supervisor-tick log summary). Per-row failures (PR fetch
+        timeout, DB write error) are logged and swallowed so one bad
+        row cannot stall the sweep or the tick.
+        """
+        assert self._conn is not None, "connect() must run before resurrection sweep"
+
+        candidates = self._list_orphan_pr_failed_agents()
+        if not candidates:
+            return 0
+
+        resurrected = 0
+        for row in candidates:
+            agent_id = row["agent_id"]
+            pr_number = row["pr_number"]
+            issue_number = row["issue_number"]
+
+            # Budget check — count past resurrections for this agent_id
+            # via the phase_transitions audit log. This avoids needing
+            # a new schema column for the counter (#3399 is pure code).
+            past_attempts = self._count_orphan_pr_resurrections(agent_id)
+            if past_attempts >= ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS:
+                self._log.info(
+                    "daemon.orphan_pr_resurrection_skipped",
+                    extra={
+                        "event": "orphan_pr_resurrection_skipped",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "pr_number": pr_number,
+                        "issue_number": issue_number,
+                        "reason": "budget_exhausted",
+                        "past_attempts": past_attempts,
+                        "max_attempts": ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS,
+                    },
+                )
+                continue
+
+            # PR-state guard. Re-uses the same classifier as the
+            # awaiting_ci handler so the gate is consistent — if the
+            # PR isn't currently green-and-mergeable, don't resurrect.
+            pr_status = self._fetch_pr_status(pr_number)
+            if pr_status is None:
+                # Transient gh failure — log and skip; next tick re-tries.
+                self._log.info(
+                    "daemon.orphan_pr_resurrection_skipped",
+                    extra={
+                        "event": "orphan_pr_resurrection_skipped",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "pr_number": pr_number,
+                        "issue_number": issue_number,
+                        "reason": "pr_view_failed",
+                    },
+                )
+                continue
+
+            # The classifier returns 'green' only when all checks are
+            # SUCCESS/SKIPPED AND mergeable=MERGEABLE AND
+            # mergeStateStatus=CLEAN. Closed/merged PRs come back with
+            # mergeable in a different state, so this catches them too.
+            rollup_state = self._classify_check_rollup(pr_status)
+            if rollup_state != "green":
+                self._log.info(
+                    "daemon.orphan_pr_resurrection_skipped",
+                    extra={
+                        "event": "orphan_pr_resurrection_skipped",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "pr_number": pr_number,
+                        "issue_number": issue_number,
+                        "reason": f"rollup_state_{rollup_state}",
+                        "mergeable": pr_status.get("mergeable"),
+                        "merge_state_status": pr_status.get("mergeStateStatus"),
+                    },
+                )
+                continue
+
+            # Flip status='running' phase='awaiting_ci' and force
+            # execution_mode='subprocess'. The append to
+            # phase_transitions is part of the same transaction so the
+            # next sweep's budget count is accurate even if the daemon
+            # crashes between writes.
+            if not self._mark_agent_resurrected_for_orphan_pr(agent_id):
+                # Already logged inside the helper; advance to next row.
+                continue
+
+            self._log.info(
+                "daemon.agent_resurrected_for_orphan_pr",
+                extra={
+                    "event": "agent_resurrected_for_orphan_pr",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "pr_number": pr_number,
+                    "issue_number": issue_number,
+                    "past_attempts": past_attempts,
+                    "new_attempts": past_attempts + 1,
+                    "mergeable": pr_status.get("mergeable"),
+                    "merge_state_status": pr_status.get("mergeStateStatus"),
+                },
+            )
+            resurrected += 1
+
+        return resurrected
+
+    def _list_orphan_pr_failed_agents(self) -> list[dict[str, Any]]:
+        """SELECT failed agents with an open PR_number for the
+        resurrection sweep (#3399).
+
+        Returns rows where ``status='failed' AND pr_number IS NOT NULL
+        AND ended_at > now() - ORPHAN_PR_RESURRECTION_LOOKBACK``.
+        Issue-number-NULL rows (scheduled-skill agents from #3379) are
+        excluded — they don't carry a real issue and shouldn't trigger
+        resurrection bookkeeping. Returns ``[]`` on DB error so the
+        supervisor tick can continue without this work.
+
+        Result rows are dicts with ``agent_id``, ``pr_number``,
+        ``issue_number``. Worktree path is intentionally NOT selected:
+        the worktree was cleaned up at terminal time, and the
+        resurrection path drives ``gh pr merge`` directly without
+        touching the local filesystem.
+        """
+        assert self._conn is not None, "connect() must run before reading"
+
+        rows: list[dict[str, Any]] = []
+        try:
+            with self._conn.cursor() as cur:
+                # Inline the lookback as a parameter rather than baking
+                # a hard-coded ``interval '24 hours'`` into the SQL —
+                # makes the constant the single source of truth and
+                # keeps the query tunable from one place.
+                cur.execute(
+                    "SELECT agent_id, pr_number, issue_number "
+                    "FROM dispatcher.agents "
+                    "WHERE status = 'failed' "
+                    "  AND pr_number IS NOT NULL "
+                    "  AND issue_number IS NOT NULL "
+                    "  AND ended_at IS NOT NULL "
+                    "  AND ended_at > now() - %s "
+                    "ORDER BY ended_at DESC",
+                    (ORPHAN_PR_RESURRECTION_LOOKBACK,),
+                )
+                for raw in cur.fetchall():
+                    rows.append(
+                        {
+                            "agent_id": str(raw[0]),
+                            "pr_number": int(raw[1]),
+                            "issue_number": int(raw[2]),
+                        }
+                    )
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.orphan_pr_list_failed",
+                extra={
+                    "event": "orphan_pr_list_failed",
+                    "run_id": self._run_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return []
+        return rows
+
+    def _count_orphan_pr_resurrections(self, agent_id: str) -> int:
+        """Return how many times this agent has been resurrected by
+        the orphan-PR sweep (#3399).
+
+        Counted by reading append-only
+        ``dispatcher.phase_transitions`` rows whose phase is
+        :data:`PHASE_RESURRECTED_FOR_ORPHAN_PR`. Returns 0 on DB error
+        so a transient hiccup cannot block resurrection (the worst case
+        on read failure is one extra resurrection that still respects
+        every other gate — the next tick re-evaluates).
+        """
+        assert self._conn is not None, "connect() must run before counting"
+
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT count(*) FROM dispatcher.phase_transitions "
+                    "WHERE agent_id = %s AND phase = %s",
+                    (agent_id, PHASE_RESURRECTED_FOR_ORPHAN_PR),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            self._log.exception(
+                "daemon.orphan_pr_count_failed",
+                extra={
+                    "event": "orphan_pr_count_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return 0
+        if row is None:
+            return 0
+        return int(row[0] or 0)
+
+    def _mark_agent_resurrected_for_orphan_pr(self, agent_id: str) -> bool:
+        """Flip a failed-but-mergeable agent back to ``status='running'
+        AND phase='awaiting_ci'`` and write the audit transition (#3399).
+
+        Both UPDATE and INSERT happen in the same transaction so the
+        next supervisor tick's budget count and the next advance loop
+        see a consistent state — either both writes land or neither.
+        Returns True on success; False on DB error (logged + rolled
+        back).
+
+        Forces ``execution_mode='subprocess'`` so
+        :meth:`_advance_running_agents`'s ECS short-circuit doesn't
+        skip the resurrected row — the original ECS task-runner is
+        gone and the daemon owns the merge path here.
+
+        Clears ``ended_at``, ``exit_code``, and ``failure_summary`` on
+        the row so the admin page renders the resurrected agent as a
+        live row again rather than a confusing terminal+running mix.
+        """
+        assert self._conn is not None, "connect() must run before resurrection"
+
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE dispatcher.agents "
+                    "SET status = 'running', "
+                    "    phase = 'awaiting_ci', "
+                    "    execution_mode = 'subprocess', "
+                    "    ended_at = NULL, "
+                    "    exit_code = NULL, "
+                    "    failure_summary = NULL "
+                    "WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                cur.execute(
+                    "INSERT INTO dispatcher.phase_transitions "
+                    "    (agent_id, phase) "
+                    "VALUES (%s, %s)",
+                    (agent_id, PHASE_RESURRECTED_FOR_ORPHAN_PR),
+                )
+            self._conn.commit()
+            return True
+        except Exception:
+            self._log.exception(
+                "daemon.orphan_pr_resurrect_failed",
+                extra={
+                    "event": "orphan_pr_resurrect_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                },
+            )
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return False
+
     def _list_advanceable_agents(self) -> list[dict[str, Any]]:
         """Return agents waiting for the next state-machine step.
 
@@ -13067,6 +13412,43 @@ class DispatcherDaemon:
             return
 
         # awaiting_ci_transition.next_phase == "fix_ci" (CI red)
+        #
+        # Issue #3399 defensive guard: if the agent's worktree was
+        # cleaned up (e.g. this row was resurrected by the orphan-PR
+        # sweep — the original worktree was removed at terminal time),
+        # the fix-ci spawn would fail trying to read the missing
+        # working directory. Fail cleanly here instead of letting
+        # _run_fix_ci crash on a missing path. The PR was green when
+        # the sweep resurrected it; the red flip between sweep tick
+        # and this tick means the operator owns the next move (often a
+        # transient that re-greens, in which case a future tick will
+        # resurrect again under the same budget).
+        worktree_path = agent.get("worktree_path") or ""
+        worktree_exists = bool(worktree_path) and Path(worktree_path).exists()
+        if not worktree_exists:
+            self._log.warning(
+                "daemon.awaiting_ci_red_worktree_missing",
+                extra={
+                    "event": "awaiting_ci_red_worktree_missing",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "pr_number": pr_number,
+                    "worktree_path": worktree_path,
+                    "detail": (
+                        "CI flipped red after orphan-PR resurrection — "
+                        "worktree gone, cannot run fix-ci. Marking failed."
+                    ),
+                },
+            )
+            # Re-flip to status='failed'. The row was previously failed
+            # before the sweep; falling back to that state keeps the
+            # admin page coherent. Next sweep tick re-evaluates if CI
+            # re-greens (subject to the resurrection budget).
+            self._mark_agent_terminal(
+                agent_id, status="failed", phase="awaiting_ci", exit_code=None
+            )
+            return
+
         self._run_fix_ci(agent, pr_status)
 
     def _fetch_pr_status(self, pr_number: int) -> dict[str, Any] | None:
@@ -21431,7 +21813,16 @@ class DispatcherDaemon:
                rows + enqueues retry markers; the GitHub rate-limit
                guard sets ``self._gh_rate_skip_until`` when the budget
                is low.
-            4. **Phase 3B (#2787):** call ``_advance_running_agents``.
+            4. **Issue #3399:** call ``_resurrect_orphan_pr_agents``
+               BEFORE the advance pass. Scans for failed agents whose
+               PR has gone mergeable since the agent died (transient
+               flake cleared, sibling PRs landed, operator re-ran a
+               check) and flips them back to ``status='running' AND
+               phase='awaiting_ci'`` so the same tick's advance pass
+               picks them up and merges. Skipped when the rate-limit
+               flag is set (the sweep calls ``gh pr view`` per
+               candidate).
+            5. **Phase 3B (#2787):** call ``_advance_running_agents``.
                Iterates agents in ``awaiting_ci``/``awaiting_deploy``
                and drives each one forward by one state-machine step.
                Errors are caught per-agent so one bad row cannot stall
@@ -21500,6 +21891,29 @@ class DispatcherDaemon:
             )
 
         rate_skip_active = self._gh_rate_skip_active()
+
+        # Issue #3399: orphan-PR resurrection sweep. Runs BEFORE the
+        # advance pass so any agent flipped from status='failed' back
+        # to status='running' AND phase='awaiting_ci' is picked up by
+        # _list_advanceable_agents in the very same tick — the
+        # supervisor merges the orphaned PR within one tick of it
+        # becoming mergeable rather than waiting an extra tick.
+        # Skipped when the rate-limit flag is set; the sweep calls
+        # ``gh pr view`` per candidate, which would burn the remaining
+        # budget and delay the reset for the same reason as the 3B
+        # advance pass.
+        orphan_pr_resurrected = 0
+        if not rate_skip_active:
+            try:
+                orphan_pr_resurrected = self._resurrect_orphan_pr_agents()
+            except Exception:
+                self._log.exception(
+                    "daemon.orphan_pr_sweep_failed",
+                    extra={
+                        "event": "orphan_pr_sweep_failed",
+                        "run_id": self._run_id,
+                    },
+                )
 
         # Phase 3B (#2787): advance agents that are past push_and_pr.
         # Wrapped in try/except — the heartbeat + metric emission below
@@ -21641,6 +22055,7 @@ class DispatcherDaemon:
                 "failures_last_hour": failures_last_hour,
                 "heartbeat_metric_emitted": metric_emitted,
                 "agents_advanced": agents_advanced,
+                "orphan_pr_resurrected": orphan_pr_resurrected,
                 "stuck_flagged": stuck_flagged,
                 "retry_markers_processed": retry_processed,
                 "rate_skip_active": rate_skip_active,
@@ -21668,6 +22083,7 @@ class DispatcherDaemon:
             "failures_last_hour": failures_last_hour,
             "heartbeat_metric_emitted": 1 if metric_emitted else 0,
             "agents_advanced": agents_advanced,
+            "orphan_pr_resurrected": orphan_pr_resurrected,
             "stuck_flagged": stuck_flagged,
             "retry_markers_processed": retry_processed,
             "rate_skip_active": 1 if rate_skip_active else 0,

--- a/scripts/dispatcher/tests/test_daemon_orphan_pr_resurrection.py
+++ b/scripts/dispatcher/tests/test_daemon_orphan_pr_resurrection.py
@@ -1,0 +1,688 @@
+"""Unit tests for the orphan-PR resurrection sweep (#3399).
+
+Covers :meth:`DispatcherDaemon._resurrect_orphan_pr_agents` and its
+helpers ``_list_orphan_pr_failed_agents``,
+``_count_orphan_pr_resurrections``, and
+``_mark_agent_resurrected_for_orphan_pr``.
+
+The acceptance criteria from issue #3399:
+
+1. **Happy path** — failed agent + open mergeable green PR → flipped
+   to ``status='running' AND phase='awaiting_ci'``, audit row written
+   to ``dispatcher.phase_transitions``, ``agent_resurrected_for_orphan_pr``
+   log event fired.
+2. **Closed/merged PR** (mergeable != 'MERGEABLE') → skipped with
+   reason ``rollup_state_red`` (the classifier rejects non-MERGEABLE).
+3. **Dirty PR** (mergeStateStatus != 'CLEAN') → skipped with reason
+   ``rollup_state_red``.
+4. **CI still pending** → skipped with reason ``rollup_state_pending``.
+5. **Agent older than 24h** → not even fetched (excluded by SELECT).
+6. **Already resurrected 3 times** → skipped with reason
+   ``budget_exhausted``.
+7. **Sweep wired into supervisor_tick** — orphan_pr_resurrected
+   counter surfaces in the tick's return dict.
+8. **Sweep skipped when rate-limit flag is set** — the supervisor
+   skips the sweep alongside the advance pass.
+
+All external calls (``gh pr view``, psycopg) are mocked — no real
+GitHub / DB writes.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — mirror the test_daemon_phase3b / merge_auto_unstick
+# fixtures so this test file can evolve independently.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.orphan_pr.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+def _pr_status_green() -> dict[str, Any]:
+    """gh pr view payload that classifies as 'green'."""
+    return {
+        "statusCheckRollup": [
+            {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "ci-passed"},
+        ],
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "headRefOid": "head-sha",
+        "mergeCommit": None,
+    }
+
+
+def _pr_status_dirty() -> dict[str, Any]:
+    """gh pr view payload with mergeStateStatus=DIRTY (rebase needed)."""
+    return {
+        "statusCheckRollup": [
+            {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "ci-passed"},
+        ],
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "DIRTY",
+        "headRefOid": "head-sha",
+        "mergeCommit": None,
+    }
+
+
+def _pr_status_pending() -> dict[str, Any]:
+    """gh pr view payload with at least one in-progress check."""
+    return {
+        "statusCheckRollup": [
+            {"status": "IN_PROGRESS", "conclusion": None, "name": "ci-passed"},
+        ],
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "UNSTABLE",
+        "headRefOid": "head-sha",
+        "mergeCommit": None,
+    }
+
+
+def _pr_status_closed() -> dict[str, Any]:
+    """gh pr view payload for a closed/merged PR (mergeable != 'MERGEABLE')."""
+    return {
+        "statusCheckRollup": [
+            {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "ci-passed"},
+        ],
+        # GitHub reports CONFLICTING / UNKNOWN for closed/merged PRs in
+        # most cases; the classifier just needs anything other than
+        # MERGEABLE to bail.
+        "mergeable": "CONFLICTING",
+        "mergeStateStatus": "DIRTY",
+        "headRefOid": "head-sha",
+        "mergeCommit": None,
+    }
+
+
+# --------------------------------------------------------------------------
+# Constants
+# --------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_lookback_is_24_hours(self) -> None:
+        assert daemon.ORPHAN_PR_RESURRECTION_LOOKBACK == timedelta(hours=24)
+
+    def test_max_attempts_is_three(self) -> None:
+        # Issue #3399 spec: "don't resurrect more than 2-3 times per
+        # agent_id". 3 keeps us at the upper bound.
+        assert daemon.ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS == 3
+
+    def test_phase_marker_constant(self) -> None:
+        assert daemon.PHASE_RESURRECTED_FOR_ORPHAN_PR == "resurrected_for_orphan_pr"
+
+
+# --------------------------------------------------------------------------
+# _resurrect_orphan_pr_agents — happy path: green mergeable PR
+# --------------------------------------------------------------------------
+
+
+class TestResurrectionHappyPath:
+    def test_failed_agent_with_mergeable_green_pr_is_resurrected(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # Stub the SELECT and the per-agent count query through
+        # fetchall_queue / fetch_queue. Both UPDATE+INSERT for the
+        # resurrection commit then run on the same fake cursor.
+        agent_id = "agent-7f656b9f"
+        pr_number = 3391
+        issue_number = 3375
+        conn.cursor_instance.fetchall_queue.append(
+            [(agent_id, pr_number, issue_number)]
+        )
+        # _count_orphan_pr_resurrections fetchone — 0 prior attempts.
+        conn.cursor_instance.fetch_queue.append((0,))
+
+        # Stub _fetch_pr_status to return the canonical green payload.
+        # PR #3391 is the live test case from the issue body.
+        d._fetch_pr_status = lambda pr: _pr_status_green()  # type: ignore[method-assign]
+
+        n = d._resurrect_orphan_pr_agents()
+
+        assert n == 1, "expected one row resurrected"
+
+        # The resurrection success event fired with the right shape.
+        events = handler.events("agent_resurrected_for_orphan_pr")
+        assert events, "expected agent_resurrected_for_orphan_pr event"
+        assert events[0].agent_id == agent_id
+        assert events[0].pr_number == pr_number
+        assert events[0].issue_number == issue_number
+        assert events[0].past_attempts == 0
+        assert events[0].new_attempts == 1
+
+        # The UPDATE flipped status='running' phase='awaiting_ci' and
+        # forced execution_mode='subprocess' so the ECS short-circuit
+        # in _advance_running_agents doesn't skip the row.
+        update_calls = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+        ]
+        assert update_calls, "expected agents UPDATE"
+        sql, params = update_calls[-1]
+        assert "status = 'running'" in sql
+        assert "phase = 'awaiting_ci'" in sql
+        assert "execution_mode = 'subprocess'" in sql
+        assert "ended_at = NULL" in sql
+        assert params == (agent_id,)
+
+        # The phase_transitions INSERT wrote the audit row with the
+        # PHASE_RESURRECTED_FOR_ORPHAN_PR marker.
+        insert_calls = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.phase_transitions" in e[0]
+        ]
+        assert insert_calls, "expected phase_transitions INSERT"
+        _, insert_params = insert_calls[-1]
+        assert insert_params == (agent_id, daemon.PHASE_RESURRECTED_FOR_ORPHAN_PR)
+
+
+# --------------------------------------------------------------------------
+# _resurrect_orphan_pr_agents — negative paths
+# --------------------------------------------------------------------------
+
+
+class TestResurrectionNegativePaths:
+    def test_closed_or_unmergeable_pr_is_skipped(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue.append([("agent-closed", 999, 100)])
+        conn.cursor_instance.fetch_queue.append((0,))
+        # Closed/declined PRs come back as mergeable != 'MERGEABLE'.
+        d._fetch_pr_status = lambda pr: _pr_status_closed()  # type: ignore[method-assign]
+
+        n = d._resurrect_orphan_pr_agents()
+
+        assert n == 0
+        # NO resurrection success event.
+        assert handler.events("agent_resurrected_for_orphan_pr") == []
+        # Skip event fired with rollup_state reason (red, because the
+        # classifier returns 'red' when checks pass but mergeable is
+        # CONFLICTING — see _classify_check_rollup's final fallback).
+        skipped = handler.events("orphan_pr_resurrection_skipped")
+        assert skipped, "expected orphan_pr_resurrection_skipped"
+        assert skipped[0].reason.startswith("rollup_state_")
+        # NO UPDATE.
+        update_calls = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+        ]
+        assert update_calls == []
+
+    def test_dirty_pr_is_skipped(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue.append([("agent-dirty", 888, 200)])
+        conn.cursor_instance.fetch_queue.append((0,))
+        d._fetch_pr_status = lambda pr: _pr_status_dirty()  # type: ignore[method-assign]
+
+        n = d._resurrect_orphan_pr_agents()
+
+        assert n == 0
+        assert handler.events("agent_resurrected_for_orphan_pr") == []
+        skipped = handler.events("orphan_pr_resurrection_skipped")
+        assert skipped, "expected orphan_pr_resurrection_skipped"
+        # mergeStateStatus=DIRTY drops the classifier into the 'red'
+        # fallback (mergeable=MERGEABLE but merge_state != CLEAN).
+        assert skipped[0].reason == "rollup_state_red"
+
+    def test_pending_ci_is_skipped(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue.append([("agent-pending", 777, 300)])
+        conn.cursor_instance.fetch_queue.append((0,))
+        d._fetch_pr_status = lambda pr: _pr_status_pending()  # type: ignore[method-assign]
+
+        n = d._resurrect_orphan_pr_agents()
+
+        assert n == 0
+        skipped = handler.events("orphan_pr_resurrection_skipped")
+        assert skipped, "expected orphan_pr_resurrection_skipped"
+        assert skipped[0].reason == "rollup_state_pending"
+
+    def test_pr_view_failure_is_skipped_no_db_write(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue.append([("agent-pr-view-fail", 666, 400)])
+        conn.cursor_instance.fetch_queue.append((0,))
+        # _fetch_pr_status returns None on transient gh failure.
+        d._fetch_pr_status = lambda pr: None  # type: ignore[method-assign]
+
+        n = d._resurrect_orphan_pr_agents()
+
+        assert n == 0
+        skipped = handler.events("orphan_pr_resurrection_skipped")
+        assert skipped, "expected orphan_pr_resurrection_skipped"
+        assert skipped[0].reason == "pr_view_failed"
+        # NO UPDATE — we don't flip a row when we can't see PR state.
+        update_calls = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+        ]
+        assert update_calls == []
+
+    def test_resurrection_budget_exhausted_skipped(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue.append(
+            [("agent-budget-exhausted", 555, 500)]
+        )
+        # 3 prior resurrections — at the budget cap.
+        conn.cursor_instance.fetch_queue.append(
+            (daemon.ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS,)
+        )
+
+        # Sentinel: _fetch_pr_status must NOT be called when budget
+        # check short-circuits. (Saves a gh API call.)
+        called: list[int] = []
+
+        def boom(pr: int) -> dict[str, Any]:
+            called.append(pr)
+            return _pr_status_green()
+
+        d._fetch_pr_status = boom  # type: ignore[method-assign]
+
+        n = d._resurrect_orphan_pr_agents()
+
+        assert n == 0
+        assert called == [], "_fetch_pr_status should not be called past budget"
+        skipped = handler.events("orphan_pr_resurrection_skipped")
+        assert skipped, "expected orphan_pr_resurrection_skipped"
+        assert skipped[0].reason == "budget_exhausted"
+        assert skipped[0].past_attempts == daemon.ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS
+        assert skipped[0].max_attempts == daemon.ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS
+
+    def test_no_candidates_returns_zero_no_log(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        # SELECT returns no rows.
+        conn.cursor_instance.fetchall_queue.append([])
+
+        # Sentinel: _fetch_pr_status must NOT be called.
+        called: list[int] = []
+        d._fetch_pr_status = lambda pr: called.append(pr) or None  # type: ignore[method-assign]
+
+        n = d._resurrect_orphan_pr_agents()
+
+        assert n == 0
+        assert called == []
+        assert handler.events("agent_resurrected_for_orphan_pr") == []
+        assert handler.events("orphan_pr_resurrection_skipped") == []
+
+
+# --------------------------------------------------------------------------
+# _list_orphan_pr_failed_agents — SELECT shape
+# --------------------------------------------------------------------------
+
+
+class TestListOrphanPrFailedAgents:
+    def test_select_filters_status_failed_and_pr_not_null(self, tmp_path: Path) -> None:
+        d, conn, _ = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue.append([])
+
+        d._list_orphan_pr_failed_agents()
+
+        sql_executed = [e[0] for e in conn.cursor_instance.executed]
+        assert sql_executed, "expected at least one SQL call"
+        sql = sql_executed[-1]
+        # The SELECT must filter on the three orphan-PR predicates.
+        assert "status = 'failed'" in sql
+        assert "pr_number IS NOT NULL" in sql
+        assert "issue_number IS NOT NULL" in sql
+        # Recency filter parameterised by the lookback constant.
+        assert "ended_at > now() - %s" in sql
+        # Bound by ended_at IS NOT NULL so we never trip on a half-
+        # written terminal row.
+        assert "ended_at IS NOT NULL" in sql
+
+    def test_select_passes_lookback_constant(self, tmp_path: Path) -> None:
+        d, conn, _ = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue.append([])
+
+        d._list_orphan_pr_failed_agents()
+
+        last = conn.cursor_instance.executed[-1]
+        # The interval is bound through the parameter list, NOT inlined
+        # into the SQL — so the constant is the single source of truth.
+        assert last[1] == (daemon.ORPHAN_PR_RESURRECTION_LOOKBACK,)
+
+
+# --------------------------------------------------------------------------
+# Sweep wired into supervisor_tick
+# --------------------------------------------------------------------------
+
+
+class TestSupervisorTickWiring:
+    def test_sweep_runs_in_supervisor_tick_and_surfaces_in_summary(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # ── Stubs to neutralize the rest of the tick. ──
+        d._check_stuck_agents = lambda: 0  # type: ignore[method-assign]
+        d._check_gh_rate_limit = lambda: None  # type: ignore[method-assign]
+        d._gh_rate_skip_active = lambda: False  # type: ignore[method-assign]
+        d._advance_running_agents = lambda: 0  # type: ignore[method-assign]
+        d._process_retry_markers = lambda: 0  # type: ignore[method-assign]
+        d._check_diagnoser_circuit_breaker = lambda: None  # type: ignore[method-assign]
+        d._reap_diagnoser_subprocesses = lambda: 0  # type: ignore[method-assign]
+        d._run_diagnoser_pass = lambda: 0  # type: ignore[method-assign]
+        d._scheduled_skills_tick = lambda: {  # type: ignore[method-assign]
+            "rows_scanned": 0,
+            "fires_succeeded": 0,
+            "fires_skipped_cap": 0,
+            "fires_skipped_collision": 0,
+            "fires_failed": 0,
+        }
+        d._emit_heartbeat_metric = lambda: True  # type: ignore[method-assign]
+
+        # The sweep itself: stub it directly so we don't have to
+        # re-stage all the sub-fetches.
+        sweep_calls: list[int] = []
+
+        def fake_sweep() -> int:
+            sweep_calls.append(1)
+            return 2  # arbitrary positive number
+
+        d._resurrect_orphan_pr_agents = fake_sweep  # type: ignore[method-assign]
+
+        # The smoke-test SELECT in supervisor_tick wants a fetchone result.
+        conn.cursor_instance.fetch_queue.append((0,))
+
+        summary = d.supervisor_tick()
+
+        # Sweep was invoked.
+        assert sweep_calls == [1], "expected sweep called once per tick"
+        # Counter surfaces in the return dict for cron/CloudWatch.
+        assert summary["orphan_pr_resurrected"] == 2
+        # Counter surfaces in the supervisor_tick log event.
+        ticks = handler.events("supervisor_tick")
+        assert ticks, "expected supervisor_tick log event"
+        assert ticks[0].orphan_pr_resurrected == 2
+
+    def test_sweep_skipped_when_rate_limit_active(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        d._check_stuck_agents = lambda: 0  # type: ignore[method-assign]
+        d._check_gh_rate_limit = lambda: None  # type: ignore[method-assign]
+        # Rate-limit flag IS active — sweep + advance both skip.
+        d._gh_rate_skip_active = lambda: True  # type: ignore[method-assign]
+        d._gh_rate_skip_until = datetime.now(UTC)  # type: ignore[attr-defined]
+        d._process_retry_markers = lambda: 0  # type: ignore[method-assign]
+        d._check_diagnoser_circuit_breaker = lambda: None  # type: ignore[method-assign]
+        d._reap_diagnoser_subprocesses = lambda: 0  # type: ignore[method-assign]
+        d._run_diagnoser_pass = lambda: 0  # type: ignore[method-assign]
+        d._scheduled_skills_tick = lambda: {  # type: ignore[method-assign]
+            "rows_scanned": 0,
+            "fires_succeeded": 0,
+            "fires_skipped_cap": 0,
+            "fires_skipped_collision": 0,
+            "fires_failed": 0,
+        }
+        d._emit_heartbeat_metric = lambda: True  # type: ignore[method-assign]
+
+        sweep_calls: list[int] = []
+
+        def fake_sweep() -> int:
+            sweep_calls.append(1)
+            return 999
+
+        d._resurrect_orphan_pr_agents = fake_sweep  # type: ignore[method-assign]
+
+        conn.cursor_instance.fetch_queue.append((0,))
+
+        summary = d.supervisor_tick()
+
+        # Sweep NOT called — same skip-when-rate-limited policy as the
+        # advance pass.
+        assert sweep_calls == [], "sweep must be skipped when rate-limit flag is set"
+        assert summary["orphan_pr_resurrected"] == 0
+
+
+# --------------------------------------------------------------------------
+# _count_orphan_pr_resurrections + _mark_agent_resurrected — DB error paths
+# --------------------------------------------------------------------------
+
+
+class TestAwaitingCiRedWorktreeMissingGuard:
+    """The defensive guard in ``_advance_awaiting_ci`` that catches a
+    resurrected agent whose worktree no longer exists, and whose PR
+    has flipped from green-at-sweep to red-at-tick (#3399)."""
+
+    def test_red_with_missing_worktree_marks_failed_no_fix_ci_spawn(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # PR fetch returns a 'red' rollup (mergeable but with a failed
+        # check) — the classifier returns 'red'/'fix_ci'.
+        red_payload = {
+            "statusCheckRollup": [
+                {"status": "COMPLETED", "conclusion": "FAILURE", "name": "ci-passed"},
+            ],
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "UNSTABLE",
+            "headRefOid": "head-sha",
+            "mergeCommit": None,
+        }
+        d._fetch_pr_status = lambda pr: red_payload  # type: ignore[method-assign]
+
+        # Sentinel: _run_fix_ci must NOT be called when the worktree
+        # is missing — that's the defensive guard #3399 adds.
+        fix_ci_calls: list[tuple[str, int]] = []
+
+        def fake_fix_ci(agent: dict[str, Any], pr_status: dict[str, Any]) -> None:
+            fix_ci_calls.append((agent["agent_id"], agent["pr_number"]))
+
+        d._run_fix_ci = fake_fix_ci  # type: ignore[method-assign]
+
+        # And _mark_agent_terminal must be called with status='failed'.
+        terminal_calls: list[dict[str, Any]] = []
+
+        def fake_terminal(agent_id: str, **kwargs: Any) -> None:
+            terminal_calls.append({"agent_id": agent_id, **kwargs})
+
+        d._mark_agent_terminal = fake_terminal  # type: ignore[method-assign]
+
+        # Worktree path that does NOT exist on disk — the resurrected
+        # agent's original worktree was cleaned up at terminal time.
+        agent = {
+            "agent_id": "agent-resurrected-then-red",
+            "issue_number": 3399,
+            "phase": "awaiting_ci",
+            "pr_number": 3391,
+            "worktree_path": str(tmp_path / "does-not-exist"),
+            "retries_used": 0,
+        }
+
+        d._advance_awaiting_ci(agent)
+
+        # Defensive event fired with the right shape.
+        events = handler.events("awaiting_ci_red_worktree_missing")
+        assert events, "expected awaiting_ci_red_worktree_missing event"
+        assert events[0].agent_id == "agent-resurrected-then-red"
+        assert events[0].pr_number == 3391
+
+        # NO fix-ci spawn.
+        assert fix_ci_calls == [], "fix-ci must not run when worktree is gone"
+
+        # Marked failed cleanly.
+        assert len(terminal_calls) == 1
+        assert terminal_calls[0]["status"] == "failed"
+        assert terminal_calls[0]["phase"] == "awaiting_ci"
+
+    def test_red_with_existing_worktree_still_runs_fix_ci(self, tmp_path: Path) -> None:
+        """Regression guard — the defensive check must NOT short-circuit
+        normal red-CI handling for live agents whose worktree is intact.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        red_payload = {
+            "statusCheckRollup": [
+                {"status": "COMPLETED", "conclusion": "FAILURE", "name": "ci-passed"},
+            ],
+            "mergeable": "MERGEABLE",
+            "mergeStateStatus": "UNSTABLE",
+            "headRefOid": "head-sha",
+            "mergeCommit": None,
+        }
+        d._fetch_pr_status = lambda pr: red_payload  # type: ignore[method-assign]
+
+        fix_ci_calls: list[tuple[str, int]] = []
+        d._run_fix_ci = lambda agent, ps: fix_ci_calls.append(  # type: ignore[method-assign]
+            (agent["agent_id"], agent["pr_number"])
+        )
+
+        # tmp_path EXISTS on disk — the worktree is intact.
+        agent = {
+            "agent_id": "agent-live-red",
+            "issue_number": 100,
+            "phase": "awaiting_ci",
+            "pr_number": 200,
+            "worktree_path": str(tmp_path),
+            "retries_used": 0,
+        }
+
+        d._advance_awaiting_ci(agent)
+
+        # Defensive event must NOT fire.
+        assert handler.events("awaiting_ci_red_worktree_missing") == []
+        # fix-ci runs as normal.
+        assert fix_ci_calls == [("agent-live-red", 200)]
+
+
+class TestDbErrorPaths:
+    def test_count_returns_zero_on_db_error(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def boom(*_a: Any, **_k: Any) -> None:
+            raise RuntimeError("connection lost")
+
+        conn.cursor_instance.execute = boom  # type: ignore[assignment]
+
+        n = d._count_orphan_pr_resurrections("agent-x")
+
+        assert n == 0
+        # Failure event logged so CloudWatch captures the issue.
+        assert handler.events("orphan_pr_count_failed")
+
+    def test_mark_returns_false_on_db_error(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def boom(*_a: Any, **_k: Any) -> None:
+            raise RuntimeError("write error")
+
+        conn.cursor_instance.execute = boom  # type: ignore[assignment]
+
+        ok = d._mark_agent_resurrected_for_orphan_pr("agent-x")
+
+        assert ok is False
+        assert handler.events("orphan_pr_resurrect_failed")
+
+    def test_list_returns_empty_on_db_error(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def boom(*_a: Any, **_k: Any) -> None:
+            raise RuntimeError("select fail")
+
+        conn.cursor_instance.execute = boom  # type: ignore[assignment]
+
+        rows = d._list_orphan_pr_failed_agents()
+
+        assert rows == []
+        assert handler.events("orphan_pr_list_failed")


### PR DESCRIPTION
## Summary

Adds a per-supervisor-tick orphan-PR resurrection sweep. When a daemon-spawned agent dies after creating a PR (e.g. `status='failed' phase='fix_ci_failed'`) and the PR later goes mergeable on its own (transient flake clears, sibling PRs land), the new sweep flips the row back to `status='running' AND phase='awaiting_ci'` so the existing advance loop merges it within the same tick. Bounded by 24h recency, 3-attempt-per-agent budget, and the `_classify_check_rollup` green gate.

Closes #3399

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (19 new + 1725 existing dispatcher tests)
- [x] CI green

### Post-deploy verification
- [ ] PR #3391 (the live test case from the issue body — agent #7f656b9f died `fix_ci_failed/failed` 2026-04-26T00:47Z, CI now green, mergeable=CLEAN) is automatically resurrected and merged within 1-2 supervisor ticks of deploy.
- [ ] CloudWatch query on `/ecs/judgemind-dispatcher-dev` over a 30-min window post-deploy: `filter event in ["agent_resurrected_for_orphan_pr", "merge_pr_attempt"] | fields @timestamp, agent_id, pr_number | sort @timestamp asc` returns the expected resurrection + merge sequence.
- [ ] Agent-row state transitions captured via `scripts/dev-db-query.sh` show the row moved `failed → running → succeeded`.
- [ ] Verification evidence posted on issue #3399 (see A.8).
