### PR TITLE
fix(dispatcher): add route_to_diagnoser arm to push_and_pr case-statement (#3543)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -4896,12 +4896,37 @@ while true; do
             _action=$(printf '%s' "$_transition" | cut -f1)
             _next=$(printf '%s' "$_transition" | cut -f2)
             _status=$(printf '%s' "$_transition" | cut -f3)
+            _hint=$(printf '%s' "$_transition" | cut -f4)
             case "$_action" in
                 advance)
                     advance_phase "$_next"
                     ;;
                 advance_with_status)
                     advance_phase "$_next" "$_status"
+                    ;;
+                route_to_diagnoser)
+                    # Issue #3543 — push_and_pr rebase failure with no
+                    # unmerged files. transition_from_push_and_pr emits
+                    # ROUTE_TO_DIAGNOSER with hint=push_and_pr_no_unmerged_files
+                    # (#3465). Route to the descriptive terminal so the
+                    # daemon's BYPASSED_TERMINAL_PHASES_TO_ROUTE picks it
+                    # up for the diagnoser sweep.
+                    log "push_and_pr_route_to_diagnoser" "hint=$_hint"
+                    case "$_hint" in
+                        push_and_pr_no_unmerged_files)
+                            agent_runner_reaped_failure \
+                                "push_and_pr_no_unmerged_files" \
+                                "push_and_pr_no_unmerged_files" \
+                                "push_and_pr rebase failed with no unmerged files"
+                            ;;
+                        *)
+                            log "push_and_pr_route_unrecognized_hint" "hint=$_hint"
+                            agent_runner_reaped_failure \
+                                "diagnoser_route_unrecognized_hint" \
+                                "diagnoser_route_unrecognized_hint" \
+                                "push_and_pr route_to_diagnoser received unrecognized hint=${_hint:-(empty)}"
+                            ;;
+                    esac
                     ;;
                 *)
                     # Issue #3455 — descriptive terminal instead of
@@ -4910,7 +4935,7 @@ while true; do
                     agent_runner_reaped_failure \
                         "push_and_pr_transition_unrecognized" \
                         "push_and_pr_transition_unrecognized" \
-                        "push_and_pr returned action=$_action (not advance / advance_with_status)"
+                        "push_and_pr returned action=$_action (not advance / advance_with_status / route_to_diagnoser)"
                     ;;
             esac
             ;;

--- a/scripts/dispatcher/tests/test_agent_runner_no_unmerged_files.py
+++ b/scripts/dispatcher/tests/test_agent_runner_no_unmerged_files.py
@@ -108,3 +108,33 @@ class TestRouteToDignoserListsPushAndPrNoUnmergedFiles:
             "route_to_diagnoser dispatch case must include "
             "`push_and_pr_no_unmerged_files` in the descriptive-hint allow-list (#3465)"
         )
+
+
+class TestPushAndPrCaseArmHasRouteToDiagnoser:
+    """The push_and_pr) case-arm must contain a ``route_to_diagnoser)``
+    arm and a ``push_and_pr_no_unmerged_files)`` hint sub-case (#3543)."""
+
+    @staticmethod
+    def _push_and_pr_block(text: str) -> str:
+        """Return the substring between ``push_and_pr)`` and the next
+        top-level ``fix_conflict)`` arm."""
+        start = text.find("        push_and_pr)\n")
+        end = text.find("        fix_conflict)\n", start)
+        assert start != -1, "push_and_pr) arm not found in entrypoint"
+        assert end != -1, "fix_conflict) arm not found after push_and_pr) arm"
+        return text[start:end]
+
+    def test_push_and_pr_arm_has_route_to_diagnoser(self) -> None:
+        text = _script_text()
+        block = self._push_and_pr_block(text)
+        assert re.search(r"route_to_diagnoser\)", block), (
+            "push_and_pr) case-arm must contain a route_to_diagnoser) arm (#3543)"
+        )
+
+    def test_push_and_pr_arm_has_no_unmerged_files_hint(self) -> None:
+        text = _script_text()
+        block = self._push_and_pr_block(text)
+        assert re.search(r"push_and_pr_no_unmerged_files\)", block), (
+            "push_and_pr) case-arm must contain a push_and_pr_no_unmerged_files) "
+            "hint sub-case (#3543)"
+        )

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -5899,6 +5899,296 @@ else
          "psql log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
 fi
 
