### PR TITLE
fix(dx): fix nullable-column-reads audit defects (#3428)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1150,8 +1150,6 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Fetch origin/main for diff base
-        run: git fetch origin main --depth=50
       - name: Check for unguarded reads of columns with dropped NOT NULL constraint
         run: scripts/check-nullable-column-reads.sh --base origin/main
 

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -247,13 +247,13 @@ scripts/check-nullable-column-reads.sh --migration packages/api/migrations/49_fo
        ...
    ```
 
-2. **File-level acknowledgment** — if null values are handled via logic the linter cannot trace (e.g. a downstream consumer filters them), add a comment at the top of the file:
+2. **Per-column acknowledgment** — if null values are handled via logic the linter cannot trace (e.g. a downstream consumer filters them), add a comment at the top of the file with the column name:
 
    ```python
-   # nullable-ok: hearing_date is filtered upstream by the ingest pipeline
+   # nullable-ok: hearing_date: filtered upstream by the ingest pipeline
    ```
 
-   The comment suppresses the violation for that entire file. Use sparingly — prefer explicit guards at the read site.
+   The column name is required; the annotation suppresses violations only for that column in the file. Use sparingly — prefer explicit guards at the read site.
 
 ### Bash patterns
 

--- a/scripts/check-nullable-column-reads.py
+++ b/scripts/check-nullable-column-reads.py
@@ -54,24 +54,22 @@ _AUDIT_DIRS = [
     "packages/web",
 ]
 
-# Regex: match ALTER TABLE ... ALTER COLUMN <col> DROP NOT NULL
-# Handles optional schema prefix, multi-word table names, surrounding
-# whitespace, and case insensitivity. Captures (table, column).
+# Two-pass parser regexes for ALTER TABLE ... ALTER COLUMN ... DROP NOT NULL.
 #
-# Pattern:
-#   ALTER TABLE [schema.]table ... ALTER COLUMN col DROP NOT NULL
-#   (the "..." between ALTER TABLE and ALTER COLUMN can span lines, but we
-#   match single-line or allow one optional intermediate clause like TYPE)
-_DROP_NOT_NULL_RE = re.compile(
-    r"""
-    ALTER \s+ TABLE \s+
-    (?:[\w]+\.)? ([\w]+)   # optional schema prefix, then table name
-    \s+ ALTER \s+ COLUMN \s+
-    ([\w]+)                # column name
-    (?:\s+\w+)*?           # optional TYPE clause words
-    \s+ DROP \s+ NOT \s+ NULL
-    """,
-    re.VERBOSE | re.IGNORECASE,
+# Pass 1: Capture the table name from an ALTER TABLE statement header.
+#   Handles optional schema prefix; captures bare table name.
+_ALTER_TABLE_HEAD_RE = re.compile(
+    r"^\s*ALTER\s+TABLE\s+(?:[\w]+\.)?([\w]+)\b",
+    re.IGNORECASE,
+)
+
+# Pass 2: Find every ALTER COLUMN ... DROP NOT NULL action within a statement.
+#   Handles comma-separated action lists such as:
+#     ALTER COLUMN a TYPE TEXT, ALTER COLUMN b DROP NOT NULL
+#   Captures the column name for each DROP NOT NULL action.
+_DROP_NOT_NULL_ACTION_RE = re.compile(
+    r"ALTER\s+COLUMN\s+([\w]+)(?:\s+\w+)*?\s+DROP\s+NOT\s+NULL",
+    re.IGNORECASE,
 )
 
 # SELECT-shaped patterns: a string that looks like it reads a column.
@@ -125,15 +123,25 @@ class Violation:
 
 def parse_dropped_not_null(sql_text: str) -> list[tuple[str, str]]:
     """Return a list of (table, column) pairs for every ``ALTER COLUMN col
-    DROP NOT NULL`` statement in *sql_text*.
+    DROP NOT NULL`` action in *sql_text*.
 
     Case-insensitive. Handles optional ``schema.`` prefix on the table name
     (the schema prefix is stripped — callers match on bare table name only,
     since columns are the key discriminator).
 
+    Uses a two-pass parser so that comma-separated action lists are handled
+    correctly:
+      - Pass 1: split into ``;``-terminated statements (after stripping
+        ``--`` line comments) and identify each ``ALTER TABLE`` statement's
+        table name via ``_ALTER_TABLE_HEAD_RE``.
+      - Pass 2: run ``_DROP_NOT_NULL_ACTION_RE.finditer`` within each
+        statement body to collect every ``ALTER COLUMN … DROP NOT NULL``
+        action, yielding one (table, column) pair per match.
+
     Examples that match:
         ALTER TABLE derived.rulings ALTER COLUMN hearing_date DROP NOT NULL;
         ALTER TABLE dispatcher.agents ALTER COLUMN issue_number DROP NOT NULL;
+        ALTER TABLE foo ALTER COLUMN a TYPE TEXT, ALTER COLUMN b DROP NOT NULL;
 
     Examples that do NOT match:
         ALTER TABLE foo ADD COLUMN bar TEXT;
@@ -141,10 +149,20 @@ def parse_dropped_not_null(sql_text: str) -> list[tuple[str, str]]:
         ALTER TABLE foo ALTER COLUMN bar SET NOT NULL;
     """
     results: list[tuple[str, str]] = []
-    for m in _DROP_NOT_NULL_RE.finditer(sql_text):
-        table = m.group(1).lower()
-        column = m.group(2).lower()
-        results.append((table, column))
+
+    # Strip single-line -- comments so they don't confuse the parser.
+    stripped = re.sub(r"--[^\n]*", "", sql_text)
+
+    # Split on semicolons into individual statements.
+    for statement in stripped.split(";"):
+        head_match = _ALTER_TABLE_HEAD_RE.search(statement)
+        if head_match is None:
+            continue
+        table = head_match.group(1).lower()
+        for action_match in _DROP_NOT_NULL_ACTION_RE.finditer(statement):
+            column = action_match.group(1).lower()
+            results.append((table, column))
+
     return results
 
 
@@ -186,9 +204,16 @@ def find_changed_migrations(base_ref: str, repo_root: Path) -> list[Path]:
 # ---------------------------------------------------------------------------
 
 
-def _file_has_nullable_ok(text: str) -> bool:
-    """Return True if the file carries a ``# nullable-ok: <reason>`` line."""
-    return bool(re.search(r"#\s*nullable-ok\s*:", text, re.IGNORECASE))
+def _column_has_nullable_ok(text: str, column: str) -> bool:
+    """Return True if the file carries a ``# nullable-ok: <column>: <reason>``
+    annotation for *column*.
+
+    The annotation format is ``# nullable-ok: <column>: <reason>``.  The
+    column name must match exactly (case-insensitive).  A generic annotation
+    without a column name does NOT suppress violations.
+    """
+    pattern = r"#\s*nullable-ok\s*:\s*" + re.escape(column) + r"\s*:"
+    return bool(re.search(pattern, text, re.IGNORECASE))
 
 
 def _text_has_null_guard(text: str, column: str) -> bool:
@@ -253,7 +278,7 @@ def audit_column_reads(
     1. It references the column name (fast pre-filter).
     2. It has a SELECT-shaped reference to the column.
     3. It does NOT have ``<column> IS NOT NULL`` anywhere in the file.
-    4. It does NOT carry a ``# nullable-ok: <reason>`` file-level ack.
+    4. It does NOT carry a ``# nullable-ok: <column>: <reason>`` per-column ack.
 
     Only `.py` files are scanned (SQL templates and TypeScript resolvers are
     out of scope for v1).
@@ -282,8 +307,8 @@ def audit_column_reads(
                 if not _file_has_select_shaped_reference(text, column):
                     continue
 
-                # File-level ack — skip if present.
-                if _file_has_nullable_ok(text):
+                # Per-column ack — skip if this column is acknowledged.
+                if _column_has_nullable_ok(text, column):
                     continue
 
                 # NULL guard check — skip if present.
@@ -298,7 +323,7 @@ def audit_column_reads(
                         reason=(
                             f"File references '{column}' in a SELECT context "
                             f"but has no IS NOT NULL guard and no "
-                            f"# nullable-ok: annotation."
+                            f"# nullable-ok: {column}: annotation."
                         ),
                     )
                 )
@@ -428,8 +453,8 @@ def main() -> int:
         file=sys.stderr,
     )
     print(
-        "  2. Add a file-level acknowledgment if NULL is handled elsewhere:\n"
-        "       # nullable-ok: <reason explaining how NULL is handled>",
+        "  2. Add a per-column acknowledgment if NULL is handled elsewhere:\n"
+        "       # nullable-ok: <column>: <reason explaining how NULL is handled>",
         file=sys.stderr,
     )
     print("", file=sys.stderr)

--- a/scripts/tests/test_check_nullable_column_reads.py
+++ b/scripts/tests/test_check_nullable_column_reads.py
@@ -22,6 +22,7 @@ _spec.loader.exec_module(mod)
 
 parse_dropped_not_null = mod.parse_dropped_not_null
 audit_column_reads = mod.audit_column_reads
+_column_has_nullable_ok = mod._column_has_nullable_ok
 
 
 # ---------------------------------------------------------------------------
@@ -117,9 +118,9 @@ class TestAuditColumnReads:
         assert violations == []
 
     def test_passes_with_nullable_ok_annotation(self, tmp_path: Path) -> None:
-        """A file carrying # nullable-ok: <reason> is explicitly ack'd — no violation."""
+        """A file carrying # nullable-ok: <column>: <reason> is explicitly ack'd — no violation."""
         code = (
-            "# nullable-ok: issue_number is None for scheduled-skill agents\n"
+            "# nullable-ok: issue_number: is None for scheduled-skill agents\n"
             'query = "SELECT issue_number FROM dispatcher.agents"\n'
             'issue_num = row["issue_number"]\n'
         )
@@ -153,3 +154,62 @@ class TestAuditColumnReads:
         self._make_scripts_file(tmp_path, "constants.py", code)
         violations = audit_column_reads(tmp_path, [("agents", "issue_number")])
         assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# parse_dropped_not_null — multi-action ALTER TABLE (AC1)
+# ---------------------------------------------------------------------------
+
+
+class TestParseDroppedNotNullMultiAction:
+    def test_extracts_from_multi_action_alter(self) -> None:
+        """Comma-separated actions: TYPE change + DROP NOT NULL yields one pair."""
+        sql = (
+            "ALTER TABLE foo ALTER COLUMN a TYPE TEXT, ALTER COLUMN b DROP NOT NULL;\n"
+        )
+        result = parse_dropped_not_null(sql)
+        assert result == [("foo", "b")]
+
+    def test_extracts_from_multi_action_two_drops(self) -> None:
+        """Two DROP NOT NULL actions in one statement both yield pairs."""
+        sql = (
+            "ALTER TABLE foo "
+            "ALTER COLUMN a DROP NOT NULL, "
+            "ALTER COLUMN b DROP NOT NULL;\n"
+        )
+        result = parse_dropped_not_null(sql)
+        assert result == [("foo", "a"), ("foo", "b")]
+
+
+# ---------------------------------------------------------------------------
+# _column_has_nullable_ok — per-column annotation (AC3)
+# ---------------------------------------------------------------------------
+
+
+class TestColumnHasNullableOk:
+    def test_nullable_ok_requires_column_name_match(self, tmp_path: Path) -> None:
+        """Annotation for column 'foo' does NOT suppress a violation on 'bar';
+        the same annotation DOES suppress a violation on 'foo'."""
+        # Write a file that reads both 'foo' and 'bar' in a SELECT context,
+        # annotated only for 'foo'.
+        code = (
+            "# nullable-ok: foo: handled upstream\n"
+            'query_foo = "SELECT foo FROM t"\n'
+            'query_bar = "SELECT bar FROM t"\n'
+            'v_foo = row["foo"]\n'
+            'v_bar = row["bar"]\n'
+        )
+        scripts_dir = tmp_path / "scripts"
+        scripts_dir.mkdir(exist_ok=True)
+        (scripts_dir / "mixed.py").write_text(code, encoding="utf-8")
+
+        violations_foo = audit_column_reads(tmp_path, [("t", "foo")])
+        violations_bar = audit_column_reads(tmp_path, [("t", "bar")])
+
+        # 'foo' is annotated — no violation.
+        assert violations_foo == [], (
+            f"Expected no violation for 'foo', got {violations_foo}"
+        )
+        # 'bar' is NOT annotated — must be flagged.
+        assert len(violations_bar) == 1
+        assert violations_bar[0].column == "bar"


### PR DESCRIPTION
## Summary

Fixed three defects in the nullable-column-reads audit guard introduced in #3398. The single-action regex now uses a two-pass parser for comma-separated ALTER COLUMN actions. Removed the shallow git fetch (depth=50) from CI and tightened the nullable-ok annotation to require a column name match.

Closes #3428

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (agent tooling / CI fix)