### PR TITLE
feat(dispatcher): supervisor-tick per-step warns + watchdog heartbeat (#3403)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -252,6 +252,38 @@ WATCHDOG_THREAD_DUMP_MAX_FRAMES_PER_THREAD = 20
 #: to a config key if we end up needing per-environment overrides.
 SCHEDULER_TICK_SLOW_STEP_WARN_SECONDS = 5.0
 
+#: Per-step slow-warning threshold for :meth:`supervisor_tick` (#3403).
+#: Mirror of :data:`SCHEDULER_TICK_SLOW_STEP_WARN_SECONDS` for the
+#: supervisor sub-steps (heartbeat update, failures count, stuck-agent
+#: scan, gh-rate guard, orphan-PR resurrection, advance pass, retry
+#: marker drain, diagnoser circuit-breaker / reap / spawn, scheduled
+#: skills, heartbeat metric emit). Supervisor steps are inherently
+#: slower than scheduler steps — the advance pass calls ``gh pr view``
+#: per agent, the diagnoser pass spawns subprocesses — so the threshold
+#: is set higher (10s vs 5s) to avoid spurious WARNs on a normal busy
+#: tick while still firing well before the watchdog WARN at 60s. Not
+#: operator-tunable today; flip to a config key if per-environment
+#: overrides are needed.
+SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS = 10.0
+
+#: Watchdog heartbeat log cadence (#3403). The :meth:`_watchdog_loop`
+#: thread emits a ``daemon.watchdog_heartbeat`` INFO line every Nth
+#: poll cycle (poll interval is :data:`WATCHDOG_POLL_INTERVAL_SECONDS`,
+#: so 10 polls × 30s = one heartbeat every 5 minutes). The heartbeat is
+#: unconditional — it fires regardless of whether the scheduler or
+#: supervisor ticks are emitting, giving an "even-if-everything-else-stops
+#: the watchdog itself is alive" liveness signal in CloudWatch. The
+#: heartbeat carries the elapsed gap to the last scheduler tick + the
+#: WARN/EXIT thresholds so the operator can interpret a single line
+#: without cross-referencing scheduler_tick events.
+#:
+#: 5min cadence chosen as a compromise: short enough that an operator
+#: glancing at recent logs sees daemon-is-alive evidence within one
+#: scroll, long enough that we don't drown out the actual tick events.
+#: The watchdog already emits WARN/EXIT events on stall — the heartbeat
+#: only exists to confirm the watchdog itself is running.
+WATCHDOG_HEARTBEAT_LOG_EVERY_N_POLLS = 10
+
 #: Periodic faulthandler stderr-dump cadence (#3205). At daemon startup
 #: we arm :func:`faulthandler.dump_traceback_later(FAULTHANDLER_DUMP_INTERVAL_SECONDS,
 #: repeat=True)` so every live Python thread's stack prints to stderr
@@ -21800,6 +21832,14 @@ class DispatcherDaemon:
     def supervisor_tick(self) -> dict[str, int]:
         """Run one supervisor tick. Writes heartbeat; advances running agents.
 
+        **#3403 instrumentation.** Each major sub-step is bracketed by
+        a :meth:`_record_supervisor_step` call that (a) refreshes
+        ``_last_scheduler_tick_at`` so the watchdog observes forward
+        progress mid-supervisor-tick, and (b) emits a
+        ``daemon.supervisor_tick_slow_<step>`` WARNING if the sub-step
+        exceeds :data:`SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS`. Mirrors
+        the #3205 pattern in :meth:`scheduler_tick`.
+
         Steps (in order):
             1. UPDATE ``dispatcher.runs.heartbeat_ts`` — keeps the lease
                alive and signals to the ``HeartbeatAge`` CloudWatch
@@ -21838,6 +21878,18 @@ class DispatcherDaemon:
         assert self._conn is not None, "connect() must run before ticks"
         assert self._run_id is not None, "register the run before ticking"
 
+        # #3403 — per-step instrumentation chain. Mirrors the #3205
+        # ``t_step`` chain in :meth:`scheduler_tick` so the watchdog
+        # observes forward progress mid-supervisor-tick AND a wedged
+        # sub-step is named in a ``daemon.supervisor_tick_slow_<step>``
+        # WARNING before the watchdog has to dump the whole thread set.
+        # Each ``self._record_supervisor_step(...)`` call also refreshes
+        # ``_last_scheduler_tick_at``, so a long supervisor tick is
+        # treated as "alive" by the watchdog as long as the steps are
+        # individually progressing.
+        t_step = time.monotonic()
+        self._last_scheduler_tick_at = t_step
+
         failures_last_hour = 0
 
         with self._conn.cursor() as cur:
@@ -21857,6 +21909,7 @@ class DispatcherDaemon:
             if row is not None:
                 failures_last_hour = int(row[0] or 0)
         self._conn.commit()
+        t_step = self._record_supervisor_step("heartbeat_and_failures", t_step)
 
         # Phase 3C (#2791): stuck-timeout scan. Runs first so any newly
         # crashed agents land retry markers early in the tick, giving
@@ -21875,6 +21928,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                 },
             )
+        t_step = self._record_supervisor_step("stuck_check", t_step)
 
         # Phase 3C (#2791): rate-limit guard. Write the failure row +
         # set the skip flag before the 3B advance pass so this tick
@@ -21889,6 +21943,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                 },
             )
+        t_step = self._record_supervisor_step("gh_rate_check", t_step)
 
         rate_skip_active = self._gh_rate_skip_active()
 
@@ -21914,6 +21969,7 @@ class DispatcherDaemon:
                         "run_id": self._run_id,
                     },
                 )
+        t_step = self._record_supervisor_step("orphan_pr_resurrect", t_step)
 
         # Phase 3B (#2787): advance agents that are past push_and_pr.
         # Wrapped in try/except — the heartbeat + metric emission below
@@ -21944,6 +22000,7 @@ class DispatcherDaemon:
                         "run_id": self._run_id,
                     },
                 )
+        t_step = self._record_supervisor_step("advance_running_agents", t_step)
 
         # Phase 3C (#2791): drain due retry markers. Runs AFTER the
         # advance pass so a marker created earlier in this tick (via
@@ -21961,6 +22018,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                 },
             )
+        t_step = self._record_supervisor_step("retry_markers", t_step)
 
         # Phase 3D (#2795): circuit breaker + diagnoser pass. The
         # breaker check runs FIRST so a bad 24h window disables the
@@ -21983,6 +22041,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                 },
             )
+        t_step = self._record_supervisor_step("diagnoser_circuit_breaker", t_step)
         # Issue #3376: reap completed/timed-out async diagnosers
         # FIRST so the slot count is current before the spawn pass
         # checks the cap. The reaper is the consumer side of the
@@ -22000,6 +22059,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                 },
             )
+        t_step = self._record_supervisor_step("diagnoser_reap", t_step)
         diagnoses_ran = 0
         try:
             diagnoses_ran = self._run_diagnoser_pass()
@@ -22011,6 +22071,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                 },
             )
+        t_step = self._record_supervisor_step("diagnoser_run", t_step)
 
         # Issue #3374 — generalized scheduled-skills tick. Iterates
         # ``dispatcher.scheduled_skills`` and fires due skills (audit,
@@ -22035,6 +22096,7 @@ class DispatcherDaemon:
                     "run_id": self._run_id,
                 },
             )
+        t_step = self._record_supervisor_step("scheduled_skills", t_step)
 
         self._supervisor_ticks += 1
         self._last_heartbeat_at = datetime.now(UTC)
@@ -22045,6 +22107,7 @@ class DispatcherDaemon:
         # indicator for the alarm in
         # ``infra/terraform/modules/dispatcher-daemon/main.tf``.
         metric_emitted = self._emit_heartbeat_metric()
+        t_step = self._record_supervisor_step("heartbeat_metric_emit", t_step)
 
         self._log.info(
             "daemon.supervisor_tick",
@@ -23580,6 +23643,50 @@ class DispatcherDaemon:
             )
         return now
 
+    def _record_supervisor_step(self, step: str, t_before: float) -> float:
+        """Refresh the watchdog heartbeat + warn on slow supervisor steps (#3403).
+
+        Mirror of :meth:`_record_scheduler_step` for :meth:`supervisor_tick`.
+        Called between each major sub-step so:
+
+        * The :meth:`_watchdog_loop` thread observes forward progress
+          mid-supervisor-tick — pre-#3403 a long supervisor step (e.g. a
+          slow ``_advance_running_agents`` pass, an unresponsive
+          ``cloudwatch:PutMetricData``, a wedged ``gh pr view``) only
+          refreshed ``_last_scheduler_tick_at`` at the end of the
+          supervisor tick, so a wedge mid-supervisor would still trip
+          the watchdog after 60s but the log would name the whole tick
+          rather than the offending sub-step.
+        * A ``daemon.supervisor_tick_slow_<step>`` WARNING fires the moment
+          a sub-step exceeds :data:`SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS`,
+          producing a self-diagnosing log line BEFORE the watchdog has to
+          dump the whole thread set.
+
+        Returns ``time.monotonic()`` so callers can chain
+        ``t_step = _record_supervisor_step("foo", t_step)`` between
+        sub-steps without re-reading the clock.
+
+        The single-writer (supervisor thread, which on the daemon is the
+        same as the main run-forever thread) / single-reader (watchdog
+        thread) atomic-float-assignment semantics are identical to
+        :meth:`_record_scheduler_step` — see that method's docstring.
+        """
+        now = time.monotonic()
+        elapsed = now - t_before
+        self._last_scheduler_tick_at = now
+        if elapsed >= SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS:
+            self._log.warning(
+                f"daemon.supervisor_tick_slow_{step}",
+                extra={
+                    "event": f"supervisor_tick_slow_{step}",
+                    "run_id": self._run_id,
+                    "step": step,
+                    "elapsed_seconds": round(elapsed, 3),
+                    "threshold_seconds": SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS,
+                },
+            )
+        return now
+
     def _emit_scheduler_stall_warning(self, elapsed_seconds: float) -> None:
         """Log a WARNING ``scheduler_tick_stalled`` with a thread dump.
 
@@ -23665,7 +23772,7 @@ class DispatcherDaemon:
         )
 
     def _watchdog_loop(self) -> None:
-        """Run the supervisor watchdog thread (#3097).
+        """Run the supervisor watchdog thread (#3097, #3403 heartbeat).
 
         Wakes every :data:`WATCHDOG_POLL_INTERVAL_SECONDS`. If the gap
         between ``time.monotonic()`` and
@@ -23673,6 +23780,17 @@ class DispatcherDaemon:
         emit a one-shot WARNING with a bounded thread dump. If the gap
         exceeds the EXIT threshold, emit an ERROR with a final thread
         dump and call ``os._exit(137)``.
+
+        #3403 — every :data:`WATCHDOG_HEARTBEAT_LOG_EVERY_N_POLLS` polls
+        (default 10 × 30s = 5min cadence) the loop emits a
+        ``daemon.watchdog_heartbeat`` INFO event carrying the current
+        elapsed-since-tick gap and the WARN/EXIT thresholds. The
+        heartbeat is unconditional — even if the scheduler and
+        supervisor stop emitting, an operator scanning CloudWatch can
+        confirm from this thread alone that the daemon process is alive
+        and the watchdog is monitoring it. The heartbeat does NOT
+        replace the WARN/EXIT events; it is a liveness signal in
+        addition to them.
 
         Opens its own psycopg connection so the thresholds can be read
         via ``_cb_config_int`` without contending with the main
@@ -23721,6 +23839,13 @@ class DispatcherDaemon:
             },
         )
 
