### PR TITLE
feat(dispatcher): add /task-v2-operational skill for non-coding work (#3507)

### DIFF
--- a/.claude/skills/task-v2-operational/SKILL.md
+++ b/.claude/skills/task-v2-operational/SKILL.md
@@ -1,0 +1,247 @@
+---
+description: Operational handler for the per-phase /task-v2 pipeline. Executes non-coding tasks (script runs, DB queries, gh actions, data rebuilds) without creating a PR. Emits a structured verdict for the dispatcher to advance the agent pipeline.
+argument-hint: "<agent-id>"
+model: opus
+maxTurns: 200
+---
+
+# /task-v2-operational skill
+
+Operational handler for the dispatcher v2 per-phase task pipeline (`docs/specs/dispatcher-v2-spec.md` §6a). Executes tasks that require only running scripts, querying the database, firing gh actions, or updating labels/issue state — without writing code or opening a PR.
+
+**Prerequisites:** The dispatcher daemon has already (a) claimed the issue, (b) created the worktree at `{worktree}`, (c) run the plan phase and determined `task_type=operational`, (d) written the input bundle to `{worktree}/tmp/dispatcher-input/operational.json`.
+
+**Goal:** Complete the operational task described in the issue, post verification evidence as an issue comment, close the issue (if done), and write a structured output JSON to `{worktree}/tmp/dispatcher-output/operational.json`. No PR. No code commits.
+
+**IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation. This subprocess is already a dispatcher-spawned background task.
+
+**IMPORTANT — Heartbeat lines.** Run the Bash tool with:
+
+- `echo PHASE_START operational` immediately after reading this SKILL.md (before Step 1).
+- `echo PHASE_DONE <verdict>` right before writing the output JSON.
+
+---
+
+## Capabilities — same as a peer /task agent
+
+You have full authority to execute operational work:
+
+- **Bash** — `scripts/ecs-run-task.sh` for ECS oneshot script runs, `scripts/dev-db-query.sh` for SQL queries, `gh` for issue/label/comment operations, `aws s3` for artifact downloads, `psql` via the scripts for DB validation. Set `timeout: 1200000` on long-running commands.
+- **Read / Glob / Grep** — full filesystem access for reading issue context, scripts, and docs.
+- **MCP servers** — `mcp__github__*` for GitHub reads, `mcp__awslabs_cloudwatch-mcp-server__*` and `mcp__awslabs_ecs-mcp-server__*` for ECS + CloudWatch reads.
+- **gh CLI** — `gh issue comment`, `gh issue close`, `gh issue edit`, `gh issue view`.
+
+> **MCP vs `gh`:** `mcp__github__get_issue` for reads. `gh issue comment --body-file`, `gh issue close`, `gh issue edit --add-label` for writes. See `docs/agent/github-api-access.md`.
+
+> **MCP vs `aws` CLI:** `scripts/ecs-run-task.sh` for ECS oneshot task launch (handles network config, log streaming, exit-code propagation). `mcp__awslabs_ecs-mcp-server__*` for cluster/task reads. See `docs/agent/aws-api-access.md`.
+
+## Bright lines — irreducible
+
+1. **No production deploy.** `terraform apply` against `environments/production/`, ECS service writes against `*-production` clusters. Human-only per `CLAUDE.md`. Use dev-tier scripts only.
+2. **No `gh auth switch`.** Operator-only.
+3. **No force-push to main, no amending merged commits.**
+4. **No code commits to the worktree branch.** Operational tasks produce zero commits — no PR is ever opened. All work is done through `scripts/ecs-run-task.sh`, `scripts/dev-db-query.sh`, or `gh` commands.
+
+If a bright line is triggered, emit `verdict=blocked` with a clear `block_reason` explaining which line was hit and what operator action is required.
+
+---
+
+## Input contract
+
+Read `{worktree}/tmp/dispatcher-input/operational.json`. Required fields (same shape as `plan.json` input plus the plan output):
+
+- `agent_id` (str) — your UUID for correlation.
+- `issue_number` (int) — the issue being worked.
+- `issue_title` (str) — title text.
+- `issue_body` (str) — raw markdown issue body.
+- `issue_comments` (list) — filtered to non-bot authors.
+- `plan_text` (str) — the plan phase output, describing exactly what to execute.
+- `acceptance_criteria` (list of str) — the acceptance criteria to verify.
+- `worktree_path` (str) — absolute path to your worktree root.
+- `repo_root` (str) — same as `worktree_path`.
+
+If the file is missing or malformed, write `verdict=blocked, block_reason="input JSON missing or malformed"` and exit 0. Never read from GitHub to reconstruct — the daemon owns the handoff.
+
+---
+
+## Output contract
+
+Write `{worktree}/tmp/dispatcher-output/operational.json` with these fields, then exit 0:
+
+```
+{
+  "agent_id": "<echo from input>",
+  "issue_number": <int>,
+  "verdict": "succeeded" | "blocked" | "failed",
+  "action_taken": "<one-line description of what was executed>",
+  "evidence_md": "<markdown evidence block — DB row counts, curl output, log lines>",
+  "block_reason": null | "<string — only when verdict=blocked>"
+}
+```
+
+Exit 0 regardless of verdict. The dispatcher reads the verdict from the JSON, not the exit code.
+
+**Verdict rules:**
+
+- `succeeded` — task completed, evidence posted, issue closed (if the AC says to close it). The agent advances to `operational_done` with `status=succeeded`.
+- `blocked` — a bright line was hit, a required secret is missing, the environment is not ready, or any other condition that needs operator action before the task can proceed. Advances to `operational_failed` with `status=needs_review`.
+- `failed` — a genuine execution failure (script errored, DB unreachable, ECS task timed out, unexpected output). Routes to the diagnoser for retry/escalation.
+
+---
+
+## Step 0 — Post-compaction recovery (READ FIRST after any context reset)
+
+If your context was just autocompacted (the summary references "previous conversation"), check the output file:
+
+```
+ls {worktree}/tmp/dispatcher-output/operational.json 2>/dev/null && echo DONE || echo RESUME
+```
+
+- **`DONE`**: the output file exists. Re-read it to confirm `verdict` is populated, then exit without re-running the task.
+- **`RESUME`**: output file missing. Continue from Step 1.
+
+---
+
+## Step 1 — Read the input bundle and understand the task
+
+Read `{worktree}/tmp/dispatcher-input/operational.json`. Extract:
+
+- The `plan_text` — the exact operational steps the plan phase prescribed.
+- The `acceptance_criteria` — what you must verify to emit `verdict=succeeded`.
+- The `issue_body` — the original issue for full context.
+
+## Step 2 — State-awareness before action (MANDATORY)
+
+Before executing anything, check what's already in flight. Duplicate ECS runs, duplicate DB rebuilds, and duplicate issue comments all have real costs.
+
+1. Run `gh issue view <issue_number> --repo judgemind/judgemind --json state,labels,comments` to confirm the issue is still open and not already completed by a prior agent.
+2. If the issue is already closed, emit `verdict=succeeded, action_taken="issue already closed by prior agent", evidence_md="Issue was already in closed state"` and exit.
+3. Check whether the operational action was already run by looking at issue comments for evidence markers from a prior agent.
+
+## Step 3 — Plan + execute
+
+Execute the operational steps described in `plan_text`. Common patterns:
+
+**ECS oneshot (data script / rebuild):**
+
+```
+scripts/ecs-run-task.sh scripts/<script>.py -- <args>
+```
+
+Use `timeout: 1200000`. The last line of stderr contains the CloudWatch log URL. Capture stdout/stderr for the evidence block.
+
+**DB query (validation / row count):**
+
+```
+scripts/dev-db-query.sh "SELECT count(*) FROM derived.rulings WHERE county = 'Santa Clara'"
+```
+
+**gh label / close:**
+
+```
+gh issue edit <N> --repo judgemind/judgemind --add-label status/done --remove-label agent/ready
+gh issue close <N> --repo judgemind/judgemind --reason completed --comment "..."
+```
+
+After executing, verify the result against each acceptance criterion. Record the verification evidence (row counts, curl responses, log lines, gh output).
+
+## Step 4 — Validate
+
+For each acceptance criterion, run the verification check described in `plan_text` or implied by the criterion text. Concrete verification patterns:
+
+- **Row count:** `scripts/dev-db-query.sh "SELECT count(*) FROM ..."` — assert count is non-zero and within expected range.
+- **Data spot-check:** `scripts/dev-db-query.sh "SELECT ... LIMIT 5"` — assert expected fields are populated.
+- **S3 presence:** `aws s3 ls s3://judgemind-document-archive-dev/<path>` — assert objects exist.
+- **ECS task exit code:** captured by `scripts/ecs-run-task.sh` — non-zero means `verdict=failed`.
+
+If any verification fails: capture the failure output and emit `verdict=failed` with the failure evidence in `evidence_md`.
+
+## Step 5 — Post evidence comment and close issue
+
+Write the evidence markdown to a temp file then post:
+
+```
+# Do NOT use heredoc — write evidence to a file first, then use --body-file
+```
+
+Write `{worktree}/tmp/dispatcher-operational/evidence.md` with a `## Verification Evidence` section, then:
+
+```
+gh issue comment <issue_number> --repo judgemind/judgemind --body-file {worktree}/tmp/dispatcher-operational/evidence.md
+```
+
+If the task is complete and the AC say to close the issue:
+
+```
+gh issue close <issue_number> --repo judgemind/judgemind --reason completed
+```
+
+## Step 6 — Write the output JSON
+
+Write `{worktree}/tmp/dispatcher-output/operational.json` with verdict + evidence. Exit 0.
+
+---
+
+## What this skill does NOT do
+
+- **Does not write code.** No edits to source files, no commits, no PR.
+- **Does not deploy to production.** ECS writes are always against dev-tier clusters.
+- **Does not spawn recursive operational agents.** If the task requires a code change, emit `verdict=blocked` with `block_reason` explaining the gap so an operator can file a coding task.
+
+## Worked example — Santa Clara county data restore
+
+Issue: "ops: restore Santa Clara county rulings after SC outage (#2419)"
+
+Plan text: "Run `rebuild_db.py --county 'Santa Clara'` via ECS oneshot. Validate row count. Post evidence. Close issue."
+
+**Step 3 execution:**
+
+```
+scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county "Santa Clara"
+```
+
+**Step 4 validation:**
+
+```
+scripts/dev-db-query.sh "SELECT count(*) FROM derived.rulings WHERE county = 'Santa Clara'"
+```
+
+Expected: count > 0 and approximately matches pre-outage snapshot.
+
+**Step 5 evidence:**
+
+```
+## Verification Evidence
+
+- ECS task `rebuild_db.py --county 'Santa Clara'` completed with exit 0.
+- `SELECT count(*) FROM derived.rulings WHERE county = 'Santa Clara'` → 4,821 rows.
+- Spot-check: `SELECT case_number, ruling_date FROM derived.rulings WHERE county = 'Santa Clara' LIMIT 5` shows data from 2026-04-15 through 2026-04-26.
+
+AC1 ✓ — Santa Clara county rulings are queryable in the DB after rebuild.
+AC2 ✓ — Row count 4,821 is within expected range of pre-outage snapshot (~4,800–4,900).
+```
+
+**Output:**
+
+```json
+{
+  "agent_id": "...",
+  "issue_number": 2419,
+  "verdict": "succeeded",
+  "action_taken": "ran rebuild_db.py --county 'Santa Clara' via ECS oneshot; 4,821 rows restored",
+  "evidence_md": "## Verification Evidence\n\n- ECS task completed exit 0.\n- 4,821 rows in derived.rulings for Santa Clara.\n",
+  "block_reason": null
+}
+```
+
+---
+
+## Reminders
+
+- No `$()`, no heredocs, no `python -c`. See the repo root `CLAUDE.md` Critical Rules.
+- All temp files go in `{worktree}/tmp/dispatcher-operational/`, never `/tmp/`.
+- Use Grep, Glob, and Read tools — never `find`, `cat`, `head`, `tail` from Bash.
+- Set `timeout: 1200000` on any long-running Bash command.
+- `evidence_md` is mandatory even for `verdict=blocked` or `verdict=failed` — include the failure output so the diagnoser can diagnose without re-running.
+- Write evidence to a file before posting to gh — never construct multi-line `--body` on the command line.
+- Post the evidence comment BEFORE closing the issue (so the comment is visible on the closed issue).

--- a/.claude/skills/task-v2-plan/SKILL.md
+++ b/.claude/skills/task-v2-plan/SKILL.md
@@ -59,6 +59,7 @@ Write `{worktree}/tmp/dispatcher-output/plan.json` with these fields, then exit 
   "issue_number": <int>,
   "go": true|false,
   "block_reason": null | "<string>",
+  "task_type": "coding" | "operational",
   "plan_text": "<markdown, ≤500 words>",
   "acceptance_criteria": ["<criterion 1>", "<criterion 2>", ...],
   "scope_check": [
@@ -136,6 +137,24 @@ Set `change_type` from this table (used by `/task-v2-verify` to pick the verific
 
 Set `dependencies_to_install` to the packages ralph's worker will need. The daemon runs `scripts/install-package-venv.sh <pkg>` for each entry in the `setup` phase before spawning ralph. Examples: `scraper-framework`, `nlp-pipeline`, `api`, `web`. Empty list for docs-only, terraform-only, or `.claude/`-only changes.
 
+## Step 4.5 — Classify task_type
+
+Set `task_type` to one of two values. This controls which pipeline branch the daemon runs after plan:
+
+| task_type | When | Pipeline |
+|---|---|---|
+| `coding` | The task requires writing or editing code, tests, docs, or config files in the repo (i.e., a PR will be opened). This is the default for any issue that touches source files. | plan → ralph → summary → push+PR → CI → merge → deploy → verify → retro |
+| `operational` | The task requires only running a script, executing a DB query, firing a gh action, adding/removing labels, rebuilding derived data, or any other operational action — **no code change, no PR**. | plan → operational skill → done |
+
+**Decision tree:**
+
+1. Does the acceptance criteria require editing any file tracked in git (Python, TypeScript, SQL, YAML, Markdown, Terraform, shell scripts, skill SKILL.md files)? → `coding`
+2. Does the issue ask to run `rebuild_db.py`, `scripts/ecs-run-task.sh`, `scripts/dev-db-query.sh`, a one-off ECS task, or a gh label/close/comment action only? → `operational`
+3. Does the issue ask to restore a specific county's data, reprocess a batch of documents, backfill derived records, or similar "run a script against the DB" work? → `operational`
+4. Unclear? Default to `coding` — the operational path skips all code-review guardrails, so false-positives here bypass the safety net.
+
+**Important:** When `task_type=operational`, set `dependencies_to_install=[]` (the operational skill does not need a ralph venv). `change_type` should still reflect what kind of system is affected (e.g. `dx_tooling`, `backfill_script`, `no_deployed_component`).
+
 ## Step 5 — Write the plan
 
 For `go=true`, write `plan_text` as ≤500 words of markdown covering:
@@ -190,6 +209,7 @@ For an issue "fix(scraping): Orange County department parsing drops leading zero
 - `scope_check`: one entry for `re.search(r"dept=(\d+)"` grep, `locations_found: ["packages/scraper-framework/src/courts/ca/orange.py:142", "packages/scraper-framework/src/courts/ca/riverside.py:98"]`, `in_scope: false, note: "Riverside uses same pattern — file follow-up to audit all counties"`.
 - `relevant_files`: `["packages/scraper-framework/src/courts/ca/orange.py", "packages/scraper-framework/tests/courts/ca/test_orange.py"]`.
 - `change_type`: `scraper`.
+- `task_type`: `coding`.
 - `dependencies_to_install`: `["scraper-framework"]`.
 - `plan_text`: covers the one-line regex fix, the new regression test against a fixture, the out-of-scope note for Riverside, and the AC verification map.
 - `collapsed_comments`: result of `collapse_comments(issue_comments)` — empty list when no issue comments, or the collapsed/verbatim list otherwise.
@@ -199,6 +219,17 @@ For an issue "docs(agent): add retro phase to task skill" where the task skill d
 
 - `go`: false.
 - `block_reason`: `"issue references .claude/skills/task/SKILL.md §5 but that section was removed in #2710; acceptance criteria need sharpening against current skill structure"`.
+
+For an issue "ops: restore Santa Clara county data after SC outage (#2419)":
+
+- `acceptance_criteria`: `["Santa Clara county rulings are queryable in the DB after rebuild.", "Row count matches pre-outage snapshot."]`
+- `scope_check`: one entry confirming `rebuild_db.py --county "Santa Clara"` is the right script.
+- `relevant_files`: `["scripts/rebuild_db.py", "docs/agent/infrastructure-reference.md"]`.
+- `change_type`: `backfill_script`.
+- `task_type`: `operational`.
+- `dependencies_to_install`: `[]`.
+- `plan_text`: "Run `rebuild_db.py --county 'Santa Clara'` via ECS oneshot. Query derived.rulings to confirm count. Post evidence comment and close issue."
+- `go`: true.
 
 ## Reminders
 

--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -1819,6 +1819,7 @@ phase_to_skill() {
         fix_conflict)   printf 'fix-conflict' ;;  # #3225
         verify)         printf 'verify' ;;
         retro)          printf 'retro' ;;
+        operational)    printf 'operational' ;;  # #3507
         *)              die "no_skill_mapping_for_phase=$1" ;;
     esac
 }
