### PR TITLE
fix(scraping): label slash and month-name date patterns in _parse_header_date (#3601)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -3570,19 +3570,48 @@ def _append_ruling_from_case(
 def _parse_header_date(info: str) -> str | None:
     """Extract a hearing date from a page-header string, returning ISO YYYY-MM-DD.
 
-    Tries three patterns in priority order so that the existing ISO path
-    wins over ambiguous slash or month-name matches (#3559):
+    Tries five patterns in priority order so that labeled dates win over bare
+    dates when both appear in the same header (e.g. "Filed 1/15/2024 — Hearing
+    Date 3/16/2026" resolves to 2026-03-16, not 2024-01-15) (#3601):
 
-    1. ``Hearing Date: YYYY-MM-DD`` — explicit ISO label (existing behaviour).
-    2. Month-name: ``March 16, 2026`` — common in OC multimodal PDFs.
-    3. Slash: ``3/16/2026`` or ``03/16/2026`` — alternate courts.
+    1. ``Hearing Date: YYYY-MM-DD`` — explicit ISO label (highest priority).
+    2. Month-name labeled: ``Hearing Date March 16, 2026`` (#3601).
+    3. Slash labeled: ``Hearing Date 3/16/2026`` (#3601).
+    4. Month-name bare: ``March 16, 2026`` — fallback for OC multimodal PDFs.
+    5. Slash bare: ``3/16/2026`` or ``03/16/2026`` — fallback for other courts.
     """
     # 1. Existing ISO path — must remain the highest-priority match.
     m = re.search(r"Hearing Date:\s*(\d{4}-\d{2}-\d{2})", info)
     if m:
         return m.group(1)
 
-    # 2. Month-name format, e.g. "March 16, 2026".
+    # 2. Month-name with label prefix, e.g. "Hearing Date March 16, 2026".
+    m = re.search(
+        r"(?:Hearing Date|Calendar Date|Date)[:\s]+"
+        r"((?:January|February|March|April|May|June|July|August|September|"
+        r"October|November|December)\s+\d{1,2},\s*\d{4})",
+        info,
+        re.IGNORECASE,
+    )
+    if m:
+        try:
+            return datetime.strptime(m.group(1), "%B %d, %Y").strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+
+    # 3. Slash format with label prefix, e.g. "Hearing Date 3/16/2026".
+    m = re.search(
+        r"(?:Hearing Date|Calendar Date|Date)[:\s]+(\d{1,2}/\d{1,2}/\d{4})",
+        info,
+        re.IGNORECASE,
+    )
+    if m:
+        try:
+            return datetime.strptime(m.group(1), "%m/%d/%Y").strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+
+    # 4. Month-name bare format, e.g. "March 16, 2026" (OC multimodal PDFs).
     m = re.search(
         r"\b((?:January|February|March|April|May|June|July|August|September|"
         r"October|November|December)\s+\d{1,2},\s*\d{4})\b",
@@ -3594,7 +3623,7 @@ def _parse_header_date(info: str) -> str | None:
         except ValueError:
             pass
 
-    # 3. Slash format, e.g. "3/16/2026" or "03/16/2026".
+    # 5. Slash bare format, e.g. "3/16/2026" or "03/16/2026".
     m = re.search(r"\b(\d{1,2}/\d{1,2}/\d{4})\b", info)
     if m:
         try:

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -1061,6 +1061,26 @@ class TestJoinPageRows:
         """
         assert _parse_header_date("13/05/2026") is None
 
+    def test_parse_header_date_labeled_slash_wins_over_unlabeled(self) -> None:
+        """Labeled slash date takes priority over an earlier unlabeled slash date (#3601).
+
+        When a header contains both a bare slash date ("Filed 1/15/2024") and a
+        labeled slash date ("Hearing Date 3/16/2026"), the labeled date must win.
+        """
+        assert _parse_header_date("Filed 1/15/2024 — Hearing Date 3/16/2026") == "2026-03-16"
+
+    def test_parse_header_date_labeled_month_name_wins_over_unlabeled(self) -> None:
+        """Labeled month-name date takes priority over an earlier unlabeled month-name date (#3601).
+
+        When a header contains both a bare month-name date ("Filed January 15, 2024")
+        and a labeled month-name date ("Hearing Date March 16, 2026"), the labeled
+        date must win.
+        """
+        assert (
+            _parse_header_date("Filed January 15, 2024 — Hearing Date March 16, 2026")
+            == "2026-03-16"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Calendar header detection tests (#2096)


### PR DESCRIPTION
## Summary

Fixes date-parsing ambiguity in `_parse_header_date()` by prioritizing labeled date patterns ("Hearing Date 3/16/2026") over bare patterns ("3/16/2026") when both appear in the same header. Prevents court PDFs with dual-date stamps from selecting the wrong date for ruling lookups.

Closes #3601

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — all 9 header_date tests pass)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (fix is internal scraper logic, requires integration testing with real PDFs post-deploy)