### PR TITLE
docs(spotcheck): clarify final_phase vs phase column distinction

### DIFF
--- a/.claude/skills/spotcheck/SKILL.md
+++ b/.claude/skills/spotcheck/SKILL.md
@@ -153,7 +153,7 @@ Once you've worked through the sample, you usually still have time. Use it. The 
 Possible directions (pick what feels productive — don't try to do them all):
 
 - **Scraper drift.** Check `telemetry.scraper_runs` for counties with declining capture rates or unusual error patterns. `scripts/dev-db-query.sh` for the SELECT.
-- **Dispatcher behavior.** Skim the last 24h of `dispatcher.agents` rows — failure-class concentration, repeated stuck_timeouts on the same issue, `final_phase` distribution. Anything anomalous?
+- **Dispatcher behavior.** Skim the last 24h of `dispatcher.agents` rows — failure-class concentration, repeated stuck_timeouts on the same issue, terminal `phase` distribution (the column is `phase`, not `final_phase` — `final_phase` is the status-file / structured-log field name). Anything anomalous?
 - **Dead or abandoned columns.** Check whether columns marked deprecated in migrations are still being written or read by application code. A column with stale data is worse than a missing one.
 - **Stale documentation.** Source-file docstrings or `README.md` files in `packages/` that contradict the current code (a frequent spotcheck finding — investigations land but the docstrings stay stale; see #2434 and B.1.5 in `.claude/skills/task/SKILL.md`).
 - **Field completeness regressions.** `derived.rulings` null-rate per field over recent days — sudden cliff = regression. Compare against the field-completeness loop notes (`MEMORY.md` → `field-completeness-loop.md`) if you have access.


### PR DESCRIPTION
## Root cause

`.claude/skills/spotcheck/SKILL.md` (Step 3 — Look beyond the bidirectional sample) tells spotcheck agents to skim `dispatcher.agents` rows for `final_phase distribution`. There is no `final_phase` column on `dispatcher.agents` — the column is `phase`. `final_phase` exists only as:

- a structured-log field emitted by `scripts/dispatcher/daemon.py`
- a status-file convention used by `/task` agents

Spotcheck agents writing an audit query off this guidance hit `psycopg.errors.UndefinedColumn: column "final_phase" does not exist` and have to fix the query themselves before continuing.

## Fix

One-line edit on the dispatcher-behavior bullet to disambiguate:

> Skim the last 24h of `dispatcher.agents` rows — failure-class concentration, repeated stuck_timeouts on the same issue, terminal `phase` distribution (the column is `phase`, not `final_phase` — `final_phase` is the status-file / structured-log field name).

## Test plan

- [x] `scripts/check-markdown-links.sh .claude/skills/spotcheck/SKILL.md` — clean
- [x] Diff is single-line, scope-contained

Found by: /spotcheck (2026-04-28)
