### PR TITLE
fix(dispatcher): use canonical CI rollup classifier in orphan-PR sweep (#3399)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -12791,11 +12791,22 @@ class DispatcherDaemon:
                 )
                 continue
 
-            # The classifier returns 'green' only when all checks are
-            # SUCCESS/SKIPPED AND mergeable=MERGEABLE AND
-            # mergeStateStatus=CLEAN. Closed/merged PRs come back with
-            # mergeable in a different state, so this catches them too.
-            rollup_state = self._classify_check_rollup(pr_status)
+            # Use the same canonical classifier (_ci_rollup_state via
+            # transition_from_awaiting_ci) the awaiting_ci handler
+            # uses, so the green gate is consistent across both call
+            # sites. Critically, this classifier returns 'pending'
+            # (not 'red') when ``mergeable=UNKNOWN`` — GitHub flips
+            # state to UNKNOWN intermittently while it recomputes, and
+            # the legacy ``_classify_check_rollup`` would mis-skip
+            # the row in that window. Reasons surface as 'CI green' /
+            # 'CI red' / 'CI pending' from the transition.reason field.
+            ci_transition = transition_from_awaiting_ci(pr_status)
+            _reason_to_state = {
+                "CI green": "green",
+                "CI red": "red",
+                "CI pending": "pending",
+            }
+            rollup_state = _reason_to_state.get(ci_transition.reason, "pending")
             if rollup_state != "green":
                 self._log.info(
                     "daemon.orphan_pr_resurrection_skipped",

--- a/scripts/dispatcher/tests/test_daemon_orphan_pr_resurrection.py
+++ b/scripts/dispatcher/tests/test_daemon_orphan_pr_resurrection.py
@@ -294,9 +294,10 @@ class TestResurrectionNegativePaths:
         assert n == 0
         # NO resurrection success event.
         assert handler.events("agent_resurrected_for_orphan_pr") == []
-        # Skip event fired with rollup_state reason (red, because the
-        # classifier returns 'red' when checks pass but mergeable is
-        # CONFLICTING — see _classify_check_rollup's final fallback).
+        # Skip event fired with rollup_state reason. The canonical
+        # _ci_rollup_state treats mergeable=CONFLICTING as 'pending'
+        # (transient — GitHub may recompute), so the skip reason is
+        # rollup_state_pending. The important thing is we skip.
         skipped = handler.events("orphan_pr_resurrection_skipped")
         assert skipped, "expected orphan_pr_resurrection_skipped"
         assert skipped[0].reason.startswith("rollup_state_")
@@ -320,9 +321,45 @@ class TestResurrectionNegativePaths:
         assert handler.events("agent_resurrected_for_orphan_pr") == []
         skipped = handler.events("orphan_pr_resurrection_skipped")
         assert skipped, "expected orphan_pr_resurrection_skipped"
-        # mergeStateStatus=DIRTY drops the classifier into the 'red'
-        # fallback (mergeable=MERGEABLE but merge_state != CLEAN).
-        assert skipped[0].reason == "rollup_state_red"
+        # mergeStateStatus=DIRTY drops the classifier into the
+        # 'pending' fallback (the canonical _ci_rollup_state treats
+        # "checks pass but merge state isn't yet CLEAN" as pending,
+        # not red — same behavior the awaiting_ci handler uses).
+        assert skipped[0].reason == "rollup_state_pending"
+
+    def test_mergeable_unknown_classifies_as_pending_not_red(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression guard for the issue caught during PR #3399 verify
+        on PR #3391. GitHub flips mergeable + mergeStateStatus to
+        UNKNOWN intermittently while it recomputes (classic refresh
+        window). The canonical _ci_rollup_state classifier handles
+        this as 'pending' (so the next supervisor tick re-checks),
+        not as 'red' (which the legacy classifier did, causing the
+        sweep to mis-skip a row that was actually mergeable). The
+        switch to transition_from_awaiting_ci closes that gap."""
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetchall_queue.append([("agent-unknown", 666, 600)])
+        conn.cursor_instance.fetch_queue.append((0,))
+        unknown_payload = {
+            "statusCheckRollup": [
+                {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "ci-passed"},
+            ],
+            "mergeable": "UNKNOWN",
+            "mergeStateStatus": "UNKNOWN",
+            "headRefOid": "head-sha",
+            "mergeCommit": None,
+        }
+        d._fetch_pr_status = lambda pr: unknown_payload  # type: ignore[method-assign]
+
+        n = d._resurrect_orphan_pr_agents()
+
+        assert n == 0, "UNKNOWN must NOT count as green"
+        # NOT 'red' — that was the legacy bug. Pending means we'll
+        # re-check next tick.
+        skipped = handler.events("orphan_pr_resurrection_skipped")
+        assert skipped, "expected orphan_pr_resurrection_skipped"
+        assert skipped[0].reason == "rollup_state_pending"
 
     def test_pending_ci_is_skipped(self, tmp_path: Path) -> None:
         d, conn, handler = _make_daemon(tmp_path)


### PR DESCRIPTION
## Summary

Follow-up to #3402. The merged orphan-PR sweep used the legacy `_classify_check_rollup` helper, which returns `'red'` when `mergeable=UNKNOWN` — and GitHub flips `mergeable` + `mergeStateStatus` to `UNKNOWN` intermittently while it recomputes after a status change. On the live test case (PR #3391), every supervisor tick fetched the PR, hit `UNKNOWN`, classified as `'red'`, and skipped resurrection — so the sweep deployed but never resurrected anything.

Switch to `transition_from_awaiting_ci` (the same canonical classifier the awaiting_ci handler uses) which correctly returns `'pending'` for `mergeable=UNKNOWN`. The sweep retries on the next tick once GitHub recomputes mergeable, instead of skipping with a misleading `'red'` reason.

Adds a regression test (`test_mergeable_unknown_classifies_as_pending_not_red`) so this can't regress silently.

Refs #3399

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (20 orphan-PR resurrection tests + 1726 existing dispatcher tests)
- [x] CI green

### Post-deploy verification
- [ ] PR #3391 (the live test case) is resurrected and merged within 1-2 supervisor ticks of deploy.
- [ ] CloudWatch shows `agent_resurrected_for_orphan_pr` event for agent_id `7f656b9f-3b90-4825-9951-4cf861b58314` and `pr_merged` event for PR 3391.
- [ ] DB query confirms agent row moved `failed → running → succeeded`.
- [ ] Verification evidence posted on issue #3399.
