### PR TITLE
fix(dispatcher): bifurcate handle_fix_ci empty-diff to catch LLM hallucination (#3635)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -3182,10 +3182,15 @@ handle_fix_ci() {
             return 0
         fi
 
-        # Empty-diff check (#3245, refined #3580): ``git diff --cached
-        # --quiet`` exits 0 when nothing is staged. After a PATCHED
-        # verdict that's the "fix is already in the baseline" case —
-        # not a failure. It happens routinely when:
+        # Empty-diff check (#3245, refined #3580, bifurcated #3635):
+        # ``git diff --cached --quiet`` exits 0 when nothing is staged.
+        # After a PATCHED verdict that's an ambiguous signal — it could
+        # mean:
+        #
+        #   Benign (ahead > 0): the fix is already in the rebased
+        #   baseline and there is nothing new to commit, BUT prior
+        #   commits on this branch mean CI will still observe the
+        #   patched state. It happens routinely when:
         #   1. The pre-fix_ci rebase pulled in a sibling PR that landed
         #      the same fix on main first.
         #   2. The skill's edit was idempotent (re-writing the existing
@@ -3193,28 +3198,50 @@ handle_fix_ci() {
         #      it edited a file.
         #   3. A prior fix_ci attempt on the same branch already
         #      committed the fix and this is a retry.
-        # In all three cases the correct action is to advance to
-        # awaiting_ci so the next supervisor tick observes the now-green
-        # CI rollup. The skill's PATCHED self-report was correct in
-        # concluding "the fix is in"; there's just nothing for THIS
-        # invocation to commit.
+        #   Correct action: advance to awaiting_ci so the next
+        #   supervisor tick observes the now-green CI rollup.
         #
-        # Pre-#3580 we treated this as terminal fix_ci_failed/patch_empty,
-        # which left the issue stuck in a daemon-cooldown loop forever
-        # (re-claim → rebase pulls in the same fix → empty diff → fail
-        # → cooldown → repeat).
+        #   Malign (ahead == 0): the branch has NO commits ahead of
+        #   origin/main — the LLM hallucinated a PATCHED verdict without
+        #   actually committing anything (lost commit, missing ``git
+        #   add``, skill bug). Advancing to awaiting_ci here would poll
+        #   CI forever on a branch indistinguishable from main. Correct
+        #   action: terminal-fail as fix_ci_failed/fix_ci_patched_without_commit.
         #
-        # Log event renamed fix_ci_patch_empty → fix_ci_patch_empty_already_applied
-        # so dashboards / alerts split on the new name and don't treat
-        # this as a failure class.
+        # Pre-#3580 the empty-diff branch always terminal-failed
+        # (fix_ci_failed/patch_empty), which left issues stuck in a
+        # daemon-cooldown loop (re-claim → rebase pulls in same fix →
+        # empty diff → fail → cooldown → repeat). #3580 fixed the
+        # benign case by advancing unconditionally. #3635 restores a
+        # terminal path for the malign case so LLM-hallucination / lost-
+        # commit failures surface as failures instead of being silently
+        # swallowed by an infinite awaiting_ci loop.
+        #
+        # Log events:
+        #   fix_ci_patch_empty_already_applied — benign (ahead > 0)
+        #   fix_ci_patch_empty_no_commits      — malign (ahead == 0)
         set +e
         git -C "$REPO_ROOT" diff --cached --quiet \
             > /dev/null 2>&1
         _diff_rc=$?
         set -e
         if [[ "$_diff_rc" -eq 0 ]]; then
+            _ahead=$(git -C "$REPO_ROOT" rev-list --count origin/main..HEAD 2>/dev/null || printf '0')
+            if [[ "$_ahead" == "0" ]]; then
+                _head_sha=$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || printf 'unknown')
+                log "fix_ci_patch_empty_no_commits" \
+                    "verdict=$_verdict" \
+                    "ahead=$_ahead" \
+                    "head_sha=$_head_sha"
+                agent_runner_reaped_failure \
+                    "fix_ci_failed" \
+                    "fix_ci_patched_without_commit" \
+                    "fix-ci returned PATCHED but worktree has no commits ahead of origin/main"
+                return 0
+            fi
             log "fix_ci_patch_empty_already_applied" \
                 "verdict=$_verdict" \
+                "ahead=$_ahead" \
                 "commit_message=$_commit_msg"
             advance_phase "awaiting_ci"
             printf '%s' "$_output"

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -4193,11 +4193,23 @@ case "$sub" in
         # GIT_DIFF_CACHED_EXIT=0. Default is 1 (there ARE staged changes).
         exit "${GIT_DIFF_CACHED_EXIT:-1}"
         ;;
+    rev-list)
+        # ``git rev-list --count origin/main..HEAD`` — prints how many
+        # commits the branch is ahead of origin/main. Default 1 means
+        # existing tests that don't set GIT_REV_LIST_COUNT keep their
+        # current benign (already-applied) semantics.
+        printf '%s\n' "${GIT_REV_LIST_COUNT:-1}"
+        exit 0
+        ;;
     commit)
         exit "${GIT_COMMIT_EXIT:-0}"
         ;;
     push)
         exit "${GIT_PUSH_EXIT:-0}"
+        ;;
+    rev-parse)
+        printf 'deadbeefcafe000000000000000000000000cafe\n'
+        exit 0
         ;;
     *)
         exit 0
@@ -4637,6 +4649,84 @@ if ! grep -q "phase = 'fix_ci_failed'" "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/n
 else
     fail "#3245 T49 — does NOT advance to fix_ci_failed on FLAKY" \
          "psql-log: $(cat "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null)"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════
