### PR TITLE
fix(dispatcher): move verify/fix-ci/retro subprocesses off MainThread (#3658)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -2550,6 +2550,15 @@ class DispatcherDaemon:
         self._watchdog_thread: threading.Thread | None = None
         self._watchdog_stop: threading.Event = threading.Event()
         self._watchdog_warn_emitted_for_gap: bool = False
+        # #3658 — async phase subprocess tracker for verify / fix-ci / retro.
+        # Keyed by ``agent_id``, value is a dict with keys:
+        #   ``phase``, ``pid``, ``stdout_path``, ``stderr_path``,
+        #   ``jsonl_path``, ``worktree_path``, ``started_at``,
+        #   ``deadline_at``.
+        # In-memory only (lost on daemon restart — handled by the
+        # existing ``verify_already_completed`` short-circuit and the
+        # recovery-path code in ``_run_verify_and_complete``).
+        self._phase_subprocess_inflight: dict[str, dict] = {}
 
     # ------------------------------------------------------------------
     # Thread-aware connection accessor (#2847).
@@ -13999,6 +14008,24 @@ class DispatcherDaemon:
                         },
                     )
                 continue
+            # #3658 — if this agent already has an async phase subprocess
+            # in flight (verify / fix-ci / retro), skip re-entering the
+            # phase handler. The reaper pass in supervisor_tick will call
+            # the finalizer once the subprocess exits.
+            if agent_id in self._phase_subprocess_inflight:
+                self._log.debug(
+                    "daemon.advance_skipped_async_inflight",
+                    extra={
+                        "event": "advance_skipped_async_inflight",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "phase": phase,
+                        "inflight_phase": self._phase_subprocess_inflight[agent_id].get(
+                            "phase"
+                        ),
+                    },
+                )
+                continue
             try:
                 if phase == "awaiting_ci":
                     self._advance_awaiting_ci(agent)
@@ -14743,16 +14770,25 @@ class DispatcherDaemon:
         return None
 
     def _run_fix_ci(self, agent: dict[str, Any], pr_status: dict[str, Any]) -> None:
-        """Gather failing-job logs, spawn ``/task-v2-fix-ci``, handle verdict.
+        """Gather failing-job logs, spawn ``/task-v2-fix-ci`` async, handle verdict.
 
-        Escalates to ``status='failed'`` when ``retries_used >=
-        FIX_CI_MAX_RETRIES`` (spec §8 ``ci_red_after_retries``). On
-        ``PATCHED`` verdict, applies the patch via ``git add -A`` +
-        ``git commit`` + ``git push``, increments ``retries_used``, and
-        leaves the agent in ``awaiting_ci`` so the next supervisor
-        tick re-polls. On ``BLOCKED`` — mark failed. On ``FLAKY`` —
-        no-op; let the next tick re-poll (GitHub may re-run flaky jobs
-        automatically, or the operator can nudge).
+        Pre-#3658 this blocked MainThread for the full fix-ci duration.
+        Post-#3658 it delegates to ``_start_fix_ci`` which writes the
+        input bundle and fire-and-forgets the subprocess.
+        """
+        self._start_fix_ci(agent, pr_status)
+
+    def _start_fix_ci(self, agent: dict[str, Any], pr_status: dict[str, Any]) -> None:
+        """Build the fix-ci input bundle and fire-and-forget the subprocess (#3658).
+
+        Escalates to ``status='failed'`` synchronously when
+        ``retries_used >= FIX_CI_MAX_RETRIES`` (no subprocess needed).
+        Otherwise writes ``phase_input.json`` and calls
+        :meth:`_spawn_phase_subprocess_async` — returns immediately.
+
+        The full verdict handling (PATCHED / FLAKY / BLOCKED) is
+        delegated to ``_finalize_fix_ci`` which runs on a later tick
+        via the reaper.
         """
         agent_id = agent["agent_id"]
         pr_number = agent["pr_number"]
@@ -14789,10 +14825,7 @@ class DispatcherDaemon:
                 },
             )
             # ROUTING (#3062): failure row written above with a tier-3
-            # category → diagnoser picks it up. Inline pattern (not
-            # ``_handle_agent_failure``) preserves the existing
-            # ``detected_by="scheduler"`` marker and ``details`` shape
-            # that the diagnoser-context bundler expects.
+            # category → diagnoser picks it up.
             self._mark_agent_terminal(
                 agent_id, status="failed", phase="awaiting_ci", exit_code=None
             )
@@ -14817,9 +14850,9 @@ class DispatcherDaemon:
         self._write_phase_input(worktree, "fix-ci", fix_ci_input)
 
         self._log.info(
-            "daemon.fix_ci_started",
+            "daemon.fix_ci_started_async",
             extra={
-                "event": "fix_ci_started",
+                "event": "fix_ci_started_async",
                 "run_id": self._run_id,
                 "agent_id": agent_id,
                 "pr_number": pr_number,
@@ -14828,10 +14861,69 @@ class DispatcherDaemon:
             },
         )
 
-        exit_code = self._run_subprocess_or_fail(agent_id, "fix-ci", worktree)
+        # #3658 — async fire-and-forget. Store agent dict in ctx so the
+        # finalizer can call _apply_fix_ci_patch(agent, ...) without
+        # re-querying the DB.
+        deadline = float(STUCK_TIMEOUT_SECONDS_BY_PHASE.get("fix_ci", 18000))
+        self._spawn_phase_subprocess_async(
+            phase="fix-ci",
+            worktree=worktree,
+            agent_id=agent_id,
+            deadline_seconds=deadline,
+            ctx={
+                "agent": dict(agent),
+                "pr_number": pr_number,
+                "issue_number": issue_number,
+                "retries_used": retries_used,
+            },
+        )
+
+    def _finalize_fix_ci(
+        self,
+        agent_id: str,
+        worktree: Path,
+        exit_code: int | None,
+    ) -> None:
+        """Post-completion handler for an async fix-ci subprocess (#3658).
+
+        Called by :meth:`_reap_phase_subprocesses` once the subprocess
+        exits (or is killed for deadline). Handles the same output
+        parsing / transition logic that ``_run_fix_ci`` previously ran
+        inline after ``_run_subprocess_or_fail`` returned.
+
+        ``exit_code=None`` means the subprocess was killed (timeout).
+        """
+        inflight = self._phase_subprocess_inflight.get(agent_id, {})
+        ctx = inflight.get("ctx", {})
+        agent = ctx.get("agent") or {}
+        pr_number = ctx.get("pr_number")
+        issue_number = ctx.get("issue_number")
+        retries_used = int(ctx.get("retries_used") or 0)
+
         if exit_code is None:
-            # Subprocess infra failure — agent already marked failed
-            # inside _run_subprocess_or_fail. Stop.
+            # Subprocess killed — treat as infra failure; agent already
+            # failed inside _reap_phase_subprocesses timeout path.
+            self._log.warning(
+                "daemon.fix_ci_killed",
+                extra={
+                    "event": "fix_ci_killed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "pr_number": pr_number,
+                    "detail": "subprocess killed (deadline exceeded)",
+                },
+            )
+            self._handle_agent_failure(
+                agent_id=agent_id,
+                phase="awaiting_ci",
+                category=FAILURE_CATEGORY_PHASE_OUTPUT_MISSING,
+                stderr_tail="",
+                exit_code=None,
+                details={
+                    "missing_phase_output": "fix-ci",
+                    "reason": "deadline_exceeded",
+                },
+            )
             return
 
         fix_ci_output = self._read_phase_output(worktree, "fix-ci")
@@ -14877,10 +14969,6 @@ class DispatcherDaemon:
         )
         verdict = str(fix_ci_output.get("verdict") or "").upper()
 
-        # Dispatch through the pure phase-transition catalog (#2976).
-        # All side-effect logic (logging events, apply-patch call,
-        # failure-row writes) is preserved verbatim; only the DECISION
-        # about which path to take is driven by transition_from_fix_ci.
         fix_ci_transition = transition_from_fix_ci(fix_ci_output)
 
         if fix_ci_transition.action == TransitionAction.ADVANCE:
@@ -14903,7 +14991,6 @@ class DispatcherDaemon:
             return
 
         # fix_ci_transition.action == ROUTE_TO_DIAGNOSER
-        # verdict == "BLOCKED" or unrecognized
         block_reason = fix_ci_output.get("block_reason")
         self._log.warning(
             "daemon.fix_ci_blocked",
@@ -14916,13 +15003,6 @@ class DispatcherDaemon:
                 "block_reason": block_reason,
             },
         )
-        # ROUTING (#3062 #3068): ROUTED via ``_handle_agent_failure``
-        # with the tier-3 ``FAILURE_CATEGORY_FIX_CI_BLOCKED`` category.
-        # Exact analog of the ralph_not_ship fix (#3054): fix-ci
-        # returned BLOCKED with a ``block_reason``, no mechanical retry
-        # will help, and the diagnoser's ``block_on_existing_task`` /
-        # ``file_prerequisite_task`` / ``block_and_comment`` /
-        # ``escalate`` actions are the right responses.
         self._handle_agent_failure(
             agent_id=agent_id,
             phase="awaiting_ci",
@@ -15609,23 +15689,45 @@ class DispatcherDaemon:
         merge_sha: str,
         deploy_runs: list[dict[str, Any]],
     ) -> None:
-        """Spawn ``/task-v2-verify``, post evidence comment, advance to done.
+        """Spawn ``/task-v2-verify`` asynchronously (#3658), post evidence, advance.
+
+        Pre-#3658 this method blocked MainThread for the full verify
+        duration (30–50 min) via ``_run_subprocess_or_fail``. Post-#3658
+        it delegates to ``_start_verify`` which writes the input bundle
+        and fire-and-forgets the subprocess. The reaper pass
+        (:meth:`_reap_phase_subprocesses`) calls ``_finalize_verify``
+        once the subprocess exits on a subsequent tick.
+        """
+        self._start_verify(agent, pr_status, merge_sha, deploy_runs)
+
+    def _start_verify(
+        self,
+        agent: dict[str, Any],
+        pr_status: dict[str, Any],
+        merge_sha: str,
+        deploy_runs: list[dict[str, Any]],
+    ) -> None:
+        """Build the verify input bundle and fire-and-forget the subprocess (#3658).
+
+        Handles the short-circuit cases (skip_reason, already_completed)
+        synchronously on MainThread (they are cheap DB reads). For the
+        normal case, writes ``phase_input.json`` and calls
+        :meth:`_spawn_phase_subprocess_async` — returns immediately
+        without blocking on the subprocess.
 
         Issue #2953: ``status='succeeded'`` was already written at merge
         time by ``_write_merged_at`` — this method no longer flips the
         status. Its remaining responsibilities are (a) short-circuit
         when ``verify_skip_reason`` is set (dispatcher-self-PR case),
-        (b) run the verify subprocess, (c) stamp ``verified_at`` on
-        VERIFIED/SKIPPED verdict, and (d) advance ``phase`` to ``done``
-        so the retro phase picks it up on the next tick.
+        (b) async-spawn the verify subprocess, (c) stamp ``verified_at``
+        on VERIFIED/SKIPPED verdict (delegated to ``_finalize_verify``),
+        and (d) advance ``phase`` to ``done`` (also delegated).
 
         A FAILED verdict flips status back to ``failed`` via
         ``_mark_agent_terminal`` — verify failing post-merge is a real
         problem (the deployed code didn't behave as expected) and the
         admin cockpit should surface it in red even though the PR
-        technically shipped. The row still has ``merged_at`` populated
-        so the milestone breakdown tooltip can show "merged X · verify
-        failed" on operator hover.
+        technically shipped.
         """
         agent_id = agent["agent_id"]
         issue_number = agent["issue_number"]
@@ -15761,9 +15863,9 @@ class DispatcherDaemon:
         self._write_phase_input(worktree, "verify", verify_input)
 
         self._log.info(
-            "daemon.verify_started",
+            "daemon.verify_started_async",
             extra={
-                "event": "verify_started",
+                "event": "verify_started_async",
                 "run_id": self._run_id,
                 "agent_id": agent_id,
                 "pr_number": pr_number,
@@ -15772,19 +15874,50 @@ class DispatcherDaemon:
             },
         )
 
-        exit_code = self._run_subprocess_or_fail(agent_id, "verify", worktree)
+        # #3658 — async fire-and-forget. Store context the finalizer needs
+        # (pr_number, issue_number, merge_sha, merged_at_set) so it can
+        # log correctly without a second DB round-trip.
+        deadline = float(STUCK_TIMEOUT_SECONDS_BY_PHASE.get("verify", 3000))
+        self._spawn_phase_subprocess_async(
+            phase="verify",
+            worktree=worktree,
+            agent_id=agent_id,
+            deadline_seconds=deadline,
+            ctx={
+                "pr_number": pr_number,
+                "issue_number": issue_number,
+                "merge_sha": merge_sha,
+                "merged_at_set": merged_at_set,
+            },
+        )
+
+    def _finalize_verify(
+        self,
+        agent_id: str,
+        worktree: Path,
+        exit_code: int | None,
+    ) -> None:
+        """Post-completion handler for an async verify subprocess (#3658).
+
+        Called by :meth:`_reap_phase_subprocesses` once the subprocess
+        exits (or is killed for exceeding its deadline). Handles the same
+        read-output / persist / post-evidence / transition logic that
+        ``_run_verify_and_complete`` previously ran inline after
+        ``_run_subprocess_or_fail`` returned.
+
+        ``exit_code=None`` means the subprocess was killed for timeout —
+        treated the same as a subprocess-infra failure.
+        """
+        # Recover the spawn-time context stored by _spawn_phase_subprocess_async.
+        inflight = self._phase_subprocess_inflight.get(agent_id, {})
+        ctx = inflight.get("ctx", {})
+        pr_number = ctx.get("pr_number")
+        issue_number = ctx.get("issue_number")
+        merge_sha = str(ctx.get("merge_sha") or "")
+        merged_at_set = bool(ctx.get("merged_at_set", True))
+
+        # exit_code is None when the process was killed (timeout / SIGKILL).
         if exit_code is None:
-            # Issue #3055 — ``_run_subprocess_or_fail`` already flipped
-            # the row to ``status='failed'`` via its internal failure
-            # handlers. On an already-merged agent that is wrong: the
-            # PR shipped, ``merged_at`` is stamped, and a verify
-            # subprocess crash shouldn't retroactively invert the audit
-            # trail. Any post-merge verify infra failure is bookkeeping
-            # noise, not a product regression. Restore the row to
-            # ``status='succeeded'`` and advance phase to ``done`` so
-            # retro runs on the next tick. The distinct
-            # ``verify_infra_failure_post_merge`` event gives operators
-            # the grep hook for "verify-was-broken-but-shipped" cases.
             if merged_at_set:
                 self._log.warning(
                     "daemon.verify_infra_failure_post_merge",
@@ -15794,11 +15927,11 @@ class DispatcherDaemon:
                         "agent_id": agent_id,
                         "issue_number": issue_number,
                         "pr_number": pr_number,
-                        "detail": "subprocess failed before output parse",
+                        "detail": "subprocess killed (deadline exceeded)",
                     },
                 )
                 self._restore_succeeded_and_advance_done(agent_id)
-            return  # subprocess failure already marked (or restored) by now
+            return
 
         verify_output = self._read_phase_output(worktree, "verify")
         if verify_output is None:
@@ -15820,10 +15953,7 @@ class DispatcherDaemon:
             # :meth:`_restore_succeeded_and_advance_done` instead of
             # :meth:`_handle_agent_failure` so ``status`` stays
             # ``succeeded`` and the admin cockpit doesn't render an
-            # already-shipped PR red. Pre-#3055 this path flipped the
-            # row to ``failed`` and the Opus diagnoser then escalated
-            # it to ``diagnoser_escalate/failed`` — inverting the
-            # authoritative success signal on an already-shipped PR.
+            # already-shipped PR red.
             if merged_at_set:
                 self._log.warning(
                     "daemon.verify_infra_failure_post_merge",
@@ -15872,15 +16002,10 @@ class DispatcherDaemon:
             )
 
         # Dispatch through the pure phase-transition catalog (#2976).
-        # Side-effect logic (logging events, failure-row writes) is
-        # preserved verbatim; only the DECISION about which path to take
-        # is driven by transition_from_verify.
-        # Keep the verdict string for the daemon.agent_completed log event below.
         verdict = str(verify_output.get("verdict") or "").upper()
         verify_transition = transition_from_verify(verify_output)
 
         if verify_transition.action == TransitionAction.ROUTE_TO_DIAGNOSER:
-            # verify_transition.failure_hint == FAILURE_HINT_VERIFY_FAILED_POST_MERGE
             failure_reason = verify_output.get("failure_reason")
             self._log.warning(
                 "daemon.verify_failed",
@@ -15892,22 +16017,6 @@ class DispatcherDaemon:
                     "failure_reason": failure_reason,
                 },
             )
