### PR TITLE
docs(scraper-framework): correct stale S3 key format in README

### DIFF
--- a/packages/scraper-framework/README.md
+++ b/packages/scraper-framework/README.md
@@ -19,7 +19,7 @@ Court data scraping framework and ingestion pipeline for Judgemind. This is the 
 ## What It Produces (Outputs)
 
 - **Redis Streams events** -- `document.captured` (scraper output) and `scraper.health` (operational metrics).
-- **S3 objects** -- Archived raw documents (immutable, path: `/{state}/{county}/{court}/{case_id}/...`).
+- **S3 objects** -- Archived raw documents (immutable, content-addressed key: `{state}/{county}/{court}/raw/{content_hash}.{ext}`).
 - **PostgreSQL rows** -- Courts, judges, cases, documents, rulings, and parties via the ingestion worker's three-tier extraction pipeline (scraper fields -> LLM extraction -> regex fallback).
 - **OpenSearch index** -- `tentative_rulings` index for full-text search, populated by the ingestion worker.
 


### PR DESCRIPTION
## Summary

The `scraper-framework` README documented the S3 archive path as
`/{state}/{county}/{court}/{case_id}/...`, but the actual key produced by
`build_s3_key()` in `packages/scraper-framework/src/framework/storage.py:27-33`
is `{state}/{county}/{court}/raw/{content_hash}.{ext}` — content-addressed,
no leading slash, no `case_id` segment, and a fixed `raw/` prefix.

This isn't a recent drift — the README description has been wrong since at
least `665f409` (content-addressed keys are a long-standing architectural
decision; see Architecture Spec §4.4). It would mislead anyone using the
README to reason about S3 layout, dedup, or rebuild.

## Test plan

- [x] `scripts/check-markdown-links.sh packages/scraper-framework/README.md` — clean.
- [x] Diff matches the live `build_s3_key()` output and the in-code docstring at `storage.py:16`.

Found by: /spotcheck
