### PR TITLE
feat(dispatcher): surface agent-runner SKILL phase changes to CloudWatch (#3462)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -2018,6 +2018,7 @@ handle_scheduled_skill() {
     fi
 
     log "scheduled_skill_begin" "skill=$_skill_name" "agent_id=$AGENT_ID"
+    start_skill_phase_watcher "$_skill_name"
     set +e
     (
         cd "$REPO_ROOT" || exit 127
@@ -2029,6 +2030,7 @@ handle_scheduled_skill() {
     )
     _rc=$?
     set -e
+    stop_skill_phase_watcher
     log "scheduled_skill_done" "skill=$_skill_name" "exit_code=$_rc"
 
     # Persist the result envelope as a phase_output row for operator
@@ -3356,6 +3358,105 @@ stop_ralph_head_watcher() {
         "pid=$_ralph_watcher_pid" \
         "wait_rc=$_wait_rc"
     _ralph_watcher_pid=""
+}
+
+# ── Skill phase watcher (#3462) ───────────────────────────────────────────
+#
+# Tails ``$REPO_ROOT/tmp/agent-status/$AGENT_ID.txt`` while a scheduled
+# skill (audit, spotcheck, etc.) is running and fans each ``phase:``
+# change out as a structured ``agent_runner.skill_phase_change`` event
+# on stdout (fd 3 via ``log``).
+#
+# This fills the observability gap between ``scheduled_skill_begin`` and
+# ``scheduled_skill_done`` — cron skills can run for 10–90 min and the
+# entrypoint emits nothing during that window. The SKILL itself already
+# writes ``phase: <value>`` / ``summary: <value>`` to the status file;
+# this watcher just surfaces those updates in real time.
+#
+# Modeled directly on the ``ralph_head_watcher_*`` pattern above —
+# same trap idiom, same backgrounded-sleep SIGTERM handshake, same
+# sentinel file.
+
+AGENT_RUNNER_SKILL_PHASE_POLL_INTERVAL="${AGENT_RUNNER_SKILL_PHASE_POLL_INTERVAL:-5}"
+
+skill_phase_watcher_loop() {
+    # Body of the backgrounded subshell. Runs until killed by
+    # stop_skill_phase_watcher. Never exits on its own.
+    #
+    # Parses ``phase:`` and ``summary:`` lines from the status file on
+    # each tick. When the ``phase`` value changes, emits
+    # ``log "skill_phase_change" ...``. Bash 3.2 compatible — plain
+    # awk, no associative arrays.
+    _skill_name_w="$1"
+
+    _watcher_sleep_pid=""
+    trap '[[ -n "$_watcher_sleep_pid" ]] && kill "$_watcher_sleep_pid" 2>/dev/null; exit 0' TERM INT
+
+    _status_file="$REPO_ROOT/tmp/agent-status/$AGENT_ID.txt"
+    _last_phase=""
+
+    log "skill_phase_watcher_started" \
+        "skill=$_skill_name_w" \
+        "poll_interval=$AGENT_RUNNER_SKILL_PHASE_POLL_INTERVAL" \
+        "status_file=$_status_file"
+
+    # Sentinel so the test harness can confirm the watcher started.
+    printf 'started\n' > "$AGENT_WORKSPACE/skill-phase-watcher.started"
+
+    while true; do
+        if [[ -f "$_status_file" ]]; then
+            _cur_phase=$(awk '/^phase: /{print substr($0, 8)}' "$_status_file" 2>/dev/null | head -n 1 || true)
+            _cur_summary=$(awk '/^summary: /{print substr($0, 10)}' "$_status_file" 2>/dev/null | head -n 1 || true)
+            if [[ -n "$_cur_phase" && "$_cur_phase" != "$_last_phase" ]]; then
+                log "skill_phase_change" \
+                    "skill=$_skill_name_w" \
+                    "phase=$_cur_phase" \
+                    "summary=${_cur_summary:-}"
+                _last_phase="$_cur_phase"
+            fi
+        fi
+        sleep "$AGENT_RUNNER_SKILL_PHASE_POLL_INTERVAL" &
+        _watcher_sleep_pid=$!
+        wait "$_watcher_sleep_pid" 2>/dev/null || true
+        _watcher_sleep_pid=""
+    done
+}
+
+start_skill_phase_watcher() {
+    # Fork the watcher subshell. Sets ``$_skill_phase_watcher_pid`` in
+    # the caller's scope (global var — bash 3.2 compat, no ``local -n``).
+    # When AGENT_RUNNER_DISABLE_SKILL_PHASE_WATCHER=1 (tests, emergency
+    # kill-switch), skip entirely.
+    _skill_phase_watcher_pid=""
+    if [[ "${AGENT_RUNNER_DISABLE_SKILL_PHASE_WATCHER:-0}" == "1" ]]; then
+        log "skill_phase_watcher_disabled"
+        return 0
+    fi
+
+    # Run the loop in a subshell. fd 3 is inherited so log() still
+    # writes to the top-level stdout the CloudWatch agent reads.
+    skill_phase_watcher_loop "$1" &
+    _skill_phase_watcher_pid=$!
+    log "skill_phase_watcher_forked" "pid=$_skill_phase_watcher_pid" "skill=$1"
+}
+
+stop_skill_phase_watcher() {
+    # Kill the watcher subshell + reap it. Idempotent — safe to call
+    # on disable path where _skill_phase_watcher_pid is empty.
+    if [[ -z "${_skill_phase_watcher_pid:-}" ]]; then
+        return 0
+    fi
+    if kill "$_skill_phase_watcher_pid" 2>/dev/null; then
+        log "skill_phase_watcher_kill_sent" "pid=$_skill_phase_watcher_pid"
+    fi
+    set +e
+    wait "$_skill_phase_watcher_pid" 2>/dev/null
+    _wait_rc=$?
+    set -e
+    log "skill_phase_watcher_stopped" \
+        "pid=$_skill_phase_watcher_pid" \
+        "wait_rc=$_wait_rc"
+    _skill_phase_watcher_pid=""
 }
 
 persist_ralph_patch() {

--- a/scripts/tests/test_agent_runner_synthetic_skill_phase.sh
+++ b/scripts/tests/test_agent_runner_synthetic_skill_phase.sh
@@ -374,6 +374,154 @@ else
 fi
 
 # ══════════════════════════════════════════════════════════════════════════
+# Test 4: skill_phase_watcher emits skill_phase_change events (#3462)
+#
+# A claude stub writes phase changes to the per-agent status file while
+# the entrypoint's handle_scheduled_skill blocks. The skill phase watcher
+# polls every 1s (AGENT_RUNNER_SKILL_PHASE_POLL_INTERVAL=1) and must emit
+# at least 2 distinct skill_phase_change events before the skill exits.
+#
+# Asserts:
+#   * ≥2 distinct agent_runner.skill_phase_change events in stdout
+#   * Each event contains agent_id, phase, summary, ts (log() shape)
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-skill-phase.txt"
+printf 'spotcheck\n' > "$PHASE_FIXTURE_FILE"
+KIND_FIXTURE="scheduled_skill"
+watcher_workspace="$TEST_TMP/skill-phase-watcher-workspace"
+mkdir -p "$watcher_workspace"
+
+# The status file lives at REPO_ROOT/tmp/agent-status/AGENT_ID.txt.
+# REPO_ROOT = AGENT_WORKSPACE/repo (set in the entrypoint).
+# Create the directory and pre-seed with step-1.
+WATCHER_AGENT_ID="dddd1111-2222-3333-4444-555555555555"
+watcher_status_dir="$watcher_workspace/repo/tmp/agent-status"
+mkdir -p "$watcher_status_dir"
+printf 'phase: spotcheck-step-1\nsummary: starting\n' \
+    > "$watcher_status_dir/$WATCHER_AGENT_ID.txt"
+
+# Write a specialised claude stub that advances phase then exits success.
+# Sleep 2s between writes so the 1s poll catches each transition.
+cat > "$STUB_BIN/claude" <<'CLAUDEPHASEEOF'
+#!/usr/bin/env bash
+set -u
+INVOCATIONS_DIR="${INVOCATIONS_DIR}"
+. "$(dirname "$0")/_record_invocation.sh" claude "$@"
+
+for arg in "$@"; do
+    case "$arg" in
+        /*)
+            cmd=$(printf '%s' "$arg" | awk '{print $1}')
+            printf '%s\n' "$cmd" >> "$INVOCATIONS_DIR/claude-slash-cmd.log"
+            break
+            ;;
+    esac
+done
+
+if [[ -n "${CLAUDE_SKILL_PHASE_STATUS_FILE:-}" ]]; then
+    printf 'phase: spotcheck-step-2\nsummary: running checks\n' \
+        > "$CLAUDE_SKILL_PHASE_STATUS_FILE"
+    sleep 2
+    printf 'phase: done\nsummary: complete\n' \
+        > "$CLAUDE_SKILL_PHASE_STATUS_FILE"
+    sleep 1
+fi
+
+printf '{"result": "SHIPPED — filed 2 issues"}\n'
+exit 0
+CLAUDEPHASEEOF
+chmod +x "$STUB_BIN/claude"
+
+set +e
+out=$(AGENT_ID="$WATCHER_AGENT_ID" \
+      ISSUE_NUMBER="" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$watcher_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      KIND_FIXTURE="$KIND_FIXTURE" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
+      AGENT_RUNNER_SKILL_PHASE_POLL_INTERVAL=1 \
+      CLAUDE_SKILL_PHASE_STATUS_FILE="$watcher_status_dir/$WATCHER_AGENT_ID.txt" \
+      bash "$ENTRYPOINT" 2>&1)
+rc=$?
+set -e
+
+if [[ $rc -eq 0 ]]; then
+    pass "skill_phase_watcher test: entrypoint exits cleanly (rc=0)"
+else
+    fail "skill_phase_watcher test: entrypoint exits cleanly" \
+         "rc=$rc, out tail: $(printf '%s\n' "$out" | tail -20)"
+fi
+
+# Count distinct skill_phase_change events.
+phase_change_count=$(printf '%s\n' "$out" \
+    | grep -c '"event": "agent_runner.skill_phase_change"' || true)
+if [[ "$phase_change_count" -ge 2 ]]; then
+    pass "skill_phase_watcher emits >=2 skill_phase_change events (got $phase_change_count)"
+else
+    fail "skill_phase_watcher emits >=2 skill_phase_change events" \
+         "got $phase_change_count — out tail: $(printf '%s\n' "$out" | tail -30)"
+fi
+
+# Assert each event contains required fields (agent_id, phase, summary, ts).
+# Extract one matching line and verify all four fields are present via jq.
+if command -v jq >/dev/null 2>&1; then
+    _sample_event=$(printf '%s\n' "$out" \
+        | grep '"event": "agent_runner.skill_phase_change"' | head -n 1 || true)
+    if [[ -n "$_sample_event" ]]; then
+        _has_agent_id=$(printf '%s' "$_sample_event" | jq -r '.agent_id // ""' 2>/dev/null || true)
+        _has_phase=$(printf '%s' "$_sample_event" | jq -r '.phase // ""' 2>/dev/null || true)
+        _has_summary=$(printf '%s' "$_sample_event" | jq -r 'has("summary") | tostring' 2>/dev/null || true)
+        _has_ts=$(printf '%s' "$_sample_event" | jq -r '.ts // ""' 2>/dev/null || true)
+        if [[ -n "$_has_agent_id" && -n "$_has_phase" && "$_has_summary" == "true" && -n "$_has_ts" ]]; then
+            pass "skill_phase_change event contains agent_id, phase, summary, ts"
+        else
+            fail "skill_phase_change event contains agent_id, phase, summary, ts" \
+                 "agent_id='$_has_agent_id' phase='$_has_phase' summary_key=$_has_summary ts='$_has_ts'"
+        fi
+    else
+        fail "skill_phase_change event contains agent_id, phase, summary, ts" \
+             "no matching event line found in output"
+    fi
+else
+    pass "skill_phase_change event field check (skipped — jq unavailable)"
+fi
+
+# Restore the generic claude stub for any tests added after this.
+cat > "$STUB_BIN/claude" <<'CLAUDEEOF'
+#!/usr/bin/env bash
+set -u
+INVOCATIONS_DIR="${INVOCATIONS_DIR}"
+. "$(dirname "$0")/_record_invocation.sh" claude "$@"
+
+for arg in "$@"; do
+    case "$arg" in
+        /*)
+            cmd=$(printf '%s' "$arg" | awk '{print $1}')
+            printf '%s\n' "$cmd" >> "$INVOCATIONS_DIR/claude-slash-cmd.log"
+            break
+            ;;
+    esac
+done
+
+if [[ -n "${CLAUDE_RESULT_OVERRIDE:-}" ]]; then
+    printf '%s\n' "$CLAUDE_RESULT_OVERRIDE"
+else
+    printf '{"result": "SHIPPED — filed 3 issues"}\n'
+fi
+exit "${CLAUDE_EXIT_OVERRIDE:-0}"
+CLAUDEEOF
+chmod +x "$STUB_BIN/claude"
+
+# ══════════════════════════════════════════════════════════════════════════
 # Summary
 # ══════════════════════════════════════════════════════════════════════════
 echo "----"

--- a/scripts/tests/test_agent_runner_synthetic_skill_phase.sh
+++ b/scripts/tests/test_agent_runner_synthetic_skill_phase.sh
@@ -126,6 +126,8 @@ chmod +x "$STUB_BIN/psql"
 # ── claude stub ────────────────────────────────────────────────────────────
 # Records the slash-command invoked and emits a canned envelope. Honors
 # CLAUDE_VERDICT_OVERRIDE for synthetic-skill verdict assertions.
+# When CLAUDE_SKILL_PHASE_STATUS_FILE is set, simulates phase transitions
+# by writing to the status file (used by Test 4 / skill_phase_watcher).
 cat > "$STUB_BIN/claude" <<'CLAUDEEOF'
 #!/usr/bin/env bash
 set -u
@@ -142,6 +144,16 @@ for arg in "$@"; do
             ;;
     esac
 done
+
+# Simulate skill phase transitions when the watcher test sets this file.
+if [[ -n "${CLAUDE_SKILL_PHASE_STATUS_FILE:-}" ]]; then
+    printf 'phase: spotcheck-step-2\nsummary: running checks\n' \
+        > "$CLAUDE_SKILL_PHASE_STATUS_FILE"
+    sleep 2
+    printf 'phase: done\nsummary: complete\n' \
+        > "$CLAUDE_SKILL_PHASE_STATUS_FILE"
+    sleep 1
+fi
 
 # Emit the requested envelope. Default = SHIPPED-style success result.
 if [[ -n "${CLAUDE_RESULT_OVERRIDE:-}" ]]; then
@@ -402,38 +414,6 @@ mkdir -p "$watcher_status_dir"
 printf 'phase: spotcheck-step-1\nsummary: starting\n' \
     > "$watcher_status_dir/$WATCHER_AGENT_ID.txt"
 
-# Write a specialised claude stub that advances phase then exits success.
-# Sleep 2s between writes so the 1s poll catches each transition.
-cat > "$STUB_BIN/claude" <<'CLAUDEPHASEEOF'
-#!/usr/bin/env bash
-set -u
-INVOCATIONS_DIR="${INVOCATIONS_DIR}"
-. "$(dirname "$0")/_record_invocation.sh" claude "$@"
-
-for arg in "$@"; do
-    case "$arg" in
-        /*)
-            cmd=$(printf '%s' "$arg" | awk '{print $1}')
-            printf '%s\n' "$cmd" >> "$INVOCATIONS_DIR/claude-slash-cmd.log"
-            break
-            ;;
-    esac
-done
-
-if [[ -n "${CLAUDE_SKILL_PHASE_STATUS_FILE:-}" ]]; then
-    printf 'phase: spotcheck-step-2\nsummary: running checks\n' \
-        > "$CLAUDE_SKILL_PHASE_STATUS_FILE"
-    sleep 2
-    printf 'phase: done\nsummary: complete\n' \
-        > "$CLAUDE_SKILL_PHASE_STATUS_FILE"
-    sleep 1
-fi
-
-printf '{"result": "SHIPPED — filed 2 issues"}\n'
-exit 0
-CLAUDEPHASEEOF
-chmod +x "$STUB_BIN/claude"
-
 set +e
 out=$(AGENT_ID="$WATCHER_AGENT_ID" \
       ISSUE_NUMBER="" \
@@ -494,32 +474,6 @@ if command -v jq >/dev/null 2>&1; then
 else
     pass "skill_phase_change event field check (skipped — jq unavailable)"
 fi
-
-# Restore the generic claude stub for any tests added after this.
-cat > "$STUB_BIN/claude" <<'CLAUDEEOF'
-#!/usr/bin/env bash
-set -u
-INVOCATIONS_DIR="${INVOCATIONS_DIR}"
-. "$(dirname "$0")/_record_invocation.sh" claude "$@"
-
-for arg in "$@"; do
-    case "$arg" in
-        /*)
-            cmd=$(printf '%s' "$arg" | awk '{print $1}')
-            printf '%s\n' "$cmd" >> "$INVOCATIONS_DIR/claude-slash-cmd.log"
-            break
-            ;;
-    esac
-done
-
-if [[ -n "${CLAUDE_RESULT_OVERRIDE:-}" ]]; then
-    printf '%s\n' "$CLAUDE_RESULT_OVERRIDE"
-else
-    printf '{"result": "SHIPPED — filed 3 issues"}\n'
-fi
-exit "${CLAUDE_EXIT_OVERRIDE:-0}"
-CLAUDEEOF
-chmod +x "$STUB_BIN/claude"
 
 # ══════════════════════════════════════════════════════════════════════════
 # Summary


### PR DESCRIPTION
## Summary

Added three new shell functions (`skill_phase_watcher_loop`, `start_skill_phase_watcher`, `stop_skill_phase_watcher`) to the agent-runner entrypoint to capture phase changes from the per-agent status file and emit them as structured `agent_runner.skill_phase_change` events. Wired into `handle_scheduled_skill` to run during scheduled-skill execution (spotcheck, audit, etc.).

Fills the observability gap identified in #3459 verification: scheduled skills running silently in the container for 5+ minutes with no intermediate signals to CloudWatch. Modeled directly on the existing `ralph_head_watcher_*` pattern.

Closes #3462

## Test plan

### Automated checks

- [x] Lint passes (`shellcheck` on entrypoint.sh)
- [x] Format check passes (bash code style)
- [x] Tests pass (`bash scripts/tests/test_agent_runner_synthetic_skill_phase.sh` — all 13 tests pass including new Test 4)
- [x] CI green

### Post-deploy verification

- [ ] Launch a `/spotcheck` agent on dev, query CloudWatch for ≥3 distinct `phase` values
- [ ] Verify `aws logs filter-log-events` returns `agent_runner.skill_phase_change` events with all four fields (agent_id, phase, summary, ts)
- [ ] Verification evidence posted on #3462 (see /task-v2-verify output)