### PR TITLE
fix(spotcheck): follow previous_version_id chain in run_spotcheck originals query

### DIFF
--- a/scripts/spotcheck/run_spotcheck.py
+++ b/scripts/spotcheck/run_spotcheck.py
@@ -90,7 +90,20 @@ def sample_originals(cur: psycopg.Cursor, county: str, n: int) -> list[dict]:
 
     originals = []
     for s3_key, s3_bucket, doc_id in sampled_docs:
+        # A naive ``WHERE d.s3_key = <key>`` misses rulings when the queried
+        # S3 key is a content-hash-dedup *loser* (#2569): the loser's document
+        # row is marked superseded with its rulings deleted, while the actual
+        # rulings for those cases live on the *winner*'s document (a different
+        # s3_key).  Follow ``documents.previous_version_id`` so either the
+        # winner or the loser key surfaces the canonical rulings.  Mirrors the
+        # CTE pattern in ``scripts/spotcheck/fetch.py`` ``OriginalsStrategy``.
         cur.execute("""
+            WITH target_docs AS (
+                SELECT id FROM documents WHERE s3_key = %s
+                UNION
+                SELECT previous_version_id AS id FROM documents
+                WHERE s3_key = %s AND previous_version_id IS NOT NULL
+            )
             SELECT r.id::text AS ruling_id, r.outcome::text,
                    r.motion_type, r.hearing_date::text, r.department,
                    cs.case_number, cs.case_title,
@@ -98,12 +111,11 @@ def sample_originals(cur: psycopg.Cursor, county: str, n: int) -> list[dict]:
                    length(r.ruling_text) AS ruling_text_length,
                    left(r.ruling_text, 300) AS ruling_text_preview
             FROM rulings r
-            JOIN documents d ON r.document_id = d.id
+            JOIN target_docs td ON r.document_id = td.id
             JOIN cases cs ON r.case_id = cs.id
             LEFT JOIN judges j ON r.judge_id = j.id
-            WHERE d.s3_key = %s
             ORDER BY r.id
-        """, (s3_key,))
+        """, (s3_key, s3_key))
         cols = [desc[0] for desc in cur.description]
         derived = [dict(zip(cols, row)) for row in cur.fetchall()]
 

--- a/scripts/tests/test_run_spotcheck.py
+++ b/scripts/tests/test_run_spotcheck.py
@@ -13,17 +13,23 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
-# DATABASE_URL is read at module import time; satisfy it before importing.
-os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost/test")
-
-# psycopg + boto3 are imported at module level; mock them so the import
-# succeeds in the lightweight scripts-tests environment.
+# ``run_spotcheck`` reads ``DATABASE_URL`` and imports ``psycopg`` / ``boto3``
+# at module load time.  Set the env var + install module mocks just long
+# enough to import, then restore the prior environment so this test module
+# does not leak state to siblings — ``test_spotcheck_fetch`` has a
+# ``DATABASE_URL``-conditional code path (see ``fetch.py`` line ~396) that
+# fails when this env var is set.
+_had_database_url = "DATABASE_URL" in os.environ
+if not _had_database_url:
+    os.environ["DATABASE_URL"] = "postgresql://test:test@localhost/test"
 sys.modules.setdefault("psycopg", MagicMock())
 sys.modules.setdefault("boto3", MagicMock())
-
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "spotcheck"))
 
 import run_spotcheck  # noqa: E402
+
+if not _had_database_url:
+    del os.environ["DATABASE_URL"]
 
 
 class TestSampleOriginalsFollowsPreviousVersionChain:

--- a/scripts/tests/test_run_spotcheck.py
+++ b/scripts/tests/test_run_spotcheck.py
@@ -1,0 +1,70 @@
+"""Tests for scripts/spotcheck/run_spotcheck.py.
+
+Regression test for #2569 follow-up: the bidirectional spotcheck must follow
+``documents.previous_version_id`` so content-hash dedup losers do not appear
+as false-positive zero-derived rulings.  Mirrors the CTE pattern that
+``scripts/spotcheck/fetch.py`` ``OriginalsStrategy`` uses since #2650.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# DATABASE_URL is read at module import time; satisfy it before importing.
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost/test")
+
+# psycopg + boto3 are imported at module level; mock them so the import
+# succeeds in the lightweight scripts-tests environment.
+sys.modules.setdefault("psycopg", MagicMock())
+sys.modules.setdefault("boto3", MagicMock())
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "spotcheck"))
+
+import run_spotcheck  # noqa: E402
+
+
+class TestSampleOriginalsFollowsPreviousVersionChain:
+    """The originals query must follow ``previous_version_id`` (#2569)."""
+
+    def _run_with_empty_result(self) -> str:
+        """Invoke ``sample_originals`` with a mock cursor and return the second
+        executed SQL string (the per-document rulings query, not the sample
+        selection query).
+        """
+        cur = MagicMock()
+        # First execute() = sample documents (return one row).
+        # Second execute() = fetch derived rulings for that doc (return empty).
+        cur.fetchall.side_effect = [
+            [("ca/contra_costa/superior_court/raw/abc.pdf", "bucket", "doc-1")],
+            [],
+        ]
+        cur.description = [("ruling_id",)]
+        run_spotcheck.sample_originals(cur, "Contra Costa", 5)
+        # Second call is the per-doc rulings query.
+        return cur.execute.call_args_list[1][0][0]
+
+    def test_query_uses_target_docs_cte(self) -> None:
+        sql = self._run_with_empty_result()
+        assert "target_docs" in sql, (
+            "sample_originals must use the target_docs CTE so dedup losers' "
+            "rulings (linked via previous_version_id) are surfaced."
+        )
+
+    def test_query_unions_previous_version_id(self) -> None:
+        sql = self._run_with_empty_result()
+        assert "previous_version_id" in sql, (
+            "sample_originals must follow documents.previous_version_id to "
+            "find rulings on the winner doc when a loser key is sampled."
+        )
+
+    def test_query_no_naive_s3_key_join(self) -> None:
+        """The pre-fix shape ``JOIN documents d ON r.document_id = d.id ...
+        WHERE d.s3_key = %s`` must be gone — it produces false-positive
+        zero-derived counts for content-hash dedup losers."""
+        sql = self._run_with_empty_result()
+        # The new query joins through ``target_docs td``; the old one joined
+        # through ``documents d`` directly.  Assert the new shape is present.
+        assert "target_docs td" in sql


