### PR TITLE
fix(dispatcher): route ralph_not_ship to diagnoser instead of local handler

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -225,7 +225,19 @@ If the conflict is structural (semantic collision — function rewritten on main
 
 ### Per-category guidance — `agent_runner_route_stub` (#3366) — historical
 
-Pre-#3455 the agent-runner entrypoint hit a transition shape it didn't know how to route (often `ralph_not_ship` — ralph terminated with a non-SHIP verdict) and emitted `agent_runner_route_stub`. Post-#3455 those fall-throughs are eliminated — the entrypoint emits descriptive terminal phases (`ralph_baseline_transition_unrecognized`, `push_and_pr_transition_unrecognized`, `phase_unknown_<phase>`, etc.) via `agent_runner_reaped_failure`, and `ralph_not_ship` is handled locally (post comment + add `status/blocked`) without bouncing to the diagnoser. If you do see an `agent_runner_route_stub` row in the wild, that's a pre-#3455 agent or a regression — read `context.details.route_hint`, the agent's commits (`git log --oneline origin/main..HEAD`), and the latest reviewer feedback (`{worktree}/tmp/ralph/*-feedback.md` if present), and route to `retry_with_hint` (write a hint, set `next_directive=respawn_at=ralph` if you reset the agent's commits, otherwise `terminal`) or to the inline-#3455 `terminal` shape with `action_taken="block_and_comment"`.
+Pre-#3455 the agent-runner entrypoint hit a transition shape it didn't know how to route (often `ralph_not_ship` — ralph terminated with a non-SHIP verdict) and emitted `agent_runner_route_stub`. Post-#3455 those fall-throughs are eliminated — the entrypoint emits descriptive terminal phases (`ralph_baseline_transition_unrecognized`, `push_and_pr_transition_unrecognized`, `phase_unknown_<phase>`, etc.) via `agent_runner_reaped_failure`. Post-#3586 `ralph_not_ship` is routed through the diagnoser (see below). If you do see an `agent_runner_route_stub` row in the wild, that's a pre-#3455 agent or a regression — read `context.details.route_hint`, the agent's commits (`git log --oneline origin/main..HEAD`), and the latest reviewer feedback (`{worktree}/tmp/ralph/*-feedback.md` if present), and route to `retry_with_hint` (write a hint, set `next_directive=respawn_at=ralph` if you reset the agent's commits, otherwise `terminal`) or to the inline-#3455 `terminal` shape with `action_taken="block_and_comment"`.
+
+### Per-category guidance — `ralph_not_ship` (#3586)
+
+Routed here when ralph terminated with a non-SHIP verdict (typically `BLOCKED` — the implementation cannot proceed without a prerequisite). The agent-runner passes ralph's `block_reason` as the third arg to `agent_runner_reaped_failure`, so `context.details.stderr_tail` carries the block_reason verbatim. The ralph phase_outputs row (if present) also surfaces `verdict`, `iterations_used`, and `block_reason` via `context.details`.
+
+**Typical actions based on block_reason content:**
+
+- **`file_prerequisite_task`** — when the block_reason names a missing dependency, external prerequisite, or upstream issue that must land first. File a `type/task` issue for the prerequisite, then write `next_directive=terminal` with `action_taken="file_prerequisite_task"` and a `block_issued_number` in the directive. The daemon will `block_and_comment` automatically.
+- **`block_and_comment`** — when the block is in operator territory (ambiguous AC, product decision needed, requires human judgment). Post an informative comment on the issue, add `status/blocked`, remove `agent/ready`. Write `next_directive=terminal` with `action_taken="block_and_comment"`.
+- **`close`** — when the issue is stale, the block_reason reveals the task is a NOOP (already done, unreachable by design), or AC cannot be satisfied by any reasonable implementation. Write `next_directive=terminal` with `action_taken="close"`.
+- **`escalate`** — when the block_reason is ambiguous and you cannot determine the right action. Write `next_directive=terminal` with `action_taken="escalate"`.
+- **inline-#3455 `terminal` shape** — for any of the above, prefer `action="terminal"` with a descriptive `action_taken` + `summary` so the diagnoser collapses the executor layer rather than delegating back to the daemon.
 
 ### Per-category guidance — AC-infeasibility (#3010)
 

--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -3935,108 +3935,12 @@ EOF
     exit 0
 }
 
