### PR TITLE
fix(dispatcher): disable spotcheck cron until architecture decision (#3450)

### DIFF
--- a/packages/api/migrations/51_dispatcher-disable-spotcheck-cron.sql
+++ b/packages/api/migrations/51_dispatcher-disable-spotcheck-cron.sql
@@ -1,0 +1,47 @@
+-- Up Migration
+--
+-- Dispatcher v2 — disable spotcheck scheduled skill (issue #3450).
+--
+-- The /spotcheck SKILL.md Step 0 launches a one-shot ECS task to
+-- populate an S3 path, then reads from that path. The agent-runner
+-- leaf IAM role does not include ecs:RunTask or the required S3
+-- grants, so every cron-spawned spotcheck agent fails at Step 0.
+-- This migration disables the row until a type/decision follow-up
+-- (filed by /task-v2-retro after this PR merges) chooses between:
+--
+--   Option A — widen the agent-runner IAM role to include ecs:RunTask
+--              + S3 list/get/put (broadens the documented threat model).
+--   Option B — refactor /spotcheck so the daemon launches the oneshot
+--              before spawning the agent (non-trivial daemon change).
+--
+-- Design notes
+-- ------------
+-- * WHERE name = 'spotcheck' AND enabled = true — idempotent guard.
+--   Re-applying this migration after a Down rollback is a no-op
+--   (the row is already enabled=false, no rows match, zero updates).
+--
+-- * notes text is appended, not replaced — preserves any operator
+--   annotations already present in the column.
+--
+-- Rollback
+-- --------
+-- UPDATE dispatcher.scheduled_skills SET enabled = true
+--   WHERE name = 'spotcheck';
+-- Note: the appended notes text is NOT restored by Down — it is a
+-- partial rollback. The row itself is re-enabled for scheduling.
+
+UPDATE dispatcher.scheduled_skills
+SET
+    enabled = false,
+    notes   = notes
+              || ' Disabled by #3450 — spotcheck cron is incompatible'
+              || ' with the agent-runner leaf-role IAM scope;'
+              || ' type/decision follow-up tracks A vs B.'
+WHERE name = 'spotcheck'
+  AND enabled = true;
+
+
+-- Down Migration
+UPDATE dispatcher.scheduled_skills
+SET enabled = true
+WHERE name = 'spotcheck';

--- a/scripts/dispatcher/tests/test_scheduled_skills_schema.py
+++ b/scripts/dispatcher/tests/test_scheduled_skills_schema.py
@@ -139,3 +139,41 @@ def test_daily_report_down_migration() -> None:
     assert "-- Down Migration" in text
     assert "DELETE FROM dispatcher.scheduled_skills" in text
     assert "'dispatcher-daily-report'" in text
+
+
+# ---------------------------------------------------------------------------
+# Migration 51 — disable spotcheck scheduled skill (issue #3450)
+# ---------------------------------------------------------------------------
+
+MIGRATION_51_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "packages"
+    / "api"
+    / "migrations"
+    / "51_dispatcher-disable-spotcheck-cron.sql"
+)
+
+
+def _migration_51_text() -> str:
+    return MIGRATION_51_PATH.read_text(encoding="utf-8")
+
+
+def test_disable_spotcheck_migration_file_exists() -> None:
+    assert MIGRATION_51_PATH.is_file(), (
+        f"expected migration file at {MIGRATION_51_PATH}; issue #3450 ships migration 51"
+    )
+
+
+def test_disable_spotcheck_migration_targets_spotcheck_row() -> None:
+    """Migration 51 must UPDATE the spotcheck row to enabled = false."""
+    text = _migration_51_text()
+    assert "WHERE name = 'spotcheck'" in text
+    assert "enabled = false" in text
+
+
+def test_disable_spotcheck_down_migration() -> None:
+    """Migration 51 Down section must restore enabled = true for spotcheck."""
+    text = _migration_51_text()
+    assert "-- Down Migration" in text
+    assert "enabled = true" in text
+    assert "'spotcheck'" in text


### PR DESCRIPTION
## Summary

Disables the idle_spotcheck_cron scheduled skill via migration 51 (dispatcher.scheduled_skills). The /spotcheck data-quality agents were failing at Step 0 due to IAM scope limitations on the agent-runner role, which requires choosing between three options: widen the role's ECS/S3 permissions (Option A), refactor /spotcheck to have the daemon launch the oneshot (Option B), or defer the decision (Option C).

This PR implements Option C: disable the cron and defer the architectural decision. A type/decision follow-up issue will be filed by /task-v2-retro to choose between A and B.

Closes #3450

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
- [x] CI green

### Post-deploy verification

- [ ] Migration 51 applied: `psql $DATABASE_URL -c "SELECT enabled, name FROM dispatcher.scheduled_skills WHERE name = 'spotcheck';"` shows `enabled = false`.
- [ ] No new spotcheck agents spawned by cron (dashboard check post-deploy).
- [ ] Verification evidence posted on #3450.