-            # Issue #2953: verify failed post-merge is a genuine
-            # regression signal — the deployed code didn't behave as
-            # expected. Flip status back to ``failed`` so the admin
-            # cockpit renders red. ``merged_at`` stays populated so the
-            # tooltip can read "merged X · verify failed" instead of
-            # hiding the shipment entirely.
-            #
-            # ROUTING (#3062 #3071): ROUTED via ``_handle_agent_failure``
-            # with the tier-3 ``FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE``
-            # category. Post-merge context differs from pre-merge
-            # failures: the PR is merged, the code is on main.
-            # ``retry`` is a no-op; the diagnoser's primary actions
-            # are ``file_prerequisite_task`` (p1 regression issue),
-            # ``block_and_comment`` (repro steps), or ``escalate``.
-            # See :file:`.claude/skills/diagnose-failure/SKILL.md` for
-            # the dedicated per-category guidance.
             self._handle_agent_failure(
                 agent_id=agent_id,
                 phase="done",
@@ -15927,9 +16036,7 @@ class DispatcherDaemon:
 
         # verify_transition.action == ADVANCE, next_phase == "done"
         # VERIFIED or SKIPPED — stamp ``verified_at`` and advance phase
-        # so the retro phase picks up the row next tick. ``status`` is
-        # already ``succeeded`` from merge-time; no re-flip needed
-        # (issue #2953).
+        # so the retro phase picks up the row next tick.
         self._write_verified_at(agent_id)
         self._update_agent_phase(agent_id, verify_transition.next_phase or "done")
         self._log.info(
@@ -16122,17 +16229,24 @@ class DispatcherDaemon:
     # succeeded; only the post-success bookkeeping varies.
 
     def _run_retro_phase(self, agent: dict[str, Any]) -> None:
-        """Spawn ``/task-v2-retro`` and file any retro issues it produces.
+        """Spawn ``/task-v2-retro`` asynchronously (#3658) and file issues.
 
-        Reads ``dispatcher.phase_transitions`` + ``dispatcher.failures``
-        for this agent, writes the retro input bundle, runs the
-        subprocess, parses the output, and calls ``gh issue create``
-        once per entry in ``retro_issues``. Transitions the agent's
-        phase to :data:`PHASE_RETRO_DONE` on success or
-        :data:`PHASE_RETRO_FAILED` on subprocess / parse failure.
+        Pre-#3658 this blocked MainThread via ``_spawn_phase_subprocess``.
+        Post-#3658 it delegates to ``_start_retro`` which writes the input
+        bundle and fire-and-forgets the subprocess.
+        """
+        self._start_retro(agent)
 
-        ``status='succeeded'`` is preserved across this advance — the
-        retro is bookkeeping for an already-successful run.
+    def _start_retro(self, agent: dict[str, Any]) -> None:
+        """Build the retro input bundle and fire-and-forget the subprocess (#3658).
+
+        Handles the worktree-missing short-circuit synchronously (cheap
+        filesystem check). Otherwise writes ``phase_input.json`` and
+        calls :meth:`_spawn_phase_subprocess_async` — returns immediately.
+
+        The full output-parsing / issue-filing / phase-advance logic is
+        delegated to ``_finalize_retro`` which runs on a later tick via
+        the reaper.
         """
         agent_id = agent["agent_id"]
         issue_number = agent["issue_number"]
@@ -16155,16 +16269,14 @@ class DispatcherDaemon:
             self._update_agent_phase(agent_id, PHASE_CLEANUP_DONE)
             return
 
-        # Build the retro input bundle. The retro skill's SKILL.md
-        # documents the contract — we satisfy the required fields and
-        # the optional ones we can derive cheaply from DB state.
+        # Build the retro input bundle.
         retro_input = self._build_retro_input(agent)
         self._write_phase_input(worktree, "retro", retro_input)
 
         self._log.info(
-            "daemon.retro_started",
+            "daemon.retro_started_async",
             extra={
-                "event": "retro_started",
+                "event": "retro_started_async",
                 "run_id": self._run_id,
                 "agent_id": agent_id,
                 "issue_number": issue_number,
@@ -16174,13 +16286,41 @@ class DispatcherDaemon:
             },
         )
 
-        # Spawn the retro subprocess. Failure here flips to retro_failed
-        # but does NOT touch the agent's succeeded status.
-        try:
-            exit_code, duration_s = self._spawn_phase_subprocess(
-                "retro", worktree, agent_id
-            )
-        except subprocess.TimeoutExpired:
+        deadline = float(STUCK_TIMEOUT_SECONDS_BY_PHASE.get("retro", 3000))
+        self._spawn_phase_subprocess_async(
+            phase="retro",
+            worktree=worktree,
+            agent_id=agent_id,
+            deadline_seconds=deadline,
+            ctx={
+                "issue_number": issue_number,
+                "pr_number": pr_number,
+            },
+        )
+
+    def _finalize_retro(
+        self,
+        agent_id: str,
+        worktree: Path,
+        exit_code: int | None,
+    ) -> None:
+        """Post-completion handler for an async retro subprocess (#3658).
+
+        Called by :meth:`_reap_phase_subprocesses` once the subprocess
+        exits (or is killed for deadline). Handles the same output
+        parsing / issue filing / phase advance logic that ``_run_retro_phase``
+        previously ran inline after ``_spawn_phase_subprocess`` returned.
+
+        ``exit_code=None`` means the subprocess was killed (timeout).
+        """
+        inflight = self._phase_subprocess_inflight.get(agent_id, {})
+        ctx = inflight.get("ctx", {})
+        issue_number = ctx.get("issue_number")
+        pr_number = ctx.get("pr_number")
+
+        retro_failed_transition = transition_from_retro(False)
+
+        if exit_code is None:
             extra: dict[str, Any] = {
                 "event": "retro_timeout",
                 "run_id": self._run_id,
@@ -16190,24 +16330,6 @@ class DispatcherDaemon:
             if preview:
                 extra["stderr_preview"] = preview
             self._log.warning("daemon.retro_timeout", extra=extra)
-            # transition_from_retro(False) → next_phase == PHASE_RETRO_FAILED
-            retro_failed_transition = transition_from_retro(False)
-            self._update_agent_phase(
-                agent_id, retro_failed_transition.next_phase or PHASE_RETRO_FAILED
-            )
-            return
-        except (FileNotFoundError, OSError) as exc:
-            extra = {
-                "event": "retro_subprocess_error",
-                "run_id": self._run_id,
-                "agent_id": agent_id,
-                "detail": str(exc),
-            }
-            preview = self._extract_log_preview(worktree, "retro")
-            if preview:
-                extra["stderr_preview"] = preview
-            self._log.warning("daemon.retro_subprocess_error", extra=extra)
-            retro_failed_transition = transition_from_retro(False)
             self._update_agent_phase(
                 agent_id, retro_failed_transition.next_phase or PHASE_RETRO_FAILED
             )
@@ -16219,13 +16341,11 @@ class DispatcherDaemon:
                 "run_id": self._run_id,
                 "agent_id": agent_id,
                 "exit_code": exit_code,
-                "duration_s": duration_s,
             }
             preview = self._extract_log_preview(worktree, "retro")
             if preview:
                 extra["stderr_preview"] = preview
             self._log.warning("daemon.retro_nonzero_exit", extra=extra)
-            retro_failed_transition = transition_from_retro(False)
             self._update_agent_phase(
                 agent_id, retro_failed_transition.next_phase or PHASE_RETRO_FAILED
             )
@@ -16242,7 +16362,6 @@ class DispatcherDaemon:
             if preview:
                 extra["stderr_preview"] = preview
             self._log.warning("daemon.retro_output_missing", extra=extra)
-            retro_failed_transition = transition_from_retro(False)
             self._update_agent_phase(
                 agent_id, retro_failed_transition.next_phase or PHASE_RETRO_FAILED
             )
@@ -16258,9 +16377,7 @@ class DispatcherDaemon:
             usage=self._parse_phase_usage(worktree, "retro"),
         )
 
-        # File the retro issues. Each entry becomes a separate
-        # ``gh issue create``. Honour the per-agent cap defensively —
-        # the skill is supposed to produce only high-signal findings.
+        # File the retro issues.
         retro_issues = retro_output.get("retro_issues") or []
         if not isinstance(retro_issues, list):
             retro_issues = []
@@ -16285,15 +16402,7 @@ class DispatcherDaemon:
             if new_issue is not None:
                 filed += 1
 
-        # Issue #2953: stamp ``retroed_at`` BEFORE advancing phase so a
-        # crash between the two writes leaves the milestone column set
-        # — the admin cockpit can render the "retro completed" signal
-        # even if the phase advance failed. Paired reads of
-        # ``phase=retro_done`` and ``retroed_at IS NOT NULL`` are both
-        # authoritative (post this fix).
-        # Dispatch through the pure phase-transition catalog (#2976).
         retro_done_transition = transition_from_retro(True)
-        # retro_done_transition.next_phase == PHASE_RETRO_DONE
         self._write_retroed_at(agent_id)
         self._update_agent_phase(
             agent_id, retro_done_transition.next_phase or PHASE_RETRO_DONE
@@ -16309,7 +16418,6 @@ class DispatcherDaemon:
                 "no_findings": bool(retro_output.get("no_findings")),
                 "issues_filed": filed,
                 "issues_attempted": len(retro_issues),
-                "duration_s": duration_s,
             },
         )
 
@@ -19898,6 +20006,316 @@ class DispatcherDaemon:
 
         return int(proc.pid)
 
+    # ------------------------------------------------------------------
+    # #3658 — async fire-and-forget spawn for verify / fix-ci / retro.
+    # Models the same pattern as ``_spawn_diagnoser_subprocess`` so a
+    # slow verify / fix-ci / retro no longer blocks MainThread and cannot
+    # trip the 120s ``scheduler_tick_stalled_exiting`` watchdog.
+    # ------------------------------------------------------------------
+
+    def _spawn_phase_subprocess_async(
+        self,
+        phase: str,
+        worktree: Path,
+        agent_id: str,
+        deadline_seconds: float,
+        ctx: dict[str, Any] | None = None,
+    ) -> int | None:
+        """Spawn ``claude -p /task-v2-<phase> <agent_id>`` fire-and-forget (#3658).
+
+        Mirrors :meth:`_spawn_diagnoser_subprocess` (fire-and-forget
+        ``Popen`` + immediate FD close). The reaper pass
+        (:meth:`_reap_phase_subprocesses`) reads results on a later tick.
+
+        ``ctx`` is an optional dict of additional per-phase data that the
+        corresponding finalizer (``_finalize_verify``, etc.) needs but that
+        is not trivially re-read from the DB — e.g. ``merge_sha``,
+        ``pr_number``, ``issue_number``. It is stored verbatim in the
+        ``_phase_subprocess_inflight`` entry under the key ``"ctx"``.
+
+        Returns the subprocess PID on success, or ``None`` if the launch
+        failed. The entry in ``_phase_subprocess_inflight`` is registered
+        before this method returns so the very next tick can check it.
+        """
+        overrides = self._read_max_turns_overrides()
+        max_turns = self._max_turns_for_phase(phase, overrides=overrides)
+        model = self._model_for_phase(phase, agent_id)
+
+        stdout_path = worktree / "tmp" / f"claude-p-{phase}.stdout.json"
+        stderr_path = worktree / "tmp" / f"claude-p-{phase}.stderr.log"
+        jsonl_path = worktree / ".dispatcher" / f"{phase}-{agent_id}.jsonl"
+        stdout_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Post-merge phases (verify, retro) use the baseline repo cwd so the
+        # skill is discoverable even when the per-agent worktree has been wiped.
+        popen_cwd: Path = worktree
+        if (
+            phase in POST_MERGE_PHASES_USING_BASELINE_CWD
+            and self._cfg.baseline_repo_root is not None
+        ):
+            popen_cwd = self._cfg.baseline_repo_root
+
+        cmd = [
+            "claude",
+            "-p",
+            f"/task-v2-{phase} {agent_id}",
+            "--max-turns",
+            str(max_turns),
+            "--model",
+            model,
+            "--output-format",
+            "json",
+            "--dangerously-skip-permissions",
+        ]
+
+        try:
+            stdout_file = stdout_path.open("w", encoding="utf-8")
+        except OSError:
+            self._log.exception(
+                "daemon.phase_async_spawn_stdout_open_failed",
+                extra={
+                    "event": "phase_async_spawn_stdout_open_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": phase,
+                    "stdout_path": str(stdout_path),
+                },
+            )
+            return None
+        try:
+            stderr_file = stderr_path.open("w", encoding="utf-8")
+        except OSError:
+            stdout_file.close()
+            self._log.exception(
+                "daemon.phase_async_spawn_stderr_open_failed",
+                extra={
+                    "event": "phase_async_spawn_stderr_open_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": phase,
+                    "stderr_path": str(stderr_path),
+                },
+            )
+            return None
+
+        try:
+            proc: subprocess.Popen[str] = subprocess.Popen(  # noqa: S603 — literal trusted cmd
+                cmd,
+                stdout=stdout_file,
+                stderr=stderr_file,
+                text=True,
+                cwd=str(popen_cwd),
+                # noqa: timeout-required: issue-3658-fire-and-forget-reaper-enforces-deadline
+                start_new_session=True,
+            )
+        except FileNotFoundError:
+            stdout_file.close()
+            stderr_file.close()
+            self._log.error(
+                "daemon.phase_async_spawn_failed",
+                extra={
+                    "event": "phase_async_spawn_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": phase,
+                    "reason": "claude_binary_not_found",
+                },
+            )
+            return None
+        except OSError:
+            stdout_file.close()
+            stderr_file.close()
+            self._log.exception(
+                "daemon.phase_async_spawn_failed",
+                extra={
+                    "event": "phase_async_spawn_failed",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": phase,
+                    "reason": "popen_oserror",
+                },
+            )
+            return None
+
+        # Close the parent's FD copies; the child holds its own dup.
+        try:
+            stdout_file.close()
+        except Exception:  # pragma: no cover — defensive
+            pass
+        try:
+            stderr_file.close()
+        except Exception:  # pragma: no cover — defensive
+            pass
+
+        pid = int(proc.pid)
+        now = datetime.now(UTC)
+        self._phase_subprocess_inflight[agent_id] = {
+            "phase": phase,
+            "pid": pid,
+            "stdout_path": str(stdout_path),
+            "stderr_path": str(stderr_path),
+            "jsonl_path": str(jsonl_path),
+            "worktree_path": str(worktree),
+            "started_at": now,
+            "deadline_at": now + timedelta(seconds=deadline_seconds),
+            "ctx": ctx or {},
+        }
+        self._log.info(
+            "daemon.phase_async_spawned",
+            extra={
+                "event": "phase_async_spawned",
+                "run_id": self._run_id,
+                "agent_id": agent_id,
+                "phase": phase,
+                "pid": pid,
+                "deadline_seconds": deadline_seconds,
+            },
+        )
+        return pid
+
+    def _reap_phase_subprocesses(self) -> int:
+        """Reap completed/timed-out async verify/fix-ci/retro subprocesses (#3658).
+
+        Called from :meth:`supervisor_tick` before the advance pass so
+        that completed subprocesses finalize in the same tick they exit.
+        Mirrors :meth:`_reap_diagnoser_subprocesses`.
+
+          * **Process gone** — subprocess exited; dispatch to the
+            per-phase finalizer (``_finalize_verify``,
+            ``_finalize_fix_ci``, ``_finalize_retro``).
+          * **Alive past deadline** — SIGKILL the process group; route
+            the finalizer with ``exit_code=None`` (timeout).
+          * **Alive within deadline** — leave; check next tick.
+
+        Returns the number of reaped entries for log/test correlation.
+        """
+        if not self._phase_subprocess_inflight:
+            return 0
+
+        reaped = 0
+        now = datetime.now(UTC)
+        agent_ids = list(self._phase_subprocess_inflight.keys())
+
+        for agent_id in agent_ids:
+            entry = self._phase_subprocess_inflight.get(agent_id)
+            if entry is None:
+                continue
+            phase = entry["phase"]
+            pid = entry["pid"]
+            deadline_at = entry["deadline_at"]
+            worktree = Path(entry["worktree_path"])
+
+            try:
+                if self._process_alive(pid):
+                    if now >= deadline_at:
+                        elapsed = (now - entry["started_at"]).total_seconds()
+                        self._log.warning(
+                            "daemon.phase_async_deadline_exceeded",
+                            extra={
+                                "event": "phase_async_deadline_exceeded",
+                                "run_id": self._run_id,
+                                "agent_id": agent_id,
+                                "phase": phase,
+                                "subprocess_pid": pid,
+                                "elapsed_seconds": elapsed,
+                            },
+                        )
+                        self._kill_phase_subprocess(pid)
+                        del self._phase_subprocess_inflight[agent_id]
+                        self._finalize_phase_subprocess(
+                            agent_id=agent_id,
+                            phase=phase,
+                            worktree=worktree,
+                            exit_code=None,
+                        )
+                        reaped += 1
+                    # else: still within deadline — check next tick.
+                    continue
+
+                # Process gone — finalize.
+                del self._phase_subprocess_inflight[agent_id]
+                self._finalize_phase_subprocess(
+                    agent_id=agent_id,
+                    phase=phase,
+                    worktree=worktree,
+                    exit_code=0,
+                )
+                reaped += 1
+            except Exception:
+                self._log.exception(
+                    "daemon.phase_async_reap_iteration_failed",
+                    extra={
+                        "event": "phase_async_reap_iteration_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "phase": phase,
+                        "subprocess_pid": pid,
+                    },
+                )
+                # Best-effort fallback so one bad reap doesn't stall later ones.
+                self._phase_subprocess_inflight.pop(agent_id, None)
+                reaped += 1
+
+        return reaped
+
+    def _kill_phase_subprocess(self, pid: int) -> None:
+        """SIGKILL the process group of a timed-out phase subprocess (#3658).
+
+        Uses SIGKILL directly (unlike the diagnoser which gives a
+        SIGTERM grace period) because the 3s grace in
+        ``_kill_diagnoser_process`` is too long for the supervisor-tick
+        path when multiple processes might time out simultaneously.
+        """
+        try:
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
+        except ProcessLookupError:
+            return  # already gone
+        except Exception:  # pragma: no cover — defensive
+            self._log.exception(
+                "daemon.phase_async_kill_failed",
+                extra={
+                    "event": "phase_async_kill_failed",
+                    "run_id": self._run_id,
+                    "subprocess_pid": pid,
+                },
+            )
+
+    def _finalize_phase_subprocess(
+        self,
+        agent_id: str,
+        phase: str,
+        worktree: Path,
+        exit_code: int | None,
+    ) -> None:
+        """Dispatch to the per-phase post-completion handler (#3658).
+
+        Routes completed (or deadline-exceeded) subprocess entries to
+        the appropriate finalizer. ``exit_code=None`` means the
+        subprocess was killed for exceeding its deadline.
+        """
+        if phase == "verify":
+            self._finalize_verify(
+                agent_id=agent_id, worktree=worktree, exit_code=exit_code
+            )
+        elif phase == "fix-ci":
+            self._finalize_fix_ci(
+                agent_id=agent_id, worktree=worktree, exit_code=exit_code
+            )
+        elif phase == "retro":
+            self._finalize_retro(
+                agent_id=agent_id, worktree=worktree, exit_code=exit_code
+            )
+        else:
+            self._log.warning(
+                "daemon.phase_async_unknown_phase",
+                extra={
+                    "event": "phase_async_unknown_phase",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "phase": phase,
+                },
+            )
+
     def _read_recommendation(self, diagnosis_id: int) -> dict[str, Any] | None:
         """Read ``dispatcher.diagnoses.recommendation`` for the given row.
 
@@ -22844,6 +23262,24 @@ class DispatcherDaemon:
 
         rate_skip_active = self._gh_rate_skip_active()
 
+        # #3658 — reap completed/timed-out async verify/fix-ci/retro
+        # subprocesses. Runs BEFORE the advance pass so completed
+        # subprocesses finalize in the same tick they exit and their
+        # agent_ids are removed from ``_phase_subprocess_inflight``
+        # before ``_advance_running_agents`` checks the dict.
+        phase_subprocs_reaped = 0
+        try:
+            phase_subprocs_reaped = self._reap_phase_subprocesses()
+        except Exception:
+            self._log.exception(
+                "daemon.phase_async_reap_pass_failed",
+                extra={
+                    "event": "phase_async_reap_pass_failed",
+                    "run_id": self._run_id,
+                },
+            )
+        t_step = self._record_supervisor_step("phase_async_reap", t_step)
+
         # Issue #3399: orphan-PR resurrection sweep. Runs BEFORE the
         # advance pass so any agent flipped from status='failed' back
         # to status='running' AND phase='awaiting_ci' is picked up by
@@ -23021,6 +23457,8 @@ class DispatcherDaemon:
                 "rate_skip_active": rate_skip_active,
                 "diagnoses_ran": diagnoses_ran,
                 "diagnoses_reaped": diagnoses_reaped,
+                # #3658 — async phase subprocess reaper observability.
+                "phase_subprocs_reaped": phase_subprocs_reaped,
                 # #3374 — generalized scheduled-skills tick observability.
                 "scheduled_skills_rows_scanned": scheduled_skills_summary[
                     "rows_scanned"
@@ -23049,6 +23487,8 @@ class DispatcherDaemon:
             "rate_skip_active": 1 if rate_skip_active else 0,
             "diagnoses_ran": diagnoses_ran,
             "diagnoses_reaped": diagnoses_reaped,
+            # #3658 — async phase subprocess reaper observability.
+            "phase_subprocs_reaped": phase_subprocs_reaped,
             # #3374 — generalized scheduled-skills tick observability.
             "scheduled_skills_rows_scanned": scheduled_skills_summary["rows_scanned"],
             "scheduled_skills_fires_succeeded": scheduled_skills_summary[

--- a/scripts/dispatcher/tests/test_agent_runner_no_route_stub.py
+++ b/scripts/dispatcher/tests/test_agent_runner_no_route_stub.py
@@ -108,9 +108,7 @@ class TestRalphNotShipDescriptiveTerminal:
             r"^handle_ralph_not_ship_local\s*\(\s*\)\s*\{",
             text,
             re.MULTILINE,
-        ), (
-            "handle_ralph_not_ship_local function must not be defined (#3586 removed it)"
-        )
+        ), "handle_ralph_not_ship_local function must not be defined (#3586 removed it)"
 
     def test_route_to_diagnoser_dispatches_ralph_not_ship_as_descriptive_terminal(
         self,

--- a/scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py
+++ b/scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py
@@ -383,7 +383,6 @@ class TestFixCiBlockedRouting:
         d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
         d._materialize_prior_attempts = MagicMock(return_value=0)  # type: ignore[method-assign]
         d._write_phase_input = MagicMock()  # type: ignore[method-assign]
-        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
         d._read_phase_output = MagicMock(return_value=fix_ci_output)  # type: ignore[method-assign]
         d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
         d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
@@ -393,6 +392,30 @@ class TestFixCiBlockedRouting:
         d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._apply_fix_ci_patch = MagicMock()  # type: ignore[method-assign]
+
+    def _run_fix_ci_finalize(
+        self,
+        d: daemon.DispatcherDaemon,
+        agent: dict[str, Any],
+        worktree: Path,
+        exit_code: int = 0,
+    ) -> None:
+        """Populate inflight ctx and call _finalize_fix_ci directly (#3658)."""
+        agent_id = agent["agent_id"]
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "fix-ci",
+            "pid": 99999,
+            "worktree_path": worktree,
+            "started_at": 0.0,
+            "deadline_at": 99999.0,
+            "ctx": {
+                "agent": dict(agent),
+                "pr_number": agent.get("pr_number"),
+                "issue_number": agent.get("issue_number"),
+                "retries_used": agent.get("retries_used", 0),
+            },
+        }
+        d._finalize_fix_ci(agent_id, worktree, exit_code)
 
     def test_blocked_verdict_routes(self, tmp_path: Path) -> None:
         d, _conn, _handler = _make_daemon(tmp_path, scope="fix_ci_blocked")
@@ -414,9 +437,8 @@ class TestFixCiBlockedRouting:
             "worktree_path": str(worktree),
             "retries_used": 1,
         }
-        pr_status: dict[str, Any] = {"statusCheckRollup": []}
 
-        d._run_fix_ci(agent, pr_status)
+        self._run_fix_ci_finalize(d, agent, worktree)
 
         d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
         kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
@@ -451,7 +473,7 @@ class TestFixCiBlockedRouting:
             "retries_used": 0,
         }
 
-        d._run_fix_ci(agent, {"statusCheckRollup": []})
+        self._run_fix_ci_finalize(d, agent, worktree)
 
         d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
         kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
@@ -483,7 +505,7 @@ class TestFixCiBlockedRouting:
             "retries_used": 0,
         }
 
-        d._run_fix_ci(agent, {"statusCheckRollup": []})
+        self._run_fix_ci_finalize(d, agent, worktree)
 
         d._handle_agent_failure.assert_not_called()  # type: ignore[union-attr]
         d._apply_fix_ci_patch.assert_called_once()  # type: ignore[union-attr]
@@ -850,37 +872,59 @@ class TestVerifyFailedPostMergeSkillContract:
 
 
 class TestVerifyFailedPostMergeRouting:
+    def _patch_verify(
+        self, d: daemon.DispatcherDaemon, *, verify_output: dict[str, Any]
+    ) -> None:
+        d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
+        d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
+        d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
+        d._read_phase_output = MagicMock(return_value=verify_output)  # type: ignore[method-assign]
+        d._write_merged_at = MagicMock()  # type: ignore[method-assign]
+        d._post_evidence_comment = MagicMock()  # type: ignore[method-assign]
+        d._write_verified_at = MagicMock()  # type: ignore[method-assign]
+        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
+        d._restore_succeeded_and_advance_done = MagicMock()  # type: ignore[method-assign]
+
+    def _run_verify_finalize(
+        self,
+        d: daemon.DispatcherDaemon,
+        agent: dict[str, Any],
+        worktree: Path,
+        merge_sha: str,
+        exit_code: int = 0,
+    ) -> None:
+        """Populate inflight ctx and call _finalize_verify directly (#3658)."""
+        agent_id = agent["agent_id"]
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "verify",
+            "pid": 99999,
+            "worktree_path": worktree,
+            "started_at": 0.0,
+            "deadline_at": 99999.0,
+            "ctx": {
+                "pr_number": agent.get("pr_number"),
+                "issue_number": agent.get("issue_number"),
+                "merge_sha": merge_sha,
+                "merged_at_set": agent.get("merged_at") is not None,
+            },
+        }
+        d._finalize_verify(agent_id, worktree, exit_code)
+
     def test_failed_verdict_routes(self, tmp_path: Path) -> None:
         d, _conn, _handler = _make_daemon(tmp_path, scope="verify_failed_pm")
         worktree = tmp_path / "wt"
         worktree.mkdir()
 
-        d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
-        d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
-        d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
-        d._read_phase_output = MagicMock(  # type: ignore[method-assign]
-            return_value={
+        self._patch_verify(
+            d,
+            verify_output={
                 "verdict": "FAILED",
                 "failure_reason": "search endpoint returned 500 on sample ruling",
                 "evidence_md": "## Verify\n\n- FAIL: AC#1 — got 500",
-            }
+            },
         )
-        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
-        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
-        d._write_merged_at = MagicMock()  # type: ignore[method-assign]
-        d._read_verify_skip_reason = MagicMock(return_value=None)  # type: ignore[method-assign]
-        d._post_evidence_comment = MagicMock()  # type: ignore[method-assign]
-        d._write_verified_at = MagicMock()  # type: ignore[method-assign]
-        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
-        d._materialize_prior_attempts = MagicMock(return_value=0)  # type: ignore[method-assign]
-        d._extract_acceptance_criteria = MagicMock(return_value=[])  # type: ignore[method-assign]
-        d._fetch_issue_body = MagicMock(return_value="")  # type: ignore[method-assign]
-        d._fetch_pr_diff = MagicMock(return_value="")  # type: ignore[method-assign]
-        d._list_committed_files_at_head = MagicMock(return_value=[])  # type: ignore[method-assign]
-        d._detect_verify_skip_reason = MagicMock(return_value=None)  # type: ignore[method-assign]
-        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
-        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
-        d._restore_succeeded_and_advance_done = MagicMock()  # type: ignore[method-assign]
 
         agent = {
             "agent_id": "agent-verify-fail",
@@ -889,9 +933,8 @@ class TestVerifyFailedPostMergeRouting:
             "worktree_path": str(worktree),
             "merged_at": datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC),
         }
-        pr_status = {"mergeCommit": {"oid": "f00dbabe"}}
 
-        d._run_verify_and_complete(agent, pr_status, "f00dbabe", [])
+        self._run_verify_finalize(d, agent, worktree, "f00dbabe")
 
         d._handle_agent_failure.assert_called_once()  # type: ignore[union-attr]
         kwargs = d._handle_agent_failure.call_args.kwargs  # type: ignore[union-attr]
@@ -917,30 +960,13 @@ class TestVerifyFailedPostMergeRouting:
         worktree = tmp_path / "wt"
         worktree.mkdir()
 
-        d._persist_phase_output = MagicMock()  # type: ignore[method-assign]
-        d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
-        d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
-        d._read_phase_output = MagicMock(  # type: ignore[method-assign]
-            return_value={
+        self._patch_verify(
+            d,
+            verify_output={
                 "verdict": "VERIFIED",
                 "evidence_md": "## Verify\n\n- PASS: AC#1",
-            }
+            },
         )
-        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
-        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
-        d._write_merged_at = MagicMock()  # type: ignore[method-assign]
-        d._read_verify_skip_reason = MagicMock(return_value=None)  # type: ignore[method-assign]
-        d._post_evidence_comment = MagicMock()  # type: ignore[method-assign]
-        d._write_verified_at = MagicMock()  # type: ignore[method-assign]
-        d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
-        d._materialize_prior_attempts = MagicMock(return_value=0)  # type: ignore[method-assign]
-        d._extract_acceptance_criteria = MagicMock(return_value=[])  # type: ignore[method-assign]
-        d._fetch_issue_body = MagicMock(return_value="")  # type: ignore[method-assign]
-        d._fetch_pr_diff = MagicMock(return_value="")  # type: ignore[method-assign]
-        d._list_committed_files_at_head = MagicMock(return_value=[])  # type: ignore[method-assign]
-        d._detect_verify_skip_reason = MagicMock(return_value=None)  # type: ignore[method-assign]
-        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
-        d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
 
         agent = {
             "agent_id": "agent-verified",
@@ -949,9 +975,8 @@ class TestVerifyFailedPostMergeRouting:
             "worktree_path": str(worktree),
             "merged_at": datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC),
         }
-        pr_status = {"mergeCommit": {"oid": "f00dbabe"}}
 
-        d._run_verify_and_complete(agent, pr_status, "f00dbabe", [])
+        self._run_verify_finalize(d, agent, worktree, "f00dbabe")
 
         d._handle_agent_failure.assert_not_called()  # type: ignore[union-attr]
         d._write_verified_at.assert_called_once()  # type: ignore[union-attr]
@@ -1067,9 +1092,9 @@ class TestFixCiForceWithLease:
 
 
 class TestFixCiRebaseOutcomeLogEvent:
-    """Verify ``_run_fix_ci`` emits a ``daemon.fix_ci_rebase_outcome`` log
-    event unconditionally after parsing the fix-ci output JSON (AC6, issue
-    #2966).
+    """Verify ``_finalize_fix_ci`` emits a ``daemon.fix_ci_rebase_outcome``
+    log event unconditionally after parsing the fix-ci output JSON (AC6,
+    issue #2966).
 
     Three parametrized cases: clean / resolved / conflict_unresolvable.
     Also covers the None case (old skill payload without rebase_outcome).
@@ -1085,7 +1110,6 @@ class TestFixCiRebaseOutcomeLogEvent:
         d._read_full_phase_log = MagicMock(return_value="")  # type: ignore[method-assign]
         d._parse_phase_usage = MagicMock(return_value=None)  # type: ignore[method-assign]
         d._read_phase_output = MagicMock(return_value=fix_ci_output)  # type: ignore[method-assign]
-        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
         d._write_phase_input = MagicMock()  # type: ignore[method-assign]
         d._extract_failing_jobs = MagicMock(return_value=[])  # type: ignore[method-assign]
         d._fetch_pr_diff = MagicMock(return_value="")  # type: ignore[method-assign]
@@ -1100,14 +1124,27 @@ class TestFixCiRebaseOutcomeLogEvent:
         worktree = tmp_path / "wt"
         worktree.mkdir()
         self._patch(d, fix_ci_output=fix_ci_output)
-        agent = {
-            "agent_id": f"agent-{scope}",
-            "pr_number": 9966,
-            "issue_number": 2966,
-            "worktree_path": str(worktree),
-            "retries_used": 0,
+        agent_id = f"agent-{scope}"
+        # Populate inflight ctx so _finalize_fix_ci has the metadata it needs.
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "fix-ci",
+            "pid": 99999,
+            "worktree_path": worktree,
+            "started_at": 0.0,
+            "deadline_at": 99999.0,
+            "ctx": {
+                "agent": {
+                    "agent_id": agent_id,
+                    "pr_number": 9966,
+                    "issue_number": 2966,
+                    "retries_used": 0,
+                },
+                "pr_number": 9966,
+                "issue_number": 2966,
+                "retries_used": 0,
+            },
         }
-        d._run_fix_ci(agent, {"statusCheckRollup": []})
+        d._finalize_fix_ci(agent_id, worktree, 0)
         return handler
 
     def test_rebase_outcome_clean_logged(self, tmp_path: Path) -> None:

--- a/scripts/dispatcher/tests/test_daemon_milestone_columns.py
+++ b/scripts/dispatcher/tests/test_daemon_milestone_columns.py
@@ -762,7 +762,6 @@ class TestRetroStampsRetroedAt:
 
         d._build_retro_input = MagicMock(return_value={"ralph_iterations": 1})  # type: ignore[method-assign]
         d._write_phase_input = MagicMock()  # type: ignore[method-assign]
-        d._spawn_phase_subprocess = MagicMock(return_value=(0, 1.23))  # type: ignore[method-assign]
         d._read_phase_output = MagicMock(  # type: ignore[method-assign]
             return_value={"retro_issues": [], "no_findings": True}
         )
@@ -777,6 +776,27 @@ class TestRetroStampsRetroedAt:
             "pr_number": 99,
             "worktree_path": str(worktree),
         }
+
+        # #3658: stub _spawn_phase_subprocess_async to call _finalize_retro immediately.
+        def fake_spawn_async(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> None:
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": worktree,
+                "started_at": 0.0,
+                "deadline_at": 99999.0,
+                "ctx": ctx or {},
+            }
+            d._finalize_retro(agent_id, worktree, 0)
+
+        d._spawn_phase_subprocess_async = fake_spawn_async  # type: ignore[method-assign]
+
         d._run_retro_phase(agent)
 
         # retroed_at stamped.

--- a/scripts/dispatcher/tests/test_daemon_orphan_pr_race.py
+++ b/scripts/dispatcher/tests/test_daemon_orphan_pr_race.py
@@ -317,9 +317,7 @@ class TestOrphanPrRecoveryPendingProceedPaths:
 
         result = d._orphan_pr_recovery_pending(42)
 
-        assert result is False, (
-            "transient gh failure must not block the claim path"
-        )
+        assert result is False, "transient gh failure must not block the claim path"
 
     def test_pick_candidate_proceeds_when_budget_exhausted(
         self, tmp_path: Path

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -876,9 +876,17 @@ class TestAwaitingCiRedPatched:
 
         monkeypatch.setattr(subprocess, "run", fake_run)
 
-        # fix-ci subprocess writes the PATCHED output.
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            out_dir = wt / "tmp" / "dispatcher-output"
+        # #3658: _start_fix_ci fires async. Stub _spawn_phase_subprocess_async
+        # to write the output file and call _finalize_fix_ci immediately so
+        # the test exercises the full flow synchronously.
+        def fake_spawn_async(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> None:
+            out_dir = worktree / "tmp" / "dispatcher-output"
             out_dir.mkdir(parents=True, exist_ok=True)
             assert phase == "fix-ci"
             (out_dir / "fix-ci.json").write_text(
@@ -896,9 +904,18 @@ class TestAwaitingCiRedPatched:
                     }
                 )
             )
-            return 0, 0.1
+            # Register inflight so _finalize_fix_ci can read ctx.
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": worktree,
+                "started_at": 0.0,
+                "deadline_at": 99999.0,
+                "ctx": ctx or {},
+            }
+            d._finalize_fix_ci(agent_id, worktree, 0)
 
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
         agent = {
             "agent_id": "aabbccdd-eeff-0011-2233-445566778899",
@@ -910,8 +927,8 @@ class TestAwaitingCiRedPatched:
         }
         d._advance_awaiting_ci(agent)
 
-        # fix_ci_started event.
-        assert handler.events("fix_ci_started")
+        # fix_ci_started_async event (#3658: event renamed from fix_ci_started).
+        assert handler.events("fix_ci_started_async")
         # fix_ci_patched event (successful apply).
         patched = handler.events("fix_ci_patched")
         assert patched
@@ -971,8 +988,15 @@ class TestAwaitingCiRedBlocked:
 
         monkeypatch.setattr(subprocess, "run", fake_run)
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            out_dir = wt / "tmp" / "dispatcher-output"
+        # #3658: stub _spawn_phase_subprocess_async to call finalizer immediately.
+        def fake_spawn_async(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> None:
+            out_dir = worktree / "tmp" / "dispatcher-output"
             out_dir.mkdir(parents=True, exist_ok=True)
             (out_dir / "fix-ci.json").write_text(
                 json.dumps(
@@ -989,9 +1013,17 @@ class TestAwaitingCiRedBlocked:
                     }
                 )
             )
-            return 0, 0.1
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": worktree,
+                "started_at": 0.0,
+                "deadline_at": 99999.0,
+                "ctx": ctx or {},
+            }
+            d._finalize_fix_ci(agent_id, worktree, 0)
 
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
         agent = {
             "agent_id": "aabbccdd-eeff-0011-2233-445566778899",
@@ -1049,8 +1081,15 @@ class TestAwaitingCiRedFlaky:
 
         monkeypatch.setattr(subprocess, "run", fake_run)
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            out_dir = wt / "tmp" / "dispatcher-output"
+        # #3658: stub _spawn_phase_subprocess_async to call finalizer immediately.
+        def fake_spawn_async(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> None:
+            out_dir = worktree / "tmp" / "dispatcher-output"
             out_dir.mkdir(parents=True, exist_ok=True)
             (out_dir / "fix-ci.json").write_text(
                 json.dumps(
@@ -1067,9 +1106,17 @@ class TestAwaitingCiRedFlaky:
                     }
                 )
             )
-            return 0, 0.1
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": worktree,
+                "started_at": 0.0,
+                "deadline_at": 99999.0,
+                "ctx": ctx or {},
+            }
+            d._finalize_fix_ci(agent_id, worktree, 0)
 
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
         agent = {
             "agent_id": "a1",
@@ -1423,8 +1470,15 @@ class TestAwaitingDeploySuccess:
 
         monkeypatch.setattr(subprocess, "run", fake_run)
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            out_dir = wt / "tmp" / "dispatcher-output"
+        # #3658: stub _spawn_phase_subprocess_async to call finalizer immediately.
+        def fake_spawn_async(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> None:
+            out_dir = worktree / "tmp" / "dispatcher-output"
             out_dir.mkdir(parents=True, exist_ok=True)
             assert phase == "verify"
             (out_dir / "verify.json").write_text(
@@ -1446,9 +1500,17 @@ class TestAwaitingDeploySuccess:
                     }
                 )
             )
-            return 0, 0.1
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": worktree,
+                "started_at": 0.0,
+                "deadline_at": 99999.0,
+                "ctx": ctx or {},
+            }
+            d._finalize_verify(agent_id, worktree, 0)
 
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
         agent = {
             "agent_id": "a1",
@@ -1460,8 +1522,8 @@ class TestAwaitingDeploySuccess:
         }
         d._advance_awaiting_deploy(agent)
 
-        # verify_started event.
-        assert handler.events("verify_started")
+        # verify_started_async event (#3658: event renamed from verify_started).
+        assert handler.events("verify_started_async")
         # Evidence comment was posted.
         assert handler.events("evidence_comment_posted")
         comment_cmds = [c for c in call_log if c[:3] == ["gh", "issue", "comment"]]
@@ -1551,8 +1613,15 @@ class TestAwaitingDeployNoDeployRun:
 
         monkeypatch.setattr(subprocess, "run", fake_run)
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            out_dir = wt / "tmp" / "dispatcher-output"
+        # #3658: stub _spawn_phase_subprocess_async to call finalizer immediately.
+        def fake_spawn_async(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> None:
+            out_dir = worktree / "tmp" / "dispatcher-output"
             out_dir.mkdir(parents=True, exist_ok=True)
             (out_dir / "verify.json").write_text(
                 json.dumps(
@@ -1569,9 +1638,17 @@ class TestAwaitingDeployNoDeployRun:
                     }
                 )
             )
-            return 0, 0.1
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": worktree,
+                "started_at": 0.0,
+                "deadline_at": 99999.0,
+                "ctx": ctx or {},
+            }
+            d._finalize_verify(agent_id, worktree, 0)
 
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
         agent = {
             "agent_id": "a1",
@@ -2000,7 +2077,7 @@ class TestVerifyRecoveryShortCircuit:
         )
 
     def test_phase_output_missing_on_merged_agent_preserves_succeeded(
-        self, monkeypatch: Any, tmp_path: Path
+        self, tmp_path: Path
     ) -> None:
         """When the verify subprocess returns exit 0 but fails to write
         ``verify.json`` (the #3055 recovery-path failure mode — claude
@@ -2009,38 +2086,14 @@ class TestVerifyRecoveryShortCircuit:
         :meth:`_handle_agent_failure` which flipped the row to
         ``status='failed'`` and handed it to the Opus diagnoser. On a
         merged PR that's wrong — restore ``status='succeeded'`` and
-        advance phase → ``done`` instead."""
+        advance phase → ``done`` instead.
+
+        #3658: test updated to call _finalize_verify directly; the
+        merged_at_set flag comes from the inflight ctx."""
         d, conn, handler = _make_daemon(tmp_path)
         agent = self._agent(tmp_path)
-        pr_status: dict[str, Any] = {}
-        deploy_runs: list[dict[str, Any]] = []
+        worktree = Path(agent["worktree_path"])
 
-        # First: _read_verify_skip_reason returns None.
-        # Second: _read_merged_at_and_verified_at returns (True, False) —
-        # PR merged but verify has never run.
-        conn.cursor_instance.fetch_queue = [
-            (None,),
-            (True, False),
-        ]
-
-        # Short-circuit the input-assembly helpers so we land directly
-        # on the phase_output_missing branch.
-        d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
-            return_value={
-                "issue_number": agent["issue_number"],
-                "issue_title": "t",
-                "issue_body": "- [ ] criterion",
-                "issue_comments": [],
-                "issue_labels": [],
-                "blocked_by": [],
-                "parent_issue": None,
-            }
-        )
-        d._select_deploy_status = MagicMock(return_value=None)  # type: ignore[method-assign]
-        d._infer_change_type = MagicMock(return_value="dx")  # type: ignore[method-assign]
-        d._touched_services_from_runs = MagicMock(return_value=[])  # type: ignore[method-assign]
-        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
-        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
         # The output file is not written — simulate the #3055 failure.
         d._read_phase_output = MagicMock(return_value=None)  # type: ignore[method-assign]
         # Guard rail: the failure handler must NOT be called on the
@@ -2052,7 +2105,21 @@ class TestVerifyRecoveryShortCircuit:
 
         d._handle_agent_failure = forbid_handle_failure  # type: ignore[method-assign]
 
-        d._run_verify_and_complete(agent, pr_status, "merge-sha", deploy_runs)
+        # Populate inflight ctx with merged_at_set=True (PR already merged).
+        d._phase_subprocess_inflight[agent["agent_id"]] = {
+            "phase": "verify",
+            "pid": 99999,
+            "worktree_path": worktree,
+            "started_at": 0.0,
+            "deadline_at": 99999.0,
+            "ctx": {
+                "pr_number": agent["pr_number"],
+                "issue_number": agent["issue_number"],
+                "merge_sha": "merge-sha",
+                "merged_at_set": True,
+            },
+        }
+        d._finalize_verify(agent["agent_id"], worktree, 0)
 
         assert not handle_failure_calls, (
             "Must NOT flip status=failed on a phase_output_missing "
@@ -2074,39 +2141,20 @@ class TestVerifyRecoveryShortCircuit:
         )
 
     def test_phase_output_missing_on_unmerged_agent_still_flips_failed(
-        self, monkeypatch: Any, tmp_path: Path
+        self, tmp_path: Path
     ) -> None:
         """Regression guard: on the rare ``merged_at IS NULL`` code path
         (pre-#2953 agents, or a state inconsistency), the original
         failure routing via :meth:`_handle_agent_failure` must still
         fire. Otherwise we'd silently hide genuine verify regressions
-        for agents whose merge-time columns somehow never got stamped."""
-        d, conn, _handler = _make_daemon(tmp_path)
+        for agents whose merge-time columns somehow never got stamped.
+
+        #3658: test updated to call _finalize_verify directly; the
+        merged_at_set flag comes from the inflight ctx (set to False)."""
+        d, _conn, _handler = _make_daemon(tmp_path)
         agent = self._agent(tmp_path)
-        pr_status: dict[str, Any] = {}
-        deploy_runs: list[dict[str, Any]] = []
+        worktree = Path(agent["worktree_path"])
 
-        conn.cursor_instance.fetch_queue = [
-            (None,),
-            (False, False),  # not merged, not verified
-        ]
-
-        d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
-            return_value={
-                "issue_number": agent["issue_number"],
-                "issue_title": "t",
-                "issue_body": "- [ ] criterion",
-                "issue_comments": [],
-                "issue_labels": [],
-                "blocked_by": [],
-                "parent_issue": None,
-            }
-        )
-        d._select_deploy_status = MagicMock(return_value=None)  # type: ignore[method-assign]
-        d._infer_change_type = MagicMock(return_value="dx")  # type: ignore[method-assign]
-        d._touched_services_from_runs = MagicMock(return_value=[])  # type: ignore[method-assign]
-        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
-        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
         d._read_phase_output = MagicMock(return_value=None)  # type: ignore[method-assign]
 
         handle_failure_calls: list[Any] = []
@@ -2116,7 +2164,21 @@ class TestVerifyRecoveryShortCircuit:
 
         d._handle_agent_failure = record_handle_failure  # type: ignore[method-assign]
 
-        d._run_verify_and_complete(agent, pr_status, "merge-sha", deploy_runs)
+        # Populate inflight ctx with merged_at_set=False (not yet merged).
+        d._phase_subprocess_inflight[agent["agent_id"]] = {
+            "phase": "verify",
+            "pid": 99999,
+            "worktree_path": worktree,
+            "started_at": 0.0,
+            "deadline_at": 99999.0,
+            "ctx": {
+                "pr_number": agent["pr_number"],
+                "issue_number": agent["issue_number"],
+                "merge_sha": "merge-sha",
+                "merged_at_set": False,
+            },
+        }
+        d._finalize_verify(agent["agent_id"], worktree, 0)
 
         assert handle_failure_calls, (
             "Legacy (unmerged) phase_output_missing path must still "

--- a/scripts/dispatcher/tests/test_daemon_phase3e.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3e.py
@@ -322,10 +322,16 @@ class TestRunRetroPhaseZeroFindings:
         d, conn, handler = _make_daemon(tmp_path)
         agent = _succeeded_agent(tmp_path)
 
-        # Stub the retro spawn to write a no-findings output.
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+        # #3658: stub _spawn_phase_subprocess_async to call finalizer immediately.
+        def fake_spawn_async(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> None:
             assert phase == "retro"
-            output_dir = wt / "tmp" / "dispatcher-output"
+            output_dir = worktree / "tmp" / "dispatcher-output"
             output_dir.mkdir(parents=True, exist_ok=True)
             output_dir.joinpath("retro.json").write_text(
                 json.dumps(
@@ -338,9 +344,17 @@ class TestRunRetroPhaseZeroFindings:
                     }
                 )
             )
-            return 0, 1.5
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": worktree,
+                "started_at": 0.0,
+                "deadline_at": 99999.0,
+                "ctx": ctx or {},
+            }
+            d._finalize_retro(agent_id, worktree, 0)
 
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
         # Monkeypatch subprocess.run so that any unexpected gh call
         # would surface clearly. With zero retro issues, no gh call
@@ -413,13 +427,27 @@ class TestRunRetroPhaseMultipleIssues:
             ],
         }
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            output_dir = wt / "tmp" / "dispatcher-output"
+        def fake_spawn_async(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> None:
+            output_dir = worktree / "tmp" / "dispatcher-output"
             output_dir.mkdir(parents=True, exist_ok=True)
             output_dir.joinpath("retro.json").write_text(json.dumps(retro_payload))
-            return 0, 5.0
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": worktree,
+                "started_at": 0.0,
+                "deadline_at": 99999.0,
+                "ctx": ctx or {},
+            }
+            d._finalize_retro(agent_id, worktree, 0)
 
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
         gh_calls: list[list[str]] = []
 
