### PR TITLE
fix(scraping): mark split-superseded documents with change_type (#3510)

### DIFF
--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -5057,7 +5057,7 @@ class TestSupersedeDocument:
     """Tests for _supersede_document()."""
 
     def test_executes_delete_and_update_queries(self) -> None:
-        """Deletes old rulings then marks document as superseded."""
+        """Deletes old rulings then marks document as superseded with change_type."""
         conn = MagicMock()
         cur = MagicMock()
         cur.rowcount = 1
@@ -5076,12 +5076,34 @@ class TestSupersedeDocument:
         delete_params = cur.execute.call_args_list[0][0][1]
         assert delete_params == (str(_DOC_ID_1),)
 
-        # Second call: UPDATE document status to superseded
+        # Second call: UPDATE document status to superseded with change_type
         update_sql = cur.execute.call_args_list[1][0][0]
         assert "UPDATE documents" in update_sql
         assert "superseded" in update_sql
+        assert "change_type" in update_sql
         update_params = cur.execute.call_args_list[1][0][1]
-        assert update_params == (str(_DOC_ID_1),)
+        assert "split_supersede" in update_params
+        assert str(_DOC_ID_1) in update_params
+
+    def test_custom_change_type_kwarg(self) -> None:
+        """Passing a custom change_type renders it into the UPDATE params."""
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.rowcount = 0
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=cur)
+        ctx.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = ctx
+
+        reingest._supersede_document(conn, str(_DOC_ID_2), change_type="test_custom")
+
+        assert cur.execute.call_count == 2
+
+        update_sql = cur.execute.call_args_list[1][0][0]
+        assert "change_type" in update_sql
+        update_params = cur.execute.call_args_list[1][0][1]
+        assert "test_custom" in update_params
+        assert str(_DOC_ID_2) in update_params
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/backfill_split_supersede.py
+++ b/scripts/backfill_split_supersede.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# one-off: true
+"""Backfill change_type (and previous_version_id where possible) for
+pre-existing split-superseded documents (#3510).
+
+Finds ``derived.documents`` rows where ``status='superseded'``,
+``previous_version_id IS NULL``, and ``change_type IS NULL`` — these are
+documents that were marked superseded before the live-code fix in #3510
+started populating ``change_type``.
+
+For each loser it attempts to find the canonical successor via:
+  1. Find all ``active`` siblings sharing the same ``case_id`` that have at
+     least one row in ``derived.rulings``.
+  2. Pick the most-recently-``created_at`` sibling as the successor.
+
+If a viable sibling is found:
+  UPDATE SET previous_version_id = <sibling.id>, change_type = 'split_supersede'
+
+If case_id IS NULL or no sibling has rulings:
+  UPDATE SET change_type = 'split_supersede_unverified'
+
+Both UPDATE statements include an idempotent WHERE guard
+(``AND previous_version_id IS NULL AND change_type IS NULL``) so the script
+is safe to run multiple times.
+
+This is an ECS oneshot script: no local imports from scripts/, only stdlib +
+installed packages.
+
+Usage (ECS):
+    scripts/ecs-run-task.sh scripts/backfill_split_supersede.py -- --dry-run
+    scripts/ecs-run-task.sh scripts/backfill_split_supersede.py -- --dry-run --limit 5
+    scripts/ecs-run-task.sh scripts/backfill_split_supersede.py -- --county "Los Angeles"
+    scripts/ecs-run-task.sh scripts/backfill_split_supersede.py
+
+Options:
+    --dry-run       Show what would be updated without writing to DB.
+    --limit N       Maximum number of loser rows to process (default: all).
+    --county NAME   Scope to one county (case-insensitive, default: all).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections import defaultdict
+
+# Ensure the scraper-framework source is importable
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "packages", "scraper-framework", "src"
+    ),
+)
+
+import psycopg  # noqa: E402
+import structlog  # noqa: E402
+
+from framework.logging import configure_structlog  # noqa: E402
+
+configure_structlog(contextvars=True)
+logger = structlog.get_logger()
+
+# ---------------------------------------------------------------------------
+# SQL constants
+# ---------------------------------------------------------------------------
+
+# SELECT all pre-existing superseded documents with no change_type yet.
+_SELECT_LOSERS = """
+    SELECT
+        d.id::text        AS loser_id,
+        d.case_id::text   AS loser_case_id,
+        co.county         AS county
+    FROM derived.documents d
+    JOIN derived.courts co ON co.id = d.court_id
+    WHERE d.status = 'superseded'
+      AND d.previous_version_id IS NULL
+      AND d.change_type IS NULL
+"""
+
+# Find active siblings sharing the same case_id that have at least one ruling.
+# Returns newest-first (by created_at) so pick_sibling_for_loser takes first.
+_SELECT_SIBLING_CANDIDATES = """
+    SELECT d.id::text, d.created_at
+    FROM derived.documents d
+    WHERE d.case_id = %s::uuid
+      AND d.status = 'active'
+      AND d.id != %s::uuid
+      AND EXISTS (
+          SELECT 1 FROM derived.rulings r WHERE r.document_id = d.id
+      )
+    ORDER BY d.created_at DESC
+"""
+
+# Idempotent UPDATE when a sibling successor is found.
+_UPDATE_LOSER_WITH_SIBLING = (
+    "UPDATE derived.documents "
+    "SET previous_version_id = %s::uuid, "
+    "    change_type = 'split_supersede' "
+    "WHERE id = %s::uuid "
+    "  AND previous_version_id IS NULL "
+    "  AND change_type IS NULL"
+)
+
+# Idempotent UPDATE when no viable sibling is found.
+_UPDATE_LOSER_UNVERIFIED = (
+    "UPDATE derived.documents "
+    "SET change_type = 'split_supersede_unverified' "
+    "WHERE id = %s::uuid "
+    "  AND previous_version_id IS NULL "
+    "  AND change_type IS NULL"
+)
+
+_BATCH_SIZE = 100
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers -- testable without a live DB
+# ---------------------------------------------------------------------------
+
+
+def pick_sibling_for_loser(candidates: list[dict]) -> str | None:
+    """Return the newest sibling document id, or None if no candidates.
+
+    Parameters
+    ----------
+    candidates:
+        Each dict must have at least an ``"id"`` key (str UUID) and a
+        ``"created_at"`` key.  The list should already be ordered
+        newest-first (as returned by ``_SELECT_SIBLING_CANDIDATES``).
+
+    Returns
+    -------
+    str | None
+        The id of the newest candidate when at least one exists, else
+        ``None``.
+    """
+    if not candidates:
+        return None
+    # Candidates are pre-sorted newest-first by the SQL ORDER BY.
+    return candidates[0]["id"]
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def fetch_losers(
+    conn: psycopg.Connection,
+    *,
+    limit: int | None = None,
+    county: str | None = None,
+) -> list[dict]:
+    """Fetch pre-existing superseded documents that need backfilling."""
+    query = _SELECT_LOSERS
+    params: list[object] = []
+
+    if county:
+        query += " AND lower(co.county) = lower(%s)"
+        params.append(county)
+
+    query += " ORDER BY co.county, d.id"
+
+    if limit is not None:
+        query += f" LIMIT {limit}"
+
+    with conn.cursor() as cur:
+        cur.execute(query, params or None)
+        rows = cur.fetchall()
+
+    return [
+        {
+            "loser_id": row[0],
+            "loser_case_id": row[1],
+            "county": row[2],
+        }
+        for row in rows
+    ]
+
+
+def find_sibling_candidates(
+    conn: psycopg.Connection,
+    loser_id: str,
+    case_id: str,
+) -> list[dict]:
+    """Find active siblings with rulings sharing case_id with the loser."""
+    with conn.cursor() as cur:
+        cur.execute(_SELECT_SIBLING_CANDIDATES, (case_id, loser_id))
+        rows = cur.fetchall()
+    return [{"id": row[0], "created_at": row[1]} for row in rows]
+
+
+def apply_update_with_sibling(
+    conn: psycopg.Connection,
+    updates: list[tuple[str, str]],
+    *,
+    dry_run: bool,
+) -> int:
+    """Execute a batch of sibling-link UPDATE statements.
+
+    Parameters
+    ----------
+    updates:
+        List of ``(sibling_id, loser_id)`` tuples.
+    dry_run:
+        If ``True``, log the intended updates but do not execute.
+
+    Returns
+    -------
+    int
+        Number of intended links (dry-run) or rows actually updated (write).
+    """
+    if dry_run:
+        for sibling_id, loser_id in updates:
+            logger.info(
+                "DRY RUN: would link loser to sibling",
+                loser_id=loser_id,
+                sibling_id=sibling_id,
+                change_type="split_supersede",
+            )
+        return len(updates)
+
+    updated = 0
+    with conn.cursor() as cur:
+        for sibling_id, loser_id in updates:
+            cur.execute(_UPDATE_LOSER_WITH_SIBLING, (sibling_id, loser_id))
+            updated += cur.rowcount
+    conn.commit()
+    return updated
+
+
+def apply_update_unverified(
+    conn: psycopg.Connection,
+    loser_ids: list[str],
+    *,
+    dry_run: bool,
+) -> int:
+    """Execute a batch of unverified UPDATE statements.
+
+    Parameters
+    ----------
+    loser_ids:
+        List of loser document ids.
+    dry_run:
+        If ``True``, log the intended updates but do not execute.
+
+    Returns
+    -------
+    int
+        Number of intended updates (dry-run) or rows actually updated (write).
+    """
+    if dry_run:
+        for loser_id in loser_ids:
+            logger.info(
+                "DRY RUN: would mark loser unverified",
+                loser_id=loser_id,
+                change_type="split_supersede_unverified",
+            )
+        return len(loser_ids)
+
+    updated = 0
+    with conn.cursor() as cur:
+        for loser_id in loser_ids:
+            cur.execute(_UPDATE_LOSER_UNVERIFIED, (loser_id,))
+            updated += cur.rowcount
+    conn.commit()
+    return updated
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:  # noqa: C901 -- acceptable complexity for a one-off script
+    """Run the split_supersede change_type backfill."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill change_type for pre-existing split-superseded documents (#3510)."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be updated without writing to DB.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum number of loser rows to process (default: all).",
+    )
+    parser.add_argument(
+        "--county",
+        type=str,
+        default=None,
+        help="Scope to one county by name (case-insensitive, default: all).",
+    )
+    args = parser.parse_args()
+
+    db_url = os.environ.get("DATABASE_URL")
+    if not db_url:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    conn = psycopg.connect(db_url, autocommit=False)
+    try:
+        losers = fetch_losers(conn, limit=args.limit, county=args.county)
+        total = len(losers)
+        logger.info(
+            "Fetched superseded losers to process",
+            total=total,
+            dry_run=args.dry_run,
+            county=args.county,
+        )
+
+        if not losers:
+            logger.info(
+                "No losers to process -- all superseded docs already backfilled"
+            )
+            return
+
+        linked = 0
+        unverified = 0
+        county_counts: dict[str, int] = defaultdict(int)
+        pending_sibling_updates: list[tuple[str, str]] = []
+        pending_unverified_ids: list[str] = []
+
+        def flush_batches() -> None:
+            nonlocal linked, unverified
+            if pending_sibling_updates:
+                linked += apply_update_with_sibling(
+                    conn, pending_sibling_updates, dry_run=args.dry_run
+                )
+                pending_sibling_updates.clear()
+            if pending_unverified_ids:
+                unverified += apply_update_unverified(
+                    conn, pending_unverified_ids, dry_run=args.dry_run
+                )
+                pending_unverified_ids.clear()
+
+        for loser in losers:
+            loser_id = loser["loser_id"]
+            loser_case_id = loser["loser_case_id"]
+            county = loser["county"]
+
+            sibling_id: str | None = None
+            if loser_case_id is not None:
+                candidates = find_sibling_candidates(conn, loser_id, loser_case_id)
+                sibling_id = pick_sibling_for_loser(candidates)
+
+            if sibling_id is not None:
+                pending_sibling_updates.append((sibling_id, loser_id))
+                county_counts[county] += 1
+                logger.debug(
+                    "queued sibling link",
+                    loser_id=loser_id,
+                    sibling_id=sibling_id,
+                    county=county,
+                )
+            else:
+                reason = (
+                    "no_case_id" if loser_case_id is None else "no_sibling_with_rulings"
+                )
+                pending_unverified_ids.append(loser_id)
+                logger.debug(
+                    "queued unverified",
+                    loser_id=loser_id,
+                    county=county,
+                    reason=reason,
+                )
+
+            if (
+                len(pending_sibling_updates) + len(pending_unverified_ids)
+                >= _BATCH_SIZE
+            ):
+                flush_batches()
+
+        flush_batches()  # final partial batch
+
+        logger.info(
+            "backfill_split_supersede_summary",
+            event="backfill_split_supersede_summary",
+            total_scanned=total,
+            linked=linked,
+            unverified=unverified,
+            per_county=dict(county_counts),
+            dry_run=args.dry_run,
+        )
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reingest_from_s3.py
+++ b/scripts/reingest_from_s3.py
@@ -1879,17 +1879,25 @@ def _reparse_document_multimodal(
 def _supersede_document(
     conn: psycopg.Connection,
     document_id: str,
+    change_type: str = "split_supersede",
 ) -> None:
     """Mark a document as superseded (replaced by split children).
 
-    Sets ``documents.status = 'superseded'`` so the original unsplit
-    document is excluded from future queries and reingest runs.
-    The row is preserved for audit trail purposes.
+    Sets ``documents.status = 'superseded'`` and ``change_type`` so the
+    original unsplit document is excluded from future queries and reingest
+    runs.  The row is preserved for audit trail purposes.
 
     Also deletes any ruling rows that reference the original document,
     since the split children create their own ruling rows with correct
     per-ruling text.  Without this, the old single-ruling row (with
     corrupted or merged text) would persist alongside the new split rows.
+
+    Parameters
+    ----------
+    change_type:
+        Reason code written to ``documents.change_type``.  Defaults to
+        ``'split_supersede'`` (the live split path).  Pass a different
+        value when calling from a backfill or test context.
     """
     with conn.cursor() as cur:
         cur.execute(
@@ -1898,8 +1906,9 @@ def _supersede_document(
         )
         deleted = cur.rowcount
         cur.execute(
-            "UPDATE documents SET status = 'superseded' WHERE id = %s::uuid",
-            (document_id,),
+            "UPDATE documents SET status = 'superseded', change_type = %s"
+            " WHERE id = %s::uuid",
+            (change_type, document_id),
         )
     logger.debug(
         "Superseded document %s (deleted %d old ruling(s))",

--- a/scripts/tests/test_backfill_split_supersede.py
+++ b/scripts/tests/test_backfill_split_supersede.py
@@ -1,0 +1,320 @@
+"""Tests for the backfill_split_supersede script (#3510).
+
+Tests cover:
+  1. SQL constants contain the idempotent WHERE guard.
+  2. Candidate picker selects newest sibling with rulings.
+  3. Falls back to 'split_supersede_unverified' when no valid sibling.
+  4. UPDATE SQL shapes for both paths.
+  5. Dry-run mode skips DB writes.
+
+All database access is mocked -- these tests verify the pure helper logic,
+SELECT filters, and UPDATE shapes without requiring live services.
+
+The script depends on psycopg, structlog, and framework (scraper-framework),
+which are not available in the lightweight CI scripts-tests environment.
+We mock them in sys.modules before importing the script under test.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Pre-import mocking -- the script imports psycopg, structlog, and
+# framework.logging at module level, which are not installed in the CI
+# scripts-tests environment.
+# ---------------------------------------------------------------------------
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+_mock_psycopg = MagicMock()
+_mock_structlog = MagicMock()
+_mock_structlog.get_logger.return_value = MagicMock()
+_mock_framework = MagicMock()
+_mock_framework_logging = MagicMock()
+
+_modules_to_mock = {
+    "psycopg": _mock_psycopg,
+    "structlog": _mock_structlog,
+    "framework": _mock_framework,
+    "framework.logging": _mock_framework_logging,
+}
+
+_saved_modules: dict[str, object] = {}
+for _mod_name, _mock_mod in _modules_to_mock.items():
+    if _mod_name in sys.modules:
+        _saved_modules[_mod_name] = sys.modules[_mod_name]
+    sys.modules[_mod_name] = _mock_mod
+
+import backfill_split_supersede as backfill  # noqa: E402
+
+# Restore sys.modules so the mock injection doesn't break other test files.
+for _mod_name in list(_modules_to_mock.keys()):
+    if _mod_name in _saved_modules:
+        sys.modules[_mod_name] = _saved_modules[_mod_name]
+    elif _mod_name in sys.modules:
+        del sys.modules[_mod_name]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_conn(fetchall_return: list) -> tuple[MagicMock, MagicMock]:
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value.__enter__ = MagicMock(return_value=cur)
+    conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    cur.fetchall.return_value = fetchall_return
+    return conn, cur
+
+
+# ---------------------------------------------------------------------------
+# SQL constant shape tests
+# ---------------------------------------------------------------------------
+
+
+class TestSelectLosersSqlShape:
+    """The _SELECT_LOSERS constant must contain the correct WHERE guards."""
+
+    def test_filters_superseded_status(self) -> None:
+        assert "superseded" in backfill._SELECT_LOSERS
+
+    def test_filters_previous_version_id_is_null(self) -> None:
+        assert "previous_version_id IS NULL" in backfill._SELECT_LOSERS
+
+    def test_filters_change_type_is_null(self) -> None:
+        assert "change_type IS NULL" in backfill._SELECT_LOSERS
+
+
+class TestUpdateWithSiblingSqlShape:
+    """_UPDATE_LOSER_WITH_SIBLING must set both fields and have idempotent guard."""
+
+    def test_sets_previous_version_id(self) -> None:
+        assert "previous_version_id" in backfill._UPDATE_LOSER_WITH_SIBLING
+
+    def test_sets_change_type_split_supersede(self) -> None:
+        assert "split_supersede" in backfill._UPDATE_LOSER_WITH_SIBLING
+
+    def test_has_idempotent_guard_previous_version_id(self) -> None:
+        assert "previous_version_id IS NULL" in backfill._UPDATE_LOSER_WITH_SIBLING
+
+    def test_has_idempotent_guard_change_type(self) -> None:
+        assert "change_type IS NULL" in backfill._UPDATE_LOSER_WITH_SIBLING
+
+
+class TestUpdateUnverifiedSqlShape:
+    """_UPDATE_LOSER_UNVERIFIED must set change_type and have idempotent guard."""
+
+    def test_sets_change_type_split_supersede_unverified(self) -> None:
+        assert "split_supersede_unverified" in backfill._UPDATE_LOSER_UNVERIFIED
+
+    def test_has_idempotent_guard_previous_version_id(self) -> None:
+        assert "previous_version_id IS NULL" in backfill._UPDATE_LOSER_UNVERIFIED
+
+    def test_has_idempotent_guard_change_type(self) -> None:
+        assert "change_type IS NULL" in backfill._UPDATE_LOSER_UNVERIFIED
+
+
+# ---------------------------------------------------------------------------
+# pick_sibling_for_loser tests
+# ---------------------------------------------------------------------------
+
+
+class TestPickSiblingForLoser:
+    """pick_sibling_for_loser selects newest sibling (first after ORDER BY DESC)."""
+
+    def test_single_candidate_returns_its_id(self) -> None:
+        candidates = [{"id": "sibling-uuid-1", "created_at": "2026-01-01"}]
+        result = backfill.pick_sibling_for_loser(candidates)
+        assert result == "sibling-uuid-1"
+
+    def test_multiple_candidates_returns_first_newest(self) -> None:
+        # Candidates are pre-sorted newest-first by SQL ORDER BY created_at DESC.
+        candidates = [
+            {"id": "newest-uuid", "created_at": "2026-03-01"},
+            {"id": "older-uuid", "created_at": "2025-12-01"},
+        ]
+        result = backfill.pick_sibling_for_loser(candidates)
+        assert result == "newest-uuid"
+
+    def test_empty_candidates_returns_none(self) -> None:
+        result = backfill.pick_sibling_for_loser([])
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# apply_update_with_sibling tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplyUpdateWithSibling:
+    """apply_update_with_sibling executes UPDATE SQL with correct shape."""
+
+    def test_executes_update_with_sibling_sql(self) -> None:
+        conn, cur = _make_conn([])
+        cur.rowcount = 1
+        backfill.apply_update_with_sibling(
+            conn, [("sibling-id", "loser-id")], dry_run=False
+        )
+        cur.execute.assert_called_once()
+        call_sql = cur.execute.call_args[0][0]
+        assert "previous_version_id" in call_sql
+        assert "split_supersede" in call_sql
+        assert "previous_version_id IS NULL" in call_sql
+        assert "change_type IS NULL" in call_sql
+
+    def test_dry_run_skips_execute(self) -> None:
+        conn, cur = _make_conn([])
+        backfill.apply_update_with_sibling(
+            conn, [("sibling-id", "loser-id")], dry_run=True
+        )
+        cur.execute.assert_not_called()
+        conn.commit.assert_not_called()
+
+    def test_commits_on_write(self) -> None:
+        conn, cur = _make_conn([])
+        cur.rowcount = 1
+        backfill.apply_update_with_sibling(
+            conn, [("sibling-id", "loser-id")], dry_run=False
+        )
+        conn.commit.assert_called_once()
+
+    def test_returns_count_of_intended_updates_on_dry_run(self) -> None:
+        conn, cur = _make_conn([])
+        updates = [("s1", "l1"), ("s2", "l2")]
+        count = backfill.apply_update_with_sibling(conn, updates, dry_run=True)
+        assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# apply_update_unverified tests
+# ---------------------------------------------------------------------------
+
+
+class TestApplyUpdateUnverified:
+    """apply_update_unverified sets change_type='split_supersede_unverified'."""
+
+    def test_executes_unverified_update_sql(self) -> None:
+        conn, cur = _make_conn([])
+        cur.rowcount = 1
+        backfill.apply_update_unverified(conn, ["loser-id"], dry_run=False)
+        cur.execute.assert_called_once()
+        call_sql = cur.execute.call_args[0][0]
+        assert "split_supersede_unverified" in call_sql
+        assert "previous_version_id IS NULL" in call_sql
+        assert "change_type IS NULL" in call_sql
+
+    def test_dry_run_skips_execute(self) -> None:
+        conn, cur = _make_conn([])
+        backfill.apply_update_unverified(conn, ["loser-id"], dry_run=True)
+        cur.execute.assert_not_called()
+        conn.commit.assert_not_called()
+
+    def test_commits_on_write(self) -> None:
+        conn, cur = _make_conn([])
+        cur.rowcount = 1
+        backfill.apply_update_unverified(conn, ["loser-id"], dry_run=False)
+        conn.commit.assert_called_once()
+
+    def test_returns_count_of_intended_updates_on_dry_run(self) -> None:
+        conn, cur = _make_conn([])
+        count = backfill.apply_update_unverified(conn, ["l1", "l2", "l3"], dry_run=True)
+        assert count == 3
+
+
+# ---------------------------------------------------------------------------
+# End-to-end main() smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestMain:
+    """Smoke tests for main() with mocked psycopg."""
+
+    def _set_argv(self, *args: str) -> None:
+        sys.argv = ["backfill_split_supersede.py", *args]
+
+    def _setup_conn(
+        self,
+        mock_psycopg: MagicMock,
+        loser_rows: list,
+        sibling_rows: list,
+    ) -> tuple[MagicMock, MagicMock]:
+        mock_conn = MagicMock()
+        mock_psycopg.connect.return_value = mock_conn
+        mock_cur = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cur)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        # fetchall is called once for losers, then per-loser for sibling candidates.
+        mock_cur.fetchall.side_effect = [loser_rows, sibling_rows]
+        mock_cur.rowcount = 1
+        return mock_conn, mock_cur
+
+    @patch("backfill_split_supersede.psycopg")
+    def test_sibling_found_issues_update_with_sibling(
+        self, mock_psycopg: MagicMock
+    ) -> None:
+        """Single active sibling with rulings -> UPDATE with previous_version_id."""
+        loser_rows = [("loser-uuid-1", "case-uuid-1", "Los Angeles")]
+        sibling_rows = [("sibling-uuid-1", "2026-03-01")]
+        mock_conn, mock_cur = self._setup_conn(mock_psycopg, loser_rows, sibling_rows)
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://fake/db"}):
+            self._set_argv()
+            backfill.main()
+
+        update_calls = [
+            c for c in mock_cur.execute.call_args_list if "UPDATE" in str(c)
+        ]
+        assert len(update_calls) >= 1
+        # The UPDATE should reference previous_version_id
+        assert any("previous_version_id" in str(c) for c in update_calls)
+
+    @patch("backfill_split_supersede.psycopg")
+    def test_no_sibling_issues_unverified_update(self, mock_psycopg: MagicMock) -> None:
+        """No active siblings with rulings -> UPDATE change_type='split_supersede_unverified'."""
+        loser_rows = [("loser-uuid-2", "case-uuid-2", "Fresno")]
+        sibling_rows: list = []
+        mock_conn, mock_cur = self._setup_conn(mock_psycopg, loser_rows, sibling_rows)
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://fake/db"}):
+            self._set_argv()
+            backfill.main()
+
+        update_calls = [
+            c for c in mock_cur.execute.call_args_list if "UPDATE" in str(c)
+        ]
+        assert len(update_calls) >= 1
+        assert any("split_supersede_unverified" in str(c) for c in update_calls)
+
+    @patch("backfill_split_supersede.psycopg")
+    def test_dry_run_no_update_no_commit(self, mock_psycopg: MagicMock) -> None:
+        """--dry-run: no UPDATE, no commit."""
+        loser_rows = [("loser-uuid-1", "case-uuid-1", "Los Angeles")]
+        sibling_rows = [("sibling-uuid-1", "2026-03-01")]
+        mock_conn, mock_cur = self._setup_conn(mock_psycopg, loser_rows, sibling_rows)
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://fake/db"}):
+            self._set_argv("--dry-run")
+            backfill.main()
+
+        update_calls = [
+            c for c in mock_cur.execute.call_args_list if "UPDATE" in str(c)
+        ]
+        assert len(update_calls) == 0
+        mock_conn.commit.assert_not_called()
+
+    @patch("backfill_split_supersede.psycopg")
+    def test_empty_fetch_exits_early(self, mock_psycopg: MagicMock) -> None:
+        """No losers -> no UPDATE, no commit."""
+        mock_conn, mock_cur = self._setup_conn(mock_psycopg, [], [])
+        mock_cur.fetchall.side_effect = [[]]
+        with patch.dict(os.environ, {"DATABASE_URL": "postgresql://fake/db"}):
+            self._set_argv()
+            backfill.main()
+
+        update_calls = [
+            c for c in mock_cur.execute.call_args_list if "UPDATE" in str(c)
+        ]
+        assert len(update_calls) == 0
+        mock_conn.commit.assert_not_called()


### PR DESCRIPTION
## Summary

Fixed observability bug where split-superseded documents were indistinguishable from actual orphans. Added `change_type='split_supersede'` kwarg to `_supersede_document()` and created a comprehensive backfill script to retroactively populate the 459 LA + 1 Fresno pre-existing orphan-superseded docs.

Closes #3510

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] Run backfill script: `scripts/ecs-run-task.sh scripts/backfill_split_supersede.py -- --dry-run` to verify safe execution
- [ ] Execute backfill: `scripts/ecs-run-task.sh scripts/backfill_split_supersede.py` (idempotent, safe to re-run)
- [ ] Verify backfill reduced orphan count: `scripts/dev-db-query.sh "SELECT c.county, COUNT(*) FROM derived.documents d JOIN courts c ON d.court_id = c.id WHERE d.status='superseded' AND d.previous_version_id IS NULL AND d.change_type IS NULL GROUP BY c.county"` should return 0 rows for Los Angeles and Fresno
- [ ] Re-run spotcheck and verify zero-derived originals are reduced: `[o for o in data.json['originals_by_county']['Los Angeles'] if o['derived_count']==0]` returns 0 entries (or only real issues)
- [ ] Verification evidence posted on #3510 (see /task-v2-verify output)