### PR TITLE
fix(ingestion): resolve_judge arbitration can now bootstrap when Step 1 short-circuits (#3503)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -1196,6 +1196,80 @@ def resolve_judge_from_department(
     return None
 
 
+def _maybe_arbitrate(
+    cur: psycopg.Cursor,
+    judge_id: str,
+    raw_name: str,
+    incoming_canonical: str,
+    roster_normalized: str,
+    source: str,
+    confidence: float = 1.0,
+) -> bool:
+    """Check corroborating evidence and promote incoming_canonical if warranted.
+
+    Queries non-roster aliases for ``incoming_canonical`` on the given judge.
+    If >=1 distinct non-roster source already corroborates the incoming spelling,
+    promotes it to the new canonical name, demotes the roster name as an alias,
+    and inserts the caller's raw name under the caller's source.
+
+    Returns True if promotion occurred, False otherwise.
+    """
+    cur.execute(
+        """
+        SELECT LOWER(raw_name), source
+        FROM judge_aliases
+        WHERE judge_id = %s::uuid
+          AND source NOT IN ('roster_match', 'roster')
+          AND LOWER(raw_name) = LOWER(%s)
+        """,
+        (judge_id, incoming_canonical),
+    )
+    alias_rows = cur.fetchall()
+    existing_non_roster_sources = {
+        row_alias[1] for row_alias in alias_rows if row_alias[1] is not None
+    }
+    if not existing_non_roster_sources:
+        return False
+
+    # Promote incoming spelling as the new canonical
+    cur.execute(
+        """
+        UPDATE judges SET canonical_name = %s, updated_at = NOW()
+        WHERE id = %s::uuid
+        """,
+        (incoming_canonical, judge_id),
+    )
+    # Preserve the demoted roster name as an alias
+    cur.execute(
+        """
+        INSERT INTO judge_aliases
+            (judge_id, raw_name, source, confidence, is_verified)
+        VALUES (%s::uuid, %s, 'roster_match', %s, FALSE)
+        ON CONFLICT (judge_id, lower(raw_name), source) DO NOTHING
+        """,
+        (judge_id, roster_normalized, confidence),
+    )
+    # Insert the incoming raw name as alias with caller's source
+    cur.execute(
+        """
+        INSERT INTO judge_aliases
+            (judge_id, raw_name, source, confidence, is_verified)
+        VALUES (%s::uuid, %s, %s, 1.0, FALSE)
+        ON CONFLICT (judge_id, lower(raw_name), source) DO NOTHING
+        """,
+        (judge_id, raw_name, source),
+    )
+    logger.info(
+        "resolve_judge: arbitration promoted %r over roster typo %r "
+        "(corroborated by sources=%r) for judge %s",
+        incoming_canonical,
+        roster_normalized,
+        existing_non_roster_sources,
+        judge_id,
+    )
+    return True
+
+
 def resolve_judge(
     conn: psycopg.Connection,
     raw_name: str,
@@ -1244,7 +1318,7 @@ def resolve_judge(
         # same name arrives in different casing — see #1453)
         cur.execute(
             """
-            SELECT ja.judge_id
+            SELECT ja.judge_id, j.canonical_name
             FROM judge_aliases ja
             JOIN judges j ON j.id = ja.judge_id
             WHERE LOWER(ja.raw_name) = LOWER(%s) AND j.court_id = %s::uuid
@@ -1255,7 +1329,21 @@ def resolve_judge(
         row = cur.fetchone()
         if row is not None:
             judge_id: str = str(row[0])
+            matched_canonical: str = str(row[1])
             logger.debug("resolve_judge: found existing alias for %r -> %s", raw_name, judge_id)
+            # Step 1 arbitration (#3503): if the matched judge's canonical differs
+            # from the incoming canonical and a source is provided, run arbitration
+            # so that corroborating evidence accumulated across calls can promote
+            # the incoming spelling even after Step 1 short-circuits future steps.
+            if source and matched_canonical.lower() != canonical.lower():
+                _maybe_arbitrate(
+                    cur,
+                    judge_id,
+                    raw_name,
+                    incoming_canonical=canonical,
+                    roster_normalized=matched_canonical,
+                    source=source,
+                )
             return judge_id
 
         # Step 2: Check judges table for exact canonical_name + court_id match
@@ -1371,85 +1459,46 @@ def resolve_judge(
                     row = cur.fetchone()
                     if row is not None:
                         judge_id = str(row[0])
-                        # Step 3b arbitration (#3484): when the incoming canonical
-                        # differs from the roster canonical, check whether the
-                        # incoming spelling has independent source corroboration.
-                        # If >=1 distinct non-roster source already supports the
-                        # incoming spelling, promote it to the new canonical name
-                        # and demote the roster typo to an alias.
+                        # Step 3b arbitration (#3484/#3503): when the incoming
+                        # canonical differs from the roster canonical, check
+                        # whether the incoming spelling has independent source
+                        # corroboration.  Delegate to _maybe_arbitrate which
+                        # promotes if >=1 distinct non-roster source already
+                        # supports the incoming spelling.
                         incoming_canonical = canonical  # the normalized incoming name
-                        if incoming_canonical.lower() != roster_normalized.lower() and source:
-                            # Query judge_aliases for the matched judge to find
-                            # distinct non-roster sources that corroborate the
-                            # incoming spelling.
-                            cur.execute(
-                                """
-                                SELECT LOWER(raw_name), source
-                                FROM judge_aliases
-                                WHERE judge_id = %s::uuid
-                                  AND source NOT IN ('roster_match', 'roster')
-                                  AND LOWER(raw_name) = LOWER(%s)
-                                """,
-                                (judge_id, incoming_canonical),
+                        if (
+                            incoming_canonical.lower() != roster_normalized.lower()
+                            and source
+                            and _maybe_arbitrate(
+                                cur,
+                                judge_id,
+                                raw_name,
+                                incoming_canonical=incoming_canonical,
+                                roster_normalized=roster_normalized,
+                                source=source,
+                                confidence=confidence,
                             )
-                            alias_rows = cur.fetchall()
-                            # Count distinct non-roster sources already in aliases
-                            existing_non_roster_sources = {
-                                row_alias[1] for row_alias in alias_rows if row_alias[1] is not None
-                            }
-                            # Promote if >=1 distinct non-roster source already
-                            # corroborates the incoming spelling in the alias table.
-                            # The alias table records a prior call from a non-roster
-                            # source, constituting independent corroboration.
-                            if existing_non_roster_sources:
-                                # Promote incoming spelling as the new canonical
-                                cur.execute(
-                                    """
-                                    UPDATE judges SET canonical_name = %s, updated_at = NOW()
-                                    WHERE id = %s::uuid
-                                    """,
-                                    (incoming_canonical, judge_id),
-                                )
-                                # Preserve the demoted roster name as an alias
-                                cur.execute(
-                                    """
-                                    INSERT INTO judge_aliases
-                                        (judge_id, raw_name, source, confidence, is_verified)
-                                    VALUES (%s::uuid, %s, 'roster_match', %s, FALSE)
-                                    ON CONFLICT (judge_id, lower(raw_name), source) DO NOTHING
-                                    """,
-                                    (judge_id, roster_normalized, confidence),
-                                )
-                                # Insert the incoming raw name as alias with caller's source
-                                cur.execute(
-                                    """
-                                    INSERT INTO judge_aliases
-                                        (judge_id, raw_name, source, confidence, is_verified)
-                                    VALUES (%s::uuid, %s, %s, 1.0, FALSE)
-                                    ON CONFLICT (judge_id, lower(raw_name), source) DO NOTHING
-                                    """,
-                                    (judge_id, raw_name, source),
-                                )
-                                logger.info(
-                                    "resolve_judge: arbitration promoted %r over roster typo %r "
-                                    "(corroborated by sources=%r) for judge %s",
-                                    incoming_canonical,
-                                    roster_normalized,
-                                    existing_non_roster_sources,
-                                    judge_id,
-                                )
-                                return judge_id
+                        ):
+                            return judge_id
 
-                        # No arbitration needed (or no source label) — link via
-                        # roster_match alias as before
+                        # No arbitration needed (or no corroboration yet) — link
+                        # via the caller's source when available so the next call
+                        # can accumulate corroborating evidence (#3503).
+                        # When source is None or canonicals match, fall back to
+                        # 'roster_match' as before.
+                        fall_through_source = (
+                            source
+                            if (source and incoming_canonical.lower() != roster_normalized.lower())
+                            else "roster_match"
+                        )
                         cur.execute(
                             """
                             INSERT INTO judge_aliases
                                 (judge_id, raw_name, source, confidence, is_verified)
-                            VALUES (%s::uuid, %s, 'roster_match', %s, FALSE)
+                            VALUES (%s::uuid, %s, %s, %s, FALSE)
                             ON CONFLICT DO NOTHING
                             """,
-                            (judge_id, raw_name, confidence),
+                            (judge_id, raw_name, fall_through_source, confidence),
                         )
                         logger.info(
                             "resolve_judge: roster match %r -> %r (confidence=%.2f) -> %s",

--- a/packages/scraper-framework/tests/ingestion/test_db_judge_resolve.py
+++ b/packages/scraper-framework/tests/ingestion/test_db_judge_resolve.py
@@ -1,4 +1,4 @@
-"""Tests for source-authority arbitration in resolve_judge (issue #3484).
+"""Tests for source-authority arbitration in resolve_judge (issue #3484 / #3503).
 
 Covers:
   - Roster typo loses to corroborated calendar spelling
@@ -6,13 +6,17 @@ Covers:
   - Single non-roster source does not override multi-source roster
   - Repeated same-source calls do not count as independent
   - Existing two-source corroboration promotes on third call
+  - Two-call sequence: second call promotes via Step 1 arbitration (#3503)
+  - Multi-source bootstrap: two calls from different sources flip canonical (#3503)
+  - Step 1 arbitration skips when canonical already matches (#3503)
+  - Step 3b fall-through stores caller source instead of roster_match (#3503)
 """
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from ingestion.db import resolve_judge
+from ingestion.db import clear_roster_cache, resolve_judge
 
 
 def _make_mock_conn() -> tuple[MagicMock, MagicMock]:
@@ -236,3 +240,208 @@ class TestRosterTypoArbitration:
             f"Expected 1 UPDATE judges call (2 prior sources corroborate), got: {update_calls}"
         )
         assert "Matthew C. Braner" in update_calls[0]
+
+
+class TestStep1ArbitrationWireUp:
+    """Tests for the Step 1 arbitration wire-up added in issue #3503.
+
+    Step 1 now runs _maybe_arbitrate after an alias hit when the matched
+    judge's canonical_name differs from the incoming canonical and a source
+    is provided.  This means corroboration evidence accumulates across calls
+    even after Step 1 short-circuits Step 3b.
+    """
+
+    def test_two_call_sequence_promotes_on_second_call(self) -> None:
+        """Two calls with the same source flip canonical on the second call.
+
+        Scenario:
+        - Judge exists as 'Mattew C. Braner' (roster typo).
+        - Call 1: raw_name='MATTHEW C. BRANER', source='sd_calendar'.
+          No alias exists yet → goes through Step 3b → no corroboration →
+          fall-through INSERT stores source='sd_calendar' alias.
+        - Call 2: raw_name='MATTHEW C. BRANER', source='sd_calendar'.
+          Step 1 finds the alias inserted in call 1, matched canonical is
+          'Mattew C. Braner' != 'Matthew C. Braner' → _maybe_arbitrate runs →
+          finds sd_calendar alias → promotes canonical to 'Matthew C. Braner'.
+        """
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Clear the roster cache so call 1 populates it (call 2 reuses it).
+        clear_roster_cache("court-uuid-1")
+
+        # fetchone side_effect across both resolve_judge calls:
+        # --- Call 1 ---
+        # Step 1: no alias yet
+        # Step 2: no exact canonical 'Matthew C. Braner'
+        # _get_roster_names: court_code lookup
+        # _get_roster_names: snapshot lookup
+        # Step 3b: judge with 'Mattew C. Braner' exists
+        # --- Call 2 ---
+        # Step 1: alias found, matched canonical is 'Mattew C. Braner'
+        mock_cur.fetchone.side_effect = [
+            None,  # Call1 Step1: no alias
+            None,  # Call1 Step2: no exact canonical
+            ("ca-san_diego",),  # Call1 _get_roster_names: court_code
+            ({"D1": "Mattew C. Braner"},),  # Call1 _get_roster_names: snapshot
+            ("existing-judge-uuid",),  # Call1 Step3b: judge exists
+            ("existing-judge-uuid", "Mattew C. Braner"),  # Call2 Step1: alias hit
+        ]
+
+        # fetchall side_effect across both calls:
+        # --- Call 1 ---
+        # Step3 near-dup: empty
+        # _maybe_arbitrate in Step3b: no existing aliases yet
+        # --- Call 2 ---
+        # _maybe_arbitrate in Step1: sd_calendar alias from call1 exists
+        mock_cur.fetchall.side_effect = [
+            [],  # Call1 Step3 near-dup
+            [],  # Call1 _maybe_arbitrate: no corroboration yet
+            [("matthew c. braner", "sd_calendar")],  # Call2 _maybe_arbitrate: promotes!
+        ]
+
+        result1 = resolve_judge(
+            mock_conn, "MATTHEW C. BRANER", "court-uuid-1", source="sd_calendar"
+        )
+        result2 = resolve_judge(
+            mock_conn, "MATTHEW C. BRANER", "court-uuid-1", source="sd_calendar"
+        )
+
+        assert result1 == "existing-judge-uuid"
+        assert result2 == "existing-judge-uuid"
+
+        # Call 2 must have issued UPDATE judges to promote the incoming spelling
+        all_sql_calls = [str(c) for c in mock_cur.execute.call_args_list]
+        update_calls = [c for c in all_sql_calls if "UPDATE judges" in c]
+        assert len(update_calls) == 1, (
+            f"Expected 1 UPDATE judges call on second call, got: {update_calls}"
+        )
+        assert "Matthew C. Braner" in update_calls[0]
+
+    def test_multi_source_bootstrap_promotes(self) -> None:
+        """Two calls from different sources flip the canonical.
+
+        Scenario:
+        - Judge exists as 'Mattew C. Braner' (roster typo).
+        - Call 1: source='sd_calendar' → fall-through inserts sd_calendar alias.
+        - Call 2: source='sd_roa' → Step 1 finds the alias from call 1,
+          sees canonical mismatch, calls _maybe_arbitrate which finds the
+          sd_calendar alias → promotes canonical to 'Matthew C. Braner'.
+        """
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        clear_roster_cache("court-uuid-2")
+
+        mock_cur.fetchone.side_effect = [
+            None,  # Call1 Step1: no alias
+            None,  # Call1 Step2: no exact canonical
+            ("ca-san_diego",),  # Call1 _get_roster_names: court_code
+            ({"D1": "Mattew C. Braner"},),  # Call1 _get_roster_names: snapshot
+            ("existing-judge-uuid",),  # Call1 Step3b: judge exists
+            ("existing-judge-uuid", "Mattew C. Braner"),  # Call2 Step1: alias hit
+        ]
+        mock_cur.fetchall.side_effect = [
+            [],  # Call1 Step3 near-dup
+            [],  # Call1 _maybe_arbitrate: no corroboration yet
+            [("matthew c. braner", "sd_calendar")],  # Call2 _maybe_arbitrate: sd_calendar present
+        ]
+
+        result1 = resolve_judge(
+            mock_conn, "MATTHEW C. BRANER", "court-uuid-2", source="sd_calendar"
+        )
+        result2 = resolve_judge(mock_conn, "MATTHEW C. BRANER", "court-uuid-2", source="sd_roa")
+
+        assert result1 == "existing-judge-uuid"
+        assert result2 == "existing-judge-uuid"
+
+        all_sql_calls = [str(c) for c in mock_cur.execute.call_args_list]
+        update_calls = [c for c in all_sql_calls if "UPDATE judges" in c]
+        assert len(update_calls) == 1, (
+            f"Expected 1 UPDATE judges call on second call, got: {update_calls}"
+        )
+        assert "Matthew C. Braner" in update_calls[0]
+
+    def test_step1_arbitration_skips_when_canonical_matches(self) -> None:
+        """Step 1 skips _maybe_arbitrate when the matched canonical matches incoming.
+
+        If the judge's canonical_name already equals the normalized incoming
+        name, there is no mismatch to resolve — arbitration must not run.
+        """
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Step 1 returns the alias with a canonical that matches the incoming name
+        mock_cur.fetchone.side_effect = [
+            ("existing-judge-uuid", "Matthew C. Braner"),  # Step1: alias found, canonical matches
+        ]
+
+        result = resolve_judge(mock_conn, "MATTHEW C. BRANER", "court-uuid-3", source="sd_calendar")
+
+        assert result == "existing-judge-uuid"
+
+        # No fetchall calls should happen (no _maybe_arbitrate, no near-dup check)
+        mock_cur.fetchall.assert_not_called()
+
+        # No UPDATE issued
+        all_sql_calls = [str(c) for c in mock_cur.execute.call_args_list]
+        update_calls = [c for c in all_sql_calls if "UPDATE judges" in c]
+        assert len(update_calls) == 0, (
+            f"Expected 0 UPDATE calls when canonical matches, got: {update_calls}"
+        )
+
+    def test_step3b_fallthrough_stores_caller_source(self) -> None:
+        """Fall-through INSERT uses caller's source, not 'roster_match'.
+
+        When Step 3b finds a roster match, the incoming canonical differs from
+        the roster canonical, a source is provided, and there is no prior
+        corroboration yet — the alias INSERT should use the caller's source
+        (e.g. 'sd_calendar') so the evidence accumulates for future calls.
+        """
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        clear_roster_cache("court-uuid-4")
+
+        mock_cur.fetchone.side_effect = [
+            None,  # Step1: no alias
+            None,  # Step2: no exact canonical
+            ("ca-san_diego",),  # _get_roster_names: court_code
+            ({"D1": "Mattew C. Braner"},),  # _get_roster_names: snapshot
+            ("existing-judge-uuid",),  # Step3b: judge with roster name exists
+        ]
+        mock_cur.fetchall.side_effect = [
+            [],  # Step3 near-dup
+            [],  # _maybe_arbitrate: no corroboration yet
+        ]
+
+        result = resolve_judge(mock_conn, "MATTHEW C. BRANER", "court-uuid-4", source="sd_calendar")
+
+        assert result == "existing-judge-uuid"
+
+        # No promotion should have occurred
+        all_sql_calls = [str(c) for c in mock_cur.execute.call_args_list]
+        update_calls = [c for c in all_sql_calls if "UPDATE judges" in c]
+        assert len(update_calls) == 0, (
+            f"Expected 0 UPDATE calls on single call with no corroboration, got: {update_calls}"
+        )
+
+        # The fall-through INSERT must use 'sd_calendar', not 'roster_match'
+        insert_calls = [c for c in all_sql_calls if "INSERT INTO judge_aliases" in c]
+        assert len(insert_calls) >= 1, "Expected at least one INSERT INTO judge_aliases"
+        # The last INSERT (the fall-through) should contain the caller's source
+        last_insert = insert_calls[-1]
+        assert "sd_calendar" in last_insert, (
+            f"Expected fall-through INSERT to use 'sd_calendar', got: {last_insert}"
+        )
+        assert "roster_match" not in last_insert, (
+            f"Expected fall-through INSERT to NOT use 'roster_match', got: {last_insert}"
+        )

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -1401,8 +1401,8 @@ def test_resolve_judge_existing_alias() -> None:
     mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
     mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
 
-    # Simulate existing alias found
-    mock_cur.fetchone.return_value = ("existing-judge-uuid",)
+    # Simulate existing alias found — Step 1 SELECT now returns (judge_id, canonical_name) (#3503)
+    mock_cur.fetchone.return_value = ("existing-judge-uuid", "John A. Smith")
 
     result = resolve_judge(mock_conn, "Smith, John A.", "court-uuid-1")
 
@@ -2032,8 +2032,10 @@ def test_process_event_passes_county_max_output_tokens_to_llm(
 
     mock_conn, mock_cur = _make_mock_conn()
     mock_psycopg.connect.return_value = mock_conn
-    # Return enough values for the full processing pipeline
-    mock_cur.fetchone.return_value = ("uuid-1",)
+    # Return enough values for the full processing pipeline.
+    # 2-tuple satisfies Step 1 resolve_judge (judge_id, canonical_name) (#3503);
+    # all other fetchone callers only unpack row[0] so the extra element is harmless.
+    mock_cur.fetchone.return_value = ("uuid-1", "uuid-1")
     mock_cur.fetchall.return_value = []
     mock_cur.rowcount = 1
 
@@ -2069,8 +2071,10 @@ def test_process_event_default_max_tokens_for_unconfigured_county(
 
     mock_conn, mock_cur = _make_mock_conn()
     mock_psycopg.connect.return_value = mock_conn
-    # Return enough values for the full processing pipeline
-    mock_cur.fetchone.return_value = ("uuid-1",)
+    # Return enough values for the full processing pipeline.
+    # 2-tuple satisfies Step 1 resolve_judge (judge_id, canonical_name) (#3503);
+    # all other fetchone callers only unpack row[0] so the extra element is harmless.
+    mock_cur.fetchone.return_value = ("uuid-1", "uuid-1")
     mock_cur.fetchall.return_value = []
     mock_cur.rowcount = 1
 

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -1072,7 +1072,8 @@ class TestResolveJudge:
     def test_returns_existing_alias(self) -> None:
         conn = _mock_conn()
         cur = conn.cursor.return_value.__enter__.return_value
-        cur.fetchone.return_value = ("existing-judge-id",)
+        # Step 1 SELECT now returns (judge_id, canonical_name) (#3503)
+        cur.fetchone.return_value = ("existing-judge-id", "John Smith")
         result = resolve_judge(conn, "Hon. John Smith", "court-1")
         assert result == "existing-judge-id"
 
@@ -1108,7 +1109,8 @@ class TestResolveJudge:
     def test_strips_nul_from_raw_name(self) -> None:
         conn = _mock_conn()
         cur = conn.cursor.return_value.__enter__.return_value
-        cur.fetchone.return_value = ("existing-judge-id",)
+        # Step 1 SELECT now returns (judge_id, canonical_name) (#3503)
+        cur.fetchone.return_value = ("existing-judge-id", "John Smith")
         result = resolve_judge(conn, "John\x00 Smith", "court-1")
         assert result == "existing-judge-id"
         # Verify NUL was stripped from the name passed to SQL
@@ -1129,7 +1131,8 @@ class TestResolveJudge:
         """Verify alias lookup uses LOWER() for case-insensitive matching (#1453)."""
         conn = _mock_conn()
         cur = conn.cursor.return_value.__enter__.return_value
-        cur.fetchone.return_value = ("existing-judge-id",)
+        # Step 1 SELECT now returns (judge_id, canonical_name) (#3503)
+        cur.fetchone.return_value = ("existing-judge-id", "John Smith")
         resolve_judge(conn, "HON. JOHN SMITH", "court-1")
         sql = cur.execute.call_args_list[0][0][0]
         assert "LOWER" in sql

--- a/packages/scraper-framework/tests/test_judge_dedup.py
+++ b/packages/scraper-framework/tests/test_judge_dedup.py
@@ -542,8 +542,8 @@ class TestResolveJudgeRosterIntegration:
         """When an alias already exists, roster is never consulted."""
         mock_conn, mock_cur = self._make_mock_conn()
 
-        # Step 1: alias found
-        mock_cur.fetchone.return_value = ("existing-judge-uuid",)
+        # Step 1: alias found — returns (judge_id, canonical_name) now (#3503)
+        mock_cur.fetchone.return_value = ("existing-judge-uuid", "John Smith")
 
         result = resolve_judge(mock_conn, "John Smith", "court-uuid-1")
 


### PR DESCRIPTION
## Summary

Fixed judge name arbitration bootstrap logic in `resolve_judge`. The prior implementation (#3484/#3497) was dead code because Step 1's alias-hit short-circuit prevented Step 3b from ever re-running on subsequent calls, so the corroborating evidence accumulated behind a 'roster_match' source label that the arbitration query explicitly excluded. Added `_maybe_arbitrate()` helper and wired it into both Step 1 (post-short-circuit) and Step 3b (fall-through), enabling arbitration to promote incoming spellings even after Step 1 finds an alias. Changed fall-through source from hardcoded 'roster_match' to the caller's source when provided and canonical differs.

Closes #3503

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest packages/scraper-framework/tests/ingestion/test_db_judge_resolve.py -xvs` and full suite)
- [x] CI green

### Pre-deploy verification

Code verifications (via pytest mocks):
- Two-call sequence with same source (`sd_calendar`) flips canonical on second call when Step 1 short-circuits
- Multi-source bootstrap flips canonical across different sources (`sd_calendar` + `sd_roa`)
- Step 1 arbitration skips when canonical already matches (no spurious promotion)
- Step 3b fall-through uses caller's source (not 'roster_match') when canonical differs and source provided

### Post-deploy verification

- [ ] `judges.canonical_name='Mattew C. Braner'` rows in SD court corrected to `'Matthew C. Braner'` (verify via `scripts/dev-db-query.sh`)
- [ ] `judge_aliases` for affected judges show correct source labels (roster_match for demoted name, sd_calendar/sd_roa for corroborating names)
- [ ] Audit query returns zero judges where every alias source is roster_match/roster AND no judge with same canonical observed by non-roster scraper in last 30 days
- [ ] Verification evidence posted on #3503 (see /task-v2-verify output)