### PR TITLE
fix(dispatcher): awaiting_deploy filters deploy runs by headSha, not multi-workflow flags (#3514)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -3648,12 +3648,18 @@ FIX_CONFLICT_MAX_ATTEMPTS="${AGENT_RUNNER_FIX_CONFLICT_MAX_ATTEMPTS:-2}"
 # daemon.py.
 STALE_ROLLUP_MARKER="base branch policy prohibits the merge"
 
-# Deploy workflow filenames we watch on the merge SHA. Mirrors the
-# ``DEPLOY_WORKFLOW_NAMES`` frozenset in daemon.py (which reads
-# ``workflowName``); the entrypoint queries by workflow-file path
-# instead (``--workflow <file>.yml``) because bash stubs can match
-# file names more reliably than display names.
-DEPLOY_WORKFLOWS="${AGENT_RUNNER_DEPLOY_WORKFLOWS:-deploy-api.yml deploy-dispatcher.yml deploy-scraper.yml deploy-production.yml deploy-production-web.yml terraform.yml deploy-agent-runner.yml}"
+# Deploy workflow display names we watch on the merge SHA. Must match
+# the ``name:`` field in each ``.github/workflows/`` file. Mirrors the
+# ``DEPLOY_WORKFLOW_NAMES`` frozenset in daemon.py exactly — both paths
+# post-filter ``gh run list`` output by ``workflowName``.
+#
+# IMPORTANT (#3514): we intentionally do NOT use multi-``--workflow``
+# flags with ``gh run list``. The ``-w``/``--workflow`` flag is
+# single-valued; when invoked multiple times only the LAST value is
+# honoured, silently dropping all other workflows from the result.
+# Instead we fetch all runs for the commit and post-filter by
+# ``workflowName`` via ``jq``. See ``find_deploy_runs`` below.
+DEPLOY_WORKFLOW_NAMES_BASH="${AGENT_RUNNER_DEPLOY_WORKFLOW_NAMES:-Deploy API|Deploy Dispatcher|Deploy Scraper|Deploy Production|Deploy Production (Web)|Terraform|Deploy Agent Runner}"
 
 read_pr_number() {
     # Query ``dispatcher.agents.pr_number`` for the current agent.
@@ -4308,32 +4314,50 @@ handle_merge() {
 }
 
 find_deploy_runs() {
-    # $1 = merge SHA. Writes the JSON array response from
-    # ``gh run list --commit <sha> --workflow <w1> --workflow <w2> ...
-    # --json databaseId,workflowName,status,conclusion,createdAt``
-    # to ``$AGENT_WORKSPACE/deploy-runs.json``. On failure writes ``[]``.
+    # $1 = merge SHA. Fetches ``gh run list --commit <sha>`` (no
+    # ``--workflow`` flags — see note below) and post-filters the JSON
+    # via ``jq`` to keep only entries whose ``workflowName`` is in
+    # ``$DEPLOY_WORKFLOW_NAMES_BASH`` AND whose ``headSha`` equals the
+    # merge SHA. Writes the filtered array to
+    # ``$AGENT_WORKSPACE/deploy-runs.json``. On failure writes ``[]``.
+    #
+    # NOTE (#3514): multi-``--workflow`` is intentionally NOT used here.
+    # ``gh run list --workflow`` is single-valued; when multiple ``-w``
+    # flags are passed, only the last value is honoured and all other
+    # workflows are silently dropped from the result. This caused the
+    # awaiting_deploy false-positive in PR #3509 where Deploy Dispatcher
+    # was excluded from the match set while still in_progress. We
+    # instead fetch all runs for the commit and post-filter by display
+    # name, mirroring daemon.py's ``_find_deploy_runs``.
     _sha="$1"
     _out_file="$AGENT_WORKSPACE/deploy-runs.json"
-    # Build the --workflow flag list from $DEPLOY_WORKFLOWS (space-
-    # separated file names). Bash 3.2: use positional args.
-    set --
-    for _w in $DEPLOY_WORKFLOWS; do
-        set -- "$@" --workflow "$_w"
-    done
+    _raw_file="$AGENT_WORKSPACE/deploy-runs-raw.json"
     set +e
     gh run list \
         --repo judgemind/judgemind \
         --commit "$_sha" \
-        "$@" \
-        --json databaseId,workflowName,status,conclusion,createdAt \
+        --json databaseId,workflowName,status,conclusion,createdAt,headSha \
         --limit 20 \
-        > "$_out_file" \
+        > "$_raw_file" \
         2> "$AGENT_WORKSPACE/gh-run-list.stderr.log"
     _gh_rc=$?
     set -e
     if [[ "$_gh_rc" -ne 0 ]]; then
         printf '[]' > "$_out_file"
+        return 0
     fi
+    # Post-filter: keep only entries whose workflowName is in the deploy
+    # names list and whose headSha matches the merge SHA (defensive
+    # guard — ``--commit`` already filters server-side, but gh may
+    # return runs for nearby commits under edge-case pagination).
+    _names_pipe="$DEPLOY_WORKFLOW_NAMES_BASH"
+    jq --arg sha "$_sha" --arg names_pipe "$_names_pipe" \
+        '[.[] | select(
+            (.workflowName as $n | ($names_pipe | split("|") | index($n)) != null)
+            and .headSha == $sha
+        )]' \
+        "$_raw_file" > "$_out_file" 2>/dev/null \
+        || printf '[]' > "$_out_file"
     return 0
 }
 