### PR DESCRIPTION
## Root cause

`scripts/spotcheck/run_spotcheck.py:100` — the `sample_originals` per-document
rulings query used `JOIN documents d ON r.document_id = d.id ... WHERE d.s3_key = %s`.

When the sampled `s3_key` is a content-hash-dedup *loser* (#2569), this
returns zero derived rulings: the loser's `documents` row is superseded
with its rulings deleted, while the canonical rulings live on the
*winner* doc (a different `s3_key`, linked via
`documents.previous_version_id`).

`scripts/spotcheck/fetch.py` `OriginalsStrategy.expand` (lines 350-386) was
already fixed for this pattern in PR #2650 (the #2569 follow-through). But
`run_spotcheck.py` was added two days ago in PR #3292 and never picked up the
fix, so the bidirectional spotcheck has been emitting false-positive
"originals_zero_derived" counts ever since.

## Symptoms

The 2026-04-27 spotcheck (`s3://judgemind-document-archive-dev/spotcheck/20260427T001952Z.json`)
flagged 8/10 zero-derived for Contra Costa, 5/10 for Santa Clara, 4/10 for
Orange. Manual inspection of three CC PDFs:

- `ca/contra_costa/superior_court/raw/26478e25...pdf` — content hash
  `a9a4db79...` ≠ key prefix → loser. PDF contains valid Department 32
  tentative rulings; appeared as zero-derived (this is the same PDF that
  was in the original #2569 evidence — re-flagged today by the same bug
  in a new code path).
- `ca/contra_costa/superior_court/raw/704b94ea...pdf` — content hash
  `e107ea71...` ≠ key prefix → loser. Same false-positive pattern.
- `ca/contra_costa/superior_court/raw/234f88b5...pdf` — content hash
  matches key prefix → not a loser, has 16 derived rulings (the query
  worked here because no dedup happened).

## Fix

Mirrors `scripts/spotcheck/fetch.py`'s `OriginalsStrategy.expand`: a
`target_docs` CTE that unions the matched-by-`s3_key` doc id with the
`previous_version_id` of any doc that has the queried key, so either the
winner or the loser key surfaces the canonical rulings.

## Tests

`scripts/tests/test_run_spotcheck.py` — three regression tests
asserting the new query shape: uses the `target_docs` CTE, references
`previous_version_id`, and the old naive `JOIN documents d ... WHERE
d.s3_key` shape is gone.

```
$ python3 -m pytest scripts/tests/test_run_spotcheck.py -v
========= 3 passed in 0.17s =========
```

Found by: /spotcheck
