### PR TITLE
fix(dispatcher): enforce Closes #N in daemon-spawned PRs + post-merge cleanup (#3411)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -2338,6 +2338,37 @@ handle_push_and_pr() {
         return 0
     fi
 
+    # ── #3411: ensure ``Closes #<ISSUE_NUMBER>`` (or equivalent) is
+    # present in the PR body. /task-v2-summary doesn't always emit
+    # the keyword, and without it GitHub won't auto-close the issue
+    # on merge — leaving the daemon's ready queue stuck with done-
+    # but-unclaimable issues. This is the entrypoint-side mirror of
+    # daemon.py's ``_ensure_closes_keyword``. Idempotent: if the
+    # keyword for $ISSUE_NUMBER is already present, the body is left
+    # unchanged. Defense in depth across both subprocess + ECS modes.
+    if [[ -n "$_pr_body_md" && -n "$ISSUE_NUMBER" ]]; then
+        # Case-insensitive grep for any of: close|closes|closed,
+        # fix|fixes|fixed, resolve|resolves|resolved followed by
+        # whitespace then ``#<ISSUE_NUMBER>`` with a word boundary so
+        # ``#3411`` doesn't match a request body containing ``#34110``.
+        # Use ``-E`` for extended regex (portable across grep
+        # implementations on Linux + macOS bash 3.2). Escape the
+        # ``#`` even though it's not regex-special — defensive.
+        _close_pattern="(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+#${ISSUE_NUMBER}([^0-9]|$)"
+        if ! printf '%s' "$_pr_body_md" | grep -qiE "$_close_pattern"; then
+            log "push_and_pr_closes_keyword_appended" "issue_number=$ISSUE_NUMBER"
+            # Strip trailing whitespace/newlines so we don't end up
+            # with an oversized blank-line tail, then append the
+            # keyword as its own paragraph.
+            _pr_body_md="$(printf '%s' "$_pr_body_md" | sed -e 's/[[:space:]]*$//')
+
+Closes #${ISSUE_NUMBER}
+"
+        else
+            log "push_and_pr_closes_keyword_present" "issue_number=$ISSUE_NUMBER"
+        fi
+    fi
+
     # ── #3176: open the PR with summary's pr_title + pr_body_md when
     # available. Fall back to ``--fill`` so a missing summary still
     # produces a PR (degraded but not abandoned).
@@ -3698,6 +3729,89 @@ try_auto_unstick_merge() {
     return 0
 }
 
