### PR TITLE
docs(specs): align dispatcher-v2 spec + SKILL.md with code reality (#3565)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -8,7 +8,9 @@ maxTurns: 200
 
 Perform a comprehensive codebase health audit, filing GitHub issues for every actionable finding. This skill is read-only — it analyzes and reports but never modifies source code.
 
-**Trigger:** The dispatcher spawns `/audit` every 20 merged PRs (tracked via `prs_since_last_audit` in `tmp/dispatcher_state.json`). It can also be invoked manually.
+**Trigger:** The laptop dispatcher spawns `/audit` every 20 merged PRs (tracked via `prs_since_last_audit` in `tmp/dispatcher_state.json`). It can also be invoked manually.
+
+> **Daemon-mode caveat.** Under dispatcher v2 (Fargate; `scripts/dispatcher/daemon.py`) `/audit` is fired by the daemon's `_scheduled_skills_tick` from a `dispatcher.scheduled_skills` row with `every_n_merges` (see `dispatcher-audit/SKILL.md` for the same machinery). The status-file mechanics in Steps 0 and 0a below are laptop-only — each ECS agent runs in a fresh container with no `tmp/agent-status/` to recover from, and the daemon owns agent state in `dispatcher.phase_transitions`. In daemon mode skip the status-file writes silently (best-effort observability, not a correctness gate); in laptop mode keep them.
 
 **Prerequisites:** Must be in a worktree. No special dependencies required — the audit uses Read, Grep, Glob, `mcp__github__*` tools (preferred for reads), and `gh` CLI (for writes and ops without MCP equivalents).
 
@@ -26,7 +28,9 @@ Create a working directory for audit state:
 {worktree}/tmp/audit/
 ```
 
-### Status file setup
+### Status file setup (laptop dispatcher only)
+
+> **Daemon mode skip.** Under dispatcher v2 the daemon owns agent state in `dispatcher.phase_transitions` and there is no `tmp/agent-status/` directory in the ECS container. Skip the status-file setup below silently. The rest of Step 0 (working directory, data fetch) still applies.
 
 Set up the agent status file for post-compaction recovery. The agent id is derived from the worktree path (e.g. `agent-ab4722a2`). Create the status directory if needed:
 
@@ -48,7 +52,9 @@ Use the Write tool to create or overwrite this file at each phase transition thr
 
 ---
 
-## Step 0a — Post-compaction recovery (READ FIRST after any context reset)
+## Step 0a — Post-compaction recovery (laptop dispatcher only; READ FIRST after any context reset)
+
+> **Daemon mode skip.** Under dispatcher v2 each phase runs in a fresh ECS container under a wall-clock budget — autocompaction is not a concern, and there is no status file to read. Skip this entire step in daemon mode.
 
 **When this applies:** Your context just went through autocompaction (the conversation summary references "previous conversation"), or you are otherwise starting a turn without a clear memory of which step you are in. Autocompaction preserves what was done but elides procedural imperatives, so the summary alone cannot tell you whether the audit is complete — the **status file** is authoritative (see #2545).
 

--- a/.claude/skills/dispatcher-audit/SKILL.md
+++ b/.claude/skills/dispatcher-audit/SKILL.md
@@ -146,7 +146,7 @@ Filed issues: (list issue URLs, or "none" if 0 filed)
 Commented on existing issues: (list comment URLs, or "none" if 0 existing)
 ```
 
-The `FILED ISSUES` header (or any non-empty output) signals success to `handle_scheduled_skill` (agent-runner-entrypoint.sh line ~2082).
+The `FILED ISSUES` header (or any non-empty output) signals success to `handle_scheduled_skill` in `scripts/dispatcher/agent-runner-entrypoint.sh`. (Function-name reference rather than line number — the entrypoint is large and shifts; line cites drift, function names don't.)
 
 ---
 

--- a/.claude/skills/dispatcher-startup/SKILL.md
+++ b/.claude/skills/dispatcher-startup/SKILL.md
@@ -5,6 +5,8 @@ argument-hint: "[max_slots=<N>] [skip=<csv>] [only=<#N1,#N2,...>] [agent_account
 
 # /dispatcher-startup skill
 
+> **Scope: laptop dispatcher (pre-v2).** This is the laptop dispatcher pre-v2. The dispatcher v2 daemon (Fargate; `scripts/dispatcher/daemon.py`) does its own startup-sweep work in-process (e.g. `recover_abandoned_agents`, queue scan) — nothing in this file applies to the daemon. See `docs/specs/dispatcher-v2-spec.md`.
+
 **Purpose.** Dispatcher startup historically burns roughly 100k tokens of main-context on raw `gh` / `mcp__github__*` output before the first `/task` agent spawns — `list_issues` over a busy `agent/ready` queue can exceed the MCP token ceiling on its own, and each `gh pr view --json statusCheckRollup,mergeable,mergeStateStatus` adds ~12k characters. The dispatcher rotates every ~40 loop iterations, so the main-context tax is paid fresh on every restart. This skill moves that work into a short-lived isolated subagent that returns ~40 lines of markdown.
 
 **Called by:** `/dispatcher` at startup (once per session), replacing inline startup steps 2–5. Not called by `/task`, `/ralph`, `/audit`, `/spotcheck`, or any other skill.

--- a/.claude/skills/dispatcher/SKILL.md
+++ b/.claude/skills/dispatcher/SKILL.md
@@ -5,6 +5,8 @@ argument-hint: "[max-agents | #issue1 #issue2 ...]"
 
 # /dispatcher skill
 
+> **Scope: laptop dispatcher (pre-v2).** This is the laptop dispatcher pre-v2. The dispatcher v2 daemon (Fargate; `scripts/dispatcher/daemon.py`) is a separate artifact — nothing in this file applies to the daemon. See `docs/specs/dispatcher-v2-spec.md` for the daemon's contract.
+
 Enable dispatcher mode for the current interactive session. This transforms the session into an autonomous work queue manager that continuously launches `/task` agents, merges completed PRs, triages issues, and communicates via Telegram.
 
 **Dispatcher mode is opt-in.** Interactive sessions are general-purpose by default. The user invokes `/dispatcher` when they want autonomous queue management.

--- a/.claude/skills/ralph/SKILL.md
+++ b/.claude/skills/ralph/SKILL.md
@@ -19,7 +19,7 @@ Implement the current task using a ralph loop: an iterative work-then-review cyc
 
 Do not ask for confirmation. Work autonomously through every step.
 
-**IMPORTANT — Ralph is NOT the end of the task.** When this skill completes, the calling `/task` workflow has 8 more mandatory steps remaining (A.2b through A.9: process summary, commit, push, PR, CI, merge, deploy, retrospective). Ralph completing means the code is ready — but the code has not been committed, pushed, reviewed by CI, or merged. Exiting after ralph is a known failure mode (#721). (Under dispatcher v2, the equivalent steps are owned by the daemon's `summary`, `push_and_pr`, `ci_watch`, `merge`, `deploy_watch`, `verify`, and `retro` phases.)
+**IMPORTANT — Ralph is NOT the end of the task.** When this skill completes, the calling `/task` workflow has 8 more mandatory steps remaining (A.2b through A.9: process summary, commit, push, PR, CI, merge, deploy, retrospective). Ralph completing means the code is ready — but the code has not been committed, pushed, reviewed by CI, or merged. Exiting after ralph is a known failure mode (#721). (Under dispatcher v2, the equivalent steps are owned by the daemon's `summary`, `push_and_pr`, `awaiting_ci`, `merge`, `awaiting_deploy`, `verify`, and `retro` phases.)
 
 **IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation anywhere in the ralph loop. All work runs synchronously in the foreground. Subagents (worker, reviewer) are already background tasks from the parent's perspective — further backgrounding causes completion notifications to surface in the wrong context and leads to lost results.
 

--- a/.claude/skills/spotcheck/SKILL.md
+++ b/.claude/skills/spotcheck/SKILL.md
@@ -31,7 +31,9 @@ The original court documents are authoritative. They are the source of truth —
 
 ---
 
-## Step 0a — Post-compaction recovery (READ FIRST after any context reset)
+## Step 0a — Post-compaction recovery (laptop dispatcher only; READ FIRST after any context reset)
+
+> **Daemon mode skip.** Under dispatcher v2 (Fargate; `scripts/dispatcher/daemon.py`) the daemon spawns `/spotcheck` from a `dispatcher.scheduled_skills` row in a fresh ECS container — there is no `tmp/agent-status/` to resume from, and `scripts/check-task-recovery.sh` does not run there. Skip this entire step in daemon mode. The status-file machinery below is laptop-only.
 
 If your context was just autocompacted (the summary references "previous conversation"), run the recovery check before anything else:
 

--- a/.claude/skills/task/SKILL.md
+++ b/.claude/skills/task/SKILL.md
@@ -6,6 +6,8 @@ maxTurns: 200
 
 # /task skill
 
+> **Scope: laptop dispatcher (pre-v2).** This is the laptop dispatcher pre-v2. The dispatcher v2 daemon (Fargate; `scripts/dispatcher/daemon.py`) is a separate artifact — nothing in this file applies to the daemon (which uses the per-phase `/task-v2-*` skills). See `docs/specs/dispatcher-v2-spec.md`.
+
 Pick up one issue from the Judgemind backlog and complete it autonomously. Do not ask for confirmation at any point — work through every step and stop only when the PR is green and review has been requested (or when an investigation task has posted its findings, closed the issue, and unblocked any dependents).
 
 **IMPORTANT — No backgrounding.** Do not use `run_in_background` on any Bash command, Agent tool call, or any other operation anywhere in a `/task` agent. All work runs synchronously in the foreground. The `/task` agent is already a background subagent from the dispatcher's perspective — further backgrounding causes completion notifications to surface in the wrong context (the dispatcher), leading to confusion and lost results.

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -5,6 +5,8 @@ argument-hint: ""
 
 # /tdd skill
 
+> **Scope: laptop dispatcher (pre-v2).** This is the laptop dispatcher pre-v2. The dispatcher v2 daemon (Fargate; `scripts/dispatcher/daemon.py`) is a separate artifact — nothing in this file applies to the daemon (which calls `/task-v2-ralph` and its inner `/ralph` instead). See `docs/specs/dispatcher-v2-spec.md`.
+
 Implement the current task using test-driven development. This skill assumes you are already in a worktree with a claimed issue (use `/task` first to set up).
 
 **When to use this skill:** Python packages (scrapers, API logic, NLP pipeline) and TypeScript packages (API, frontend) — any task where you can write and run tests locally.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -970,6 +970,22 @@ jobs:
         run: scripts/check-deprecated-models.sh
 
   # ---------------------------------------------------------------
+  # Spec / SKILL.md drift guard: diagnoser action vocabulary
+  # ---------------------------------------------------------------
+  # Asserts that .claude/skills/diagnose-failure/SKILL.md and the
+  # daemon's DIAGNOSER_ACTIONS frozenset (scripts/dispatcher/daemon.py)
+  # describe the same set of actions. Regression test for issue #3565
+  # (audit found drift on the 9th action `terminal`).
+  spec-action-vocabulary-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check diagnoser action vocabulary parity
+        run: scripts/check-spec-action-vocabulary.sh
+      - name: Self-test the vocabulary checker
+        run: scripts/tests/test_check_spec_action_vocabulary.sh
+
+  # ---------------------------------------------------------------
   # Hardcoded model guard: enforce model ID centralization
   # ---------------------------------------------------------------
   hardcoded-models-check:

--- a/docs/specs/dispatcher-v2-spec.md
+++ b/docs/specs/dispatcher-v2-spec.md
@@ -128,22 +128,28 @@ The scheduler drives a per-phase state machine for each active agent. Each tick:
 5. **Advance per-agent state machines.** For each active agent, determine the next phase based on `dispatcher.agents.phase` and spawn the corresponding subprocess. Phase map (see §6a for skill definitions):
 
    ```
-   (new)                    → claim        [mechanical]
-   claim                    → planning     [claude -p /task-v2-plan]
-   planning                 → setup        [mechanical: install deps]
-   setup                    → ralph        [claude -p /task-v2-ralph]
-   ralph:ship               → summary      [claude -p /task-v2-summary]
-   ralph:ac_infeasible      → diagnose     [claude -p /diagnose-failure; §8]
-   summary:ok               → push_and_pr  [mechanical: git + gh pr create]
-   summary:ac_infeasible    → diagnose     [claude -p /diagnose-failure; §8]
-   push_and_pr              → ci_watch     [mechanical: gh run watch]
-   ci_watch:green           → merge        [mechanical: gh pr merge]
-   ci_watch:red             → ci_fix       [claude -p /task-v2-fix-ci]
-   merge                    → deploy_watch [mechanical: gh run watch on deploy wf]
-   deploy_watch             → verify       [claude -p /task-v2-verify]
-   verify                   → retro        [claude -p /task-v2-retro]
-   retro                    → done         [mechanical: cleanup]
+   (new)                       → claim             [mechanical]
+   claim                       → planning          [claude -p /task-v2-plan]
+   planning:coding             → setup             [mechanical: install deps]
+   planning:operational        → operational       [claude -p /task-v2-operational; #3507]
+   setup                       → ralph             [claude -p /task-v2-ralph]
+   ralph:ship                  → summary           [claude -p /task-v2-summary]
+   ralph:ac_infeasible         → diagnose          [claude -p /diagnose-failure; §8]
+   summary:ok                  → push_and_pr       [mechanical: git + gh pr create]
+   summary:ac_infeasible       → diagnose          [claude -p /diagnose-failure; §8]
+   push_and_pr                 → awaiting_ci       [mechanical: gh run watch]
+   awaiting_ci:green           → merge             [mechanical: gh pr merge]
+   awaiting_ci:red             → fix_ci            [claude -p /task-v2-fix-ci]
+   merge                       → awaiting_deploy   [mechanical: gh run watch on deploy wf]
+   awaiting_deploy             → verify            [claude -p /task-v2-verify]
+   verify                      → retro             [claude -p /task-v2-retro]
+   retro                       → done              [mechanical: cleanup]
+   operational:succeeded       → operational_done  [terminal: status=succeeded]
+   operational:blocked         → operational_failed [terminal: status=needs_review]
+   operational:failed          → diagnose          [hint=operational_failed; claude -p /diagnose-failure; §8]
    ```
+
+   Phase-name authority: real phase names live in `daemon.py` `AGENT_RUNNER_VALID_START_PHASES`, `agent-runner-entrypoint.sh` `phase_to_skill`, and `scripts/dispatcher/phase_transitions.py` `ACTIVE_PHASES`. The map above uses those names. (Earlier drafts used `ci_watch` / `deploy_watch` / `ci_fix`; those are spec-only legacy names that never matched the daemon — renamed to `awaiting_ci` / `awaiting_deploy` / `fix_ci` per the audit in #3565. NOTE: `scripts/dispatcher/phases.py` `PHASE_FLOW_FORWARD` keeps `ci_watch` / `deploy_watch` as **admin-UI display labels** for the phase-flow tooltip; that is intentional and orthogonal to the daemon's actual phase strings — see the docstring there. The admin UI module re-labels for display.)
 
 6. **Spawn subprocess for current phase.** For agents whose phase calls for an LLM: build the input bundle from `dispatcher.*` + git state, write to `{worktree}/tmp/dispatcher-input/<phase>.json`, spawn `claude -p '/task-v2-<phase> <agent_id>'` with `--max-turns 500` and the subprocess-wide 180-min timeout. Each phase reads the input JSON and writes `{worktree}/tmp/dispatcher-output/<phase>.json`, which the daemon parses and persists to `dispatcher.phase_outputs` before advancing `dispatcher.agents.phase`.
 7. **Reap completions.** For each subprocess that exited since last tick: parse exit code + output.json, update `dispatcher.agents.phase`, emit failure row if non-zero.
@@ -161,6 +167,8 @@ New skills in .claude/skills/task-v2-\*/SKILL.md, each narrowly scoped to one ph
 | `/task-v2-ralph`[^ralph-subagent][^ralph-runs-every-type][^ralph-ac-infeasible] | plan from above, worktree path | SHIP verdict + implementation diff in git, OR `AC_INFEASIBLE` verdict with `infeasible_acs` array (see footnote) | ~45-90 min (multi-invocation internally, same as today) |
 | `/task-v2-summary`[^summary-ac-infeasible][^summary-deferred-acs] | issue body + git diff | process-summary comment (AC mapping), commit message, PR body, `deferred_acs` array (see footnote), OR `AC_INFEASIBLE` verdict with `infeasible_acs` array (see footnote) | ~10 min |
 | `/task-v2-fix-ci` | PR #N, CI failure logs | patch + commit message, OR explicit "give up — blocker" signal | ~15-30 min |
+| `/task-v2-fix-conflict` | rebase-conflict bundle (`conflict_files`, base SHA, agent SHA) | resolved file set + commit, OR `unresolvable` signal naming the conflict-class | ~10-20 min |
+| `/task-v2-operational`[^operational-skill] | issue body + classification from plan (non-coding task) | structured verdict: `succeeded` / `blocked` / `failed`, `action_taken`, `evidence_md`, optional `block_reason` | ~10-30 min |
 | `/task-v2-verify`[^verify-deferred-acs] | PR #N, deploy status, AC list, `deferred_acs` from summary | verification evidence comment with per-criterion proof (including the deferred ACs, see footnote) | ~10-15 min |
 | `/task-v2-retro` | full agent history (phase_transitions, failures, PR URL) | retrospective issue body(s) to file | ~10 min |
 
@@ -174,6 +182,8 @@ New skills in .claude/skills/task-v2-\*/SKILL.md, each narrowly scoped to one ph
 
 [^summary-deferred-acs]: **Deferred-to-verify ACs — marker + heuristic.** Some ACs are only verifiable once the PR is merged and deployed (e.g. `Verify: query OpenSearch count against dev DB after rebuild_db --reset --county runs`). Summary cannot validate these against the pre-merge diff — checking them there would always flag unmet and force a spurious `needs_review`. Summary classifies each AC *before* running the diff validator: (a) **marker** — `Verify:` line begins with `(post-deploy)` → deferred; (b) **heuristic** — the `Verify:` line references a dev/prod artifact (`scripts/ecs-run-task.sh`, `curl dev.api...`, `POST /<index>/_count`, `rebuild_db`, `gh run watch` on a deploy workflow, etc.) → deferred; (c) otherwise → validate against the diff as today. Deferred ACs are listed in summary's output as `deferred_acs: [{index: N, reason: "marker" | "heuristic", verify_instruction: "<the Verify: line text>"}]` and are NOT counted toward `needs_review` or `AC_INFEASIBLE`. The marker is authoritative; when an author knows an AC is post-deploy, they write `Verify: (post-deploy) ...` and summary's classifier never reaches the heuristic. The heuristic exists because a large backlog of pre-convention issues is authored without the marker and cannot be retrofitted (their authors are ephemeral prior dispatcher runs). False-positive heuristic (tagging a code-verifiable AC as deferred) is benign: verify phase runs it post-deploy and either catches the gap or confirms the pass. False-negative (missing a post-deploy AC) is the current behavior — no regression.
 
+[^operational-skill]: **Operational handler (#3507).** Non-coding tasks — script runs, DB queries, gh actions, data rebuilds — bypass the ralph→summary→push_and_pr→merge pipeline entirely. Plan emits `task_type: "operational"` (`task-v2-plan/SKILL.md:62, 140-156`); the daemon routes through `phase_transitions.py:606-612` to `PHASE_OPERATIONAL`; the entrypoint executes `claude -p /task-v2-operational $AGENT_ID` (`agent-runner-entrypoint.sh:5077-5126`). Verdicts are consumed by `phase_transitions.py:642-674`: `succeeded` → `operational_done` terminal (status=succeeded, no PR); `blocked` → `operational_failed` terminal (status=needs_review); `failed` → `ROUTE_TO_DIAGNOSER` with hint `operational_failed`. Stuck-timeout cap is 3600 s (`daemon.py:1028`).
+
 [^verify-deferred-acs]: **Verify consumes `deferred_acs` from summary.** The verify phase today walks the issue's AC list and produces per-criterion proof against the deployed dev environment. With summary emitting `deferred_acs`, verify now has an explicit list of which ACs were skipped pre-merge — those are the first ones it runs (using the `verify_instruction` field carried forward from summary's output). Any AC not in `deferred_acs` was already validated against the diff by summary; verify can either re-confirm post-deploy (belt) or trust summary's pre-merge pass (skip and rely on CI). Default: re-run everything verify can, so the post-deploy evidence comment covers 100% of ACs. The comment explicitly labels which ACs were deferred and why (marker vs heuristic) so operators reading a PR trail can see which validations were time-shifted.
 
 **Per-phase context budget — measured in spike 0.3.** Analytical measurement (chars/3.5 heuristic + bounded tool-call estimates) against fixtures from #2513 (the 108-min long-tail candidate) + PR #2534 showed all six phases land comfortably inside the 200k-token window with 4×+ headroom. Peak was `/task-v2-fix-ci` at ~42k tokens (~21% of window); `/task-v2-ralph` stays bounded at ~39k (~20%) specifically because its worker+reviewer subagents run in fresh contexts (see the footnote on the ralph row). No sub-split is required. Spike 0.3 scheduled a follow-up empirical re-measurement on Fargate against production skills (#2714). See `docs/investigations/dispatcher-v2-spike-0.3.md`.
@@ -186,57 +196,11 @@ The daemon handles everything between: worktree setup, `git add/commit/push`, `g
 
 **Post-compaction recovery machinery from `/task` disappears.** The phase-split design means no individual phase runs long enough to autocompact. The daemon's resume-from-`phase`-on-boot is the structural equivalent, owned by Python rather than the LLM's status-file discipline.
 
-### 6b. Runner abstraction
+### 6b. Runner abstraction (today)
 
-Each per-phase subprocess is spawned through a `Runner` interface:
+**Today: claude-only.** Every phase subprocess is `claude -p '/<skill> <agent_id>'` with `--max-turns 500` and the container's MCP config path. There is no `Runner` Protocol class implementation in the codebase, no `GeminiRunner` / `CursorRunner` / `OpenCodeRunner` class, and no reader of `dispatcher.config.runner_by_phase` or `model_by_phase` in `daemon.py` — the seed config rows exist (§19) but nothing consumes them. The model used for each phase is implicit per the skill's frontmatter (`model: opus` / `sonnet` / `haiku` in .claude/skills/task-v2-\*/SKILL.md), not chosen by the daemon.
 
-```python
-class Runner(Protocol):
-    def run(
-        self,
-        skill: str,           # e.g. "task-v2-plan"
-        worktree: Path,
-        input_json: Path,     # {worktree}/tmp/dispatcher-input/<phase>.json
-        output_json: Path,    # {worktree}/tmp/dispatcher-output/<phase>.json
-        timeout_s: int,
-    ) -> RunResult: ...       # {exit_code, stderr_tail, duration_s}
-```
-
-First implementation: `ClaudeRunner` — shells out to `claude -p '/<skill> <agent_id>'` with `--max-turns 500` and the container's MCP config path.
-
-**Candidate secondary runners** (verified 2026-04-18):
-
-| Runner | Invocation | Agentic? | Hooks | Skills loaded from | MCP | Notes |
-|---|---|---|---|---|---|---|
-| **Claude Code** | `claude -p '/<skill> <id>'` | yes | `PreToolUse`, `PostToolUse`, `SubagentStop`, etc. — shell-exec, write directly to `dispatcher.failures` via `emit_failure.py` | `.claude/skills/` | yes | First-class. `--max-turns`, no `--timeout`; wrap with OS `timeout(1)`. |
-| **Gemini CLI** (`@google/gemini-cli`, [repo](https://github.com/google-gemini/gemini-cli)) | `gemini -p '<prompt>' --output-format stream-json` | yes | `BeforeTool`/`AfterTool`/`SessionStart`/`SessionEnd` — same `settings.json`-style shell-exec with stdin/stdout JSON, exit code `2` blocks. **Semantics are 1:1 with Claude, but event names differ** — Claude-spelled `PreToolUse` / `PostToolUse` entries in a shared `settings.json` are silently dropped by Gemini with a one-line startup warning, so `settings.json` matchers must be written per-runner (or mechanically converted via `gemini hooks migrate --from-claude`). Verified against Gemini CLI 0.38.2, spike 0.4 (#2686). | `.gemini/skills/` **or** `.agents/skills/` (cross-tool standard) | yes, native | Exit codes 0/1/41/53: `0` success, `1` invocation/flag-parse error, `41` auth missing, `53` turn-limit — *better* granularity than `claude -p`'s `1`-for-everything. Turn-limit mechanism is **`settings.json.model.maxSessionTurns`**, not a CLI flag (`--max-turns` does not exist in Gemini 0.38.2 and produces exit 1 if passed — the `GeminiRunner` writes the limit into the worktree's `.gemini/settings.json` before spawning). Auth: on Fargate use API key (`GEMINI_API_KEY`); OAuth free tier (1000 rpd on Gemini 3 Pro) requires interactive browser flow and is operator-laptop-only. Tool names differ (`read_file`/`write_file`/`run_shell_command`) so hook matchers need a rewrite layer. |
-| **OpenCode** ([sst/opencode](https://github.com/sst/opencode)) | `opencode run "<prompt>"` | yes | `tool.execute.before` / `tool.execute.after` as in-process TS/JS plugins (cleaner — live Postgres connection, typed args, mutate or throw-to-abort). **No `SubagentStop` equivalent** — closest is `session.idle` via a generic `event` firehose ([#5409](https://github.com/sst/opencode/issues/5409) tracks the gap) | `.claude/skills/` is read natively; commands need duplication in `.opencode/commands/` | yes | No `--max-turns` or `--timeout` flags — wrap with OS `timeout(1)`. Exit codes undocumented; verify empirically. |
-| **Cursor CLI** (`cursor-agent`, [docs](https://cursor.com/docs/cli/overview)) | `cursor-agent -p '<prompt>' -m <model>` | yes | `hooks.json` stdio-JSON shell-exec model (introduced Cursor 1.7, Oct 2025). 6 events: `beforeShellExecution`, `beforeReadFile`, `beforeMCPExecution`, `afterFileEdit`, `beforeSubmitPrompt`, `stop`. Exit 2 = deny (same convention as Claude). **Missing:** no `SessionStart`/`SessionEnd`, no generic `beforeFileEdit`, no `SubagentStop`. `beforeReadFile` supports secret-redaction before the LLM sees content — stronger than Claude there | `.cursor/rules/` (nestable `.mdc`); also reads `CLAUDE.md` and AGENTS.md natively; Skills via SKILL.md (Cursor 2.4+) | yes, via `mcp.json` | Known bugs: `-p` mode can hang indefinitely ([forum 150246](https://forum.cursor.com/t/cursor-agent-p-print-headless-mode-hangs-indefinitely-and-never-returns/150246)); sandbox + hook `"ask"` response is ignored ([forum 155438](https://forum.cursor.com/t/beforeshellexecution-returns-permission-ask-but-sandboxed-agent-shell-still-runs-the-command-sandbox-true/155438)). Validate with timeout wrapper before daemon use. |
-
-Runner selection lives in `dispatcher.config` as a per-phase map (`runner_by_phase`), defaulting to `claude` for every phase. Overriding is a single config update — no daemon redeploy. The same config can be overridden per agent (e.g. cost experiments on specific issues) via `dispatcher.agents.runner_override jsonb`.
-
-**Skills portability — use the `.agents/skills/` cross-tool standard.** Gemini CLI and OpenCode both agreed on `agentskills.io` (the SKILL.md frontmatter format Anthropic also uses) and both read `.agents/skills/` as a deliberately cross-tool path. Plan: keep our canonical skill files under .claude/skills/task-v2-\*/SKILL.md (Claude reads these directly), and symlink `.agents/skills/task-v2-*/` → the same directories so Gemini and OpenCode pick them up without duplication. OpenCode additionally reads `.claude/skills/` directly. Non-standard frontmatter fields (`allowed-tools`, `model`) silently drop on non-Claude runners — audit and move those into runner-specific adapters or inline instructions. Slash-command entry points are per-runner: `/task-v2-*` works in Claude; `.opencode/commands/*.md` must be duplicated for OpenCode; Gemini uses its own slash-command config.
-
-**Hooks parity.** Our `PreToolUse` / `SubagentStop` / `PostToolUse` hooks (§9) write directly to `dispatcher.failures`. Parity picture by runner:
-- **Claude Code and Gemini CLI — near-full parity, with naming caveat.** Both support shell-exec hooks with matcher regex, stdin/stdout JSON contracts, and exit-code-based blocking. `SessionStart`/`SessionEnd` map to our `SubagentStop` use case. `emit_failure.py` itself works unchanged (the stdin JSON payload has identical field shape — `session_id`, `transcript_path`, `cwd`, `hook_event_name`, `tool_name`, `tool_input`, verified in spike 0.4 #2686). **The event names differ, however:** Claude uses `PreToolUse` / `PostToolUse`; Gemini uses `BeforeTool` / `AfterTool`. A shared `settings.json` with both keys is safe — each runner silently drops the other's key with a one-line startup warning — but hook registration blocks must be written per-runner (or auto-converted via `gemini hooks migrate --from-claude`). Tool names also differ (`Read`/`Write`/`Bash` on Claude vs. `read_file`/`write_file`/`run_shell_command` on Gemini), so matcher regexes need a per-runner namespace.
-- **Cursor CLI — partial.** `beforeShellExecution` / `beforeReadFile` / `afterFileEdit` / `beforeMCPExecution` / `beforeSubmitPrompt` / `stop` cover the preflight and post-edit surface. Exit code 2 = deny (same convention as Claude), so `emit_failure.py` works with minimal adaptation. No `SessionStart`/`SessionEnd` or dedicated `SubagentStop` — fall back to daemon post-exit reconciliation for no-commit/no-push detection. `beforeReadFile`'s content-redaction capability is a bonus we don't get elsewhere (useful if we ever feed secrets through agents).
-- **OpenCode — partial.** `tool.execute.before`/`.after` cover the preflight/observability hooks (arguably *better* — typed args, mutate or throw-to-abort, live in-process Postgres connection). No `SubagentStop` equivalent; fall back to daemon post-exit reconciliation (PR-vs-GH check from Risk 1, git-state check on the worktree, `gh pr view` for branch state) to cover no-commit-on-exit / no-push-on-exit. Hooks are Bun/TS plugins, not shell commands — small shim required or the plugin shells out to `scripts/dispatcher/emit_failure.py`.
-- **Any runner without hooks** — everything routes through post-exit reconciliation at coarser granularity and higher latency. All paths converge on the same `dispatcher.failures` categories.
-
-**Model support.** Orthogonal to the runner choice: each runner exposes a different set of model providers.
-
-| Runner | Anthropic | Google | OpenAI | xAI | Open-weight | Local |
-|---|---|---|---|---|---|---|
-| **Claude Code** | yes — API, Bedrock, Vertex, Foundry (toggled via `CLAUDE_CODE_USE_*` env vars) | no (officially) | no (officially) — works via LiteLLM/Bifrost gateway, unsupported | no | no | no officially |
-| **Gemini CLI** | no | yes — AI Studio OAuth free tier + API key + Vertex | no | no | no | no |
-| **OpenCode** | yes — Anthropic API, Bedrock, Vertex | yes — AI Studio + Vertex | yes — direct + Azure | yes — Grok | yes — Groq, Together, Cerebras, DeepSeek, OpenRouter, HF | yes — Ollama, LM Studio, llama.cpp |
-| **Cursor CLI** | yes (curated) | yes (curated) | yes (curated) | partial (curated) | partial (curated) | no |
-
-Model selection at the CLI: Claude uses `--model <alias\|id>` (aliases `opus`/`sonnet`/`haiku` or full IDs like `claude-opus-4-7`) and `--max-turns <N>` for turn-limiting; Gemini uses `-m <model-id>` (aliases `auto`/`pro`/`flash`/`flash-lite`) and has **no `--max-turns` flag** — turn-limiting is `settings.json.model.maxSessionTurns`, written by the `GeminiRunner` into the worktree's `.gemini/settings.json` before spawning (verified against Gemini CLI 0.38.2 in spike 0.4 #2686); OpenCode uses `-m <provider>/<model>` (e.g. `anthropic/claude-opus-4-7`, `google/gemini-3-pro`, `openai/gpt-5`); Cursor uses `--model <id>` against its curated roster (enumerate via `cursor-agent models`). Model selection is stored in `dispatcher.config.model_by_phase` (parallel to `runner_by_phase`) and overridable per agent via `dispatcher.agents.model_override`.
-
-**Consequence for multi-model experiments.** If we want to mix, say, Opus 4.7 for planning + Gemini 3 Pro for summary + GPT-5 for CI-fix, the simplest path is **OpenCode as the single runner** — one binary, one config, three API keys. The alternative is one runner per phase (`ClaudeRunner` for Anthropic phases, `GeminiRunner` for Google phases, `OpenCodeRunner` only for OpenAI phases), which costs us three binaries and three auth models but keeps each runner's native feature set (e.g. Claude's `opusplan` auto plan-on-Opus / execute-on-Sonnet has no equivalent in OpenCode). Defer this decision until shadow-mode data tells us whether the model swap actually moves quality/cost metrics.
-
-**Cost/quality shadow mode.** A future experiment — `runner_shadow` in config lets a second runner execute the same phase in parallel with its output discarded and diff-logged to `dispatcher.phase_outputs` (distinguished by `phase='<phase>@shadow:<runner>'`). Useful for measuring "would Gemini have produced a similar plan?" without cutting over. Out of scope for Phase 1-4 migration; noted here so the schema doesn't preclude it. The Gemini free OAuth tier (1000 rpd on Gemini 3 Pro) is generous enough to run meaningful shadow traffic without a budget line.
+The multi-runner architecture (Cursor CLI, Gemini CLI, OpenCode candidate runners; per-phase / per-agent runner overrides; hooks-parity matrix; model-provider matrix; `runner_shadow` cost/quality shadow mode) is described in §F1 (Future Direction) — not yet shipped. When it does ship, the tracking issue (TBD) should also flip the `runner_by_phase` and `model_by_phase` seed values to read-and-honour rather than nominal-only.
 
 ### 6c. ECS execution mode (per-agent Fargate)
 
@@ -364,6 +328,11 @@ Note: `enableExecuteCommand` only takes effect on freshly-launched tasks. Tasks 
 | `summary_ac_infeasible` | 3 | Post-exit parse of summary output's `infeasible_acs` array | Summary found an unmet AC that is structurally impossible (references a non-existent symbol, self-contradicts, or out-of-scope) — diagnose immediately. Ralph's diff is discarded on this branch; diagnoser's `reissue` triggers a fresh plan→ralph. |
 | `ci_red_after_retries` | 3 | Scheduler | PR has failing CI and `dispatcher.agents.retries_used >= 3` — diagnose immediately |
 | `merge_unstick_exhausted` | 3 | Scheduler (merge-phase handler) | `gh pr merge --squash` rejected with `base branch policy prohibits the merge` after the daemon already auto-unstuck once by pushing an empty commit (#2641). Second occurrence in the same agent's lifetime — mechanical retry budget `MERGE_UNSTICK_MAX_ATTEMPTS=1` already spent. Diagnose immediately; typical causes are a real CI failure masquerading as a stale rollup, non-CI branch-protection requirements, or a GitHub API anomaly the daemon can't work around mechanically. |
+| `merge_conflict_at_push` | 3 | Entrypoint (push-and-pr / push-fix-ci handler) | `git push` rejected because the branch diverged from `origin/main` between agent's last fetch and push. Routed via `BYPASSED_TERMINAL_PHASES_TO_ROUTE` (`daemon.py:1326, 1372-1385`) — the diagnoser's preferred resolution is to invoke `/task-v2-fix-conflict` to rebase semantically. #2964. |
+| `conflict_unresolvable` | 3 | Entrypoint (post-`/task-v2-fix-conflict`) | `/task-v2-fix-conflict` exhausted its budget without resolving the rebase conflict. Bundle includes `conflict_files`, the base SHA, and the agent SHA so the diagnoser can decide between `block_and_comment`, `file_prerequisite_task`, or splitting the issue. Routed via `BYPASSED_TERMINAL_PHASES_TO_ROUTE` (`daemon.py:1304, 1373`). #3225. |
+| `verify_failed_post_merge` | 3 | Entrypoint (verify phase, post-merge) | `/task-v2-verify` reports unmet ACs against the deployed dev environment after a successful merge + deploy. Routed via `BYPASSED_TERMINAL_PHASES_TO_ROUTE` (`daemon.py:1275, 1381`). The diagnoser decides whether to file a follow-up issue, escalate, or reopen with reissue scope. #3071. |
+| `agent_runner_route_stub` | 3 | Entrypoint (any phase with no recognized next-phase routing) | The agent-runner hit a phase transition the entrypoint has no handler for (typically a daemon-level concept that wasn't propagated to the entrypoint). Generic terminal that always routes to the diagnoser with `route_hint` carrying the original phase. `daemon.py:1339, 1374`. #3366. |
+| `operational_failed` | 3 | Entrypoint (post-`/task-v2-operational`, verdict=`failed`) | `/task-v2-operational` exited with `verdict: "failed"` — the script run, DB query, or gh action errored in a way the operational skill could not classify as a clean `blocked`. Diagnoser decides between retry-with-hint (transient cause), block_and_comment (permanent cause), or escalate. `daemon.py:1321, 1385`. #3507. |
 
 **Escalation:** 3 failures on the same issue in 24h → add `status/needs-human` + `priority/p1` (no p0 — human-only), post comment with the full taxonomy history, fire Telegram with the issue URL. Daemon moves on. (For Tier 2/3 failures, the diagnoser may escalate sooner; see below.)
 
@@ -794,12 +763,88 @@ INSERT INTO dispatcher.config (key, value, updated_by) VALUES
   ('backoff_seconds',      '[60,300,900]', 'init'),
   ('idle_audit_every_n_prs', '20',   'init'),
   ('idle_spotcheck_cron',  '"0 14 * * *"', 'init'),
-  -- Runner selection: per-phase map. Overridable per-agent via dispatcher.agents.runner_override.
-  ('runner_by_phase', '{"plan":"claude","ralph":"claude","summary":"claude","fix_ci":"claude","verify":"claude","retro":"claude","diagnose":"claude"}', 'init'),
+  -- Runner selection: per-phase map. Reserved for the future multi-runner architecture (§F1) — no
+  -- code in daemon.py reads this column today; every phase runs `claude -p` regardless. Overridable
+  -- per-agent via dispatcher.agents.runner_override (also nominal-only today).
+  ('runner_by_phase', '{"plan":"claude","ralph":"claude","summary":"claude","fix_ci":"claude","fix_conflict":"claude","operational":"claude","verify":"claude","retro":"claude","diagnose":"claude"}', 'init'),
   -- Model selection: per-phase map. Values are runner-native model IDs (Claude aliases, OpenCode provider/model strings, etc.).
-  ('model_by_phase',  '{"plan":"opus","ralph":"sonnet","summary":"haiku","fix_ci":"sonnet","verify":"haiku","retro":"haiku","diagnose":"opus"}', 'init'),
-  ('runner_shadow',    '{}',         'init');  -- e.g. {"summary":"gemini"} runs gemini in parallel, output diff-logged only
+  -- Nominal today: the actual model is set by the skill frontmatter (model: opus etc.) on each .claude/skills/task-v2-*/SKILL.md (no backticks intentional — see #3565).
+  -- The `operational` value matches the `model: opus` frontmatter on `.claude/skills/task-v2-operational/SKILL.md`.
+  ('model_by_phase',  '{"plan":"opus","ralph":"sonnet","summary":"haiku","fix_ci":"sonnet","fix_conflict":"sonnet","operational":"opus","verify":"haiku","retro":"haiku","diagnose":"opus"}', 'init'),
+  ('runner_shadow',    '{}',         'init');  -- §F2 future experiment: e.g. {"summary":"gemini"} runs gemini in parallel, output diff-logged only
 ```
+
+---
+
+## Future Direction (aspirational, not yet shipped)
+
+This section collects design content that pre-dated the Phase 4 ECS rollout but never made it into shipped code. Spec content here is **not authoritative for current behavior** — the body of this document (§§1–19) describes today. Items in this section are referenced only by tracking issues; if you find code consuming them, the right move is to delete the dead consumer or land the missing producer.
+
+### F1. Multi-runner architecture (Cursor / Gemini / OpenCode)
+
+**Status: not implemented.** The seed `dispatcher.config.runner_by_phase` and `dispatcher.config.model_by_phase` rows exist (§19) but no code in `daemon.py` reads them. Today every phase is `claude -p` with the model chosen implicitly by the skill's frontmatter. This subsection captures the design as drafted in 2026-04-18 so a future runner-selection PR can pick it up without re-deriving everything.
+
+**Justification for keeping as Future Direction.** Multi-runner pays off only if (a) a non-Claude model demonstrably moves a quality/cost metric on at least one phase, OR (b) Anthropic capacity becomes a bottleneck. Neither is true today; building the abstraction now would be premature. The scaffolding cost (per-runner hook adapters, skill portability via `.agents/skills/`, per-runner exit-code parsers) is real.
+
+#### Runner Protocol (proposed)
+
+Each per-phase subprocess would be spawned through a `Runner` interface:
+
+```python
+class Runner(Protocol):
+    def run(
+        self,
+        skill: str,           # e.g. "task-v2-plan"
+        worktree: Path,
+        input_json: Path,     # {worktree}/tmp/dispatcher-input/<phase>.json
+        output_json: Path,    # {worktree}/tmp/dispatcher-output/<phase>.json
+        timeout_s: int,
+    ) -> RunResult: ...       # {exit_code, stderr_tail, duration_s}
+```
+
+First implementation would be `ClaudeRunner` — the existing `claude -p '/<skill> <agent_id>'` invocation factored behind the protocol.
+
+#### Candidate secondary runners (verified 2026-04-18)
+
+| Runner | Invocation | Agentic? | Hooks | Skills loaded from | MCP | Notes |
+|---|---|---|---|---|---|---|
+| **Claude Code** | `claude -p '/<skill> <id>'` | yes | `PreToolUse`, `PostToolUse`, `SubagentStop`, etc. — shell-exec, write directly to `dispatcher.failures` via `emit_failure.py` | `.claude/skills/` | yes | First-class. `--max-turns`, no `--timeout`; wrap with OS `timeout(1)`. |
+| **Gemini CLI** (`@google/gemini-cli`, [repo](https://github.com/google-gemini/gemini-cli)) | `gemini -p '<prompt>' --output-format stream-json` | yes | `BeforeTool`/`AfterTool`/`SessionStart`/`SessionEnd` — same `settings.json`-style shell-exec with stdin/stdout JSON, exit code `2` blocks. **Semantics are 1:1 with Claude, but event names differ** — Claude-spelled `PreToolUse` / `PostToolUse` entries in a shared `settings.json` are silently dropped by Gemini with a one-line startup warning, so `settings.json` matchers must be written per-runner (or mechanically converted via `gemini hooks migrate --from-claude`). Verified against Gemini CLI 0.38.2, spike 0.4 (#2686). | `.gemini/skills/` **or** `.agents/skills/` (cross-tool standard) | yes, native | Exit codes 0/1/41/53: `0` success, `1` invocation/flag-parse error, `41` auth missing, `53` turn-limit — *better* granularity than `claude -p`'s `1`-for-everything. Turn-limit mechanism is **`settings.json.model.maxSessionTurns`**, not a CLI flag (`--max-turns` does not exist in Gemini 0.38.2 and produces exit 1 if passed — the `GeminiRunner` writes the limit into the worktree's `.gemini/settings.json` before spawning). Auth: on Fargate use API key (`GEMINI_API_KEY`); OAuth free tier (1000 rpd on Gemini 3 Pro) requires interactive browser flow and is operator-laptop-only. Tool names differ (`read_file`/`write_file`/`run_shell_command`) so hook matchers need a rewrite layer. |
+| **OpenCode** ([sst/opencode](https://github.com/sst/opencode)) | `opencode run "<prompt>"` | yes | `tool.execute.before` / `tool.execute.after` as in-process TS/JS plugins (cleaner — live Postgres connection, typed args, mutate or throw-to-abort). **No `SubagentStop` equivalent** — closest is `session.idle` via a generic `event` firehose ([#5409](https://github.com/sst/opencode/issues/5409) tracks the gap) | `.claude/skills/` is read natively; commands need duplication in `.opencode/commands/` | yes | No `--max-turns` or `--timeout` flags — wrap with OS `timeout(1)`. Exit codes undocumented; verify empirically. |
+| **Cursor CLI** (`cursor-agent`, [docs](https://cursor.com/docs/cli/overview)) | `cursor-agent -p '<prompt>' -m <model>` | yes | `hooks.json` stdio-JSON shell-exec model (introduced Cursor 1.7, Oct 2025). 6 events: `beforeShellExecution`, `beforeReadFile`, `beforeMCPExecution`, `afterFileEdit`, `beforeSubmitPrompt`, `stop`. Exit 2 = deny (same convention as Claude). **Missing:** no `SessionStart`/`SessionEnd`, no generic `beforeFileEdit`, no `SubagentStop`. `beforeReadFile` supports secret-redaction before the LLM sees content — stronger than Claude there | `.cursor/rules/` (nestable `.mdc`); also reads `CLAUDE.md` and AGENTS.md natively; Skills via SKILL.md (Cursor 2.4+) | yes, via `mcp.json` | Known bugs: `-p` mode can hang indefinitely ([forum 150246](https://forum.cursor.com/t/cursor-agent-p-print-headless-mode-hangs-indefinitely-and-never-returns/150246)); sandbox + hook `"ask"` response is ignored ([forum 155438](https://forum.cursor.com/t/beforeshellexecution-returns-permission-ask-but-sandboxed-agent-shell-still-runs-the-command-sandbox-true/155438)). Validate with timeout wrapper before daemon use. |
+
+When implemented, runner selection would live in `dispatcher.config` as a per-phase map (`runner_by_phase`), defaulting to `claude` for every phase. Overriding would be a single config update — no daemon redeploy. The same config could be overridden per agent (e.g. cost experiments on specific issues) via `dispatcher.agents.runner_override jsonb`.
+
+#### Skills portability — `.agents/skills/` cross-tool standard
+
+Gemini CLI and OpenCode both agreed on `agentskills.io` (the SKILL.md frontmatter format Anthropic also uses) and both read `.agents/skills/` as a deliberately cross-tool path. Plan: keep canonical skill files under .claude/skills/task-v2-\*/SKILL.md (Claude reads these directly) and symlink `.agents/skills/task-v2-\*/` → the same directories so Gemini and OpenCode pick them up without duplication. OpenCode additionally reads `.claude/skills/` directly. Non-standard frontmatter fields (`allowed-tools`, `model`) silently drop on non-Claude runners — audit and move those into runner-specific adapters or inline instructions. Slash-command entry points are per-runner: `/task-v2-*` works in Claude; `.opencode/commands/*.md` must be duplicated for OpenCode; Gemini uses its own slash-command config.
+
+#### Hooks parity
+
+Our `PreToolUse` / `SubagentStop` / `PostToolUse` hooks (§9) write directly to `dispatcher.failures`. Parity picture by runner:
+- **Claude Code and Gemini CLI — near-full parity, with naming caveat.** Both support shell-exec hooks with matcher regex, stdin/stdout JSON contracts, and exit-code-based blocking. `SessionStart`/`SessionEnd` map to our `SubagentStop` use case. `emit_failure.py` itself works unchanged (the stdin JSON payload has identical field shape — `session_id`, `transcript_path`, `cwd`, `hook_event_name`, `tool_name`, `tool_input`, verified in spike 0.4 #2686). **The event names differ, however:** Claude uses `PreToolUse` / `PostToolUse`; Gemini uses `BeforeTool` / `AfterTool`. A shared `settings.json` with both keys is safe — each runner silently drops the other's key with a one-line startup warning — but hook registration blocks must be written per-runner (or auto-converted via `gemini hooks migrate --from-claude`). Tool names also differ (`Read`/`Write`/`Bash` on Claude vs. `read_file`/`write_file`/`run_shell_command` on Gemini), so matcher regexes need a per-runner namespace.
+- **Cursor CLI — partial.** `beforeShellExecution` / `beforeReadFile` / `afterFileEdit` / `beforeMCPExecution` / `beforeSubmitPrompt` / `stop` cover the preflight and post-edit surface. Exit code 2 = deny (same convention as Claude), so `emit_failure.py` works with minimal adaptation. No `SessionStart`/`SessionEnd` or dedicated `SubagentStop` — fall back to daemon post-exit reconciliation for no-commit/no-push detection. `beforeReadFile`'s content-redaction capability is a bonus we don't get elsewhere (useful if we ever feed secrets through agents).
+- **OpenCode — partial.** `tool.execute.before`/`.after` cover the preflight/observability hooks (arguably *better* — typed args, mutate or throw-to-abort, live in-process Postgres connection). No `SubagentStop` equivalent; fall back to daemon post-exit reconciliation (PR-vs-GH check from Risk 1, git-state check on the worktree, `gh pr view` for branch state) to cover no-commit-on-exit / no-push-on-exit. Hooks are Bun/TS plugins, not shell commands — small shim required or the plugin shells out to `scripts/dispatcher/emit_failure.py`.
+- **Any runner without hooks** — everything routes through post-exit reconciliation at coarser granularity and higher latency. All paths converge on the same `dispatcher.failures` categories.
+
+#### Model support
+
+Orthogonal to the runner choice: each runner exposes a different set of model providers.
+
+| Runner | Anthropic | Google | OpenAI | xAI | Open-weight | Local |
+|---|---|---|---|---|---|---|
+| **Claude Code** | yes — API, Bedrock, Vertex, Foundry (toggled via `CLAUDE_CODE_USE_*` env vars) | no (officially) | no (officially) — works via LiteLLM/Bifrost gateway, unsupported | no | no | no officially |
+| **Gemini CLI** | no | yes — AI Studio OAuth free tier + API key + Vertex | no | no | no | no |
+| **OpenCode** | yes — Anthropic API, Bedrock, Vertex | yes — AI Studio + Vertex | yes — direct + Azure | yes — Grok | yes — Groq, Together, Cerebras, DeepSeek, OpenRouter, HF | yes — Ollama, LM Studio, llama.cpp |
+| **Cursor CLI** | yes (curated) | yes (curated) | yes (curated) | partial (curated) | partial (curated) | no |
+
+Model selection at the CLI: Claude uses `--model <alias\|id>` (aliases `opus`/`sonnet`/`haiku` or full IDs like `claude-opus-4-7`) and `--max-turns <N>` for turn-limiting; Gemini uses `-m <model-id>` (aliases `auto`/`pro`/`flash`/`flash-lite`) and has **no `--max-turns` flag** — turn-limiting is `settings.json.model.maxSessionTurns`, written by the `GeminiRunner` into the worktree's `.gemini/settings.json` before spawning (verified against Gemini CLI 0.38.2 in spike 0.4 #2686); OpenCode uses `-m <provider>/<model>` (e.g. `anthropic/claude-opus-4-7`, `google/gemini-3-pro`, `openai/gpt-5`); Cursor uses `--model <id>` against its curated roster (enumerate via `cursor-agent models`). When implemented, model selection would be stored in `dispatcher.config.model_by_phase` (parallel to `runner_by_phase`) and overridable per agent via `dispatcher.agents.model_override`.
+
+**Consequence for multi-model experiments.** If we want to mix, say, Opus 4.7 for planning + Gemini 3 Pro for summary + GPT-5 for CI-fix, the simplest path would be **OpenCode as the single runner** — one binary, one config, three API keys. The alternative is one runner per phase (`ClaudeRunner` for Anthropic phases, `GeminiRunner` for Google phases, `OpenCodeRunner` only for OpenAI phases), which costs three binaries and three auth models but keeps each runner's native feature set (e.g. Claude's `opusplan` auto plan-on-Opus / execute-on-Sonnet has no equivalent in OpenCode). Defer this decision until shadow-mode data tells us whether the model swap actually moves quality/cost metrics.
+
+### F2. `runner_shadow` cost/quality shadow mode
+
+**Status: future experiment.** A second runner could execute the same phase in parallel with its output discarded and diff-logged to `dispatcher.phase_outputs` (distinguished by `phase='<phase>@shadow:<runner>'`). Useful for measuring "would Gemini have produced a similar plan?" without cutting over. Out of scope for Phases 1–4; the seed config row `('runner_shadow', '{}')` (§19) is reserved so the schema doesn't preclude it. The Gemini free OAuth tier (1000 rpd on Gemini 3 Pro) is generous enough to run meaningful shadow traffic without a budget line.
 
 ---
 

--- a/scripts/check-spec-action-vocabulary.sh
+++ b/scripts/check-spec-action-vocabulary.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# check-spec-action-vocabulary.sh — Detect drift between the diagnoser action vocabulary
+# documented in `.claude/skills/diagnose-failure/SKILL.md` and the daemon's authoritative
+# `DIAGNOSER_ACTIONS` frozenset in `scripts/dispatcher/daemon.py`.
+#
+# Why: Issue #3565 found that the spec/SKILL.md drifted away from the code while
+# the daemon kept evolving (added the 9th action `terminal` in #3455). The audit's
+# operator-explicit follow-up was a CI-time check that catches future drift before it
+# anchors a wrong operational decision.
+#
+# This script is the regression test for the diagnoser-vocabulary drift class. Other
+# drift classes (phase names, failure categories, config knobs) are tracked as
+# follow-up p3 issues — see #3565 for the full audit.
+#
+# Usage:
+#   scripts/check-spec-action-vocabulary.sh
+#
+# Exit codes:
+#   0 — vocabulary matches
+#   1 — drift detected (lists missing-from-spec / missing-from-code)
+#   2 — internal error (couldn't parse one of the source files)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DAEMON_PY="$REPO_ROOT/scripts/dispatcher/daemon.py"
+SKILL_MD="$REPO_ROOT/.claude/skills/diagnose-failure/SKILL.md"
+
+if [[ ! -f "$DAEMON_PY" ]]; then
+    echo "ERROR: $DAEMON_PY not found" >&2
+    exit 2
+fi
+if [[ ! -f "$SKILL_MD" ]]; then
+    echo "ERROR: $SKILL_MD not found" >&2
+    exit 2
+fi
+
+# Delegate the parse + diff to a Python helper for robustness — bash regex
+# alone is brittle against multi-line frozenset literals and prose paragraphs.
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+"$PYTHON_BIN" - "$DAEMON_PY" "$SKILL_MD" <<'PYEOF'
+import re
+import sys
+from pathlib import Path
+
+daemon_py = Path(sys.argv[1])
+skill_md = Path(sys.argv[2])
+
+# ── 1. Parse DIAGNOSER_ACTIONS from daemon.py ──────────────────────────
+# The frozenset literal spans multiple lines, e.g.:
+#
+#     DIAGNOSER_ACTIONS: frozenset[str] = frozenset(
+#         {
+#             "retry",
+#             ...
+#             "terminal",
+#         }
+#     )
+#
+# Capture everything between the opening `frozenset(` and the matching `)`.
+daemon_text = daemon_py.read_text()
+m = re.search(
+    r"DIAGNOSER_ACTIONS\s*:\s*frozenset\[str\]\s*=\s*frozenset\(\s*\{(.*?)\}\s*\)",
+    daemon_text,
+    re.DOTALL,
+)
+if not m:
+    print("ERROR: could not locate DIAGNOSER_ACTIONS frozenset in daemon.py", file=sys.stderr)
+    print("Expected: DIAGNOSER_ACTIONS: frozenset[str] = frozenset({...})", file=sys.stderr)
+    sys.exit(2)
+
+# Extract quoted strings from the captured body.
+daemon_actions = set(re.findall(r'"([a-z_]+)"', m.group(1)))
+if not daemon_actions:
+    print("ERROR: DIAGNOSER_ACTIONS frozenset parsed empty in daemon.py", file=sys.stderr)
+    sys.exit(2)
+
+# ── 2. Parse the action vocabulary from diagnose-failure/SKILL.md ──────
+# The SKILL.md has a canonical "Recommendation contract — 9 known actions" line that
+# lists all eight legacy actions inline as `action`-quoted code, plus a separate
+# table row (or prose mention) for `terminal`. We grep all backticked tokens that
+# look like action keys near the "9 known actions" sentence and the action-table
+# / decision-tree sections.
+skill_text = skill_md.read_text()
+
+# Anchor: find the "Recommendation contract — N known actions" line; collect every
+# backticked snake_case token from that line onward through the "Inline-action
+# pattern" / "Action selection" / decision-tree sections. Stop at the audit-trail
+# header to avoid pulling in `git_commit` / `gh_issue_close` etc. that name SIDE
+# EFFECTS rather than recommendation actions.
+anchor = re.search(r"Recommendation contract.*?known actions", skill_text)
+if not anchor:
+    print("ERROR: SKILL.md missing the 'Recommendation contract — N known actions' anchor", file=sys.stderr)
+    sys.exit(2)
+
+start = anchor.start()
+# Stop region — first occurrence of "## Audit trail" or end of file
+stop_match = re.search(r"^##\s+Audit trail", skill_text[start:], re.MULTILINE)
+end = start + (stop_match.start() if stop_match else len(skill_text) - start)
+region = skill_text[start:end]
+
+# Tokens we treat as "documented actions": backticked snake_case identifiers
+# that match any token in the daemon set, plus any new tokens that look like
+# action keys (lowercase, underscore-only, no dots/dashes/digits).
+candidate_actions = set(re.findall(r"`([a-z][a-z_]*[a-z])`", region))
+
+# Allow-list of non-action tokens that legitimately appear in the same region:
+# they are field names, sub-skill names, directive shapes, or audit-event names.
+NON_ACTION_TOKENS = {
+    "action", "action_taken", "actions_taken", "recommendation", "reasoning",
+    "hint", "new_scope", "summary", "evidence", "next_directive", "respawn_at",
+    "status", "agent_id", "diagnosis_id", "context", "phase", "verdict",
+    "task-v2-fix-conflict", "task-v2-fix-ci", "task-v2-ralph", "task-v2-plan",
+    "task-v2-summary", "task-v2-verify", "task-v2-retro", "task-v2-operational",
+    "ralph", "tdd", "audit", "spotcheck", "gh", "git", "claude", "opus",
+    "sonnet", "haiku", "scripts", "diagnose-failure", "task-v2", "task",
+    "diagnoser_terminal", "agent_runner_route_stub", "operational_failed",
+    "merge_conflict_at_push", "conflict_unresolvable", "verify_failed_post_merge",
+    "ralph_ac_infeasible", "summary_ac_infeasible", "ci_red_after_retries",
+    "merge_unstick_exhausted", "stuck_timeout", "no_commit_on_exit",
+    "no_push_on_exit", "ralph_max_iterations", "subprocess_turn_limit",
+    "subprocess_auth_fail", "subprocess_crash", "subprocess_oom_or_kill",
+    "rate_limit_529", "cwd_drift", "gh_rate_exhausted", "subprocess",
+    "ecs", "claiming", "planning", "setup", "summary", "push_and_pr",
+    "awaiting_ci", "fix_ci", "merge", "awaiting_deploy", "verify", "retro",
+    "operational", "operational_done", "diagnose", "done",
+    "needs_review", "succeeded", "failed", "pending", "completed", "running",
+    "blocked", "infeasible_acs", "deferred_acs", "actions_taken",
+    "git_commit", "git_push", "gh_issue_create", "gh_issue_edit",
+    "gh_issue_comment", "gh_issue_close", "skill_invoke", "bash_run",
+    "diagnoser_did_not_complete", "diagnoser_completed_terminal",
+    "diagnoser_timeout", "diagnoser_enabled", "diagnoser_fleet_decisions_cap",
+    "true", "false", "null",
+    # Tools / commands / branches that show up in the same prose region but
+    # are emphatically not action-vocabulary tokens.
+    "aws", "github", "psql", "main", "master", "run_in_background",
+    "max-turns", "timeout", "max_turns",
+}
+documented_actions = {tok for tok in candidate_actions if tok not in NON_ACTION_TOKENS}
+
+# ── 3. Compare the two sets ────────────────────────────────────────────
+missing_from_skill = daemon_actions - documented_actions
+missing_from_daemon = documented_actions - daemon_actions
+
+if not missing_from_skill and not missing_from_daemon:
+    print(
+        f"OK: diagnoser action vocabulary is in sync. "
+        f"{len(daemon_actions)} actions: "
+        f"{', '.join(sorted(daemon_actions))}"
+    )
+    sys.exit(0)
+
+print("DRIFT: diagnoser action vocabulary is out of sync between daemon.py and SKILL.md.", file=sys.stderr)
+print(file=sys.stderr)
+print(f"  daemon DIAGNOSER_ACTIONS ({daemon_py}):", file=sys.stderr)
+print(f"    {sorted(daemon_actions)}", file=sys.stderr)
+print(f"  SKILL.md documented actions ({skill_md}):", file=sys.stderr)
+print(f"    {sorted(documented_actions)}", file=sys.stderr)
+print(file=sys.stderr)
+
+if missing_from_skill:
+    print(
+        f"  Actions in daemon.py but NOT documented in SKILL.md: "
+        f"{sorted(missing_from_skill)}",
+        file=sys.stderr,
+    )
+    print(
+        "  -> Either add these to the 'Recommendation contract — N known actions' line "
+        "and the action-selection table, OR remove them from DIAGNOSER_ACTIONS if no "
+        "longer used.",
+        file=sys.stderr,
+    )
+
+if missing_from_daemon:
+    print(
+        f"  Actions documented in SKILL.md but NOT in daemon.py DIAGNOSER_ACTIONS: "
+        f"{sorted(missing_from_daemon)}",
+        file=sys.stderr,
+    )
+    print(
+        "  -> Either add to DIAGNOSER_ACTIONS in scripts/dispatcher/daemon.py, OR remove "
+        "from SKILL.md if no longer supported. (If the token is a non-action that the "
+        "allow-list missed, add it to NON_ACTION_TOKENS in this script.)",
+        file=sys.stderr,
+    )
+
+print(file=sys.stderr)
+print(
+    "See docs/specs/dispatcher-v2-spec.md §8 'Diagnosis Step' for the contract, and "
+    "issue #3565 for the audit that motivated this check.",
+    file=sys.stderr,
+)
+sys.exit(1)
+PYEOF

--- a/scripts/tests/test_check_spec_action_vocabulary.sh
+++ b/scripts/tests/test_check_spec_action_vocabulary.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# test_check_spec_action_vocabulary.sh — Tests for check-spec-action-vocabulary.sh
+#
+# Verifies that the diagnoser-vocabulary drift check (a) passes against the
+# current repo state (regression: it was authored to be in-sync), and (b)
+# fails when the daemon and SKILL.md disagree on the action vocabulary.
+#
+# Usage:
+#   scripts/tests/test_check_spec_action_vocabulary.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$REPO_ROOT/check-spec-action-vocabulary.sh"
+FAILURES=0
+TESTS=0
+
+if [[ ! -x "$CHECK_SCRIPT" ]]; then
+    echo "FAIL: $CHECK_SCRIPT not found or not executable"
+    exit 1
+fi
+
+# ─── Test 1: current repo state passes ──────────────────────────────────
+TESTS=$((TESTS + 1))
+if "$CHECK_SCRIPT" > /dev/null 2>&1; then
+    echo "PASS: current repo state has no drift"
+else
+    echo "FAIL: current repo state should pass but the checker reported drift"
+    FAILURES=$((FAILURES + 1))
+fi
+
+# ─── Test 2: injected drift fails ───────────────────────────────────────
+# Stage a copy of the repo fragment with one extra action in the daemon's
+# DIAGNOSER_ACTIONS frozenset and run the check against the staged copy.
+TESTS=$((TESTS + 1))
+
+STAGE=$(mktemp -d)
+cleanup() { rm -rf "$STAGE"; }
+trap cleanup EXIT
+
+mkdir -p "$STAGE/scripts/dispatcher"
+mkdir -p "$STAGE/.claude/skills/diagnose-failure"
+
+# Synthesize a minimal daemon.py with an extra action that the SKILL won't have.
+cat > "$STAGE/scripts/dispatcher/daemon.py" <<'PY'
+DIAGNOSER_ACTIONS: frozenset[str] = frozenset(
+    {
+        "retry",
+        "retry_with_hint",
+        "reissue",
+        "escalate",
+        "close",
+        "block_and_comment",
+        "file_prerequisite_task",
+        "block_on_existing_task",
+        "terminal",
+        "future_action_not_in_skill",
+    }
+)
+PY
+
+# Copy the real SKILL.md unchanged. Drift = action in daemon, missing from SKILL.
+cp "$REPO_ROOT/../.claude/skills/diagnose-failure/SKILL.md" \
+   "$STAGE/.claude/skills/diagnose-failure/SKILL.md"
+
+# Run the check against the staged repo by copying the script and pointing it
+# at the stage via REPO_ROOT.
+cp "$CHECK_SCRIPT" "$STAGE/check-spec-action-vocabulary.sh"
+chmod +x "$STAGE/check-spec-action-vocabulary.sh"
+
+# Patch the script to use the staged paths (cheaper than re-architecting the
+# script to take args; this is a test).
+python3 - "$STAGE/check-spec-action-vocabulary.sh" "$STAGE" <<'PY'
+import sys, pathlib
+script_path = pathlib.Path(sys.argv[1])
+stage = pathlib.Path(sys.argv[2])
+text = script_path.read_text()
+text = text.replace(
+    'REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"',
+    f'REPO_ROOT="{stage}"',
+    1,
+)
+script_path.write_text(text)
+PY
+
+if "$STAGE/check-spec-action-vocabulary.sh" > "$STAGE/out.log" 2>&1; then
+    echo "FAIL: injected daemon-side drift should have been detected"
+    cat "$STAGE/out.log"
+    FAILURES=$((FAILURES + 1))
+else
+    if grep -q 'future_action_not_in_skill' "$STAGE/out.log"; then
+        echo "PASS: injected drift (extra action in daemon) is detected"
+    else
+        echo "FAIL: drift detected but the message did not name 'future_action_not_in_skill'"
+        cat "$STAGE/out.log"
+        FAILURES=$((FAILURES + 1))
+    fi
+fi
+
+# ─── Test 3: SKILL.md mentions an action the daemon doesn't have ────────
+TESTS=$((TESTS + 1))
+
+STAGE2=$(mktemp -d)
+cleanup2() { rm -rf "$STAGE2"; }
+trap 'cleanup; cleanup2' EXIT
+
+mkdir -p "$STAGE2/scripts/dispatcher"
+mkdir -p "$STAGE2/.claude/skills/diagnose-failure"
+
+cp "$REPO_ROOT/dispatcher/daemon.py" "$STAGE2/scripts/dispatcher/daemon.py"
+
+# Synthesize a SKILL.md whose canonical action line invents an extra action.
+cat > "$STAGE2/.claude/skills/diagnose-failure/SKILL.md" <<'MD'
+# diagnose-failure
+
+**Recommendation contract — 10 known actions; prefer `terminal`.** Issue #3032's
+recommendation field stays for audit. The daemon's deterministic consumer reads
+it and runs the matching action: `retry`, `retry_with_hint`, `reissue`,
+`escalate`, `close`, `block_and_comment`, `file_prerequisite_task`,
+`block_on_existing_task`, `terminal`, `phantom_action_not_in_daemon`.
+
+## Audit trail
+later sections.
+MD
+
+cp "$CHECK_SCRIPT" "$STAGE2/check-spec-action-vocabulary.sh"
+chmod +x "$STAGE2/check-spec-action-vocabulary.sh"
+
+python3 - "$STAGE2/check-spec-action-vocabulary.sh" "$STAGE2" <<'PY'
+import sys, pathlib
+script_path = pathlib.Path(sys.argv[1])
+stage = pathlib.Path(sys.argv[2])
+text = script_path.read_text()
+text = text.replace(
+    'REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"',
+    f'REPO_ROOT="{stage}"',
+    1,
+)
+script_path.write_text(text)
+PY
+
+if "$STAGE2/check-spec-action-vocabulary.sh" > "$STAGE2/out.log" 2>&1; then
+    echo "FAIL: injected SKILL-side drift should have been detected"
+    cat "$STAGE2/out.log"
+    FAILURES=$((FAILURES + 1))
+else
+    if grep -q 'phantom_action_not_in_daemon' "$STAGE2/out.log"; then
+        echo "PASS: injected drift (extra action in SKILL.md) is detected"
+    else
+        echo "FAIL: drift detected but the message did not name 'phantom_action_not_in_daemon'"
+        cat "$STAGE2/out.log"
+        FAILURES=$((FAILURES + 1))
+    fi
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Realign `docs/specs/dispatcher-v2-spec.md` and several SKILL.md files with what the dispatcher v2 daemon (Fargate; `scripts/dispatcher/daemon.py`) actually does today. Move aspirational multi-runner content to a new "Future Direction (aspirational, not yet shipped)" section. Adds a CI guard that catches future drift on the diagnoser action vocabulary.

Closes #3565.

## Drift inventory and fixes (per the definitive audit comment on #3565)

### Critical — would otherwise anchor wrong operational decisions

- **`docs/specs/dispatcher-v2-spec.md` §6 phase map** — added the missing `operational` branch (4 rows: `planning:operational → operational → operational_done / operational_failed → diagnose`). Cite: `daemon.py:1028, 1321`, `phase_transitions.py:606-674`, `agent-runner-entrypoint.sh:1884, 5077-5126`, #3507.
- **§6a per-phase skills table** — added `/task-v2-fix-conflict` and `/task-v2-operational` rows (both ship in production with full SKILL.md files; the entrypoint invokes them via `phase_to_skill`).
- **§8 failure taxonomy** — added 5 missing categories that route via `BYPASSED_TERMINAL_PHASES_TO_ROUTE` (`daemon.py:1275-1339`, `1372-1385`):
  - `merge_conflict_at_push` (#2964)
  - `conflict_unresolvable` (#3225)
  - `verify_failed_post_merge` (#3071)
  - `agent_runner_route_stub` (#3366)
  - `operational_failed` (#3507)

### Behavior-mismatch

- **§6 phase names** — renamed spec-only legacy `ci_watch` / `deploy_watch` / `ci_fix` to the daemon's actual names `awaiting_ci` / `awaiting_deploy` / `fix_ci` (sources: `daemon.py:1821-1834` `AGENT_RUNNER_VALID_START_PHASES`, `agent-runner-entrypoint.sh:1876-1887` `phase_to_skill`, `phase_transitions.py:1339-1357` `ACTIVE_PHASES`). Also added a clarifying note that `scripts/dispatcher/phases.py` keeps `ci_watch`/`deploy_watch` as **admin-UI display labels** intentionally — that file is orthogonal to the daemon's actual phase strings.
- **`.claude/skills/ralph/SKILL.md:22`** — same drift, fixed inline.
- **§19 seed `runner_by_phase` and `model_by_phase`** — added `operational` entry (`"operational":"claude"`, `"operational":"opus"` matching the SKILL.md frontmatter `model: opus`). Also added `fix_conflict` for parity.
- **`audit/SKILL.md:11` + Steps 0/0a, `spotcheck/SKILL.md` Step 0a** — added daemon-mode caveats (status-file machinery is laptop-only; daemon owns state in `dispatcher.phase_transitions`, agents run in fresh ECS containers).

### Verified-real (audit's "unable to determine" items confirmed)

The audit flagged 3 items it couldn't conclusively trace. Read the daemon code; all three exist exactly as the SKILL.md text describes. No doc change needed:

- `DIAGNOSER_SUBPROCESS_TIMEOUT_SECONDS = 90 * 60` — real at `daemon.py:1729`.
- `dispatcher.config.diagnoser_fleet_decisions_cap` — real at `daemon.py:19328`.
- `FIX_CI_MAX_RETRIES = 3` — real at `daemon.py:685`.

### Stale references

- **`dispatcher-audit/SKILL.md:149`** — dropped the `~2082` entrypoint line number, kept the function-name reference (`handle_scheduled_skill`). Entrypoint is 5236 lines and growing; line cites drift, function names don't.
- **2-line preamble for `dispatcher/`, `task/`, `tdd/`, `dispatcher-startup/` SKILL.md** — these are laptop-only legacy. Added a clear scope note at the top of each so daemon-context readers know the file doesn't apply.

### Aspirational content moved to "Future Direction"

- **§6b multi-runner architecture** — moved Cursor CLI / Gemini CLI / OpenCode runner content, hooks-parity matrix, model-provider matrix, runner-selection-via-config-knobs design to the new **§F1**. Today's §6b is a brief paragraph that says: claude-only, no per-phase model override (model is implicit per skill frontmatter). Notes that the seed `runner_by_phase` / `model_by_phase` rows in §19 are nominal-only — no code in `daemon.py` reads them today.
- **`runner_shadow` cost/quality shadow mode** → new **§F2**. Already framed as a future experiment; relocated for coherence.

## Regression test (per #3565 AC #3, #3566 follow-up)

Added a CI guard that catches future drift on the diagnoser action vocabulary — the specific drift class that anchored the audit:

- **`scripts/check-spec-action-vocabulary.sh`** — parses `daemon.py:DIAGNOSER_ACTIONS` frozenset (lines 1796-1808) AND `.claude/skills/diagnose-failure/SKILL.md`'s "Recommendation contract — N known actions" prose region. Asserts both name the same set of actions; fails with exit 1 listing which actions are missing where.
- **`scripts/tests/test_check_spec_action_vocabulary.sh`** — 3 self-tests: (a) current repo state passes, (b) injected daemon-side drift fails with the synthetic action name in the error, (c) injected SKILL-side drift fails with the synthetic action name in the error.
- **`.github/workflows/ci.yml`** — new `spec-action-vocabulary-check` job runs both on every PR.

Other drift classes (phase-name drift checks, broader failure-category drift checks) are scoped to follow-up p3 issues per the audit's explicit punch-list.

## Test plan

- [x] `scripts/check-spec-action-vocabulary.sh` returns 0 on this PR's tip
- [x] `scripts/tests/test_check_spec_action_vocabulary.sh` — 3/3 pass
- [x] `scripts/check-markdown-links.sh` — clean (97 files checked, 0 broken)
- [x] `scripts/check-ci-job-skipped.sh` — clean (CI workflow edits don't introduce a skipped job)
- [x] `shellcheck` clean on the new shell scripts (only SC2329 info on trap-invoked cleanup functions, which is a known false positive)
- [ ] CI green (will be confirmed in `gh run watch` post-push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
