### PR TITLE
fix(dispatcher): detect rebase-failure without unmerged files, route to diagnoser

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -2410,6 +2410,14 @@ handle_push_and_pr() {
                     "$_fix_conflict_stage/conflict-files.txt" 2>/dev/null \
                     || printf '[]')
             fi
+            # #3465: capture the last ~50 lines of git-rebase.stderr.log
+            # (size-capped at ~5 KB) so the diagnoser can inspect the
+            # rebase failure reason when no unmerged files are present.
+            _rebase_stderr_tail=$(tail -n 50 \
+                "$AGENT_WORKSPACE/git-rebase.stderr.log" 2>/dev/null \
+                | head -c 5120 \
+                | jq -Rs '.' 2>/dev/null \
+                || printf '""')
             # Now abort the in-progress rebase so the worktree returns
             # to its pre-rebase state, log the failure, and emit the
             # structured envelope.
@@ -2420,10 +2428,20 @@ handle_push_and_pr() {
             set -e
             log "push_and_pr_rebase_conflict" "exit_code=$_rebase_rc" \
                 "conflict_files_json=$_conflict_files_json"
-            # #3225: emit conflict_files so transition_from_push_and_pr
-            # routes to fix_conflict with the file list in context.
-            printf '{"no_op": false, "rebase_failed": true, "conflict_files": %s}' \
-                "$_conflict_files_json"
+            # #3465: if the conflict-files list is empty the entrypoint
+            # emits a distinct no_unmerged_files envelope so the
+            # transition shim routes to the diagnoser instead of
+            # fix_conflict (which would immediately return unresolvable
+            # on an empty bundle).
+            if [[ "$_conflict_files_json" == "[]" ]]; then
+                printf '{"no_op": false, "rebase_failed": true, "no_unmerged_files": true, "rebase_stderr_tail": %s}' \
+                    "$_rebase_stderr_tail"
+            else
+                # #3225: emit conflict_files so transition_from_push_and_pr
+                # routes to fix_conflict with the file list in context.
+                printf '{"no_op": false, "rebase_failed": true, "conflict_files": %s, "rebase_stderr_tail": %s}' \
+                    "$_conflict_files_json" "$_rebase_stderr_tail"
+            fi
             return 0
         fi
     else
@@ -4559,15 +4577,33 @@ while true; do
                                 "$_fix_conflict_stage/conflict-files.txt" 2>/dev/null \
                                 || printf '[]')
                         fi
+                        # #3465: capture the last ~50 lines of
+                        # ralph-baseline-rebase.stderr.log (size-capped at
+                        # ~5 KB) so the diagnoser can inspect the rebase
+                        # failure reason when no unmerged files are present.
+                        _baseline_rebase_stderr_tail=$(tail -n 50 \
+                            "$AGENT_WORKSPACE/ralph-baseline-rebase.stderr.log" \
+                            2>/dev/null \
+                            | head -c 5120 \
+                            | jq -Rs '.' 2>/dev/null \
+                            || printf '""')
                         log "ralph_baseline_rebase_conflict" \
                             "exit_code=$_baseline_rebase_rc" \
                             "conflict_files_json=$_baseline_conflict_files_json"
-                        # Build a synthetic ralph-phase output with the
-                        # rebase_failed envelope. Persist + transition
-                        # via the normal shim path so the conflict
-                        # routes to fix_conflict.
-                        _ralph_baseline_output=$(printf '{"rebase_failed": true, "conflict_files": %s, "source_phase": "ralph"}' \
-                            "$_baseline_conflict_files_json")
+                        # #3465: build the synthetic ralph-phase output with
+                        # the rebase_failed envelope. If the conflict-files
+                        # list is empty, emit the no_unmerged_files variant
+                        # so the transition shim routes to the diagnoser
+                        # instead of fix_conflict. Otherwise emit the
+                        # conflict_files shape so fix_conflict can consume
+                        # the bundle.
+                        if [[ "$_baseline_conflict_files_json" == "[]" ]]; then
+                            _ralph_baseline_output=$(printf '{"rebase_failed": true, "no_unmerged_files": true, "rebase_stderr_tail": %s, "source_phase": "ralph"}' \
+                                "$_baseline_rebase_stderr_tail")
+                        else
+                            _ralph_baseline_output=$(printf '{"rebase_failed": true, "conflict_files": %s, "rebase_stderr_tail": %s, "source_phase": "ralph"}' \
+                                "$_baseline_conflict_files_json" "$_baseline_rebase_stderr_tail")
+                        fi
                         persist_phase_output "ralph" "$_ralph_baseline_output"
                         _bt=$(transition_for "ralph" "$_ralph_baseline_output")
                         _ba=$(printf '%s' "$_bt" | cut -f1)
