### PR TITLE
fix(dispatcher): add exit 0 to agent_runner_reaped_failure, defend TERMINAL_PHASES (#3494)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -3825,6 +3825,15 @@ EOF
                 SET phase = '$_term_phase', status = 'failed'
               WHERE agent_id = '$AGENT_ID';"
     log "phase_advanced" "next_phase=$_term_phase" "status=failed"
+    # #3494 — exit unconditionally after marking the agent terminal in
+    # DB. This closes the dispatch loop: the while-loop re-reads the
+    # phase each iteration, and without this exit the loop would see the
+    # new phase_unknown / ralph_not_ship / *_transition_unrecognized
+    # value, find no matching case arm, fall to `*)`, and re-emit
+    # phase_unknown for up to MAX_PHASE_ITERATIONS (default 40) before
+    # the safety cap fires. With exit 0 the process terminates cleanly
+    # after the first call — exactly one reaped_failure log line.
+    exit 0
 }
 
 handle_ralph_not_ship_local() {

--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -4373,12 +4373,12 @@ handle_awaiting_deploy() {
         _poll_count=$((_poll_count + 1))
         if [[ "$_poll_count" -gt "$_max_polls" ]]; then
             log "awaiting_deploy_max_polls_hit" "pr_number=$_pr_number" "poll_count=$_poll_count"
+            printf '{"timeout": true, "pr_number": %s, "max_polls": %s}' \
+                "$_pr_number" "$_poll_count"
             agent_runner_reaped_failure \
                 "awaiting_deploy_timeout" \
                 "deploy_max_polls" \
                 "pr=$_pr_number poll_count=$_poll_count last_state=$_last_state"
-            printf '{"timeout": true, "pr_number": %s, "max_polls": %s}' \
-                "$_pr_number" "$_poll_count"
             return 0
         fi
         if [[ -n "$_merge_sha" ]]; then
@@ -4425,12 +4425,12 @@ handle_awaiting_deploy() {
                 "merge_sha=$_merge_sha" \
                 "elapsed_s=$_elapsed" \
                 "last_state=$_last_state"
+            printf '{"timeout": true, "merge_sha": "%s", "elapsed_s": %s}' \
+                "$_merge_sha" "$_elapsed"
             agent_runner_reaped_failure \
                 "awaiting_deploy_timeout" \
                 "deploy_timeout" \
                 "pr=$_pr_number sha=$_merge_sha elapsed_s=$_elapsed"
-            printf '{"timeout": true, "merge_sha": "%s", "elapsed_s": %s}' \
-                "$_merge_sha" "$_elapsed"
             return 0
         fi
         sleep "$DEPLOY_POLL_INTERVAL"

--- a/scripts/dispatcher/phase_transitions.py
+++ b/scripts/dispatcher/phase_transitions.py
@@ -345,6 +345,21 @@ TERMINAL_STATUSES: frozenset[str] = frozenset(
     }
 )
 
+# #3494 — loop-closure terminals emitted by agent_runner_reaped_failure
+# when the dispatch loop sees an unrecognized phase or a route-to-diagnoser
+# verdict that is handled locally. These strings were introduced in PR #3458
+# but were never added to TERMINAL_PHASES, causing the dispatch loop to re-read
+# the phase each iteration, find no matching case arm, fall to `*)`, and
+# re-emit phase_unknown for up to 40 iterations before the safety cap fired.
+# The primary fix is exit 0 in agent_runner_reaped_failure (see
+# agent-runner-entrypoint.sh); adding them here is defense-in-depth so
+# is_terminal() also returns True if the loop somehow re-enters.
+PHASE_PHASE_UNKNOWN = "phase_unknown"
+PHASE_RALPH_NOT_SHIP = "ralph_not_ship"
+PHASE_RALPH_BASELINE_TRANSITION_UNRECOGNIZED = "ralph_baseline_transition_unrecognized"
+PHASE_POST_CLAUDE_TRANSITION_UNRECOGNIZED = "post_claude_transition_unrecognized"
+PHASE_PUSH_AND_PR_TRANSITION_UNRECOGNIZED = "push_and_pr_transition_unrecognized"
+
 # ---------------------------------------------------------------------------
 # Terminal phases — the agent's phase loop exits when the next phase is one
 # of these. The daemon's supervisor tick uses this set to decide whether an
@@ -378,6 +393,13 @@ TERMINAL_PHASES: frozenset[str] = frozenset(
         PHASE_AGENT_RUNNER_ROUTE_STUB,
         # #3374 — synthetic scheduled-skill failure terminal.
         PHASE_SCHEDULED_SKILL_FAILED,
+        # #3494 — loop-closure terminals (defense-in-depth; primary fix
+        # is exit 0 in agent_runner_reaped_failure).
+        PHASE_PHASE_UNKNOWN,
+        PHASE_RALPH_NOT_SHIP,
+        PHASE_RALPH_BASELINE_TRANSITION_UNRECOGNIZED,
+        PHASE_POST_CLAUDE_TRANSITION_UNRECOGNIZED,
+        PHASE_PUSH_AND_PR_TRANSITION_UNRECOGNIZED,
     }
 )
 
@@ -1281,6 +1303,12 @@ __all__ = [
     "PHASE_FIX_CI_FAILED",
     "PHASE_AGENT_RUNNER_ROUTE_STUB",
     "PHASE_SCHEDULED_SKILL_FAILED",
+    # #3494 — loop-closure terminals
+    "PHASE_PHASE_UNKNOWN",
+    "PHASE_RALPH_NOT_SHIP",
+    "PHASE_RALPH_BASELINE_TRANSITION_UNRECOGNIZED",
+    "PHASE_POST_CLAUDE_TRANSITION_UNRECOGNIZED",
+    "PHASE_PUSH_AND_PR_TRANSITION_UNRECOGNIZED",
     # Verdict constants
     "VERDICT_SHIP",
     "VERDICT_AC_INFEASIBLE",

--- a/scripts/dispatcher/tests/test_agent_runner_no_route_stub.py
+++ b/scripts/dispatcher/tests/test_agent_runner_no_route_stub.py
@@ -142,3 +142,58 @@ class TestRalphNotShipLocalHandlerExists:
             "route_to_diagnoser case arm should dispatch `ralph_not_ship` to "
             "handle_ralph_not_ship_local (not route_stub)"
         )
+
+
+class TestReapedFailureExitsUnconditionally:
+    """Issue #3494 — static lint: ``agent_runner_reaped_failure`` must
+    terminate the script via ``exit 0`` as its last non-comment,
+    non-blank line.
+
+    PR #3458 replaced ``advance_phase agent_runner_route_stub`` with
+    ``agent_runner_reaped_failure`` calls that emit descriptive phase
+    strings. None of those strings were in ``TERMINAL_PHASES``, so the
+    dispatch loop re-read the phase, found no matching case arm, fell to
+    ``*)``, and re-emitted ``phase_unknown`` for up to 40 iterations
+    before the safety cap fired. The fix adds ``exit 0`` as the final
+    statement of the function body; this test ensures it stays there.
+    """
+
+    def _function_body_lines(self) -> list[str]:
+        """Extract the body lines of ``agent_runner_reaped_failure()``."""
+        text = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
+        # Match the function definition opening.
+        m = re.search(
+            r"^agent_runner_reaped_failure\s*\(\s*\)\s*\{",
+            text,
+            re.MULTILINE,
+        )
+        assert m is not None, "agent_runner_reaped_failure function not found"
+        # Walk forward from the opening brace to the matching closing brace.
+        # We count brace depth; the function is closed when depth returns to 0.
+        start = m.end()
+        body_chars: list[str] = []
+        depth = 1
+        for ch in text[start:]:
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            body_chars.append(ch)
+        return "".join(body_chars).splitlines()
+
+    def test_agent_runner_reaped_failure_last_line_is_exit_0(self) -> None:
+        """The last non-comment, non-blank line of ``agent_runner_reaped_failure``
+        must be ``exit 0`` (#3494)."""
+        lines = self._function_body_lines()
+        # Collect non-comment, non-blank lines.
+        executable = [
+            line for line in lines if line.strip() and not line.lstrip().startswith("#")
+        ]
+        assert executable, "agent_runner_reaped_failure body has no executable lines"
+        last = executable[-1].strip()
+        assert last == "exit 0", (
+            f"Last executable line of agent_runner_reaped_failure must be "
+            f"'exit 0' (#3494) to close the dispatch loop. Got: {last!r}"
+        )

--- a/scripts/dispatcher/tests/test_phase_transitions.py
+++ b/scripts/dispatcher/tests/test_phase_transitions.py
@@ -1019,6 +1019,28 @@ class TestTerminalPhaseAndStatus:
         """#3137 — agent-runner route stub terminal (Stage 1b)."""
         assert pt.is_terminal_phase(pt.PHASE_AGENT_RUNNER_ROUTE_STUB) is True
 
+    def test_is_terminal_phase_true_for_loop_closure_terminals(self) -> None:
+        """#3494 — loop-closure terminals set by agent_runner_reaped_failure.
+
+        PR #3458 introduced descriptive phase strings (phase_unknown,
+        ralph_not_ship, *_transition_unrecognized) but did not add them to
+        TERMINAL_PHASES, causing the dispatch loop to spin for up to 40
+        iterations before the safety cap fired. These must be terminal so
+        is_terminal() returns True as defense-in-depth.
+        """
+        assert pt.is_terminal_phase(pt.PHASE_PHASE_UNKNOWN) is True
+        assert pt.is_terminal_phase(pt.PHASE_RALPH_NOT_SHIP) is True
+        assert (
+            pt.is_terminal_phase(pt.PHASE_RALPH_BASELINE_TRANSITION_UNRECOGNIZED)
+            is True
+        )
+        assert (
+            pt.is_terminal_phase(pt.PHASE_POST_CLAUDE_TRANSITION_UNRECOGNIZED) is True
+        )
+        assert (
+            pt.is_terminal_phase(pt.PHASE_PUSH_AND_PR_TRANSITION_UNRECOGNIZED) is True
+        )
+
     def test_fix_conflict_is_intermediate_not_terminal(self) -> None:
         """#3225 — fix_conflict is active, not terminal (it advances)."""
         assert pt.is_terminal_phase(pt.PHASE_FIX_CONFLICT) is False

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -5216,6 +5216,157 @@ else
          "output: $t56_out"
 fi
 
+# ══════════════════════════════════════════════════════════════════════════
+# Test 57: #3494 — agent_runner_reaped_failure exits unconditionally.
+#
+# PR #3458 replaced ``advance_phase agent_runner_route_stub`` with
+# ``agent_runner_reaped_failure`` emitting descriptive phase strings
+# (phase_unknown, ralph_not_ship, post_claude_transition_unrecognized).
+# The dispatch loop had two bugs:
+#   (a) None of those strings were in TERMINAL_PHASES, so is_terminal()
+#       returned False. (Fixed by adding them to TERMINAL_PHASES.)
+#   (b) agent_runner_reaped_failure lacked ``exit 0``, so the `*)` arm
+#       could re-enter for unknown phases not yet in TERMINAL_PHASES.
+#       (Fixed by adding exit 0 to the function body.)
+#
+# T57a: For phases now in TERMINAL_PHASES (phase_unknown, ralph_not_ship,
+#   post_claude_transition_unrecognized) — the loop exits via the
+#   is_terminal() check BEFORE reaching the `*)` arm. No
+#   agent_runner_reaped_failure call occurs. Verifies the defense-in-depth
+#   fix: exit 0, no cap hit, phase_terminal logged.
+#
+# T57b: For a truly alien phase (not in any TERMINAL_PHASES, not in any
+#   case arm) — the `*)` arm fires and calls agent_runner_reaped_failure.
+#   The exit 0 fix ensures the loop does NOT spin. Verifies exit 0,
+#   exactly 1 reaped_failure line, no cap hit, and DB UPDATE lands.
+# ══════════════════════════════════════════════════════════════════════════
+
+# T57a: Phases now in TERMINAL_PHASES — exit via is_terminal(), no reaped_failure.
+_t57a_test_terminal_phase() {
+    # $1 = phase now in TERMINAL_PHASES; exits via phase_terminal path.
+    _phase="$1"
+    setup_fixtures
+    PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t57a-${_phase}.txt"
+    printf '%s\n' "$_phase" > "$PHASE_FIXTURE_FILE"
+
+    _t57a_workspace="$TEST_TMP/t57a-workspace-${_phase}"
+    mkdir -p "$_t57a_workspace"
+
+    set +e
+    _t57a_out=$(
+        AGENT_ID="57000000-3494-0000-0000-000000003494" \
+        ISSUE_NUMBER="3494" \
+        DATABASE_URL="postgres://test" \
+        GITHUB_TOKEN="" \
+        AGENT_WORKSPACE="$_t57a_workspace" \
+        REPO_URL="https://example.invalid/repo.git" \
+        PATH="$STUB_BIN:$PATH" \
+        INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+        PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+        PRIOR_PATCH_FIXTURE="" \
+        PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+        PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+        AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
+        bash "$ENTRYPOINT" 2>&1
+    )
+    _t57a_rc=$?
+    set -e
+
+    # (1) Exit code 0 — clean exit via is_terminal() path.
+    if [[ "$_t57a_rc" -eq 0 ]]; then
+        pass "#3494 T57a [${_phase}] — exit code 0 (terminal phase exits cleanly)"
+    else
+        fail "#3494 T57a [${_phase}] — exit code 0 (terminal phase exits cleanly)" \
+             "rc=$_t57a_rc out tail: $(printf '%s' "$_t57a_out" | tail -c 800)"
+    fi
+
+    # (2) phase_terminal event logged — confirms is_terminal() fired.
+    if printf '%s' "$_t57a_out" | grep -q "phase_terminal"; then
+        pass "#3494 T57a [${_phase}] — phase_terminal event logged"
+    else
+        fail "#3494 T57a [${_phase}] — phase_terminal event logged" \
+             "out tail: $(printf '%s' "$_t57a_out" | tail -c 800)"
+    fi
+
+    # (3) phase_iteration_cap_hit ABSENT — loop did not spin to the cap.
+    if printf '%s' "$_t57a_out" | grep -q "phase_iteration_cap_hit"; then
+        fail "#3494 T57a [${_phase}] — phase_iteration_cap_hit absent (no loop spin)" \
+             "out tail: $(printf '%s' "$_t57a_out" | tail -c 800)"
+    else
+        pass "#3494 T57a [${_phase}] — phase_iteration_cap_hit absent (no loop spin)"
+    fi
+}
+
+_t57a_test_terminal_phase "phase_unknown"
+_t57a_test_terminal_phase "ralph_not_ship"
+_t57a_test_terminal_phase "post_claude_transition_unrecognized"
+
+# T57b: A truly alien phase not in TERMINAL_PHASES and not in any case arm —
+# the `*)` arm fires, calling agent_runner_reaped_failure. The exit 0 fix
+# ensures the loop does NOT spin for MAX_PHASE_ITERATIONS.
+# We use a synthetic phase name that can never be wired or terminal.
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t57b.txt"
+printf 'never_wired_3494_alien\n' > "$PHASE_FIXTURE_FILE"
+
+_t57b_workspace="$TEST_TMP/t57b-workspace"
+mkdir -p "$_t57b_workspace"
+
+set +e
+_t57b_out=$(
+    AGENT_ID="57bb0000-3494-0000-0000-000000003494" \
+    ISSUE_NUMBER="3494" \
+    DATABASE_URL="postgres://test" \
+    GITHUB_TOKEN="" \
+    AGENT_WORKSPACE="$_t57b_workspace" \
+    REPO_URL="https://example.invalid/repo.git" \
+    PATH="$STUB_BIN:$PATH" \
+    INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+    PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+    PRIOR_PATCH_FIXTURE="" \
+    PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+    PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+    AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
+    bash "$ENTRYPOINT" 2>&1
+)
+_t57b_rc=$?
+set -e
+
+# (1) Exit code 0 — agent_runner_reaped_failure exits cleanly via exit 0.
+if [[ "$_t57b_rc" -eq 0 ]]; then
+    pass "#3494 T57b [alien phase] — exit code 0 (exit 0 in reaped_failure)"
+else
+    fail "#3494 T57b [alien phase] — exit code 0 (exit 0 in reaped_failure)" \
+         "rc=$_t57b_rc out tail: $(printf '%s' "$_t57b_out" | tail -c 800)"
+fi
+
+# (2) Exactly 1 agent_runner_reaped_failure log line — no loop spin (AC3).
+_t57b_reaped_count=$(printf '%s' "$_t57b_out" | grep -c "agent_runner_reaped_failure" || true)
+if [[ "$_t57b_reaped_count" -eq 1 ]]; then
+    pass "#3494 T57b [alien phase] — exactly 1 agent_runner_reaped_failure line (AC3)"
+else
+    fail "#3494 T57b [alien phase] — exactly 1 agent_runner_reaped_failure line (AC3)" \
+         "count=$_t57b_reaped_count out: $(printf '%s' "$_t57b_out" | tail -c 800)"
+fi
+
+# (3) phase_iteration_cap_hit ABSENT — loop did not spin to the 10-iter cap.
+if printf '%s' "$_t57b_out" | grep -q "phase_iteration_cap_hit"; then
+    fail "#3494 T57b [alien phase] — phase_iteration_cap_hit absent (no loop spin)" \
+         "out tail: $(printf '%s' "$_t57b_out" | tail -c 800)"
+else
+    pass "#3494 T57b [alien phase] — phase_iteration_cap_hit absent (no loop spin)"
+fi
+
+# (4) psql.log contains UPDATE setting phase=phase_unknown (reaped_failure
+# uses "phase_unknown" as the terminal for unknown-phase events).
+# psql.log uses $'...' quoting so single quotes appear as \' in the log.
+if grep -q "SET phase = \\\\'phase_unknown\\\\'" "$INVOCATIONS_DIR/psql.log"; then
+    pass "#3494 T57b [alien phase] — psql UPDATE for phase=phase_unknown landed"
+else
+    fail "#3494 T57b [alien phase] — psql UPDATE for phase=phase_unknown landed" \
+         "psql.log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Fixed the dispatcher loop-spin bug where any agent hitting an unknown phase would spin for up to 40 iterations before being killed by the safety cap. Added `exit 0` to `agent_runner_reaped_failure()` to terminate the dispatch loop cleanly after marking an agent terminal in the database. Also added 5 new phase constants to `TERMINAL_PHASES` for defense-in-depth.

Closes #3494

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` / bash integration tests)
- [x] CI green

### Post-deploy verification

- [ ] Unblock issue #2335 (or #3433) and wait for daemon to claim it
- [ ] Confirm the agent terminates within ~5 seconds (not 2.5 minutes)
- [ ] Verify exactly ONE `agent_runner_reaped_failure` event is emitted
- [ ] Verification evidence posted on #3494 (see /task-v2-verify output)