### PR TITLE
fix(dispatcher): pass ctx to finalizers before deleting inflight entry (#3698)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -14883,6 +14883,7 @@ class DispatcherDaemon:
         agent_id: str,
         worktree: Path,
         exit_code: int | None,
+        ctx: dict[str, Any] | None = None,
     ) -> None:
         """Post-completion handler for an async fix-ci subprocess (#3658).
 
@@ -14892,13 +14893,19 @@ class DispatcherDaemon:
         inline after ``_run_subprocess_or_fail`` returned.
 
         ``exit_code=None`` means the subprocess was killed (timeout).
+
+        ``ctx`` is the spawn-time context snapshot passed from
+        :meth:`_finalize_phase_subprocess` (#3698).  It is never
+        re-read from ``_phase_subprocess_inflight`` here because that
+        entry has already been deleted by the time this method is called.
         """
-        inflight = self._phase_subprocess_inflight.get(agent_id, {})
-        ctx = inflight.get("ctx", {})
-        agent = ctx.get("agent") or {}
-        pr_number = ctx.get("pr_number")
-        issue_number = ctx.get("issue_number")
-        retries_used = int(ctx.get("retries_used") or 0)
+        # Use the spawn-time context passed explicitly (not re-read from inflight,
+        # which has already been deleted — see #3698).
+        _ctx = ctx or {}
+        agent = _ctx.get("agent") or {}
+        pr_number = _ctx.get("pr_number")
+        issue_number = _ctx.get("issue_number")
+        retries_used = int(_ctx.get("retries_used") or 0)
 
         if exit_code is None:
             # Subprocess killed — treat as infra failure; agent already
@@ -15896,6 +15903,7 @@ class DispatcherDaemon:
         agent_id: str,
         worktree: Path,
         exit_code: int | None,
+        ctx: dict[str, Any] | None = None,
     ) -> None:
         """Post-completion handler for an async verify subprocess (#3658).
 
@@ -15907,14 +15915,19 @@ class DispatcherDaemon:
 
         ``exit_code=None`` means the subprocess was killed for timeout —
         treated the same as a subprocess-infra failure.
+
+        ``ctx`` is the spawn-time context snapshot passed from
+        :meth:`_finalize_phase_subprocess` (#3698).  It is never
+        re-read from ``_phase_subprocess_inflight`` here because that
+        entry has already been deleted by the time this method is called.
         """
-        # Recover the spawn-time context stored by _spawn_phase_subprocess_async.
-        inflight = self._phase_subprocess_inflight.get(agent_id, {})
-        ctx = inflight.get("ctx", {})
-        pr_number = ctx.get("pr_number")
-        issue_number = ctx.get("issue_number")
-        merge_sha = str(ctx.get("merge_sha") or "")
-        merged_at_set = bool(ctx.get("merged_at_set", True))
+        # Use the spawn-time context passed explicitly (not re-read from inflight,
+        # which has already been deleted — see #3698).
+        _ctx = ctx or {}
+        pr_number = _ctx.get("pr_number")
+        issue_number = _ctx.get("issue_number")
+        merge_sha = str(_ctx.get("merge_sha") or "")
+        merged_at_set = bool(_ctx.get("merged_at_set", True))
 
         # exit_code is None when the process was killed (timeout / SIGKILL).
         if exit_code is None:
@@ -16303,6 +16316,7 @@ class DispatcherDaemon:
         agent_id: str,
         worktree: Path,
         exit_code: int | None,
+        ctx: dict[str, Any] | None = None,
     ) -> None:
         """Post-completion handler for an async retro subprocess (#3658).
 
@@ -16312,11 +16326,17 @@ class DispatcherDaemon:
         previously ran inline after ``_spawn_phase_subprocess`` returned.
 
         ``exit_code=None`` means the subprocess was killed (timeout).
+
+        ``ctx`` is the spawn-time context snapshot passed from
+        :meth:`_finalize_phase_subprocess` (#3698).  It is never
+        re-read from ``_phase_subprocess_inflight`` here because that
+        entry has already been deleted by the time this method is called.
         """
-        inflight = self._phase_subprocess_inflight.get(agent_id, {})
-        ctx = inflight.get("ctx", {})
-        issue_number = ctx.get("issue_number")
-        pr_number = ctx.get("pr_number")
+        # Use the spawn-time context passed explicitly (not re-read from inflight,
+        # which has already been deleted — see #3698).
+        _ctx = ctx or {}
+        issue_number = _ctx.get("issue_number")
+        pr_number = _ctx.get("pr_number")
 
         retro_failed_transition = transition_from_retro(False)
 
