### PR TITLE
fix(dx): consolidate duplicate stubs in entrypoint test + add guard (#3415)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -639,6 +639,9 @@ jobs:
       - name: Check docs describe the actual rebuild_db.py CLI
         if: matrix.shard == 'python'
         run: scripts/check-no-rebuild-db-skip-reset.sh
+      - name: Check test files do not redefine the same stub binary
+        if: matrix.shard == 'python'
+        run: scripts/check-no-duplicate-stubs.sh
       # Cross-checks every non-stdlib import under scripts/dispatcher/ against
       # the pip install step in Dockerfile.dispatcher. Motivated by the #2773
       # boto3 scope miss (#2776): PR #2771 added `import boto3` but did not

--- a/scripts/check-no-duplicate-stubs.sh
+++ b/scripts/check-no-duplicate-stubs.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# check-no-duplicate-stubs.sh — Forbid duplicate stub-generation blocks for
+# the same binary in any test file under scripts/tests/.
+#
+# A stub definition looks like:
+#   cat > "$STUB_BIN/<binary>" <<HEREDOC
+#
+# When the same binary appears more than once in a single test file, the
+# second block silently overwrites the first — discarding any routes that
+# were merged into the initial definition.  This caused a regression in
+# test_agent_runner_entrypoint.sh where Stage-1 gh/psql routes were
+# dropped when Stage-2 definitions re-declared the same binary (see #3415).
+#
+# Usage:
+#   scripts/check-no-duplicate-stubs.sh          # scan scripts/tests/test_*.sh
+#   scripts/check-no-duplicate-stubs.sh [dir]    # scan test_*.sh under [dir]
+#
+# Exit codes:
+#   0 — No violations found.
+#   1 — One or more test files redefine the same stub binary more than once.
+
+# venv: none
+# permanent: true
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCAN_DIR="${1:-$REPO_ROOT/scripts/tests}"
+
+# ─── Files that legitimately contain duplicate stubs as test fixtures ─────────
+# The peer test for this guard creates intentional duplicate stubs to verify
+# that the guard detects them.  Exclude it from the scan.
+EXCLUDE_FILES=(
+    "scripts/tests/test_check_no_duplicate_stubs.sh"
+)
+
+violations=0
+
+# ─── Scan each test file ─────────────────────────────────────────────────────
+while IFS= read -r -d '' test_file; do
+    # Skip explicitly-excluded files.
+    skip_file=false
+    for excl in "${EXCLUDE_FILES[@]}"; do
+        if [[ "$test_file" == *"$excl" ]]; then
+            skip_file=true
+            break
+        fi
+    done
+    if "$skip_file"; then
+        continue
+    fi
+
+    # Collect all binary names and their line numbers in this file.
+    # Format: "<lineno> <binary>"
+    declare -A binary_first_line=()
+    declare -A binary_count=()
+
+    while IFS= read -r match_line; do
+        # match_line format from grep -n: "<lineno>:<content>"
+        lineno="${match_line%%:*}"
+        content="${match_line#*:}"
+
+        # Skip comment lines (first non-whitespace char is #).
+        if [[ "$content" =~ ^[[:space:]]*# ]]; then
+            continue
+        fi
+
+        # Extract the binary name via shell pattern match.
+        # Pattern: cat > "$STUB_BIN/<binary>" <<
+        if [[ "$content" =~ cat[[:space:]]+\>[[:space:]]+\"\$STUB_BIN/([^\"]*)\"[[:space:]]+\<\< ]]; then
+            binary="${BASH_REMATCH[1]}"
+
+            if [[ -z "${binary_first_line[$binary]:-}" ]]; then
+                binary_first_line[$binary]="$lineno"
+                binary_count[$binary]=1
+            else
+                binary_count[$binary]=$(( binary_count[$binary] + 1 ))
+                if [[ ${binary_count[$binary]} -eq 2 ]]; then
+                    # First time we detect a duplicate — emit the error.
+                    if [[ $violations -eq 0 ]]; then
+                        echo "ERROR: Test file(s) redefine the same stub binary more than once."
+                        echo ""
+                        echo "  The second cat > \"\$STUB_BIN/<binary>\" << block overwrites the"
+                        echo "  first, silently discarding any routes merged into the initial"
+                        echo "  definition.  Consolidate both definitions into the first block."
+                        echo ""
+                    fi
+                    echo "    File:   $test_file"
+                    echo "    Binary: $binary"
+                    echo "    Line 1: ${binary_first_line[$binary]}"
+                    echo "    Line 2: $lineno"
+                    echo ""
+                    violations=$(( violations + 1 ))
+                fi
+            fi
+        fi
+    done < <(grep -n 'cat > "\$STUB_BIN/' "$test_file" 2>/dev/null || true)
+
+    unset binary_first_line
+    unset binary_count
+done < <(find "$SCAN_DIR" -maxdepth 1 -name 'test_*.sh' -print0 2>/dev/null)
+
+if [[ $violations -gt 0 ]]; then
+    echo "  Found $violations duplicate stub definition(s)."
+    echo ""
+    echo "  Fix: merge the routes from the second stub block into the first"
+    echo "  definition, then delete the second cat > \"\$STUB_BIN/<binary>\" <<"
+    echo "  block entirely."
+    echo ""
+    exit 1
+fi
+
+echo "All clean — no duplicate stub definitions detected."
+exit 0

--- a/scripts/check-no-duplicate-stubs.sh
+++ b/scripts/check-no-duplicate-stubs.sh
@@ -50,54 +50,45 @@ while IFS= read -r -d '' test_file; do
         continue
     fi
 
-    # Collect all binary names and their line numbers in this file.
-    # Format: "<lineno> <binary>"
-    declare -A binary_first_line=()
-    declare -A binary_count=()
-
+    # Collect all (lineno binary) pairs from this file, skipping comment lines.
+    pairs=""
     while IFS= read -r match_line; do
-        # match_line format from grep -n: "<lineno>:<content>"
         lineno="${match_line%%:*}"
         content="${match_line#*:}"
-
-        # Skip comment lines (first non-whitespace char is #).
         if [[ "$content" =~ ^[[:space:]]*# ]]; then
             continue
         fi
-
-        # Extract the binary name via shell pattern match.
-        # Pattern: cat > "$STUB_BIN/<binary>" <<
         if [[ "$content" =~ cat[[:space:]]+\>[[:space:]]+\"\$STUB_BIN/([^\"]*)\"[[:space:]]+\<\< ]]; then
             binary="${BASH_REMATCH[1]}"
-
-            if [[ -z "${binary_first_line[$binary]:-}" ]]; then
-                binary_first_line[$binary]="$lineno"
-                binary_count[$binary]=1
-            else
-                binary_count[$binary]=$(( binary_count[$binary] + 1 ))
-                if [[ ${binary_count[$binary]} -eq 2 ]]; then
-                    # First time we detect a duplicate — emit the error.
-                    if [[ $violations -eq 0 ]]; then
-                        echo "ERROR: Test file(s) redefine the same stub binary more than once."
-                        echo ""
-                        echo "  The second cat > \"\$STUB_BIN/<binary>\" << block overwrites the"
-                        echo "  first, silently discarding any routes merged into the initial"
-                        echo "  definition.  Consolidate both definitions into the first block."
-                        echo ""
-                    fi
-                    echo "    File:   $test_file"
-                    echo "    Binary: $binary"
-                    echo "    Line 1: ${binary_first_line[$binary]}"
-                    echo "    Line 2: $lineno"
-                    echo ""
-                    violations=$(( violations + 1 ))
-                fi
-            fi
+            pairs="${pairs}${lineno} ${binary}"$'\n'
         fi
     done < <(grep -n 'cat > "\$STUB_BIN/' "$test_file" 2>/dev/null || true)
 
-    unset binary_first_line
-    unset binary_count
+    # Use awk (POSIX, bash-3.2-safe) to find binaries defined more than once.
+    # For each duplicate binary, awk prints "<binary> <line1> <line2>".
+    while IFS=' ' read -r binary line1 line2; do
+        if [[ $violations -eq 0 ]]; then
+            echo "ERROR: Test file(s) redefine the same stub binary more than once."
+            echo ""
+            echo "  The second cat > \"\$STUB_BIN/<binary>\" << block overwrites the"
+            echo "  first, silently discarding any routes merged into the initial"
+            echo "  definition.  Consolidate both definitions into the first block."
+            echo ""
+        fi
+        echo "    File:   $test_file"
+        echo "    Binary: $binary"
+        echo "    Line 1: $line1"
+        echo "    Line 2: $line2"
+        echo ""
+        violations=$(( violations + 1 ))
+    done < <(printf '%s' "$pairs" | awk '
+        NF == 2 {
+            lineno = $1; binary = $2
+            cnt[binary]++
+            if (cnt[binary] == 1) { first[binary] = lineno }
+            else if (cnt[binary] == 2) { print binary, first[binary], lineno }
+        }
+    ')
 done < <(find "$SCAN_DIR" -maxdepth 1 -name 'test_*.sh' -print0 2>/dev/null)
 
 if [[ $violations -gt 0 ]]; then

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -143,6 +143,39 @@ case "$query" in
         printf '%s\n' "${MERGE_UNSTICK_ATTEMPTS_FIXTURE:-0}"
         exit 0
         ;;
+    *"SELECT COALESCE(pr_number"*"FROM dispatcher.agents"*)
+        printf '%s' "${DB_AGENT_PR_NUMBER:-0}"
+        exit 0
+        ;;
+    *"SELECT COALESCE(retries_used"*"FROM dispatcher.agents"*)
+        printf '%s' "${DB_AGENT_RETRIES_USED:-0}"
+        exit 0
+        ;;
+    *"EXTRACT(EPOCH FROM (now() - started_at))"*"FROM dispatcher.agents"*)
+        printf '%s' "${DB_AGENT_TOTAL_DURATION_S:-0}"
+        exit 0
+        ;;
+    *"SELECT output_json"*"FROM dispatcher.phase_outputs"*)
+        # Route by phase name substring.
+        if [[ "$query" == *"phase = 'summary'"* && -f "${DB_SUMMARY_OUTPUT_FIXTURE:-}" ]]; then
+            cat "$DB_SUMMARY_OUTPUT_FIXTURE"
+        elif [[ "$query" == *"phase = 'verify'"* && -f "${DB_VERIFY_OUTPUT_FIXTURE:-}" ]]; then
+            cat "$DB_VERIFY_OUTPUT_FIXTURE"
+        fi
+        exit 0
+        ;;
+    *"FROM dispatcher.phase_transitions"*)
+        if [[ -f "${DB_PHASE_TRANSITIONS_FIXTURE:-}" ]]; then
+            cat "$DB_PHASE_TRANSITIONS_FIXTURE"
+        fi
+        exit 0
+        ;;
+    *"FROM dispatcher.failures"*)
+        if [[ -f "${DB_FAILURES_FIXTURE:-}" ]]; then
+            cat "$DB_FAILURES_FIXTURE"
+        fi
+        exit 0
+        ;;
     *"SELECT patch_content"*)
         if [[ -f "${PRIOR_PATCH_FIXTURE:-}" ]]; then
             cat "$PRIOR_PATCH_FIXTURE"
@@ -432,13 +465,22 @@ case "$sub $verb" in
         exit "${GH_PR_CREATE_EXIT:-0}"
         ;;
     "pr view")
+        # Shim-test fixture (Stage 2) first, then post-PR fixture,
+        # then a canonical green-rollup fallback so happy-path tests can
+        # traverse awaiting_ci → merge → awaiting_deploy without setting
+        # any fixture at all.
+        if [[ -n "${GH_PR_FIXTURE:-}" && -f "$GH_PR_FIXTURE" ]]; then
+            cat "$GH_PR_FIXTURE"
+            exit 0
+        fi
         if [[ -n "${GH_PR_VIEW_JSON_FIXTURE:-}" && -f "${GH_PR_VIEW_JSON_FIXTURE:-}" ]]; then
             cat "$GH_PR_VIEW_JSON_FIXTURE"
-        else
-            # Default: green rollup, mergeable, with a merge SHA so
-            # happy-path tests can traverse awaiting_ci → merge →
-            # awaiting_deploy without fixture overrides.
-            cat <<'JSONEOF'
+            exit 0
+        fi
+        # Default: green rollup, mergeable, with a merge SHA so
+        # happy-path tests can traverse awaiting_ci → merge →
+        # awaiting_deploy without fixture overrides.
+        cat <<'JSONEOF'
 {
   "statusCheckRollup": [
     {"name": "ci-passed", "status": "COMPLETED", "conclusion": "SUCCESS"}
@@ -449,8 +491,14 @@ case "$sub $verb" in
   "mergeCommit": {"oid": "deadbeefcafe"}
 }
 JSONEOF
-        fi
         exit 0
+        ;;
+    "pr diff")
+        if [[ -n "${GH_PR_DIFF_FIXTURE:-}" && -f "$GH_PR_DIFF_FIXTURE" ]]; then
+            cat "$GH_PR_DIFF_FIXTURE"
+            exit 0
+        fi
+        exit 1
         ;;
     "pr merge")
         if [[ -n "${GH_PR_MERGE_STDERR:-}" ]]; then
@@ -458,18 +506,37 @@ JSONEOF
         fi
         exit "${GH_PR_MERGE_EXIT:-0}"
         ;;
+    "run view")
+        if [[ -n "${GH_RUN_LOG_FIXTURE:-}" && -f "$GH_RUN_LOG_FIXTURE" ]]; then
+            cat "$GH_RUN_LOG_FIXTURE"
+            exit 0
+        fi
+        exit 1
+        ;;
     "run list")
