### PR TITLE
docs(agent): add duplicate-PR consolidation example to diagnose-failure SKILL.md (#3725)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -198,7 +198,7 @@ The first eight are the legacy decision tree (still supported for backward compa
 8. **Tracking issue already exists** → either:
    - **Preferred (#3455 inline):** validate the blocker is open via `gh issue view`, append `Blocked by #<N>` yourself, add `status/blocked`, remove `agent/ready`, post the comment, then emit `action="terminal"` with `action_taken="block_on_existing_task"`.
    - Legacy fallback: `action="block_on_existing_task"` with `blocker_issue_number`.
-9. **Inline-action terminal (#3455)** → `action="terminal"`. Preferred whenever you've performed gh side-effects yourself. Required fields: `action_taken` (descriptive string — e.g. `"close"`, `"escalate"`, `"block_and_comment"`, `"file_prerequisite_task"`, `"block_on_existing_task"`, or any other string that names what you did) and `summary` (one paragraph, ≤500 chars, what you did and why). Optional: `evidence` (longer prose with log lines, gh output, etc.).
+9. **Inline-action terminal (#3455)** → `action="terminal"`. Preferred whenever you've performed gh side-effects yourself. Required fields: `action_taken` (descriptive string — e.g. `"close"`, `"escalate"`, `"block_and_comment"`, `"file_prerequisite_task"`, `"block_on_existing_task"`, or any other string that names what you did) and `summary` (one paragraph, ≤500 chars, what you did and why). Optional: `evidence` (longer prose with log lines, gh output, etc.). For the duplicate-PR pattern (N>1 open PRs Closes-keyword'd to the same issue), see Example 8 — `action_taken="consolidate_duplicate_prs"`.
 
 **When uncertain, prefer `escalate` over a wrong guess.** A human re-classification is cheap; a wrong `close` or `reissue` can destroy context.
 
@@ -555,6 +555,47 @@ next_directive: "terminal"
 actions_taken: [
   {"type": "gh_issue_edit", "labels_added": ["status/invalid"]},
   {"type": "gh_issue_close", "issue_number": 3297, "reason": "not planned"}
+]
+```
+### Example 8 — duplicate-PR consolidation, close inline (#3725)
+
+```text
+Trigger: diagnoser invoked on any failure_category when N>1 open PRs all carry
+"Closes #<issue>" in their body. The operator invariant "one PR per issue" is
+violated. Detected during any diagnosis run, regardless of the triggering
+failure_category.
+
+Detection:
+  gh pr list --repo judgemind/judgemind --state open \
+    --search "in:body Closes #<issue>" \
+    --json number,headRefName,updatedAt,statusCheckRollup
+  returns rows for PR #3628 and PR #3650 (N=2).
+
+Selection (pick the canonical PR to keep):
+  1. Most recent push: compare updatedAt across rows -- pick max.
+  2. Tie-break: fewest CI failures (count statusCheckRollup entries with
+     status=FAILURE across each PR).
+  3. Tie-break: largest diff:
+       gh pr diff <N> --patch | wc -l   (higher line count wins)
+  chosen = #3650, duplicates = [#3628].
+
+Action (inline, one Bash call per duplicate):
+  gh pr close 3628 --repo judgemind/judgemind \
+    --comment "Closing as duplicate of #3650" --delete-branch
+
+Issue label state: leave status/in-progress in place.
+The daemon's existing CI-watch / merge logic on #3650 takes over from here.
+No agent/ready toggling needed.
+
+Recommendation: {
+  "action": "terminal",
+  "action_taken": "consolidate_duplicate_prs",
+  "summary": "detected N=2 open PRs with Closes #3601 -- #3628, #3650. Closed #3628 as duplicate of #3650 (most recent push). Daemon CI-watch proceeds on #3650.",
+  "reasoning": "..."
+}
+next_directive: "terminal"
+actions_taken: [
+  {"type": "gh_pr_close", "pr_number": 3628, "comment": "Closing as duplicate of #3650", "delete_branch": true}
 ]
 ```
 

--- a/scripts/dispatcher/tests/test_skill_md_contracts.py
+++ b/scripts/dispatcher/tests/test_skill_md_contracts.py
@@ -584,3 +584,48 @@ class TestTaskV2FixCiSkillContracts:
             "task-v2-fix-ci/SKILL.md must document the FIX_CI_REBASE_OUTCOME "
             "heartbeat echo line (issue #2966 AC6)"
         )
+
+
+# ------------------------------------------------------------------
+# Issue #3725 — duplicate-PR consolidation example contract coverage.
+# ------------------------------------------------------------------
+
+
+class TestDuplicatePrConsolidationContract:
+    """diagnose-failure/SKILL.md must document the duplicate-PR
+    consolidation pattern (Example 8) as a regression guard (issue #3725)."""
+
+    def test_duplicate_pr_example_present(self) -> None:
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        assert "duplicate-PR consolidation" in content, (
+            "diagnose-failure/SKILL.md must contain 'duplicate-PR consolidation' "
+            "example (issue #3725)"
+        )
+
+    def test_duplicate_pr_detection_command_present(self) -> None:
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        assert "in:body Closes" in content, (
+            "diagnose-failure/SKILL.md must document the gh search pattern "
+            "'in:body Closes' for duplicate-PR detection (issue #3725)"
+        )
+
+    def test_duplicate_pr_close_template_present(self) -> None:
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        assert "Closing as duplicate of" in content, (
+            "diagnose-failure/SKILL.md must document the close-comment template "
+            "'Closing as duplicate of' (issue #3725)"
+        )
+
+    def test_duplicate_pr_action_taken_present(self) -> None:
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        assert "consolidate_duplicate_prs" in content, (
+            "diagnose-failure/SKILL.md must document 'consolidate_duplicate_prs' "
+            "as the action_taken value (issue #3725)"
+        )
+
+    def test_duplicate_pr_3725_issue_reference(self) -> None:
+        content = _read(_DIAGNOSE_FAILURE_SKILL)
+        assert "#3725" in content, (
+            "diagnose-failure/SKILL.md must reference '#3725' for traceability "
+            "(issue #3725)"
+        )


### PR DESCRIPTION
## Summary

Addressed #3725 by documenting the duplicate-PR consolidation pattern in diagnose-failure/SKILL.md as Example 8. Diagnoser can now detect N>1 open PRs with the same `Closes #<issue>` keyword, select the best one by most-recent push (with CI-failure and diff-size tie-breaks), and close the duplicates inline via `gh pr close` with a standardized comment. The daemon's existing CI-watch/merge logic then proceeds on the chosen PR.

Closes #3725

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`) — all 56 tests in test_skill_md_contracts.py pass
- [x] CI green

### Post-deploy verification

- [ ] Stage a duplicate-PR scenario (two PRs with `Closes #<issue>`) in dev
- [ ] Trigger a diagnoser invocation (via a failure on the issue or manual `/task-v2` run)
- [ ] Observe diagnoser detects the pattern and closes the duplicate PR with "Closing as duplicate of #<chosen>" comment
- [ ] Verification evidence posted on #3725 (see /task-v2-verify output)