### PR TITLE
scripts(cleanup): one-off OC fused-title cleanup orchestrator with post-rebuild verification (#2522)

### DIFF
--- a/scripts/cleanup_oc_fused_titles_2522.py
+++ b/scripts/cleanup_oc_fused_titles_2522.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Clean up 98 fused OC case_titles by rebuilding derived.* for Orange County.
+
+The LLM extractor bug (fixed in PR #2515) caused multi-case PDFs in Orange
+County to produce a single fused case_title like "Smith v. Jones v. Brown"
+instead of two separate rulings.  Now that rebuild_db.py routes raw PDFs
+through the post-fix splitter (_split_fused_case_info), a clean
+--reset --county Orange rebuild re-derives correctly-split rulings.
+
+Dry-run by default; pass --apply to execute the rebuild.
+
+Usage (via ECS):
+    scripts/ecs-run-task.sh --cpu 2048 --memory 8192 \\
+        scripts/cleanup_oc_fused_titles_2522.py -- --apply
+"""
+
+# venv: scraper-framework
+# one-off: true
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+
+import psycopg
+import structlog
+
+from framework.logging import configure_structlog
+
+configure_structlog()
+logger = structlog.get_logger()
+
+# Acceptance-criterion SQL (AC#2):
+# returns the count of OC rulings whose case_title contains a double-v pattern
+# indicating a fused multi-case title.
+_FUSED_TITLE_SQL = r"""
+SELECT COUNT(*) FROM derived.documents d
+JOIN derived.courts ct ON ct.id = d.court_id
+JOIN derived.rulings r ON r.document_id = d.id
+LEFT JOIN derived.cases c ON c.id = r.case_id
+WHERE ct.county ILIKE '%orange%'
+AND c.case_title ~* '\sv[s]?\.?\s.+\sv[s]?\.?\s'
+"""
+
+# Spot-check content_hash prefixes from the issue body (documented fused docs).
+_SPOT_CHECK_PREFIXES = ("1578e425", "37ef41f8", "bec66550")
+
+_SPOT_CHECK_SQL = """
+SELECT COUNT(DISTINCT r.case_id) FROM derived.documents d
+JOIN derived.rulings r ON r.document_id = d.id
+WHERE d.content_hash LIKE %s
+"""
+
+
+def _count_fused(conn: psycopg.Connection) -> int:
+    with conn.cursor() as cur:
+        cur.execute(_FUSED_TITLE_SQL)
+        return cur.fetchone()[0]
+
+
+def _spot_check(conn: psycopg.Connection) -> None:
+    for prefix in _SPOT_CHECK_PREFIXES:
+        with conn.cursor() as cur:
+            cur.execute(_SPOT_CHECK_SQL, (prefix + "%",))
+            distinct_cases = cur.fetchone()[0]
+        logger.info(
+            "spot_check",
+            content_hash_prefix=prefix,
+            distinct_case_ids=distinct_cases,
+        )
+        assert distinct_cases >= 2, (
+            f"Expected >= 2 distinct case_ids for hash prefix {prefix!r}, "
+            f"got {distinct_cases}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        default=False,
+        help="Execute the rebuild (default: dry-run only).",
+    )
+    parser.add_argument(
+        "--rebuild-script",
+        default="scripts/rebuild_db.py",
+        help="Path to rebuild_db.py (injectable for testing).",
+    )
+    args = parser.parse_args()
+
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        logger.error("DATABASE_URL not set")
+        sys.exit(2)
+
+    with psycopg.connect(db_url) as conn:
+        # Step 1: count fused OC titles
+        baseline = _count_fused(conn)
+        logger.info("fused_title_baseline", count=baseline)
+
+        # Step 2: already clean?
+        if baseline == 0:
+            logger.info(
+                "already_clean", message="No fused OC titles found — nothing to do."
+            )
+            return 0
+
+        # Step 3: dry-run
+        rebuild_cmd = [
+            sys.executable,
+            args.rebuild_script,
+            "--county",
+            "Orange",
+            "--reset",
+        ]
+        if not args.apply:
+            logger.info(
+                "dry_run",
+                fused_count=baseline,
+                would_run=" ".join(rebuild_cmd),
+            )
+            return 0
+
+        # Step 4: execute rebuild
+        logger.info("running_rebuild", cmd=rebuild_cmd)
+        subprocess.run(rebuild_cmd, check=True)
+
+        # Step 5: re-count and verify
+        post_count = _count_fused(conn)
+        logger.info("post_rebuild_count", count=post_count)
+        if post_count != 0:
+            raise RuntimeError(
+                f"Rebuild completed but {post_count} fused OC titles remain. "
+                "Manual investigation required."
+            )
+
+        # Step 6: spot-check three known content_hash prefixes
+        _spot_check(conn)
+
+    logger.info("cleanup_complete", status="ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_cleanup_oc_fused_titles_2522.py
+++ b/scripts/tests/test_cleanup_oc_fused_titles_2522.py
@@ -1,0 +1,239 @@
+"""Tests for cleanup_oc_fused_titles_2522 script.
+
+Tests cover:
+- baseline zero skips rebuild (already_clean)
+- dry-run skips rebuild (no --apply)
+- --apply invokes rebuild and verifies post-count
+- --apply raises RuntimeError when post-count is nonzero
+- spot-check queries all three content_hash prefixes
+- count SQL contains the exact regex acceptance criterion
+
+The script depends on psycopg and structlog, which are not available in the
+lightweight CI scripts-tests environment. We mock them in sys.modules before
+importing the script under test.
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Pre-import mocking — the script imports psycopg and structlog at module
+# level, which are not installed in the CI scripts-tests environment.
+# ---------------------------------------------------------------------------
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+_mock_psycopg = MagicMock()
+_mock_structlog = MagicMock()
+_mock_framework_logging = MagicMock()
+
+_modules_to_mock = {
+    "psycopg": _mock_psycopg,
+    "structlog": _mock_structlog,
+    "framework": MagicMock(),
+    "framework.logging": _mock_framework_logging,
+}
+
+_saved_modules: dict[str, object] = {}
+for _mod_name, _mock_mod in _modules_to_mock.items():
+    if _mod_name in sys.modules:
+        _saved_modules[_mod_name] = sys.modules[_mod_name]
+    sys.modules[_mod_name] = _mock_mod
+
+import cleanup_oc_fused_titles_2522  # noqa: E402
+
+# Restore sys.modules so mock injection doesn't pollute other test files.
+for _mod_name in list(_modules_to_mock.keys()):
+    if _mod_name in _saved_modules:
+        sys.modules[_mod_name] = _saved_modules[_mod_name]
+    elif _mod_name in sys.modules:
+        del sys.modules[_mod_name]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FUSED_COUNT_SQL_FRAGMENT = r"\sv[s]?\.?\s.+\sv[s]?\.?\s"
+_SPOT_CHECK_HASHES = ("1578e425", "37ef41f8", "bec66550")
+
+
+def _make_cursor_mock(side_effects: list) -> MagicMock:
+    """Return a cursor mock whose fetchone() returns items from side_effects."""
+    cur = MagicMock()
+    cur.fetchone.side_effect = side_effects
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    return cur
+
+
+def _make_conn_mock(cursor_mock: MagicMock) -> MagicMock:
+    conn = MagicMock()
+    conn.cursor.return_value = cursor_mock
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Test 1: baseline zero — skips rebuild, exits 0
+# ---------------------------------------------------------------------------
+
+
+def test_baseline_zero_skips_rebuild() -> None:
+    """When baseline count is 0, exits 0 and never calls subprocess.run."""
+    # fetchone() returns count=0 for the fused-title query
+    cur = _make_cursor_mock([(0,)])
+    conn = _make_conn_mock(cur)
+
+    with patch("cleanup_oc_fused_titles_2522.psycopg") as mock_psycopg:
+        mock_psycopg.connect.return_value = conn
+        with patch("cleanup_oc_fused_titles_2522.subprocess") as mock_subprocess:
+            with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+                with patch("sys.argv", ["cleanup_oc_fused_titles_2522.py"]):
+                    result = cleanup_oc_fused_titles_2522.main()
+
+    assert result == 0
+    mock_subprocess.run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: dry-run (no --apply) — skips rebuild, exits 0
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_skips_rebuild() -> None:
+    """Without --apply, even with baseline > 0, subprocess.run is not called."""
+    cur = _make_cursor_mock([(42,)])
+    conn = _make_conn_mock(cur)
+
+    with patch("cleanup_oc_fused_titles_2522.psycopg") as mock_psycopg:
+        mock_psycopg.connect.return_value = conn
+        with patch("cleanup_oc_fused_titles_2522.subprocess") as mock_subprocess:
+            with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+                with patch("sys.argv", ["cleanup_oc_fused_titles_2522.py"]):
+                    result = cleanup_oc_fused_titles_2522.main()
+
+    assert result == 0
+    mock_subprocess.run.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: --apply invokes rebuild with correct args and verifies post-count 0
+# ---------------------------------------------------------------------------
+
+
+def test_apply_invokes_rebuild_and_verifies() -> None:
+    """With --apply, subprocess.run is called with --county Orange --reset, exits 0."""
+    # First fetchone: baseline count=5; subsequent fetchones for re-count + spot-check
+    spot_check_returns = [(2,), (3,), (2,)]  # three hashes, all >= 2
+    cur = _make_cursor_mock(
+        [(5,), (0,)] + spot_check_returns  # baseline=5, post-rebuild=0
+    )
+    conn = _make_conn_mock(cur)
+
+    with patch("cleanup_oc_fused_titles_2522.psycopg") as mock_psycopg:
+        mock_psycopg.connect.return_value = conn
+        with patch("cleanup_oc_fused_titles_2522.subprocess") as mock_subprocess:
+            mock_subprocess.run.return_value = MagicMock(returncode=0)
+            with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+                with patch(
+                    "sys.argv",
+                    ["cleanup_oc_fused_titles_2522.py", "--apply"],
+                ):
+                    result = cleanup_oc_fused_titles_2522.main()
+
+    assert result == 0
+    # Verify subprocess.run was called with --county Orange --reset
+    assert mock_subprocess.run.call_count == 1
+    call_args = mock_subprocess.run.call_args[0][0]  # positional list arg
+    assert "--county" in call_args
+    assert "Orange" in call_args
+    assert "--reset" in call_args
+
+
+# ---------------------------------------------------------------------------
+# Test 4: --apply raises RuntimeError when post-rebuild count is nonzero
+# ---------------------------------------------------------------------------
+
+
+def test_apply_raises_when_post_count_nonzero() -> None:
+    """RuntimeError raised when post-rebuild fused count is still > 0."""
+    cur = _make_cursor_mock([(10,), (3,)])  # baseline=10, post-rebuild=3 (still dirty)
+    conn = _make_conn_mock(cur)
+
+    with patch("cleanup_oc_fused_titles_2522.psycopg") as mock_psycopg:
+        mock_psycopg.connect.return_value = conn
+        with patch("cleanup_oc_fused_titles_2522.subprocess") as mock_subprocess:
+            mock_subprocess.run.return_value = MagicMock(returncode=0)
+            with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+                with patch(
+                    "sys.argv",
+                    ["cleanup_oc_fused_titles_2522.py", "--apply"],
+                ):
+                    with pytest.raises(RuntimeError):
+                        cleanup_oc_fused_titles_2522.main()
+
+
+# ---------------------------------------------------------------------------
+# Test 5: spot-check queries all three content_hash prefixes
+# ---------------------------------------------------------------------------
+
+
+def test_spot_check_queries_three_hashes() -> None:
+    """After rebuild, the script queries each of the three content_hash prefixes."""
+    spot_check_returns = [(2,), (2,), (2,)]
+    cur = _make_cursor_mock([(5,), (0,)] + spot_check_returns)
+    conn = _make_conn_mock(cur)
+
+    with patch("cleanup_oc_fused_titles_2522.psycopg") as mock_psycopg:
+        mock_psycopg.connect.return_value = conn
+        with patch("cleanup_oc_fused_titles_2522.subprocess") as mock_subprocess:
+            mock_subprocess.run.return_value = MagicMock(returncode=0)
+            with patch.dict(os.environ, {"DATABASE_URL": "postgresql://test"}):
+                with patch(
+                    "sys.argv",
+                    ["cleanup_oc_fused_titles_2522.py", "--apply"],
+                ):
+                    cleanup_oc_fused_titles_2522.main()
+
+    # There should have been exactly 5 fetchone calls:
+    # 1 baseline, 1 post-rebuild count, 3 spot-check hashes
+    assert cur.fetchone.call_count == 5
+
+    # Verify each hash prefix appeared in execute() calls
+    execute_calls = cur.execute.call_args_list
+    executed_sql_and_params = [
+        (str(c[0][0]) if c[0] else "", c[0][1] if len(c[0]) > 1 else ())
+        for c in execute_calls
+    ]
+    for prefix in _SPOT_CHECK_HASHES:
+        found = any(
+            prefix in str(param)
+            for _, params in executed_sql_and_params
+            for param in (params if isinstance(params, (list, tuple)) else [params])
+        )
+        assert found, f"Hash prefix {prefix!r} not found in any DB execute call"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: count SQL contains the exact regex from AC#2
+# ---------------------------------------------------------------------------
+
+
+def test_count_sql_matches_acceptance_criterion() -> None:
+    r"""The SQL used to count fused titles contains the exact regex pattern.
+
+    The acceptance criterion requires the regex: \sv[s]?\.?\s.+\sv[s]?\.?\s
+    """
+    source = inspect.getsource(cleanup_oc_fused_titles_2522)
+    assert _FUSED_COUNT_SQL_FRAGMENT in source, (
+        f"Expected SQL fragment {_FUSED_COUNT_SQL_FRAGMENT!r} not found in source. "
+        "The count SQL must match the acceptance criterion exactly."
+    )


### PR DESCRIPTION
## Summary

Created `scripts/cleanup_oc_fused_titles_2522.py` — a one-off ECS orchestrator for cleaning up 98 fused Orange County case-titles on dev. Defaults to dry-run; with `--apply` runs `rebuild_db.py --county Orange --reset` to re-derive correctly-split rulings through the post-fix LLM splitter (PR #2515). Includes spot-checks on three known problematic content_hash prefixes to verify the rebuild produced distinct case_ids per ruling.

Closes #2522

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`) — 6 passing tests
- [x] CI green

### Post-deploy verification

- [ ] Run script with `--apply` on dev database
- [ ] Verify fused-title count query returns 0
- [ ] Confirm spot-checked documents have 2+ distinct case_ids
- [ ] Verification evidence posted on #2522 (see /task-v2-verify output)