### PR TITLE
feat(agent): mirror ralph review logs to S3 for durable history (#2647)

### DIFF
--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -495,21 +495,42 @@ The reviewers have approved the implementation. Before returning, log a summary 
 
 ### 3a — Log review summary
 
-Write the following to `{worktree}/tmp/ralph/log_summary.py` (substituting actual paths):
+Write the following to `{worktree}/tmp/ralph/log_summary.py` (substituting actual paths for `{worktree}` and `{repo_root}`):
 
 ```python
 import sys
-sys.path.insert(0, "<repo_root>/scripts")
-from ralph_review_log import log_summary
+import re
 from pathlib import Path
 
+sys.path.insert(0, "<repo_root>/scripts")
+from ralph_review_log import log_summary
+
 state_dir = Path("<worktree>/tmp/ralph")
+worktree = Path("<worktree>")
 iteration = int(state_dir.joinpath("iteration.txt").read_text(encoding="utf-8").strip())
+
+# Derive agent_id from the worktree basename (e.g. "agent-ab4722a2").
+_wt_name = worktree.name
+agent_id = _wt_name if re.match(r"^agent-[0-9a-f]+$", _wt_name) else None
+
+# Derive issue_number from the first line of task.md (format: "# Issue #<N> — <title>").
+issue_number = None
+_task_md = state_dir / "task.md"
+if _task_md.exists():
+    try:
+        _first = _task_md.read_text(encoding="utf-8").splitlines()[0]
+        _m = re.match(r"^#\s+Issue\s+#(\d+)", _first)
+        if _m:
+            issue_number = int(_m.group(1))
+    except (OSError, IndexError, ValueError):
+        pass
 
 log_summary(
     state_dir,
     total_iterations=iteration,
     final_verdict="SHIP",
+    agent_id=agent_id,
+    issue_number=issue_number,
 )
 ```
 

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -85,6 +85,16 @@ Rules that apply to every script or service that writes or copies objects under 
 
 Helpers are in `packages/scraper-framework/src/framework/s3_integrity.py` — use `verify_key_matches_bytes` for a boolean check and `assert_key_matches_bytes` for a hard assertion (raises `S3MislabelError` on any mismatch or missing object).
 
+## Telemetry artifacts
+
+S3 paths for agent observability data, all under `s3://judgemind-document-archive-dev/`:
+
+- **`ralph-reviews/<YYYY-MM-DD>/<agent-id>-<issue>.jsonl`** — complete `review-log.jsonl` for one ralph run. One object per agent run. Written by `scripts/ralph_review_log.py::log_summary` (on SHIP) and `scripts/cleanup_worktree.sh` (best-effort fallback on teardown). Schema: JSONL with `type` field — `"review"` (one per iteration per reviewer), `"summary"` (one at loop end), `"dissent_override"` (optional).
+
+Upload helper: `scripts/telemetry_upload.py` — lazy-imports boto3, swallows all errors (network, credentials, missing boto3), returns `True`/`False`. Never raises. Import as a library (`from telemetry_upload import mirror_to_s3`) or invoke directly (`python3 scripts/telemetry_upload.py <local-path> <s3-key>`).
+
+IAM grant: `s3:PutObject` on `<document_archive_bucket>/ralph-reviews/*`, wired into both the `dispatcher-daemon` and `dispatcher-agent-runner` modules via `task_ralph_review_telemetry` policies.
+
 ## Performance awareness
 
 Every diff review must check for these common bottlenecks:

--- a/infra/terraform/modules/dispatcher-agent-runner/main.tf
+++ b/infra/terraform/modules/dispatcher-agent-runner/main.tf
@@ -450,6 +450,39 @@ resource "aws_iam_role_policy" "task_spotcheck_oneshot" {
   })
 }
 
+# Grants `s3:PutObject` on the ralph-reviews/ prefix so the agent-runner
+# container can mirror review-log.jsonl telemetry after each ralph SHIP (via
+# log_summary's S3 upload path) and before each worktree teardown (via the
+# cleanup_worktree.sh best-effort fallback).
+#
+# Reuses `spotcheck_document_archive_bucket_arn` — the same
+# `judgemind-document-archive-<env>` bucket that already holds spotcheck and
+# data-quality artifacts.  Forward-compatible with Stage 2 per-agent ECS
+# migration (#3086/#3091) where `log_summary` runs inside the agent-runner
+# container.
+#
+# Disabled (count=0) when `spotcheck_document_archive_bucket_arn` is empty —
+# safe for stacks that do not provision the document-archive bucket.
+
+resource "aws_iam_role_policy" "task_ralph_review_telemetry" {
+  count = var.spotcheck_document_archive_bucket_arn != "" ? 1 : 0
+
+  name = "${local.task_family}-task-ralph-review-telemetry"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowPutRalphReviewTelemetry"
+        Effect   = "Allow"
+        Action   = "s3:PutObject"
+        Resource = "${var.spotcheck_document_archive_bucket_arn}/ralph-reviews/*"
+      },
+    ]
+  })
+}
+
 # ─── ECS Task Definition ───────────────────────────────────────────────────
 #
 # CPU / memory: 4096 / 16384 to match the subprocess-daemon envelope —

--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -469,6 +469,34 @@ resource "aws_iam_role_policy" "task_s3_archive_list" {
   })
 }
 
