### PR TITLE
fix(dispatcher): push_and_pr route_to_diagnoser routes uniformly to diagnoser (#3558)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -223,6 +223,33 @@ Routed here on the bypass-fix from #3366. Read `context.details.conflict_files` 
 
 If the conflict is structural (semantic collision — function rewritten on main, feature reverted), recommend `escalate` (or the inline-#3455 `terminal` shape) or `reissue` with a clarified `new_scope`, and write `next_directive=terminal`.
 
+### Per-category guidance — `push_and_pr_no_unmerged_files` (#3558)
+
+Routed here when `transition_from_push_and_pr` emitted `route_to_diagnoser` with `hint=push_and_pr_no_unmerged_files`: the push_and_pr phase detected that the pre-push rebase left no unmerged files to push — i.e. the agent's branch produced no diff against `origin/main` by the time it reached push_and_pr.
+
+**Gather evidence first:**
+
+```
+# Check if a PR for this issue already landed on main
+git -C {worktree} log origin/main --oneline --grep '#<issue_number>' | head -10
+
+# Check for any open PRs referencing this issue
+gh pr list --repo judgemind/judgemind --search '#<issue_number> is:open'
+
+# Read the ralph verdict for this agent cycle
+cat {worktree}/tmp/ralph/ralph-done.txt 2>/dev/null || echo '(missing)'
+```
+
+**Three known dispositions:**
+
+1. **`already_fixed`** — a prior PR merged the change; the agent's worktree rebased on top and has nothing left to push. Action: close the issue inline (`gh issue close <N> --comment "Closed: already resolved in <PR/commit URL>"`), remove `agent/ready` / `status/in-progress`, emit `action="terminal"` with `action_taken="close"` and `next_directive=terminal`.
+
+2. **`stale_issue`** — the issue describes a change that is no longer needed (premise invalidated by other work, spec changed, etc.). Action: post a `## Diagnosis` comment explaining the staleness, close (`gh issue close <N>`), emit `action="terminal"` with `action_taken="close"` and `next_directive=terminal`.
+
+3. **`ralph_silent_failure`** — ralph returned SHIP but made no commits (bug in the worker: passed checks, wrote no files, committed nothing). The branch has no diff. Action: clear any sentinel files that would make ralph think it already ran (`rm -f {worktree}/tmp/ralph/ralph-done.txt`), emit `action="terminal"` with `action_taken="retry_with_hint"`, `next_directive=respawn_at=ralph`, and include a `hint` field with `"ralph_produced_no_diff"` so the next worker knows to investigate the zero-diff condition.
+
+**When uncertain:** post a `## Diagnosis (3D escalation)` comment on the issue, add `status/needs-human`, emit `action="terminal"` with `action_taken="escalate"` and `next_directive=terminal`.
+
 ### Per-category guidance — `agent_runner_route_stub` (#3366) — historical
 
 Pre-#3455 the agent-runner entrypoint hit a transition shape it didn't know how to route (often `ralph_not_ship` — ralph terminated with a non-SHIP verdict) and emitted `agent_runner_route_stub`. Post-#3455 those fall-throughs are eliminated — the entrypoint emits descriptive terminal phases (`ralph_baseline_transition_unrecognized`, `push_and_pr_transition_unrecognized`, `phase_unknown_<phase>`, etc.) via `agent_runner_reaped_failure`, and `ralph_not_ship` is handled locally (post comment + add `status/blocked`) without bouncing to the diagnoser. If you do see an `agent_runner_route_stub` row in the wild, that's a pre-#3455 agent or a regression — read `context.details.route_hint`, the agent's commits (`git log --oneline origin/main..HEAD`), and the latest reviewer feedback (`{worktree}/tmp/ralph/*-feedback.md` if present), and route to `retry_with_hint` (write a hint, set `next_directive=respawn_at=ralph` if you reset the agent's commits, otherwise `terminal`) or to the inline-#3455 `terminal` shape with `action_taken="block_and_comment"`.

--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -4967,28 +4967,20 @@ while true; do
                     advance_phase "$_next" "$_status"
                     ;;
                 route_to_diagnoser)
-                    # Issue #3543 — push_and_pr rebase failure with no
-                    # unmerged files. transition_from_push_and_pr emits
-                    # ROUTE_TO_DIAGNOSER with hint=push_and_pr_no_unmerged_files
-                    # (#3465). Route to the descriptive terminal so the
-                    # daemon's BYPASSED_TERMINAL_PHASES_TO_ROUTE picks it
-                    # up for the diagnoser sweep.
+                    # Issue #3558 — collapse the inner hint sub-case.
+                    # All hints from transition_from_push_and_pr route to
+                    # the same descriptive terminal so the daemon's
+                    # BYPASSED_TERMINAL_PHASES_TO_ROUTE + TIER_3_CATEGORIES
+                    # picks the failure up for the diagnoser sweep.
+                    # Model: fix_conflict and operational arms (lines
+                    # 5035–5046, 5108–5116) — one fixed category, no hint
+                    # sub-case. The hint string is embedded in the reason
+                    # field for diagnoser context.
                     log "push_and_pr_route_to_diagnoser" "hint=$_hint"
-                    case "$_hint" in
-                        push_and_pr_no_unmerged_files)
-                            agent_runner_reaped_failure \
-                                "push_and_pr_no_unmerged_files" \
-                                "push_and_pr_no_unmerged_files" \
-                                "push_and_pr rebase failed with no unmerged files"
-                            ;;
-                        *)
-                            log "push_and_pr_route_unrecognized_hint" "hint=$_hint"
-                            agent_runner_reaped_failure \
-                                "diagnoser_route_unrecognized_hint" \
-                                "diagnoser_route_unrecognized_hint" \
-                                "push_and_pr route_to_diagnoser received unrecognized hint=${_hint:-(empty)}"
-                            ;;
-                    esac
+                    agent_runner_reaped_failure \
+                        "push_and_pr_no_unmerged_files" \
+                        "push_and_pr_no_unmerged_files" \
+                        "push_and_pr route_to_diagnoser — hint=$_hint"
                     ;;
                 *)
                     # Issue #3455 — descriptive terminal instead of

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1695,6 +1695,13 @@ TIER_3_CATEGORIES: frozenset[str] = frozenset(
         # here so the empowered diagnoser can apply broader judgment
         # than the entrypoint's local routing table.
         FAILURE_CATEGORY_AGENT_RUNNER_ROUTE_STUB,
+        # #3558: push_and_pr phase routed to diagnoser because transition
+        # detected no unmerged files (i.e. the agent produced no diff).
+        # Tier-3 fits: this is a judgment-call failure (already_fixed /
+        # stale_issue / ralph_silent_failure) that requires the diagnoser
+        # to inspect the issue + branch state rather than a mechanical
+        # retry.
+        FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
     }
 )
 

