### PR TITLE
Remove unused templates module from scraper-framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ jobs:
             scraper-framework:
               - 'packages/scraper-framework/src/framework/**'
               - 'packages/scraper-framework/src/ingestion/**'
-              - 'packages/scraper-framework/src/templates/**'
               - 'packages/scraper-framework/src/validation/**'
               - 'packages/scraper-framework/tests/**'
               - 'packages/scraper-framework/pyproject.toml'

--- a/packages/scraper-framework/pyproject.toml
+++ b/packages/scraper-framework/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/framework", "src/courts", "src/templates", "src/validation", "src/ingestion"]
+packages = ["src/framework", "src/courts", "src/validation", "src/ingestion"]
 
 [project]
 name = "judgemind-scraper-framework"
@@ -60,12 +60,12 @@ ignore = [
 ]
 
 [tool.ruff.lint.isort]
-known-first-party = ["framework", "courts", "templates", "validation", "ingestion"]
+known-first-party = ["framework", "courts", "validation", "ingestion"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 pythonpath = ["src"]
-addopts = "--cov=framework --cov=courts --cov=templates --cov=validation --cov=ingestion --cov-report=term --cov-report=html:htmlcov --cov-report=xml:coverage.xml"
+addopts = "--cov=framework --cov=courts --cov=validation --cov=ingestion --cov-report=term --cov-report=html:htmlcov --cov-report=xml:coverage.xml"
 markers = [
     "regression: scraper regression tests against archived fixtures",
     "normalization_integration: contract tests for normalize_motion_type vs scraper outputs",


### PR DESCRIPTION
## Summary

Removed the empty `packages/scraper-framework/src/templates/` directory and all references to it in build configuration and CI. The directory was 0-bytes and completely unused (no imports found in the codebase). Cleaned up three entries from `pyproject.toml` and one stale glob in `ci.yml`.

Closes #3542

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (no tests required — cleanup only)
- [ ] CI green

### Post-deploy verification

- [ ] N/A — no deployed component (chore/cleanup only)