### PR TITLE
test(scripts): broaden AST guard for duplicate event= kwargs (#3540)

### DIFF
--- a/scripts/tests/test_backfill_split_supersede.py
+++ b/scripts/tests/test_backfill_split_supersede.py
@@ -6,7 +6,6 @@ Tests cover:
   3. Falls back to 'split_supersede_unverified' when no valid sibling.
   4. UPDATE SQL shapes for both paths.
   5. Dry-run mode skips DB writes.
-  6. No duplicate event= kwarg in logger calls (AST-based, #3527).
 
 All database access is mocked -- these tests verify the pure helper logic,
 SELECT filters, and UPDATE shapes without requiring live services.
@@ -18,7 +17,6 @@ We mock them in sys.modules before importing the script under test.
 
 from __future__ import annotations
 
-import ast
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -321,56 +319,3 @@ class TestMain:
         assert len(update_calls) == 0
         mock_conn.commit.assert_not_called()
 
-
-# ---------------------------------------------------------------------------
-# AST-based regression test: no duplicate event= kwarg (#3527)
-# ---------------------------------------------------------------------------
-
-_LOGGER_LEVELS = {"info", "warning", "error", "debug", "critical"}
-
-
-class TestNoDuplicateEventKwarg:
-    """Ensure no logger.<level>(positional_string, event=...) duplicate pattern.
-
-    structlog's bound logger maps the first positional arg to 'event='
-    automatically.  Passing both raises TypeError at runtime.  This test
-    parses the script source via ast.parse so it catches the bug without
-    executing any DB or structlog code.
-    """
-
-    def _get_script_path(self) -> str:
-        return os.path.join(
-            os.path.dirname(__file__), "..", "backfill_split_supersede.py"
-        )
-
-    def test_no_logger_call_has_both_positional_and_event_kwarg(self) -> None:
-        script_path = self._get_script_path()
-        with open(script_path) as fh:
-            source = fh.read()
-
-        tree = ast.parse(source, filename=script_path)
-
-        violations: list[int] = []
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Call):
-                continue
-            func = node.func
-            # Match logger.<level>(...) call shapes.
-            if not (
-                isinstance(func, ast.Attribute)
-                and func.attr in _LOGGER_LEVELS
-                and isinstance(func.value, ast.Name)
-                and func.value.id == "logger"
-            ):
-                continue
-            # Violation: has at least one positional arg AND a keyword arg named 'event'.
-            has_positional = len(node.args) > 0
-            has_event_kwarg = any(kw.arg == "event" for kw in node.keywords)
-            if has_positional and has_event_kwarg:
-                violations.append(node.lineno)
-
-        assert violations == [], (
-            f"Duplicate event= kwarg found in backfill_split_supersede.py "
-            f"at lines: {violations}. Remove the explicit event= kwarg — "
-            f"structlog maps the first positional arg to event= automatically."
-        )

--- a/scripts/tests/test_no_duplicate_event_kwargs.py
+++ b/scripts/tests/test_no_duplicate_event_kwargs.py
@@ -1,0 +1,143 @@
+"""Broad AST guard for duplicate event= kwargs in top-level data scripts (#3540).
+
+Covers every scripts/backfill_*.py and scripts/cleanup_*.py.
+
+structlog's bound logger maps the first positional argument to 'event='
+automatically.  Passing both a positional arg and an explicit event= keyword
+raises TypeError at runtime.  This guard catches the pattern statically via
+ast.parse so it surfaces in CI without requiring live services.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_LOGGER_LEVELS = {"info", "warning", "error", "debug", "critical"}
+_SCRIPT_GLOBS = ("scripts/backfill_*.py", "scripts/cleanup_*.py")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _walk_logger_violations(source: str, filename: str) -> list[tuple[str, int]]:
+    """Return (filename, lineno) for each logger.<level> call that has both
+    a positional arg and an explicit event= keyword argument.
+
+    These are always bugs: structlog maps the first positional arg to event=
+    automatically, so supplying both raises TypeError at runtime.
+    """
+    tree = ast.parse(source, filename=filename)
+    violations: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (
+            isinstance(func, ast.Attribute)
+            and func.attr in _LOGGER_LEVELS
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "logger"
+        ):
+            continue
+        has_positional = len(node.args) > 0
+        has_event_kwarg = any(kw.arg == "event" for kw in node.keywords)
+        if has_positional and has_event_kwarg:
+            violations.append((filename, node.lineno))
+    return violations
+
+
+def _discover_scripts() -> list[Path]:
+    """Return all scripts matching _SCRIPT_GLOBS, excluding scripts/archive/."""
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    paths: list[Path] = []
+    for glob_pattern in _SCRIPT_GLOBS:
+        for path in sorted(repo_root.glob(glob_pattern)):
+            # Defensive filter: skip anything under scripts/archive/ in case
+            # a glob pattern is broadened in the future.
+            if "archive" in path.parts:
+                continue
+            paths.append(path)
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Sanity check: discovery must be non-empty
+# ---------------------------------------------------------------------------
+
+
+def test_glob_finds_at_least_one_script() -> None:
+    """_discover_scripts() must return at least one script.
+
+    If this fails, the glob patterns in _SCRIPT_GLOBS no longer match any
+    file and the parametrized guard below is silently a no-op.
+    """
+    scripts = _discover_scripts()
+    assert len(scripts) >= 1, (
+        f"_discover_scripts() returned no scripts — patterns {_SCRIPT_GLOBS} "
+        "matched nothing under scripts/. Update _SCRIPT_GLOBS if the files moved."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Broad parametrized guard
+# ---------------------------------------------------------------------------
+
+
+class TestNoDuplicateEventKwargAcrossScripts:
+    """AST guard that runs against every discovered data script."""
+
+    @pytest.mark.parametrize("script_path", _discover_scripts(), ids=lambda p: p.name)
+    def test_no_logger_call_has_both_positional_and_event_kwarg(
+        self, script_path: Path
+    ) -> None:
+        source = script_path.read_text()
+        repo_root = Path(__file__).resolve().parent.parent.parent
+        rel = script_path.relative_to(repo_root)
+        violations = _walk_logger_violations(source, str(rel))
+        assert violations == [], (
+            f"Duplicate event= kwarg found in {rel} at lines: "
+            f"{[lineno for _, lineno in violations]}. "
+            "Remove the explicit event= kwarg — structlog maps the first "
+            "positional arg to event= automatically."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Self-check: verify the helper itself works correctly
+# ---------------------------------------------------------------------------
+
+
+class TestGuardSelfCheck:
+    """Verify the AST walker detects violations and passes clean calls."""
+
+    def test_helper_flags_known_violation(self) -> None:
+        """Inline regression fixture: logger.info with both positional and event=."""
+        source = """\
+import structlog
+logger = structlog.get_logger()
+logger.info("x", event="y")
+"""
+        violations = _walk_logger_violations(source, "fixture.py")
+        assert len(violations) == 1, (
+            f"Expected exactly one violation, got: {violations}"
+        )
+        assert violations[0] == ("fixture.py", 3)
+
+    def test_helper_passes_clean_call(self) -> None:
+        """A clean logger.info call with only a positional arg must pass."""
+        source = """\
+import structlog
+logger = structlog.get_logger()
+logger.info("x")
+"""
+        violations = _walk_logger_violations(source, "fixture.py")
+        assert violations == []


### PR DESCRIPTION
## Summary

Generalized the duplicate `event=` kwarg AST guard to cover all top-level `scripts/backfill_*.py` and `scripts/cleanup_*.py` scripts via parametrized pytest. Moved the guard logic to a dedicated test file with broad glob patterns, ensuring every new backfill or cleanup script is automatically covered. Added a regression fixture to verify the guard correctly detects violations.

Closes #3540

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest`) — 31 tests pass, including new parametrized suite and regression fixtures
- [x] CI green — pre-push hook confirmed

### Post-deploy verification

- [ ] Verify the parametrized test runs against all current backfill_*.py scripts: `pytest scripts/tests/test_no_duplicate_event_kwargs.py::TestNoDuplicateEventKwargAcrossScripts -v`
- [ ] Verify the regression fixture detects violations: `pytest scripts/tests/test_no_duplicate_event_kwargs.py::TestGuardSelfCheck -v`
- [ ] Confirm sanity check passes (glob non-empty): `pytest scripts/tests/test_no_duplicate_event_kwargs.py::test_glob_finds_at_least_one_script -v`