### PR TITLE
fix(dispatcher): split silent-hang threshold from total-runtime cap (#3731)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1032,14 +1032,83 @@ STUCK_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
     # `claude -p /<skill>` and only persist `phase_transitions` at end, so the
     # reaper only sees `now() - started_at`. Set ceilings well above documented
     # runtimes; the diagnoser will still pick up a truly hung row eventually.
-    "spotcheck": 5400,                  # 90 min — SKILL.md says "one-hour spot-check"
-    "audit": 5400,                      # 90 min — every-N-merges audit, similar shape
-    "dispatcher-audit": 5400,           # 90 min — 6-hourly health probes (#2865)
-    "dispatcher-daily-report": 1800,    # 30 min — short summary skill (#3375)
+    "spotcheck": 5400,  # 90 min — SKILL.md says "one-hour spot-check"
+    "audit": 5400,  # 90 min — every-N-merges audit, similar shape
+    "dispatcher-audit": 5400,  # 90 min — 6-hourly health probes (#2865)
+    "dispatcher-daily-report": 1800,  # 30 min — short summary skill (#3375)
     "paused_by_killswitch": 60,  # 1 min — terminal phase, should be swept quickly
     "force_stopped": 60,  # 1 min — #2884 operator force_stop terminal phase
     "daemon_restart_abandoned": 60,  # 1 min — terminal phase from restart recovery
     "agent_runner_route_stub": 60,  # 1 min — terminal phase from unrecognized route/transition
+}
+
+#: Global fallback for the silent-hang threshold — used when a phase
+#: is not present in :data:`SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE` and
+#: no live override is set. 30 minutes covers the longest legitimate
+#: "no phase_transitions" gap across all known phases (issue #3731).
+SILENT_HANG_DEFAULT_SECONDS: int = 1800  # 30 min
+
+#: Per-phase silent-hang threshold (seconds) — issue #3731. **Distinct
+#: from :data:`STUCK_TIMEOUT_SECONDS_BY_PHASE`**: this is the
+#: "no-progress" window, measured against ``now - max(phase_transitions.ts)``.
+#: ``STUCK_TIMEOUT_SECONDS_BY_PHASE`` is the absolute total-runtime cap,
+#: measured against ``now - started_at``. Pre-#3731 the reaper conflated
+#: the two and used the (much larger) total-runtime values for both
+#: decisions, so a hung ralph waited up to 15h before getting reaped
+#: even though it had emitted zero phase_transitions for hours.
+#:
+#: Concrete instance the bug burned (#3731): agent ``9943a31e`` on
+#: #3663 emitted its last ``phase_transitions`` event at 04:33:54Z then
+#: went silent for 12h while still showing ``status=running,
+#: phase=ralph``. The cap slot was wasted for the full 12h. Reap was
+#: only triggered by an operator force_stop at 16:21:46Z.
+#:
+#: The thresholds below are tight enough to detect a genuinely-hung
+#: subprocess in <2h while loose enough not to false-positive on
+#: legitimate slow-iteration phases:
+#:
+#: * ``ralph`` — 90 min. A healthy ralph emits ``ralph_iteration_*``
+#:   phase_transitions every few minutes (worker work + reviewer
+#:   review). 90 min covers the longest observed legitimate iteration
+#:   (worst-case Claude Sonnet 4.5 + three reviewers on a hard issue
+#:   ~30-40 min) with a 2× safety margin. Anything silent for >90 min
+#:   is a hung subprocess (Claude OOM, network hang, container freeze).
+#: * ``plan`` / ``planning`` / ``summary`` / ``verify`` / ``retro`` —
+#:   30 min each. These are single-pass LLM phases: one
+#:   ``phase_transitions`` row at start, one at end. 30 min covers any
+#:   legitimate single-pass runtime with a wide margin.
+#: * ``push_and_pr`` — 15 min. Git-only phase (no LLM). Anything
+#:   silent for >15 min is a TCP retry storm or a hung ``git push``.
+#: * ``operational`` — 60 min, matching the total-runtime cap. The
+#:   operational phase emits one ``phase_transitions`` row at end (no
+#:   sub-events), so the silent-hang and total-runtime windows are
+#:   functionally the same. Listing it here keeps the lookup uniform
+#:   without changing semantics.
+#: * Phases not listed fall back to :data:`SILENT_HANG_DEFAULT_SECONDS`
+#:   (30 min).
+#:
+#: Operators can override via ``dispatcher.config.silent_hang_timeout_s_by_phase``
+#: (JSONB object merged into this default at read time — see
+#: :meth:`_silent_hang_timeout_for_phase`).
+SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE: dict[str, int] = {
+    "ralph": 5400,  # 90 min — see module-level rationale
+    "plan": 1800,  # 30 min — single-pass LLM
+    "planning": 1800,  # 30 min — alias for plan (same as STUCK table)
+    "summary": 1800,  # 30 min — single-pass LLM
+    "verify": 1800,  # 30 min — single-pass LLM
+    "retro": 1800,  # 30 min — single-pass LLM
+    "push_and_pr": 900,  # 15 min — git-only, no LLM
+    "operational": 3600,  # 60 min — matches total-runtime cap
+    "fix_ci": 1800,  # 30 min — single-pass LLM (similar shape to summary/verify)
+    "claiming": 60,  # 1 min — single gh + psycopg call
+    "awaiting_ci": 1800,  # 30 min — sleeps then polls; long gap = stuck poller
+    "awaiting_deploy": 1800,  # 30 min — sleeps then polls; long gap = stuck poller
+    # Scheduled-skill phase names — emit phase_transitions only at end,
+    # so silent-hang threshold matches total-runtime cap.
+    "spotcheck": 5400,
+    "audit": 5400,
+    "dispatcher-audit": 5400,
+    "dispatcher-daily-report": 1800,
 }
 
 #: Terminal statuses on ``dispatcher.agents.status`` — the worker thread
@@ -17260,6 +17329,88 @@ class DispatcherDaemon:
                 continue
         return out
 
+    def _silent_hang_timeout_for_phase(
+        self, phase: str | None, *, overrides: dict[str, int] | None = None
+    ) -> int:
+        """Return the silent-hang threshold in seconds for a given phase.
+
+        **Distinct from :meth:`_stuck_timeout_for_phase`** — that method
+        returns the absolute total-runtime cap (compared against
+        ``now - started_at``). This method returns the silent-hang
+        window (compared against ``now - max(phase_transitions.ts)``).
+        Pre-#3731 the two were conflated and the reaper used the larger
+        total-runtime value for both decisions, leaving hung ralph
+        agents pinned for up to 15h.
+
+        Resolution order (first hit wins):
+
+        1. ``overrides`` argument (a pre-read JSONB object from
+           ``dispatcher.config.silent_hang_timeout_s_by_phase`` — the
+           supervisor tick reads this once per sweep and passes it in).
+           Operators can live-edit any phase's silent-hang threshold
+           via this config row without a redeploy.
+        2. :data:`SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE` — module-level
+           defaults from the per-phase rationale block in this file.
+        3. :data:`SILENT_HANG_DEFAULT_SECONDS` — 30-minute fallback for
+           any phase not covered above.
+
+        A ``None`` or unknown phase falls back to the global default.
+        Issue #3731.
+        """
+        key = (phase or "").strip()
+        if overrides and key and key in overrides:
+            try:
+                value = int(overrides[key])
+                if value > 0:
+                    return value
+            except (TypeError, ValueError):
+                pass
+        if key and key in SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE:
+            return SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE[key]
+        return SILENT_HANG_DEFAULT_SECONDS
+
+    def _read_silent_hang_timeout_overrides(self) -> dict[str, int]:
+        """Read the live ``silent_hang_timeout_s_by_phase`` config override.
+
+        Parallel to :meth:`_read_stuck_timeout_overrides`. Returns an
+        empty dict on missing row, malformed JSON, or any read error —
+        the caller's fallback chain
+        (:meth:`_silent_hang_timeout_for_phase`) picks up the module
+        defaults cleanly in that case. Issue #3731.
+        """
+        assert self._conn is not None, "connect() must run before config read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT value FROM dispatcher.config WHERE key = %s",
+                    ("silent_hang_timeout_s_by_phase",),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover
+                pass
+            return {}
+        if row is None or row[0] is None:
+            return {}
+        raw = row[0]
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw)
+            except json.JSONDecodeError:
+                return {}
+        if not isinstance(raw, dict):
+            return {}
+        out: dict[str, int] = {}
+        for k, v in raw.items():
+            try:
+                out[str(k)] = int(v)
+            except (TypeError, ValueError):
+                continue
+        return out
+
     def _max_turns_for_phase(
         self, phase: str, *, overrides: dict[str, int] | None = None
     ) -> int:
@@ -17331,13 +17482,41 @@ class DispatcherDaemon:
     def _check_stuck_agents(self) -> int:
         """Find running agents whose current phase has been stuck too long.
 
-        Per-phase thresholds (issue #2872 Bug B) replace the old single
-        30-minute global threshold. Each running agent's elapsed time
-        since the most-recent ``phase_transitions.ts`` (or
-        ``started_at`` if no transitions yet) is compared against the
-        threshold for its current ``phase`` —
-        :meth:`_stuck_timeout_for_phase` handles the lookup with live
-        config overrides.
+        Two independent reap conditions are evaluated per running agent
+        (issue #3731 — split prior single-threshold conflation):
+
+        1. **Silent-hang** — ``now - max(phase_transitions.ts)``
+           compared against
+           :data:`SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE` (90 min for
+           ralph, 30 min for short LLM phases, 15 min for
+           ``push_and_pr``). Catches agents whose subprocess crashed /
+           hung / OOM'd without writing any phase_transitions row.
+        2. **Total-runtime** — ``now - started_at`` compared against
+           :data:`STUCK_TIMEOUT_SECONDS_BY_PHASE` (15 hr for ralph,
+           etc.). Catches genuinely runaway agents that ARE still
+           emitting phase_transitions but for too long.
+
+        :meth:`_silent_hang_timeout_for_phase` and
+        :meth:`_stuck_timeout_for_phase` perform the lookups with
+        live config overrides
+        (``dispatcher.config.silent_hang_timeout_s_by_phase`` and
+        ``dispatcher.config.stuck_timeout_s_by_phase`` respectively).
+
+        **Decision precedence.** When both conditions trip, silent-hang
+        wins — it is the more diagnostic signal (no events at all
+        means subprocess hang) and routes through the diagnoser for
+        log-tail inspection. When only total-runtime trips (agent IS
+        emitting events but for too long), the existing stuck_timeout
+        path takes over (mechanical retry first occurrence, diagnoser
+        on recurrence).
+
+        Pre-#3731 the reaper used the (much larger) total-runtime
+        threshold for the silent-hang decision — a hung ralph waited
+        up to 15 hours before getting reaped despite emitting zero
+        phase_transitions for that whole time. Concrete instance
+        2026-04-28: agent ``9943a31e`` on issue #3663 emitted last
+        phase_transitions at 04:33:54Z, then stayed silent for 12h
+        while occupying a cap slot. Manual force_stop at 16:21:46Z.
 
         **Subprocess-mode flagged agents** get a ``dispatcher.failures``
         row with ``category='stuck_timeout'``, are flipped to
@@ -17380,21 +17559,38 @@ class DispatcherDaemon:
         """
         assert self._conn is not None, "connect() must run before stuck check"
 
-        # Candidate rows: every running agent (subprocess or ECS) whose
-        # last phase_transition is older than its phase's threshold.
-        # The per-phase threshold comparison happens in Python so we
-        # can consult both the live config override and the module-
-        # level defaults without expressing them as SQL.
+        # Candidate rows: every running agent (subprocess or ECS).
+        # We compute TWO independent elapsed values per row:
+        #
+        # * ``silent_seconds`` — ``now - max(phase_transitions.ts)``,
+        #   the no-progress window. Compared against
+        #   :data:`SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE` (#3731). When
+        #   ``phase_transitions`` has no rows yet (e.g. brand-new agent
+        #   in claiming) this falls back to ``now - started_at`` so the
+        #   reaper still has SOMETHING to compare against.
+        # * ``total_runtime_seconds`` — ``now - started_at``, the
+        #   absolute runtime cap. Compared against
+        #   :data:`STUCK_TIMEOUT_SECONDS_BY_PHASE`. Catches genuinely
+        #   runaway agents that ARE making progress (phase_transitions
+        #   updating) but for too long.
+        #
+        # Pre-#3731 the SELECT returned a single ``elapsed_seconds``
+        # value computed as ``now - COALESCE(pt.last_ts, started_at)``
+        # — i.e. silent-hang semantics — and the reaper compared it
+        # against the (much larger) total-runtime threshold. That meant
+        # a hung ralph agent (no phase_transitions for hours) had to
+        # wait the full 15h cap before getting reaped. The split fixes
+        # that: each agent is reaped if EITHER threshold is exceeded.
         #
         # #3656: the SELECT no longer excludes ``execution_mode='ecs'``
         # (the previous #3158 filter). The Python loop below branches
         # on mode to deliver the right signal — SIGKILL/retry-marker
         # for subprocess, ``ecs:StopTask`` + diagnoser for ECS.
         #
-        # Fields: agent_id, issue_number, phase, elapsed_seconds,
-        #         execution_mode, agent_task_arn.
+        # Fields: agent_id, issue_number, phase, silent_seconds,
+        #         total_runtime_seconds, execution_mode, agent_task_arn.
         candidates: list[
-            tuple[str, int | None, str | None, float, str, str | None]
+            tuple[str, int | None, str | None, float, float, str, str | None]
         ] = []
         try:
             with self._conn.cursor() as cur:
@@ -17402,7 +17598,10 @@ class DispatcherDaemon:
                     "SELECT a.agent_id, a.issue_number, a.phase, "
                     "       EXTRACT(EPOCH FROM ("
                     "           now() - COALESCE(pt.last_ts, a.started_at)"
-                    "       )) AS elapsed_seconds, "
+                    "       )) AS silent_seconds, "
+                    "       EXTRACT(EPOCH FROM ("
+                    "           now() - a.started_at"
+                    "       )) AS total_runtime_seconds, "
                     "       COALESCE(a.execution_mode, 'subprocess') "
                     "         AS execution_mode, "
                     "       a.agent_task_arn "
@@ -17416,11 +17615,11 @@ class DispatcherDaemon:
                 )
                 rows = cur.fetchall()
                 for row in rows:
-                    raw_mode = row[4] if len(row) > 4 else None
+                    raw_mode = row[5] if len(row) > 5 else None
                     mode = (
                         str(raw_mode).lower() if raw_mode is not None else "subprocess"
                     )
