### PR TITLE
ci: detect silent-drop on rebase for appended-list files (#3670)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -692,6 +692,28 @@ if [ -n "$changed_scripts_py" ]; then
 fi
 
 # -------------------------------------------------------------------
+# Rebase silent-drop guard — run whenever an appended-list file changes
+# -------------------------------------------------------------------
+# Detects markers in WATCH_FILES that would be silently dropped by
+# git merge-tree (i.e. a rebase onto origin/main would lose test
+# blocks without producing a conflict). See issue #3670.
+changed_watch_files=$(echo "$changed_files" | grep -F 'scripts/tests/test_agent_runner_entrypoint.sh' || true)
+if [ -n "$changed_watch_files" ]; then
+    echo "pre-push: checking for silent marker drops in appended-list files..." >&2
+    if [ -x scripts/check-rebase-no-silent-drop.sh ]; then
+        if ! run_check "_" "scripts/check-rebase-no-silent-drop.sh" scripts/check-rebase-no-silent-drop.sh; then
+            echo "  A rebase onto origin/main would silently drop a test marker." >&2
+            echo "  Rebase interactively and ensure all markers survive, or add" >&2
+            echo "  a sentinel line between blocks so git can distinguish them." >&2
+            echo "  See docs/agent/code-standards.md §Silent-drop guard." >&2
+            failures=$((failures + 1))
+        fi
+    else
+        echo "  WARNING: scripts/check-rebase-no-silent-drop.sh not found or not executable — skipping" >&2
+    fi
+fi
+
+# -------------------------------------------------------------------
 # PR existence check (advisory — runs before push completes)
 # -------------------------------------------------------------------
 # Git has no native post-push hook. We check here as the closest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,6 +606,8 @@ jobs:
       PYTHONPATH: scripts
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
@@ -646,6 +648,15 @@ jobs:
       - name: Check test files do not redefine the same stub binary
         if: matrix.shard == 'python'
         run: scripts/check-no-duplicate-stubs.sh
+      # Issue #3670: detect markers in appended-list files (e.g.
+      # test_agent_runner_entrypoint.sh) that would be silently dropped
+      # by git merge-tree when rebasing onto origin/main — i.e. a merge
+      # that produces no conflict markers but loses a test block.
+      # fetch-depth: 0 (set on this job's checkout) ensures origin/main
+      # is reachable. The check exits 0 gracefully on shallow clones.
+      - name: Check rebase does not silently drop appended-list markers
+        if: matrix.shard == 'python'
+        run: scripts/check-rebase-no-silent-drop.sh
       # Cross-checks every non-stdlib import under scripts/dispatcher/ against
       # the pip install step in Dockerfile.dispatcher. Motivated by the #2773
       # boto3 scope miss (#2776): PR #2771 added `import boto3` but did not

--- a/docs/agent/code-standards.md
+++ b/docs/agent/code-standards.md
@@ -159,6 +159,21 @@ Each test block in `scripts/tests/test_agent_runner_entrypoint.sh` carries a uni
 
 **Why issue numbers?** GitHub issue numbers are globally unique within the repository. Two agents working on different issues N1 ≠ N2 always produce non-overlapping `T_issue<N1>` and `T_issue<N2>` markers, so parallel PRs that both add tests can never collide on a marker name.
 
+#### Silent-drop guard
+
+Even with unique issue-number markers, a 3-way git merge can silently discard one side's appended test block if both branches add lines at the same end-of-file region and the merge heuristics pick only one side. The **silent-drop guard** (`scripts/check-rebase-no-silent-drop.sh`) detects this at pre-push and in CI before a PR is merged.
+
+**How it works:** the script calls `git merge-tree --write-tree origin/main HEAD` to compute an in-memory 3-way merge without touching the working tree. For each watched file, it collects all `MARKER_PATTERN` lines present in HEAD or `origin/main` and verifies that each one survives into the merged tree. If any marker is absent from the merged result **and** the merged file contains no `<<<<<<<` conflict markers (which would make the conflict user-visible), the script exits 1 with a diagnostic naming the dropped marker(s).
+
+**Configuration:**
+
+- `WATCH_FILES` — hardcoded list of 'appended-list' files to check. Initial entry: `scripts/tests/test_agent_runner_entrypoint.sh`. Add new files here when a new appended-list file is identified.
+- `MARKER_PATTERN` — ERE passed to `grep -E`. Default: `^# Test T(_issue)?[0-9]+`. Override via environment variable if a different file uses a different marker scheme.
+
+**Wiring:** the guard runs in the pre-push hook whenever `scripts/tests/test_agent_runner_entrypoint.sh` is in the pushed diff. It also runs as an explicit CI step (`Check rebase does not silently drop appended-list markers`) in the `scripts-tests` job (python shard). The CI checkout uses `fetch-depth: 0` so `origin/main` is always reachable. On shallow clones (or repos with no `origin/main`), the guard exits 0 gracefully.
+
+**Fix when the guard fires:** rebase interactively (`git rebase -i origin/main`) and ensure both sides' marker blocks appear in the final result. If the merge heuristics keep collapsing them, add a unique sentinel comment line (e.g. `# --- T_issue<N> end ---`) after each block to give git distinct context to anchor the merge hunks.
+
 ### Coverage gates (enforced in CI)
 
 - **Diff coverage:** new/changed lines must have >= 90% test coverage. CI runs `diff-cover` against `coverage.xml` (Python) or `lcov.info` (TypeScript).

--- a/scripts/check-rebase-no-silent-drop.sh
+++ b/scripts/check-rebase-no-silent-drop.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# check-rebase-no-silent-drop.sh — Detect silent marker drops in a
+# git merge-tree of HEAD against origin/main for watched files.
+#
+# 'Appended-list' files (e.g. scripts/tests/test_agent_runner_entrypoint.sh)
+# are extended by multiple parallel agents. When two branches both append
+# markers near the end of the file, git merge-tree can silently drop one
+# side's additions without emitting a conflict marker. This check detects
+# that case so the problem surfaces as a CI failure rather than as a
+# missing test.
+#
+# Strategy (Option A): use `git merge-tree --write-tree origin/main HEAD`
+# to compute an in-memory 3-way merge. For each watched file, compare the
+# set of unique markers in HEAD, origin/main, and the merged tree. Any
+# marker present in HEAD or origin/main but absent in the merged result —
+# without a `<<<<<<<` conflict marker in the merged file — is a silent drop.
+#
+# Usage:
+#   scripts/check-rebase-no-silent-drop.sh
+#
+# Exit codes:
+#   0 — No silent drops detected (or origin/main is unreachable — skipped).
+#   1 — One or more markers would be silently dropped by rebase.
+
+# venv: none
+# permanent: true
+
+set -euo pipefail
+
+# REPO_ROOT can be overridden via environment variable for testing.
+: "${REPO_ROOT:=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+# ─── Files to watch for silent drops ─────────────────────────────────────────
+# Add entries here when a new 'appended-list' file is identified.
+WATCH_FILES=(
+    "scripts/tests/test_agent_runner_entrypoint.sh"
+)
+
+# ─── Marker pattern (ERE, passed to grep -E) ─────────────────────────────────
+MARKER_PATTERN="^# Test T(_issue)?[0-9]+"
+
+# ─── Check that origin/main is reachable ─────────────────────────────────────
+if ! git -C "$REPO_ROOT" rev-parse --verify origin/main >/dev/null 2>&1; then
+    echo "check-rebase-no-silent-drop: origin/main is unreachable (shallow clone or no remote) — skipping."
+    exit 0
+fi
+
+# ─── Compute the merged tree ─────────────────────────────────────────────────
+# git merge-tree --write-tree prints the tree SHA as the first line on stdout,
+# optionally followed by conflict information on subsequent lines.
+# It exits 0 for a clean merge and 1 when conflicts are present — we capture
+# just the first line (the SHA) unconditionally.
+merge_tree_output=$(git -C "$REPO_ROOT" merge-tree --write-tree origin/main HEAD 2>/dev/null || true)
+merged_tree=$(printf '%s\n' "$merge_tree_output" | head -n 1)
+
+if [ -z "$merged_tree" ]; then
+    echo "check-rebase-no-silent-drop: could not compute merge-tree — skipping."
+    exit 0
+fi
+
+violations=0
+
+# ─── Check each watched file ─────────────────────────────────────────────────
+for rel_file in "${WATCH_FILES[@]}"; do
+    # Collect markers from HEAD
+    head_markers=$(git -C "$REPO_ROOT" show "HEAD:$rel_file" 2>/dev/null \
+        | grep -E "$MARKER_PATTERN" | sort -u || true)
+
+    # Collect markers from origin/main
+    main_markers=$(git -C "$REPO_ROOT" show "origin/main:$rel_file" 2>/dev/null \
+        | grep -E "$MARKER_PATTERN" | sort -u || true)
+
+    # Collect markers from the merged tree
+    merged_content=$(git -C "$REPO_ROOT" show "${merged_tree}:${rel_file}" 2>/dev/null || true)
+    merged_markers=$(printf '%s' "$merged_content" | grep -E "$MARKER_PATTERN" | sort -u || true)
+
+    # Check for conflict markers in the merged file
+    if printf '%s' "$merged_content" | grep -q '^<<<<<<<'; then
+        # Conflict is visible — rebase will halt with a conflict; not a silent drop.
+        continue
+    fi
+
+    # Union of markers from HEAD and origin/main
+    all_expected=$(printf '%s\n%s\n' "$head_markers" "$main_markers" \
+        | grep -v '^$' | sort -u || true)
+
+    if [ -z "$all_expected" ]; then
+        # No markers in either side — nothing to check.
+        continue
+    fi
+
+    # Find any marker that is expected but absent from the merged result
+    while IFS= read -r marker; do
+        [ -z "$marker" ] && continue
+        if ! printf '%s\n' "$merged_markers" | grep -qxF "$marker"; then
+            if [ $violations -eq 0 ]; then
+                echo "ERROR: git merge-tree would silently drop marker(s) when rebasing HEAD onto origin/main."
+                echo ""
+                echo "  This means a rebase of your branch onto main would lose test blocks"
+                echo "  or other appended-list entries without producing a conflict. The"
+                echo "  missing markers must be preserved."
+                echo ""
+                echo "  Fix: rebase interactively and ensure both sides' markers survive,"
+                echo "  or restructure the conflicting appended-list file so git can"
+                echo "  distinguish the two sets of additions."
+                echo ""
+            fi
+            echo "    File:           $rel_file"
+            echo "    Dropped marker: $marker"
+            echo ""
+            violations=$(( violations + 1 ))
+        fi
+    done < <(printf '%s\n' "$all_expected")
+done
+
+if [ $violations -gt 0 ]; then
+    echo "  Found $violations silently-dropped marker(s)."
+    echo ""
+    exit 1
+fi
+
+echo "All clean — no silent marker drops detected."
+exit 0

--- a/scripts/tests/test_check_rebase_no_silent_drop.sh
+++ b/scripts/tests/test_check_rebase_no_silent_drop.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# test_check_rebase_no_silent_drop.sh — Tests for check-rebase-no-silent-drop.sh.
+#
+# Creates isolated git fixture repositories to verify that the checker
+# correctly detects silent marker drops while passing when:
+#   - Both sides' markers survive the merge
+#   - git merge-tree emits conflict markers (visible conflict, not silent)
+#   - origin/main is unreachable (shallow clone / no remote)
+#
+# Usage:
+#   scripts/tests/test_check_rebase_no_silent_drop.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_SCRIPT="$SCRIPT_DIR/check-rebase-no-silent-drop.sh"
+FAILURES=0
+TESTS=0
+
+# Use a temp directory for fixture repos.
+TMPDIR_TEST=$(mktemp -d)
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+}
+trap cleanup EXIT
+
+# ─── Helpers ─────────────────────────────────────────────────────────────────
+
+# assert_fails <desc> <repo_dir>
+assert_fails() {
+    local desc="$1"
+    local repo_dir="$2"
+    TESTS=$((TESTS + 1))
+    if REPO_ROOT="$repo_dir" "$CHECK_SCRIPT" > /dev/null 2>&1; then
+        echo "FAIL: $desc (expected failure, got success)"
+        REPO_ROOT="$repo_dir" "$CHECK_SCRIPT" 2>&1 | sed 's/^/    /' || true
+        FAILURES=$((FAILURES + 1))
+    else
+        echo "PASS: $desc"
+    fi
+}
+
+# assert_passes <desc> <repo_dir>
+assert_passes() {
+    local desc="$1"
+    local repo_dir="$2"
+    TESTS=$((TESTS + 1))
+    if REPO_ROOT="$repo_dir" "$CHECK_SCRIPT" > /dev/null 2>&1; then
+        echo "PASS: $desc"
+    else
+        echo "FAIL: $desc (expected success, got failure)"
+        echo "  Output:"
+        REPO_ROOT="$repo_dir" "$CHECK_SCRIPT" 2>&1 | sed 's/^/    /' || true
+        FAILURES=$((FAILURES + 1))
+    fi
+}
+
+# init_repo <dir>
+# Initialises a bare-minimum git repo with git identity.
+init_repo() {
+    local dir="$1"
+    mkdir -p "$dir"
+    git -C "$dir" init -q
+    git -C "$dir" config user.email "test@example.com"
+    git -C "$dir" config user.name "Test"
+    git -C "$dir" checkout -q -b main 2>/dev/null || true
+}
+
+# commit_file <dir> <relative-path> <content> <message>
+commit_file() {
+    local dir="$1"
+    local rel="$2"
+    local content="$3"
+    local msg="$4"
+    local abs_path="$dir/$rel"
+    mkdir -p "$(dirname "$abs_path")"
+    printf '%s\n' "$content" > "$abs_path"
+    git -C "$dir" add "$rel"
+    git -C "$dir" commit -q -m "$msg"
+}
+
+# ─── Test 1: Silent drop detected → script exits 1 ───────────────────────────
+# origin/main has "# Test T_issue9001" in the watched file.
+# HEAD replaces that marker line with "# Test T_issue9002" (same file position).
+# git merge-tree: base=T_issue9001, main unchanged=T_issue9001, HEAD=T_issue9002.
+# merge-tree accepts HEAD's change (only HEAD changed this line): result has T_issue9002.
+# No conflict markers, T_issue9001 is silently absent → violation detected.
+{
+    fix1="$TMPDIR_TEST/fix1"
+    bare1="$TMPDIR_TEST/bare1.git"
+    init_repo "$fix1"
+
+    # base (= what will become origin/main): file has T_issue9001
+    commit_file "$fix1" "scripts/tests/test_agent_runner_entrypoint.sh" \
+        "# preamble
+# Test T_issue9001: marker from base" \
+        "base: add T_issue9001"
+
+    git init -q --bare "$bare1"
+    git -C "$fix1" remote add origin "$bare1"
+    git -C "$fix1" push -q origin main
+
+    # HEAD branch replaces T_issue9001 with T_issue9002
+    git -C "$fix1" checkout -q -b topic
+    printf '%s\n' "# preamble
+# Test T_issue9002: marker from topic" > "$fix1/scripts/tests/test_agent_runner_entrypoint.sh"
+    git -C "$fix1" add "scripts/tests/test_agent_runner_entrypoint.sh"
+    git -C "$fix1" commit -q -m "topic: replace T_issue9001 with T_issue9002"
+
+    # merge-tree: only HEAD changed the line → result has T_issue9002, not T_issue9001.
+    # origin/main has T_issue9001, merged lacks it → silent drop → exits 1.
+    assert_fails "Silent drop detected: T_issue9001 in origin/main but absent from merge-tree result" "$fix1"
+}
+
+# ─── Test 2: Both markers preserved → script exits 0 ─────────────────────────
+# origin/main appends T_issue9003 on a new line (relative to base).
+# HEAD branches from base and appends T_issue9004 on a different new line.
+# git merge-tree can combine both additions without conflict → both present.
+{
+    fix2="$TMPDIR_TEST/fix2"
+    bare2="$TMPDIR_TEST/bare2.git"
+    init_repo "$fix2"
+
+    # base: file is empty (no markers yet)
+    commit_file "$fix2" "scripts/tests/test_agent_runner_entrypoint.sh" \
+        "# preamble" \
+        "base"
+
+    # origin/main: appends T_issue9003
+    printf '%s\n' "# preamble
+# Test T_issue9003: marker from main" > "$fix2/scripts/tests/test_agent_runner_entrypoint.sh"
+    git -C "$fix2" add "scripts/tests/test_agent_runner_entrypoint.sh"
+    git -C "$fix2" commit -q -m "main: add T_issue9003"
+
+    git init -q --bare "$bare2"
+    git -C "$fix2" remote add origin "$bare2"
+    git -C "$fix2" push -q origin main
+
+    # HEAD branches from base and appends T_issue9004
+    base_sha2=$(git -C "$fix2" rev-list --max-parents=0 HEAD)
+    git -C "$fix2" checkout -q -b topic "$base_sha2"
+    printf '%s\n' "# preamble
+# Test T_issue9004: marker from topic" > "$fix2/scripts/tests/test_agent_runner_entrypoint.sh"
+    git -C "$fix2" add "scripts/tests/test_agent_runner_entrypoint.sh"
+    git -C "$fix2" commit -q -m "topic: add T_issue9004"
+
+    # Both sides added new marker lines (different content, same position).
+    # git merge-tree will combine them (or conflict, which also passes).
+    assert_passes "Both markers preserved: T_issue9003 and T_issue9004 both in merge-tree result" "$fix2"
+}
+
+# ─── Test 3: merge-tree emits conflict markers → script exits 0 ───────────────
+# Both sides modify the same line to different incompatible content.
+# git merge-tree emits <<<<<<<; check exits 0 (visible conflict, not silent drop).
+{
+    fix3="$TMPDIR_TEST/fix3"
+    bare3="$TMPDIR_TEST/bare3.git"
+    init_repo "$fix3"
+
+    commit_file "$fix3" "scripts/tests/test_agent_runner_entrypoint.sh" \
+        "# preamble
+# shared line" \
+        "base"
+
+    # origin/main: changes shared line to T_issue9005
+    printf '%s\n' "# preamble
+# Test T_issue9005: main version" > "$fix3/scripts/tests/test_agent_runner_entrypoint.sh"
+    git -C "$fix3" add "scripts/tests/test_agent_runner_entrypoint.sh"
+    git -C "$fix3" commit -q -m "main: change to T_issue9005"
+
+    git init -q --bare "$bare3"
+    git -C "$fix3" remote add origin "$bare3"
+    git -C "$fix3" push -q origin main
+
+    # HEAD branches from base and changes the SAME shared line to T_issue9006
+    base_sha3=$(git -C "$fix3" rev-list --max-parents=0 HEAD)
+    git -C "$fix3" checkout -q -b topic "$base_sha3"
+    printf '%s\n' "# preamble
+# Test T_issue9006: topic version" > "$fix3/scripts/tests/test_agent_runner_entrypoint.sh"
+    git -C "$fix3" add "scripts/tests/test_agent_runner_entrypoint.sh"
+    git -C "$fix3" commit -q -m "topic: change to T_issue9006"
+
+    # Both sides changed the same line → merge-tree emits <<<<<<< conflict markers.
+    # The check detects conflict markers and exits 0 (user-visible conflict).
+    assert_passes "Conflict markers present: check exits 0 (visible conflict, not silent drop)" "$fix3"
+}
+
+# ─── Test 4: origin/main unreachable → script exits 0 ────────────────────────
+# Repo has no origin remote — simulates shallow clone or fresh local repo.
+# The check should detect the missing origin/main and exit 0 gracefully.
+{
+    fix4="$TMPDIR_TEST/fix4"
+    init_repo "$fix4"
+
+    commit_file "$fix4" "scripts/tests/test_agent_runner_entrypoint.sh" \
+        "# preamble
+# Test T_issue9007: some marker" \
+        "base"
+
+    # No origin remote — origin/main is unreachable.
+    assert_passes "origin/main unreachable: check skips gracefully and exits 0" "$fix4"
+}
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

This PR implements Option A: a `git merge-tree` based guard (`scripts/check-rebase-no-silent-drop.sh`) that detects when test markers in appended-list files are silently dropped during a rebase without emitting conflict markers. The check is wired into the pre-push hook and CI pipeline, with a 4-case regression test suite validating correct behavior across different merge scenarios.

Closes #3670

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass: `scripts/tests/test_check_rebase_no_silent_drop.sh` (4 test cases all pass)
- [x] CI green

### Manual verification

- Silent-drop guard triggers on pre-push when `scripts/tests/test_agent_runner_entrypoint.sh` is in the diff
- Guard exits 0 when origin/main is unreachable (shallow clones, no remote)
- Guard detects the scenario from #3656 (both branches appending to same end-of-file region)
- Guard passes when both sides' markers survive the merge or when git emits a visible conflict marker

### Post-deploy verification

- [x] N/A — no deployed component (CI, pre-push hook, agent docs)