-handle_ralph_not_ship_local() {
-    # Issue #3455 Path B — handle ``ralph_not_ship`` locally instead of
-    # routing to the diagnoser. Pre-#3455 this hint hit the
-    # ``advance_phase agent_runner_route_stub`` fall-through (line ~4433)
-    # because the daemon-side ralph_not_ship handler was never wired —
-    # 14 agents died at ``diagnoser_route_stub`` for absent-handler
-    # reasons. The empowered diagnoser doesn't add value here: ralph
-    # already wrote a ``block_reason`` explaining why it couldn't ship.
-    # We just relay that reason to the issue as a comment, add
-    # ``status/blocked``, and emit a clean terminal.
-    #
-    # $1 = the ralph phase output JSON (so we can extract block_reason).
-    _ralph_output="${1:-}"
-    _block_reason=$(printf '%s' "$_ralph_output" | jq -r '.block_reason // ""' 2>/dev/null)
-    _verdict=$(printf '%s' "$_ralph_output" | jq -r '.verdict // ""' 2>/dev/null)
-    _iterations_used=$(printf '%s' "$_ralph_output" | jq -r '.iterations_used // ""' 2>/dev/null)
-    log "ralph_not_ship_local_handler" \
-        "issue_number=$ISSUE_NUMBER" \
-        "verdict=$_verdict" \
-        "iterations_used=$_iterations_used" \
-        "block_reason_preview=$(printf '%s' "$_block_reason" | head -c 120)"
-
-    if [[ -n "$ISSUE_NUMBER" ]]; then
-        # Compose the comment body in a temp file to avoid heredoc /
-        # quoted-string preflight issues. ``$AGENT_WORKSPACE`` is the
-        # entrypoint's writable scratch dir.
-        _comment_file="$AGENT_WORKSPACE/ralph-not-ship-comment.md"
-        {
-            printf '## Ralph determined it cannot ship\n\n'
-            if [[ -n "$_verdict" && "$_verdict" != "null" ]]; then
-                printf 'Verdict: `%s`\n\n' "$_verdict"
-            fi
-            if [[ -n "$_iterations_used" && "$_iterations_used" != "null" && "$_iterations_used" != "" ]]; then
-                printf 'Iterations used: %s\n\n' "$_iterations_used"
-            fi
-            if [[ -n "$_block_reason" && "$_block_reason" != "null" ]]; then
-                printf '**Block reason from ralph:**\n\n'
-                printf '> %s\n\n' "$_block_reason"
-            else
-                printf 'Ralph did not provide a structured block_reason.\n\n'
-            fi
-            printf 'Adding `status/blocked` so the issue stays off the queue '
-            printf 'until a human reviews the block reason and decides whether '
-            printf 'to clarify the AC, file a prerequisite, or close as NOOP.\n'
-            printf '\n'
-            printf '_Posted by the agent-runner ralph_not_ship local handler '
-            printf '(#3455). The diagnoser was not invoked — ralph already '
-            printf 'identified the block; relaying its reasoning verbatim is '
-            printf 'cheaper and more honest than another LLM pass over the '
-            printf 'same evidence._\n'
-        } > "$_comment_file" 2> "$AGENT_WORKSPACE/ralph-not-ship-comment.stderr.log"
-
-        set +e
-        gh issue comment "$ISSUE_NUMBER" \
-            --repo judgemind/judgemind \
-            --body-file "$_comment_file" \
-            > "$AGENT_WORKSPACE/ralph-not-ship-comment.stdout.log" \
-            2>> "$AGENT_WORKSPACE/ralph-not-ship-comment.stderr.log"
-        _comment_rc=$?
-        set -e
-        if [[ "$_comment_rc" -ne 0 ]]; then
-            log "ralph_not_ship_local_comment_failed" \
-                "issue_number=$ISSUE_NUMBER" "exit_code=$_comment_rc"
-        else
-            log "ralph_not_ship_local_comment_posted" \
-                "issue_number=$ISSUE_NUMBER"
-        fi
-
-        # Add status/blocked + remove agent/ready so the issue is fully
-        # off the queue until human review. Both ops are idempotent.
-        set +e
-        gh issue edit "$ISSUE_NUMBER" \
-            --repo judgemind/judgemind \
-            --add-label status/blocked \
-            --remove-label agent/ready \
-            > "$AGENT_WORKSPACE/ralph-not-ship-label.stdout.log" \
-            2> "$AGENT_WORKSPACE/ralph-not-ship-label.stderr.log"
-        _label_rc=$?
-        set -e
-        if [[ "$_label_rc" -ne 0 ]]; then
-            log "ralph_not_ship_local_label_failed" \
-                "issue_number=$ISSUE_NUMBER" "exit_code=$_label_rc"
-        else
-            log "ralph_not_ship_local_label_applied" \
-                "issue_number=$ISSUE_NUMBER"
-        fi
-    else
-        log "ralph_not_ship_local_no_issue_number" \
-            "skipping comment + label edits — no ISSUE_NUMBER set"
-    fi
-
-    # Always emit the descriptive terminal. The reason carries the
-    # block_reason so operators / failure dashboards see the cause.
-    _reason_for_terminal="$_block_reason"
-    if [[ -z "$_reason_for_terminal" ]]; then
-        _reason_for_terminal="ralph emitted non-SHIP verdict ${_verdict:-(missing)} without block_reason"
-    fi
-    agent_runner_reaped_failure \
-        "ralph_not_ship" \
-        "ralph_not_ship" \
-        "$_reason_for_terminal"
-}
+# handle_ralph_not_ship_local was removed in #3586. ``ralph_not_ship``
+# is now routed through the diagnoser via the descriptive-terminal arm
+# in the post-claude dispatch (see BYPASSED_TERMINAL_PHASES_TO_ROUTE).
+# The local handler was defined in #3455 and handled by posting a
+# comment + adding status/blocked; those actions are now the diagnoser's
+# responsibility based on block_reason analysis.
 
 fetch_pr_status() {
     # $1 = pr_number. Writes the JSON response from
@@ -4997,8 +4901,19 @@ while true; do
                                 "fix_conflict skill returned unresolvable or budget exhausted"
                             ;;
                         ralph_not_ship)
