### PR TITLE
fix(dispatcher): write verify/retro phase input to phase-aligned IO root (#3468)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -6278,35 +6278,98 @@ class DispatcherDaemon:
         match = re.search(r"(?im)^\s*parent\s*:\s*#(\d+)\s*$", body)
         return int(match.group(1)) if match else None
 
+    def _phase_io_root(self, worktree: Path, phase: str) -> Path:
+        """Return the filesystem root that the phase subprocess will treat as cwd.
+
+        Mirrors the cwd-selection logic in :meth:`_spawn_phase_subprocess` so
+        that input/output JSON paths are always aligned with the subprocess's
+        working directory.  Post-merge phases (``verify``, ``retro``) run with
+        ``cwd=baseline_repo_root`` in Fargate mode; all other phases run with
+        ``cwd=worktree``.  Using this helper instead of a bare ``worktree``
+        reference in :meth:`_write_phase_input` and :meth:`_read_phase_output`
+        keeps the two policies in sync and prevents the path-misalignment that
+        caused ``verify_infra_failure_post_merge`` + ``phase_output_missing``
+        (#3468).
+        """
+        if (
+            phase in POST_MERGE_PHASES_USING_BASELINE_CWD
+            and self._cfg.baseline_repo_root is not None
+        ):
+            return self._cfg.baseline_repo_root
+        return worktree
+
     def _write_phase_input(
         self,
         worktree: Path,
         phase: str,
         payload: dict[str, Any],
     ) -> Path:
-        """Write ``{worktree}/tmp/dispatcher-input/<phase>.json``.
+        """Write the phase input JSON under the IO root for this phase.
 
-        Creates parent dirs. Returns the absolute path for logging.
+        For post-merge phases (``verify``, ``retro``) in Fargate mode the
+        primary write target is ``{baseline_repo_root}/tmp/dispatcher-input/
+        <phase>.json`` — that is the path the subprocess's cwd will resolve
+        to when it reads ``tmp/dispatcher-input/<phase>.json``.  The file is
+        also written to ``{worktree}/tmp/dispatcher-input/<phase>.json`` so
+        that acceptance criteria that check the worktree path continue to pass
+        and so that local-dev fixtures (where both roots are the same) keep
+        working unchanged.
+
+        For pre-merge phases the two writes land on the same path (IO root ==
+        worktree), so the dual-write is harmless.
+
+        Creates parent dirs. Returns the primary (IO-root-relative) path for
+        logging.
         """
-        input_dir = worktree / "tmp" / "dispatcher-input"
-        input_dir.mkdir(parents=True, exist_ok=True)
-        input_path = input_dir / f"{phase}.json"
-        input_path.write_text(json.dumps(payload, indent=2, default=str))
-        return input_path
+        payload_text = json.dumps(payload, indent=2, default=str)
+
+        # Primary write — under the IO root the subprocess will use.
+        io_root = self._phase_io_root(worktree, phase)
+        primary_dir = io_root / "tmp" / "dispatcher-input"
+        primary_dir.mkdir(parents=True, exist_ok=True)
+        primary_path = primary_dir / f"{phase}.json"
+        primary_path.write_text(payload_text)
+
+        # Belt-and-suspenders write — always keep a copy under the worktree so
+        # callers that reference the worktree path directly (e.g. acceptance
+        # tests, ECS entrypoint) continue to find the file.
+        if io_root != worktree:
+            worktree_dir = worktree / "tmp" / "dispatcher-input"
+            worktree_dir.mkdir(parents=True, exist_ok=True)
+            (worktree_dir / f"{phase}.json").write_text(payload_text)
+
+        return primary_path
 
     def _read_phase_output(self, worktree: Path, phase: str) -> dict[str, Any] | None:
-        """Read ``{worktree}/tmp/dispatcher-output/<phase>.json``.
+        """Read the phase output JSON, preferring the IO root over the worktree.
+
+        For post-merge phases (``verify``, ``retro``) in Fargate mode the
+        subprocess writes output relative to ``baseline_repo_root`` (its cwd).
+        Prefer that path; fall back to the worktree-relative path so ECS-mode
+        agents (where both paths coincide) and pre-merge phases continue to
+        work unchanged.
 
         Returns the parsed JSON, or ``None`` if the file is missing /
         malformed (the caller treats that as a phase failure).
         """
-        output_path = worktree / "tmp" / "dispatcher-output" / f"{phase}.json"
-        if not output_path.exists():
-            return None
-        try:
-            return json.loads(output_path.read_text())
-        except json.JSONDecodeError:
-            return None
+        io_root = self._phase_io_root(worktree, phase)
+        primary_path = io_root / "tmp" / "dispatcher-output" / f"{phase}.json"
+        if primary_path.exists():
+            try:
+                return json.loads(primary_path.read_text())
+            except json.JSONDecodeError:
+                return None
+
+        # Fall back to worktree path (covers ECS mode and local dev where the
+        # io_root IS the worktree, and therefore primary_path == fallback_path).
+        fallback_path = worktree / "tmp" / "dispatcher-output" / f"{phase}.json"
+        if fallback_path.exists() and fallback_path != primary_path:
+            try:
+                return json.loads(fallback_path.read_text())
+            except json.JSONDecodeError:
+                return None
+
+        return None
 
     def _persist_phase_output(
         self,
@@ -11263,7 +11326,8 @@ class DispatcherDaemon:
             "issue_number": issue_number,
             "issue_title": bundle.get("issue_title", ""),
             "issue_body": bundle.get("issue_body", ""),
-            "collapsed_comments": plan_output.get("collapsed_comments") or bundle.get("issue_comments", []),
+            "collapsed_comments": plan_output.get("collapsed_comments")
+            or bundle.get("issue_comments", []),
             "ralph_summary": ralph_output.get("summary", ""),
             "changed_files": changed_files,
             "git_diff": git_diff,

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -2078,3 +2078,146 @@ class TestVerifyRecoveryShortCircuit:
         assert handle_failure_calls[0]["category"] == (
             daemon.FAILURE_CATEGORY_PHASE_OUTPUT_MISSING
         )
+
+
+# --------------------------------------------------------------------------
+# #3468 — _phase_io_root / _write_phase_input / _read_phase_output alignment
+# --------------------------------------------------------------------------
+
+
+class TestVerifyPhaseIoRoot:
+    """Issue #3468 — post-merge phases (verify, retro) run with
+    ``cwd=baseline_repo_root`` in Fargate mode, but the pre-#3468 IO
+    helpers always wrote/read relative to the worktree.  The helpers now
+    use :meth:`~daemon.DispatcherDaemon._phase_io_root` to select the
+    correct root so paths stay aligned with the subprocess cwd.
+
+    Tests in this class cover the verify phase; the retro-phase mirror
+    lives in ``test_daemon_phase3e.TestRetroPhaseIoRoot``."""
+
+    def test_verify_input_written_to_baseline_repo_root_for_post_merge_subprocess(
+        self, tmp_path: Path
+    ) -> None:
+        """In Fargate mode (``baseline_repo_root`` set) the input JSON for
+        ``verify`` must be written under ``{baseline_repo_root}/tmp/
+        dispatcher-input/verify.json`` — that is the path the subprocess
+        resolves when it reads ``tmp/dispatcher-input/verify.json`` from its
+        cwd."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        d._cfg.baseline_repo_root = baseline
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        payload = {"pr_number": 42, "agent_id": "test-agent"}
+        d._write_phase_input(worktree, "verify", payload)
+
+        expected = baseline / "tmp" / "dispatcher-input" / "verify.json"
+        assert expected.exists(), (
+            f"Input JSON must be written to baseline_repo_root: {expected}"
+        )
+        assert json.loads(expected.read_text()) == payload
+
+    def test_verify_input_also_present_in_worktree_for_post_merge(
+        self, tmp_path: Path
+    ) -> None:
+        """Belt-and-suspenders: ``_write_phase_input`` for a post-merge
+        phase must ALSO write to ``{worktree}/tmp/dispatcher-input/
+        verify.json`` so that acceptance-criteria checks that look at the
+        worktree path continue to pass (AC #1)."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        d._cfg.baseline_repo_root = baseline
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        payload = {"pr_number": 42, "agent_id": "test-agent"}
+        d._write_phase_input(worktree, "verify", payload)
+
+        wt_path = worktree / "tmp" / "dispatcher-input" / "verify.json"
+        assert wt_path.exists(), (
+            f"Input JSON must also be written to worktree for AC #1: {wt_path}"
+        )
+        assert json.loads(wt_path.read_text()) == payload
+
+    def test_verify_read_phase_output_prefers_baseline_root(
+        self, tmp_path: Path
+    ) -> None:
+        """When the verify subprocess writes its output to
+        ``{baseline_repo_root}/tmp/dispatcher-output/verify.json``
+        (because cwd=baseline_repo_root), ``_read_phase_output`` must
+        return that content rather than returning ``None`` because the
+        worktree-relative path is empty."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        d._cfg.baseline_repo_root = baseline
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        # Write output only at the baseline path — worktree path is absent.
+        out_dir = baseline / "tmp" / "dispatcher-output"
+        out_dir.mkdir(parents=True)
+        expected_output = {"verdict": "VERIFIED", "evidence": "curl 200"}
+        (out_dir / "verify.json").write_text(json.dumps(expected_output))
+
+        result = d._read_phase_output(worktree, "verify")
+        assert result == expected_output, (
+            f"_read_phase_output must prefer the baseline-root path; got {result!r}"
+        )
+
+    def test_verify_read_phase_output_falls_back_to_worktree(
+        self, tmp_path: Path
+    ) -> None:
+        """Fallback: when the baseline-root output file is absent (e.g. ECS
+        mode where subprocess writes relative to worktree), ``_read_phase_output``
+        must return the worktree-relative file's contents."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        # No baseline_repo_root → local-dev / ECS mode.
+        assert d._cfg.baseline_repo_root is None
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        out_dir = worktree / "tmp" / "dispatcher-output"
+        out_dir.mkdir(parents=True)
+        expected_output = {"verdict": "VERIFIED", "evidence": "log line"}
+        (out_dir / "verify.json").write_text(json.dumps(expected_output))
+
+        result = d._read_phase_output(worktree, "verify")
+        assert result == expected_output, (
+            f"_read_phase_output must fall back to worktree path; got {result!r}"
+        )
+
+    def test_plan_input_only_written_to_worktree_not_baseline(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression guard: non-post-merge phases (``plan``) must NOT
+        dual-write to ``baseline_repo_root``.  Only the worktree path is
+        written, so the IO-root selection has no side-effect on pre-merge
+        phases even when ``baseline_repo_root`` is configured."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        d._cfg.baseline_repo_root = baseline
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        payload = {"issue_number": 99}
+        d._write_phase_input(worktree, "plan", payload)
+
+        # Worktree path written.
+        wt_path = worktree / "tmp" / "dispatcher-input" / "plan.json"
+        assert wt_path.exists(), f"Plan input must be written to worktree: {wt_path}"
+
+        # Baseline path must NOT be written for a pre-merge phase.
+        baseline_path = baseline / "tmp" / "dispatcher-input" / "plan.json"
+        assert not baseline_path.exists(), (
+            f"Plan input must NOT be written to baseline_repo_root: {baseline_path}"
+        )

--- a/scripts/dispatcher/tests/test_daemon_phase3e.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3e.py
@@ -1259,3 +1259,106 @@ class TestDiagnosisOutcomeWriteback:
         d._mark_agent_terminal("agent-1", status="succeeded", phase="done", exit_code=0)
         # Failure event logged.
         assert handler.events("diagnosis_outcome_update_failed")
+
+
+# --------------------------------------------------------------------------
+# #3468 — _phase_io_root / _write_phase_input / _read_phase_output alignment
+#          (retro phase mirror of test_daemon_phase3b.TestVerifyPhaseIoRoot)
+# --------------------------------------------------------------------------
+
+
+class TestRetroPhaseIoRoot:
+    """Issue #3468 — retro is a post-merge phase and shares the same
+    IO-root misalignment bug as verify.  These tests mirror
+    ``test_daemon_phase3b.TestVerifyPhaseIoRoot`` for the ``retro`` phase."""
+
+    def test_retro_input_written_to_baseline_repo_root_for_post_merge_subprocess(
+        self, tmp_path: Path
+    ) -> None:
+        """In Fargate mode (``baseline_repo_root`` set) the input JSON for
+        ``retro`` must be written under ``{baseline_repo_root}/tmp/
+        dispatcher-input/retro.json`` — the path the subprocess resolves
+        from its cwd."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        d._cfg.baseline_repo_root = baseline
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        payload = {"agent_id": "retro-test", "issue_number": 777}
+        d._write_phase_input(worktree, "retro", payload)
+
+        expected = baseline / "tmp" / "dispatcher-input" / "retro.json"
+        assert expected.exists(), (
+            f"Retro input JSON must be written to baseline_repo_root: {expected}"
+        )
+        assert json.loads(expected.read_text()) == payload
+
+    def test_retro_input_also_present_in_worktree_for_post_merge(
+        self, tmp_path: Path
+    ) -> None:
+        """Belt-and-suspenders: the worktree copy must also be written so
+        acceptance-criteria checks referencing the worktree path pass (AC #4)."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        d._cfg.baseline_repo_root = baseline
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        payload = {"agent_id": "retro-test", "issue_number": 777}
+        d._write_phase_input(worktree, "retro", payload)
+
+        wt_path = worktree / "tmp" / "dispatcher-input" / "retro.json"
+        assert wt_path.exists(), (
+            f"Retro input JSON must also be written to worktree: {wt_path}"
+        )
+        assert json.loads(wt_path.read_text()) == payload
+
+    def test_retro_read_phase_output_prefers_baseline_root(
+        self, tmp_path: Path
+    ) -> None:
+        """When the retro subprocess writes output to
+        ``{baseline_repo_root}/tmp/dispatcher-output/retro.json`` (cwd=baseline),
+        ``_read_phase_output`` must return that content."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        baseline = tmp_path / "baseline"
+        baseline.mkdir()
+        d._cfg.baseline_repo_root = baseline
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        out_dir = baseline / "tmp" / "dispatcher-output"
+        out_dir.mkdir(parents=True)
+        expected_output = {"issues_to_file": [{"title": "Follow-up A"}]}
+        (out_dir / "retro.json").write_text(json.dumps(expected_output))
+
+        result = d._read_phase_output(worktree, "retro")
+        assert result == expected_output, (
+            f"_read_phase_output must prefer baseline-root for retro; got {result!r}"
+        )
+
+    def test_retro_read_phase_output_falls_back_to_worktree(
+        self, tmp_path: Path
+    ) -> None:
+        """Fallback: when baseline-root file is absent (local-dev / ECS),
+        ``_read_phase_output`` must return the worktree-relative content."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        assert d._cfg.baseline_repo_root is None
+
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+
+        out_dir = worktree / "tmp" / "dispatcher-output"
+        out_dir.mkdir(parents=True)
+        expected_output = {"issues_to_file": []}
+        (out_dir / "retro.json").write_text(json.dumps(expected_output))
+
+        result = d._read_phase_output(worktree, "retro")
+        assert result == expected_output, (
+            f"_read_phase_output must fall back to worktree for retro; got {result!r}"
+        )


### PR DESCRIPTION
## Summary

Post-merge phases (verify, retro) run with `cwd=baseline_repo_root` in Fargate mode, but the phase I/O helpers always wrote/read relative to the worktree path. This caused the daemon to write input JSON to the wrong filesystem location, making it impossible for the verify and retro skills to find their input files. Every daemon green was silently skipping verification.

Added `_phase_io_root()` helper that mirrors the subprocess cwd-selection logic from `_spawn_phase_subprocess()`. Post-merge phases now dual-write their input JSON: primary write to IO root (where subprocess cwd resolves to), belt-and-suspenders copy to worktree (backwards compatibility). Output reads prefer the IO-root path with fallback to worktree.

Closes #3468

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
- [x] CI green

### Post-deploy verification

- [ ] Monitor 5 daemon greens post-merge to confirm `verify_infra_failure_post_merge` count = 0 (AC #5)
- [ ] Verify skill produces real verdict with evidence instead of input-missing fallback (AC #2)
- [ ] Retro skill receives input file and emits proper findings (AC #4)
- [ ] Verification evidence posted on #3468 (see /task-v2-verify output)