@@ -483,13 +511,27 @@ class TestRunRetroPhaseMultipleIssues:
             ],
         }
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            output_dir = wt / "tmp" / "dispatcher-output"
+        def fake_spawn_async(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> None:
+            output_dir = worktree / "tmp" / "dispatcher-output"
             output_dir.mkdir(parents=True, exist_ok=True)
             output_dir.joinpath("retro.json").write_text(json.dumps(retro_payload))
-            return 0, 1.0
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": worktree,
+                "started_at": 0.0,
+                "deadline_at": 99999.0,
+                "ctx": ctx or {},
+            }
+            d._finalize_retro(agent_id, worktree, 0)
 
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
         gh_calls: list[list[str]] = []
 
@@ -523,10 +565,26 @@ class TestRunRetroPhaseFailures:
         d, conn, handler = _make_daemon(tmp_path)
         agent = _succeeded_agent(tmp_path)
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            return 1, 2.0  # non-zero exit, no output written
+        # #3658: stub _spawn_phase_subprocess_async; nonzero exit → call
+        # _finalize_retro with exit_code=1, no output file written.
+        def fake_spawn_async(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> None:
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": worktree,
+                "started_at": 0.0,
+                "deadline_at": 99999.0,
+                "ctx": ctx or {},
+            }
+            d._finalize_retro(agent_id, worktree, 1)  # non-zero exit
 
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
         d._run_retro_phase(agent)
 
         # Phase flipped to retro_failed.
