### PR TITLE
fix(scraping): wrap scraper_cls() in try/except to prevent constructor-TypeError cascade (#3499)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/la_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/la_tentatives.py
@@ -49,6 +49,7 @@ import time
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from datetime import datetime
+from typing import Any
 
 import httpx
 import structlog
@@ -824,8 +825,9 @@ class LATentativeRulingsScraper(BaseScraper):
         event_bus: EventBus | None = None,
         dept_judge_map: dict[str, str] | None = None,
         court_directory: CourtDirectory | None = None,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(config, archiver=archiver, event_bus=event_bus)
+        super().__init__(config, archiver=archiver, event_bus=event_bus, **kwargs)
         self._dept_judge_map: dict[str, str] = dept_judge_map or {}
         self._court_directory = court_directory
         self._court_id: str = "ca_los_angeles"
@@ -1021,8 +1023,9 @@ class LAAppellateTentativeRulingsScraper(BaseScraper):
         config: ScraperConfig,
         archiver: S3Archiver | None = None,
         event_bus: EventBus | None = None,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(config, archiver=archiver, event_bus=event_bus)
+        super().__init__(config, archiver=archiver, event_bus=event_bus, **kwargs)
 
     def fetch_documents(self) -> list[CapturedDocument]:
         docs: list[CapturedDocument] = []

--- a/packages/scraper-framework/src/courts/ca/sd_calendar.py
+++ b/packages/scraper-framework/src/courts/ca/sd_calendar.py
@@ -46,6 +46,7 @@ import re
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import Any
 
 import httpx
 import structlog
@@ -490,8 +491,9 @@ class SDCalendarScraper(BaseScraper):
         archiver: S3Archiver | None = None,
         event_bus: EventBus | None = None,
         day_numbers: list[int] | None = None,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(config, archiver=archiver, event_bus=event_bus)
+        super().__init__(config, archiver=archiver, event_bus=event_bus, **kwargs)
         # Which day numbers (1-5) to fetch.  Default: [2] (tomorrow).
         self._day_numbers = day_numbers or [2]
 

--- a/packages/scraper-framework/src/courts/ca/sd_pipeline.py
+++ b/packages/scraper-framework/src/courts/ca/sd_pipeline.py
@@ -17,6 +17,8 @@ Integration issue: #903
 
 from __future__ import annotations
 
+from typing import Any
+
 import structlog
 
 from framework import BaseScraper, CapturedDocument, ScraperConfig
@@ -58,8 +60,9 @@ class SDPipelineScraper(BaseScraper):
         headless: bool = True,
         archiver: S3Archiver | None = None,
         event_bus: EventBus | None = None,
+        **kwargs: Any,
     ) -> None:
-        super().__init__(config, archiver=archiver, event_bus=event_bus)
+        super().__init__(config, archiver=archiver, event_bus=event_bus, **kwargs)
         self._day_numbers = day_numbers
         self._proxy_url = proxy_url
         self._headless = headless

--- a/packages/scraper-framework/src/courts/ca/sd_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sd_tentatives.py
@@ -552,7 +552,7 @@ class SDTentativeRulingsScraper(BaseScraper):
         event_bus: EventBus | None = None,
         **kwargs: Any,
     ) -> None:
-        super().__init__(config, archiver=archiver, event_bus=event_bus)
+        super().__init__(config, archiver=archiver, event_bus=event_bus, **kwargs)
         self._case_numbers = case_numbers or []
         self._proxy_url = proxy_url or os.environ.get("SD_PROXY_URL")
         self._headless = headless

--- a/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/sf_civil_tentatives.py
@@ -598,7 +598,7 @@ class SFCivilTentativeRulingsScraper(BaseScraper):
         proxy_url: str | None = None,
         **kwargs: Any,
     ) -> None:
-        super().__init__(config=config, archiver=archiver, event_bus=event_bus)
+        super().__init__(config=config, archiver=archiver, event_bus=event_bus, **kwargs)
         self._dept_judge_map: dict[str, str] = dept_judge_map or {}
         self._session_id: str | None = session_id
         self._headless: bool = headless

--- a/packages/scraper-framework/src/framework/runner.py
+++ b/packages/scraper-framework/src/framework/runner.py
@@ -584,16 +584,31 @@ def run_scrapers(scraper_ids: list[str] | None = None) -> int:
             if scraper_id in sf_civil_scraper_ids and sf_dept_judge_map:
                 extra_kwargs["dept_judge_map"] = sf_dept_judge_map
 
-            scraper = scraper_cls(
-                config=config,
-                archiver=archiver,
-                event_bus=event_bus,
-                db_conn=db_conn,
-                **extra_kwargs,
-            )
-
-            run_start = time.monotonic()
             run_started_at = datetime.now(UTC)
