### PR TITLE
fix(dispatcher): eliminate route_stub fall-throughs + collapse diagnoser executor (#3455)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -4,7 +4,7 @@ argument-hint: "<diagnosis_id>"
 model: opus
 ---
 
-# /diagnose-failure skill — empowered diagnoser (issue #3366)
+# /diagnose-failure skill — empowered diagnoser (issue #3366, #3455)
 
 Last-ditch resolution point for any failure the per-phase pipeline can't auto-recover from. Invoked as `claude -p '/diagnose-failure <diagnosis_id>'` by the daemon when an agent terminates with a tier-2/3 failure category. Reads the failure context, **does whatever needs doing** (patch the agent's branch, file a prerequisite issue, comment, edit labels), and writes a 3-state directive (`respawn_at=<phase>` / `terminal` / NULL) that the daemon's reaper consumes.
 
@@ -12,13 +12,15 @@ This is the v1 mental model that v2 lost: one smart agent with broad context han
 
 **No turn cap, no wall-clock cap (within reason).** The daemon's `DIAGNOSER_SUBPROCESS_TIMEOUT_SECONDS` is set to 90 minutes as a sanity ceiling for sub-skill invocations and real diagnostic work; operator visibility on long-running diagnoses comes via the structured-log stream, not a hard kill.
 
-**Recommendation contract preserved (8 known actions).** Issue #3032's recommendation field stays for audit / operator review and the weekly report — the daemon's deterministic consumer still reads it and runs the matching action (`retry`, `retry_with_hint`, `reissue`, `escalate`, `close`, `block_and_comment`, `file_prerequisite_task`, `block_on_existing_task`). What's new in #3366 is that you ALSO write a `next_directive` column AND can take direct side effects (commit/push, gh issue create/edit) when the situation calls for it.
+**Recommendation contract — 9 known actions; prefer `terminal`.** Issue #3032's recommendation field stays for audit / operator review and the weekly report — the daemon's deterministic consumer reads it and runs the matching action (`retry`, `retry_with_hint`, `reissue`, `escalate`, `close`, `block_and_comment`, `file_prerequisite_task`, `block_on_existing_task`). What's new in #3366 is that you ALSO write a `next_directive` column AND can take direct side effects (commit/push, gh issue create/edit) when the situation calls for it.
+
+**Issue #3455 — collapse the executor layer.** Pre-#3455, `escalate` / `close` / `block_and_comment` / `file_prerequisite_task` / `block_on_existing_task` instructed the **daemon** to perform the gh writes (close, comment, label, file). That double-tiered the work — the diagnoser already has full peer-tier `gh` CLI authority — and any action without a daemon-side handler was dying at `agent_runner_route_stub`. Post-#3455 the **preferred** shape is `action="terminal"`: the SKILL itself runs `gh issue close`, `gh issue comment`, `gh issue edit`, `gh issue create`, etc., and emits a descriptive `action_taken` string for audit. The daemon's consumer just records the diagnosis and marks the agent terminal with phase `diagnoser_terminal` — one phase, no per-action variants. The legacy actions still work for backward compat (older skill outputs keep deserializing), but new diagnoses should use `terminal` whenever the SKILL has handled the gh side-effects directly. See §Action selection below.
 
 **Prerequisites:** The daemon has already (a) written a `dispatcher.diagnoses` row with `status='pending'` and a serialized context bundle, (b) spawned this skill with the `diagnosis_id` as the argument AND with the `JUDGEMIND_DIAGNOSER_RUN=1` env var set (the bright-line hook reads this).
 
 **Goal — three writes to the `dispatcher.diagnoses` row before exit:**
 
-1. `recommendation` (JSONB) — the 8-action shape (or a novel action string for operator review). Same schema as #3032.
+1. `recommendation` (JSONB) — the 9-action shape (or a novel action string for operator review). See §Output contract.
 2. `next_directive` (TEXT) — `respawn_at=<phase>` | `terminal` | NULL.
 3. `actions_taken` (JSONB array) — append-only audit log of every side-effect you took.
 
@@ -61,6 +63,7 @@ Schema for each entry:
 {"ts": "...", "type": "gh_issue_create", "issue_number": 3401, "title": "..."}
 {"ts": "...", "type": "gh_issue_edit", "issue_number": 3297, "labels_added": ["status/blocked"], "labels_removed": ["agent/ready"]}
 {"ts": "...", "type": "gh_issue_comment", "issue_number": 3297, "body_preview": "first 200 chars..."}
