### PR TITLE
test(api, web): add regression tests for diagnoser effectiveness panel null-field bug (#3653)

### DIFF
--- a/packages/api/tests/dispatcher-enrichment.unit.test.ts
+++ b/packages/api/tests/dispatcher-enrichment.unit.test.ts
@@ -1508,6 +1508,56 @@ describe('diagnoserRowToGraphQL', () => {
     // through so the DateTimeScalar.serialize function handles formatting.
     expect(out.day).toBe(isoDay);
   });
+
+  it('maps null recommended_action to (unknown) sentinel (#3626)', () => {
+    // Reproduces: recommendation={} in the DB → recommendation->>'action' = NULL
+    // in SQL → row.recommended_action = null.  Without the ?? '(unknown)' guard
+    // the GraphQL String! field would receive null, causing a non-null
+    // serialization error that drops the entire weeklyDiagnoserReport array.
+    const row: DiagnoserEffectivenessRow = {
+      recommended_action: null,
+      observed_outcome: 'failed',
+      count: '3',
+      day: '2026-04-22T00:00:00+00:00',
+    };
+    const out = diagnoserRowToGraphQL(row);
+    expect(out.recommendedAction).toBe('(unknown)');
+    expect(out.observedOutcome).toBe('failed');
+    expect(out.count).toBe(3);
+  });
+
+  it('maps null observed_outcome to (unknown) sentinel (#3653)', () => {
+    // Reproduces: outcome present but missing retry_outcome key
+    // (e.g. outcome={"final_status":"succeeded","resolved_at":"..."}) →
+    // outcome->>'retry_outcome' = NULL in SQL → row.observed_outcome = null.
+    // Without the ?? '(unknown)' guard the GraphQL String! field would receive
+    // null, causing a non-null serialization error that drops the entire
+    // weeklyDiagnoserReport array, rendering the panel empty (#3653).
+    const row: DiagnoserEffectivenessRow = {
+      recommended_action: 'retry',
+      observed_outcome: null,
+      count: '2',
+      day: '2026-04-21T00:00:00+00:00',
+    };
+    const out = diagnoserRowToGraphQL(row);
+    expect(out.observedOutcome).toBe('(unknown)');
+    expect(out.recommendedAction).toBe('retry');
+    expect(out.count).toBe(2);
+  });
+
+  it('maps both null recommended_action and null observed_outcome to (unknown) (#3653)', () => {
+    // Worst-case: neither action nor retry_outcome is present in the JSONB fields.
+    const row: DiagnoserEffectivenessRow = {
+      recommended_action: null,
+      observed_outcome: null,
+      count: '1',
+      day: '2026-04-20T00:00:00+00:00',
+    };
+    const out = diagnoserRowToGraphQL(row);
+    expect(out.recommendedAction).toBe('(unknown)');
+    expect(out.observedOutcome).toBe('(unknown)');
+    expect(out.count).toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/api/tests/dispatcher.integration.test.ts
+++ b/packages/api/tests/dispatcher.integration.test.ts
@@ -1207,4 +1207,120 @@ describe('weeklyDiagnoserReport — admin', () => {
     expect(body.errors![0].extensions?.code).toBe('NOT_FOUND');
     expect(body.data == null || body.data.weeklyDiagnoserReport == null).toBe(true);
   });
+
+  it('multi-day rollup with 5+ buckets returns full result set including null-outcome rows (#3653)', async () => {
+    // Regression test for the production scenario that triggered the empty-panel
+    // bug: multiple buckets spread across different calendar days, with a mix of
+    // null/non-null recommended_action values AND a row whose outcome JSONB has
+    // no retry_outcome key (observed_outcome = null in SQL) — both must be mapped
+    // to '(unknown)' without throwing a non-null GraphQL serialization error.
+    //
+    // Asserts: body.errors === undefined AND rows.length >= 5, mirroring the
+    // 7-bucket production shape the operator confirmed on 2026-04-27.
+
+    const agentId = await insertAgent({ issueNumber: 800005, status: 'failed', phase: 'ralph' });
+    const failureId = await insertFailure({
+      agentId,
+      category: 'subprocess_crash',
+      detectedBy: 'scheduler',
+    });
+
+    // Spread rows across 5 distinct calendar days within the 7-day window.
+    const day = (daysAgo: number): string =>
+      new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
+
+    // Bucket 1 — day 5: retry / succeeded
+    await insertDiagnosis({
+      agentId,
+      failureId,
+      recommendation: { action: 'retry' },
+      outcome: { retry_outcome: 'succeeded', final_status: 'succeeded', resolved_at: day(5) },
+      completedAt: day(5),
+    });
+
+    // Bucket 2 — day 4: retry / failed
+    await insertDiagnosis({
+      agentId,
+      failureId,
+      recommendation: { action: 'retry' },
+      outcome: { retry_outcome: 'failed', final_status: 'failed', resolved_at: day(4) },
+      completedAt: day(4),
+    });
+
+    // Bucket 3 — day 3: skip / failed
+    await insertDiagnosis({
+      agentId,
+      failureId,
+      recommendation: { action: 'skip' },
+      outcome: { retry_outcome: 'failed', final_status: 'failed', resolved_at: day(3) },
+      completedAt: day(3),
+    });
+
+    // Bucket 4 — day 2: null action (recommendation={}) / succeeded
+    // Tests that null recommended_action → '(unknown)' without a non-null error.
+    await insertDiagnosis({
+      agentId,
+      failureId,
+      recommendation: {},
+      outcome: { retry_outcome: 'succeeded', final_status: 'succeeded', resolved_at: day(2) },
+      completedAt: day(2),
+    });
+
+    // Bucket 5 — day 1: escalate / null observed_outcome
+    // Tests that outcome present but without retry_outcome key → null observed_outcome
+    // → '(unknown)' without a non-null GraphQL serialization error (#3653).
+    await insertDiagnosis({
+      agentId,
+      failureId,
+      recommendation: { action: 'escalate' },
+      outcome: { final_status: 'succeeded', resolved_at: day(1) }, // intentionally no retry_outcome
+      completedAt: day(1),
+    });
+
+    // Bucket 6 — day 1: escalate / succeeded (same day as bucket 5, different outcome)
+    await insertDiagnosis({
+      agentId,
+      failureId,
+      recommendation: { action: 'escalate' },
+      outcome: { retry_outcome: 'succeeded', final_status: 'succeeded', resolved_at: day(1) },
+      completedAt: day(1),
+    });
+
+    const body = await gql(QUERY, undefined, adminToken);
+
+    // No GraphQL errors — the null-action and null-outcome rows must NOT cause
+    // a non-null serialization error that would zero out the entire array.
+    expect(body.errors).toBeUndefined();
+
+    const rows = body.data?.weeklyDiagnoserReport as Array<{
+      recommendedAction: string;
+      observedOutcome: string;
+      count: number;
+      day: string;
+    }>;
+    expect(Array.isArray(rows)).toBe(true);
+
+    // At least 5 distinct (action × outcome × day) buckets must be returned —
+    // the production shape had 7.  Other describe blocks may add rows too, so
+    // use >= instead of ==.
+    expect(rows.length).toBeGreaterThanOrEqual(5);
+
+    // Null-action bucket must appear as '(unknown)'.
+    const nullActionBucket = rows.find(
+      (r) => r.recommendedAction === '(unknown)' && r.observedOutcome === 'succeeded',
+    );
+    expect(nullActionBucket).toBeDefined();
+
+    // Null-outcome bucket (bucket 5, no retry_outcome key) must appear as '(unknown)'.
+    const nullOutcomeBucket = rows.find(
+      (r) => r.recommendedAction === 'escalate' && r.observedOutcome === '(unknown)',
+    );
+    expect(nullOutcomeBucket).toBeDefined();
+
+    // day field must be a non-empty string for every row (DateTime scalar).
+    for (const r of rows) {
+      expect(typeof r.day).toBe('string');
+      expect(r.day.length).toBeGreaterThan(0);
+    }
+  });
 });

--- a/packages/web/src/app/(main)/admin/dispatcher/__tests__/DiagnoserEffectivenessPanel.test.tsx
+++ b/packages/web/src/app/(main)/admin/dispatcher/__tests__/DiagnoserEffectivenessPanel.test.tsx
@@ -102,6 +102,27 @@ describe('DiagnoserEffectivenessPanel', () => {
     expect(rows[0]).toHaveTextContent('3');
   });
 
+  it('renders (unknown) sentinel for null-outcome rows (#3653)', () => {
+    // Regression test: outcome JSONB present but lacking retry_outcome key →
+    // API maps observed_outcome to '(unknown)'.  The panel must render the
+    // '(unknown)' badge without crashing or showing empty state.
+    mockQueryResult = {
+      data: {
+        weeklyDiagnoserReport: [
+          makeRow({ recommendedAction: 'escalate', observedOutcome: '(unknown)', count: 2 }),
+        ],
+      },
+      loading: false,
+      error: undefined,
+    };
+    render(<DiagnoserEffectivenessPanel />);
+    const rows = screen.getAllByTestId('diagnoser-effectiveness-row');
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent('escalate');
+    expect(rows[0]).toHaveTextContent('(unknown)');
+    expect(rows[0]).toHaveTextContent('2');
+  });
+
   it('renders skeleton placeholders while loading with no data yet', () => {
     mockQueryResult = {
       data: undefined,


### PR DESCRIPTION
## Summary

Added regression tests for diagnoser effectiveness panel bug (#3653). Root cause: null values in `recommendation.action` or `outcome.retry_outcome` JSONB fields caused GraphQL non-null serialization errors that silently dropped the entire `weeklyDiagnoserReport` array. The source code fix (using `?? '(unknown)'` sentinel) was already shipped in #3626. This PR adds test coverage to prevent future silent failures.

Closes #3653

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] Cockpit panel displays 5+ diagnoser effectiveness rows
- [ ] No empty-state message when data exists
- [ ] Verification evidence posted on #3653 (see /task-v2-verify output)