+# ══════════════════════════════════════════════════════════════════════════
+# Test T61: #3543 — push_and_pr) dispatch arm — route_to_diagnoser path.
+#
+# Sub-test A: transition_for returns route_to_diagnoser with hint
+#   push_and_pr_no_unmerged_files.
+# Expected behaviour:
+#   1. push_and_pr_route_to_diagnoser log line emitted.
+#   2. agent_runner_reaped_failure called with category push_and_pr_no_unmerged_files.
+#   3. advance_phase NOT called.
+#   4. push_and_pr_transition_unrecognized NOT emitted.
+#
+# Sub-test B (regression): transition_for returns advance\tawaiting_ci\t\t.
+# Expected behaviour:
+#   1. advance_phase awaiting_ci called.
+#   2. push_and_pr_route_to_diagnoser NOT emitted.
+# ══════════════════════════════════════════════════════════════════════════
+
+t61_state_dir="$TEST_TMP/t61-state"
+t61_stub_bin="$TEST_TMP/t61-bin"
+t61_workspace="$TEST_TMP/t61-workspace"
+t61_repo_root="$TEST_TMP/t61-repo"
+mkdir -p "$t61_state_dir" "$t61_stub_bin" "$t61_workspace" "$t61_repo_root"
+mkdir -p "$t61_repo_root/tmp/dispatcher-input"
+mkdir -p "$t61_repo_root/tmp/dispatcher-output"
+
+# psql stub — responds to phase SELECT with push_and_pr.
+cat > "$t61_stub_bin/psql" <<'T61PSQLEOF'
+#!/usr/bin/env bash
+query=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in -c) shift; query="$1" ;; esac
+    shift || true
+done
+if [[ "$query" == *"SELECT phase"* ]]; then printf 'push_and_pr\n'; fi
+exit 0
+T61PSQLEOF
+chmod +x "$t61_stub_bin/psql"
+
+cat > "$t61_stub_bin/git" <<'T61GITEOF'
+#!/usr/bin/env bash
+exit 0
+T61GITEOF
+chmod +x "$t61_stub_bin/git"
+
+cat > "$t61_stub_bin/gh" <<'T61GHEOF'
+#!/usr/bin/env bash
+exit 0
+T61GHEOF
+chmod +x "$t61_stub_bin/gh"
+
+# ── Sub-test A: route_to_diagnoser with push_and_pr_no_unmerged_files ──────
+
+t61a_state_dir="$t61_state_dir/a"
+mkdir -p "$t61a_state_dir"
+
+_t61a_transition_for_override="
+transition_for() {
+    if [[ \"\${1:-}\" == 'push_and_pr' ]]; then
+        printf 'route_to_diagnoser\t\t\tpush_and_pr_no_unmerged_files'
+    fi
+}
+"
+
+_t61a_reaped_failure_override="
+agent_runner_reaped_failure() {
+    printf 'REAPED_FAILURE %s\n' \"\${1:-}\" >> \"\${T61A_STATE_DIR}/reaped-log.txt\"
+    log 'agent_runner_reaped_failure' \"phase=\$1\" \"hint=\$2\"
+}
+"
+
+_t61a_advance_phase_override="
+advance_phase() {
+    printf 'ADVANCE_PHASE %s\n' \"\${1:-}\" >> \"\${T61A_STATE_DIR}/advance-log.txt\"
+}
+"
+
+_t61a_handle_push_and_pr_override="
+handle_push_and_pr() {
+    printf '{\"no_unmerged_files\": true}\n'
+}
+"
+
+t61a_out=$(
+    set +eu
+    export T61A_STATE_DIR="$t61a_state_dir"
+    export AGENT_WORKSPACE="$t61_workspace"
+    export REPO_ROOT="$t61_repo_root"
+    export AGENT_ID="61616161-dead-beef-cafe-000000000001"
+    export ISSUE_NUMBER="3543"
+    export DATABASE_URL="postgresql://stub"
+    export AGENT_RUNNER_DRY_RUN="0"
+    export PATH="$t61_stub_bin:$PATH"
+    source "$t58_funcs"
+    eval "$_t61a_transition_for_override"
+    eval "$_t61a_reaped_failure_override"
+    eval "$_t61a_advance_phase_override"
+    eval "$_t61a_handle_push_and_pr_override"
+    # Drive the push_and_pr dispatch logic directly (mirrors the entrypoint).
+    _output=$(handle_push_and_pr)
+    persist_phase_output "push_and_pr" "$_output"
+    _transition=$(transition_for "push_and_pr" "$_output")
+    _action=$(printf '%s' "$_transition" | cut -f1)
+    _next=$(printf '%s' "$_transition" | cut -f2)
+    _status=$(printf '%s' "$_transition" | cut -f3)
+    _hint=$(printf '%s' "$_transition" | cut -f4)
+    case "$_action" in
+        advance)
+            advance_phase "$_next"
+            ;;
+        advance_with_status)
+            advance_phase "$_next" "$_status"
+            ;;
+        route_to_diagnoser)
+            log "push_and_pr_route_to_diagnoser" "hint=$_hint"
+            case "$_hint" in
+                push_and_pr_no_unmerged_files)
+                    agent_runner_reaped_failure \
+                        "push_and_pr_no_unmerged_files" \
+                        "push_and_pr_no_unmerged_files" \
+                        "push_and_pr rebase failed with no unmerged files"
+                    ;;
+                *)
+                    log "push_and_pr_route_unrecognized_hint" "hint=$_hint"
+                    agent_runner_reaped_failure \
+                        "diagnoser_route_unrecognized_hint" \
+                        "diagnoser_route_unrecognized_hint" \
+                        "push_and_pr route_to_diagnoser received unrecognized hint=${_hint:-(empty)}"
+                    ;;
+            esac
+            ;;
+        *)
+            log "push_and_pr_transition_unrecognized" "action=$_action"
+            agent_runner_reaped_failure \
+                "push_and_pr_transition_unrecognized" \
+                "push_and_pr_transition_unrecognized" \
+                "push_and_pr returned action=$_action"
+            ;;
+    esac
+    echo "subshell_done"
+    2>&1
+) 2>&1
+
+# T61A (1): subshell completed.
+if printf '%s' "$t61a_out" | grep -q "subshell_done"; then
+    pass "#3543 T61A [push_and_pr route_to_diagnoser] — dispatch subshell ran to completion"
+else
+    fail "#3543 T61A [push_and_pr route_to_diagnoser] — dispatch subshell ran to completion" \
+         "out tail: $(printf '%s' "$t61a_out" | tail -c 600)"
+fi
+
+# T61A (2): push_and_pr_route_to_diagnoser log line emitted.
+if printf '%s' "$t61a_out" | grep -q "push_and_pr_route_to_diagnoser"; then
+    pass "#3543 T61A [push_and_pr route_to_diagnoser] — push_and_pr_route_to_diagnoser log emitted"
+else
+    fail "#3543 T61A [push_and_pr route_to_diagnoser] — push_and_pr_route_to_diagnoser log emitted" \
+         "out: $(printf '%s' "$t61a_out" | tail -c 600)"
+fi
+
+# T61A (3): agent_runner_reaped_failure called with push_and_pr_no_unmerged_files.
+if [[ -f "$t61a_state_dir/reaped-log.txt" ]] && grep -q "REAPED_FAILURE push_and_pr_no_unmerged_files" "$t61a_state_dir/reaped-log.txt"; then
+    pass "#3543 T61A [push_and_pr route_to_diagnoser] — agent_runner_reaped_failure called with push_and_pr_no_unmerged_files"
+else
+    fail "#3543 T61A [push_and_pr route_to_diagnoser] — agent_runner_reaped_failure called with push_and_pr_no_unmerged_files" \
+         "reaped-log: $(cat "$t61a_state_dir/reaped-log.txt" 2>/dev/null || echo '(missing)')"
+fi
+
+# T61A (4): advance_phase NOT called on route_to_diagnoser path.
+if [[ ! -f "$t61a_state_dir/advance-log.txt" ]] || ! grep -q "ADVANCE_PHASE" "$t61a_state_dir/advance-log.txt"; then
+    pass "#3543 T61A [push_and_pr route_to_diagnoser] — advance_phase not called on route_to_diagnoser"
+else
+    fail "#3543 T61A [push_and_pr route_to_diagnoser] — advance_phase not called on route_to_diagnoser" \
+         "advance-log: $(cat "$t61a_state_dir/advance-log.txt" 2>/dev/null)"
+fi
+
+# T61A (5): push_and_pr_transition_unrecognized NOT emitted.
+if ! printf '%s' "$t61a_out" | grep -q "push_and_pr_transition_unrecognized"; then
+    pass "#3543 T61A [push_and_pr route_to_diagnoser] — push_and_pr_transition_unrecognized not emitted"
+else
+    fail "#3543 T61A [push_and_pr route_to_diagnoser] — push_and_pr_transition_unrecognized not emitted" \
+         "out: $(printf '%s' "$t61a_out" | grep "push_and_pr_transition_unrecognized")"
+fi
+
+# ── Sub-test B: advance happy-path regression ──────────────────────────────
+
+t61b_state_dir="$t61_state_dir/b"
+mkdir -p "$t61b_state_dir"
+
+_t61b_transition_for_override="
+transition_for() {
+    if [[ \"\${1:-}\" == 'push_and_pr' ]]; then
+        printf 'advance\tawaiting_ci\t\t'
+    fi
+}
+"
+
+_t61b_advance_phase_override="
+advance_phase() {
+    printf 'ADVANCE_PHASE %s\n' \"\${1:-}\" >> \"\${T61B_STATE_DIR}/advance-log.txt\"
+}
+"
+
+_t61b_handle_push_and_pr_override="
+handle_push_and_pr() {
+    printf '{\"pr_number\": 9999}\n'
+}
+"
+
+t61b_out=$(
+    set +eu
+    export T61B_STATE_DIR="$t61b_state_dir"
+    export AGENT_WORKSPACE="$t61_workspace"
+    export REPO_ROOT="$t61_repo_root"
+    export AGENT_ID="61616162-dead-beef-cafe-000000000001"
+    export ISSUE_NUMBER="3543"
+    export DATABASE_URL="postgresql://stub"
+    export AGENT_RUNNER_DRY_RUN="0"
+    export PATH="$t61_stub_bin:$PATH"
+    source "$t58_funcs"
+    eval "$_t61b_transition_for_override"
+    eval "$_t61b_advance_phase_override"
+    eval "$_t61b_handle_push_and_pr_override"
+    # Drive the push_and_pr dispatch logic directly.
+    _output=$(handle_push_and_pr)
+    persist_phase_output "push_and_pr" "$_output"
+    _transition=$(transition_for "push_and_pr" "$_output")
+    _action=$(printf '%s' "$_transition" | cut -f1)
+    _next=$(printf '%s' "$_transition" | cut -f2)
+    _status=$(printf '%s' "$_transition" | cut -f3)
+    _hint=$(printf '%s' "$_transition" | cut -f4)
+    case "$_action" in
+        advance)
+            advance_phase "$_next"
+            ;;
+        advance_with_status)
+            advance_phase "$_next" "$_status"
+            ;;
+        route_to_diagnoser)
+            log "push_and_pr_route_to_diagnoser" "hint=$_hint"
+            case "$_hint" in
+                push_and_pr_no_unmerged_files)
+                    agent_runner_reaped_failure \
+                        "push_and_pr_no_unmerged_files" \
+                        "push_and_pr_no_unmerged_files" \
+                        "push_and_pr rebase failed with no unmerged files"
+                    ;;
+                *)
+                    log "push_and_pr_route_unrecognized_hint" "hint=$_hint"
+                    agent_runner_reaped_failure \
+                        "diagnoser_route_unrecognized_hint" \
+                        "diagnoser_route_unrecognized_hint" \
+                        "push_and_pr route_to_diagnoser received unrecognized hint=${_hint:-(empty)}"
+                    ;;
+            esac
+            ;;
+        *)
+            log "push_and_pr_transition_unrecognized" "action=$_action"
+            agent_runner_reaped_failure \
+                "push_and_pr_transition_unrecognized" \
+                "push_and_pr_transition_unrecognized" \
+                "push_and_pr returned action=$_action"
+            ;;
+    esac
+    echo "subshell_done"
+    2>&1
+) 2>&1
+
+# T61B (1): subshell completed.
+if printf '%s' "$t61b_out" | grep -q "subshell_done"; then
+    pass "#3543 T61B [push_and_pr advance] — dispatch subshell ran to completion"
+else
+    fail "#3543 T61B [push_and_pr advance] — dispatch subshell ran to completion" \
+         "out tail: $(printf '%s' "$t61b_out" | tail -c 600)"
+fi
+
+# T61B (2): advance_phase awaiting_ci called.
+if [[ -f "$t61b_state_dir/advance-log.txt" ]] && grep -q "ADVANCE_PHASE awaiting_ci" "$t61b_state_dir/advance-log.txt"; then
+    pass "#3543 T61B [push_and_pr advance] — advance_phase awaiting_ci called"
+else
+    fail "#3543 T61B [push_and_pr advance] — advance_phase awaiting_ci called" \
+         "advance-log: $(cat "$t61b_state_dir/advance-log.txt" 2>/dev/null || echo '(missing)')"
+fi
+
+# T61B (3): push_and_pr_route_to_diagnoser NOT emitted on advance path.
+if ! printf '%s' "$t61b_out" | grep -q "push_and_pr_route_to_diagnoser"; then
+    pass "#3543 T61B [push_and_pr advance] — push_and_pr_route_to_diagnoser not emitted on advance"
+else
+    fail "#3543 T61B [push_and_pr advance] — push_and_pr_route_to_diagnoser not emitted on advance" \
+         "out: $(printf '%s' "$t61b_out" | grep "push_and_pr_route_to_diagnoser")"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Fixes a critical dispatcher bug where agents transitioning from fix_conflict → push_and_pr with a rebase failure were dying with `push_and_pr_transition_unrecognized` instead of routing to the diagnoser. The root cause was a missing `route_to_diagnoser` case arm in the push_and_pr dispatch statement.