@@ -559,10 +617,25 @@ class TestRunRetroPhaseFailures:
         d, conn, handler = _make_daemon(tmp_path)
         agent = _succeeded_agent(tmp_path)
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            raise subprocess.TimeoutExpired(cmd="claude", timeout=300)
+        # #3658: timeout is now signaled by _finalize_retro with exit_code=None.
+        def fake_spawn_async(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> None:
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": worktree,
+                "started_at": 0.0,
+                "deadline_at": 99999.0,
+                "ctx": ctx or {},
+            }
+            d._finalize_retro(agent_id, worktree, None)  # killed = timeout
 
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
         d._run_retro_phase(agent)
 
         retro_failed_updates = [
@@ -581,11 +654,25 @@ class TestRunRetroPhaseFailures:
         d, conn, handler = _make_daemon(tmp_path)
         agent = _succeeded_agent(tmp_path)
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            # Exit 0 but no output file.
-            return 0, 1.0
+        # #3658: exit 0 but no output file.
+        def fake_spawn_async(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> None:
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": worktree,
+                "started_at": 0.0,
+                "deadline_at": 99999.0,
+                "ctx": ctx or {},
+            }
+            d._finalize_retro(agent_id, worktree, 0)  # exit 0, no output file
 
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
         d._run_retro_phase(agent)
 
         retro_failed_updates = [
@@ -612,13 +699,27 @@ class TestRunRetroPhaseFailures:
             ],
         }
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            output_dir = wt / "tmp" / "dispatcher-output"
+        def fake_spawn_async(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> None:
+            output_dir = worktree / "tmp" / "dispatcher-output"
             output_dir.mkdir(parents=True, exist_ok=True)
             output_dir.joinpath("retro.json").write_text(json.dumps(retro_payload))
-            return 0, 1.0
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": worktree,
+                "started_at": 0.0,
+                "deadline_at": 99999.0,
+                "ctx": ctx or {},
+            }
+            d._finalize_retro(agent_id, worktree, 0)
 
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
         # Issue #3089: ``_file_retro_issue`` now routes through the
         # shared 3-attempt 1s+2s retry helper (``_subprocess_with_retry``).