-                            log "ralph_not_ship_local" "hint=$_hint"
-                            handle_ralph_not_ship_local "$_output"
+                            # #3586 — route through diagnoser via
+                            # BYPASSED_TERMINAL_PHASES_TO_ROUTE (reversed
+                            # from the #3455 local-handler path).
+                            # Pass block_reason as the third arg so the
+                            # failures-row reason/stderr_tail carries
+                            # ralph's structured block_reason for the
+                            # diagnoser to act on.
+                            _block_reason=$(printf '%s' "$_output" | jq -r '.block_reason // ""' 2>/dev/null)
+                            log "diagnoser_route_ralph_not_ship" "hint=$_hint" "phase=$_current"
+                            agent_runner_reaped_failure \
+                                "ralph_not_ship" \
+                                "ralph_not_ship" \
+                                "$_block_reason"
                             ;;
                         ralph_ac_infeasible|summary_ac_infeasible|fix_ci_blocked|verify_failed_post_merge|push_and_pr_no_unmerged_files)
                             # Descriptive terminal — the daemon's

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1362,13 +1362,11 @@ FAILURE_CATEGORY_AGENT_RUNNER_ROUTE_STUB = "agent_runner_route_stub"
 #: ``advance_with_status`` (terminal status), not ``route_to_diagnoser``,
 #: so the daemon has its own explicit handling for it.
 #:
