### PR TITLE
fix(infra): grant s3:GetObject on oneshot-scripts/* to agent-runner

### DIFF
--- a/infra/terraform/modules/dispatcher-agent-runner/main.tf
+++ b/infra/terraform/modules/dispatcher-agent-runner/main.tf
@@ -465,12 +465,17 @@ resource "aws_iam_role_policy" "task_spotcheck_oneshot" {
       ],
       var.spotcheck_oneshot_script_bucket_arn != "" ? [
         {
-          # Upload scripts >8KB via pre-signed URL. Scoped to the
-          # oneshot-scripts/ prefix inside the caller-supplied assets bucket.
+          # Upload + download scripts >8KB via pre-signed URL. Scoped to
+          # the oneshot-scripts/ prefix inside the caller-supplied assets
+          # bucket. GetObject is required because the URL is signed by
+          # this principal — S3 evaluates the signing principal's IAM
+          # policy at request time, so the oneshot container's anonymous
+          # urllib download fails with 403 unless GetObject is granted.
           Sid    = "AllowUploadSpotcheckOneshotScripts"
           Effect = "Allow"
           Action = [
             "s3:PutObject",
+            "s3:GetObject",
             "s3:DeleteObject",
           ]
           Resource = "${var.spotcheck_oneshot_script_bucket_arn}/oneshot-scripts/*"


### PR DESCRIPTION
## Summary

`scripts/ecs-run-task.sh` uploads scripts >8KB to `s3://judgemind-assets-dev/oneshot-scripts/` and hands the oneshot container a presigned download URL it fetches via `urllib.request.urlretrieve` (no AWS credentials in the container; the URL is its own authorization).

After #3475 the agent-runner role had `s3:PutObject` + `s3:DeleteObject` on `oneshot-scripts/*` but **not** `s3:GetObject`. Pre-signed URLs derive their authorization from the signing principal: S3 evaluates the agent-runner role's IAM policy *at request time*, so the urllib download fails with HTTP 403 — `AccessDenied`, "no identity-based policy allows the s3:GetObject action".

This patch adds `s3:GetObject` to the existing `AllowUploadSpotcheckOneshotScripts` statement and renames the comment to reflect the dual purpose.

## Root cause evidence

Reproduced from inside the agent-runner ECS task that ran `/spotcheck`:

```
$ aws s3 cp /tmp/test.txt s3://judgemind-assets-dev/oneshot-scripts/spotcheck-test/test.txt
upload: ...

$ URL=$(aws s3 presign s3://judgemind-assets-dev/oneshot-scripts/spotcheck-test/test.txt --expires-in 600)
$ curl -sS -o /tmp/dl -w "%{http_code}\n" "$URL"
403
$ cat /tmp/dl
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>User: arn:aws:sts::155326049300:assumed-role/judgemind-dispatcher-agent-runner-dev-task/...
  is not authorized to perform: s3:GetObject on resource:
  "arn:aws:s3:::judgemind-assets-dev/oneshot-scripts/spotcheck-test/test.txt"
  because no identity-based policy allows the s3:GetObject action</Message>
```

## Why not also touch dispatcher-daemon?

`infra/terraform/modules/dispatcher-daemon/main.tf` has the same statement (`AllowUploadOneshotScripts`, lines 411-423) with the identical PutObject+DeleteObject pattern. That codepath is not currently failing in production, so I'm leaving it alone — flagging it here for whoever picks up the next oneshot delivery from the daemon. Same fix applies if it's ever exercised.

## Test plan

- [ ] CI plan/apply on `infra/terraform/environments/dev` succeeds.
- [ ] After dev-apply: re-run `scripts/ecs-run-task.sh scripts/spotcheck/run_spotcheck.py -- --n 1` from an agent-runner task and confirm exit code 0 + JSON written to `s3://judgemind-document-archive-dev/spotcheck/`.
- [ ] Re-run `/spotcheck` from the dispatcher cron and confirm Step 0 no longer logs `HTTPError 403`.

Found by: `/spotcheck` (2026-04-26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