@@ -700,13 +801,27 @@ class TestRunRetroPhaseFailures:
         ]
         retro_payload = {"no_findings": False, "retro_issues": many_issues}
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            output_dir = wt / "tmp" / "dispatcher-output"
+        def fake_spawn_async(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> None:
+            output_dir = worktree / "tmp" / "dispatcher-output"
             output_dir.mkdir(parents=True, exist_ok=True)
             output_dir.joinpath("retro.json").write_text(json.dumps(retro_payload))
-            return 0, 1.0
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": worktree,
+                "started_at": 0.0,
+                "deadline_at": 99999.0,
+                "ctx": ctx or {},
+            }
+            d._finalize_retro(agent_id, worktree, 0)
 
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
         n = {"i": 0}
 

--- a/scripts/dispatcher/tests/test_daemon_phase_failure_preview.py
+++ b/scripts/dispatcher/tests/test_daemon_phase_failure_preview.py
@@ -23,7 +23,6 @@ Covers:
 from __future__ import annotations
 
 import logging
-import subprocess
 import sys
 from pathlib import Path
 from typing import Any
@@ -324,27 +323,23 @@ class TestPhaseOutputMissingPreview:
         worktree.mkdir()
         _write_phase_log(worktree, "fix-ci", "fix-ci subprocess returned wrong shape")
 
