### PR TITLE
fix(web): remove View Transitions root-snapshot flicker from dispatcher cockpit polls (#3584)

### DIFF
--- a/packages/web/src/app/(main)/admin/dispatcher/DiagnoserEffectivenessPanel.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DiagnoserEffectivenessPanel.tsx
@@ -54,9 +54,9 @@ export function DiagnoserEffectivenessPanel() {
             </tr>
           </thead>
           <tbody>
-            {rows.map((row, idx) => (
+            {rows.map((row) => (
               <tr
-                key={idx}
+                key={`${row.day}|${row.recommendedAction}|${row.observedOutcome}`}
                 className="border-t border-border hover:bg-muted/50"
                 data-testid="diagnoser-effectiveness-row"
               >

--- a/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/DispatcherDashboard.tsx
@@ -5,7 +5,6 @@ import { notFound } from 'next/navigation';
 import { useMutation, useQuery } from '@apollo/client';
 import { useAuth } from '@/providers/AuthProvider';
 import { ErrorBanner } from '@/components/ErrorBanner';
-import { useViewTransitionUpdate } from '@/hooks/useViewTransition';
 import { PAGE_TITLE } from '@/lib/typography';
 import {
   DISPATCHER_CONTROL_MUTATION,
@@ -138,49 +137,37 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
     }
   }, [error]);
 
-  // Magic Move wiring (#2967). Apollo's `useQuery` pushes poll results
-  // straight into `data`, but Magic Move needs the DOM mutation to happen
-  // *inside* a `document.startViewTransition` callback so the browser
-  // can snapshot the old frame, run the React render, then animate each
-  // `view-transition-name` from its old position to its new one. We
-  // mirror `data` into a local `renderedData` state and flip it through
-  // the view-transition wrapper; the panel components render from the
-  // mirror, so every poll update (and every imperative `refetch()`)
-  // flows through the animation path without changing Apollo's cache
-  // behaviour. On first paint we initialise synchronously — the very
-  // first frame would have no "old" snapshot to animate from anyway.
+  // Data mirror for rendered state (#2967 / #3584). Apollo's `useQuery`
+  // pushes poll results straight into `data`; we mirror that into a local
+  // `renderedData` so the panel components always render from a stable
+  // reference that is only updated inside this effect.
   //
-  // #3220: also bypass the wrapper while any cockpit dialog is open.
-  // #3206 stripped `viewTransitionName` from panel rows when a dialog is
-  // open, but `document.startViewTransition` *always* snapshots the root
-  // viewport into `::view-transition-*(root)` regardless of whether any
-  // named targets exist. Native scrollbars are browser UI — not DOM
-  // content — so they're not captured in the root snapshot and briefly
-  // disappear during the ~250ms cross-fade. On the dialog's
-  // `max-h-[60vh] overflow-y-auto` body, that produces a 2s on/off
-  // scrollbar flicker matching the poll cadence. Synchronous update
-  // while a dialog is open side-steps the root transition entirely.
-  // When the dialog closes, the next poll goes back through
-  // `startViewTransitionUpdate` and Magic Move resumes on the panels.
+  // #2967 originally wrapped updates in `document.startViewTransition` to
+  // drive Magic Move animations on every poll cycle. #3584 reverted that:
+  // `document.startViewTransition` snapshots the *entire root viewport*
+  // (including the Header in app/layout.tsx) into `::view-transition-*(root)`
+  // and cross-fades it for ~250ms, causing cockpit row text and the header
+  // logo region to flicker on every 2s poll regardless of whether any
+  // named transition targets exist. React's keyed reconciliation already
+  // preserves DOM-node identity for unchanged rows, so the view-transition
+  // wrapper buys nothing and only adds operator-visible flicker.
+  //
+  // Per-row `view-transition-name` style spreads in ActiveAgentsTable /
+  // RecentCompletionsPanel / QueuePanel / QueueFullDialog are harmless once
+  // `startViewTransition` is never called and are left in place for any
+  // future scoped use.
   const [renderedData, setRenderedData] = useState<DispatcherStateData | undefined>(
     data,
   );
-  const startViewTransitionUpdate = useViewTransitionUpdate();
   const lastAppliedDataRef = useRef<DispatcherStateData | undefined>(data);
   useEffect(() => {
     if (data === undefined) return;
     if (data === lastAppliedDataRef.current) return;
-    const hasPrior = lastAppliedDataRef.current !== undefined;
     lastAppliedDataRef.current = data;
-    if (!hasPrior || fullDialogKind !== null) {
-      // First successful fetch — no prior frame to transition from.
-      // Dialog open (#3220) — skip the root view-transition to avoid
-      // scrollbar flicker on the dialog's scroll container.
-      setRenderedData(data);
-      return;
-    }
-    startViewTransitionUpdate(() => setRenderedData(data));
-  }, [data, fullDialogKind, startViewTransitionUpdate]);
+    // Synchronous update — React's keyed reconciliation preserves DOM-node
+    // identity for unchanged rows without any view-transition wrapper.
+    setRenderedData(data);
+  }, [data]);
 
   const [dispatcherControl, { loading: controlLoading }] =
     useMutation<DispatcherControlData>(DISPATCHER_CONTROL_MUTATION);
@@ -343,12 +330,11 @@ function DispatcherDashboardInner({ authReady }: { authReady: boolean }) {
     return <ErrorBanner message="Failed to load dispatcher state." onRetry={() => void refetch()} />;
   }
 
-  // `showInitialLoad` was historically `loading && !state`. After the
-  // Magic Move mirror (#2967) it also needs to cover the one-render
-  // gap between Apollo populating `data` and the useEffect flipping
-  // `renderedData`: if we render before the effect commits, `state`
-  // would be undefined even though data is ready. `data && !state`
-  // catches that frame and keeps the skeleton up.
+  // `showInitialLoad` was historically `loading && !state`. The data-mirror
+  // pattern (#2967) introduced a one-render gap between Apollo populating
+  // `data` and the useEffect flipping `renderedData`: if we render before the
+  // effect commits, `state` would be undefined even though data is ready.
+  // `data && !state` catches that frame and keeps the skeleton up.
   const showInitialLoad = (loading && !state) || (data !== undefined && !state);
 
   return (

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DispatcherDashboard.test.tsx
@@ -434,21 +434,21 @@ describe('DispatcherDashboard — #2860 circuit-breaker banner', () => {
   });
 });
 
-describe('DispatcherDashboard — #2967 Magic Move state update wrapping', () => {
+// #2967 originally wrapped poll state updates in document.startViewTransition
+// to drive Magic Move animations. #3584 reverted that because the root
+// viewport snapshot caused operator-visible header flicker on every 2s poll.
+// The data-mirror effect now always updates synchronously.
+describe('DispatcherDashboard — #3584 synchronous poll state update (no view-transition)', () => {
   beforeEach(() => {
     mockControlMutate.mockClear();
     mockSetConfigMutate.mockClear();
     mockRefetch.mockClear();
   });
 
-  it('wraps subsequent poll state updates in document.startViewTransition when available', async () => {
-    // Stub the View Transitions API on the jsdom document. We capture
-    // the callback the hook passes in so we can assert that the state
-    // mutation happens *inside* the transition (flushSync + setState),
-    // not eagerly.
-    const captured: Array<() => void> = [];
+  it('does NOT call startViewTransition on a poll-driven update (#3584)', async () => {
+    // Install the stub — post-fix, it must never be called.
     const startViewTransition = vi.fn((cb: () => void) => {
-      captured.push(cb);
+      cb();
       return { finished: Promise.resolve() };
     });
     (
@@ -457,9 +457,6 @@ describe('DispatcherDashboard — #2967 Magic Move state update wrapping', () =>
       }
     ).startViewTransition = startViewTransition;
 
-    // Also pin `matchMedia` to a non-reducing response so the hook
-    // does not short-circuit on the reduced-motion branch. jsdom does
-    // not implement matchMedia natively.
     const originalMatchMedia = window.matchMedia;
     (window as unknown as { matchMedia: typeof window.matchMedia }).matchMedia =
       ((query: string) => ({
@@ -474,16 +471,11 @@ describe('DispatcherDashboard — #2967 Magic Move state update wrapping', () =>
       })) as typeof window.matchMedia;
 
     try {
-      // Initial frame — state A. First render initialises the mirror
-      // synchronously; no transition wrapping on the very first paint
-      // (no prior frame to transition from).
       mockQueryData = { dispatcherState: { ...BASE_STATE } };
       const { rerender } = renderDashboard();
       expect(startViewTransition).not.toHaveBeenCalled();
 
-      // Simulate a poll landing a *new* data reference. Apollo always
-      // returns a fresh object on each network reply, so reference
-      // equality is the trigger the mirror watches.
+      // Simulate a poll landing a *new* data reference.
       mockQueryData = {
         dispatcherState: {
           ...BASE_STATE,
@@ -492,14 +484,14 @@ describe('DispatcherDashboard — #2967 Magic Move state update wrapping', () =>
       };
       rerender(<DispatcherDashboard />);
 
+      // Wait for the effect to run and verify state was updated
+      // (queueDepth reflected in the badge).
       await waitFor(() => {
-        expect(startViewTransition).toHaveBeenCalledTimes(1);
+        expect(screen.getByTestId('queue-ready-count')).toHaveTextContent('0 / 99');
       });
-      // The callback passed in must be a function — the hook runs it
-      // via `flushSync` to satisfy the View Transitions snapshot
-      // contract. We confirm it is callable and idempotent.
-      expect(typeof captured[0]).toBe('function');
-      expect(() => captured[0]()).not.toThrow();
+      // startViewTransition must never have been called — the update is
+      // now synchronous per #3584.
+      expect(startViewTransition).not.toHaveBeenCalled();
     } finally {
       delete (
         document as unknown as {
@@ -512,15 +504,12 @@ describe('DispatcherDashboard — #2967 Magic Move state update wrapping', () =>
     }
   });
 
-  it('falls through cleanly when startViewTransition is undefined (Firefox today)', () => {
-    // Ensure no global stub leaks in from a previous test.
+  it('renders updated poll data without startViewTransition (Firefox-like env)', async () => {
     delete (
       document as unknown as {
         startViewTransition?: (cb: () => void) => unknown;
       }
     ).startViewTransition;
-    // Initial render on a "Firefox-like" environment — must not throw
-    // and must render the panels with the state we provided.
     mockQueryData = {
       dispatcherState: {
         ...BASE_STATE,
@@ -528,7 +517,9 @@ describe('DispatcherDashboard — #2967 Magic Move state update wrapping', () =>
       },
     };
     renderDashboard();
-    expect(screen.getByTestId('queue-ready-count')).toHaveTextContent('0 / 7');
+    await waitFor(() => {
+      expect(screen.getByTestId('queue-ready-count')).toHaveTextContent('0 / 7');
+    });
   });
 });
 
@@ -988,13 +979,13 @@ describe('DispatcherDashboard — DiagnoserEffectivenessPanel (#2800)', () => {
   });
 });
 
-// #3220: the root view-transition wrapper itself must be skipped while
-// any cockpit dialog is open. Even without named transition targets,
-// `document.startViewTransition` snapshots the entire viewport into
-// `::view-transition-*(root)` and cross-fades for ~250ms — during which
-// native scrollbars vanish and reappear, producing a 2s on/off flicker
-// on the dialog's scrollable body that matches the poll cadence.
-describe('DispatcherDashboard — #3220 root view-transition gate while dialog open', () => {
+// #3220 originally tested that the root view-transition wrapper was skipped
+// while a dialog was open. #3584 reverted the view-transition wrapping on
+// polls entirely — startViewTransition is never called on any poll update.
+// The dialog-open / dialog-closed distinction no longer affects the poll
+// path; the per-row `view-transition-name` suppression (#3206) is still
+// tested in the '#3206 dialog-open view-transition gate' describe above.
+describe('DispatcherDashboard — #3220 / #3584 no view-transition on any poll (with or without dialog)', () => {
   beforeEach(() => {
     mockControlMutate.mockClear();
     mockSetConfigMutate.mockClear();
@@ -1004,16 +995,8 @@ describe('DispatcherDashboard — #3220 root view-transition gate while dialog o
     mockQueueFullData.COMPLETED = undefined;
   });
 
-  function installViewTransitionStub(): {
-    startViewTransition: ReturnType<typeof vi.fn>;
-    restore: () => void;
-  } {
+  it('does NOT call startViewTransition on a poll update while a dialog is open', async () => {
     const startViewTransition = vi.fn((cb: () => void): unknown => {
-      // Run the callback so `setRenderedData` actually commits —
-      // otherwise subsequent rerenders see a stale mirror. The real
-      // API wraps this in `flushSync`, but for the purpose of
-      // asserting "was startViewTransition called?" we don't need to
-      // reproduce the snapshot semantics.
       cb();
       return { finished: Promise.resolve() };
     });
@@ -1023,153 +1006,60 @@ describe('DispatcherDashboard — #3220 root view-transition gate while dialog o
       }
     ).startViewTransition = startViewTransition;
 
-    const originalMatchMedia = window.matchMedia;
-    (window as unknown as { matchMedia: typeof window.matchMedia }).matchMedia =
-      ((query: string) => ({
-        matches: false,
-        media: query,
-        onchange: null,
-        addListener: () => {},
-        removeListener: () => {},
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        dispatchEvent: () => false,
-      })) as typeof window.matchMedia;
-
-    return {
-      startViewTransition,
-      restore: () => {
-        delete (
-          document as unknown as {
-            startViewTransition?: (cb: () => void) => unknown;
-          }
-        ).startViewTransition;
-        (
-          window as unknown as { matchMedia: typeof window.matchMedia }
-        ).matchMedia = originalMatchMedia;
-      },
-    };
-  }
-
-  it('does NOT call startViewTransition on a poll-driven update while a dialog is open', async () => {
-    const { startViewTransition, restore } = installViewTransitionStub();
     try {
-      // Initial frame — first render initialises the mirror synchronously.
       mockQueryData = { dispatcherState: { ...BASE_STATE } };
       mockQueueFullData.READY = {
-        dispatcherQueueFull: {
-          kind: 'READY',
-          queueItems: [],
-          completions: [],
-        },
+        dispatcherQueueFull: { kind: 'READY', queueItems: [], completions: [] },
       };
       const { rerender } = renderDashboard();
-      expect(startViewTransition).not.toHaveBeenCalled();
-
-      // Open the Ready dialog. Opening the dialog is itself a React
-      // state update (`setFullDialogKind('READY')`), and the effect
-      // that mirrors Apollo's `data` has `fullDialogKind` in its
-      // dependency list — but there's no new `data` reference yet, so
-      // the effect's early-returns (`data === lastAppliedDataRef.current`)
-      // short-circuit and no transition fires.
       fireEvent.click(screen.getByTestId('queue-ready-count'));
       await screen.findByTestId('queue-full-dialog');
-      expect(startViewTransition).not.toHaveBeenCalled();
 
-      // Now simulate a poll landing a *new* `data` reference while the
-      // dialog is open. With the #3220 gate in place, the effect takes
-      // the synchronous branch (`fullDialogKind !== null`) and never
-      // calls `startViewTransitionUpdate`.
-      mockQueryData = {
-        dispatcherState: {
-          ...BASE_STATE,
-          queueDepth: 42,
-        },
-      };
+      mockQueryData = { dispatcherState: { ...BASE_STATE, queueDepth: 42 } };
       rerender(<DispatcherDashboard />);
 
-      // Give the effect a tick to run. `waitFor` will retry until the
-      // timeout; we expect it to *still* be zero at the end, so we
-      // just yield once and assert.
       await waitFor(() => {
-        // The dialog is still open — sanity check.
         expect(screen.queryByTestId('queue-full-dialog')).not.toBeNull();
       });
       expect(startViewTransition).not.toHaveBeenCalled();
     } finally {
-      restore();
+      delete (
+        document as unknown as {
+          startViewTransition?: (cb: () => void) => unknown;
+        }
+      ).startViewTransition;
     }
   });
 
-  it('DOES call startViewTransition on a poll-driven update when no dialog is open (regression guard)', async () => {
-    const { startViewTransition, restore } = installViewTransitionStub();
+  it('does NOT call startViewTransition on a poll update when no dialog is open (#3584)', async () => {
+    const startViewTransition = vi.fn((cb: () => void): unknown => {
+      cb();
+      return { finished: Promise.resolve() };
+    });
+    (
+      document as unknown as {
+        startViewTransition?: (cb: () => void) => unknown;
+      }
+    ).startViewTransition = startViewTransition;
+
     try {
       mockQueryData = { dispatcherState: { ...BASE_STATE } };
       const { rerender } = renderDashboard();
       expect(startViewTransition).not.toHaveBeenCalled();
 
-      // New data reference arrives — no dialog open, so the wrapper fires.
-      mockQueryData = {
-        dispatcherState: {
-          ...BASE_STATE,
-          queueDepth: 42,
-        },
-      };
+      mockQueryData = { dispatcherState: { ...BASE_STATE, queueDepth: 42 } };
       rerender(<DispatcherDashboard />);
 
       await waitFor(() => {
-        expect(startViewTransition).toHaveBeenCalledTimes(1);
-      });
-    } finally {
-      restore();
-    }
-  });
-
-  it('resumes wrapping poll updates in startViewTransition after the dialog closes', async () => {
-    const { startViewTransition, restore } = installViewTransitionStub();
-    try {
-      mockQueryData = { dispatcherState: { ...BASE_STATE } };
-      mockQueueFullData.READY = {
-        dispatcherQueueFull: {
-          kind: 'READY',
-          queueItems: [],
-          completions: [],
-        },
-      };
-      const { rerender } = renderDashboard();
-
-      // Open the dialog.
-      fireEvent.click(screen.getByTestId('queue-ready-count'));
-      await screen.findByTestId('queue-full-dialog');
-
-      // Poll lands while dialog is open — no transition.
-      mockQueryData = {
-        dispatcherState: { ...BASE_STATE, queueDepth: 1 },
-      };
-      rerender(<DispatcherDashboard />);
-      await waitFor(() => {
-        expect(screen.queryByTestId('queue-full-dialog')).not.toBeNull();
+        expect(screen.getByTestId('queue-ready-count')).toHaveTextContent('0 / 42');
       });
       expect(startViewTransition).not.toHaveBeenCalled();
-
-      // Close the dialog — QueueFullDialog's `onClose` flips the kind
-      // to null. We trigger it by pressing Escape on the dialog, which
-      // Radix handles by firing onOpenChange(false).
-      fireEvent.keyDown(document.body, { key: 'Escape', code: 'Escape' });
-      await waitFor(() => {
-        expect(screen.queryByTestId('queue-full-dialog')).toBeNull();
-      });
-
-      // Next poll with a new data reference should now be wrapped.
-      mockQueryData = {
-        dispatcherState: { ...BASE_STATE, queueDepth: 2 },
-      };
-      rerender(<DispatcherDashboard />);
-      await waitFor(() => {
-        expect(startViewTransition).toHaveBeenCalledTimes(1);
-      });
     } finally {
-      restore();
+      delete (
+        document as unknown as {
+          startViewTransition?: (cb: () => void) => unknown;
+        }
+      ).startViewTransition;
     }
   });
 });

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/cockpit-poll-stability.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/cockpit-poll-stability.test.tsx
@@ -1,0 +1,343 @@
+/**
+ * Regression tests for cockpit poll-triggered flicker (#3584).
+ *
+ * Root cause: `document.startViewTransition` was called on every Apollo poll
+ * cycle in `DispatcherDashboard.tsx`. The View Transitions API snapshots the
+ * *entire root viewport* (including the Header in app/layout.tsx) into
+ * `::view-transition-*(root)` and cross-fades it for ~250ms — causing the
+ * header logo region and cockpit rows to flicker on every 2s poll.
+ *
+ * Fix (#3584): the data-mirror `useEffect` now calls `setRenderedData(data)`
+ * synchronously. React's keyed reconciliation preserves DOM-node identity for
+ * unchanged rows without any view-transition wrapper.
+ *
+ * AC2 note: the route-level Header lives in `packages/web/src/app/layout.tsx`
+ * (line ~58) and is rendered OUTSIDE the polled `DispatcherDashboard` subtree,
+ * so it is inherently stable across refetches regardless of this fix.
+ *
+ * These tests verify:
+ *   AC3 / AC6 — DOM-node identity is preserved for unchanged rows across a
+ *               simulated refetch (same data and new-agent-appended variants).
+ *   AC4       — No skeleton renders during refetch when prior data exists.
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Apollo mocks — mirrors the pattern from DispatcherDashboard.test.tsx.
+// ---------------------------------------------------------------------------
+
+const mockControlMutate = vi.fn().mockResolvedValue({ data: {} });
+const mockSetConfigMutate = vi.fn().mockResolvedValue({ data: {} });
+const mockRefetch = vi.fn().mockResolvedValue({ data: {} });
+
+let mockQueryData: { dispatcherState?: Record<string, unknown> } | undefined;
+
+vi.mock('@apollo/client', async () => {
+  const actual = await vi.importActual<typeof import('@apollo/client')>('@apollo/client');
+  return {
+    ...actual,
+    useQuery: (
+      doc: { definitions?: Array<{ name?: { value?: string } }> },
+      options?: { variables?: { kind?: string }; skip?: boolean },
+    ) => {
+      const opName = doc?.definitions?.[0]?.name?.value ?? '';
+      if (opName === 'DispatcherQueueFull') {
+        return {
+          data: options?.skip ? undefined : { dispatcherQueueFull: { kind: options?.variables?.kind ?? 'READY', queueItems: [], completions: [] } },
+          loading: false,
+          error: undefined,
+          refetch: mockRefetch,
+        };
+      }
+      if (opName === 'WeeklyDiagnoserReport') {
+        return {
+          data: { weeklyDiagnoserReport: [] },
+          loading: false,
+          error: undefined,
+          refetch: mockRefetch,
+        };
+      }
+      return {
+        data: mockQueryData,
+        loading: false,
+        error: undefined,
+        refetch: mockRefetch,
+      };
+    },
+    useMutation: (doc: { definitions?: Array<{ name?: { value?: string } }> }) => {
+      const opName = doc?.definitions?.[0]?.name?.value ?? '';
+      if (opName === 'DispatcherControl') return [mockControlMutate, { loading: false }];
+      if (opName === 'DispatcherSetConfig') return [mockSetConfigMutate, { loading: false }];
+      return [vi.fn(), { loading: false }];
+    },
+  };
+});
+
+vi.mock('next/navigation', () => ({
+  notFound: () => { throw new Error('notFound called in test'); },
+}));
+
+vi.mock('@/providers/AuthProvider', () => ({
+  useAuth: () => ({
+    user: { id: '1', email: 'admin@test.com', role: 'admin' },
+    loading: false,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const BASE_STATE = {
+  currentRun: {
+    runId: 'run-1',
+    startedAt: '2026-04-18T10:00:00Z',
+    stoppedAt: null,
+    heartbeatTs: new Date().toISOString(),
+    versionSha: 'deadbeefcafe0000',
+    host: 'ip-10-0-0-1',
+    pid: 1234,
+  },
+  activeAgents: [],
+  recentFailures: [],
+  queueDepth: 0,
+  blockedDepth: 0,
+  queueReady: [],
+  queueBlocked: [],
+  recentCompletions: [],
+  recentCompletionsCount: 0,
+  config: [
+    { key: 'concurrency_cap', value: '3', updatedAt: '2026-04-18T09:00:00Z', updatedBy: 'init' },
+    { key: 'backoff_seconds', value: '[60,300,900]', updatedAt: '2026-04-18T09:00:00Z', updatedBy: 'init' },
+  ],
+  spawnFrozenUntil: null,
+  circuitBreakerOpen: false,
+  capFlippedBy: null,
+};
+
+const AGENT_A = {
+  id: 'aaaaaaaa-1111-2222-3333-444444444444',
+  issueNumber: 100,
+  issueTitle: 'agent-a',
+  priority: 'p2',
+  worktreePath: '/Users/x/.claude/worktrees/agent-aaaaaaaa',
+  phase: 'ralph',
+  status: 'running',
+  startedAt: '2026-04-18T11:00:00Z',
+  endedAt: null,
+  exitCode: null,
+  prNumber: null,
+  retriesUsed: 0,
+};
+
+const AGENT_B = {
+  id: 'bbbbbbbb-1111-2222-3333-444444444444',
+  issueNumber: 200,
+  issueTitle: 'agent-b',
+  priority: 'p2',
+  worktreePath: '/Users/x/.claude/worktrees/agent-bbbbbbbb',
+  phase: 'verify',
+  status: 'running',
+  startedAt: '2026-04-18T11:10:00Z',
+  endedAt: null,
+  exitCode: null,
+  prNumber: null,
+  retriesUsed: 0,
+};
+
+const AGENT_C = {
+  id: 'cccccccc-1111-2222-3333-444444444444',
+  issueNumber: 300,
+  issueTitle: 'agent-c',
+  priority: 'p2',
+  worktreePath: '/Users/x/.claude/worktrees/agent-cccccccc',
+  phase: 'ralph',
+  status: 'running',
+  startedAt: '2026-04-18T11:20:00Z',
+  endedAt: null,
+  exitCode: null,
+  prNumber: null,
+  retriesUsed: 0,
+};
+
+import { DispatcherDashboard } from '../DispatcherDashboard';
+
+function renderDashboard() {
+  return render(<DispatcherDashboard />);
+}
+
+// ---------------------------------------------------------------------------
+// AC3 / AC6: DOM-node identity preserved across refetch
+// ---------------------------------------------------------------------------
+
+describe('DispatcherDashboard — #3584 cockpit poll stability (AC3/AC6)', () => {
+  beforeEach(() => {
+    mockControlMutate.mockClear();
+    mockSetConfigMutate.mockClear();
+    mockRefetch.mockClear();
+  });
+
+  it('preserves DOM-node identity for both agent rows after a refetch with identical data (AC3)', async () => {
+    // Initial render with 2 active agents.
+    mockQueryData = {
+      dispatcherState: {
+        ...BASE_STATE,
+        activeAgents: [AGENT_A, AGENT_B],
+      },
+    };
+    const { rerender } = renderDashboard();
+
+    // Wait for the rows to appear.
+    await waitFor(() => {
+      expect(screen.getByTestId(`active-agent-row-${AGENT_A.id}`)).toBeInTheDocument();
+      expect(screen.getByTestId(`active-agent-row-${AGENT_B.id}`)).toBeInTheDocument();
+    });
+
+    // Capture the DOM element references BEFORE the refetch.
+    const rowABefore = screen.getByTestId(`active-agent-row-${AGENT_A.id}`);
+    const rowBBefore = screen.getByTestId(`active-agent-row-${AGENT_B.id}`);
+
+    // Simulate a poll arriving with a new object reference but identical content.
+    // (Apollo always returns a fresh object on each network reply.)
+    mockQueryData = {
+      dispatcherState: {
+        ...BASE_STATE,
+        activeAgents: [{ ...AGENT_A }, { ...AGENT_B }],
+      },
+    };
+    rerender(<DispatcherDashboard />);
+
+    // Wait for the effect to commit the new data.
+    await waitFor(() => {
+      expect(screen.getByTestId(`active-agent-row-${AGENT_A.id}`)).toBeInTheDocument();
+    });
+
+    // AC3: the DOM nodes must be the SAME objects — not remounted.
+    const rowAAfter = screen.getByTestId(`active-agent-row-${AGENT_A.id}`);
+    const rowBAfter = screen.getByTestId(`active-agent-row-${AGENT_B.id}`);
+
+    expect(rowAAfter).toBe(rowABefore);
+    expect(rowBAfter).toBe(rowBBefore);
+  });
+
+  it('preserves identity for existing rows when a new agent is appended (AC6)', async () => {
+    // Initial render with 2 agents.
+    mockQueryData = {
+      dispatcherState: {
+        ...BASE_STATE,
+        activeAgents: [AGENT_A, AGENT_B],
+      },
+    };
+    const { rerender } = renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`active-agent-row-${AGENT_A.id}`)).toBeInTheDocument();
+      expect(screen.getByTestId(`active-agent-row-${AGENT_B.id}`)).toBeInTheDocument();
+    });
+
+    const rowABefore = screen.getByTestId(`active-agent-row-${AGENT_A.id}`);
+    const rowBBefore = screen.getByTestId(`active-agent-row-${AGENT_B.id}`);
+
+    // Refetch with a third agent appended.
+    mockQueryData = {
+      dispatcherState: {
+        ...BASE_STATE,
+        activeAgents: [{ ...AGENT_A }, { ...AGENT_B }, AGENT_C],
+      },
+    };
+    rerender(<DispatcherDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`active-agent-row-${AGENT_C.id}`)).toBeInTheDocument();
+    });
+
+    // Existing rows keep their DOM identity.
+    expect(screen.getByTestId(`active-agent-row-${AGENT_A.id}`)).toBe(rowABefore);
+    expect(screen.getByTestId(`active-agent-row-${AGENT_B.id}`)).toBe(rowBBefore);
+
+    // New row mounts fresh.
+    const rowCAfter = screen.getByTestId(`active-agent-row-${AGENT_C.id}`);
+    expect(rowCAfter).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // AC4: no skeleton renders during refetch when prior data exists
+  // ---------------------------------------------------------------------------
+
+  it('does not render a skeleton during refetch when prior data exists (AC4)', async () => {
+    // Initial render — data already present.
+    mockQueryData = {
+      dispatcherState: {
+        ...BASE_STATE,
+        activeAgents: [AGENT_A],
+      },
+    };
+    renderDashboard();
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`active-agent-row-${AGENT_A.id}`)).toBeInTheDocument();
+    });
+
+    // The skeleton pulse blocks are only rendered during `showInitialLoad`.
+    // Once data is present they must be absent.
+    // The skeleton shell renders four `animate-pulse` divs and a fifth
+    // for the bottom bar. We look for the dispatcher-two-column-deck to
+    // confirm data is rendered and the skeleton is not.
+    expect(screen.getByTestId('dispatcher-two-column-deck')).toBeInTheDocument();
+    // No skeleton animation elements visible at the top level.
+    // The SkeletonShell is a sibling of the two-column-deck; if the deck
+    // is present the skeleton branch is not rendered.
+    expect(screen.queryByText(/animate-pulse/)).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // AC4 variant: startViewTransition is never called (post-#3584 regression
+  // guard that would catch a re-introduction of the wrapping).
+  // ---------------------------------------------------------------------------
+
+  it('never calls startViewTransition on any poll cycle (#3584 regression guard)', async () => {
+    const startViewTransition = vi.fn((cb: () => void): unknown => {
+      cb();
+      return { finished: Promise.resolve() };
+    });
+    (
+      document as unknown as { startViewTransition?: (cb: () => void) => unknown }
+    ).startViewTransition = startViewTransition;
+
+    try {
+      mockQueryData = {
+        dispatcherState: { ...BASE_STATE, activeAgents: [AGENT_A, AGENT_B] },
+      };
+      const { rerender } = renderDashboard();
+
+      await waitFor(() => {
+        expect(screen.getByTestId(`active-agent-row-${AGENT_A.id}`)).toBeInTheDocument();
+      });
+
+      // Simulate multiple poll cycles.
+      for (let i = 1; i <= 3; i++) {
+        mockQueryData = {
+          dispatcherState: {
+            ...BASE_STATE,
+            activeAgents: [{ ...AGENT_A }, { ...AGENT_B }],
+            queueDepth: i,
+          },
+        };
+        rerender(<DispatcherDashboard />);
+      }
+
+      await waitFor(() => {
+        expect(screen.getByTestId('queue-ready-count')).toHaveTextContent('0 / 3');
+      });
+
+      // startViewTransition must NEVER have been called across any of the polls.
+      expect(startViewTransition).not.toHaveBeenCalled();
+    } finally {
+      delete (
+        document as unknown as { startViewTransition?: (cb: () => void) => unknown }
+      ).startViewTransition;
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Removed the `document.startViewTransition` wrapper from dispatcher cockpit poll-update cycles. The View Transitions API snapshots the entire root viewport (including the Header in app/layout.tsx) and cross-fades it for ~250ms on every 2s poll, causing operator-visible flicker on the cockpit header and row text. React's keyed reconciliation already preserves DOM-node identity for unchanged rows; the wrapper was unnecessary overhead.

Also fixed a stray `key={idx}` array-index key in DiagnoserEffectivenessPanel.tsx to use stable row-content composite key.

Closes #3584

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`) — 330 tests pass per ralph output
- [x] CI green

### Post-deploy verification

- [ ] Poll-cycle pixel-diff: dev.judgemind.org/admin/dispatcher — capture screenshot before/after poll cycle; diff must be zero in top-bar region (top 80px) and unchanged list rows (see /task-v2-verify output for detailed procedure)
- [ ] Regression test suite passes: cockpit-poll-stability.test.tsx DOM-node identity assertions confirm no remount/re-render on poll refetch