### PR TITLE
fix(dispatcher-audit): add mandatory dedup gate and stable probe-id prefixes (#3512)

### DIFF
--- a/.claude/skills/dispatcher-audit/SKILL.md
+++ b/.claude/skills/dispatcher-audit/SKILL.md
@@ -81,7 +81,36 @@ For each finding where `should_file_issue` is `true`:
 
 Write the issue body to a temp file. Use the Write tool with content derived from the finding's `body` field. File path: `tmp/dispatcher-audit/issue-body-PROBE.txt` (replace `PROBE` with the finding's `probe` value, e.g. `convergence_regression`).
 
-Then create the GitHub issue:
+### Sub-step 3.0 — Check for existing open issue (MANDATORY dedup gate)
+
+Before filing a new issue, extract the stable probe-identifier prefix from `finding.title` (e.g. `[bad-outcome-streak]`, `[convergence-regression]`, `[site-health-frontend]`, `[site-health-graphql]`, `[site-health-doc-count]`). Search for an existing open issue with that prefix:
+
+```
+gh issue list \
+    --repo judgemind/judgemind \
+    --label source/dispatcher-audit \
+    --state open \
+    --search "[PROBE_PREFIX] in:title" \
+    --json number,title
+```
+
+Replace `[PROBE_PREFIX]` with the bracketed prefix from the finding's title (e.g. `[bad-outcome-streak]`).
+
+**Branch on result:**
+
+- **If one or more open issues match** (dedup hit): pick the lowest-numbered match and add a comment instead of filing a new issue. Skip `gh issue create`.
+
+  ```
+  gh issue comment ISSUE_NUMBER \
+      --repo judgemind/judgemind \
+      --body-file tmp/dispatcher-audit/issue-body-PROBE.txt
+  ```
+
+  Record the comment URL. Do **not** run `gh issue create` for this finding.
+
+- **If no match** (no existing open issue): proceed with `gh issue create` as normal (sub-step 3.1 below).
+
+### Sub-step 3.1 — Create new issue (only when no existing open issue found)
 
 ```
 gh issue create \
@@ -98,7 +127,7 @@ Replace `FINDING_TITLE` with the finding's `title` field.
 
 **Important:** Never use priority/p0. The maximum priority for dispatcher-audit findings is p2.
 
-Repeat for each finding with `should_file_issue=true`. Record the issue URL from each `gh issue create` output.
+Repeat sub-steps 3.0–3.1 for each finding with `should_file_issue=true`. Record the issue URL or comment URL from each action.
 
 ---
 
@@ -111,8 +140,10 @@ FILED ISSUES
 
 Dispatcher audit complete. Probes run: convergence_regression, bad_outcome_streak, site_health.
 Findings: N total, M filed as GitHub issues.
+Filed N new, commented on M existing.
 
 Filed issues: (list issue URLs, or "none" if 0 filed)
+Commented on existing issues: (list comment URLs, or "none" if 0 existing)
 ```
 
 The `FILED ISSUES` header (or any non-empty output) signals success to `handle_scheduled_skill` (agent-runner-entrypoint.sh line ~2082).