-        agent = {
-            "agent_id": "agent-123",
-            "issue_number": 1,
-            "phase": "awaiting_ci",
-            "pr_number": 77,
-            "worktree_path": str(worktree),
-            "retries_used": 0,
-            "status": "running",
-        }
-        pr_status = {"statusCheckRollup": []}
+        agent_id = "agent-123"
 
         # Short-circuit helpers that require richer state.
-        d._fetch_pr_diff = MagicMock(return_value="")  # type: ignore[method-assign]
-        d._branch_for_agent = MagicMock(return_value="agent/x")  # type: ignore[method-assign]
-        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
-        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
         d._read_phase_output = MagicMock(return_value=None)  # type: ignore[method-assign]
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
 
-        d._run_fix_ci(agent, pr_status)
+        # #3658: call _finalize_fix_ci directly (async path).
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "fix-ci",
+            "pid": 99999,
+            "worktree_path": worktree,
+            "started_at": 0.0,
+            "deadline_at": 99999.0,
+            "ctx": {"pr_number": 77, "issue_number": 1, "retries_used": 0, "agent": {}},
+        }
+        d._finalize_fix_ci(agent_id, worktree, 0)
 
         events = handler.events("phase_output_missing")
         assert events
@@ -358,42 +353,31 @@ class TestPhaseOutputMissingPreview:
         worktree.mkdir()
         _write_phase_log(worktree, "verify", "Verify skill crashed on AC #3")
 
-        agent = {
-            "agent_id": "agent-123",
-            "issue_number": 1,
-            "phase": "awaiting_deploy",
-            "pr_number": 77,
-            "worktree_path": str(worktree),
-            "retries_used": 0,
-            "status": "running",
-        }
-        pr_status = {"statusCheckRollup": []}
-        merge_sha = "deadbeef"
-        deploy_runs: list[dict[str, Any]] = []
+        agent_id = "agent-123"
 
         # Short-circuit helpers — verify's input-assembly is long and we
         # only want the missing-output branch.
-        d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
-            return_value={
-                "issue_number": 1,
-                "issue_title": "t",
-                "issue_body": "- [ ] do thing",
-                "issue_comments": [],
-                "issue_labels": [],
-                "blocked_by": [],
-                "parent_issue": None,
-            }
-        )
-        d._select_deploy_status = MagicMock(return_value=None)  # type: ignore[method-assign]
-        d._infer_change_type = MagicMock(return_value="dx")  # type: ignore[method-assign]
-        d._touched_services_from_runs = MagicMock(return_value=[])  # type: ignore[method-assign]
-        d._write_phase_input = MagicMock()  # type: ignore[method-assign]
-        d._run_subprocess_or_fail = MagicMock(return_value=0)  # type: ignore[method-assign]
         d._read_phase_output = MagicMock(return_value=None)  # type: ignore[method-assign]
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
 
-        d._run_verify_and_complete(agent, pr_status, merge_sha, deploy_runs)
+        # #3658: call _finalize_verify directly; merged_at_set=False routes
+        # through handle_agent_failure (the desired "phase_output_missing" path).
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "verify",
+            "pid": 99999,
+            "worktree_path": worktree,
+            "started_at": 0.0,
+            "deadline_at": 99999.0,
+            "ctx": {
+                "pr_number": 77,
+                "issue_number": 1,
+                "merge_sha": "deadbeef",
+                "merged_at_set": False,
+            },
+        }
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+        d._finalize_verify(agent_id, worktree, 0)
 
         events = handler.events("phase_output_missing")
         assert events
@@ -442,6 +426,30 @@ class TestRetroFailurePreviews:
         )
         d._write_phase_input = MagicMock()  # type: ignore[method-assign]
         d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
+        d._read_phase_output = MagicMock(return_value=None)  # type: ignore[method-assign]
+
+    def _run_retro_finalize(
+        self,
+        d: daemon.DispatcherDaemon,
+        agent: dict[str, Any],
+        worktree: Path,
+        exit_code: int | None,
+    ) -> None:
+        """#3658: populate inflight registry and call _finalize_retro directly
+        (mirrors the reaper pattern used in test_daemon_phase3e.py)."""
+        agent_id = agent["agent_id"]
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "retro",
+            "pid": 99999,
+            "worktree_path": worktree,
+            "started_at": 0.0,
+            "deadline_at": 99999.0,
+            "ctx": {
+                "issue_number": agent.get("issue_number"),
+                "pr_number": agent.get("pr_number"),
+            },
+        }
+        d._finalize_retro(agent_id, worktree, exit_code)
 
     def test_nonzero_exit_logs_preview(self, monkeypatch: Any, tmp_path: Path) -> None:
         d, _conn, handler = _make_daemon(tmp_path)
@@ -450,11 +458,8 @@ class TestRetroFailurePreviews:
         _write_phase_log(worktree, "retro", "retro exit 1: bad haiku")
         self._prep(d, agent)
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            return 1, 2.0
-
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
-        d._run_retro_phase(agent)
+        # #3658: async path — call _finalize_retro directly with nonzero exit.
+        self._run_retro_finalize(d, agent, worktree, exit_code=1)
 
         events = handler.events("retro_nonzero_exit")
         assert events
@@ -468,14 +473,12 @@ class TestRetroFailurePreviews:
     ) -> None:
         d, _conn, handler = _make_daemon(tmp_path)
         agent = _succeeded_agent(tmp_path)
+        worktree = Path(agent["worktree_path"])
         # No phase log written.
         self._prep(d, agent)
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            return 1, 2.0
-
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
-        d._run_retro_phase(agent)
+        # #3658: async path — nonzero exit, no log file.
+        self._run_retro_finalize(d, agent, worktree, exit_code=1)
 
         events = handler.events("retro_nonzero_exit")
         assert events
@@ -491,11 +494,9 @@ class TestRetroFailurePreviews:
         )
         self._prep(d, agent)
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            raise subprocess.TimeoutExpired(cmd="claude", timeout=300)
-
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
-        d._run_retro_phase(agent)
+        # #3658: async path — exit_code=None means reaper killed the process
+        # (deadline exceeded), which maps to the retro_timeout event.
+        self._run_retro_finalize(d, agent, worktree, exit_code=None)
 
         events = handler.events("retro_timeout")
         assert events
@@ -507,24 +508,43 @@ class TestRetroFailurePreviews:
     def test_subprocess_error_logs_preview(
         self, monkeypatch: Any, tmp_path: Path
     ) -> None:
+        """#3658: retro_subprocess_error is replaced by phase_async_spawn_failed.
+
+        Pre-#3658, a FileNotFoundError during Popen was caught synchronously
+        inside _spawn_phase_subprocess and logged as ``retro_subprocess_error``.
+        Post-#3658, the same OS error is caught inside
+        _spawn_phase_subprocess_async and logged as ``phase_async_spawn_failed``
+        (phase="retro").  No stderr_preview is attached because the subprocess
+        never ran — there is no log to read.
+        """
         d, _conn, handler = _make_daemon(tmp_path)
         agent = _succeeded_agent(tmp_path)
         worktree = Path(agent["worktree_path"])
         _write_phase_log(worktree, "retro", "pre-spawn OS error log content")
         self._prep(d, agent)
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
+        # Patch subprocess.Popen so the actual _spawn_phase_subprocess_async
+        # raises FileNotFoundError (simulating "claude" binary missing).
+        import subprocess as _subprocess
+
+        _orig_popen = _subprocess.Popen
+
+        def _fake_popen(*args: Any, **kwargs: Any) -> None:
             raise FileNotFoundError("claude binary missing")
 
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
+        monkeypatch.setattr(_subprocess, "Popen", _fake_popen)
+
+        # Call _start_retro (fires async spawn) via _run_retro_phase.
         d._run_retro_phase(agent)
 
-        events = handler.events("retro_subprocess_error")
+        # The event is now phase_async_spawn_failed, not retro_subprocess_error.
+        events = handler.events("phase_async_spawn_failed")
         assert events
         record = events[0]
