### PR TITLE
fix(api): enable trustProxy to fix per-IP rate-limit keying behind ALB (#3643)

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -17,6 +17,7 @@ export async function buildApp(db?: Pool, os?: Client): Promise<FastifyInstance>
 
   const app = Fastify({
     logger: process.env.NODE_ENV !== 'test',
+    trustProxy: true,
   });
 
   // ── CORS ────────────────────────────────────────────────────────────────
@@ -92,7 +93,7 @@ export async function buildApp(db?: Pool, os?: Client): Promise<FastifyInstance>
         // Fresh DataLoaders, auth context, and OpenSearch client per request.
         context: async () => {
           const user = await extractUser(req, pool);
-          const ip = req.ip ?? req.headers['x-forwarded-for'] ?? 'unknown';
+          const ip = req.ip ?? 'unknown';
           const cookieHeader =
             typeof req.headers.cookie === 'string' ? req.headers.cookie : '';
           // #2884: X-MFA-Token parsing removed with the MFA re-auth gate.

--- a/packages/api/tests/login-rate-limit-per-ip.integration.test.ts
+++ b/packages/api/tests/login-rate-limit-per-ip.integration.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Integration test: login rate-limit keys on client IP resolved from
+ * X-Forwarded-For when trustProxy is enabled.
+ *
+ * Verifies AC3 of issue #3643: per-IP rate-limiting works correctly behind
+ * the ALB now that Fastify is configured with trustProxy: true.
+ *
+ * Strategy:
+ * - Mock the `redis` module with a per-key in-memory counter (mirrors
+ *   auth-rate-limit.unit.test.ts style).
+ * - Use a stub pool that returns no user rows (login always fails with
+ *   UNAUTHENTICATED — the important thing is reaching the rate-limit check).
+ * - Disable `DISABLE_LOGIN_RATE_LIMIT` so the real rate-limit path runs.
+ * - Send 11 login mutations from IP 1.2.3.4; assert the 11th is RATE_LIMITED.
+ * - Send 1 login mutation from IP 5.6.7.8; assert it is UNAUTHENTICATED (not
+ *   rate-limited — a fresh IP with 0 prior attempts).
+ *
+ * NOTE: This file uses vi.resetModules() + dynamic import in beforeAll to
+ * get a fresh rate-limit module instance, since rate-limit.ts caches the Redis
+ * client at module scope. The per-key counter is maintained in a Map held in
+ * the mock closure.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import type { Pool } from 'pg';
+import type { FastifyInstance } from 'fastify';
+
+// ---------------------------------------------------------------------------
+// Mock redis — must be declared before any imports that transitively import it
+// ---------------------------------------------------------------------------
+
+// Hoisted mock functions — these are captured by vi.mock() factory below
+const mockIncr = vi.hoisted(() => vi.fn());
+const mockExpire = vi.hoisted(() => vi.fn());
+const mockConnect = vi.hoisted(() => vi.fn());
+const mockCreateClient = vi.hoisted(() => vi.fn());
+
+vi.mock('redis', () => ({
+  createClient: mockCreateClient,
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal stub Pool — returns empty rows for all queries, no-ops on end(). */
+function makeStubPool(): Pool {
+  return {
+    query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+    end: vi.fn(async () => undefined),
+  } as unknown as Pool;
+}
+
+async function gql(
+  app: FastifyInstance,
+  query: string,
+  variables?: Record<string, unknown>,
+  headers?: Record<string, string>,
+) {
+  const res = await app.inject({
+    method: 'POST',
+    url: '/graphql',
+    headers: { 'content-type': 'application/json', ...headers },
+    payload: JSON.stringify({ query, variables }),
+  });
+  return {
+    body: JSON.parse(res.body) as {
+      data?: Record<string, unknown>;
+      errors?: Array<{ message: string; extensions?: { code?: string } }>;
+    },
+    statusCode: res.statusCode,
+  };
+}
+
+const LOGIN_MUTATION = `
+  mutation($email: String!, $password: String!) {
+    login(email: $email, password: $password) {
+      accessToken
+      user { id email }
+    }
+  }
+`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('login rate-limit — per-IP keying via XFF / trustProxy', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    // Reset module registry so rate-limit.ts starts with a fresh redisClient = null
+    vi.resetModules();
+    // Clear any leftover mock state from other test files
+    vi.resetAllMocks();
+    delete process.env.DISABLE_LOGIN_RATE_LIMIT;
+
+    // Per-key counter, reset here for a clean state
+    const keyCounters = new Map<string, number>();
+
+    // Re-implement the mocks fresh after resetAllMocks()
+    mockIncr.mockImplementation(async (key: string) => {
+      const next = (keyCounters.get(key) ?? 0) + 1;
+      keyCounters.set(key, next);
+      return next;
+    });
+    mockExpire.mockResolvedValue(true);
+    mockConnect.mockResolvedValue(undefined);
+    mockCreateClient.mockReturnValue({
+      incr: mockIncr,
+      expire: mockExpire,
+      connect: mockConnect,
+    });
+
+    // Dynamic import after vi.resetModules() so rate-limit.ts re-initialises
+    const { buildApp } = await import('../src/app');
+    app = await buildApp(makeStubPool());
+  }, 20_000);
+
+  afterAll(async () => {
+    await app?.close();
+    delete process.env.DISABLE_LOGIN_RATE_LIMIT;
+  });
+
+  it('allows the first 10 login attempts from IP 1.2.3.4 (UNAUTHENTICATED, not RATE_LIMITED)', async () => {
+    for (let i = 1; i <= 10; i++) {
+      const { body } = await gql(
+        app,
+        LOGIN_MUTATION,
+        { email: 'nobody@nowhere.invalid', password: 'irrelevant' },
+        { 'x-forwarded-for': '1.2.3.4' },
+      );
+      // Each attempt should fail with UNAUTHENTICATED (user not found),
+      // not RATE_LIMITED — the rate limit hasn't been exceeded yet.
+      expect(body.errors, `attempt ${i} should have errors`).toBeDefined();
+      expect(
+        body.errors![0].extensions?.code,
+        `attempt ${i} should be UNAUTHENTICATED not RATE_LIMITED`,
+      ).toBe('UNAUTHENTICATED');
+    }
+  });
+
+  it('rate-limits the 11th login attempt from IP 1.2.3.4', async () => {
+    const { body } = await gql(
+      app,
+      LOGIN_MUTATION,
+      { email: 'nobody@nowhere.invalid', password: 'irrelevant' },
+      { 'x-forwarded-for': '1.2.3.4' },
+    );
+
+    expect(body.errors).toBeDefined();
+    expect(body.errors![0].extensions?.code).toBe('RATE_LIMITED');
+  });
+
+  it('does NOT rate-limit a fresh IP (5.6.7.8) — gets UNAUTHENTICATED', async () => {
+    const { body } = await gql(
+      app,
+      LOGIN_MUTATION,
+      { email: 'nobody@nowhere.invalid', password: 'irrelevant' },
+      { 'x-forwarded-for': '5.6.7.8' },
+    );
+
+    expect(body.errors).toBeDefined();
+    // Should be UNAUTHENTICATED (user not found), not RATE_LIMITED
+    expect(body.errors![0].extensions?.code).toBe('UNAUTHENTICATED');
+  });
+});

--- a/packages/api/tests/trust-proxy.unit.test.ts
+++ b/packages/api/tests/trust-proxy.unit.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit test: Fastify trustProxy resolves req.ip from X-Forwarded-For header.
+ *
+ * Verifies AC1 of issue #3643: `trustProxy: true` is correctly set so that
+ * Fastify resolves `req.ip` from the XFF header injected by the ALB.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { buildApp } from '../src/app';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildApp();
+
+  // Register a test-only route to echo req.ip back to the caller.
+  // We register it after buildApp so it doesn't pollute production routes.
+  app.get('/__test/echo-ip', async (req) => {
+    return { ip: req.ip };
+  });
+}, 10_000);
+
+afterAll(async () => {
+  await app?.close();
+});
+
+describe('trustProxy — req.ip resolution from X-Forwarded-For', () => {
+  it('resolves req.ip to the XFF client IP (1.2.3.4) when trustProxy is true', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/__test/echo-ip',
+      headers: {
+        'x-forwarded-for': '1.2.3.4',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as { ip: string };
+    expect(body.ip).toBe('1.2.3.4');
+  });
+
+  it('resolves req.ip to the first IP in a multi-hop XFF chain', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/__test/echo-ip',
+      headers: {
+        'x-forwarded-for': '9.8.7.6, 10.0.0.1',
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body) as { ip: string };
+    // Fastify with trustProxy: true resolves to the leftmost (client) IP
+    expect(body.ip).toBe('9.8.7.6');
+  });
+});


### PR DESCRIPTION
## Summary

Fixed login rate-limit keying by enabling Fastify `trustProxy: true`. Previously, `req.ip` resolved to the ALB's internal IP instead of the X-Forwarded-For client address, causing all login attempts to be bucketed under one ALB IP and exhausting the global rate limit. This opened DoS (every user shares one limiter) and brute-force gaps (per-account throttling is ineffective). 

Removed dead X-Forwarded-For fallback and added tests validating per-IP rate-limiting.

Closes #3643

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] `scripts/dev-db-query.sh` sample login failure logs confirm `ip` field is client-facing IP (from X-Forwarded-For), not ALB IP (10.x.x.x)
- [ ] Hit `/login` from two distinct public IPs in sequence; confirm first IP hits limit after 10 attempts and second IP is unthrottled
- [ ] Verification evidence posted on #3643 (see /task-v2-verify output)