--- a/scripts/dispatcher/tests/test_agent_runner_no_unmerged_files.py
+++ b/scripts/dispatcher/tests/test_agent_runner_no_unmerged_files.py
@@ -112,7 +112,8 @@ class TestRouteToDignoserListsPushAndPrNoUnmergedFiles:
 
 class TestPushAndPrCaseArmHasRouteToDiagnoser:
     """The push_and_pr) case-arm must contain a ``route_to_diagnoser)``
-    arm and a ``push_and_pr_no_unmerged_files)`` hint sub-case (#3543)."""
+    arm and must NOT special-case ``push_and_pr_no_unmerged_files`` as a
+    hint sub-case (#3558 — uniform dispatch, no inner case "$_hint")."""
 
     @staticmethod
     def _push_and_pr_block(text: str) -> str:
@@ -131,10 +132,13 @@ class TestPushAndPrCaseArmHasRouteToDiagnoser:
             "push_and_pr) case-arm must contain a route_to_diagnoser) arm (#3543)"
         )
 
-    def test_push_and_pr_arm_has_no_unmerged_files_hint(self) -> None:
+    def test_push_and_pr_arm_has_no_inner_hint_case(self) -> None:
+        """After #3558 the route_to_diagnoser arm must NOT contain an
+        inner ``case "$_hint"`` sub-dispatch — all hints route uniformly
+        to the same agent_runner_reaped_failure call."""
         text = _script_text()
         block = self._push_and_pr_block(text)
