### PR TITLE
fix(scraping): loosen case-number regex and reorder strip→dedupe→strip cleanup (#3511)

### DIFF
--- a/packages/scraper-framework/src/courts/ca/ventura_tentatives.py
+++ b/packages/scraper-framework/src/courts/ca/ventura_tentatives.py
@@ -572,12 +572,16 @@ class VenturaTentativeRulingsScraper(BaseScraper):
                             strip_trailing_case_number,
                         )
 
-                        deduped = dedupe_repeated_title(doc.case_title)
-                        if deduped:
-                            doc.case_title = deduped
+                        # Strip → dedupe → strip ordering (#3511).
                         without_cn = strip_trailing_case_number(doc.case_title)
                         if without_cn:
                             doc.case_title = without_cn
+                        deduped = dedupe_repeated_title(doc.case_title)
+                        if deduped:
+                            doc.case_title = deduped
+                        without_cn2 = strip_trailing_case_number(doc.case_title)
+                        if without_cn2:
+                            doc.case_title = without_cn2
 
                     if not llm_used:
                         # Log that regex path was used for debugging.

--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -1509,16 +1509,22 @@ def clean_case_title(raw_title: str) -> str | None:
     # Collapse whitespace and newlines.
     cleaned = " ".join(raw_title.split())
 
-    # Dedupe repeated title segments (#2370) — Ventura LLM sometimes
-    # returns the same title 2-3x concatenated.
+    # Strip → dedupe → strip ordering (#3511): strip trailing case number
+    # first so dedupe sees a clean boundary; then dedupe repeated segments;
+    # then strip again in case dedupe surfaced a trailing fragment from a
+    # middle copy.  This handles titles like
+    # "A v. B A v. B 2024CUBC020894" → "A v. B".
+    without_cn = strip_trailing_case_number(cleaned)
+    if without_cn:
+        cleaned = without_cn
+
     deduped = dedupe_repeated_title(cleaned)
     if deduped:
         cleaned = deduped
 
-    # Strip trailing case numbers appended to the title (#2370).
-    without_cn = strip_trailing_case_number(cleaned)
-    if without_cn:
-        cleaned = without_cn
+    without_cn2 = strip_trailing_case_number(cleaned)
+    if without_cn2:
+        cleaned = without_cn2
 
     # --- Probate / estate / conservatorship / guardianship titles ---
     probate_m = re.match(
@@ -1877,16 +1883,17 @@ def extract_judge_name(ruling_text: str) -> str | None:
 # (new and old probate) plus common short fragments.
 _TRAILING_CASE_NUMBER_RE = re.compile(
     r"\s+(?:"
-    # Ventura new format: 4-digit year + 4-letter type + 6-digit sequence
-    r"\d{4}[A-Z]{4}\d{6}"
+    # Ventura new format: 4-digit year + 2-5 letters + 4-8 digits (case-insensitive)
+    r"\d{4}[A-Za-z]{2,5}\d{4,8}"
     # Ventura old-format probate (plus truncated PRL variants).
-    r"|\d{10,12}PR[A-Z]{1,3}"
+    r"|\d{10,12}PR[A-Za-z]{1,3}"
     # Generic CV... / CIV... / dash-separated formats
-    r"|CV[A-Z]{2,4}\d{5,}"
-    r"|CIV[A-Z]{2}\d{5,}"
+    r"|CV[A-Za-z]{2,4}\d{5,}"
+    r"|CIV[A-Za-z]{2}\d{5,}"
     r"|\d{2,4}-\d{5,}"
-    r"|\d{2}[A-Z]{2}CV\d{5,}"
+    r"|\d{2}[A-Za-z]{2}CV\d{5,}"
     r")\s*$",
+    re.IGNORECASE,
 )
 
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -1555,17 +1555,10 @@ class IngestionWorker:
         # LLM sometimes appends (#2370).  These are cheap checks that
         # always run; they leave well-formed titles unchanged.
         if case_title:
-            deduped = dedupe_repeated_title(case_title)
-            if deduped and deduped != case_title:
-                logger.info(
-                    "Removed repeated title segments",
-                    extra={
-                        "document_id": document_id,
-                        "old_title": case_title[:120],
-                        "new_title": deduped[:120],
-                    },
-                )
-                case_title = deduped
+            # Strip → dedupe → strip ordering (#3511): strip trailing case
+            # number first so dedupe sees a clean boundary, then dedupe
+            # repeated segments, then strip again in case dedupe surfaced a
+            # trailing fragment from a middle copy.
             without_cn = strip_trailing_case_number(case_title)
             if without_cn and without_cn != case_title:
                 logger.info(
@@ -1577,6 +1570,28 @@ class IngestionWorker:
                     },
                 )
                 case_title = without_cn
