### PR TITLE
fix(dispatcher): extend NULL-anchor cron lookback from 1 minute to 24 hours (#3424)

### DIFF
--- a/scripts/dispatcher/scheduled_skills.py
+++ b/scripts/dispatcher/scheduled_skills.py
@@ -27,6 +27,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
+#: Lookback window used when ``last_triggered_at`` is NULL (first-ever fire or
+#: manually reset).  Walking 24 hours ensures that a cron whose exact minute
+#: already passed today is still found and fired once on the next daemon tick,
+#: matching standard cron "fire exactly once if missed" semantics.  24 hours
+#: also matches the existing 24h iteration-cap safety guard so the two
+#: constants stay in sync without an extra config knob.
+_NULL_ANCHOR_LOOKBACK = timedelta(hours=24)
+
 
 # Field bounds, matching the standard 5-field cron layout:
 #   minute hour day_of_month month day_of_week
@@ -149,10 +157,14 @@ def should_fire_cron(
     inclusive) and return True if any minute in that range matches the
     cron schedule.
 
-    On first-ever fire (``last_triggered_at is None``) the anchor is
-    set to ``now - 1 minute`` so that a cron expression matching the
-    *current* minute fires on this tick rather than waiting until the
-    next match.
+    On first-ever fire (``last_triggered_at is None``) — including
+    rows that were manually reset to NULL — the anchor walks back a
+    full :data:`_NULL_ANCHOR_LOOKBACK` (24 hours) from ``now``.  This
+    ensures the most-recent past match within the last day is found
+    and fired exactly once on this tick, even if the cron's target
+    minute already passed today.  The existing 24h iteration cap (see
+    below) bounds the walk identically, so no extra config knob is
+    needed.
 
     Bounds:
       - The walk is capped at 24 hours so a daemon that was offline
@@ -162,8 +174,9 @@ def should_fire_cron(
     """
     schedule = parse_cron(expression)
     if last_triggered_at is None:
-        # First fire — let "now matches" trigger immediately.
-        anchor = now - timedelta(minutes=1)
+        # Never fired (or manually reset) — walk back 24h so the
+        # most-recent past match is found and fired on this tick.
+        anchor = now - _NULL_ANCHOR_LOOKBACK
     else:
         anchor = last_triggered_at
     # Defensive: if last_triggered is in the future (clock skew or

--- a/scripts/dispatcher/tests/test_scheduled_skills_cron.py
+++ b/scripts/dispatcher/tests/test_scheduled_skills_cron.py
@@ -112,10 +112,11 @@ class TestShouldFireCron:
         now = datetime(2026, 4, 25, 14, 0, tzinfo=UTC)
         assert should_fire_cron("0 14 * * *", None, now) is True
 
-    def test_first_fire_no_match_yet(self) -> None:
+    def test_first_fire_no_match_in_24h(self) -> None:
+        # An expression that can never match (Feb 30 does not exist) yields
+        # False regardless of the NULL-anchor 24h lookback.
         now = datetime(2026, 4, 25, 13, 0, tzinfo=UTC)
-        # First fire, but the schedule is 14:00 and now is 13:00.
-        assert should_fire_cron("0 14 * * *", None, now) is False
+        assert should_fire_cron("0 0 30 2 *", None, now) is False
 
     def test_no_fire_before_next_match(self) -> None:
         # Last fired at 14:00; "now" is 14:01 — same matching minute
@@ -162,3 +163,33 @@ class TestShouldFireCron:
         now = datetime(2026, 4, 25, 14, 1, tzinfo=UTC)
         with pytest.raises(CronParseError):
             should_fire_cron("not a cron", last, now)
+
+    # ------------------------------------------------------------------
+    # NULL-anchor 24h lookback (issue #3424)
+    # ------------------------------------------------------------------
+
+    def test_first_fire_finds_match_within_24h(self) -> None:
+        """AC #1 + AC #4: last=None, now=13:00Z, expr 0 12 * * * → True.
+
+        The cron's 12:00 slot already passed today (1 hour ago), but the
+        24h lookback window reaches back to yesterday's 12:00, so the walk
+        finds today's 12:00 and returns True.
+        """
+        now = datetime(2026, 4, 25, 13, 0, tzinfo=UTC)
+        assert should_fire_cron("0 12 * * *", None, now) is True
+
+    def test_consecutive_ticks_fire_once(self) -> None:
+        """AC #5: two consecutive ticks; second must NOT re-fire.
+
+        First tick: last=None, now=12:00:30Z → True (12:00 found in window).
+        Second tick: last=12:00:30Z (set by caller after first fire),
+        now=12:01:30Z → False (next 12:00 is tomorrow).
+        """
+        now_first = datetime(2026, 4, 25, 12, 0, 30, tzinfo=UTC)
+        assert should_fire_cron("0 12 * * *", None, now_first) is True
+
+        last_after_first_fire = datetime(2026, 4, 25, 12, 0, 30, tzinfo=UTC)
+        now_second = datetime(2026, 4, 25, 12, 1, 30, tzinfo=UTC)
+        assert (
+            should_fire_cron("0 12 * * *", last_after_first_fire, now_second) is False
+        )

--- a/scripts/dispatcher/tests/test_scheduled_skills_null_anchor_cap_catchup.py
+++ b/scripts/dispatcher/tests/test_scheduled_skills_null_anchor_cap_catchup.py
@@ -1,0 +1,190 @@
+"""NULL-anchor cap-catchup test for ``_scheduled_skills_tick`` (issue #3424).
+
+Asserts that when a cron row has ``last_triggered_at = NULL`` and the daemon
+is at concurrency cap on the first tick, the row's ``last_triggered_at`` is
+NOT updated (preserving NULL).  On the next tick — when cap clears — the
+24h NULL-anchor lookback fires the skill and issues the UPDATE.
+
+Maps acceptance criteria #3 and #6 from issue #3424.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from pathlib import Path
+from typing import Any
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+
+def _make_daemon(fake_conn: _FakeConnection) -> daemon.DispatcherDaemon:
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake-for-tests",
+        tick_scheduler_seconds=30,
+        tick_supervisor_seconds=120,
+        log_level="DEBUG",
+        version_sha="deadbee",
+        host="test-host",
+        pid=4242,
+    )
+    logger = logging.getLogger("dispatcher.test.null_anchor_cap_catchup")
+    logger.addHandler(logging.NullHandler())
+    logger.propagate = False
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = fake_conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d
+
+
+class TestNullAnchorCapCatchup:
+    def test_cap_busy_at_target_minute_preserves_null_anchor_and_catches_up(
+        self,
+    ) -> None:
+        """AC #3 + AC #6: cap-skip preserves NULL; next tick fires + UPDATEs.
+
+        Tick 1: ``last_triggered_at = NULL``, cron ``0 12 * * *``, now 12:00Z.
+                Concurrency cap = 0 → fires_skipped_cap = 1.
+                No ``UPDATE dispatcher.scheduled_skills`` should be issued.
+
+        Tick 2: ``last_triggered_at = NULL`` still (not changed by Tick 1).
+                now = 13:00Z, cap = 5, active = 1, no collision.
+                The 24h NULL-anchor lookback finds 12:00 → fires_succeeded = 1.
+                An ``UPDATE dispatcher.scheduled_skills`` is issued.
+        """
+        # --- Tick 1: cap = 0, skill would match but is blocked by cap ---
+        fake_conn = _FakeConnection()
+        row = ("daily-report", "/dispatcher-daily-report", "cron", "0 12 * * *", None)
+        fake_conn.cursor_instance.fetchall_queue = [
+            [row],
+        ]
+        # _read_concurrency_cap_for_scheduler → fetchone → cap = 0
+        # _active_agent_count → fetchone → active = 1
+        fake_conn.cursor_instance.fetch_queue = [
+            ("0",),  # concurrency_cap = 0
+            (1,),  # active_agent_count = 1  (1 >= 0 → skip)
+        ]
+
+        d = _make_daemon(fake_conn)
+        launch_calls: list[Any] = []
+        d._launch_agent_ecs_task = (  # type: ignore[method-assign]
+            lambda agent_id, issue_number: launch_calls.append(agent_id) or "arn"
+        )
+
+        # Freeze now via monkeypatching the daemon's internal clock is not
+        # straightforward — instead pass now indirectly by letting the
+        # real _scheduled_skills_tick compute now() naturally.  However,
+        # since we need a deterministic now for the cron evaluation, we
+        # override the datetime used inside the tick by patching
+        # ``daemon.datetime`` to return our frozen time.
+        #
+        # Simpler approach: set _now_for_scheduled_skills if the daemon
+        # exposes it, otherwise rely on the real wall clock being close
+        # enough to the test's expected window.  Since the test expression
+        # ``0 12 * * *`` with a NULL anchor reaches back 24h, any
+        # invocation within the 24h window will return True.  We just
+        # need to ensure the cap-skip path runs on Tick 1.
+        summary1 = d._scheduled_skills_tick()
+
+        assert summary1["fires_skipped_cap"] == 1, (
+            f"Tick 1 should skip due to cap=0, got: {summary1}"
+        )
+        assert summary1["fires_succeeded"] == 0
+
+        # No UPDATE should have been issued — last_triggered_at stays NULL.
+        update_sqls = [
+            sql
+            for sql, _ in fake_conn.cursor_instance.executed
+            if sql.strip().upper().startswith("UPDATE DISPATCHER.SCHEDULED_SKILLS")
+        ]
+        assert update_sqls == [], (
+            f"No UPDATE should be issued on cap-skip; found: {update_sqls}"
+        )
+
+        # --- Tick 2: cap = 5, active = 1, no collision — should fire ---
+        fake_conn2 = _FakeConnection()
+        # Row still has last_triggered_at = None (not mutated by Tick 1).
+        fake_conn2.cursor_instance.fetchall_queue = [
+            [row],
+        ]
+        # _read_concurrency_cap_for_scheduler → cap = 5
+        # _active_agent_count → active = 1 (1 < 5 → proceed)
+        # _scheduled_skill_running → None (no collision)
+        fake_conn2.cursor_instance.fetch_queue = [
+            ("5",),  # concurrency_cap = 5
+            (1,),  # active_agent_count = 1
+            None,  # collision check: no running agent with phase="daily-report"
+        ]
+
+        d2 = _make_daemon(fake_conn2)
+        launch_calls2: list[Any] = []
+        d2._launch_agent_ecs_task = (  # type: ignore[method-assign]
+            lambda agent_id, issue_number: launch_calls2.append(agent_id) or "arn:tick2"
+        )
+
+        summary2 = d2._scheduled_skills_tick()
+
+        assert summary2["fires_succeeded"] == 1, (
+            f"Tick 2 should fire (NULL anchor + 24h lookback), got: {summary2}"
+        )
+        assert summary2["fires_skipped_cap"] == 0
+
+        # An UPDATE should have been issued on Tick 2.
+        update_sqls2 = [
+            sql
+            for sql, _ in fake_conn2.cursor_instance.executed
+            if sql.strip().upper().startswith("UPDATE DISPATCHER.SCHEDULED_SKILLS")
+        ]
+        assert len(update_sqls2) == 1, (
+            f"Exactly one UPDATE should be issued on fire; found: {update_sqls2}"
+        )
+        assert launch_calls2, "ECS launch should have been called on Tick 2"


### PR DESCRIPTION
## Summary

Fixed cron-based scheduled skills silently missing their target minute due to an overly narrow NULL-anchor lookup window. When a scheduled skill has never fired (last_triggered_at = NULL), the prior logic anchored the cron walk 1 minute back, almost guaranteeing a miss unless a supervisor tick landed exactly on the cron's target minute. This caused dispatcher-daily-report to miss its 12:00Z fire today and would have affected spotcheck at 14:00Z.

Extended the first-fire anchor from 1 minute to 24 hours (matching the existing iteration-cap bound), so the skill catches its most-recent target minute even if it already passed today.

Closes #3424

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
- [x] CI green

All 23 tests in test_scheduled_skills_cron.py and test_scheduled_skills_null_anchor_cap_catchup.py pass.

### Post-deploy verification

- [ ] Strip `last_triggered_at` to NULL on dispatcher-daily-report or spotcheck in dev dispatcher.scheduled_skills table
- [ ] Observe daemon fires the skill on the next tick within minutes, even if the cron's exact minute already passed today
- [ ] Check daemon logs for the scheduled-skill dispatch event
- [ ] Verification evidence posted on #3424 (see /task-v2-verify output)