@@ -20220,6 +20240,7 @@ class DispatcherDaemon:
                                 "elapsed_seconds": elapsed,
                             },
                         )
+                        ctx_snapshot = entry.get("ctx", {}) or {}
                         self._kill_phase_subprocess(pid)
                         del self._phase_subprocess_inflight[agent_id]
                         self._finalize_phase_subprocess(
@@ -20227,18 +20248,21 @@ class DispatcherDaemon:
                             phase=phase,
                             worktree=worktree,
                             exit_code=None,
+                            ctx=ctx_snapshot,
                         )
                         reaped += 1
                     # else: still within deadline — check next tick.
                     continue
 
                 # Process gone — finalize.
+                ctx_snapshot = entry.get("ctx", {}) or {}
                 del self._phase_subprocess_inflight[agent_id]
                 self._finalize_phase_subprocess(
                     agent_id=agent_id,
                     phase=phase,
                     worktree=worktree,
                     exit_code=0,
+                    ctx=ctx_snapshot,
                 )
                 reaped += 1
             except Exception:
@@ -20286,24 +20310,32 @@ class DispatcherDaemon:
         phase: str,
         worktree: Path,
         exit_code: int | None,
+        ctx: dict[str, Any] | None = None,
     ) -> None:
         """Dispatch to the per-phase post-completion handler (#3658).
 
         Routes completed (or deadline-exceeded) subprocess entries to
         the appropriate finalizer. ``exit_code=None`` means the
         subprocess was killed for exceeding its deadline.
+
+        ``ctx`` carries the spawn-time context snapshot captured by
+        :meth:`_reap_phase_subprocesses` before the inflight entry is
+        deleted.  Finalizers receive it as an explicit parameter so they
+        never re-read from ``_phase_subprocess_inflight`` after deletion
+        (#3698).
         """
+        _ctx = ctx or {}
         if phase == "verify":
             self._finalize_verify(
-                agent_id=agent_id, worktree=worktree, exit_code=exit_code
+                agent_id=agent_id, worktree=worktree, exit_code=exit_code, ctx=_ctx
             )
         elif phase == "fix-ci":
             self._finalize_fix_ci(
-                agent_id=agent_id, worktree=worktree, exit_code=exit_code
+                agent_id=agent_id, worktree=worktree, exit_code=exit_code, ctx=_ctx
             )
         elif phase == "retro":
             self._finalize_retro(
-                agent_id=agent_id, worktree=worktree, exit_code=exit_code
+                agent_id=agent_id, worktree=worktree, exit_code=exit_code, ctx=_ctx
             )
         else:
             self._log.warning(

--- a/scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py
+++ b/scripts/dispatcher/tests/test_daemon_audit_routing_gaps.py
@@ -400,22 +400,15 @@ class TestFixCiBlockedRouting:
         worktree: Path,
         exit_code: int = 0,
     ) -> None:
-        """Populate inflight ctx and call _finalize_fix_ci directly (#3658)."""
+        """Call _finalize_fix_ci directly with explicit ctx (#3698)."""
         agent_id = agent["agent_id"]
-        d._phase_subprocess_inflight[agent_id] = {
-            "phase": "fix-ci",
-            "pid": 99999,
-            "worktree_path": worktree,
-            "started_at": 0.0,
-            "deadline_at": 99999.0,
-            "ctx": {
-                "agent": dict(agent),
-                "pr_number": agent.get("pr_number"),
-                "issue_number": agent.get("issue_number"),
-                "retries_used": agent.get("retries_used", 0),
-            },
+        ctx = {
+            "agent": dict(agent),
+            "pr_number": agent.get("pr_number"),
+            "issue_number": agent.get("issue_number"),
+            "retries_used": agent.get("retries_used", 0),
         }
-        d._finalize_fix_ci(agent_id, worktree, exit_code)
+        d._finalize_fix_ci(agent_id, worktree, exit_code, ctx=ctx)
 
     def test_blocked_verdict_routes(self, tmp_path: Path) -> None:
         d, _conn, _handler = _make_daemon(tmp_path, scope="fix_ci_blocked")
@@ -895,22 +888,15 @@ class TestVerifyFailedPostMergeRouting:
         merge_sha: str,
         exit_code: int = 0,
     ) -> None:
-        """Populate inflight ctx and call _finalize_verify directly (#3658)."""
+        """Call _finalize_verify directly with explicit ctx (#3698)."""
         agent_id = agent["agent_id"]
-        d._phase_subprocess_inflight[agent_id] = {
-            "phase": "verify",
-            "pid": 99999,
-            "worktree_path": worktree,
-            "started_at": 0.0,
-            "deadline_at": 99999.0,
-            "ctx": {
-                "pr_number": agent.get("pr_number"),
-                "issue_number": agent.get("issue_number"),
-                "merge_sha": merge_sha,
-                "merged_at_set": agent.get("merged_at") is not None,
-            },
+        ctx = {
+            "pr_number": agent.get("pr_number"),
+            "issue_number": agent.get("issue_number"),
+            "merge_sha": merge_sha,
+            "merged_at_set": agent.get("merged_at") is not None,
         }
-        d._finalize_verify(agent_id, worktree, exit_code)
+        d._finalize_verify(agent_id, worktree, exit_code, ctx=ctx)
 
     def test_failed_verdict_routes(self, tmp_path: Path) -> None:
         d, _conn, _handler = _make_daemon(tmp_path, scope="verify_failed_pm")
@@ -1125,26 +1111,19 @@ class TestFixCiRebaseOutcomeLogEvent:
         worktree.mkdir()
         self._patch(d, fix_ci_output=fix_ci_output)
         agent_id = f"agent-{scope}"
-        # Populate inflight ctx so _finalize_fix_ci has the metadata it needs.
-        d._phase_subprocess_inflight[agent_id] = {
-            "phase": "fix-ci",
-            "pid": 99999,
-            "worktree_path": worktree,
-            "started_at": 0.0,
-            "deadline_at": 99999.0,
-            "ctx": {
-                "agent": {
-                    "agent_id": agent_id,
-                    "pr_number": 9966,
-                    "issue_number": 2966,
-                    "retries_used": 0,
-                },
+        # Pass ctx explicitly (#3698 — no longer read from inflight after delete).
+        ctx = {
+            "agent": {
+                "agent_id": agent_id,
                 "pr_number": 9966,
                 "issue_number": 2966,
                 "retries_used": 0,
             },
+            "pr_number": 9966,
+            "issue_number": 2966,
+            "retries_used": 0,
         }
-        d._finalize_fix_ci(agent_id, worktree, 0)
+        d._finalize_fix_ci(agent_id, worktree, 0, ctx=ctx)
         return handler
 
     def test_rebase_outcome_clean_logged(self, tmp_path: Path) -> None:

--- a/scripts/dispatcher/tests/test_daemon_milestone_columns.py
+++ b/scripts/dispatcher/tests/test_daemon_milestone_columns.py
@@ -777,7 +777,7 @@ class TestRetroStampsRetroedAt:
             "worktree_path": str(worktree),
         }
 
-        # #3658: stub _spawn_phase_subprocess_async to call _finalize_retro immediately.
+        # #3658/#3698: stub _spawn_phase_subprocess_async to call _finalize_retro immediately.
         def fake_spawn_async(
             phase: str,
             worktree: Path,
@@ -785,15 +785,8 @@ class TestRetroStampsRetroedAt:
             deadline_seconds: float,
             ctx: dict | None = None,
         ) -> None:
-            d._phase_subprocess_inflight[agent_id] = {
-                "phase": phase,
-                "pid": 99999,
-                "worktree_path": worktree,
-                "started_at": 0.0,
-                "deadline_at": 99999.0,
-                "ctx": ctx or {},
-            }
-            d._finalize_retro(agent_id, worktree, 0)
+            # Pass ctx explicitly to finalizer (#3698).
+            d._finalize_retro(agent_id, worktree, 0, ctx=ctx or {})
 
         d._spawn_phase_subprocess_async = fake_spawn_async  # type: ignore[method-assign]
 

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -904,16 +904,8 @@ class TestAwaitingCiRedPatched:
                     }
                 )
             )
