### PR TITLE
fix(scraping): Fresno single-ruling PDFs skip LLM enrichment (#3599)

### DIFF
--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -355,9 +355,12 @@ def _try_fresno_pdf_split(
     Detection gate: only triggers when event is Fresno county **and** content
     format is ``"pdf"`` — avoids false-positive matches on other courts.
 
-    When ``_split_rulings`` returns ``[]`` (single-ruling PDF or unexpected
-    layout), this function returns ``False`` so the existing LLM path handles
-    it (AC4).
+    When ``_split_rulings`` returns ``[]`` (no numbered entries found) or a
+    1-element list (single-ruling PDF), this function returns ``False`` so the
+    existing LLM path handles it (#3599, AC4).  The deterministic regex
+    extraction does not reliably populate ``outcome``/``motion_type`` for
+    single-ruling PDFs; falling through to ``_llm_enrich_fields`` restores
+    pre-#3553 behaviour.
 
     Mirrors the SD/LA pattern (``_try_sd_calendar_split`` #2447,
     ``_try_la_html_split`` #2450).
@@ -374,7 +377,13 @@ def _try_fresno_pdf_split(
 
     split_rulings = _split_rulings(ruling_text)
     if not split_rulings:
-        # Single-ruling PDF or unrecognised layout — fall through to LLM.
+        # No numbered entries found — fall through to LLM.
+        return False
+    if len(split_rulings) == 1:
+        # Single-ruling PDF — the deterministic regex extraction does not
+        # reliably populate outcome/motion_type. Fall through to the LLM
+        # path so _llm_enrich_fields fills those fields (matches pre-#3553
+        # behavior; AC4 of #3534, fix for #3599).
         return False
 
     logger.info(
@@ -390,9 +399,9 @@ def _try_fresno_pdf_split(
 
     from .split_ids import make_split_document_id
 
-    is_multi = len(split_rulings) > 1
+    # At this point len(split_rulings) > 1 — always generate split document IDs.
     for idx, sr in enumerate(split_rulings):
-        split_doc_id = make_split_document_id(document_id, idx) if is_multi else document_id
+        split_doc_id = make_split_document_id(document_id, idx)
         hearing_date_value: str | None = None
         if sr.hearing_date is not None:
             hearing_date_value = (

--- a/packages/scraper-framework/tests/test_llm_extraction_path.py
+++ b/packages/scraper-framework/tests/test_llm_extraction_path.py
@@ -2899,3 +2899,86 @@ class TestFresnoPdfSplit:
             "_try_fresno_pdf_split must return False when content_format != 'pdf'."
         )
         assert dispatched == []
+
+    def test_single_numbered_ruling_falls_through_to_llm(self) -> None:
+        """Single-ruling Fresno PDFs (len == 1) must return False (#3599).
+
+        When ``_split_rulings`` returns a 1-element list, the deterministic
+        splitter cannot reliably populate outcome/motion_type, so the function
+        must fall through to the LLM path.  This is the regression assertion
+        for #3599: before the fix, len==1 would proceed through the split loop
+        and dispatch an event with ``_llm_extracted=True`` but without a real
+        LLM call, leaving outcome/motion_type as None.
+        """
+        from ingestion.worker import _try_fresno_pdf_split
+
+        dispatched: list = []
+
+        # One numbered entry — _split_rulings returns a 1-element list.
+        single_ruling_text = (
+            "(1) Tentative Ruling\n"
+            "Re: Smith v. Jones\n"
+            "Superior Court Case No. 25CECG00001\n"
+            "Hearing Date: April 28, 2026 (Dept. 503)\n"
+            "Motion: Demurrer to Complaint\n"
+            "Tentative Ruling:\n"
+            "To sustain the demurrer with leave to amend.\n"
+        )
+
+        event = _make_event(
+            scraper_id="ca-fresno-tentatives-civil",
+            state="CA",
+            county="Fresno",
+            content_format="pdf",
+        )
+        result = _try_fresno_pdf_split(
+            event,
+            event["document_id"],
+            single_ruling_text,
+            dispatched.append,
+        )
+
+        assert result is False, (
+            "_try_fresno_pdf_split must return False when _split_rulings "
+            "returns a 1-element list, so the caller falls through to the LLM."
+        )
+        assert dispatched == [], "No events should be dispatched for a single-ruling Fresno PDF."
+
+    def test_multi_ruling_still_dispatches_with_llm_extracted_flag(self) -> None:
+        """Multi-ruling Fresno PDFs still dispatch with _split_processed=True
+        and _llm_extracted=True (regression guard for #3534).
+
+        Uses the 403 fixture (8 rulings).  Checks that the ``_llm_extracted``
+        flag is set on every dispatched event so downstream workers skip a
+        redundant LLM call.
+        """
+        ruling_text = self._load_fixture_text("fresno_403_20260310_d019042f.pdf")
+        worker, _ = _make_worker()
+
+        with patch.object(worker, "process_event") as mock_process:
+            event = _make_event(
+                scraper_id="rebuild-ca-fresno",
+                state="CA",
+                county="Fresno",
+                content_format="pdf",
+                ruling_text=ruling_text,
+            )
+            result = worker._llm_split_document(
+                event,
+                event["document_id"],
+                ruling_text,
+                "CA",
+                "Fresno",
+            )
+
+        assert result is True
+        assert mock_process.call_count == 8
+
+        dispatched_events = [call.args[0] for call in mock_process.call_args_list]
+        for ev in dispatched_events:
+            assert ev.get("_split_processed") is True, (
+                f"Expected _split_processed=True on event {ev.get('case_number')!r}"
+            )
+            assert ev.get("_llm_extracted") is True, (
+                f"Expected _llm_extracted=True on event {ev.get('case_number')!r}"
+            )


### PR DESCRIPTION
## Summary

Fixed Fresno single-ruling PDF null `outcome`/`motion_type` regression introduced in #3553. When the deterministic PDF splitter returns a single ruling, the function now returns False to fall through to the LLM enrichment path, ensuring those fields are populated. Added regression tests for both single and multi-ruling paths.

Closes #3599

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
- [x] CI green

All per ralph output: 71 TestFresnoPdfSplit + adjacent tests pass; pre-push hook green.

### Post-deploy verification

- [ ] Single-ruling Fresno PDF query confirms non-null `outcome` and `motion_type` (AC 1, verified post-deploy by /task-v2-verify)
- [ ] Verification evidence posted on #3599 (see /task-v2-verify output)