### PR TITLE
fix(dispatcher): port #3303 WIP-title rejection into ECS entrypoint's handle_push_and_pr (#3333)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -2378,6 +2378,35 @@ handle_push_and_pr() {
         log "push_and_pr_summary_output_missing" "path=$_summary_path"
     fi
 
+    # ── #3333: WIP-title + empty-title/body guard — runs BEFORE the push
+    # so a bad summary.json never orphans a branch on origin. Equivalent
+    # to daemon.py's pr_title.lstrip().upper().startswith("WIP") check.
+    # Order: validate → (amend) → rebase → push → PR-create.
+    _has_title="false"
+    _has_body="false"
+    _title_is_wip="false"
+    [[ -n "$_pr_title" ]] && _has_title="true"
+    [[ -n "$_pr_body_md" ]] && _has_body="true"
+    # Portable bash 3.2: strip leading whitespace, upper-case, then grep
+    # for a WIP prefix.  ``printf | sed | tr | grep`` avoids bash-only
+    # ``${var^^}`` and ``[[ =~ ]]`` Unicode edge-cases.
+    _pr_title_trimmed=$(printf '%s' "$_pr_title" | sed 's/^[[:space:]]*//')
+    _pr_title_upper=$(printf '%s' "$_pr_title_trimmed" | tr '[:lower:]' '[:upper:]')
+    if printf '%s' "$_pr_title_upper" | grep -qE '^WIP'; then
+        _title_is_wip="true"
+    fi
+    if [[ "$_has_title" == "false" || "$_has_body" == "false" || "$_title_is_wip" == "true" ]]; then
+        _pr_title_preview=$(printf '%s' "$_pr_title" | head -c 80)
+        log "push_and_pr_summary_output_incomplete" \
+            "has_title=$_has_title" \
+            "has_body=$_has_body" \
+            "title_is_wip=$_title_is_wip" \
+            "pr_title_preview=$_pr_title_preview"
+        printf '{"no_op": false, "summary_output_incomplete": true, "title_is_wip": %s, "has_title": %s, "has_body": %s}' \
+            "$_title_is_wip" "$_has_title" "$_has_body"
+        return 0
+    fi
+
     # ── #3176: amend ralph's placeholder commit with summary's
     # conventional-commits message. Mirrors the daemon's
     # ``git commit --amend -F <file>`` — see daemon.py ~L10914.
@@ -2574,33 +2603,22 @@ Closes #${ISSUE_NUMBER}
         fi
     fi
 
-    # ── #3176: open the PR with summary's pr_title + pr_body_md when
-    # available. Fall back to ``--fill`` so a missing summary still
-    # produces a PR (degraded but not abandoned).
+    # ── #3176/#3333: open the PR with summary's pr_title + pr_body_md.
+    # The validation above guarantees both are non-empty and non-WIP,
+    # so we no longer need a ``--fill`` fallback — that branch is gone.
     log "push_and_pr_pr_create_begin"
     _pr_body_path="$AGENT_WORKSPACE/pr_body.md"
     set +e
-    if [[ -n "$_pr_title" && -n "$_pr_body_md" ]]; then
-        printf '%s' "$_pr_body_md" > "$_pr_body_path"
-        gh pr create \
-            --repo judgemind/judgemind \
-            --base main \
-            --head "$BRANCH_NAME" \
-            --title "$_pr_title" \
-            --body-file "$_pr_body_path" \
-            > "$AGENT_WORKSPACE/gh-pr-create.stdout.log" \
-            2> "$AGENT_WORKSPACE/gh-pr-create.stderr.log"
-        _pr_rc=$?
-    else
-        gh pr create \
-            --repo judgemind/judgemind \
-            --base main \
-            --head "$BRANCH_NAME" \
-            --fill \
-            > "$AGENT_WORKSPACE/gh-pr-create.stdout.log" \
-            2> "$AGENT_WORKSPACE/gh-pr-create.stderr.log"
-        _pr_rc=$?
-    fi
+    printf '%s' "$_pr_body_md" > "$_pr_body_path"
+    gh pr create \
+        --repo judgemind/judgemind \
+        --base main \
+        --head "$BRANCH_NAME" \
+        --title "$_pr_title" \
+        --body-file "$_pr_body_path" \
+        > "$AGENT_WORKSPACE/gh-pr-create.stdout.log" \
+        2> "$AGENT_WORKSPACE/gh-pr-create.stderr.log"
+    _pr_rc=$?
     set -e
     log "push_and_pr_pr_create_done" "exit_code=$_pr_rc"
     if [[ "$_pr_rc" -ne 0 ]]; then
