### PR TITLE
fix(ingestion): add dedup-aware content_hash bucket to S3 orphan audit (#3522)

### DIFF
--- a/scripts/audit_correctly_labeled_s3_orphans.py
+++ b/scripts/audit_correctly_labeled_s3_orphans.py
@@ -75,6 +75,7 @@ COUNTY_PREFIXES: dict[str, str] = {
 
 # Classification result literals
 PRESENT_IN_DB = "present_in_db"
+PRESENT_IN_DB_VIA_CONTENT_HASH = "present_in_db_via_content_hash"
 MISLABELED = "mislabeled"
 CORRECTLY_LABELED_ORPHAN = "correctly_labeled_orphan"
 
@@ -131,6 +132,24 @@ def fetch_db_s3_keys(conn: object, county: str) -> set[str]:
     return {row[0] for row in rows if row[0]}
 
 
+def fetch_db_content_hashes(conn: object, county: str) -> set[str]:
+    """Return the set of content_hash values from derived.documents for *county*.
+
+    Queries: SELECT content_hash FROM derived.documents WHERE s3_key LIKE 'ca/<county>/%'
+
+    Filters by s3_key prefix (not content_hash) to avoid conflating cross-county
+    collisions. NULLs are excluded.
+    """
+    pattern = f"ca/{county}/%"
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT content_hash FROM derived.documents WHERE s3_key LIKE %s",
+            (pattern,),
+        )
+        rows = cur.fetchall()
+    return {row[0] for row in rows if row[0]}
+
+
 # ---------------------------------------------------------------------------
 # Classification
 # ---------------------------------------------------------------------------
@@ -141,19 +160,23 @@ def classify(
     last_modified: datetime,
     s3: object,
     db_keys: set[str],
+    db_content_hashes: set[str],
     *,
     verify_bytes: bool = False,
 ) -> str:
-    """Classify one S3 object as present_in_db, mislabeled, or correctly_labeled_orphan.
+    """Classify one S3 object as present_in_db, present_in_db_via_content_hash, mislabeled, or correctly_labeled_orphan.
 
     Classification logic:
     1. If `key` is in db_keys → PRESENT_IN_DB (normal, healthy record).
-    2. If verify_bytes=True: HEAD the object, download its bytes, and SHA-256
+    2. Extract filename_hash from key. If filename_hash is in db_content_hashes →
+       PRESENT_IN_DB_VIA_CONTENT_HASH (dedup loser: the content exists in DB under
+       a different s3_key; the content-addressed naming contract guarantees the
+       filename hash equals the bytes hash, so set membership is sufficient).
+    3. If verify_bytes=False (bulk pass): an object absent from both sets is
+       classified CORRECTLY_LABELED_ORPHAN.
+    4. If verify_bytes=True: HEAD the object, download its bytes, and SHA-256
        them.  If the bytes hash does not match the filename hash → MISLABELED
        (migration artifact, handled by #2638).  If they match → CORRECTLY_LABELED_ORPHAN.
-    3. If verify_bytes=False (bulk pass): we trust the filename is correct per
-       the content-addressed naming contract.  An object absent from db_keys and
-       not verified as mislabeled is classified CORRECTLY_LABELED_ORPHAN.
 
     In practice the mislabeled class is bounded and already audited by #2638.
     The bulk pass (verify_bytes=False) is safe because any mislabeled object
@@ -166,17 +189,23 @@ def classify(
         last_modified: LastModified timestamp from list_objects_v2.
         s3: boto3 S3 client.
         db_keys: Set of s3_key values from derived.documents for this county.
+        db_content_hashes: Set of content_hash values from derived.documents for
+            this county. Used to detect dedup-loser keys whose content is already
+            present in the DB under a different s3_key.
         verify_bytes: If True, download the object and verify byte hash.
     """
     if key in db_keys:
         return PRESENT_IN_DB
 
+    # Extract the expected hash from the filename (content-addressed naming contract).
+    filename = key.rsplit("/", 1)[-1]
+    filename_hash = filename.split(".")[0]
+
+    if filename_hash in db_content_hashes:
+        return PRESENT_IN_DB_VIA_CONTENT_HASH
+
     if not verify_bytes:
         return CORRECTLY_LABELED_ORPHAN
-
-    # Extract the expected hash from the filename.
-    filename = key.rsplit("/", 1)[-1]
-    expected_hash = filename.split(".")[0]
 
     try:
         response = s3.get_object(Bucket=BUCKET, Key=key)
@@ -187,7 +216,7 @@ def classify(
         # Cannot verify; treat as correctly labeled to avoid false mislabels.
         return CORRECTLY_LABELED_ORPHAN
 
-    if actual_hash != expected_hash:
+    if actual_hash != filename_hash:
         return MISLABELED
 
     return CORRECTLY_LABELED_ORPHAN
@@ -244,12 +273,15 @@ def run_audit(
     for county, prefix in counties.items():
         logger.info("Scanning county=%s prefix=%s", county, prefix)
 
-        # Fetch DB keys for this county.
+        # Fetch DB keys and content hashes for this county.
         db_keys = fetch_db_s3_keys(conn, county)
         logger.info("  DB keys for %s: %d", county, len(db_keys))
+        db_content_hashes = fetch_db_content_hashes(conn, county)
+        logger.info("  DB content hashes for %s: %d", county, len(db_content_hashes))
 
         # Accumulate per-classification lists.
         in_db_count = 0
+        in_db_via_content_hash_count = 0
         orphan_keys: list[tuple[str, datetime, int]] = []
         mislabeled_count = 0
         orphans_by_month: dict[str, int] = defaultdict(int)
@@ -258,10 +290,12 @@ def run_audit(
             s3, prefix, limit=limit
         ):
             classification = classify(
-                key, last_modified, s3, db_keys, verify_bytes=False
+                key, last_modified, s3, db_keys, db_content_hashes, verify_bytes=False
             )
             if classification == PRESENT_IN_DB:
                 in_db_count += 1
+            elif classification == PRESENT_IN_DB_VIA_CONTENT_HASH:
+                in_db_via_content_hash_count += 1
             elif classification == MISLABELED:
                 mislabeled_count += 1
             else:
@@ -269,13 +303,16 @@ def run_audit(
                 orphans_by_month[_month_key(last_modified)] += 1
 
         orphan_count = len(orphan_keys)
-        total = in_db_count + orphan_count + mislabeled_count
+        total = (
+            in_db_count + in_db_via_content_hash_count + orphan_count + mislabeled_count
+        )
 
         logger.info(
-            "  %s: total=%d in_db=%d orphans=%d mislabeled=%d",
+            "  %s: total=%d in_db=%d in_db_via_content_hash=%d orphans=%d mislabeled=%d",
             county,
             total,
             in_db_count,
+            in_db_via_content_hash_count,
             orphan_count,
             mislabeled_count,
         )
@@ -285,7 +322,9 @@ def run_audit(
         sample_pool = random.sample(orphan_keys, sample_size) if sample_size > 0 else []
         sample_verified: list[dict] = []
         for s_key, s_lm, _s_size in sample_pool:
-            verified_cls = classify(s_key, s_lm, s3, db_keys, verify_bytes=True)
+            verified_cls = classify(
+                s_key, s_lm, s3, db_keys, db_content_hashes, verify_bytes=True
+            )
             sample_verified.append(
                 {
                     "key": s_key,
@@ -302,6 +341,7 @@ def run_audit(
         county_summary = {
             "total": total,
             "in_db": in_db_count,
+            "in_db_via_content_hash": in_db_via_content_hash_count,
             "orphans": orphan_count,
             "mislabeled": mislabeled_count,
             "orphans_by_month": dict(sorted(orphans_by_month.items())),
@@ -321,10 +361,13 @@ def _print_report(result: dict) -> None:
     print("=" * 60)
     for county, stats in result["counties"].items():
         print(f"\n{county.upper()}")
-        print(f"  Total flat-hash keys scanned: {stats['total']}")
-        print(f"  Present in DB:                {stats['in_db']}")
-        print(f"  Correctly-labeled orphans:    {stats['orphans']}")
-        print(f"  Mislabeled (migration bug):   {stats['mislabeled']}")
+        print(f"  Total flat-hash keys scanned:                  {stats['total']}")
+        print(f"  Present in DB:                                 {stats['in_db']}")
+        print(
+            f"  Present in DB (via content_hash dedup):        {stats['in_db_via_content_hash']}"
+        )
+        print(f"  Correctly-labeled orphans:                     {stats['orphans']}")
+        print(f"  Mislabeled (migration bug):                    {stats['mislabeled']}")
         if stats["orphans_by_month"]:
             print("  Orphans by month:")
             for month, cnt in sorted(stats["orphans_by_month"].items()):

--- a/scripts/tests/test_audit_correctly_labeled_s3_orphans.py
+++ b/scripts/tests/test_audit_correctly_labeled_s3_orphans.py
@@ -58,10 +58,12 @@ for _mod_name in list(_modules_to_mock.keys()):
 FLAT_HASH_RE = _script.FLAT_HASH_RE
 list_raw_flat_hash_keys = _script.list_raw_flat_hash_keys
 fetch_db_s3_keys = _script.fetch_db_s3_keys
+fetch_db_content_hashes = _script.fetch_db_content_hashes
 classify = _script.classify
 run_audit = _script.run_audit
 
 PRESENT_IN_DB = _script.PRESENT_IN_DB
+PRESENT_IN_DB_VIA_CONTENT_HASH = _script.PRESENT_IN_DB_VIA_CONTENT_HASH
 MISLABELED = _script.MISLABELED
 CORRECTLY_LABELED_ORPHAN = _script.CORRECTLY_LABELED_ORPHAN
 
@@ -228,17 +230,43 @@ class TestClassify:
         key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
         db_keys = {key}
         mock_s3 = MagicMock()
-        result = classify(key, _NOW, mock_s3, db_keys, verify_bytes=False)
+        result = classify(key, _NOW, mock_s3, db_keys, set(), verify_bytes=False)
         assert result == PRESENT_IN_DB
 
     def test_correctly_labeled_orphan_bulk_pass(self) -> None:
-        """classify returns CORRECTLY_LABELED_ORPHAN when key absent from db_keys (bulk)."""
+        """classify returns CORRECTLY_LABELED_ORPHAN when key absent from db_keys and db_content_hashes (bulk)."""
         key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
         db_keys: set[str] = set()
         mock_s3 = MagicMock()
-        result = classify(key, _NOW, mock_s3, db_keys, verify_bytes=False)
+        result = classify(key, _NOW, mock_s3, db_keys, set(), verify_bytes=False)
         assert result == CORRECTLY_LABELED_ORPHAN
         # Should not call S3 in bulk pass.
+        mock_s3.get_object.assert_not_called()
+
+    def test_present_in_db_via_content_hash_bulk_pass(self) -> None:
+        """classify returns PRESENT_IN_DB_VIA_CONTENT_HASH when filename hash is in db_content_hashes."""
+        key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
+        db_keys: set[str] = set()
+        db_content_hashes = {_VALID_HASH}
+        mock_s3 = MagicMock()
+        result = classify(
+            key, _NOW, mock_s3, db_keys, db_content_hashes, verify_bytes=False
+        )
+        assert result == PRESENT_IN_DB_VIA_CONTENT_HASH
+        # Should not call S3 — dedup is determined by set membership.
+        mock_s3.get_object.assert_not_called()
+
+    def test_present_in_db_via_content_hash_with_verify_bytes(self) -> None:
+        """classify returns PRESENT_IN_DB_VIA_CONTENT_HASH before byte-verify when hash matches."""
+        key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
+        db_keys: set[str] = set()
+        db_content_hashes = {_VALID_HASH}
+        mock_s3 = MagicMock()
+        result = classify(
+            key, _NOW, mock_s3, db_keys, db_content_hashes, verify_bytes=True
+        )
+        assert result == PRESENT_IN_DB_VIA_CONTENT_HASH
+        # Content-hash check is a short-circuit; S3 should not be called.
         mock_s3.get_object.assert_not_called()
 
     def test_correctly_labeled_orphan_with_byte_verify(self) -> None:
@@ -249,7 +277,7 @@ class TestClassify:
         db_keys: set[str] = set()
         mock_s3 = MagicMock()
         mock_s3.get_object.return_value = {"Body": BytesIO(content)}
-        result = classify(key, _NOW, mock_s3, db_keys, verify_bytes=True)
+        result = classify(key, _NOW, mock_s3, db_keys, set(), verify_bytes=True)
         assert result == CORRECTLY_LABELED_ORPHAN
         mock_s3.get_object.assert_called_once()
 
@@ -262,7 +290,7 @@ class TestClassify:
         db_keys: set[str] = set()
         mock_s3 = MagicMock()
         mock_s3.get_object.return_value = {"Body": BytesIO(content)}
-        result = classify(key, _NOW, mock_s3, db_keys, verify_bytes=True)
+        result = classify(key, _NOW, mock_s3, db_keys, set(), verify_bytes=True)
         assert result == MISLABELED
         # Confirm actual hash != wrong hash so we're testing the right thing.
         assert actual_hash != wrong_hash
@@ -273,7 +301,7 @@ class TestClassify:
         db_keys: set[str] = set()
         mock_s3 = MagicMock()
         mock_s3.get_object.side_effect = Exception("S3 error")
-        result = classify(key, _NOW, mock_s3, db_keys, verify_bytes=True)
+        result = classify(key, _NOW, mock_s3, db_keys, set(), verify_bytes=True)
         assert result == CORRECTLY_LABELED_ORPHAN
 
     def test_present_in_db_skips_byte_verify(self) -> None:
@@ -281,7 +309,7 @@ class TestClassify:
         key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
         db_keys = {key}
         mock_s3 = MagicMock()
-        result = classify(key, _NOW, mock_s3, db_keys, verify_bytes=True)
+        result = classify(key, _NOW, mock_s3, db_keys, set(), verify_bytes=True)
         assert result == PRESENT_IN_DB
         mock_s3.get_object.assert_not_called()
 
@@ -342,7 +370,80 @@ class TestFetchDbS3Keys:
 
 
 # ---------------------------------------------------------------------------
-# 5. run_audit — JSON output schema is stable
+# 5. fetch_db_content_hashes — correct LIKE query and return type
+# ---------------------------------------------------------------------------
+
+
+class TestFetchDbContentHashes:
+    def test_queries_with_correct_like_pattern(self) -> None:
+        """fetch_db_content_hashes issues LIKE 'ca/santa_clara/%' query on s3_key column."""
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        cursor_mock.fetchall.return_value = [
+            (_VALID_HASH,),
+        ]
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        hashes = fetch_db_content_hashes(mock_conn, "santa_clara")
+
+        assert isinstance(hashes, set)
+        assert _VALID_HASH in hashes
+
+        # Verify the query uses LIKE on s3_key with the right pattern.
+        call_args = cursor_mock.execute.call_args
+        query = call_args[0][0]
+        pattern = call_args[0][1][0]
+        assert "LIKE" in query
+        assert pattern == "ca/santa_clara/%"
+        assert "content_hash" in query
+        assert "s3_key" in query
+
+    def test_returns_empty_set_when_no_rows(self) -> None:
+        """fetch_db_content_hashes returns an empty set when DB has no matching rows."""
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        cursor_mock.fetchall.return_value = []
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        hashes = fetch_db_content_hashes(mock_conn, "orange")
+        assert hashes == set()
+
+    def test_filters_none_content_hashes(self) -> None:
+        """fetch_db_content_hashes omits rows with NULL content_hash."""
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        hash_val = "b" * 64
+        cursor_mock.fetchall.return_value = [
+            (hash_val,),
+            (None,),
+        ]
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        hashes = fetch_db_content_hashes(mock_conn, "orange")
+        assert None not in hashes
+        assert len(hashes) == 1
+        assert hash_val in hashes
+
+    def test_orange_county_pattern(self) -> None:
+        """fetch_db_content_hashes uses 'ca/orange/%' pattern for orange county."""
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        cursor_mock.fetchall.return_value = []
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        fetch_db_content_hashes(mock_conn, "orange")
+
+        call_args = cursor_mock.execute.call_args
+        pattern = call_args[0][1][0]
+        assert pattern == "ca/orange/%"
+
+
+# ---------------------------------------------------------------------------
+# 6. run_audit — JSON output schema is stable
 # ---------------------------------------------------------------------------
 
 
@@ -385,6 +486,7 @@ class TestRunAuditJsonSchema:
         county = result["counties"]["santa_clara"]
         assert "total" in county
         assert "in_db" in county
+        assert "in_db_via_content_hash" in county
         assert "orphans" in county
         assert "mislabeled" in county
         assert "orphans_by_month" in county
@@ -414,6 +516,58 @@ class TestRunAuditJsonSchema:
         assert county["orphans"] == 1
         assert county["in_db"] == 1
         assert county["total"] == 2
+
+    def test_in_db_via_content_hash_key_present_in_output(self) -> None:
+        """run_audit always includes in_db_via_content_hash key in county summary."""
+        key = f"ca/santa_clara/superior_court/raw/{_VALID_HASH}.pdf"
+        mock_s3 = self._make_s3_with_keys([key])
+        mock_conn = self._make_conn_with_db_keys([key])
+
+        result = run_audit(
+            mock_s3,
+            mock_conn,
+            {"santa_clara": "ca/santa_clara/"},
+            limit=None,
+            sample_head_objects=0,
+            output_json=True,
+        )
+
+        county = result["counties"]["santa_clara"]
+        assert "in_db_via_content_hash" in county
+        assert isinstance(county["in_db_via_content_hash"], int)
+
+    def test_dedup_loser_counted_as_in_db_via_content_hash(self) -> None:
+        """run_audit classifies a key as in_db_via_content_hash when its filename hash is in DB content hashes."""
+        dedup_loser_key = f"ca/orange/superior_court/raw/{_VALID_HASH}.pdf"
+
+        mock_s3 = self._make_s3_with_keys([dedup_loser_key])
+
+        # s3_keys query returns empty (key not present by s3_key)
+        # content_hashes query returns the hash (content present under different key)
+        mock_conn = MagicMock()
+        cursor_mock = MagicMock()
+        # First call → fetch_db_s3_keys → empty; second call → fetch_db_content_hashes → has the hash
+        cursor_mock.fetchall.side_effect = [[], [(_VALID_HASH,)]]
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=cursor_mock)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = run_audit(
+            mock_s3,
+            mock_conn,
+            {"orange": "ca/orange/"},
+            limit=None,
+            sample_head_objects=0,
+            output_json=True,
+        )
+
+        county = result["counties"]["orange"]
+        assert county["in_db_via_content_hash"] == 1
+        assert county["orphans"] == 0
+        assert county["in_db"] == 0
+        # total = in_db + in_db_via_content_hash + orphans + mislabeled
+        assert county["total"] == 1
+        # all_clean still True because there are no true orphans
+        assert result["all_clean"] is True
 
     def test_json_schema_sample_verified_fields(self) -> None:
         """sample_verified entries contain key, last_modified, and classification."""


### PR DESCRIPTION
## Summary

Added dedup-aware content_hash classification to the S3 orphan audit script. Investigation confirmed SC's 13 orphans are valid ruling documents (substantive multi-page PDFs with lost Redis Stream events, not stub/unparseable content). OC spot-query revealed zero content-hash duplicates, indicating the elevated OC orphan count is not caused by deduplication; root-cause investigation filed separately.

Closes #3522

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest`) — 41 passed including 4 new dedup-specific test cases
- [x] CI green

### Post-deploy verification

- [ ] Re-run `scripts/audit_correctly_labeled_s3_orphans.py --county orange --sample-head-objects 500 --json` and verify `in_db_via_content_hash` bucket is populated correctly; confirm `orphans` count reflects true residual (not dedup losers)
- [ ] Verification evidence posted on #3522 (see /task-v2-verify output)