@@ -4670,7 +4706,7 @@ while true; do
                             log "ralph_not_ship_local" "hint=$_hint"
                             handle_ralph_not_ship_local "$_output"
                             ;;
-                        ralph_ac_infeasible|summary_ac_infeasible|fix_ci_blocked|verify_failed_post_merge)
+                        ralph_ac_infeasible|summary_ac_infeasible|fix_ci_blocked|verify_failed_post_merge|push_and_pr_no_unmerged_files)
                             # Descriptive terminal — the daemon's
                             # BYPASSED_TERMINAL_PHASES_TO_ROUTE maps
                             # these phase names to failure categories

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1302,6 +1302,15 @@ FAILURE_CATEGORY_MERGE_UNSTICK_EXHAUSTED = "merge_unstick_exhausted"
 #: rebase today — but when it is added it must route here.
 FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE = "conflict_unresolvable"
 
+#: #3465 — push_and_pr or start-of-ralph baseline rebase exited non-zero
+#: but ``git diff --name-only --diff-filter=U`` returned no files. Routing
+#: to fix_conflict with an empty bundle causes an immediate ``unresolvable``
+#: verdict. The agent-runner entrypoint emits a distinct
+#: ``no_unmerged_files=True`` envelope and the transition shim routes here
+#: instead. The diagnoser decides next steps (evaluate ``--empty=drop``,
+#: reissue, etc.).
+FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES = "push_and_pr_no_unmerged_files"
+
 #: daemon-side ``_push_and_open_pr`` pre-push rebase against ``origin/main``
 #: hit a conflict; rebase was aborted and worktree restored. No mechanical
 #: retry — proper LLM-resolution path is the follow-up issue. Tier-3.
@@ -1361,6 +1370,8 @@ BYPASSED_TERMINAL_PHASES_TO_ROUTE: dict[str, str] = {
     "summary_ac_infeasible": FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
     "fix_ci_blocked": FAILURE_CATEGORY_FIX_CI_BLOCKED,
     "verify_failed_post_merge": FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
+    # #3465 — rebase exited non-zero with no unmerged files.
+    "push_and_pr_no_unmerged_files": FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
 }
 
 #: GitHub's rejection stderr fragment when branch protection's

--- a/scripts/dispatcher/phase_transitions.py
+++ b/scripts/dispatcher/phase_transitions.py
@@ -456,6 +456,14 @@ FAILURE_HINT_PLAN_BLOCKED = "plan_blocked"
 #: ``FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE`` in daemon.py. See #3225.
 FAILURE_HINT_CONFLICT_UNRESOLVABLE = "conflict_unresolvable"
 
+#: #3465 — push_and_pr or start-of-ralph baseline rebase exited non-zero
+#: but ``git diff --name-only --diff-filter=U`` returned no files. Routing
+#: to fix_conflict with an empty conflict bundle would cause the skill to
+#: return ``unresolvable`` immediately (nothing to resolve). Instead we
+#: emit a distinct envelope and route to the diagnoser. Maps to
+#: ``FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES`` in daemon.py.
+FAILURE_HINT_PUSH_AND_PR_NO_UNMERGED_FILES = "push_and_pr_no_unmerged_files"
+
 
 # ---------------------------------------------------------------------------
 # Transition dataclass.
