### PR TITLE
fix(dx): resolve pre-push hook coverage.xml path bug (#2548)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -250,17 +250,13 @@ while read -r local_ref local_sha remote_ref remote_sha; do
             # it just must not run at the same time as pytest-cov.)
             testmon_flag=""
             xdist_flag=""
-            if ! run_check "$pkg" "pytest" "$pkg_dir/.venv/bin/pytest" $testmon_flag $xdist_flag "$pkg_dir/tests/" -x -q --tb=line; then
-                echo "  Run: $pkg_dir/.venv/bin/pytest $pkg_dir/tests/ -v --tb=short" >&2
+            if ! run_check "$pkg" "pytest" bash -c "cd $(printf '%q' "$pkg_dir") && ./.venv/bin/pytest $testmon_flag $xdist_flag tests/ -x -q --tb=line"; then
+                echo "  Run: cd $pkg_dir && ./.venv/bin/pytest tests/ -v --tb=short" >&2
                 failures=$((failures + 1))
             fi
-            # pytest-cov writes coverage.xml relative to CWD (the repo root
-            # when run from the hook), not relative to the package rootdir.
-            # Sync it to the package dir so the coverage floor check below
-            # reads the fresh file instead of a stale one from a prior run.
-            if [ -f "coverage.xml" ] && [ "coverage.xml" -nt "$pkg_dir/coverage.xml" ] 2>/dev/null; then
-                cp "coverage.xml" "$pkg_dir/coverage.xml"
-            fi
+            # pytest-cov writes coverage.xml relative to CWD. Running pytest
+            # with CWD = pkg_dir ensures coverage.xml lands in pkg_dir, where
+            # the coverage floor check below expects it.
         else
             echo "  WARNING: pytest not found for $pkg — skipping tests" >&2
             echo "  Install with: $pkg_dir/.venv/bin/pip install -e '.[dev]'" >&2

--- a/scripts/check-diff-coverage.sh
+++ b/scripts/check-diff-coverage.sh
@@ -116,7 +116,7 @@ if [[ "$PKG_TYPE" == "python" ]]; then
     # Run tests to generate coverage (unless --skip-tests)
     if [[ "$SKIP_TESTS" == "false" ]]; then
         echo "Running pytest with coverage for $PACKAGE..." >&2
-        if ! "$PYTEST" "$PKG_DIR/tests/" -x -q --tb=line 2>&1; then
+        if ! (cd "$PKG_DIR" && "$PYTEST" tests/ -x -q --tb=line) 2>&1; then
             echo "" >&2
             echo "FAILED: Tests failed for $PACKAGE. Fix tests before checking diff coverage." >&2
             exit 1

--- a/scripts/tests/test_pre_push.sh
+++ b/scripts/tests/test_pre_push.sh
@@ -687,6 +687,51 @@ else
 fi
 
 # ───────────────────────────────────────────────────────────────────────
+# Scenario 15: pytest runs with CWD = package dir; coverage.xml lands
+#              in pkg dir, NOT repo root (#2548)
+# ───────────────────────────────────────────────────────────────────────
+# Seeds testpkg with a stub pytest that writes coverage.xml to its CWD.
+# With the old hook (CWD = repo root) the file would appear at $WORK/coverage.xml.
+# With the fixed hook (CWD = pkg_dir) it appears at $WORK/packages/testpkg/coverage.xml.
+echo "[scenario 15] pytest CWD = package dir; coverage.xml lands in pkg (#2548)"
+init_workspace
+git -C "$WORK" checkout --quiet -b feature-pytest-cwd
+
+seed_testpkg
+mkdir -p "$WORK/packages/testpkg/.venv/bin"
+
+# Stub ruff: always exits 0 so pytest path is reached.
+cat > "$WORK/packages/testpkg/.venv/bin/ruff" <<'RUFF'
+#!/usr/bin/env bash
+exit 0
+RUFF
+chmod +x "$WORK/packages/testpkg/.venv/bin/ruff"
+
+# Stub pytest: writes coverage.xml containing a sentinel to its CWD and exits 0.
+cat > "$WORK/packages/testpkg/.venv/bin/pytest" <<'PYTEST'
+#!/usr/bin/env bash
+echo "sentinel-coverage-2548" > coverage.xml
+exit 0
+PYTEST
+chmod +x "$WORK/packages/testpkg/.venv/bin/pytest"
+
+git -C "$WORK" add packages/testpkg
+git -C "$WORK" commit --quiet -m "feat: add testpkg"
+feat_sha="$(git -C "$WORK" rev-parse HEAD)"
+
+run_hook "refs/heads/feature-pytest-cwd $feat_sha refs/heads/feature-pytest-cwd $ZERO_SHA"
+
+if [ "$hook_rc" -ne 0 ]; then
+    report_fail "hook should exit 0 with stub pytest that passes (#2548)" "$hook_out"
+elif [ ! -f "$WORK/packages/testpkg/coverage.xml" ]; then
+    report_fail "packages/testpkg/coverage.xml must exist — pytest must run with CWD = pkg_dir (#2548)" "$hook_out"
+elif [ -f "$WORK/coverage.xml" ]; then
+    report_fail "coverage.xml must NOT exist in repo root — pytest must not run with CWD = repo root (#2548)" "$hook_out"
+else
+    report_pass "pytest CWD = package dir: coverage.xml lands in pkg dir, not repo root (#2548)"
+fi
+
+# ───────────────────────────────────────────────────────────────────────
 # Summary
 # ───────────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Summary

Fixed the pytest working directory bug in the pre-push hook that caused false test failures due to stale coverage files. The hook now runs pytest with `cd $pkg_dir`, matching CI's behavior and ensuring coverage.xml lands in the correct package directory.

Closes #2548

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — Scenario 15 verifies coverage.xml placement; all 15 scenarios pass)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (pre-push hook, local tooling, test harness)