-#: ``ralph_not_ship`` is intentionally NOT in this map. Issue #3455
-#: handles that hint locally in the agent-runner entrypoint
-#: (``handle_ralph_not_ship_local``) — ralph already wrote a structured
-#: ``block_reason`` and the diagnoser doesn't add value there. The
-#: terminal phase still reads ``ralph_not_ship`` for operator visibility,
-#: but no diagnoser is invoked. Same shape as ``conflict_unresolvable``
-#: legacy treatment minus the routing.
+#: ``ralph_not_ship`` was intentionally NOT in this map (issue #3455 /
+#: local handler). Issue #3586 reverses that decision: the diagnoser
+#: CAN add value — ``file_prerequisite_task``, ``block_and_comment``,
+#: ``close``, or ``escalate`` based on the ``block_reason`` ralph
+#: surfaced — so we now route it through the same bypass-terminal sweep.
 BYPASSED_TERMINAL_PHASES_TO_ROUTE: dict[str, str] = {
     "conflict_unresolvable": FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE,
     "agent_runner_route_stub": FAILURE_CATEGORY_AGENT_RUNNER_ROUTE_STUB,
@@ -1383,6 +1381,9 @@ BYPASSED_TERMINAL_PHASES_TO_ROUTE: dict[str, str] = {
     "push_and_pr_no_unmerged_files": FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
     # #3507 — operational skill returned failed/unrecognized verdict.
     "operational_failed": FAILURE_CATEGORY_OPERATIONAL_FAILED,
+    # #3586 — ralph returned non-SHIP verdict; diagnoser takes over from
+    # the former local handler so it can file prereqs / close / escalate.
+    "ralph_not_ship": FAILURE_CATEGORY_RALPH_NOT_SHIP,
 }
 
 #: GitHub's rejection stderr fragment when branch protection's
@@ -12269,6 +12270,44 @@ class DispatcherDaemon:
                         ):
                             if key in raw:
                                 details[key] = raw[key]
+            except Exception:
+                try:
+                    self._conn.rollback()
+                except Exception:  # pragma: no cover
+                    pass
+
+        if terminal_phase == "ralph_not_ship":
+            # #3586 — pull the ralph phase_outputs row to surface
+            # verdict, iterations_used, and block_reason for the
+            # diagnoser. The entrypoint passes block_reason as the
+            # third arg to agent_runner_reaped_failure (written to the
+            # terminal-phase row's ``reason`` field above), but the
+            # ralph row has the full structured output.
+            try:
+                with self._conn.cursor() as cur:
+                    cur.execute(
+                        "SELECT output_json FROM dispatcher.phase_outputs "
+                        "WHERE agent_id = %s AND phase = 'ralph' "
+                        "ORDER BY ts DESC LIMIT 1",
+                        (agent_id,),
+                    )
+                    row = cur.fetchone()
+                self._conn.commit()
+                if row is not None and row[0] is not None:
+                    raw = row[0]
+                    if isinstance(raw, str):
+                        try:
+                            raw = json.loads(raw)
+                        except json.JSONDecodeError:
+                            raw = {}
+                    if isinstance(raw, dict):
+                        for key in ("verdict", "iterations_used", "block_reason"):
+                            if key in raw:
+                                details[key] = raw[key]
+                        # Ensure block_reason also surfaces as stderr_tail
+                        # so diagnoser §Step 1 verbatim-quote rule applies.
+                        if "block_reason" in raw and "stderr_tail" not in details:
+                            details["stderr_tail"] = raw["block_reason"]
             except Exception:
                 try:
                     self._conn.rollback()

--- a/scripts/dispatcher/tests/test_agent_runner_no_route_stub.py
+++ b/scripts/dispatcher/tests/test_agent_runner_no_route_stub.py
@@ -95,53 +95,48 @@ class TestNoRouteStubInExecutableLines:
         )
 
 
-class TestRalphNotShipLocalHandlerExists:
-    """Issue #3455 — the new handler that handles ``ralph_not_ship``
-    locally instead of routing to the diagnoser."""
+class TestRalphNotShipDescriptiveTerminal:
+    """Issue #3586 — ``ralph_not_ship`` is now routed through the
+    diagnoser via the descriptive-terminal path (BYPASSED_TERMINAL_PHASES_TO_ROUTE),
+    not handled locally by the defunct ``handle_ralph_not_ship_local``
+    function from #3455."""
 
-    def test_handle_ralph_not_ship_local_function_defined(self) -> None:
+    def test_handle_ralph_not_ship_local_function_not_defined(self) -> None:
+        """The local handler must be gone — #3586 removed it."""
         text = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
-        # Match the function definition opening — ``handle_ralph_not_ship_local() {``.
-        assert re.search(
+        assert not re.search(
             r"^handle_ralph_not_ship_local\s*\(\s*\)\s*\{",
             text,
             re.MULTILINE,
-        ), "handle_ralph_not_ship_local function not defined"
+        ), (
+            "handle_ralph_not_ship_local function must not be defined (#3586 removed it)"
+        )
 
-    def test_handler_posts_comment_with_block_reason(self) -> None:
+    def test_route_to_diagnoser_dispatches_ralph_not_ship_as_descriptive_terminal(
+        self,
+    ) -> None:
+        """Verify the ``ralph_not_ship)`` case arm now calls
+        ``agent_runner_reaped_failure "ralph_not_ship"`` directly
+        (descriptive-terminal path) rather than the local handler."""
         text = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