@@ -4939,6 +4940,56 @@ while true; do
             # just invokes the handler and lets the next loop tick
             # observe the new phase row.
             handle_fix_ci >/dev/null
+            ;;
+        operational)
+            # #3507: operational phase. Runs the /task-v2-operational
+            # skill for tasks that need only a script run / DB query / gh
+            # action — no code change, no PR. Modeled on the verify)
+            # arm: run_claude_phase + persist_phase_output +
+            # transition_for dispatch.
+            #
+            # Verdicts from /task-v2-operational:
+            #   succeeded → advance_with_status → operational_done/succeeded
+            #   blocked   → advance_with_status → operational_failed/needs_review
+            #   failed / missing / unrecognized → route_to_diagnoser
+            #     → agent_runner_reaped_failure "operational_failed"
+            _output=$(run_claude_phase "operational")
+            persist_phase_output "operational" "$_output"
+            _transition=$(transition_for "operational" "$_output")
+            _action=$(printf '%s' "$_transition" | cut -f1)
+            _next=$(printf '%s' "$_transition" | cut -f2)
+            _status=$(printf '%s' "$_transition" | cut -f3)
+            _hint=$(printf '%s' "$_transition" | cut -f4)
+            log "operational_transition_shim_done" \
+                "action=$_action" \
+                "next=$_next" \
+                "status=$_status" \
+                "hint=$_hint"
+            case "$_action" in
+                advance)
+                    advance_phase "$_next"
+                    ;;
+                advance_with_status)
+                    advance_phase "$_next" "$_status"
+                    ;;
+                route_to_diagnoser)
+                    # operational_failed is the only hint expected here.
+                    # Route to the descriptive terminal so the diagnoser
+                    # sweep picks it up via BYPASSED_TERMINAL_PHASES_TO_ROUTE.
+                    log "operational_route_to_diagnoser" "hint=$_hint"
+                    agent_runner_reaped_failure \
+                        "operational_failed" \
+                        "operational_failed" \
+                        "operational skill returned non-succeeded verdict — hint=$_hint"
+                    ;;
+                *)
+                    log "operational_transition_unrecognized" "action=$_action"
+                    agent_runner_reaped_failure \
+                        "post_claude_transition_unrecognized" \
+                        "post_claude_transition_unrecognized" \
+                        "operational returned action=$_action (not advance / advance_with_status / route_to_diagnoser)"
+                    ;;
+            esac
             ;;
         awaiting_ci)
             # #3176: real implementation — poll ``gh pr view`` rollup,

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1311,6 +1311,14 @@ FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE = "conflict_unresolvable"
 #: reissue, etc.).
 FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES = "push_and_pr_no_unmerged_files"
 
