### PR TITLE
fix(scripts): remove duplicate event= kwarg from backfill scripts (#3527)

### DIFF
--- a/scripts/archive/backfill_previous_version_id.py
+++ b/scripts/archive/backfill_previous_version_id.py
@@ -350,7 +350,6 @@ def main() -> None:  # noqa: C901 -- acceptable complexity for a one-off script
 
         logger.info(
             "backfill_previous_version_id_summary",
-            event="backfill_previous_version_id_summary",
             total_scanned=total,
             linked=linked,
             unlinkable=unlinkable,

--- a/scripts/backfill_split_supersede.py
+++ b/scripts/backfill_split_supersede.py
@@ -382,7 +382,6 @@ def main() -> None:  # noqa: C901 -- acceptable complexity for a one-off script
 
         logger.info(
             "backfill_split_supersede_summary",
-            event="backfill_split_supersede_summary",
             total_scanned=total,
             linked=linked,
             unverified=unverified,

--- a/scripts/tests/test_backfill_split_supersede.py
+++ b/scripts/tests/test_backfill_split_supersede.py
@@ -6,6 +6,7 @@ Tests cover:
   3. Falls back to 'split_supersede_unverified' when no valid sibling.
   4. UPDATE SQL shapes for both paths.
   5. Dry-run mode skips DB writes.
+  6. No duplicate event= kwarg in logger calls (AST-based, #3527).
 
 All database access is mocked -- these tests verify the pure helper logic,
 SELECT filters, and UPDATE shapes without requiring live services.
@@ -17,6 +18,7 @@ We mock them in sys.modules before importing the script under test.
 
 from __future__ import annotations
 
+import ast
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -318,3 +320,57 @@ class TestMain:
         ]
         assert len(update_calls) == 0
         mock_conn.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# AST-based regression test: no duplicate event= kwarg (#3527)
+# ---------------------------------------------------------------------------
+
+_LOGGER_LEVELS = {"info", "warning", "error", "debug", "critical"}
+
+
+class TestNoDuplicateEventKwarg:
+    """Ensure no logger.<level>(positional_string, event=...) duplicate pattern.
+
+    structlog's bound logger maps the first positional arg to 'event='
+    automatically.  Passing both raises TypeError at runtime.  This test
+    parses the script source via ast.parse so it catches the bug without
+    executing any DB or structlog code.
+    """
+
+    def _get_script_path(self) -> str:
+        return os.path.join(
+            os.path.dirname(__file__), "..", "backfill_split_supersede.py"
+        )
+
+    def test_no_logger_call_has_both_positional_and_event_kwarg(self) -> None:
+        script_path = self._get_script_path()
+        with open(script_path) as fh:
+            source = fh.read()
+
+        tree = ast.parse(source, filename=script_path)
+
+        violations: list[int] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            # Match logger.<level>(...) call shapes.
+            if not (
+                isinstance(func, ast.Attribute)
+                and func.attr in _LOGGER_LEVELS
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "logger"
+            ):
+                continue
+            # Violation: has at least one positional arg AND a keyword arg named 'event'.
+            has_positional = len(node.args) > 0
+            has_event_kwarg = any(kw.arg == "event" for kw in node.keywords)
+            if has_positional and has_event_kwarg:
+                violations.append(node.lineno)
+
+        assert violations == [], (
+            f"Duplicate event= kwarg found in backfill_split_supersede.py "
+            f"at lines: {violations}. Remove the explicit event= kwarg — "
+            f"structlog maps the first positional arg to event= automatically."
+        )


### PR DESCRIPTION
## Summary

Removes duplicate `event=` kwarg from logger.info() calls in backfill_split_supersede.py and backfill_previous_version_id.py. Structlog's bound logger automatically maps the first positional argument to event=, so passing both raises TypeError at runtime. This fixes the issue where backfill_split_supersede.py crashed on the summary log with "meth() got multiple values for argument 'event'".

Also adds TestNoDuplicateEventKwarg, an AST-based regression test that parses the script source and asserts no logger call passes both a positional event string and an explicit event= kwarg.

Closes #3527

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`) — pre-push hook passed
- [x] Format check passes (`ruff format --check`) — pre-push hook passed
- [x] Tests pass (`pytest`) — all 26 tests pass, including new TestNoDuplicateEventKwarg
- [x] CI green — per ralph output

### Post-deploy verification

- [ ] `scripts/ecs-run-task.sh scripts/backfill_split_supersede.py -- --dry-run` reports `Task completed with exit code: 0`
- [ ] Verification evidence posted on #3527 (see /task-v2-verify output)