+            deduped = dedupe_repeated_title(case_title)
+            if deduped and deduped != case_title:
+                logger.info(
+                    "Removed repeated title segments",
+                    extra={
+                        "document_id": document_id,
+                        "old_title": case_title[:120],
+                        "new_title": deduped[:120],
+                    },
+                )
+                case_title = deduped
+            without_cn2 = strip_trailing_case_number(case_title)
+            if without_cn2 and without_cn2 != case_title:
+                logger.info(
+                    "Stripped trailing case number from title (post-dedupe)",
+                    extra={
+                        "document_id": document_id,
+                        "old_title": case_title[:120],
+                        "new_title": without_cn2[:120],
+                    },
+                )
+                case_title = without_cn2
 
         # For LLM-extracted events, the LLM-provided case_title can be
         # messy (motion descriptions, case citations, multiple parties).

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -2317,6 +2317,58 @@ class TestStripTrailingCaseNumber:
         # Should strip the malformed case number from the end
         assert strip_trailing_case_number(raw) == "In the Matter of Denise Guadalupe Mejia"
 
+    def test_strips_ventura_mixed_case_5_digit(self) -> None:
+        """Strip Ventura new-format case number with mixed-case letters and 5 digits (#3511)."""
+        from ingestion.extract import strip_trailing_case_number
+
+        raw = "X 2024Cubco20894"
+        assert strip_trailing_case_number(raw) == "X"
+
+    def test_strips_ventura_lowercase_5_digit(self) -> None:
+        """Strip Ventura new-format case number with all-lowercase letters and 5 digits (#3511)."""
+        from ingestion.extract import strip_trailing_case_number
+
+        raw = "X 2024cubco20894"
+        assert strip_trailing_case_number(raw) == "X"
+
+    def test_strips_4_digit_trailing(self) -> None:
+        """Strip Ventura new-format case number with 4-digit sequence (#3511)."""
+        from ingestion.extract import strip_trailing_case_number
+
+        raw = "X 2024CUBC0204"
+        assert strip_trailing_case_number(raw) == "X"
+
+    def test_strips_7_digit_trailing(self) -> None:
+        """Strip Ventura new-format case number with 7-digit sequence (#3511)."""
+        from ingestion.extract import strip_trailing_case_number
+
+        raw = "X 2024CUBC1234567"
+        assert strip_trailing_case_number(raw) == "X"
+
+
+class TestTitleCleanupOrdering:
+    """End-to-end tests for the strip → dedupe → strip cleanup ordering (#3511).
+
+    When a title contains both a repeated segment AND a trailing case number,
+    applying dedupe before strip leaves a residual case-number fragment from
+    the middle copy.  The correct order is strip → dedupe → strip so the
+    second strip removes any newly exposed trailing fragment.
+    """
+
+    def test_ventura_duplicate_title_with_trailing_case_number(self) -> None:
+        """Full cleanup: deduplicate then strip trailing case number (#3511)."""
+        from ingestion.extract import dedupe_repeated_title, strip_trailing_case_number
+
+        raw = (
+            "Jamonte Clay v. Community Memorial Health System "
+            "Jamonte Clay v. Community Memorial Health System "
+            "2024Cubco20894"
+        )
+        step1 = strip_trailing_case_number(raw)
+        step2 = dedupe_repeated_title(step1)
+        step3 = strip_trailing_case_number(step2)
+        assert step3 == "Jamonte Clay v. Community Memorial Health System"
+
 
 class TestIsProbateDecedentName:
     """Tests for is_probate_decedent_name() — checks whether a candidate

--- a/scripts/backfill_repeated_title_cleanup.py
+++ b/scripts/backfill_repeated_title_cleanup.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+# venv: scraper-framework
+# one-off: true
+"""Backfill duplicated case titles and trailing case-number fragments (#3511).
+
+Finds rows in derived.cases where the case_title either:
+  - contains a repeated segment (e.g. "A v. B A v. B"), or
+  - ends with a stray case-number fragment (e.g. "... 2024Cubco20894")
+
+and applies the corrected strip → dedupe → strip cleanup sequence.
+
+Usage:
+    scripts/with-secret.sh \\
+        -e DATABASE_URL=judgemind/dev/db/connection:.url \\
+        -- scripts/run-py.sh scripts/backfill_repeated_title_cleanup.py
+
+Options:
+    --dry-run         Print what would be updated without writing to the database.
+    --batch-size N    Number of cases per batch (default: 100).
+    --limit N         Maximum total cases to process (default: unlimited).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+import psycopg
+
+from ingestion.extract import dedupe_repeated_title, strip_trailing_case_number
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# SQL queries
+# ---------------------------------------------------------------------------
+
+# Select cases with long repeated titles or trailing case-number fragments.
+# Uses keyset pagination on (id) for efficient batching.
+FETCH_QUERY = """
+    SELECT id, case_title
+    FROM derived.cases
+    WHERE (
+        (
+            LENGTH(case_title) > 100
+            AND case_title ~ '(.{20,}) \\1'
+        ) OR (
+            case_title ~* '\\s+\\d{4}[A-Za-z]{2,5}\\d{4,8}\\s*$'
+        )
+    )
+      AND id > %s
+    ORDER BY id
+    LIMIT %s
+"""
+
+UPDATE_QUERY = """
+    UPDATE derived.cases
+    SET case_title = %s,
+        updated_at = NOW()
+    WHERE id = %s::uuid
+"""
+
+# Zero UUID for the first batch cursor
+_CURSOR_MIN_UUID = "00000000-0000-0000-0000-000000000000"
+
+
+def _cleanup_title(title: str) -> str:
+    """Apply strip → dedupe → strip cleanup sequence."""
+    result = strip_trailing_case_number(title) or title
+    result = dedupe_repeated_title(result) or result
+    result = strip_trailing_case_number(result) or result
+    return result
+
+
+def backfill_batch(
+    conn: psycopg.Connection,
+    batch_size: int = 100,
+    cursor: str = _CURSOR_MIN_UUID,
+) -> tuple[int, int, str]:
+    """Process one batch of affected case titles.
+
+    Returns (processed, updated, next_cursor).
+    """
+    processed = 0
+    updated = 0
+    next_cursor = cursor
+
+    with conn.cursor() as cur:
+        cur.execute(FETCH_QUERY, (cursor, batch_size))
+        rows = cur.fetchall()
+
+    if not rows:
+        return 0, 0, cursor
+
+    for case_id, old_title in rows:
+        processed += 1
+        next_cursor = str(case_id)
+
+        if not old_title:
+            continue
+
+        new_title = _cleanup_title(old_title)
+
+        if new_title == old_title:
+            logger.debug("Skipping case %s — no change", case_id)
+            continue
+
+        logger.info("Case %s: %r -> %r", case_id, old_title[:120], new_title[:120])
+
+        with conn.cursor() as cur:
+            cur.execute(UPDATE_QUERY, (new_title, str(case_id)))
+        updated += 1
+
+    return processed, updated, next_cursor
+
+
+def run_backfill(
+    dsn: str,
+    *,
+    batch_size: int = 100,
+    limit: int | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Run the full backfill.  Returns summary stats."""
+    total_processed = 0
+    total_updated = 0
+    cursor: str = _CURSOR_MIN_UUID
+
+    with psycopg.connect(dsn) as conn:
+        while True:
+            effective_batch = batch_size
+            if limit is not None:
+                remaining = limit - total_processed
+                if remaining <= 0:
+                    break
+                effective_batch = min(batch_size, remaining)
+
+            processed, updated, cursor = backfill_batch(conn, effective_batch, cursor)
+            total_processed += processed
+            total_updated += updated
+
+            if dry_run:
+                conn.rollback()
+            else:
+                conn.commit()
+
+            logger.info(
+                "Batch: processed=%d updated=%d (total: %d/%d)%s",
+                processed,
+                updated,
+                total_processed,
+                total_updated,
+                " [dry-run, rolled back]" if dry_run else " [committed]",
+            )
+
+            if processed < effective_batch:
+                break
+
+    return {
+        "total_processed": total_processed,
+        "total_updated": total_updated,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill duplicated case titles and trailing case-number fragments.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be updated without writing to the database.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Number of cases per batch (default: 100).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Maximum total cases to process.",
+    )
+    args = parser.parse_args()
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        logger.error("DATABASE_URL environment variable is required")
+        sys.exit(1)
+
+    stats = run_backfill(
+        dsn,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+
+    logger.info(
+        "Backfill complete: %d cases processed, %d updated",
+        stats["total_processed"],
+        stats["total_updated"],
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Ventura case numbers with mixed-case letters and variable digit counts (e.g. `2024Cubco20894`) were not matched by the strict `\d{4}[A-Z]{4}\d{6}` pattern, causing duplicated titles to persist into the database. This PR loosens the regex to accept mixed-case and variable digit counts, and reorders the title-cleanup sequence at all three call sites from dedupe-then-strip to strip→dedupe→strip so the second strip removes fragments exposed by deduping.

Closes #3511

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `ruff format --check`)
- [x] Tests pass (`pytest packages/scraper-framework/tests/ -k title_cleanup`)
- [x] CI green

### Post-deploy verification

- [ ] Query case `9f31f9bd...` in dev database confirms case_title is de-duplicated and case-number fragment is stripped (see #3511 AC 1)
- [ ] Execute backfill script: `scripts/with-secret.sh -e DATABASE_URL=judgemind/dev/db/connection:.url -- scripts/run-py.sh scripts/backfill_repeated_title_cleanup.py` and verify population of prefix-repeat titles reduces to baseline order of magnitude (see #3511 AC 3)
- [ ] Verification evidence posted on #3511 (see /task-v2-verify output)