### PR TITLE
fix(api): signature-verify Google OAuth id_token, check email_verified (#3594)

### DIFF
--- a/packages/api/package-lock.json
+++ b/packages/api/package-lock.json
@@ -17,6 +17,7 @@
         "bcryptjs": "^3",
         "dataloader": "^2.2.3",
         "fastify": "^5.8",
+        "google-auth-library": "^9.15.1",
         "graphql": "^16.8",
         "jsonwebtoken": "^9.0",
         "node-pg-migrate": "^7.0",
@@ -3823,6 +3824,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3996,6 +4006,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bcryptjs": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
@@ -4003,6 +4033,15 @@
       "license": "BSD-3-Clause",
       "bin": {
         "bcrypt": "bin/bcrypt"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/body-parser": {
@@ -4842,6 +4881,12 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
@@ -5244,6 +5289,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/generic-pool": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
@@ -5431,6 +5518,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5454,6 +5567,19 @@
       "integrity": "sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA==",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/has-flag": {
@@ -5545,6 +5671,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -5803,6 +5942,15 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -11224,6 +11372,11 @@
         "acorn": "^8.11.0"
       }
     },
+    "agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
+    },
     "ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -11344,10 +11497,20 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "bcryptjs": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
       "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="
+    },
+    "bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="
     },
     "body-parser": {
       "version": "1.20.4",
@@ -11983,6 +12146,11 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
@@ -12265,6 +12433,35 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
+    "gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "requires": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+        }
+      }
+    },
+    "gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "requires": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      }
+    },
     "generic-pool": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
@@ -12390,6 +12587,24 @@
         "slash": "^3.0.0"
       }
     },
+    "google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      }
+    },
+    "google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="
+    },
     "gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -12405,6 +12620,15 @@
       "version": "16.13.0",
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.0.tgz",
       "integrity": "sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA=="
+    },
+    "gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "requires": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      }
     },
     "has-flag": {
       "version": "4.0.0",
@@ -12462,6 +12686,15 @@
         "setprototypeof": "~1.2.0",
         "statuses": "~2.0.2",
         "toidentifier": "~1.0.1"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "requires": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
       }
     },
     "human-signals": {
@@ -12640,6 +12873,14 @@
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
+      }
+    },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
       }
     },
     "json-buffer": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -27,6 +27,7 @@
     "bcryptjs": "^3",
     "dataloader": "^2.2.3",
     "fastify": "^5.8",
+    "google-auth-library": "^9.15.1",
     "graphql": "^16.8",
     "jsonwebtoken": "^9.0",
     "node-pg-migrate": "^7.0",
@@ -41,10 +42,10 @@
     "@types/pg": "^8",
     "@typescript-eslint/eslint-plugin": "^7",
     "@typescript-eslint/parser": "^7",
+    "@vitest/coverage-v8": "^1.4",
     "eslint": "^8",
     "tsx": "^4.7",
     "typescript": "^5.4",
-    "vitest": "^1.4",
-    "@vitest/coverage-v8": "^1.4"
+    "vitest": "^1.4"
   }
 }

--- a/packages/api/src/graphql/auth-resolvers.ts
+++ b/packages/api/src/graphql/auth-resolvers.ts
@@ -2,6 +2,7 @@ import type { Pool } from 'pg';
 import type { FastifyReply } from 'fastify';
 import { z } from 'zod';
 import { GraphQLError } from 'graphql';