-        # The handler body should reference both gh issue comment + the
-        # block_reason it relays.
-        assert "gh issue comment" in text
-        assert "block_reason" in text
-        # And it should add status/blocked + remove agent/ready.
-        assert "--add-label status/blocked" in text
-        assert "--remove-label agent/ready" in text
-
-    def test_handler_emits_ralph_not_ship_terminal(self) -> None:
-        text = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
-        # The handler should call agent_runner_reaped_failure with
-        # the ``ralph_not_ship`` terminal phase.
+        # The case arm should call agent_runner_reaped_failure with
+        # "ralph_not_ship" as the phase arg — no handle_ralph_not_ship_local call.
         assert re.search(
-            r'agent_runner_reaped_failure\s*\\?\s*\n?\s*"ralph_not_ship"',
+            r'agent_runner_reaped_failure\s*\\\s*\n\s*"ralph_not_ship"',
             text,
-        ), "handler must emit `ralph_not_ship` terminal via agent_runner_reaped_failure"
+        ), (
+            "ralph_not_ship case arm must emit descriptive terminal via "
+            'agent_runner_reaped_failure "ralph_not_ship" (#3586)'
+        )
 
-    def test_route_to_diagnoser_dispatches_ralph_not_ship_locally(self) -> None:
-        """Verify the case-block in the post-claude dispatch arm calls
-        the local handler for ``ralph_not_ship`` (not advance_phase to
-        agent_runner_route_stub)."""
-        text = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
-        # Look for the ``ralph_not_ship)`` case arm calling
-        # ``handle_ralph_not_ship_local``.
-        m = re.search(
-            r"ralph_not_ship\)\s*\n\s*log\b[^\n]*\n\s*handle_ralph_not_ship_local",
-            text,
-        )
-        assert m is not None, (
-            "route_to_diagnoser case arm should dispatch `ralph_not_ship` to "
-            "handle_ralph_not_ship_local (not route_stub)"
-        )
+    def test_ralph_not_ship_case_arm_not_calling_local_handler(self) -> None:
+        """Double-check: the ralph_not_ship case arm must NOT call
+        handle_ralph_not_ship_local anywhere in executable code."""
+        for lineno, line in _executable_lines():
+            assert "handle_ralph_not_ship_local" not in line, (
+                f"handle_ralph_not_ship_local found in executable code at L{lineno} "
+                "(#3586 removed this function)"
+            )
 
 
 class TestReapedFailureExitsUnconditionally:

--- a/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
+++ b/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
@@ -46,6 +46,7 @@ from dispatcher.daemon import (  # noqa: E402
     FAILURE_CATEGORY_AGENT_RUNNER_ROUTE_STUB,
     FAILURE_CATEGORY_CONFLICT_UNRESOLVABLE,
     FAILURE_CATEGORY_OPERATIONAL_FAILED,
+    FAILURE_CATEGORY_RALPH_NOT_SHIP,
     TIER_3_CATEGORIES,
 )
 
@@ -125,12 +126,13 @@ class TestBypassedTerminalConstants:
         # post-claude ``route_to_diagnoser`` arm in
         # agent-runner-entrypoint.sh. Each phase maps to its
         # FAILURE_CATEGORY so the diagnoser sweep picks them up.
-        # ``ralph_not_ship`` is intentionally NOT here — it's handled
-        # locally by the entrypoint.
+        # Issue #3586 adds ``ralph_not_ship`` — reversed from the
+        # #3455 local-handler path; the diagnoser now handles it.
         from dispatcher.daemon import (
             FAILURE_CATEGORY_FIX_CI_BLOCKED,
             FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
             FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
+            FAILURE_CATEGORY_RALPH_NOT_SHIP,
             FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
             FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
         )
@@ -144,6 +146,7 @@ class TestBypassedTerminalConstants:
             "verify_failed_post_merge": FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
             "push_and_pr_no_unmerged_files": FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
             "operational_failed": FAILURE_CATEGORY_OPERATIONAL_FAILED,
+            "ralph_not_ship": FAILURE_CATEGORY_RALPH_NOT_SHIP,
         }
 
 
