### PR TITLE
test(scraping): replace silent pytest.skip guards with assertions (#3598)

### DIFF
--- a/packages/scraper-framework/tests/test_audit_oc_ruling_integrity.py
+++ b/packages/scraper-framework/tests/test_audit_oc_ruling_integrity.py
@@ -23,11 +23,7 @@ SCRIPTS_DIR = Path(__file__).resolve().parents[3] / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
-# Import will fail until the script exists — skip the entire module if so.
-try:
-    import audit_oc_ruling_integrity as audit
-except ImportError:
-    pytest.skip("audit_oc_ruling_integrity.py not yet created", allow_module_level=True)
+import audit_oc_ruling_integrity as audit  # noqa: E402, I001
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_eval_enrichment_scorer.py
+++ b/packages/scraper-framework/tests/test_eval_enrichment_scorer.py
@@ -762,8 +762,7 @@ class TestFixtureLoading:
     def test_load_and_score_real_fixtures(self) -> None:
         """Integration test: load real fixtures and score a perfect extraction."""
         fixtures_dir = Path(__file__).resolve().parent / "fixtures" / "enrichment"
-        if not fixtures_dir.exists():
-            pytest.skip("Enrichment fixtures not found")
+        assert fixtures_dir.exists(), f"Enrichment fixtures missing: {fixtures_dir}"
 
         # Import the CLI module's load function
         sys.path.insert(0, str(SCRIPTS_EVAL_DIR))
@@ -823,8 +822,7 @@ class TestFixtureLoading:
     def test_load_fixtures_county_filter(self) -> None:
         """Test that county filter works."""
         fixtures_dir = Path(__file__).resolve().parent / "fixtures" / "enrichment"
-        if not fixtures_dir.exists():
-            pytest.skip("Enrichment fixtures not found")
+        assert fixtures_dir.exists(), f"Enrichment fixtures missing: {fixtures_dir}"
 
         sys.path.insert(0, str(SCRIPTS_EVAL_DIR))
         from eval_enrichment import load_fixtures
@@ -840,8 +838,7 @@ class TestFixtureLoading:
     def test_load_fixtures_includes_acceptable_alternatives(self) -> None:
         """Verify that acceptable_alternatives are loaded from fixture JSON."""
         fixtures_dir = Path(__file__).resolve().parent / "fixtures" / "enrichment"
-        if not fixtures_dir.exists():
-            pytest.skip("Enrichment fixtures not found")
+        assert fixtures_dir.exists(), f"Enrichment fixtures missing: {fixtures_dir}"
 
         sys.path.insert(0, str(SCRIPTS_EVAL_DIR))
         from eval_enrichment import load_fixtures
@@ -854,8 +851,7 @@ class TestFixtureLoading:
     def test_load_fixtures_includes_case_title_in_text(self) -> None:
         """Verify that case_title_in_text flag is loaded from fixture JSON."""
         fixtures_dir = Path(__file__).resolve().parent / "fixtures" / "enrichment"
-        if not fixtures_dir.exists():
-            pytest.skip("Enrichment fixtures not found")
+        assert fixtures_dir.exists(), f"Enrichment fixtures missing: {fixtures_dir}"
 
         sys.path.insert(0, str(SCRIPTS_EVAL_DIR))
         from eval_enrichment import load_fixtures
@@ -944,8 +940,7 @@ class TestDefaultFixturesPathValidation:
         """DEFAULT_FIXTURES_DIR must contain at least MIN_TOTAL_FIXTURES fixtures."""
         from eval_enrichment import DEFAULT_FIXTURES_DIR, MIN_TOTAL_FIXTURES, load_fixtures
 
-        if not DEFAULT_FIXTURES_DIR.is_dir():
-            pytest.skip("DEFAULT_FIXTURES_DIR does not exist or is not a directory")
+        assert DEFAULT_FIXTURES_DIR.is_dir(), f"Enrichment fixtures missing: {DEFAULT_FIXTURES_DIR}"
 
         fixtures = load_fixtures(DEFAULT_FIXTURES_DIR)
         assert len(fixtures) >= MIN_TOTAL_FIXTURES, (
@@ -958,8 +953,7 @@ class TestDefaultFixturesPathValidation:
         """DEFAULT_FIXTURES_DIR must contain county subdirectories."""
         from eval_enrichment import DEFAULT_FIXTURES_DIR
 
-        if not DEFAULT_FIXTURES_DIR.is_dir():
-            pytest.skip("DEFAULT_FIXTURES_DIR does not exist or is not a directory")
+        assert DEFAULT_FIXTURES_DIR.is_dir(), f"Enrichment fixtures missing: {DEFAULT_FIXTURES_DIR}"
 
         county_dirs = [d.name for d in sorted(DEFAULT_FIXTURES_DIR.iterdir()) if d.is_dir()]
         assert len(county_dirs) >= 5, (

--- a/packages/scraper-framework/tests/test_eval_la_extraction.py
+++ b/packages/scraper-framework/tests/test_eval_la_extraction.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 # Add eval scripts directory to path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 EVAL_DIR = REPO_ROOT / "scripts" / "eval"
@@ -74,8 +72,7 @@ class TestExtractHtmlText:
     def test_extracts_text_from_valid_fixture(self) -> None:
         """Should extract text from fixture with speechSynthesis div."""
         fixture_path = FIXTURES_DIR / "la_ruling_pas_p.html"
-        if not fixture_path.exists():
-            pytest.skip("Fixture not found")
+        assert fixture_path.exists(), f"Fixture missing: {fixture_path}"
         text = extract_html_text(fixture_path)
         assert text is not None
         assert "DEPARTMENT P LAW AND MOTION RULINGS" in text
@@ -85,16 +82,14 @@ class TestExtractHtmlText:
     def test_returns_none_for_error_page(self) -> None:
         """Error pages without speechSynthesis div return None."""
         fixture_path = FIXTURES_DIR / "la_ruling_van_a.html"
-        if not fixture_path.exists():
-            pytest.skip("Fixture not found")
+        assert fixture_path.exists(), f"Fixture missing: {fixture_path}"
         text = extract_html_text(fixture_path)
         assert text is None
 
     def test_multicase_fixture_contains_both_cases(self) -> None:
         """Multi-case fixtures should contain all case numbers."""
         fixture_path = FIXTURES_DIR / "la_ruling_response.html"
-        if not fixture_path.exists():
-            pytest.skip("Fixture not found")
+        assert fixture_path.exists(), f"Fixture missing: {fixture_path}"
         text = extract_html_text(fixture_path)
         assert text is not None
         assert "24NNCV02551" in text

--- a/packages/scraper-framework/tests/test_llm_extract.py
+++ b/packages/scraper-framework/tests/test_llm_extract.py
@@ -11,8 +11,6 @@ from datetime import date
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from framework.llm_schema import ConfidenceLevel, FieldConfidence
 from ingestion.llm_extract import (
     _SYSTEM_PROMPT,
@@ -126,8 +124,7 @@ class TestPreprocessHtml:
     def test_real_la_fixture(self) -> None:
         """Test preprocessing against a real LA court ruling fixture."""
         fixture_path = FIXTURES_DIR / "la_ruling_response.html"
-        if not fixture_path.exists():
-            pytest.skip("LA fixture not available")
+        assert fixture_path.exists(), f"Fixture missing: {fixture_path}"
         raw_html = fixture_path.read_text()
         result = preprocess_html(raw_html)
         # After preprocessing, the result should be much shorter than the raw HTML
@@ -138,8 +135,7 @@ class TestPreprocessHtml:
     def test_real_la_bh205_fixture(self) -> None:
         """Test preprocessing against the large BH205 LA fixture."""
         fixture_path = FIXTURES_DIR / "la_ruling_bh205.html"
-        if not fixture_path.exists():
-            pytest.skip("LA BH205 fixture not available")
+        assert fixture_path.exists(), f"Fixture missing: {fixture_path}"
         raw_html = fixture_path.read_text()
         result = preprocess_html(raw_html)
         # The preprocessed text should be dramatically smaller
@@ -148,8 +144,7 @@ class TestPreprocessHtml:
     def test_real_la_com_a_fixture(self) -> None:
         """Test preprocessing against the COM A LA fixture."""
         fixture_path = FIXTURES_DIR / "la_ruling_com_a.html"
-        if not fixture_path.exists():
-            pytest.skip("LA COM A fixture not available")
+        assert fixture_path.exists(), f"Fixture missing: {fixture_path}"
         raw_html = fixture_path.read_text()
         result = preprocess_html(raw_html)
         assert len(result) < len(raw_html)
@@ -981,8 +976,7 @@ class TestRealFixtures:
     def test_la_ruling_response_preprocessing(self) -> None:
         """Verify LA ruling HTML is preprocessed and sent to the LLM."""
         fixture_path = FIXTURES_DIR / "la_ruling_response.html"
-        if not fixture_path.exists():
-            pytest.skip("LA fixture not available")
+        assert fixture_path.exists(), f"Fixture missing: {fixture_path}"
 
         raw_html = fixture_path.read_text()
         response_json = json.dumps(
@@ -1019,8 +1013,7 @@ class TestRealFixtures:
     def test_la_dept_header_fixture(self) -> None:
         """Test with the LA dept header fixture."""
         fixture_path = FIXTURES_DIR / "la_ruling_dept_header.html"
-        if not fixture_path.exists():
-            pytest.skip("LA dept header fixture not available")
+        assert fixture_path.exists(), f"Fixture missing: {fixture_path}"
 
         raw_html = fixture_path.read_text()
         response_json = json.dumps(

--- a/packages/scraper-framework/tests/test_llm_extractor.py
+++ b/packages/scraper-framework/tests/test_llm_extractor.py
@@ -7,6 +7,7 @@ transient errors, chunking, metadata overrides, and token usage logging.
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import MagicMock, patch
 
 import anthropic
@@ -1087,10 +1088,7 @@ class TestRetryConstants:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.skipif(
-    True,  # noqa: FBT003 — Always skip in automated testing
-    reason="Integration test requires ANTHROPIC_API_KEY — run manually",
-)
+@pytest.mark.skipif(not os.getenv("ANTHROPIC_API_KEY"), reason="needs ANTHROPIC_API_KEY")
 class TestIntegration:
     """Integration tests against the real Anthropic API.
 

--- a/packages/scraper-framework/tests/test_llm_split_guards.py
+++ b/packages/scraper-framework/tests/test_llm_split_guards.py
@@ -79,9 +79,9 @@ class TestLlmSplitGuards:
         """
         _, llm_registry = _load_registries()
         if not llm_registry:
-            pytest.skip(
+            pytest.fail(
                 "No scraper modules export _llm_extract_rulings — "
-                "guard test is a no-op until a scraper joins the LLM registry"
+                "guard test cannot validate any scrapers; registry discovery may be broken"
             )
 
     @pytest.mark.parametrize("scraper_id", _LLM_SCRAPER_IDS, ids=_LLM_SCRAPER_IDS)

--- a/packages/scraper-framework/tests/test_reingest_registry.py
+++ b/packages/scraper-framework/tests/test_reingest_registry.py
@@ -307,8 +307,10 @@ class TestLlmSplitRegistryDiscovery:
                 for factory in _discover_config_factories(mod):
                     expected_llm_ids.add(factory().scraper_id)
 
-        if not expected_llm_ids:
-            pytest.skip("No scraper modules export _llm_extract_rulings")
+        assert expected_llm_ids, (
+            "No scraper modules export _llm_extract_rulings — "
+            "registry discovery is broken or no LLM scrapers registered"
+        )
 
         actual_llm_ids = set(reingest._LLM_SPLIT_REGISTRY.keys())
         missing = expected_llm_ids - actual_llm_ids


### PR DESCRIPTION
## Summary

Removed all silent `pytest.skip` regression masks from 7 test files in scraper-framework that were masking the exact failures they were designed to catch:
- Module-level ImportError guard on `audit_oc_ruling_integrity` import (script now exists)
- 10 fixture-path existence checks (fixtures are committed to the tree)
- 2 empty-registry checks (empty registry is the regression signal)
- 1 always-true skipif on an integration test (now env-gated via `ANTHROPIC_API_KEY`)

Closes #3598

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest -q`): 348 tests pass
- [x] CI green (pre-push hook confirmed)

### Post-deploy verification

- [x] N/A — no deployed component (test-only changes)