### PR TITLE
fix(api): add JWT_SECRET load-time guard and wire via Secrets Manager (#3593)

### DIFF
--- a/infra/terraform/modules/api-service/main.tf
+++ b/infra/terraform/modules/api-service/main.tf
@@ -157,6 +157,28 @@ resource "aws_lb_listener" "http_redirect" {
   }
 }
 
+# ─── JWT Secret ─────────────────────────────────────────────────────────────
+
+resource "random_password" "jwt_secret" {
+  length           = 64
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "aws_secretsmanager_secret" "jwt" {
+  name                    = "judgemind/${var.environment}/api/jwt_secret"
+  description             = "JWT signing secret for Judgemind API (${var.environment})"
+  recovery_window_in_days = var.environment == "production" ? 30 : 0
+}
+
+# NOTE: This secret_version IS Terraform-managed — the value is derived from
+# a random_password resource. Do NOT add ignore_changes here; Terraform must
+# keep the secret in sync with the generated password.
+resource "aws_secretsmanager_secret_version" "jwt" {
+  secret_id     = aws_secretsmanager_secret.jwt.id
+  secret_string = jsonencode({ secret = random_password.jwt_secret.result })
+}
+
 # ─── IAM: Secrets Manager access for the execution role ─────────────────────
 # The execution role needs to read secrets to inject DATABASE_URL and
 # OpenSearch credentials into the container at launch.
@@ -188,6 +210,7 @@ resource "aws_iam_role_policy" "api_secrets" {
         Resource = compact([
           var.db_connection_secret_arn,
           var.opensearch_credentials_secret_arn,
+          aws_secretsmanager_secret.jwt.arn,
         ])
       }
     ]
@@ -304,6 +327,10 @@ resource "aws_ecs_task_definition" "api" {
           {
             name      = "DATABASE_URL"
             valueFrom = "${var.db_connection_secret_arn}:url::"
+          },
+          {
+            name      = "JWT_SECRET"
+            valueFrom = "${aws_secretsmanager_secret.jwt.arn}:secret::"
           }
         ],
         var.opensearch_credentials_secret_arn != "" ? [

--- a/packages/api/.env.example
+++ b/packages/api/.env.example
@@ -16,6 +16,9 @@ TEST_DATABASE_URL=postgres://judgemind:localdev@localhost:5432/judgemind_test
 REDIS_URL=redis://localhost:6379
 
 # JWT
+# Production: must be set to a random non-default value (≥64 chars recommended).
+# The server throws at startup if NODE_ENV=production and this is unset or equals
+# the dev literal 'dev-jwt-secret-change-in-production'.
 JWT_SECRET=change-me-in-production
 
 # Object Storage (local dev uses MinIO via docker-compose)

--- a/packages/api/src/auth/tokens.ts
+++ b/packages/api/src/auth/tokens.ts
@@ -1,7 +1,19 @@
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 
-const JWT_SECRET = process.env.JWT_SECRET ?? 'dev-jwt-secret-change-in-production';
+const DEV_JWT_SECRET = 'dev-jwt-secret-change-in-production';
+
+if (
+  process.env.NODE_ENV === 'production' &&
+  (!process.env.JWT_SECRET || process.env.JWT_SECRET === DEV_JWT_SECRET)
+) {
+  throw new Error(
+    'JWT_SECRET must be set to a non-default value in production. ' +
+      'Set JWT_SECRET to a random secret of at least 64 characters.',
+  );
+}
+
+const JWT_SECRET = process.env.JWT_SECRET ?? DEV_JWT_SECRET;
 const ACCESS_TOKEN_EXPIRY = '15m';
 const REFRESH_TOKEN_EXPIRY_DAYS = 30;
 

--- a/packages/api/tests/auth-tokens.unit.test.ts
+++ b/packages/api/tests/auth-tokens.unit.test.ts
@@ -58,7 +58,7 @@ describe('signVerificationToken / verifyVerificationToken', () => {
   });
 
   it('rejects a token with wrong purpose', () => {
-    const secret = process.env.JWT_SECRET ?? 'dev-jwt-secret-change-in-production';
+    const secret = 'test-jwt-secret-not-real';
     const badToken = jwt.sign({ sub: 'user-1', purpose: 'password-reset' }, secret, {
       expiresIn: '24h',
     });
@@ -121,5 +121,35 @@ describe('hashRefreshToken', () => {
   it('matches the hash from generateRefreshToken', () => {
     const { token, hash } = generateRefreshToken();
     expect(hashRefreshToken(token)).toBe(hash);
+  });
+});
+
+describe('JWT_SECRET load-time guard', () => {
+  it('throws when NODE_ENV=production and JWT_SECRET is unset', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('JWT_SECRET', '');
+    vi.resetModules();
+    await expect(import('../src/auth/tokens')).rejects.toThrow(
+      'JWT_SECRET must be set to a non-default value in production',
+    );
+    vi.unstubAllEnvs();
+  });
+
+  it('throws when NODE_ENV=production and JWT_SECRET equals the dev literal', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    vi.stubEnv('JWT_SECRET', 'dev-jwt-secret-change-in-production');
+    vi.resetModules();
+    await expect(import('../src/auth/tokens')).rejects.toThrow(
+      'JWT_SECRET must be set to a non-default value in production',
+    );
+    vi.unstubAllEnvs();
+  });
+
+  it('does NOT throw when NODE_ENV is non-production and JWT_SECRET is unset', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('JWT_SECRET', '');
+    vi.resetModules();
+    await expect(import('../src/auth/tokens')).resolves.toBeDefined();
+    vi.unstubAllEnvs();
   });
 });

--- a/packages/api/tests/setup-env.ts
+++ b/packages/api/tests/setup-env.ts
@@ -1,0 +1,1 @@
+process.env.JWT_SECRET ||= 'test-jwt-secret-not-real';

--- a/packages/api/vitest.config.ts
+++ b/packages/api/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
+    setupFiles: ['./tests/setup-env.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov'],


### PR DESCRIPTION
## Summary

Adds a production-only guard in `packages/api/src/auth/tokens.ts` that throws at module load when `NODE_ENV=production` and `JWT_SECRET` is unset or equals the dev literal, preventing accidental deployment of a forgeable-token vulnerability. Wires `JWT_SECRET` into the dev API task definition via Secrets Manager (random-password generation, secret creation, and IAM access), following the pattern used for `OPENSEARCH_PASSWORD`.

Closes #3593

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`) — 342+ tests pass including three new load-time-guard tests
- [x] CI green

### Post-deploy verification

- [ ] Log into dev, capture a valid bearer token
- [ ] Deploy API with new JWT_SECRET from Secrets Manager
- [ ] Hit a protected endpoint with the captured token → expect 401
- [ ] Hit a protected endpoint without a token, trigger refresh flow → expect new valid token
- [ ] Verification evidence posted on #3593 (see /task-v2-verify output)