-                    raw_arn = row[5] if len(row) > 5 else None
+                    raw_arn = row[6] if len(row) > 6 else None
                     task_arn = str(raw_arn) if raw_arn is not None else None
                     candidates.append(
                         (
@@ -17428,6 +17627,7 @@ class DispatcherDaemon:
                             int(row[1]) if row[1] is not None else None,
                             str(row[2]) if row[2] is not None else None,
                             float(row[3]) if row[3] is not None else 0.0,
+                            float(row[4]) if row[4] is not None else 0.0,
                             mode,
                             task_arn,
                         )
@@ -17447,33 +17647,50 @@ class DispatcherDaemon:
                 pass
             return 0
 
-        # Read the per-phase override map once per sweep. Empty on
-        # missing row / malformed JSON — ``_stuck_timeout_for_phase``
-        # falls back to module defaults cleanly.
-        overrides = self._read_stuck_timeout_overrides()
+        # Read both per-phase override maps once per sweep. Empty on
+        # missing row / malformed JSON — the helpers fall back to
+        # module defaults cleanly.
+        stuck_overrides = self._read_stuck_timeout_overrides()
+        silent_hang_overrides = self._read_silent_hang_timeout_overrides()
 
         flagged = 0
         for (
             agent_id,
             issue_number,
             phase,
-            elapsed_seconds,
+            silent_seconds,
+            total_runtime_seconds,
             execution_mode,
             agent_task_arn,
         ) in candidates:
-            threshold = self._stuck_timeout_for_phase(phase, overrides=overrides)
-            if elapsed_seconds < threshold:
+            stuck_threshold = self._stuck_timeout_for_phase(
+                phase, overrides=stuck_overrides
+            )
+            silent_threshold = self._silent_hang_timeout_for_phase(
+                phase, overrides=silent_hang_overrides
+            )
+            silent_hang_tripped = silent_seconds >= silent_threshold
+            total_runtime_tripped = total_runtime_seconds >= stuck_threshold
+            if not silent_hang_tripped and not total_runtime_tripped:
                 continue
+            # Decision precedence (#3731): silent-hang takes precedence
+            # when both trip. Silent-hang is the tighter, more
+            # diagnostic signal — the agent stopped emitting events
+            # entirely, so route through the diagnoser for log-tail
+            # inspection. If only total-runtime trips, the agent IS
+            # still emitting events; the existing stuck_timeout path
+            # (mechanical retry first occurrence, diagnoser on
+            # recurrence) is the right call.
             try:
-                if execution_mode == "ecs":
-                    # #3656: ECS-mode silent-hang reaper. Issue
-                    # ``ecs:StopTask`` (best-effort — the
-                    # ``_handle_agent_failure`` row is the source of
-                    # truth even if the StopTask call itself fails),
-                    # then route through the unified failure path so
-                    # the diagnoser inspects last known phase + log
-                    # tail before deciding retry vs. escalate.
-                    self._force_stop_ecs_task(agent_id, agent_task_arn)
+                if silent_hang_tripped:
+                    # Silent-hang: agent has emitted no phase_transitions
+                    # for ``silent_seconds`` ≥ phase's silent-hang
+                    # threshold. ECS rows get an additional StopTask
+                    # call (best-effort); subprocess rows skip the
+                    # StopTask but still route through the unified
+                    # failure path with the silent_hang category.
+                    if execution_mode == "ecs":
+                        self._force_stop_ecs_task(agent_id, agent_task_arn)
                     self._log.warning(
                         "daemon.agent_silent_hang_reaped",
                         extra={
@@ -17482,8 +17699,10 @@ class DispatcherDaemon:
                             "agent_id": agent_id,
                             "issue_number": issue_number,
                             "phase": phase,
-                            "stuck_seconds": int(elapsed_seconds),
-                            "threshold_seconds": threshold,
+                            "stuck_seconds": int(silent_seconds),
+                            "threshold_seconds": silent_threshold,
+                            "total_runtime_seconds": int(total_runtime_seconds),
+                            "total_runtime_threshold_seconds": stuck_threshold,
                             "agent_task_arn": agent_task_arn,
                         },
                     )
@@ -17494,8 +17713,10 @@ class DispatcherDaemon:
                         stderr_tail="",
                         exit_code=None,
                         details={
-                            "stuck_seconds": int(elapsed_seconds),
-                            "threshold_seconds": threshold,
+                            "stuck_seconds": int(silent_seconds),
+                            "threshold_seconds": silent_threshold,
+                            "total_runtime_seconds": int(total_runtime_seconds),
+                            "total_runtime_threshold_seconds": stuck_threshold,
                             "last_known_phase": phase,
                             "execution_mode": execution_mode,
                             "agent_task_arn": agent_task_arn,
@@ -17505,13 +17726,15 @@ class DispatcherDaemon:
                     flagged += 1
                     continue
 
+                # total-runtime-only path: mechanical first-occurrence
+                # retry, diagnoser on recurrence (existing behavior).
                 failure_id = self._write_failure(
                     agent_id=agent_id,
                     category=FAILURE_CATEGORY_STUCK_TIMEOUT,
                     detected_by="supervisor",
                     details={
-                        "stuck_seconds": int(elapsed_seconds),
-                        "threshold_seconds": threshold,
+                        "stuck_seconds": int(total_runtime_seconds),
+                        "threshold_seconds": stuck_threshold,
                         "last_known_phase": phase,
                         "issue_number": issue_number,
                     },
@@ -17538,8 +17761,8 @@ class DispatcherDaemon:
                         "issue_number": issue_number,
                         "category": FAILURE_CATEGORY_STUCK_TIMEOUT,
                         "phase": phase,
-                        "stuck_seconds": int(elapsed_seconds),
-                        "threshold_seconds": threshold,
+                        "stuck_seconds": int(total_runtime_seconds),
+                        "threshold_seconds": stuck_threshold,
                     },
                 )
                 # Emit alert signal for CloudWatch alarm (#2878): if this

--- a/scripts/dispatcher/tests/test_daemon_execution_mode_audit.py
+++ b/scripts/dispatcher/tests/test_daemon_execution_mode_audit.py
@@ -213,17 +213,22 @@ class TestCheckStuckAgentsExecutionModeFilter:
     def test_subprocess_agent_still_flagged_on_timeout(self, tmp_path: Path) -> None:
         """A subprocess-mode agent stuck past its threshold still flips crashed."""
         d, conn, handler = _make_daemon(tmp_path)
-        # Override the config read so the per-phase overrides lookup
-        # returns an empty dict and we fall back to module defaults
-        # (``ralph`` = 54000s).
+        # Override both config reads so we fall back to module defaults
+        # (ralph stuck=54000s, ralph silent_hang=5400s).
         d._read_stuck_timeout_overrides = lambda: {}  # type: ignore[assignment]
-        # One subprocess agent stuck 60000s in ralph (exceeds 54000s).
+        d._read_silent_hang_timeout_overrides = lambda: {}  # type: ignore[assignment]
+        # Post-#3731 row shape: (agent_id, issue_number, phase,
+        # silent_seconds, total_runtime_seconds, execution_mode,
+        # agent_task_arn). Set silent=1800 (under 5400 silent
+        # threshold) and total=60000 (over 54000 stuck threshold) so
+        # ONLY total-runtime trips → stuck_timeout category preserved.
         conn.cursor_instance.fetchall_queue = [
-            [("agent-sub", 2807, "ralph", 60000.0)],
+            [("agent-sub", 2807, "ralph", 1800.0, 60000.0, "subprocess", None)],
         ]
         # Per _flag_stuck_agents path: failure_id RETURNING from
         # _write_failure, prior stuck check (no prior), retry marker
-        # COUNT, backoff config.
+        # COUNT, backoff config. Override reads are stubbed via the
+        # method replacements above so no fetchone for those.
         conn.cursor_instance.fetch_queue = [
             (42,),  # failure_id RETURNING from _write_failure
             None,  # _has_prior_stuck_timeout_in_window — no prior

--- a/scripts/dispatcher/tests/test_daemon_phase3c.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3c.py
@@ -212,27 +212,30 @@ class TestCheckStuckAgents:
     ) -> None:
         d, conn, handler = _make_daemon(tmp_path)
 
-        # Seeded row: one stale ralph agent. Elapsed 55000s > 54000s
-        # (ralph default threshold bumped 10× in #2885). #2872 — the
-        # SELECT returns (agent_id, issue_number, phase, elapsed_seconds)
-        # and the Python-side comparison applies the per-phase
-        # threshold. The kind column was removed from the SELECT
-        # post-#2927 — every row is daemon-owned by construction.
+        # Seeded row: one stale ralph agent. The post-#3731 reaper
+        # evaluates two thresholds independently:
+        #   * silent_seconds=1800 — under ralph silent-hang (5400s),
+        #   * total_runtime_seconds=55000 — over ralph total-runtime
+        #     (54000s, bumped 10× in #2885).
+        # Total-runtime trips alone → stuck_timeout category (existing
+        # behavior preserved). Row tuple shape (#3656/#3731):
+        # (agent_id, issue_number, phase, silent_seconds,
+        #  total_runtime_seconds, execution_mode, agent_task_arn).
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "ralph", 55000.0)],
+            [("agent-1", 42, "ralph", 1800.0, 55000.0, "subprocess", None)],
         ]
         # Order inside _check_stuck_agents + _create_retry_marker:
         # (1) stuck_timeout_s_by_phase override read (returns None → fall
         # through to module defaults),
