### PR TITLE
fix(scraping): recognize narrative date formats in PDF headers (#3559)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -29,6 +29,7 @@ import os
 import re
 import time
 from dataclasses import dataclass
+from datetime import datetime
 
 import anthropic
 import structlog
@@ -3537,7 +3538,9 @@ def _append_ruling_from_case(
         )
         text = None
 
-    # Apply metadata overrides, then header extraction, for judge/dept/date.
+    # Metadata precedence: per-row scraper/DB values (metadata kwarg) win over
+    # header-extracted values (header_judge/dept/date), which are only used as a
+    # fallback.  Both layers default to None when no value is available.
     judge_name: str | None = None
     department: str | None = None
     hearing_date: str | None = None
@@ -3562,6 +3565,44 @@ def _append_ruling_from_case(
             ruling_text=text,
         )
     )
+
+
+def _parse_header_date(info: str) -> str | None:
+    """Extract a hearing date from a page-header string, returning ISO YYYY-MM-DD.
+
+    Tries three patterns in priority order so that the existing ISO path
+    wins over ambiguous slash or month-name matches (#3559):
+
+    1. ``Hearing Date: YYYY-MM-DD`` — explicit ISO label (existing behaviour).
+    2. Month-name: ``March 16, 2026`` — common in OC multimodal PDFs.
+    3. Slash: ``3/16/2026`` or ``03/16/2026`` — alternate courts.
+    """
+    # 1. Existing ISO path — must remain the highest-priority match.
+    m = re.search(r"Hearing Date:\s*(\d{4}-\d{2}-\d{2})", info)
+    if m:
+        return m.group(1)
+
+    # 2. Month-name format, e.g. "March 16, 2026".
+    m = re.search(
+        r"\b((?:January|February|March|April|May|June|July|August|September|"
+        r"October|November|December)\s+\d{1,2},\s*\d{4})\b",
+        info,
+    )
+    if m:
+        try:
+            return datetime.strptime(m.group(1), "%B %d, %Y").strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+
+    # 3. Slash format, e.g. "3/16/2026" or "03/16/2026".
+    m = re.search(r"\b(\d{1,2}/\d{1,2}/\d{4})\b", info)
+    if m:
+        try:
+            return datetime.strptime(m.group(1), "%m/%d/%Y").strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+
+    return None
 
 
 def _join_page_rows(
@@ -3599,10 +3640,9 @@ def _join_page_rows(
             dept_match = re.search(r"(?:Department|Dept\.?)\s+([A-Z0-9]+)", info, re.IGNORECASE)
             if dept_match and not header_dept:
                 header_dept = dept_match.group(1).strip()
-            # Extract hearing date from "Hearing Date: YYYY-MM-DD" pattern
-            date_match = re.search(r"Hearing Date:\s*(\d{4}-\d{2}-\d{2})", info)
-            if date_match and not header_date:
-                header_date = date_match.group(1)
+            # Extract hearing date from header (ISO, month-name, or slash formats).
+            if not header_date:
+                header_date = _parse_header_date(info)
 
     # Track entry_number -> case_index for cross-reference resolution (#2317).
     entry_number_to_index: dict[int, int] = {}

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -2769,6 +2769,51 @@ class IngestionWorker:
             fallback_text=ruling_text,
         )
 
+        # When a multi-ruling document produces results but every entry is
+        # missing both judge and department, the header metadata was not
+        # captured by the LLM — write a best-effort telemetry row so the
+        # failure rate is dashboard-queryable (#3559).
+        if len(converted) > 1 and all(
+            cr.judge_name is None and cr.department is None for cr in converted
+        ):
+            try:
+                conn = self._get_connection()
+                with conn.cursor() as cur:
+                    cur.execute("SAVEPOINT multimodal_null_metadata_metric")
+                    try:
+                        cur.execute(
+                            """
+                            INSERT INTO data_quality_metrics
+                                (recorded_at, county, metric_name,
+                                 metric_value, metadata)
+                            VALUES (now(), %s, %s, %s, %s::jsonb)
+                            """,
+                            (
+                                county,
+                                "multimodal_all_null_metadata",
+                                1,
+                                json.dumps(
+                                    {
+                                        "document_id": document_id,
+                                        "s3_key": event_data.get("s3_key"),
+                                        "state": state,
+                                        "county": county,
+                                        "scraper_id": event_data.get("scraper_id"),
+                                        "ruling_count": len(converted),
+                                    }
+                                ),
+                            ),
+                        )
+                        cur.execute("RELEASE SAVEPOINT multimodal_null_metadata_metric")
+                    except Exception:  # noqa: BLE001 — best-effort
+                        cur.execute("ROLLBACK TO SAVEPOINT multimodal_null_metadata_metric")
+                        raise
+            except Exception:  # noqa: BLE001 — telemetry is best-effort
+                logger.debug(
+                    "multimodal_all_null_metadata telemetry write failed",
+                    exc_info=True,
+                )
+
         # Clean up stale split-child documents from a previous processing run
         # that produced more rulings than this run (#2295).  The new split IDs
         # will be upserted cleanly; any old IDs beyond the new count are

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -6326,3 +6326,85 @@ def test_llm_split_writes_multimodal_all_null_metadata_metric() -> None:
     assert meta["ruling_count"] == 2
     # Savepoint must be used for best-effort protection.
     assert any("SAVEPOINT multimodal_null_metadata_metric" in s for s in executed_sql)
+
+
+def test_llm_split_multimodal_null_metadata_insert_failure_swallowed() -> None:
+    """Inner savepoint rollback executes when the metric INSERT fails (#3559).
+
+    When cur.execute raises on the INSERT, the inner handler must issue
+    ROLLBACK TO SAVEPOINT and re-raise; the outer handler swallows the error
+    so _llm_split_document still returns True (telemetry is best-effort).
+    """
+    from framework.llm_schema import ExtractedRuling
+
+    worker, _ = _make_worker()
+    worker._llm_client = MagicMock()
+
+    null_ruling_1 = ExtractedRuling(
+        extracted_case_number="30-2024-00000003",
+        extracted_case_title="Alpha v. Beta",
+        extracted_judge_name=None,
+        department=None,
+        motion_type=None,
+        outcome=None,
+        hearing_date="2026-03-16",
+        extracted_parties=[],
+        ruling_text="GRANTED.",
+        case_type=None,
+    )
+    null_ruling_2 = ExtractedRuling(
+        extracted_case_number="30-2024-00000004",
+        extracted_case_title="Gamma v. Delta",
+        extracted_judge_name=None,
+        department=None,
+        motion_type=None,
+        outcome=None,
+        hearing_date="2026-03-16",
+        extracted_parties=[],
+        ruling_text="DENIED.",
+        case_type=None,
+    )
+
+    mock_extractor = MagicMock()
+    mock_extractor.extract.return_value = [null_ruling_1, null_ruling_2]
+
+    event = _make_event(
+        document_id="multimodal-doc-0000-0000-000000000002",
+        scraper_id="ca-oc-tentatives",
+        state="CA",
+        county="Orange",
+        s3_key="ca/orange/superior_court/raw/multi-ruling-fail.pdf",
+        ruling_text="Some multipage ruling text",
+        judge_name=None,
+        department=None,
+    )
+
+    mock_conn, mock_cur = _make_mock_conn()
+
+    def _raise_on_insert(sql: str, *args: object, **kwargs: object) -> None:
+        if "INSERT INTO data_quality_metrics" in sql:
+            raise Exception("simulated DB write error")
+
+    mock_cur.execute.side_effect = _raise_on_insert
+
+    with (
+        patch.object(worker, "_get_framework_extractor", return_value=mock_extractor),
+        patch.object(worker, "_get_multimodal_extractor", return_value=None),
+        patch.object(worker, "_get_connection", return_value=mock_conn),
+        patch("ingestion.worker.delete_stale_split_children", return_value=0),
+        patch.object(worker, "process_event"),
+    ):
+        result = worker._llm_split_document(
+            event,
+            event["document_id"],
+            event["ruling_text"],
+            event["state"],
+            event["county"],
+            raw_pdf_bytes=None,
+        )
+
+    assert result is True
+    executed_sql = [call[0][0] for call in mock_cur.execute.call_args_list]
+    assert any(
+        "ROLLBACK TO SAVEPOINT multimodal_null_metadata_metric" in s for s in executed_sql
+    ), "Inner handler must roll back the savepoint on INSERT failure (#3559)."

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -6221,3 +6221,108 @@ def test_insert_ruling_content_hash_collision_supersedes_loser_force_update() ->
     # must not touch the winner's ruling row.
     all_sql = [call.args[0] if call.args else "" for call in cur.execute.call_args_list]
     assert not any("UPDATE rulings SET" in s for s in all_sql)
+
+
+# ---------------------------------------------------------------------------
+# #3559 — multimodal_all_null_metadata telemetry
+# ---------------------------------------------------------------------------
+
+
+def test_llm_split_writes_multimodal_all_null_metadata_metric() -> None:
+    """When a multi-ruling doc has all-null judge/department, write telemetry (#3559).
+
+    Feeds a synthetic event through ``_llm_split_document`` where the
+    framework extractor returns two ``ExtractedRuling`` objects, both with
+    ``extracted_judge_name=None`` and ``department=None``.  Asserts that one
+    ``data_quality_metrics`` row with ``metric_name="multimodal_all_null_metadata"``
+    is written inside a savepoint-protected block, mirroring the
+    ``zero_ruling_extraction`` pattern.
+    """
+    from framework.llm_schema import ExtractedRuling
+
+    worker, _ = _make_worker()
+    worker._llm_client = MagicMock()
+
+    # Two rulings, both with null judge_name and department — triggers the
+    # multimodal_all_null_metadata telemetry path.
+    null_ruling_1 = ExtractedRuling(
+        extracted_case_number="30-2024-00000001",
+        extracted_case_title="Alpha v. Beta",
+        extracted_judge_name=None,
+        department=None,
+        motion_type=None,
+        outcome=None,
+        hearing_date="2026-03-16",
+        extracted_parties=[],
+        ruling_text="GRANTED.",
+        case_type=None,
+    )
+    null_ruling_2 = ExtractedRuling(
+        extracted_case_number="30-2024-00000002",
+        extracted_case_title="Gamma v. Delta",
+        extracted_judge_name=None,
+        department=None,
+        motion_type=None,
+        outcome=None,
+        hearing_date="2026-03-16",
+        extracted_parties=[],
+        ruling_text="DENIED.",
+        case_type=None,
+    )
+
+    mock_extractor = MagicMock()
+    mock_extractor.extract.return_value = [null_ruling_1, null_ruling_2]
+
+    event = _make_event(
+        document_id="multimodal-doc-0000-0000-000000000001",
+        scraper_id="ca-oc-tentatives",
+        state="CA",
+        county="Orange",
+        s3_key="ca/orange/superior_court/raw/multi-ruling.pdf",
+        ruling_text="Some multipage ruling text",
+        judge_name=None,
+        department=None,
+    )
+
+    mock_conn, mock_cur = _make_mock_conn()
+
+    with (
+        patch.object(worker, "_get_framework_extractor", return_value=mock_extractor),
+        patch.object(worker, "_get_multimodal_extractor", return_value=None),
+        patch.object(worker, "_get_connection", return_value=mock_conn),
+        patch("ingestion.worker.delete_stale_split_children", return_value=0),
+        patch.object(worker, "process_event"),
+    ):
+        result = worker._llm_split_document(
+            event,
+            event["document_id"],
+            event["ruling_text"],
+            event["state"],
+            event["county"],
+            raw_pdf_bytes=None,
+        )
+
+    assert result is True
+    executed_sql = [call[0][0] for call in mock_cur.execute.call_args_list]
+    assert any("INSERT INTO data_quality_metrics" in s for s in executed_sql), (
+        "Multi-ruling all-null-metadata must write a data_quality_metrics row (#3559)."
+    )
+    # Verify the metric params.
+    metric_calls = [
+        call
+        for call in mock_cur.execute.call_args_list
+        if "INSERT INTO data_quality_metrics" in call[0][0]
+    ]
+    assert len(metric_calls) == 1
+    params = metric_calls[0][0][1]
+    # (county, metric_name, metric_value, metadata_json)
+    assert params[0] == "Orange"
+    assert params[1] == "multimodal_all_null_metadata"
+    assert params[2] == 1
+    meta = json.loads(params[3])
+    assert meta["document_id"] == "multimodal-doc-0000-0000-000000000001"
+    assert meta["s3_key"] == "ca/orange/superior_court/raw/multi-ruling.pdf"
+    assert meta["state"] == "CA"
+    assert meta["ruling_count"] == 2
+    # Savepoint must be used for best-effort protection.
+    assert any("SAVEPOINT multimodal_null_metadata_metric" in s for s in executed_sql)

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -972,6 +972,78 @@ class TestJoinPageRows:
         assert "Department C25" not in (rulings[0].extracted_case_title or "")
         assert rulings[1].extracted_case_number == "2024-00002"
 
+    @pytest.mark.parametrize(
+        "header_text,expected_date",
+        [
+            # Month-name format from OC PDFs.
+            (
+                "TENTATIVE RULINGS\nDEPARTMENT C27\nJUDGE BRADLEY ERDOSI\nMarch 16, 2026",
+                "2026-03-16",
+            ),
+            # ISO format regression — existing path must still match.
+            (
+                "Hearing Date: 2026-03-16",
+                "2026-03-16",
+            ),
+            # Slash format without leading zero.
+            (
+                "3/16/2026",
+                "2026-03-16",
+            ),
+            # Slash format with leading zero.
+            (
+                "03/16/2026",
+                "2026-03-16",
+            ),
+        ],
+    )
+    def test_header_date_narrative_formats(self, header_text: str, expected_date: str) -> None:
+        """_join_page_rows recognises narrative date formats in header rows (#3559)."""
+        rows = [
+            {
+                "entry_number": None,
+                "case_info": header_text,
+                "ruling_text": "",
+            },
+            {
+                "entry_number": 1,
+                "case_info": "2024-01393434 Smith v. Jones",
+                "ruling_text": "GRANTED.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 1
+        assert rulings[0].hearing_date == expected_date, (
+            f"Expected {expected_date!r} from header {header_text!r}, "
+            f"got {rulings[0].hearing_date!r}"
+        )
+
+    def test_header_date_case_caption_does_not_bleed(self) -> None:
+        """A date inside a case caption (entry row) does NOT bleed into header_date (#3559).
+
+        The regex must only scan header rows (entry_number is None, ruling_text empty),
+        so a date like "filed 2024-01-15" in the case_info of a real ruling row
+        must not set hearing_date on sibling rulings.
+        """
+        rows = [
+            # Real ruling row (not a header) with a date in the case caption.
+            {
+                "entry_number": 1,
+                "case_info": "2024-01393434 Smith v. Jones — filed 2024-01-15",
+                "ruling_text": "GRANTED.",
+            },
+            {
+                "entry_number": 2,
+                "case_info": "2024-00002 Alpha v. Beta",
+                "ruling_text": "DENIED.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 2
+        # Neither ruling should have a hearing_date derived from the case caption.
+        assert rulings[0].hearing_date is None
+        assert rulings[1].hearing_date is None
+
 
 # ---------------------------------------------------------------------------
 # Calendar header detection tests (#2096)

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -34,6 +34,7 @@ from framework.llm_extractor import (
     _is_new_case,
     _is_short_unsubstantive_ruling,
     _join_page_rows,
+    _parse_header_date,
     _parse_page_rows,
     _render_pdf_pages,
     _resolve_cross_references,
@@ -1043,6 +1044,22 @@ class TestJoinPageRows:
         # Neither ruling should have a hearing_date derived from the case caption.
         assert rulings[0].hearing_date is None
         assert rulings[1].hearing_date is None
+
+    def test_parse_header_date_invalid_month_name_returns_none(self) -> None:
+        """Month-name regex match with an out-of-range day returns None (#3559).
+
+        "February 30, 2026" matches the month-name regex but strptime raises
+        ValueError; the except branch must pass and return None.
+        """
+        assert _parse_header_date("February 30, 2026") is None
+
+    def test_parse_header_date_invalid_slash_returns_none(self) -> None:
+        """Slash-format regex match with an out-of-range month returns None (#3559).
+
+        "13/05/2026" matches the slash regex but strptime raises ValueError
+        (month 13 is invalid); the except branch must pass and return None.
+        """
+        assert _parse_header_date("13/05/2026") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Orange County multi-case PDFs were losing judge/department/hearing_date metadata because the header-date extraction regex only matched ISO format (`Hearing Date: YYYY-MM-DD`), while OC PDFs use narrative dates like "March 16, 2026". Added `_parse_header_date` helper function supporting ISO, month-name, and slash date formats with priority ordering to preserve the ISO path.

Also added `multimodal_all_null_metadata` telemetry in the worker's multimodal extraction loop to flag documents where every ruling has null judge/department, making this failure mode observable post-deploy.

Closes #3559

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — 6679 tests pass, 96% diff coverage
- [x] CI green (pre-push hook green)

### Post-deploy verification

- [ ] OC reingest with `--bust-llm-cache` recovers judge/department/hearing_date on the four sampled PDFs (Verify: `scripts/dev-db-query.sh` returns 0 null counts)
- [ ] OC null-metadata rate drops from ~40% to ≤ 5% across multi-case originals (Verify: re-run spotcheck with 25 samples)
- [ ] `multimodal_all_null_metadata` metric appears in CloudWatch when the null-metadata failure recurs
- [ ] Verification evidence posted on #3559 (see /task-v2-verify output)