+#: #3507 — the ``/task-v2-operational`` skill returned ``verdict=failed``
+#: or an unrecognized verdict (script errored, DB unreachable, ECS task
+#: timed out, unexpected output). Route through the empowered diagnoser
+#: so it can decide retry / escalate / close the issue. Operational
+#: tasks have no PR to rebuild, so ``respawn_at=operational`` is the
+#: likely directive on a transient failure.
+FAILURE_CATEGORY_OPERATIONAL_FAILED = "operational_failed"
+
 #: daemon-side ``_push_and_open_pr`` pre-push rebase against ``origin/main``
 #: hit a conflict; rebase was aborted and worktree restored. No mechanical
 #: retry — proper LLM-resolution path is the follow-up issue. Tier-3.
@@ -1372,6 +1380,8 @@ BYPASSED_TERMINAL_PHASES_TO_ROUTE: dict[str, str] = {
     "verify_failed_post_merge": FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
     # #3465 — rebase exited non-zero with no unmerged files.
     "push_and_pr_no_unmerged_files": FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
+    # #3507 — operational skill returned failed/unrecognized verdict.
+    "operational_failed": FAILURE_CATEGORY_OPERATIONAL_FAILED,
 }
 
 #: GitHub's rejection stderr fragment when branch protection's
@@ -9468,6 +9478,20 @@ class DispatcherDaemon:
             return
         if self._check_killswitch_and_abort(agent_id, "planning", issue_number):
             return
+        # #3507 — branch on task_type. Operational tasks bypass ralph
+        # entirely and run the operational skill directly. Coding tasks
+        # (or any unrecognized task_type) continue to ralph as before.
+        _plan_output: dict[str, Any] = {}
+        try:
+            _fetched = self._fetch_phase_output(agent_id, "plan")
+            if _fetched is not None:
+                _plan_output = _fetched
+        except Exception:
+            pass  # non-fatal; default to coding path
+        _task_type = str(_plan_output.get("task_type") or "").lower().strip()
+        if _task_type == "operational":
+            self._run_operational_phase(agent_id, issue_number, worktree)
+            return
         ok = self._run_ralph_phase(agent_id, issue_number, worktree)
         if not ok:
             return
@@ -10962,6 +10986,166 @@ class DispatcherDaemon:
             return False
 
         return True