-            # Register inflight so _finalize_fix_ci can read ctx.
-            d._phase_subprocess_inflight[agent_id] = {
-                "phase": phase,
-                "pid": 99999,
-                "worktree_path": worktree,
-                "started_at": 0.0,
-                "deadline_at": 99999.0,
-                "ctx": ctx or {},
-            }
-            d._finalize_fix_ci(agent_id, worktree, 0)
+            # Pass ctx explicitly to finalizer (#3698).
+            d._finalize_fix_ci(agent_id, worktree, 0, ctx=ctx or {})
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
@@ -1013,15 +1005,8 @@ class TestAwaitingCiRedBlocked:
                     }
                 )
             )
-            d._phase_subprocess_inflight[agent_id] = {
-                "phase": phase,
-                "pid": 99999,
-                "worktree_path": worktree,
-                "started_at": 0.0,
-                "deadline_at": 99999.0,
-                "ctx": ctx or {},
-            }
-            d._finalize_fix_ci(agent_id, worktree, 0)
+            # Pass ctx explicitly to finalizer (#3698).
+            d._finalize_fix_ci(agent_id, worktree, 0, ctx=ctx or {})
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
@@ -1106,15 +1091,8 @@ class TestAwaitingCiRedFlaky:
                     }
                 )
             )
-            d._phase_subprocess_inflight[agent_id] = {
-                "phase": phase,
-                "pid": 99999,
-                "worktree_path": worktree,
-                "started_at": 0.0,
-                "deadline_at": 99999.0,
-                "ctx": ctx or {},
-            }
-            d._finalize_fix_ci(agent_id, worktree, 0)
+            # Pass ctx explicitly to finalizer (#3698).
+            d._finalize_fix_ci(agent_id, worktree, 0, ctx=ctx or {})
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
@@ -1500,15 +1478,8 @@ class TestAwaitingDeploySuccess:
                     }
                 )
             )
-            d._phase_subprocess_inflight[agent_id] = {
-                "phase": phase,
-                "pid": 99999,
-                "worktree_path": worktree,
-                "started_at": 0.0,
-                "deadline_at": 99999.0,
-                "ctx": ctx or {},
-            }
-            d._finalize_verify(agent_id, worktree, 0)
+            # Pass ctx explicitly to finalizer (#3698).
+            d._finalize_verify(agent_id, worktree, 0, ctx=ctx or {})
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
@@ -1638,15 +1609,8 @@ class TestAwaitingDeployNoDeployRun:
                     }
                 )
             )
-            d._phase_subprocess_inflight[agent_id] = {
-                "phase": phase,
-                "pid": 99999,
-                "worktree_path": worktree,
-                "started_at": 0.0,
-                "deadline_at": 99999.0,
-                "ctx": ctx or {},
-            }
-            d._finalize_verify(agent_id, worktree, 0)
+            # Pass ctx explicitly to finalizer (#3698).
+            d._finalize_verify(agent_id, worktree, 0, ctx=ctx or {})
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
@@ -2105,21 +2069,18 @@ class TestVerifyRecoveryShortCircuit:
 
         d._handle_agent_failure = forbid_handle_failure  # type: ignore[method-assign]
 