+close_issue_post_merge() {
+    # Issue #3411 — belt-and-suspenders post-merge issue cleanup.
+    # Mirrors daemon.py's ``_close_issue_post_merge``. If the PR body
+    # lacked a ``Closes #N`` keyword (or GitHub failed to auto-close
+    # for any other reason), close the originating issue + strip
+    # ``agent/ready`` so it doesn't reappear in the daemon's queue
+    # scan. The PR-body validation in handle_push_and_pr makes this
+    # branch rare, but the keep-the-queue-clean invariant matters
+    # more than the cost of an extra ``gh issue view`` per merge.
+    #
+    # Args: $1 = issue_number, $2 = pr_number.
+    # Best-effort — every failure is logged but does not propagate.
+    _issue_num="$1"
+    _pr_num="$2"
+    if [[ -z "$_issue_num" ]]; then
+        log "post_merge_cleanup_skipped" "reason=no_issue_number"
+        return 0
+    fi
+    # Probe issue state. Write stdout to a file so we can capture the
+    # exit code distinctly from the substitution's exit code (a
+    # ``$( ... || printf '' )`` pattern always exits 0 regardless of
+    # whether gh succeeded — losing the probe failure signal).
+    set +e
+    gh issue view "$_issue_num" \
+        --repo judgemind/judgemind \
+        --json state \
+        --jq '.state' \
+        > "$AGENT_WORKSPACE/gh-issue-state.stdout.log" \
+        2> "$AGENT_WORKSPACE/gh-issue-state.stderr.log"
+    _probe_rc=$?
+    set -e
+    _state=""
+    if [[ -s "$AGENT_WORKSPACE/gh-issue-state.stdout.log" ]]; then
+        _state=$(tr -d '\n\r' < "$AGENT_WORKSPACE/gh-issue-state.stdout.log")
+    fi
+    if [[ "$_probe_rc" -ne 0 || -z "$_state" ]]; then
+        log "post_merge_cleanup_probe_failed" \
+            "issue_number=$_issue_num" "exit_code=$_probe_rc"
+        return 0
+    fi
+    # ``gh issue view --json state`` returns ``OPEN`` or ``CLOSED``.
+    # Compare case-insensitively for safety.
+    _state_upper=$(printf '%s' "$_state" | tr '[:lower:]' '[:upper:]')
+    if [[ "$_state_upper" != "OPEN" ]]; then
+        log "post_merge_cleanup_skipped" \
+            "issue_number=$_issue_num" "reason=already_closed" "state=$_state"
+        return 0
+    fi
+    log "post_merge_cleanup_begin" "issue_number=$_issue_num" "pr_number=$_pr_num"
+    # Close the issue with a comment naming the PR + cleanup origin.
+    _close_comment="Closed by PR #${_pr_num} (autonomous post-merge cleanup, see #3411 — PR body did not contain \`Closes #${_issue_num}\` keyword so GitHub didn't auto-close)."
+    set +e
+    gh issue close "$_issue_num" \
+        --repo judgemind/judgemind \
+        --reason completed \
+        --comment "$_close_comment" \
+        > "$AGENT_WORKSPACE/gh-issue-close.stdout.log" \
+        2> "$AGENT_WORKSPACE/gh-issue-close.stderr.log"
+    _close_rc=$?
+    set -e
+    if [[ "$_close_rc" -ne 0 ]]; then
+        log "post_merge_cleanup_close_failed" \
+            "issue_number=$_issue_num" "exit_code=$_close_rc"
+        # Continue to label-strip even if close failed — the label is
+        # the queue-visible signal; close is for the operator UI.
+    fi
+    # Strip agent/ready so the issue is fully off the queue.
+    set +e
+    gh issue edit "$_issue_num" \
+        --repo judgemind/judgemind \
+        --remove-label agent/ready \
+        > "$AGENT_WORKSPACE/gh-issue-remove-label.stdout.log" \
+        2> "$AGENT_WORKSPACE/gh-issue-remove-label.stderr.log"
+    _label_rc=$?
+    set -e
+    if [[ "$_label_rc" -ne 0 ]]; then
+        log "post_merge_cleanup_label_strip_failed" \
+            "issue_number=$_issue_num" "exit_code=$_label_rc"
+    fi
+    log "post_merge_cleanup_done" "issue_number=$_issue_num" "pr_number=$_pr_num"
+    return 0
+}
+
 handle_merge() {
     # Squash-merge the PR with branch-delete. On stale-rollup stderr,
     # attempt one auto-unstick (push empty commit, go back to
@@ -3732,6 +3846,16 @@ handle_merge() {
             _merge_sha=""
         fi
         log "merge_succeeded" "pr_number=$_pr_number" "merge_sha=$_merge_sha"
+        # ── #3411: post-merge issue cleanup (belt & suspenders) ───────
+        # Mirror daemon.py's ``_close_issue_post_merge``. If the PR
+        # body lacked a ``Closes #N`` keyword (or GitHub failed to
+        # auto-close for any other reason), close the issue + strip
+        # ``agent/ready`` so it doesn't reappear in the daemon's
+        # ready-queue scan. The PR-body validation in handle_push_and_pr
+        # makes this a rare branch, but the keep-the-queue-clean
+        # invariant is more important than minimizing redundant gh
+        # calls.
+        close_issue_post_merge "$ISSUE_NUMBER" "$_pr_number"
         printf '{"merged": true, "pr_number": %s, "merge_sha": "%s"}' \
             "$_pr_number" "$_merge_sha"
         return 0

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -7698,6 +7698,106 @@ class DispatcherDaemon:
             # succeeded the moment the PR shipped. Best-effort; matches
             # the ``_mark_agent_terminal`` teardown path (#2866).
             self._gh_issue_remove_labels(issue_number, [STATUS_IN_PROGRESS_LABEL])
+            # Issue #3411: post-merge issue cleanup. Defense in depth
+            # against PRs whose body doesn't contain ``Closes #N`` —
+            # GitHub won't auto-close the issue, so the daemon has to
+            # do it explicitly. The PR-body validation in
+            # :meth:`_ensure_closes_keyword` makes this branch a
+            # belt-and-suspenders safety net for legacy PRs and edge
+            # cases where the keyword somehow gets stripped during
+            # rebase / amend.
+            try:
+                self._close_issue_post_merge(int(issue_number), pr_number)
+            except Exception:
+                self._log.exception(
+                    "daemon.close_issue_post_merge_failed",
+                    extra={
+                        "event": "close_issue_post_merge_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "issue_number": issue_number,
+                        "pr_number": pr_number,
+                    },
+                )
+
+    def _close_issue_post_merge(self, issue_number: int, pr_number: int | None) -> None:
+        """Close the originating issue + strip ``agent/ready`` after PR merge.
+
+        Issue #3411. Belt-and-suspenders for the (now-rare) case where
+        the PR body lacks a ``Closes #N`` keyword and GitHub doesn't
+        auto-close the issue. Mirrors the manual ``gh issue close +
+        gh issue edit --remove-label agent/ready`` flow operators have
+        been running by hand on stale ready-queue entries.
+
+        Behavior:
+
+        - If the issue is already CLOSED, no-op (logs ``post_merge_
+          cleanup_skipped`` with reason ``already_closed``).
+        - If the issue is OPEN, post a close comment naming the merged
+          PR and the autonomous-cleanup origin (cites #3411 so future
+          operators reading the comment can find this code path), then
+          strip ``agent/ready`` so the issue is fully off the queue.
+
+        Best-effort: any failure (gh probe flake, close timeout,
+        label-strip non-zero) is logged but does not raise. The
+        primary correctness invariant — ``status='succeeded'`` and
+        ``merged_at`` are stamped — was already committed by
+        :meth:`_write_merged_at` before reaching this method.
+        """
+        if not self._gh_issue_is_open(issue_number):
+            self._log.info(
+                "daemon.post_merge_cleanup_skipped",
+                extra={
+                    "event": "post_merge_cleanup_skipped",
+                    "run_id": self._run_id,
+                    "issue_number": issue_number,
+                    "pr_number": pr_number,
+                    "reason": "already_closed",
+                },
+            )
+            return
+        # Compose the close comment. Naming the PR + the cleanup
+        # origin (#3411) makes the comment self-explanatory in the
+        # issue thread; operators reading it later can grep for #3411
+        # to find this code path.
+        if pr_number is not None:
+            comment = (
+                f"Closed by PR #{pr_number} (autonomous post-merge cleanup, "
+                f"see #3411 — PR body did not contain ``Closes #{issue_number}`` "
+                f"keyword so GitHub didn't auto-close)."
+            )
+        else:
+            # pr_number is unexpectedly missing — close without naming
+            # the PR rather than skipping the cleanup entirely.
+            comment = (
+                f"Closed by merged PR (autonomous post-merge cleanup, "
+                f"see #3411 — PR body did not contain ``Closes #{issue_number}`` "
+                f"keyword so GitHub didn't auto-close)."
+            )
+        self._log.info(
+            "daemon.post_merge_cleanup_begin",
+            extra={
+                "event": "post_merge_cleanup_begin",
+                "run_id": self._run_id,
+                "issue_number": issue_number,
+                "pr_number": pr_number,
+            },
+        )
+        self._gh_issue_close(issue_number, comment=comment, reason="completed")
+        # Strip ``agent/ready`` so the issue doesn't reappear in the
+        # daemon's queue scan on the next supervisor tick. The label
+        # remove is independently retried by ``_gh_issue_remove_labels``;
+        # idempotent if the label is already absent.
+        self._gh_issue_remove_labels(issue_number, ["agent/ready"])
+        self._log.info(
+            "daemon.post_merge_cleanup_done",
+            extra={
+                "event": "post_merge_cleanup_done",
+                "run_id": self._run_id,
+                "issue_number": issue_number,
+                "pr_number": pr_number,
+            },
+        )
 
     def _write_verified_at(self, agent_id: str) -> None:
         """Stamp ``verified_at = now()`` when the verify phase succeeds.
@@ -12043,6 +12143,24 @@ class DispatcherDaemon:
             )
             return
 
+        # Issue #3411: ensure ``Closes #<issue_number>`` is present in
+        # the PR body so GitHub auto-closes the issue on merge.
+        # /task-v2-summary doesn't always emit the keyword (observed on
+        # PRs #3393, #3391, #3390 and others). Without this guarantee
+        # the issue stays OPEN with ``agent/ready`` and the daemon
+        # re-evaluates it every supervisor tick under the
+        # ``already_attempted`` cooldown — wasting candidate-eval cost
+        # and masking the true ready-queue size. The helper is
+        # idempotent when the keyword is already present.
+        #
+        # Runs AFTER the empty-body validation above so the validation
+        # branch still trips on ``pr_body_md=""`` from summary —
+        # otherwise this helper would synthesize a non-empty body
+        # ("Closes #N") and mask a malformed summary output as
+        # shippable. Order matters: validate → inject.
+        if issue_number is not None:
+            pr_body_md = self._ensure_closes_keyword(pr_body_md, int(issue_number))
+
         # git commit --amend -F <file>. Issue #2971: Ralph's Step 2.5
         # commits its work directly (placeholder message "WIP: ralph
         # output") and leaves the commit in place. We amend that commit
@@ -12680,6 +12798,62 @@ class DispatcherDaemon:
             if match:
                 return int(match.group(1))
         return None
+
+    @staticmethod
+    def _ensure_closes_keyword(body: str, issue_number: int) -> str:
+        """Ensure the PR body contains a ``Closes #<issue_number>`` keyword.
+
+        Issue #3411 — daemon-spawned PRs have been merging without a
+        ``Closes #N`` / ``Fixes #N`` GitHub keyword in the body, leaving
+        the originating issue OPEN with ``agent/ready`` and stuck in
+        the daemon's ``already_attempted`` cooldown. This helper is the
+        last-line guarantee that EVERY PR body shipped by the daemon
+        carries the closing keyword for its issue, regardless of what
+        ``/task-v2-summary`` produced.
+
+        Behavior:
+
+        - If the body already contains a closing keyword pointing at
+          ``issue_number`` (any of ``Closes #N`` / ``Fixes #N`` /
+          ``Resolves #N``, case-insensitive), return ``body`` unchanged.
+        - Otherwise (no closing keyword, or a closing keyword for some
+          OTHER issue number), append ``\\n\\nCloses #<issue_number>\\n``
+          to ``body``.
+
+        The "wrong issue number" case is intentionally additive — we
+        don't strip the existing wrong-issue keyword (which would
+        mutate operator-visible content) but we DO append our own so
+        the issue we actually care about gets closed. The result is
+        a PR that closes both the wrong-and-our-issue (rare but
+        observed in copy-paste regressions); operators can correct
+        the surplus close manually if needed.
+
+        Pure function — no I/O, no side effects.
+        """
+        import re  # noqa: PLC0415
+
+        # GitHub recognizes: close, closes, closed, fix, fixes, fixed,
+        # resolve, resolves, resolved (case-insensitive). Match the
+        # full set so we don't add a duplicate ``Closes #N`` when the
+        # summary skill emitted ``Resolves #N``.
+        # See https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
+        pattern = re.compile(
+            r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#"
+            + str(issue_number)
+            + r"\b",
+            re.IGNORECASE,
+        )
+        if pattern.search(body or ""):
+            return body
+        # Append. Use \n\n separator so the keyword is its own
+        # paragraph and doesn't accidentally land on the same line as
+        # a trailing summary paragraph.
+        suffix = f"\n\nCloses #{issue_number}\n"
+        # Strip trailing whitespace/newlines first so we don't end up
+        # with ``...\n\n\n\nCloses #N\n``. Idempotent under repeated
+        # invocation when the keyword IS present (covered by the
+        # unchanged-return branch above).
+        return (body or "").rstrip() + suffix
 
     # ── Phase 3B post-PR orchestration (supervisor-tick step 3) ─────────
     #

--- a/scripts/dispatcher/tests/test_daemon_closes_keyword.py
+++ b/scripts/dispatcher/tests/test_daemon_closes_keyword.py
@@ -1,0 +1,349 @@
+"""Unit tests for the ``Closes #N`` PR-body guarantee + post-merge issue
+cleanup added by issue #3411.
+
+Two surfaces are covered:
+
+1. ``DispatcherDaemon._ensure_closes_keyword`` — pure-functional helper
+   that appends ``Closes #<issue_number>`` to a PR body when no closing
+   keyword is already present for that issue. Idempotent.
+
+2. ``DispatcherDaemon._close_issue_post_merge`` — best-effort post-merge
+   cleanup called from ``_write_merged_at``. Closes the issue + strips
+   ``agent/ready`` if the issue is still OPEN; no-ops if already
+   CLOSED. All gh I/O is mocked.
+
+Why it matters: PRs #3393, #3391, #3390, and others were merged by the
+daemon without a ``Closes #N`` keyword in the body, so GitHub didn't
+auto-close their issues. The daemon then re-evaluated those stale
+``agent/ready`` issues every supervisor tick, wasting candidate-eval
+cost and masking the true ready-queue size. These tests pin down the
+fix shape so a future refactor doesn't quietly drop the guarantee.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from dispatcher import daemon  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# _ensure_closes_keyword — pure-functional PR-body guarantee
+# --------------------------------------------------------------------------
+
+
+class TestEnsureClosesKeyword:
+    """Acceptance criteria from issue #3411 — minimum test set."""
+
+    def test_appends_when_keyword_missing(self) -> None:
+        """The required behavior — body without Closes keyword gets it."""
+        body = "## Summary\n\nFixes a thing.\n"
+        result = daemon.DispatcherDaemon._ensure_closes_keyword(body, 3411)
+        assert "Closes #3411" in result
+        # Original content preserved verbatim.
+        assert "## Summary" in result
+        assert "Fixes a thing." in result
+
+    def test_idempotent_when_keyword_present(self) -> None:
+        """Body with ``Closes #<N>`` already present is unchanged."""
+        body = "## Summary\n\nFixes a thing.\n\nCloses #3411\n"
+        result = daemon.DispatcherDaemon._ensure_closes_keyword(body, 3411)
+        assert result == body
+
+    def test_recognizes_fixes_keyword(self) -> None:
+        """``Fixes #N`` is the GitHub equivalent — should not double-append."""
+        body = "## Summary\n\nFixes #3411\n"
+        result = daemon.DispatcherDaemon._ensure_closes_keyword(body, 3411)
+        assert result == body
+        # And critically — only one instance.
+        assert result.count("3411") == 1
+
+    def test_recognizes_resolves_keyword(self) -> None:
+        """``Resolves #N`` is a GitHub-recognized closing keyword."""
+        body = "## Summary\n\nResolves #3411\n"
+        result = daemon.DispatcherDaemon._ensure_closes_keyword(body, 3411)
+        assert result == body
+
+    def test_recognizes_closed_past_tense(self) -> None:
+        """``Closed #N`` (past tense) is a recognized keyword too."""
+        body = "## Summary\n\nClosed #3411\n"
+        result = daemon.DispatcherDaemon._ensure_closes_keyword(body, 3411)
+        assert result == body
+
+    def test_case_insensitive_keyword_match(self) -> None:
+        """``CLOSES #N`` / ``closes #N`` should both count as present."""
+        for variant in ("CLOSES #3411", "closes #3411", "Closes #3411"):
+            body = f"## Summary\n\n{variant}\n"
+            result = daemon.DispatcherDaemon._ensure_closes_keyword(body, 3411)
+            assert result == body, f"variant {variant!r} should be recognized"
+
+    def test_appends_when_keyword_targets_other_issue(self) -> None:
+        """``Closes #other`` does NOT count as our issue — append our keyword."""
+        body = "## Summary\n\nCloses #999\n"
+        result = daemon.DispatcherDaemon._ensure_closes_keyword(body, 3411)
+        # Both keywords present — the surplus close is rare in practice
+        # (would only happen on a copy-paste regression) and operators
+        # can correct it manually. Critical invariant: OUR issue gets
+        # closed.
+        assert "Closes #3411" in result
+        assert "Closes #999" in result
+
+    def test_word_boundary_prevents_substring_match(self) -> None:
+        """``Closes #34110`` must NOT be recognized as ``Closes #3411``."""
+        body = "## Summary\n\nCloses #34110\n"
+        result = daemon.DispatcherDaemon._ensure_closes_keyword(body, 3411)
+        # Our keyword must be appended — the existing ``Closes #34110``
+        # is a different issue.
+        assert "Closes #3411\n" in result or result.endswith("Closes #3411\n")
+
+    def test_empty_body_gets_keyword(self) -> None:
+        """Empty / None body still produces a valid Closes-only body."""
+        result = daemon.DispatcherDaemon._ensure_closes_keyword("", 3411)
+        assert "Closes #3411" in result
+        # And does not have a leading blank-line tail.
+        assert not result.startswith("\n\n\n")
+
+    def test_no_excessive_blank_lines_on_append(self) -> None:
+        """Trailing whitespace stripped before append — no `\\n\\n\\n` tail."""
+        body = "## Summary\n\nFixes a thing.\n\n\n\n"
+        result = daemon.DispatcherDaemon._ensure_closes_keyword(body, 3411)
+        # The append separator is exactly two newlines.
+        assert "Fixes a thing.\n\nCloses #3411\n" in result
+        # No 3+-newline run anywhere in the result.
+        assert "\n\n\n" not in result
+
+
+# --------------------------------------------------------------------------
+# _close_issue_post_merge — best-effort post-merge cleanup
+# --------------------------------------------------------------------------
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.closes.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._run_id = "test-run-id"
+    return d, handler
+
+
+class TestClosePostMerge:
+    def test_skips_when_issue_already_closed(self, tmp_path: Path) -> None:
+        """If the issue is CLOSED, no gh close / label-strip is invoked."""
+        d, handler = _make_daemon(tmp_path)
+        d._gh_issue_is_open = MagicMock(return_value=False)  # type: ignore[method-assign]
+        d._gh_issue_close = MagicMock()  # type: ignore[method-assign]
+        d._gh_issue_remove_labels = MagicMock()  # type: ignore[method-assign]
+
+        d._close_issue_post_merge(issue_number=42, pr_number=100)
+
+        d._gh_issue_close.assert_not_called()
+        d._gh_issue_remove_labels.assert_not_called()
+        skipped = handler.events("post_merge_cleanup_skipped")
+        assert skipped, "expected post_merge_cleanup_skipped log event"
+        assert getattr(skipped[0], "reason", None) == "already_closed"
+
+    def test_closes_and_strips_label_when_open(self, tmp_path: Path) -> None:
+        """If the issue is OPEN, both close + agent/ready strip are invoked."""
+        d, _handler = _make_daemon(tmp_path)
+        d._gh_issue_is_open = MagicMock(return_value=True)  # type: ignore[method-assign]
+        d._gh_issue_close = MagicMock()  # type: ignore[method-assign]
+        d._gh_issue_remove_labels = MagicMock()  # type: ignore[method-assign]
+
+        d._close_issue_post_merge(issue_number=42, pr_number=100)
+
+        d._gh_issue_close.assert_called_once()
+        # close kwargs: issue_number positional, comment + reason kw.
+        call_args = d._gh_issue_close.call_args
+        assert call_args.args[0] == 42
+        assert call_args.kwargs["reason"] == "completed"
+        # The comment names the PR # for operator legibility AND
+        # cites #3411 so the audit trail is self-explanatory.
+        assert "PR #100" in call_args.kwargs["comment"]
+        assert "#3411" in call_args.kwargs["comment"]
+        d._gh_issue_remove_labels.assert_called_once_with(42, ["agent/ready"])
+
+    def test_close_comment_handles_missing_pr_number(self, tmp_path: Path) -> None:
+        """pr_number=None still produces a coherent close comment."""
+        d, _handler = _make_daemon(tmp_path)
+        d._gh_issue_is_open = MagicMock(return_value=True)  # type: ignore[method-assign]
+        d._gh_issue_close = MagicMock()  # type: ignore[method-assign]
+        d._gh_issue_remove_labels = MagicMock()  # type: ignore[method-assign]
+
+        d._close_issue_post_merge(issue_number=42, pr_number=None)
+
+        call_args = d._gh_issue_close.call_args
+        # No literal "PR #None" in the comment.
+        assert "PR #None" not in call_args.kwargs["comment"]
+        # Still cites #3411.
+        assert "#3411" in call_args.kwargs["comment"]
+        d._gh_issue_remove_labels.assert_called_once_with(42, ["agent/ready"])
+
+
+# --------------------------------------------------------------------------
+# Integration: _write_merged_at calls _close_issue_post_merge after the
+# label release.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+class TestWriteMergedAtIntegration:
+    def test_calls_close_issue_post_merge_after_label_release(
+        self, tmp_path: Path
+    ) -> None:
+        """_write_merged_at should call _close_issue_post_merge with the
+        same issue number + pr number it received, AFTER the
+        status/in-progress label release."""
+        d, _handler = _make_daemon(tmp_path)
+        d._conn = _FakeConnection()  # type: ignore[assignment]
+        d._write_diagnosis_outcome_for_agent = MagicMock()  # type: ignore[method-assign]
+        d._write_terminal_outcome = MagicMock()  # type: ignore[method-assign]
+        d._evaluate_circuit_breaker = MagicMock()  # type: ignore[method-assign]
+
+        # Track the order of calls to label release vs post-merge cleanup.
+        call_order: list[str] = []
+        d._gh_issue_remove_labels = MagicMock(  # type: ignore[method-assign]
+            side_effect=lambda issue, labels: call_order.append(
+                f"remove_labels:{issue}:{labels}"
+            )
+        )
+        d._close_issue_post_merge = MagicMock(  # type: ignore[method-assign]
+            side_effect=lambda issue_number, pr_number: call_order.append(
+                f"close_post_merge:{issue_number}:{pr_number}"
+            )
+        )
+
+        d._write_merged_at("aaaa-bbbb", pr_number=123, issue_number=42)
+
+        d._close_issue_post_merge.assert_called_once_with(42, 123)
+        # Order: status/in-progress release first, then post-merge close.
+        assert call_order == [
+            "remove_labels:42:['status/in-progress']",
+            "close_post_merge:42:123",
+        ]
+
+    def test_close_failure_does_not_propagate(self, tmp_path: Path) -> None:
+        """A raise inside _close_issue_post_merge is caught and logged."""
+        d, handler = _make_daemon(tmp_path)
+        d._conn = _FakeConnection()  # type: ignore[assignment]
+        d._write_diagnosis_outcome_for_agent = MagicMock()  # type: ignore[method-assign]
+        d._write_terminal_outcome = MagicMock()  # type: ignore[method-assign]
+        d._evaluate_circuit_breaker = MagicMock()  # type: ignore[method-assign]
+        d._gh_issue_remove_labels = MagicMock()  # type: ignore[method-assign]
+        d._close_issue_post_merge = MagicMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("gh down")
+        )
+
+        # Does NOT raise.
+        d._write_merged_at("aaaa-bbbb", pr_number=123, issue_number=42)
+
+        failures = handler.events("close_issue_post_merge_failed")
+        assert failures, "expected failure event when cleanup raises"
+
+    def test_skips_close_when_issue_number_is_none(self, tmp_path: Path) -> None:
+        """No issue_number means no cleanup attempted (no crash on int())."""
+        d, _handler = _make_daemon(tmp_path)
+        d._conn = _FakeConnection()  # type: ignore[assignment]
+        d._write_diagnosis_outcome_for_agent = MagicMock()  # type: ignore[method-assign]
+        d._write_terminal_outcome = MagicMock()  # type: ignore[method-assign]
+        d._evaluate_circuit_breaker = MagicMock()  # type: ignore[method-assign]
+        d._gh_issue_remove_labels = MagicMock()  # type: ignore[method-assign]
+        d._close_issue_post_merge = MagicMock()  # type: ignore[method-assign]
+
+        d._write_merged_at("aaaa-bbbb", pr_number=123)
+
+        d._close_issue_post_merge.assert_not_called()
+
+
+# --------------------------------------------------------------------------
+# Integration: _push_and_open_pr appends Closes #N before writing pr_body.md
+# --------------------------------------------------------------------------
+#
+# The full _push_and_open_pr is too large to drive end-to-end here without
+# extensive mocking; the integration assertion is delegated to the
+# bash-side test for the entrypoint (test_agent_runner_entrypoint.sh) and
+# the dedicated unit tests for ``_ensure_closes_keyword`` above. The call-
+# site wiring is verified by the static check below.
+
+
+class TestEnsureClosesKeywordCallSite:
+    def test_push_and_open_pr_invokes_ensure_closes_keyword(self) -> None:
+        """The call site exists in the daemon and references issue_number.
+
+        Static-source check: PR-body validation must remain wired into
+        ``_push_and_open_pr``. Refactors that move the validation to a
+        different call site MUST update this test to point at the new
+        call site — the goal is to keep someone from silently dropping
+        the guarantee. (This is a lightweight alternative to driving
+        the full ~600-line _push_and_open_pr through a mocked harness.)
+        """
+        source = Path(daemon.__file__).read_text(encoding="utf-8")
+        # The wiring must call _ensure_closes_keyword somewhere AND that
+        # somewhere must be inside the same module that calls
+        # ``gh pr create``.
+        assert "_ensure_closes_keyword" in source
+        # Confirm it's called with an issue_number (defensive — guards
+        # against a refactor that drops the second arg).
+        assert "self._ensure_closes_keyword(pr_body_md," in source

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -469,6 +469,21 @@ JSONEOF
     "auth login"|"auth setup-git")
         exit 0
         ;;