-        assert re.search(r"push_and_pr_no_unmerged_files\)", block), (
-            "push_and_pr) case-arm must contain a push_and_pr_no_unmerged_files) "
-            "hint sub-case (#3543)"
+        assert not re.search(r'case "\$_hint"', block), (
+            'push_and_pr) route_to_diagnoser arm must not contain an inner '
+            'case "$_hint" sub-case after #3558 (uniform dispatch)'
         )

--- a/scripts/dispatcher/tests/test_push_and_pr_no_unmerged_files_in_tier3.py
+++ b/scripts/dispatcher/tests/test_push_and_pr_no_unmerged_files_in_tier3.py
@@ -1,0 +1,49 @@
+"""Issue #3558 — verify ``FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES``
+is a member of ``TIER_3_CATEGORIES`` in ``daemon.py``.
+
+The operational bug fixed in #3558: ``FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES``
+was referenced in ``BYPASSED_TERMINAL_PHASES_TO_ROUTE`` but absent from all tier
+sets (TIER_2_FIRST_OCCURRENCE_CATEGORIES, TIER_2_RECURRENCE_CATEGORIES, TIER_3_CATEGORIES).
+``_find_diagnoser_candidates`` (daemon.py) drops any failure whose category is not in
+those tier sets, so the diagnoser never fired — the issue got re-claimed on the next
+tick instead of being routed to the diagnoser.
+
+This test guards against regression of that membership.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Add the dispatcher package to sys.path so we can import daemon symbols.
+_DISPATCHER_DIR = Path(__file__).resolve().parents[1]
+if str(_DISPATCHER_DIR) not in sys.path:
+    sys.path.insert(0, str(_DISPATCHER_DIR))
+
+from daemon import (  # noqa: E402
+    FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
+    TIER_3_CATEGORIES,
+)
+
+
+class TestPushAndPrNoUnmergedFilesInTier3:
+    """``FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES`` must be in
+    ``TIER_3_CATEGORIES`` so ``_find_diagnoser_candidates`` picks it up
+    for the diagnoser sweep (#3558)."""
+
+    def test_category_in_tier3(self) -> None:
+        assert FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES in TIER_3_CATEGORIES, (
+            f"FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES "
+            f"({FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES!r}) must be in "
+            f"TIER_3_CATEGORIES to allow _find_diagnoser_candidates to select it "
+            f"(#3558 regression guard)"
+        )
+
+    def test_category_value(self) -> None:
+        """The constant's string value must match the phase/category name used
+        by the entrypoint and BYPASSED_TERMINAL_PHASES_TO_ROUTE."""
+        assert FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES == "push_and_pr_no_unmerged_files", (
+            "FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES value changed — "
+            "update BYPASSED_TERMINAL_PHASES_TO_ROUTE and entrypoint accordingly"
+        )

--- a/scripts/dispatcher/tests/test_push_and_pr_no_unmerged_files_in_tier3.py
+++ b/scripts/dispatcher/tests/test_push_and_pr_no_unmerged_files_in_tier3.py
@@ -16,12 +16,12 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-# Add the dispatcher package to sys.path so we can import daemon symbols.
-_DISPATCHER_DIR = Path(__file__).resolve().parents[1]
-if str(_DISPATCHER_DIR) not in sys.path:
-    sys.path.insert(0, str(_DISPATCHER_DIR))
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
 
-from daemon import (  # noqa: E402
+from dispatcher.daemon import (  # noqa: E402
     FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
     TIER_3_CATEGORIES,
 )

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -5972,10 +5972,10 @@ else
 fi
 
 # ══════════════════════════════════════════════════════════════════════════
-# Test T61: #3543 — push_and_pr) dispatch arm — route_to_diagnoser path.
+# Test T61: #3543/#3558 — push_and_pr) dispatch arm — route_to_diagnoser path.
 #
 # Sub-test A: transition_for returns route_to_diagnoser with hint
-#   push_and_pr_no_unmerged_files.
+#   push_and_pr_no_unmerged_files (#3558: uniform dispatch, no inner case "$_hint").
 # Expected behaviour:
 #   1. push_and_pr_route_to_diagnoser log line emitted.
 #   2. agent_runner_reaped_failure called with category push_and_pr_no_unmerged_files.
@@ -5986,6 +5986,14 @@ fi
 # Expected behaviour:
 #   1. advance_phase awaiting_ci called.
 #   2. push_and_pr_route_to_diagnoser NOT emitted.
+#
+# Sub-test C (#3558): transition_for returns route_to_diagnoser with a novel hint
+#   (e.g. novel_hint). Confirms uniform dispatch — same terminal category regardless
+#   of hint value.
+# Expected behaviour:
+#   1. push_and_pr_route_to_diagnoser log line emitted.
+#   2. agent_runner_reaped_failure called with category push_and_pr_no_unmerged_files.
+#   3. advance_phase NOT called.
 # ══════════════════════════════════════════════════════════════════════════
 
 t61_state_dir="$TEST_TMP/t61-state"
@@ -6084,22 +6092,12 @@ t61a_out=$(
             advance_phase "$_next" "$_status"
             ;;
         route_to_diagnoser)
+            # #3558 — uniform dispatch: no inner case "$_hint".
             log "push_and_pr_route_to_diagnoser" "hint=$_hint"
-            case "$_hint" in
-                push_and_pr_no_unmerged_files)
-                    agent_runner_reaped_failure \
-                        "push_and_pr_no_unmerged_files" \
-                        "push_and_pr_no_unmerged_files" \
-                        "push_and_pr rebase failed with no unmerged files"
-                    ;;
-                *)
-                    log "push_and_pr_route_unrecognized_hint" "hint=$_hint"
-                    agent_runner_reaped_failure \
-                        "diagnoser_route_unrecognized_hint" \
-                        "diagnoser_route_unrecognized_hint" \
-                        "push_and_pr route_to_diagnoser received unrecognized hint=${_hint:-(empty)}"
-                    ;;
-            esac
+            agent_runner_reaped_failure \
+                "push_and_pr_no_unmerged_files" \
+                "push_and_pr_no_unmerged_files" \
+                "push_and_pr route_to_diagnoser — hint=$_hint"
             ;;
         *)
             log "push_and_pr_transition_unrecognized" "action=$_action"