@@ -5066,6 +5084,12 @@ while true; do
                                 "push_and_pr_no_unmerged_files" \
                                 "push_and_pr_no_unmerged_files" \
                                 "push_and_pr rebase failed with no unmerged files"
+                            ;;
+                        summary_output_incomplete)
+                            agent_runner_reaped_failure \
+                                "summary_output_incomplete" \
+                                "summary_output_incomplete" \
+                                "summary skill output incomplete or WIP-prefixed title"
                             ;;
                         *)
                             log "push_and_pr_route_unrecognized_hint" "hint=$_hint"

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1383,6 +1383,10 @@ BYPASSED_TERMINAL_PHASES_TO_ROUTE: dict[str, str] = {
     "push_and_pr_no_unmerged_files": FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
     # #3507 — operational skill returned failed/unrecognized verdict.
     "operational_failed": FAILURE_CATEGORY_OPERATIONAL_FAILED,
+    # #3333 — push_and_pr detected incomplete summary output or WIP-prefixed
+    # title. Classified as phase_output_missing so the diagnoser can re-run
+    # the summary phase and retry.
+    "summary_output_incomplete": FAILURE_CATEGORY_PHASE_OUTPUT_MISSING,
 }
 
 #: GitHub's rejection stderr fragment when branch protection's

--- a/scripts/dispatcher/phase_transitions.py
+++ b/scripts/dispatcher/phase_transitions.py
@@ -504,6 +504,12 @@ FAILURE_HINT_CONFLICT_UNRESOLVABLE = "conflict_unresolvable"
 #: ``FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES`` in daemon.py.
 FAILURE_HINT_PUSH_AND_PR_NO_UNMERGED_FILES = "push_and_pr_no_unmerged_files"
 
+#: #3333 — push_and_pr detected that the summary skill output was incomplete
+#: (missing pr_title or pr_body_md) or the pr_title was WIP-prefixed.
+#: Maps to ``FAILURE_CATEGORY_PHASE_OUTPUT_MISSING`` in daemon.py so the
+#: diagnoser sweep treats it as a retryable skill-output failure.
+FAILURE_HINT_SUMMARY_OUTPUT_INCOMPLETE = "summary_output_incomplete"
+
 #: #3507 — The operational skill returned ``verdict=failed`` or an
 #: unrecognized verdict. Maps to ``FAILURE_CATEGORY_OPERATIONAL_FAILED``
 #: in daemon.py.
@@ -818,6 +824,26 @@ def transition_from_push_and_pr(
             next_phase=PHASE_NO_OP,
             terminal_status=AgentStatus.SUCCEEDED.value,
             reason="push_and_pr no-op SHIP (#3039)",
+        )
+    # #3333: summary skill output was incomplete or pr_title was WIP-prefixed.
+    # MUST come before rebase_failed branches — summary validation runs before
+    # the push, so rebase_failed and summary_output_incomplete should never
+    # co-occur, but if they somehow do, incomplete output wins (no orphan
+    # branch was created).
+    if output and output.get("summary_output_incomplete"):
+        return PhaseTransition(
+            action=TransitionAction.ROUTE_TO_DIAGNOSER,
+            failure_hint=FAILURE_HINT_SUMMARY_OUTPUT_INCOMPLETE,
+            reason=(
+                "push_and_pr summary output incomplete or WIP-prefixed title — "
+                "routing to diagnoser (#3333)"
+            ),
+            context={
+                "title_is_wip": output.get("title_is_wip"),
+                "has_title": output.get("has_title"),
+                "has_body": output.get("has_body"),
+                "source_phase": "push_and_pr",
+            },
         )
     # #3465: rebase exited non-zero but produced no unmerged files.
     # MUST come before the generic rebase_failed branch so the empty
