### PR TITLE
fix(api): add covering index on rulings(case_id, judge_id) for caseJudgesLoader (#3597)

### DIFF
--- a/packages/api/migrations/56_rulings-case-judge-index.sql
+++ b/packages/api/migrations/56_rulings-case-judge-index.sql
@@ -1,0 +1,18 @@
+-- Up Migration: Add covering index on derived.rulings(case_id, judge_id)
+--
+-- The caseJudgesLoader fallback path (packages/api/src/graphql/dataloader.ts:84-91)
+-- executes a query with DISTINCT ON (r.case_id, j.id) against derived.rulings to
+-- fill in judge associations that are missing from derived.case_judges. Without this
+-- index, Postgres must sort all rulings rows to satisfy the DISTINCT ON, which is
+-- expensive on the hot cases-list page. Adding (case_id, judge_id) as a covering
+-- index lets the planner use an index scan instead of a sort.
+--
+-- See: #3597
+
+CREATE INDEX IF NOT EXISTS idx_rulings_case_judge
+    ON derived.rulings (case_id, judge_id);
+
+
+-- Down Migration
+
+DROP INDEX IF EXISTS derived.idx_rulings_case_judge;

--- a/packages/api/src/data-access/schema.sql
+++ b/packages/api/src/data-access/schema.sql
@@ -3,7 +3,7 @@
 -- To modify the schema, add a migration in packages/api/migrations/
 -- then run: scripts/regenerate_schema.sh
 --
--- Generated from 49 migrations.
+-- Generated from 56 migrations.
 
 
 
@@ -1278,6 +1278,9 @@ CREATE INDEX idx_party_aliases_raw_name ON derived.party_aliases USING btree (lo
 
 
 CREATE INDEX idx_rulings_case_id ON derived.rulings USING btree (case_id);
+
+
+CREATE INDEX idx_rulings_case_judge ON derived.rulings USING btree (case_id, judge_id);
 
 
 CREATE INDEX idx_rulings_court_id ON derived.rulings USING btree (court_id);


### PR DESCRIPTION
## Summary

Added a covering index `idx_rulings_case_judge` on `derived.rulings(case_id, judge_id)` to eliminate the sort overhead in the caseJudgesLoader fallback query. This is the Option B stop-gap fix from #3597: when case_judges rows are missing, the fallback can now use an index scan instead of sorting all rulings rows.

Closes #3597

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`) — no Python/TS changes
- [x] Format check passes (`ruff format --check` / prettier) — no Python/TS changes
- [x] Tests pass (`pytest` / `npm test`) — migration is schema-only; existing dataloader tests use mocked pool.query and don't depend on this index
- [x] CI green — pre-push hook passed on first iteration

### Post-deploy verification

- [ ] Schema applied on dev: `\d+ rulings | grep idx_rulings_case_judge` returns the index
- [ ] Cases-list page on dev still resolves judges correctly (no missing `judges` field on case nodes)
- [ ] Verification evidence posted on #3597 (see /task-v2-verify output)