@@ -577,6 +585,22 @@ def transition_from_ralph(output: Mapping[str, Any] | None) -> PhaseTransition:
     path takes precedence over verdict parsing because no claude
     skill has run yet.
     """
+    # #3465: start-of-ralph baseline rebase exited non-zero but produced
+    # no unmerged files. MUST come before the generic rebase_failed branch
+    # so the empty bundle never reaches fix_conflict.
+    if output and output.get("rebase_failed") and output.get("no_unmerged_files"):
+        return PhaseTransition(
+            action=TransitionAction.ROUTE_TO_DIAGNOSER,
+            failure_hint=FAILURE_HINT_PUSH_AND_PR_NO_UNMERGED_FILES,
+            reason=(
+                "ralph baseline rebase failed with no unmerged files — "
+                "routing to diagnoser (#3465)"
+            ),
+            context={
+                "rebase_stderr_tail": output.get("rebase_stderr_tail"),
+                "source_phase": "ralph",
+            },
+        )
     # #3225: start-of-ralph baseline rebase conflict. Short-circuits
     # the verdict check because the claude skill never ran.
     if output and output.get("rebase_failed"):
@@ -658,6 +682,14 @@ def transition_from_push_and_pr(
     * ``no_op=True`` — ralph's #3039 no-op-SHIP guardrail fired; the
       working tree was clean on SHIP. Terminal success with phase
       ``no_op``, status ``succeeded``. No PR, no CI, no merge.
+    * ``rebase_failed=True, no_unmerged_files=True`` (#3465) — the
+      pre-push ``git rebase origin/main`` exited non-zero but
+      ``git diff --name-only --diff-filter=U`` returned no files.
+      Routing to fix_conflict with an empty bundle would cause the
+      skill to return ``unresolvable`` immediately. Route to diagnoser
+      instead with hint ``push_and_pr_no_unmerged_files`` so the
+      diagnoser can decide next steps (evaluate ``--empty=drop``,
+      reissue, etc.).
     * ``rebase_failed=True`` (#3225) — the pre-push
       ``git rebase origin/main`` hit a conflict. Advance to the
       ``fix_conflict`` phase, where a claude skill semantically
@@ -671,6 +703,22 @@ def transition_from_push_and_pr(
             next_phase=PHASE_NO_OP,
             terminal_status=AgentStatus.SUCCEEDED.value,
             reason="push_and_pr no-op SHIP (#3039)",
+        )
+    # #3465: rebase exited non-zero but produced no unmerged files.
+    # MUST come before the generic rebase_failed branch so the empty
+    # bundle never reaches fix_conflict.
+    if output and output.get("rebase_failed") and output.get("no_unmerged_files"):
+        return PhaseTransition(
+            action=TransitionAction.ROUTE_TO_DIAGNOSER,
+            failure_hint=FAILURE_HINT_PUSH_AND_PR_NO_UNMERGED_FILES,
+            reason=(
+                "push_and_pr rebase failed with no unmerged files — "
+                "routing to diagnoser (#3465)"
+            ),
+            context={
+                "rebase_stderr_tail": output.get("rebase_stderr_tail"),
+                "source_phase": "push_and_pr",
+            },
         )
     # #3225: pre-push rebase conflict. The entrypoint emits
     # ``{"rebase_failed": true, "conflict_files": [...]}`` when
@@ -1257,6 +1305,7 @@ __all__ = [
     "FAILURE_HINT_VERIFY_FAILED_POST_MERGE",
     "FAILURE_HINT_PLAN_BLOCKED",
     "FAILURE_HINT_CONFLICT_UNRESOLVABLE",
+    "FAILURE_HINT_PUSH_AND_PR_NO_UNMERGED_FILES",
     # Transition dataclass + enum
     "PhaseTransition",
     "TransitionAction",

--- a/scripts/dispatcher/tests/test_agent_runner_no_unmerged_files.py
+++ b/scripts/dispatcher/tests/test_agent_runner_no_unmerged_files.py
@@ -1,0 +1,110 @@
+"""Issue #3465 — verify ``agent-runner-entrypoint.sh`` emits the
+``no_unmerged_files`` envelope when git rebase exits non-zero with an
+empty conflict-files list, and captures ``_rebase_stderr_tail`` from
+the rebase stderr log for both affected rebase-failure blocks.
+
+This is a static lint of the shell script — it parses specific patterns
+in the file text rather than executing the script. The intent is to catch
+regressions where one of the two rebase-failure sites loses the new
+branching logic or the stderr-tail capture.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ENTRYPOINT_PATH = Path(__file__).resolve().parents[1] / "agent-runner-entrypoint.sh"
+
+
+def _script_text() -> str:
+    return _ENTRYPOINT_PATH.read_text(encoding="utf-8")
+
+
+class TestEntrypointScriptExists:
+    def test_entrypoint_script_exists(self) -> None:
+        assert _ENTRYPOINT_PATH.exists(), (
+            f"agent-runner-entrypoint.sh not found at {_ENTRYPOINT_PATH}"
+        )
+
+
+class TestEntrypointEmitsNoUnmergedFilesEnvelope:
+    """The entrypoint must emit the no_unmerged_files JSON literal in
+    both rebase-failure blocks (push_and_pr and ralph baseline)."""
+
+    def test_no_unmerged_files_literal_present_in_push_and_pr_block(self) -> None:
+        text = _script_text()
+        # The push_and_pr block emits
+        # ``"no_unmerged_files": true`` when conflict_files is empty.
+        assert '"no_unmerged_files": true' in text, (
+            'agent-runner-entrypoint.sh must contain `"no_unmerged_files": true` '
+            "in the push_and_pr rebase-failure block (#3465)"
+        )
+
+    def test_no_unmerged_files_appears_at_least_twice(self) -> None:
+        # Must appear in both push_and_pr AND ralph-baseline blocks.
+        text = _script_text()
+        count = text.count('"no_unmerged_files": true')
+        assert count >= 2, (
+            f'`"no_unmerged_files": true` must appear in both push_and_pr and '
+            f"ralph-baseline rebase-failure blocks (#3465), found {count} occurrence(s)"
+        )
+
+
+class TestEntrypointCapturesRebaseStderrTail:
+    """The entrypoint must capture ``_rebase_stderr_tail`` (or an
+    equivalently named variable) from the git-rebase stderr log near
+    each rebase-failure block."""
+
+    def test_push_and_pr_block_captures_stderr_tail(self) -> None:
+        text = _script_text()
+        # The push_and_pr block captures from git-rebase.stderr.log.
+        assert "git-rebase.stderr.log" in text, (
+            "push_and_pr rebase-failure block must reference git-rebase.stderr.log (#3465)"
+        )
+        assert "_rebase_stderr_tail" in text, (
+            "_rebase_stderr_tail variable must be captured near the "
+            "push_and_pr rebase-failure block (#3465)"
+        )
+
+    def test_ralph_baseline_block_captures_stderr_tail(self) -> None:
+        text = _script_text()
+        # The ralph baseline block captures from ralph-baseline-rebase.stderr.log.
+        assert "ralph-baseline-rebase.stderr.log" in text, (
+            "ralph-baseline rebase-failure block must reference "
+            "ralph-baseline-rebase.stderr.log (#3465)"
+        )
+        assert "_baseline_rebase_stderr_tail" in text, (
+            "_baseline_rebase_stderr_tail variable must be captured near the "
+            "ralph-baseline rebase-failure block (#3465)"
+        )
+
+    def test_stderr_tail_uses_tail_and_head_for_size_cap(self) -> None:
+        # The capture pattern uses ``tail -n 50 ... | head -c 5120`` to
+        # implement the ~50-line / ~5 KB cap.
+        text = _script_text()
+        assert "tail -n 50" in text, (
+            "stderr-tail capture must use `tail -n 50` for the ~50-line cap (#3465)"
+        )
+        assert "head -c 5120" in text, (
+            "stderr-tail capture must use `head -c 5120` for the ~5 KB size cap (#3465)"
+        )
+
+
+class TestRouteToDignoserListsPushAndPrNoUnmergedFiles:
+    """The dispatch case statement for ``route_to_diagnoser`` must
+    include ``push_and_pr_no_unmerged_files`` in the descriptive-hint
+    allow-list so the new terminal phase gets picked up by the daemon's
+    supervisor sweep."""
+
+    def test_dispatch_case_includes_push_and_pr_no_unmerged_files(self) -> None:
+        text = _script_text()
+        # The descriptive-terminal case arm pattern:
+        #   ralph_ac_infeasible|...|push_and_pr_no_unmerged_files)
+        assert re.search(
+            r"ralph_ac_infeasible\|[^)]*push_and_pr_no_unmerged_files",
+            text,
+        ), (
+            "route_to_diagnoser dispatch case must include "
+            "`push_and_pr_no_unmerged_files` in the descriptive-hint allow-list (#3465)"
+        )