--- a/scripts/dispatcher/audit_probes.py
+++ b/scripts/dispatcher/audit_probes.py
@@ -191,7 +191,7 @@ def probe_convergence_regression(
     return [
         Finding(
             probe="convergence_regression",
-            title=f"Ralph iteration p95 regression: {recent_p95:.1f} vs baseline {baseline_p95:.1f} ({ratio:.1f}x)",
+            title=f"[convergence-regression] Ralph iteration p95 regression: {recent_p95:.1f} vs baseline {baseline_p95:.1f} ({ratio:.1f}x)",
             body=(
                 f"The p95 ralph-iteration count over the recent 6-hour window is "
                 f"{recent_p95:.1f}, which is {ratio:.1f}x the baseline window p95 "
@@ -244,7 +244,7 @@ def probe_bad_outcome_streak(
     return [
         Finding(
             probe="bad_outcome_streak",
-            title=f"Bad-outcome streak: {streak} consecutive non-shipped terminals",
+            title=f"[bad-outcome-streak] Bad-outcome streak: {streak} consecutive non-shipped terminals",
             body=(
                 f"The last {streak} completed agents all ended in a non-shipped "
                 f"state (failed, crashed, terminated, etc.). The circuit breaker "
@@ -300,7 +300,7 @@ def probe_site_health(
                 findings.append(
                     Finding(
                         probe="site_health",
-                        title="DB document count is zero — possible data loss or pipeline stall",
+                        title="[site-health-doc-count] DB document count is zero — possible data loss or pipeline stall",
                         body=(
                             "A spot-check query against ``derived.documents`` returned 0 rows. "
                             "This may indicate the ingestion pipeline has stalled, the table "
@@ -317,7 +317,7 @@ def probe_site_health(
                 findings.append(
                     Finding(
                         probe="site_health",
-                        title="DB document-count probe failed",
+                        title="[site-health-doc-count] DB document-count probe failed",
                         body=(
                             f"The derived.documents count query returned an unexpected "
                             f"result (status={status}, body={body!r:.80}).\n\n"
@@ -333,11 +333,13 @@ def probe_site_health(
 
         # HTTP endpoint check
         if status != 200:
-            label = "GraphQL API" if "graphql" in endpoint.lower() else "site"
+            is_graphql = "graphql" in endpoint.lower()
+            label = "GraphQL API" if is_graphql else "site"
+            probe_id = "site-health-graphql" if is_graphql else "site-health-frontend"
             findings.append(
                 Finding(
                     probe="site_health",
-                    title=f"{label} endpoint unhealthy: {endpoint} returned HTTP {status}",
+                    title=f"[{probe_id}] {label} endpoint unhealthy: {endpoint} returned HTTP {status}",
                     body=(
                         f"The {label} endpoint ``{endpoint}`` returned HTTP {status}. "
                         f"Expected 200.\n\n"

--- a/scripts/dispatcher/tests/test_audit_probes.py
+++ b/scripts/dispatcher/tests/test_audit_probes.py
@@ -78,6 +78,9 @@ def test_probe_convergence_regression_flags_p95_jump() -> None:
     f = findings[0]
     assert isinstance(f, Finding)
     assert f.severity in ("warning", "critical")
+    assert f.title.startswith("[convergence-regression]"), (
+        f"Expected title to start with '[convergence-regression]', got: {f.title!r}"
+    )
     assert (
         "convergence" in f.title.lower()
         or "iteration" in f.title.lower()
@@ -110,6 +113,9 @@ def test_probe_bad_outcome_streak_at_threshold() -> None:
     f = findings[0]
     assert isinstance(f, Finding)
     assert f.should_file_issue is True
+    assert f.title.startswith("[bad-outcome-streak]"), (
+        f"Expected title to start with '[bad-outcome-streak]', got: {f.title!r}"
+    )
     assert "streak" in f.title.lower() or "outcome" in f.title.lower()
 
 
@@ -147,6 +153,12 @@ def test_probe_site_health_flags_non_200() -> None:
         "dev.judgemind.org" in t or "site" in t.lower() or "health" in t.lower()
         for t in titles
     ), f"Expected a finding about dev.judgemind.org, got titles: {titles}"
+    # The frontend finding must carry the stable probe-id prefix.
+    frontend_findings = [f for f in findings if "dev.judgemind.org" in f.title]
+    assert frontend_findings, f"Expected a frontend finding, got titles: {titles}"
+    assert frontend_findings[0].title.startswith("[site-health-frontend]"), (
+        f"Expected title to start with '[site-health-frontend]', got: {frontend_findings[0].title!r}"
+    )
 
 
 def test_probe_site_health_quiet_when_all_green() -> None:
@@ -171,6 +183,9 @@ def test_probe_site_health_flags_zero_document_count() -> None:
     assert len(findings) >= 1, (
         f"Expected at least 1 finding for zero docs, got {findings}"
     )
+    assert findings[0].title.startswith("[site-health-doc-count]"), (
+        f"Expected title to start with '[site-health-doc-count]', got: {findings[0].title!r}"
+    )
 
 
 def test_probe_site_health_flags_graphql_non_200() -> None:
@@ -188,6 +203,13 @@ def test_probe_site_health_flags_graphql_non_200() -> None:
     assert any("graphql" in t.lower() or "api" in t.lower() for t in titles), (
         f"Expected a finding about the GraphQL endpoint, got titles: {titles}"
     )
+    graphql_findings = [
+        f for f in findings if "graphql" in f.title.lower() or "api" in f.title.lower()
+    ]
+    assert graphql_findings, f"Expected a graphql finding, got titles: {titles}"
+    assert graphql_findings[0].title.startswith("[site-health-graphql]"), (
+        f"Expected title to start with '[site-health-graphql]', got: {graphql_findings[0].title!r}"
+    )
 
 
 def test_probe_site_health_handles_unparseable_doc_count() -> None:
@@ -201,6 +223,9 @@ def test_probe_site_health_handles_unparseable_doc_count() -> None:
     # count will be -1 (ValueError on "Internal Server Error"), status != 200
     assert len(findings) >= 1, (
         f"Expected at least 1 finding for unparseable count + non-200, got {findings}"
+    )
+    assert findings[0].title.startswith("[site-health-doc-count]"), (
+        f"Expected title to start with '[site-health-doc-count]', got: {findings[0].title!r}"
     )
 
 


### PR DESCRIPTION
## Summary

Prevents duplicate issues from being filed every 6h when audit probe conditions persist. Added a mandatory dedup gate (Sub-step 3.0) to dispatcher-audit SKILL.md Step 3 that searches for existing open issues with `source/dispatcher-audit` label before filing, and comments on the lowest-numbered match instead. All Finding titles now include stable [probe-id] prefixes for robust matching, and tests assert the prefix presence.

Closes #3512

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — all 14 audit_probes tests pass)
- [x] CI green

### Post-deploy verification

- [ ] Run audit cron twice; verify no duplicate of #3498/#3476 is filed
- [ ] Verify `gh issue list --label source/dispatcher-audit --state open --search "[bad-outcome-streak] in:title"` returns one open issue
- [ ] Verification evidence posted on #3512 (see /task-v2-verify output)