@@ -406,3 +409,80 @@ class TestReapRoutesBypassedTerminals:
         mock_finalize.assert_called_once_with(agent_id, issue_number)
         assert summary["reaped_success"] == 1
         assert summary["reaped_failure"] == 0
+
+    def test_ralph_not_ship_routes_through_handle_agent_failure(self) -> None:
+        """Issue #3586 — ``ralph_not_ship`` terminal phase routes through
+        ``_handle_agent_failure`` (not the defunct local handler from #3455).
+
+        AC #2 regression contract: this test MUST FAIL against pre-#3586
+        code (where ``ralph_not_ship`` was absent from
+        ``BYPASSED_TERMINAL_PHASES_TO_ROUTE``).
+        """
+        d = self._make_reaper_daemon()
+        cur = d._main_conn._cursor  # type: ignore[attr-defined]
+        agent_id = "agent-ralph-not-ship"
+        issue_number = 99010
+        arn = "arn:aws:ecs:us-west-2:123:task/test/ralph-not-ship"
+
+        # 1. Initial SELECT for active agent rows.
+        cur.fetchall_queue = [
+            [
+                self._agent_row(
+                    agent_id, issue_number, arn, "ralph_not_ship", "failed"
+                )
+            ],
+        ]
+        # 2. _read_agent_status_phase + _build_bypassed_terminal_details
+        #    fetches: terminal phase_outputs row, then ralph phase_outputs row.
+        cur.fetch_queue = [
+            ("failed", "ralph_not_ship"),  # _read_agent_status_phase
+            (
+                {
+                    "category": "ralph_not_ship",
+                    "reason": "ralph cannot proceed without prerequisite #2840",
+                },
+            ),  # terminal phase_outputs row
+            (
+                {
+                    "verdict": "BLOCKED",
+                    "iterations_used": 3,
+                    "block_reason": "ralph cannot proceed without prerequisite #2840",
+                },
+            ),  # ralph phase_outputs row
+        ]
+
+        d._ecs_client.describe_tasks.return_value = {  # type: ignore[attr-defined]
+            "tasks": [
+                {
+                    "taskArn": arn,
+                    "lastStatus": "STOPPED",
+                    "stopCode": "EssentialContainerExited",
+                    "containers": [{"exitCode": 0}],
+                }
+            ]
+        }
+
+        with patch.object(d, "_handle_agent_failure") as mock_handle:
+            with patch.object(d, "_clear_agent_task_arn") as mock_clear:
+                summary = d._reap_completed_agent_tasks()
+
+        mock_handle.assert_called_once()
+        kwargs = mock_handle.call_args.kwargs
+        assert kwargs["agent_id"] == agent_id
+        assert kwargs["category"] == FAILURE_CATEGORY_RALPH_NOT_SHIP
+        assert kwargs["phase"] == "ralph_not_ship"
+        assert kwargs["issue_number"] == issue_number
+        # block_reason carried through as stderr_tail for diagnoser §Step 1.
+        assert (
+            "prerequisite #2840" in kwargs["details"]["stderr_tail"]
+        ), f"block_reason not in stderr_tail: {kwargs['details'].get('stderr_tail')!r}"
+        assert kwargs["details"]["terminal_phase"] == "ralph_not_ship"
+
+        # ARN clear ran so the next reap tick excludes the row.
+        mock_clear.assert_called_once_with(
+            agent_id=agent_id, issue_number=issue_number, branch="route_to_diagnoser"
+        )
+
+        # Counted as a failure reap, not a success reap.
+        assert summary["reaped_failure"] == 1
+        assert summary["reaped_success"] == 0


### PR DESCRIPTION
## Summary

Ralph's BLOCKED verdict (ralph_not_ship terminal phase) now routes through the diagnoser instead of the defunct local handler from #3455. The diagnoser can then file prerequisite tasks, block-and-comment, close, or escalate based on block_reason analysis. This fixes the regression where ralph BLOCKED agents terminated without producing diagnoser rows, leaving issues stuck without actionable next steps.

Closes #3586

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] Re-add `agent/ready` to issue #2840, let agent run and verify it produces a `dispatcher.diagnoses` row with diagnoser action (file_prerequisite_task / close / escalate / terminal)
- [ ] Verification evidence posted on #3586 (see /task-v2-verify output)