+{"ts": "...", "type": "gh_issue_close", "issue_number": 3297, "reason": "not planned"}
 {"ts": "...", "type": "skill_invoke", "skill": "task-v2-fix-conflict", "exit_code": 0}
 {"ts": "...", "type": "bash_run", "cmd": "git rebase origin/main", "exit_code": 0}
 ```
@@ -72,6 +75,7 @@ Action types to log:
 - `gh_issue_create` — `gh issue create`, with the new issue number.
 - `gh_issue_edit` — `gh issue edit`, including label add/remove and body changes.
 - `gh_issue_comment` — `gh issue comment`.
+- `gh_issue_close` — `gh issue close`, with the reason.
 - `skill_invoke` — every sub-skill call.
 - `bash_run` — non-trivial commands (don't log every `cat`/`ls`/`grep`; log every `git rebase` / `gh issue close` / `aws ...` / `pytest` / etc.).
 
@@ -170,22 +174,46 @@ On 2026-04-23 the Opus diagnoser hallucinated a PAT-scope cascade push-rejection
 
 ## Step 2 — Decide the action shape
 
-Walk the decision tree below. For most cases the action shape is clear from the failure category and the verbatim stderr. **Pre-#3366 the diagnoser was constrained to recommendation-only output; post-#3366 you can also do the work directly** — patch the agent's branch, file the issue with `gh issue create`, etc. Use that authority when the action is mechanical and obvious; reserve recommendation-only output (no direct side effects) for cases where a human should still review.
+Walk the decision tree below. For most cases the action shape is clear from the failure category and the verbatim stderr. **Pre-#3366 the diagnoser was constrained to recommendation-only output; post-#3366 you can also do the work directly** — patch the agent's branch, file the issue with `gh issue create`, etc. **Post-#3455 the preferred shape for any case where you've taken gh side-effects yourself is `action="terminal"`** — see "Inline-action terminal" below.
 
-### Action selection — the eight known recommendations
+### Action selection — the nine known recommendations
 
-Same decision tree as before #3366; the recommendation field stays as audit context.
+The first eight are the legacy decision tree (still supported for backward compat); the ninth (`terminal`) is the new collapsed shape preferred post-#3455.
 
 1. **External-dep transient** (`subprocess_crash` with 5xx/timeout, no fleet-wide pattern) → `retry`. No comment needed.
 2. **Scope ambiguity / missing context** (`subprocess_turn_limit` / `ci_red_after_retries` looping on a fixable thing) → `retry_with_hint`. Write a concrete `hint`.
 3. **AC mismatch with reality** (ralph SHIPped, CI caught a drift; the AC uses a renamed field) → `reissue`. Write a `new_scope` body (full rewrite — see below).
-4. **Needs human** (`type/decision`, missing secret, vendor billing) → `escalate`.
-5. **Issue invalid** (duplicate, already-closed, not reproducible) → `close`.
-6. **Operator-action blocker, in-flight** → `block_and_comment`.
-7. **Operator-action blocker, new** → `file_prerequisite_task` with focused `title` + `body`.
-8. **Tracking issue already exists** → `block_on_existing_task` with `blocker_issue_number`.
+4. **Needs human** (`type/decision`, missing secret, vendor billing) → either:
+   - **Preferred (#3455 inline):** post the `## Diagnosis (3D escalation)` comment yourself via `gh issue comment`, add `status/needs-human` + `priority/p1` via `gh issue edit --add-label`, then emit `action="terminal"` with `action_taken="escalate"`.
+   - Legacy fallback: `action="escalate"` and let the daemon do the gh writes.
+5. **Issue invalid** (duplicate, already-closed, not reproducible) → either:
+   - **Preferred (#3455 inline):** add `status/invalid` and run `gh issue close <N> --reason "not planned"` yourself with the diagnosis as the close comment, then emit `action="terminal"` with `action_taken="close"`.
+   - Legacy fallback: `action="close"` and let the daemon do the gh writes.
+6. **Operator-action blocker, in-flight** → either:
+   - **Preferred (#3455 inline):** post `## Diagnosis (3D block)` yourself, add `status/blocked`, remove `agent/ready`, then emit `action="terminal"` with `action_taken="block_and_comment"`.
+   - Legacy fallback: `action="block_and_comment"`.
+7. **Operator-action blocker, new** → either:
+   - **Preferred (#3455 inline):** run `gh issue create` yourself with the title + body, capture the new issue number, append `Blocked by #<new>` to the current issue body via `gh issue edit --body-file`, add `status/blocked`, post the explanatory comment, then emit `action="terminal"` with `action_taken="file_prerequisite_task"`.
+   - Legacy fallback: `action="file_prerequisite_task"` with `title` + `body`.
+8. **Tracking issue already exists** → either:
+   - **Preferred (#3455 inline):** validate the blocker is open via `gh issue view`, append `Blocked by #<N>` yourself, add `status/blocked`, remove `agent/ready`, post the comment, then emit `action="terminal"` with `action_taken="block_on_existing_task"`.
+   - Legacy fallback: `action="block_on_existing_task"` with `blocker_issue_number`.
+9. **Inline-action terminal (#3455)** → `action="terminal"`. Preferred whenever you've performed gh side-effects yourself. Required fields: `action_taken` (descriptive string — e.g. `"close"`, `"escalate"`, `"block_and_comment"`, `"file_prerequisite_task"`, `"block_on_existing_task"`, or any other string that names what you did) and `summary` (one paragraph, ≤500 chars, what you did and why). Optional: `evidence` (longer prose with log lines, gh output, etc.).
 
 **When uncertain, prefer `escalate` over a wrong guess.** A human re-classification is cheap; a wrong `close` or `reissue` can destroy context.
+
+### Inline-action terminal — the concrete how-to
+
+When you decide to take gh side-effects yourself (the preferred path post-#3455), use this pattern:
+
+1. **Run the gh command(s) directly** via Bash. Examples:
+   - `gh issue close <N> --repo judgemind/judgemind --comment "<body>" --reason "not planned"`
+   - `gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/dispatcher-diagnoser/comment.md`
+   - `gh issue edit <N> --repo judgemind/judgemind --add-label status/blocked --remove-label agent/ready`
+   - `gh issue create --repo judgemind/judgemind --title "<title>" --body-file <body-file> --label "<labels>"`
+2. **Log each gh write to `actions_taken`** via `log_action.py` — `gh_issue_close`, `gh_issue_comment`, `gh_issue_edit`, `gh_issue_create` types.
+3. **Emit `action="terminal"`** in the recommendation with descriptive `action_taken` + `summary`.
+4. **Set `next_directive=terminal`** — the daemon's `_consume_action_terminal` simply records the diagnosis and marks the agent terminal at phase `diagnoser_terminal`. No additional gh writes from the daemon.
 
 ### Per-category guidance — `conflict_unresolvable` (#3225 / #3366)
 
@@ -193,13 +221,11 @@ Routed here on the bypass-fix from #3366. Read `context.details.conflict_files` 
 
 **You can fix it directly.** If the conflict is small (e.g. anthropic SDK floor reconciliation, parallel renames), check out the agent's branch, edit the file, commit, push, and write `next_directive=respawn_at=push_and_pr`. The daemon's reaper will spawn a fresh agent-runner that resumes at `push_and_pr` and runs the rest of the pipeline against your committed resolution.
 
-If the conflict is structural (semantic collision — function rewritten on main, feature reverted), recommend `escalate` or `reissue` with a clarified `new_scope`, and write `next_directive=terminal`.
+If the conflict is structural (semantic collision — function rewritten on main, feature reverted), recommend `escalate` (or the inline-#3455 `terminal` shape) or `reissue` with a clarified `new_scope`, and write `next_directive=terminal`.
 
-### Per-category guidance — `agent_runner_route_stub` (#3366)
+### Per-category guidance — `agent_runner_route_stub` (#3366) — historical
 
-The agent-runner entrypoint hit a transition shape it didn't know how to route (often `ralph_not_ship` — ralph terminated with a non-SHIP verdict). Read `context.details.route_hint`, the agent's commits (`git log --oneline origin/main..HEAD`), and the latest reviewer feedback (`{worktree}/tmp/ralph/*-feedback.md` if present).
-
-Most cases route to `retry_with_hint` (write a hint, set `next_directive=respawn_at=ralph` if you reset the agent's commits, otherwise `terminal`) or `block_and_comment` / `escalate` for structurally-stuck cases.
+Pre-#3455 the agent-runner entrypoint hit a transition shape it didn't know how to route (often `ralph_not_ship` — ralph terminated with a non-SHIP verdict) and emitted `agent_runner_route_stub`. Post-#3455 those fall-throughs are eliminated — the entrypoint emits descriptive terminal phases (`ralph_baseline_transition_unrecognized`, `push_and_pr_transition_unrecognized`, `phase_unknown_<phase>`, etc.) via `agent_runner_reaped_failure`, and `ralph_not_ship` is handled locally (post comment + add `status/blocked`) without bouncing to the diagnoser. If you do see an `agent_runner_route_stub` row in the wild, that's a pre-#3455 agent or a regression — read `context.details.route_hint`, the agent's commits (`git log --oneline origin/main..HEAD`), and the latest reviewer feedback (`{worktree}/tmp/ralph/*-feedback.md` if present), and route to `retry_with_hint` (write a hint, set `next_directive=respawn_at=ralph` if you reset the agent's commits, otherwise `terminal`) or to the inline-#3455 `terminal` shape with `action_taken="block_and_comment"`.
 
 ### Per-category guidance — AC-infeasibility (#3010)
 
@@ -209,11 +235,11 @@ The full AC-infeasibility tables (ralph_ac_infeasible vs summary_ac_infeasible d
 
 ### Per-category guidance — `merge_conflict_at_push` (#2964)
 
-Daemon-side pre-push rebase hit a conflict; rebase aborted, no PR opened. Read `context.details.conflict_files`. Pre-#3366 the recommendation was the only output; post-#3366 you can attempt to resolve the rebase yourself if the conflict looks routine (parallel imports, lockfile noise) and write `next_directive=respawn_at=push_and_pr`. For structural conflicts, recommend `block_and_comment` or `file_prerequisite_task` and `next_directive=terminal`.
+Daemon-side pre-push rebase hit a conflict; rebase aborted, no PR opened. Read `context.details.conflict_files`. Pre-#3366 the recommendation was the only output; post-#3366 you can attempt to resolve the rebase yourself if the conflict looks routine (parallel imports, lockfile noise) and write `next_directive=respawn_at=push_and_pr`. For structural conflicts, recommend `block_and_comment` (or inline-#3455 `terminal` with `action_taken="block_and_comment"`) or `file_prerequisite_task` and `next_directive=terminal`.
 
 ### Per-category guidance — `verify_failed_post_merge` (#3071)
 
-PR is already merged; deploy is live; verify caught a regression. The issue is closed-via-merge — `reissue` / `close` / `retry` are no-ops. **Do not pick `retry` or `retry_with_hint` for this category.** `retry` is a no-op in the post-merge flow (the daemon does not re-run `/task-v2-verify` from the retry-marker path; `phase='done'` is terminal in the post-merge pipeline). Recommend `file_prerequisite_task` (regression issue with the verify evidence_md as reproducer, p1) or `block_and_comment` (needs-human). `next_directive=terminal` always — there's no respawn that re-runs verify on a closed issue.
+PR is already merged; deploy is live; verify caught a regression. The issue is closed-via-merge — `reissue` / `close` / `retry` are no-ops. **Do not pick `retry` or `retry_with_hint` for this category.** `retry` is a no-op in the post-merge flow (the daemon does not re-run `/task-v2-verify` from the retry-marker path; `phase='done'` is terminal in the post-merge pipeline). Recommend `file_prerequisite_task` (regression issue with the verify evidence_md as reproducer, p1) or `block_and_comment` (needs-human) — or the inline-#3455 `terminal` equivalent. `next_directive=terminal` always — there's no respawn that re-runs verify on a closed issue.
 
 **Do not pick `reissue` for this category.** The issue is already closed via merge; editing its body with a new scope will not re-open the PR or revert the merge. `reissue` is a pre-merge remedy.
 
@@ -226,6 +252,8 @@ PR is already merged; deploy is live; verify caught a regression. The issue is c
 If the recommendation alone is enough (the daemon's deterministic consumer handles `retry`/`reissue`/`escalate`/etc.), just write the recommendation + directive.
 
 If you need to do the work directly — commit a fix, file an issue, post a structured comment that needs LLM-authored prose — DO IT. Log every side effect to `actions_taken` (see §Audit trail). When the work is done, write `next_directive=respawn_at=<phase>` (if the agent should resume the pipeline) or `next_directive=terminal` (if you handled everything).
+
+**Post-#3455 preference:** for any case where you take gh side-effects, prefer `action="terminal"` (with `action_taken` + `summary`). This collapses the executor layer — the daemon stops doing redundant gh writes for actions the SKILL has already executed.
 
 ### Sub-skill invocation
 
@@ -329,30 +357,36 @@ with psycopg.connect(os.environ["DATABASE_URL"]) as conn:
 
 **Do not add `status = 'completed'` or `completed_at = now()` to this UPDATE.** The daemon's `_consume_diagnosis` / `_mark_diagnosis_completed` owns the `status` transition. Premature `'completed'` causes the reaper (`WHERE status='pending'`) to skip the row and silently drop the directive (issue #3422).
 
-Recommendation shape (unchanged from #3032):
+Recommendation shape:
 
 ```json
 {
-  "action": "retry" | "retry_with_hint" | "reissue" | "escalate" | "close" | "block_and_comment" | "file_prerequisite_task" | "block_on_existing_task" | "<novel-action-string>",
+  "action": "retry" | "retry_with_hint" | "reissue" | "escalate" | "close" | "block_and_comment" | "file_prerequisite_task" | "block_on_existing_task" | "terminal" | "<novel-action-string>",
   "reasoning": "<one paragraph; first sentence MUST quote the verbatim stderr line — see §Step 1>",
   "hint": "<conditional — retry_with_hint only>",
   "new_scope": "<conditional — reissue only; full rewritten issue body>",
   "title": "<conditional — file_prerequisite_task only>",
   "body": "<conditional — file_prerequisite_task only>",
   "block_labels": ["<conditional — file_prerequisite_task only>"],
-  "blocker_issue_number": 42
+  "blocker_issue_number": 42,
+  "action_taken": "<conditional — terminal only; descriptive string naming what you did>",
+  "summary": "<conditional — terminal only; one paragraph, ≤500 chars>",
+  "evidence": "<optional — terminal only; longer prose with log/gh-output evidence>"
 }
 ```
 
-Field rules (unchanged from #3032):
+Field rules:
 
-- `action` (required) — one of the eight known strings, OR a novel action string.
-- `reasoning` (required) — single paragraph (≤500 chars). **First sentence MUST quote the verbatim stderr line** (in backticks or double-quotes), per §Step 1.
+- `action` (required) — one of the nine known strings, OR a novel action string.
+- `reasoning` (required for legacy actions) — single paragraph (≤500 chars). **First sentence MUST quote the verbatim stderr line** (in backticks or double-quotes), per §Step 1. For `terminal` the same rule applies to `summary`.
 - `hint` (conditional) — required when `action='retry_with_hint'`.
 - `new_scope` (conditional) — required when `action='reissue'`. **Wholesale body rewrite** — preserve `## Goal`, `## Scope`, `## Acceptance criteria`, `## Priority`, `## References` + any `Parent: #N` / `Blocked by #N` lines.
 - `title` + `body` (conditional) — required when `action='file_prerequisite_task'`. Title is conventional-commits style.
 - `block_labels` (optional) — for `file_prerequisite_task`.
 - `blocker_issue_number` (conditional) — required when `action='block_on_existing_task'`. Positive integer.
+- `action_taken` (conditional) — required when `action='terminal'` (#3455). Non-empty string describing what gh side-effect you performed (e.g. `"close"`, `"escalate"`, `"file_prerequisite_task"`).
+- `summary` (conditional) — required when `action='terminal'` (#3455). Non-empty paragraph. **First sentence MUST quote the verbatim stderr line** when one is identifiable (same rule as `reasoning`).
+- `evidence` (optional, terminal-only) — longer prose. Useful for capturing gh output / log lines without bloating `summary`.
 
 Exit 0 when all three writes (recommendation + directive + actions_taken) are persisted. The daemon writes `status='completed'` after consuming the directive — the SKILL does not. Exit non-zero on hard failure — the daemon marks the diagnosis `status='failed'` and falls back to mechanical escalation.
 
@@ -366,9 +400,9 @@ Exit 0 when all three writes (recommendation + directive + actions_taken) are pe
 
 3. **Classify.** Identify `failure_category` and `tier`. Read `prior_mechanical_fix` (tier 2) or `ci_log_url` (tier 3). Now scan `prior_diagnoses_this_issue` + `recent_fleet_decisions` for patterns. If a pattern conflicts with your verbatim quote, trust the quote.
 
-4. **Decide.** Walk the decision tree. Pick the action shape and the directive shape (respawn_at vs terminal).
+4. **Decide.** Walk the decision tree. Pick the action shape (preferring `terminal` post-#3455 when you'll be doing gh side-effects yourself) and the directive shape (respawn_at vs terminal).
 
-5. **Act.** Execute side effects (commit, push, gh issue create/edit, etc.) if needed. Log each one via `log_action.py` to `actions_taken`. Or skip side effects entirely and let the daemon's recommendation consumer handle it.
+5. **Act.** Execute side effects (commit, push, gh issue create/edit, gh issue close, gh issue comment, etc.) if needed. Log each one via `log_action.py` to `actions_taken`. Or skip side effects entirely and let the daemon's recommendation consumer handle it (legacy path).
 
 6. **Write recommendation + directive.** Run `write_recommendation.py` and `write_directive.py`. Both update the same row. `status` stays `'pending'` — the daemon's reaper picks it up on the next tick and writes `'completed'` after applying the directive.
 
@@ -394,7 +428,7 @@ actions_taken: [
 ]
 ```
 
-### Example 2 — fleet-wide PAT-scope cascade, file a prerequisite
+### Example 2 — fleet-wide PAT-scope cascade, file a prerequisite (inline #3455)
 
 Training example — `#99001` is a synthetic placeholder. In a real diagnosis, file the issue and use the returned number.
 
@@ -403,11 +437,21 @@ context.failure_category = "push_failed"
 verbatim stderr: "remote: refusing to allow a Personal Access Token..."
 context.recent_fleet_decisions: 3 prior block_on_existing_task on the same blocker issue.
 
-Recommendation: {"action": "file_prerequisite_task", "title": "...", "body": "...", "reasoning": "..."}
+Action (inline): gh issue create → got #99001; gh issue edit on the current
+issue to append "Blocked by #99001"; gh issue edit --add-label status/blocked;
+gh issue comment with the explanatory diagnosis.
+
+Recommendation: {
+  "action": "terminal",
+  "action_taken": "file_prerequisite_task",
+  "summary": "The stderr ends with `\"remote: refusing to allow a Personal Access Token...\"`. Filed #99001 as the prerequisite tracking issue and blocked the current issue on it.",
+  "reasoning": "..."
+}
 next_directive: "terminal"
 actions_taken: [
-  {"type": "gh_issue_create", "issue_number": 99001, ...},
-  {"type": "gh_issue_edit", "issue_number": 3297, "labels_added": ["status/blocked"]}
+  {"type": "gh_issue_create", "issue_number": 99001, "title": "..."},
+  {"type": "gh_issue_edit", "issue_number": 3297, "labels_added": ["status/blocked"]},
+  {"type": "gh_issue_comment", "issue_number": 3297, "body_preview": "## Diagnosis (3D block-on-prerequisite) ..."}
 ]
 ```
 
@@ -423,28 +467,43 @@ next_directive: "respawn_at=planning"  (let a fresh plan→ralph run against the
 actions_taken: []  (no direct side effects this run)
 ```
 
-### Example 4 — uncertain stderr, escalate cleanly
+### Example 4 — uncertain stderr, escalate inline (#3455 preferred)
 
 ```text
 context.failure_category = "subprocess_crash"
 verbatim stderr: empty (just progress output).
 
-Recommendation: {"action": "escalate", "reasoning": "stderr_tail had no FAILED: line — only progress output."}
+Action (inline): gh issue comment with "## Diagnosis (3D escalation) ..." reasoning;
+gh issue edit --add-label status/needs-human,priority/p1.
+
+Recommendation: {
+  "action": "terminal",
+  "action_taken": "escalate",
+  "summary": "stderr_tail had no FAILED: line — only progress output. Posted the escalation comment and added status/needs-human + priority/p1.",
+  "reasoning": "..."
+}
 next_directive: "terminal"
-actions_taken: []  (let the daemon's escalate consumer add labels + post the comment)
+actions_taken: [
+  {"type": "gh_issue_comment", "issue_number": 3297, "body_preview": "## Diagnosis (3D escalation) ..."},
+  {"type": "gh_issue_edit", "issue_number": 3297, "labels_added": ["status/needs-human", "priority/p1"]}
+]
 ```
 
-(Or do the gh writes yourself and log them in `actions_taken` — both paths are valid; just be consistent.)
-
-### Example 5 — conflict_unresolvable, semantic collision, escalate
+### Example 5 — conflict_unresolvable, semantic collision, escalate inline
 
 ```text
 context.failure_category = "conflict_unresolvable"
 context.details.resolution_notes = "function X was rewritten on main; agent's call no longer type-checks"
 
-Recommendation: {"action": "escalate", "reasoning": "..."}
+Action (inline): gh issue comment with the escalation diagnosis;
+gh issue edit --add-label status/needs-human,priority/p1.
+
+Recommendation: {"action": "terminal", "action_taken": "escalate", "summary": "..."}
 next_directive: "terminal"
-actions_taken: []
+actions_taken: [
+  {"type": "gh_issue_comment", ...},
+  {"type": "gh_issue_edit", "labels_added": ["status/needs-human", "priority/p1"]}
+]
 ```
 
 ### Example 6 — conflict_unresolvable, routine parallel-edit, fix it directly
@@ -465,6 +524,28 @@ actions_taken: [
 ]
 ```
 
+### Example 7 — issue duplicate, close inline (#3455)
+
+```text
+context.failure_category = "ralph_ac_infeasible"
+verbatim stderr: "AC#1 unmet: feature already shipped in #3000"
+
+Action (inline): gh issue edit --add-label status/invalid;
+gh issue close <N> --reason "not planned" --comment "<body>".
+
+Recommendation: {
+  "action": "terminal",
+  "action_taken": "close",
+  "summary": "The stderr ends with `\"AC#1 unmet: feature already shipped in #3000\"`. Closed as duplicate of #3000.",
+  "reasoning": "..."
+}
+next_directive: "terminal"
+actions_taken: [
+  {"type": "gh_issue_edit", "labels_added": ["status/invalid"]},
+  {"type": "gh_issue_close", "issue_number": 3297, "reason": "not planned"}
+]
+```
+
 ---
 
 ## Reminders
@@ -474,6 +555,7 @@ actions_taken: [
 - Bright lines are hook-enforced (`JUDGEMIND_DIAGNOSER_RUN=1` env). Do not work around a block — escalate instead.
 - `actions_taken` is mandatory for every side-effect action.
 - `next_directive` is mandatory before exit (use `terminal` if no respawn is needed). NULL means "I crashed", which falls back to escalate + a `diagnoser_did_not_complete` log event.
-- §Step 1 (verbatim stderr quote in reasoning) is mandatory.
+- §Step 1 (verbatim stderr quote in reasoning / summary) is mandatory.
+- **Prefer `action="terminal"` (#3455) when you take gh side-effects yourself.** The legacy `escalate` / `close` / `block_and_comment` / `file_prerequisite_task` / `block_on_existing_task` actions still work — the daemon will perform the gh writes — but doubling up (SKILL does it AND emits a legacy action) causes duplicate comments and labels.
 - Exit 0 means "directive + recommendation + audit log written". Exit non-zero means "I could not diagnose" — the daemon falls back to fixed mechanical escalation.
 - **Do not set `status='completed'`** in `write_recommendation.py`. That column is owned by the daemon's `_mark_diagnosis_completed` method (issue #3422).

--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -3637,6 +3637,109 @@ agent_runner_reaped_failure() {
     log "phase_advanced" "next_phase=$_term_phase" "status=failed"
 }
 
+handle_ralph_not_ship_local() {
+    # Issue #3455 Path B — handle ``ralph_not_ship`` locally instead of
+    # routing to the diagnoser. Pre-#3455 this hint hit the
+    # ``advance_phase agent_runner_route_stub`` fall-through (line ~4433)
+    # because the daemon-side ralph_not_ship handler was never wired —
+    # 14 agents died at ``diagnoser_route_stub`` for absent-handler
+    # reasons. The empowered diagnoser doesn't add value here: ralph
+    # already wrote a ``block_reason`` explaining why it couldn't ship.
+    # We just relay that reason to the issue as a comment, add
+    # ``status/blocked``, and emit a clean terminal.
+    #
+    # $1 = the ralph phase output JSON (so we can extract block_reason).
+    _ralph_output="${1:-}"
+    _block_reason=$(printf '%s' "$_ralph_output" | jq -r '.block_reason // ""' 2>/dev/null)
+    _verdict=$(printf '%s' "$_ralph_output" | jq -r '.verdict // ""' 2>/dev/null)
+    _iterations_used=$(printf '%s' "$_ralph_output" | jq -r '.iterations_used // ""' 2>/dev/null)
+    log "ralph_not_ship_local_handler" \
+        "issue_number=$ISSUE_NUMBER" \
+        "verdict=$_verdict" \
+        "iterations_used=$_iterations_used" \
+        "block_reason_preview=$(printf '%s' "$_block_reason" | head -c 120)"
+
+    if [[ -n "$ISSUE_NUMBER" ]]; then
+        # Compose the comment body in a temp file to avoid heredoc /
+        # quoted-string preflight issues. ``$AGENT_WORKSPACE`` is the
+        # entrypoint's writable scratch dir.
+        _comment_file="$AGENT_WORKSPACE/ralph-not-ship-comment.md"
+        {
+            printf '## Ralph determined it cannot ship\n\n'
+            if [[ -n "$_verdict" && "$_verdict" != "null" ]]; then
+                printf 'Verdict: `%s`\n\n' "$_verdict"
+            fi
+            if [[ -n "$_iterations_used" && "$_iterations_used" != "null" && "$_iterations_used" != "" ]]; then
+                printf 'Iterations used: %s\n\n' "$_iterations_used"
+            fi
+            if [[ -n "$_block_reason" && "$_block_reason" != "null" ]]; then
+                printf '**Block reason from ralph:**\n\n'
+                printf '> %s\n\n' "$_block_reason"
+            else
+                printf 'Ralph did not provide a structured block_reason.\n\n'
+            fi
+            printf 'Adding `status/blocked` so the issue stays off the queue '
+            printf 'until a human reviews the block reason and decides whether '
+            printf 'to clarify the AC, file a prerequisite, or close as NOOP.\n'
+            printf '\n'
+            printf '_Posted by the agent-runner ralph_not_ship local handler '
+            printf '(#3455). The diagnoser was not invoked — ralph already '
+            printf 'identified the block; relaying its reasoning verbatim is '
+            printf 'cheaper and more honest than another LLM pass over the '
+            printf 'same evidence._\n'
+        } > "$_comment_file" 2> "$AGENT_WORKSPACE/ralph-not-ship-comment.stderr.log"
+
+        set +e
+        gh issue comment "$ISSUE_NUMBER" \
+            --repo judgemind/judgemind \
+            --body-file "$_comment_file" \
+            > "$AGENT_WORKSPACE/ralph-not-ship-comment.stdout.log" \
+            2>> "$AGENT_WORKSPACE/ralph-not-ship-comment.stderr.log"
+        _comment_rc=$?
+        set -e
+        if [[ "$_comment_rc" -ne 0 ]]; then
+            log "ralph_not_ship_local_comment_failed" \
+                "issue_number=$ISSUE_NUMBER" "exit_code=$_comment_rc"
+        else
+            log "ralph_not_ship_local_comment_posted" \
+                "issue_number=$ISSUE_NUMBER"
+        fi
+
+        # Add status/blocked + remove agent/ready so the issue is fully
+        # off the queue until human review. Both ops are idempotent.
+        set +e
+        gh issue edit "$ISSUE_NUMBER" \
+            --repo judgemind/judgemind \
+            --add-label status/blocked \
+            --remove-label agent/ready \
+            > "$AGENT_WORKSPACE/ralph-not-ship-label.stdout.log" \
+            2> "$AGENT_WORKSPACE/ralph-not-ship-label.stderr.log"
+        _label_rc=$?
+        set -e
+        if [[ "$_label_rc" -ne 0 ]]; then
+            log "ralph_not_ship_local_label_failed" \
+                "issue_number=$ISSUE_NUMBER" "exit_code=$_label_rc"
+        else
+            log "ralph_not_ship_local_label_applied" \
+                "issue_number=$ISSUE_NUMBER"
+        fi
+    else
+        log "ralph_not_ship_local_no_issue_number" \
+            "skipping comment + label edits — no ISSUE_NUMBER set"
+    fi
+
+    # Always emit the descriptive terminal. The reason carries the
+    # block_reason so operators / failure dashboards see the cause.
+    _reason_for_terminal="$_block_reason"
+    if [[ -z "$_reason_for_terminal" ]]; then
+        _reason_for_terminal="ralph emitted non-SHIP verdict ${_verdict:-(missing)} without block_reason"
+    fi
+    agent_runner_reaped_failure \
+        "ralph_not_ship" \
+        "ralph_not_ship" \
+        "$_reason_for_terminal"
+}
+
 fetch_pr_status() {
     # $1 = pr_number. Writes the JSON response from
     # ``gh pr view <N> --json statusCheckRollup,mergeable,
@@ -4371,8 +4474,20 @@ while true; do
                         if [[ "$_ba" == "advance" ]]; then
                             advance_phase "$_bn"
                         else
+                            # Issue #3455 — replace the route_stub
+                            # fall-through with a descriptive terminal
+                            # so the daemon row reads
+                            # ``ralph_baseline_transition_unrecognized``
+                            # instead of ``agent_runner_route_stub``.
+                            # No diagnoser routing — this is a code
+                            # bug surface (transition_for returned a
+                            # shape we don't handle), not a semantic
+                            # failure the diagnoser can fix.
                             log "ralph_baseline_transition_unrecognized" "action=$_ba"
-                            advance_phase "agent_runner_route_stub" "crashed"
+                            agent_runner_reaped_failure \
+                                "ralph_baseline_transition_unrecognized" \
+                                "ralph_baseline_transition_unrecognized" \
+                                "transition_for returned action=$_ba (expected advance after rebase_failed envelope)"
                         fi
                         continue
                     fi
@@ -4416,26 +4531,79 @@ while true; do
                     advance_phase "$_next" "$_status"
                     ;;
                 route_to_diagnoser)
-                    # #3225: for the conflict_unresolvable hint, route
-                    # to the dedicated terminal so the diagnoser
-                    # supervisor sweep picks it up with the right
-                    # category. Other hints keep the Stage-1b stub
-                    # terminal (the daemon-side failure router owns
-                    # the real category mapping for those).
-                    if [[ "$_hint" == "conflict_unresolvable" ]]; then
-                        log "diagnoser_route_conflict_unresolvable" "hint=$_hint"
-                        agent_runner_reaped_failure \
-                            "conflict_unresolvable" \
-                            "conflict_unresolvable" \
-                            "fix_conflict skill returned unresolvable or budget exhausted"
-                    else
-                        log "diagnoser_route_stub" "hint=$_hint"
-                        advance_phase "agent_runner_route_stub" "failed"
-                    fi
+                    # Issue #3455 Path B — replace the
+                    # ``advance_phase agent_runner_route_stub`` fall-
+                    # through with descriptive terminals. Three cases:
+                    #
+                    #   1. ``conflict_unresolvable`` (#3225) — keep
+                    #      the dedicated terminal so the diagnoser
+                    #      supervisor sweep picks it up with the
+                    #      right category. Routed via
+                    #      ``BYPASSED_TERMINAL_PHASES_TO_ROUTE``.
+                    #   2. ``ralph_not_ship`` — handle locally.
+                    #      Ralph already wrote a structured
+                    #      ``block_reason``; we relay it as an issue
+                    #      comment + add ``status/blocked``, then
+                    #      emit the ``ralph_not_ship`` terminal
+                    #      (NOT routed to the diagnoser). 14 agents
+                    #      pre-#3455 died here at ``route_stub``.
+                    #   3. Other hints (e.g. ``ralph_ac_infeasible``,
+                    #      ``summary_ac_infeasible``,
+                    #      ``fix_ci_blocked``,
+                    #      ``verify_failed_post_merge``) — emit a
+                    #      descriptive terminal whose phase name
+                    #      matches the hint. The daemon's
+                    #      ``BYPASSED_TERMINAL_PHASES_TO_ROUTE``
+                    #      maps these to the corresponding
+                    #      ``FAILURE_CATEGORY_*`` so the diagnoser
+                    #      sweep picks them up.
+                    case "$_hint" in
+                        conflict_unresolvable)
+                            log "diagnoser_route_conflict_unresolvable" "hint=$_hint"
+                            agent_runner_reaped_failure \
+                                "conflict_unresolvable" \
+                                "conflict_unresolvable" \
+                                "fix_conflict skill returned unresolvable or budget exhausted"
+                            ;;
+                        ralph_not_ship)
+                            log "ralph_not_ship_local" "hint=$_hint"
+                            handle_ralph_not_ship_local "$_output"
+                            ;;
+                        ralph_ac_infeasible|summary_ac_infeasible|fix_ci_blocked|verify_failed_post_merge)
+                            # Descriptive terminal — the daemon's
+                            # BYPASSED_TERMINAL_PHASES_TO_ROUTE maps
+                            # these phase names to failure categories
+                            # so the diagnoser sweep picks them up.
+                            log "diagnoser_route_descriptive" "hint=$_hint" "phase=$_current"
+                            agent_runner_reaped_failure \
+                                "$_hint" \
+                                "$_hint" \
+                                "post-claude phase=$_current emitted route_to_diagnoser hint=$_hint"
+                            ;;
+                        *)
+                            # Truly novel hint we don't recognize.
+                            # Emit a descriptive terminal so the
+                            # operator sees what shape leaked through
+                            # without tripping the route_stub bug.
+                            log "diagnoser_route_unrecognized_hint" "hint=$_hint" "phase=$_current"
+                            agent_runner_reaped_failure \
+                                "diagnoser_route_unrecognized_hint" \
+                                "diagnoser_route_unrecognized_hint" \
+                                "post-claude phase=$_current emitted route_to_diagnoser hint=${_hint:-(empty)}"
+                            ;;
+                    esac
                     ;;
                 unrecognized|*)
-                    log "transition_unrecognized" "phase=$_current" "action=$_action"
-                    advance_phase "agent_runner_route_stub" "crashed"
+                    # Issue #3455 — descriptive terminal instead of
+                    # ``agent_runner_route_stub``. transition_for
+                    # returned a shape this dispatch arm doesn't
+                    # handle — that's a code-drift bug, not a semantic
+                    # failure, so no diagnoser routing.
+                    log "post_claude_transition_unrecognized" "phase=$_current" "action=$_action"
+                    agent_runner_reaped_failure \
+                        "post_claude_transition_unrecognized" \
+                        "post_claude_transition_unrecognized" \
+                        "phase=$_current returned action=$_action (not advance / advance_with_status / route_to_diagnoser)"
                     ;;
             esac
             ;;
@@ -4472,8 +4640,13 @@ while true; do
                     advance_phase "$_next" "$_status"
                     ;;
                 *)
+                    # Issue #3455 — descriptive terminal instead of
+                    # ``agent_runner_route_stub``.
                     log "push_and_pr_transition_unrecognized" "action=$_action"
-                    advance_phase "agent_runner_route_stub" "crashed"
+                    agent_runner_reaped_failure \
+                        "push_and_pr_transition_unrecognized" \
+                        "push_and_pr_transition_unrecognized" \
+                        "push_and_pr returned action=$_action (not advance / advance_with_status)"
                     ;;
             esac
             ;;
@@ -4645,8 +4818,18 @@ while true; do
             advance_phase "$_next"
             ;;
         *)
+            # Issue #3455 — descriptive terminal instead of
+            # ``agent_runner_route_stub``. The catch-all fires when
+            # the phase column reads a value the dispatch loop
+            # doesn't recognize — that's a code-drift bug (a new
+            # phase landed in dispatcher.agents without being
+            # wired here), not a semantic failure, so no diagnoser
+            # routing.
             log "phase_unknown" "phase=$_current"
-            advance_phase "agent_runner_route_stub" "crashed"
+            agent_runner_reaped_failure \
+                "phase_unknown" \
+                "phase_unknown" \
+                "dispatch loop saw unknown phase=$_current (not wired in agent-runner-entrypoint.sh)"
             ;;
     esac
 done

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -20289,6 +20289,13 @@ class DispatcherDaemon:
         )
         self._gh_issue_add_labels(issue_number, ["status/blocked"])
         self._gh_issue_remove_labels(issue_number, ["agent/ready"])
+        # ROUTING (#3062): close-out of the diagnoser pass — the upstream
+        # failure row that triggered this pass already exists. Intentionally
+        # NOT routed through ``_handle_agent_failure`` (would cause an
+        # infinite diagnoser loop on re-pick). See the umbrella ROUTING
+        # comment on ``_consume_action_escalate`` (#3062) — this is the 5th
+        # diagnoser-consumer action method, just outside the 250-line check
+        # window from that umbrella.
         self._mark_agent_terminal(
             agent_id,
             status="failed",

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1332,9 +1332,35 @@ FAILURE_CATEGORY_AGENT_RUNNER_ROUTE_STUB = "agent_runner_route_stub"
 #:
 #: Both phases are already in :data:`TIER_3_CATEGORIES` so the
 #: candidate-finder treats them as first-occurrence diagnose-immediately.
+#:
+#: Issue #3455 — the entrypoint's ``route_to_diagnoser`` arm now emits
+#: descriptive terminal phases (``ralph_ac_infeasible``,
+#: ``summary_ac_infeasible``, ``fix_ci_blocked``,
+#: ``verify_failed_post_merge``) instead of bouncing through
+#: ``agent_runner_route_stub``. Mapping each phase to its
+#: ``FAILURE_CATEGORY_*`` constant lets the reaper still spawn the
+#: diagnoser via the same bypassed-terminal sweep. ``plan_blocked``
+#: is intentionally NOT here — that hint comes through
+#: ``advance_with_status`` (terminal status), not ``route_to_diagnoser``,
+#: so the daemon has its own explicit handling for it.
+#:
+#: ``ralph_not_ship`` is intentionally NOT in this map. Issue #3455
+#: handles that hint locally in the agent-runner entrypoint
+#: (``handle_ralph_not_ship_local``) — ralph already wrote a structured
+#: ``block_reason`` and the diagnoser doesn't add value there. The
+#: terminal phase still reads ``ralph_not_ship`` for operator visibility,
+#: but no diagnoser is invoked. Same shape as ``conflict_unresolvable``
+#: legacy treatment minus the routing.
 BYPASSED_TERMINAL_PHASES_TO_ROUTE: dict[str, str] = {
     "conflict_unresolvable": FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE,
     "agent_runner_route_stub": FAILURE_CATEGORY_AGENT_RUNNER_ROUTE_STUB,
+    # #3455 — descriptive terminals from agent-runner-entrypoint.sh's
+    # ``route_to_diagnoser`` arm. Each maps to the corresponding
+    # FAILURE_CATEGORY so the diagnoser sweep picks them up.
+    "ralph_ac_infeasible": FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
+    "summary_ac_infeasible": FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
+    "fix_ci_blocked": FAILURE_CATEGORY_FIX_CI_BLOCKED,
+    "verify_failed_post_merge": FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
 }
 
 #: GitHub's rejection stderr fragment when branch protection's
@@ -1724,7 +1750,7 @@ DIAGNOSER_MODEL = "opus"
 #: these fit, and the unrecognized-actions table is the review path.
 #:
 #: The first five (``retry`` through ``close``) are the original set
-#: from issue #2795. The last three are added in #3032:
+#: from issue #2795. The next three are added in #3032:
 #:   - ``block_and_comment`` — apply ``status/blocked`` + remove
 #:     ``agent/ready`` + post comment. For operator-action blockers
 #:     (PAT scope, missing secret, infra gap) that do not warrant a
@@ -1735,6 +1761,16 @@ DIAGNOSER_MODEL = "opus"
 #:   - ``block_on_existing_task`` — append ``Blocked by #<N>`` to the
 #:     current issue body when the diagnoser identifies an already-open
 #:     tracking issue for the root cause. Avoids duplicate tickets.
+#:
+#: The final ``terminal`` action (issue #3455) is the post-#3366 shape:
+#: the SKILL itself performs whatever gh side-effects are needed (close,
+#: comment, label, file prerequisite) and emits ``action="terminal"``
+#: with descriptive ``action_taken`` / ``summary`` / ``evidence`` fields.
+#: The daemon's consumer just records the diagnosis and marks the agent
+#: terminal — no per-action gh writes from Python, no per-action phase
+#: name. Collapses the diagnoser-action executor layer (#3455 Path A);
+#: the legacy actions stay for backward compat but ``terminal`` is the
+#: preferred shape going forward.
 DIAGNOSER_ACTIONS: frozenset[str] = frozenset(
     {
         "retry",
@@ -1745,6 +1781,7 @@ DIAGNOSER_ACTIONS: frozenset[str] = frozenset(
         "block_and_comment",
         "file_prerequisite_task",
         "block_on_existing_task",
+        "terminal",
     }
 )
 
@@ -19339,6 +19376,9 @@ class DispatcherDaemon:
             ``body``.
           - ``block_on_existing_task`` — positive integer
             ``blocker_issue_number``.
+          - ``terminal`` (#3455) — non-empty strings ``action_taken``
+            and ``summary``. The SKILL has already performed any gh
+            side-effects; these fields are descriptive only.
         All other fields are advisory.
 
         Returns None when the action is missing, not in the known set,
@@ -19372,6 +19412,13 @@ class DispatcherDaemon:
                 or isinstance(blocker, bool)
                 or blocker <= 0
             ):
+                return None
+        if action == "terminal":
+            action_taken = recommendation.get("action_taken")
+            summary = recommendation.get("summary")
+            if not isinstance(action_taken, str) or not action_taken.strip():
+                return None
+            if not isinstance(summary, str) or not summary.strip():
                 return None
         return action
 
@@ -19826,6 +19873,16 @@ class DispatcherDaemon:
                 else 0,
                 reasoning=reasoning,
             )
+        elif action == "terminal":
+            # Issue #3455 Path A — the SKILL handled the gh actions
+            # itself. Daemon just records the diagnosis and marks the
+            # agent terminal with a single phase name.
+            self._consume_action_terminal(
+                agent_id=agent_id,
+                issue_number=issue_number,
+                action_taken=str(recommendation.get("action_taken") or ""),
+                summary=str(recommendation.get("summary") or ""),
+            )
 
         # Emit instrumentation and mark the diagnosis completed AFTER the
         # action handler runs (issue #3422 — the SKILL must NOT set
@@ -19997,6 +20054,52 @@ class DispatcherDaemon:
             )
         self._mark_agent_terminal(
             agent_id, status="failed", phase="diagnoser_escalate", exit_code=None
+        )
+
+    def _consume_action_terminal(
+        self,
+        *,
+        agent_id: str,
+        issue_number: int | None,
+        action_taken: str,
+        summary: str,
+    ) -> None:
+        """Record a SKILL-executed diagnosis as a clean terminal.
+
+        Issue #3455 Path A: the empowered diagnoser SKILL has the same
+        peer-tier authority as a /task agent (Bash, gh CLI, Edit, Write,
+        Agent). When the SKILL handles the gh actions itself — closing
+        the issue, adding labels, posting the comment, filing the
+        prerequisite task — it emits ``action="terminal"`` so the daemon
+        does NO additional gh writes here. We just mark the agent
+        terminal with a single phase name (``diagnoser_terminal``) and
+        let the directive consumer free the slot.
+
+        This collapses the previous executor layer (one ``_consume_action_*``
+        per action × one ``diagnoser_<action>`` phase name) into a single
+        consumer + phase pair. The per-action variants
+        (``_consume_action_close`` etc.) remain for backward compat —
+        older skills that emit ``action="close"`` keep working — but new
+        skills are expected to emit ``action="terminal"`` and do their
+        own gh writes inline.
+
+        ``action_taken`` is descriptive only (e.g. ``"close"``,
+        ``"escalate"``, ``"file_prerequisite_task"``). The daemon does
+        not dispatch on it; it logs it for operator visibility / audit.
+        """
+        self._log.info(
+            "daemon.diagnoser_terminal_recorded",
+            extra={
+                "event": "diagnoser_terminal_recorded",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "action_taken": action_taken,
+                "summary": summary[:240] if isinstance(summary, str) else "",
+            },
+        )
+        self._mark_agent_terminal(
+            agent_id, status="failed", phase="diagnoser_terminal", exit_code=None
         )
 
     def _consume_action_close(

--- a/scripts/dispatcher/tests/test_agent_runner_no_route_stub.py
+++ b/scripts/dispatcher/tests/test_agent_runner_no_route_stub.py
@@ -1,0 +1,144 @@
+"""Issue #3455 — verify ``agent-runner-entrypoint.sh`` does not advance
+to ``agent_runner_route_stub`` outside comments.
+
+The fix replaced 5 fall-through call sites that previously emitted
+``advance_phase "agent_runner_route_stub" "<status>"`` with descriptive
+``agent_runner_reaped_failure`` invocations. The phase string
+``route_stub`` may still appear in comments documenting the change, but
+must not appear in any executable line.
+
+This test is a static lint of the shell script — it parses the file
+line by line, strips comment-only lines and trailing comments, and
+greps the executable remainder for ``route_stub``. Any hit fails.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+# The agent-runner entrypoint, anchored to the dispatcher package.
+_ENTRYPOINT_PATH = Path(__file__).resolve().parents[1] / "agent-runner-entrypoint.sh"
+
+
+def _strip_comment(line: str) -> str:
+    """Return ``line`` with any trailing ``#`` comment removed.
+
+    Naive but sufficient for shell — we don't have ``#`` inside string
+    literals in the dispatch sites under test. The only quoted strings
+    around the call sites are the phase / category / reason args to
+    ``agent_runner_reaped_failure``, none of which contain ``#``.
+    """
+    # Skip comment-only lines outright.
+    stripped = line.lstrip()
+    if stripped.startswith("#"):
+        return ""
+    # Find the first ``#`` that is not preceded by a backslash. Bash
+    # comments require a space-prefix when not at start-of-line, so the
+    # naive scan-for-`# ` works.
+    m = re.search(r"(^|[^\\])# ", line)
+    if m is None:
+        return line
+    cut = m.start() if m.group(1) == "" else m.start() + 1
+    return line[:cut]
+
+
+def _executable_lines() -> list[tuple[int, str]]:
+    """Return ``(lineno, executable_part)`` for every non-comment line."""
+    text = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
+    out: list[tuple[int, str]] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        executable = _strip_comment(line)
+        if executable.strip():
+            out.append((i, executable))
+    return out
+
+
+class TestNoRouteStubInExecutableLines:
+    def test_entrypoint_script_exists(self) -> None:
+        assert _ENTRYPOINT_PATH.exists(), (
+            f"agent-runner-entrypoint.sh not found at {_ENTRYPOINT_PATH}"
+        )
+
+    def test_no_route_stub_in_executable_code(self) -> None:
+        """The bright line from #3455: zero ``route_stub`` references
+        in executable shell. Comment-only references (documenting the
+        prior bug or the fix) are allowed."""
+        offenders = [
+            (lineno, line.rstrip())
+            for (lineno, line) in _executable_lines()
+            if "route_stub" in line
+        ]
+        assert offenders == [], (
+            "agent-runner-entrypoint.sh must not contain `route_stub` "
+            "in executable lines (#3455). Hits:\n"
+            + "\n".join(f"  L{n}: {text}" for n, text in offenders)
+        )
+
+    def test_no_advance_to_route_stub_phase(self) -> None:
+        """Even-stronger check: no line advances to a phase named
+        ``agent_runner_route_stub``. ``advance_phase
+        "agent_runner_route_stub"`` was the buggy emit; the fix uses
+        ``agent_runner_reaped_failure`` with descriptive phase names.
+        """
+        text = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
+        # Build a regex that matches advance_phase "agent_runner_route_stub"
+        # — covering single, double, and unquoted variants.
+        pattern = re.compile(
+            r'^[^#]*advance_phase\s+"?agent_runner_route_stub"?',
+            re.MULTILINE,
+        )
+        hits = pattern.findall(text)
+        assert hits == [], (
+            f"`advance_phase agent_runner_route_stub` must not appear in "
+            f"executable code (#3455). Found {len(hits)} hit(s)."
+        )
+
+
+class TestRalphNotShipLocalHandlerExists:
+    """Issue #3455 — the new handler that handles ``ralph_not_ship``
+    locally instead of routing to the diagnoser."""
+
+    def test_handle_ralph_not_ship_local_function_defined(self) -> None:
+        text = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
+        # Match the function definition opening — ``handle_ralph_not_ship_local() {``.
+        assert re.search(
+            r"^handle_ralph_not_ship_local\s*\(\s*\)\s*\{",
+            text,
+            re.MULTILINE,
+        ), "handle_ralph_not_ship_local function not defined"
+
+    def test_handler_posts_comment_with_block_reason(self) -> None:
+        text = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
+        # The handler body should reference both gh issue comment + the
+        # block_reason it relays.
+        assert "gh issue comment" in text
+        assert "block_reason" in text
+        # And it should add status/blocked + remove agent/ready.
+        assert "--add-label status/blocked" in text
+        assert "--remove-label agent/ready" in text
+
+    def test_handler_emits_ralph_not_ship_terminal(self) -> None:
+        text = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
+        # The handler should call agent_runner_reaped_failure with
+        # the ``ralph_not_ship`` terminal phase.
+        assert re.search(
+            r'agent_runner_reaped_failure\s*\\?\s*\n?\s*"ralph_not_ship"',
+            text,
+        ), "handler must emit `ralph_not_ship` terminal via agent_runner_reaped_failure"
+
+    def test_route_to_diagnoser_dispatches_ralph_not_ship_locally(self) -> None:
+        """Verify the case-block in the post-claude dispatch arm calls
+        the local handler for ``ralph_not_ship`` (not advance_phase to
+        agent_runner_route_stub)."""
+        text = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
+        # Look for the ``ralph_not_ship)`` case arm calling
+        # ``handle_ralph_not_ship_local``.
+        m = re.search(
+            r"ralph_not_ship\)\s*\n\s*log\b[^\n]*\n\s*handle_ralph_not_ship_local",
+            text,
+        )
+        assert m is not None, (
+            "route_to_diagnoser case arm should dispatch `ralph_not_ship` to "
+            "handle_ralph_not_ship_local (not route_stub)"
+        )

--- a/scripts/dispatcher/tests/test_daemon_diagnoser_routing.py
+++ b/scripts/dispatcher/tests/test_daemon_diagnoser_routing.py
@@ -131,12 +131,15 @@ def _make_daemon(cursor: _FakeCursor | None = None) -> daemon.DispatcherDaemon:
 
 
 # --------------------------------------------------------------------------
-# AC#4 — DIAGNOSER_ACTIONS is now 8 (open menu, issue #3032)
+# AC#4 — DIAGNOSER_ACTIONS is now 9 (open menu, issue #3032 + #3455)
 # --------------------------------------------------------------------------
 
 
 class TestDiagnoserActionsExpanded:
-    def test_eight_known_actions(self) -> None:
+    def test_nine_known_actions(self) -> None:
+        # Issue #3455 added the ``terminal`` action (collapse the
+        # daemon-side executor layer; the SKILL performs gh side
+        # effects itself).
         assert DIAGNOSER_ACTIONS == frozenset(
             {
                 "retry",
@@ -147,6 +150,7 @@ class TestDiagnoserActionsExpanded:
                 "block_and_comment",
                 "file_prerequisite_task",
                 "block_on_existing_task",
+                "terminal",
             }
         )
 
@@ -154,10 +158,16 @@ class TestDiagnoserActionsExpanded:
         for action in ("retry", "retry_with_hint", "reissue", "escalate", "close"):
             assert action in DIAGNOSER_ACTIONS
 
-    def test_three_new_actions(self) -> None:
+    def test_three_3032_actions(self) -> None:
         assert "block_and_comment" in DIAGNOSER_ACTIONS
         assert "file_prerequisite_task" in DIAGNOSER_ACTIONS
         assert "block_on_existing_task" in DIAGNOSER_ACTIONS
+
+    def test_3455_terminal_action(self) -> None:
+        # Issue #3455 — collapsed executor layer. The SKILL performs
+        # gh side-effects itself; the daemon just records the diagnosis
+        # and marks the agent terminal.
+        assert "terminal" in DIAGNOSER_ACTIONS
 
 
 # --------------------------------------------------------------------------
@@ -1422,3 +1432,250 @@ class TestConsumeDiagnosisLifecycle:
         event_rec = apply_failed_events[0]
         assert getattr(event_rec, "diagnosis_id", None) == 56
         assert getattr(event_rec, "action", "sentinel") is None
+
+
+# --------------------------------------------------------------------------
+# Issue #3455 — `terminal` action: collapse the executor layer.
+# The SKILL performs gh side-effects itself; daemon just records the
+# diagnosis and marks the agent terminal with a single phase name.
+# --------------------------------------------------------------------------
+
+
+class TestTerminalActionValidation:
+    """Validation rules for the new ``action="terminal"`` shape (#3455)."""
+
+    def test_action_terminal_in_known_set(self) -> None:
+        assert "terminal" in DIAGNOSER_ACTIONS
+
+    def test_validate_accepts_terminal_with_required_fields(self) -> None:
+        d = _make_daemon()
+        rec = {
+            "action": "terminal",
+            "action_taken": "close",
+            "summary": "Closed as duplicate of #3000.",
+            "reasoning": "Stderr ends with 'duplicate'.",
+        }
+        assert d._validate_recommendation(rec) == "terminal"
+
+    def test_validate_rejects_terminal_missing_action_taken(self) -> None:
+        d = _make_daemon()
+        rec = {
+            "action": "terminal",
+            "summary": "Closed.",
+        }
+        assert d._validate_recommendation(rec) is None
+
+    def test_validate_rejects_terminal_missing_summary(self) -> None:
+        d = _make_daemon()
+        rec = {
+            "action": "terminal",
+            "action_taken": "close",
+        }
+        assert d._validate_recommendation(rec) is None
+
+    def test_validate_rejects_terminal_with_empty_action_taken(self) -> None:
+        d = _make_daemon()
+        rec = {
+            "action": "terminal",
+            "action_taken": "   ",
+            "summary": "Closed.",
+        }
+        assert d._validate_recommendation(rec) is None
+
+    def test_validate_rejects_terminal_with_empty_summary(self) -> None:
+        d = _make_daemon()
+        rec = {
+            "action": "terminal",
+            "action_taken": "close",
+            "summary": "",
+        }
+        assert d._validate_recommendation(rec) is None
+
+    def test_validate_rejects_terminal_with_non_string_action_taken(self) -> None:
+        d = _make_daemon()
+        rec = {
+            "action": "terminal",
+            "action_taken": 42,  # int, not str
+            "summary": "Closed.",
+        }
+        assert d._validate_recommendation(rec) is None
+
+
+class TestConsumeActionTerminal:
+    """Direct-handler tests for ``_consume_action_terminal`` (#3455).
+
+    The handler is intentionally minimal: no gh writes (the SKILL did
+    them inline), just mark the agent terminal at the single phase
+    ``diagnoser_terminal``.
+    """
+
+    def test_marks_agent_terminal_with_single_phase_name(self) -> None:
+        d = _make_daemon()
+        with patch.object(d, "_mark_agent_terminal") as mock_mark:
+            d._consume_action_terminal(
+                agent_id="agent-3455-1",
+                issue_number=99001,
+                action_taken="close",
+                summary="Closed as duplicate of #3000.",
+            )
+        mock_mark.assert_called_once()
+        kwargs = mock_mark.call_args.kwargs
+        assert kwargs["status"] == "failed"
+        assert kwargs["phase"] == "diagnoser_terminal"
+        assert kwargs["exit_code"] is None
+
+    def test_does_not_call_gh_helpers(self) -> None:
+        """The SKILL already did the gh writes; daemon must NOT duplicate them."""
+        d = _make_daemon()
+        with (
+            patch.object(d, "_gh_issue_comment") as mock_comment,
+            patch.object(d, "_gh_issue_close") as mock_close,
+            patch.object(d, "_gh_issue_add_labels") as mock_add,
+            patch.object(d, "_gh_issue_remove_labels") as mock_remove,
+            patch.object(d, "_gh_issue_create") as mock_create,
+            patch.object(d, "_mark_agent_terminal"),
+        ):
+            d._consume_action_terminal(
+                agent_id="agent-3455-1",
+                issue_number=99001,
+                action_taken="block_and_comment",
+                summary="Posted block reasoning + status/blocked.",
+            )
+        mock_comment.assert_not_called()
+        mock_close.assert_not_called()
+        mock_add.assert_not_called()
+        mock_remove.assert_not_called()
+        mock_create.assert_not_called()
+
+    def test_terminal_phase_is_same_for_all_action_taken_values(self) -> None:
+        """``diagnoser_terminal`` is the single phase name — no per-action
+        variants. This is the #3455 collapse invariant.
+        """
+        d = _make_daemon()
+        observed_phases: list[str] = []
+        for action_taken in (
+            "close",
+            "escalate",
+            "block_and_comment",
+            "file_prerequisite_task",
+            "block_on_existing_task",
+        ):
+            with patch.object(d, "_mark_agent_terminal") as mock_mark:
+                d._consume_action_terminal(
+                    agent_id=f"agent-{action_taken}",
+                    issue_number=99001,
+                    action_taken=action_taken,
+                    summary=f"Did {action_taken}.",
+                )
+            observed_phases.append(mock_mark.call_args.kwargs["phase"])
+
+        assert observed_phases == ["diagnoser_terminal"] * 5
+
+    def test_no_issue_number_still_marks_terminal(self) -> None:
+        d = _make_daemon()
+        with patch.object(d, "_mark_agent_terminal") as mock_mark:
+            d._consume_action_terminal(
+                agent_id="agent-3455-1",
+                issue_number=None,
+                action_taken="escalate",
+                summary="No issue number.",
+            )
+        mock_mark.assert_called_once()
+        assert mock_mark.call_args.kwargs["phase"] == "diagnoser_terminal"
+
+    def test_emits_diagnoser_terminal_recorded_log_event(self, caplog: Any) -> None:
+        import logging as _logging
+
+        d = _make_daemon()
+        caplog.set_level(_logging.INFO, logger="test.daemon")
+        with patch.object(d, "_mark_agent_terminal"):
+            d._consume_action_terminal(
+                agent_id="agent-3455-2",
+                issue_number=99002,
+                action_taken="file_prerequisite_task",
+                summary="Filed #99003 as prerequisite.",
+            )
+        events = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "diagnoser_terminal_recorded"
+        ]
+        assert events, "daemon.diagnoser_terminal_recorded event not emitted"
+        evt = events[0]
+        assert getattr(evt, "agent_id", None) == "agent-3455-2"
+        assert getattr(evt, "issue_number", None) == 99002
+        assert getattr(evt, "action_taken", None) == "file_prerequisite_task"
+
+
+class TestConsumeDiagnosisDispatchesTerminal:
+    """Integration: ``_consume_diagnosis`` routes ``action="terminal"``
+    to ``_consume_action_terminal`` and marks the diagnosis completed.
+    """
+
+    def test_terminal_action_marks_completed_and_emits_event(self, caplog: Any) -> None:
+        import logging as _logging
+
+        d = _make_daemon()
+        caplog.set_level(_logging.INFO, logger="test.daemon")
+        candidate = {
+            "agent_id": "agent-3455-disp",
+            "issue_number": 99001,
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+        }
+        rec = {
+            "action": "terminal",
+            "action_taken": "close",
+            "summary": "Closed as duplicate.",
+            "reasoning": "Stderr ends with 'duplicate of #3000'.",
+        }
+        mark_called: list[int] = []
+
+        with (
+            patch.object(d, "_read_recommendation", return_value=rec),
+            patch.object(d, "_consume_action_terminal") as mock_handler,
+            patch.object(
+                d,
+                "_mark_diagnosis_completed",
+                side_effect=lambda did: mark_called.append(did),
+            ),
+        ):
+            result = d._consume_diagnosis(diagnosis_id=88, candidate=candidate)
+
+        assert result == "terminal"
+        mock_handler.assert_called_once()
+        kwargs = mock_handler.call_args.kwargs
+        assert kwargs["agent_id"] == "agent-3455-disp"
+        assert kwargs["issue_number"] == 99001
+        assert kwargs["action_taken"] == "close"
+        assert kwargs["summary"] == "Closed as duplicate."
+        assert mark_called == [88]
+
+        events = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "directive_applied"
+        ]
+        assert events
+        assert getattr(events[0], "action", None) == "terminal"
+
+    def test_terminal_with_missing_required_field_falls_back_to_escalate(self) -> None:
+        d = _make_daemon()
+        candidate = {
+            "agent_id": "agent-3455-bad",
+            "issue_number": 99001,
+            "category": FAILURE_CATEGORY_PUSH_FAILED,
+        }
+        # Missing ``summary`` — validation fails, falls back to escalate.
+        rec = {"action": "terminal", "action_taken": "close"}
+
+        with (
+            patch.object(d, "_read_recommendation", return_value=rec),
+            patch.object(d, "_apply_mechanical_escalation") as mock_esc,
+            patch.object(d, "_mark_diagnosis_failed"),
+            patch.object(d, "_consume_action_terminal") as mock_term,
+        ):
+            result = d._consume_diagnosis(diagnosis_id=89, candidate=candidate)
+
+        assert result == "escalate_fallback"
+        mock_esc.assert_called_once()
+        mock_term.assert_not_called()

--- a/scripts/dispatcher/tests/test_daemon_phase3d.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3d.py
@@ -1420,7 +1420,9 @@ class TestConstants:
         assert daemon.FAILURE_CATEGORY_CI_RED_AFTER_RETRIES == "ci_red_after_retries"
 
     def test_diagnoser_actions_exhaustive(self) -> None:
-        # Issue #3032 expanded the known action set from 5 to 8. The
+        # Issue #3032 expanded the known action set from 5 to 8. Issue
+        # #3455 added ``terminal`` (collapse the daemon-side executor
+        # layer; the SKILL performs gh side-effects itself). The
         # daemon's consumer still has an explicit switch so any
         # addition here must also land in ``_consume_diagnosis``. The
         # closed-enum guardrail in the diagnoser skill itself is
@@ -1437,6 +1439,7 @@ class TestConstants:
                 "block_and_comment",
                 "file_prerequisite_task",
                 "block_on_existing_task",
+                "terminal",
             }
         )
 

--- a/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
+++ b/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
@@ -120,9 +120,26 @@ class TestBypassedTerminalConstants:
         assert FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE in TIER_3_CATEGORIES
 
     def test_bypassed_terminal_map_shape(self) -> None:
+        # Issue #3455 added descriptive terminal phases for the
+        # post-claude ``route_to_diagnoser`` arm in
+        # agent-runner-entrypoint.sh. Each phase maps to its
+        # FAILURE_CATEGORY so the diagnoser sweep picks them up.
+        # ``ralph_not_ship`` is intentionally NOT here — it's handled
+        # locally by the entrypoint.
+        from dispatcher.daemon import (
+            FAILURE_CATEGORY_FIX_CI_BLOCKED,
+            FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
+            FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
+            FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
+        )
+
         assert BYPASSED_TERMINAL_PHASES_TO_ROUTE == {
             "conflict_unresolvable": FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE,
             "agent_runner_route_stub": FAILURE_CATEGORY_AGENT_RUNNER_ROUTE_STUB,
+            "ralph_ac_infeasible": FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
+            "summary_ac_infeasible": FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
+            "fix_ci_blocked": FAILURE_CATEGORY_FIX_CI_BLOCKED,
+            "verify_failed_post_merge": FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
         }
 
 


### PR DESCRIPTION
## Summary

Eliminates the `agent_runner_route_stub` fall-through bug (42 historical agent failures) and collapses the diagnoser-action executor layer into a single SKILL-driven `terminal` action (#3455).

**Path A — collapse the diagnoser executor.** New `terminal` action in `DIAGNOSER_ACTIONS`. The empowered diagnoser SKILL now performs gh side-effects itself (close, comment, label, file prerequisite) and emits `action="terminal"` with `action_taken` + `summary` fields. The daemon's new `_consume_action_terminal` simply records the diagnosis and marks the agent terminal at one phase (`diagnoser_terminal`) — no per-action gh writes, no per-action phase variants. Legacy 8-action set retained for backward compat. `SKILL.md` updated with the new shape and inline-action examples.

**Path B — eliminate route_stub fall-throughs.** All 5 `advance_phase "agent_runner_route_stub"` call sites in `agent-runner-entrypoint.sh` replaced with descriptive `agent_runner_reaped_failure` invocations. New `handle_ralph_not_ship_local` handles `ralph_not_ship` inline (post block_reason + add `status/blocked` + emit clean terminal — no diagnoser bounce). Other route_to_diagnoser hints (`ralph_ac_infeasible`, `summary_ac_infeasible`, `fix_ci_blocked`, `verify_failed_post_merge`) emit descriptive terminals routed to the diagnoser via new entries in `BYPASSED_TERMINAL_PHASES_TO_ROUTE`. `grep -n route_stub scripts/dispatcher/agent-runner-entrypoint.sh` returns zero non-comment hits (verified by new static-lint test).

Closes #3455
Closes #3334
Closes #3452

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass (1806 + 1 skipped before this PR; new tests added)
- [ ] CI green

### Post-deploy verification
- [ ] After merge + dev deploy, unblock #3433 and confirm next agent attempt routes to a known handler (NOT `agent_runner_route_stub`)
- [ ] Run `grep -n route_stub scripts/dispatcher/agent-runner-entrypoint.sh` on deployed code — should return zero non-comment hits
- [ ] Verification evidence posted on issue (see A.8)