4 agents were lost in 2h on 2 distinct issues (#3407, #2777) before this was identified. Both issues are now stuck in a retry loop, costing 1 ECS task per retry attempt.

Closes #3543

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`) — ruff clean
- [x] Format check passes (`ruff format --check` / prettier) — ruff clean
- [x] Tests pass (`pytest` / `npm test`) — pytest 9/9 ✓
- [x] CI green — all checks passed

### Regression testing

**Test T61A:** Verifies route_to_diagnoser path with push_and_pr_no_unmerged_files hint:
- Transition returns route_to_diagnoser\tpush_and_pr_no_unmerged_files
- push_and_pr_route_to_diagnoser log line emitted
- agent_runner_reaped_failure called with push_and_pr_no_unmerged_files category
- advance_phase NOT called
- push_and_pr_transition_unrecognized NOT emitted

**Test T61B:** Regression test for existing advance path:
- Transition returns advance\tawaiting_ci
- advance_phase awaiting_ci called
- push_and_pr_route_to_diagnoser NOT emitted

### Post-deploy verification

- [ ] Retry #3407 (or #2777) by removing status/blocked label, adding agent/ready label
- [ ] Verify next agent run on that issue transitions to diagnoser phase (not push_and_pr_transition_unrecognized)
- [ ] Confirmation evidence posted on #3543 (see /task-v2-verify output)