### PR TITLE
fix(web): split dispatcher ActiveAgentRow into two-line layout for mobile readability (#3583)

### DIFF
--- a/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/ActiveAgentsTable.tsx
@@ -140,84 +140,96 @@ function ActiveAgentRow({
       data-testid={`active-agent-row-${agent.id}`}
     >
       <div
-        className="flex flex-wrap items-center gap-x-3 gap-y-1"
+        className="flex flex-col gap-1"
         style={innerStyle}
         data-testid={`active-agent-inner-${agent.id}`}
       >
-        <span
-          className="w-20 flex-shrink-0 font-mono text-xs text-foreground"
-          title={agent.id}
+        {/* Line 1 — agent details: short ID, phase chip, Logs link,
+            elapsed time, Retry/Kill buttons pushed right with ml-auto. */}
+        <div
+          className="flex items-center gap-x-3"
+          data-testid={`active-agent-line-agent-${agent.id}`}
         >
-          {shortAgentId(agent.id)}
-        </span>
-        {/* Unified (issue, priority, title) prefix — matches QueuePanel
-            and RecentCompletionsPanel (#2899). */}
-        <span className="flex-shrink-0">
-          <IssueLink number={agent.issueNumber} />
-        </span>
-        <span className="flex-shrink-0">
-          <PriorityBadge priority={agent.priority} />
-        </span>
-        <span
-          className="min-w-0 flex-1 truncate text-foreground"
-          data-testid="active-agent-title"
-          title={agent.issueTitle ?? undefined}
-        >
-          {agent.issueTitle ?? (
-            <span className="italic text-muted-foreground">
-              (title unavailable)
-            </span>
-          )}
-        </span>
-        <span
-          className="flex-shrink-0 cursor-help rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground"
-          data-testid={`active-agent-phase-${agent.id}`}
-          title={phaseTooltip}
-        >
-          {phaseChipText}
-        </span>
-        <span className="flex-shrink-0 text-xs">
-          {logsHref ? (
-            <a
-              href={logsHref}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-brand-accent dark:text-brand-accent-light underline-offset-2 hover:underline"
-            >
-              Logs &rarr;
-            </a>
-          ) : (
-            <span
-              title={agent.worktreePath}
-              className="font-mono text-muted-foreground"
-            >
-              {agent.worktreePath.split('/').pop() ?? agent.worktreePath}
-            </span>
-          )}
-        </span>
-        <span className="w-16 flex-shrink-0 text-right font-mono text-xs text-muted-foreground">
-          {elapsed}
-        </span>
-        <span className="flex flex-shrink-0 gap-1">
-          <Button
-            type="button"
-            variant="outline"
-            size="xs"
-            disabled={disabled}
-            onClick={() => onAction('retry', agent.id)}
+          <span
+            className="w-20 flex-shrink-0 font-mono text-xs text-foreground"
+            title={agent.id}
           >
-            Retry
-          </Button>
-          <Button
-            type="button"
-            variant="destructive"
-            size="xs"
-            disabled={disabled}
-            onClick={() => onAction('force_stop', agent.id)}
+            {shortAgentId(agent.id)}
+          </span>
+          <span
+            className="flex-shrink-0 cursor-help rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground"
+            data-testid={`active-agent-phase-${agent.id}`}
+            title={phaseTooltip}
           >
-            Kill
-          </Button>
-        </span>
+            {phaseChipText}
+          </span>
+          <span className="flex-shrink-0 text-xs">
+            {logsHref ? (
+              <a
+                href={logsHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-brand-accent dark:text-brand-accent-light underline-offset-2 hover:underline"
+              >
+                Logs &rarr;
+              </a>
+            ) : (
+              <span
+                title={agent.worktreePath}
+                className="font-mono text-muted-foreground"
+              >
+                {agent.worktreePath.split('/').pop() ?? agent.worktreePath}
+              </span>
+            )}
+          </span>
+          <span className="w-16 flex-shrink-0 text-right font-mono text-xs text-muted-foreground">
+            {elapsed}
+          </span>
+          <span className="ml-auto flex flex-shrink-0 gap-1">
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              disabled={disabled}
+              onClick={() => onAction('retry', agent.id)}
+            >
+              Retry
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              size="xs"
+              disabled={disabled}
+              onClick={() => onAction('force_stop', agent.id)}
+            >
+              Kill
+            </Button>
+          </span>
+        </div>
+        {/* Line 2 — issue details: IssueLink, PriorityBadge, title.
+            Mirrors QueueRow and RecentCompletionRow (#2899 / #3583). */}
+        <div
+          className="flex items-start gap-x-3"
+          data-testid={`active-agent-line-issue-${agent.id}`}
+        >
+          <span className="flex-shrink-0">
+            <IssueLink number={agent.issueNumber} />
+          </span>
+          <span className="flex-shrink-0">
+            <PriorityBadge priority={agent.priority} />
+          </span>
+          <span
+            className="min-w-0 flex-1 break-words text-foreground"
+            data-testid="active-agent-title"
+            title={agent.issueTitle ?? undefined}
+          >
+            {agent.issueTitle ?? (
+              <span className="italic text-muted-foreground">
+                (title unavailable)
+              </span>
+            )}
+          </span>
+        </div>
       </div>
     </li>
   );

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/ActiveAgentsTable.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/ActiveAgentsTable.test.tsx
@@ -233,3 +233,56 @@ describe('ActiveAgentsTable — #3206 view-transition gate while dialog open', (
     );
   });
 });
