### PR TITLE
fix(dispatcher): return None from _count_orphan_pr_resurrections on DB error (#3427)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -12964,6 +12964,22 @@ class DispatcherDaemon:
             # via the phase_transitions audit log. This avoids needing
             # a new schema column for the counter (#3399 is pure code).
             past_attempts = self._count_orphan_pr_resurrections(agent_id)
+            if past_attempts is None:
+                # DB read failed — skip rather than grant a free pass.
+                # Checked BEFORE _fetch_pr_status to avoid a wasted gh
+                # API call when we already know we can't proceed safely.
+                self._log.info(
+                    "daemon.orphan_pr_resurrection_skipped",
+                    extra={
+                        "event": "orphan_pr_resurrection_skipped",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "pr_number": pr_number,
+                        "issue_number": issue_number,
+                        "reason": "count_failed",
+                    },
+                )
+                continue
             if past_attempts >= ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS:
                 self._log.info(
                     "daemon.orphan_pr_resurrection_skipped",
@@ -13119,16 +13135,16 @@ class DispatcherDaemon:
             return []
         return rows
 
-    def _count_orphan_pr_resurrections(self, agent_id: str) -> int:
+    def _count_orphan_pr_resurrections(self, agent_id: str) -> int | None:
         """Return how many times this agent has been resurrected by
         the orphan-PR sweep (#3399).
 
         Counted by reading append-only
         ``dispatcher.phase_transitions`` rows whose phase is
-        :data:`PHASE_RESURRECTED_FOR_ORPHAN_PR`. Returns 0 on DB error
-        so a transient hiccup cannot block resurrection (the worst case
-        on read failure is one extra resurrection that still respects
-        every other gate — the next tick re-evaluates).
+        :data:`PHASE_RESURRECTED_FOR_ORPHAN_PR`. Returns ``None`` on DB
+        error so the caller can distinguish "zero resurrections" from
+        "count failed" — a ``None`` result causes the candidate to be
+        skipped rather than granted a free pass.
         """
         assert self._conn is not None, "connect() must run before counting"
 
@@ -13154,7 +13170,7 @@ class DispatcherDaemon:
                 self._conn.rollback()
             except Exception:  # pragma: no cover — best-effort
                 pass
-            return 0
+            return None
         if row is None:
             return 0
         return int(row[0] or 0)

--- a/scripts/dispatcher/tests/test_daemon_orphan_pr_resurrection.py
+++ b/scripts/dispatcher/tests/test_daemon_orphan_pr_resurrection.py
@@ -425,6 +425,50 @@ class TestResurrectionNegativePaths:
         assert skipped[0].past_attempts == daemon.ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS
         assert skipped[0].max_attempts == daemon.ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS
 
+    def test_count_failed_skips_candidate_no_resurrection(self, tmp_path: Path) -> None:
+        """When _count_orphan_pr_resurrections returns None (DB error),
+        the candidate must be skipped without calling _fetch_pr_status
+        (no wasted gh API call) and without any resurrection DB write.
+        A distinct orphan_pr_resurrection_skipped event with
+        reason='count_failed' must be logged (#3427).
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # One candidate row in the list.
+        conn.cursor_instance.fetchall_queue.append([("agent-count-fail", 444, 600)])
+
+        # Force _count_orphan_pr_resurrections to return None.
+        d._count_orphan_pr_resurrections = lambda agent_id: None  # type: ignore[method-assign]
+
+        # Sentinel: _fetch_pr_status must NOT be called.
+        pr_status_calls: list[int] = []
+
+        def fetch_pr_sentinel(pr: int) -> dict[str, Any]:
+            pr_status_calls.append(pr)
+            return _pr_status_green()
+
+        d._fetch_pr_status = fetch_pr_sentinel  # type: ignore[method-assign]
+
+        n = d._resurrect_orphan_pr_agents()
+
+        assert n == 0, "no resurrection expected"
+        assert pr_status_calls == [], (
+            "_fetch_pr_status must NOT be called on count_failed"
+        )
+        # No resurrection event.
+        assert handler.events("agent_resurrected_for_orphan_pr") == []
+        # Distinct skip event with count_failed reason.
+        skipped = handler.events("orphan_pr_resurrection_skipped")
+        assert skipped, "expected orphan_pr_resurrection_skipped event"
+        assert skipped[0].reason == "count_failed"
+        # No UPDATE issued.
+        update_calls = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+        ]
+        assert update_calls == []
+
     def test_no_candidates_returns_zero_no_log(self, tmp_path: Path) -> None:
         d, conn, handler = _make_daemon(tmp_path)
         # SELECT returns no rows.
@@ -684,7 +728,7 @@ class TestAwaitingCiRedWorktreeMissingGuard:
 
 
 class TestDbErrorPaths:
-    def test_count_returns_zero_on_db_error(self, tmp_path: Path) -> None:
+    def test_count_returns_none_on_db_error(self, tmp_path: Path) -> None:
         d, conn, handler = _make_daemon(tmp_path)
 
         def boom(*_a: Any, **_k: Any) -> None:
@@ -694,7 +738,7 @@ class TestDbErrorPaths:
 
         n = d._count_orphan_pr_resurrections("agent-x")
 
-        assert n == 0
+        assert n is None
         # Failure event logged so CloudWatch captures the issue.
         assert handler.events("orphan_pr_count_failed")
 


### PR DESCRIPTION
## Summary

Fixed `_count_orphan_pr_resurrections` to return `None` on DB errors instead of `0`, preventing the orphan-PR budget-cap bypass. The caller now skips affected candidates (avoiding wasted gh API calls) and logs a distinct skip event.

Closes #3427

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — all 21 tests pass
- [x] CI green

### Post-deploy verification

- [ ] N/A — no deployed component (internal dispatcher daemon logic, no schema or external behavior change)