-        preview = getattr(record, "stderr_preview", None)
-        assert preview is not None
-        assert "pre-spawn" in preview
+        assert getattr(record, "phase", None) == "retro"
+        assert getattr(record, "reason", None) == "claude_binary_not_found"
+
+        monkeypatch.setattr(_subprocess, "Popen", _orig_popen)
 
     def test_output_missing_logs_preview(
         self, monkeypatch: Any, tmp_path: Path
@@ -535,12 +555,8 @@ class TestRetroFailurePreviews:
         _write_phase_log(worktree, "retro", "retro JSON write failed silently")
         self._prep(d, agent)
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            # Exit 0 but no output file written.
-            return 0, 1.0
-
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
-        d._run_retro_phase(agent)
+        # #3658: async path — exit 0 but no output file (read returns None via mock).
+        self._run_retro_finalize(d, agent, worktree, exit_code=0)
 
         events = handler.events("retro_output_missing")
         assert events
@@ -567,11 +583,8 @@ class TestRetroFailurePreviews:
         _write_phase_log(worktree, "retro", "Z" * 3000)
         self._prep(d, agent)
 
-        def fake_spawn(phase: str, wt: Path, agent_id: str) -> tuple[int, float]:
-            return 1, 1.0
-
-        monkeypatch.setattr(d, "_spawn_phase_subprocess", fake_spawn)
-        d._run_retro_phase(agent)
+        # #3658: async path — nonzero exit, log truncated to 2000 chars.
+        self._run_retro_finalize(d, agent, worktree, exit_code=1)
 
         events = handler.events("retro_nonzero_exit")
         assert events

--- a/scripts/dispatcher/tests/test_daemon_summary_deferred_acs.py
+++ b/scripts/dispatcher/tests/test_daemon_summary_deferred_acs.py
@@ -169,7 +169,11 @@ class TestSummaryDeferredAcsPersisted:
                     "summary": "…",
                     "changed_files": ["scripts/foo.py"],
                 },
-                "plan": {"acceptance_criteria": [], "scope_check": [], "collapsed_comments": []},
+                "plan": {
+                    "acceptance_criteria": [],
+                    "scope_check": [],
+                    "collapsed_comments": [],
+                },
             }.get(phase)
         )
         d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]