+# Test T_issue3635: #3635 — PATCHED + empty staged diff + NO commits ahead
+# → terminal-fail (fix_ci_failed / fix_ci_patched_without_commit), NOT
+# advance to awaiting_ci.
+#
+# Scenario: the fix-ci skill returns PATCHED, git add succeeds, but
+# git diff --cached is empty (nothing actually staged) AND git rev-list
+# reports 0 commits ahead of origin/main. This is the LLM-hallucination /
+# lost-commit / missing-git-add case: advancing to awaiting_ci would poll
+# CI forever on a branch indistinguishable from main.
+#
+# Assertions:
+#   (a) fix_ci_patch_empty_no_commits log event emitted.
+#   (b) fix_ci_patch_empty_already_applied log event NOT emitted.
+#   (c) psql-log shows phase = 'fix_ci_failed' and status = 'failed'
+#       (terminal-fail path via agent_runner_reaped_failure).
+#   (d) stdout contains category=fix_ci_patched_without_commit
+#       (from the agent_runner_reaped_failure log line).
+#   (e) no git commit or push attempted (nothing to commit / push).
+# ══════════════════════════════════════════════════════════════════════════
+
+T3635_json='{"verdict": "PATCHED", "commit_message": "fix(area): thing — CI (#9999)", "changed_files": []}'
+run_fix_ci_test "t3635" "$T3635_json" GIT_DIFF_CACHED_EXIT=0 GIT_REV_LIST_COUNT=0
+
+# (a) fix_ci_patch_empty_no_commits log event emitted.
+if printf '%s' "$FIXCI_TEST_OUT" | grep -q "fix_ci_patch_empty_no_commits"; then
+    pass "#3635 T_issue3635 — fix_ci_patch_empty_no_commits log event emitted"
+else
+    fail "#3635 T_issue3635 — fix_ci_patch_empty_no_commits log event emitted" \
+         "output: $FIXCI_TEST_OUT"
+fi
+
+# (b) fix_ci_patch_empty_already_applied log event NOT emitted.
+if ! printf '%s' "$FIXCI_TEST_OUT" | grep -q "fix_ci_patch_empty_already_applied"; then
+    pass "#3635 T_issue3635 — fix_ci_patch_empty_already_applied NOT emitted"
+else
+    fail "#3635 T_issue3635 — fix_ci_patch_empty_already_applied NOT emitted" \
+         "output: $FIXCI_TEST_OUT"
+fi
+
+# (c) psql-log shows phase = 'fix_ci_failed' (terminal-fail).
+if grep -q "phase = 'fix_ci_failed'" "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null; then
+    pass "#3635 T_issue3635 — advances to fix_ci_failed terminal (malign empty-diff)"
+else
+    fail "#3635 T_issue3635 — advances to fix_ci_failed terminal (malign empty-diff)" \
+         "psql-log: $(cat "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null)"
+fi
+
+# (c) Negative: must NOT have advanced to awaiting_ci.
+if ! grep -q "SET phase = 'awaiting_ci'" "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null; then
+    pass "#3635 T_issue3635 — does NOT advance to awaiting_ci on malign empty-diff"
+else
+    fail "#3635 T_issue3635 — does NOT advance to awaiting_ci on malign empty-diff" \
+         "psql-log: $(cat "$FIXCI_TEST_STATE/psql-log.txt" 2>/dev/null)"
+fi
+
+# (d) category=fix_ci_patched_without_commit carried in the failure log line.
+if printf '%s' "$FIXCI_TEST_OUT" | grep -q "fix_ci_patched_without_commit"; then
+    pass "#3635 T_issue3635 — category=fix_ci_patched_without_commit in output"
+else
+    fail "#3635 T_issue3635 — category=fix_ci_patched_without_commit in output" \
+         "output: $FIXCI_TEST_OUT"
+fi
+
+# (e) No git commit or push attempted.
+if ! grep -qE "CALL .*\\bcommit\\b" "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3635 T_issue3635 — no git commit attempted on malign empty-diff"
+else
+    fail "#3635 T_issue3635 — no git commit attempted on malign empty-diff" \
+         "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
+fi
+if ! grep -qE "CALL .*\\bpush\\b" "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null; then
+    pass "#3635 T_issue3635 — no git push attempted on malign empty-diff"
+else
+    fail "#3635 T_issue3635 — no git push attempted on malign empty-diff" \
+         "git-log: $(cat "$FIXCI_TEST_STATE/git-log.txt" 2>/dev/null)"
 fi
 
 # ══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

The PATCHED+empty-diff branch in `handle_fix_ci` conflated two distinct cases:
1. **Benign:** fix already in rebased baseline (commits ahead of origin/main) → advance to awaiting_ci
2. **Malign:** LLM hallucinated PATCHED without committing (no commits ahead) → terminal-fail as fix_ci_patched_without_commit

This PR adds a `git rev-list --count origin/main..HEAD` check to distinguish these cases. When the branch has no commits ahead, the code now terminal-fails with proper diagnostics instead of advancing to awaiting_ci, which would poll CI forever on a branch indistinguishable from main.

Closes #3635

## Test plan

### Automated checks
- [x] Bash tests pass: `scripts/tests/test_agent_runner_entrypoint.sh` — new test T_issue3635 with 7 assertions covering the malign path
- [x] Lint passes
- [x] Format check passes
- [x] CI green

### Post-deploy verification
- [ ] (post-deploy) Audit probe `probe_bad_outcome_streak` confirms new `fix_ci_patch_empty_no_commits` outcome is counted in bad-outcome aggregations
- [ ] Verification evidence posted on #3635 (see /task-v2-verify output)