+        # Shim-test fixture (Stage 2) first, then post-PR fixture,
+        # then empty array fallback so awaiting_deploy's "no runs → verify"
+        # branch lights up without fixture setup.
+        if [[ -n "${GH_RUN_LIST_FIXTURE:-}" && -f "$GH_RUN_LIST_FIXTURE" ]]; then
+            cat "$GH_RUN_LIST_FIXTURE"
+            exit 0
+        fi
         if [[ -n "${GH_RUN_LIST_JSON_FIXTURE:-}" && -f "${GH_RUN_LIST_JSON_FIXTURE:-}" ]]; then
             cat "$GH_RUN_LIST_JSON_FIXTURE"
-        else
-            printf '[]\n'
+            exit 0
         fi
+        printf '[]\n'
         exit "${GH_RUN_LIST_EXIT:-0}"
         ;;
     "auth login"|"auth setup-git")
         exit 0
         ;;
     "issue view")
+        # GH_ISSUE_FIXTURE: full JSON fixture file (Stage 2 shim tests).
+        if [[ -n "${GH_ISSUE_FIXTURE:-}" && -f "$GH_ISSUE_FIXTURE" ]]; then
+            cat "$GH_ISSUE_FIXTURE"
+            exit 0
+        fi
         # #3411: post-merge cleanup probe. Test fixture
         # GH_ISSUE_STATE_FIXTURE controls the returned state
         # ("OPEN" | "CLOSED"). Defaults to CLOSED so existing tests