@@ -249,7 +253,11 @@ class TestSummaryDeferredAcsPersisted:
         d._fetch_phase_output = MagicMock(  # type: ignore[method-assign]
             side_effect=lambda agent_id, phase: {
                 "ralph": {"verdict": "SHIP", "summary": "", "changed_files": []},
-                "plan": {"acceptance_criteria": [], "scope_check": [], "collapsed_comments": []},
+                "plan": {
+                    "acceptance_criteria": [],
+                    "scope_check": [],
+                    "collapsed_comments": [],
+                },
             }.get(phase)
         )
         d._fetch_issue_bundle = MagicMock(  # type: ignore[method-assign]

--- a/scripts/dispatcher/tests/test_daemon_supervisor_async_phase.py
+++ b/scripts/dispatcher/tests/test_daemon_supervisor_async_phase.py
@@ -1,0 +1,761 @@
+"""Async phase subprocess spawn/reap (#3658).
+
+Move verify / fix-ci / retro phase subprocesses off MainThread so a
+slow 5+ minute verify cannot trip the 120s ``scheduler_tick_stalled_exiting``
+watchdog.
+
+Three test trios — one per phase (verify, fix-ci, retro):
+
+1. ``test_<phase>_subprocess_does_not_block_supervisor_tick`` — assert
+   that starting the phase does NOT block (no ``proc.wait()`` on MainThread),
+   the agent appears in ``_phase_subprocess_inflight``, and a
+   ``<phase>_started_async`` event is emitted.
+
+2. ``test_followup_tick_finalizes_completed_<phase>`` — register an
+   in-flight entry with a dead PID; assert the reaper finalizes it,
+   reads output, advances phase, and clears the inflight entry.
+
+3. ``test_<phase>_deadline_exceeded_does_not_kill_daemon`` — register
+   an in-flight entry with a deadline in the past and a "alive" PID;
+   assert the reaper kills the process group, routes the agent to the
+   failure / timeout handler, and supervisor_tick returns normally.
+
+These tests FAIL against the pre-#3658 code (which called
+``_run_subprocess_or_fail`` synchronously on MainThread).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+# Make ``scripts`` importable.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from dispatcher import daemon  # noqa: E402
+
+UTC = timezone.utc
+
+
+# ---------------------------------------------------------------------------
+# Minimal DB fakes — same pattern as test_daemon_verify_skip_ecs.py
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        pass
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConn, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.async_phase.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConn()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+        baseline_repo_root=tmp_path,
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+def _minimal_agent(
+    tmp_path: Path,
+    *,
+    agent_id: str = "agent-test-1",
+    phase: str = "awaiting_deploy",
+    status: str = "succeeded",
+    pr_number: int = 101,
+    issue_number: int = 999,
+    retries_used: int = 0,
+) -> dict[str, Any]:
+    return {
+        "agent_id": agent_id,
+        "issue_number": issue_number,
+        "phase": phase,
+        "pr_number": pr_number,
+        "worktree_path": str(tmp_path),
+        "retries_used": retries_used,
+        "status": status,
+        "execution_mode": "subprocess",
+        "merge_unstick_attempts": 0,
+    }
+
+
+def _write_verified_output(worktree: Path, *, verdict: str = "VERIFIED") -> None:
+    """Write a minimal verify phase_output.json so _finalize_verify can read it."""
+    output_dir = worktree / "tmp" / "dispatcher-output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "verify.json").write_text(
+        json.dumps({"verdict": verdict, "evidence_md": "All good."})
+    )
+
+
+def _write_fix_ci_output(worktree: Path, *, verdict: str = "FLAKY") -> None:
+    output_dir = worktree / "tmp" / "dispatcher-output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "fix-ci.json").write_text(
+        json.dumps({"verdict": verdict, "flaky_evidence": "flake"})
+    )
+
+
+def _write_retro_output(worktree: Path) -> None:
+    output_dir = worktree / "tmp" / "dispatcher-output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "retro.json").write_text(
+        json.dumps({"no_findings": True, "retro_issues": []})
+    )
+
+
+# ---------------------------------------------------------------------------
+# Verify trio
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyAsyncPhase:
+    """Verify subprocess is async: spawn/reap does not block MainThread."""
+
+    def test_verify_subprocess_does_not_block_supervisor_tick(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """AC1 + AC2: starting verify does NOT block; agent enters inflight."""
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        spawn_calls: list[dict] = []
+
+        def fake_spawn(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> int | None:
+            spawn_calls.append(
+                {
+                    "phase": phase,
+                    "agent_id": agent_id,
+                    "deadline_seconds": deadline_seconds,
+                }
+            )
+            # Register entry in inflight so _advance_running_agents skips next time.
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 99999,
+                "worktree_path": str(worktree),
+                "started_at": datetime.now(UTC),
+                "deadline_at": datetime.now(UTC) + timedelta(seconds=deadline_seconds),
+                "ctx": ctx or {},
+            }
+            return 99999
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn)
+
+        # Stub the short-circuit reads so _start_verify gets past them.
+        monkeypatch.setattr(d, "_read_verify_skip_reason", lambda _: None)
+        monkeypatch.setattr(
+            d, "_read_merged_at_and_verified_at", lambda _: (True, False)
+        )
+
+        # Minimal stubs for the input-bundle builder.
+        monkeypatch.setattr(d, "_fetch_issue_bundle", lambda n: {"issue_body": ""})
+        monkeypatch.setattr(d, "_fetch_phase_output", lambda *a, **kw: None)
+        monkeypatch.setattr(d, "_select_deploy_status", lambda runs: None)
+        monkeypatch.setattr(d, "_infer_change_type", lambda runs: "dx_tooling")
+        monkeypatch.setattr(d, "_touched_services_from_runs", lambda runs: [])
+        monkeypatch.setattr(d, "_write_phase_input", lambda *a, **kw: Path(tmp_path))
+
+        agent = _minimal_agent(tmp_path, phase="awaiting_deploy")
+
+        start = time.monotonic()
+        d._start_verify(
+            agent=agent,
+            pr_status={},
+            merge_sha="abc123",
+            deploy_runs=[],
+        )
+        elapsed = time.monotonic() - start
+
+        # Must return quickly — no proc.wait() on MainThread.
+        assert elapsed < 2.0, (
+            f"_start_verify must return within 2s (got {elapsed:.3f}s). "
+            "Regression guard for issue #3658 — pre-fix code called "
+            "_run_subprocess_or_fail which proc.wait()-ed synchronously."
+        )
+
+        # Agent must be registered as inflight.
+        assert agent["agent_id"] in d._phase_subprocess_inflight, (
+            "Agent must appear in _phase_subprocess_inflight after _start_verify"
+        )
+        assert d._phase_subprocess_inflight[agent["agent_id"]]["phase"] == "verify"
+
+        # Async event must be emitted.
+        started_events = handler.events("verify_started_async")
+        assert len(started_events) == 1, (
+            f"Expected exactly one verify_started_async event, got {len(started_events)}"
+        )
+
+    def test_followup_tick_finalizes_completed_verify(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """AC1: a subsequent tick's reaper finalizes a completed verify subprocess."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        agent_id = "agent-verify-done"
+
+        # Pre-populate inflight with a dead PID.
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "verify",
+            "pid": 11111,
+            "worktree_path": str(tmp_path),
+            "started_at": datetime.now(UTC) - timedelta(seconds=10),
+            "deadline_at": datetime.now(UTC) + timedelta(seconds=3000),
+            "ctx": {
+                "pr_number": 42,
+                "issue_number": 99,
+                "merge_sha": "deadbeef",
+                "merged_at_set": True,
+            },
+        }
+
+        # PID is gone (process completed).
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon, "_process_alive", staticmethod(lambda pid: False)
+        )
+
+        # Write output so _finalize_verify reads VERIFIED.
+        _write_verified_output(tmp_path, verdict="VERIFIED")
+
+        # Stub DB writes to avoid psycopg.
+        write_verified_calls: list[str] = []
+        monkeypatch.setattr(
+            d, "_write_verified_at", lambda aid: write_verified_calls.append(aid)
+        )
+        update_phase_calls: list[tuple] = []
+        monkeypatch.setattr(
+            d,
+            "_update_agent_phase",
+            lambda aid, phase: update_phase_calls.append((aid, phase)),
+        )
+        monkeypatch.setattr(d, "_persist_phase_output", lambda *a, **kw: None)
+        monkeypatch.setattr(d, "_post_evidence_comment", lambda *a, **kw: None)
+
+        # Run reaper.
+        reaped = d._reap_phase_subprocesses()
+
+        assert reaped == 1, f"Expected 1 reaped entry, got {reaped}"
+
+        # Inflight entry must be cleared.
+        assert agent_id not in d._phase_subprocess_inflight, (
+            "Inflight entry must be cleared after finalization"
+        )
+
+        # _write_verified_at must have been called.
+        assert agent_id in write_verified_calls, (
+            "_write_verified_at must be called on VERIFIED verdict"
+        )
+
+        # Phase must advance to 'done'.
+        assert any(
+            aid == agent_id and ph == "done" for aid, ph in update_phase_calls
+        ), f"Phase must advance to 'done'; got {update_phase_calls}"
+
+    def test_verify_deadline_exceeded_does_not_kill_daemon(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """AC3: deadline-exceeded reap kills process group and transitions to failure."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        agent_id = "agent-verify-timeout"
+
+        # Register entry with deadline in the past.
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "verify",
+            "pid": 22222,
+            "worktree_path": str(tmp_path),
+            "started_at": datetime.now(UTC) - timedelta(seconds=4000),
+            "deadline_at": datetime.now(UTC) - timedelta(seconds=100),  # in the past
+            "ctx": {
+                "pr_number": 55,
+                "issue_number": 88,
+                "merge_sha": "abc",
+                "merged_at_set": True,
+            },
+        }
+
+        # PID is still alive (deadline exceeded but process not done).
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon, "_process_alive", staticmethod(lambda pid: True)
+        )
+
+        kill_calls: list[int] = []
+        monkeypatch.setattr(
+            d, "_kill_phase_subprocess", lambda pid: kill_calls.append(pid)
+        )
+
+        restore_calls: list[str] = []
+        monkeypatch.setattr(
+            d,
+            "_restore_succeeded_and_advance_done",
+            lambda aid: restore_calls.append(aid),
+        )
+
+        # Run reaper — must not raise.
+        reaped = d._reap_phase_subprocesses()
+
+        assert reaped == 1, f"Expected 1 reaped entry, got {reaped}"
+
+        # Process must have been killed.
+        assert 22222 in kill_calls, (
+            "_kill_phase_subprocess must be called for a deadline-exceeded PID"
+        )
+
+        # Inflight cleared.
+        assert agent_id not in d._phase_subprocess_inflight
+
+        # Deadline-exceeded events emitted.
+        deadline_events = handler.events("phase_async_deadline_exceeded")
+        assert len(deadline_events) == 1
+        assert deadline_events[0].phase == "verify"
+
+
+# ---------------------------------------------------------------------------
+# Fix-CI trio
+# ---------------------------------------------------------------------------
+
+
+class TestFixCiAsyncPhase:
+    """Fix-CI subprocess is async: spawn/reap does not block MainThread."""
+
+    def test_fix_ci_subprocess_does_not_block_supervisor_tick(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Starting fix-ci does NOT block; agent enters inflight."""
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        spawn_calls: list[dict] = []
+
+        def fake_spawn(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> int | None:
+            spawn_calls.append({"phase": phase, "agent_id": agent_id})
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 88888,
+                "worktree_path": str(worktree),
+                "started_at": datetime.now(UTC),
+                "deadline_at": datetime.now(UTC) + timedelta(seconds=deadline_seconds),
+                "ctx": ctx or {},
+            }
+            return 88888
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn)
+
+        # Stub helpers that _start_fix_ci calls.
+        monkeypatch.setattr(d, "_extract_failing_jobs", lambda pr_status: [])
+        monkeypatch.setattr(d, "_fetch_pr_diff", lambda wt, pr: "")
+        monkeypatch.setattr(d, "_branch_for_agent", lambda aid: "feature/test")
+        monkeypatch.setattr(d, "_write_phase_input", lambda *a, **kw: Path(tmp_path))
+
+        agent = _minimal_agent(tmp_path, phase="awaiting_ci", status="running")
+
+        start = time.monotonic()
+        d._start_fix_ci(agent=agent, pr_status={})
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 2.0, (
+            f"_start_fix_ci must return within 2s (got {elapsed:.3f}s). "
+            "Regression guard for issue #3658."
+        )
+        assert agent["agent_id"] in d._phase_subprocess_inflight
+        assert d._phase_subprocess_inflight[agent["agent_id"]]["phase"] == "fix-ci"
+
+        started_events = handler.events("fix_ci_started_async")
+        assert len(started_events) == 1
+
+    def test_followup_tick_finalizes_completed_fix_ci(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Reaper finalizes a completed fix-ci subprocess."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        agent_id = "agent-fix-ci-done"
+        agent_dict = _minimal_agent(tmp_path, agent_id=agent_id, phase="awaiting_ci")
+
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "fix-ci",
+            "pid": 33333,
+            "worktree_path": str(tmp_path),
+            "started_at": datetime.now(UTC) - timedelta(seconds=60),
+            "deadline_at": datetime.now(UTC) + timedelta(seconds=18000),
+            "ctx": {
+                "agent": dict(agent_dict),
+                "pr_number": 77,
+                "issue_number": 11,
+                "retries_used": 0,
+            },
+        }
+
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon, "_process_alive", staticmethod(lambda pid: False)
+        )
+
+        # Write FLAKY output so the finalizer takes the no-op FLAKY path.
+        _write_fix_ci_output(tmp_path, verdict="FLAKY")
+
+        log_info_calls: list[str] = []
+        original_info = d._log.info
+        monkeypatch.setattr(
+            d._log,
+            "info",
+            lambda msg, **kw: (
+                log_info_calls.append(kw.get("extra", {}).get("event", ""))
+                or original_info(msg, **kw)
+            ),
+        )
+        monkeypatch.setattr(d, "_persist_phase_output", lambda *a, **kw: None)
+
+        reaped = d._reap_phase_subprocesses()
+
+        assert reaped == 1
+        assert agent_id not in d._phase_subprocess_inflight
+
+        flaky_events = handler.events("fix_ci_flaky")
+        assert len(flaky_events) == 1
+
+    def test_fix_ci_deadline_exceeded_does_not_kill_daemon(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Deadline-exceeded fix-ci reap kills PG and marks agent failed."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        agent_id = "agent-fix-ci-timeout"
+
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "fix-ci",
+            "pid": 44444,
+            "worktree_path": str(tmp_path),
+            "started_at": datetime.now(UTC) - timedelta(seconds=20000),
+            "deadline_at": datetime.now(UTC) - timedelta(seconds=200),
+            "ctx": {
+                "pr_number": 77,
+                "issue_number": 11,
+                "retries_used": 0,
+            },
+        }
+
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon, "_process_alive", staticmethod(lambda pid: True)
+        )
+        kill_calls: list[int] = []
+        monkeypatch.setattr(
+            d, "_kill_phase_subprocess", lambda pid: kill_calls.append(pid)
+        )
+        failure_calls: list[str] = []
+        monkeypatch.setattr(
+            d,
+            "_handle_agent_failure",
+            lambda *, agent_id, **kw: failure_calls.append(agent_id),
+        )
+
+        reaped = d._reap_phase_subprocesses()
+
+        assert reaped == 1
+        assert 44444 in kill_calls
+        assert agent_id not in d._phase_subprocess_inflight
+        assert any(aid == agent_id for aid in failure_calls)
+
+        deadline_events = handler.events("phase_async_deadline_exceeded")
+        assert len(deadline_events) == 1
+        assert deadline_events[0].phase == "fix-ci"
+
+
+# ---------------------------------------------------------------------------
+# Retro trio
+# ---------------------------------------------------------------------------
+
+
+class TestRetroAsyncPhase:
+    """Retro subprocess is async: spawn/reap does not block MainThread."""
+
+    def test_retro_subprocess_does_not_block_supervisor_tick(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Starting retro does NOT block; agent enters inflight."""
+        d, _conn, handler = _make_daemon(tmp_path)
+
+        spawn_calls: list[dict] = []
+
+        def fake_spawn(
+            phase: str,
+            worktree: Path,
+            agent_id: str,
+            deadline_seconds: float,
+            ctx: dict | None = None,
+        ) -> int | None:
+            spawn_calls.append({"phase": phase, "agent_id": agent_id})
+            d._phase_subprocess_inflight[agent_id] = {
+                "phase": phase,
+                "pid": 77777,
+                "worktree_path": str(worktree),
+                "started_at": datetime.now(UTC),
+                "deadline_at": datetime.now(UTC) + timedelta(seconds=deadline_seconds),
+                "ctx": ctx or {},
+            }
+            return 77777
+
+        monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn)
+        monkeypatch.setattr(d, "_build_retro_input", lambda agent: {})
+        monkeypatch.setattr(d, "_write_phase_input", lambda *a, **kw: Path(tmp_path))
+
+        agent = _minimal_agent(tmp_path, phase="done", status="succeeded")
+
+        start = time.monotonic()
+        d._start_retro(agent=agent)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 2.0, (
+            f"_start_retro must return within 2s (got {elapsed:.3f}s). "
+            "Regression guard for issue #3658."
+        )
+        assert agent["agent_id"] in d._phase_subprocess_inflight
+        assert d._phase_subprocess_inflight[agent["agent_id"]]["phase"] == "retro"
+
+        started_events = handler.events("retro_started_async")
+        assert len(started_events) == 1
+
+    def test_followup_tick_finalizes_completed_retro(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Reaper finalizes a completed retro subprocess."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        agent_id = "agent-retro-done"
+
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "retro",
+            "pid": 55555,
+            "worktree_path": str(tmp_path),
+            "started_at": datetime.now(UTC) - timedelta(seconds=120),
+            "deadline_at": datetime.now(UTC) + timedelta(seconds=3000),
+            "ctx": {"issue_number": 200, "pr_number": 201},
+        }
+
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon, "_process_alive", staticmethod(lambda pid: False)
+        )
+        _write_retro_output(tmp_path)
+
+        write_retroed_calls: list[str] = []
+        monkeypatch.setattr(
+            d, "_write_retroed_at", lambda aid: write_retroed_calls.append(aid)
+        )
+        update_phase_calls: list[tuple] = []
+        monkeypatch.setattr(
+            d,
+            "_update_agent_phase",
+            lambda aid, phase: update_phase_calls.append((aid, phase)),
+        )
+        monkeypatch.setattr(d, "_persist_phase_output", lambda *a, **kw: None)
+        monkeypatch.setattr(d, "_file_retro_issue", lambda *a, **kw: None)
+
+        reaped = d._reap_phase_subprocesses()
+
+        assert reaped == 1
+        assert agent_id not in d._phase_subprocess_inflight
+
+        # _write_retroed_at must have been called.
+        assert agent_id in write_retroed_calls, (
+            "_write_retroed_at must be called after successful retro"
+        )
+
+        # Phase must advance to retro_done.
+        assert any(
+            aid == agent_id and ph == daemon.PHASE_RETRO_DONE
+            for aid, ph in update_phase_calls
+        ), f"Phase must advance to PHASE_RETRO_DONE; got {update_phase_calls}"
+
+        done_events = handler.events("retro_done")
+        assert len(done_events) == 1
+
+    def test_retro_deadline_exceeded_does_not_kill_daemon(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Deadline-exceeded retro reap kills PG and advances to retro_failed."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        agent_id = "agent-retro-timeout"
+
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "retro",
+            "pid": 66666,
+            "worktree_path": str(tmp_path),
+            "started_at": datetime.now(UTC) - timedelta(seconds=5000),
+            "deadline_at": datetime.now(UTC) - timedelta(seconds=300),
+            "ctx": {"issue_number": 300, "pr_number": 301},
+        }
+
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon, "_process_alive", staticmethod(lambda pid: True)
+        )
+        kill_calls: list[int] = []
+        monkeypatch.setattr(
+            d, "_kill_phase_subprocess", lambda pid: kill_calls.append(pid)
+        )
+
+        update_phase_calls: list[tuple] = []
+        monkeypatch.setattr(
+            d,
+            "_update_agent_phase",
+            lambda aid, ph: update_phase_calls.append((aid, ph)),
+        )
+
+        reaped = d._reap_phase_subprocesses()
+
+        assert reaped == 1
+        assert 66666 in kill_calls
+        assert agent_id not in d._phase_subprocess_inflight
+
+        # Finalizer must advance phase to retro_failed (via timeout path).
+        assert any(
+            aid == agent_id and ph == daemon.PHASE_RETRO_FAILED
+            for aid, ph in update_phase_calls
+        ), (
+            f"Phase must advance to PHASE_RETRO_FAILED on timeout; got {update_phase_calls}"
+        )
+
+        deadline_events = handler.events("phase_async_deadline_exceeded")
+        assert len(deadline_events) == 1
+        assert deadline_events[0].phase == "retro"
+
+
+# ---------------------------------------------------------------------------
+# _advance_running_agents inflight skip
+# ---------------------------------------------------------------------------
+
+
+class TestAdvanceRunningAgentsSkipsInflight:
+    """_advance_running_agents must skip agents with an in-flight subprocess."""
+
+    def test_inflight_agent_not_re_entered(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """If an agent_id is in _phase_subprocess_inflight, the advance loop
+        must NOT call _start_verify / _run_retro_phase for it."""
+        d, _conn, handler = _make_daemon(tmp_path)
+        agent_id = "agent-inflight-skip"
+
+        # Pre-register as inflight.
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "verify",
+            "pid": 12345,
+            "worktree_path": str(tmp_path),
+            "started_at": datetime.now(UTC),
+            "deadline_at": datetime.now(UTC) + timedelta(seconds=3000),
+            "ctx": {},
+        }
+
+        # Make the agent appear advanceable as an awaiting_deploy row.
+        advanceable = [
+            {
+                "agent_id": agent_id,
+                "issue_number": 123,
+                "phase": "awaiting_deploy",
+                "pr_number": 42,
+                "worktree_path": str(tmp_path),
+                "retries_used": 0,
+                "status": "succeeded",
+                "merge_unstick_attempts": 0,
+                "execution_mode": "subprocess",
+            }
+        ]
+        monkeypatch.setattr(d, "_list_advanceable_agents", lambda: advanceable)
+
+        advance_deploy_calls: list[str] = []
+        monkeypatch.setattr(
+            d,
+            "_advance_awaiting_deploy",
+            lambda agent: advance_deploy_calls.append(agent["agent_id"]),
+        )
+
+        d._advance_running_agents()
+
+        # Inflight agent must NOT be passed to _advance_awaiting_deploy.
+        assert agent_id not in advance_deploy_calls, (
+            "_advance_awaiting_deploy must not be called for an inflight agent — "
+            "the reaper owns finalization. Regression guard for issue #3658."
+        )
+
+        # Event emitted for the skip.
+        skip_events = handler.events("advance_skipped_async_inflight")
+        assert len(skip_events) == 1

--- a/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
+++ b/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
@@ -426,11 +426,7 @@ class TestReapRoutesBypassedTerminals:
 
         # 1. Initial SELECT for active agent rows.
         cur.fetchall_queue = [
-            [
-                self._agent_row(
-                    agent_id, issue_number, arn, "ralph_not_ship", "failed"
-                )
-            ],
+            [self._agent_row(agent_id, issue_number, arn, "ralph_not_ship", "failed")],
         ]
         # 2. _read_agent_status_phase + _build_bypassed_terminal_details
         #    fetches: terminal phase_outputs row, then ralph phase_outputs row.
@@ -473,9 +469,9 @@ class TestReapRoutesBypassedTerminals:
         assert kwargs["phase"] == "ralph_not_ship"
         assert kwargs["issue_number"] == issue_number
         # block_reason carried through as stderr_tail for diagnoser §Step 1.
-        assert (
-            "prerequisite #2840" in kwargs["details"]["stderr_tail"]
-        ), f"block_reason not in stderr_tail: {kwargs['details'].get('stderr_tail')!r}"
+        assert "prerequisite #2840" in kwargs["details"]["stderr_tail"], (
+            f"block_reason not in stderr_tail: {kwargs['details'].get('stderr_tail')!r}"
+        )
         assert kwargs["details"]["terminal_phase"] == "ralph_not_ship"
 
         # ARN clear ran so the next reap tick excludes the row.


### PR DESCRIPTION
## Summary

Moved verify, fix-ci, and retro phase subprocess calls off MainThread using a fire-and-forget pattern (matching the existing diagnoser async model). Pre-#3658, any phase taking >2 minutes would trigger the 120s watchdog while the MainThread blocked on subprocess.wait(timeout=3h), killing the daemon. Post-#3658, phases spawn async and a reaper pass on each supervisor_tick reaps completions or kills deadline-exceeded processes without blocking.

Closes #3658

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)  
- [x] Tests pass: 1927 tests + 10 new async tests (all pass)
- [x] CI green

### Post-deploy verification

- [ ] Monitor for `scheduler_tick_stalled_exiting` events over next 7 days; should drop to 0 (or only fire for genuine MainThread CPU stalls, not subprocess waits). Check via CloudWatch Insights filter: `fields @timestamp, @message | filter @message like /scheduler_tick_stalled_exiting/ | stats count() by bin(5m)`
- [ ] Verification evidence posted on #3658 (see /task-v2-verify output)