### PR TITLE
fix(dispatcher): awaiting_deploy false-positive classification on shipped PRs (#3587)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -3833,13 +3833,28 @@ classify_pr_rollup() {
 
 classify_deploy_runs() {
     # $1 = path to ``gh run list --json status,conclusion,...`` stdout.
-    # Prints one of: success / failure / pending / none. Matches
-    # ``_classify_deploy_runs`` in daemon.py. ``none`` means no
-    # matching deploy runs — caller treats as "no deploy applicable".
+    # Prints one of: success / failure / cancelled / pending / none / poll_error.
+    # Matches ``_classify_deploy_runs`` in daemon.py.
+    #   - "none"       — no matching deploy runs (grace-window logic applies).
+    #   - "poll_error" — sentinel null written by find_deploy_runs on gh failure.
+    #   - "cancelled"  — a run for the merge SHA was CANCELLED (separate from
+    #                    failure so the caller can route to the diagnoser rather
+    #                    than treating a concurrency-cancelled run as a hard
+    #                    deploy failure, #3587).
     _runs_file="$1"
     if [[ ! -s "$_runs_file" ]]; then
         printf 'none'
         return 0
+    fi
+    # Check for null sentinel (written by find_deploy_runs on gh API failure).
+    _first_char=$(head -c 1 "$_runs_file" 2>/dev/null || printf '')
+    if [[ "$_first_char" == "n" ]]; then
+        # Content is "null" — this is the poll-error sentinel, not an empty array.
+        _sentinel_content=$(cat "$_runs_file" 2>/dev/null || printf '')
+        if [[ "$_sentinel_content" == "null" ]]; then
+            printf 'poll_error'
+            return 0
+        fi
     fi
     _state=$(jq -r '
         def classify:
@@ -3850,9 +3865,11 @@ classify_deploy_runs() {
                 | (.conclusion // "" | ascii_upcase) as $co
                 | if $st != "COMPLETED" then "pending"
                   elif ($co == "SUCCESS" or $co == "SKIPPED" or $co == "NEUTRAL") then "ok"
+                  elif $co == "CANCELLED" then "cancelled"
                   else "failure" end]) as $outcomes
               | if ($outcomes | index("pending")) then "pending"
                 elif ($outcomes | index("failure")) then "failure"
+                elif ($outcomes | index("cancelled")) then "cancelled"
                 else "success" end
             end;
         classify
@@ -4435,7 +4452,16 @@ find_deploy_runs() {
     _gh_rc=$?
     set -e
     if [[ "$_gh_rc" -ne 0 ]]; then
-        printf '[]' > "$_out_file"
+        # Distinguish API/network failure from "no runs found": write a
+        # null sentinel so classify_deploy_runs can return "poll_error"
+        # instead of "none". "none" would start the grace-window timer
+        # prematurely on a transient gh outage; "poll_error" lets the
+        # caller retry with a bounded counter (#3587).
+        printf 'null' > "$_out_file"
+        log "find_deploy_runs_gh_error" \
+            "merge_sha=$_sha" \
+            "gh_rc=$_gh_rc" \
+            "stderr=$(head -c 200 "$AGENT_WORKSPACE/gh-run-list.stderr.log" 2>/dev/null || true)"
         return 0
     fi
     # Post-filter: keep only entries whose workflowName is in the deploy
@@ -4485,7 +4511,9 @@ handle_awaiting_deploy() {
     _start_ts=$(date -u +%s)
     _last_state=""
     _poll_count=0
+    _poll_error_count=0
     _max_polls="${AGENT_RUNNER_DEPLOY_MAX_POLLS:-60}"
+    _max_poll_errors="${AGENT_RUNNER_DEPLOY_MAX_POLL_ERRORS:-5}"
     while true; do
         _poll_count=$((_poll_count + 1))
         if [[ "$_poll_count" -gt "$_max_polls" ]]; then
@@ -4517,12 +4545,19 @@ handle_awaiting_deploy() {
                 "elapsed_seconds=$_elapsed_poll"
             # Log individual run details for observability.
             if [[ -s "$AGENT_WORKSPACE/deploy-runs.json" ]]; then
-                jq -r '.[] | "run_id=\(.databaseId) run_head_sha=\(.headSha // "?") run_status=\(.status // "?") run_conclusion=\(.conclusion // "?") workflow=\(.workflowName // "?")"' \
+                jq -r 'if type == "array" then .[] | "run_id=\(.databaseId) run_head_sha=\(.headSha // "?") run_status=\(.status // "?") run_conclusion=\(.conclusion // "?") workflow=\(.workflowName // "?")" else empty end' \
                     "$AGENT_WORKSPACE/deploy-runs.json" 2>/dev/null \
                     | while IFS= read -r _run_line; do
                         log "awaiting_deploy_run_detail" "pr_number=$_pr_number" "$_run_line"
                     done
             fi
+            # Structured classify outcome log for self-diagnosis (#3587).
+            log "awaiting_deploy_classify_outcome" \
+                "pr_number=$_pr_number" \
+                "merge_sha=$_merge_sha" \
+                "deploy_state=$_state" \
+                "poll_count=$_poll_count" \
+                "poll_error_count=$_poll_error_count"
         else
             _state="pending"
         fi
@@ -4535,12 +4570,48 @@ handle_awaiting_deploy() {
             return 0
         fi
         if [[ "$_state" == "failure" ]]; then
+            # #3587: printf BEFORE agent_runner_reaped_failure so the JSON
+            # envelope reaches the parent shell's command substitution. The
+            # reaper calls exit 0, which terminates the subshell; any printf
+            # after it is unreachable and the parent sees empty $_output.
+            printf '{"deploy_state": "failure", "merge_sha": "%s"}' "$_merge_sha"
             agent_runner_reaped_failure \
                 "awaiting_deploy_failed" \
                 "deploy_failed" \
                 "pr=$_pr_number sha=$_merge_sha"
-            printf '{"deploy_state": "failure", "merge_sha": "%s"}' "$_merge_sha"
             return 0
+        fi
+        if [[ "$_state" == "cancelled" ]]; then
+            # #3587: a concurrency-cancelled run (superseded by a later push)
+            # is NOT a hard deploy failure. Emit the envelope and let the
+            # dispatch case arm call agent_runner_reaped_failure so the
+            # diagnoser can route it via BYPASSED_TERMINAL_PHASES_TO_ROUTE.
+            printf '{"deploy_state": "cancelled", "merge_sha": "%s"}' "$_merge_sha"
+            return 0
+        fi
+        if [[ "$_state" == "poll_error" ]]; then
+            # #3587: gh run list returned non-zero (transient API/network
+            # failure). Treat as pending for retry purposes — do NOT
+            # immediately terminal-fail. After _max_poll_errors consecutive
+            # errors, give up and terminal-fail with a distinct category so
+            # the diagnoser knows this was a poller crash, not a deploy failure.
+            _poll_error_count=$((_poll_error_count + 1))
+            log "awaiting_deploy_poll_error" \
+                "pr_number=$_pr_number" \
+                "merge_sha=$_merge_sha" \
+                "poll_error_count=$_poll_error_count" \
+                "max_poll_errors=$_max_poll_errors"
+            if [[ "$_poll_error_count" -ge "$_max_poll_errors" ]]; then
+                printf '{"deploy_state": "poll_error", "merge_sha": "%s", "poll_error_count": %s}' \
+                    "$_merge_sha" "$_poll_error_count"
+                agent_runner_reaped_failure \
+                    "awaiting_deploy_failed" \
+                    "deploy_poll_error" \
+                    "pr=$_pr_number sha=$_merge_sha consecutive_poll_errors=$_poll_error_count"
+                return 0
+            fi
+            # Retry — fall through to sleep and next iteration.
+            _state="pending"
         fi
         _now_ts=$(date -u +%s)
         _elapsed=$((_now_ts - _start_ts))
@@ -5300,8 +5371,21 @@ while true; do
                 :
             elif [[ "$_deploy_state" == "success" || "$_deploy_state" == "none" ]]; then
                 advance_phase "verify"
-            elif [[ "$_deploy_state" == "failure" ]]; then
+            elif [[ "$_deploy_state" == "failure" || "$_deploy_state" == "poll_error" ]]; then
+                # agent_runner_reaped_failure already called inside
+                # handle_awaiting_deploy before printf emitted the envelope.
                 :
+            elif [[ "$_deploy_state" == "cancelled" ]]; then
+                # #3587: concurrency-cancelled deploy. Route to diagnoser via
+                # BYPASSED_TERMINAL_PHASES_TO_ROUTE so the diagnoser can
+                # evaluate whether a later run succeeded for this merge.
+                log "awaiting_deploy_cancelled" \
+                    "deploy_state=cancelled" \
+                    "output=$_output"
+                agent_runner_reaped_failure \
+                    "awaiting_deploy_failed" \
+                    "deploy_cancelled" \
+                    "deploy run was cancelled (concurrency cancel) pr=$(printf '%s' "$_output" | jq -r '.merge_sha // ""' 2>/dev/null)"
             else
                 log "awaiting_deploy_unrecognized_output" "output=$_output"
                 agent_runner_reaped_failure \

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1383,6 +1383,11 @@ BYPASSED_TERMINAL_PHASES_TO_ROUTE: dict[str, str] = {
     "push_and_pr_no_unmerged_files": FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
     # #3507 — operational skill returned failed/unrecognized verdict.
     "operational_failed": FAILURE_CATEGORY_OPERATIONAL_FAILED,
+    # #3587 — deploy run failed, cancelled, or poller crashed. Route to
+    # diagnoser so it can inspect the deploy outcome and re-queue if the
+    # cancellation was a transient concurrency event (a later push
+    # superseded this run but the merge_sha deploy actually succeeded).
+    "awaiting_deploy_failed": FAILURE_CATEGORY_DEPLOY_FAILED,
 }
 
 #: GitHub's rejection stderr fragment when branch protection's

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -2269,3 +2269,31 @@ class TestVerifyPhaseIoRoot:
         assert not baseline_path.exists(), (
             f"Plan input must NOT be written to baseline_repo_root: {baseline_path}"
         )
+
+
+class TestBypassedTerminalPhasesRouteGuard:
+    """Guard tests asserting that BYPASSED_TERMINAL_PHASES_TO_ROUTE contains
+    the expected phase→category mappings so the diagnoser sweep picks them up.
+
+    Mirrors the pattern established by earlier guard tests (#3514, #3587).
+    Each entry here documents a terminal phase that bypasses the default
+    failure path and routes to the empowered diagnoser instead.
+    """
+
+    def test_awaiting_deploy_failed_routes_to_deploy_failed(self) -> None:
+        """#3587 — ``awaiting_deploy_failed`` must map to
+        ``FAILURE_CATEGORY_DEPLOY_FAILED`` so that cancelled/crash terminal
+        phases from handle_awaiting_deploy reach the diagnoser sweep rather
+        than silently dying without routing.
+        """
+        assert "awaiting_deploy_failed" in daemon.BYPASSED_TERMINAL_PHASES_TO_ROUTE, (
+            "awaiting_deploy_failed must be in BYPASSED_TERMINAL_PHASES_TO_ROUTE "
+            "(added by #3587 to route cancelled/poll-crash deploy terminals to diagnoser)"
+        )
+        assert (
+            daemon.BYPASSED_TERMINAL_PHASES_TO_ROUTE["awaiting_deploy_failed"]
+            == daemon.FAILURE_CATEGORY_DEPLOY_FAILED
+        ), (
+            "awaiting_deploy_failed must map to FAILURE_CATEGORY_DEPLOY_FAILED, "
+            f"got {daemon.BYPASSED_TERMINAL_PHASES_TO_ROUTE['awaiting_deploy_failed']!r}"
+        )

--- a/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
+++ b/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
@@ -128,6 +128,7 @@ class TestBypassedTerminalConstants:
         # ``ralph_not_ship`` is intentionally NOT here — it's handled
         # locally by the entrypoint.
         from dispatcher.daemon import (
+            FAILURE_CATEGORY_DEPLOY_FAILED,
             FAILURE_CATEGORY_FIX_CI_BLOCKED,
             FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
             FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
@@ -144,6 +145,7 @@ class TestBypassedTerminalConstants:
             "verify_failed_post_merge": FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
             "push_and_pr_no_unmerged_files": FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
             "operational_failed": FAILURE_CATEGORY_OPERATIONAL_FAILED,
+            "awaiting_deploy_failed": FAILURE_CATEGORY_DEPLOY_FAILED,
         }
 
 

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -6768,6 +6768,230 @@ else
          "out: $(printf '%s' "$t63b_out" | grep "ralph_baseline_route_to_diagnoser")"
 fi
 
+# ══════════════════════════════════════════════════════════════════════════
+# Test T64a (#3587): cancelled-only fixture — single run with matching
+# headSha, status=COMPLETED, conclusion=CANCELLED.
+#
+# Expected:
+#   1. classify emits deploy_state=cancelled (NOT failure).
+#   2. Terminal phase = awaiting_deploy_failed (NOT unrecognized_output).
+#   3. awaiting_deploy_classify_outcome log line is emitted with
+#      deploy_state=cancelled.
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t64a.txt"
+printf 'awaiting_deploy\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t64a_runs="$TEST_TMP/t64a-runs.json"
+cat > "$t64a_runs" <<'EOF'
+[
+  {"databaseId": 400, "workflowName": "Deploy Dispatcher", "status": "COMPLETED", "conclusion": "CANCELLED", "createdAt": "2026-04-27T04:00:00Z", "headSha": "deadbeefcafe"}
+]
+EOF
+
+t64a_workspace="$TEST_TMP/t64a-workspace"
+set +e
+t64a_out=$(run_post_pr_phase "awaiting_deploy" "$t64a_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_RUN_LIST_JSON_FIXTURE=$t64a_runs" \
+    "AGENT_RUNNER_DEPLOY_GRACE_SECONDS=9999")
+set -e
+
+# (1) awaiting_deploy_classify_outcome log line emitted with cancelled.
+if printf '%s' "$t64a_out" | grep -q "awaiting_deploy_classify_outcome" && \
+   printf '%s' "$t64a_out" | grep "awaiting_deploy_classify_outcome" | grep -q "deploy_state=cancelled"; then
+    pass "#3587 T64a [cancelled run] — awaiting_deploy_classify_outcome emitted with deploy_state=cancelled"
+else
+    fail "#3587 T64a [cancelled run] — awaiting_deploy_classify_outcome emitted with deploy_state=cancelled" \
+         "out tail: $(printf '%s' "$t64a_out" | tail -c 600)"
+fi
+
+# (2) awaiting_deploy_cancelled log line emitted.
+if printf '%s' "$t64a_out" | grep -q "awaiting_deploy_cancelled"; then
+    pass "#3587 T64a [cancelled run] — awaiting_deploy_cancelled log line emitted"
+else
+    fail "#3587 T64a [cancelled run] — awaiting_deploy_cancelled log line emitted" \
+         "out tail: $(printf '%s' "$t64a_out" | tail -c 600)"
+fi
+
+# (3) terminal phase = awaiting_deploy_failed (NOT unrecognized_output).
+_t64a_final=$(cat "$PHASE_FIXTURE_FILE" 2>/dev/null || printf '')
+if [[ "$_t64a_final" == "awaiting_deploy_failed" ]]; then
+    pass "#3587 T64a [cancelled run] — terminal phase = awaiting_deploy_failed"
+else
+    fail "#3587 T64a [cancelled run] — terminal phase = awaiting_deploy_failed" \
+         "actual final phase: $_t64a_final"
+fi
+
+# (4) unrecognized_output NOT emitted.
+if ! printf '%s' "$t64a_out" | grep -q "awaiting_deploy_unrecognized_output"; then
+    pass "#3587 T64a [cancelled run] — awaiting_deploy_unrecognized_output not emitted"
+else
+    fail "#3587 T64a [cancelled run] — awaiting_deploy_unrecognized_output not emitted" \
+         "out: $(printf '%s' "$t64a_out" | grep "awaiting_deploy_unrecognized_output")"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test T64b (#3587 AC1 reinforcement): empty runs BEFORE grace window.
+# No deploy runs exist yet; grace window has NOT elapsed. Assert the phase
+# does NOT advance to verify prematurely — it should timeout instead.
+# (After grace window → verify is covered by T60b.)
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t64b.txt"
+printf 'awaiting_deploy\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t64b_runs="$TEST_TMP/t64b-runs.json"
+printf '[]' > "$t64b_runs"
+
+t64b_workspace="$TEST_TMP/t64b-workspace"
+set +e
+t64b_out=$(run_post_pr_phase "awaiting_deploy" "$t64b_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_RUN_LIST_JSON_FIXTURE=$t64b_runs" \
+    "AGENT_RUNNER_AWAITING_DEPLOY_TIMEOUT_SECONDS=0" \
+    "AGENT_RUNNER_DEPLOY_GRACE_SECONDS=9999")
+set -e
+
+# Phase should NOT advance to verify (grace window not elapsed).
+_t64b_final=$(cat "$PHASE_FIXTURE_FILE" 2>/dev/null || printf '')
+if [[ "$_t64b_final" != "verify" ]]; then
+    pass "#3587 T64b [empty-pre-grace] — phase does NOT advance to verify before grace window"
+else
+    fail "#3587 T64b [empty-pre-grace] — phase does NOT advance to verify before grace window" \
+         "phase advanced to: $_t64b_final"
+fi
+
+# Phase should timeout (not premature success/verify).
+if printf '%s' "$t64b_out" | grep -q "awaiting_deploy_timeout"; then
+    pass "#3587 T64b [empty-pre-grace] — phase timeouts (not premature verify)"
+else
+    fail "#3587 T64b [empty-pre-grace] — phase timeouts (not premature verify)" \
+         "out tail: $(printf '%s' "$t64b_out" | tail -c 600)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test T64c (#3587 AC3): poll-crash fixture — gh run list exits non-zero.
+# Assert handle_awaiting_deploy retries (no immediate terminal), emits
+# awaiting_deploy_poll_error log line, and eventually terminals after
+# exhausting _max_poll_errors (set to 1 for test speed).
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t64c.txt"
+printf 'awaiting_deploy\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t64c_workspace="$TEST_TMP/t64c-workspace"
+set +e
+t64c_out=$(run_post_pr_phase "awaiting_deploy" "$t64c_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_RUN_LIST_EXIT=1" \
+    "AGENT_RUNNER_DEPLOY_MAX_POLL_ERRORS=1" \
+    "AGENT_RUNNER_DEPLOY_GRACE_SECONDS=9999")
+set -e
+
+# (1) awaiting_deploy_poll_error log line emitted.
+if printf '%s' "$t64c_out" | grep -q "awaiting_deploy_poll_error"; then
+    pass "#3587 T64c [poll-crash] — awaiting_deploy_poll_error log line emitted"
+else
+    fail "#3587 T64c [poll-crash] — awaiting_deploy_poll_error log line emitted" \
+         "out tail: $(printf '%s' "$t64c_out" | tail -c 600)"
+fi
+
+# (2) terminal phase = awaiting_deploy_failed (via poll_error exhaustion).
+_t64c_final=$(cat "$PHASE_FIXTURE_FILE" 2>/dev/null || printf '')
+if [[ "$_t64c_final" == "awaiting_deploy_failed" ]]; then
+    pass "#3587 T64c [poll-crash] — terminal phase = awaiting_deploy_failed after poll-error exhaustion"
+else
+    fail "#3587 T64c [poll-crash] — terminal phase = awaiting_deploy_failed after poll-error exhaustion" \
+         "actual final phase: $_t64c_final"
+fi
+
+# (3) NOT immediate terminal on first error — reaped with deploy_poll_error category.
+if printf '%s' "$t64c_out" | grep -q "agent_runner_reaped_failure" && \
+   printf '%s' "$t64c_out" | grep "agent_runner_reaped_failure" | grep -q "deploy_poll_error"; then
+    pass "#3587 T64c [poll-crash] — reaped with deploy_poll_error category"
+else
+    fail "#3587 T64c [poll-crash] — reaped with deploy_poll_error category" \
+         "out: $(printf '%s' "$t64c_out" | grep "agent_runner_reaped_failure")"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test T64d (#3587 AC4 subshell-exit regression): one run COMPLETED+FAILURE
+# on the merge_sha. Assert:
+#   1. phase_outputs.awaiting_deploy.output_json is the structured
+#      {"deploy_state":"failure",...} envelope, NOT "{}".
+#   2. Terminal phase = awaiting_deploy_failed (NOT unrecognized_output).
+#
+# This is the subshell-exit ordering bug fix: printf must emit the JSON
+# envelope BEFORE agent_runner_reaped_failure calls exit 0.
+# ══════════════════════════════════════════════════════════════════════════
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t64d.txt"
+printf 'awaiting_deploy\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t64d_runs="$TEST_TMP/t64d-runs.json"
+cat > "$t64d_runs" <<'EOF'
+[
+  {"databaseId": 500, "workflowName": "Deploy Dispatcher", "status": "COMPLETED", "conclusion": "FAILURE", "createdAt": "2026-04-27T05:00:00Z", "headSha": "deadbeefcafe"}
+]
+EOF
+
+t64d_workspace="$TEST_TMP/t64d-workspace"
+set +e
+t64d_out=$(run_post_pr_phase "awaiting_deploy" "$t64d_workspace" \
+    "PHASE_FIXTURE_FILE=$PHASE_FIXTURE_FILE" \
+    "PRIOR_PATCH_FIXTURE=" \
+    "PR_NUMBER_FIXTURE=9999" \
+    "GH_RUN_LIST_JSON_FIXTURE=$t64d_runs" \
+    "AGENT_RUNNER_DEPLOY_GRACE_SECONDS=9999")
+set -e
+
+# (1) deploy_state=failure in output (structured envelope was emitted).
+if printf '%s' "$t64d_out" | grep -q '"deploy_state": "failure"\|deploy_state.*failure'; then
+    pass "#3587 T64d [subshell-exit regression] — deploy_state=failure in log output"
+else
+    fail "#3587 T64d [subshell-exit regression] — deploy_state=failure in log output" \
+         "out tail: $(printf '%s' "$t64d_out" | tail -c 600)"
+fi
+
+# (2) terminal phase = awaiting_deploy_failed (NOT unrecognized_output).
+_t64d_final=$(cat "$PHASE_FIXTURE_FILE" 2>/dev/null || printf '')
+if [[ "$_t64d_final" == "awaiting_deploy_failed" ]]; then
+    pass "#3587 T64d [subshell-exit regression] — terminal phase = awaiting_deploy_failed"
+else
+    fail "#3587 T64d [subshell-exit regression] — terminal phase = awaiting_deploy_failed" \
+         "actual final phase: $_t64d_final"
+fi
+
+# (3) unrecognized_output NOT emitted (envelope was captured by parent shell).
+if ! printf '%s' "$t64d_out" | grep -q "awaiting_deploy_unrecognized_output"; then
+    pass "#3587 T64d [subshell-exit regression] — awaiting_deploy_unrecognized_output NOT emitted"
+else
+    fail "#3587 T64d [subshell-exit regression] — awaiting_deploy_unrecognized_output NOT emitted" \
+         "out: $(printf '%s' "$t64d_out" | grep "awaiting_deploy_unrecognized_output")"
+fi
+
+# (4) Verify psql persist_phase_output was called with non-empty JSON for
+#     awaiting_deploy (structured envelope, not "{}").
+# The persist_phase_output call uses psql with the output JSON. Check the
+# psql log for the deploy_state keyword.
+if grep -q "deploy_state" "$INVOCATIONS_DIR/psql.log"; then
+    pass "#3587 T64d [subshell-exit regression] — psql log contains deploy_state (non-empty envelope persisted)"
+else
+    fail "#3587 T64d [subshell-exit regression] — psql log contains deploy_state (non-empty envelope persisted)" \
+         "psql log tail: $(tail -c 500 "$INVOCATIONS_DIR/psql.log")"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## Summary

Fixed awaiting_deploy false-positive failure classification (issue #2723 symptom) by correcting the subshell-exit ordering so JSON output reaches the parent shell, adding cancelled/poll_error outcome detection, and wiring awaiting_deploy_failed into the diagnoser-routing system for proper triage of cancelled/transient-crash scenarios.

Closes #3587

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` on test_daemon_phase3b.py; bash test suite on test_agent_runner_entrypoint.sh)
- [x] CI green

### Post-deploy verification

- [ ] Trigger another PR merge in dev
- [ ] Confirm awaiting_deploy waits for the correct Deploy Dispatcher run for that merge_sha
- [ ] Confirm phase_outputs.awaiting_deploy.output_json is not empty (contains structured deploy_state/merge_sha)
- [ ] Verification evidence posted on #3587 (see /task-v2-verify output)