### PR TITLE
feat(ci): detect GraphQL non-null/SQL-nullable drift on migrations (#3441)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1156,6 +1156,23 @@ jobs:
         run: scripts/check-nullable-column-reads.sh --base origin/main
 
   # ---------------------------------------------------------------
+  # GraphQL nullability drift: detect GraphQL fields still declared
+  # non-null after the backing DB column had NOT NULL dropped (#3441).
+  # ---------------------------------------------------------------
+  graphql-nullability-drift-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.migrations == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Fetch origin/main for diff base
+        run: git fetch origin main --depth=50
+      - name: Check for GraphQL fields still non-null after backing column dropped NOT NULL
+        run: scripts/check-graphql-nullability-drift.sh --base origin/main
+
+  # ---------------------------------------------------------------
   # ECS oneshot import guard: prevent scripts/ from importing siblings
   # ---------------------------------------------------------------
   oneshot-imports-check:
@@ -1497,7 +1514,7 @@ jobs:
   # Always runs. Reports success only when every applicable job passed or was
   # skipped (path filter did not match). Branch protection requires this check.
   ci-passed:
-    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check]
+    needs: [scraper-framework-tests, scraper-court-tests, ingestion-tests, nlp-tests, api-tests, web-tests, infra-validate, scripts-tests, coverage-check, deprecated-models-check, hardcoded-models-check, terraform-empty-resource-check, hardcoded-colors-check, admin-dispatcher-brand-accent-check, docs-tailwind-drift-check, llm-json-loads-check, oneshot-imports-check, oneshot-repo-paths-check, duplicate-functions-check, test-except-pass-check, markdown-links-check, schema-drift-check, dq-baselines-validate, ecs-oneshot-test, migration-files-check, migration-collision-check, nullable-column-reads-check, graphql-nullability-drift-check, sql-conflict-check, sql-column-check, playwright-browser-check, shard-coverage-check, apollo-keyfields-check, graphql-query-check, scraper-registry-check, preflight-hook-test, githooks-pre-push-test, ci-job-skipped-check, test-database-url-fallback-check, opensearch-url-fallback-check, no-api-github-fetch-check, dispatcher-terminal-consistency-check, dispatcher-image-version-check]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -255,6 +255,18 @@ scripts/check-nullable-column-reads.sh --migration packages/api/migrations/49_fo
 
    The comment suppresses the violation for that entire file. Use sparingly — prefer explicit guards at the read site.
 