@@ -6208,22 +6206,12 @@ t61b_out=$(
             advance_phase "$_next" "$_status"
             ;;
         route_to_diagnoser)
+            # #3558 — uniform dispatch: no inner case "$_hint".
             log "push_and_pr_route_to_diagnoser" "hint=$_hint"
-            case "$_hint" in
-                push_and_pr_no_unmerged_files)
-                    agent_runner_reaped_failure \
-                        "push_and_pr_no_unmerged_files" \
-                        "push_and_pr_no_unmerged_files" \
-                        "push_and_pr rebase failed with no unmerged files"
-                    ;;
-                *)
-                    log "push_and_pr_route_unrecognized_hint" "hint=$_hint"
-                    agent_runner_reaped_failure \
-                        "diagnoser_route_unrecognized_hint" \
-                        "diagnoser_route_unrecognized_hint" \
-                        "push_and_pr route_to_diagnoser received unrecognized hint=${_hint:-(empty)}"
-                    ;;
-            esac
+            agent_runner_reaped_failure \
+                "push_and_pr_no_unmerged_files" \
+                "push_and_pr_no_unmerged_files" \
+                "push_and_pr route_to_diagnoser — hint=$_hint"
             ;;
         *)
             log "push_and_pr_transition_unrecognized" "action=$_action"