+
+describe('ActiveAgentsTable — two-line row layout (#3583)', () => {
+  it('renders agent-details line wrapper containing the phase chip and agent ID', () => {
+    const agent = makeAgent();
+    render(
+      <ActiveAgentsTable agents={[agent]} onAgentAction={vi.fn()} />,
+    );
+    const agentLine = screen.getByTestId(`active-agent-line-agent-${agent.id}`);
+    expect(agentLine).toBeInTheDocument();
+    // Phase chip is inside the agent-details line.
+    const phaseChip = screen.getByTestId(`active-agent-phase-${agent.id}`);
+    expect(agentLine.contains(phaseChip)).toBe(true);
+    // Short agent ID text is inside the agent-details line.
+    expect(agentLine.textContent).toContain('aabbccdd');
+  });
+
+  it('renders issue-details line wrapper containing the title element', () => {
+    const agent = makeAgent();
+    render(
+      <ActiveAgentsTable agents={[agent]} onAgentAction={vi.fn()} />,
+    );
+    const issueLine = screen.getByTestId(`active-agent-line-issue-${agent.id}`);
+    expect(issueLine).toBeInTheDocument();
+    // Title is inside the issue-details line.
+    const title = screen.getByTestId('active-agent-title');
+    expect(issueLine.contains(title)).toBe(true);
+  });
+
+  it('renders the title element with break-words class (not truncate)', () => {
+    const agent = makeAgent();
+    render(
+      <ActiveAgentsTable agents={[agent]} onAgentAction={vi.fn()} />,
+    );
+    const title = screen.getByTestId('active-agent-title');
+    expect(title.className).toContain('break-words');
+    expect(title.className).not.toContain('truncate');
+  });
+
+  it('renders agent-details and issue-details line wrappers as siblings inside inner wrapper', () => {
+    const agent = makeAgent();
+    render(
+      <ActiveAgentsTable agents={[agent]} onAgentAction={vi.fn()} />,
+    );
+    const inner = screen.getByTestId(`active-agent-inner-${agent.id}`);
+    const agentLine = screen.getByTestId(`active-agent-line-agent-${agent.id}`);
+    const issueLine = screen.getByTestId(`active-agent-line-issue-${agent.id}`);
+    // Both line wrappers are direct children of the inner wrapper.
+    expect(inner.contains(agentLine)).toBe(true);
+    expect(inner.contains(issueLine)).toBe(true);
+    // They are siblings — same parent.
+    expect(agentLine.parentElement).toBe(issueLine.parentElement);
+  });
+});


### PR DESCRIPTION
## Summary

Refactored the dispatcher's Active Agents table row to use a two-line stacked layout, making issue titles fully readable on mobile and improving desktop readability. Agent details (ID, phase chip, logs link, elapsed time, action buttons) display on the first line, while issue details (number, priority, title) display on the second line. Changed title text handling from `truncate` to `break-words` to prevent text cutoff.

Closes #3583

## Test plan

### Automated checks

- [ ] Lint passes (`npm run lint`)
- [ ] Format check passes (`prettier --check`)
- [ ] Tests pass (`npm test`)
- [ ] CI green

### Post-deploy verification

- [ ] Load `dev.judgemind.org/admin/dispatcher` on a phone viewport (iPhone SE / 375px width)
- [ ] Confirm issue titles are fully readable for in-flight agents (not truncated)
- [ ] Verify desktop layout maintains intentional visual hierarchy and spacing
- [ ] Verification evidence posted on #3583 (see /task-v2-verify output)