### PR TITLE
fix(spotcheck): use WITH RECURSIVE to walk full previous_version_id chains (#3537)

### DIFF
--- a/scripts/spotcheck/fetch.py
+++ b/scripts/spotcheck/fetch.py
@@ -353,25 +353,24 @@ class OriginalsStrategy(ExpansionStrategy):
         # queried S3 key is a content-hash-dedup *loser* (#2569): the
         # loser's document row is marked superseded with its rulings
         # deleted, while the actual rulings for those cases live on the
-        # *winner*'s document (a different s3_key).  We follow the
-        # ``documents.previous_version_id`` link so either the winner or
-        # the loser S3 key surfaces the canonical rulings.
-        #
-        # The subquery collects (a) any document that currently has this
-        # s3_key and (b) any document that points to one of those docs
-        # via ``previous_version_id`` (the winner when this key is a
-        # loser), then the outer query fetches rulings linked to ANY of
-        # those doc ids.
+        # *winner*'s document (a different s3_key).  Walk the full
+        # ``previous_version_id`` chain (loser → winner → terminal) so
+        # any key in a multi-hop supersede chain surfaces all canonical
+        # rulings.  The recursive arm joins
+        # ``documents d ON d.id = td.previous_version_id`` to follow
+        # each hop until no further successor exists.
         #
         # Escape single quotes in the S3 key for SQL safety.
         safe_key = entity_id.replace("'", "''")
         query = (
-            "WITH target_docs AS ("
-            "  SELECT id FROM documents WHERE s3_key = '" + safe_key + "' "
+            "WITH RECURSIVE target_docs AS ("
+            "  SELECT id, previous_version_id FROM documents WHERE s3_key = '"
+            + safe_key
+            + "' "
             "  UNION "
-            "  SELECT previous_version_id AS id FROM documents "
-            "  WHERE s3_key = '" + safe_key + "' "
-            "    AND previous_version_id IS NOT NULL "
+            "  SELECT d.id, d.previous_version_id "
+            "  FROM documents d "
+            "  JOIN target_docs td ON d.id = td.previous_version_id "
             ") "
             "SELECT r.id::text AS ruling_id, r.outcome::text, "
             "r.motion_type, r.hearing_date::text, r.department, "

--- a/scripts/spotcheck/run_spotcheck.py
+++ b/scripts/spotcheck/run_spotcheck.py
@@ -18,6 +18,7 @@ The result JSON is written to:
 The caller can download it with:
     aws s3 cp s3://<bucket>/spotcheck/<timestamp>.json tmp/spotcheck/data.json
 """
+
 from __future__ import annotations
 
 import argparse
@@ -33,15 +34,23 @@ DATABASE_URL = os.environ["DATABASE_URL"]
 BUCKET = os.environ.get("JUDGEMIND_ARCHIVE_BUCKET", "judgemind-document-archive-dev")
 
 ALL_COUNTIES = [
-    "Los Angeles", "Orange", "Riverside", "San Bernardino",
-    "Santa Clara", "Ventura", "Contra Costa", "Fresno",
-    "San Francisco", "San Diego",
+    "Los Angeles",
+    "Orange",
+    "Riverside",
+    "San Bernardino",
+    "Santa Clara",
+    "Ventura",
+    "Contra Costa",
+    "Fresno",
+    "San Francisco",
+    "San Diego",
 ]
 
 
 def sample_rulings(cur: psycopg.Cursor, county: str, n: int) -> list[dict]:
     """Sample N random rulings for a county with full context."""
-    cur.execute("""
+    cur.execute(
+        """
         SELECT
             r.id::text AS ruling_id,
             r.outcome::text,
@@ -66,7 +75,9 @@ def sample_rulings(cur: psycopg.Cursor, county: str, n: int) -> list[dict]:
         WHERE c.county = %s
         ORDER BY random()
         LIMIT %s
-    """, (county, n))
+    """,
+        (county, n),
+    )
     columns = [desc[0] for desc in cur.description]
     return [dict(zip(columns, row)) for row in cur.fetchall()]
 
@@ -74,7 +85,8 @@ def sample_rulings(cur: psycopg.Cursor, county: str, n: int) -> list[dict]:
 def sample_originals(cur: psycopg.Cursor, county: str, n: int) -> list[dict]:
     """Sample N random original documents and their derived rulings."""
     # Sample from documents table (not S3) to avoid orphaned keys
-    cur.execute("""
+    cur.execute(
+        """
         WITH sampled AS (
             SELECT DISTINCT ON (d.s3_key)
                 d.s3_key, d.s3_bucket, d.id::text AS doc_id
@@ -85,7 +97,9 @@ def sample_originals(cur: psycopg.Cursor, county: str, n: int) -> list[dict]:
         )
         SELECT s3_key, s3_bucket, doc_id FROM sampled
         ORDER BY random() LIMIT %s
-    """, (county, n))
+    """,
+        (county, n),
+    )
     sampled_docs = cur.fetchall()
 
     originals = []
@@ -94,15 +108,18 @@ def sample_originals(cur: psycopg.Cursor, county: str, n: int) -> list[dict]:
         # S3 key is a content-hash-dedup *loser* (#2569): the loser's document
         # row is marked superseded with its rulings deleted, while the actual
         # rulings for those cases live on the *winner*'s document (a different
-        # s3_key).  Follow ``documents.previous_version_id`` so either the
-        # winner or the loser key surfaces the canonical rulings.  Mirrors the
-        # CTE pattern in ``scripts/spotcheck/fetch.py`` ``OriginalsStrategy``.
-        cur.execute("""
-            WITH target_docs AS (
-                SELECT id FROM documents WHERE s3_key = %s
+        # s3_key).  Walk the full ``previous_version_id`` chain
+        # (loser → winner → terminal) so any key in a multi-hop supersede
+        # chain surfaces all canonical rulings.  Mirrors the CTE pattern in
+        # ``scripts/spotcheck/fetch.py`` ``OriginalsStrategy``.
+        cur.execute(
+            """
+            WITH RECURSIVE target_docs AS (
+                SELECT id, previous_version_id FROM documents WHERE s3_key = %s
                 UNION
-                SELECT previous_version_id AS id FROM documents
-                WHERE s3_key = %s AND previous_version_id IS NOT NULL
+                SELECT d.id, d.previous_version_id
+                FROM documents d
+                JOIN target_docs td ON d.id = td.previous_version_id
             )
             SELECT r.id::text AS ruling_id, r.outcome::text,
                    r.motion_type, r.hearing_date::text, r.department,
@@ -115,20 +132,24 @@ def sample_originals(cur: psycopg.Cursor, county: str, n: int) -> list[dict]:
             JOIN cases cs ON r.case_id = cs.id
             LEFT JOIN judges j ON r.judge_id = j.id
             ORDER BY r.id
-        """, (s3_key, s3_key))
+        """,
+            (s3_key,),
+        )
         cols = [desc[0] for desc in cur.description]
         derived = [dict(zip(cols, row)) for row in cur.fetchall()]
 
         case_titles = list({r["case_title"] for r in derived if r.get("case_title")})
 
-        originals.append({
-            "s3_key": s3_key,
-            "s3_bucket": s3_bucket,
-            "derived_count": len(derived),
-            "all_same_case": len(case_titles) == 1 and len(derived) > 1,
-            "distinct_case_titles": len(case_titles),
-            "derived_rulings": derived,
-        })
+        originals.append(
+            {
+                "s3_key": s3_key,
+                "s3_bucket": s3_bucket,
+                "derived_count": len(derived),
+                "all_same_case": len(case_titles) == 1 and len(derived) > 1,
+                "distinct_case_titles": len(case_titles),
+                "derived_rulings": derived,
+            }
+        )
 
     return originals
 
@@ -156,7 +177,9 @@ def get_county_stats(cur: psycopg.Cursor) -> dict:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run bidirectional spotcheck")
-    parser.add_argument("--n", type=int, default=10, help="Samples per county per direction")
+    parser.add_argument(
+        "--n", type=int, default=10, help="Samples per county per direction"
+    )
     parser.add_argument("--county", help="Single county to check (default: all)")
     args = parser.parse_args()
 
@@ -187,8 +210,10 @@ def main() -> None:
                     result["originals_by_county"][county] = []
                     continue
 
-                print(f"Sampling {county} ({stats['ruling_count']} rulings)...",
-                      file=sys.stderr)
+                print(
+                    f"Sampling {county} ({stats['ruling_count']} rulings)...",
+                    file=sys.stderr,
+                )
 
                 result["rulings_by_county"][county] = sample_rulings(
                     cur, county, args.n
@@ -211,8 +236,10 @@ def main() -> None:
     )
 
     print(f"\nResult written to s3://{BUCKET}/{s3_key}", file=sys.stderr)
-    print(f"Download with: aws s3 cp s3://{BUCKET}/{s3_key} tmp/spotcheck/data.json",
-          file=sys.stderr)
+    print(
+        f"Download with: aws s3 cp s3://{BUCKET}/{s3_key} tmp/spotcheck/data.json",
+        file=sys.stderr,
+    )
 
     # Also print a compact summary to stdout (this shows in CloudWatch logs)
     summary = {
@@ -225,8 +252,9 @@ def main() -> None:
         same_case_count = sum(1 for o in originals if o.get("all_same_case"))
         zero_derived = sum(1 for o in originals if o.get("derived_count", 0) == 0)
         null_judges = sum(1 for r in rulings if not r.get("judge_name"))
-        unknown_cases = sum(1 for r in rulings
-                          if (r.get("case_number") or "").startswith("UNKNOWN"))
+        unknown_cases = sum(
+            1 for r in rulings if (r.get("case_number") or "").startswith("UNKNOWN")
+        )
         null_departments = sum(1 for r in rulings if not r.get("department"))
         empty_ruling_text = sum(
             1 for r in rulings if (r.get("ruling_text_length") or 0) == 0
@@ -236,12 +264,14 @@ def main() -> None:
         )
         # Also check originals' derived rulings for empty text and long titles
         orig_empty_text = sum(
-            1 for o in originals
+            1
+            for o in originals
             for dr in o.get("derived_rulings", [])
             if (dr.get("ruling_text_length") or 0) == 0
         )
         orig_long_titles = sum(
-            1 for o in originals
+            1
+            for o in originals
             for dr in o.get("derived_rulings", [])
             if len(dr.get("case_title") or "") > 100
         )

--- a/scripts/tests/test_run_spotcheck.py
+++ b/scripts/tests/test_run_spotcheck.py
@@ -32,6 +32,76 @@ if not _had_database_url:
     del os.environ["DATABASE_URL"]
 
 
+class TestSampleOriginalsRecursiveChain:
+    """The originals query must use WITH RECURSIVE to walk multi-hop chains (#3537)."""
+
+    def _get_per_doc_sql(self) -> str:
+        """Return the SQL from the second execute() call (the per-doc rulings query)."""
+        cur = MagicMock()
+        cur.fetchall.side_effect = [
+            [("ca/contra_costa/doc_a.pdf", "bucket", "doc-a")],
+            [],
+        ]
+        cur.description = [("ruling_id",)]
+        run_spotcheck.sample_originals(cur, "Contra Costa", 1)
+        return cur.execute.call_args_list[1][0][0]
+
+    def test_query_uses_recursive_cte(self) -> None:
+        sql = self._get_per_doc_sql()
+        assert "WITH RECURSIVE" in sql, (
+            "sample_originals must use WITH RECURSIVE to walk multi-hop "
+            "previous_version_id chains (#3537)."
+        )
+
+    def test_query_recursion_joins_previous_version_id(self) -> None:
+        import re
+
+        sql = self._get_per_doc_sql()
+        normalized = re.sub(r"\s+", " ", sql).lower()
+        assert "d.id = td.previous_version_id" in normalized, (
+            "Recursive arm must join target_docs td ON d.id = td.previous_version_id "
+            "to walk each hop of the supersede chain."
+        )
+
+    def test_chain_returns_rulings_from_terminal_doc(self) -> None:
+        """A 3-doc chain A→B→C: sampling A's s3_key must surface C's ruling."""
+        cur = MagicMock()
+        cur.fetchall.side_effect = [
+            [("key_A", "bucket", "doc-A")],
+            [
+                (
+                    "ruling-C",
+                    "granted",
+                    None,
+                    None,
+                    None,
+                    "BC001",
+                    "Smith v Jones",
+                    "Judge Smith",
+                    150,
+                    "text preview",
+                )
+            ],
+        ]
+        cur.description = [
+            ("ruling_id",),
+            ("outcome",),
+            ("motion_type",),
+            ("hearing_date",),
+            ("department",),
+            ("case_number",),
+            ("case_title",),
+            ("judge_name",),
+            ("ruling_text_length",),
+            ("ruling_text_preview",),
+        ]
+        result = run_spotcheck.sample_originals(cur, "Contra Costa", 1)
+        assert len(result) == 1
+        original = result[0]
+        assert original["derived_count"] == 1
+        assert original["derived_rulings"][0]["ruling_id"] == "ruling-C"
+
+
 class TestSampleOriginalsFollowsPreviousVersionChain:
     """The originals query must follow ``previous_version_id`` (#2569)."""
 

--- a/scripts/tests/test_spotcheck_fetch.py
+++ b/scripts/tests/test_spotcheck_fetch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -22,6 +23,45 @@ from fetch import (
     fetch_manifest,
     register_strategy,
 )
+
+
+class TestOriginalsStrategyRecursiveChain:
+    """OriginalsStrategy query must use WITH RECURSIVE to walk multi-hop chains (#3537)."""
+
+    def _get_derived_sql(self, tmp_path: Path) -> str:
+        """Capture the SQL passed to _run_db_query by OriginalsStrategy.expand."""
+        captured: list[str] = []
+
+        def capture_sql(sql: str, params: Any = None) -> list[dict[str, Any]]:
+            captured.append(sql)
+            return []
+
+        item_dir = tmp_path / "test-doc"
+        item_dir.mkdir()
+        strategy = OriginalsStrategy()
+        with (
+            patch("fetch._fetch_s3_object", return_value=False),
+            patch("fetch._run_db_query", side_effect=capture_sql),
+        ):
+            strategy.expand("ca/contra_costa/doc_a.pdf", item_dir)
+
+        assert captured, "Expected _run_db_query to be called at least once"
+        return captured[0]
+
+    def test_query_uses_recursive_cte(self, tmp_path: Path) -> None:
+        sql = self._get_derived_sql(tmp_path)
+        assert "WITH RECURSIVE" in sql, (
+            "OriginalsStrategy must use WITH RECURSIVE to walk multi-hop "
+            "previous_version_id chains (#3537)."
+        )
+
+    def test_query_recursion_joins_previous_version_id(self, tmp_path: Path) -> None:
+        sql = self._get_derived_sql(tmp_path)
+        normalized = re.sub(r"\s+", " ", sql).lower()
+        assert "d.id = td.previous_version_id" in normalized, (
+            "Recursive arm must join target_docs td ON d.id = td.previous_version_id "
+            "to walk each hop of the supersede chain."
+        )
 
 
 class TestStrategyRegistry:
@@ -81,16 +121,16 @@ class TestRulingsStrategy:
         item_dir.mkdir()
 
         db_response = [
-                {
-                    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                    "ruling_text": "The motion is GRANTED.",
-                    "outcome": "granted",
-                    "s3_key": "CA/LA/doc.pdf",
-                    "s3_bucket": "judgemind-documents-dev",
-                    "doc_format": "pdf",
-                    "case_id": "test-case-id",
-                }
-            ]
+            {
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "ruling_text": "The motion is GRANTED.",
+                "outcome": "granted",
+                "s3_key": "CA/LA/doc.pdf",
+                "s3_bucket": "judgemind-documents-dev",
+                "doc_format": "pdf",
+                "case_id": "test-case-id",
+            }
+        ]
 
         strategy = RulingsStrategy()
         with (
@@ -108,14 +148,14 @@ class TestRulingsStrategy:
         item_dir.mkdir()
 
         db_response = [
-                {
-                    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                    "s3_key": "CA/LA/doc.pdf",
-                    "s3_bucket": "judgemind-documents-dev",
-                    "doc_format": "pdf",
-                    "case_id": "test-case-id",
-                }
-            ]
+            {
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "s3_key": "CA/LA/doc.pdf",
+                "s3_bucket": "judgemind-documents-dev",
+                "doc_format": "pdf",
+                "case_id": "test-case-id",
+            }
+        ]
 
         strategy = RulingsStrategy()
         with (
@@ -136,14 +176,14 @@ class TestRulingsStrategy:
         item_dir.mkdir()
 
         db_response = [
-                {
-                    "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                    "s3_key": "CA/LA/doc.pdf",
-                    "s3_bucket": "judgemind-documents-dev",
-                    "doc_format": "pdf",
-                    "case_id": "test-case-id",
-                }
-            ]
+            {
+                "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "s3_key": "CA/LA/doc.pdf",
+                "s3_bucket": "judgemind-documents-dev",
+                "doc_format": "pdf",
+                "case_id": "test-case-id",
+            }
+        ]
 
         strategy = RulingsStrategy()
         with (
@@ -178,14 +218,14 @@ class TestRulingsStrategy:
         item_dir.mkdir()
 
         db_response = [
-                {
-                    "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
-                    "s3_key": "CA/LA/doc.html",
-                    "s3_bucket": "judgemind-documents-dev",
-                    "doc_format": "html",
-                    "case_id": "test-case-id",
-                }
-            ]
+            {
+                "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+                "s3_key": "CA/LA/doc.html",
+                "s3_bucket": "judgemind-documents-dev",
+                "doc_format": "html",
+                "case_id": "test-case-id",
+            }
+        ]
 
         strategy = RulingsStrategy()
         with (
@@ -206,8 +246,8 @@ class TestOriginalsStrategy:
         item_dir.mkdir()
 
         derived_response = [
-                {"ruling_id": "ruling-1", "case_number": "BC123"},
-            ]
+            {"ruling_id": "ruling-1", "case_number": "BC123"},
+        ]
 
         strategy = OriginalsStrategy()
         with (
@@ -225,9 +265,9 @@ class TestOriginalsStrategy:
         item_dir.mkdir()
 
         derived_response = [
-                {"ruling_id": "ruling-1", "case_number": "BC123"},
-                {"ruling_id": "ruling-2", "case_number": "BC456"},
-            ]
+            {"ruling_id": "ruling-1", "case_number": "BC123"},
+            {"ruling_id": "ruling-2", "case_number": "BC456"},
+        ]
 
         strategy = OriginalsStrategy()
         with (
@@ -245,9 +285,9 @@ class TestOriginalsStrategy:
         item_dir.mkdir()
 
         derived_response = [
-                {"ruling_id": "ruling-1", "case_number": "BC123"},
-                {"ruling_id": "ruling-2", "case_number": "BC456"},
-            ]
+            {"ruling_id": "ruling-1", "case_number": "BC123"},
+            {"ruling_id": "ruling-2", "case_number": "BC456"},
+        ]
 
         strategy = OriginalsStrategy()
         with (


### PR DESCRIPTION
## Summary

Upgraded both spotcheck originals CTEs from single-hop UNION to WITH RECURSIVE, walking the full `previous_version_id` chain (loser → winner → terminal). Prevents false-negative "missing rulings" findings on multi-hop supersede chains in Contra Costa and other content-hash-dedup counties.

Closes #3537

## Test plan

### Automated checks

- [x] Lint passes (`ruff format --check` + `ruff check`)
- [x] Format passes (already formatted in diff)
- [x] Tests pass (`pytest scripts/tests/test_run_spotcheck.py -k chain -v` and `pytest scripts/tests/test_spotcheck_fetch.py -k chain -v`)
- [x] CI green

### Post-deploy verification

- [x] No deployed component — spotcheck is an audit script (dev-only, no prod impact)
- [x] Verification evidence posted on #3537 (see /task-v2-verify output after merge)