### PR TITLE
fix(dispatcher): route DIRTY merge conflicts to fix_conflict (#3431)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -106,6 +106,7 @@ if TYPE_CHECKING:  # pragma: no cover — types only
 from .stream_forwarder import stream_subprocess_output_async  # noqa: E402
 from .phase_transitions import (  # noqa: E402
     FAILURE_HINT_RALPH_AC_INFEASIBLE,
+    PHASE_FIX_CONFLICT,
     TransitionAction,
     transition_from_awaiting_ci,
     transition_from_awaiting_deploy,
@@ -13013,6 +13014,7 @@ class DispatcherDaemon:
                 "CI green": "green",
                 "CI red": "red",
                 "CI pending": "pending",
+                "CI conflict — routing to fix_conflict (#3431)": "conflict",
             }
             rollup_state = _reason_to_state.get(ci_transition.reason, "pending")
             if rollup_state != "green":
@@ -13600,11 +13602,13 @@ class DispatcherDaemon:
         # StatusContext (__typename=STATUSCONTEXT) entries correctly (#3200).
         awaiting_ci_transition = transition_from_awaiting_ci(pr_status)
         # Derive rollup_state from the transition reason for the ci_poll
-        # log event. Reason strings are "CI green" / "CI red" / "CI pending".
+        # log event. Reason strings are "CI green" / "CI red" / "CI pending"
+        # / "CI conflict — routing to fix_conflict (#3431)".
         _reason_to_state = {
             "CI green": "green",
             "CI red": "red",
             "CI pending": "pending",
+            "CI conflict — routing to fix_conflict (#3431)": "conflict",
         }
         rollup_state = _reason_to_state.get(awaiting_ci_transition.reason, "pending")
         self._log.info(
@@ -13626,6 +13630,29 @@ class DispatcherDaemon:
 
         if awaiting_ci_transition.next_phase == "merge":
             self._merge_pr_and_advance(agent, pr_status)
+            return
+
+        if awaiting_ci_transition.next_phase == PHASE_FIX_CONFLICT:
+            # Merge conflict (mergeStateStatus=DIRTY or mergeable=CONFLICTING)
+            # detected during CI polling (#3431). The subprocess path does not
+            # yet spawn a fix_conflict skill (see FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE
+            # comment at line ~1300 anticipating this). Route to terminal +
+            # diagnoser so the empowered diagnoser can decide next step.
+            self._handle_agent_failure(
+                agent_id=agent_id,
+                phase="awaiting_ci",
+                category=FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE,
+                stderr_tail="",
+                exit_code=None,
+                details={
+                    "mergeable": pr_status.get("mergeable"),
+                    "merge_state_status": pr_status.get("mergeStateStatus"),
+                    "detail": (
+                        "PR has a merge conflict (DIRTY/CONFLICTING) after CI — "
+                        "routing to terminal+diagnoser via conflict_unresolvable (#3431)"
+                    ),
+                },
+            )
             return
 
         # awaiting_ci_transition.next_phase == "fix_ci" (CI red)

--- a/scripts/dispatcher/phase_transitions.py
+++ b/scripts/dispatcher/phase_transitions.py
@@ -709,8 +709,11 @@ def transition_from_awaiting_ci(
       place).
     * **Green** (all SUCCESS/SKIPPED + ``mergeable=MERGEABLE`` +
       ``mergeStateStatus=CLEAN``) — advance to ``merge``.
-    * **Red** (any FAILURE/CANCELLED/TIMED_OUT/ACTION_REQUIRED) —
-      advance to ``fix_ci``.
+    * **Red / conflict** (``mergeStateStatus=DIRTY`` or
+      ``mergeable=CONFLICTING``) — advance to ``fix_conflict``
+      (#3431; code-side rebase required).
+    * **Red / CI failure** (any FAILURE/CANCELLED/TIMED_OUT/
+      ACTION_REQUIRED) — advance to ``fix_ci``.
     """
     state = _ci_rollup_state(pr_status)
     if state == "green":
@@ -720,6 +723,20 @@ def transition_from_awaiting_ci(
             reason="CI green",
         )
     if state == "red":
+        # Distinguish a true merge conflict (DIRTY/CONFLICTING) from a
+        # CI check failure so callers can route to the right fix phase.
+        merge_state = str((pr_status or {}).get("mergeStateStatus") or "").upper()
+        mergeable = str((pr_status or {}).get("mergeable") or "").upper()
+        if merge_state == "DIRTY" or mergeable == "CONFLICTING":
+            return PhaseTransition(
+                action=TransitionAction.ADVANCE,
+                next_phase=PHASE_FIX_CONFLICT,
+                reason="CI conflict — routing to fix_conflict (#3431)",
+                context={
+                    "conflict_files": [],
+                    "source_phase": "awaiting_ci",
+                },
+            )
         return PhaseTransition(
             action=TransitionAction.ADVANCE,
             next_phase=PHASE_FIX_CI,
@@ -1009,10 +1026,14 @@ def _ci_rollup_state(pr_status: Mapping[str, Any] | None) -> str:
     2. If any check is not yet complete (CheckRun status
        in_progress / queued / pending, or StatusContext state
        EXPECTED / PENDING) → pending.
-    3. If mergeable is not ``MERGEABLE`` or mergeStateStatus is not
-       ``CLEAN`` → pending (the merge-conflict polling path; we
-       treat it as "not ready yet" rather than red).
-    4. Otherwise → green.
+    3. If ``mergeStateStatus == 'DIRTY'`` or ``mergeable ==
+       'CONFLICTING'`` → red (true merge conflict requiring
+       code-side rebase; routed to fix_conflict by callers, #3431).
+    4. If mergeable is not ``MERGEABLE`` or mergeStateStatus is not
+       ``CLEAN`` for any other reason (e.g. ``UNKNOWN`` /
+       ``UNSTABLE``) → pending (transient recompute; re-poll next
+       tick).
+    5. Otherwise → green.
     """
     if not pr_status:
         return "pending"
@@ -1055,6 +1076,10 @@ def _ci_rollup_state(pr_status: Mapping[str, Any] | None) -> str:
 
     mergeable = str(pr_status.get("mergeable") or "").upper()
     merge_state = str(pr_status.get("mergeStateStatus") or "").upper()
+    # Rule 3: true merge conflict — code-side rebase required (#3431).
+    if merge_state == "DIRTY" or mergeable == "CONFLICTING":
+        return "red"
+    # Rule 4: transient recompute states (UNKNOWN, UNSTABLE, etc.) — re-poll.
     if mergeable != "MERGEABLE" or merge_state != "CLEAN":
         return "pending"
     return "green"

--- a/scripts/dispatcher/tests/test_daemon_orphan_pr_resurrection.py
+++ b/scripts/dispatcher/tests/test_daemon_orphan_pr_resurrection.py
@@ -310,6 +310,12 @@ class TestResurrectionNegativePaths:
         assert update_calls == []
 
     def test_dirty_pr_is_skipped(self, tmp_path: Path) -> None:
+        # #3431: mergeStateStatus=DIRTY is a true merge conflict, not a
+        # transient recompute. The classifier now returns 'red' (routed to
+        # fix_conflict), and the orphan sweep maps that to 'conflict' via
+        # _reason_to_state, producing reason='rollup_state_conflict'.
+        # The orphan is still skipped (operator-owned escalation path), but
+        # with a distinct reason that surfaces in CloudWatch vs. pending.
         d, conn, handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue.append([("agent-dirty", 888, 200)])
         conn.cursor_instance.fetch_queue.append((0,))
@@ -321,11 +327,7 @@ class TestResurrectionNegativePaths:
         assert handler.events("agent_resurrected_for_orphan_pr") == []
         skipped = handler.events("orphan_pr_resurrection_skipped")
         assert skipped, "expected orphan_pr_resurrection_skipped"
-        # mergeStateStatus=DIRTY drops the classifier into the
-        # 'pending' fallback (the canonical _ci_rollup_state treats
-        # "checks pass but merge state isn't yet CLEAN" as pending,
-        # not red — same behavior the awaiting_ci handler uses).
-        assert skipped[0].reason == "rollup_state_pending"
+        assert skipped[0].reason == "rollup_state_conflict"
 
     def test_mergeable_unknown_classifies_as_pending_not_red(
         self, tmp_path: Path

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -197,16 +197,29 @@ class TestCiRollupState:
         }
         assert phase_transitions._ci_rollup_state(status) == "red"
 
-    def test_all_green_but_conflicting_returns_pending(self) -> None:
-        # CONFLICTING / DIRTY are transient GitHub recompute states — the
-        # canonical classifier returns 'pending' (not 'red') so the daemon
-        # keeps polling rather than routing to fix-ci unnecessarily.
+    def test_all_green_but_dirty_returns_red(self) -> None:
+        # CONFLICTING / DIRTY is a true merge conflict requiring a code-side
+        # rebase (#3431). The canonical classifier returns 'red' so callers
+        # route to fix_conflict rather than treating it as a transient poll.
         status = {
             "statusCheckRollup": [
                 {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "lint"},
             ],
             "mergeable": "CONFLICTING",
             "mergeStateStatus": "DIRTY",
+        }
+        assert phase_transitions._ci_rollup_state(status) == "red"
+
+    def test_unknown_returns_pending(self) -> None:
+        # Regression guard for AC #3 (#3431): UNKNOWN is a transient GitHub
+        # recompute state, NOT a merge conflict. Must stay 'pending' so the
+        # supervisor re-polls rather than routing to fix_conflict.
+        status = {
+            "statusCheckRollup": [
+                {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "lint"},
+            ],
+            "mergeable": "UNKNOWN",
+            "mergeStateStatus": "UNKNOWN",
         }
         assert phase_transitions._ci_rollup_state(status) == "pending"
 
@@ -1094,6 +1107,78 @@ class TestAwaitingCiMaxRetries:
             and "failed" in e[1]
         ]
         assert failed_updates
+
+
+# --------------------------------------------------------------------------
+# _advance_awaiting_ci — DIRTY/CONFLICTING → terminal+diagnoser (#3431)
+# --------------------------------------------------------------------------
+
+
+class TestAwaitingCiConflict:
+    def test_dirty_pr_routes_to_conflict_unresolvable(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """#3431: mergeStateStatus=DIRTY is a true merge conflict.
+
+        _advance_awaiting_ci must route it to terminal+diagnoser via
+        FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE, not stay pending or
+        spawn fix-ci.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = json.dumps(
+                {
+                    "statusCheckRollup": [
+                        {"status": "COMPLETED", "conclusion": "SUCCESS"},
+                    ],
+                    "mergeable": "CONFLICTING",
+                    "mergeStateStatus": "DIRTY",
+                    "headRefOid": "head-sha",
+                    "mergeCommit": None,
+                }
+            )
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        # Fail the test if fix-ci subprocess spawns (it should not).
+        def fake_spawn(*_a: Any, **_k: Any) -> tuple[int, float]:
+            raise AssertionError("fix-ci must not spawn for a DIRTY conflict")
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+
+        agent = {
+            "agent_id": "conflict-agent-id",
+            "issue_number": 42,
+            "phase": "awaiting_ci",
+            "pr_number": 101,
+            "worktree_path": str(tmp_path),
+            "retries_used": 0,
+        }
+        d._advance_awaiting_ci(agent)
+
+        # Agent marked failed (terminal + diagnoser path via _handle_agent_failure).
+        failed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "failed" in e[1]
+        ]
+        assert failed_updates, "DIRTY PR must mark agent terminal with status=failed"
+        # failures row written with conflict_unresolvable category.
+        failures_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT" in e[0] and "dispatcher.failures" in e[0]
+        ]
+        assert failures_inserts, (
+            "DIRTY PR must write a dispatcher.failures row with conflict_unresolvable"
+        )
 
 
 # --------------------------------------------------------------------------

--- a/scripts/dispatcher/tests/test_phase_transitions.py
+++ b/scripts/dispatcher/tests/test_phase_transitions.py
@@ -300,7 +300,9 @@ class TestTransitionFromAwaitingCi:
         result = pt.transition_from_awaiting_ci(status)
         assert result.next_phase == pt.PHASE_AWAITING_CI
 
-    def test_mergeable_not_mergeable_stays_pending(self) -> None:
+    def test_mergeable_conflicting_routes_to_fix_conflict(self) -> None:
+        # mergeable=CONFLICTING is a true merge conflict (#3431) — must
+        # route to fix_conflict, not stay pending.
         status = self._make_status(
             [
                 {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "lint"},
@@ -308,14 +310,30 @@ class TestTransitionFromAwaitingCi:
             mergeable="CONFLICTING",
         )
         result = pt.transition_from_awaiting_ci(status)
-        assert result.next_phase == pt.PHASE_AWAITING_CI
+        assert result.next_phase == pt.PHASE_FIX_CONFLICT
 
-    def test_merge_state_not_clean_stays_pending(self) -> None:
+    def test_merge_state_dirty_routes_to_fix_conflict(self) -> None:
+        # mergeStateStatus=DIRTY is a true merge conflict (#3431) — must
+        # route to fix_conflict, not stay pending.
         status = self._make_status(
             [
                 {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "lint"},
             ],
             merge_state="DIRTY",
+        )
+        result = pt.transition_from_awaiting_ci(status)
+        assert result.next_phase == pt.PHASE_FIX_CONFLICT
+
+    def test_unknown_stays_pending(self) -> None:
+        # Regression guard for AC #3 (#3431): UNKNOWN is a transient GitHub
+        # recompute state, NOT a merge conflict. Must stay in awaiting_ci
+        # (pending) so the daemon re-polls rather than routing to fix_conflict.
+        status = self._make_status(
+            [
+                {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "lint"},
+            ],
+            mergeable="UNKNOWN",
+            merge_state="UNKNOWN",
         )
         result = pt.transition_from_awaiting_ci(status)
         assert result.next_phase == pt.PHASE_AWAITING_CI


### PR DESCRIPTION
## Summary

Fixed dispatcher CI conflict routing so agents with true merge conflicts (mergeStateStatus=DIRTY, mergeable=CONFLICTING) advance to fix_conflict instead of hanging in pending state. The canonical _ci_rollup_state classifier now returns 'red' for these conditions and transition_from_awaiting_ci routes them to PHASE_FIX_CONFLICT; daemon handlers escalate to terminal+diagnoser via FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE.

Closes #3431

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 174 tests pass per ralph_summary)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (dispatcher daemon internals only; verification via CloudWatch logs of agent routing + dispatcher.failures category classification)