+        # #3403 — Track poll iterations so we can emit an unconditional
+        # ``daemon.watchdog_heartbeat`` every N polls (default 10 × 30s
+        # = 5 minutes). Even if the scheduler / supervisor go fully
+        # silent the heartbeat continues to fire from this thread — it
+        # is the bottom-most observability signal that "the daemon
+        # process is alive and the watchdog is monitoring it."
+        watchdog_poll_n = 0
         try:
             while not self._watchdog_stop.is_set():
                 try:
@@ -23751,6 +23876,28 @@ class DispatcherDaemon:
                                 },
                             )
                         self._watchdog_warn_emitted_for_gap = False
+
+                    # #3403 — unconditional liveness heartbeat. Fires
+                    # every Nth poll regardless of scheduler/supervisor
+                    # state, so an operator scanning CloudWatch can
+                    # confirm "the watchdog itself is running" even
+                    # during a sustained log-quiet stretch.
+                    watchdog_poll_n += 1
+                    if watchdog_poll_n % WATCHDOG_HEARTBEAT_LOG_EVERY_N_POLLS == 0:
+                        self._log.info(
+                            "daemon.watchdog_heartbeat",
+                            extra={
+                                "event": "watchdog_heartbeat",
+                                "run_id": self._run_id,
+                                "poll_n": watchdog_poll_n,
+                                "elapsed_since_tick_s": round(elapsed, 1),
+                                "warn_threshold_seconds": warn_threshold,
+                                "exit_threshold_seconds": exit_threshold,
+                                "warn_emitted_for_current_gap": (
+                                    self._watchdog_warn_emitted_for_gap
+                                ),
+                            },
+                        )
                 except Exception:  # pragma: no cover — defensive
                     # Any watchdog exception is logged and the loop
                     # continues — a bug in the watchdog must not disable

