### PR TITLE
fix(dispatcher): advance to awaiting_ci on fix_ci empty-diff (#3580)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -2967,9 +2967,12 @@ handle_fix_conflict() {
 #
 # Log event names (``fix_ci_patch_pushed``, ``fix_ci_missing_commit_
 # message``, ``fix_ci_git_commit_failed``, ``fix_ci_git_push_failed``,
-# ``fix_ci_patch_empty``, ``fix_ci_flaky``, ``fix_ci_blocked``,
-# ``fix_ci_unrecognized_verdict``) mirror the daemon's names so
-# CloudWatch log-insights queries work across both paths.
+# ``fix_ci_patch_empty_already_applied`` (#3580 — was ``fix_ci_patch_empty``
+# pre-#3580; renamed to split it out from real failure classes since this
+# is now an advance-to-awaiting_ci event, not a terminal),
+# ``fix_ci_flaky``, ``fix_ci_blocked``, ``fix_ci_unrecognized_verdict``)
+# mirror the daemon's names so CloudWatch log-insights queries work across
+# both paths.
 #
 # Prints the phase-output JSON on stdout (the same JSON that
 # ``run_claude_phase`` emitted, possibly re-wrapped) for
@@ -3050,26 +3053,42 @@ handle_fix_ci() {
             return 0
         fi
 
-        # Empty-diff check (#3245): if the skill said PATCHED but
-        # wrote no changes to the working tree, ``git diff --cached
-        # --quiet`` exits 0 (nothing staged). Treat as BLOCKED — the
-        # skill's self-report was wrong and a plain ``git commit``
-        # would also fail non-zero downstream, but this explicit
-        # check gives a dedicated log event for CloudWatch.
+        # Empty-diff check (#3245, refined #3580): ``git diff --cached
+        # --quiet`` exits 0 when nothing is staged. After a PATCHED
+        # verdict that's the "fix is already in the baseline" case —
+        # not a failure. It happens routinely when:
+        #   1. The pre-fix_ci rebase pulled in a sibling PR that landed
+        #      the same fix on main first.
+        #   2. The skill's edit was idempotent (re-writing the existing
+        #      content); git diff is empty even though the skill thinks
+        #      it edited a file.
+        #   3. A prior fix_ci attempt on the same branch already
+        #      committed the fix and this is a retry.
+        # In all three cases the correct action is to advance to
+        # awaiting_ci so the next supervisor tick observes the now-green
+        # CI rollup. The skill's PATCHED self-report was correct in
+        # concluding "the fix is in"; there's just nothing for THIS
+        # invocation to commit.
+        #
+        # Pre-#3580 we treated this as terminal fix_ci_failed/patch_empty,
+        # which left the issue stuck in a daemon-cooldown loop forever
+        # (re-claim → rebase pulls in the same fix → empty diff → fail
+        # → cooldown → repeat).
+        #
+        # Log event renamed fix_ci_patch_empty → fix_ci_patch_empty_already_applied
+        # so dashboards / alerts split on the new name and don't treat
+        # this as a failure class.
         set +e
         git -C "$REPO_ROOT" diff --cached --quiet \
             > /dev/null 2>&1
         _diff_rc=$?
         set -e
         if [[ "$_diff_rc" -eq 0 ]]; then
-            # Exit 0 from ``diff --quiet`` = no staged changes.
-            log "fix_ci_patch_empty" \
+            log "fix_ci_patch_empty_already_applied" \
                 "verdict=$_verdict" \
                 "commit_message=$_commit_msg"
-            agent_runner_reaped_failure \
-                "fix_ci_failed" \
-                "patch_empty" \
-                "fix_ci PATCHED but no changes staged after git add -A"
+            advance_phase "awaiting_ci"
+            printf '%s' "$_output"
             return 0
         fi
 

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -4103,8 +4103,9 @@ fi
 #         advance to terminal ``fix_ci_failed``.
 #   T46 — PATCHED with empty commit_message → treated as BLOCKED,
 #         ``fix_ci_missing_commit_message`` event, terminal.
-#   T47 — PATCHED with stub that stages nothing (empty diff) → treated
-#         as BLOCKED, ``fix_ci_patch_empty`` event, terminal.
+#   T47 — PATCHED with stub that stages nothing (empty diff) → advance
+#         to awaiting_ci, ``fix_ci_patch_empty_already_applied`` event
+#         (#3580 — pre-#3580 this was terminal fix_ci_failed/patch_empty).
 #   T48 — PATCHED but ``git push`` fails → ``fix_ci_git_push_failed``
 #         event, terminal.
 #   T49 — FLAKY verdict → advance to awaiting_ci, no commit attempted.
@@ -4429,48 +4430,101 @@ else
 fi
 
 # ══════════════════════════════════════════════════════════════════════════
-# Test T47: PATCHED but ``git diff --cached --quiet`` returns 0
-# (no staged changes) → treated as BLOCKED via fix_ci_patch_empty event.
+# Test T47: #3580 — PATCHED but ``git diff --cached --quiet`` returns 0
+# (no staged changes) → advance to awaiting_ci, NOT terminal-fail.
+#
+# Empty-staged-diff after a PATCHED verdict is normal when the fix is
+# already in the rebased baseline (e.g. a sibling PR landed it first, or
+# this is an idempotent retry). The skill's PATCHED verdict was correct
+# in concluding "the fix is in"; the agent-runner's job is to advance to
+# awaiting_ci so the next supervisor tick observes the now-green CI
+# rollup. The previous behavior (terminal fix_ci_failed/patch_empty)
+# left the issue stuck in a cooldown loop forever — the daemon would
+# re-claim, the rebase would still pull in the fix, and the diff would
+# still be empty.
+#
+# Log event renamed: fix_ci_patch_empty → fix_ci_patch_empty_already_applied
+# so CloudWatch dashboards can distinguish "fix already in baseline,
+# advancing" from a real failure class.
+#
+# This test asserts the POST-fix behavior. It MUST fail against the
+# pre-#3580 entrypoint where the empty-diff branch reaped the agent as
+# fix_ci_failed.
 # ══════════════════════════════════════════════════════════════════════════
 
 t47_json='{"verdict": "PATCHED", "commit_message": "fix(area): thing — CI (#9999)", "changed_files": []}'
 run_fix_ci_test "t47" "$t47_json" GIT_DIFF_CACHED_EXIT=0
 
 if [[ "$FIXCI_TEST_RC" -eq 0 ]]; then
-    pass "#3245 T47 — handle_fix_ci exits 0 on PATCHED+empty-diff"
+    pass "#3580 T47 — handle_fix_ci exits 0 on PATCHED+empty-diff"
 else
-    fail "#3245 T47 — handle_fix_ci exits 0 on PATCHED+empty-diff" \
+    fail "#3580 T47 — handle_fix_ci exits 0 on PATCHED+empty-diff" \
          "rc=$FIXCI_TEST_RC, output: $FIXCI_TEST_OUT"
 fi
 
-# Diagnostic log event emitted.
-if printf '%s' "$FIXCI_TEST_OUT" | grep -q "fix_ci_patch_empty"; then
-    pass "#3245 T47 — fix_ci_patch_empty log event emitted"
+# New log event for the "already applied" sub-case.
+if printf '%s' "$FIXCI_TEST_OUT" | grep -q "fix_ci_patch_empty_already_applied"; then
+    pass "#3580 T47 — fix_ci_patch_empty_already_applied log event emitted"
 else
-    fail "#3245 T47 — fix_ci_patch_empty log event emitted" \
+    fail "#3580 T47 — fix_ci_patch_empty_already_applied log event emitted" \
          "output: $FIXCI_TEST_OUT"
 fi
 
-# git add ran (the stub succeeds), but no commit / push.
+# git add ran (the stub succeeds), but no commit / push (nothing to commit).
 if grep -qE "CALL .*\\badd\\b" "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
-    pass "#3245 T47 — git add ran (before empty-diff detection)"
+    pass "#3580 T47 — git add ran (before empty-diff detection)"
 else
-    fail "#3245 T47 — git add ran (before empty-diff detection)" \
+    fail "#3580 T47 — git add ran (before empty-diff detection)" \
          "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
 fi
 if ! grep -qE "CALL .*\\bcommit\\b" "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
-    pass "#3245 T47 — no git commit attempted after empty-diff detection"
+    pass "#3580 T47 — no git commit attempted on empty-diff (nothing to commit)"
 else
-    fail "#3245 T47 — no git commit attempted after empty-diff detection" \
+    fail "#3580 T47 — no git commit attempted on empty-diff (nothing to commit)" \
+         "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+if ! grep -qE "CALL .*\\bpush\\b" "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3580 T47 — no git push attempted on empty-diff (nothing to push)"
+else
+    fail "#3580 T47 — no git push attempted on empty-diff (nothing to push)" \
          "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
 fi
 
-# Terminal fix_ci_failed.
-if grep -q "phase = 'fix_ci_failed'" "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null; then
-    pass "#3245 T47 — advances to fix_ci_failed terminal on empty-diff"
+# CRITICAL: must advance to awaiting_ci (let next supervisor tick observe
+# the now-green rollup), NOT terminal-fail to fix_ci_failed.
+if grep -q "SET phase = 'awaiting_ci'" "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null; then
+    pass "#3580 T47 — advances to awaiting_ci on empty-diff (fix already in baseline)"
 else
-    fail "#3245 T47 — advances to fix_ci_failed terminal on empty-diff" \
+    fail "#3580 T47 — advances to awaiting_ci on empty-diff (fix already in baseline)" \
          "psql-log: $(cat "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null)"
+fi
+
+# Negative: must NOT have terminal-failed to fix_ci_failed.
+if ! grep -q "phase = 'fix_ci_failed'" "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null; then
+    pass "#3580 T47 — does NOT advance to fix_ci_failed on empty-diff"
+else
+    fail "#3580 T47 — does NOT advance to fix_ci_failed on empty-diff" \
+         "psql-log: $(cat "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null)"
+fi
+
+# Negative: the OLD log event name (used for terminal failure) must NOT
+# appear — downstream telemetry consumers split on the new name.
+if ! printf '%s' "$FIXCI_TEST_OUT" | grep -qE '\bfix_ci_patch_empty\b' \
+    || printf '%s' "$FIXCI_TEST_OUT" | grep -q 'fix_ci_patch_empty_already_applied'; then
+    # Either the bare event isn't there at all, or it's only the longer
+    # already-applied variant (which contains the old token as a prefix).
+    # Use a stricter check: confirm the bare event with no suffix.
+    if ! printf '%s' "$FIXCI_TEST_OUT" \
+        | grep -E 'fix_ci_patch_empty([^_]|$)' \
+        | grep -qv 'fix_ci_patch_empty_already_applied'; then
+        pass "#3580 T47 — old fix_ci_patch_empty terminal event NOT emitted"
+    else
+        fail "#3580 T47 — old fix_ci_patch_empty terminal event NOT emitted" \
+             "output: $FIXCI_TEST_OUT"
+    fi
+else
+    fail "#3580 T47 — old fix_ci_patch_empty terminal event NOT emitted" \
+         "output: $FIXCI_TEST_OUT"
 fi
 
 # ══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- `handle_fix_ci` empty-diff branch now advances to `awaiting_ci` instead of terminal `fix_ci_failed/patch_empty`. The skill's PATCHED verdict was correct in concluding "the fix is in"; the agent-runner just had nothing to commit because the rebase already pulled in the fix from main (sibling PR landed first, idempotent re-edit, or prior fix_ci attempt).
