### PR TITLE
fix(scraping): resolve cross-references on LLM cache hits for Santa Clara (#3608)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -1748,9 +1748,9 @@ def _drop_short_unsubstantive_rulings(
 # written, the new logic takes effect on cache read — avoiding an expensive
 # cache-busting reingest.
 #
-# ``_resolve_cross_references`` and ``_propagate_document_fields`` are NOT
-# re-applied here because they need the pre-join row state (entry numbers
-# and metadata that are discarded once we have ``ExtractedRuling`` objects).
+# ``_propagate_document_fields`` is NOT re-applied here — it operates on the
+# text-extraction ``ExtractionResult``, not ``ExtractedRuling[]``, so it is
+# structurally not portable to the PDF cache-hit path.
 
 
 def _apply_pdf_cache_hit_filters(
@@ -1763,14 +1763,18 @@ def _apply_pdf_cache_hit_filters(
     Mirrors the subset of filters in :func:`_join_page_rows` that operate
     purely on the final ``ExtractedRuling[]`` list.  Order matches
     ``_join_page_rows`` so the cache-hit output is equivalent to what a
-    fresh extraction would produce (for rulings that do not rely on
-    cross-reference resolution, which requires pre-join row state).
+    fresh extraction would produce.
+
+    Cross-reference resolution (#3608) runs first so stub rulings that carry
+    ``entry_number`` are resolved before the drop/dedup filters discard them,
+    mirroring the filter ordering in the fresh-extract path.
 
     Logs ``llm_extractor.cache_hit_filters_dropped`` at info level if the
     filters dropped rows — useful for observing the effect of filter
     widening in production without re-running LLM calls.
     """
     original_count = len(rulings)
+    rulings = _resolve_cross_references(rulings)
     rulings = _drop_calendar_listing_rulings(rulings)
     rulings = _drop_short_unsubstantive_rulings(rulings)
     rulings = _truncate_concatenated_case_titles(rulings)
@@ -1861,7 +1865,7 @@ _XREF_STUB_MAX_TEXT_LENGTH = 2000
 
 def _resolve_cross_references(
     rulings: list[ExtractedRuling],
-    entry_number_to_index: dict[int, int],
+    entry_number_to_index: dict[int, int] | None = None,
 ) -> list[ExtractedRuling]:
     """Resolve cross-reference entries by copying ruling_text from the referenced entry (#2317).
 
@@ -1896,8 +1900,16 @@ def _resolve_cross_references(
     rulings:
         List of ``ExtractedRuling`` objects from ``_join_page_rows``.
     entry_number_to_index:
-        Mapping from calendar line entry_number to index in ``rulings``.
+        Mapping from calendar line entry_number to index in ``rulings``.  When
+        ``None`` (cache-hit path), the map is built from each ruling's
+        ``entry_number`` field so resolution works without pre-join row state.
     """
+    # When no map is provided (cache-hit path), build it from per-ruling entry_number.
+    if entry_number_to_index is None:
+        entry_number_to_index = {
+            r.entry_number: i for i, r in enumerate(rulings) if r.entry_number is not None
+        }
+
     # Build reverse map: index -> entry_number (for "order above" lookups).
     index_to_entry: dict[int, int] = {v: k for k, v in entry_number_to_index.items()}
 
@@ -3516,6 +3528,7 @@ def _append_ruling_from_case(
     header_judge: str | None,
     header_dept: str | None,
     header_date: str | None,
+    entry_number: int | None = None,
 ) -> None:
     """Append one ``ExtractedRuling`` built from a single case_info string.
 
@@ -3563,6 +3576,7 @@ def _append_ruling_from_case(
             department=department,
             hearing_date=hearing_date,
             ruling_text=text,
+            entry_number=entry_number,
         )
     )
 
@@ -3659,6 +3673,7 @@ def _join_page_rows(
                 {
                     "case_info": row["case_info"],
                     "ruling_text": row["ruling_text"],
+                    "entry_number": row["entry_number"],
                 }
             )
             # Record entry_number -> case index for cross-reference lookups.
@@ -3679,6 +3694,7 @@ def _join_page_rows(
                     {
                         "case_info": row["case_info"],
                         "ruling_text": row["ruling_text"],
+                        "entry_number": row["entry_number"],
                     }
                 )
 
@@ -3703,6 +3719,10 @@ def _join_page_rows(
         sub_case_infos = _split_fused_case_info(case["case_info"])
         for idx, sub_info in enumerate(sub_case_infos):
             sub_text = case["ruling_text"] if idx == 0 else None
+            # Only the first sub-case of a fused split inherits the row's
+            # entry_number — subsequent sub-cases stay None because the
+            # original entry_number unambiguously refers to the first ruling.
+            sub_entry_number = case["entry_number"] if idx == 0 else None
             _append_ruling_from_case(
                 rulings,
                 sub_info,
@@ -3711,6 +3731,7 @@ def _join_page_rows(
                 header_judge=header_judge,
                 header_dept=header_dept,
                 header_date=header_date,
+                entry_number=sub_entry_number,
             )
 
     # Remap entry_number_to_index to point at the first sub-case's ruling

--- a/packages/scraper-framework/src/framework/llm_schema.py
+++ b/packages/scraper-framework/src/framework/llm_schema.py
@@ -121,6 +121,9 @@ class ExtractedRuling(BaseModel):
     case_type: ExtractionCaseType | None = None
     confidence: FieldConfidence = Field(default_factory=FieldConfidence)
     cross_reference_source: int | None = None  # entry_number ruling_text was copied from
+    # Calendar line number from the source PDF; preserved so that
+    # _resolve_cross_references can run on the cache-hit path (#3608).
+    entry_number: int | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_llm_cache_hit_filters.py
+++ b/packages/scraper-framework/tests/test_llm_cache_hit_filters.py
@@ -194,6 +194,52 @@ class TestApplyPdfCacheHitFilters:
         """Empty input yields empty output."""
         assert _apply_pdf_cache_hit_filters([], content_key="abc123def456") == []
 
+    def test_resolve_cross_references_on_cache_hit(self) -> None:
+        """_apply_pdf_cache_hit_filters resolves stub rulings via entry_number (#3608).
+
+        Simulates the Santa Clara cache-hit scenario: two cached ExtractedRuling
+        objects where the stub (entry_number=2) points to the target
+        (entry_number=1) via "See Line 1 below for...".  Without the fix, the
+        resolver was not called on the cache-hit path and the stub persisted.
+        """
+        target_text = (
+            "The demurrer is OVERRULED. Defendant's motion to dismiss is DENIED. "
+            "Plaintiff has adequately stated a claim for breach of contract and "
+            "the Court finds the allegations sufficient to survive demurrer. "
+            "Defendant shall file an answer within twenty (20) days of this ruling."
+        )
+        stub_text = (
+            "**Order on Defendants' Demurrer to the Fifth Cause of Action**\n\n"
+            "See Line 1 below for complete tentative ruling."
+        )
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="20CV374597",
+                extracted_case_title="Regional Medical v. County of SC",
+                ruling_text=target_text,
+                entry_number=1,
+            ),
+            ExtractedRuling(
+                extracted_case_number="20CV374598",
+                extracted_case_title="Doe v. County of SC",
+                ruling_text=stub_text,
+                entry_number=2,
+            ),
+        ]
+        result = _apply_pdf_cache_hit_filters(rulings, content_key="abc123def456")
+
+        # Both rulings survive (neither is a calendar listing or short text).
+        assert len(result) == 2
+
+        # Stub (index 1) must have been resolved: ruling_text replaced with
+        # the target's text and cross_reference_source set to 1.
+        assert result[1].ruling_text == target_text
+        assert result[1].cross_reference_source == 1
+
+        # Target (index 0) is unchanged.
+        assert result[0].ruling_text == target_text
+        assert result[0].cross_reference_source is None
+
 
 class TestApplyTextCacheHitFilters:
     """Unit tests for ``_apply_text_cache_hit_filters`` (#2513)."""

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -910,6 +910,42 @@ class TestJoinPageRows:
         """Empty row list returns empty ruling list."""
         assert _join_page_rows([]) == []
 
+    def test_join_page_rows_populates_entry_number(self) -> None:
+        """_join_page_rows sets entry_number on each ExtractedRuling (#3608).
+
+        Verifies that the calendar line number from each row is stored in the
+        resulting ExtractedRuling so the cache-hit resolver can use it.
+        """
+        rows = [
+            {
+                "entry_number": 1,
+                "case_info": "2024-00001 Alpha v. Beta",
+                "ruling_text": "The demurrer is OVERRULED. Plaintiff's claim survives.",
+            },
+            {
+                "entry_number": 2,
+                "case_info": "2024-00002 Gamma v. Delta",
+                "ruling_text": "Motion for summary judgment is DENIED.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 2
+        assert rulings[0].entry_number == 1
+        assert rulings[1].entry_number == 2
+
+    def test_join_page_rows_no_entry_number_stays_none(self) -> None:
+        """Rows without entry_number produce rulings with entry_number=None."""
+        rows = [
+            {
+                "entry_number": None,
+                "case_info": "2024-00001 Alpha v. Beta",
+                "ruling_text": "GRANTED. The motion is approved.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 1
+        assert rulings[0].entry_number is None
+
     def test_case_info_merging_for_continuation(self) -> None:
         """Continuation case_info is appended to previous case."""
         rows = [
@@ -3457,6 +3493,41 @@ class TestResolveCrossReferences:
         ]
         entry_map = {1: 0}
         result = _resolve_cross_references(rulings, entry_map)
+        assert result[0].ruling_text == "See Line 1 for tentative ruling."
+        assert result[0].cross_reference_source is None
+
+    def test_resolves_from_per_ruling_entry_numbers(self) -> None:
+        """entry_number_to_index=None builds the map from per-ruling entry_number fields.
+
+        This is the cache-hit path (#3608): cached ExtractedRuling[] carry
+        entry_number but there's no pre-join row state to pass an explicit map.
+        Resolution must match the behaviour of the fresh-extract path.
+        """
+        long_text = "The motion is GRANTED. " * 10  # > 100 chars
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="2024-00001",
+                ruling_text=long_text,
+                entry_number=1,
+            ),
+            ExtractedRuling(
+                extracted_case_number="2024-00002",
+                ruling_text="See Line 1 for tentative ruling.",
+                entry_number=2,
+            ),
+        ]
+        # Pass entry_number_to_index=None — resolver must build the map itself.
+        result = _resolve_cross_references(rulings, None)
+        assert result[1].ruling_text == long_text
+        assert result[1].cross_reference_source == 1
+
+    def test_none_map_no_entry_numbers_no_crash(self) -> None:
+        """entry_number_to_index=None with no entry_number fields is a no-op."""
+        rulings = [
+            self._make_ruling("2024-00001", "See Line 1 for tentative ruling."),
+        ]
+        # No entry_number on any ruling → empty map → no resolution.
+        result = _resolve_cross_references(rulings, None)
         assert result[0].ruling_text == "See Line 1 for tentative ruling."
         assert result[0].cross_reference_source is None
 

--- a/packages/scraper-framework/tests/test_llm_schema.py
+++ b/packages/scraper-framework/tests/test_llm_schema.py
@@ -255,6 +255,35 @@ class TestExtractedRuling:
         with pytest.raises(ValidationError):
             ExtractedRuling(case_type="invalid_type")
 
+    def test_extracted_ruling_entry_number_field(self) -> None:
+        """entry_number field exists, serializes correctly, and defaults to None."""
+        # Instantiation with entry_number set
+        ruling = ExtractedRuling(entry_number=5)
+        assert ruling.entry_number == 5
+
+        # Round-trip via model_dump / model_validate
+        dumped = ruling.model_dump()
+        assert dumped["entry_number"] == 5
+        restored = ExtractedRuling.model_validate(dumped)
+        assert restored.entry_number == 5
+
+        # Round-trip via JSON serialization
+        json_str = ruling.model_dump_json()
+        restored_json = ExtractedRuling.model_validate_json(json_str)
+        assert restored_json.entry_number == 5
+
+        # Legacy serialized rows that lack the field default to None
+        legacy_dict = {
+            "extracted_case_number": "2024-00001",
+            "ruling_text": "The motion is GRANTED.",
+        }
+        legacy_ruling = ExtractedRuling.model_validate(legacy_dict)
+        assert legacy_ruling.entry_number is None
+
+        # Default is None when not specified
+        default_ruling = ExtractedRuling()
+        assert default_ruling.entry_number is None
+
     def test_distinguishes_raw_from_resolved(self) -> None:
         """Verify extracted_ prefix fields exist and non-prefixed don't."""
         ruling = ExtractedRuling(


### PR DESCRIPTION
## Summary

Added `entry_number: int | None = None` field to `ExtractedRuling` to preserve calendar line identifiers through the LLM cache. Refactored `_resolve_cross_references` to self-build its lookup map when called without an explicit `entry_number_to_index` dict, enabling cross-reference stub resolution on cache-hit paths. Wired the resolver into `_apply_pdf_cache_hit_filters` as the first filter step so Santa Clara stubs that reference other calendar lines are resolved even when the extraction result is served from cache.

Closes #3608

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
- [x] CI green

### Post-deploy verification

- [ ] Sample 10 Santa Clara PDF extractions from cache hits; verify no unresolved cross-reference stubs (text matching `_XREF_LINE_RE` with `cross_reference_source IS NULL`)
- [ ] Run `/spotcheck` on Santa Clara county; compare stub prevalence to baseline from 2026-04-27 (~24% of sampled rulings)
- [ ] Verification evidence posted on #3608 (see /task-v2-verify output)