### PR TITLE
fix(dispatcher): add operational phase to stuck_timeout_s_by_phase config (#3524)

### DIFF
--- a/.claude/skills/task-v2-operational/SKILL.md
+++ b/.claude/skills/task-v2-operational/SKILL.md
@@ -156,6 +156,24 @@ For each acceptance criterion, run the verification check described in `plan_tex
 
 If any verification fails: capture the failure output and emit `verdict=failed` with the failure evidence in `evidence_md`.
 
+## Step 4.5 — Time-budget discipline (#3524)
+
+The supervisor flags operational agents as stuck after 3600s (60 min). Respect
+that budget in your own retry loop: do not exhaust the entire window on
+repetitive validation attempts against the same data.
+
+**Rule:** If you have run the operation and validate more than 3 times against
+the same data without the success criterion being met, do NOT keep retrying.
+Emit `verdict=blocked` with `block_reason` describing the non-converging
+condition and `evidence_md` containing the last validation output. Looping is
+the bug.
+
+**Why:** Repeating the same ECS run or DB query when the underlying data has
+not changed cannot produce a different result. A BLOCKED verdict routes to the
+operator / diagnoser so the root cause (data not populated, wrong script args,
+missing dependency) can be fixed — rather than burning the 60-min budget and
+having the supervisor catch the agent as stuck anyway.
+
 ## Step 5 — Post evidence comment and close issue
 
 Write the evidence markdown to a temp file then post:

--- a/packages/api/migrations/55_dispatcher-stuck-timeout-operational.sql
+++ b/packages/api/migrations/55_dispatcher-stuck-timeout-operational.sql
@@ -1,0 +1,56 @@
+-- Up Migration
+--
+-- Dispatcher v2 — add operational phase to stuck_timeout_s_by_phase config
+-- (#3524).
+--
+-- Context
+-- -------
+-- The operational phase (/task-v2-operational) had no entry in the
+-- ``stuck_timeout_s_by_phase`` JSONB config row, so hung operational agents
+-- fell back to the global ``STUCK_TIMEOUT_SECONDS`` default (30 min).
+-- Observed incidents: agent running issue #2522 ran 96 min; issue #2630
+-- ran 72 min — both exceeding 60 min without being caught as stuck.
+-- Most operational tasks (ECS oneshot runs, DB rebuilds, label/comment
+-- actions) finish within ~30 min. 60 min gives 2× headroom while still
+-- catching genuinely hung agents.
+--
+-- Design notes
+-- ------------
+-- - Uses ``jsonb_set`` to ADD the ``operational`` key without destroying
+--   existing operator overrides on other keys (e.g. a manually raised
+--   ralph threshold). The ``32_dispatcher-stuck-timeout-10x-bump.sql``
+--   migration used ``EXCLUDED.value`` to overwrite the entire JSONB
+--   object; this migration is additive-only to preserve live operator
+--   tuning.
+-- - ``ON CONFLICT (key) DO UPDATE`` handles the case where the config
+--   row already exists (expected: migration 32 seeded it). If somehow
+--   the row doesn't exist yet, the INSERT path creates a fresh JSONB
+--   object with just the operational key; the other phase values will
+--   fall through to ``STUCK_TIMEOUT_SECONDS_BY_PHASE`` module defaults
+--   until migration 32 is applied.
+-- - ``updated_by='init-3524'`` distinguishes this migration's write
+--   from a manual operator edit. The admin page sets ``updated_by``
+--   to a GitHub login when operators tune the row.
+
+INSERT INTO dispatcher.config (key, value, updated_by) VALUES
+    ('stuck_timeout_s_by_phase',
+     '{"operational":3600}'::jsonb,
+     'init-3524')
+ON CONFLICT (key) DO UPDATE
+    SET value      = jsonb_set(dispatcher.config.value, '{operational}', '3600'),
+        updated_by = 'init-3524',
+        updated_at = NOW();
+
+
+-- Down Migration
+--
+-- Down strategy: remove the operational key from the JSONB object.
+-- This leaves all other per-phase overrides intact and restores the
+-- pre-#3524 posture where operational agents fall back to the global
+-- ``STUCK_TIMEOUT_SECONDS`` default (or the module default once the
+-- code is also reverted).
+UPDATE dispatcher.config
+    SET value      = value - 'operational',
+        updated_by = 'revert-3524',
+        updated_at = NOW()
+    WHERE key = 'stuck_timeout_s_by_phase';

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1025,6 +1025,7 @@ STUCK_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
     "fix_ci": 18000,  # 5 hr (was 30 min) — single /task-v2-fix-ci, issue #2885
     "verify": 3000,  # 50 min (was unset, fell back to 30 min global) — issue #2885
     "retro": 3000,  # 50 min (was 20 min) — single /task-v2-retro, issue #2885
+    "operational": 3600,  # 60 min — most ops finish in ~30 min; 2× headroom, issue #3524
     "paused_by_killswitch": 60,  # 1 min — terminal phase, should be swept quickly
     "force_stopped": 60,  # 1 min — #2884 operator force_stop terminal phase
     "daemon_restart_abandoned": 60,  # 1 min — terminal phase from restart recovery
@@ -4756,7 +4757,10 @@ class DispatcherDaemon:
         # Budget check — if the sweep already hit the cap, let the claim
         # proceed (resurrection won't pick it up).
         past_attempts = self._count_orphan_pr_resurrections(agent_id)
-        if past_attempts is None or past_attempts >= ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS:
+        if (
+            past_attempts is None
+            or past_attempts >= ORPHAN_PR_RESURRECTION_MAX_ATTEMPTS
+        ):
             return False
 
         # PR-state guard — same classifier as the sweep.

--- a/scripts/dispatcher/tests/test_daemon_stuck_check_operational.py
+++ b/scripts/dispatcher/tests/test_daemon_stuck_check_operational.py
@@ -1,0 +1,250 @@
+"""Regression tests for the operational-phase stuck-timeout threshold (#3524).
+
+Verifies that :meth:`~dispatcher.daemon.DispatcherDaemon._check_stuck_agents`
+correctly uses the 3600s (60 min) threshold for the ``operational`` phase
+added in issue #3524 to :data:`~dispatcher.daemon.STUCK_TIMEOUT_SECONDS_BY_PHASE`.
+
+Two test cases:
+
+* **Positive** — an operational agent at elapsed 3700s (> 3600s threshold) is
+  flagged as stuck: a ``dispatcher.failures`` row is inserted with
+  ``category=stuck_timeout`` and ``phase='operational'``, the agent is flipped
+  to ``status='crashed'``, and a retry marker is enqueued.
+* **Negative** — an operational agent at elapsed 3500s (< 3600s threshold) is
+  NOT flagged; ``_check_stuck_agents`` returns 0.
+
+Fixture style mirrors ``test_daemon_phase3c.py::TestCheckStuckAgents`` —
+uses the same ``_FakeCursor`` / ``_FakeConnection`` / ``_CapturingLogHandler``
+pattern and documents the exact ``fetch_queue`` ordering inline.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — mirrors test_daemon_phase3c.py
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.stuck_operational.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+
+class TestOperationalPhaseStuckTimeout:
+    def test_operational_agent_over_threshold_flagged_as_stuck(
+        self, tmp_path: Path
+    ) -> None:
+        """An operational agent at elapsed 3700s (> 3600s threshold) is flagged.
+
+        Verifies: failure row inserted with category=stuck_timeout and
+        phase='operational', agent flipped to 'crashed', retry marker enqueued.
+        (#3524 — add operational threshold to STUCK_TIMEOUT_SECONDS_BY_PHASE.)
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # Seeded row: one stale operational agent. Elapsed 3700s > 3600s
+        # (operational threshold added in #3524). The SELECT returns
+        # (agent_id, issue_number, phase, elapsed_seconds) and the
+        # Python-side comparison applies the per-phase threshold.
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-op-1", 3524, "operational", 3700.0)],
+        ]
+        # Order inside _check_stuck_agents + _create_retry_marker:
+        # (1) stuck_timeout_s_by_phase override read (returns None → fall
+        #     through to module defaults — where "operational": 3600 now lives),
+        # (2) RETURNING failure_id from _write_failure INSERT,
+        # (3) _has_prior_stuck_timeout_in_window SELECT (returns None →
+        #     first occurrence, no repeated event),
+        # (4) COUNT prior markers in _create_retry_marker,
+        # (5) read backoff_seconds config.
+        conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase override — unset
+            (100,),  # failure_id from _write_failure RETURNING
+            None,  # _has_prior_stuck_timeout_in_window — no prior
+            (0,),  # prior retry marker count
+            ("[60,300,900]",),  # backoff schedule
+        ]
+
+        flagged = d._check_stuck_agents()
+        assert flagged == 1
+
+        # Failure row inserted with correct category and agent_id.
+        failure_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert len(failure_inserts) == 1
+        params = failure_inserts[0][1]
+        assert params[0] == "agent-op-1"  # agent_id
+        assert params[1] == daemon.FAILURE_CATEGORY_STUCK_TIMEOUT
+        assert params[2] == "supervisor"
+
+        # Agent flipped to 'crashed'.
+        crashed_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "crashed" in e[1]
+        ]
+        assert crashed_updates
+
+        # daemon.failure_detected event emitted with stuck_timeout category.
+        detected = handler.events("failure_detected")
+        assert detected
+        assert detected[0].category == daemon.FAILURE_CATEGORY_STUCK_TIMEOUT  # type: ignore[attr-defined]
+
+        # Retry marker inserted for the operational agent.
+        marker_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert len(marker_inserts) == 1
+        marker_params = marker_inserts[0][1]
+        assert marker_params[0] == "agent-op-1"
+        assert marker_params[1] == daemon.FAILURE_CATEGORY_STUCK_TIMEOUT
+        assert marker_params[2] == 1  # first attempt
+
+    def test_operational_agent_under_threshold_not_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        """An operational agent at elapsed 3500s (< 3600s threshold) is NOT flagged.
+
+        The Python-side per-phase threshold check filters out the agent
+        before any failure row or retry marker is written. (#3524)
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # Seeded row: operational agent at 3500s — below the 3600s threshold.
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-op-2", 3524, "operational", 3500.0)],
+        ]
+        # Only the per-sweep override read fires (fetchone for the config row).
+        # The agent is filtered by elapsed < threshold, so no failure/marker
+        # DB calls are made.
+        conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase override — unset
+        ]
+
+        flagged = d._check_stuck_agents()
+        assert flagged == 0
+
+        # No failure row written.
+        failure_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert failure_inserts == []
+
+        # No retry marker written.
+        marker_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert marker_inserts == []
+
+        # No failure_detected event logged.
+        detected = handler.events("failure_detected")
+        assert detected == []


### PR DESCRIPTION
## Summary

Added "operational": 3600 second threshold to dispatcher stuck-timeout configuration. Operational agents now timeout and get reaped after 60 minutes of execution. New migration seeds the config row; daemon.py provides module default. Updated /task-v2-operational SKILL.md with explicit time-budget discipline to bound retry loops and emit BLOCKED verdicts when operations don't converge.

Closes #3524

## Test plan

### Automated checks

- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (regression test added: test_daemon_stuck_check_operational.py)
- [x] CI green

### Post-deploy verification

- [ ] Force a hung operational agent (inject sleep 7200 in operational skill input)
- [ ] Verify supervisor reaper flags it as stuck after 3600s
- [ ] Verify dispatcher.failures row has category=stuck_timeout and phase=operational
- [ ] Verification evidence posted on #3524 (see /task-v2-verify output)