@@ -1705,260 +1772,6 @@ else
     fail "#3135 — entrypoint stamps phase_input_shim.py file on disk" \
          "expected file not found: $SHIM_PY"
 fi
-
-# Extend the gh stub with richer routes for the Stage 2 fetches and the
-# #3176 post-PR mechanical phases:
-#   * ``gh issue view <N> --json ...``    → read $GH_ISSUE_FIXTURE
-#   * ``gh pr view <N> --json ...``       → read $GH_PR_FIXTURE (shim
-#                                           tests) OR #3176
-#                                           $GH_PR_VIEW_JSON_FIXTURE
-#                                           (post-PR tests) — falls
-#                                           back to a canonical green
-#                                           rollup when neither is set.
-#   * ``gh pr diff <N>``                  → read $GH_PR_DIFF_FIXTURE
-#   * ``gh pr create``                    → honour GH_PR_CREATE_EXIT
-#                                           (defaults to 0, printing a
-#                                           canonical PR URL).
-#   * ``gh pr merge``                     → honour GH_PR_MERGE_EXIT +
-#                                           GH_PR_MERGE_STDERR (#3176).
-#   * ``gh run view --log-failed --job``  → read $GH_RUN_LOG_FIXTURE
-#   * ``gh run list --commit <sha>``      → read $GH_RUN_LIST_FIXTURE
-#                                           (shim tests) OR #3176
-#                                           $GH_RUN_LIST_JSON_FIXTURE
-#                                           (post-PR tests) — falls
-#                                           back to ``[]``.
-cat > "$STUB_BIN/gh" <<'GHEOF'
-#!/usr/bin/env bash
-set -u
-INVOCATIONS_DIR="${INVOCATIONS_DIR}"
-. "$(dirname "$0")/_record_invocation.sh" gh "$@"
-
-# Parse subcommand chain.
-if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
-    if [[ -n "${GH_ISSUE_FIXTURE:-}" && -f "$GH_ISSUE_FIXTURE" ]]; then
-        cat "$GH_ISSUE_FIXTURE"
-        exit 0
-    fi
-    # #3411: post-merge cleanup probe uses ``gh issue view <N>
-    # --json state --jq .state``. Honor GH_ISSUE_STATE_FIXTURE
-    # ("OPEN" | "CLOSED") so close_issue_post_merge tests can drive
-    # both branches. Defaults to CLOSED so existing tests that
-    # traverse merge → awaiting_deploy don't accidentally exercise
-    # the close path.
-    if printf '%s' "$*" | grep -q -- "--json state"; then
-        printf '%s\n' "${GH_ISSUE_STATE_FIXTURE:-CLOSED}"
-        exit "${GH_ISSUE_VIEW_EXIT:-0}"
-    fi
-    exit 1
-fi
-
-# #3411: gh issue close + gh issue edit (post-merge cleanup actions).
-if [[ "${1:-}" == "issue" && "${2:-}" == "close" ]]; then
-    exit "${GH_ISSUE_CLOSE_EXIT:-0}"
-fi
-if [[ "${1:-}" == "issue" && "${2:-}" == "edit" ]]; then
-    exit "${GH_ISSUE_EDIT_EXIT:-0}"
-fi
-
-if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
-    # Shim-test fixture (Stage 2) first, then #3176 post-PR fixture,
-    # then a canonical green-rollup fallback so happy-path tests can
-    # traverse awaiting_ci → merge → awaiting_deploy without setting
-    # any fixture at all.
-    if [[ -n "${GH_PR_FIXTURE:-}" && -f "$GH_PR_FIXTURE" ]]; then
-        cat "$GH_PR_FIXTURE"
-        exit 0
-    fi
-    if [[ -n "${GH_PR_VIEW_JSON_FIXTURE:-}" && -f "$GH_PR_VIEW_JSON_FIXTURE" ]]; then
-        cat "$GH_PR_VIEW_JSON_FIXTURE"
-        exit 0
-    fi
-    cat <<'JSONEOF'
-{
-  "statusCheckRollup": [
-    {"name": "ci-passed", "status": "COMPLETED", "conclusion": "SUCCESS"}
-  ],
-  "mergeable": "MERGEABLE",
-  "mergeStateStatus": "CLEAN",
-  "headRefOid": "deadbeefcafe",
-  "mergeCommit": {"oid": "deadbeefcafe"}
-}
-JSONEOF
-    exit 0
-fi
-
-if [[ "${1:-}" == "pr" && "${2:-}" == "diff" ]]; then
-    if [[ -n "${GH_PR_DIFF_FIXTURE:-}" && -f "$GH_PR_DIFF_FIXTURE" ]]; then
-        cat "$GH_PR_DIFF_FIXTURE"
-        exit 0
-    fi
-    exit 1
-fi
-
-if [[ "${1:-}" == "pr" && "${2:-}" == "merge" ]]; then
-    # #3176: handle_merge calls ``gh pr merge <N> --squash --delete-branch``.
-    if [[ -n "${GH_PR_MERGE_STDERR:-}" ]]; then
-        printf '%s\n' "$GH_PR_MERGE_STDERR" >&2
-    fi
-    exit "${GH_PR_MERGE_EXIT:-0}"
-fi
-
-if [[ "${1:-}" == "run" && "${2:-}" == "view" ]]; then
-    if [[ -n "${GH_RUN_LOG_FIXTURE:-}" && -f "$GH_RUN_LOG_FIXTURE" ]]; then
-        cat "$GH_RUN_LOG_FIXTURE"
-        exit 0
-    fi
-    exit 1
-fi
-
-if [[ "${1:-}" == "run" && "${2:-}" == "list" ]]; then
-    # Shim-test fixture (Stage 2) first, then #3176 post-PR fixture,
-    # then empty array fallback so awaiting_deploy's "no runs → verify"
-    # branch lights up without fixture setup.
-    if [[ -n "${GH_RUN_LIST_FIXTURE:-}" && -f "$GH_RUN_LIST_FIXTURE" ]]; then
-        cat "$GH_RUN_LIST_FIXTURE"
-        exit 0
-    fi
-    if [[ -n "${GH_RUN_LIST_JSON_FIXTURE:-}" && -f "$GH_RUN_LIST_JSON_FIXTURE" ]]; then
-        cat "$GH_RUN_LIST_JSON_FIXTURE"
-        exit 0
-    fi
-    printf '[]\n'
-    exit "${GH_RUN_LIST_EXIT:-0}"
-fi
-
-# Legacy route kept for push_and_pr tests.
-sub=""
-for arg in "$@"; do
-    if [[ "$sub" == "" && "$arg" != --* && "$arg" != -* ]]; then
-        sub="$arg"
-        continue
-    fi
-    if [[ -n "$sub" && "$sub" == "pr" && "$arg" != --* && "$arg" != -* ]]; then
-        if [[ "$arg" == "create" ]]; then
-            printf 'https://github.com/judgemind/judgemind/pull/9999\n'
-            exit "${GH_PR_CREATE_EXIT:-0}"
-        fi
-    fi
-done
-
-exit 0
-GHEOF
-chmod +x "$STUB_BIN/gh"
-
-# Extend the psql stub with Stage 2 SELECTs on dispatcher.agents,
-# dispatcher.phase_outputs, dispatcher.phase_transitions, and
-# dispatcher.failures. Each new fixture env var is read on-demand so
-# individual tests configure only what they need.
-cat > "$STUB_BIN/psql" <<'PSQLEOF'
-#!/usr/bin/env bash
-set -u
-INVOCATIONS_DIR="${INVOCATIONS_DIR}"
-. "$(dirname "$0")/_record_invocation.sh" psql "$@"
-
-query=""
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        -c)
-            shift
-            query="$1"
-            ;;
-    esac
-    shift || true
-done
-
-case "$query" in
-    *"SELECT phase"*"FROM dispatcher.agents"*)
-        if [[ -f "${PHASE_FIXTURE_FILE:-}" ]]; then
-            head -n 1 "$PHASE_FIXTURE_FILE"
-        fi
-        exit 0
-        ;;
-    *"SELECT pr_number"*"FROM dispatcher.agents"*)
-        # #3176 — post-PR handlers read pr_number from the agent row.
-        printf '%s\n' "${PR_NUMBER_FIXTURE:-9999}"
-        exit 0
-        ;;
-    *"SELECT COALESCE(merge_unstick_attempts"*|*"SELECT merge_unstick_attempts"*)
-        # #3176 — handle_merge's auto-unstick budget check.
-        printf '%s\n' "${MERGE_UNSTICK_ATTEMPTS_FIXTURE:-0}"
-        exit 0
-        ;;
-    *"SELECT COALESCE(pr_number"*"FROM dispatcher.agents"*)
-        printf '%s' "${DB_AGENT_PR_NUMBER:-0}"
-        exit 0
-        ;;
-    *"SELECT COALESCE(retries_used"*"FROM dispatcher.agents"*)
-        printf '%s' "${DB_AGENT_RETRIES_USED:-0}"
-        exit 0
-        ;;
-    *"EXTRACT(EPOCH FROM (now() - started_at))"*"FROM dispatcher.agents"*)
-        printf '%s' "${DB_AGENT_TOTAL_DURATION_S:-0}"
-        exit 0
-        ;;
-    *"SELECT output_json"*"FROM dispatcher.phase_outputs"*)
-        # Route by phase name substring.
-        if [[ "$query" == *"phase = 'summary'"* && -f "${DB_SUMMARY_OUTPUT_FIXTURE:-}" ]]; then
-            cat "$DB_SUMMARY_OUTPUT_FIXTURE"
-        elif [[ "$query" == *"phase = 'verify'"* && -f "${DB_VERIFY_OUTPUT_FIXTURE:-}" ]]; then
-            cat "$DB_VERIFY_OUTPUT_FIXTURE"
-        fi
-        exit 0
-        ;;
-    *"FROM dispatcher.phase_transitions"*)
-        if [[ -f "${DB_PHASE_TRANSITIONS_FIXTURE:-}" ]]; then
-            cat "$DB_PHASE_TRANSITIONS_FIXTURE"
-        fi
-        exit 0
-        ;;
-    *"FROM dispatcher.failures"*)
-        if [[ -f "${DB_FAILURES_FIXTURE:-}" ]]; then
-            cat "$DB_FAILURES_FIXTURE"
-        fi
-        exit 0
-        ;;
-    *"SELECT patch_content"*)
-        if [[ -f "${PRIOR_PATCH_FIXTURE:-}" ]]; then
-            cat "$PRIOR_PATCH_FIXTURE"
-        fi
-        exit 0
-        ;;
-    *"UPDATE dispatcher.agents"*"SET phase ="*)
-        new_phase=$(printf '%s' "$query" | sed -n "s/.*SET phase = '\\([^']*\\)'.*/\\1/p")
-        if [[ -n "$new_phase" && -f "${PHASE_FIXTURE_FILE:-}" ]]; then
-            printf '%s\n' "$new_phase" > "$PHASE_FIXTURE_FILE"
-        fi
-        exit 0
-        ;;
-    *"UPDATE dispatcher.agents"*"SET ended_at"*)
-        exit 0
-        ;;
-    *"INSERT INTO dispatcher.phase_outputs"*)
-        exit 0
-        ;;
-    *"INSERT INTO dispatcher.ralph_patches"*)
-        # #3144 T26 knob — see equivalent in the earlier stub (L151).
-        if [[ "${PSQL_FAIL_ON_INSERT:-0}" == "1" ]]; then
-            exit 1
-        fi
-        exit 0
-        ;;
-    *"SELECT 1 FROM dispatcher.ralph_patches"*)
-        if [[ "${RALPH_PATCH_EXISTS:-0}" == "1" ]]; then
-            printf '1\n'
-        fi
-        exit 0
-        ;;
-    *"UPDATE dispatcher.agents"*"SET ralph_iterations_observed"*)
-        # #3144 HEAD-watcher counter bump.
-        exit 0
-        ;;
-    *)
-        exit 0
-        ;;
-esac
-PSQLEOF
-chmod +x "$STUB_BIN/psql"
 
 # Helper: invoke the shim directly and print the JSON payload path.
 run_shim() {

--- a/scripts/tests/test_check_no_duplicate_stubs.sh
+++ b/scripts/tests/test_check_no_duplicate_stubs.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# test_check_no_duplicate_stubs.sh — Tests for check-no-duplicate-stubs.sh.
+#
+# Creates temporary files to verify that the checker correctly detects
+# duplicate stub-generation blocks for the same binary while allowing
+# single definitions, different binaries, comment-only mentions, and
+# files outside scripts/tests/.
+#
+# Usage:
+#   scripts/tests/test_check_no_duplicate_stubs.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-no-duplicate-stubs.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory so we don't pollute the repo.  We pass this dir
+# as the scan directory explicitly, so the guard looks for test_*.sh
+# files inside it rather than the real scripts/tests/ directory.
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+# create_test_file <name> <content>
+# Creates $TMPDIR_TEST/<name> (mkdir -p parents) and returns the path.
+create_test_file() {
+    local name="$1"
+    local content="$2"
+    local dir
+    dir="$(dirname "$TMPDIR_TEST/$name")"
+    mkdir -p "$dir"
+    local path="$TMPDIR_TEST/$name"
+    printf '%s\n' "$content" > "$path"
+    echo "$path"
+}
+
+assert_fails() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+assert_passes() {
+    local desc="$1"
+    TESTS=$((TESTS + 1))
+    if "$CHECK_SCRIPT" "$TMPDIR_TEST" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+reset_tmpdir() {
+    rm -rf "$TMPDIR_TEST"/*
+    rm -rf "$TMPDIR_TEST"/.[!.]* 2>/dev/null || true
+}
+
+# ─── Test 1: Single stub definition passes ───────────────────────────────────
+create_test_file "test_something.sh" 'cat > "$STUB_BIN/gh" <<'"'"'GHEOF'"'"'
+#!/usr/bin/env bash
+exit 0
+GHEOF'
+assert_passes "Single gh stub definition passes"
+reset_tmpdir
+
+# ─── Test 2: Duplicate gh stubs fail ─────────────────────────────────────────
+create_test_file "test_agent_runner.sh" 'cat > "$STUB_BIN/gh" <<'"'"'GHEOF'"'"'
+#!/usr/bin/env bash
+exit 0
+GHEOF
+
+cat > "$STUB_BIN/gh" <<'"'"'GHEOF2'"'"'
+#!/usr/bin/env bash
+exit 1
+GHEOF2'
+assert_fails "Duplicate gh stubs in same file are detected"
+reset_tmpdir
+
+# ─── Test 3: Duplicate gh stubs — error names both line numbers ───────────────
+test_file=$(create_test_file "test_agent_runner.sh" 'cat > "$STUB_BIN/gh" <<'"'"'GHEOF'"'"'
+#!/usr/bin/env bash
+exit 0
+GHEOF
+
+cat > "$STUB_BIN/gh" <<'"'"'GHEOF2'"'"'
+#!/usr/bin/env bash
+exit 1
+GHEOF2')
+TESTS=$((TESTS + 1))
+output=$("$CHECK_SCRIPT" "$TMPDIR_TEST" 2>&1 || true)
+if printf '%s' "$output" | grep -q 'Line 1:' && printf '%s' "$output" | grep -q 'Line 2:'; then
+    echo "PASS: Error message names both line numbers"
+else
+    echo "FAIL: Error message does not name both line numbers"
+    echo "  Output: $output"
+    FAILURES=$((FAILURES + 1))
+fi
+reset_tmpdir
+
+# ─── Test 4: Different binaries in same file pass ─────────────────────────────
+create_test_file "test_something.sh" 'cat > "$STUB_BIN/gh" <<'"'"'GHEOF'"'"'
+#!/usr/bin/env bash
+exit 0
+GHEOF
+cat > "$STUB_BIN/psql" <<'"'"'PSQLEOF'"'"'
+#!/usr/bin/env bash
+exit 0
+PSQLEOF'
+assert_passes "Different binaries (gh and psql) in same file pass"
+reset_tmpdir
+
+# ─── Test 5: Comment-only mentions pass ───────────────────────────────────────
+create_test_file "test_something.sh" '# cat > "$STUB_BIN/gh" << would be the pattern
+# We define gh stub below:
+cat > "$STUB_BIN/gh" <<'"'"'GHEOF'"'"'
+#!/usr/bin/env bash
+exit 0
+GHEOF'
+assert_passes "Comment-only mentions of the pattern are not flagged"
+reset_tmpdir
+
+# ─── Test 6: Files outside scripts/tests/ are not scanned ────────────────────
+# Create a duplicate-stub file in a subdirectory — guard uses maxdepth 1
+# so it won't descend into subdirs.
+mkdir -p "$TMPDIR_TEST/subdir"
+printf '%s\n' 'cat > "$STUB_BIN/gh" <<'"'"'EOF'"'"'
+exit 0
+EOF
+cat > "$STUB_BIN/gh" <<'"'"'EOF2'"'"'
+exit 1
+EOF2' > "$TMPDIR_TEST/subdir/test_nested.sh"
+assert_passes "Files in subdirectories are not scanned (maxdepth 1)"
+reset_tmpdir
+
+# ─── Test 7: Non-test_*.sh files are not scanned ─────────────────────────────
+create_test_file "helper_utils.sh" 'cat > "$STUB_BIN/gh" <<'"'"'EOF'"'"'
+exit 0
+EOF
+cat > "$STUB_BIN/gh" <<'"'"'EOF2'"'"'
+exit 1
+EOF2'
+assert_passes "Files not matching test_*.sh glob are not scanned"
+reset_tmpdir
+
+# ─── Test 8: Empty directory passes ──────────────────────────────────────────
+assert_passes "Empty directory passes"
+
+# ─── Test 9: Duplicate psql stubs fail ───────────────────────────────────────
+create_test_file "test_agent_runner.sh" 'cat > "$STUB_BIN/psql" <<'"'"'PSQLEOF'"'"'
+#!/usr/bin/env bash
+exit 0
+PSQLEOF
+
+cat > "$STUB_BIN/psql" <<'"'"'PSQLEOF2'"'"'
+#!/usr/bin/env bash
+exit 1
+PSQLEOF2'
+assert_fails "Duplicate psql stubs in same file are detected"
+reset_tmpdir
+
+# ─── Test 10: Multiple files — violation in one, clean in other ───────────────
+create_test_file "test_clean.sh" 'cat > "$STUB_BIN/gh" <<'"'"'GHEOF'"'"'
+#!/usr/bin/env bash
+exit 0
+GHEOF'
+create_test_file "test_bad.sh" 'cat > "$STUB_BIN/gh" <<'"'"'GHEOF'"'"'
+#!/usr/bin/env bash
+exit 0
+GHEOF
+cat > "$STUB_BIN/gh" <<'"'"'GHEOF2'"'"'
+#!/usr/bin/env bash
+exit 1
+GHEOF2'
+assert_fails "Violation in one file is detected even when another file is clean"
+reset_tmpdir
+
+# ─── Test 11: No self-match on ci.yml step name ──────────────────────────────
+# The step name in .github/workflows/ci.yml that runs this guard must
+# not itself contain the forbidden pattern (cat > "$STUB_BIN/...").
+# The guard scans test_*.sh files, so the synthesized step-name file
+# (ci_step_names.sh) won't match the glob — guard always passes in
+# TMPDIR_TEST. The assertion still verifies the step name is not
+# mis-named in a way that would cause issues.
+# shellcheck source=./_guard_self_match_helpers.sh
+source "$SCRIPT_DIR/tests/_guard_self_match_helpers.sh"
+assert_no_self_match_on_ci_step_name \
+    "scripts/check-no-duplicate-stubs.sh" "sh"
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Eliminated silent stub-generation overwrites in test_agent_runner_entrypoint.sh by consolidating duplicate blocks for gh (old lines 406→1730) and psql (108→1853) into single definitions with integrated routes. Created scripts/check-no-duplicate-stubs.sh hygiene guard to prevent this entire class of issue in future tests.

Closes #3415

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` + `ruff format --check`)
- [x] Tests pass (`pytest` on peer test suite: 11/11 passing per ralph output)
- [x] CI green

### Post-deploy verification

- [ ] N/A — no deployed component (test/CI infrastructure only)