@@ -4382,9 +4406,31 @@ handle_awaiting_deploy() {
                 "pr=$_pr_number poll_count=$_poll_count last_state=$_last_state"
             return 0
         fi
+        _now_poll_ts=$(date -u +%s)
+        _elapsed_poll=$((_now_poll_ts - _start_ts))
         if [[ -n "$_merge_sha" ]]; then
             find_deploy_runs "$_merge_sha"
             _state=$(classify_deploy_runs "$AGENT_WORKSPACE/deploy-runs.json")
+            # Per-poll structured detail log: one line per matched run
+            # plus a summary. Visible in CloudWatch as awaiting_deploy_poll_detail.
+            # Satisfies AC#5 (instrumentation: merge_sha, matched_run_count,
+            # run_id, run_head_sha, run_status, run_conclusion, elapsed_seconds).
+            _matched_count=$(jq 'if type == "array" then length else 0 end' \
+                "$AGENT_WORKSPACE/deploy-runs.json" 2>/dev/null || printf '0')
+            log "awaiting_deploy_poll_detail" \
+                "pr_number=$_pr_number" \
+                "merge_sha=$_merge_sha" \
+                "deploy_state=$_state" \
+                "matched_run_count=$_matched_count" \
+                "elapsed_seconds=$_elapsed_poll"
+            # Log individual run details for observability.
+            if [[ -s "$AGENT_WORKSPACE/deploy-runs.json" ]]; then
+                jq -r '.[] | "run_id=\(.databaseId) run_head_sha=\(.headSha // "?") run_status=\(.status // "?") run_conclusion=\(.conclusion // "?") workflow=\(.workflowName // "?")"' \
+                    "$AGENT_WORKSPACE/deploy-runs.json" 2>/dev/null \
+                    | while IFS= read -r _run_line; do
+                        log "awaiting_deploy_run_detail" "pr_number=$_pr_number" "$_run_line"
+                    done
+            fi
         else
             _state="pending"
         fi

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -306,6 +306,54 @@ class TestDeployWorkflowNamesContents:
 
 
 # --------------------------------------------------------------------------
+# _find_deploy_runs — regression guard: no --workflow flag (#3514)
+# --------------------------------------------------------------------------
+
+
+class TestFindDeployRuns_MultiWorkflowGuard:
+    """Regression guard (#3514): daemon._find_deploy_runs must NOT pass any
+    ``--workflow`` flag to ``gh run list``.
+
+    The ``-w``/``--workflow`` flag is single-valued; when multiple flags are
+    passed only the LAST value is honoured, silently dropping all other
+    workflows.  The ECS entrypoint had this bug (fixed in the same PR).
+    This class ensures daemon.py's ``_find_deploy_runs`` never regresses to
+    the entrypoint.sh pattern.
+    """
+
+    def test_no_workflow_flag_in_gh_run_list(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        captured_cmds: list[list[str]] = []
+
+        def fake_run(
+            cmd: list[str], *args: Any, **kwargs: Any
+        ) -> subprocess.CompletedProcess:
+            captured_cmds.append(list(cmd))
+            r: subprocess.CompletedProcess = subprocess.CompletedProcess(cmd, 0)
+            r.stdout = "[]"
+            r.stderr = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        d, _conn, _handler = _make_daemon(tmp_path)
+        d._find_deploy_runs("deadbeefcafe0011")
+
+        # At least one ``gh run list`` call must have been made.
+        gh_run_list_calls = [c for c in captured_cmds if c[:3] == ["gh", "run", "list"]]
+        assert gh_run_list_calls, (
+            "_find_deploy_runs must invoke 'gh run list'; no such call captured"
+        )
+        # None of the gh run list calls may contain --workflow.
+        for cmd in gh_run_list_calls:
+            assert "--workflow" not in cmd, (
+                f"daemon._find_deploy_runs passed '--workflow' to gh run list — "
+                f"this reintroduces the #3514 bug where only the last workflow "
+                f"is matched.  Post-filter by workflowName instead.  cmd={cmd}"
+            )
+
+
+# --------------------------------------------------------------------------
 # _extract_merge_sha
 # --------------------------------------------------------------------------
 

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -4737,14 +4737,14 @@ for _ev in fix_conflict_handler_done fix_conflict_persist_done \
 done
 
 # ══════════════════════════════════════════════════════════════════════════
-# DEPLOY_WORKFLOWS default — static regression guard (#3185)
+# DEPLOY_WORKFLOW_NAMES_BASH default — static regression guard (#3185, #3514)
 # ══════════════════════════════════════════════════════════════════════════
 
-if grep -qE '^DEPLOY_WORKFLOWS=.*deploy-agent-runner\.yml' "$ENTRYPOINT"; then
-    pass "#3185 — DEPLOY_WORKFLOWS default includes deploy-agent-runner.yml"
+if grep -qE '^DEPLOY_WORKFLOW_NAMES_BASH=.*Deploy Agent Runner' "$ENTRYPOINT"; then
+    pass "#3185 — DEPLOY_WORKFLOW_NAMES_BASH default includes 'Deploy Agent Runner'"
 else
-    fail "#3185 — DEPLOY_WORKFLOWS default includes deploy-agent-runner.yml" \
-         "deploy-agent-runner.yml not found in DEPLOY_WORKFLOWS default in $ENTRYPOINT"
+    fail "#3185 — DEPLOY_WORKFLOW_NAMES_BASH default includes 'Deploy Agent Runner'" \
+         "'Deploy Agent Runner' not found in DEPLOY_WORKFLOW_NAMES_BASH default in $ENTRYPOINT"
 fi
 
 # ══════════════════════════════════════════════════════════════════════════
@@ -5721,6 +5721,182 @@ if [[ ! -f "$t59_state_dir/advance-log.txt" ]] || ! grep -q "ADVANCE_PHASE" "$t5
 else
     fail "#3507 T59 [operational failed] — advance_phase not called on route_to_diagnoser" \
          "advance-log: $(cat "$t59_state_dir/advance-log.txt" 2>/dev/null)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 60a (#3514 regression): prior completed-success run with DIFFERENT
+# headSha + actual run for merge_sha with IN_PROGRESS → deploy_state=pending.
+#
+# This reproduces the exact production failure from PR #3509: gh returns
+# both a prior run (different SHA, COMPLETED/SUCCESS) and the current run
+# (matching SHA, IN_PROGRESS). The matcher must filter by headSha so the
+# prior completed run does NOT advance the phase prematurely.
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t60a.txt"
+printf 'awaiting_deploy\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+# The default gh pr view fixture has mergeCommit.oid = "deadbeefcafe".
+# The prior run has a DIFFERENT headSha to exercise the filter.
+t60a_runs="$TEST_TMP/t60a-runs.json"
+cat > "$t60a_runs" <<'EOF'
+[
+  {"databaseId": 100, "workflowName": "Deploy Agent Runner", "status": "COMPLETED", "conclusion": "SUCCESS", "createdAt": "2026-04-01T03:00:00Z", "headSha": "aabbccddeeff0011"},
+  {"databaseId": 101, "workflowName": "Deploy Agent Runner", "status": "IN_PROGRESS", "conclusion": null, "createdAt": "2026-04-27T03:02:00Z", "headSha": "deadbeefcafe"}
+]
+EOF
+
+t60a_workspace="$TEST_TMP/t60a-workspace"
+set +e
+t60a_out=$(run_post_pr_phase "awaiting_deploy" "$t60a_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_RUN_LIST_JSON_FIXTURE=$t60a_runs" \
+    "AGENT_RUNNER_AWAITING_DEPLOY_TIMEOUT_SECONDS=0" \
+    "AGENT_RUNNER_DEPLOY_GRACE_SECONDS=9999")
+set -e
+
+if printf '%s' "$t60a_out" | grep -q "awaiting_deploy_timeout"; then
+    pass "#3514 T60a — prior completed-success with different headSha → pending → timeout (not premature success)"
+else
+    fail "#3514 T60a — prior completed-success with different headSha → pending → timeout (not premature success)" \
+         "out tail: $(printf '%s' "$t60a_out" | tail -c 600)"
+fi
+
+# Phase must NOT advance to verify (no premature success).
+_t60a_final=$(cat "$PHASE_FIXTURE_FILE" 2>/dev/null || printf '')
+if [[ "$_t60a_final" != "verify" ]]; then
+    pass "#3514 T60a — phase does NOT advance to verify on prior-sha match"
+else
+    fail "#3514 T60a — phase does NOT advance to verify on prior-sha match" \
+         "phase advanced to: $_t60a_final"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 60b (#3514 regression): empty match-set → grace window → verify.
+#
+# No deploy runs exist yet for the merge SHA. The matcher returns "none"
+# and after the grace window elapses the agent advances to verify
+# (docs-only PR semantic). This documents and locks the current behaviour.
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t60b.txt"
+printf 'awaiting_deploy\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t60b_runs="$TEST_TMP/t60b-runs.json"
+printf '[]' > "$t60b_runs"
+
+t60b_workspace="$TEST_TMP/t60b-workspace"
+set +e
+t60b_out=$(run_post_pr_phase "awaiting_deploy" "$t60b_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_RUN_LIST_JSON_FIXTURE=$t60b_runs" \
+    "AGENT_RUNNER_DEPLOY_GRACE_SECONDS=0")
+set -e
+
+if printf '%s' "$t60b_out" | grep -q "awaiting_deploy_no_runs"; then
+    pass "#3514 T60b — empty match-set → no_runs branch hit"
+else
+    fail "#3514 T60b — empty match-set → no_runs branch hit" \
+         "out tail: $(printf '%s' "$t60b_out" | tail -c 500)"
+fi
+
+if grep -q "SET phase = \\\\'verify\\\\'" "$INVOCATIONS_DIR/psql.log"; then
+    pass "#3514 T60b — empty match-set → advances to verify"
+else
+    fail "#3514 T60b — empty match-set → advances to verify" \
+         "psql log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 60c (#3514 regression): two-run fixture — one COMPLETED+SUCCESS
+# Deploy Agent Runner + one IN_PROGRESS Deploy Dispatcher, both with
+# matching merge_sha → deploy_state=pending (any in_progress blocks success).
+#
+# This is the exact production failure scenario from PR #3509.
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t60c.txt"
+printf 'awaiting_deploy\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t60c_runs="$TEST_TMP/t60c-runs.json"
+cat > "$t60c_runs" <<'EOF'
+[
+  {"databaseId": 200, "workflowName": "Deploy Agent Runner", "status": "COMPLETED", "conclusion": "SUCCESS", "createdAt": "2026-04-27T03:02:47Z", "headSha": "deadbeefcafe"},
+  {"databaseId": 201, "workflowName": "Deploy Dispatcher", "status": "IN_PROGRESS", "conclusion": null, "createdAt": "2026-04-27T03:02:50Z", "headSha": "deadbeefcafe"}
+]
+EOF
+
+t60c_workspace="$TEST_TMP/t60c-workspace"
+set +e
+t60c_out=$(run_post_pr_phase "awaiting_deploy" "$t60c_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_RUN_LIST_JSON_FIXTURE=$t60c_runs" \
+    "AGENT_RUNNER_AWAITING_DEPLOY_TIMEOUT_SECONDS=0" \
+    "AGENT_RUNNER_DEPLOY_GRACE_SECONDS=9999")
+set -e
+
+if printf '%s' "$t60c_out" | grep -q "awaiting_deploy_timeout"; then
+    pass "#3514 T60c — two-run fixture (one SUCCESS, one IN_PROGRESS) → pending → timeout"
+else
+    fail "#3514 T60c — two-run fixture (one SUCCESS, one IN_PROGRESS) → pending → timeout" \
+         "out tail: $(printf '%s' "$t60c_out" | tail -c 600)"
+fi
+
+_t60c_final=$(cat "$PHASE_FIXTURE_FILE" 2>/dev/null || printf '')
+if [[ "$_t60c_final" != "verify" ]]; then
+    pass "#3514 T60c — phase does NOT advance to verify while Deploy Dispatcher in_progress"
+else
+    fail "#3514 T60c — phase does NOT advance to verify while Deploy Dispatcher in_progress" \
+         "phase advanced to: $_t60c_final"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test 60d (#3514 regression): matching headSha COMPLETED+SUCCESS →
+# deploy_state=success → phase advances to verify.
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t60d.txt"
+printf 'awaiting_deploy\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t60d_runs="$TEST_TMP/t60d-runs.json"
+cat > "$t60d_runs" <<'EOF'
+[
+  {"databaseId": 300, "workflowName": "Deploy Agent Runner", "status": "COMPLETED", "conclusion": "SUCCESS", "createdAt": "2026-04-27T03:05:00Z", "headSha": "deadbeefcafe"}
+]
+EOF
+
+t60d_workspace="$TEST_TMP/t60d-workspace"
+set +e
+t60d_out=$(run_post_pr_phase "awaiting_deploy" "$t60d_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_RUN_LIST_JSON_FIXTURE=$t60d_runs" \
+    "AGENT_RUNNER_DEPLOY_GRACE_SECONDS=9999")
+set -e
+
+if printf '%s' "$t60d_out" | grep -q 'deploy_state.*success\|"deploy_state": "success"'; then
+    pass "#3514 T60d — matching headSha COMPLETED+SUCCESS → deploy_state=success"
+else
+    fail "#3514 T60d — matching headSha COMPLETED+SUCCESS → deploy_state=success" \
+         "out tail: $(printf '%s' "$t60d_out" | tail -c 600)"
+fi
+
+if grep -q "SET phase = \\\\'verify\\\\'" "$INVOCATIONS_DIR/psql.log"; then
+    pass "#3514 T60d — deploy success → phase advances to verify"
+else
+    fail "#3514 T60d — deploy success → phase advances to verify" \
+         "psql log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
 fi
 
 # ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixed awaiting_deploy false-positive where it reported success before the Deploy Dispatcher workflow actually completed. The bug: `gh run list --workflow` is single-valued; passing multiple `-w` values silently honors only the last and drops all others from results. This caused the phase to match a *prior* completed run instead of the current in-progress run, then report success prematurely.

Rewrite find_deploy_runs to post-filter by workflowName and headSha via jq instead of using multi-valued --workflow flags (mirrors daemon.py's correct implementation). Add structured per-poll logging for observability and four regression tests covering the #3509 production scenario.

Closes #3514

## Test plan

### Automated checks

- [ ] Lint passes (`ruff check` / `npm run lint`)
- [ ] Format check passes (`ruff format --check` / prettier)
- [ ] Tests pass (`pytest` / `npm test`)
- [ ] CI green

### Post-deploy verification

- [ ] Trigger a PR merge in dev; confirm awaiting_deploy waits for the correct Deploy Dispatcher run for that merge-sha
- [ ] Confirm awaiting_deploy returns success only after the deploy workflow reaches status=COMPLETED, conclusion=SUCCESS
- [ ] Confirm verify phase does not see in_progress status for the deploy run
- [ ] Verification evidence posted on #3514 (see /task-v2-verify output)