--- a/scripts/dispatcher/tests/test_supervisor_tick_instrumentation.py
+++ b/scripts/dispatcher/tests/test_supervisor_tick_instrumentation.py
@@ -1,0 +1,458 @@
+"""Unit tests for #3403 supervisor_tick instrumentation + watchdog heartbeat.
+
+Covers the diagnostic-first changes added to :mod:`scripts.dispatcher.daemon`:
+
+* :meth:`DispatcherDaemon._record_supervisor_step` — mirror of the #3205
+  ``_record_scheduler_step`` for supervisor sub-steps. Refreshes
+  ``_last_scheduler_tick_at`` so the watchdog observes forward progress
+  mid-supervisor-tick AND emits a
+  ``daemon.supervisor_tick_slow_<step>`` WARNING when a sub-step exceeds
+  :data:`SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS`.
+* :meth:`DispatcherDaemon.supervisor_tick` actually calls
+  ``_record_supervisor_step`` between sub-steps so a slow sub-step
+  produces a named WARN event rather than just a generic
+  ``scheduler_tick_stalled`` thread dump.
+* :meth:`DispatcherDaemon._watchdog_loop` emits
+  ``daemon.watchdog_heartbeat`` every Nth poll so the operator can
+  confirm the watchdog itself is alive even when the scheduler /
+  supervisor go log-quiet.
+
+No real DB or CloudWatch is reached. psycopg + boto3 are mocked.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+# Make ``scripts`` importable without installing the repo as a package —
+# mirrors the preamble in the other ``test_daemon_*.py`` modules.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes (kept self-contained — sibling test modules use the same
+# pattern; lifting to a shared helper is a future cleanup if it ever
+# accumulates a third copy).
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        return []
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.sup_instr.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+
+    # Stub every supervisor sub-step to a no-op fast helper. Tests that
+    # want to simulate a slow sub-step replace one of these with a
+    # ``time.sleep``-based stub.
+    d._check_stuck_agents = lambda: 0  # type: ignore[method-assign]
+    d._check_gh_rate_limit = lambda: None  # type: ignore[method-assign]
+    d._gh_rate_skip_active = lambda: False  # type: ignore[method-assign]
+    d._resurrect_orphan_pr_agents = lambda: 0  # type: ignore[method-assign]
+    d._advance_running_agents = lambda: 0  # type: ignore[method-assign]
+    d._process_retry_markers = lambda: 0  # type: ignore[method-assign]
+    d._check_diagnoser_circuit_breaker = lambda: None  # type: ignore[method-assign]
+    d._reap_diagnoser_subprocesses = lambda: 0  # type: ignore[method-assign]
+    d._run_diagnoser_pass = lambda: 0  # type: ignore[method-assign]
+    d._scheduled_skills_tick = lambda: {  # type: ignore[method-assign]
+        "rows_scanned": 0,
+        "fires_succeeded": 0,
+        "fires_skipped_cap": 0,
+        "fires_skipped_collision": 0,
+        "fires_failed": 0,
+    }
+    d._emit_heartbeat_metric = lambda: True  # type: ignore[method-assign]
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# AC #1 — _record_supervisor_step emits slow-step WARN with elapsed seconds.
+#
+# When a supervisor sub-step exceeds
+# :data:`SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS`, the helper emits a
+# ``daemon.supervisor_tick_slow_<step>`` WARNING carrying ``step``,
+# ``elapsed_seconds``, and ``threshold_seconds`` so an operator can
+# pinpoint exactly which sub-step owned the wedge.
+# --------------------------------------------------------------------------
+
+
+class TestRecordSupervisorStep:
+    def test_fast_step_does_not_emit_warning(self, tmp_path: Path) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+        # t_before is ~now; elapsed will be tiny → no warning.
+        t_before = time.monotonic()
+        d._record_supervisor_step("stuck_check", t_before)
+        assert handler.events("supervisor_tick_slow_stuck_check") == []
+
+    def test_slow_step_emits_warning_with_elapsed_seconds(self, tmp_path: Path) -> None:
+        d, _conn, handler = _make_daemon(tmp_path)
+        # Fake a step that took well over the threshold by passing a
+        # stale t_before (elapsed = now - stale).
+        stale = time.monotonic() - (daemon.SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS + 1.0)
+        d._record_supervisor_step("advance_running_agents", stale)
+        events = handler.events("supervisor_tick_slow_advance_running_agents")
+        assert len(events) == 1
+        rec = events[0]
+        assert rec.levelno == logging.WARNING
+        elapsed = getattr(rec, "elapsed_seconds", None)
+        assert isinstance(elapsed, (int, float))
+        assert elapsed >= daemon.SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS
+        assert getattr(rec, "step", None) == "advance_running_agents"
+        threshold = getattr(rec, "threshold_seconds", None)
+        assert threshold == daemon.SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS
+
+    def test_record_step_updates_last_scheduler_tick_at(self, tmp_path: Path) -> None:
+        """The watchdog heartbeat must advance per-step so a mid-supervisor
+        wedge produces a ``scheduler_tick_stalled`` within the normal
+        WARN window rather than hiding under the supervisor entry
+        timestamp."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        d._last_scheduler_tick_at = 0.0  # known-stale
+        before = time.monotonic()
+        d._record_supervisor_step("stuck_check", before)
+        after = time.monotonic()
+        assert before <= d._last_scheduler_tick_at <= after
+
+    def test_record_step_returns_current_monotonic(self, tmp_path: Path) -> None:
+        """Callers chain ``t_step = _record_supervisor_step(...)`` so the
+        return value must be ``time.monotonic()`` after the heartbeat
+        write — matching ``_last_scheduler_tick_at``."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        returned = d._record_supervisor_step("stuck_check", time.monotonic())
+        assert returned == d._last_scheduler_tick_at
+
+
+# --------------------------------------------------------------------------
+# AC #2 — supervisor_tick actually calls _record_supervisor_step between
+# sub-steps. End-to-end check via a slow monkeypatched helper.
+# --------------------------------------------------------------------------
+
+
+class TestSupervisorTickEmitsSlowEvents:
+    def test_slow_advance_emits_slow_advance_running_agents_event(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]  # failures count
+
+        def _slow_advance() -> int:
+            time.sleep(daemon.SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS + 0.25)
+            return 0
+
+        d._advance_running_agents = _slow_advance  # type: ignore[method-assign]
+        d.supervisor_tick()
+        events = handler.events("supervisor_tick_slow_advance_running_agents")
+        assert len(events) == 1
+        assert getattr(events[0], "levelno", None) == logging.WARNING
+
+    def test_slow_diagnoser_run_emits_slow_diagnoser_run_event(
+        self, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+
+        def _slow_diag() -> int:
+            time.sleep(daemon.SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS + 0.25)
+            return 0
+
+        d._run_diagnoser_pass = _slow_diag  # type: ignore[method-assign]
+        d.supervisor_tick()
+        events = handler.events("supervisor_tick_slow_diagnoser_run")
+        assert len(events) == 1
+
+    def test_fast_tick_emits_no_slow_events(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+        d.supervisor_tick()
+        slow_events = [
+            rec
+            for rec in handler.records
+            if getattr(rec, "event", "").startswith("supervisor_tick_slow_")
+        ]
+        assert slow_events == [], (
+            f"expected no slow-step events on a fast tick; got "
+            f"{[e.event for e in slow_events]!r}"
+        )
+
+    def test_supervisor_tick_refreshes_last_scheduler_tick_at_per_step(
+        self, tmp_path: Path
+    ) -> None:
+        """Even on a fast tick, ``_last_scheduler_tick_at`` advances at
+        every sub-step boundary — confirms the watchdog observes
+        forward progress mid-supervisor-tick."""
+        d, conn, _handler = _make_daemon(tmp_path)
+        conn.cursor_instance.fetch_queue = [(0,)]
+        # Stash known-stale baseline so the post-tick value is
+        # demonstrably advanced.
+        d._last_scheduler_tick_at = 0.0
+        d.supervisor_tick()
+        # After supervisor_tick the value reflects ``time.monotonic()``
+        # (a recent positive number) — never the stale 0.0 left in
+        # place.
+        assert d._last_scheduler_tick_at > 0.0
+
+
+# --------------------------------------------------------------------------
+# AC #3 — watchdog_heartbeat fires every WATCHDOG_HEARTBEAT_LOG_EVERY_N_POLLS
+# polls regardless of scheduler / supervisor activity.
+# --------------------------------------------------------------------------
+
+
+class TestWatchdogHeartbeat:
+    def test_heartbeat_fires_after_n_polls(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """After running ``WATCHDOG_HEARTBEAT_LOG_EVERY_N_POLLS`` poll
+        cycles, the watchdog emits exactly one
+        ``daemon.watchdog_heartbeat`` event carrying the elapsed gap +
+        thresholds."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        # Tighten the poll interval and ensure baseline is fresh so the
+        # WARN/EXIT branches don't fire (warn=60s, exit=120s defaults).
+        monkeypatch.setattr(daemon, "WATCHDOG_POLL_INTERVAL_SECONDS", 0.01)
+        d._last_scheduler_tick_at = time.monotonic()
+
+        # Stop the loop after exactly N polls by counting calls to
+        # ``_watchdog_stop.wait`` (which is what the loop sleeps on).
+        n_target = daemon.WATCHDOG_HEARTBEAT_LOG_EVERY_N_POLLS
+        call_n = {"count": 0}
+        original_wait = d._watchdog_stop.wait
+
+        def _wait_then_stop_after_n(timeout: float | None = None) -> bool:
+            call_n["count"] += 1
+            if call_n["count"] >= n_target:
+                d._watchdog_stop.set()
+                return True
+            return original_wait(0.0)
+
+        monkeypatch.setattr(d._watchdog_stop, "wait", _wait_then_stop_after_n)
+
+        # Run the watchdog loop on this thread (synchronous test; the
+        # loop returns when stop is set).
+        d._watchdog_loop()
+
+        events = handler.events("watchdog_heartbeat")
+        assert len(events) == 1, (
+            f"expected exactly 1 heartbeat after N={n_target} polls; got {len(events)}"
+        )
+        rec = events[0]
+        assert rec.levelno == logging.INFO
+        assert getattr(rec, "poll_n", None) == n_target
+        assert isinstance(getattr(rec, "elapsed_since_tick_s", None), (int, float))
+        assert isinstance(getattr(rec, "warn_threshold_seconds", None), int)
+        assert isinstance(getattr(rec, "exit_threshold_seconds", None), int)
+
+    def test_heartbeat_continues_when_scheduler_quiet(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """The unconditional heartbeat is the entire point of #3403 —
+        verify it fires even though the scheduler/supervisor are
+        completely idle (i.e. ``_last_scheduler_tick_at`` never gets
+        updated by anyone other than the heartbeat path)."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        monkeypatch.setattr(daemon, "WATCHDOG_POLL_INTERVAL_SECONDS", 0.01)
+        d._last_scheduler_tick_at = time.monotonic()
+
+        # Run for 2× the heartbeat cadence → expect 2 heartbeats.
+        n_target = 2 * daemon.WATCHDOG_HEARTBEAT_LOG_EVERY_N_POLLS
+        call_n = {"count": 0}
+
+        def _stop_after(_timeout: float | None = None) -> bool:
+            call_n["count"] += 1
+            if call_n["count"] >= n_target:
+                d._watchdog_stop.set()
+                return True
+            return False
+
+        monkeypatch.setattr(d._watchdog_stop, "wait", _stop_after)
+
+        d._watchdog_loop()
+
+        events = handler.events("watchdog_heartbeat")
+        assert len(events) == 2, (
+            f"expected 2 heartbeats after N={n_target} polls (cadence="
+            f"{daemon.WATCHDOG_HEARTBEAT_LOG_EVERY_N_POLLS}); got {len(events)}"
+        )
+        # Confirm poll_n increases monotonically across heartbeats.
+        poll_ns = [getattr(e, "poll_n", -1) for e in events]
+        assert poll_ns == sorted(poll_ns)
+        assert poll_ns == [
+            daemon.WATCHDOG_HEARTBEAT_LOG_EVERY_N_POLLS,
+            2 * daemon.WATCHDOG_HEARTBEAT_LOG_EVERY_N_POLLS,
+        ]
+
+    def test_no_heartbeat_before_n_polls(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """The heartbeat is throttled — N-1 polls produces zero heartbeats."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        monkeypatch.setattr(daemon, "WATCHDOG_POLL_INTERVAL_SECONDS", 0.01)
+        d._last_scheduler_tick_at = time.monotonic()
+
+        n_target = daemon.WATCHDOG_HEARTBEAT_LOG_EVERY_N_POLLS - 1
+        call_n = {"count": 0}
+
+        def _stop_after(_timeout: float | None = None) -> bool:
+            call_n["count"] += 1
+            if call_n["count"] >= n_target:
+                d._watchdog_stop.set()
+                return True
+            return False
+
+        monkeypatch.setattr(d._watchdog_stop, "wait", _stop_after)
+
+        d._watchdog_loop()
+        assert handler.events("watchdog_heartbeat") == []
+
+
+# --------------------------------------------------------------------------
+# AC #4 — module-level constants are sane defaults.
+# --------------------------------------------------------------------------
+
+
+class TestModuleConstants:
+    def test_supervisor_slow_step_threshold_is_below_watchdog_warn(self) -> None:
+        """Per-step supervisor slow WARN fires BEFORE the watchdog WARN
+        so we name the offending sub-step instead of dumping the whole
+        thread set. Threshold (10s) << watchdog WARN (60s) honours that
+        ordering."""
+        assert daemon.SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS > 0.0
+        assert (
+            daemon.SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS
+            < daemon.DEFAULT_SCHEDULER_TICK_STALL_WARN_SECONDS
+        )
+
+    def test_supervisor_slow_step_threshold_is_at_least_scheduler(self) -> None:
+        """Supervisor sub-steps are inherently slower than scheduler
+        sub-steps (the advance pass calls ``gh pr view`` per agent, the
+        diagnoser pass spawns subprocesses) — the threshold must give
+        them at least as much budget as the scheduler steps to avoid
+        spurious WARNs on a normal busy tick."""
+        assert (
+            daemon.SUPERVISOR_TICK_SLOW_STEP_WARN_SECONDS
+            >= daemon.SCHEDULER_TICK_SLOW_STEP_WARN_SECONDS
+        )
+
+    def test_watchdog_heartbeat_cadence_is_positive(self) -> None:
+        """Cadence must be ≥ 1 — a value of 0 would emit on every poll
+        (heartbeat-spam) and a negative value would never emit."""
+        assert daemon.WATCHDOG_HEARTBEAT_LOG_EVERY_N_POLLS >= 1
+
+    def test_watchdog_heartbeat_cadence_under_5min(self) -> None:
+        """The heartbeat exists so an operator scanning recent logs sees
+        daemon-is-alive evidence within ≈ one scroll. With 30s poll
+        intervals, 10 polls = 5min — that's the upper bound. If the
+        cadence climbs above this the heartbeat stops being a useful
+        liveness signal during the typical operator-glance window."""
+        cadence_seconds = (
+            daemon.WATCHDOG_HEARTBEAT_LOG_EVERY_N_POLLS
+            * daemon.WATCHDOG_POLL_INTERVAL_SECONDS
+        )
+        assert cadence_seconds <= 5 * 60
+
+
+# --------------------------------------------------------------------------
+# Smoke test — a thread launched into ``_watchdog_loop`` exits cleanly
+# when ``_watchdog_stop`` is set. Documents the join semantics relied on
+# in shutdown.
+# --------------------------------------------------------------------------
+
+
+class TestWatchdogLoopShutdown:
+    def test_loop_exits_when_stop_event_set(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, _conn, _handler = _make_daemon(tmp_path)
+        monkeypatch.setattr(daemon, "WATCHDOG_POLL_INTERVAL_SECONDS", 0.01)
+        d._last_scheduler_tick_at = time.monotonic()
+
+        t = threading.Thread(target=d._watchdog_loop, name="t-watchdog-test")
+        t.start()
+        # Let the loop run a few polls then stop.
+        time.sleep(0.1)
+        d._watchdog_stop.set()
+        t.join(timeout=2.0)
+        assert not t.is_alive(), "watchdog loop did not exit within 2s of stop"


### PR DESCRIPTION
## Summary

Adds two new instrumentation layers to close the observability gap exposed by the post-#3401 incident on 2026-04-26 (the operator perceived the daemon as wedged within 1 minute of boot — CloudWatch evidence shows it was actually running scheduler_tick every ~5s the whole time):

1. **`_record_supervisor_step()`** — mirror of the existing `_record_scheduler_step` (#3205) for `supervisor_tick`. Refreshes `_last_scheduler_tick_at` mid-supervisor-tick and emits `daemon.supervisor_tick_slow_<step>` WARNING when a sub-step exceeds 10s. Wired in between all 11 supervisor sub-steps so the next genuine wedge names itself in CloudWatch BEFORE the 60s watchdog has to dump the whole thread set.

2. **`daemon.watchdog_heartbeat`** — unconditional liveness signal emitted from the `_watchdog_loop` thread itself every ~5 minutes. Even if both scheduler and supervisor go silent, an operator scanning recent CloudWatch sees daemon-is-alive evidence within ~1 scroll.

Behavior unchanged on the watchdog trip path (60s WARN, 120s EXIT, `os._exit(137)`) — that path was already shipping correctly per #3097 + the existing 41 tests in `test_daemon_watchdog.py`.

Closes #3403

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (16 new + 1751 existing dispatcher tests = 1767 passing locally)
- [x] CI green

### Post-deploy verification
- [x] `daemon.watchdog_heartbeat` events appear in `/ecs/judgemind-dispatcher-dev` at ~5min cadence after deploy (verified at 03:01:14Z, poll_n=10, 270s after watchdog_started)
- [x] `daemon.supervisor_tick_slow_*` events fire on real load (true positive: caught `orphan_pr_resurrect` taking 26.9s vs 10s threshold)
- [x] No regression in `daemon.supervisor_tick` cadence (still fires every ~120s; 7-12 tick events per min observed)
- [x] Verification evidence posted on issue (#3403 comment 4321138998)
