### PR TITLE
fix(infra): fix ingestion-worker task flapping (#3556)

### DIFF
--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -517,9 +517,14 @@ resource "aws_ecs_service" "ingestion_worker" {
   # running container without a VPN or bastion host.
   enable_execute_command = true
 
-  # Restart the task if it exits unexpectedly.
-  deployment_minimum_healthy_percent = 0
-  deployment_maximum_percent         = 100
+  # Rolling-no-gap deploy policy: bring up the new task first, wait for it to
+  # reach RUNNING, then drain the old one. With desired_count=1 the 0/100
+  # policy guaranteed a 30–120 s window with runningCount=0 on every deploy
+  # (#3556). 100/200 eliminates that gap. wait_for_steady_state=true ensures
+  # terraform-apply blocks until the service settles.
+  deployment_minimum_healthy_percent = 100
+  deployment_maximum_percent         = 200
+  wait_for_steady_state              = true
 
   network_configuration {
     subnets          = var.private_subnet_ids

--- a/scripts/dev-db-query.sh
+++ b/scripts/dev-db-query.sh
@@ -139,21 +139,43 @@ if [[ -z "$stripped" ]]; then
 fi
 
 # ─── Resolve a running task ARN ──────────────────────────────────────────────
+# Poll list-tasks for up to LIST_TASKS_POLL_TIMEOUT_SECS (default 60 s),
+# retrying every 3 s. Defense-in-depth for a rolling deploy: even with the
+# 100/200 deploy policy, an operator-issued force-new-deployment can briefly
+# leave ECS in a state where the new task is PENDING and list-tasks returns
+# nothing. Without retries a transient empty response would abort the query.
+# Mirrors the polling pattern in scripts/wait-for-rollout.sh.
 
-task_arn=$(aws ecs list-tasks \
-    --cluster "$CLUSTER" \
-    --service-name "$SERVICE" \
-    --desired-status RUNNING \
-    --region "$REGION" \
-    --query 'taskArns[0]' \
-    --output text)
+LIST_TASKS_POLL_TIMEOUT_SECS="${LIST_TASKS_POLL_TIMEOUT_SECS:-60}"
+_list_tasks_start=$(date +%s)
+_list_tasks_deadline=$((_list_tasks_start + LIST_TASKS_POLL_TIMEOUT_SECS))
 
-if [[ -z "$task_arn" || "$task_arn" == "None" ]]; then
-    echo "Error: no running task found for service $SERVICE in cluster $CLUSTER" >&2
-    echo "Check that the ingestion worker is running:" >&2
-    echo "  aws ecs describe-services --cluster $CLUSTER --services $SERVICE --region $REGION --query 'services[0].runningCount'" >&2
-    exit 1
-fi
+task_arn=""
+while true; do
+    task_arn=$(aws ecs list-tasks \
+        --cluster "$CLUSTER" \
+        --service-name "$SERVICE" \
+        --desired-status RUNNING \
+        --region "$REGION" \
+        --query 'taskArns[0]' \
+        --output text)
+
+    if [[ -n "$task_arn" && "$task_arn" != "None" ]]; then
+        break
+    fi
+
+    _now=$(date +%s)
+    if [[ "$_now" -ge "$_list_tasks_deadline" ]]; then
+        echo "Error: no running task found for service $SERVICE in cluster $CLUSTER" >&2
+        echo "Check that the ingestion worker is running:" >&2
+        echo "  aws ecs describe-services --cluster $CLUSTER --services $SERVICE --region $REGION --query 'services[0].runningCount'" >&2
+        exit 1
+    fi
+
+    _elapsed=$((_now - _list_tasks_start))
+    echo "No running task yet (${_elapsed}s elapsed), retrying in 3 s..." >&2
+    sleep 3
+done
 
 # ─── Build the command ───────────────────────────────────────────────────────
 

--- a/scripts/tests/test_dev_db_query.sh
+++ b/scripts/tests/test_dev_db_query.sh
@@ -465,6 +465,80 @@ PAYLOAD
     fi
 }
 
+# ── Polling tests (#3556) ──────────────────────────────────────────────────
+
+# Mock aws CLI that returns None for the first N list-tasks calls, then returns
+# a real task ARN. A state file in a temp dir tracks the call count.
+# execute-command is stubbed as a no-op so polling-success tests don't need a
+# full SSM payload.
+setup_mock_aws_poll_then_arn() {
+    local empty_calls="$1"   # number of list-tasks calls that return None
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+    local mock_bin="$tmpdir/bin"
+    local state_file="$tmpdir/call_count"
+    mkdir -p "$mock_bin"
+    echo "0" > "$state_file"
+
+    cat > "$mock_bin/aws" << MOCK_AWS
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "ecs" && "\${2:-}" == "list-tasks" ]]; then
+    count=\$(cat "$state_file")
+    count=\$((count + 1))
+    echo "\$count" > "$state_file"
+    if [[ "\$count" -le $empty_calls ]]; then
+        echo "None"
+    else
+        echo "arn:aws:ecs:us-west-2:000000000000:task/fake-cluster/fake-task-id"
+    fi
+    exit 0
+fi
+if [[ "\${1:-}" == "ecs" && "\${2:-}" == "execute-command" ]]; then
+    # No-op stub — we only care that the script reached this stage.
+    echo "[]"
+    exit 0
+fi
+echo "Mock aws: unexpected command: \$*" >&2
+exit 1
+MOCK_AWS
+    chmod +x "$mock_bin/aws"
+    echo "$mock_bin"
+}
+
+test_polls_until_task_appears() {
+    # list-tasks returns None on the first 2 calls, then a real ARN on the 3rd.
+    # The script should retry and eventually reach the execute-command stage.
+    local mock_bin
+    mock_bin=$(setup_mock_aws_poll_then_arn 2)
+    local output rc=0
+    output=$(LIST_TASKS_POLL_TIMEOUT_SECS=10 run_script "$mock_bin" "SELECT 1" 2>&1) || rc=$?
+
+    # Success means the script proceeded past list-tasks (reached execute-command).
+    # The mock execute-command exits 0, so the overall exit code should be 0.
+    if [[ $rc -eq 0 && "$output" != *"no running task found"* ]]; then
+        pass "polls until task appears: proceeds to execute-command on 3rd try"
+    else
+        fail "polls until task appears: proceeds to execute-command on 3rd try" \
+            "rc=$rc output=$output"
+    fi
+}
+
+test_polls_then_gives_up_with_clear_error() {
+    # list-tasks always returns None. With a short timeout, the script should
+    # give up and exit non-zero with the "no running task" error message.
+    local mock_bin
+    mock_bin=$(setup_mock_aws_no_tasks)
+    local output rc=0
+    output=$(LIST_TASKS_POLL_TIMEOUT_SECS=2 run_script "$mock_bin" "SELECT 1" 2>&1) || rc=$?
+
+    if [[ $rc -ne 0 && "$output" == *"no running task"* ]]; then
+        pass "polls then gives up: exits non-zero with 'no running task' error"
+    else
+        fail "polls then gives up: exits non-zero with 'no running task' error" \
+            "rc=$rc output=$output"
+    fi
+}
+
 # ── Run all ────────────────────────────────────────────────────────────────
 
 test_no_args_shows_usage
