### PR TITLE
fix(infra): add s3:PutObject and ecs:ListTasks to dispatcher-agent-runner role (#3472)

### DIFF
--- a/infra/terraform/environments/dev/.terraform.lock.hcl
+++ b/infra/terraform/environments/dev/.terraform.lock.hcl
@@ -28,7 +28,9 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.8.1"
   hashes = [
+    "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
     "h1:u8AKlWVDTH5r9YLSeswoVEjiY72Rt4/ch7U+61ZDkiQ=",
+    "h1:wxTpDeGDDAX7NqoazTc5qVQQiGHuhQHdS9a42h0Bir8=",
     "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
     "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",
     "zh:229665ddf060aa0ed315597908483eee5b818a17d09b6417a0f52fd9405c4f57",

--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -383,6 +383,7 @@ module "dispatcher_agent_runner" {
   spotcheck_oneshot_source_execution_role_arn = module.compute.task_execution_role_arn
   spotcheck_ecs_cluster_arn                   = module.compute.cluster_arn
   spotcheck_document_archive_bucket_arn       = module.document_archive.bucket_arn
+  spotcheck_oneshot_script_bucket_arn         = "arn:aws:s3:::judgemind-assets-dev"
 }
 
 output "ecr_repository_url" {

--- a/infra/terraform/modules/dispatcher-agent-runner/main.tf
+++ b/infra/terraform/modules/dispatcher-agent-runner/main.tf
@@ -317,136 +317,166 @@ resource "aws_iam_role_policy" "task_spotcheck_oneshot" {
 
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
-      {
-        # Register a fresh oneshot task definition for each /spotcheck
-        # invocation. AWS does not accept ARN scoping on this action.
-        Sid      = "AllowRegisterOneshotTaskDefinition"
-        Effect   = "Allow"
-        Action   = "ecs:RegisterTaskDefinition"
-        Resource = "*"
-      },
-      {
-        Sid      = "AllowDeregisterOneshotTaskDefinition"
-        Effect   = "Allow"
-        Action   = "ecs:DeregisterTaskDefinition"
-        Resource = local.spotcheck_oneshot_family_arn_pattern
-      },
-      {
-        # Source-task-def read (template) + freshly registered oneshot
-        # task-def read. AWS requires `*` on this action.
-        Sid      = "AllowDescribeOneshotTaskDefinitions"
-        Effect   = "Allow"
-        Action   = "ecs:DescribeTaskDefinition"
-        Resource = "*"
-      },
-      {
-        # Launch the oneshot, scoped to the dev oneshot family on this
-        # cluster only.
-        Sid      = "AllowRunOneshotTask"
-        Effect   = "Allow"
-        Action   = "ecs:RunTask"
-        Resource = local.spotcheck_oneshot_family_arn_pattern
-        Condition = {
-          ArnEquals = {
-            "ecs:cluster" = var.spotcheck_ecs_cluster_arn
+    Statement = concat(
+      [
+        {
+          # Register a fresh oneshot task definition for each /spotcheck
+          # invocation. AWS does not accept ARN scoping on this action.
+          Sid      = "AllowRegisterOneshotTaskDefinition"
+          Effect   = "Allow"
+          Action   = "ecs:RegisterTaskDefinition"
+          Resource = "*"
+        },
+        {
+          Sid      = "AllowDeregisterOneshotTaskDefinition"
+          Effect   = "Allow"
+          Action   = "ecs:DeregisterTaskDefinition"
+          Resource = local.spotcheck_oneshot_family_arn_pattern
+        },
+        {
+          # Source-task-def read (template) + freshly registered oneshot
+          # task-def read. AWS requires `*` on this action.
+          Sid      = "AllowDescribeOneshotTaskDefinitions"
+          Effect   = "Allow"
+          Action   = "ecs:DescribeTaskDefinition"
+          Resource = "*"
+        },
+        {
+          # Launch the oneshot, scoped to the dev oneshot family on this
+          # cluster only.
+          Sid      = "AllowRunOneshotTask"
+          Effect   = "Allow"
+          Action   = "ecs:RunTask"
+          Resource = local.spotcheck_oneshot_family_arn_pattern
+          Condition = {
+            ArnEquals = {
+              "ecs:cluster" = var.spotcheck_ecs_cluster_arn
+            }
           }
-        }
-      },
-      {
-        # Stop a hung oneshot if /spotcheck times out (the launcher's
-        # cleanup path uses StopTask before exiting).
-        Sid      = "AllowStopOneshotTask"
-        Effect   = "Allow"
-        Action   = "ecs:StopTask"
-        Resource = local.spotcheck_oneshot_family_arn_pattern
-        Condition = {
-          ArnEquals = {
-            "ecs:cluster" = var.spotcheck_ecs_cluster_arn
+        },
+        {
+          # Stop a hung oneshot if /spotcheck times out (the launcher's
+          # cleanup path uses StopTask before exiting).
+          Sid      = "AllowStopOneshotTask"
+          Effect   = "Allow"
+          Action   = "ecs:StopTask"
+          Resource = local.spotcheck_oneshot_family_arn_pattern
+          Condition = {
+            ArnEquals = {
+              "ecs:cluster" = var.spotcheck_ecs_cluster_arn
+            }
           }
-        }
-      },
-      {
-        # Poll DescribeTasks until the oneshot finishes; DescribeServices
-        # resolves the cluster's networking config for RunTask. Both
-        # actions require `*` at the API level — the cluster-ARN
-        # condition is the defence-in-depth control.
-        Sid    = "AllowDescribeOneshotRunningTasks"
-        Effect = "Allow"
-        Action = [
-          "ecs:DescribeTasks",
-          "ecs:DescribeServices",
-        ]
-        Resource = "*"
-        Condition = {
-          ArnEquals = {
-            "ecs:cluster" = var.spotcheck_ecs_cluster_arn
+        },
+        {
+          # Poll DescribeTasks until the oneshot finishes; DescribeServices
+          # resolves the cluster's networking config for RunTask. Both
+          # actions require `*` at the API level — the cluster-ARN
+          # condition is the defence-in-depth control.
+          Sid    = "AllowDescribeOneshotRunningTasks"
+          Effect = "Allow"
+          Action = [
+            "ecs:DescribeTasks",
+            "ecs:DescribeServices",
+          ]
+          Resource = "*"
+          Condition = {
+            ArnEquals = {
+              "ecs:cluster" = var.spotcheck_ecs_cluster_arn
+            }
           }
-        }
-      },
-      {
-        # PassRole the oneshot's source task + execution roles.
-        # Without this, RunTask fails with `AccessDeniedException:
-        # User ... is not authorized to pass role ... because no
-        # identity-based policy allows the iam:PassRole action`.
-        Sid      = "AllowPassOneshotRoles"
-        Effect   = "Allow"
-        Action   = "iam:PassRole"
-        Resource = local.spotcheck_oneshot_pass_role_arns
-        Condition = {
-          StringEquals = {
-            "iam:PassedToService" = "ecs-tasks.amazonaws.com"
+        },
+        {
+          # PassRole the oneshot's source task + execution roles.
+          # Without this, RunTask fails with `AccessDeniedException:
+          # User ... is not authorized to pass role ... because no
+          # identity-based policy allows the iam:PassRole action`.
+          Sid      = "AllowPassOneshotRoles"
+          Effect   = "Allow"
+          Action   = "iam:PassRole"
+          Resource = local.spotcheck_oneshot_pass_role_arns
+          Condition = {
+            StringEquals = {
+              "iam:PassedToService" = "ecs-tasks.amazonaws.com"
+            }
           }
-        }
-      },
-      {
-        # Resolve a `--role <name>` override (ecs-run-task.sh calls
-        # `aws iam get-role --role-name <name>` to map a role name to
-        # an ARN before RunTask). Scoped to this account's
-        # `judgemind-*-${env}` roles only.
-        Sid      = "AllowResolveOneshotRoleName"
-        Effect   = "Allow"
-        Action   = "iam:GetRole"
-        Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/judgemind-*-${var.environment}"
-      },
-      {
-        # Stream the oneshot's CloudWatch logs back into the agent-
-        # runner's stdout (the launcher tails the ingestion-worker
-        # log group, where oneshot tasks inherit their log config).
-        # Scoped to judgemind-* log groups in this account/region.
-        Sid    = "AllowReadOneshotLogs"
-        Effect = "Allow"
-        Action = [
-          "logs:DescribeLogStreams",
-          "logs:GetLogEvents",
-          "logs:FilterLogEvents",
-        ]
-        Resource = "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/judgemind-*:*"
-      },
-      {
-        # /spotcheck reads its sampling JSON output back from
-        # s3://judgemind-document-archive-${env}/spotcheck/... and
-        # downloads paired PDFs from s3://.../ca/<county>/raw/...
-        # GetBucketLocation is a precondition for `aws s3 cp` against
-        # a regional bucket from a multi-region SDK call path.
-        Sid    = "AllowSpotcheckBucketReads"
-        Effect = "Allow"
-        Action = [
-          "s3:ListBucket",
-          "s3:GetBucketLocation",
-        ]
-        Resource = var.spotcheck_document_archive_bucket_arn
-      },
-      {
-        # Object-level read on the same bucket. /spotcheck never
-        # writes — no PutObject / DeleteObject is granted. The oneshot
-        # itself uses the iam_scraper role for writes.
-        Sid      = "AllowSpotcheckObjectReads"
-        Effect   = "Allow"
-        Action   = "s3:GetObject"
-        Resource = "${var.spotcheck_document_archive_bucket_arn}/*"
-      },
-    ]
+        },
+        {
+          # Resolve a `--role <name>` override (ecs-run-task.sh calls
+          # `aws iam get-role --role-name <name>` to map a role name to
+          # an ARN before RunTask). Scoped to this account's
+          # `judgemind-*-${env}` roles only.
+          Sid      = "AllowResolveOneshotRoleName"
+          Effect   = "Allow"
+          Action   = "iam:GetRole"
+          Resource = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/judgemind-*-${var.environment}"
+        },
+        {
+          # Stream the oneshot's CloudWatch logs back into the agent-
+          # runner's stdout (the launcher tails the ingestion-worker
+          # log group, where oneshot tasks inherit their log config).
+          # Scoped to judgemind-* log groups in this account/region.
+          Sid    = "AllowReadOneshotLogs"
+          Effect = "Allow"
+          Action = [
+            "logs:DescribeLogStreams",
+            "logs:GetLogEvents",
+            "logs:FilterLogEvents",
+          ]
+          Resource = "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:log-group:/ecs/judgemind-*:*"
+        },
+        {
+          # /spotcheck reads its sampling JSON output back from
+          # s3://judgemind-document-archive-${env}/spotcheck/... and
+          # downloads paired PDFs from s3://.../ca/<county>/raw/...
+          # GetBucketLocation is a precondition for `aws s3 cp` against
+          # a regional bucket from a multi-region SDK call path.
+          Sid    = "AllowSpotcheckBucketReads"
+          Effect = "Allow"
+          Action = [
+            "s3:ListBucket",
+            "s3:GetBucketLocation",
+          ]
+          Resource = var.spotcheck_document_archive_bucket_arn
+        },
+        {
+          # Object-level read on the same bucket. /spotcheck never
+          # writes — no PutObject / DeleteObject is granted. The oneshot
+          # itself uses the iam_scraper role for writes.
+          Sid      = "AllowSpotcheckObjectReads"
+          Effect   = "Allow"
+          Action   = "s3:GetObject"
+          Resource = "${var.spotcheck_document_archive_bucket_arn}/*"
+        },
+        {
+          # List running tasks on the dev cluster so dev-db-query.sh and
+          # ecs-run.sh can resolve the running task ARN. AWS requires
+          # Resource = "*" on ListTasks; the cluster-ARN condition is the
+          # defence-in-depth control.
+          Sid      = "AllowSpotcheckListTasks"
+          Effect   = "Allow"
+          Action   = "ecs:ListTasks"
+          Resource = "*"
+          Condition = {
+            ArnEquals = {
+              "ecs:cluster" = var.spotcheck_ecs_cluster_arn
+            }
+          }
+        },
+      ],
+      var.spotcheck_oneshot_script_bucket_arn != "" ? [
+        {
+          # Upload scripts >8KB via pre-signed URL. Scoped to the
+          # oneshot-scripts/ prefix inside the caller-supplied assets bucket.
+          Sid    = "AllowUploadSpotcheckOneshotScripts"
+          Effect = "Allow"
+          Action = [
+            "s3:PutObject",
+            "s3:DeleteObject",
+          ]
+          Resource = "${var.spotcheck_oneshot_script_bucket_arn}/oneshot-scripts/*"
+        },
+      ] : [],
+    )
   })
 }
 

--- a/infra/terraform/modules/dispatcher-agent-runner/variables.tf
+++ b/infra/terraform/modules/dispatcher-agent-runner/variables.tf
@@ -120,8 +120,15 @@ variable "repo_url" {
 #     + PDF artifacts back after the oneshot writes them.
 #
 # Deliberately NOT granted:
-#   - s3:PutObject / DeleteObject anywhere — /spotcheck is read-only on
-#     S3 (the oneshot itself uses the iam_scraper role for writes).
+#   - s3:PutObject / DeleteObject on the document-archive bucket —
+#     /spotcheck is read-only on the archive (the oneshot itself uses the
+#     iam_scraper role for writes). PutObject + DeleteObject ARE granted
+#     on the `oneshot-scripts/*` prefix of the assets bucket
+#     (spotcheck_oneshot_script_bucket_arn) — that is the launcher's
+#     script-staging path (scripts/ecs-run-task.sh:547-577) and is
+#     distinct from the archive read-only contract.
+#   - ecs:ListTasks IS granted, scoped to the dev cluster, to allow
+#     dev-db-query.sh:143 to list running tasks.
 #   - ECR DescribeImages — only used by the daemon's stale-image path.
 #   - Bucket-level grants beyond ListBucket + GetBucketLocation (no
 #     PutBucketPolicy / GetBucketAcl etc.).
@@ -146,6 +153,12 @@ variable "spotcheck_ecs_cluster_arn" {
 
 variable "spotcheck_document_archive_bucket_arn" {
   description = "ARN of the document-archive bucket (`judgemind-document-archive-<env>`). Spotcheck's bidirectional sampling reads ruling JSON + PDF artifacts from this bucket via `aws s3 cp`."
+  type        = string
+  default     = ""
+}
+
+variable "spotcheck_oneshot_script_bucket_arn" {
+  description = "ARN of the assets bucket (`judgemind-assets-<env>`) used for staging oneshot scripts >8 KB via pre-signed URL. When non-empty, grants s3:PutObject + s3:DeleteObject on the `oneshot-scripts/*` prefix (scripts/ecs-run-task.sh:547-577). Leave empty to skip the grant."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Summary

Added `s3:PutObject` and `s3:DeleteObject` on `judgemind-assets-dev/oneshot-scripts/*` and `ecs:ListTasks` (cluster-scoped) to the dispatcher-agent-runner IAM role. These permissions unblock `/spotcheck` script upload via S3 pre-signed URL and dev database query via `scripts/dev-db-query.sh`.

Closes #3472

## Test plan

### Automated checks

- [x] Lint passes (`terraform fmt` applied, validated)
- [x] Terraform validate passes (pre-push hook exit 0)
- [x] No tests apply (infrastructure code)
- [x] CI green

### Post-deploy verification

- [ ] `/spotcheck` agent successfully uploads oneshot script (CloudWatch log: "Uploading to s3://judgemind-assets-dev/oneshot-scripts/...") and runs to completion
- [ ] `scripts/dev-db-query.sh` resolves running task ARN via `ecs list-tasks` without AccessDenied error
- [ ] New spotcheck result artifact appears in `s3://judgemind-document-archive-dev/spotcheck/` after next cron fire
- [ ] Verification evidence posted on #3472 (see /task-v2-verify output)