### PR TITLE
fix(scraping): allow 2-char Asian surnames in judge validation (#3036)

### DIFF
--- a/packages/scraper-framework/src/ingestion/db.py
+++ b/packages/scraper-framework/src/ingestion/db.py
@@ -644,6 +644,17 @@ _VALID_SHORT_FINAL_WORDS = {
     "ii",
     "iii",
     "iv",
+    # Common 2-character Asian surnames that are legitimate but would otherwise
+    # be rejected by the _MIN_SURNAME_LENGTH or vowel-check rules.
+    "vu",  # Vietnamese
+    "lo",  # Chinese/Vietnamese
+    "li",  # Chinese
+    "wu",  # Chinese
+    "xu",  # Chinese
+    "hu",  # Chinese
+    "lu",  # Chinese
+    "fu",  # Chinese
+    "ng",  # Cantonese (consonant-only, also blocked by vowel rule)
 }
 
 # Minimum length for the last word to be considered a plausible surname

--- a/packages/scraper-framework/tests/test_ingestion_db.py
+++ b/packages/scraper-framework/tests/test_ingestion_db.py
@@ -1344,6 +1344,22 @@ class TestLooksLikeValidJudgeNameTruncation:
         """'John K' — single character, not a suffix — rejected."""
         assert _looks_like_valid_judge_name("John K") is False
 
+    def test_accepts_asian_surname_vu(self) -> None:
+        """'Nathan Nhan Vu' — AC2: 2-char surname 'Vu' is a valid Vietnamese name."""
+        assert _looks_like_valid_judge_name("Nathan Nhan Vu") is True
+
+    def test_accepts_asian_surname_lo(self) -> None:
+        """'Thomas J. Lo' — AC3: 2-char surname 'Lo' is a valid Asian name."""
+        assert _looks_like_valid_judge_name("Thomas J. Lo") is True
+
+    def test_accepts_asian_surname_wu(self) -> None:
+        """'Jane Wu' — 2-char surname 'Wu' is a valid Chinese name."""
+        assert _looks_like_valid_judge_name("Jane Wu") is True
+
+    def test_accepts_asian_surname_ng(self) -> None:
+        """'David Ng' — 2-char consonant-only surname 'Ng' is a valid Cantonese name."""
+        assert _looks_like_valid_judge_name("David Ng") is True
+
 
 # ---------------------------------------------------------------------------
 # _strip_middle_initials


### PR DESCRIPTION
## Summary

Extended `_VALID_SHORT_FINAL_WORDS` in judge-name validation to accept nine 2-character Asian surnames (vu, lo, li, wu, xu, hu, lu, fu, ng). This unblocks 148 Orange County rulings for judges Nathan Nhan Vu (dept N15) and Thomas J. Lo (dept C44) that were rejected due to the overly restrictive surname-length check. Added four regression tests to prevent future regressions.

Closes #3036

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
- [x] CI green (pre-push hook passed locally; all three reviewers approved)

### Post-deploy verification

- [ ] Execute backfill for Orange County depts N15 and C44 via separate operational issue
- [ ] Verify: `SELECT COUNT(*) FROM derived.rulings r JOIN derived.courts c ON c.id = r.court_id WHERE c.county = 'Orange' AND r.department IN ('N15', 'C44') AND r.judge_id IS NULL;` returns 0
- [ ] Verification evidence posted on #3036 (see /task-v2-verify output)