### PR TITLE
fix(infra): tighten OpenSearch IAM access_policies with specific role ARNs (#3704)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -10,6 +10,8 @@
 #
 # Object lock is intentionally disabled for dev so test objects can be deleted.
 
+data "aws_caller_identity" "current" {}
+
 # Look up API key secrets so we can pass their ARNs to the compute module
 # without hardcoding the random Secrets Manager suffix.
 data "aws_secretsmanager_secret" "anthropic_api_key" {
@@ -150,6 +152,15 @@ module "search" {
   instance_type   = "t3.small.search"
   instance_count  = 1
   ebs_volume_size = 20
+
+  principal_arns = [
+    # API ECS task role -- name is deterministic from modules/api-service/main.tf.
+    # Built as a string (not module.api_service.task_role_arn) to avoid a
+    # Terraform dependency cycle: api_service already consumes
+    # module.search.master_credentials_secret_arn / domain_endpoint.
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/judgemind-api-task-dev",
+    module.iam_scraper.role_arn, # ingestion-worker + ECS-oneshot tasks
+  ]
 }
 
 module "api_service" {

--- a/infra/terraform/environments/production/main.tf
+++ b/infra/terraform/environments/production/main.tf
@@ -93,6 +93,11 @@ module "search" {
   instance_type   = "t3.medium.search"
   instance_count  = 1
   ebs_volume_size = 50
+
+  # Add the api-task role here when production grows an api_service module.
+  principal_arns = [
+    module.iam_scraper.role_arn, # ingestion-worker + ECS-oneshot tasks
+  ]
 }
 
 module "ses" {

--- a/infra/terraform/modules/search/main.tf
+++ b/infra/terraform/modules/search/main.tf
@@ -107,12 +107,15 @@ resource "aws_opensearch_domain" "main" {
     }
   }
 
+  # Defence-in-depth (#3704): the security group is the network gate (HTTPS
+  # from VPC CIDR only); this IAM policy is the second layer, restricting
+  # es:* to enumerated role ARNs instead of the prior AWS="*" wildcard.
   access_policies = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
         Effect    = "Allow"
-        Principal = { AWS = "*" }
+        Principal = { AWS = var.principal_arns }
         Action    = "es:*"
         Resource  = "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/judgemind-${var.environment}/*"
       }

--- a/infra/terraform/modules/search/variables.tf
+++ b/infra/terraform/modules/search/variables.tf
@@ -47,3 +47,13 @@ variable "master_user_name" {
   type        = string
   default     = "admin"
 }
+
+variable "principal_arns" {
+  description = "IAM role/user ARNs allowed to call es:* on this OpenSearch domain (#3704). An empty list would deny all IAM access, so at least one ARN is required."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.principal_arns) > 0
+    error_message = "principal_arns must contain at least one ARN; an empty list would deny all IAM access to OpenSearch."
+  }
+}


### PR DESCRIPTION
## Summary

Implemented defence-in-depth on the OpenSearch domain by replacing the wide-open `Principal = { AWS = "*" }` IAM policy with a list of specific role ARNs. The security group remains the network gate (HTTPS from VPC CIDR only); this IAM layer is now a second gate restricting access to enumerated principals.

Added a new `principal_arns` variable to the search module with validation requiring at least one ARN (to prevent accidental lockout). Wired the variable in dev (api-task role + iam_scraper) and production (iam_scraper only, since production has no api_service deployed). Added `data "aws_caller_identity"` to dev/main.tf to construct the API task role ARN deterministically, avoiding a Terraform dependency cycle.

Closes #3704

## Test plan

### Automated checks

- [x] Lint passes (`terraform fmt` and `terraform validate` — per ralph_summary)
- [x] Terraform syntax valid for both dev and production configurations
- [x] CI green

### Post-deploy verification

- [ ] `terraform plan` against dev shows only the expected `access_policies` change
- [ ] `terraform apply` succeeds on dev
- [ ] API search resolver returns 200 (curl `https://dev.api.judgemind.org/graphql` with a search query)
- [ ] An unrelated role/EC2 instance cannot call `es:DescribeDomain` against the OpenSearch cluster
- [ ] Verification evidence posted on #3704 (see /task-v2-verify output)