+    "issue view")
+        # #3411: post-merge cleanup probe. Test fixture
+        # GH_ISSUE_STATE_FIXTURE controls the returned state
+        # ("OPEN" | "CLOSED"). Defaults to CLOSED so existing tests
+        # that traverse merge → awaiting_deploy don't accidentally
+        # exercise the close path.
+        printf '%s\n' "${GH_ISSUE_STATE_FIXTURE:-CLOSED}"
+        exit "${GH_ISSUE_VIEW_EXIT:-0}"
+        ;;
+    "issue close")
+        exit "${GH_ISSUE_CLOSE_EXIT:-0}"
+        ;;
+    "issue edit")
+        exit "${GH_ISSUE_EDIT_EXIT:-0}"
+        ;;
 esac
 
 exit 0
@@ -1724,7 +1739,25 @@ if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
         cat "$GH_ISSUE_FIXTURE"
         exit 0
     fi
+    # #3411: post-merge cleanup probe uses ``gh issue view <N>
+    # --json state --jq .state``. Honor GH_ISSUE_STATE_FIXTURE
+    # ("OPEN" | "CLOSED") so close_issue_post_merge tests can drive
+    # both branches. Defaults to CLOSED so existing tests that
+    # traverse merge → awaiting_deploy don't accidentally exercise
+    # the close path.
+    if printf '%s' "$*" | grep -q -- "--json state"; then
+        printf '%s\n' "${GH_ISSUE_STATE_FIXTURE:-CLOSED}"
+        exit "${GH_ISSUE_VIEW_EXIT:-0}"
+    fi
     exit 1
