### PR TITLE
fix(dispatcher): reap silent-hang ECS agents (timeouts + daemon reaper) (#3656)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -2408,12 +2408,22 @@ handle_push_and_pr() {
     # and the agent terminates without opening an orphan PR.
     log "push_and_pr_fetch_main_begin"
     set +e
-    git -C "$REPO_ROOT" fetch origin main \
+    # #3656: bound network IO at NETWORK_TIMEOUT_SECONDS — a hung
+    # ``git fetch`` would otherwise pin the cap slot indefinitely.
+    # ``timeout`` exits 124 on SIGTERM-after-timeout; the existing
+    # best-effort fetch-failure path (logged + fall through to push)
+    # handles 124 cleanly without a separate envelope branch.
+    timeout "$NETWORK_TIMEOUT_SECONDS" \
+        git -C "$REPO_ROOT" fetch origin main \
         > "$AGENT_WORKSPACE/git-fetch-main.stdout.log" \
         2> "$AGENT_WORKSPACE/git-fetch-main.stderr.log"
     _fetch_rc=$?
     set -e
     log "push_and_pr_fetch_main_done" "exit_code=$_fetch_rc"
+    if [[ "$_fetch_rc" -eq 124 ]]; then
+        log "push_and_pr_fetch_main_timeout" \
+            "elapsed_seconds=$NETWORK_TIMEOUT_SECONDS"
+    fi
     if [[ "$_fetch_rc" -eq 0 ]]; then
         log "push_and_pr_rebase_begin"
         set +e
@@ -2612,12 +2622,33 @@ handle_push_and_pr() {
 
     log "push_and_pr_push_begin" "branch=$BRANCH_NAME"
     set +e
-    git -C "$REPO_ROOT" push -u origin "$BRANCH_NAME" \
+    # #3656: bound ``git push`` network IO at NETWORK_TIMEOUT_SECONDS.
+    # Pre-#3656 the bare push could hang indefinitely on kernel TCP
+    # retry of an already-broken socket — observed for 16+ minutes on
+    # agent 2ff6e282 (#3608) before manual ``aws ecs stop-task``. The
+    # ``timeout`` wrapper guarantees ``handle_push_and_pr`` always
+    # returns within NETWORK_TIMEOUT_SECONDS + a few seconds of
+    # bookkeeping, freeing the cap slot for a fresh agent.
+    timeout "$NETWORK_TIMEOUT_SECONDS" \
+        git -C "$REPO_ROOT" push -u origin "$BRANCH_NAME" \
         > "$AGENT_WORKSPACE/git-push.stdout.log" \
         2> "$AGENT_WORKSPACE/git-push.stderr.log"
     _push_rc=$?
     set -e
     log "push_and_pr_push_done" "exit_code=$_push_rc"
+    if [[ "$_push_rc" -eq 124 ]]; then
+        # #3656: timeout fired — emit a distinct envelope so the
+        # diagnoser can differentiate a hung push from a non-zero exit
+        # (PAT scope, pre-push hook, etc.). The ``reason=push_timeout``
+        # field flows through ``transition_from_push_and_pr`` into the
+        # ``dispatcher.failures`` row so CloudWatch Logs Insights
+        # queries can grep for ``push_timeout`` to count incidents.
+        log "push_and_pr_push_timeout" \
+            "elapsed_seconds=$NETWORK_TIMEOUT_SECONDS" \
+            "branch=$BRANCH_NAME"
+        printf '{"no_op": false, "push_failed": true, "reason": "push_timeout"}'
+        return 0
+    fi
     if [[ "$_push_rc" -ne 0 ]]; then
         log "push_and_pr_push_failed" "exit_code=$_push_rc"
         # Emit a minimal failure envelope; the transition shim will
@@ -2663,9 +2694,14 @@ Closes #${ISSUE_NUMBER}
     log "push_and_pr_pr_create_begin"
     _pr_body_path="$AGENT_WORKSPACE/pr_body.md"
     set +e
+    # #3656: bound ``gh pr create`` network IO at NETWORK_TIMEOUT_SECONDS
+    # — same hung-network defense as the ``git push`` site above. A
+    # GitHub API outage / token-rotation hang on ``gh pr create`` would
+    # otherwise pin the cap slot indefinitely.
     if [[ -n "$_pr_title" && -n "$_pr_body_md" ]]; then
         printf '%s' "$_pr_body_md" > "$_pr_body_path"
-        gh pr create \
+        timeout "$NETWORK_TIMEOUT_SECONDS" \
+            gh pr create \
             --repo judgemind/judgemind \
             --base main \
             --head "$BRANCH_NAME" \
@@ -2675,7 +2711,8 @@ Closes #${ISSUE_NUMBER}
             2> "$AGENT_WORKSPACE/gh-pr-create.stderr.log"
         _pr_rc=$?
     else
-        gh pr create \
+        timeout "$NETWORK_TIMEOUT_SECONDS" \
+            gh pr create \
             --repo judgemind/judgemind \
             --base main \
             --head "$BRANCH_NAME" \
@@ -2686,6 +2723,15 @@ Closes #${ISSUE_NUMBER}
     fi
     set -e
     log "push_and_pr_pr_create_done" "exit_code=$_pr_rc"
+    if [[ "$_pr_rc" -eq 124 ]]; then
+        # #3656: timeout fired during ``gh pr create``. Emit a distinct
+        # envelope (``reason=pr_create_timeout``) so the diagnoser can
+        # differentiate a hung create from a non-zero exit.
+        log "push_and_pr_pr_create_timeout" \
+            "elapsed_seconds=$NETWORK_TIMEOUT_SECONDS"
+        printf '{"no_op": false, "pr_create_failed": true, "reason": "pr_create_timeout"}'
+        return 0
+    fi
     if [[ "$_pr_rc" -ne 0 ]]; then
         log "push_and_pr_pr_create_failed" "exit_code=$_pr_rc"
         printf '{"no_op": false, "pr_create_failed": true}'
@@ -3822,6 +3868,21 @@ FIX_CONFLICT_MAX_ATTEMPTS="${AGENT_RUNNER_FIX_CONFLICT_MAX_ATTEMPTS:-2}"
 # protection rejection. Matches ``STALE_ROLLUP_STDERR_MARKER`` in
 # daemon.py.
 STALE_ROLLUP_MARKER="base branch policy prohibits the merge"
+
+# #3656: hard timeout (seconds) on network-blocking git/gh operations
+# inside ``handle_push_and_pr`` — ``git fetch origin main``, ``git
+# push``, and ``gh pr create``. Wraps each call in ``timeout`` so a
+# hung network IO does not silently consume an ECS cap slot for hours.
+# The agent-runner container's ``bash`` keeps running while a child
+# ``git push`` blocks indefinitely on auth-retry / network drop, so
+# Fargate's "container alive" liveness signal is not enough — every
+# observed hang in 2026-04-27 (#3608 / agent 2ff6e282) was the daemon
+# silently waiting on the kernel's TCP retry of an already-broken
+# socket. Default 300s leaves plenty of headroom for a healthy push +
+# PR-create round trip while bounding the worst case to 5 minutes.
+# Tests override to 1 (or use a stub ``timeout`` shim) to drive the
+# 124-exit branch deterministically.
+NETWORK_TIMEOUT_SECONDS="${AGENT_RUNNER_NETWORK_TIMEOUT_SECONDS:-300}"
 
 # Deploy workflow display names we watch on the merge SHA. Must match
 # the ``name:`` field in each ``.github/workflows/`` file. Mirrors the

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1338,6 +1338,23 @@ FAILURE_CATEGORY_MERGE_CONFLICT_AT_PUSH = "merge_conflict_at_push"
 #: ``_reap_completed_agent_tasks`` for the routing site.
 FAILURE_CATEGORY_AGENT_RUNNER_ROUTE_STUB = "agent_runner_route_stub"
 
+#: #3656 — ECS-mode agent went silent inside the Fargate container
+#: (e.g. ``git push`` hung on auth/network, ``gh pr create`` blocked on
+#: a GitHub API outage, claude-p stalled mid-tool-loop). The container
+#: stays alive so the existing ``_reap_completed_agent_tasks`` STOPPED-
+#: lifecycle path never fires; pre-#3656 the daemon's per-phase stuck
+#: timer explicitly excluded ECS mode. The new daemon-side check (in
+#: :meth:`DispatcherDaemon._check_stuck_agents`) issues
+#: ``ecs:StopTask`` and routes the row through
+#: :meth:`_handle_agent_failure` under this category so the cap slot
+#: is freed promptly. Tier-2 first-occurrence: a hung agent is almost
+#: never self-healing and the diagnoser should look at the last known
+#: phase + last few log lines before deciding retry vs. escalate. The
+#: agent-runner Layer 1 timeouts (``push_and_pr_push_timeout`` etc.)
+#: are the cheap primary defense; this category is the systemic
+#: backstop for any internal hang the timeouts don't anticipate.
+FAILURE_CATEGORY_AGENT_SILENT_HANG = "agent_silent_hang"
+
 #: #3366 — terminal-phase → failure-category map for the bypass-prone
 #: terminals the ECS entrypoint emits with ``status='failed'`` AND
 #: container exit 0. The reaper observes these in the
@@ -1654,6 +1671,9 @@ TIER_2_FIRST_OCCURRENCE_CATEGORIES: frozenset[str] = frozenset(
         FAILURE_CATEGORY_FIX_CI_APPLY_FAILED,  # #3069
         FAILURE_CATEGORY_DEPLOY_FAILED,  # #3070
         FAILURE_CATEGORY_PHASE_OUTPUT_FETCH_FAILED,  # #3385
+        # #3656 — ECS-mode silent-hang reaper. Diagnoser inspects the
+        # last known phase + log tail to decide retry vs. escalate.
+        FAILURE_CATEGORY_AGENT_SILENT_HANG,
     }
 )
 
@@ -17179,32 +17199,40 @@ class DispatcherDaemon:
         :meth:`_stuck_timeout_for_phase` handles the lookup with live
         config overrides.
 
-        Each flagged agent gets a ``dispatcher.failures`` row with
-        ``category='stuck_timeout'``, is flipped to ``status='crashed'``,
-        and enqueues a retry marker so
-        :meth:`_process_retry_markers` can reset it with a fresh
+        **Subprocess-mode flagged agents** get a ``dispatcher.failures``
+        row with ``category='stuck_timeout'``, are flipped to
+        ``status='crashed'``, and enqueue a retry marker so
+        :meth:`_process_retry_markers` can reset them with a fresh
         worktree. After #2927 every running row is daemon-owned
         (label-only /task coordination), so no kind-filter is needed
         — the #2903 task-skill guard has been removed.
 
-        **Execution-mode filter (#3158).** The SELECT excludes
-        ``execution_mode = 'ecs'`` rows. The per-phase stuck timer was
-        designed for subprocess-mode agents, whose
-        ``phase_transitions.ts`` is written by the daemon itself — so a
-        stuck subprocess always surfaces as an older MAX(ts). ECS
-        agents run the phase loop inside an independent Fargate task
-        whose lifecycle belongs to ECS, not to the daemon: a truly-hung
-        ECS task is caught by :meth:`_reap_completed_agent_tasks` when
-        ECS transitions the task to STOPPED (container health check,
-        SIGKILL, OOM) and routed via :meth:`_handle_agent_failure` with
-        category ``agent_task_stopped_unexpectedly``. Applying the
-        per-phase timer to an ECS agent is a silent-agent-loss risk:
-        (a) it flips the row to ``crashed`` while the Fargate task
-        keeps running (zombie state), (b) it enqueues a retry marker
-        which :meth:`_resume_retrying_agent` would pick up and
-        silently fork to subprocess mode. NULL ``execution_mode``
-        (pre-#3091 migration 41 rows) defaults to subprocess via
-        ``COALESCE``.
+        **ECS-mode flagged agents (#3656).** Pre-#3656 the SELECT here
+        explicitly excluded ``execution_mode = 'ecs'`` (#3158), under
+        the assumption that a hung ECS task would surface as an ECS
+        STOPPED transition reaped by :meth:`_reap_completed_agent_tasks`
+        — but that requires the container to actually exit, which it
+        does not when the agent-runner's ``bash`` is alive while a
+        child ``git push`` blocks indefinitely on TCP retry. Observed
+        2026-04-27 on agent ``2ff6e282`` (#3608): 16+ minutes of
+        ``push_and_pr_push_begin`` silence followed by manual
+        ``aws ecs stop-task``. The cap slot was unusable for the full
+        duration. The fix removes the exclusion and adds a dedicated
+        ECS branch: when an ECS row exceeds its phase threshold, the
+        daemon issues ``ecs:StopTask(agent_task_arn)`` (best-effort,
+        delegated to :meth:`_force_stop_ecs_task`) and routes through
+        :meth:`_handle_agent_failure` with category
+        :data:`FAILURE_CATEGORY_AGENT_SILENT_HANG`. The diagnoser then
+        inspects the last known phase + log tail to choose retry
+        vs. file_prerequisite_task vs. escalate. No retry marker is
+        enqueued here — the diagnoser owns that decision.
+
+        NULL ``execution_mode`` (pre-#3091 migration 41 rows) defaults
+        to subprocess via ``COALESCE``. Agent-runner Layer 1 timeouts
+        (``push_and_pr_push_timeout`` etc.) are the cheap primary
+        defense and resolve in <5 min; this daemon-side reaper is the
+        15-minute systemic backstop for any internal hang the
+        timeouts don't anticipate.
 
         Returns the number of stuck agents flagged this tick (for
         logging). Exceptions are caught per-agent + logged; one bad
@@ -17212,41 +17240,56 @@ class DispatcherDaemon:
         """
         assert self._conn is not None, "connect() must run before stuck check"
 
-        # Candidate rows: every running subprocess-mode agent,
-        # regardless of elapsed time. The per-phase threshold
-        # comparison happens in Python so we can consult both the live
-        # config override and the module-level defaults without
-        # expressing them as SQL.
+        # Candidate rows: every running agent (subprocess or ECS) whose
+        # last phase_transition is older than its phase's threshold.
+        # The per-phase threshold comparison happens in Python so we
+        # can consult both the live config override and the module-
+        # level defaults without expressing them as SQL.
         #
-        # #3158: ``COALESCE(a.execution_mode, 'subprocess') <> 'ecs'``
-        # excludes ECS-mode agents — see method docstring for rationale.
+        # #3656: the SELECT no longer excludes ``execution_mode='ecs'``
+        # (the previous #3158 filter). The Python loop below branches
+        # on mode to deliver the right signal — SIGKILL/retry-marker
+        # for subprocess, ``ecs:StopTask`` + diagnoser for ECS.
         #
-        # Fields: agent_id, issue_number, phase, elapsed_seconds.
-        candidates: list[tuple[str, int | None, str | None, float]] = []
+        # Fields: agent_id, issue_number, phase, elapsed_seconds,
+        #         execution_mode, agent_task_arn.
+        candidates: list[
+            tuple[str, int | None, str | None, float, str, str | None]
+        ] = []
         try:
             with self._conn.cursor() as cur:
                 cur.execute(
                     "SELECT a.agent_id, a.issue_number, a.phase, "
                     "       EXTRACT(EPOCH FROM ("
                     "           now() - COALESCE(pt.last_ts, a.started_at)"
-                    "       )) AS elapsed_seconds "
+                    "       )) AS elapsed_seconds, "
+                    "       COALESCE(a.execution_mode, 'subprocess') "
+                    "         AS execution_mode, "
+                    "       a.agent_task_arn "
                     "FROM dispatcher.agents a "
                     "LEFT JOIN LATERAL ("
                     "    SELECT MAX(ts) AS last_ts "
                     "    FROM dispatcher.phase_transitions "
                     "    WHERE agent_id = a.agent_id"
                     ") pt ON TRUE "
-                    "WHERE a.status = 'running' "
-                    "  AND COALESCE(a.execution_mode, 'subprocess') <> 'ecs'",
+                    "WHERE a.status = 'running'",
                 )
                 rows = cur.fetchall()
                 for row in rows:
+                    raw_mode = row[4] if len(row) > 4 else None
+                    mode = (
+                        str(raw_mode).lower() if raw_mode is not None else "subprocess"
+                    )
+                    raw_arn = row[5] if len(row) > 5 else None
+                    task_arn = str(raw_arn) if raw_arn is not None else None
                     candidates.append(
                         (
                             str(row[0]),
                             int(row[1]) if row[1] is not None else None,
                             str(row[2]) if row[2] is not None else None,
                             float(row[3]) if row[3] is not None else 0.0,
+                            mode,
+                            task_arn,
                         )
                     )
             self._conn.commit()
@@ -17270,11 +17313,58 @@ class DispatcherDaemon:
         overrides = self._read_stuck_timeout_overrides()
 
         flagged = 0
-        for agent_id, issue_number, phase, elapsed_seconds in candidates:
+        for (
+            agent_id,
+            issue_number,
+            phase,
+            elapsed_seconds,
+            execution_mode,
+            agent_task_arn,
+        ) in candidates:
             threshold = self._stuck_timeout_for_phase(phase, overrides=overrides)
             if elapsed_seconds < threshold:
                 continue
             try:
+                if execution_mode == "ecs":
+                    # #3656: ECS-mode silent-hang reaper. Issue
+                    # ``ecs:StopTask`` (best-effort — the
+                    # ``_handle_agent_failure`` row is the source of
+                    # truth even if the StopTask call itself fails),
+                    # then route through the unified failure path so
+                    # the diagnoser inspects last known phase + log
+                    # tail before deciding retry vs. escalate.
+                    self._force_stop_ecs_task(agent_id, agent_task_arn)
+                    self._log.warning(
+                        "daemon.agent_silent_hang_reaped",
+                        extra={
+                            "event": "agent_silent_hang_reaped",
+                            "run_id": self._run_id,
+                            "agent_id": agent_id,
+                            "issue_number": issue_number,
+                            "phase": phase,
+                            "stuck_seconds": int(elapsed_seconds),
+                            "threshold_seconds": threshold,
+                            "agent_task_arn": agent_task_arn,
+                        },
+                    )
+                    self._handle_agent_failure(
+                        agent_id=agent_id,
+                        phase=phase or "unknown",
+                        category=FAILURE_CATEGORY_AGENT_SILENT_HANG,
+                        stderr_tail="",
+                        exit_code=None,
+                        details={
+                            "stuck_seconds": int(elapsed_seconds),
+                            "threshold_seconds": threshold,
+                            "last_known_phase": phase,
+                            "execution_mode": execution_mode,
+                            "agent_task_arn": agent_task_arn,
+                        },
+                        issue_number=issue_number,
+                    )
+                    flagged += 1
+                    continue
+
                 failure_id = self._write_failure(
                     agent_id=agent_id,
                     category=FAILURE_CATEGORY_STUCK_TIMEOUT,

--- a/scripts/dispatcher/tests/test_daemon_execution_mode_audit.py
+++ b/scripts/dispatcher/tests/test_daemon_execution_mode_audit.py
@@ -134,29 +134,51 @@ def _make_daemon(
 
 
 # --------------------------------------------------------------------------
-# Fix 1 — _check_stuck_agents filters execution_mode='ecs'
+# Fix 1 — _check_stuck_agents handles BOTH execution modes (#3656)
 # --------------------------------------------------------------------------
 
 
 class TestCheckStuckAgentsExecutionModeFilter:
-    """The supervisor stuck-timeout scan must not flag ECS-mode agents.
+    """The supervisor stuck-timeout scan must reap BOTH execution modes.
 
-    Pre-#3158, the SELECT returned every ``status='running'`` row and
-    applied the per-phase threshold uniformly. For a long ECS ralph
-    exceeding 15h the scan would flip the ECS row to ``crashed`` and
-    enqueue a retry marker — which (absent the #3158 fix in
-    :meth:`_resume_retrying_agent`) would silently fork the agent to
-    subprocess mode on the next scheduler tick.
+    History:
 
-    Post-#3158, the SELECT carries
-    ``COALESCE(a.execution_mode, 'subprocess') <> 'ecs'`` so ECS rows
-    never reach the per-phase timer. An ECS task that's actually hung
-    is caught by :meth:`_reap_completed_agent_tasks` when ECS itself
-    stops it.
+    * Pre-#3158, the SELECT returned every ``status='running'`` row and
+      applied the per-phase threshold uniformly. For a long ECS ralph
+      exceeding 15h the scan would flip the ECS row to ``crashed`` and
+      enqueue a retry marker — which (absent the #3158 fix in
+      :meth:`_resume_retrying_agent`) would silently fork the agent to
+      subprocess mode on the next scheduler tick.
+    * #3158 (2026-04-…) added
+      ``COALESCE(a.execution_mode, 'subprocess') <> 'ecs'`` so ECS rows
+      never reached the per-phase timer. The premise: a hung ECS task
+      would surface as a STOPPED transition reaped by
+      :meth:`_reap_completed_agent_tasks`.
+    * #3656 (2026-04-27) — the premise was wrong. ``bash`` keeps
+      running while a child ``git push`` blocks indefinitely, so ECS
+      never STOPs the task. Observed for 16+ minutes on agent
+      ``2ff6e282`` (#3608) before manual ``aws ecs stop-task``. The
+      fix removes the exclusion: the SELECT returns every
+      ``status='running'`` row plus ``execution_mode`` and
+      ``agent_task_arn``, and the Python loop branches by mode —
+      subprocess takes the legacy ``stuck_timeout`` + retry-marker
+      path; ECS takes a new ``ecs:StopTask`` + ``agent_silent_hang``
+      → diagnoser path. See
+      :class:`~dispatcher.tests.test_daemon_stuck_check_ecs_silent_hang.TestEcsSilentHangReaper`
+      for the ECS-branch coverage.
     """
 
-    def test_select_filters_execution_mode_ecs(self, tmp_path: Path) -> None:
-        """The SELECT excludes ``execution_mode = 'ecs'`` via COALESCE."""
+    def test_select_no_longer_filters_execution_mode_ecs(self, tmp_path: Path) -> None:
+        """The SELECT carries no ``<> 'ecs'`` clause (#3656).
+
+        Asserts both directions of the change at once:
+
+        * The legacy filter substring is absent — confirms #3158's
+          exclusion was actually removed.
+        * The new SELECT pulls ``execution_mode`` and
+          ``agent_task_arn`` so the Python loop has the data it needs
+          to dispatch the ECS branch.
+        """
         d, conn, _handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue = [[]]
 
@@ -172,9 +194,20 @@ class TestCheckStuckAgentsExecutionModeFilter:
         ]
         assert selects, "expected _check_stuck_agents to issue the SELECT"
         sql, _params = selects[0]
-        assert "COALESCE(a.execution_mode, 'subprocess') <> 'ecs'" in sql, (
-            "_check_stuck_agents must filter out execution_mode='ecs' rows. "
-            "Actual SQL: " + sql
+        # #3656 — the legacy #3158 filter is gone.
+        assert "<> 'ecs'" not in sql, (
+            "#3656 removed the execution_mode='ecs' exclusion; the SELECT "
+            "should now reap ECS rows too. Actual SQL: " + sql
+        )
+        # The mode + arn columns are present so the Python loop can
+        # dispatch ECS rows to ``ecs:StopTask`` + ``_handle_agent_failure``.
+        assert "execution_mode" in sql, (
+            "#3656 — SELECT must return execution_mode for the Python "
+            "branch dispatch. Actual SQL: " + sql
+        )
+        assert "agent_task_arn" in sql, (
+            "#3656 — SELECT must return agent_task_arn so _force_stop_ecs_task "
+            "can issue the StopTask call. Actual SQL: " + sql
         )
 
     def test_subprocess_agent_still_flagged_on_timeout(self, tmp_path: Path) -> None:

--- a/scripts/dispatcher/tests/test_daemon_stuck_check_ecs_silent_hang.py
+++ b/scripts/dispatcher/tests/test_daemon_stuck_check_ecs_silent_hang.py
@@ -1,0 +1,518 @@
+"""Regression tests for the ECS-mode silent-hang reaper (#3656).
+
+Verifies that :meth:`~dispatcher.daemon.DispatcherDaemon._check_stuck_agents`
+now reaps ECS-mode agents whose phase has exceeded its threshold instead
+of silently leaving them as zombie cap-slot pins.
+
+Pre-#3656 the per-phase stuck-timeout SELECT excluded ``execution_mode =
+'ecs'`` (issue #3158), under the assumption that a hung ECS task would
+surface as a STOPPED transition reaped by ``_reap_completed_agent_tasks``.
+That assumption is wrong when the agent-runner container's ``bash`` is
+alive while a child ``git push`` blocks indefinitely on TCP retry —
+observed 2026-04-27 on agent ``2ff6e282`` (#3608) for 16+ minutes
+before manual ``aws ecs stop-task``.
+
+Six test cases:
+
+* **ECS positive — over threshold flagged as silent_hang** — an ECS
+  agent at elapsed 2000s on phase ``push_and_pr`` (1800s default
+  threshold) is reaped: ``_force_stop_ecs_task`` is called with the
+  agent's ``agent_task_arn``, a ``dispatcher.failures`` row is written
+  with ``category='agent_silent_hang'``, the agent row is flipped to
+  ``status='failed'``, and the ``daemon.agent_silent_hang_reaped``
+  event is emitted. NO retry marker is enqueued — the diagnoser owns
+  that decision.
+* **ECS negative — under threshold not flagged** — an ECS agent at
+  elapsed 600s on the same phase is NOT flagged.
+* **ECS no task_arn — still routes through failure path** — defensive
+  behavior: a hung ECS row with ``agent_task_arn=NULL`` (rare —
+  pre-launch crash) still gets a failure row written. The
+  ``_force_stop_ecs_task`` call no-ops cleanly.
+* **Subprocess regression — over-threshold subprocess still flagged
+  with stuck_timeout** — confirm the existing subprocess path is
+  unchanged. A retry marker is enqueued, category is still
+  ``stuck_timeout``, and ``_force_stop_ecs_task`` is NOT called.
+* **Mixed batch — both modes coexist in one tick** — one ECS + one
+  subprocess agent both over threshold; both are flagged but with
+  different categories and routing.
+* **Tier-2 first-occurrence wiring** — ``FAILURE_CATEGORY_AGENT_SILENT_HANG``
+  is in :data:`TIER_2_FIRST_OCCURRENCE_CATEGORIES` so the diagnoser
+  picks it up immediately rather than waiting for a recurrence.
+
+Fixture style mirrors ``test_daemon_stuck_check_operational.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — mirrors test_daemon_stuck_check_operational.py
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.stuck_ecs_hang.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+        # Provide a non-empty cluster ARN so _force_stop_ecs_task
+        # actually attempts the stop_task call (else it short-circuits
+        # and we can't assert the call happened).
+        ecs_cluster_arn="arn:aws:ecs:us-west-2:155326049300:cluster/judgemind-dispatcher",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    # Stub the ECS client so _force_stop_ecs_task records a call without
+    # hitting the network.
+    d._ecs_client = MagicMock()
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+
+class TestEcsSilentHangReaper:
+    """Issue #3656 — ECS-mode agents are reaped on phase-stuck threshold."""
+
+    def test_ecs_agent_over_threshold_reaped_as_silent_hang(
+        self, tmp_path: Path
+    ) -> None:
+        """ECS agent at elapsed 2000s on push_and_pr (1800s default) is reaped.
+
+        Asserts:
+        * ``_force_stop_ecs_task`` issues an ``ecs:StopTask`` call
+          against the recorded ``agent_task_arn``.
+        * ``dispatcher.failures`` row is written with
+          ``category='agent_silent_hang'``.
+        * Agent row is flipped to ``status='failed'`` (via
+          ``_handle_agent_failure`` → ``_mark_agent_terminal``).
+        * ``daemon.agent_silent_hang_reaped`` log event is emitted.
+        * NO retry marker is enqueued (diagnoser owns the decision).
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # Seeded row: ECS agent on push_and_pr, elapsed 2000s.
+        # ``push_and_pr`` is not in STUCK_TIMEOUT_SECONDS_BY_PHASE so
+        # the threshold is the global STUCK_TIMEOUT_SECONDS default
+        # (1800s / 30 min). Mirrors the 2026-04-27 incident shape
+        # (#3608 / agent 2ff6e282) where the actual hang lasted >75 min.
+        task_arn = (
+            "arn:aws:ecs:us-west-2:155326049300:task/"
+            "judgemind-dispatcher/9d333e50bb3c4653b4ba8eb6506f9d13"
+        )
+        conn.cursor_instance.fetchall_queue = [
+            [
+                (
+                    "2ff6e282-a431-493c-bc3e-b899d4c92ca1",
+                    3608,
+                    "push_and_pr",
+                    2000.0,  # 2000s > 1800s default threshold
+                    "ecs",
+                    task_arn,
+                ),
+            ],
+        ]
+        # Order of fetchone calls inside _check_stuck_agents (ECS branch
+        # via _handle_agent_failure → _write_failure → _mark_agent_terminal):
+        # (1) stuck_timeout_s_by_phase override read — returns None.
+        # (2) failure_id from _write_failure RETURNING.
+        conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase override unset
+            (200,),  # failure_id from _write_failure RETURNING
+        ]
+
+        flagged = d._check_stuck_agents()
+        assert flagged == 1
+
+        # ASSERT 1: ecs:StopTask was issued for the recorded ARN.
+        assert d._ecs_client is not None
+        d._ecs_client.stop_task.assert_called_once()
+        call_kwargs = d._ecs_client.stop_task.call_args.kwargs
+        assert call_kwargs["task"] == task_arn
+        assert call_kwargs["cluster"] == d._cfg.ecs_cluster_arn
+
+        # ASSERT 2: dispatcher.failures row written with the new category.
+        failure_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert len(failure_inserts) == 1
+        params = failure_inserts[0][1]
+        assert params[0] == "2ff6e282-a431-493c-bc3e-b899d4c92ca1"
+        assert params[1] == daemon.FAILURE_CATEGORY_AGENT_SILENT_HANG
+
+        # ASSERT 3: agent flipped to 'failed' (via _handle_agent_failure
+        # → _mark_agent_terminal which uses status='failed').
+        terminal_updates = [
+            e
+            for e in conn.cursor_instance.executed
+            if "UPDATE dispatcher.agents" in e[0]
+            and e[1] is not None
+            and "failed" in e[1]
+        ]
+        assert terminal_updates
+
+        # ASSERT 4: daemon.agent_silent_hang_reaped event was emitted.
+        reaped = handler.events("agent_silent_hang_reaped")
+        assert reaped, "expected agent_silent_hang_reaped log event"
+        assert reaped[0].agent_id == "2ff6e282-a431-493c-bc3e-b899d4c92ca1"  # type: ignore[attr-defined]
+        assert reaped[0].agent_task_arn == task_arn  # type: ignore[attr-defined]
+        assert reaped[0].phase == "push_and_pr"  # type: ignore[attr-defined]
+
+        # ASSERT 5: NO retry marker for this ECS row — the diagnoser
+        # owns the retry/escalate decision via the silent_hang category
+        # being in TIER_2_FIRST_OCCURRENCE_CATEGORIES.
+        marker_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert marker_inserts == [], (
+            "ECS silent-hang must not enqueue a retry marker — diagnoser routes"
+        )
+
+        # ASSERT 6: agent_failure_routed event from _handle_agent_failure
+        # (sanity that the unified routing path was hit).
+        routed = handler.events("agent_failure_routed")
+        assert routed
+        assert routed[0].category == daemon.FAILURE_CATEGORY_AGENT_SILENT_HANG  # type: ignore[attr-defined]
+
+    def test_ecs_agent_under_threshold_not_flagged(self, tmp_path: Path) -> None:
+        """ECS agent at elapsed 600s on push_and_pr (1800s default) is NOT flagged.
+
+        Confirms the threshold guard fires before the StopTask + failure
+        write so an in-progress ECS agent is not preempted.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        conn.cursor_instance.fetchall_queue = [
+            [
+                (
+                    "agent-ecs-fast",
+                    3656,
+                    "push_and_pr",
+                    600.0,  # well below 1800s default threshold
+                    "ecs",
+                    "arn:aws:ecs:us-west-2:155326049300:task/cluster/abc",
+                ),
+            ],
+        ]
+        conn.cursor_instance.fetch_queue = [None]
+
+        flagged = d._check_stuck_agents()
+        assert flagged == 0
+
+        # No StopTask call.
+        assert d._ecs_client is not None
+        d._ecs_client.stop_task.assert_not_called()
+
+        # No failure row.
+        failure_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert failure_inserts == []
+
+        # No silent-hang event.
+        assert handler.events("agent_silent_hang_reaped") == []
+
+    def test_ecs_agent_with_null_task_arn_still_routes_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """ECS row with agent_task_arn=NULL still gets a failure row.
+
+        Defensive case: a hung ECS agent that crashed before
+        ``_launch_agent_ecs_task`` could persist its ARN. We can't
+        StopTask it, but we still want the row off the cap-slot count
+        with a failure routed through the diagnoser.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        conn.cursor_instance.fetchall_queue = [
+            [
+                (
+                    "agent-ecs-no-arn",
+                    3656,
+                    "push_and_pr",
+                    2000.0,  # > 1800s default threshold
+                    "ecs",
+                    None,  # missing ARN
+                ),
+            ],
+        ]
+        conn.cursor_instance.fetch_queue = [
+            None,
+            (201,),  # failure_id RETURNING
+        ]
+
+        flagged = d._check_stuck_agents()
+        assert flagged == 1
+
+        # _force_stop_ecs_task short-circuits on missing ARN; no
+        # ``stop_task`` call fires.
+        assert d._ecs_client is not None
+        d._ecs_client.stop_task.assert_not_called()
+
+        # But the failure row + log event + terminal flip still happen.
+        failure_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert len(failure_inserts) == 1
+        assert failure_inserts[0][1][1] == daemon.FAILURE_CATEGORY_AGENT_SILENT_HANG
+
+        reaped = handler.events("agent_silent_hang_reaped")
+        assert reaped
+        assert reaped[0].agent_task_arn is None  # type: ignore[attr-defined]
+
+    def test_subprocess_agent_over_threshold_still_uses_stuck_timeout(
+        self, tmp_path: Path
+    ) -> None:
+        """Subprocess regression — the existing path is unchanged.
+
+        Confirms that the #3656 SELECT change (dropping the
+        ``<> 'ecs'`` filter and adding execution_mode + task_arn
+        columns) does not regress the subprocess-mode behavior.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        conn.cursor_instance.fetchall_queue = [
+            [
+                (
+                    "agent-subproc",
+                    3656,
+                    "push_and_pr",
+                    2000.0,  # > 1800s default threshold
+                    "subprocess",
+                    None,
+                ),
+            ],
+        ]
+        # Subprocess path's fetch sequence (unchanged from the
+        # pre-#3656 test fixtures):
+        # (1) stuck_timeout_s_by_phase override — None.
+        # (2) failure_id RETURNING.
+        # (3) _has_prior_stuck_timeout_in_window — None (first occurrence).
+        # (4) prior retry-marker count.
+        # (5) backoff schedule.
+        conn.cursor_instance.fetch_queue = [
+            None,
+            (300,),
+            None,
+            (0,),
+            ("[60,300,900]",),
+        ]
+
+        flagged = d._check_stuck_agents()
+        assert flagged == 1
+
+        # NO StopTask call for subprocess.
+        assert d._ecs_client is not None
+        d._ecs_client.stop_task.assert_not_called()
+
+        # No silent-hang event for subprocess.
+        assert handler.events("agent_silent_hang_reaped") == []
+
+        # Subprocess hits the existing failure_detected event with
+        # stuck_timeout category.
+        detected = handler.events("failure_detected")
+        assert detected
+        assert detected[0].category == daemon.FAILURE_CATEGORY_STUCK_TIMEOUT  # type: ignore[attr-defined]
+
+        # And the existing retry marker IS enqueued.
+        marker_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert len(marker_inserts) == 1
+        assert marker_inserts[0][1][1] == daemon.FAILURE_CATEGORY_STUCK_TIMEOUT
+
+    def test_mixed_batch_ecs_and_subprocess_routed_correctly(
+        self, tmp_path: Path
+    ) -> None:
+        """One ECS + one subprocess in the same scan — distinct routing.
+
+        The Python loop in ``_check_stuck_agents`` must dispatch each
+        candidate to the right branch independently. A single bad ECS
+        StopTask call must not stall the subprocess flag (and vice
+        versa).
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        ecs_arn = "arn:aws:ecs:us-west-2:155326049300:task/cluster/ecs1"
+        conn.cursor_instance.fetchall_queue = [
+            [
+                (
+                    "agent-mixed-ecs",
+                    3656,
+                    "push_and_pr",
+                    2000.0,  # > 1800s default
+                    "ecs",
+                    ecs_arn,
+                ),
+                (
+                    "agent-mixed-sub",
+                    3656,
+                    "summary",  # 6000s threshold (#2885)
+                    7000.0,  # > 6000s
+                    "subprocess",
+                    None,
+                ),
+            ],
+        ]
+        conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase override
+            # ECS agent failure write (first):
+            (400,),
+            # subprocess agent failure write:
+            (401,),
+            None,  # _has_prior_stuck_timeout_in_window
+            (0,),  # prior retry markers
+            ("[60,300,900]",),  # backoff schedule
+        ]
+
+        flagged = d._check_stuck_agents()
+        assert flagged == 2
+
+        # ECS got StopTask, subprocess didn't.
+        assert d._ecs_client is not None
+        assert d._ecs_client.stop_task.call_count == 1
+        d._ecs_client.stop_task.assert_called_with(
+            cluster=d._cfg.ecs_cluster_arn,
+            task=ecs_arn,
+            reason="operator_force_stop",
+        )
+
+        # Two failure rows — one of each category.
+        failure_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert len(failure_inserts) == 2
+        categories = {row[1][1] for row in failure_inserts}
+        assert categories == {
+            daemon.FAILURE_CATEGORY_AGENT_SILENT_HANG,
+            daemon.FAILURE_CATEGORY_STUCK_TIMEOUT,
+        }
+
+        # Exactly one retry marker (for the subprocess).
+        marker_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.retry_markers" in e[0]
+        ]
+        assert len(marker_inserts) == 1
+        assert marker_inserts[0][1][0] == "agent-mixed-sub"
+
+        # Both events fired exactly once.
+        assert len(handler.events("agent_silent_hang_reaped")) == 1
+        assert len(handler.events("failure_detected")) == 1
+
+    def test_silent_hang_category_is_tier_2_first_occurrence(self) -> None:
+        """The new category routes through the diagnoser on first hit.
+
+        Sanity check that ``FAILURE_CATEGORY_AGENT_SILENT_HANG`` is in
+        :data:`TIER_2_FIRST_OCCURRENCE_CATEGORIES` so
+        ``_find_diagnoser_candidates`` picks it up immediately rather
+        than waiting for a recurrence — the operator wants the
+        diagnoser to inspect the last known phase + log tail before
+        deciding retry vs. escalate.
+        """
+        assert (
+            daemon.FAILURE_CATEGORY_AGENT_SILENT_HANG
+            in daemon.TIER_2_FIRST_OCCURRENCE_CATEGORIES
+        )

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -568,6 +568,26 @@ ln -sf "$(command -v python3)" "$STUB_BIN/python3"
 # date + sed + tr + printf + cut are shell built-ins or coreutils;
 # the test inherits whatever the parent shell has on PATH.
 
+# #3656: handle_push_and_pr now wraps git fetch / git push / gh pr create
+# in ``timeout NETWORK_TIMEOUT_SECONDS`` to bound silent-hang risk.
+# Most pre-#3656 tests (T50, T51, T52, T64, the integration paths) do
+# NOT exercise the 124-exit branch — they need a passthrough ``timeout``
+# binary so the wrapped commands run identically to the pre-#3656 path.
+# macOS does not ship coreutils' ``timeout(1)`` so ``command -v timeout``
+# returns nothing and a real PATH lookup would exit 127, breaking those
+# tests on operator laptops. This stub matches GNU ``timeout(1)``
+# semantics for the no-timer-fired path: drop the seconds arg, exec
+# the inner command transparently. Tests that DO exercise the 124
+# branch (T66, #3656) override this stub in their own per-test ``$_tbin``
+# directory. See #3656 for the full layered defense rationale.
+cat > "$STUB_BIN/timeout" <<'TIMEOUTEOF'
+#!/usr/bin/env bash
+# argv: <seconds> <inner-cmd> <inner-args...>
+shift  # discard the seconds arg
+exec "$@"
+TIMEOUTEOF
+chmod +x "$STUB_BIN/timeout"
+
 # ── Test fixtures ──────────────────────────────────────────────────────────
 
 setup_fixtures() {
@@ -6816,6 +6836,12 @@ for fn in db_exec db_query_one log persist_phase_output \
     ' "$ENTRYPOINT" >> "$t64_funcs"
 done
 
+# #3656: handle_push_and_pr now references NETWORK_TIMEOUT_SECONDS
+# (the ``timeout`` wrapper around git fetch / git push / gh pr create).
+# T64 doesn't drive the 124-exit branch — it just needs the constant
+# defined so the wrapped commands run normally under ``set -u``.
+grep '^NETWORK_TIMEOUT_SECONDS=' "$ENTRYPOINT" >> "$t64_funcs"
+
 if grep -q "^handle_push_and_pr()" "$t64_funcs"; then
     pass "#3614 T64 setup — extracted handle_push_and_pr from entrypoint"
 else
@@ -6913,6 +6939,22 @@ case "$sub" in
 esac
 T64GITEOF
     chmod +x "$_tbin/git"
+
+    # #3656: passthrough ``timeout`` stub. handle_push_and_pr now wraps
+    # git fetch / git push / gh pr create in ``timeout NETWORK_TIMEOUT_SECONDS``.
+    # T64 does NOT exercise the 124-exit branch — it just needs a
+    # ``timeout`` binary on PATH that execs the inner command transparently
+    # so the test runs identically pre- and post-#3656. macOS does not
+    # ship coreutils' ``timeout(1)``, so a real ``timeout`` lookup would
+    # exit 127 and break the test on operator laptops. This stub matches
+    # GNU ``timeout`` semantics for the no-timer-fired path.
+    cat > "$_tbin/timeout" <<'T64TIMEOUTEOF'
+#!/usr/bin/env bash
+# argv: <seconds> <inner-cmd> <inner-args...>
+shift  # discard the seconds arg
+exec "$@"
+T64TIMEOUTEOF
+    chmod +x "$_tbin/timeout"
 
     # gh stub — log invocations, default exit 0.
     cat > "$_tbin/gh" <<'T64GHEOF'
@@ -7984,6 +8026,453 @@ if [[ -f "$T66_TEST_STATE/git-log.txt" ]]; then
              "found $_t66c_rev_list_calls call(s); git-log: $(cat "$T66_TEST_STATE/git-log.txt")"
     fi
 fi
+
+# Test T67: #3656 — network-blocking ops in handle_push_and_pr are wrapped
+# in ``timeout NETWORK_TIMEOUT_SECONDS``, and a 124 exit emits a
+# distinct ``*_timeout`` log + structured failure envelope.
+#
+# Pre-#3656 a hung ``git push`` (network drop, GitHub auth retry loop,
+# PAT mid-rotation) would block indefinitely — observed for 16+ minutes
+# on agent 2ff6e282 (#3608) before manual ``aws ecs stop-task``. The
+# fix wraps the call in ``timeout`` so a hang surfaces as a clean 124
+# exit routed through ``handle_push_and_pr``'s existing failure path.
+#
+# Three sub-tests cover the three wrapped sites (git push, gh pr create,
+# git fetch). Each uses a stub ``timeout`` shim that returns 124
+# unconditionally for the targeted call — emulating "outer process
+# killed inner subprocess after the timer fired" — so we can drive
+# the 124 branch deterministically without burning real wall-clock
+# seconds.
+#
+# Self-contained per the issue's "don't share fixture stubs across
+# test markers" rule. Marker churn for this fix:
+#   * Original PR #3661 used T65 — collided with the (merged-first)
+#     #3657 T65 for #3651's ralph_baseline empty-rebase test.
+#   * Re-dispatch initially used T66 with a ``T66_*`` env namespace —
+#     collided with the (merged-during-CI) #3666 T66 for #3662's
+#     post-fix_conflict re-rebase test.
+#   * Final marker T67 with a self-contained ``T67_*`` env namespace
+#     and its own ``run_t67_test`` driver. No shared fixture state
+#     with T64/T65/T66 — each test block owns its $_tbin per-test
+#     stub directory and env vars.
+# ══════════════════════════════════════════════════════════════════════════
+
+# Extract handle_push_and_pr + minimal dependencies (mirrors T64's
+# extraction). We need ``log``, ``db_exec``, ``persist_phase_output``,
+# and ``handle_push_and_pr`` itself plus the ``NETWORK_TIMEOUT_SECONDS``
+# constant from the post-function config block.
+t67_funcs="$TEST_TMP/t67-funcs.sh"
+printf 'exec 3>&1\n' > "$t67_funcs"
+
+for fn in db_exec db_query_one log persist_phase_output \
+          handle_push_and_pr; do
+    awk -v FN="^${fn}\\\\(\\\\)" '
+        $0 ~ FN { in_fn=1 }
+        in_fn { print }
+        in_fn && /^}$/ { exit }
+    ' "$ENTRYPOINT" >> "$t67_funcs"
+done
+
+# Append the NETWORK_TIMEOUT_SECONDS constant declaration so
+# ``handle_push_and_pr`` finds it when sourced standalone.
+grep '^NETWORK_TIMEOUT_SECONDS=' "$ENTRYPOINT" >> "$t67_funcs"
+
+if grep -q "^NETWORK_TIMEOUT_SECONDS=" "$t67_funcs"; then
+    pass "#3656 T67 setup — extracted NETWORK_TIMEOUT_SECONDS constant"
+else
+    fail "#3656 T67 setup — extracted NETWORK_TIMEOUT_SECONDS constant" \
+         "fixture tail: $(tail -c 400 "$t67_funcs")"
+fi
+
+if grep -q "^handle_push_and_pr()" "$t67_funcs"; then
+    pass "#3656 T67 setup — extracted handle_push_and_pr from entrypoint"
+else
+    fail "#3656 T67 setup — extracted handle_push_and_pr from entrypoint" \
+         "fixture head: $(head -c 400 "$t67_funcs")"
+fi
+
+# Per-test runner with a stub ``timeout`` binary that can be
+# parameterised to return 124 only for the targeted command (git
+# fetch / git push / gh pr create) and pass-through for everything
+# else. This is more realistic than env-toggling all three calls
+# because it lets us assert that ONE site fires its timeout while
+# the OTHERS run normally.
+#
+# Stub control via env vars:
+#   T67_TIMEOUT_TARGET — substring to match in the timeout's argv.
+#                        When the substring matches, ``timeout`` exits
+#                        124 without invoking the inner command.
+#                        Otherwise it execs the inner command directly.
+#                        Examples: "fetch", "push", "pr create".
+#   T67_REV_LIST_PRE   — count returned for the FIRST rev-list call
+#                        (pre-rebase). Default 1 (something to push).
+#   T67_REV_LIST_POST  — count for the SECOND rev-list call (post-rebase).
+#                        Default 1 (rebase preserved the agent's commits).
+#   GIT_REBASE_EXIT    — exit code for ``git rebase origin/main``.
+#                        Default 0 (clean rebase).
+run_t67_test() {
+    _test_id="$1"
+    shift
+
+    _tworkspace="$TEST_TMP/${_test_id}-workspace"
+    _trepo="$TEST_TMP/${_test_id}-repo"
+    _tstate="$TEST_TMP/${_test_id}-state"
+    _tbin="$TEST_TMP/${_test_id}-bin"
+    mkdir -p "$_tworkspace" "$_trepo" "$_tstate" "$_tbin"
+    mkdir -p "$_trepo/tmp/dispatcher-output" "$_trepo/tmp/dispatcher-input"
+
+    # rev-list counter file — written/read by the git stub to alternate
+    # responses across calls (mirrors T64's pattern).
+    printf '0\n' > "$_tstate/rev-list-call-count.txt"
+
+    # ``timeout`` stub — the heart of T67. Logs every call. When the
+    # T67_TIMEOUT_TARGET substring appears in the inner command argv,
+    # exits 124 (mirroring real ``timeout`` behaviour after SIGTERM
+    # on timer expiry). Otherwise execs the inner command directly so
+    # other ``timeout``-wrapped calls in the same test run normally.
+    cat > "$_tbin/timeout" <<'T67TIMEOUTEOF'
+#!/usr/bin/env bash
+set -u
+# argv: <seconds> <inner-cmd> <inner-args...>
+_secs="${1:-}"
+shift || true
+_inner_argv="$*"
+printf 'CALL secs=%s argv=%s\n' "$_secs" "$_inner_argv" \
+    >> "${T_STATE_DIR}/timeout-log.txt"
+# T67_TIMEOUT_TARGET — substring match against the inner argv.
+if [[ -n "${T67_TIMEOUT_TARGET:-}" && "$_inner_argv" == *"${T67_TIMEOUT_TARGET}"* ]]; then
+    # Emulate real ``timeout(1)`` after SIGTERM-on-timer-expiry.
+    exit 124
+fi
+# No match — exec the inner command transparently.
+exec "$@"
+T67TIMEOUTEOF
+    chmod +x "$_tbin/timeout"
+
+    # git stub — reused pattern from T64. Records every invocation;
+    # returns parameterised exit codes for fetch/push/rebase.
+    cat > "$_tbin/git" <<'T67GITEOF'
+#!/usr/bin/env bash
+set -u
+printf '%s\n' "CALL $*" >> "${T_STATE_DIR}/git-log.txt"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -C) shift 2 || true; continue ;;
+        *) break ;;
+    esac
+done
+
+sub="${1:-}"
+case "$sub" in
+    rev-list)
+        _counter_file="${T_STATE_DIR}/rev-list-call-count.txt"
+        _n=$(cat "$_counter_file" 2>/dev/null || printf '0')
+        _next=$((_n + 1))
+        printf '%s\n' "$_next" > "$_counter_file"
+        if [[ "$_n" == "0" ]]; then
+            printf '%s\n' "${T67_REV_LIST_PRE:-1}"
+        else
+            printf '%s\n' "${T67_REV_LIST_POST:-1}"
+        fi
+        exit 0
+        ;;
+    fetch)
+        exit "${GIT_FETCH_EXIT:-0}"
+        ;;
+    rebase)
+        for _arg in "$@"; do
+            if [[ "$_arg" == "--abort" ]]; then exit 0; fi
+        done
+        exit "${GIT_REBASE_EXIT:-0}"
+        ;;
+    diff)
+        exit 0
+        ;;
+    push)
+        exit "${GIT_PUSH_EXIT:-0}"
+        ;;
+    commit)
+        exit "${GIT_COMMIT_EXIT:-0}"
+        ;;
+    rev-parse|merge-base)
+        printf 'deadbeefcafe\n'
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+T67GITEOF
+    chmod +x "$_tbin/git"
+
+    # gh stub — log + return PR URL on ``pr create``, exit 0 by default.
+    cat > "$_tbin/gh" <<'T67GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "CALL $*" >> "${T_STATE_DIR}/gh-log.txt"
+if [[ "${1:-}" == "pr" && "${2:-}" == "create" ]]; then
+    printf 'https://github.com/judgemind/judgemind/pull/9999\n'
+fi
+exit "${GH_EXIT:-0}"
+T67GHEOF
+    chmod +x "$_tbin/gh"
+
+    # psql stub — log only.
+    cat > "$_tbin/psql" <<'T67PSQLEOF'
+#!/usr/bin/env bash
+query=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in -c) shift; query="$1" ;; esac
+    shift || true
+done
+printf 'CALL %s\n' "$query" >> "${T_STATE_DIR}/psql-log.txt"
+exit 0
+T67PSQLEOF
+    chmod +x "$_tbin/psql"
+
+    if command -v jq >/dev/null 2>&1; then
+        ln -sf "$(command -v jq)" "$_tbin/jq"
+    fi
+
+    set +e
+    _tout=$(env \
+        T_STATE_DIR="$_tstate" \
+        PATH="$_tbin:$PATH" \
+        AGENT_ID="${_test_id}-dead-beef-cafe-000000000099" \
+        ISSUE_NUMBER="3656" \
+        AGENT_WORKSPACE="$_tworkspace" \
+        REPO_ROOT="$_trepo" \
+        BRANCH_NAME="agent/${_test_id}abcd" \
+        DATABASE_URL="postgres://test" \
+        AGENT_RUNNER_DRY_RUN="0" \
+        "$@" \
+        bash -c '
+            set -uo pipefail
+            # shellcheck disable=SC1090
+            . "'"$t67_funcs"'"
+            handle_push_and_pr
+        ' 2>&1)
+    _trc=$?
+    set -e
+
+    T67_TEST_RC="$_trc"
+    T67_TEST_OUT="$_tout"
+    T67_TEST_STATE="$_tstate"
+}
+
+# ── Sub-test A: ``git push`` timeout → push_timeout envelope ────────────────
+#
+# T67_TIMEOUT_TARGET="push -u" matches only the ``git push -u origin``
+# call site (not ``git fetch`` or ``gh pr create``). Asserts:
+#   * ``push_and_pr_push_timeout`` log emitted with elapsed_seconds.
+#   * Envelope is ``{"no_op": false, "push_failed": true, "reason": "push_timeout"}``.
+#   * ``gh pr create`` is NOT invoked (function returns at the timeout).
+# Test would fail against unfixed code (no timeout wrapper, no
+# ``*_timeout`` log, push hang-forever).
+run_t67_test "t67a" T67_TIMEOUT_TARGET="push -u" T67_REV_LIST_PRE=1 T67_REV_LIST_POST=1 GIT_REBASE_EXIT=0
+
+if [[ "$T67_TEST_RC" -eq 0 ]]; then
+    pass "#3656 T67A — handle_push_and_pr exits 0 on git push timeout"
+else
+    fail "#3656 T67A — handle_push_and_pr exits 0 on git push timeout" \
+         "rc=$T67_TEST_RC, output: $T67_TEST_OUT"
+fi
+
+# CRITICAL — push_timeout log event emitted.
+if printf '%s' "$T67_TEST_OUT" | grep -q "push_and_pr_push_timeout"; then
+    pass "#3656 T67A — push_and_pr_push_timeout log event emitted"
+else
+    fail "#3656 T67A — push_and_pr_push_timeout log event emitted" \
+         "output: $T67_TEST_OUT"
+fi
+
+# CRITICAL — log includes elapsed_seconds field (not bare event).
+# The ``log`` helper emits structured JSON, so the field appears as
+# ``"elapsed_seconds": "300"`` — match either JSON-quoted or
+# key=value forms to keep the assertion implementation-agnostic.
+if printf '%s' "$T67_TEST_OUT" \
+    | grep "push_and_pr_push_timeout" \
+    | grep -qE '("?elapsed_seconds"?[[:space:]]*[:=][[:space:]]*"?[0-9]+)'; then
+    pass "#3656 T67A — push timeout log includes elapsed_seconds"
+else
+    fail "#3656 T67A — push timeout log includes elapsed_seconds" \
+         "output: $T67_TEST_OUT"
+fi
+
+# CRITICAL — envelope has the reason=push_timeout discriminator.
+if printf '%s' "$T67_TEST_OUT" | grep -qE '"reason":[[:space:]]*"push_timeout"'; then
+    pass "#3656 T67A — envelope contains reason=push_timeout"
+else
+    fail "#3656 T67A — envelope contains reason=push_timeout" \
+         "output: $T67_TEST_OUT"
+fi
+
+# CRITICAL — push_failed=true so the transition shim still routes
+# through the existing failure path.
+if printf '%s' "$T67_TEST_OUT" | grep -qE '"push_failed":[[:space:]]*true'; then
+    pass "#3656 T67A — envelope contains push_failed=true"
+else
+    fail "#3656 T67A — envelope contains push_failed=true" \
+         "output: $T67_TEST_OUT"
+fi
+
+# CRITICAL — gh pr create NOT invoked (function returned early).
+if ! grep -qE "CALL .*\\bpr\\b.*\\bcreate\\b" "$T67_TEST_STATE/gh-log.txt" 2>/dev/null; then
+    pass "#3656 T67A — gh pr create NOT invoked after push timeout"
+else
+    fail "#3656 T67A — gh pr create NOT invoked after push timeout" \
+         "gh-log: $(cat "$T67_TEST_STATE/gh-log.txt" 2>/dev/null)"
+fi
+
+# Sanity — the timeout stub WAS invoked at least once (proves the
+# ``timeout`` wrapper is on the call path, not silently absent).
+if grep -q "argv=git" "$T67_TEST_STATE/timeout-log.txt" 2>/dev/null; then
+    pass "#3656 T67A — timeout wrapper invoked on git command"
+else
+    fail "#3656 T67A — timeout wrapper invoked on git command" \
+         "timeout-log: $(cat "$T67_TEST_STATE/timeout-log.txt" 2>/dev/null)"
+fi
+
+# ── Sub-test B: ``gh pr create`` timeout → pr_create_timeout envelope ──────
+#
+# T67_TIMEOUT_TARGET="pr create" matches only the ``gh pr create`` call.
+# git push runs normally (so we exercise the path past the push site).
+run_t67_test "t67b" T67_TIMEOUT_TARGET="pr create" T67_REV_LIST_PRE=1 T67_REV_LIST_POST=1 GIT_REBASE_EXIT=0
+
+if [[ "$T67_TEST_RC" -eq 0 ]]; then
+    pass "#3656 T67B — handle_push_and_pr exits 0 on gh pr create timeout"
+else
+    fail "#3656 T67B — handle_push_and_pr exits 0 on gh pr create timeout" \
+         "rc=$T67_TEST_RC, output: $T67_TEST_OUT"
+fi
+
+# CRITICAL — pr_create_timeout log event emitted.
+if printf '%s' "$T67_TEST_OUT" | grep -q "push_and_pr_pr_create_timeout"; then
+    pass "#3656 T67B — push_and_pr_pr_create_timeout log event emitted"
+else
+    fail "#3656 T67B — push_and_pr_pr_create_timeout log event emitted" \
+         "output: $T67_TEST_OUT"
+fi
+
+# CRITICAL — envelope has the pr_create_timeout reason discriminator.
+if printf '%s' "$T67_TEST_OUT" | grep -qE '"reason":[[:space:]]*"pr_create_timeout"'; then
+    pass "#3656 T67B — envelope contains reason=pr_create_timeout"
+else
+    fail "#3656 T67B — envelope contains reason=pr_create_timeout" \
+         "output: $T67_TEST_OUT"
+fi
+
+# CRITICAL — pr_create_failed=true (preserves existing failure routing).
+if printf '%s' "$T67_TEST_OUT" | grep -qE '"pr_create_failed":[[:space:]]*true'; then
+    pass "#3656 T67B — envelope contains pr_create_failed=true"
+else
+    fail "#3656 T67B — envelope contains pr_create_failed=true" \
+         "output: $T67_TEST_OUT"
+fi
+
+# CRITICAL — git push DID run (path got past the push call site,
+# proving the timeout target was scoped to ``gh pr create`` only).
+if grep -qE "CALL .*\\bpush\\b.*-u\\b.*\\borigin\\b" "$T67_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3656 T67B — git push DID run (timeout was scoped to gh pr create)"
+else
+    fail "#3656 T67B — git push DID run (timeout was scoped to gh pr create)" \
+         "git-log: $(cat "$T67_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+
+# ── Sub-test C: ``git fetch`` timeout → fetch_main_timeout log only ─────────
+#
+# T67_TIMEOUT_TARGET="fetch origin" matches only the pre-push
+# ``git fetch origin main``. The fetch is best-effort by design — a
+# 124 should emit the timeout log but fall through to the push (which
+# we then let succeed). Asserts:
+#   * ``push_and_pr_fetch_main_timeout`` log emitted.
+#   * Function continues to git push (not early-return on fetch
+#     timeout — fetch failure has always been best-effort, and #3656
+#     preserves that).
+#   * Final envelope is NOT the push_timeout shape (fetch timeout
+#     should not look like a push timeout to the diagnoser).
+run_t67_test "t67c" T67_TIMEOUT_TARGET="fetch origin" T67_REV_LIST_PRE=1 T67_REV_LIST_POST=1 GIT_REBASE_EXIT=0
+
+if [[ "$T67_TEST_RC" -eq 0 ]]; then
+    pass "#3656 T67C — handle_push_and_pr exits 0 on git fetch timeout (best-effort)"
+else
+    fail "#3656 T67C — handle_push_and_pr exits 0 on git fetch timeout (best-effort)" \
+         "rc=$T67_TEST_RC, output: $T67_TEST_OUT"
+fi
+
+# CRITICAL — fetch_main_timeout log event emitted.
+if printf '%s' "$T67_TEST_OUT" | grep -q "push_and_pr_fetch_main_timeout"; then
+    pass "#3656 T67C — push_and_pr_fetch_main_timeout log event emitted"
+else
+    fail "#3656 T67C — push_and_pr_fetch_main_timeout log event emitted" \
+         "output: $T67_TEST_OUT"
+fi
+
+# CRITICAL — git push DID run (best-effort fetch failure falls through).
+if grep -qE "CALL .*\\bpush\\b.*-u\\b.*\\borigin\\b" "$T67_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3656 T67C — git push DID run after fetch timeout (best-effort fall-through)"
+else
+    fail "#3656 T67C — git push DID run after fetch timeout (best-effort fall-through)" \
+         "git-log: $(cat "$T67_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+
+# Final envelope must NOT be the push_timeout shape (the fetch
+# timeout fell through to a successful push + PR create).
+if ! printf '%s' "$T67_TEST_OUT" | grep -qE '"reason":[[:space:]]*"push_timeout"'; then
+    pass "#3656 T67C — final envelope is NOT push_timeout (fetch fell through)"
+else
+    fail "#3656 T67C — final envelope is NOT push_timeout (fetch fell through)" \
+         "output: $T67_TEST_OUT"
+fi
+
+# ── Sub-test D: happy-path regression — no timeout target → all run ─────────
+#
+# T67_TIMEOUT_TARGET unset (empty). The ``timeout`` stub falls through
+# to exec the inner command, so every wrapped site behaves exactly as
+# pre-#3656. Asserts no ``*_timeout`` log fires and the happy-path
+# envelope is unchanged.
+run_t67_test "t67d" T67_REV_LIST_PRE=1 T67_REV_LIST_POST=1 GIT_REBASE_EXIT=0
+
+if [[ "$T67_TEST_RC" -eq 0 ]]; then
+    pass "#3656 T67D — handle_push_and_pr exits 0 on happy path (no timeouts)"
+else
+    fail "#3656 T67D — handle_push_and_pr exits 0 on happy path (no timeouts)" \
+         "rc=$T67_TEST_RC, output: $T67_TEST_OUT"
+fi
+
+# Happy path emits NO ``*_timeout`` log lines.
+if ! printf '%s' "$T67_TEST_OUT" | grep -qE "(push|pr_create|fetch_main)_timeout"; then
+    pass "#3656 T67D — no *_timeout log events on happy path"
+else
+    fail "#3656 T67D — no *_timeout log events on happy path" \
+         "output: $T67_TEST_OUT"
+fi
+
+# Happy path envelope does NOT carry a reason field (push_timeout /
+# pr_create_timeout discriminators are absent).
+if ! printf '%s' "$T67_TEST_OUT" | grep -qE '"reason":[[:space:]]*"(push_timeout|pr_create_timeout)"'; then
+    pass "#3656 T67D — happy-path envelope has no timeout reason field"
+else
+    fail "#3656 T67D — happy-path envelope has no timeout reason field" \
+         "output: $T67_TEST_OUT"
+fi
+
+# Both push and pr create DID run.
+if grep -qE "CALL .*\\bpush\\b.*-u\\b.*\\borigin\\b" "$T67_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3656 T67D — git push ran on happy path"
+else
+    fail "#3656 T67D — git push ran on happy path" \
+         "git-log: $(cat "$T67_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+
+if grep -qE "CALL .*\\bpr\\b.*\\bcreate\\b" "$T67_TEST_STATE/gh-log.txt" 2>/dev/null; then
+    pass "#3656 T67D — gh pr create ran on happy path"
+else
+    fail "#3656 T67D — gh pr create ran on happy path" \
+         "gh-log: $(cat "$T67_TEST_STATE/gh-log.txt" 2>/dev/null)"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────
 
 # ── Summary ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Two complementary defensive layers for the silent-agent-loss failure mode where ECS-mode agents go silent inside the container (e.g. `git push` hangs on auth/network) and never get reaped — observed 2026-04-27 on agent `2ff6e282` (#3608, 16+ minutes of `push_and_pr_push_begin` silence before manual `aws ecs stop-task`).

- **Layer 1 (entrypoint):** wrap `git fetch` / `git push` / `gh pr create` in `handle_push_and_pr` with `timeout NETWORK_TIMEOUT_SECONDS` (default 300s). Exit 124 emits a distinct `*_timeout` log event and a structured failure envelope (`reason=push_timeout` / `pr_create_timeout`) routed through the existing failure path.
- **Layer 2 (daemon):** drop the `<> 'ecs'` filter in `_check_stuck_agents` (added by #3158 under the wrong premise — `bash` keeps running while a child `git push` blocks on TCP retry, so ECS never STOPs the task). The SELECT now returns `execution_mode` + `agent_task_arn`; the Python loop dispatches ECS rows to `ecs:StopTask` + `_handle_agent_failure(category=agent_silent_hang)` (new `TIER_2_FIRST_OCCURRENCE` category) while keeping the legacy subprocess `stuck_timeout` + retry-marker path unchanged.

Marker churn: this PR uses **T67** for its bash regression test. PR #3661 (closed) used T65 which collided with #3657's T65 for #3651. The first push of this PR used T66 which then collided with #3666's T66 for #3662 (which merged during this PR's CI window). Final landing on T67 with a self-contained `T67_*` env namespace.

Closes #3656

## Test plan

### Automated checks
- [x] Lint passes (ruff check)
- [x] Format check passes (ruff format --check)
- [x] Tests pass (1913 dispatcher pytest + T67 23/23 + T64 13/13 regression locally)
- [x] CI green

### Post-deploy verification
- [x] After dispatcher deploy, confirm new daemon image is running (check `version_sha` in `/ecs/judgemind-dispatcher-dev` startup log via CloudWatch Insights). Confirmed: `version_sha=4783429` matches merge SHA.
- [x] Confirm subprocess `stuck_timeout` regression: existing `daemon.failure_detected` events with `category=stuck_timeout` continue to fire normally for any subprocess hangs. Confirmed: subprocess regression test passes; legacy code path unchanged.
- [x] If a real ECS agent hangs in the next 24h, the daemon emits `daemon.agent_silent_hang_reaped` and the cap slot is freed within ~30 min instead of indefinitely. **Confirmed within 7 seconds of deploy** — agent `f25986ad` on issue #3601 was stuck 4132s (~69 min) in `push_and_pr`, reaped immediately post-deploy with `daemon.agent_silent_hang_reaped` event + diagnoser spawn.
- [x] Verification evidence posted on issue (see https://github.com/judgemind/judgemind/issues/3656#issuecomment-4331325145)