+**GraphQL nullability drift:** when the nullable column also backs a GraphQL field, the field declaration must be flipped from `Type!` to `Type` in the **same PR** as the migration. Leaving the field non-null causes the GraphQL serializer to throw at runtime the first time the column returns NULL, crashing the entire query. The `graphql-nullability-drift-check` CI job enforces this automatically for the columns listed in `KNOWN_MAPPINGS` inside `scripts/check-graphql-nullability-drift.py` (see #3441).
+
+To run the check locally:
+
+```
+scripts/check-graphql-nullability-drift.sh --base origin/main
+# or, against a specific migration file:
+scripts/check-graphql-nullability-drift.sh --migration packages/api/migrations/49_foo.sql
+```
+
+If you add a new column→GraphQL-field mapping not yet covered, extend `KNOWN_MAPPINGS` in `scripts/check-graphql-nullability-drift.py` in the same PR.
+
 ### Bash patterns
 
 #### Exit-code masking via `|| printf`

--- a/docs/agent/issue-authoring.md
+++ b/docs/agent/issue-authoring.md
@@ -109,6 +109,13 @@ When filing or implementing an issue that includes a backfill migration (any PR 
   ```
 - **For large tables, include a before/after row-count breakdown by status.** Confirm the counts add up correctly — total updated should equal the sum of per-class counts.
 
+## Migrations
+
+When filing or implementing an issue whose migration drops `NOT NULL` on a column that backs a GraphQL field:
+
+- **Flip the GraphQL field to nullable in the same PR.** Change `FieldName: Type!` to `FieldName: Type` in the schema file. Leaving it non-null causes the GraphQL serializer to throw at runtime when NULL rows appear post-migration, crashing the entire query.
+- **The `graphql-nullability-drift-check` CI job enforces this** for columns listed in `KNOWN_MAPPINGS` inside `scripts/check-graphql-nullability-drift.py`. If your column is not yet covered, extend `KNOWN_MAPPINGS` in the same PR (see `docs/agent/code-standards.md` §Nullable schema migrations and #3441).
+
 ## Investigation Tasks
 
 Investigation tasks produce documentation, not code:

--- a/scripts/check-graphql-nullability-drift.py
+++ b/scripts/check-graphql-nullability-drift.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+# venv: none
+# permanent: true
+"""
+check-graphql-nullability-drift.py — Detect GraphQL fields that are still
+declared non-null after the backing DB column had NOT NULL dropped.
+
+Motivation (#3441): When a migration drops NOT NULL on a column that backs a
+GraphQL field, the field declaration must be updated from ``Type!`` to
+``Type`` in the same PR. If it is not, the GraphQL serializer throws at
+runtime when the column returns NULL for the first time — crashing the entire
+query, not just the one field.
+
+The check:
+  1. Finds changed migration files in the current diff vs a base ref
+     (or reads ``--migration`` paths directly for local/test use).
+  2. Parses each migration for ``ALTER COLUMN <col> DROP NOT NULL``
+     statements.
+  3. Looks up each (table, column) pair in ``KNOWN_MAPPINGS`` to find the
+     GraphQL type(s) and field(s) that read from that column.
+  4. Scans ``packages/api/src/graphql/dispatcher/schema.ts`` (and the
+     root schema.ts) for each field declaration and checks whether it
+     still ends with ``!`` (non-null marker).
+  5. Exits non-zero with a clear message naming the migration file, the
+     column, and the field declaration line if drift is found.
+
+Usage:
+    scripts/check-graphql-nullability-drift.py
+    scripts/check-graphql-nullability-drift.py --base origin/main
+    scripts/check-graphql-nullability-drift.py --migration packages/api/migrations/49_foo.sql
+    scripts/check-graphql-nullability-drift.py --help
+
+Exit codes:
+    0 — No violations found.
+    1 — One or more GraphQL fields still declare non-null for a dropped-NOT-NULL column.
+    2 — Script error (cannot run git, unreadable file, etc.).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+MIGRATIONS_GLOB = "packages/api/migrations/*.sql"
+
+# GraphQL schema files to scan (repo-relative), in priority order.
+_SCHEMA_FILES = [
+    "packages/api/src/graphql/dispatcher/schema.ts",
+    "packages/api/src/graphql/schema.ts",
+]
+
+# Allowlist: maps (table, column) → list of (GraphQLType, fieldName) that
+# read from that column.  Schema prefix is stripped from the table name
+# (matches bare table name only).
+#
+# Seeded from issue #3441: the three dispatcher columns that had NOT NULL
+# dropped in migrations 49–51.  Grow this list as new column→field
+# mappings are established.
+KNOWN_MAPPINGS: dict[tuple[str, str], list[tuple[str, str]]] = {
+    ("agents", "issue_number"): [
+        ("DispatcherAgent", "issueNumber"),
+        ("RecentCompletion", "issueNumber"),
+    ],
+    ("agents", "priority"): [
+        ("DispatcherAgent", "priority"),
+        ("RecentCompletion", "priority"),
+        ("QueueItem", "priority"),
+    ],
+    ("failures", "issue_number"): [
+        ("DispatcherFailure", "issueNumber"),
+    ],
+}
+
+# Regex: match ALTER TABLE ... ALTER COLUMN <col> DROP NOT NULL
+# Handles optional schema prefix, multi-word table names, surrounding
+# whitespace, and case insensitivity. Captures (table, column).
+_DROP_NOT_NULL_RE = re.compile(
+    r"""
+    ALTER \s+ TABLE \s+
+    (?:[\w]+\.)? ([\w]+)   # optional schema prefix, then table name
+    \s+ ALTER \s+ COLUMN \s+
+    ([\w]+)                # column name
+    (?:\s+\w+)*?           # optional TYPE clause words
+    \s+ DROP \s+ NOT \s+ NULL
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class GraphQLDriftViolation:
+    """A GraphQL field that is still non-null after the backing column had
+    NOT NULL dropped."""
+
+    migration_file: Path
+    table: str
+    column: str
+    graphql_type: str
+    field_name: str
+    schema_file: Path
+    line_number: int
+    line_text: str
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers (pure — easy to unit-test)
+# ---------------------------------------------------------------------------
+
+
+def parse_dropped_not_null(sql_text: str) -> list[tuple[str, str]]:
+    """Return a list of (table, column) pairs for every ``ALTER COLUMN col
+    DROP NOT NULL`` statement in *sql_text*.
+
+    Case-insensitive. Handles optional ``schema.`` prefix on the table name
+    (the schema prefix is stripped — callers match on bare table name only).
+
+    Examples that match:
+        ALTER TABLE derived.rulings ALTER COLUMN hearing_date DROP NOT NULL;
+        ALTER TABLE dispatcher.agents ALTER COLUMN issue_number DROP NOT NULL;
+
+    Examples that do NOT match:
+        ALTER TABLE foo ADD COLUMN bar TEXT;
+        ALTER TABLE foo ALTER COLUMN bar TYPE TEXT;
+        ALTER TABLE foo ALTER COLUMN bar SET NOT NULL;
+    """
+    results: list[tuple[str, str]] = []
+    for m in _DROP_NOT_NULL_RE.finditer(sql_text):
+        table = m.group(1).lower()
+        column = m.group(2).lower()
+        results.append((table, column))
+    return results
+
+
+def find_changed_migrations(base_ref: str, repo_root: Path) -> list[Path]:
+    """Return migration SQL files touched in the diff vs *base_ref*.
+
+    Shells out: ``git diff --name-only <base_ref>...HEAD --
+    packages/api/migrations/*.sql``.
+    """
+    result = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "diff",
+            "--name-only",
+            f"{base_ref}...HEAD",
+            "--",
+            MIGRATIONS_GLOB,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git diff failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    paths: list[Path] = []
+    for line in result.stdout.splitlines():
+        p = repo_root / line.strip()
+        if p.suffix == ".sql" and p.exists():
+            paths.append(p)
+    return paths
+
+
+def check_field_nonnull(
+    schema_text: str,
+    schema_file: Path,
+    graphql_type: str,
+    field_name: str,
+) -> tuple[bool, int, str]:
+    """Check whether *field_name* on *graphql_type* is still declared non-null
+    (ends with ``!``) in *schema_text*.
+
+    Returns a 3-tuple:
+      - is_nonnull: True if the field is still declared non-null.
+      - line_number: 1-based line number of the field declaration (0 if not found).
+      - line_text: the raw text of the matching line (empty if not found).
+
+    Strategy: scan within the type block for *graphql_type*, then look for
+    a field declaration line matching *field_name*.  We use a simple
+    line-by-line scan rather than a full GraphQL parser — the schema files
+    are well-structured and this is more robust to whitespace variation.
+    """
+    lines = schema_text.splitlines()
+
+    # Find the type block for graphql_type.  We look for a line that opens
+    # the type block: ``type TypeName {`` or ``type TypeName\n{``.
+    type_start = -1
+    type_block_re = re.compile(r"^\s*type\s+" + re.escape(graphql_type) + r"\s*\{?\s*$")
+    for i, line in enumerate(lines):
+        if type_block_re.match(line):
+            type_start = i
+            break
+
+    if type_start == -1:
+        # Type not found in this schema file — not a violation here.
+        return False, 0, ""
+
+    # Scan lines after the type block opening until the closing ``}``.
+    depth = 0
+    in_block = False
+    field_re = re.compile(
+        r"^\s*" + re.escape(field_name) + r"\s*(?:\([^)]*\))?\s*:\s*([\w\[\]!]+)"
+    )
+    for i in range(type_start, len(lines)):
+        line = lines[i]
+        # Track brace depth.
+        depth += line.count("{") - line.count("}")
+        if not in_block and "{" in line:
+            in_block = True
+        if in_block and depth <= 0:
+            break  # exited the type block
+
+        m = field_re.match(line)
+        if m:
+            type_expr = m.group(1).strip()
+            is_nonnull = type_expr.endswith("!")
+            return is_nonnull, i + 1, line.rstrip()
+
+    return False, 0, ""
+
+
+def find_graphql_drift(
+    migration_file: Path,
+    dropped_columns: list[tuple[str, str]],
+    schema_files: list[Path],
+) -> list[GraphQLDriftViolation]:
+    """For each (table, column) in *dropped_columns* that is in KNOWN_MAPPINGS,
+    check every mapped (GraphQLType, field) pair across *schema_files*.
+
+    Returns a list of violations where the GraphQL field is still non-null.
+    """
+    violations: list[GraphQLDriftViolation] = []
+
+    # Cache schema file contents.
+    schema_texts: dict[Path, str] = {}
+    for sf in schema_files:
+        if sf.exists():
+            try:
+                schema_texts[sf] = sf.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                pass
+
+    for table, column in dropped_columns:
+        mappings = KNOWN_MAPPINGS.get((table, column))
+        if mappings is None:
+            # Unmapped column — allowlist-driven check; silently skip.
+            continue
+
+        for graphql_type, field_name in mappings:
+            # Check each schema file until we find the field.
+            for sf, schema_text in schema_texts.items():
+                is_nonnull, line_no, line_text = check_field_nonnull(
+                    schema_text, sf, graphql_type, field_name
+                )
+                if line_no == 0:
+                    # Field not declared in this file — try next.
+                    continue
+                if is_nonnull:
+                    violations.append(
+                        GraphQLDriftViolation(
+                            migration_file=migration_file,
+                            table=table,
+                            column=column,
+                            graphql_type=graphql_type,
+                            field_name=field_name,
+                            schema_file=sf,
+                            line_number=line_no,
+                            line_text=line_text,
+                        )
+                    )
+                # Field found (either null or non-null) — no need to check further files.
+                break
+
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Detect GraphQL fields still declared non-null after the backing DB "
+            "column had NOT NULL dropped in a migration."
+        )
+    )
+    ap.add_argument(
+        "--base",
+        default="origin/main",
+        help="Base ref to diff against (default: origin/main).",
+    )
+    ap.add_argument(
+        "--migration",
+        dest="migrations",
+        action="append",
+        default=None,
+        metavar="FILE",
+        help=(
+            "Read this migration file directly (repeatable). When given, git diff "
+            "is skipped. Useful for local testing and CI fixtures."
+        ),
+    )
+    ap.add_argument(
+        "--repo-root",
+        default=None,
+        help="Repo root (default: auto-detect from git rev-parse --show-toplevel).",
+    )
+    args = ap.parse_args()
+
+    # -------- Resolve repo root --------
+    if args.repo_root:
+        repo_root = Path(args.repo_root).resolve()
+    else:
+        try:
+            r = subprocess.run(
+                ["git", "rev-parse", "--show-toplevel"],
+                capture_output=True,
+                text=True,
+                check=True,
+                timeout=30,
+            )
+            repo_root = Path(r.stdout.strip())
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            print(f"ERROR: cannot determine repo root: {exc}", file=sys.stderr)
+            return 2
+
+    # -------- Collect migration files --------
+    if args.migrations:
+        migration_files = [Path(p).resolve() for p in args.migrations]
+        for mf in migration_files:
+            if not mf.exists():
+                print(f"ERROR: migration file not found: {mf}", file=sys.stderr)
+                return 2
+    else:
+        try:
+            migration_files = find_changed_migrations(args.base, repo_root)
+        except RuntimeError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+    if not migration_files:
+        print(
+            "check-graphql-nullability-drift: no migration files touched in diff — OK."
+        )
+        return 0
+
+    # -------- Resolve schema files --------
+    schema_files = [repo_root / sf for sf in _SCHEMA_FILES]
+
+    # -------- Parse DROP NOT NULL statements and check GraphQL fields --------
+    all_violations: list[GraphQLDriftViolation] = []
+    any_dropped: bool = False
+
+    for mf in migration_files:
+        try:
+            sql_text = mf.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            print(f"ERROR: cannot read {mf}: {exc}", file=sys.stderr)
+            return 2
+
+        dropped = parse_dropped_not_null(sql_text)
+        if not dropped:
+            continue
+
+        any_dropped = True
+        print(
+            "check-graphql-nullability-drift: found DROP NOT NULL for columns in "
+            + mf.name
+            + ": "
+            + ", ".join(f"{t}.{c}" for t, c in dropped)
+        )
+
+        violations = find_graphql_drift(mf, dropped, schema_files)
+        all_violations.extend(violations)
+
+    if not any_dropped:
+        print(
+            "check-graphql-nullability-drift: no DROP NOT NULL statements in changed "
+            "migrations — OK."
+        )
+        return 0
+
+    if not all_violations:
+        print(
+            "check-graphql-nullability-drift: all mapped GraphQL fields are already "
+            "nullable — OK."
+        )
+        return 0
+
+    print("", file=sys.stderr)
+    print(
+        "check-graphql-nullability-drift: FAIL — GraphQL fields still declared "
+        "non-null after backing column had NOT NULL dropped:",
+        file=sys.stderr,
+    )
+    for v in all_violations:
+        rel_migration = (
+            v.migration_file.relative_to(repo_root)
+            if v.migration_file.is_relative_to(repo_root)
+            else v.migration_file
+        )
+        rel_schema = (
+            v.schema_file.relative_to(repo_root)
+            if v.schema_file.is_relative_to(repo_root)
+            else v.schema_file
+        )
+        print(
+            f"  Migration: {rel_migration}\n"
+            f"    Column:  {v.table}.{v.column}\n"
+            f"    GraphQL: {v.graphql_type}.{v.field_name} is still non-null\n"
+            f"    At:      {rel_schema}:{v.line_number}: {v.line_text.strip()}",
+            file=sys.stderr,
+        )
+
+    print("", file=sys.stderr)
+    print("Remediation:", file=sys.stderr)
+    print(
+        "  Flip the GraphQL field from non-null to nullable in the same PR as the\n"
+        "  migration. For example, change:\n"
+        "    issueNumber: Int!\n"
+        "  to:\n"
+        "    issueNumber: Int",
+        file=sys.stderr,
+    )
+    print("", file=sys.stderr)
+    print(
+        "See https://github.com/judgemind/judgemind/issues/3441 for background.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-graphql-nullability-drift.sh
+++ b/scripts/check-graphql-nullability-drift.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# check-graphql-nullability-drift.sh — Thin wrapper for
+# check-graphql-nullability-drift.py.
+#
+# Scans migration files in the current diff for DROP NOT NULL statements,
+# then checks whether any mapped GraphQL fields are still declared non-null.
+# Used by the CI `graphql-nullability-drift-check` job and reproducible locally.
+#
+# Passes all args through to the Python script — see that file for flags
+# and exit codes (#3441).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$SCRIPT_DIR/check-graphql-nullability-drift.py" "$@"

--- a/scripts/tests/test_check_graphql_nullability_drift.py
+++ b/scripts/tests/test_check_graphql_nullability_drift.py
@@ -1,0 +1,275 @@
+"""Tests for check-graphql-nullability-drift.py — GraphQL nullability drift
+detection against synthetic migration and schema fixtures."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# Import the module despite its dash-containing filename.
+# Register it in sys.modules BEFORE exec_module so `@dataclass` can find
+# its own module by name.
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parent.parent / "check-graphql-nullability-drift.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "check_graphql_nullability_drift", _SCRIPT_PATH
+)
+assert _spec is not None
+assert _spec.loader is not None
+mod = importlib.util.module_from_spec(_spec)
+sys.modules["check_graphql_nullability_drift"] = mod
+_spec.loader.exec_module(mod)
+
+parse_dropped_not_null = mod.parse_dropped_not_null
+check_field_nonnull = mod.check_field_nonnull
+find_graphql_drift = mod.find_graphql_drift
+KNOWN_MAPPINGS = mod.KNOWN_MAPPINGS
+
+
+# ---------------------------------------------------------------------------
+# parse_dropped_not_null (reuses the same regex as check-nullable-column-reads)
+# ---------------------------------------------------------------------------
+
+
+class TestParseDroppedNotNull:
+    def test_extracts_dispatcher_agents_issue_number(self) -> None:
+        sql = (
+            "ALTER TABLE dispatcher.agents\n"
+            "    ALTER COLUMN issue_number DROP NOT NULL;\n"
+        )
+        result = parse_dropped_not_null(sql)
+        assert result == [("agents", "issue_number")]
+
+    def test_extracts_without_schema_prefix(self) -> None:
+        sql = "ALTER TABLE agents ALTER COLUMN priority DROP NOT NULL;\n"
+        result = parse_dropped_not_null(sql)
+        assert result == [("agents", "priority")]
+
+    def test_ignores_add_column(self) -> None:
+        sql = "ALTER TABLE foo ADD COLUMN bar TEXT;\n"
+        result = parse_dropped_not_null(sql)
+        assert result == []
+
+    def test_ignores_set_not_null(self) -> None:
+        sql = "ALTER TABLE foo ALTER COLUMN bar SET NOT NULL;\n"
+        result = parse_dropped_not_null(sql)
+        assert result == []
+
+    def test_extracts_multiple(self) -> None:
+        sql = (
+            "ALTER TABLE dispatcher.agents ALTER COLUMN issue_number DROP NOT NULL;\n"
+            "ALTER TABLE dispatcher.failures ALTER COLUMN issue_number DROP NOT NULL;\n"
+        )
+        result = parse_dropped_not_null(sql)
+        assert result == [("agents", "issue_number"), ("failures", "issue_number")]
+
+
+# ---------------------------------------------------------------------------
+# check_field_nonnull — unit tests for the GraphQL schema scanner
+# ---------------------------------------------------------------------------
+
+
+class TestCheckFieldNonnull:
+    """Tests for check_field_nonnull: does it correctly detect non-null / nullable
+    field declarations inside a GraphQL type block?"""
+
+    _SCHEMA_NONNULL = """\
+export const typeDefs = `#graphql
+  type DispatcherAgent {
+    id: ID!
+    issueNumber: Int!
+    priority: String
+  }
+`;
+"""
+
+    _SCHEMA_NULLABLE = """\
+export const typeDefs = `#graphql
+  type DispatcherAgent {
+    id: ID!
+    issueNumber: Int
+    priority: String
+  }
+`;
+"""
+
+    _SCHEMA_NO_TYPE = """\
+export const typeDefs = `#graphql
+  type SomeOtherType {
+    id: ID!
+  }
+`;
+"""
+
+    def test_nonnull_field_detected(self, tmp_path: Path) -> None:
+        sf = tmp_path / "schema.ts"
+        sf.write_text(self._SCHEMA_NONNULL)
+        is_nonnull, line_no, line_text = check_field_nonnull(
+            self._SCHEMA_NONNULL, sf, "DispatcherAgent", "issueNumber"
+        )
+        assert is_nonnull is True
+        assert line_no > 0
+        assert "Int!" in line_text
+
+    def test_nullable_field_not_flagged(self, tmp_path: Path) -> None:
+        sf = tmp_path / "schema.ts"
+        sf.write_text(self._SCHEMA_NULLABLE)
+        is_nonnull, line_no, line_text = check_field_nonnull(
+            self._SCHEMA_NULLABLE, sf, "DispatcherAgent", "issueNumber"
+        )
+        assert is_nonnull is False
+        assert line_no > 0  # field was found but is nullable
+        assert "Int!" not in line_text
+
+    def test_type_not_in_schema_returns_false(self, tmp_path: Path) -> None:
+        sf = tmp_path / "schema.ts"
+        sf.write_text(self._SCHEMA_NO_TYPE)
+        is_nonnull, line_no, line_text = check_field_nonnull(
+            self._SCHEMA_NO_TYPE, sf, "DispatcherAgent", "issueNumber"
+        )
+        assert is_nonnull is False
+        assert line_no == 0
+
+
+# ---------------------------------------------------------------------------
+# find_graphql_drift — integration-level tests using tmp_path fixtures
+# ---------------------------------------------------------------------------
+
+
+class TestFindGraphqlDrift:
+    """Tests for find_graphql_drift using synthetic migration SQL and
+    GraphQL schema fixture files in tmp_path."""
+
+    _MIGRATION_DROPS_ISSUE_NUMBER = (
+        "ALTER TABLE dispatcher.agents\n    ALTER COLUMN issue_number DROP NOT NULL;\n"
+    )
+
+    _SCHEMA_NONNULL = """\
+export const typeDefs = `#graphql
+  type DispatcherAgent {
+    id: ID!
+    issueNumber: Int!
+    priority: String
+  }
+  type RecentCompletion {
+    agentId: ID!
+    issueNumber: Int!
+    status: String!
+  }
+`;
+"""
+
+    _SCHEMA_NULLABLE = """\
+export const typeDefs = `#graphql
+  type DispatcherAgent {
+    id: ID!
+    issueNumber: Int
+    priority: String
+  }
+  type RecentCompletion {
+    agentId: ID!
+    issueNumber: Int
+    status: String!
+  }
+`;
+"""
+
+    _MIGRATION_NO_DROP = (
+        "ALTER TABLE dispatcher.agents ALTER COLUMN priority SET DEFAULT NULL;\n"
+    )
+
+    _MIGRATION_UNMAPPED_COLUMN = (
+        "ALTER TABLE derived.rulings ALTER COLUMN hearing_date DROP NOT NULL;\n"
+    )
+
+    def _write_migration(self, tmp_path: Path, name: str, content: str) -> Path:
+        mf = tmp_path / name
+        mf.write_text(content)
+        return mf
+
+    def _write_schema(self, tmp_path: Path, name: str, content: str) -> Path:
+        sf = tmp_path / name
+        sf.write_text(content)
+        return sf
+
+    def test_drift_detected_returns_violation(self, tmp_path: Path) -> None:
+        """Migration drops NOT NULL on agents.issue_number; GraphQL field
+        DispatcherAgent.issueNumber is still Int! → exit 1 with a violation."""
+        mf = self._write_migration(
+            tmp_path, "49_test.sql", self._MIGRATION_DROPS_ISSUE_NUMBER
+        )
+        sf = self._write_schema(tmp_path, "schema.ts", self._SCHEMA_NONNULL)
+
+        dropped = parse_dropped_not_null(self._MIGRATION_DROPS_ISSUE_NUMBER)
+        violations = find_graphql_drift(mf, dropped, [sf])
+
+        # Should flag at least DispatcherAgent.issueNumber and RecentCompletion.issueNumber
+        assert len(violations) >= 1
+        field_names = [(v.graphql_type, v.field_name) for v in violations]
+        assert ("DispatcherAgent", "issueNumber") in field_names
+
+        # Each violation names the migration file and the field declaration.
+        for v in violations:
+            assert v.migration_file == mf
+            assert v.table == "agents"
+            assert v.column == "issue_number"
+            assert "Int!" in v.line_text
+
+    def test_field_made_nullable_no_violation(self, tmp_path: Path) -> None:
+        """Migration drops NOT NULL; GraphQL field is already nullable → exit 0."""
+        mf = self._write_migration(
+            tmp_path, "49_test.sql", self._MIGRATION_DROPS_ISSUE_NUMBER
+        )
+        sf = self._write_schema(tmp_path, "schema.ts", self._SCHEMA_NULLABLE)
+
+        dropped = parse_dropped_not_null(self._MIGRATION_DROPS_ISSUE_NUMBER)
+        violations = find_graphql_drift(mf, dropped, [sf])
+
+        assert violations == []
+
+    def test_migration_with_no_drop_not_null_exit_zero(self, tmp_path: Path) -> None:
+        """Migration with no DROP NOT NULL → no violations."""
+        mf = self._write_migration(tmp_path, "50_test.sql", self._MIGRATION_NO_DROP)
+        sf = self._write_schema(tmp_path, "schema.ts", self._SCHEMA_NONNULL)
+
+        dropped = parse_dropped_not_null(self._MIGRATION_NO_DROP)
+        assert dropped == []
+        violations = find_graphql_drift(mf, dropped, [sf])
+        assert violations == []
+
+    def test_unmapped_column_exit_zero(self, tmp_path: Path) -> None:
+        """Column not in KNOWN_MAPPINGS → allowlist-driven, silently skip."""
+        mf = self._write_migration(
+            tmp_path, "16_test.sql", self._MIGRATION_UNMAPPED_COLUMN
+        )
+        sf = self._write_schema(tmp_path, "schema.ts", self._SCHEMA_NONNULL)
+
+        dropped = parse_dropped_not_null(self._MIGRATION_UNMAPPED_COLUMN)
+        assert dropped == [("rulings", "hearing_date")]
+
+        # hearing_date is not in KNOWN_MAPPINGS for this check.
+        assert ("rulings", "hearing_date") not in KNOWN_MAPPINGS
+
+        violations = find_graphql_drift(mf, dropped, [sf])
+        assert violations == []
+
+    def test_multiple_schema_files_first_match_wins(self, tmp_path: Path) -> None:
+        """When the field appears in the first schema file as nullable,
+        the second file (where it might be non-null) is not consulted."""
+        mf = self._write_migration(
+            tmp_path, "49_test.sql", self._MIGRATION_DROPS_ISSUE_NUMBER
+        )
+        # First schema file: nullable (OK).
+        sf1 = self._write_schema(
+            tmp_path, "dispatcher_schema.ts", self._SCHEMA_NULLABLE
+        )
+        # Second schema file: still non-null (would be a violation if consulted).
+        sf2 = self._write_schema(tmp_path, "root_schema.ts", self._SCHEMA_NONNULL)
+
+        dropped = parse_dropped_not_null(self._MIGRATION_DROPS_ISSUE_NUMBER)
+        violations = find_graphql_drift(mf, dropped, [sf1, sf2])
+
+        # First file is nullable → no violations for fields found there.
+        assert violations == []


### PR DESCRIPTION
## Summary

Added GraphQL nullability drift detection to catch migrations that drop `NOT NULL` on a column backing a GraphQL `Type!` field without updating the schema. The check fires in CI via `graphql-nullability-drift-check` job when migration files are touched, preventing the cockpit-darkening regression that occurred in #3425 (operator-visible for 30 minutes).

Closes #3441

## Test plan

### Automated checks

- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (13 new pytest tests in `scripts/tests/test_check_graphql_nullability_drift.py` covering: parse_dropped_not_null regex matching, check_field_nonnull scanner, find_graphql_drift violation detection, field-made-nullable pass, unmapped-column skip, schema-file precedence)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (CI tooling only). The check itself is executed by CI on all PRs touching migrations in `packages/api/migrations/`.