+# Grants `s3:PutObject` on the ralph-reviews/ prefix so the daemon can
+# mirror review-log.jsonl telemetry after each ralph SHIP (via log_summary's
+# S3 upload path) and before each worktree teardown (via cleanup_worktree.sh's
+# best-effort fallback).
+#
+# Scoped to `<bucket>/ralph-reviews/*` — no broader write access is granted.
+# Disabled (count=0) when `document_archive_bucket_arn` is empty — safe for
+# staging / throwaway stacks that don't provision the archive bucket.
+
+resource "aws_iam_role_policy" "task_ralph_review_telemetry" {
+  count = var.document_archive_bucket_arn != "" ? 1 : 0
+
+  name = "${local.service_name}-task-ralph-review-telemetry"
+  role = aws_iam_role.task.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowPutRalphReviewTelemetry"
+        Effect   = "Allow"
+        Action   = "s3:PutObject"
+        Resource = "${var.document_archive_bucket_arn}/ralph-reviews/*"
+      },
+    ]
+  })
+}
+
 resource "aws_iam_role_policy" "task_ecs_exec_ssm" {
   name = "${local.service_name}-task-ecs-exec-ssm"
   role = aws_iam_role.task.id

--- a/scripts/cleanup_worktree.sh
+++ b/scripts/cleanup_worktree.sh
@@ -126,6 +126,60 @@ agent_is_finished() {
     fi
 }
 
+# --- Mirror review-log.jsonl to S3 before teardown (best-effort) ---
+# Derives agent_id from the worktree basename and issue_number from the
+# first line of {worktree}/tmp/ralph/task.md, then calls telemetry_upload.py.
+# Non-zero exit from the upload is silently ignored — telemetry must never
+# abort a cleanup.
+_mirror_review_log_best_effort() {
+    local worktree_path="$1"
+    local repo_root="$2"
+
+    local review_log="$worktree_path/tmp/ralph/review-log.jsonl"
+
+    # Skip if log does not exist or is empty
+    if [[ ! -s "$review_log" ]]; then
+        return 0
+    fi
+
+    # Derive agent_id from worktree basename (expected: agent-<hex>)
+    local dir_base agent_id
+    dir_base="$(basename "$worktree_path")"
+    agent_id="$dir_base"
+
+    # Derive issue_number from first line of task.md (format: "# Issue #<N> — ...")
+    local task_md="$worktree_path/tmp/ralph/task.md"
+    local issue_number=""
+    if [[ -f "$task_md" ]]; then
+        local first_line
+        first_line="$(head -n 1 "$task_md" 2>/dev/null)"
+        # Extract the number after "# Issue #"
+        if [[ "$first_line" =~ ^#[[:space:]]+Issue[[:space:]]+#([0-9]+) ]]; then
+            issue_number="${BASH_REMATCH[1]}"
+        fi
+    fi
+
+    # Build S3 key: ralph-reviews/<YYYY-MM-DD>/<agent_id>-<issue>.jsonl
+    local today s3_key
+    today="$(date -u +%Y-%m-%d 2>/dev/null)"
+    if [[ -z "$issue_number" ]]; then
+        s3_key="ralph-reviews/${today}/${agent_id}.jsonl"
+    else
+        s3_key="ralph-reviews/${today}/${agent_id}-${issue_number}.jsonl"
+    fi
+
+    local upload_script="$repo_root/scripts/telemetry_upload.py"
+    if [[ ! -f "$upload_script" ]]; then
+        echo "telemetry_upload.py not found — skipping review-log S3 mirror" >&2
+        return 0
+    fi
+
+    echo "Mirroring review log to s3://.../${s3_key}" >&2
+    # 10-second timeout; ignore non-zero exit — telemetry must never abort cleanup
+    timeout 10 python3 "$upload_script" "$review_log" "$s3_key" 2>&1 | sed 's/^/[telemetry] /' >&2 || true
+    return 0
+}
+
 # --- Remove the worktree ---
 remove_worktree() {
     local repo_root="$1"
@@ -230,6 +284,10 @@ main() {
         echo "ERROR: agent appears to still be running: $reason" >&2
         return 1
     fi
+
+    # Best-effort: mirror review-log.jsonl to S3 before tearing down the worktree.
+    # The upload runs with a 10s timeout and never aborts cleanup on failure.
+    _mirror_review_log_best_effort "$worktree_path" "$repo_root"
 
     # Remove the worktree (this also cd's to repo root)
     if remove_worktree "$repo_root" "$worktree_path"; then

--- a/scripts/log_ralph_summary.py
+++ b/scripts/log_ralph_summary.py
@@ -7,6 +7,7 @@ from the review log and appends a summary JSONL record.
 
 Usage:
     python3 scripts/log_ralph_summary.py <worktree-path> [--verdict SHIP|MAX_ITERATIONS]
+        [--agent-id <agent-id>] [--issue-number <N>]
 
 The script reads:
   {worktree}/tmp/ralph/iteration.txt       — Final iteration number
@@ -14,11 +15,21 @@ The script reads:
 
 It appends a summary record to:
   {worktree}/tmp/ralph/review-log.jsonl
+
+When --agent-id and --issue-number are both provided (or successfully derived
+from the worktree path / task.md), the complete review-log.jsonl is also
+mirrored to S3 under ralph-reviews/<YYYY-MM-DD>/<agent-id>-<issue>.jsonl.
+If either flag is absent, they are derived from:
+  - agent_id: basename of <worktree-path> (e.g. "agent-ab4722a2")
+  - issue_number: first line of {worktree}/tmp/ralph/task.md
+    (expected format: "# Issue #<N> — <title>")
+Both fallbacks return None on miss; missing inputs skip the upload.
 """
 # permanent: true
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 
@@ -28,12 +39,43 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from ralph_review_log import log_summary
 
 
+def _derive_agent_id(worktree: Path) -> str | None:
+    """Derive agent_id from the worktree basename.
+
+    Expected basename pattern: ``agent-<id>`` (e.g. ``agent-ab4722a2``).
+    Returns the full basename (e.g. ``agent-ab4722a2``) or None on miss.
+    """
+    name = worktree.name
+    if re.match(r"^agent-[0-9a-f]+$", name):
+        return name
+    return None
+
+
+def _derive_issue_number(state_dir: Path) -> int | None:
+    """Derive issue_number from the first line of task.md.
+
+    Expected format: ``# Issue #<N> — <title>``
+    Returns the integer issue number or None on miss.
+    """
+    task_md = state_dir / "task.md"
+    if not task_md.exists():
+        return None
+    try:
+        first_line = task_md.read_text(encoding="utf-8").splitlines()[0]
+        m = re.match(r"^#\s+Issue\s+#(\d+)", first_line)
+        if m:
+            return int(m.group(1))
+    except (OSError, IndexError, ValueError):
+        pass
+    return None
+
+
 def main() -> None:
     """Entry point."""
     if len(sys.argv) < 2:
         print(
             "Usage: python3 scripts/log_ralph_summary.py <worktree-path> "
-            "[--verdict SHIP|MAX_ITERATIONS]",
+            "[--verdict SHIP|MAX_ITERATIONS] [--agent-id <id>] [--issue-number <N>]",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -45,11 +87,37 @@ def main() -> None:
         print(f"ERROR: Ralph state directory not found: {state_dir}", file=sys.stderr)
         sys.exit(1)
 
-    # Parse optional --verdict flag
+    # Parse optional flags
     final_verdict = "SHIP"
-    for i, arg in enumerate(sys.argv[2:], start=2):
-        if arg == "--verdict" and i + 1 < len(sys.argv):
-            final_verdict = sys.argv[i + 1]
+    agent_id_arg: str | None = None
+    issue_number_arg: int | None = None
+
+    args = sys.argv[2:]
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--verdict" and i + 1 < len(args):
+            final_verdict = args[i + 1]
+            i += 2
+        elif arg == "--agent-id" and i + 1 < len(args):
+            agent_id_arg = args[i + 1]
+            i += 2
+        elif arg == "--issue-number" and i + 1 < len(args):
+            try:
+                issue_number_arg = int(args[i + 1])
+            except ValueError:
+                pass
+            i += 2
+        else:
+            i += 1
+
+    # Derive agent_id / issue_number from context when not explicitly supplied
+    agent_id = agent_id_arg if agent_id_arg is not None else _derive_agent_id(worktree)
+    issue_number = (
+        issue_number_arg
+        if issue_number_arg is not None
+        else _derive_issue_number(state_dir)
+    )
 
     # Read iteration
     iteration_path = state_dir / "iteration.txt"
@@ -65,10 +133,17 @@ def main() -> None:
         state_dir,
         total_iterations=total_iterations,
         final_verdict=final_verdict,
+        agent_id=agent_id,
+        issue_number=issue_number,
     )
+
+    upload_note = ""
+    if agent_id is not None and issue_number is not None:
+        upload_note = f" (S3 upload attempted: agent={agent_id}, issue={issue_number})"
 
     print(
         f"Ralph summary logged: iterations={total_iterations}, verdict={final_verdict}"
+        f"{upload_note}"
     )
 
 

--- a/scripts/ralph_review_log.py
+++ b/scripts/ralph_review_log.py
@@ -81,11 +81,20 @@ def log_summary(
     total_iterations: int,
     final_verdict: str,
     reviews: list[dict[str, Any]] | None = None,
+    agent_id: str | None = None,
+    issue_number: int | None = None,
 ) -> None:
     """Log a summary record at the end of the ralph loop.
 
     Computes agreement rate and catch patterns from the review log
     if individual reviews are provided.
+
+    After writing the summary record, if both ``agent_id`` and
+    ``issue_number`` are provided, mirrors the complete review-log.jsonl
+    to S3 under ``ralph-reviews/<YYYY-MM-DD>/<agent_id>-<issue_number>.jsonl``.
+    The upload is best-effort: S3 failures are logged as warnings and never
+    abort the function.  ``telemetry_upload`` is lazy-imported so this module
+    remains stdlib-only when the upload path is not exercised.
 
     Args:
         state_dir: Path to {worktree}/tmp/ralph/.
@@ -93,6 +102,10 @@ def log_summary(
         final_verdict: Final loop outcome — "SHIP" or "MAX_ITERATIONS".
         reviews: Optional list of review records to compute agreement stats.
             If not provided, reads them from the log file.
+        agent_id: Agent identifier (e.g. ``agent-ab4722a2``).  When provided
+            together with ``issue_number``, triggers the S3 upload.
+        issue_number: GitHub issue number the ralph run addressed.  When
+            provided together with ``agent_id``, triggers the S3 upload.
     """
     if reviews is None:
         reviews = read_reviews(state_dir)
@@ -151,6 +164,22 @@ def log_summary(
         record["adversarial_only_catches"] = adversarial_only_catches
 
     _append_record(state_dir, record)
+
+    # Mirror the complete review-log.jsonl to S3 as a telemetry artifact.
+    # Best-effort: S3 failure never aborts the function.
+    # Lazy-import telemetry_upload so this module stays stdlib-only when
+    # the upload path is not exercised (e.g. detect_persistent_dissent reads).
+    if agent_id is not None and issue_number is not None:
+        try:
+            import telemetry_upload as _tu  # noqa: PLC0415
+
+            log_file = _log_path(state_dir)
+            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            s3_key = f"ralph-reviews/{today}/{agent_id}-{issue_number}.jsonl"
+            _tu.mirror_to_s3(Path(log_file), s3_key)
+        except Exception:  # noqa: BLE001
+            # Swallow any unexpected error so telemetry never blocks the loop.
+            pass
 
 
 def read_reviews(state_dir: str | Path) -> list[dict[str, Any]]:

--- a/scripts/telemetry_upload.py
+++ b/scripts/telemetry_upload.py
@@ -1,0 +1,113 @@
+"""Reusable helper for mirroring local files to S3 as telemetry artifacts.
+
+Designed to be imported by scripts that want to upload a local file to S3
+without failing hard when S3 is unavailable (network issues, missing creds,
+boto3 not installed in the current venv, etc.).
+
+Typical usage::
+
+    from telemetry_upload import mirror_to_s3
+    ok = mirror_to_s3(Path("/tmp/review-log.jsonl"), "ralph-reviews/2026-01-01/agent-abc-123.jsonl")
+
+The function is best-effort: all errors are swallowed, logged as warnings,
+and the return value indicates success/failure without raising.
+"""
+# permanent: true
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BUCKET = "judgemind-document-archive-dev"
+
+
+def mirror_to_s3(
+    local_path: Path,
+    s3_key: str,
+    bucket: str | None = None,
+) -> bool:
+    """Upload a local file to S3 as a telemetry artifact.
+
+    All errors (network, credentials, missing boto3) are swallowed and logged
+    as warnings so callers never fail hard on a telemetry upload.
+
+    Args:
+        local_path: Path to the local file to upload.
+        s3_key: S3 object key (no leading slash).
+        bucket: Target S3 bucket name.  Defaults to the ``JUDGEMIND_TELEMETRY_BUCKET``
+            environment variable, falling back to ``judgemind-document-archive-dev``.
+
+    Returns:
+        ``True`` on a successful upload; ``False`` on any failure.
+    """
+    if bucket is None:
+        bucket = os.environ.get("JUDGEMIND_TELEMETRY_BUCKET", _DEFAULT_BUCKET)
+
+    try:
+        import boto3  # type: ignore[import]
+        from botocore.exceptions import (  # type: ignore[import]
+            ClientError,
+            EndpointConnectionError,
+            NoCredentialsError,
+        )
+    except ImportError:
+        logger.warning(
+            "boto3 not available — skipping S3 upload of %s to s3://%s/%s",
+            local_path,
+            bucket,
+            s3_key,
+        )
+        return False
+
+    try:
+        data = local_path.read_bytes()
+    except OSError as exc:
+        logger.warning(
+            "Cannot read %s for S3 upload: %s",
+            local_path,
+            exc,
+        )
+        return False
+
+    try:
+        client = boto3.client("s3")
+        client.put_object(
+            Bucket=bucket,
+            Key=s3_key,
+            Body=data,
+        )
+        logger.info(
+            "Uploaded %s to s3://%s/%s (%d bytes)",
+            local_path,
+            bucket,
+            s3_key,
+            len(data),
+        )
+        return True
+    except (ClientError, EndpointConnectionError, NoCredentialsError) as exc:
+        logger.warning(
+            "S3 upload of %s to s3://%s/%s failed: %s",
+            local_path,
+            bucket,
+            s3_key,
+            exc,
+        )
+        return False
+
+
+if __name__ == "__main__":
+    import sys
+
+    logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
+    if len(sys.argv) != 3:
+        print(
+            "Usage: python3 telemetry_upload.py <local-path> <s3-key>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    ok = mirror_to_s3(Path(sys.argv[1]), sys.argv[2])
+    sys.exit(0 if ok else 1)

--- a/scripts/tests/test_cleanup_worktree_review_log_mirror.sh
+++ b/scripts/tests/test_cleanup_worktree_review_log_mirror.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# test_cleanup_worktree_review_log_mirror.sh — Tests for the review-log
+# S3 mirroring logic added to cleanup_worktree.sh (#2647).
+#
+# Exercises the _mirror_review_log_best_effort() helper that is called
+# just before remove_worktree. Uses a bin-stubs directory on PATH to
+# intercept the python3 call and assert it was invoked with the expected
+# telemetry_upload.py path and S3 key.
+#
+# Usage:
+#   scripts/tests/test_cleanup_worktree_review_log_mirror.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CLEANUP_SCRIPT="$REPO_ROOT/scripts/cleanup_worktree.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+cleanup_temps() {
+    set +e
+    for d in "${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}"; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup_temps EXIT
+
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    echo "$dir"
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Build a minimal real git repo with a .claude/worktrees/agent-<id> worktree.
+# Sets globals: REPO WORKTREE AGENT_ID
+setup_git_repo() {
+    REPO=$(make_temp_dir)
+    git -C "$REPO" init --initial-branch main -q
+    git -C "$REPO" config user.email "test@example.com"
+    git -C "$REPO" config user.name "Test"
+    touch "$REPO/CLAUDE.md"
+    git -C "$REPO" add CLAUDE.md
+    git -C "$REPO" commit -m "init" -q
+
+    AGENT_ID="deadbeef"
+    local worktree_rel=".claude/worktrees/agent-${AGENT_ID}"
+    mkdir -p "$(dirname "$REPO/$worktree_rel")"
+    git -C "$REPO" worktree add -q "$REPO/$worktree_rel" -b "test-branch-${AGENT_ID}"
+    WORKTREE="$REPO/$worktree_rel"
+
+    # Copy cleanup script into the repo
+    mkdir -p "$REPO/scripts"
+    cp "$CLEANUP_SCRIPT" "$REPO/scripts/cleanup_worktree.sh"
+    chmod +x "$REPO/scripts/cleanup_worktree.sh"
+
+    # Write telemetry_upload.py stub into the repo's scripts/ dir
+    cat > "$REPO/scripts/telemetry_upload.py" <<'PYEOF'
+#!/usr/bin/env python3
+"""Stub telemetry_upload for test environments."""
+import sys
+ok = True
+print(f"STUB telemetry_upload: {' '.join(sys.argv[1:])}", file=sys.stderr)
+sys.exit(0 if ok else 1)
+PYEOF
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+# Test 1: _mirror_review_log_best_effort uploads when review-log.jsonl exists
+test_mirror_uploads_when_review_log_exists() {
+    setup_git_repo
+
+    # Create a synthetic ralph state dir with a non-empty review-log.jsonl
+    local ralph_dir="$WORKTREE/tmp/ralph"
+    mkdir -p "$ralph_dir"
+    echo '{"type": "summary", "final_verdict": "SHIP"}' > "$ralph_dir/review-log.jsonl"
+    echo "# Issue #2647 — Ralph review-log S3 mirror" > "$ralph_dir/task.md"
+
+    # Create a stub HOME/.claude/projects dir so agent_is_finished passes
+    local stub_home
+    stub_home=$(make_temp_dir)
+    mkdir -p "$stub_home/.claude/projects"
+
+    # Create a synthetic JSONL session log so cleanup can verify agent finished
+    local session_jsonl="$stub_home/.claude/projects/agent-${AGENT_ID}-session.jsonl"
+    printf '{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}\n' \
+        > "$session_jsonl"
+
+    # Capture stderr output from the cleanup script — python3 call should appear
+    local output
+    local exit_code=0
+    output=$(HOME="$stub_home" bash "$REPO/scripts/cleanup_worktree.sh" \
+        ".claude/worktrees/agent-${AGENT_ID}" 2>&1) || exit_code=$?
+
+    if echo "$output" | grep -q "telemetry_upload"; then
+        pass "_mirror_review_log_best_effort: python3 telemetry_upload.py was invoked"
+    else
+        fail "_mirror_review_log_best_effort: python3 telemetry_upload.py was invoked" \
+            "expected 'telemetry_upload' in output: $output (exit=$exit_code)"
+    fi
+}
+
+# Test 2: review-log key includes the issue number derived from task.md
+test_mirror_key_includes_issue_number() {
+    setup_git_repo
+
+    local ralph_dir="$WORKTREE/tmp/ralph"
+    mkdir -p "$ralph_dir"
+    echo '{"type": "summary"}' > "$ralph_dir/review-log.jsonl"
+    echo "# Issue #2647 — Ralph review-log S3 mirror" > "$ralph_dir/task.md"
+
+    local stub_home
+    stub_home=$(make_temp_dir)
+    mkdir -p "$stub_home/.claude/projects"
+    local session_jsonl="$stub_home/.claude/projects/agent-${AGENT_ID}-session.jsonl"
+    printf '{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}\n' \
+        > "$session_jsonl"
+
+    local output
+    local exit_code=0
+    output=$(HOME="$stub_home" bash "$REPO/scripts/cleanup_worktree.sh" \
+        ".claude/worktrees/agent-${AGENT_ID}" 2>&1) || exit_code=$?
+
+    if echo "$output" | grep -q "2647"; then
+        pass "_mirror_review_log_best_effort: S3 key includes issue number 2647"
+    else
+        fail "_mirror_review_log_best_effort: S3 key includes issue number 2647" \
+            "expected '2647' in output: $output"
+    fi
+}
+
+# Test 3: no upload when review-log.jsonl is absent
+test_no_upload_when_no_review_log() {
+    setup_git_repo
+
+    # Do NOT create tmp/ralph/review-log.jsonl — only the worktree dir
+    mkdir -p "$WORKTREE/tmp/ralph"
+
+    local stub_home
+    stub_home=$(make_temp_dir)
+    mkdir -p "$stub_home/.claude/projects"
+    local session_jsonl="$stub_home/.claude/projects/agent-${AGENT_ID}-session.jsonl"
+    printf '{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}\n' \
+        > "$session_jsonl"
+
+    local output
+    local exit_code=0
+    output=$(HOME="$stub_home" bash "$REPO/scripts/cleanup_worktree.sh" \
+        ".claude/worktrees/agent-${AGENT_ID}" 2>&1) || exit_code=$?
+
+    if echo "$output" | grep -q "telemetry_upload"; then
+        fail "no upload when review-log.jsonl absent" \
+            "unexpected telemetry_upload call: $output"
+    else
+        pass "no upload when review-log.jsonl absent"
+    fi
+}
+
+# Test 4: no upload when review-log.jsonl is empty
+test_no_upload_when_review_log_empty() {
+    setup_git_repo
+
+    local ralph_dir="$WORKTREE/tmp/ralph"
+    mkdir -p "$ralph_dir"
+    # Create a zero-byte file
+    > "$ralph_dir/review-log.jsonl"
+
+    local stub_home
+    stub_home=$(make_temp_dir)
+    mkdir -p "$stub_home/.claude/projects"
+    local session_jsonl="$stub_home/.claude/projects/agent-${AGENT_ID}-session.jsonl"
+    printf '{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}\n' \
+        > "$session_jsonl"
+
+    local output
+    local exit_code=0
+    output=$(HOME="$stub_home" bash "$REPO/scripts/cleanup_worktree.sh" \
+        ".claude/worktrees/agent-${AGENT_ID}" 2>&1) || exit_code=$?
+
+    if echo "$output" | grep -q "telemetry_upload"; then
+        fail "no upload when review-log.jsonl is empty" \
+            "unexpected telemetry_upload call: $output"
+    else
+        pass "no upload when review-log.jsonl is empty"
+    fi
+}
+
+# Test 5: cleanup succeeds even if the upload fails (non-zero python3 exit)
+test_cleanup_succeeds_even_if_upload_fails() {
+    setup_git_repo
+
+    local ralph_dir="$WORKTREE/tmp/ralph"
+    mkdir -p "$ralph_dir"
+    echo '{"type": "summary"}' > "$ralph_dir/review-log.jsonl"
+
+    # Overwrite telemetry_upload.py with a stub that exits 1 (simulate S3 failure)
+    cat > "$REPO/scripts/telemetry_upload.py" <<'PYEOF'
+#!/usr/bin/env python3
+import sys
+print("STUB telemetry_upload: upload failed", file=sys.stderr)
+sys.exit(1)
+PYEOF
+
+    local stub_home
+    stub_home=$(make_temp_dir)
+    mkdir -p "$stub_home/.claude/projects"
+    local session_jsonl="$stub_home/.claude/projects/agent-${AGENT_ID}-session.jsonl"
+    printf '{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}\n' \
+        > "$session_jsonl"
+
+    local exit_code=0
+    HOME="$stub_home" bash "$REPO/scripts/cleanup_worktree.sh" \
+        ".claude/worktrees/agent-${AGENT_ID}" >/dev/null 2>&1 || exit_code=$?
+
+    if [[ "$exit_code" -eq 0 ]]; then
+        pass "cleanup succeeds even if upload fails"
+    else
+        fail "cleanup succeeds even if upload fails" \
+            "expected exit 0, got $exit_code"
+    fi
+}
+
+# ── Run all tests ──────────────────────────────────────────────────────────
+
+test_mirror_uploads_when_review_log_exists
+test_mirror_key_includes_issue_number
+test_no_upload_when_no_review_log
+test_no_upload_when_review_log_empty
+test_cleanup_succeeds_even_if_upload_fails
+
+echo ""
+echo "────────────────────────────────────────────"
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+if [[ $FAILURES -gt 0 ]]; then
+    echo "$FAILURES test(s) FAILED"
+    exit 1
+fi
+echo "All tests passed."
+exit 0

--- a/scripts/tests/test_ralph_review_log.py
+++ b/scripts/tests/test_ralph_review_log.py
@@ -328,6 +328,134 @@ class TestLogSummary:
         record = json.loads(log_path.read_text(encoding="utf-8").strip())
         assert record["final_verdict"] == "MAX_ITERATIONS"
 
+    def test_uploads_to_s3_when_agent_id_and_issue_provided(
+        self, state_dir: Path
+    ) -> None:
+        """S3 upload is attempted when both agent_id and issue_number are provided."""
+        import sys
+        from unittest.mock import MagicMock
+
+        # Set up a mock telemetry_upload module that we can inspect
+        mock_mirror = MagicMock(return_value=True)
+        mock_telemetry = MagicMock()
+        mock_telemetry.mirror_to_s3 = mock_mirror
+
+        sys.modules["telemetry_upload"] = mock_telemetry
+        try:
+            log_summary(
+                state_dir,
+                total_iterations=1,
+                final_verdict="SHIP",
+                reviews=[],
+                agent_id="agent-ab4722a2",
+                issue_number=2647,
+            )
+        finally:
+            sys.modules.pop("telemetry_upload", None)
+
+        assert mock_mirror.called
+        call_args = mock_mirror.call_args
+        # First positional arg is the log file path
+        log_path_arg = call_args[0][0]
+        assert str(log_path_arg).endswith("review-log.jsonl")
+        # Second positional arg is the S3 key
+        s3_key_arg = call_args[0][1]
+        assert s3_key_arg.startswith("ralph-reviews/")
+        assert "agent-ab4722a2-2647.jsonl" in s3_key_arg
+
+    def test_skips_upload_when_agent_id_missing(self, state_dir: Path) -> None:
+        """S3 upload is skipped when agent_id is None."""
+        import sys
+        from unittest.mock import MagicMock
+
+        mock_mirror = MagicMock(return_value=True)
+        mock_telemetry = MagicMock()
+        mock_telemetry.mirror_to_s3 = mock_mirror
+
+        sys.modules["telemetry_upload"] = mock_telemetry
+        try:
+            log_summary(
+                state_dir,
+                total_iterations=1,
+                final_verdict="SHIP",
+                reviews=[],
+                agent_id=None,
+                issue_number=2647,
+            )
+        finally:
+            sys.modules.pop("telemetry_upload", None)
+
+        mock_mirror.assert_not_called()
+
+    def test_skips_upload_when_issue_number_missing(self, state_dir: Path) -> None:
+        """S3 upload is skipped when issue_number is None."""
+        import sys
+        from unittest.mock import MagicMock
+
+        mock_mirror = MagicMock(return_value=True)
+        mock_telemetry = MagicMock()
+        mock_telemetry.mirror_to_s3 = mock_mirror
+
+        sys.modules["telemetry_upload"] = mock_telemetry
+        try:
+            log_summary(
+                state_dir,
+                total_iterations=1,
+                final_verdict="SHIP",
+                reviews=[],
+                agent_id="agent-ab4722a2",
+                issue_number=None,
+            )
+        finally:
+            sys.modules.pop("telemetry_upload", None)
+
+        mock_mirror.assert_not_called()
+
+    def test_s3_failure_is_non_fatal(self, state_dir: Path) -> None:
+        """S3 upload failure does not raise and local log write still succeeds."""
+        import sys
+        from unittest.mock import MagicMock
+
+        mock_mirror = MagicMock(side_effect=RuntimeError("S3 exploded"))
+        mock_telemetry = MagicMock()
+        mock_telemetry.mirror_to_s3 = mock_mirror
+
+        sys.modules["telemetry_upload"] = mock_telemetry
+        try:
+            # Must not raise
+            log_summary(
+                state_dir,
+                total_iterations=1,
+                final_verdict="SHIP",
+                reviews=[],
+                agent_id="agent-ab4722a2",
+                issue_number=2647,
+            )
+        finally:
+            sys.modules.pop("telemetry_upload", None)
+
+        # Local write still happened
+        log_path = state_dir / "review-log.jsonl"
+        assert log_path.exists()
+        record = json.loads(log_path.read_text(encoding="utf-8").strip())
+        assert record["type"] == "summary"
+
+    def test_local_write_unchanged_when_upload_skipped(self, state_dir: Path) -> None:
+        """Local review-log.jsonl is written exactly as before regardless of upload."""
+        log_summary(
+            state_dir,
+            total_iterations=3,
+            final_verdict="SHIP",
+            reviews=[],
+            agent_id=None,
+            issue_number=None,
+        )
+        log_path = state_dir / "review-log.jsonl"
+        record = json.loads(log_path.read_text(encoding="utf-8").strip())
+        assert record["type"] == "summary"
+        assert record["total_iterations"] == 3
+        assert record["final_verdict"] == "SHIP"
+
 
 class TestReviewTimer:
     """Tests for ReviewTimer context manager."""

--- a/scripts/tests/test_telemetry_upload.py
+++ b/scripts/tests/test_telemetry_upload.py
@@ -1,0 +1,228 @@
+"""Tests for telemetry_upload module.
+
+Covers:
+- success returns True
+- ClientError from put_object returns False without raising
+- NoCredentialsError returns False without raising
+- ImportError (boto3 absent) returns False without raising
+- correct Bucket and Key are passed to put_object
+- bucket defaults to JUDGEMIND_TELEMETRY_BUCKET env var
+- bucket falls back to judgemind-document-archive-dev when env var absent
+
+telemetry_upload lazy-imports boto3 inside the function body, so we control
+boto3/botocore availability by manipulating sys.modules before each call.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Generator
+from unittest.mock import MagicMock
+
+import pytest
+
+# Add scripts directory to path so we can import the module
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import telemetry_upload  # noqa: E402
+
+
+def _make_botocore_exceptions(
+    client_error: type[Exception] | None = None,
+    endpoint_error: type[Exception] | None = None,
+    no_creds_error: type[Exception] | None = None,
+) -> MagicMock:
+    """Build a mock botocore.exceptions module with configurable exception types."""
+    mock_exc = MagicMock()
+    mock_exc.ClientError = client_error or Exception
+    mock_exc.EndpointConnectionError = endpoint_error or Exception
+    mock_exc.NoCredentialsError = no_creds_error or Exception
+    return mock_exc
+
+
+@pytest.fixture(autouse=True)
+def _restore_boto3_modules() -> Generator[None, None, None]:
+    """Ensure boto3/botocore are restored in sys.modules after each test."""
+    saved = {
+        k: sys.modules.get(k) for k in ("boto3", "botocore", "botocore.exceptions")
+    }
+    yield
+    for k, v in saved.items():
+        if v is None:
+            sys.modules.pop(k, None)
+        else:
+            sys.modules[k] = v
+
+
+class TestMirrorToS3:
+    """Tests for mirror_to_s3 function."""
+
+    def test_success_returns_true(self, tmp_path: Path) -> None:
+        """Successful put_object call returns True."""
+        local_file = tmp_path / "review-log.jsonl"
+        local_file.write_bytes(b'{"type": "summary"}\n')
+
+        mock_s3_client = MagicMock()
+        mock_boto3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3_client
+        mock_botocore_exc = _make_botocore_exceptions()
+
+        sys.modules["boto3"] = mock_boto3
+        sys.modules["botocore"] = MagicMock()
+        sys.modules["botocore.exceptions"] = mock_botocore_exc
+
+        result = telemetry_upload.mirror_to_s3(
+            local_file,
+            "ralph-reviews/2026-04-26/agent-abc-123.jsonl",
+            bucket="test-bucket",
+        )
+
+        assert result is True
+        mock_s3_client.put_object.assert_called_once()
+
+    def test_client_error_returns_false(self, tmp_path: Path) -> None:
+        """ClientError from put_object returns False without raising."""
+        local_file = tmp_path / "review-log.jsonl"
+        local_file.write_bytes(b'{"type": "summary"}\n')
+
+        class FakeClientError(Exception):
+            pass
+
+        mock_s3_client = MagicMock()
+        mock_s3_client.put_object.side_effect = FakeClientError("Access Denied")
+        mock_boto3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3_client
+        mock_botocore_exc = _make_botocore_exceptions(client_error=FakeClientError)
+
+        sys.modules["boto3"] = mock_boto3
+        sys.modules["botocore"] = MagicMock()
+        sys.modules["botocore.exceptions"] = mock_botocore_exc
+
+        result = telemetry_upload.mirror_to_s3(
+            local_file,
+            "ralph-reviews/2026-04-26/agent-abc-123.jsonl",
+            bucket="test-bucket",
+        )
+
+        assert result is False
+
+    def test_no_credentials_error_returns_false(self, tmp_path: Path) -> None:
+        """NoCredentialsError returns False without raising."""
+        local_file = tmp_path / "review-log.jsonl"
+        local_file.write_bytes(b'{"type": "summary"}\n')
+
+        class FakeNoCredentialsError(Exception):
+            pass
+
+        mock_s3_client = MagicMock()
+        mock_s3_client.put_object.side_effect = FakeNoCredentialsError("No creds")
+        mock_boto3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3_client
+        mock_botocore_exc = _make_botocore_exceptions(
+            no_creds_error=FakeNoCredentialsError
+        )
+
+        sys.modules["boto3"] = mock_boto3
+        sys.modules["botocore"] = MagicMock()
+        sys.modules["botocore.exceptions"] = mock_botocore_exc
+
+        result = telemetry_upload.mirror_to_s3(
+            local_file,
+            "ralph-reviews/2026-04-26/agent-abc-123.jsonl",
+            bucket="test-bucket",
+        )
+
+        assert result is False
+
+    def test_import_error_swallowed_when_boto3_absent(self, tmp_path: Path) -> None:
+        """ImportError when boto3 is absent returns False without raising."""
+        local_file = tmp_path / "review-log.jsonl"
+        local_file.write_bytes(b'{"type": "summary"}\n')
+
+        # Simulate boto3 being completely absent
+        sys.modules["boto3"] = None  # type: ignore[assignment]
+
+        result = telemetry_upload.mirror_to_s3(
+            local_file,
+            "ralph-reviews/2026-04-26/agent-abc-123.jsonl",
+            bucket="test-bucket",
+        )
+
+        assert result is False
+
+    def test_correct_bucket_and_key_passed(self, tmp_path: Path) -> None:
+        """Correct Bucket and Key are forwarded to put_object."""
+        local_file = tmp_path / "review-log.jsonl"
+        content = b'{"type": "review"}\n{"type": "summary"}\n'
+        local_file.write_bytes(content)
+
+        mock_s3_client = MagicMock()
+        mock_boto3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3_client
+        mock_botocore_exc = _make_botocore_exceptions()
+
+        sys.modules["boto3"] = mock_boto3
+        sys.modules["botocore"] = MagicMock()
+        sys.modules["botocore.exceptions"] = mock_botocore_exc
+
+        telemetry_upload.mirror_to_s3(
+            local_file,
+            "ralph-reviews/2026-04-26/agent-deadbeef-999.jsonl",
+            bucket="judgemind-document-archive-dev",
+        )
+
+        call_kwargs = mock_s3_client.put_object.call_args[1]
+        assert call_kwargs["Bucket"] == "judgemind-document-archive-dev"
+        assert call_kwargs["Key"] == "ralph-reviews/2026-04-26/agent-deadbeef-999.jsonl"
+        assert call_kwargs["Body"] == content
+
+    def test_default_bucket_from_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When bucket=None, uses JUDGEMIND_TELEMETRY_BUCKET env var."""
+        local_file = tmp_path / "review-log.jsonl"
+        local_file.write_bytes(b"test\n")
+        monkeypatch.setenv("JUDGEMIND_TELEMETRY_BUCKET", "my-custom-bucket")
+
+        mock_s3_client = MagicMock()
+        mock_boto3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3_client
+        mock_botocore_exc = _make_botocore_exceptions()
+
+        sys.modules["boto3"] = mock_boto3
+        sys.modules["botocore"] = MagicMock()
+        sys.modules["botocore.exceptions"] = mock_botocore_exc
+
+        telemetry_upload.mirror_to_s3(
+            local_file,
+            "ralph-reviews/2026-04-26/agent-deadbeef-999.jsonl",
+        )
+
+        call_kwargs = mock_s3_client.put_object.call_args[1]
+        assert call_kwargs["Bucket"] == "my-custom-bucket"
+
+    def test_default_bucket_fallback_when_env_absent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Falls back to judgemind-document-archive-dev when env var not set."""
+        local_file = tmp_path / "review-log.jsonl"
+        local_file.write_bytes(b"test\n")
+        monkeypatch.delenv("JUDGEMIND_TELEMETRY_BUCKET", raising=False)
+
+        mock_s3_client = MagicMock()
+        mock_boto3 = MagicMock()
+        mock_boto3.client.return_value = mock_s3_client
+        mock_botocore_exc = _make_botocore_exceptions()
+
+        sys.modules["boto3"] = mock_boto3
+        sys.modules["botocore"] = MagicMock()
+        sys.modules["botocore.exceptions"] = mock_botocore_exc
+
+        telemetry_upload.mirror_to_s3(
+            local_file,
+            "ralph-reviews/2026-04-26/agent-deadbeef-999.jsonl",
+        )
+
+        call_kwargs = mock_s3_client.put_object.call_args[1]
+        assert call_kwargs["Bucket"] == "judgemind-document-archive-dev"


### PR DESCRIPTION
## Summary

Added best-effort S3 mirroring of ralph review logs (`review-log.jsonl`) for durable observability and historical audit trail. Review logs now automatically upload to S3 after each successful ralph run and as a fallback during worktree teardown, enabling data retention and post-mortem analysis of review loops.

Closes #2647

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] (post-deploy) Run the dispatcher in dev mode and observe that ralph runs produce new objects in S3 at `s3://judgemind-document-archive-dev/ralph-reviews/<YYYY-MM-DD>/<agent-id>-<issue>.jsonl`
- [ ] (post-deploy) Verify key format: agent-id is worktree basename (agent-*), issue number is GitHub issue number
- [ ] (post-deploy) Confirm worktree teardown on interrupted/stuck runs also uploads fallback via cleanup_worktree.sh
- [ ] (post-deploy) Verify no backfill: S3 contents from before this deploy are untouched; only new runs produce objects
- [ ] Verification evidence posted on #2647 (see /task-v2-verify output)

## Implementation notes

- **No backfill:** All prior review logs have been destroyed per the original issue scope. S3 contents start empty on deploy.
- **Error handling:** S3 upload failures (network, credentials, missing boto3) are logged as warnings and never block the ralph loop or worktree teardown.
- **Local behavior unchanged:** The local `{worktree}/tmp/ralph/review-log.jsonl` file is written exactly as before. In-loop reads (dissent-detection logic) continue to read from the local file.
- **Lazy import:** `telemetry_upload` is lazy-imported so the `ralph_review_log` module remains stdlib-only when the upload path is not exercised (e.g., calls to `detect_persistent_dissent`).