### PR TITLE
fix(scraping): require label prefix for slash/month-name dates (#3601)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -3584,19 +3584,48 @@ def _append_ruling_from_case(
 def _parse_header_date(info: str) -> str | None:
     """Extract a hearing date from a page-header string, returning ISO YYYY-MM-DD.
 
-    Tries three patterns in priority order so that the existing ISO path
-    wins over ambiguous slash or month-name matches (#3559):
+    Tries five patterns in priority order so that labeled dates win over bare
+    dates when both appear in the same header (e.g. "Filed 1/15/2024 — Hearing
+    Date 3/16/2026" resolves to 2026-03-16, not 2024-01-15) (#3601):
 
-    1. ``Hearing Date: YYYY-MM-DD`` — explicit ISO label (existing behaviour).
-    2. Month-name: ``March 16, 2026`` — common in OC multimodal PDFs.
-    3. Slash: ``3/16/2026`` or ``03/16/2026`` — alternate courts.
+    1. ``Hearing Date: YYYY-MM-DD`` — explicit ISO label (highest priority).
+    2. Month-name labeled: ``Hearing Date March 16, 2026`` (#3601).
+    3. Slash labeled: ``Hearing Date 3/16/2026`` (#3601).
+    4. Month-name bare: ``March 16, 2026`` — fallback for OC multimodal PDFs.
+    5. Slash bare: ``3/16/2026`` or ``03/16/2026`` — fallback for other courts.
     """
     # 1. Existing ISO path — must remain the highest-priority match.
     m = re.search(r"Hearing Date:\s*(\d{4}-\d{2}-\d{2})", info)
     if m:
         return m.group(1)
 
-    # 2. Month-name format, e.g. "March 16, 2026".
+    # 2. Month-name with label prefix, e.g. "Hearing Date March 16, 2026".
+    m = re.search(
+        r"(?:Hearing Date|Calendar Date|Date)[:\s]+"
+        r"((?:January|February|March|April|May|June|July|August|September|"
+        r"October|November|December)\s+\d{1,2},\s*\d{4})",
+        info,
+        re.IGNORECASE,
+    )
+    if m:
+        try:
+            return datetime.strptime(m.group(1), "%B %d, %Y").strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+
+    # 3. Slash format with label prefix, e.g. "Hearing Date 3/16/2026".
+    m = re.search(
+        r"(?:Hearing Date|Calendar Date|Date)[:\s]+(\d{1,2}/\d{1,2}/\d{4})",
+        info,
+        re.IGNORECASE,
+    )
+    if m:
+        try:
+            return datetime.strptime(m.group(1), "%m/%d/%Y").strftime("%Y-%m-%d")
+        except ValueError:
+            pass
+
+    # 4. Month-name bare format, e.g. "March 16, 2026" (OC multimodal PDFs).
     m = re.search(
         r"\b((?:January|February|March|April|May|June|July|August|September|"
         r"October|November|December)\s+\d{1,2},\s*\d{4})\b",
@@ -3608,7 +3637,7 @@ def _parse_header_date(info: str) -> str | None:
         except ValueError:
             pass
 
-    # 3. Slash format, e.g. "3/16/2026" or "03/16/2026".
+    # 5. Slash bare format, e.g. "3/16/2026" or "03/16/2026".
     m = re.search(r"\b(\d{1,2}/\d{1,2}/\d{4})\b", info)
     if m:
         try:

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -1117,6 +1117,24 @@ class TestJoinPageRows:
             == "2026-03-16"
         )
 
+    def test_parse_header_date_labeled_month_name_invalid_returns_none(self) -> None:
+        """Labeled month-name regex match with an out-of-range day falls through (#3601).
+
+        "Hearing Date February 30, 2026" matches the labeled month-name regex but
+        strptime raises ValueError; the except branch must pass and the function
+        continues to the bare fallbacks (which also fail), returning None.
+        """
+        assert _parse_header_date("Hearing Date February 30, 2026") is None
+
+    def test_parse_header_date_labeled_slash_invalid_returns_none(self) -> None:
+        """Labeled slash regex match with an out-of-range month falls through (#3601).
+
+        "Hearing Date 13/05/2026" matches the labeled slash regex but strptime raises
+        ValueError (month 13 is invalid); the except branch must pass and the function
+        continues to the bare fallbacks (which also fail), returning None.
+        """
+        assert _parse_header_date("Hearing Date 13/05/2026") is None
+
 
 # ---------------------------------------------------------------------------
 # Calendar header detection tests (#2096)

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -1097,6 +1097,26 @@ class TestJoinPageRows:
         """
         assert _parse_header_date("13/05/2026") is None
 
+    def test_parse_header_date_labeled_slash_wins_over_unlabeled(self) -> None:
+        """Labeled slash date takes priority over an earlier unlabeled slash date (#3601).
+
+        When a header contains both a bare slash date ("Filed 1/15/2024") and a
+        labeled slash date ("Hearing Date 3/16/2026"), the labeled date must win.
+        """
+        assert _parse_header_date("Filed 1/15/2024 — Hearing Date 3/16/2026") == "2026-03-16"
+
+    def test_parse_header_date_labeled_month_name_wins_over_unlabeled(self) -> None:
+        """Labeled month-name date takes priority over an earlier unlabeled month-name date (#3601).
+
+        When a header contains both a bare month-name date ("Filed January 15, 2024")
+        and a labeled month-name date ("Hearing Date March 16, 2026"), the labeled
+        date must win.
+        """
+        assert (
+            _parse_header_date("Filed January 15, 2024 — Hearing Date March 16, 2026")
+            == "2026-03-16"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Calendar header detection tests (#2096)


### PR DESCRIPTION
## Summary

Fixed `_parse_header_date` in `llm_extractor.py` so labeled slash and month-name date patterns take priority over bare fallbacks. This prevents matching the wrong date when headers contain multiple dates (e.g., "Filed 1/15/2024 — Hearing Date 3/16/2026").

Closes #3601

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — 6713 passed, 1 skipped, 0 failures
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (scraper-framework logic, verified via unit tests and existing integration test suite)