-        # (2) RETURNING failure_id from _write_failure INSERT,
-        # (3) _has_prior_stuck_timeout_in_window SELECT (returns None →
+        # (2) silent_hang_timeout_s_by_phase override read (None) [#3731],
+        # (3) RETURNING failure_id from _write_failure INSERT,
+        # (4) _has_prior_stuck_timeout_in_window SELECT (returns None →
         #     first occurrence, no repeated event),
-        # (4) COUNT prior markers in _create_retry_marker,
-        # (5) read backoff_seconds config.
-        # Post-#2927 the #2903 _lookup_agent_kind defensive fetch is
-        # gone — no task-skill rows exist to guard against.
+        # (5) COUNT prior markers in _create_retry_marker,
+        # (6) read backoff_seconds config.
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            None,  # silent_hang_timeout_s_by_phase override — unset
             (42,),  # failure_id from _write_failure RETURNING
             None,  # _has_prior_stuck_timeout_in_window — no prior
             (0,),  # prior retry marker count
@@ -299,22 +302,28 @@ class TestCheckStuckAgents:
 
     def test_multiple_stuck_agents_all_flagged(self, tmp_path: Path) -> None:
         d, conn, handler = _make_daemon(tmp_path)
-        # Two stuck agents: ralph exceeds 54000s threshold at 55000s,
-        # claiming exceeds 5min threshold at 600s. (#2872 per-phase
-        # thresholds replace the single 30min global; #2885 bumped
-        # ralph 10× from 90min to 15hr.)
+        # Two stuck agents — both want stuck_timeout (total-runtime
+        # only, no silent-hang) routing under #3731 split.
+        # ralph: silent=1800 (under 5400 silent threshold), total=55000
+        #        (over 54000 stuck threshold) → stuck_timeout fires.
+        # claiming: silent=30 (under 60 silent threshold), total=600
+        #           (over 300s stuck threshold) → stuck_timeout fires.
+        # Row tuple shape (#3731): (agent_id, issue_number, phase,
+        #   silent_seconds, total_runtime_seconds, execution_mode,
+        #   agent_task_arn).
         conn.cursor_instance.fetchall_queue = [
             [
-                ("agent-1", 1, "ralph", 55000.0),
-                ("agent-2", 2, "claiming", 600.0),
+                ("agent-1", 1, "ralph", 1800.0, 55000.0, "subprocess", None),
+                ("agent-2", 2, "claiming", 30.0, 600.0, "subprocess", None),
             ],
         ]
         # Queue: (1) stuck_timeout_s_by_phase override (unset),
+        # (2) silent_hang_timeout_s_by_phase override (unset) [#3731],
         # then for each agent: failure_id RETURNING, prior_stuck check,
         # prior marker count, backoff config.
-        # Post-#2927 the #2903 _lookup_agent_kind fetch is gone.
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase — unset
+            None,  # silent_hang_timeout_s_by_phase — unset
             (42,),  # failure_id RETURNING for agent-1
             None,  # _has_prior_stuck_timeout_in_window for agent-1 — no prior
             (0,),  # prior marker count for agent-1

--- a/scripts/dispatcher/tests/test_daemon_restart_cascade.py
+++ b/scripts/dispatcher/tests/test_daemon_restart_cascade.py
@@ -682,15 +682,20 @@ class TestPerPhaseStuckTimeout:
     """
 
     def test_ralph_below_threshold_not_flagged(self, tmp_path: Path) -> None:
-        """A 2.5-minute ralph is not stuck (threshold is 90 min)."""
+        """A 2.5-minute ralph is not stuck (threshold is 15 hr).
+
+        Row tuple shape (#3731): (agent_id, issue_number, phase,
+        silent_seconds, total_runtime_seconds, execution_mode,
+        agent_task_arn). Both silent and total are 150s — under both
+        thresholds. The reaper does not fire.
+        """
         d, conn, _handler = _make_daemon(tmp_path)
-        # SELECT returns (agent_id, issue_number, phase, elapsed).
-        # Post-#2927 the #2903 ``kind`` column was dropped.
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "ralph", 150.0)],  # 2.5 min elapsed
+            [("agent-1", 42, "ralph", 150.0, 150.0, "subprocess", None)],
         ]
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            None,  # silent_hang_timeout_s_by_phase override — unset
         ]
         assert d._check_stuck_agents() == 0
 
@@ -698,21 +703,30 @@ class TestPerPhaseStuckTimeout:
         """A 90-second plan is not stuck (threshold is 2.5 hr, #2885)."""
         d, conn, _handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "plan", 90.0)],
+            [("agent-1", 42, "plan", 90.0, 90.0, "subprocess", None)],
         ]
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            None,  # silent_hang_timeout_s_by_phase override — unset
         ]
         assert d._check_stuck_agents() == 0
 
     def test_ralph_over_threshold_flagged(self, tmp_path: Path) -> None:
-        """A 16-hour ralph IS stuck (threshold is 15 hr / 54000s, #2885)."""
+        """A 16-hour ralph IS stuck (total-runtime threshold 15 hr exceeded).
+
+        Post-#3731: silent_seconds set under the 5400s ralph silent-hang
+        threshold so only the total-runtime path fires (preserves
+        original test intent — stuck_timeout category, not silent-hang).
+        """
         d, conn, handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "ralph", 57600.0)],  # 16 hr
+            # silent=1800 (under 5400 silent threshold), total=57600
+            # (over 54000 stuck threshold) → stuck_timeout fires.
+            [("agent-1", 42, "ralph", 1800.0, 57600.0, "subprocess", None)],
         ]
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            None,  # silent_hang_timeout_s_by_phase override — unset
             (42,),  # failure_id RETURNING from _write_failure
             None,  # _has_prior_stuck_timeout_in_window — no prior
             (0,),  # prior retry marker count
@@ -727,13 +741,15 @@ class TestPerPhaseStuckTimeout:
     def test_config_override_wins_over_default(self, tmp_path: Path) -> None:
         """Operator override in ``stuck_timeout_s_by_phase`` takes precedence."""
         d, conn, _handler = _make_daemon(tmp_path)
