### PR TITLE
fix(dispatcher): nullable issueNumber for scheduled-skill agents (#3425)

### DIFF
--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -120,7 +120,16 @@ export const dispatcherTypeDefs = `#graphql
   """
   type DispatcherAgent {
     id: ID!
-    issueNumber: Int!
+    """Issue number the agent is working on. Nullable for
+    scheduled-skill agents (\`/audit\`, \`/spotcheck\`,
+    \`/dispatcher-daily-report\`) which have no closing GitHub
+    issue — see migration 49 (issue #3381) and bug #3425. Pre-#3425
+    this was \`Int!\`, which crashed the entire \`dispatcherState\`
+    GraphQL query when a scheduled-skill agent was running because
+    the serializer threw on NULL → Int!. The cockpit renders the
+    null case as an em-dash placeholder via \`IssueLink\`'s null
+    branch (see \`packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx\`)."""
+    issueNumber: Int
     """Issue title captured at claim time by the daemon's
     \`_atomic_claim\` from the queue-snapshot enrichment, issue #2820.
     Null when the issue is not in the snapshot or the row predates
@@ -260,8 +269,14 @@ export const dispatcherTypeDefs = `#graphql
   type RecentCompletion {
     """Agent id (UUID)."""
     agentId: ID!
-    """Issue the agent was working on."""
-    issueNumber: Int!
+    """Issue the agent was working on. Nullable for scheduled-skill
+    agents (\`/audit\`, \`/spotcheck\`, \`/dispatcher-daily-report\`)
+    which have no closing GitHub issue — see migration 49 (issue
+    #3381) and bug #3425. Same nullability change applied to
+    \`DispatcherAgent.issueNumber\` and to the GraphQL \`DispatcherFailure.issueNumber\`
+    field; clients render the null case as an em-dash via the
+    \`IssueLink\` null branch."""
+    issueNumber: Int
     """Priority label captured at claim time — one of p0 | p1 | p2 | p3 | null.
     Same semantics as \`DispatcherAgent.priority\`: reflects "priority
     when spawned". Pre-migration-33 rows return null (em-dash in the

--- a/packages/api/tests/dispatcher-enrichment.unit.test.ts
+++ b/packages/api/tests/dispatcher-enrichment.unit.test.ts
@@ -1557,6 +1557,69 @@ describe('GraphQL schema — BlockerRef type (issue #2989)', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Issue #3425 — issueNumber is nullable on DispatcherAgent + RecentCompletion
+//
+// Scheduled-skill agents (`/audit`, `/spotcheck`, `/dispatcher-daily-report`)
+// have `dispatcher.agents.issue_number = NULL` by design — they're not
+// addressing a GitHub issue (migration 49 / issue #3381). Pre-#3425 the
+// schema declared these GraphQL fields as `Int!` (non-null), which caused
+// the entire `dispatcherState` query to 500 the moment a scheduled-skill
+// agent landed in `activeAgents` or `recentCompletions`: the GraphQL
+// serializer threw on NULL → Int! and every panel went dark for the
+// operator. Pinning the nullability here so a future cleanup doesn't
+// silently re-introduce the regression.
+//
+// `QueueItem.issueNumber` stays `Int!` — queue items are GitHub issues
+// by definition, never scheduled-skill agent rows.
+// ---------------------------------------------------------------------------
+describe('GraphQL schema — issueNumber nullability (issue #3425)', () => {
+  const baseSchema = `
+    type Query { _noop: Boolean }
+    type Mutation { _noop: Boolean }
+  `;
+
+  it('DispatcherAgent.issueNumber is nullable (Int, not Int!)', () => {
+    const schema = buildSchema(baseSchema + dispatcherTypeDefs);
+    const agentType = schema.getType('DispatcherAgent') as import('graphql').GraphQLObjectType;
+    expect(agentType).toBeTruthy();
+    const issueNumberField = agentType.getFields()['issueNumber'];
+    expect(issueNumberField).toBeTruthy();
+    expect(issueNumberField.type.toString()).toBe('Int');
+  });
+
+  it('RecentCompletion.issueNumber is nullable (Int, not Int!)', () => {
+    const schema = buildSchema(baseSchema + dispatcherTypeDefs);
+    const completionType = schema.getType('RecentCompletion') as import('graphql').GraphQLObjectType;
+    expect(completionType).toBeTruthy();
+    const issueNumberField = completionType.getFields()['issueNumber'];
+    expect(issueNumberField).toBeTruthy();
+    expect(issueNumberField.type.toString()).toBe('Int');
+  });
+
+  it('DispatcherFailure.issueNumber is nullable (regression guard)', () => {
+    // Already nullable pre-#3425 because failures can predate their agent
+    // (joins via `agents.issue_number`). Pin it so the bulk-edit doesn't
+    // accidentally flip it.
+    const schema = buildSchema(baseSchema + dispatcherTypeDefs);
+    const failureType = schema.getType('DispatcherFailure') as import('graphql').GraphQLObjectType;
+    expect(failureType).toBeTruthy();
+    const issueNumberField = failureType.getFields()['issueNumber'];
+    expect(issueNumberField.type.toString()).toBe('Int');
+  });
+
+  it('QueueItem.issueNumber stays Int! (queue items are always GitHub issues)', () => {
+    // Sanity guard: the bulk-flip-to-nullable in #3425 must not touch
+    // QueueItem. Queue items come from agent/ready scans of GitHub
+    // issues, never from `dispatcher.agents.issue_number`.
+    const schema = buildSchema(baseSchema + dispatcherTypeDefs);
+    const queueItemType = schema.getType('QueueItem') as import('graphql').GraphQLObjectType;
+    expect(queueItemType).toBeTruthy();
+    const issueNumberField = queueItemType.getFields()['issueNumber'];
+    expect(issueNumberField.type.toString()).toBe('Int!');
+  });
+});
+
 describe('queueItemFromSnapshot — BlockerRef shape (issue #2989)', () => {
   it('AC3: legacy row with blockedBy=number[] wraps to [{number, title: null}]', () => {
     // Pre-migration snapshot: daemon wrote blockedBy as number[] or body-only.

--- a/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
@@ -118,9 +118,18 @@ function ActiveAgentRow({
   // view-transitions (fired by `useViewTransitionUpdate` in
   // `DispatcherDashboard`) don't paint browser-managed
   // `::view-transition-*` pseudo-elements over an open full-list dialog.
-  const outerStyle = animated
-    ? ({ viewTransitionName: `issue-${agent.issueNumber}` } as CSSProperties)
-    : undefined;
+  //
+  // #3425: when `agent.issueNumber` is null (scheduled-skill agents:
+  // `/audit`, `/spotcheck`, `/dispatcher-daily-report` per migration 49)
+  // we drop the issue-keyed `viewTransitionName` and rely on the inner
+  // `agent-X` name only. Multiple concurrent null-issue rows would
+  // otherwise share the same `issue-null` ident, which the browser would
+  // collapse into one transition target — the inner agent-keyed name
+  // already provides a stable per-row identity for the Magic Move.
+  const outerStyle =
+    animated && agent.issueNumber !== null
+      ? ({ viewTransitionName: `issue-${agent.issueNumber}` } as CSSProperties)
+      : undefined;
   const innerStyle = animated
     ? ({ viewTransitionName: `agent-${agent.id}` } as CSSProperties)
     : undefined;

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ActiveAgentsTable.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ActiveAgentsTable.test.tsx
@@ -58,6 +58,30 @@ describe('ActiveAgentsTable — unified (issue, priority, title) prefix', () => 
     );
     expect(screen.getByText('(title unavailable)')).toBeInTheDocument();
   });
+
+  // #3425: scheduled-skill agents (`/audit`, `/spotcheck`,
+  // `/dispatcher-daily-report`) have `issue_number = NULL`. Pre-#3425
+  // the dispatcher cockpit went dark — the GraphQL serializer threw on
+  // NULL → Int! and `IssueLink` declared `number: number`. The fix is
+  // bulk: schema + TS types both nullable, `IssueLink` renders an
+  // em-dash placeholder for null. This test pins the active-agents
+  // path so a future regression can't silently re-introduce the crash
+  // for the most common scheduled-skill case (a running audit agent).
+  it('#3425: renders without crashing when issueNumber is null (scheduled-skill agent)', () => {
+    const agent = makeAgent({
+      id: 'aaa93855-4a85-4785-af10-fc68d03aef59',
+      issueNumber: null,
+      issueTitle: null,
+      // Scheduled-skill agents have no priority/pN label either.
+      priority: null,
+      phase: 'audit',
+    });
+    expect(() =>
+      render(<ActiveAgentsTable agents={[agent]} onAgentAction={vi.fn()} />),
+    ).not.toThrow();
+    // IssueLink renders the em-dash placeholder span for null.
+    expect(screen.getByTestId('issue-link-null')).toBeInTheDocument();
+  });
 });
 
 describe('ActiveAgentsTable — phase tooltip', () => {

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/RecentCompletionsPanel.test.tsx
@@ -64,6 +64,38 @@ describe('RecentCompletionsPanel', () => {
     expect(screen.getByText('—')).toBeInTheDocument();
   });
 
+  // #3425: scheduled-skill agents (`/audit`, `/spotcheck`,
+  // `/dispatcher-daily-report`) have `issue_number = NULL`. The whole
+  // dispatcher cockpit went dark when one of them landed in
+  // `recentCompletions` because the GraphQL serializer threw on
+  // NULL → Int! and `IssueLink` declared `number: number`. The fix
+  // makes both sides nullable; this test pins the rendered output for
+  // the audit/spotcheck case so the regression can't slip back in.
+  it('#3425: renders the IssueLink null branch when issueNumber is null (scheduled-skill agent)', () => {
+    const items = [
+      completion({
+        agentId: 'aaa93855-4a85-4785-af10-fc68d03aef59',
+        issueNumber: null,
+        // Scheduled-skill agents have null issue title too — the
+        // panel's existing `issueTitle ?? '(title unavailable)'`
+        // handling is what surfaces a useful label.
+        issueTitle: null,
+        prNumber: null,
+        // No priority either — claim-time priority capture is keyed
+        // off the issue's `priority/pN` label, which doesn't exist
+        // for scheduled-skill agents.
+        priority: null,
+      }),
+    ];
+    expect(() =>
+      render(<RecentCompletionsPanel completions={items} nowMs={now} />),
+    ).not.toThrow();
+    // IssueLink's null branch renders an em-dash span with this testid.
+    expect(screen.getByTestId('issue-link-null')).toBeInTheDocument();
+    // No anchor for an absent issue.
+    expect(screen.queryByTestId('issue-link-0')).not.toBeInTheDocument();
+  });
+
   // --- #2818 — density pass: "(no PR)" filler and "N min ago" column removed.
   it('#2818: renders nothing in place of a missing PR (no "(no PR)" text)', () => {
     const items = [completion({ prNumber: null, agentId: 'agent-2' })];

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ui-primitives.test.tsx
@@ -34,6 +34,58 @@ describe('IssueLink', () => {
     // readability regression where links render as low-contrast gray.
     expect(link.className).not.toMatch(/(^|\s)text-accent(\s|$)/);
   });
+
+  // Regression guard for #3425. Scheduled-skill agents (`/audit`,
+  // `/spotcheck`, `/dispatcher-daily-report`) have
+  // `dispatcher.agents.issue_number = NULL` by design (migration 49 /
+  // issue #3381). Pre-#3425 `IssueLink` declared `number: number`
+  // (non-null) and the cockpit blew up the moment one of those agents
+  // landed in the active or recently-completed lists. Centralizing the
+  // null branch on `IssueLink` means every call site
+  // (ActiveAgentsTable, RecentCompletionsPanel, QueueFullDialog via
+  // RecentCompletionRow) gets the placeholder for free.
+  describe('null issueNumber (#3425)', () => {
+    it('renders an em-dash placeholder span when number is null', () => {
+      render(<IssueLink number={null} />);
+      const placeholder = screen.getByTestId('issue-link-null');
+      // `&mdash;` is U+2014 EM DASH — the same glyph PriorityBadge uses
+      // for its null branch and RecentFailuresPanel uses for its inline
+      // null guard. Keep the codepoint pinned so tooling that
+      // greps for em-dashes (BRAND.md compliance, snapshot review) finds
+      // a consistent one.
+      expect(placeholder.textContent).toBe('—');
+      // Must not be an anchor — there is no GitHub issue to link to.
+      expect(placeholder.tagName.toLowerCase()).toBe('span');
+      expect(placeholder.getAttribute('href')).toBeNull();
+    });
+
+    it('placeholder uses muted-foreground (no brand-accent link styling)', () => {
+      render(<IssueLink number={null} />);
+      const placeholder = screen.getByTestId('issue-link-null');
+      expect(placeholder.className).toContain('text-muted-foreground');
+      // Belt-and-suspenders: the placeholder must NOT carry the
+      // brand-accent link colour — otherwise an operator scanning the
+      // Recently Completed panel would think the em-dash is a clickable
+      // link (it's not).
+      expect(placeholder.className).not.toContain('text-brand-accent');
+    });
+
+    it('forwards the title prop onto the placeholder when provided', () => {
+      render(<IssueLink number={null} title="audit (no closing issue)" />);
+      const placeholder = screen.getByTestId('issue-link-null');
+      expect(placeholder.getAttribute('title')).toBe(
+        'audit (no closing issue)',
+      );
+    });
+
+    it('does not crash when number is null (smoke test)', () => {
+      // Guards against the pre-#3425 regression mode where rendering a
+      // null issueNumber threw "cannot read property of null" or
+      // produced an `#null` href. The whole point of this branch is
+      // graceful handling.
+      expect(() => render(<IssueLink number={null} />)).not.toThrow();
+    });
+  });
 });
 
 describe('PRLink', () => {

--- a/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ui-primitives.tsx
@@ -54,8 +54,39 @@ const BRAND_LINK_CLASSES =
  * attribute for a browser tooltip — used by `QueueRow` to surface
  * blocker details on the `#NNNN` link in the Queue: Blocked panel
  * (issue #2989). Pass `undefined` (or omit) for no tooltip.
+ *
+ * `number={null}` renders an em-dash placeholder span instead of an
+ * anchor — used by panels that surface scheduled-skill agents (audit,
+ * spotcheck, daily-report) whose `dispatcher.agents.issue_number` is
+ * NULL by design (migration 49 / issue #3381). Bug #3425: the prior
+ * non-nullable signature crashed the entire dispatcher cockpit
+ * (server-side `Int!` serializer threw on NULL → all panels dark)
+ * once a scheduled-skill agent landed in the active or recently-
+ * completed lists. Centralizing the null branch on `IssueLink` means
+ * every call site (ActiveAgentsTable, RecentCompletionsPanel,
+ * RecentFailuresPanel, QueueFullDialog via RecentCompletionRow) gets
+ * the placeholder for free without per-site guards.
  */
-export function IssueLink({ number, className, title }: { number: number; className?: string; title?: string }) {
+export function IssueLink({
+  number,
+  className,
+  title,
+}: {
+  number: number | null;
+  className?: string;
+  title?: string;
+}) {
+  if (number === null) {
+    return (
+      <span
+        className="font-mono text-muted-foreground"
+        data-testid="issue-link-null"
+        title={title}
+      >
+        &mdash;
+      </span>
+    );
+  }
   const href = `https://github.com/${REPO}/issues/${number}`;
   return (
     <a

--- a/packages/web/src/lib/dispatcher-queries.ts
+++ b/packages/web/src/lib/dispatcher-queries.ts
@@ -194,7 +194,12 @@ export interface DispatcherRun {
 
 export interface DispatcherAgent {
   id: string;
-  issueNumber: number;
+  /** Issue number the agent is working on. Nullable for
+   * scheduled-skill agents (`/audit`, `/spotcheck`,
+   * `/dispatcher-daily-report`) which have no closing GitHub issue —
+   * see migration 49 (issue #3381) and bug #3425. The cockpit renders
+   * the null case via `IssueLink`'s null branch (em-dash placeholder). */
+  issueNumber: number | null;
   /** Issue title captured at claim time from the queue-snapshot
    * enrichment (#2820). Null for pre-migration-28 rows or when the
    * issue was not in the snapshot at claim time — the UI renders
@@ -275,7 +280,11 @@ export interface QueueItem {
 
 export interface RecentCompletion {
   agentId: string;
-  issueNumber: number;
+  /** Issue the agent was working on. Nullable for scheduled-skill
+   * agents (`/audit`, `/spotcheck`, `/dispatcher-daily-report`) which
+   * have no closing GitHub issue — see migration 49 (issue #3381) and
+   * bug #3425. */
+  issueNumber: number | null;
   issueTitle: string | null;
   /** Priority label captured at claim time — `p0` | `p1` | `p2` | `p3`
    * | null. Same semantics as `DispatcherAgent.priority`; pre-migration-33


### PR DESCRIPTION
## Summary

Hot-fix for the dispatcher cockpit going fully dark whenever a scheduled-skill agent (`/audit`, `/spotcheck`, `/dispatcher-daily-report`) is in `activeAgents` or `recentCompletions`. The GraphQL schema declared `issueNumber: Int!` on `DispatcherAgent` + `RecentCompletion`, but those agents have `dispatcher.agents.issue_number = NULL` by design (migration 49 / #3381). The serializer threw on NULL → Int!, the entire `dispatcherState` query 500'd, and every cockpit panel went dark for the operator.

Server-side: flipped both schema fields to nullable `Int`. Client-side: `IssueLink` now accepts `number | null` and renders an em-dash placeholder span when null — covers every call site through one primitive instead of per-site guards.

Closes #3425

## Test plan

### Automated checks
- [x] Lint passes (web + api)
- [x] Format check passes (lint covers it via eslint)
- [x] Tests pass (web 1488 / api 337 unit, plus new `IssueLink number={null}`, `RecentCompletionsPanel` null-issueNumber row, `ActiveAgentsTable` audit-shaped row, schema-shape regression guards on all four `issueNumber` fields)
- [x] Build passes (`next build` for `packages/web` clean)
- [x] CI green

### Post-deploy verification
- [x] Open https://judgemind-web-dev.vercel.app/admin/dispatcher and confirm the page renders all panels without 500 — verified via screenshot, all panels populated.
- [x] Confirm the running audit agent (`aaa93855…`) appears in Active/Recently-completed with an em-dash placeholder where the issue link normally sits — verified, em-dash visible next to `scheduled_skill:audit`.
- [x] Confirm the Recently completed panel and its full-list dialog render the NULL-issue terminal rows without crashing — verified via dialog-open screenshot, dialog renders cleanly with em-dash placeholders for the audit + dispatcher-daily-report rows.
- [x] Verification evidence posted on issue #3425 (see comment thread).
