### PR TITLE
fix(scraping): block test-fixture writes to telemetry.scraper_runs (#3518)

### DIFF
--- a/packages/scraper-framework/tests/conftest.py
+++ b/packages/scraper-framework/tests/conftest.py
@@ -196,6 +196,31 @@ def _disable_llm_s3_cache() -> Generator[None, None, None]:
 
 
 @pytest.fixture(autouse=True, scope="session")
+def _block_telemetry_db_writes() -> Generator[None, None, None]:
+    """Prevent any test from accidentally writing to ``telemetry.scraper_runs``.
+
+    Two layers of protection applied for the full test session:
+
+    1. ``DATABASE_URL`` is patched to the empty string so that
+       ``framework.runner._connect_db`` short-circuits its early-return guard
+       (``if not database_url: return None``).
+    2. ``framework.runner._connect_db`` is patched directly to return ``None``
+       in case any code path reads DATABASE_URL before the env patch takes
+       effect, or if a future refactor skips the env-var check.
+
+    Tests that need a real (mock) DB connection apply their own
+    ``patch("framework.runner._connect_db", ...)`` which takes precedence
+    over this session-level patch within their context-manager scope —
+    the stacked patches in ``TestConnectDb`` (test_runner.py:850-879) and
+    the ``Test*RecordScraperRun*`` / ``TestRecordScraperException*`` classes
+    are unaffected.
+    """
+    with patch.dict(os.environ, {"DATABASE_URL": ""}):
+        with patch("framework.runner._connect_db", return_value=None):
+            yield
+
+
+@pytest.fixture(autouse=True, scope="session")
 def _fast_retry_sleeps() -> Generator[None, None, None]:
     """Replace ``time.sleep`` in the retry module with a no-op.
 

--- a/packages/scraper-framework/tests/test_check_scraper_zero_record_streak.py
+++ b/packages/scraper-framework/tests/test_check_scraper_zero_record_streak.py
@@ -178,7 +178,12 @@ class TestCheckZeroRecordStreaks:
         assert result.breaches[0].threshold == 2
 
     def test_brand_new_scraper_with_zeros_is_insufficient_history(self) -> None:
-        """No historical nonzero run = insufficient_history, NOT breach."""
+        """No historical nonzero run = insufficient_history, NOT breach.
+
+        Pass ``known_scraper_ids=None`` to disable the unknown-scraper
+        partition so a fictional scraper ID can exercise the
+        insufficient-history path without being filtered out first.
+        """
         rows = [
             ("ca-new-scraper", NOW - timedelta(hours=1), 0, "success"),
             ("ca-new-scraper", NOW - timedelta(hours=25), 0, "success"),
@@ -192,6 +197,7 @@ class TestCheckZeroRecordStreaks:
             daily_threshold=2,
             frequent_scraper_ids=set(),
             exclusions=set(),
+            known_scraper_ids=None,  # disable unknown-ID check for this unit test
         )
         assert not result.breaches
         assert len(result.insufficient_history) == 1
@@ -355,6 +361,144 @@ class TestOutputFormatting:
         assert "BREACHES" in text
         assert "INSUFFICIENT HISTORY" in text
         assert "(none)" in text
+
+
+# ---------------------------------------------------------------------------
+# Unknown scraper ID (fixture-pollution) warning tests
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownScraperIdWarning:
+    """Verify that scraper IDs absent from the registry are routed to the
+    ``unknown_scrapers`` warning category and skipped in the streak check."""
+
+    def test_unknown_id_appears_in_unknown_scrapers(self) -> None:
+        """An ID not in ``known_scraper_ids`` must end up in
+        ``CheckResult.unknown_scrapers`` and NOT in breaches or
+        insufficient_history."""
+        rows = [
+            ("test-stub", NOW - timedelta(hours=1), 0, "success"),
+            ("test-stub", NOW - timedelta(hours=25), 0, "success"),
+            # No historical nonzero run — would be insufficient_history if
+            # it were a known scraper; it should be unknown instead.
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+            known_scraper_ids={"ca-la-tentatives-civil"},  # test-stub is NOT here
+        )
+        assert result.unknown_scrapers == ["test-stub"]
+        assert result.checked_count == 0
+        assert result.excluded_count == 0
+        assert not result.breaches
+        assert not result.insufficient_history
+
+    def test_unknown_ids_are_not_streak_checked(self) -> None:
+        """Unknown scrapers with a breach-length streak must NOT appear in
+        breaches — they are suppressed as potential test pollution."""
+        rows = [
+            # Unknown scraper with a long zero-record streak
+            ("good", NOW - timedelta(hours=1), 0, "success"),
+            ("good", NOW - timedelta(hours=25), 0, "success"),
+            ("good", NOW - timedelta(hours=49), 5, "success"),
+            # Known scraper, also with a streak — this one SHOULD breach
+            ("ca-oc-tentatives", NOW - timedelta(hours=2), 0, "success"),
+            ("ca-oc-tentatives", NOW - timedelta(hours=26), 0, "success"),
+            ("ca-oc-tentatives", NOW - timedelta(hours=50), 18, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+            known_scraper_ids={"ca-oc-tentatives"},  # "good" is NOT here
+        )
+        assert "good" in result.unknown_scrapers
+        # The known scraper breaches normally
+        assert len(result.breaches) == 1
+        assert result.breaches[0].scraper_id == "ca-oc-tentatives"
+        assert result.checked_count == 1
+
+    def test_multiple_unknown_ids_all_reported(self) -> None:
+        """All unknown scraper IDs are collected in ``unknown_scrapers``, sorted."""
+        rows = [
+            ("failing", NOW - timedelta(hours=1), 0, "success"),
+            ("run-raiser", NOW - timedelta(hours=2), 0, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+            known_scraper_ids=set(),  # no known scrapers → both are unknown
+        )
+        assert sorted(result.unknown_scrapers) == ["failing", "run-raiser"]
+        assert result.checked_count == 0
+        assert not result.breaches
+
+    def test_none_known_scrapers_disables_partition(self) -> None:
+        """Passing ``known_scraper_ids=None`` disables the unknown-ID check:
+        all fetched IDs are treated as known and streak-checked normally."""
+        rows = [
+            ("test-stub", NOW - timedelta(hours=1), 0, "success"),
+            ("test-stub", NOW - timedelta(hours=25), 0, "success"),
+            ("test-stub", NOW - timedelta(hours=49), 3, "success"),
+        ]
+        conn = _mock_conn(rows)
+        result = check_zero_record_streaks(
+            conn,
+            now=NOW,
+            threshold=3,
+            daily_threshold=2,
+            frequent_scraper_ids=set(),
+            exclusions=set(),
+            known_scraper_ids=None,  # disabled — treat everything as known
+        )
+        # The scraper has streak=2 (daily threshold=2) → breach
+        assert len(result.breaches) == 1
+        assert result.breaches[0].scraper_id == "test-stub"
+        assert result.unknown_scrapers == []
+
+    def test_format_text_includes_unknown_warning(self) -> None:
+        """``format_text`` lists unknown scrapers in a WARNING block."""
+        result = CheckResult(
+            breaches=[],
+            insufficient_history=[],
+            checked_count=0,
+            excluded_count=0,
+            unknown_scrapers=["test-stub", "good"],
+        )
+        text = format_text(result)
+        assert "WARNING" in text
+        assert "test-stub" in text
+        assert "good" in text
+        assert "test pollution" in text
+
+    def test_format_json_includes_unknown_scrapers_key(self) -> None:
+        """``format_json`` includes an ``unknown_scrapers`` array."""
+        import json as _json
+
+        result = CheckResult(
+            breaches=[],
+            insufficient_history=[],
+            checked_count=0,
+            excluded_count=0,
+            unknown_scrapers=["test-stub"],
+        )
+        payload = _json.loads(format_json(result))
+        assert "unknown_scrapers" in payload
+        assert payload["unknown_scrapers"] == ["test-stub"]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_conftest_db_block.py
+++ b/packages/scraper-framework/tests/test_conftest_db_block.py
@@ -1,0 +1,56 @@
+"""Regression tests for the ``_block_telemetry_db_writes`` autouse fixture.
+
+These tests verify that the session-scoped fixture in ``conftest.py``
+successfully prevents real DB writes during the test session.  They will
+fail immediately if the fixture is removed, weakened, or mis-scoped —
+making any regression visible before it reaches CI.
+
+Two assertions are checked:
+1. ``os.environ["DATABASE_URL"]`` is empty inside a test (the env patch
+   is active).
+2. ``framework.runner._connect_db()`` returns ``None`` (the function-level
+   patch is active).
+
+Note: the module-attribute lookup (``import framework.runner as runner_mod``
+then ``runner_mod._connect_db()``) is intentional — it sees the patched
+version installed by the autouse fixture rather than any import-time-bound
+local reference.
+"""
+
+from __future__ import annotations
+
+import os
+
+import framework.runner as runner_mod
+
+
+def test_database_url_is_empty_in_test_env() -> None:
+    """DATABASE_URL must be empty (empty string or absent) during tests.
+
+    The ``_block_telemetry_db_writes`` autouse fixture patches DATABASE_URL
+    to ``""`` for the entire test session.  If it is non-empty here, the
+    fixture has been dropped or weakened and real DB connections could be
+    attempted from runner tests.
+    """
+    assert os.environ.get("DATABASE_URL", "") == "", (
+        "DATABASE_URL is non-empty inside the test session — "
+        "the _block_telemetry_db_writes autouse fixture may have been removed "
+        "or weakened.  Restore it in conftest.py to prevent accidental writes "
+        "to telemetry.scraper_runs."
+    )
+
+
+def test_connect_db_returns_none_in_test_env() -> None:
+    """``framework.runner._connect_db()`` must return ``None`` during tests.
+
+    The ``_block_telemetry_db_writes`` autouse fixture patches
+    ``framework.runner._connect_db`` to return ``None`` for the entire test
+    session.  If it returns anything else here, the fixture has been dropped
+    or weakened and runner tests could open live DB connections.
+    """
+    result = runner_mod._connect_db()
+    assert result is None, (
+        f"_connect_db() returned {result!r} instead of None inside the test "
+        "session — the _block_telemetry_db_writes autouse fixture may have "
+        "been removed or weakened.  Restore it in conftest.py."
+    )

--- a/scripts/check-scraper-zero-record-streak.py
+++ b/scripts/check-scraper-zero-record-streak.py
@@ -58,7 +58,7 @@ import json
 import logging
 import os
 import sys
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -155,6 +155,7 @@ class CheckResult:
     insufficient_history: list[InsufficientHistory]
     checked_count: int
     excluded_count: int
+    unknown_scrapers: list[str] = field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -197,6 +198,31 @@ def _fetch_recent_runs(
             sid, started_at, records, status = row[0], row[1], row[2], row[3]
             out.setdefault(sid, []).append((started_at, int(records), status))
     return out
+
+
+# ---------------------------------------------------------------------------
+# Registry helpers — known scraper IDs
+# ---------------------------------------------------------------------------
+
+
+def _load_known_scraper_ids() -> set[str] | None:
+    """Return the set of all registered scraper IDs from framework.runner.
+
+    Returns ``None`` when the framework package is not importable (e.g. when
+    running in an environment without the scraper-framework venv active).  In
+    that case callers should treat *all* fetched IDs as known to avoid false
+    positives.
+    """
+    try:
+        from framework.runner import get_scraper_ids  # type: ignore[import-not-found]
+
+        return set(get_scraper_ids())
+    except ImportError:
+        logger.debug(
+            "framework.runner not importable — unknown-scraper check skipped. "
+            "Activate the scraper-framework venv to enable this check."
+        )
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -251,6 +277,12 @@ def has_historical_nonzero(runs: list[tuple[datetime, int, str]]) -> bool:
 # Main check
 # ---------------------------------------------------------------------------
 
+# Sentinel value for the ``known_scraper_ids`` parameter of
+# ``check_zero_record_streaks``.  Using a private sentinel (instead of None)
+# allows callers to distinguish "auto-load from registry" (default) from
+# "explicitly disable the check" (pass None).
+_SENTINEL: set[str] = object()  # type: ignore[assignment]
+
 
 def check_zero_record_streaks(
     conn: psycopg.Connection,  # type: ignore[type-arg]
@@ -262,6 +294,7 @@ def check_zero_record_streaks(
     scraper_id: str | None = None,
     exclusions: set[str] | None = None,
     frequent_scraper_ids: set[str] | None = None,
+    known_scraper_ids: set[str] | None = _SENTINEL,  # type: ignore[assignment]
 ) -> CheckResult:
     """Run the zero-record streak check.
 
@@ -281,10 +314,16 @@ def check_zero_record_streaks(
         exclusions: Scrapers to skip. Defaults to ``EXCLUSIONS``.
         frequent_scraper_ids: Scraper IDs that run more than once per day.
             Defaults to ``FREQUENT_SCRAPER_IDS``.
+        known_scraper_ids: Set of registered scraper IDs from
+            ``framework.runner.get_scraper_ids()``.  When the sentinel is
+            passed (the default), the function calls
+            ``_load_known_scraper_ids()`` automatically.  Pass ``None``
+            explicitly to disable the unknown-ID check (e.g. in environments
+            without the venv).  Pass a set to override (useful in tests).
 
     Returns:
-        ``CheckResult`` with breaches, insufficient-history entries, and
-        counts for logging/summary output.
+        ``CheckResult`` with breaches, insufficient-history entries, unknown
+        scraper IDs, and counts for logging/summary output.
     """
     excl = exclusions if exclusions is not None else EXCLUSIONS
     freq = (
@@ -293,17 +332,27 @@ def check_zero_record_streaks(
         else FREQUENT_SCRAPER_IDS
     )
 
+    # Resolve known IDs: sentinel → auto-load; explicit None → skip check.
+    if known_scraper_ids is _SENTINEL:
+        known_scraper_ids = _load_known_scraper_ids()
+
     cutoff = now - timedelta(days=lookback_days)
     by_scraper = _fetch_recent_runs(conn, cutoff, scraper_id)
 
     breaches: list[Breach] = []
     insufficient: list[InsufficientHistory] = []
+    unknown: list[str] = []
     checked = 0
     excluded = 0
 
     for sid in sorted(by_scraper.keys()):
         if sid in excl:
             excluded += 1
+            continue
+
+        # Partition: unknown scraper IDs are likely test pollution.
+        if known_scraper_ids is not None and sid not in known_scraper_ids:
+            unknown.append(sid)
             continue
 
         runs = by_scraper[sid]
@@ -354,11 +403,19 @@ def check_zero_record_streaks(
                 )
             )
 
+    if unknown:
+        logger.warning(
+            "WARNING: unknown scraper IDs in telemetry.scraper_runs "
+            "(likely test pollution): %s",
+            ", ".join(sorted(unknown)),
+        )
+
     return CheckResult(
         breaches=breaches,
         insufficient_history=insufficient,
         checked_count=checked,
         excluded_count=excluded,
+        unknown_scrapers=sorted(unknown),
     )
 
 
@@ -383,6 +440,7 @@ def format_json(result: CheckResult) -> str:
         "insufficient_history": [asdict(ih) for ih in result.insufficient_history],
         "checked_count": result.checked_count,
         "excluded_count": result.excluded_count,
+        "unknown_scrapers": result.unknown_scrapers,
         "healthy": len(result.breaches) == 0,
     }
     return json.dumps(payload, indent=2, sort_keys=True)
@@ -397,6 +455,15 @@ def format_text(result: CheckResult) -> str:
         f"{len(result.breaches)} breach(es), "
         f"{len(result.insufficient_history)} insufficient-history."
     )
+
+    if result.unknown_scrapers:
+        lines.append("")
+        lines.append(
+            "WARNING: unknown scraper IDs in telemetry.scraper_runs "
+            "(likely test pollution):"
+        )
+        for uid in result.unknown_scrapers:
+            lines.append(f"  * {uid}")
 
     if result.breaches:
         lines.append("")


### PR DESCRIPTION
## Summary

Blocked accidental writes to `telemetry.scraper_runs` from runner tests by adding a session-scoped autouse fixture that patches `DATABASE_URL` and `framework.runner._connect_db` to return `None`. Added regression tests to catch future removals or weakening of the block. Extended the zero-record-streak check to route unknown scraper IDs (likely test pollution) to a warning category instead of streak-checking them.

Closes #3518

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest`) — 6649 passed, 2 skipped
- [x] CI green

### Post-deploy verification

- [ ] Database cleanup (delete test-fixture rows from `telemetry.scraper_runs`) via `/task-v2-verify` (requires ecs-run-task deployment)
- [ ] Zero-record-streak check reports no unknown scraper IDs via `scripts/dev-db-query.sh`
- [ ] Verification evidence posted on #3518 (see /task-v2-verify output)