### PR TITLE
feat(scraping): add cc_dept_judges.py snapshot scraper (#3692)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,7 @@ jobs:
           - shard: 1
             test-paths: >-
               tests/courts/test_cc_tentatives.py
+              tests/courts/test_cc_dept_judges.py
               tests/courts/test_fresno_tentatives.py
               tests/courts/test_oc_tentatives.py
               tests/courts/test_oc_family_law_tentatives.py

--- a/packages/scraper-framework/src/courts/ca/cc_dept_judges.py
+++ b/packages/scraper-framework/src/courts/ca/cc_dept_judges.py
@@ -1,0 +1,362 @@
+"""Contra Costa County Superior Court -- Department-to-Judge Mapping.
+
+Scrapes department-to-judge mappings from the Contra Costa tentative rulings
+index page:
+    https://retired.cc-courts.org/civil/motions-hearings-tentative.aspx
+
+Each ``<div class='tr-dir'>`` block on the page contains a ``<span>`` header
+with the format::
+
+    Department NN - Judge Name
+    Department NN - Judge Name (Probate)
+    Department NN - Comm Name
+
+The mapping is extracted from these headers, with a URL-path fallback for any
+block whose span text is absent or unparseable (reusing the
+``_URL_DEPT_JUDGE_RE`` pattern already established in ``cc_tentatives.py``).
+
+Source selection rationale
+--------------------------
+A prior investigation (docs/investigations/judge-roster-sources.md, lines
+205-213) concluded that Contra Costa has **no dedicated judicial-officer
+roster page** (the candidate URLs cc-courts.org/general-info/judicial-
+officers.aspx and similar were checked and rejected). The only reliable
+public source of dept-to-judge mapping is this same tentative-rulings index
+page, consistent with ``SantaClaraCourtDirectory`` in ``sc_tentatives.py``.
+
+This module provides:
+    - ``parse_index_page_html()`` -- extract DepartmentJudge records from the
+      index-page HTML.
+    - ``build_department_judge_map()`` -- build a dept->judge lookup.
+    - ``lookup_judge_for_department()`` -- look up a judge by department.
+    - ``_fetch_and_parse_directory()`` -- HTTP GET + parse (shared helper).
+    - ``fetch_department_judge_mapping()`` -- convenience wrapper.
+    - ``ContraCostaCourtDirectory`` -- CourtDirectory subclass with S3
+      archival and DB snapshotting.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import httpx
+import structlog
+from bs4 import BeautifulSoup
+
+from framework.court_directory import CourtDirectory
+
+from .la_dept_judges import normalize_department
+
+if TYPE_CHECKING:
+    import psycopg
+
+logger = structlog.get_logger(__name__)
+
+INDEX_URL = "https://retired.cc-courts.org/civil/motions-hearings-tentative.aspx"
+
+# Regex for the <span> header inside a tr-dir block.
+# Matches: "Department NN - Judge Name", "Department NN - Comm Name",
+#          "Department NN - Judge Name (Probate)", etc.
+# Group "department" captures the zero-padded number.
+# Group "name_raw" captures everything after the dash separator.
+_HEADER_RE = re.compile(
+    r"Department\s+(?P<department>\d+)\s*-\s*(?P<name_raw>.+)",
+    re.IGNORECASE,
+)
+
+# Prefixes to strip from the name portion when "Judge" or "Comm" appears.
+# e.g. "Judge Reyes" -> "Reyes", "Comm Yamamoto" -> "Yamamoto"
+_NAME_PREFIX_RE = re.compile(
+    r"^(?:Judge|Comm(?:issioner)?)\s+",
+    re.IGNORECASE,
+)
+
+# Suffixes to strip from judge names (case-insensitive).
+_PROBATE_SUFFIX_RE = re.compile(r"\s*\(Probate\)\s*$", re.IGNORECASE)
+
+# URL-path fallback: "Department 16 - Judge Reyes" inside an href attribute.
+# Reused from cc_tentatives.py (same source page).
+_URL_DEPT_JUDGE_RE = re.compile(
+    r"Department\s+(?P<department>\d+)\s*-\s*Judge\s+(?P<judge_name>[^/\\]+)",
+    re.IGNORECASE,
+)
+
+
+@dataclass
+class DepartmentJudge:
+    """A department-to-judge entry extracted from the CC index page."""
+
+    department: str
+    judge_name: str
+
+
+def _clean_name(raw_name: str) -> str:
+    """Strip title prefix and Probate suffix from a raw name string.
+
+    Examples::
+
+        "Judge Reyes"           -> "Reyes"
+        "Comm Yamamoto"         -> "Yamamoto"
+        "Judge George (Probate)"-> "George"
+        "Leonard Marquez"       -> "Leonard Marquez"
+
+    Args:
+        raw_name: The text after "Department NN - " in the header.
+
+    Returns:
+        The cleaned judge/commissioner name, or empty string if blank.
+    """
+    name = raw_name.strip()
+    # Strip "(Probate)" or similar suffixes
+    name = _PROBATE_SUFFIX_RE.sub("", name).strip()
+    # Strip "Judge " / "Comm " / "Commissioner " prefix
+    name = _NAME_PREFIX_RE.sub("", name).strip()
+    # Normalize internal whitespace (e.g. double spaces)
+    name = " ".join(name.split())
+    return name
+
+
+def parse_index_page_html(html: str) -> list[DepartmentJudge]:
+    """Parse the CC tentative rulings index page for dept-to-judge mappings.
+
+    Iterates over ``<div class='tr-dir'>`` blocks. For each block:
+
+    1. Reads the header ``<span>`` text and applies ``_HEADER_RE``.
+    2. If the header is absent or unparseable, falls back to matching
+       ``_URL_DEPT_JUDGE_RE`` against the ``href`` of the first
+       ``<a class='tentative-ruling'>`` link in the block.
+
+    Blocks that yield no department/judge pair are silently skipped.
+
+    Args:
+        html: The raw HTML of the index page.
+
+    Returns:
+        A list of DepartmentJudge records (one per unique, parseable block).
+    """
+    soup = BeautifulSoup(html, "lxml")
+    entries: list[DepartmentJudge] = []
+    seen: set[str] = set()
+
+    for div in soup.find_all("div", class_="tr-dir"):
+        department: str | None = None
+        judge_name: str | None = None
+
+        # --- Primary path: parse the bold <span> header ---
+        span = div.find("span", style=lambda s: s and "font-weight:bold" in s)
+        if span:
+            header_text = span.get_text(separator=" ", strip=True)
+            m = _HEADER_RE.match(header_text)
+            if m:
+                department = m.group("department")
+                judge_name = _clean_name(m.group("name_raw"))
+
+        # --- Fallback path: extract from the first .tentative-ruling href ---
+        if not department or not judge_name:
+            link = div.find("a", class_="tentative-ruling")
+            if link:
+                href = link.get("href", "")
+                # Normalize Windows backslashes
+                href_norm = href.replace("\\", "/")
+                fm = _URL_DEPT_JUDGE_RE.search(href_norm)
+                if fm:
+                    department = fm.group("department")
+                    raw = fm.group("judge_name").strip()
+                    judge_name = _PROBATE_SUFFIX_RE.sub("", raw).strip()
+                    judge_name = " ".join(judge_name.split())
+
+        if not department or not judge_name:
+            continue
+
+        norm = normalize_department(department)
+        if norm in seen:
+            logger.debug(
+                "Duplicate CC department -- skipping",
+                department=norm,
+                judge_name=judge_name,
+            )
+            continue
+        seen.add(norm)
+        entries.append(DepartmentJudge(department=department, judge_name=judge_name))
+
+    logger.info("Parsed CC department-judge entries", count=len(entries))
+    return entries
+
+
+def build_department_judge_map(
+    entries: list[DepartmentJudge],
+) -> dict[str, str]:
+    """Build a normalized-department -> judge-name mapping.
+
+    Department numbers are normalized (leading zeros stripped) so lookups
+    work regardless of padding.
+
+    Args:
+        entries: List of DepartmentJudge records from ``parse_index_page_html``.
+
+    Returns:
+        Dict mapping normalized department strings to judge names.
+    """
+    dept_map: dict[str, str] = {}
+    for entry in entries:
+        norm_dept = normalize_department(entry.department)
+        if norm_dept not in dept_map:
+            dept_map[norm_dept] = entry.judge_name
+        else:
+            logger.debug(
+                "Duplicate CC department -- keeping first entry",
+                department=norm_dept,
+                existing=dept_map[norm_dept],
+                duplicate=entry.judge_name,
+            )
+    return dept_map
+
+
+def lookup_judge_for_department(
+    dept_map: dict[str, str],
+    department: str,
+) -> str | None:
+    """Look up the judge name for a given department number.
+
+    Normalizes the department number before lookup. Returns None if
+    the department is not in the mapping.
+
+    Args:
+        dept_map: The department-to-judge mapping from ``build_department_judge_map``.
+        department: The department number to look up (may have leading zeros).
+
+    Returns:
+        The judge's name, or None if not found.
+    """
+    norm = normalize_department(department)
+    return dept_map.get(norm)
+
+
+def _fetch_and_parse_directory(
+    timeout: float = 30.0,
+) -> tuple[bytes, dict[str, str]]:
+    """Fetch and parse the CC tentative rulings index page (shared helper).
+
+    Makes a single HTTP GET request to the index page, parses the
+    ``<div class='tr-dir'>`` blocks, and builds a department-to-judge mapping.
+
+    Args:
+        timeout: HTTP request timeout in seconds.
+
+    Returns:
+        Tuple of (raw_response_bytes, dept_to_judge_mapping).
+
+    Raises:
+        httpx.HTTPStatusError: If the HTTP request fails.
+    """
+    logger.info("Fetching CC tentative rulings index", url=INDEX_URL)
+    with httpx.Client(
+        timeout=timeout,
+        follow_redirects=True,
+        headers={"User-Agent": "Judgemind/1.0 (+https://judgemind.org/scraper)"},
+    ) as client:
+        response = client.get(INDEX_URL)
+        response.raise_for_status()
+
+    raw = response.content
+    entries = parse_index_page_html(response.text)
+    dept_map = build_department_judge_map(entries)
+    logger.info("Built CC department-judge mapping", departments=len(dept_map))
+    return raw, dept_map
+
+
+def fetch_department_judge_mapping(
+    timeout: float = 30.0,
+) -> dict[str, str]:
+    """Fetch the CC tentative rulings index and return a dept->judge mapping.
+
+    Makes a single HTTP GET request to the index page and builds a
+    department-to-judge mapping from the ``<div class='tr-dir'>`` headers.
+
+    This is a convenience function that does **not** perform snapshotting.
+    For production use with archival, use :class:`ContraCostaCourtDirectory`
+    instead.
+
+    Args:
+        timeout: HTTP request timeout in seconds.
+
+    Returns:
+        Dict mapping normalized department strings to judge names.
+
+    Raises:
+        httpx.HTTPStatusError: If the HTTP request fails.
+    """
+    _raw, dept_map = _fetch_and_parse_directory(timeout)
+    return dept_map
+
+
+class ContraCostaCourtDirectory(CourtDirectory):
+    """Contra Costa County Superior Court department-to-judge directory with snapshotting.
+
+    Implements ``CourtDirectory.fetch_current()`` by fetching the CC tentative
+    rulings index page and extracting department-to-judge mappings from the
+    ``<div class='tr-dir'>`` blocks.  The base class handles S3 archival, DB
+    storage, and content-hash deduplication.
+
+    Source: https://retired.cc-courts.org/civil/motions-hearings-tentative.aspx
+
+    Per the prior investigation (docs/investigations/judge-roster-sources.md:
+    205-213), CC has no dedicated judicial-officer roster page.  The tentative
+    rulings index is the only reliable public source of dept-to-judge mappings,
+    consistent with the ``SantaClaraCourtDirectory`` pattern in
+    ``sc_tentatives.py``.
+
+    Parameters
+    ----------
+    s3_client : object
+        A boto3 S3 client for archiving raw directory responses.
+    s3_bucket : str
+        The S3 bucket name for archival.
+    db_conn : psycopg.Connection
+        A psycopg3 connection for reading/writing snapshots.
+    timeout : float
+        HTTP request timeout in seconds (default 30.0).
+    """
+
+    #: Court identifier used for S3 keys and DB records.
+    COURT_ID: str = "ca_contra_costa"
+
+    def __init__(
+        self,
+        s3_client: object,
+        s3_bucket: str,
+        db_conn: psycopg.Connection,
+        timeout: float = 30.0,
+    ) -> None:
+        super().__init__(s3_client, s3_bucket, db_conn)
+        self._timeout = timeout
+
+    def fetch_current(self) -> tuple[bytes, dict[str, str]]:
+        """Fetch the live CC tentative rulings index for dept-to-judge mappings.
+
+        Returns
+        -------
+        tuple[bytes, dict[str, str]]
+            A tuple of (raw_html_bytes, dept_to_judge_mapping).
+        """
+        return _fetch_and_parse_directory(self._timeout)
+
+    def fetch_and_snapshot(self, court_id: str | None = None) -> dict[str, str]:
+        """Fetch the live directory and save a snapshot.
+
+        Overrides the base class to default ``court_id`` to
+        :attr:`COURT_ID` (``"ca_contra_costa"``).
+
+        Parameters
+        ----------
+        court_id : str | None
+            The court identifier.  Defaults to ``COURT_ID``.
+
+        Returns
+        -------
+        dict[str, str]
+            The parsed {department: judge_name} mapping.
+        """
+        return super().fetch_and_snapshot(court_id or self.COURT_ID)

--- a/packages/scraper-framework/tests/courts/test_cc_dept_judges.py
+++ b/packages/scraper-framework/tests/courts/test_cc_dept_judges.py
@@ -1,0 +1,283 @@
+"""Tests for Contra Costa department-to-judge mapping.
+
+Fixtures:
+    cc_index_page_mini.html — minimal CC tentative rulings index page with tr-dir blocks
+
+Source: https://retired.cc-courts.org/civil/motions-hearings-tentative.aspx
+The department-to-judge mapping is extracted from the span header of each
+``<div class='tr-dir'>`` block: "Department NN - Judge Name".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from courts.ca.cc_dept_judges import (
+    INDEX_URL,
+    ContraCostaCourtDirectory,
+    DepartmentJudge,
+    build_department_judge_map,
+    fetch_department_judge_mapping,
+    lookup_judge_for_department,
+    parse_index_page_html,
+)
+from courts.ca.la_dept_judges import normalize_department
+
+pytestmark = pytest.mark.regression
+
+FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+def _load(name: str) -> str:
+    return (FIXTURES / name).read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# parse_index_page_html — fixture-based tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseIndexPageHtml:
+    def test_parses_entries_from_mini_fixture(self) -> None:
+        html = _load("cc_index_page_mini.html")
+        entries = parse_index_page_html(html)
+        # Mini fixture has 12 tr-dir blocks
+        assert len(entries) >= 3
+
+    def test_department_14_athanasiou(self) -> None:
+        html = _load("cc_index_page_mini.html")
+        entries = parse_index_page_html(html)
+        dept_14 = [e for e in entries if normalize_department(e.department) == "14"]
+        assert len(dept_14) == 1
+        assert dept_14[0].judge_name == "Athanasiou"
+
+    def test_department_16_reyes(self) -> None:
+        html = _load("cc_index_page_mini.html")
+        entries = parse_index_page_html(html)
+        dept_16 = [e for e in entries if normalize_department(e.department) == "16"]
+        assert len(dept_16) == 1
+        assert dept_16[0].judge_name == "Reyes"
+
+    def test_department_30_george_probate_stripped(self) -> None:
+        """Probate departments have '(Probate)' suffix in header — should be stripped."""
+        html = _load("cc_index_page_mini.html")
+        entries = parse_index_page_html(html)
+        dept_30 = [e for e in entries if normalize_department(e.department) == "30"]
+        assert len(dept_30) == 1
+        assert "(Probate)" not in dept_30[0].judge_name
+        assert dept_30[0].judge_name == "George"
+
+    def test_leading_zero_normalization(self) -> None:
+        """Department 09 should be normalized to '9' in the map."""
+        html = _load("cc_index_page_mini.html")
+        entries = parse_index_page_html(html)
+        # The raw department from the header may be zero-padded
+        dept_09 = [e for e in entries if normalize_department(e.department) == "9"]
+        assert len(dept_09) == 1
+        assert dept_09[0].judge_name == "Devine"
+
+    def test_multi_word_judge_name(self) -> None:
+        """Department 34 has 'Judge  Leonard Marquez' (double space) — normalize whitespace."""
+        html = _load("cc_index_page_mini.html")
+        entries = parse_index_page_html(html)
+        dept_34 = [e for e in entries if normalize_department(e.department) == "34"]
+        assert len(dept_34) == 1
+        # Should not have double spaces
+        assert "  " not in dept_34[0].judge_name
+        # Multi-word name
+        assert "Leonard Marquez" in dept_34[0].judge_name
+
+    def test_commissioner_entry(self) -> None:
+        """Department 57 has 'Comm Yamamoto' (no 'Judge' prefix) — still parsed."""
+        html = _load("cc_index_page_mini.html")
+        entries = parse_index_page_html(html)
+        dept_57 = [e for e in entries if normalize_department(e.department) == "57"]
+        assert len(dept_57) == 1
+        assert dept_57[0].judge_name == "Yamamoto"
+
+    def test_empty_html_returns_empty(self) -> None:
+        entries = parse_index_page_html("<html><body></body></html>")
+        assert entries == []
+
+    def test_no_tr_dir_blocks_returns_empty(self) -> None:
+        html = "<html><body><div class='other'>Nothing here</div></body></html>"
+        entries = parse_index_page_html(html)
+        assert entries == []
+
+
+# ---------------------------------------------------------------------------
+# URL fallback path — when header span text is absent
+# ---------------------------------------------------------------------------
+
+
+class TestUrlFallback:
+    def test_url_fallback_when_no_header_text(self) -> None:
+        """If span header has no text, fall back to URL path regex."""
+        html = """<html><body>
+        <div class="tr-dir">
+            <span style="font-weight:bold;"></span>
+            <a class="tentative-ruling"
+               href="TR\\Department 16 - Judge Reyes\\16_031126.pdf">Mar 11, 2026</a>
+        </div>
+        </body></html>"""
+        entries = parse_index_page_html(html)
+        # Should get dept 16 from URL path fallback
+        assert len(entries) == 1
+        assert entries[0].department == "16"
+        assert entries[0].judge_name == "Reyes"
+
+
+# ---------------------------------------------------------------------------
+# build_department_judge_map
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDepartmentJudgeMap:
+    def test_builds_from_mini_fixture(self) -> None:
+        html = _load("cc_index_page_mini.html")
+        entries = parse_index_page_html(html)
+        dept_map = build_department_judge_map(entries)
+        assert len(dept_map) >= 3
+
+    def test_strips_leading_zeros_in_keys(self) -> None:
+        html = _load("cc_index_page_mini.html")
+        entries = parse_index_page_html(html)
+        dept_map = build_department_judge_map(entries)
+        # dept 09 should be normalized to "9"
+        assert "9" in dept_map
+        assert "09" not in dept_map
+
+    def test_known_departments_present(self) -> None:
+        html = _load("cc_index_page_mini.html")
+        entries = parse_index_page_html(html)
+        dept_map = build_department_judge_map(entries)
+        assert dept_map.get("14") == "Athanasiou"
+        assert dept_map.get("16") == "Reyes"
+        assert dept_map.get("30") == "George"
+
+    def test_duplicate_keeps_first(self) -> None:
+        entries = [
+            DepartmentJudge(department="16", judge_name="Reyes"),
+            DepartmentJudge(department="16", judge_name="Other"),
+        ]
+        dept_map = build_department_judge_map(entries)
+        assert dept_map["16"] == "Reyes"
+
+
+# ---------------------------------------------------------------------------
+# lookup_judge_for_department
+# ---------------------------------------------------------------------------
+
+
+class TestLookupJudgeForDepartment:
+    def test_found(self) -> None:
+        dept_map = {"14": "Athanasiou", "16": "Reyes"}
+        assert lookup_judge_for_department(dept_map, "14") == "Athanasiou"
+
+    def test_found_with_leading_zero(self) -> None:
+        """Lookup with zero-padded department normalizes before lookup."""
+        dept_map = {"9": "Devine"}
+        assert lookup_judge_for_department(dept_map, "09") == "Devine"
+
+    def test_not_found_returns_none(self) -> None:
+        dept_map = {"14": "Athanasiou"}
+        assert lookup_judge_for_department(dept_map, "99") is None
+
+
+# ---------------------------------------------------------------------------
+# fetch_department_judge_mapping — mocked HTTP
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+def test_fetch_mapping_with_mini_fixture() -> None:
+    """fetch_department_judge_mapping returns correct map from fixture."""
+    html = _load("cc_index_page_mini.html")
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+
+    dept_map = fetch_department_judge_mapping()
+    assert len(dept_map) >= 3
+    assert dept_map.get("14") == "Athanasiou"
+    assert dept_map.get("16") == "Reyes"
+
+
+@respx.mock
+def test_fetch_mapping_http_error_raises() -> None:
+    """fetch_department_judge_mapping raises on HTTP errors."""
+    respx.get(INDEX_URL).mock(return_value=httpx.Response(503))
+    with pytest.raises(httpx.HTTPStatusError):
+        fetch_department_judge_mapping()
+
+
+# ---------------------------------------------------------------------------
+# ContraCostaCourtDirectory — class-level tests
+# ---------------------------------------------------------------------------
+
+
+class TestContraCostaCourtDirectory:
+    def test_court_id(self) -> None:
+        assert ContraCostaCourtDirectory.COURT_ID == "ca_contra_costa"
+
+    @respx.mock
+    def test_fetch_current_returns_raw_and_mapping(self) -> None:
+        from unittest.mock import MagicMock
+
+        html = _load("cc_index_page_mini.html")
+        respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+
+        directory = ContraCostaCourtDirectory(
+            s3_client=MagicMock(),
+            s3_bucket="test-bucket",
+            db_conn=MagicMock(),
+        )
+        raw, mapping = directory.fetch_current()
+
+        assert isinstance(raw, bytes)
+        assert len(raw) > 0
+        assert len(mapping) >= 3
+        assert mapping.get("14") == "Athanasiou"
+        assert mapping.get("16") == "Reyes"
+
+    @respx.mock
+    def test_fetch_and_snapshot_defaults_court_id(self) -> None:
+        from unittest.mock import MagicMock
+
+        html = _load("cc_index_page_mini.html")
+        respx.get(INDEX_URL).mock(return_value=httpx.Response(200, text=html))
+
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_conn.cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        # No existing snapshot (not a duplicate)
+        mock_cursor.fetchone.return_value = None
+
+        directory = ContraCostaCourtDirectory(
+            s3_client=MagicMock(),
+            s3_bucket="test-bucket",
+            db_conn=mock_conn,
+        )
+
+        mapping = directory.fetch_and_snapshot()
+        assert len(mapping) >= 3
+        assert mapping.get("14") == "Athanasiou"
+
+
+# ---------------------------------------------------------------------------
+# Minimum coverage assertion: ≥3 known active departments
+# ---------------------------------------------------------------------------
+
+
+def test_at_least_three_active_departments_from_fixture() -> None:
+    """AC1: unit tests must assert non-empty mapping for at least 3 known CC depts."""
+    html = _load("cc_index_page_mini.html")
+    entries = parse_index_page_html(html)
+    dept_map = build_department_judge_map(entries)
+
+    known_active = ["9", "14", "16", "30"]
+    found = [d for d in known_active if d in dept_map]
+    assert len(found) >= 3, f"Expected >=3 known CC departments, got {len(found)}: {found}"

--- a/scripts/fetch_rosters.py
+++ b/scripts/fetch_rosters.py
@@ -38,6 +38,7 @@ logger = structlog.get_logger(__name__)
 # Registry of all CourtDirectory subclasses.
 # Each entry: (module_path, class_name, court_id)
 DIRECTORIES = [
+    ("courts.ca.cc_dept_judges", "ContraCostaCourtDirectory", "ca_contra_costa"),
     ("courts.ca.oc_dept_judges", "OCCourtDirectory", "ca_orange"),
     ("courts.ca.la_dept_judges", "LACourtDirectory", "ca_los_angeles"),
     ("courts.ca.fresno_dept_judges", "FresnoCourtDirectory", "ca_fresno"),

--- a/scripts/rebuild_db.py
+++ b/scripts/rebuild_db.py
@@ -1595,6 +1595,7 @@ def _fetch_rosters(
     import importlib
 
     DIRECTORIES = [
+        ("courts.ca.cc_dept_judges", "ContraCostaCourtDirectory", "ca_contra_costa"),
         ("courts.ca.oc_dept_judges", "OCCourtDirectory", "ca_orange"),
         ("courts.ca.la_dept_judges", "LACourtDirectory", "ca_los_angeles"),
         ("courts.ca.fresno_dept_judges", "FresnoCourtDirectory", "ca_fresno"),


### PR DESCRIPTION
## Summary

Added ContraCostaCourtDirectory scraper (cc_dept_judges.py) that extracts department-to-judge mappings from the Contra Costa tentative rulings index page. Includes 23 tests covering probate suffix stripping, commissioner entries, leading-zero normalization, URL fallback, and duplicate deduplication. Wired into fetch_rosters.py and rebuild_db.py DIRECTORIES registries.

Closes #3692

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] First production snapshot lands in `derived.court_directory_snapshots`: `scripts/dev-db-query.sh "SELECT court_id, captured_at, jsonb_object_keys(mapping) AS dept FROM court_directory_snapshots WHERE court_id = 'ca_contra_costa' ORDER BY captured_at DESC LIMIT 1;"` returns at least 10 keys
- [ ] After `rebuild_db.py --county "Contra Costa"` the dept-14 null-judge count drops from 15 → ≤2: `scripts/dev-db-query.sh "SELECT department, COUNT(*) FILTER (WHERE judge_id IS NULL) AS null_judge, COUNT(*) AS total FROM derived.rulings r JOIN derived.courts c ON r.court_id = c.id WHERE c.county = 'Contra Costa' GROUP BY department ORDER BY null_judge DESC LIMIT 20;"`
- [ ] Overall CC null-judge percentage drops below 2.5% (matching Ventura's 1.9% baseline)
- [ ] Verification evidence posted on #3692 (see /task-v2-verify output)