@@ -6259,6 +6247,120 @@ if ! printf '%s' "$t61b_out" | grep -q "push_and_pr_route_to_diagnoser"; then
 else
     fail "#3543 T61B [push_and_pr advance] — push_and_pr_route_to_diagnoser not emitted on advance" \
          "out: $(printf '%s' "$t61b_out" | grep "push_and_pr_route_to_diagnoser")"
+fi
+
+# ── Sub-test C: route_to_diagnoser with a novel hint (#3558 uniform dispatch) ─
+
+t61c_state_dir="$t61_state_dir/c"
+mkdir -p "$t61c_state_dir"
+
+_t61c_transition_for_override="
+transition_for() {
+    if [[ \"\${1:-}\" == 'push_and_pr' ]]; then
+        printf 'route_to_diagnoser\t\t\tnovel_hint'
+    fi
+}
+"
+
+_t61c_reaped_failure_override="
+agent_runner_reaped_failure() {
+    printf 'REAPED_FAILURE %s\n' \"\${1:-}\" >> \"\${T61C_STATE_DIR}/reaped-log.txt\"
+    log 'agent_runner_reaped_failure' \"phase=\$1\" \"hint=\$2\"
+}
+"
+
+_t61c_advance_phase_override="
+advance_phase() {
+    printf 'ADVANCE_PHASE %s\n' \"\${1:-}\" >> \"\${T61C_STATE_DIR}/advance-log.txt\"
+}
+"
+
+_t61c_handle_push_and_pr_override="
+handle_push_and_pr() {
+    printf '{\"no_unmerged_files\": true}\n'
+}
+"
+
+t61c_out=$(
+    set +eu
+    export T61C_STATE_DIR="$t61c_state_dir"
+    export AGENT_WORKSPACE="$t61_workspace"
+    export REPO_ROOT="$t61_repo_root"
+    export AGENT_ID="61616163-dead-beef-cafe-000000000001"
+    export ISSUE_NUMBER="3558"
+    export DATABASE_URL="postgresql://stub"
+    export AGENT_RUNNER_DRY_RUN="0"
+    export PATH="$t61_stub_bin:$PATH"
+    source "$t58_funcs"
+    eval "$_t61c_transition_for_override"
+    eval "$_t61c_reaped_failure_override"
+    eval "$_t61c_advance_phase_override"
+    eval "$_t61c_handle_push_and_pr_override"
+    # Drive the push_and_pr dispatch logic directly (uniform shape, #3558).
+    _output=$(handle_push_and_pr)
+    persist_phase_output "push_and_pr" "$_output"
+    _transition=$(transition_for "push_and_pr" "$_output")
+    _action=$(printf '%s' "$_transition" | cut -f1)
+    _next=$(printf '%s' "$_transition" | cut -f2)
+    _status=$(printf '%s' "$_transition" | cut -f3)
+    _hint=$(printf '%s' "$_transition" | cut -f4)
+    case "$_action" in
+        advance)
+            advance_phase "$_next"
+            ;;
+        advance_with_status)
+            advance_phase "$_next" "$_status"
+            ;;
+        route_to_diagnoser)
+            # #3558 — uniform dispatch: no inner case "$_hint".
+            log "push_and_pr_route_to_diagnoser" "hint=$_hint"
+            agent_runner_reaped_failure \
+                "push_and_pr_no_unmerged_files" \
+                "push_and_pr_no_unmerged_files" \
+                "push_and_pr route_to_diagnoser — hint=$_hint"
+            ;;
+        *)
+            log "push_and_pr_transition_unrecognized" "action=$_action"
+            agent_runner_reaped_failure \
+                "push_and_pr_transition_unrecognized" \
+                "push_and_pr_transition_unrecognized" \
+                "push_and_pr returned action=$_action"
+            ;;
+    esac
+    echo "subshell_done"
+    2>&1
+) 2>&1
+
+# T61C (1): subshell completed.
+if printf '%s' "$t61c_out" | grep -q "subshell_done"; then
+    pass "#3558 T61C [push_and_pr novel_hint uniform] — dispatch subshell ran to completion"
+else
+    fail "#3558 T61C [push_and_pr novel_hint uniform] — dispatch subshell ran to completion" \
+         "out tail: $(printf '%s' "$t61c_out" | tail -c 600)"
+fi
+
+# T61C (2): push_and_pr_route_to_diagnoser log line emitted.
+if printf '%s' "$t61c_out" | grep -q "push_and_pr_route_to_diagnoser"; then
+    pass "#3558 T61C [push_and_pr novel_hint uniform] — push_and_pr_route_to_diagnoser log emitted"
+else
+    fail "#3558 T61C [push_and_pr novel_hint uniform] — push_and_pr_route_to_diagnoser log emitted" \
+         "out: $(printf '%s' "$t61c_out" | tail -c 600)"
+fi
+
+# T61C (3): agent_runner_reaped_failure called with push_and_pr_no_unmerged_files (uniform).
+if [[ -f "$t61c_state_dir/reaped-log.txt" ]] && grep -q "REAPED_FAILURE push_and_pr_no_unmerged_files" "$t61c_state_dir/reaped-log.txt"; then
+    pass "#3558 T61C [push_and_pr novel_hint uniform] — agent_runner_reaped_failure called with push_and_pr_no_unmerged_files"
+else
+    fail "#3558 T61C [push_and_pr novel_hint uniform] — agent_runner_reaped_failure called with push_and_pr_no_unmerged_files" \
+         "reaped-log: $(cat "$t61c_state_dir/reaped-log.txt" 2>/dev/null || echo '(missing)')"
+fi
+
+# T61C (4): advance_phase NOT called on route_to_diagnoser path.
+if [[ ! -f "$t61c_state_dir/advance-log.txt" ]] || ! grep -q "ADVANCE_PHASE" "$t61c_state_dir/advance-log.txt"; then
+    pass "#3558 T61C [push_and_pr novel_hint uniform] — advance_phase not called on route_to_diagnoser"
+else
+    fail "#3558 T61C [push_and_pr novel_hint uniform] — advance_phase not called on route_to_diagnoser" \
+         "advance-log: $(cat "$t61c_state_dir/advance-log.txt" 2>/dev/null)"
 fi
 
 # ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixed the dispatcher's `push_and_pr` phase to route all `route_to_diagnoser` hints uniformly to the diagnoser instead of special-casing `push_and_pr_no_unmerged_files`. This resolves #3543's incomplete fix and prevents the Sisyphean retry loop where agents with no diff would terminal-fail instead of being triaged by the diagnoser.

Root-cause bug also fixed: `FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES` was registered in `BYPASSED_TERMINAL_PHASES_TO_ROUTE` but absent from all tier sets, causing `_find_diagnoser_candidates` to silently filter it out. Added to `TIER_3_CATEGORIES` since it is a judgment-call failure (already_fixed / stale_issue / ralph_silent_failure) that requires diagnoser inspection.

Closes #3558

## Test plan

### Automated checks

- [ ] Lint passes (`ruff check` / `npm run lint`)
- [ ] Format check passes (`ruff format --check` / prettier)
- [ ] Tests pass (`pytest` / `npm test`)
- [ ] CI green

### Post-deploy verification

- [ ] Re-add `agent/ready` to #3407 and #2777
- [ ] Next agent that hits no_unmerged_files routes to diagnoser phase, not terminal-fail
- [ ] Diagnoser produces a useful disposition (close + cite existing PR/commit, etc.)
- [ ] Verification evidence posted on #3558 (see /task-v2-verify output)