-        # Elapsed 400s — under the default 5min claiming threshold, but
-        # operator set claiming override to 300s. Should fire.
+        # silent=30 (under 60s claiming silent threshold), total=400s.
+        # Operator override sets claiming stuck threshold to 300s, so
+        # total (400) > stuck (300) → stuck_timeout fires.
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "claiming", 400.0)],
+            [("agent-1", 42, "claiming", 30.0, 400.0, "subprocess", None)],
         ]
         conn.cursor_instance.fetch_queue = [
             ('{"claiming": 300}',),  # operator override
+            None,  # silent_hang_timeout_s_by_phase override — unset
             (42,),  # failure_id RETURNING from _write_failure
             None,  # _has_prior_stuck_timeout_in_window — no prior
             (0,),  # prior marker count
@@ -744,12 +760,14 @@ class TestPerPhaseStuckTimeout:
     def test_unknown_phase_falls_back_to_global(self, tmp_path: Path) -> None:
         """Phase not in the table falls back to STUCK_TIMEOUT_SECONDS (30 min)."""
         d, conn, _handler = _make_daemon(tmp_path)
-        # Novel phase, elapsed 31 min — over the 30 min default fallback.
+        # silent=600 (under SILENT_HANG_DEFAULT 1800s), total=31min
+        # (over STUCK_TIMEOUT_SECONDS 30min default).
         conn.cursor_instance.fetchall_queue = [
-            [("agent-1", 42, "novel_phase", 31 * 60.0)],
+            [("agent-1", 42, "novel_phase", 600.0, 31 * 60.0, "subprocess", None)],
         ]
         conn.cursor_instance.fetch_queue = [
-            None,  # no override
+            None,  # stuck override — no
+            None,  # silent_hang override — no
             (42,),  # failure_id RETURNING from _write_failure
             None,  # _has_prior_stuck_timeout_in_window — no prior
             (0,),  # prior marker count
@@ -865,13 +883,22 @@ class TestIssue2885TenTimesBump:
         though the subprocess was 15s from clean exit. The new 54000s
         threshold gives ~15 hr of headroom — enough that a
         normally-progressing ralph can NEVER race against the timer.
+
+        Post-#3731 the silent-hang and total-runtime thresholds are
+        evaluated independently. A normally-progressing ralph emits
+        ``phase_transitions`` every few minutes, so silent_seconds
+        stays well under the 5400s silent-hang threshold even when
+        total_runtime is 5419s.
         """
         d, conn, _handler = _make_daemon(tmp_path)
         conn.cursor_instance.fetchall_queue = [
-            [("agent-821e96ee", 2565, "ralph", 5419.0, "task")],
+            # silent=300 (5min — healthy ralph iteration cadence),
+            # total=5419 (under 54000 ralph stuck threshold).
+            [("agent-821e96ee", 2565, "ralph", 300.0, 5419.0, "subprocess", None)],
         ]
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            None,  # silent_hang_timeout_s_by_phase override — unset
         ]
         # Pre-fix: 1. Post-fix: 0.
         assert d._check_stuck_agents() == 0

--- a/scripts/dispatcher/tests/test_daemon_retry_loop.py
+++ b/scripts/dispatcher/tests/test_daemon_retry_loop.py
@@ -141,19 +141,27 @@ class TestRetryLoopEndToEnd:
         d, conn, handler = _make_daemon(tmp_path)
 
         # ── Step 1: _check_stuck_agents ────────────────────────────────
-        # Seed one stuck ralph agent.  Elapsed 55000s > 54000s (ralph
-        # per-phase threshold, bumped 10× by #2885).
+        # Seed one stuck ralph agent. Post-#3731 the reaper evaluates
+        # silent-hang (5400s for ralph) and total-runtime (54000s) as
+        # independent thresholds. To preserve this test's intent
+        # (stuck_timeout fires, not silent_hang), set silent_seconds
+        # under 5400 and total_runtime over 54000.
+        # Row tuple shape (#3656/#3731): (agent_id, issue_number,
+        # phase, silent_seconds, total_runtime_seconds, execution_mode,
+        # agent_task_arn).
         conn.cursor_instance.fetchall_queue = [
-            [("retry-agent-1", 2794, "ralph", 55000.0)],
+            [("retry-agent-1", 2794, "ralph", 1800.0, 55000.0, "subprocess", None)],
         ]
         # Per _check_stuck_agents + _create_retry_marker call order:
         # (1) stuck_timeout_s_by_phase config override (unset → None),
-        # (2) RETURNING failure_id from _write_failure INSERT,
-        # (3) _has_prior_stuck_timeout_in_window (no prior → None),
-        # (4) COUNT prior retry markers (0 → first attempt),
-        # (5) backoff schedule.
+        # (2) silent_hang_timeout_s_by_phase override (None) [#3731],
+        # (3) RETURNING failure_id from _write_failure INSERT,
+        # (4) _has_prior_stuck_timeout_in_window (no prior → None),
+        # (5) COUNT prior retry markers (0 → first attempt),
+        # (6) backoff schedule.
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            None,  # silent_hang_timeout_s_by_phase override — unset
             (42,),  # failure_id RETURNING from _write_failure
             None,  # _has_prior_stuck_timeout_in_window — no prior
             (0,),  # prior retry marker count

--- a/scripts/dispatcher/tests/test_daemon_silent_hang_per_phase.py
+++ b/scripts/dispatcher/tests/test_daemon_silent_hang_per_phase.py
@@ -1,0 +1,406 @@
+"""Regression tests for the silent-hang-vs-total-runtime threshold split (#3731).
+
+Verifies that :meth:`~dispatcher.daemon.DispatcherDaemon._check_stuck_agents`
+distinguishes two independent reap conditions:
+
+1. **Silent-hang reap** — fires when ``now - max(phase_transitions.ts)``
+   exceeds ``SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE[phase]`` (e.g. 90 min
+   for ralph). Catches agents whose subprocess crashed / hung / OOM'd
+   without writing any phase_transitions row.
+2. **Total-runtime reap** — fires when ``now - started_at`` exceeds
+   ``STUCK_TIMEOUT_SECONDS_BY_PHASE[phase]`` (e.g. 15 hr for ralph).
+   Catches genuinely runaway agents that ARE making progress
+   (phase_transitions ARE updating) but for too long.
+
+Pre-#3731 the reaper used ``STUCK_TIMEOUT_SECONDS_BY_PHASE[phase]`` for
+**both** decisions, comparing it against ``now -
+COALESCE(pt.last_ts, started_at)``. That conflation meant a hung ralph
+agent (no phase_transitions for hours) had to wait the full 15-hour
+absolute-runtime cap before the reaper would notice. Concrete instance:
+agent ``9943a31e`` on issue #3663 emitted its last phase_transitions
+event at 04:33:54Z, then went silent for 12h while showing
+``status=running, phase=ralph``. Operator manually force-stopped at
+16:21:46Z. The cap slot was unusable for the full duration.
+
+The fix: two thresholds per phase, evaluated independently. Reap on
+EITHER (silent-hang OR total-runtime). The silent-hang threshold is
+much tighter (90 min for ralph) because a healthy ralph emits
+``ralph_iteration_*`` phase_transitions every few minutes — anything
+silent for >90 min is a hung subprocess, not a slow one.
+
+Test cases:
+
+* **Silent-hang fires (silent > threshold, total < threshold)** — ralph
+  agent with last phase_transitions.ts 100min ago and total runtime 2h.
+  Silent-hang threshold 90min exceeded → reap. Total-runtime 15h NOT
+  exceeded — without the split, this agent would NOT have been reaped.
+* **Neither fires (silent < threshold, total < threshold)** — ralph
+  agent iterating slowly: last ts 50min ago, total runtime 14h. Both
+  thresholds under cap. Don't false-positive on slow-but-healthy ralph.
+* **Total-runtime fires (total > threshold)** — ralph agent total
+  runtime 16h, last ts 30min ago. Even if silent-hang threshold isn't
+  exceeded (30min < 90min), total-runtime is. Preserve existing
+  behavior — runaway agents still get reaped.
+* **Helper returns the right thresholds** — ``_silent_hang_timeout_for_phase``
+  returns expected per-phase values from ``SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE``
+  and falls back to a global default for unknown phases.
+* **Constant table values** — the proposed defaults (ralph=5400,
+  plan/summary/verify/retro=1800, push_and_pr=900, operational=3600)
+  match the issue body and the operator's dispatch.
+
+Fixture style mirrors ``test_daemon_stuck_check_ecs_silent_hang.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+from dispatcher import daemon  # noqa: E402  — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — mirrors test_daemon_stuck_check_ecs_silent_hang.py
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.silent_hang_per_phase.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+        ecs_cluster_arn="arn:aws:ecs:us-west-2:155326049300:cluster/judgemind-dispatcher",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    d._ecs_client = MagicMock()
+    return d, conn, handler
+
+
+# --------------------------------------------------------------------------
+# Constant + helper tests (cheap — no DB fixture)
+# --------------------------------------------------------------------------
+
+
+class TestSilentHangConstants:
+    """The new ``SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE`` table values."""
+
+    def test_table_exists(self) -> None:
+        """The new constant exists at module level."""
+        assert hasattr(daemon, "SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE")
+        assert isinstance(daemon.SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE, dict)
+
+    def test_ralph_threshold_is_90_min(self) -> None:
+        """Ralph emits phase_transitions every few minutes when healthy.
+
+        90 min is generous (10× the typical iteration cadence) but tight
+        enough to reap a hung subprocess in <2h instead of waiting for
+        the 15h total-runtime cap.
+        """
+        assert daemon.SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE["ralph"] == 5400
+
+    def test_short_llm_phases_are_30_min(self) -> None:
+        """Plan / summary / verify / retro are single-pass LLM phases.
+
+        They emit a phase_transitions row at start and again at end — no
+        iteration in between. 30 min covers the longest observed
+        single-pass runtime with a wide margin.
+        """
+        assert daemon.SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE["plan"] == 1800
+        assert daemon.SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE["planning"] == 1800
+        assert daemon.SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE["summary"] == 1800
+        assert daemon.SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE["verify"] == 1800
+        assert daemon.SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE["retro"] == 1800
+
+    def test_push_and_pr_is_15_min(self) -> None:
+        """push_and_pr is git-only — no LLM. 15 min covers any TCP retry."""
+        assert daemon.SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE["push_and_pr"] == 900
+
+    def test_operational_matches_total_runtime(self) -> None:
+        """Operational phase has no phase_transitions sub-events.
+
+        Silent-hang threshold equals total-runtime threshold (60 min)
+        because there's only one phase_transitions row written (at end).
+        """
+        assert daemon.SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE["operational"] == 3600
+
+    def test_global_default_exists(self) -> None:
+        """Unknown phases fall back to a global default constant."""
+        assert hasattr(daemon, "SILENT_HANG_DEFAULT_SECONDS")
+        assert isinstance(daemon.SILENT_HANG_DEFAULT_SECONDS, int)
+        assert daemon.SILENT_HANG_DEFAULT_SECONDS == 1800
+
+
+class TestSilentHangHelperLookup:
+    """``_silent_hang_timeout_for_phase`` matches the table + global default."""
+
+    def test_known_phase_returns_table_value(self, tmp_path: Path) -> None:
+        d, _conn, _h = _make_daemon(tmp_path)
+        assert d._silent_hang_timeout_for_phase("ralph") == 5400
+        assert d._silent_hang_timeout_for_phase("push_and_pr") == 900
+
+    def test_unknown_phase_falls_back_to_global(self, tmp_path: Path) -> None:
+        d, _conn, _h = _make_daemon(tmp_path)
+        assert (
+            d._silent_hang_timeout_for_phase("nonexistent_phase_xyz")
+            == daemon.SILENT_HANG_DEFAULT_SECONDS
+        )
+
+    def test_none_phase_falls_back_to_global(self, tmp_path: Path) -> None:
+        d, _conn, _h = _make_daemon(tmp_path)
+        assert (
+            d._silent_hang_timeout_for_phase(None) == daemon.SILENT_HANG_DEFAULT_SECONDS
+        )
+
+
+# --------------------------------------------------------------------------
+# Reaper-decision tests — the core regression cases from the issue body
+# --------------------------------------------------------------------------
+
+
+class TestSilentHangPerPhaseReaper:
+    """End-to-end ``_check_stuck_agents`` behavior with the threshold split."""
+
+    def test_silent_hang_fires_when_silent_exceeds_threshold(
+        self, tmp_path: Path
+    ) -> None:
+        """Ralph agent silent 100min, total runtime 2h — REAP fires.
+
+        Silent-hang threshold (90min) exceeded; total-runtime threshold
+        (15h) NOT exceeded. Pre-#3731 this agent would have been left
+        running for another 13h — the bug. The fix is the split: ANY of
+        the two thresholds being exceeded triggers a reap.
+
+        Concrete: this matches the ``9943a31e`` incident shape from the
+        issue body (12h of silence, started_at well within total-cap).
+        Without the split, the silent-hang reaper had to wait until
+        elapsed ≥ 15h to fire.
+        """
+        d, conn, _h = _make_daemon(tmp_path)
+
+        task_arn = "arn:aws:ecs:us-west-2:155326049300:task/cluster/silent-ralph"
+        # Row schema (post-#3731): agent_id, issue_number, phase,
+        # silent_seconds, total_runtime_seconds, execution_mode,
+        # agent_task_arn.
+        conn.cursor_instance.fetchall_queue = [
+            [
+                (
+                    "9943a31e-022f-4874-84bf-3f6828de0b37",
+                    3663,
+                    "ralph",
+                    6000.0,  # 100 min silent — exceeds 5400s (90min) silent-hang
+                    7200.0,  # 2h total — under 54000s (15h) total-runtime
+                    "ecs",
+                    task_arn,
+                ),
+            ],
+        ]
+        conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase override unset
+            None,  # silent_hang_timeout_s_by_phase override unset
+            (200,),  # failure_id from _write_failure RETURNING
+        ]
+
+        flagged = d._check_stuck_agents()
+        assert flagged == 1, (
+            "ralph agent silent 100min should be reaped via silent-hang threshold"
+        )
+
+        # Failure row written with the silent-hang category.
+        failure_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert len(failure_inserts) == 1
+        assert failure_inserts[0][1][1] == daemon.FAILURE_CATEGORY_AGENT_SILENT_HANG
+
+    def test_neither_fires_when_silent_and_total_under_threshold(
+        self, tmp_path: Path
+    ) -> None:
+        """Ralph agent iterating every 50min, total runtime 14h — NO reap.
+
+        Slow ralph (legitimate 50min iterations on a hard issue) must
+        not false-positive. Both thresholds are under cap:
+        * silent: 50min < 90min
+        * total: 14h < 15h
+
+        Without the split, an aggressive silent-hang threshold could
+        accidentally false-positive on slow-but-healthy ralph. The
+        per-phase silent-hang threshold has to be high enough to
+        accommodate the longest legitimate iteration cadence.
+        """
+        d, conn, _h = _make_daemon(tmp_path)
+
+        conn.cursor_instance.fetchall_queue = [
+            [
+                (
+                    "agent-slow-ralph",
+                    3700,
+                    "ralph",
+                    3000.0,  # 50 min silent — under 5400s (90min) threshold
+                    50400.0,  # 14h total — under 54000s (15h) total-runtime
+                    "subprocess",
+                    None,
+                ),
+            ],
+        ]
+        # Override fetches for both threshold tables.
+        conn.cursor_instance.fetch_queue = [
+            None,  # stuck_timeout_s_by_phase override unset
+            None,  # silent_hang_timeout_s_by_phase override unset
+        ]
+
+        flagged = d._check_stuck_agents()
+        assert flagged == 0, (
+            "slow-but-healthy ralph (50min silent, 14h total) must not be reaped"
+        )
+
+        # No failure row.
+        failure_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert failure_inserts == []
+
+    def test_total_runtime_fires_independent_of_silent_hang(
+        self, tmp_path: Path
+    ) -> None:
+        """Ralph agent total runtime 16h, last ts 30min ago — REAP fires.
+
+        Existing behavior preserved: a runaway-but-active ralph (still
+        emitting phase_transitions every few minutes) still hits the
+        total-runtime cap. Even though silent-hang threshold (90min) is
+        NOT exceeded (30min silent), total-runtime threshold (15h) IS
+        exceeded (16h total). This is the original
+        ``STUCK_TIMEOUT_SECONDS_BY_PHASE`` semantics, kept intact.
+        """
+        d, conn, _h = _make_daemon(tmp_path)
+
+        conn.cursor_instance.fetchall_queue = [
+            [
+                (
+                    "agent-runaway-ralph",
+                    3701,
+                    "ralph",
+                    1800.0,  # 30 min silent — under 5400s threshold
+                    57600.0,  # 16h total — exceeds 54000s (15h) total-runtime
+                    "subprocess",
+                    None,
+                ),
+            ],
+        ]
+        # Subprocess path's fetch sequence (post-#3731 with the new
+        # silent-hang override read added):
+        # (1) stuck_timeout_s_by_phase override — None.
+        # (2) silent_hang_timeout_s_by_phase override — None.
+        # (3) failure_id RETURNING.
+        # (4) _has_prior_stuck_timeout_in_window — None (first occurrence).
+        # (5) prior retry-marker count.
+        # (6) backoff schedule.
+        conn.cursor_instance.fetch_queue = [
+            None,
+            None,
+            (300,),
+            None,
+            (0,),
+            ("[60,300,900]",),
+        ]
+
+        flagged = d._check_stuck_agents()
+        assert flagged == 1, (
+            "runaway ralph (16h total) must still hit total-runtime cap"
+        )
+
+        # The category should be stuck_timeout (total-runtime), not
+        # silent-hang — because the silent-hang condition didn't trip.
+        failure_inserts = [
+            e
+            for e in conn.cursor_instance.executed
+            if "INSERT INTO dispatcher.failures" in e[0]
+        ]
+        assert len(failure_inserts) == 1
+        assert failure_inserts[0][1][1] == daemon.FAILURE_CATEGORY_STUCK_TIMEOUT

--- a/scripts/dispatcher/tests/test_daemon_stuck_check_ecs_silent_hang.py
+++ b/scripts/dispatcher/tests/test_daemon_stuck_check_ecs_silent_hang.py
@@ -189,13 +189,20 @@ class TestEcsSilentHangReaper:
             "arn:aws:ecs:us-west-2:155326049300:task/"
             "judgemind-dispatcher/9d333e50bb3c4653b4ba8eb6506f9d13"
         )
+        # Post-#3731 row shape: (agent_id, issue_number, phase,
+        # silent_seconds, total_runtime_seconds, execution_mode,
+        # agent_task_arn). silent=2000 over the push_and_pr silent-hang
+        # threshold (900s) → silent-hang fires. total=2000 also over
+        # push_and_pr stuck threshold (default 1800s), but silent-hang
+        # takes precedence per #3731 decision rule.
         conn.cursor_instance.fetchall_queue = [
             [
                 (
                     "2ff6e282-a431-493c-bc3e-b899d4c92ca1",
                     3608,
                     "push_and_pr",
-                    2000.0,  # 2000s > 1800s default threshold
+                    2000.0,  # silent_seconds — over 900s silent threshold
+                    2000.0,  # total_runtime — also over 1800s stuck (silent wins)
                     "ecs",
                     task_arn,
                 ),
@@ -204,9 +211,11 @@ class TestEcsSilentHangReaper:
         # Order of fetchone calls inside _check_stuck_agents (ECS branch
         # via _handle_agent_failure → _write_failure → _mark_agent_terminal):
         # (1) stuck_timeout_s_by_phase override read — returns None.
-        # (2) failure_id from _write_failure RETURNING.
+        # (2) silent_hang_timeout_s_by_phase override read — None [#3731].
+        # (3) failure_id from _write_failure RETURNING.
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override unset
+            None,  # silent_hang_timeout_s_by_phase override unset
             (200,),  # failure_id from _write_failure RETURNING
         ]
 
@@ -275,19 +284,23 @@ class TestEcsSilentHangReaper:
         """
         d, conn, handler = _make_daemon(tmp_path)
 
+        # Post-#3731 row shape with silent + total. Both 600s — well
+        # below silent (900s) and stuck (1800s default) thresholds.
         conn.cursor_instance.fetchall_queue = [
             [
                 (
                     "agent-ecs-fast",
                     3656,
                     "push_and_pr",
-                    600.0,  # well below 1800s default threshold
+                    600.0,  # silent_seconds — under 900s
+                    600.0,  # total_runtime — under 1800s
                     "ecs",
                     "arn:aws:ecs:us-west-2:155326049300:task/cluster/abc",
                 ),
             ],
         ]
-        conn.cursor_instance.fetch_queue = [None]
+        # Both override reads fire even when no agent fires.
+        conn.cursor_instance.fetch_queue = [None, None]
 
         flagged = d._check_stuck_agents()
         assert flagged == 0
@@ -319,20 +332,25 @@ class TestEcsSilentHangReaper:
         """
         d, conn, handler = _make_daemon(tmp_path)
 
+        # Post-#3731 7-tuple: silent=2000 over 900s silent threshold →
+        # silent-hang fires. NULL agent_task_arn — _force_stop_ecs_task
+        # short-circuits cleanly.
         conn.cursor_instance.fetchall_queue = [
             [
                 (
                     "agent-ecs-no-arn",
                     3656,
                     "push_and_pr",
-                    2000.0,  # > 1800s default threshold
+                    2000.0,  # silent_seconds — over 900s
+                    2000.0,  # total_runtime — also over but silent wins
                     "ecs",
                     None,  # missing ARN
                 ),
             ],
         ]
         conn.cursor_instance.fetch_queue = [
-            None,
+            None,  # stuck override
+            None,  # silent_hang override [#3731]
             (201,),  # failure_id RETURNING
         ]
 
@@ -368,26 +386,31 @@ class TestEcsSilentHangReaper:
         """
         d, conn, handler = _make_daemon(tmp_path)
 
+        # Post-#3731: silent=600 under 900s silent threshold so silent-
+        # hang does NOT fire; total=2000 over 1800s stuck threshold so
+        # the existing stuck_timeout path fires (preserves test intent).
         conn.cursor_instance.fetchall_queue = [
             [
                 (
                     "agent-subproc",
                     3656,
                     "push_and_pr",
-                    2000.0,  # > 1800s default threshold
+                    600.0,  # silent_seconds — under 900s
+                    2000.0,  # total_runtime — over 1800s default stuck
                     "subprocess",
                     None,
                 ),
             ],
         ]
-        # Subprocess path's fetch sequence (unchanged from the
-        # pre-#3656 test fixtures):
+        # Subprocess path's fetch sequence:
         # (1) stuck_timeout_s_by_phase override — None.
-        # (2) failure_id RETURNING.
-        # (3) _has_prior_stuck_timeout_in_window — None (first occurrence).
-        # (4) prior retry-marker count.
-        # (5) backoff schedule.
+        # (2) silent_hang_timeout_s_by_phase override — None [#3731].
+        # (3) failure_id RETURNING.
+        # (4) _has_prior_stuck_timeout_in_window — None (first occurrence).
+        # (5) prior retry-marker count.
+        # (6) backoff schedule.
         conn.cursor_instance.fetch_queue = [
+            None,
             None,
             (300,),
             None,
@@ -433,21 +456,27 @@ class TestEcsSilentHangReaper:
         d, conn, handler = _make_daemon(tmp_path)
 
         ecs_arn = "arn:aws:ecs:us-west-2:155326049300:task/cluster/ecs1"
+        # Post-#3731: 7-tuple shape. ECS row trips silent-hang
+        # (silent=2000 > 900 push_and_pr silent threshold). Subprocess
+        # row trips total-runtime only (silent=900 < 1800 summary
+        # silent threshold; total=7000 > 6000 summary stuck threshold).
         conn.cursor_instance.fetchall_queue = [
             [
                 (
                     "agent-mixed-ecs",
                     3656,
                     "push_and_pr",
-                    2000.0,  # > 1800s default
+                    2000.0,  # silent_seconds — over 900 silent threshold
+                    2000.0,  # total_runtime — silent-hang takes precedence
                     "ecs",
                     ecs_arn,
                 ),
                 (
                     "agent-mixed-sub",
                     3656,
-                    "summary",  # 6000s threshold (#2885)
-                    7000.0,  # > 6000s
+                    "summary",  # silent=1800, stuck=6000 (#2885)
+                    900.0,  # silent_seconds — under 1800 silent
+                    7000.0,  # total_runtime — over 6000 stuck
                     "subprocess",
                     None,
                 ),
@@ -455,6 +484,7 @@ class TestEcsSilentHangReaper:
         ]
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override
+            None,  # silent_hang_timeout_s_by_phase override [#3731]
             # ECS agent failure write (first):
             (400,),
             # subprocess agent failure write:

--- a/scripts/dispatcher/tests/test_daemon_stuck_check_operational.py
+++ b/scripts/dispatcher/tests/test_daemon_stuck_check_operational.py
@@ -140,23 +140,27 @@ class TestOperationalPhaseStuckTimeout:
         """
         d, conn, handler = _make_daemon(tmp_path)
 
-        # Seeded row: one stale operational agent. Elapsed 3700s > 3600s
-        # (operational threshold added in #3524). The SELECT returns
-        # (agent_id, issue_number, phase, elapsed_seconds) and the
-        # Python-side comparison applies the per-phase threshold.
+        # Seeded row: stale operational agent. Post-#3731 row shape:
+        # (agent_id, issue_number, phase, silent_seconds,
+        #  total_runtime_seconds, execution_mode, agent_task_arn).
+        # silent=1800 under operational silent-hang (3600s); total=3700
+        # over operational total-runtime (3600s). Total-runtime path
+        # fires → stuck_timeout category preserved (not silent_hang).
         conn.cursor_instance.fetchall_queue = [
-            [("agent-op-1", 3524, "operational", 3700.0)],
+            [("agent-op-1", 3524, "operational", 1800.0, 3700.0, "subprocess", None)],
         ]
         # Order inside _check_stuck_agents + _create_retry_marker:
         # (1) stuck_timeout_s_by_phase override read (returns None → fall
         #     through to module defaults — where "operational": 3600 now lives),
-        # (2) RETURNING failure_id from _write_failure INSERT,
-        # (3) _has_prior_stuck_timeout_in_window SELECT (returns None →
+        # (2) silent_hang_timeout_s_by_phase override read (None) [#3731],
+        # (3) RETURNING failure_id from _write_failure INSERT,
+        # (4) _has_prior_stuck_timeout_in_window SELECT (returns None →
         #     first occurrence, no repeated event),
-        # (4) COUNT prior markers in _create_retry_marker,
-        # (5) read backoff_seconds config.
+        # (5) COUNT prior markers in _create_retry_marker,
+        # (6) read backoff_seconds config.
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            None,  # silent_hang_timeout_s_by_phase override — unset
             (100,),  # failure_id from _write_failure RETURNING
             None,  # _has_prior_stuck_timeout_in_window — no prior
             (0,),  # prior retry marker count
@@ -215,15 +219,18 @@ class TestOperationalPhaseStuckTimeout:
         """
         d, conn, handler = _make_daemon(tmp_path)
 
-        # Seeded row: operational agent at 3500s — below the 3600s threshold.
+        # Seeded row: operational agent at 3500s — below both 3600s
+        # thresholds (silent-hang and total-runtime are equal for
+        # operational by design). Post-#3731 7-tuple shape.
         conn.cursor_instance.fetchall_queue = [
-            [("agent-op-2", 3524, "operational", 3500.0)],
+            [("agent-op-2", 3524, "operational", 3500.0, 3500.0, "subprocess", None)],
         ]
-        # Only the per-sweep override read fires (fetchone for the config row).
-        # The agent is filtered by elapsed < threshold, so no failure/marker
-        # DB calls are made.
+        # Only the per-sweep override reads fire (fetchone for both
+        # config rows). The agent is filtered by elapsed < threshold,
+        # so no failure/marker DB calls are made.
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            None,  # silent_hang_timeout_s_by_phase override — unset
         ]
 
         flagged = d._check_stuck_agents()

--- a/scripts/dispatcher/tests/test_daemon_stuck_timeout_repeated.py
+++ b/scripts/dispatcher/tests/test_daemon_stuck_timeout_repeated.py
@@ -139,15 +139,22 @@ class TestStuckTimeoutRepeated:
         """
         d, conn, handler = _make_daemon(tmp_path)
 
+        # Post-#3731 row tuple: silent_seconds under 5400 (ralph silent
+        # threshold) so total-runtime path fires (stuck_timeout
+        # category, not silent_hang). Tuple shape: (agent_id,
+        # issue_number, phase, silent_seconds, total_runtime_seconds,
+        # execution_mode, agent_task_arn).
         conn.cursor_instance.fetchall_queue = [
-            [("agent-first", 101, "ralph", 57600.0)],  # 16 hr > 54000s threshold
+            [("agent-first", 101, "ralph", 1800.0, 57600.0, "subprocess", None)],
         ]
         # Fetch order with _mark_agent_terminal / _create_retry_marker stubbed:
         # (1) stuck_timeout_s_by_phase config override (unset → None),
-        # (2) RETURNING failure_id from _write_failure INSERT = 10,
-        # (3) _has_prior_stuck_timeout_in_window → None (no prior row).
+        # (2) silent_hang_timeout_s_by_phase override (None) [#3731],
+        # (3) RETURNING failure_id from _write_failure INSERT = 10,
+        # (4) _has_prior_stuck_timeout_in_window → None (no prior row).
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            None,  # silent_hang_timeout_s_by_phase override — unset
             (10,),  # failure_id RETURNING from _write_failure
             None,  # _has_prior_stuck_timeout_in_window — no prior
         ]
@@ -177,14 +184,16 @@ class TestStuckTimeoutRepeated:
         d, conn, handler = _make_daemon(tmp_path)
 
         conn.cursor_instance.fetchall_queue = [
-            [("agent-repeat", 202, "ralph", 57600.0)],
+            [("agent-repeat", 202, "ralph", 1800.0, 57600.0, "subprocess", None)],
         ]
         # Fetch order with _mark_agent_terminal / _create_retry_marker stubbed:
         # (1) stuck_timeout_s_by_phase override — unset,
-        # (2) RETURNING failure_id = 10 (current failure),
-        # (3) _has_prior_stuck_timeout_in_window → (9,) (prior row exists).
+        # (2) silent_hang_timeout_s_by_phase override — unset [#3731],
+        # (3) RETURNING failure_id = 10 (current failure),
+        # (4) _has_prior_stuck_timeout_in_window → (9,) (prior row exists).
         conn.cursor_instance.fetch_queue = [
             None,  # stuck_timeout_s_by_phase override — unset
+            None,  # silent_hang_timeout_s_by_phase override — unset
             (10,),  # failure_id RETURNING (current failure)
             (9,),  # prior failure_id within window
         ]


### PR DESCRIPTION
## Summary

Splits the dispatcher's silent-hang reaper threshold from the existing total-runtime cap. Pre-#3731 a hung ralph subprocess waited up to 15 hours for reap because the supervisor compared `now - max(phase_transitions.ts)` against `STUCK_TIMEOUT_SECONDS_BY_PHASE` (the total-runtime cap, e.g. 15h for ralph). Concrete burn: agent `9943a31e` on issue #3663 stayed silent for 12h while pinning a cap slot (manually force-stopped at 16:21:46Z 2026-04-28).

The fix introduces `SILENT_HANG_TIMEOUT_SECONDS_BY_PHASE` (90 min ralph, 30 min plan/summary/verify/retro, 15 min push_and_pr, 60 min operational, 30 min default) compared against `now - max(phase_transitions.ts)`. The total-runtime cap continues to use `STUCK_TIMEOUT_SECONDS_BY_PHASE` against `now - started_at`. The reaper evaluates both independently; silent-hang takes precedence when both trip (more diagnostic — routes through the diagnoser for log-tail inspection). Includes a parallel live-config override key `dispatcher.config.silent_hang_timeout_s_by_phase`.

Closes #3731

## Test plan

### Automated checks
- [x] Ruff check passes (already-existing `# noqa` warnings on lines 20215/20363 are unchanged from main)
- [x] Ruff format check passes
- [x] All dispatcher tests pass locally (1972 passed, 1 skipped — same baseline as main; 12 new tests added in `test_daemon_silent_hang_per_phase.py`)
- [x] CI green

### Post-deploy verification
- [x] Dev deploy succeeded (`deploy-dispatcher.yml` run #25069874356, Build+Push 1m27s + Deploy to Dev 3m14s, both green)
- [x] Merge SHA `db77833` confirmed live in dispatcher (`scripts/verify-pr-in-deployed-sha.sh 3733` → "PR #3733 landed in deployed SHA db77833")
- [x] CloudWatch confirms supervisor ticks running cleanly with new SELECT shape (tick_n=1, tick_n=2 at 18:15Z/18:17Z, `stuck_flagged: 0`, no `stuck_scan_failed`)
- [x] Verification evidence posted on issue #3731