+
+    def _run_operational_phase(
+        self, agent_id: str, issue_number: int, worktree: Path
+    ) -> None:
+        """Run ``/task-v2-operational`` for tasks classified as operational.
+
+        #3507 — Operational tasks (``task_type='operational'``) bypass the
+        ralph → summary → push+PR pipeline. The operational skill executes
+        a script / DB query / gh action directly, posts evidence to the
+        issue, and closes the issue on success. No PR, no CI, no merge.
+
+        Mirrors the structure of :meth:`_run_plan_phase` with three
+        possible outcomes:
+
+        * ``succeeded`` — advance to ``operational_done`` with
+          ``status='succeeded'``.
+        * ``blocked`` — advance to ``operational_failed`` with
+          ``status='needs_review'`` (operator must intervene).
+        * ``failed`` / missing / unrecognized — route through
+          ``_handle_agent_failure`` so the diagnoser picks it up.
+        """
+        from scripts.dispatcher.phase_transitions import transition_from_operational
+
+        self._update_agent_phase(agent_id, "operational")
+
+        # Write the operational input bundle. Mirrors plan_input shape plus
+        # the plan output so the skill has both issue context and the plan.
+        try:
+            bundle = self._fetch_issue_bundle(issue_number)
+        except RuntimeError as exc:
+            self._log.warning(
+                "daemon.operational_issue_fetch_failed",
+                extra={
+                    "event": "operational_issue_fetch_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "detail": str(exc),
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id,
+                status="failed",
+                phase="operational",
+                exit_code=None,
+                issue_number=issue_number,
+            )
+            return
+
+        # Fetch the plan output so the operational skill has full plan context.
+        plan_output: dict[str, Any] = {}
+        try:
+            fetched = self._fetch_phase_output(agent_id, "plan")
+            if fetched is not None:
+                plan_output = fetched
+        except Exception:
+            pass  # non-fatal; the operational skill falls back to issue body
+
+        operational_input = {
+            "agent_id": agent_id,
+            "worktree_path": str(worktree),
+            "repo_root": str(worktree),
+            "plan_text": plan_output.get("plan_text", ""),
+            "acceptance_criteria": plan_output.get("acceptance_criteria", []),
+            **bundle,
+        }
+        self._write_phase_input(worktree, "operational", operational_input)
+
+        exit_code = self._run_subprocess_or_fail(
+            agent_id, "operational", worktree, issue_number=issue_number
+        )
+        if exit_code is None:
+            return
+
+        operational_output = self._read_phase_output(worktree, "operational")
+        if operational_output is None:
+            extra: dict[str, Any] = {
+                "event": "phase_output_missing",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "phase": "operational",
+            }
+            preview = self._extract_log_preview(worktree, "operational")
+            if preview:
+                extra["stderr_preview"] = preview
+            self._log.warning("daemon.phase_output_missing", extra=extra)
+            self._handle_agent_failure(
+                agent_id=agent_id,
+                phase="operational",
+                category=FAILURE_CATEGORY_PHASE_OUTPUT_MISSING,
+                stderr_tail=preview or "",
+                exit_code=exit_code,
+                details={"missing_phase_output": "operational"},
+                issue_number=issue_number,
+            )
+            return
+
+        self._persist_phase_output(
+            agent_id,
+            "operational",
+            operational_output,
+            log_text=self._read_full_phase_log(worktree, "operational") or None,
+            usage=self._parse_phase_usage(worktree, "operational"),
+        )
+
+        transition = transition_from_operational(operational_output)
+        self._log.info(
+            "daemon.operational_phase_transition",
+            extra={
+                "event": "operational_phase_transition",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "issue_number": issue_number,
+                "action": transition.action.value,
+                "next_phase": transition.next_phase,
+                "terminal_status": transition.terminal_status,
+                "failure_hint": transition.failure_hint,
+            },
+        )
+
+        if transition.action.value == "advance_with_status":
+            self._mark_agent_terminal(
+                agent_id,
+                status=transition.terminal_status or "succeeded",
+                phase=transition.next_phase or "operational_done",
+                exit_code=exit_code,
+                issue_number=issue_number,
+            )
+        elif transition.action.value == "route_to_diagnoser":
+            self._handle_agent_failure(
+                agent_id=agent_id,
+                phase="operational",
+                category=FAILURE_CATEGORY_OPERATIONAL_FAILED,
+                stderr_tail=self._extract_log_preview(worktree, "operational") or "",
+                exit_code=exit_code,
+                details={
+                    "verdict": operational_output.get("verdict"),
+                    "block_reason": operational_output.get("block_reason"),
+                    "evidence_md": operational_output.get("evidence_md"),
+                },
+                issue_number=issue_number,
+            )
+        else:
+            # Unrecognized transition — crash the agent so the operator sees it.
+            self._log.error(
+                "daemon.operational_transition_unrecognized",
+                extra={
+                    "event": "operational_transition_unrecognized",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "action": transition.action.value,
+                },
+            )
+            self._mark_agent_terminal(
+                agent_id,
+                status="crashed",
+                phase="operational",
+                exit_code=exit_code,
+                issue_number=issue_number,
+            )
 
     def _run_ralph_phase(
         self, agent_id: str, issue_number: int, worktree: Path

--- a/scripts/dispatcher/phase_transitions.py
+++ b/scripts/dispatcher/phase_transitions.py
@@ -275,6 +275,21 @@ PHASE_AGENT_RUNNER_ROUTE_STUB = "agent_runner_route_stub"
 #: PR or worktree to retry against.
 PHASE_SCHEDULED_SKILL_FAILED = "scheduled_skill_failed"
 
+#: #3507 — Operational phase (``/task-v2-operational``). Non-coding tasks
+#: that need only a script run / DB query / gh action bypass the
+#: ralph → summary → push+PR pipeline entirely. Entered when the plan
+#: phase emits ``task_type="operational"``.
+PHASE_OPERATIONAL = "operational"
+
+#: #3507 — Operational succeeded terminal. The operational skill posted
+#: evidence, closed the issue, and completed without creating a PR.
+PHASE_OPERATIONAL_DONE = "operational_done"
+
+#: #3507 — Operational failed terminal. The operational skill returned
+#: ``verdict=blocked`` — the task needs operator review before it can
+#: proceed. Routed to ``needs_review`` status so the operator can see it.
+PHASE_OPERATIONAL_FAILED = "operational_failed"
+
 # ---------------------------------------------------------------------------
 # Verdict constants — the string values produced by the phase-output JSONs.
 # ---------------------------------------------------------------------------
@@ -400,6 +415,9 @@ TERMINAL_PHASES: frozenset[str] = frozenset(
         PHASE_RALPH_BASELINE_TRANSITION_UNRECOGNIZED,
         PHASE_POST_CLAUDE_TRANSITION_UNRECOGNIZED,
         PHASE_PUSH_AND_PR_TRANSITION_UNRECOGNIZED,
+        # #3507 — operational pipeline terminals.
+        PHASE_OPERATIONAL_DONE,
+        PHASE_OPERATIONAL_FAILED,
     }
 )
 
@@ -486,6 +504,11 @@ FAILURE_HINT_CONFLICT_UNRESOLVABLE = "conflict_unresolvable"
 #: ``FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES`` in daemon.py.
 FAILURE_HINT_PUSH_AND_PR_NO_UNMERGED_FILES = "push_and_pr_no_unmerged_files"
 
+#: #3507 — The operational skill returned ``verdict=failed`` or an
+#: unrecognized verdict. Maps to ``FAILURE_CATEGORY_OPERATIONAL_FAILED``
+#: in daemon.py.
+FAILURE_HINT_OPERATIONAL_FAILED = "operational_failed"
+
 
 # ---------------------------------------------------------------------------
 # Transition dataclass.
@@ -559,6 +582,11 @@ def transition_from_plan(output: Mapping[str, Any] | None) -> PhaseTransition:
 
     Blocked path: plan emitted ``verdict='BLOCKED'`` — terminal failure
     with ``status='plan_blocked'``.
+
+    #3507 — Operational path: plan emitted ``task_type='operational'``
+    — advance to the ``operational`` phase, bypassing ralph → summary
+    → push+PR entirely. Coding tasks (or any other task_type) continue
+    to ``ralph`` as before.
     """
     verdict = _verdict(output)
     if verdict == VERDICT_BLOCKED:
@@ -572,13 +600,78 @@ def transition_from_plan(output: Mapping[str, Any] | None) -> PhaseTransition:
                 "block_reason": (output or {}).get("block_reason"),
             },
         )
-    # Any non-BLOCKED output from plan is treated as "plan done,
-    # proceed to ralph". Plan does not have a SHIP / AC_INFEASIBLE
-    # branch — it's either BLOCKED or done.
+    # #3507 — Branch on task_type. operational tasks bypass ralph
+    # entirely; all other task_types (including missing/None) default
+    # to ralph so the existing pipeline is unchanged.
+    task_type = str((output or {}).get("task_type") or "").lower().strip()
+    if task_type == "operational":
+        return PhaseTransition(
+            action=TransitionAction.ADVANCE,
+            next_phase=PHASE_OPERATIONAL,
+            reason="plan classified task_type=operational",
+        )
+    # Any non-BLOCKED, non-operational output from plan is treated as
+    # "plan done, proceed to ralph". Plan does not have a SHIP /
+    # AC_INFEASIBLE branch — it's either BLOCKED, operational, or done.
     return PhaseTransition(
         action=TransitionAction.ADVANCE,
         next_phase=PHASE_RALPH,
         reason="plan completed",
+    )
+
+
+def transition_from_operational(output: Mapping[str, Any] | None) -> PhaseTransition:
+    """Return the phase transition after ``/task-v2-operational`` runs.
+
+    #3507 — Operational-task verdicts (lower-case from the skill, upper-
+    cased here via :func:`_verdict` for comparison):
+
+    * ``succeeded`` — the operational task completed. Advance to
+      ``operational_done`` with ``status='succeeded'``. No PR, no CI, no
+      merge. The skill is expected to have already posted evidence and
+      closed the issue before emitting this verdict.
+    * ``blocked`` — the task needs operator attention before it can
+      proceed (e.g. missing secret, environment not ready). Advance to
+      ``operational_failed`` with ``status='needs_review'`` so the
+      operator can see it in the cockpit.
+    * ``failed`` / missing / unrecognized — the skill encountered a
+      genuine failure (script errored, DB unreachable, etc.). Route to
+      the diagnoser with hint ``operational_failed`` so it can decide
+      whether to retry, escalate, or close the issue.
+    """
+    verdict = _verdict(output)
+    if verdict == "SUCCEEDED":
+        return PhaseTransition(
+            action=TransitionAction.ADVANCE_WITH_STATUS,
+            next_phase=PHASE_OPERATIONAL_DONE,
+            terminal_status=AgentStatus.SUCCEEDED.value,
+            reason="operational succeeded",
+            context={
+                "evidence_md": (output or {}).get("evidence_md"),
+                "action_taken": (output or {}).get("action_taken"),
+            },
+        )
+    if verdict == "BLOCKED":
+        return PhaseTransition(
+            action=TransitionAction.ADVANCE_WITH_STATUS,
+            next_phase=PHASE_OPERATIONAL_FAILED,
+            terminal_status=AgentStatus.NEEDS_REVIEW.value,
+            reason="operational blocked — needs operator review",
+            context={
+                "block_reason": (output or {}).get("block_reason"),
+                "evidence_md": (output or {}).get("evidence_md"),
+            },
+        )
+    # failed, missing, or unrecognized — route to diagnoser.
+    return PhaseTransition(
+        action=TransitionAction.ROUTE_TO_DIAGNOSER,
+        failure_hint=FAILURE_HINT_OPERATIONAL_FAILED,
+        reason=f"operational non-succeeded verdict: {verdict or '(missing)'}",
+        context={
+            "verdict": verdict,
+            "block_reason": (output or {}).get("block_reason"),
+            "evidence_md": (output or {}).get("evidence_md"),
+        },
     )
 
 
@@ -1178,6 +1271,8 @@ _VERDICT_DRIVEN_TRANSITIONS: dict[
     PHASE_FIX_CI: transition_from_fix_ci,
     PHASE_FIX_CONFLICT: transition_from_fix_conflict,
     PHASE_VERIFY: transition_from_verify,
+    # #3507 — operational pipeline.
+    PHASE_OPERATIONAL: transition_from_operational,
 }
 
 
@@ -1256,6 +1351,8 @@ ACTIVE_PHASES: frozenset[str] = frozenset(
         PHASE_AWAITING_DEPLOY,
         PHASE_VERIFY,
         PHASE_RETRO,
+        # #3507 — operational pipeline.
+        PHASE_OPERATIONAL,
     }
 )
 
@@ -1309,6 +1406,10 @@ __all__ = [
     "PHASE_RALPH_BASELINE_TRANSITION_UNRECOGNIZED",
     "PHASE_POST_CLAUDE_TRANSITION_UNRECOGNIZED",
     "PHASE_PUSH_AND_PR_TRANSITION_UNRECOGNIZED",
+    # #3507 — operational pipeline phases
+    "PHASE_OPERATIONAL",
+    "PHASE_OPERATIONAL_DONE",
+    "PHASE_OPERATIONAL_FAILED",
     # Verdict constants
     "VERDICT_SHIP",
     "VERDICT_AC_INFEASIBLE",
@@ -1334,6 +1435,7 @@ __all__ = [
     "FAILURE_HINT_PLAN_BLOCKED",
     "FAILURE_HINT_CONFLICT_UNRESOLVABLE",
     "FAILURE_HINT_PUSH_AND_PR_NO_UNMERGED_FILES",
+    "FAILURE_HINT_OPERATIONAL_FAILED",
     # Transition dataclass + enum
     "PhaseTransition",
     "TransitionAction",
@@ -1349,6 +1451,7 @@ __all__ = [
     "transition_from_awaiting_deploy",
     "transition_from_verify",
     "transition_from_retro",
+    "transition_from_operational",
     # Convenience helpers
     "next_phase_from_verdict",
     "is_terminal_phase",

--- a/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
+++ b/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
@@ -45,6 +45,7 @@ from dispatcher.daemon import (  # noqa: E402
     BYPASSED_TERMINAL_PHASES_TO_ROUTE,
     FAILURE_CATEGORY_AGENT_RUNNER_ROUTE_STUB,
     FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE,
+    FAILURE_CATEGORY_OPERATIONAL_FAILED,
     TIER_3_CATEGORIES,
 )
 
@@ -142,6 +143,7 @@ class TestBypassedTerminalConstants:
             "fix_ci_blocked": FAILURE_CATEGORY_FIX_CI_BLOCKED,
             "verify_failed_post_merge": FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
             "push_and_pr_no_unmerged_files": FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
+            "operational_failed": FAILURE_CATEGORY_OPERATIONAL_FAILED,
         }
 
 

--- a/scripts/dispatcher/tests/test_phase_contracts.py
+++ b/scripts/dispatcher/tests/test_phase_contracts.py
@@ -452,6 +452,56 @@ class TestVerifyToRetroContract:
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# #3507 — plan emits task_type field contract
+# ---------------------------------------------------------------------------
+
+
+class TestPlanTaskTypeContract:
+    """Assert task-v2-plan/SKILL.md documents the task_type field (#3507).
+
+    The plan skill must emit ``task_type: "coding" | "operational"`` so
+    the dispatcher can branch after plan without guessing. This test is
+    a forward-looking contract: it confirms the SKILL.md carries the
+    required markers so an accidental edit doesn't silently break the
+    pipeline.
+    """
+
+    def test_skill_md_contains_task_type_field(self) -> None:
+        """SKILL.md output contract must mention ``task_type``."""
+        content = _read(_TASK_V2_PLAN_SKILL)
+        assert "task_type" in content, (
+            "task-v2-plan/SKILL.md must document the task_type output field "
+            "(required since #3507 — the dispatcher branches on this field "
+            "to route operational vs coding tasks)."
+        )
+
+    def test_skill_md_documents_coding_value(self) -> None:
+        """SKILL.md must mention the ``coding`` task_type value."""
+        content = _read(_TASK_V2_PLAN_SKILL)
+        assert "coding" in content, (
+            "task-v2-plan/SKILL.md must document task_type='coding' — "
+            "the default path for issues that require a PR."
+        )
+
+    def test_skill_md_documents_operational_value(self) -> None:
+        """SKILL.md must mention the ``operational`` task_type value."""
+        content = _read(_TASK_V2_PLAN_SKILL)
+        assert "operational" in content, (
+            "task-v2-plan/SKILL.md must document task_type='operational' — "
+            "the bypass path for script/DB/label tasks that need no PR."
+        )
+
+    def test_skill_md_contains_classify_task_type_heading(self) -> None:
+        """SKILL.md must have a 'Classify task_type' decision step."""
+        content = _read(_TASK_V2_PLAN_SKILL)
+        assert "Classify task_type" in content or "task_type" in content, (
+            "task-v2-plan/SKILL.md must contain a 'Classify task_type' step "
+            "describing when to emit 'operational' vs 'coding'. "
+            "Without this, new plan agents won't know the field exists."
+        )
+
+
 class TestDaemonRalphInputAssemblyParity:
     """Assert the daemon's inline ralph_input dict carries exactly the same
     keys as ``build_ralph_input`` produces.

--- a/scripts/dispatcher/tests/test_phase_transitions.py
+++ b/scripts/dispatcher/tests/test_phase_transitions.py
@@ -30,7 +30,7 @@ from dispatcher import phase_transitions as pt  # noqa: E402
 
 
 class TestTransitionFromPlan:
-    """Plan-phase transitions: happy path + BLOCKED terminal."""
+    """Plan-phase transitions: happy path + BLOCKED terminal + task_type routing (#3507)."""
 
     def test_happy_path_advances_to_ralph(self) -> None:
         result = pt.transition_from_plan({"plan_doc": "..."})
@@ -65,6 +65,56 @@ class TestTransitionFromPlan:
     def test_blocked_verdict_lowercase_still_matches(self) -> None:
         # Verdict matching is case-insensitive via str.upper().
         result = pt.transition_from_plan({"verdict": "blocked"})
+        assert result.action == pt.TransitionAction.ADVANCE_WITH_STATUS
+        assert result.next_phase == pt.PHASE_PLAN_BLOCKED
+
+    # ── #3507 — task_type routing tests ─────────────────────────────────
+
+    def test_task_type_operational_routes_to_operational(self) -> None:
+        # When plan emits task_type=operational, transition must advance
+        # to PHASE_OPERATIONAL (bypassing ralph entirely).
+        result = pt.transition_from_plan(
+            {"task_type": "operational", "plan_text": "run rebuild_db.py"}
+        )
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_OPERATIONAL
+        assert result.terminal_status is None
+
+    def test_task_type_operational_lowercase_routes(self) -> None:
+        # task_type comparison is case-insensitive.
+        result = pt.transition_from_plan({"task_type": "OPERATIONAL"})
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_OPERATIONAL
+
+    def test_task_type_coding_routes_to_ralph(self) -> None:
+        # task_type=coding is explicitly the default coding path.
+        result = pt.transition_from_plan({"task_type": "coding"})
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_RALPH
+
+    def test_missing_task_type_defaults_to_ralph(self) -> None:
+        # Absent task_type (e.g. output from an older plan skill) must
+        # not break existing coding pipeline behavior.
+        result = pt.transition_from_plan({"plan_text": "fix the bug"})
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_RALPH
+
+    def test_none_task_type_defaults_to_ralph(self) -> None:
+        # Explicit None task_type is treated as absent.
+        result = pt.transition_from_plan({"task_type": None})
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_RALPH
+
+    def test_blocked_takes_precedence_over_task_type_operational(self) -> None:
+        # If plan emits both BLOCKED verdict AND task_type=operational,
+        # BLOCKED must win — plan said no-go.
+        result = pt.transition_from_plan(
+            {
+                "verdict": "BLOCKED",
+                "block_reason": "ambiguous AC",
+                "task_type": "operational",
+            }
+        )
         assert result.action == pt.TransitionAction.ADVANCE_WITH_STATUS
         assert result.next_phase == pt.PHASE_PLAN_BLOCKED
 
@@ -1134,6 +1184,125 @@ class TestVerdictExtraction:
         assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
 
 
+# --------------------------------------------------------------------------
+# transition_from_operational (#3507)
+# --------------------------------------------------------------------------
+
+
+class TestTransitionFromOperational:
+    """Operational-phase transitions (#3507): succeeded terminal, blocked
+    needs_review terminal, failed/missing/unrecognized → diagnoser."""
+
+    def test_succeeded_advances_to_operational_done_with_status(self) -> None:
+        result = pt.transition_from_operational(
+            {
+                "verdict": "succeeded",
+                "action_taken": "ran rebuild_db.py --county Santa Clara",
+                "evidence_md": "## Evidence\n\n4821 rows.",
+            }
+        )
+        assert result.action == pt.TransitionAction.ADVANCE_WITH_STATUS
+        assert result.next_phase == pt.PHASE_OPERATIONAL_DONE
+        assert result.terminal_status == pt.AgentStatus.SUCCEEDED.value
+        assert result.failure_hint is None
+        assert result.context.get("evidence_md") == "## Evidence\n\n4821 rows."
+        assert (
+            result.context.get("action_taken")
+            == "ran rebuild_db.py --county Santa Clara"
+        )
+
+    def test_succeeded_uppercase_still_matches(self) -> None:
+        # Verdict matching is case-insensitive.
+        result = pt.transition_from_operational({"verdict": "SUCCEEDED"})
+        assert result.action == pt.TransitionAction.ADVANCE_WITH_STATUS
+        assert result.next_phase == pt.PHASE_OPERATIONAL_DONE
+
+    def test_blocked_advances_to_operational_failed_with_needs_review(self) -> None:
+        result = pt.transition_from_operational(
+            {
+                "verdict": "blocked",
+                "block_reason": "JUDGEMIND_DB_URL secret not set in dev",
+                "evidence_md": None,
+            }
+        )
+        assert result.action == pt.TransitionAction.ADVANCE_WITH_STATUS
+        assert result.next_phase == pt.PHASE_OPERATIONAL_FAILED
+        assert result.terminal_status == pt.AgentStatus.NEEDS_REVIEW.value
+        assert result.failure_hint is None
+        assert (
+            result.context.get("block_reason")
+            == "JUDGEMIND_DB_URL secret not set in dev"
+        )
+
+    def test_blocked_uppercase_still_matches(self) -> None:
+        result = pt.transition_from_operational({"verdict": "BLOCKED"})
+        assert result.action == pt.TransitionAction.ADVANCE_WITH_STATUS
+        assert result.next_phase == pt.PHASE_OPERATIONAL_FAILED
+        assert result.terminal_status == pt.AgentStatus.NEEDS_REVIEW.value
+
+    def test_failed_routes_to_diagnoser(self) -> None:
+        result = pt.transition_from_operational(
+            {
+                "verdict": "failed",
+                "block_reason": "ECS task exited with code 1",
+                "evidence_md": "Last log line: ConnectionRefusedError",
+            }
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_OPERATIONAL_FAILED
+        assert result.next_phase is None
+        assert result.context.get("verdict") == "FAILED"
+        assert (
+            result.context.get("evidence_md") == "Last log line: ConnectionRefusedError"
+        )
+
+    def test_failed_uppercase_routes_to_diagnoser(self) -> None:
+        result = pt.transition_from_operational({"verdict": "FAILED"})
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_OPERATIONAL_FAILED
+
+    def test_missing_verdict_routes_to_diagnoser(self) -> None:
+        # A missing verdict signals the skill failed to produce structured
+        # output — route to diagnoser so it can investigate.
+        result = pt.transition_from_operational({})
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_OPERATIONAL_FAILED
+        assert result.context.get("verdict") == ""
+
+    def test_none_output_routes_to_diagnoser(self) -> None:
+        # Defensive — subprocess failure may produce None output.
+        result = pt.transition_from_operational(None)
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_OPERATIONAL_FAILED
+
+    def test_unrecognized_verdict_routes_to_diagnoser(self) -> None:
+        # An unrecognized verdict (e.g. "partial") routes to diagnoser
+        # rather than silently treating as succeeded or blocked.
+        result = pt.transition_from_operational({"verdict": "partial"})
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_OPERATIONAL_FAILED
+        assert result.context.get("verdict") == "PARTIAL"
+
+    def test_operational_done_is_terminal(self) -> None:
+        assert pt.is_terminal_phase(pt.PHASE_OPERATIONAL_DONE) is True
+
+    def test_operational_failed_is_terminal(self) -> None:
+        assert pt.is_terminal_phase(pt.PHASE_OPERATIONAL_FAILED) is True
+
+    def test_operational_is_active_not_terminal(self) -> None:
+        assert pt.is_terminal_phase(pt.PHASE_OPERATIONAL) is False
+        assert pt.PHASE_OPERATIONAL in pt.ACTIVE_PHASES
+
+    def test_operational_in_verdict_driven_dispatch(self) -> None:
+        # operational must be in the verdict-driven dispatch table so
+        # next_phase_from_verdict can route it correctly.
+        result = pt.next_phase_from_verdict(
+            pt.PHASE_OPERATIONAL, {"verdict": "succeeded"}
+        )
+        assert result.action == pt.TransitionAction.ADVANCE_WITH_STATUS
+        assert result.next_phase == pt.PHASE_OPERATIONAL_DONE
+
+
 class TestModuleContractInvariants:
     """Higher-level properties that catch drift between functions."""
 
@@ -1177,6 +1346,8 @@ class TestModuleContractInvariants:
         # Sanity-check the most-used paths.
         advance_cases = [
             pt.transition_from_plan({}),
+            pt.transition_from_operational({"verdict": "succeeded"}),
+            pt.transition_from_operational({"verdict": "blocked"}),
             pt.transition_from_ralph({"verdict": "SHIP"}),
             pt.transition_from_summary({}),
             pt.transition_from_push_and_pr({}),
@@ -1211,6 +1382,8 @@ class TestModuleContractInvariants:
             pt.transition_from_fix_ci({"verdict": "BLOCKED"}),
             pt.transition_from_verify({"verdict": "FAILED"}),
             pt.transition_from_awaiting_deploy(deploy_succeeded=False),
+            pt.transition_from_operational({"verdict": "failed"}),
+            pt.transition_from_operational({}),
         ]
         for t in diagnoser_cases:
             assert t.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER, (

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -5367,6 +5367,362 @@ else
          "psql.log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
 fi
 
+# ══════════════════════════════════════════════════════════════════════════
+# Test T58: #3507 — operational) dispatch arm — succeeded path.
+#
+# Scenario: the dispatch loop reads phase=operational and the
+# /task-v2-operational skill returns verdict=succeeded. Expected behaviour:
+#   1. run_claude_phase "operational" is invoked (phase_to_skill maps it).
+#   2. persist_phase_output "operational" is called with the output.
+#   3. transition_for "operational" returns advance_with_status
+#      operational_done succeeded.
+#   4. advance_phase "operational_done" "succeeded" is called → DB UPDATE.
+# ══════════════════════════════════════════════════════════════════════════
+
+# Extract the operational case and its dependencies from the real entrypoint.
+t58_funcs="$TEST_TMP/t58-funcs.sh"
+printf 'exec 3>&1\n' > "$t58_funcs"
+
+for fn in db_exec db_query_one log persist_phase_output \
+          phase_to_skill \
+          read_phase_output \
+          write_phase_input \
+          run_claude_phase \
+          advance_phase \
+          agent_runner_reaped_failure \
+          transition_for; do
+    awk -v FN="^${fn}\\(\\)" '
+        $0 ~ FN { in_fn=1 }
+        in_fn { print }
+        in_fn && /^}$/ { exit }
+    ' "$ENTRYPOINT" >> "$t58_funcs"
+done
+
+# Sanity: phase_to_skill maps operational.
+if grep -q "operational)" "$t58_funcs"; then
+    pass "#3507 T58 setup — operational) arm exists in extracted functions"
+else
+    fail "#3507 T58 setup — operational) arm exists in extracted functions" \
+         "grep target: 'operational)' in funcs (head 200): $(head -c 200 "$t58_funcs")"
+fi
+
+# Build a minimal workspace.
+t58_workspace="$TEST_TMP/t58-workspace"
+t58_repo_root="$TEST_TMP/t58-repo"
+t58_state_dir="$TEST_TMP/t58-state"
+t58_stub_bin="$TEST_TMP/t58-bin"
+mkdir -p "$t58_workspace" "$t58_repo_root" "$t58_state_dir" "$t58_stub_bin"
+
+# Pre-create dispatcher-input and dispatcher-output dirs.
+mkdir -p "$t58_repo_root/tmp/dispatcher-input"
+mkdir -p "$t58_repo_root/tmp/dispatcher-output"
+
+# Seed the operational skill output with verdict=succeeded.
+cat > "$t58_repo_root/tmp/dispatcher-output/operational.json" <<'T58OUTJSON'
+{
+  "agent_id": "58585858-dead-beef-cafe-000000000001",
+  "issue_number": 2419,
+  "verdict": "succeeded",
+  "action_taken": "ran rebuild_db.py --county Santa Clara; 4821 rows restored",
+  "evidence_md": "## Evidence\n\n4821 rows in derived.rulings.",
+  "block_reason": null
+}
+T58OUTJSON
+
+# psql stub: records all queries; responds to phase SELECT with "operational".
+cat > "$t58_stub_bin/psql" <<'T58PSQLEOF'
+#!/usr/bin/env bash
+set -u
+query=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -c) shift; query="$1" ;;
+    esac
+    shift || true
+done
+printf 'CALL %s\n' "$query" >> "${T58_STATE_DIR}/psql-log.txt"
+if [[ "$query" == *"SELECT phase"*"FROM dispatcher.agents"* ]]; then
+    printf 'operational\n'
+fi
+exit 0
+T58PSQLEOF
+chmod +x "$t58_stub_bin/psql"
+
+# claude stub: just logs invocation and exits 0 (run_claude_phase reads from
+# the dispatcher-output JSON, not from claude's stdout in the entrypoint's
+# read_phase_output path).
+cat > "$t58_stub_bin/claude" <<'T58CLAUDEEOF'
+#!/usr/bin/env bash
+printf 'CLAUDE_INVOKED %s\n' "$*" >> "${T58_STATE_DIR}/claude-log.txt"
+printf '{"result": "stub"}\n'
+exit 0
+T58CLAUDEEOF
+chmod +x "$t58_stub_bin/claude"
+
+# git stub: no-op.
+cat > "$t58_stub_bin/git" <<'T58GITEOF'
+#!/usr/bin/env bash
+exit 0
+T58GITEOF
+chmod +x "$t58_stub_bin/git"
+
+# gh stub: no-op.
+cat > "$t58_stub_bin/gh" <<'T58GHEOF'
+#!/usr/bin/env bash
+exit 0
+T58GHEOF
+chmod +x "$t58_stub_bin/gh"
+
+# transition_for stub: returns advance_with_status\toperational_done\tsucceeded\t
+# for the operational phase. Extracted as a shell function replacement below.
+# We override transition_for in the sourced functions file.
+_t58_transition_for_override="
+transition_for() {
+    if [[ \"\${1:-}\" == 'operational' ]]; then
+        printf 'advance_with_status\toperational_done\tsucceeded\t'
+    else
+        printf 'advance\t%s\t\t' \"\${2:-done}\"
+    fi
+}
+"
+
+# advance_phase stub: records the call.
+_t58_advance_phase_override="
+advance_phase() {
+    printf 'ADVANCE_PHASE %s %s\n' \"\${1:-}\" \"\${2:-}\" >> \"\${T58_STATE_DIR}/advance-log.txt\"
+}
+"
+
+# Run the operational case in a subshell.
+t58_out=$(
+    set +eu
+    export T58_STATE_DIR="$t58_state_dir"
+    export AGENT_WORKSPACE="$t58_workspace"
+    export REPO_ROOT="$t58_repo_root"
+    export AGENT_ID="58585858-dead-beef-cafe-000000000001"
+    export ISSUE_NUMBER="2419"
+    export DATABASE_URL="postgresql://stub"
+    export AGENT_RUNNER_DRY_RUN="0"
+    export PATH="$t58_stub_bin:$PATH"
+    # Source the extracted functions + overrides.
+    source "$t58_funcs"
+    eval "$_t58_transition_for_override"
+    eval "$_t58_advance_phase_override"
+    # Invoke just the operational dispatch logic inline.
+    _output=$(run_claude_phase "operational")
+    persist_phase_output "operational" "$_output"
+    _transition=$(transition_for "operational" "$_output")
+    _action=$(printf '%s' "$_transition" | cut -f1)
+    _next=$(printf '%s' "$_transition" | cut -f2)
+    _status=$(printf '%s' "$_transition" | cut -f3)
+    log "operational_transition_shim_done" "action=$_action" "next=$_next" "status=$_status"
+    case "$_action" in
+        advance_with_status)
+            advance_phase "$_next" "$_status"
+            ;;
+        advance)
+            advance_phase "$_next"
+            ;;
+        *)
+            printf 'UNEXPECTED_ACTION %s\n' "$_action"
+            ;;
+    esac
+    echo "subshell_done"
+    2>&1
+) 2>&1
+
+# (1) subshell exited / produced output.
+if printf '%s' "$t58_out" | grep -q "subshell_done"; then
+    pass "#3507 T58 [operational succeeded] — dispatch subshell ran to completion"
+else
+    fail "#3507 T58 [operational succeeded] — dispatch subshell ran to completion" \
+         "out tail: $(printf '%s' "$t58_out" | tail -c 600)"
+fi
+
+# (2) transition_shim_done logged with advance_with_status.
+if printf '%s' "$t58_out" | grep -q "operational_transition_shim_done.*advance_with_status"; then
+    pass "#3507 T58 [operational succeeded] — transition_shim_done logged advance_with_status"
+else
+    fail "#3507 T58 [operational succeeded] — transition_shim_done logged advance_with_status" \
+         "out: $(printf '%s' "$t58_out" | tail -c 600)"
+fi
+
+# (3) advance_phase called with operational_done succeeded.
+if [[ -f "$t58_state_dir/advance-log.txt" ]] && grep -q "ADVANCE_PHASE operational_done succeeded" "$t58_state_dir/advance-log.txt"; then
+    pass "#3507 T58 [operational succeeded] — advance_phase operational_done succeeded called"
+else
+    fail "#3507 T58 [operational succeeded] — advance_phase operational_done succeeded called" \
+         "advance-log: $(cat "$t58_state_dir/advance-log.txt" 2>/dev/null || echo '(missing)')"
+fi
+
+# (4) claude was invoked with /task-v2-operational.
+if [[ -f "$t58_state_dir/claude-log.txt" ]] && grep -q "operational" "$t58_state_dir/claude-log.txt"; then
+    pass "#3507 T58 [operational succeeded] — claude invoked with operational skill"
+else
+    fail "#3507 T58 [operational succeeded] — claude invoked with operational skill" \
+         "claude-log: $(cat "$t58_state_dir/claude-log.txt" 2>/dev/null || echo '(missing)')"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test T59: #3507 — operational) dispatch arm — failed/diagnoser path.
+#
+# Scenario: the /task-v2-operational skill returns verdict=failed.
+# Expected behaviour:
+#   1. transition_for returns route_to_diagnoser.
+#   2. agent_runner_reaped_failure "operational_failed" is called.
+#   3. No advance_phase call is made.
+# ══════════════════════════════════════════════════════════════════════════
+
+t59_workspace="$TEST_TMP/t59-workspace"
+t59_repo_root="$TEST_TMP/t59-repo"
+t59_state_dir="$TEST_TMP/t59-state"
+t59_stub_bin="$TEST_TMP/t59-bin"
+mkdir -p "$t59_workspace" "$t59_repo_root" "$t59_state_dir" "$t59_stub_bin"
+
+mkdir -p "$t59_repo_root/tmp/dispatcher-input"
+mkdir -p "$t59_repo_root/tmp/dispatcher-output"
+
+# Seed operational output with verdict=failed.
+cat > "$t59_repo_root/tmp/dispatcher-output/operational.json" <<'T59OUTJSON'
+{
+  "agent_id": "59595959-dead-beef-cafe-000000000001",
+  "issue_number": 2419,
+  "verdict": "failed",
+  "action_taken": null,
+  "evidence_md": "ECS task exited with code 1",
+  "block_reason": null
+}
+T59OUTJSON
+
+# psql stub.
+cat > "$t59_stub_bin/psql" <<'T59PSQLEOF'
+#!/usr/bin/env bash
+query=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in -c) shift; query="$1" ;; esac
+    shift || true
+done
+if [[ "$query" == *"SELECT phase"* ]]; then printf 'operational\n'; fi
+exit 0
+T59PSQLEOF
+chmod +x "$t59_stub_bin/psql"
+
+cat > "$t59_stub_bin/claude" <<'T59CLAUDEEOF'
+#!/usr/bin/env bash
+printf '{"result": "stub"}\n'
+exit 0
+T59CLAUDEEOF
+chmod +x "$t59_stub_bin/claude"
+
+cat > "$t59_stub_bin/git" <<'T59GITEOF'
+#!/usr/bin/env bash
+exit 0
+T59GITEOF
+chmod +x "$t59_stub_bin/git"
+
+cat > "$t59_stub_bin/gh" <<'T59GHEOF'
+#!/usr/bin/env bash
+exit 0
+T59GHEOF
+chmod +x "$t59_stub_bin/gh"
+
+_t59_transition_for_override="
+transition_for() {
+    if [[ \"\${1:-}\" == 'operational' ]]; then
+        printf 'route_to_diagnoser\t\t\toperational_failed'
+    fi
+}
+"
+
+_t59_reaped_failure_override="
+agent_runner_reaped_failure() {
+    printf 'REAPED_FAILURE %s\n' \"\${1:-}\" >> \"\${T59_STATE_DIR}/reaped-log.txt\"
+    log 'agent_runner_reaped_failure' \"phase=\$1\" \"hint=\$2\"
+}
+"
+
+_t59_advance_phase_override="
+advance_phase() {
+    printf 'ADVANCE_PHASE %s\n' \"\${1:-}\" >> \"\${T59_STATE_DIR}/advance-log.txt\"
+}
+"
+
+t59_out=$(
+    set +eu
+    export T59_STATE_DIR="$t59_state_dir"
+    export AGENT_WORKSPACE="$t59_workspace"
+    export REPO_ROOT="$t59_repo_root"
+    export AGENT_ID="59595959-dead-beef-cafe-000000000001"
+    export ISSUE_NUMBER="2419"
+    export DATABASE_URL="postgresql://stub"
+    export AGENT_RUNNER_DRY_RUN="0"
+    export PATH="$t59_stub_bin:$PATH"
+    source "$t58_funcs"
+    eval "$_t59_transition_for_override"
+    eval "$_t59_reaped_failure_override"
+    eval "$_t59_advance_phase_override"
+    _output=$(run_claude_phase "operational")
+    persist_phase_output "operational" "$_output"
+    _transition=$(transition_for "operational" "$_output")
+    _action=$(printf '%s' "$_transition" | cut -f1)
+    _next=$(printf '%s' "$_transition" | cut -f2)
+    _status=$(printf '%s' "$_transition" | cut -f3)
+    _hint=$(printf '%s' "$_transition" | cut -f4)
+    log "operational_transition_shim_done" "action=$_action" "next=$_next" "hint=$_hint"
+    case "$_action" in
+        advance_with_status)
+            advance_phase "$_next" "$_status"
+            ;;
+        advance)
+            advance_phase "$_next"
+            ;;
+        route_to_diagnoser)
+            log "operational_route_to_diagnoser" "hint=$_hint"
+            agent_runner_reaped_failure \
+                "operational_failed" \
+                "operational_failed" \
+                "operational skill returned non-succeeded verdict"
+            ;;
+        *)
+            printf 'UNEXPECTED_ACTION %s\n' "$_action"
+            ;;
+    esac
+    echo "subshell_done"
+    2>&1
+) 2>&1
+
+# (1) subshell completed.
+if printf '%s' "$t59_out" | grep -q "subshell_done"; then
+    pass "#3507 T59 [operational failed] — dispatch subshell ran to completion"
+else
+    fail "#3507 T59 [operational failed] — dispatch subshell ran to completion" \
+         "out tail: $(printf '%s' "$t59_out" | tail -c 600)"
+fi
+
+# (2) transition logged route_to_diagnoser.
+if printf '%s' "$t59_out" | grep -q "operational_transition_shim_done.*route_to_diagnoser"; then
+    pass "#3507 T59 [operational failed] — transition_shim_done logged route_to_diagnoser"
+else
+    fail "#3507 T59 [operational failed] — transition_shim_done logged route_to_diagnoser" \
+         "out: $(printf '%s' "$t59_out" | tail -c 600)"
+fi
+
+# (3) agent_runner_reaped_failure called with operational_failed.
+if [[ -f "$t59_state_dir/reaped-log.txt" ]] && grep -q "REAPED_FAILURE operational_failed" "$t59_state_dir/reaped-log.txt"; then
+    pass "#3507 T59 [operational failed] — agent_runner_reaped_failure called with operational_failed"
+else
+    fail "#3507 T59 [operational failed] — agent_runner_reaped_failure called with operational_failed" \
+         "reaped-log: $(cat "$t59_state_dir/reaped-log.txt" 2>/dev/null || echo '(missing)')"
+fi
+
+# (4) advance_phase NOT called on failure path.
+if [[ ! -f "$t59_state_dir/advance-log.txt" ]] || ! grep -q "ADVANCE_PHASE" "$t59_state_dir/advance-log.txt"; then
+    pass "#3507 T59 [operational failed] — advance_phase not called on route_to_diagnoser"
+else
+    fail "#3507 T59 [operational failed] — advance_phase not called on route_to_diagnoser" \
+         "advance-log: $(cat "$t59_state_dir/advance-log.txt" 2>/dev/null)"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Added operational task type to the dispatcher v2 pipeline (issue #3507). New PHASE_OPERATIONAL branch in phase_transitions.py routes tasks requiring only script runs/DB queries/gh actions past the ralph→summary→PR pipeline. Added _run_operational_phase in daemon.py, operational dispatch arm in agent-runner-entrypoint.sh, new task-v2-operational/SKILL.md skill, and task_type classification in task-v2-plan/SKILL.md. All 169 Python tests and 59 bash tests pass.

Closes #3507

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
- [x] CI green

### Post-deploy verification

- [ ] Unblock #2419 (SC restore). Daemon claims, plan classifies as operational, operational skill runs rebuild_db.py, posts evidence, closes #2419.
- [ ] Verification evidence posted on #3507