### PR TITLE
fix(dx): replace GNU-only `head -n -1` with POSIX `sed` (#3648)

### DIFF
--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -4896,7 +4896,7 @@ awk '
     /^        fix_conflict\)$/ { in_arm=1; next }
     in_arm && /^        fix_ci\)/ { exit }
     in_arm { print }
-' "$ENTRYPOINT" | head -n -1 > "$t51_dispatch_body"
+' "$ENTRYPOINT" | sed '$d' > "$t51_dispatch_body"
 
 # Sanity: dispatch block was extracted.
 if grep -q "fix_conflict_handler_done" "$t51_dispatch_body"; then


### PR DESCRIPTION
## Summary

Replaced the macOS-incompatible GNU-only `head -n -1` command with the portable POSIX
`sed '$d'` equivalent in the entrypoint test suite. This unblocks local /task agent test
runs on macOS bash 3.2 and eliminates a DX paper-cut for developers working locally on
the test validation workflow.

Closes #3648

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [x] `bash scripts/tests/test_agent_runner_entrypoint.sh` on macOS reaches final `Results: N/N passed` line
- [x] `grep -rE 'head -n -[0-9]+'` scripts/tests/` returns no matches (verify clause satisfied)