+import { OAuth2Client } from 'google-auth-library';
 import {
   hashPassword,
   verifyPassword,
@@ -40,6 +41,8 @@ const APP_URL = process.env.APP_URL ?? 'http://localhost:3000';
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID ?? '';
 const GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET ?? '';
 const GOOGLE_REDIRECT_URI = process.env.GOOGLE_REDIRECT_URI ?? `${APP_URL}/auth/google/callback`;
+
+const googleClient = new OAuth2Client(GOOGLE_CLIENT_ID);
 
 function userRow(row: Row) {
   return {
@@ -330,14 +333,32 @@ export const authResolvers = {
         });
       }
 
-      // Decode ID token (Google's id_token is a JWT — verify via Google's public keys in production)
-      const [, payloadB64] = tokenData.id_token.split('.');
-      const googlePayload = JSON.parse(Buffer.from(payloadB64, 'base64').toString()) as {
-        sub: string;
-        email: string;
-        email_verified?: boolean;
-        name?: string;
-      };
+      // Verify ID token using Google's public keys (validates iss, aud, exp, and signature)
+      let googlePayload: { sub: string; email: string; email_verified?: boolean; name?: string };
+      try {
+        const ticket = await googleClient.verifyIdToken({
+          idToken: tokenData.id_token,
+          audience: GOOGLE_CLIENT_ID,
+        });
+        const payload = ticket.getPayload();
+        if (!payload) {
+          throw new GraphQLError('Invalid Google ID token', {
+            extensions: { code: 'BAD_USER_INPUT' },
+          });
+        }
+        googlePayload = payload as typeof googlePayload;
+      } catch (err) {
+        if (err instanceof GraphQLError) throw err;
+        throw new GraphQLError('Invalid Google ID token', {
+          extensions: { code: 'BAD_USER_INPUT' },
+        });
+      }
+
+      if (googlePayload.email_verified !== true) {
+        throw new GraphQLError('Google account email is not verified', {
+          extensions: { code: 'UNAUTHENTICATED' },
+        });
+      }
 
       const { sub: googleId, email, name } = googlePayload;
 

--- a/packages/api/tests/auth-resolvers.unit.test.ts
+++ b/packages/api/tests/auth-resolvers.unit.test.ts
@@ -12,6 +12,22 @@ import type { QueryResult } from 'pg';
 import type { FastifyReply } from 'fastify';
 
 // ---------------------------------------------------------------------------
+// Mock google-auth-library
+// ---------------------------------------------------------------------------
+
+// verifyIdToken mock — tests override this via vi.mocked(mockVerifyIdToken)
+const mockVerifyIdToken = vi.fn();
+const mockGetPayload = vi.fn();
+
+vi.mock('google-auth-library', () => {
+  return {
+    OAuth2Client: vi.fn().mockImplementation(() => ({
+      verifyIdToken: mockVerifyIdToken,
+    })),
+  };
+});
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -47,6 +63,12 @@ function fakeGoogleIdToken(payload: Record<string, unknown>): string {
   return `${header}.${body}.fakesig`;
 }
 
+/** Create a mock ticket returned by verifyIdToken. */
+function makeTicket(payload: Record<string, unknown> | null) {
+  mockGetPayload.mockReturnValue(payload);
+  return { getPayload: mockGetPayload };
+}
+
 // ---------------------------------------------------------------------------
 // Tests for completeGoogleAuth
 // ---------------------------------------------------------------------------
@@ -64,6 +86,8 @@ describe('completeGoogleAuth — unit tests', () => {
     originalFetch = globalThis.fetch;
     originalClientId = process.env.GOOGLE_CLIENT_ID;
     originalClientSecret = process.env.GOOGLE_CLIENT_SECRET;
+    mockVerifyIdToken.mockReset();
+    mockGetPayload.mockReset();
   });
 
   afterEach(() => {
@@ -87,14 +111,17 @@ describe('completeGoogleAuth — unit tests', () => {
     const googlePayload = {
       sub: 'google-123',
       email: 'newuser@gmail.com',
+      email_verified: true,
       name: 'New User',
     };
 
-    // Mock fetch for Google token exchange
+    // Mock fetch for Google token exchange — verifyIdToken mock handles payload extraction
     globalThis.fetch = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ id_token: fakeGoogleIdToken(googlePayload) }),
     } as Response);
+
+    mockVerifyIdToken.mockResolvedValue(makeTicket(googlePayload));
 
     const newUser = {
       id: 'user-uuid-1',
@@ -129,6 +156,8 @@ describe('completeGoogleAuth — unit tests', () => {
     expect(result.user.email).toBe('newuser@gmail.com');
     expect(result.user.displayName).toBe('New User');
     expect(globalThis.fetch).toHaveBeenCalledOnce();
+    // Verify verifyIdToken was called (not raw base64 decode)
+    expect(mockVerifyIdToken).toHaveBeenCalledOnce();
     // Verify refresh token cookie was set
     expect(reply.header).toHaveBeenCalled();
   });
@@ -141,6 +170,7 @@ describe('completeGoogleAuth — unit tests', () => {
     const googlePayload = {
       sub: 'google-456',
       email: 'existing@gmail.com',
+      email_verified: true,
       name: 'Existing User',
     };
 
@@ -148,6 +178,8 @@ describe('completeGoogleAuth — unit tests', () => {
       ok: true,
       json: async () => ({ id_token: fakeGoogleIdToken(googlePayload) }),
     } as Response);
+
+    mockVerifyIdToken.mockResolvedValue(makeTicket(googlePayload));
 
     const existingUser = {
       id: 'user-uuid-2',
@@ -199,6 +231,7 @@ describe('completeGoogleAuth — unit tests', () => {
     const googlePayload = {
       sub: 'google-789',
       email: 'linked@gmail.com',
+      email_verified: true,
       name: 'Linked User',
     };
 
@@ -206,6 +239,8 @@ describe('completeGoogleAuth — unit tests', () => {
       ok: true,
       json: async () => ({ id_token: fakeGoogleIdToken(googlePayload) }),
     } as Response);
+
+    mockVerifyIdToken.mockResolvedValue(makeTicket(googlePayload));
 
     const existingUser = {
       id: 'user-uuid-3',
@@ -297,6 +332,76 @@ describe('completeGoogleAuth — unit tests', () => {
     await expect(
       resolvers.Mutation.completeGoogleAuth({}, { code: 'auth-code' }, ctx),
     ).rejects.toThrow('Google OAuth is not configured');
+  });
+
+  it('throws when email_verified is false (AC #2)', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'test-client-secret';
+    const resolvers = await loadResolvers();
+
+    const googlePayload = {
+      sub: 'google-unverified',
+      email: 'unverified@gmail.com',
+      email_verified: false,
+      name: 'Unverified User',
+    };
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id_token: fakeGoogleIdToken(googlePayload) }),
+    } as Response);
+
+    mockVerifyIdToken.mockResolvedValue(makeTicket(googlePayload));
+
+    const pool = mockPool([]);
+    const reply = mockReply();
+    const ctx = { pool, reply, user: null, ip: '127.0.0.1', cookieHeader: '' };
+
+    await expect(
+      resolvers.Mutation.completeGoogleAuth({}, { code: 'auth-code-unverified' }, ctx),
+    ).rejects.toThrow('Google account email is not verified');
+  });
+
+  it('throws when verifyIdToken rejects with audience error (AC #3)', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'test-client-secret';
+    const resolvers = await loadResolvers();
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id_token: 'header.payload.sig' }),
+    } as Response);
+
+    mockVerifyIdToken.mockRejectedValue(new Error('Token audience mismatch'));
+
+    const pool = mockPool([]);
+    const reply = mockReply();
+    const ctx = { pool, reply, user: null, ip: '127.0.0.1', cookieHeader: '' };
+
+    await expect(
+      resolvers.Mutation.completeGoogleAuth({}, { code: 'auth-code-bad-aud' }, ctx),
+    ).rejects.toThrow('Invalid Google ID token');
+  });
+
+  it('throws when verifyIdToken returns null payload', async () => {
+    process.env.GOOGLE_CLIENT_ID = 'test-client-id';
+    process.env.GOOGLE_CLIENT_SECRET = 'test-client-secret';
+    const resolvers = await loadResolvers();
+
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id_token: 'header.payload.sig' }),
+    } as Response);
+
+    mockVerifyIdToken.mockResolvedValue(makeTicket(null));
+
+    const pool = mockPool([]);
+    const reply = mockReply();
+    const ctx = { pool, reply, user: null, ip: '127.0.0.1', cookieHeader: '' };
+
+    await expect(
+      resolvers.Mutation.completeGoogleAuth({}, { code: 'auth-code-null-payload' }, ctx),
+    ).rejects.toThrow('Invalid Google ID token');
   });
 });
 


### PR DESCRIPTION
## Summary

Replaced insecure base64-only JWT decode in `completeGoogleAuth` with `OAuth2Client.verifyIdToken` (google-auth-library ^9), adding full RS256 signature, issuer, audience, and expiration validation. Added email_verified guard to reject unverified Google accounts before account linking — previously an unverified-email Google account could hijack a Judgemind account registered with the same email.

Closes #3594

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (345 tests, including 3 new unit tests for email_verified, audience-mismatch, and null-payload cases)
- [x] TypeScript strict mode passes
- [x] CI green

### Post-deploy verification

- [ ] Login with verified Google account succeeds; user account created/linked
- [ ] Login with unverified Google account is rejected with "Google account email is not verified" error
- [ ] Token with mismatched audience is rejected with "Invalid Google ID token" error
- [ ] Verification evidence posted on #3594