- Log event renamed `fix_ci_patch_empty` → `fix_ci_patch_empty_already_applied` so dashboards / alerts can split this advance from real failure classes. No daemon-side or downstream consumers of the old name (verified via repo grep).
- Regression test: T47 inverted to assert the new behavior. Verified to FAIL against unfixed code before applying the fix; PASSES post-fix. T44 (happy path: PATCHED + non-empty diff → stage + commit + push + advance) still green — fix didn't break the happy path.

Concrete instance from the issue: agent #61e23aa7 on PR #3563 (issue #2492) — fix_ci skill returned `verdict=PATCHED` + `notes="Fix already applied in commit 16a99fc before this invocation"`. Pre-#3580 that terminal-failed; post-#3580 it advances to `awaiting_ci`, the next supervisor tick sees the now-green CI rollup (since 16a99fc IS in main), and the agent reaches merge.

## Test plan

- [x] `scripts/tests/test_agent_runner_entrypoint.sh` runs T47 with the new assertions; T47 was confirmed to fail against unfixed code, then pass against fixed code (8/8 T47 assertions PASS post-fix).
- [x] T44 (PATCHED + non-empty diff happy path) still PASS — stage + commit + push + advance to awaiting_ci unchanged.
- [x] No regressions vs baseline: 233 PASS pre-change → 236 PASS post-change (+3 net new T47 assertions). Same 4 pre-existing FAILs unrelated to this change (`#3547 verify shim`, `#3144 T24 ralph_iteration_observed` × 3).
- [ ] Post-deploy verify: retry #2492 from the dispatcher; agent should hit the rebase + no-op-edit case, advance to `awaiting_ci`, and the supervisor tick should observe the green rollup (since fix is in via commit `16a99fc`), letting the agent reach merge.

Closes #3580