@@ -1435,6 +1461,7 @@ __all__ = [
     "FAILURE_HINT_PLAN_BLOCKED",
     "FAILURE_HINT_CONFLICT_UNRESOLVABLE",
     "FAILURE_HINT_PUSH_AND_PR_NO_UNMERGED_FILES",
+    "FAILURE_HINT_SUMMARY_OUTPUT_INCOMPLETE",
     "FAILURE_HINT_OPERATIONAL_FAILED",
     # Transition dataclass + enum
     "PhaseTransition",

--- a/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
+++ b/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
@@ -129,6 +129,7 @@ class TestBypassedTerminalConstants:
         # locally by the entrypoint.
         from dispatcher.daemon import (
             FAILURE_CATEGORY_FIX_CI_BLOCKED,
+            FAILURE_CATEGORY_PHASE_OUTPUT_MISSING,
             FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
             FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
             FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
@@ -144,6 +145,7 @@ class TestBypassedTerminalConstants:
             "verify_failed_post_merge": FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
             "push_and_pr_no_unmerged_files": FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
             "operational_failed": FAILURE_CATEGORY_OPERATIONAL_FAILED,
+            "summary_output_incomplete": FAILURE_CATEGORY_PHASE_OUTPUT_MISSING,
         }
 
 

--- a/scripts/dispatcher/tests/test_phase_transitions.py
+++ b/scripts/dispatcher/tests/test_phase_transitions.py
@@ -806,6 +806,71 @@ class TestTransitionFromPushAndPrNoUnmergedFiles:
 
 
 # --------------------------------------------------------------------------
+# transition_from_push_and_pr — summary_output_incomplete branch (#3333)
+# --------------------------------------------------------------------------
+
+
+class TestTransitionFromPushAndPrSummaryOutputIncomplete:
+    """#3333: push_and_pr detects incomplete summary output or WIP-prefixed
+    title → route to diagnoser with FAILURE_HINT_SUMMARY_OUTPUT_INCOMPLETE."""
+
+    def test_summary_output_incomplete_routes_to_diagnoser(self) -> None:
+        result = pt.transition_from_push_and_pr(
+            {
+                "no_op": False,
+                "summary_output_incomplete": True,
+                "title_is_wip": True,
+                "has_title": True,
+                "has_body": True,
+            }
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_SUMMARY_OUTPUT_INCOMPLETE
+        assert result.context["title_is_wip"] is True
+        assert result.context["has_title"] is True
+        assert result.context["has_body"] is True
+        assert result.context["source_phase"] == "push_and_pr"
+
+    def test_summary_output_incomplete_missing_title_routes_to_diagnoser(
+        self,
+    ) -> None:
+        result = pt.transition_from_push_and_pr(
+            {
+                "no_op": False,
+                "summary_output_incomplete": True,
+                "title_is_wip": False,
+                "has_title": False,
+                "has_body": True,
+            }
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_SUMMARY_OUTPUT_INCOMPLETE
+        assert result.context["has_title"] is False
+        assert result.context["has_body"] is True
+        assert result.context["title_is_wip"] is False
+
+    def test_summary_output_incomplete_takes_precedence_over_rebase_failed(
+        self,
+    ) -> None:
+        # Defensive: both flags set (shouldn't co-occur because validation runs
+        # before the push, but if they do, summary_output_incomplete wins so
+        # no orphan branch interpretation confusion arises).
+        result = pt.transition_from_push_and_pr(
+            {
+                "no_op": False,
+                "summary_output_incomplete": True,
+                "title_is_wip": True,
+                "has_title": True,
+                "has_body": True,
+                "rebase_failed": True,
+                "conflict_files": ["some/file.py"],
+            }
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_SUMMARY_OUTPUT_INCOMPLETE
+
+
+# --------------------------------------------------------------------------
 # transition_from_ralph — no_unmerged_files branch (#3465)
 # --------------------------------------------------------------------------
 

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -658,7 +658,18 @@ EOF
 PRIOR_PATCH_FIXTURE=""
 
 t2_workspace="$TEST_TMP/t2-workspace"
-mkdir -p "$t2_workspace"
+# #3333: WIP/empty validation in handle_push_and_pr requires a non-empty,
+# non-WIP summary.json. Pre-create it so the happy-path sequence reaches
+# push_and_pr → gh pr create. (The summary skill stub returns verdict=OK
+# but doesn't write to the file, so we seed it here.)
+mkdir -p "$t2_workspace/repo/tmp/dispatcher-output"
+cat > "$t2_workspace/repo/tmp/dispatcher-output/summary.json" <<'EOF'
+{
+  "commit_message": "feat(test): happy-path pipeline test (#3090)\n\nCloses #3090",
+  "pr_title": "feat(test): happy-path pipeline test (#3090)",
+  "pr_body_md": "## Summary\nHappy-path test fixture.\n\nCloses #3090\n"
+}
+EOF
 
 set +e
 out=$(AGENT_ID="11111111-2222-3333-4444-555555555555" \
@@ -1117,7 +1128,16 @@ printf 'push_and_pr\n' > "$PHASE_FIXTURE_FILE"
 PRIOR_PATCH_FIXTURE=""
 
 t8_workspace="$TEST_TMP/t8-workspace"
-mkdir -p "$t8_workspace"
+# #3333: WIP/empty validation requires a valid summary.json so handle_push_and_pr
+# reaches git push + gh pr create.
+mkdir -p "$t8_workspace/repo/tmp/dispatcher-output"
+cat > "$t8_workspace/repo/tmp/dispatcher-output/summary.json" <<'EOF'
+{
+  "commit_message": "feat(agent-runner): mechanical push_and_pr phase (#3117)\n\nCloses #3117",
+  "pr_title": "feat(agent-runner): mechanical push_and_pr phase (#3117)",
+  "pr_body_md": "## Summary\nMechanical push_and_pr test fixture.\n\nCloses #3117\n"
+}
+EOF
 
 set +e
 out=$(AGENT_ID="88888888-9999-aaaa-bbbb-cccccccccccc" \
@@ -3120,7 +3140,16 @@ printf 'push_and_pr\n' > "$PHASE_FIXTURE_FILE"
 PRIOR_PATCH_FIXTURE=""
 
 t35_workspace="$TEST_TMP/t35-workspace"
-mkdir -p "$t35_workspace"
+# #3333: WIP/empty validation runs before the rebase, so T35 needs a valid
+# summary.json (non-empty, non-WIP title + body) to reach the rebase path.
+mkdir -p "$t35_workspace/repo/tmp/dispatcher-output"
+cat > "$t35_workspace/repo/tmp/dispatcher-output/summary.json" <<'EOF'
+{
+  "commit_message": "feat(agent-runner): rebase conflict test (#3176)",
+  "pr_title": "feat(agent-runner): rebase conflict test (#3176)",
+  "pr_body_md": "## Summary\nRebase conflict fixture.\n\nCloses #3176\n"
+}
+EOF
 
 # The git stub needs to return non-zero on rebase. The only way to
 # condition the stub is via env var — add GIT_REBASE_EXIT.
@@ -3155,6 +3184,242 @@ if grep -F "rebase" "$INVOCATIONS_DIR/git.log" | grep -F "abort" >/dev/null 2>&1
 else
     fail "#3176 T35 — rebase conflict triggers git rebase --abort" \
          "git log: $(cat "$INVOCATIONS_DIR/git.log")"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# #3333 — handle_push_and_pr WIP-title rejection + --fill removal.
+#
+# AC-1: WIP-prefixed title → summary_output_incomplete envelope, no push.
+# AC-2: empty title or empty body → same envelope.
+# AC-3: no gh pr create --fill remains (grep guard).
+# AC-4(d): good title+body regression guard — T34 above already covers this.
+# ══════════════════════════════════════════════════════════════════════════
+
+# AC-3 guard: assert --fill is not present in handle_push_and_pr.
+if grep -F 'gh pr create' "$ENTRYPOINT" | grep -F -- '--fill' >/dev/null 2>&1; then
+    fail "#3333 AC-3 — no gh pr create --fill in handle_push_and_pr" \
+         "found: $(grep -F 'gh pr create' "$ENTRYPOINT" | grep -F -- '--fill')"
+else
+    pass "#3333 AC-3 — no gh pr create --fill in handle_push_and_pr"
+fi
+
+# ── Test T34a: WIP-prefixed pr_title → rejected, no push, summary_output_incomplete ─
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t34a.txt"
+printf 'push_and_pr\n' > "$PHASE_FIXTURE_FILE"
+
+t34a_workspace="$TEST_TMP/t34a-workspace"
+mkdir -p "$t34a_workspace/repo/tmp/dispatcher-output"
+cat > "$t34a_workspace/repo/tmp/dispatcher-output/summary.json" <<'EOF'
+{
+  "commit_message": "WIP: ralph output",
+  "pr_title": "WIP: ralph output",
+  "pr_body_md": "good body content describing the change"
+}
+EOF
+
+set +e
+t34a_out=$(run_post_pr_phase "push_and_pr" "$t34a_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GIT_REV_LIST_COUNT=1" \
+    "CLAUDE_VERDICT_FIXTURE=")
+set -e
+
+if printf '%s' "$t34a_out" | grep -q "push_and_pr_summary_output_incomplete"; then
+    pass "#3333 T34a — WIP title emits push_and_pr_summary_output_incomplete"
+else
+    fail "#3333 T34a — WIP title emits push_and_pr_summary_output_incomplete" \
+         "out tail: $(printf '%s' "$t34a_out" | tail -c 500)"
+fi
+
+if printf '%s' "$t34a_out" | grep -q 'push_and_pr_summary_output_incomplete'; then
+    pass "#3333 T34a — WIP title: log has push_and_pr_summary_output_incomplete"
+else
+    fail "#3333 T34a — WIP title: log has push_and_pr_summary_output_incomplete" \
+         "out tail: $(printf '%s' "$t34a_out" | tail -c 500)"
+fi
+
+if printf '%s' "$t34a_out" | grep -q '"title_is_wip": "true"'; then
+    pass "#3333 T34a — WIP title: log has title_is_wip: true"
+else
+    fail "#3333 T34a — WIP title: log has title_is_wip: true" \
+         "out tail: $(printf '%s' "$t34a_out" | tail -c 500)"
+fi
+
+# No push should have been attempted.
+if grep -F "push" "$INVOCATIONS_DIR/git.log" | grep -F "origin" | grep -v "fetch" | grep -v "rebase" >/dev/null 2>&1; then
+    fail "#3333 T34a — WIP title: no git push attempted" \
+         "git log: $(cat "$INVOCATIONS_DIR/git.log")"
+else
+    pass "#3333 T34a — WIP title: no git push attempted"
+fi
+
+# No gh pr create should have been invoked.
+if grep -F "pr" "$INVOCATIONS_DIR/gh.log" | grep -F "create" >/dev/null 2>&1; then
+    fail "#3333 T34a — WIP title: no gh pr create invoked" \
+         "gh log: $(cat "$INVOCATIONS_DIR/gh.log")"
+else
+    pass "#3333 T34a — WIP title: no gh pr create invoked"
+fi
+
+# ── Test T34b: lower-case wip with leading whitespace → rejected ────────────
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t34b.txt"
+printf 'push_and_pr\n' > "$PHASE_FIXTURE_FILE"
+
+t34b_workspace="$TEST_TMP/t34b-workspace"
+mkdir -p "$t34b_workspace/repo/tmp/dispatcher-output"
+cat > "$t34b_workspace/repo/tmp/dispatcher-output/summary.json" <<'EOF'
+{
+  "commit_message": "  wip: x",
+  "pr_title": "  wip: x",
+  "pr_body_md": "good body content describing the change"
+}
+EOF
+
+set +e
+t34b_out=$(run_post_pr_phase "push_and_pr" "$t34b_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GIT_REV_LIST_COUNT=1" \
+    "CLAUDE_VERDICT_FIXTURE=")
+set -e
+
+if printf '%s' "$t34b_out" | grep -q "push_and_pr_summary_output_incomplete"; then
+    pass "#3333 T34b — leading-space wip title rejected"
+else
+    fail "#3333 T34b — leading-space wip title rejected" \
+         "out tail: $(printf '%s' "$t34b_out" | tail -c 500)"
+fi
+
+if printf '%s' "$t34b_out" | grep -q '"title_is_wip": "true"'; then
+    pass "#3333 T34b — leading-space wip: title_is_wip: true"
+else
+    fail "#3333 T34b — leading-space wip: title_is_wip: true" \
+         "out tail: $(printf '%s' "$t34b_out" | tail -c 500)"
+fi
+
+# ── Test T34c: empty pr_title → rejected with has_title: false ─────────────
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t34c.txt"
+printf 'push_and_pr\n' > "$PHASE_FIXTURE_FILE"
+
+t34c_workspace="$TEST_TMP/t34c-workspace"
+mkdir -p "$t34c_workspace/repo/tmp/dispatcher-output"
+cat > "$t34c_workspace/repo/tmp/dispatcher-output/summary.json" <<'EOF'
+{
+  "commit_message": "feat(agent-runner): real post-PR handlers",
+  "pr_title": "",
+  "pr_body_md": "good body content describing the change"
+}
+EOF
+
+set +e
+t34c_out=$(run_post_pr_phase "push_and_pr" "$t34c_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GIT_REV_LIST_COUNT=1" \
+    "CLAUDE_VERDICT_FIXTURE=")
+set -e
+
+if printf '%s' "$t34c_out" | grep -q "push_and_pr_summary_output_incomplete"; then
+    pass "#3333 T34c — empty title emits push_and_pr_summary_output_incomplete"
+else
+    fail "#3333 T34c — empty title emits push_and_pr_summary_output_incomplete" \
+         "out tail: $(printf '%s' "$t34c_out" | tail -c 500)"
+fi
+
+if printf '%s' "$t34c_out" | grep -q '"has_title": "false"'; then
+    pass "#3333 T34c — empty title: has_title: false"
+else
+    fail "#3333 T34c — empty title: has_title: false" \
+         "out tail: $(printf '%s' "$t34c_out" | tail -c 500)"
+fi
+
+# ── Test T34d: empty pr_body_md → rejected with has_body: false ────────────
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t34d.txt"
+printf 'push_and_pr\n' > "$PHASE_FIXTURE_FILE"
+
+t34d_workspace="$TEST_TMP/t34d-workspace"
+mkdir -p "$t34d_workspace/repo/tmp/dispatcher-output"
+cat > "$t34d_workspace/repo/tmp/dispatcher-output/summary.json" <<'EOF'
+{
+  "commit_message": "feat(agent-runner): real post-PR handlers",
+  "pr_title": "feat(agent-runner): real post-PR handlers",
+  "pr_body_md": ""
+}
+EOF
+
+set +e
+t34d_out=$(run_post_pr_phase "push_and_pr" "$t34d_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GIT_REV_LIST_COUNT=1" \
+    "CLAUDE_VERDICT_FIXTURE=")
+set -e
+
+if printf '%s' "$t34d_out" | grep -q "push_and_pr_summary_output_incomplete"; then
+    pass "#3333 T34d — empty body emits push_and_pr_summary_output_incomplete"
+else
+    fail "#3333 T34d — empty body emits push_and_pr_summary_output_incomplete" \
+         "out tail: $(printf '%s' "$t34d_out" | tail -c 500)"
+fi
+
+if printf '%s' "$t34d_out" | grep -q '"has_body": "false"'; then
+    pass "#3333 T34d — empty body: has_body: false"
+else
+    fail "#3333 T34d — empty body: has_body: false" \
+         "out tail: $(printf '%s' "$t34d_out" | tail -c 500)"
+fi
+
+# ── Test T34e: mid-string wipe NOT rejected (regression guard) ──────────────
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t34e.txt"
+printf 'push_and_pr\n' > "$PHASE_FIXTURE_FILE"
+
+t34e_workspace="$TEST_TMP/t34e-workspace"
+mkdir -p "$t34e_workspace/repo/tmp/dispatcher-output"
+cat > "$t34e_workspace/repo/tmp/dispatcher-output/summary.json" <<'EOF'
+{
+  "commit_message": "feat(agent-runner): wipe stale tokens (#3333)",
+  "pr_title": "feat(agent-runner): wipe stale tokens (#3333)",
+  "pr_body_md": "## Summary\nRemoves stale token cache.\n\nCloses #3333\n"
+}
+EOF
+
+set +e
+t34e_out=$(run_post_pr_phase "push_and_pr" "$t34e_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GIT_REV_LIST_COUNT=1" \
+    "CLAUDE_VERDICT_FIXTURE=")
+set -e
+
+# This title is NOT wip-prefixed — it should proceed to gh pr create.
+if printf '%s' "$t34e_out" | grep -q "push_and_pr_summary_output_incomplete"; then
+    fail "#3333 T34e — mid-string wipe NOT rejected (regression guard)" \
+         "out tail: $(printf '%s' "$t34e_out" | tail -c 500)"
+else
+    pass "#3333 T34e — mid-string wipe NOT rejected (regression guard)"
+fi
+
+if grep -F "pr" "$INVOCATIONS_DIR/gh.log" | grep -F "create" | grep -F -- "--title" >/dev/null 2>&1; then
+    pass "#3333 T34e — mid-string wipe: gh pr create --title invoked"
+else
+    fail "#3333 T34e — mid-string wipe: gh pr create --title invoked" \
+         "gh log: $(cat "$INVOCATIONS_DIR/gh.log")"
 fi
 
 # ══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

The daemon subprocess path rejects WIP-prefixed PR titles (fixing #3303), but the ECS entrypoint path never mirrored this check. This allows agents to ship PRs with placeholder titles like "WIP: ralph output", preventing auto-close of issues and creating operator-visible noise in git history.

Port the WIP-title guard into `handle_push_and_pr` using portable bash 3.2 checks (sed/tr/grep equivalent to lstrip().upper().startswith('WIP')). Also remove the `gh pr create --fill` fallback and replace it with a deterministic `summary_output_incomplete` envelope for diagnoser routing, matching the daemon's behavior.

Closes #3333

## Test plan

### Automated checks

- [ ] Lint passes (`ruff check` / `shellcheck`)
- [ ] Format check passes (`ruff format --check`)
- [ ] Tests pass (`pytest` on phase_transitions tests + shell tests in test_agent_runner_entrypoint.sh)
- [ ] CI green

### Post-deploy verification

- [ ] Verify via synthetic test case: write a fixture summary output with `pr_title: "WIP: foo"`, run `handle_push_and_pr`, assert no PR is created and `summary_output_incomplete` envelope is emitted (matches T34a test pattern)
- [ ] Or observe 3+ consecutive ECS agent green runs and confirm PR titles are descriptive (not "WIP: ralph output" or branch names)
- [ ] Verification evidence posted on #3333