### PR TITLE
fix(dispatcher): rename timeout-required marker to remove Invalid-noqa warnings (#3734)

### DIFF
--- a/scripts/check-no-unbounded-timeouts.py
+++ b/scripts/check-no-unbounded-timeouts.py
@@ -47,10 +47,12 @@ For every ``ast.Call`` node under ``scripts/dispatcher/**/*.py`` (excluding
 
 Allowlist
 ---------
-A call may be exempted by adding ``# noqa: timeout-required: <reason>``
+A call may be exempted by adding ``# timeout-required: <reason>``
 to the same source line as the call (or any line covered by the call's
-multi-line span). A bare ``# noqa`` does NOT exempt -- the rule name
-``timeout-required`` AND a non-empty reason are required.
+multi-line span). A bare ``# noqa`` does NOT exempt -- the marker name
+``timeout-required`` AND a non-empty reason are required. The old form
+``# noqa: timeout-required: <reason>`` is retired (it emits ruff
+``Invalid # noqa directive`` warnings).
 
 Output
 ------
@@ -90,7 +92,7 @@ REQUESTS_METHODS = frozenset(
 # Allowlist marker -- see module docstring for the exact spelling. We
 # require the rule name AND a non-empty reason. Bare markers (no rule
 # name, or empty reason) are rejected -- see _line_is_allowlisted.
-_ALLOWLIST_RE = re.compile(r"#\s*noqa\s*:\s*timeout-required\s*:\s*\S+")
+_ALLOWLIST_RE = re.compile(r"#\s*timeout-required\s*:\s*\S+")
 
 
 # ---------------------------------------------------------------------------
@@ -395,7 +397,7 @@ def _node_contains(parent: ast.AST, child: ast.AST) -> bool:
 
 def _line_is_allowlisted(call: ast.Call, source_lines: list[str]) -> bool:
     """Return True if any source line covered by ``call`` carries a
-    ``# noqa: timeout-required: <reason>`` comment."""
+    ``# timeout-required: <reason>`` comment."""
     start = call.lineno
     end = getattr(call, "end_lineno", None) or start
     for lineno in range(start, end + 1):
@@ -566,7 +568,7 @@ def main(argv: list[str]) -> int:
             sys.stderr.write(f"    {line}\n")
         sys.stderr.write(
             "\nFix: add the missing kwarg, or annotate the call with\n"
-            "    # noqa: timeout-required: <reason>\n"
+            "    # timeout-required: <reason>\n"
             "on the same line. See scripts/check-no-unbounded-timeouts.py\n"
             "for the full rule table. Tracking: issue #3356.\n"
         )

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -20212,7 +20212,7 @@ class DispatcherDaemon:
                 text=True,
                 cwd=str(repo_root),
                 env=diagnoser_env,
-                # noqa: timeout-required: issue-3376-fire-and-forget-reaper-enforces-90min-budget
+                # timeout-required: issue-3376-fire-and-forget-reaper-enforces-90min-budget
                 # Detach into its own process group so the reaper's
                 # SIGTERM/SIGKILL targets only the diagnoser tree.
                 # Cross-platform safe: ``start_new_session`` is a
@@ -20360,7 +20360,7 @@ class DispatcherDaemon:
                 stderr=stderr_file,
                 text=True,
                 cwd=str(popen_cwd),
-                # noqa: timeout-required: issue-3658-fire-and-forget-reaper-enforces-deadline
+                # timeout-required: issue-3658-fire-and-forget-reaper-enforces-deadline
                 start_new_session=True,
             )
         except FileNotFoundError:

--- a/scripts/tests/test_check_no_unbounded_timeouts.py
+++ b/scripts/tests/test_check_no_unbounded_timeouts.py
@@ -350,7 +350,7 @@ class TestAllowlist:
     def test_allowlist_with_reason_exempts(self, tmp_path: Path) -> None:
         source = (
             "import requests\n"
-            "requests.get('https://example.com')  # noqa: timeout-required: test fixture\n"
+            "requests.get('https://example.com')  # timeout-required: test fixture\n"
         )
         assert _scan(tmp_path, source) == []
 
@@ -361,31 +361,40 @@ class TestAllowlist:
         assert len(violations) == 1
 
     def test_noqa_rule_only_does_not_exempt(self, tmp_path: Path) -> None:
-        """``# noqa: timeout-required`` without a colon-reason must NOT
+        """``# timeout-required`` without a colon-reason must NOT
         exempt — the rule requires a non-empty justification."""
         source = (
-            "import requests\n"
-            "requests.get('https://example.com')  # noqa: timeout-required\n"
+            "import requests\nrequests.get('https://example.com')  # timeout-required\n"
         )
         violations = _scan(tmp_path, source)
         assert len(violations) == 1
 
     def test_noqa_empty_reason_does_not_exempt(self, tmp_path: Path) -> None:
-        """``# noqa: timeout-required:`` (colon present, reason empty)
+        """``# timeout-required:`` (colon present, reason empty)
         must NOT exempt."""
         source = (
             "import requests\n"
-            "requests.get('https://example.com')  # noqa: timeout-required: \n"
+            "requests.get('https://example.com')  # timeout-required: \n"
+        )
+        violations = _scan(tmp_path, source)
+        assert len(violations) == 1
+
+    def test_noqa_prefix_form_does_not_exempt(self, tmp_path: Path) -> None:
+        """The legacy ``# noqa: timeout-required: reason`` form is retired
+        and must NOT exempt — use ``# timeout-required: reason`` instead."""
+        source = (
+            "import requests\n"
+            "requests.get('https://example.com')  # noqa: timeout-required: legacy-form\n"
         )
         violations = _scan(tmp_path, source)
         assert len(violations) == 1
 
     def test_allowlist_inside_multiline_call_exempts(self, tmp_path: Path) -> None:
-        """A noqa marker on any line covered by the call's span exempts."""
+        """A timeout-required marker on any line covered by the call's span exempts."""
         source = (
             "import requests\n"
             "requests.get(\n"
-            "    'https://example.com',  # noqa: timeout-required: legacy\n"
+            "    'https://example.com',  # timeout-required: legacy\n"
             ")\n"
         )
         assert _scan(tmp_path, source) == []


### PR DESCRIPTION
## Summary

Ruff emits `Invalid # noqa directive` warnings for `# noqa: timeout-required: <reason>` markers in daemon.py because timeout-required is not a valid ruff rule — it's a custom marker for the check-no-unbounded-timeouts.py checker. Renamed to `# timeout-required: <reason>` to stop triggering the warning while preserving the checker's exemption mechanism.

Closes #3734

## Test plan

### Automated checks

- [x] Lint passes (`ruff check scripts/dispatcher/` — no Invalid-noqa warnings)
- [x] Format check passes
- [x] Tests pass (`pytest scripts/tests/test_check_no_unbounded_timeouts.py` — 55/55 pass)
- [x] CI green

### Post-deploy verification

- [x] N/A — no deployed component (agent tooling / dispatcher config)