+            run_start = time.monotonic()
+
+            try:
+                scraper = scraper_cls(
+                    config=config,
+                    archiver=archiver,
+                    event_bus=event_bus,
+                    db_conn=db_conn,
+                    **extra_kwargs,
+                )
+            except Exception as exc:
+                log.error("Scraper construction failed", error=str(exc))
+                if db_conn:
+                    record_scraper_exception(
+                        db_conn,
+                        scraper_id,
+                        config,
+                        run_started_at,
+                        str(exc),
+                        time.monotonic() - run_start,
+                        court_id_cache,
+                    )
+                had_failure = True
+                continue
 
             try:
                 health = scraper.run()

--- a/packages/scraper-framework/tests/test_registry_construction.py
+++ b/packages/scraper-framework/tests/test_registry_construction.py
@@ -1,0 +1,90 @@
+"""Smoke-test that every entry in _build_registry() can be instantiated.
+
+This test would have caught the regression in #3499, where the runner passed
+``db_conn`` to scraper constructors that did not accept it, causing a
+TypeError that darkened 14 scrapers for days.
+
+Each scraper is constructed with exactly the arguments the runner supplies:
+  config=<default_config()>, archiver=None, event_bus=None, db_conn=None,
+  **runner_extra_kwargs(scraper_id)
+
+The ``runner_extra_kwargs`` helper mirrors the dept_judge_map injection in
+``runner.py`` lines 577-585 — currently only the LA, Riverside, Ventura, and
+SF-civil scrapers receive an extra ``dept_judge_map`` kwarg.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.runner import _REGISTRY, _build_registry  # noqa: F401 (imported for side effects)
+
+# ---------------------------------------------------------------------------
+# Helper: mirror the extra_kwargs logic from runner.py
+# ---------------------------------------------------------------------------
+
+# These mirror runner.py exactly — only ca-la-tentatives-civil receives dept_judge_map,
+# not the appellate variant.
+_LA_SCRAPER_IDS = {"ca-la-tentatives-civil"}
+_RIV_SCRAPER_IDS = {"ca-riverside-tentatives"}
+_VENTURA_SCRAPER_IDS = {"ca-ventura-tentatives"}
+_SF_CIVIL_SCRAPER_IDS = {"ca-sf-tentatives-civil"}
+
+
+def _runner_extra_kwargs(scraper_id: str) -> dict[str, object]:
+    """Return the extra kwargs runner.py would pass for this scraper_id.
+
+    Mirrors the dept_judge_map injection block (runner.py lines 577-585).
+    All dept_judge_map values are passed as an empty dict — the mapping is
+    optional and the scraper must work without it.
+    """
+    extra: dict[str, object] = {}
+    if scraper_id in _LA_SCRAPER_IDS:
+        extra["dept_judge_map"] = {}
+    if scraper_id in _RIV_SCRAPER_IDS:
+        extra["dept_judge_map"] = {}
+    if scraper_id in _VENTURA_SCRAPER_IDS:
+        extra["dept_judge_map"] = {}
+    if scraper_id in _SF_CIVIL_SCRAPER_IDS:
+        extra["dept_judge_map"] = {}
+    return extra
+
+
+# ---------------------------------------------------------------------------
+# Parametrized test
+# ---------------------------------------------------------------------------
+
+
+def _registry_params() -> list[tuple[str, type, object]]:
+    """Collect all (scraper_id, scraper_cls, config_factory) triples."""
+    _REGISTRY.clear()
+    return list(_build_registry())
+
+
+@pytest.mark.parametrize(
+    "scraper_id,scraper_cls,config_factory",
+    _registry_params(),
+    ids=[entry[0] for entry in _registry_params()],
+)
+def test_registry_scraper_accepts_db_conn(
+    scraper_id: str,
+    scraper_cls: type,
+    config_factory: object,
+) -> None:
+    """Every registry entry must instantiate without TypeError when db_conn is passed.
+
+    This is the minimal smoke-test: if constructing a registered scraper with
+    the runner's standard kwargs raises TypeError, the entire sweep will fail.
+    """
+    config = config_factory(s3_bucket="")  # type: ignore[operator]
+    extra = _runner_extra_kwargs(scraper_id)
+
+    # Must not raise TypeError (or any other exception)
+    instance = scraper_cls(
+        config=config,
+        archiver=None,
+        event_bus=None,
+        db_conn=None,
+        **extra,
+    )
+    assert instance is not None

--- a/packages/scraper-framework/tests/test_runner.py
+++ b/packages/scraper-framework/tests/test_runner.py
@@ -213,6 +213,104 @@ class TestRunScrapersErrorHandling:
 
         assert exit_code == 1
 
+    def test_constructor_failure_does_not_cascade(self) -> None:
+        """A TypeError in scraper __init__ must NOT stop subsequent scrapers.
+
+        Regression guard for #3499: runner passed db_conn to scrapers whose
+        __init__ did not accept it, causing one TypeError to take down all
+        remaining scrapers in the same sweep.
+        """
+        ran: list[str] = []
+
+        class ConstructorFailingScraper(BaseScraper):
+            def __init__(self, **kwargs: object) -> None:
+                raise TypeError("__init__() got an unexpected keyword argument 'db_conn'")
+
+            def fetch_documents(self) -> list[CapturedDocument]:  # pragma: no cover
+                return []
+
+            def parse_document(self, doc: CapturedDocument) -> CapturedDocument:  # pragma: no cover
+                return doc
+
+        class TrackingStub(StubScraper):
+            def fetch_documents(self) -> list[CapturedDocument]:
+                ran.append(self.config.scraper_id)
+                return []
+
+        def config_fail(s3_bucket: str = "") -> ScraperConfig:
+            return ScraperConfig(
+                scraper_id="failing-ctor",
+                state="CA",
+                county="Fail",
+                court="Court",
+                target_urls=["https://example.com"],
+            )
+
+        def config_good(s3_bucket: str = "") -> ScraperConfig:
+            return ScraperConfig(
+                scraper_id="good-after-ctor",
+                state="CA",
+                county="Good",
+                court="Court",
+                target_urls=["https://example.com"],
+            )
+
+        entries = [
+            ("failing-ctor", ConstructorFailingScraper, config_fail),
+            ("good-after-ctor", TrackingStub, config_good),
+        ]
+
+        with (
+            _patch_registry(entries),
+            patch("framework.runner.record_scraper_exception") as mock_record,
+        ):
+            exit_code = run_scrapers()
+
+        assert exit_code == 1, "had_failure should propagate as exit code 1"
+        assert "good-after-ctor" in ran, "good scraper must still run after constructor failure"
+        mock_record.assert_called_once()
+        call_kwargs = mock_record.call_args
+        # Second positional arg is scraper_id
+        assert call_kwargs[0][1] == "failing-ctor"
+
+    def test_constructor_failure_records_exception(self) -> None:
+        """Constructor failure with db_conn wired must insert a failure row."""
+
+        class ConstructorFailingScraper(BaseScraper):
+            def __init__(self, **kwargs: object) -> None:
+                raise TypeError("db_conn not accepted")
+
+            def fetch_documents(self) -> list[CapturedDocument]:  # pragma: no cover
+                return []
+
+            def parse_document(self, doc: CapturedDocument) -> CapturedDocument:  # pragma: no cover
+                return doc
+
+        entries = [("ctor-fail-db", ConstructorFailingScraper, _stub_config)]
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            _patch_registry(entries),
+            patch("framework.runner._connect_db", return_value=mock_conn),
+        ):
+            exit_code = run_scrapers()
+
+        assert exit_code == 1
+        insert_calls = [
+            c
+            for c in mock_cursor.execute.call_args_list
+            if len(c[0]) > 0 and "INSERT INTO scraper_runs" in str(c[0][0])
+        ]
+        assert len(insert_calls) == 1, "must record exactly one failure row for the ctor error"
+        params = insert_calls[0][0][1]
+        # scraper_id is the registry key, passed to record_scraper_exception
+        assert params[0] == "ctor-fail-db"
+        assert params[4] == "failure"  # status
+        assert "db_conn not accepted" in params[7]  # error_message
+
     def test_partial_failure_still_runs_remaining(self) -> None:
         ran = []
 


### PR DESCRIPTION
## Summary

Fixed a 14-scraper production outage caused by runner passing `db_conn` to scraper constructors that don't accept it. Wrapped the scraper instantiation in a try/except block that records failures and continues, eliminating the silent cascade. Updated 6 scraper subclasses to accept and forward `**kwargs` to `BaseScraper`, and added comprehensive regression tests including a new parametrized smoke test for all 19 registry entries.

Closes #3499

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest 6628 passed / 2 skipped`)
- [x] CI green (pre-push hook passed on first attempt)

### Post-deploy verification

- [ ] Run scraper task on dev: `scripts/ecs-run-task.sh packages/scraper-framework/src/framework/__main__.py`
- [ ] Verify all 14 dark scrapers produce new telemetry.scraper_runs rows within one cron tick: `scripts/dev-db-query.sh "SELECT scraper_id, MAX(started_at) FROM telemetry.scraper_runs WHERE scraper_id IN ('ca-la-tentatives-appellate', 'ca-oc-tentatives-civil', 'ca-oc-tentatives-family-law', 'ca-oc-tentatives-probate', 'ca-riverside-tentatives-civil', 'ca-sb-tentatives-civil', 'ca-sc-tentatives-civil', 'ca-sd-calendar', 'ca-sd-pipeline', 'ca-sd-tentatives', 'ca-sf-tentatives-civil', 'ca-sf-tentatives-family-law', 'ca-ventura-tentatives', 'federal-courtlistener-opinions') GROUP BY 1"`
- [ ] Confirmation that `started_at` timestamps are within 24h after deploy (post-deploy verification handled by /task-v2-verify)