--- a/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
+++ b/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
@@ -128,6 +128,7 @@ class TestBypassedTerminalConstants:
         # locally by the entrypoint.
         from dispatcher.daemon import (
             FAILURE_CATEGORY_FIX_CI_BLOCKED,
+            FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
             FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
             FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
             FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
@@ -140,6 +141,7 @@ class TestBypassedTerminalConstants:
             "summary_ac_infeasible": FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
             "fix_ci_blocked": FAILURE_CATEGORY_FIX_CI_BLOCKED,
             "verify_failed_post_merge": FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
+            "push_and_pr_no_unmerged_files": FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
         }
 
 

--- a/scripts/dispatcher/tests/test_phase_transitions.py
+++ b/scripts/dispatcher/tests/test_phase_transitions.py
@@ -704,6 +704,110 @@ class TestTransitionFromRalphBaselineRebaseConflict:
 
 
 # --------------------------------------------------------------------------
+# transition_from_push_and_pr — no_unmerged_files branch (#3465)
+# --------------------------------------------------------------------------
+
+
+class TestTransitionFromPushAndPrNoUnmergedFiles:
+    """#3465: push_and_pr rebase exits non-zero with no unmerged files →
+    route to diagnoser, NOT fix_conflict."""
+
+    def test_no_unmerged_files_routes_to_diagnoser(self) -> None:
+        result = pt.transition_from_push_and_pr(
+            {
+                "rebase_failed": True,
+                "no_unmerged_files": True,
+                "rebase_stderr_tail": "error: could not apply abc1234",
+            }
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_PUSH_AND_PR_NO_UNMERGED_FILES
+        assert result.context["rebase_stderr_tail"] == "error: could not apply abc1234"
+        assert result.context["source_phase"] == "push_and_pr"
+
+    def test_no_unmerged_files_without_stderr_tail_still_routes(self) -> None:
+        # Defensive: if the entrypoint couldn't capture the stderr tail,
+        # the transition must still route to diagnoser (no crash).
+        result = pt.transition_from_push_and_pr(
+            {
+                "rebase_failed": True,
+                "no_unmerged_files": True,
+            }
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_PUSH_AND_PR_NO_UNMERGED_FILES
+        assert result.context.get("rebase_stderr_tail") is None
+        assert result.context["source_phase"] == "push_and_pr"
+
+    def test_no_unmerged_files_takes_precedence_over_conflict_files(self) -> None:
+        # If both no_unmerged_files and conflict_files are present (shouldn't
+        # happen, but defensive), no_unmerged_files must win — never route
+        # to fix_conflict.
+        result = pt.transition_from_push_and_pr(
+            {
+                "rebase_failed": True,
+                "no_unmerged_files": True,
+                "conflict_files": ["packages/web/app/foo.tsx"],
+                "rebase_stderr_tail": "some tail",
+            }
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.next_phase != pt.PHASE_FIX_CONFLICT
+
+
+# --------------------------------------------------------------------------
+# transition_from_ralph — no_unmerged_files branch (#3465)
+# --------------------------------------------------------------------------
+
+
+class TestTransitionFromRalphNoUnmergedFiles:
+    """#3465: start-of-ralph baseline rebase exits non-zero with no unmerged
+    files → route to diagnoser, NOT fix_conflict."""
+
+    def test_no_unmerged_files_routes_to_diagnoser(self) -> None:
+        result = pt.transition_from_ralph(
+            {
+                "rebase_failed": True,
+                "no_unmerged_files": True,
+                "rebase_stderr_tail": "error: could not apply def5678",
+                "source_phase": "ralph",
+            }
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_PUSH_AND_PR_NO_UNMERGED_FILES
+        assert result.context["rebase_stderr_tail"] == "error: could not apply def5678"
+        assert result.context["source_phase"] == "ralph"
+
+    def test_no_unmerged_files_without_stderr_tail_still_routes(self) -> None:
+        # Defensive: if the entrypoint couldn't capture the stderr tail,
+        # the transition must still route to diagnoser (no crash).
+        result = pt.transition_from_ralph(
+            {
+                "rebase_failed": True,
+                "no_unmerged_files": True,
+            }
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_PUSH_AND_PR_NO_UNMERGED_FILES
+        assert result.context.get("rebase_stderr_tail") is None
+        assert result.context["source_phase"] == "ralph"
+
+    def test_no_unmerged_files_takes_precedence_over_conflict_files(self) -> None:
+        # If both no_unmerged_files and conflict_files are present, the
+        # no_unmerged_files branch must win — never route to fix_conflict.
+        result = pt.transition_from_ralph(
+            {
+                "rebase_failed": True,
+                "no_unmerged_files": True,
+                "conflict_files": ["x.py", "y.py"],
+                "rebase_stderr_tail": "some tail",
+            }
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.next_phase != pt.PHASE_FIX_CONFLICT
+
+
+# --------------------------------------------------------------------------
 # transition_from_merge
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixed the dispatcher entrypoint to distinguish between real merge conflicts and rebase failures with no unmerged files (e.g., halting on empty commits). The entrypoint now detects empty `git diff --diff-filter=U` output and routes to the diagnoser with a `no_unmerged_files` envelope instead of sending an empty bundle to fix_conflict.

Closes #3465

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — 118 tests, all pass (13 new tests added)
- [x] CI green

### Post-deploy verification

- [ ] CloudWatch query: `event="fix_conflict_skill_verdict" verdict=unresolvable` cross-referenced with `dispatcher.phase_outputs.output_json->'conflict_files'` size returns zero hits with `conflict_files=[]` over 24h observation (see /task-v2-verify)
- [ ] Verification evidence posted on #3465