@@ -484,6 +558,8 @@ test_strips_ssm_banners_and_trailer
 test_strips_cannot_perform_start_session_trailer
 test_strips_own_line_cannot_perform
 test_empty_output_after_strip_is_ok
+test_polls_until_task_appears
+test_polls_then_gives_up_with_clear_error
 
 echo ""
 echo "────────────────────────────────────────────────"


### PR DESCRIPTION
## Summary

The dev `judgemind-ingestion-worker-dev` ECS service was experiencing rapid task cycling (1.5–17 min lifetimes) due to a 0/100 deployment policy that created 30–120s windows with zero running tasks during deploys. These windows broke `dev-db-query.sh` and all downstream dispatcher-monitoring tools (fleet-status.sh, agent-timeline.sh, dispatcher-audit, etc.).

Fixed by: (1) switching to a 100/200 rolling-no-gap deploy policy with `wait_for_steady_state=true` to ensure new tasks reach RUNNING before old ones drain; (2) adding polling tolerance to `dev-db-query.sh` (retries `list-tasks` every 3s for up to 60s) to survive transient empty-task windows during operator-issued force-new-deployment cycles.

Closes #3556

## Test plan

### Automated checks

- [ ] Lint passes (`ruff check` / `npm run lint`)
- [ ] Format check passes (`ruff format --check` / prettier)
- [ ] Tests pass (`pytest` / `npm test`)
- [ ] CI green

### Post-deploy verification

- [ ] Observe ingestion-worker service for 1h: confirm task lifetime ≥30min on average
- [ ] Manually trigger force-new-deployment and verify dev-db-query.sh succeeds within 60s polling window
- [ ] Verification evidence posted on #3556 (see /task-v2-verify output)