-        # Populate inflight ctx with merged_at_set=True (PR already merged).
-        d._phase_subprocess_inflight[agent["agent_id"]] = {
-            "phase": "verify",
-            "pid": 99999,
-            "worktree_path": worktree,
-            "started_at": 0.0,
-            "deadline_at": 99999.0,
-            "ctx": {
+        # Pass ctx explicitly to finalizer (#3698); merged_at_set=True (PR already merged).
+        d._finalize_verify(
+            agent["agent_id"],
+            worktree,
+            0,
+            ctx={
                 "pr_number": agent["pr_number"],
                 "issue_number": agent["issue_number"],
                 "merge_sha": "merge-sha",
                 "merged_at_set": True,
             },
-        }
-        d._finalize_verify(agent["agent_id"], worktree, 0)
+        )
 
         assert not handle_failure_calls, (
             "Must NOT flip status=failed on a phase_output_missing "
@@ -2164,21 +2125,18 @@ class TestVerifyRecoveryShortCircuit:
 
         d._handle_agent_failure = record_handle_failure  # type: ignore[method-assign]
 
-        # Populate inflight ctx with merged_at_set=False (not yet merged).
-        d._phase_subprocess_inflight[agent["agent_id"]] = {
-            "phase": "verify",
-            "pid": 99999,
-            "worktree_path": worktree,
-            "started_at": 0.0,
-            "deadline_at": 99999.0,
-            "ctx": {
+        # Pass ctx explicitly to finalizer (#3698); merged_at_set=False (not yet merged).
+        d._finalize_verify(
+            agent["agent_id"],
+            worktree,
+            0,
+            ctx={
                 "pr_number": agent["pr_number"],
                 "issue_number": agent["issue_number"],
                 "merge_sha": "merge-sha",
                 "merged_at_set": False,
             },
-        }
-        d._finalize_verify(agent["agent_id"], worktree, 0)
+        )
 
         assert handle_failure_calls, (
             "Legacy (unmerged) phase_output_missing path must still "

--- a/scripts/dispatcher/tests/test_daemon_phase3e.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3e.py
@@ -344,15 +344,8 @@ class TestRunRetroPhaseZeroFindings:
                     }
                 )
             )
-            d._phase_subprocess_inflight[agent_id] = {
-                "phase": phase,
-                "pid": 99999,
-                "worktree_path": worktree,
-                "started_at": 0.0,
-                "deadline_at": 99999.0,
-                "ctx": ctx or {},
-            }
-            d._finalize_retro(agent_id, worktree, 0)
+            # Pass ctx explicitly to finalizer (#3698).
+            d._finalize_retro(agent_id, worktree, 0, ctx=ctx or {})
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
@@ -437,15 +430,8 @@ class TestRunRetroPhaseMultipleIssues:
             output_dir = worktree / "tmp" / "dispatcher-output"
             output_dir.mkdir(parents=True, exist_ok=True)
             output_dir.joinpath("retro.json").write_text(json.dumps(retro_payload))
-            d._phase_subprocess_inflight[agent_id] = {
-                "phase": phase,
-                "pid": 99999,
-                "worktree_path": worktree,
-                "started_at": 0.0,
-                "deadline_at": 99999.0,
-                "ctx": ctx or {},
-            }
-            d._finalize_retro(agent_id, worktree, 0)
+            # Pass ctx explicitly to finalizer (#3698).
+            d._finalize_retro(agent_id, worktree, 0, ctx=ctx or {})
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
@@ -521,15 +507,8 @@ class TestRunRetroPhaseMultipleIssues:
             output_dir = worktree / "tmp" / "dispatcher-output"
             output_dir.mkdir(parents=True, exist_ok=True)
             output_dir.joinpath("retro.json").write_text(json.dumps(retro_payload))
-            d._phase_subprocess_inflight[agent_id] = {
-                "phase": phase,
-                "pid": 99999,
-                "worktree_path": worktree,
-                "started_at": 0.0,
-                "deadline_at": 99999.0,
-                "ctx": ctx or {},
-            }
-            d._finalize_retro(agent_id, worktree, 0)
+            # Pass ctx explicitly to finalizer (#3698).
+            d._finalize_retro(agent_id, worktree, 0, ctx=ctx or {})
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
@@ -574,15 +553,8 @@ class TestRunRetroPhaseFailures:
             deadline_seconds: float,
             ctx: dict | None = None,
         ) -> None:
-            d._phase_subprocess_inflight[agent_id] = {
-                "phase": phase,
-                "pid": 99999,
-                "worktree_path": worktree,
-                "started_at": 0.0,
-                "deadline_at": 99999.0,
-                "ctx": ctx or {},
-            }
-            d._finalize_retro(agent_id, worktree, 1)  # non-zero exit
+            # Pass ctx explicitly to finalizer (#3698).
+            d._finalize_retro(agent_id, worktree, 1, ctx=ctx or {})  # non-zero exit
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
         d._run_retro_phase(agent)
@@ -625,15 +597,10 @@ class TestRunRetroPhaseFailures:
             deadline_seconds: float,
             ctx: dict | None = None,
         ) -> None:
-            d._phase_subprocess_inflight[agent_id] = {
-                "phase": phase,
-                "pid": 99999,
-                "worktree_path": worktree,
-                "started_at": 0.0,
-                "deadline_at": 99999.0,
-                "ctx": ctx or {},
-            }
-            d._finalize_retro(agent_id, worktree, None)  # killed = timeout
+            # Pass ctx explicitly to finalizer (#3698).
+            d._finalize_retro(
+                agent_id, worktree, None, ctx=ctx or {}
+            )  # killed = timeout
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
         d._run_retro_phase(agent)
@@ -662,15 +629,10 @@ class TestRunRetroPhaseFailures:
             deadline_seconds: float,
             ctx: dict | None = None,
         ) -> None:
-            d._phase_subprocess_inflight[agent_id] = {
-                "phase": phase,
-                "pid": 99999,
-                "worktree_path": worktree,
-                "started_at": 0.0,
-                "deadline_at": 99999.0,
-                "ctx": ctx or {},
-            }
-            d._finalize_retro(agent_id, worktree, 0)  # exit 0, no output file
+            # Pass ctx explicitly to finalizer (#3698).
+            d._finalize_retro(
+                agent_id, worktree, 0, ctx=ctx or {}
+            )  # exit 0, no output file
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
         d._run_retro_phase(agent)
@@ -709,15 +671,8 @@ class TestRunRetroPhaseFailures:
             output_dir = worktree / "tmp" / "dispatcher-output"
             output_dir.mkdir(parents=True, exist_ok=True)
             output_dir.joinpath("retro.json").write_text(json.dumps(retro_payload))
-            d._phase_subprocess_inflight[agent_id] = {
-                "phase": phase,
-                "pid": 99999,
-                "worktree_path": worktree,
-                "started_at": 0.0,
-                "deadline_at": 99999.0,
-                "ctx": ctx or {},
-            }
-            d._finalize_retro(agent_id, worktree, 0)
+            # Pass ctx explicitly to finalizer (#3698).
+            d._finalize_retro(agent_id, worktree, 0, ctx=ctx or {})
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 
@@ -811,15 +766,8 @@ class TestRunRetroPhaseFailures:
             output_dir = worktree / "tmp" / "dispatcher-output"
             output_dir.mkdir(parents=True, exist_ok=True)
             output_dir.joinpath("retro.json").write_text(json.dumps(retro_payload))
-            d._phase_subprocess_inflight[agent_id] = {
-                "phase": phase,
-                "pid": 99999,
-                "worktree_path": worktree,
-                "started_at": 0.0,
-                "deadline_at": 99999.0,
-                "ctx": ctx or {},
-            }
-            d._finalize_retro(agent_id, worktree, 0)
+            # Pass ctx explicitly to finalizer (#3698).
+            d._finalize_retro(agent_id, worktree, 0, ctx=ctx or {})
 
         monkeypatch.setattr(d, "_spawn_phase_subprocess_async", fake_spawn_async)
 

--- a/scripts/dispatcher/tests/test_daemon_phase_failure_preview.py
+++ b/scripts/dispatcher/tests/test_daemon_phase_failure_preview.py
@@ -330,16 +330,13 @@ class TestPhaseOutputMissingPreview:
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
 
-        # #3658: call _finalize_fix_ci directly (async path).
-        d._phase_subprocess_inflight[agent_id] = {
-            "phase": "fix-ci",
-            "pid": 99999,
-            "worktree_path": worktree,
-            "started_at": 0.0,
-            "deadline_at": 99999.0,
-            "ctx": {"pr_number": 77, "issue_number": 1, "retries_used": 0, "agent": {}},
-        }
-        d._finalize_fix_ci(agent_id, worktree, 0)
+        # #3658/#3698: call _finalize_fix_ci directly with explicit ctx.
+        d._finalize_fix_ci(
+            agent_id,
+            worktree,
+            0,
+            ctx={"pr_number": 77, "issue_number": 1, "retries_used": 0, "agent": {}},
+        )
 
         events = handler.events("phase_output_missing")
         assert events
@@ -361,23 +358,21 @@ class TestPhaseOutputMissingPreview:
         d._mark_agent_terminal = MagicMock()  # type: ignore[method-assign]
         d._update_agent_phase = MagicMock()  # type: ignore[method-assign]
 
-        # #3658: call _finalize_verify directly; merged_at_set=False routes
-        # through handle_agent_failure (the desired "phase_output_missing" path).
-        d._phase_subprocess_inflight[agent_id] = {
-            "phase": "verify",
-            "pid": 99999,
-            "worktree_path": worktree,
-            "started_at": 0.0,
-            "deadline_at": 99999.0,
-            "ctx": {
+        # #3658/#3698: call _finalize_verify directly with explicit ctx.
+        # merged_at_set=False routes through handle_agent_failure (the desired
+        # "phase_output_missing" path).
+        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
+        d._finalize_verify(
+            agent_id,
+            worktree,
+            0,
+            ctx={
                 "pr_number": 77,
                 "issue_number": 1,
                 "merge_sha": "deadbeef",
                 "merged_at_set": False,
             },
-        }
-        d._handle_agent_failure = MagicMock()  # type: ignore[method-assign]
-        d._finalize_verify(agent_id, worktree, 0)
+        )
 
         events = handler.events("phase_output_missing")
         assert events
@@ -435,21 +430,13 @@ class TestRetroFailurePreviews:
         worktree: Path,
         exit_code: int | None,
     ) -> None:
-        """#3658: populate inflight registry and call _finalize_retro directly
-        (mirrors the reaper pattern used in test_daemon_phase3e.py)."""
+        """#3658/#3698: call _finalize_retro directly with explicit ctx."""
         agent_id = agent["agent_id"]
-        d._phase_subprocess_inflight[agent_id] = {
-            "phase": "retro",
-            "pid": 99999,
-            "worktree_path": worktree,
-            "started_at": 0.0,
-            "deadline_at": 99999.0,
-            "ctx": {
-                "issue_number": agent.get("issue_number"),
-                "pr_number": agent.get("pr_number"),
-            },
+        ctx = {
+            "issue_number": agent.get("issue_number"),
+            "pr_number": agent.get("pr_number"),
         }
-        d._finalize_retro(agent_id, worktree, exit_code)
+        d._finalize_retro(agent_id, worktree, exit_code, ctx=ctx)
 
     def test_nonzero_exit_logs_preview(self, monkeypatch: Any, tmp_path: Path) -> None:
         d, _conn, handler = _make_daemon(tmp_path)

--- a/scripts/dispatcher/tests/test_daemon_supervisor_async_phase.py
+++ b/scripts/dispatcher/tests/test_daemon_supervisor_async_phase.py
@@ -759,3 +759,173 @@ class TestAdvanceRunningAgentsSkipsInflight:
         # Event emitted for the skip.
         skip_events = handler.events("advance_skipped_async_inflight")
         assert len(skip_events) == 1
+
+
+# ---------------------------------------------------------------------------
+# Regression: ctx must survive the inflight delete (#3698)
+# ---------------------------------------------------------------------------
+
+
+class TestReapPassesCtxToFinalizers:
+    """_reap_phase_subprocesses must pass spawn-time ctx to finalizers (#3698).
+
+    Bug: the reaper called ``del self._phase_subprocess_inflight[agent_id]``
+    BEFORE calling ``_finalize_phase_subprocess``.  The finalizers then did
+    ``self._phase_subprocess_inflight.get(agent_id, {})`` and got ``{}``,
+    losing every spawn-time field.
+
+    Fix: snapshot ctx before the delete and thread it through as an explicit
+    parameter so finalizers never re-read from the (now-deleted) inflight dict.
+
+    These tests FAIL against pre-fix code and PASS after the fix.
+    """
+
+    def test_reap_then_finalize_passes_ctx_from_spawn_verify(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """verify finalizer receives spawn-time ctx, not {}."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        agent_id = "agent-ctx-verify"
+
+        spawn_ctx = {
+            "pr_number": 42,
+            "issue_number": 99,
+            "merge_sha": "deadbeef",
+            "merged_at_set": True,
+            "agent": {"agent_id": agent_id},
+            "retries_used": 2,
+        }
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "verify",
+            "pid": 11111,
+            "worktree_path": str(tmp_path),
+            "started_at": datetime.now(UTC) - timedelta(seconds=10),
+            "deadline_at": datetime.now(UTC) + timedelta(seconds=3000),
+            "ctx": spawn_ctx,
+        }
+
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon, "_process_alive", staticmethod(lambda pid: False)
+        )
+
+        captured_ctx: list[dict] = []
+
+        def fake_finalize_verify(
+            *, agent_id: str, worktree: Path, exit_code: int | None, ctx: dict
+        ) -> None:
+            captured_ctx.append(ctx)
+
+        monkeypatch.setattr(d, "_finalize_verify", fake_finalize_verify)
+
+        d._reap_phase_subprocesses()
+
+        assert len(captured_ctx) == 1, "_finalize_verify must be called exactly once"
+        received = captured_ctx[0]
+        assert received.get("pr_number") == 42, (
+            f"Expected pr_number=42 in ctx, got: {received}"
+        )
+        assert received.get("issue_number") == 99, (
+            f"Expected issue_number=99 in ctx, got: {received}"
+        )
+        assert received.get("merge_sha") == "deadbeef", (
+            f"Expected merge_sha='deadbeef' in ctx, got: {received}"
+        )
+
+    def test_reap_then_finalize_passes_ctx_from_spawn_fix_ci(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """fix-ci finalizer receives spawn-time ctx, not {}."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        agent_id = "agent-ctx-fix-ci"
+
+        spawn_ctx = {
+            "pr_number": 42,
+            "issue_number": 99,
+            "merge_sha": "deadbeef",
+            "merged_at_set": True,
+            "agent": {"agent_id": agent_id},
+            "retries_used": 2,
+        }
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "fix-ci",
+            "pid": 22222,
+            "worktree_path": str(tmp_path),
+            "started_at": datetime.now(UTC) - timedelta(seconds=10),
+            "deadline_at": datetime.now(UTC) + timedelta(seconds=3000),
+            "ctx": spawn_ctx,
+        }
+
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon, "_process_alive", staticmethod(lambda pid: False)
+        )
+
+        captured_ctx: list[dict] = []
+
+        def fake_finalize_fix_ci(
+            *, agent_id: str, worktree: Path, exit_code: int | None, ctx: dict
+        ) -> None:
+            captured_ctx.append(ctx)
+
+        monkeypatch.setattr(d, "_finalize_fix_ci", fake_finalize_fix_ci)
+
+        d._reap_phase_subprocesses()
+
+        assert len(captured_ctx) == 1, "_finalize_fix_ci must be called exactly once"
+        received = captured_ctx[0]
+        assert received.get("pr_number") == 42, (
+            f"Expected pr_number=42 in ctx, got: {received}"
+        )
+        assert received.get("issue_number") == 99, (
+            f"Expected issue_number=99 in ctx, got: {received}"
+        )
+        assert received.get("retries_used") == 2, (
+            f"Expected retries_used=2 in ctx, got: {received}"
+        )
+
+    def test_reap_then_finalize_passes_ctx_from_spawn_retro(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """retro finalizer receives spawn-time ctx, not {}."""
+        d, _conn, _handler = _make_daemon(tmp_path)
+        agent_id = "agent-ctx-retro"
+
+        spawn_ctx = {
+            "pr_number": 42,
+            "issue_number": 99,
+            "merge_sha": "deadbeef",
+            "merged_at_set": True,
+            "agent": {"agent_id": agent_id},
+            "retries_used": 2,
+        }
+        d._phase_subprocess_inflight[agent_id] = {
+            "phase": "retro",
+            "pid": 33333,
+            "worktree_path": str(tmp_path),
+            "started_at": datetime.now(UTC) - timedelta(seconds=10),
+            "deadline_at": datetime.now(UTC) + timedelta(seconds=3000),
+            "ctx": spawn_ctx,
+        }
+
+        monkeypatch.setattr(
+            daemon.DispatcherDaemon, "_process_alive", staticmethod(lambda pid: False)
+        )
+
+        captured_ctx: list[dict] = []
+
+        def fake_finalize_retro(
+            *, agent_id: str, worktree: Path, exit_code: int | None, ctx: dict
+        ) -> None:
+            captured_ctx.append(ctx)
+
+        monkeypatch.setattr(d, "_finalize_retro", fake_finalize_retro)
+
+        d._reap_phase_subprocesses()
+
+        assert len(captured_ctx) == 1, "_finalize_retro must be called exactly once"
+        received = captured_ctx[0]
+        assert received.get("pr_number") == 42, (
+            f"Expected pr_number=42 in ctx, got: {received}"
+        )
+        assert received.get("issue_number") == 99, (
+            f"Expected issue_number=99 in ctx, got: {received}"
+        )


### PR DESCRIPTION
## Summary

Fixed a temporal-order bug in `_reap_phase_subprocesses` where spawn-time context (pr_number, issue_number, merge_sha, agent, retries_used) was lost during async phase finalization. The reaper was deleting the inflight dict entry **before** invoking finalizers; now context is snapshotted before deletion and threaded explicitly to verify/fix-ci/retro finalizers.

Closes #3698

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest scripts/dispatcher/tests/` — 195 tests, all green)
- [x] CI green

### Post-deploy verification

- [ ] CloudWatch structured log query: filter `daemon.verify_*` events on `dispatcher-daemon` log group emitted after deploy, confirm `pr_number` and `issue_number` fields are non-null (not null/missing)
- [ ] Verification evidence posted on #3698 (see /task-v2-verify output)