### PR TITLE
fix(dispatcher): apply active-agent filter in queryQueueDepth to fix 0/N cockpit display (#3743)

### DIFF
--- a/packages/api/src/graphql/dispatcher/resolvers.ts
+++ b/packages/api/src/graphql/dispatcher/resolvers.ts
@@ -328,29 +328,49 @@ async function queryCapFlippedBy(pool: Pool): Promise<string | null> {
   return normalizeJsonbString(raw);
 }
 
+/**
+ * Count of pickup-eligible `agent/ready` issues in the latest snapshot,
+ * applying the same `dispatcher.issue_has_active_agent` filter as
+ * `queryQueueReady` so the cockpit's `{shown}/{total}` header always agrees.
+ *
+ * Previously returned `queue_depth` directly from the snapshot row, which
+ * caused the cockpit to show `0 / N` instead of `0 / 0` when all N issues
+ * in the snapshot already had active agents (bug #3743). The daemon writer is
+ * consistent — `queue_depth == jsonb_array_length(issues_json)` — but the
+ * GraphQL layer must re-apply the filter to align the denominator with what
+ * `queueReady` shows.
+ *
+ * Fall back to 0 when:
+ *   - The daemon has never booted (no snapshots yet).
+ *   - The table exists but is empty (initial deploy before the first
+ *     successful scan).
+ *   - The daemon's GitHub API calls have failed for the full recent
+ *     history (transient — the next successful scan writes a row).
+ *
+ * Returning 0 keeps the GraphQL contract (`queueDepth: Int!`) honored.
+ */
 async function queryQueueDepth(pool: Pool): Promise<number> {
-  // Phase 2: return the most recent row's `queue_depth` from
-  // `dispatcher.queue_snapshots` (written by the daemon on each 30s
-  // scheduler tick — see `scripts/dispatcher/daemon.py` and migration
-  // `24_dispatcher-queue-snapshots.sql`).
-  //
-  // Fall back to 0 when:
-  //   - The daemon has never booted (no snapshots yet).
-  //   - The table exists but is empty (initial deploy before the first
-  //     successful scan).
-  //   - The daemon's GitHub API calls have failed for the full recent
-  //     history (transient — the next successful scan writes a row).
-  //
-  // Returning 0 keeps the GraphQL contract (`queueDepth: Int!`) honored.
-  const { rows } = await pool.query<{ queue_depth: number | string }>(
-    `SELECT queue_depth
-       FROM dispatcher.queue_snapshots
-       ORDER BY observed_at DESC
-       LIMIT 1`,
+  const issues = await queryLatestQueueSnapshotIssuesJson(pool);
+  if (issues.length === 0) return 0;
+
+  const issueNumbers = issues.map((i) => i.number);
+  const { rows: predicateRows } = await pool.query<{
+    issue_number: number;
+    active: boolean;
+  }>(
+    `SELECT
+       issue_number,
+       dispatcher.issue_has_active_agent(issue_number) AS active
+     FROM unnest($1::int[]) AS issue_number`,
+    [issueNumbers],
   );
-  if (rows.length === 0) return 0;
-  const raw = rows[0].queue_depth;
-  return typeof raw === 'number' ? raw : Number(raw);
+
+  const activeSet = new Set<number>();
+  for (const row of predicateRows) {
+    if (row.active) activeSet.add(row.issue_number);
+  }
+
+  return issues.filter((i) => !activeSet.has(i.number)).length;
 }
 
 /**

--- a/packages/api/src/graphql/dispatcher/schema.ts
+++ b/packages/api/src/graphql/dispatcher/schema.ts
@@ -377,10 +377,12 @@ export const dispatcherTypeDefs = `#graphql
     activeAgents: [DispatcherAgent!]!
     """Failures from \`dispatcher.failures\` in the last \`sinceHours\` (default 24)."""
     recentFailures(sinceHours: Int = 24): [DispatcherFailure!]!
-    """Count of open \`agent/ready\` issues. Sourced from the most recent row in
-    \`dispatcher.queue_snapshots\`, written by the daemon on each 30s scheduler
-    tick (Phase 2+). Returns 0 before the daemon has booted or when every
-    recent scan has failed — the admin page treats that as "queue unknown / 0"."""
+    """Count of pickup-eligible \`agent/ready\` issues in the latest snapshot.
+    Applies the same \`dispatcher.issue_has_active_agent\` filter as \`queueReady\`
+    (issues already being worked on are excluded) but without the 10-item cap,
+    so the cockpit panel header \`{queueReady.length}/{queueDepth}\` always agrees —
+    in particular, both show 0 when the filtered set is empty (bug #3743). Returns
+    0 before the daemon has booted or when every recent scan has failed."""
     queueDepth: Int!
     """Count of open \`status/blocked\` issues. Sourced from the most recent row
     in \`dispatcher.blocked_snapshots\`, written by the daemon on a slower

--- a/packages/api/tests/dispatcher.integration.test.ts
+++ b/packages/api/tests/dispatcher.integration.test.ts
@@ -343,16 +343,35 @@ describe('dispatcherState — admin', () => {
     // Seed two snapshots: an older one with depth 3, a newer one with
     // depth 7. The resolver should return 7 (latest by observed_at DESC).
     // We seed via the run we'll insert so cleanup cascades correctly.
+    //
+    // Both rows now include issues_json so the refactored resolver (which
+    // reads issues_json and re-applies the active-agent filter — bug #3743)
+    // can compute the depth correctly. None of these issue numbers have
+    // active agents, so queueDepth == jsonb_array_length(issues_json).
     const runId = await insertRun();
+    const olderIssuesJson = JSON.stringify([
+      { number: 11, title: 'A', labels: ['agent/ready'], createdAt: new Date().toISOString() },
+      { number: 22, title: 'B', labels: ['agent/ready'], createdAt: new Date().toISOString() },
+      { number: 33, title: 'C', labels: ['agent/ready'], createdAt: new Date().toISOString() },
+    ]);
+    const newerIssuesJson = JSON.stringify([
+      { number: 40, title: 'D', labels: ['agent/ready'], createdAt: new Date().toISOString() },
+      { number: 41, title: 'E', labels: ['agent/ready'], createdAt: new Date().toISOString() },
+      { number: 42, title: 'F', labels: ['agent/ready'], createdAt: new Date().toISOString() },
+      { number: 43, title: 'G', labels: ['agent/ready'], createdAt: new Date().toISOString() },
+      { number: 44, title: 'H', labels: ['agent/ready'], createdAt: new Date().toISOString() },
+      { number: 45, title: 'I', labels: ['agent/ready'], createdAt: new Date().toISOString() },
+      { number: 46, title: 'J', labels: ['agent/ready'], createdAt: new Date().toISOString() },
+    ]);
     await pool.query(
-      `INSERT INTO dispatcher.queue_snapshots (observed_at, queue_depth, issue_numbers, run_id)
-       VALUES (now() - interval '2 minutes', 3, ARRAY[11,22,33]::int[], $1)`,
-      [runId],
+      `INSERT INTO dispatcher.queue_snapshots (observed_at, queue_depth, issue_numbers, issues_json, run_id)
+       VALUES (now() - interval '2 minutes', 3, ARRAY[11,22,33]::int[], $1::jsonb, $2)`,
+      [olderIssuesJson, runId],
     );
     await pool.query(
-      `INSERT INTO dispatcher.queue_snapshots (observed_at, queue_depth, issue_numbers, run_id)
-       VALUES (now() - interval '10 seconds', 7, ARRAY[40,41,42,43,44,45,46]::int[], $1)`,
-      [runId],
+      `INSERT INTO dispatcher.queue_snapshots (observed_at, queue_depth, issue_numbers, issues_json, run_id)
+       VALUES (now() - interval '10 seconds', 7, ARRAY[40,41,42,43,44,45,46]::int[], $1::jsonb, $2)`,
+      [newerIssuesJson, runId],
     );
 
     const body = await gql(
@@ -811,6 +830,86 @@ describe('queueReady — SQL predicate functions contract (#3001)', () => {
       [ISSUE_A],
     );
     expect(rowsA[0].result).toBe(false);
+  });
+
+  it('queueDepth equals queueReady.length when active-agent filter applies (#3743)', async () => {
+    // Same fixture: A=1001, B=1002 (running agent), C=1003.
+    // queueDepth must exclude B (active) just as queueReady does.
+    // Expected: queueDepth === 2 (A + C) AND queueDepth === queueReady.length.
+    const body = await gql(
+      `{
+        dispatcherState {
+          queueDepth
+          queueReady {
+            issueNumber
+          }
+        }
+      }`,
+      undefined,
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const state = body.data?.dispatcherState as Record<string, unknown>;
+    const queueReady = state.queueReady as Array<{ issueNumber: number }>;
+    const queueDepth = state.queueDepth as number;
+
+    // B has a running agent — must be excluded from both queueReady AND depth.
+    expect(queueDepth).toBe(2);
+    expect(queueDepth).toBe(queueReady.length);
+  });
+
+  it('queueDepth === 0 and queueReady is empty when all issues have active agents (#3743 AC2)', async () => {
+    // Seed a fresh snapshot where every issue has a running agent.
+    // This is the exact scenario the issue body describes: cockpit was
+    // showing "0 / N" instead of "0 / 0".
+    const runId2 = await insertRun();
+    const ISSUE_X = 9901;
+    const ISSUE_Y = 9902;
+    const allActiveJson = JSON.stringify([
+      { number: ISSUE_X, title: 'X', labels: ['priority/p2', 'agent/ready'], createdAt: new Date().toISOString() },
+      { number: ISSUE_Y, title: 'Y', labels: ['priority/p2', 'agent/ready'], createdAt: new Date().toISOString() },
+    ]);
+    await pool.query(
+      `INSERT INTO dispatcher.queue_snapshots (observed_at, queue_depth, issue_numbers, issues_json, run_id)
+       VALUES (now() + interval '1 second', 2, ARRAY[$1, $2]::int[], $3::jsonb, $4)`,
+      [ISSUE_X, ISSUE_Y, allActiveJson, runId2],
+    );
+    // Insert running agents for both X and Y.
+    const { rows: xRows } = await pool.query<{ agent_id: string }>(
+      `INSERT INTO dispatcher.agents (issue_number, worktree_path, phase, status, started_at)
+       VALUES ($1, $2, 'ralph', 'running', now() - interval '1 minute')
+       RETURNING agent_id`,
+      [ISSUE_X, `/tmp/${MARKER}/agent-3743-x`],
+    );
+    insertedAgentIds.push(xRows[0].agent_id);
+    const { rows: yRows } = await pool.query<{ agent_id: string }>(
+      `INSERT INTO dispatcher.agents (issue_number, worktree_path, phase, status, started_at)
+       VALUES ($1, $2, 'ralph', 'running', now() - interval '1 minute')
+       RETURNING agent_id`,
+      [ISSUE_Y, `/tmp/${MARKER}/agent-3743-y`],
+    );
+    insertedAgentIds.push(yRows[0].agent_id);
+
+    const body = await gql(
+      `{
+        dispatcherState {
+          queueDepth
+          queueReady {
+            issueNumber
+          }
+        }
+      }`,
+      undefined,
+      adminToken,
+    );
+    expect(body.errors).toBeUndefined();
+    const state = body.data?.dispatcherState as Record<string, unknown>;
+    const queueReady = state.queueReady as Array<{ issueNumber: number }>;
+    const queueDepth = state.queueDepth as number;
+
+    // Both issues have running agents — cockpit must display 0 / 0.
+    expect(queueDepth).toBe(0);
+    expect(queueReady).toHaveLength(0);
   });
 });
 

--- a/packages/api/tests/dispatcher.integration.test.ts
+++ b/packages/api/tests/dispatcher.integration.test.ts
@@ -871,7 +871,7 @@ describe('queueReady — SQL predicate functions contract (#3001)', () => {
     ]);
     await pool.query(
       `INSERT INTO dispatcher.queue_snapshots (observed_at, queue_depth, issue_numbers, issues_json, run_id)
-       VALUES (now() + interval '1 second', 2, ARRAY[$1, $2]::int[], $3::jsonb, $4)`,
+       VALUES (now(), 2, ARRAY[$1, $2]::int[], $3::jsonb, $4)`,
       [ISSUE_X, ISSUE_Y, allActiveJson, runId2],
     );
     // Insert running agents for both X and Y.


### PR DESCRIPTION
## Summary

Fixed `queryQueueDepth` in the GraphQL resolver to apply the same `dispatcher.issue_has_active_agent` active-agent filter as `queryQueueReady`. Previously, the cockpit header showed `0 / N` when all N issues had running agents; now it correctly displays `0 / 0`.

Closes #3743

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`) — API package linted
- [x] Format check passes (`ruff format --check` / prettier) — TypeScript formatted
- [x] Tests pass (`pytest` / `npm test`) — dispatcher.integration.test.ts passes locally
- [ ] CI green

### Post-deploy verification

- [ ] Drain the agent-ready queue (all issues claimed or no `agent/ready` issues remain)
- [ ] Visit https://dev.judgemind.org/admin/dispatcher
- [ ] Verify "Ready" panel header shows `0 / 0` (not `0 / N`)
- [ ] Verify GraphQL query `queueDepth` equals `queueReady.length` when both should be 0
- [ ] Verification evidence posted on #3743 (see /task-v2-verify output)