+fi
+
+# #3411: gh issue close + gh issue edit (post-merge cleanup actions).
+if [[ "${1:-}" == "issue" && "${2:-}" == "close" ]]; then
+    exit "${GH_ISSUE_CLOSE_EXIT:-0}"
+fi
+if [[ "${1:-}" == "issue" && "${2:-}" == "edit" ]]; then
+    exit "${GH_ISSUE_EDIT_EXIT:-0}"
 fi
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
@@ -4641,6 +4674,303 @@ if grep -qE '^DEPLOY_WORKFLOWS=.*deploy-agent-runner\.yml' "$ENTRYPOINT"; then
 else
     fail "#3185 — DEPLOY_WORKFLOWS default includes deploy-agent-runner.yml" \
          "deploy-agent-runner.yml not found in DEPLOY_WORKFLOWS default in $ENTRYPOINT"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 50: #3411 — handle_push_and_pr appends `Closes #N` to PR body when
+# /task-v2-summary's pr_body_md doesn't include it. Asserts that the
+# pr_body.md file written before `gh pr create` contains the keyword.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t50.txt"
+printf 'push_and_pr\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t50_workspace="$TEST_TMP/t50-workspace"
+mkdir -p "$t50_workspace/repo/.git" "$t50_workspace/repo/tmp/dispatcher-output"
+
+# Pre-stage a summary.json with a PR body that LACKS Closes #N. The
+# entrypoint reads from $REPO_ROOT/tmp/dispatcher-output/summary.json
+# (REPO_ROOT="$AGENT_WORKSPACE/repo").
+cat > "$t50_workspace/repo/tmp/dispatcher-output/summary.json" <<'EOF'
+{
+  "commit_message": "feat(test): demonstrate Closes injection (#3411)",
+  "pr_title": "feat(test): demonstrate Closes injection (#3411)",
+  "pr_body_md": "## Summary\n\nDemonstrates the keyword injection.\n\n(no Closes line in this body — the entrypoint must add one)\n",
+  "unmet_criteria": []
+}
+EOF
+
+set +e
+out=$(AGENT_ID="50000000-1111-2222-3333-444444444444" \
+      ISSUE_NUMBER="3411" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t50_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="$PRIOR_PATCH_FIXTURE" \
+      CLAUDE_VERDICT_FIXTURE="" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=15 \
+      GIT_REV_LIST_COUNT=1 \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+# The entrypoint logs `push_and_pr_closes_keyword_appended` when the
+# keyword was missing and got injected.
+if printf '%s' "$out" | grep -q "push_and_pr_closes_keyword_appended"; then
+    pass "#3411 T50 — entrypoint logs closes_keyword_appended when missing"
+else
+    fail "#3411 T50 — entrypoint logs closes_keyword_appended when missing" \
+         "out tail: $(printf '%s' "$out" | tail -c 800)"
+fi
+
+# The pr_body.md the entrypoint wrote before `gh pr create` should
+# contain `Closes #3411`.
+if [[ -f "$t50_workspace/pr_body.md" ]] && grep -qF "Closes #3411" "$t50_workspace/pr_body.md"; then
+    pass "#3411 T50 — pr_body.md contains Closes #3411 after injection"
+else
+    fail "#3411 T50 — pr_body.md contains Closes #3411 after injection" \
+         "pr_body.md content: $(cat "$t50_workspace/pr_body.md" 2>/dev/null || echo '<missing>')"
+fi
+
+# Original body content must be preserved verbatim — we only append.
+if [[ -f "$t50_workspace/pr_body.md" ]] && grep -qF "Demonstrates the keyword injection" "$t50_workspace/pr_body.md"; then
+    pass "#3411 T50 — original pr_body content preserved"
+else
+    fail "#3411 T50 — original pr_body content preserved" \
+         "pr_body.md content: $(cat "$t50_workspace/pr_body.md" 2>/dev/null || echo '<missing>')"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 51: #3411 — handle_push_and_pr is a no-op (idempotent) when the
+# PR body already contains Closes #N for the agent's issue.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t51.txt"
+printf 'push_and_pr\n' > "$PHASE_FIXTURE_FILE"
+
+t51_workspace="$TEST_TMP/t51-workspace"
+mkdir -p "$t51_workspace/repo/.git" "$t51_workspace/repo/tmp/dispatcher-output"
+
+cat > "$t51_workspace/repo/tmp/dispatcher-output/summary.json" <<'EOF'
+{
+  "commit_message": "fix(thing): existing closes (#3411)",
+  "pr_title": "fix(thing): existing closes (#3411)",
+  "pr_body_md": "## Summary\n\nA fix.\n\nCloses #3411\n",
+  "unmet_criteria": []
+}
+EOF
+
+set +e
+out=$(AGENT_ID="51000000-1111-2222-3333-444444444444" \
+      ISSUE_NUMBER="3411" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t51_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="" \
+      CLAUDE_VERDICT_FIXTURE="" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=15 \
+      GIT_REV_LIST_COUNT=1 \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+# When the keyword is already present, log `closes_keyword_present`
+# (not `_appended`).
+if printf '%s' "$out" | grep -q "push_and_pr_closes_keyword_present"; then
+    pass "#3411 T51 — entrypoint logs closes_keyword_present when already there"
+else
+    fail "#3411 T51 — entrypoint logs closes_keyword_present when already there" \
+         "out tail: $(printf '%s' "$out" | tail -c 800)"
+fi
+
+if printf '%s' "$out" | grep -q "push_and_pr_closes_keyword_appended"; then
+    fail "#3411 T51 — does NOT append when keyword already present" \
+         "out tail: $(printf '%s' "$out" | tail -c 800)"
+else
+    pass "#3411 T51 — does NOT append when keyword already present"
+fi
+
+# pr_body.md should contain exactly one Closes #3411.
+if [[ -f "$t51_workspace/pr_body.md" ]]; then
+    _count=$(grep -cF "Closes #3411" "$t51_workspace/pr_body.md")
+    if [[ "$_count" == "1" ]]; then
+        pass "#3411 T51 — pr_body.md has exactly one Closes #3411 (idempotent)"
+    else
+        fail "#3411 T51 — pr_body.md has exactly one Closes #3411 (idempotent)" \
+             "count=$_count, content: $(cat "$t51_workspace/pr_body.md")"
+    fi
+else
+    fail "#3411 T51 — pr_body.md exists" "missing pr_body.md"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 52: #3411 — handle_push_and_pr appends our Closes when the
+# existing keyword targets a DIFFERENT issue number.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t52.txt"
+printf 'push_and_pr\n' > "$PHASE_FIXTURE_FILE"
+
+t52_workspace="$TEST_TMP/t52-workspace"
+mkdir -p "$t52_workspace/repo/.git" "$t52_workspace/repo/tmp/dispatcher-output"
+
+cat > "$t52_workspace/repo/tmp/dispatcher-output/summary.json" <<'EOF'
+{
+  "commit_message": "fix(thing): wrong-issue closes (#3411)",
+  "pr_title": "fix(thing): wrong-issue closes (#3411)",
+  "pr_body_md": "## Summary\n\nA fix.\n\nCloses #999\n",
+  "unmet_criteria": []
+}
+EOF
+
+set +e
+out=$(AGENT_ID="52000000-1111-2222-3333-444444444444" \
+      ISSUE_NUMBER="3411" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t52_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="" \
+      CLAUDE_VERDICT_FIXTURE="" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=15 \
+      GIT_REV_LIST_COUNT=1 \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+# Both keywords should be present in the final body.
+if [[ -f "$t52_workspace/pr_body.md" ]] && grep -qF "Closes #999" "$t52_workspace/pr_body.md"; then
+    pass "#3411 T52 — preserves wrong-issue Closes #999"
+else
+    fail "#3411 T52 — preserves wrong-issue Closes #999" \
+         "pr_body.md: $(cat "$t52_workspace/pr_body.md" 2>/dev/null)"
+fi
+
+if [[ -f "$t52_workspace/pr_body.md" ]] && grep -qF "Closes #3411" "$t52_workspace/pr_body.md"; then
+    pass "#3411 T52 — appends our Closes #3411 alongside wrong-issue keyword"
+else
+    fail "#3411 T52 — appends our Closes #3411 alongside wrong-issue keyword" \
+         "pr_body.md: $(cat "$t52_workspace/pr_body.md" 2>/dev/null)"
+fi
+
+if printf '%s' "$out" | grep -q "push_and_pr_closes_keyword_appended"; then
+    pass "#3411 T52 — logs appended event for wrong-issue case"
+else
+    fail "#3411 T52 — logs appended event for wrong-issue case" \
+         "out tail: $(printf '%s' "$out" | tail -c 800)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 53: #3411 — close_issue_post_merge invokes gh issue close + edit
+# when the issue is OPEN after a successful merge.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t53.txt"
+printf 'merge\n' > "$PHASE_FIXTURE_FILE"
+
+t53_workspace="$TEST_TMP/t53-workspace"
+set +e
+t53_out=$(run_post_pr_phase "merge" "$t53_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_ISSUE_STATE_FIXTURE=OPEN")
+set -e
+
+# Cleanup begin event fired (issue was OPEN, so we entered the cleanup
+# path).
+if printf '%s' "$t53_out" | grep -q "post_merge_cleanup_begin"; then
+    pass "#3411 T53 — post_merge_cleanup_begin logged on OPEN issue"
+else
+    fail "#3411 T53 — post_merge_cleanup_begin logged on OPEN issue" \
+         "out tail: $(printf '%s' "$t53_out" | tail -c 1000)"
+fi
+
+# gh issue close was invoked.
+if grep -F "issue" "$INVOCATIONS_DIR/gh.log" | grep -F "close" >/dev/null 2>&1; then
+    pass "#3411 T53 — gh issue close invoked"
+else
+    fail "#3411 T53 — gh issue close invoked" \
+         "gh log: $(cat "$INVOCATIONS_DIR/gh.log")"
+fi
+
+# gh issue edit --remove-label agent/ready was invoked.
+if grep -F "issue" "$INVOCATIONS_DIR/gh.log" | grep -F "remove-label" | grep -F "agent/ready" >/dev/null 2>&1; then
+    pass "#3411 T53 — gh issue edit --remove-label agent/ready invoked"
+else
+    fail "#3411 T53 — gh issue edit --remove-label agent/ready invoked" \
+         "gh log: $(cat "$INVOCATIONS_DIR/gh.log")"
+fi
+
+# Cleanup done event fired.
+if printf '%s' "$t53_out" | grep -q "post_merge_cleanup_done"; then
+    pass "#3411 T53 — post_merge_cleanup_done logged after close + label-strip"
+else
+    fail "#3411 T53 — post_merge_cleanup_done logged after close + label-strip" \
+         "out tail: $(printf '%s' "$t53_out" | tail -c 1000)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 54: #3411 — close_issue_post_merge skips when the issue is
+# already CLOSED. No gh issue close / edit invocations.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t54.txt"
+printf 'merge\n' > "$PHASE_FIXTURE_FILE"
+
+t54_workspace="$TEST_TMP/t54-workspace"
+set +e
+t54_out=$(run_post_pr_phase "merge" "$t54_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_ISSUE_STATE_FIXTURE=CLOSED")
+set -e
+
+# Skipped event fired with reason=already_closed.
+if printf '%s' "$t54_out" | grep -q "post_merge_cleanup_skipped"; then
+    pass "#3411 T54 — post_merge_cleanup_skipped logged on CLOSED issue"
+else
+    fail "#3411 T54 — post_merge_cleanup_skipped logged on CLOSED issue" \
+         "out tail: $(printf '%s' "$t54_out" | tail -c 1000)"
+fi
+
+if printf '%s' "$t54_out" | grep -q '"reason": "already_closed"'; then
+    pass "#3411 T54 — skip reason is already_closed"
+else
+    fail "#3411 T54 — skip reason is already_closed" \
+         "out tail: $(printf '%s' "$t54_out" | tail -c 1000)"
+fi
+
+# Critically: NO gh issue close invocation when issue is already CLOSED.
+if grep -F "issue" "$INVOCATIONS_DIR/gh.log" | grep -F "close" >/dev/null 2>&1; then
+    fail "#3411 T54 — does NOT invoke gh issue close on CLOSED issue" \
+         "gh log: $(cat "$INVOCATIONS_DIR/gh.log")"
+else
+    pass "#3411 T54 — does NOT invoke gh issue close on CLOSED issue"
 fi
 
 # ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two-layer defense against the "succeeded agent leaves issue OPEN with `agent/ready`" bug that today wastes ~50% of supervisor-tick candidate-evaluation cost re-considering 9-11 done-but-unclaimable issues per cycle. (1) Both subprocess- and ECS-mode PR-creation paths now ensure `Closes #<issue_number>` is in the PR body before `gh pr create`. (2) Both merge handlers add a post-merge cleanup step that closes the originating issue + strips `agent/ready` if GitHub didn't auto-close — defense in depth for legacy PRs / edge cases.

Closes #3411

## Test plan

### Automated checks
- [x] Lint passes (ruff check daemon.py, all clean)
- [x] Format check passes (ruff format applied)
- [x] Tests pass (1754 dispatcher Python tests, 245 entrypoint bash tests, including 27 new tests for #3411)
- [x] CI green (mergeable=MERGEABLE, ci-passed=SUCCESS)

### Post-deploy verification
- [x] After this PR merges, confirm THIS PR's body contains `Closes #3411` (it does — see above) and the issue auto-closes on merge — **VERIFIED**: issue #3411 is CLOSED post-merge.
- [x] Verify daemon CloudWatch logs show new container running (`version_sha=66fccd4`) — **VERIFIED**: `daemon.startup` log at 07:18:26Z with my merge SHA.
- [ ] Wait for the next daemon-shipped green; confirm that PR's body has `Closes #<N>` AND its originating issue auto-closes — **deferred to natural daemon flow**, will surface in CloudWatch as `daemon.pr_opened` + auto-close on merge.
- [x] Verification evidence posted on issue #3411 — see [comment](https://github.com/judgemind/judgemind/issues/3411#issuecomment-4321522542).
