### PR TITLE
fix(api): handle null JSONB keys in weekly diagnoser report (#3588)

### DIFF
--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -248,8 +248,8 @@ async function queryRecentFailures(pool: Pool, sinceHours: number): Promise<Row[
 
 /** Shape returned by the weekly diagnoser SQL query. */
 interface DiagnoserEffectivenessRow {
-  recommended_action: string;
-  observed_outcome: string;
+  recommended_action: string | null; // NULL when recommendation->>'action' is absent
+  observed_outcome: string | null; // NULL when outcome->>'retry_outcome' is absent
   count: string; // pg returns bigint count as string
   day: string;
 }
@@ -272,8 +272,8 @@ async function queryWeeklyDiagnoserReport(pool: Pool): Promise<DiagnoserEffectiv
 /** Convert a dispatcher.diagnoses rollup row into the GraphQL DiagnoserEffectivenessRow shape. */
 function diagnoserRowToGraphQL(row: DiagnoserEffectivenessRow): Record<string, unknown> {
   return {
-    recommendedAction: row.recommended_action,
-    observedOutcome: row.observed_outcome,
+    recommendedAction: row.recommended_action ?? '(unknown)',
+    observedOutcome: row.observed_outcome ?? '(unknown)',
     count: parseInt(row.count, 10),
     day: row.day,
   };

--- a/packages/api/tests/dispatcher.integration.test.ts
+++ b/packages/api/tests/dispatcher.integration.test.ts
@@ -1159,6 +1159,41 @@ describe('weeklyDiagnoserReport — admin', () => {
     expect(excluded).toBeUndefined();
   });
 
+  it('null recommended_action surfaces as (unknown) bucket (#3588)', async () => {
+    // Seed: agent + failure + diagnosis with recommendation={} (no action key).
+    const agentId = await insertAgent({ issueNumber: 800003, status: 'failed', phase: 'ralph' });
+    const failureId = await insertFailure({
+      agentId,
+      category: 'subprocess_crash',
+      detectedBy: 'scheduler',
+    });
+    const dayTs = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString(); // within 7 days
+    // recommendation={} → recommendation->>'action' returns NULL in SQL
+    await insertDiagnosis({
+      agentId,
+      failureId,
+      recommendation: {},
+      outcome: { retry_outcome: 'failed' },
+      completedAt: dayTs,
+    });
+
+    const body = await gql(QUERY, undefined, adminToken);
+    // The null-action row must NOT cause a GraphQL serialisation error.
+    expect(body.errors).toBeUndefined();
+    const rows = body.data?.weeklyDiagnoserReport as Array<{
+      recommendedAction: string;
+      observedOutcome: string;
+      count: number;
+      day: string;
+    }>;
+    expect(Array.isArray(rows)).toBe(true);
+    // A bucket with recommendedAction === '(unknown)' must be present.
+    const unknownBucket = rows.find((r) => r.recommendedAction === '(unknown)');
+    expect(unknownBucket).toBeDefined();
+    expect(unknownBucket!.observedOutcome).toBe('failed');
+    expect(unknownBucket!.count).toBeGreaterThanOrEqual(1);
+  });
+
   it('non-admin returns "not found" error', async () => {
     const body = await gql(QUERY, undefined, userToken);
     expect(body.errors).toBeDefined();

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DiagnoserEffectivenessPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DiagnoserEffectivenessPanel.test.tsx
@@ -84,6 +84,24 @@ describe('DiagnoserEffectivenessPanel', () => {
     expect(rows[2]).toHaveTextContent('1');
   });
 
+  it('renders (unknown) sentinel for null-action rows (#3588)', () => {
+    mockQueryResult = {
+      data: {
+        weeklyDiagnoserReport: [
+          makeRow({ recommendedAction: '(unknown)', observedOutcome: 'failed', count: 3 }),
+        ],
+      },
+      loading: false,
+      error: undefined,
+    };
+    render(<DiagnoserEffectivenessPanel />);
+    const rows = screen.getAllByTestId('diagnoser-effectiveness-row');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent('(unknown)');
+    expect(rows[0]).toHaveTextContent('failed');
+    expect(rows[0]).toHaveTextContent('3');
+  });
+
   it('renders skeleton placeholders while loading with no data yet', () => {
     mockQueryResult = {
       data: undefined,


### PR DESCRIPTION
## Summary

Fixed the weekly diagnoser effectiveness panel rendering empty by handling null JSONB key extractions in the GraphQL resolver. Widened the DiagnoserEffectivenessRow interface to accept null values and applied `?? '(unknown)'` sentinel mapping. Added regression tests to both packages/api and packages/web to prevent future null-value issues.

Closes #3588

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] Open `dev.judgemind.org/admin/dispatcher` and verify "Diagnoser effectiveness (last 7 days)" panel displays data table
- [ ] Verification evidence posted on #3588 (see /task-v2-verify output)