### PR TITLE
feat(dispatcher): instrument silent ralph_not_ship exit (#3694)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -323,6 +323,96 @@ read_agent_status() {
                    LIMIT 1;"
 }
 
+# ── ECS task-ARN capture (#3694) ───────────────────────────────────────────
+#
+# Set ``dispatcher.agents.agent_task_arn`` from the ECS metadata endpoint
+# early in the entrypoint so a future diagnoser can pull the task's
+# CloudWatch logs without hunting through ECS describe-tasks state.
+# Mirrors the same column the daemon-side ``_launch_agent_ecs_task``
+# already populates on the launch-result path; this fills it in for the
+# in-task launch ordering that #3694 caught producing
+# ``agent_task_arn=NULL`` rows on every silent ralph_not_ship failure.
+#
+# Failure modes (all best-effort, must never abort the runner):
+#
+#   * ``$ECS_CONTAINER_METADATA_URI_V4`` unset (subprocess-mode, local
+#     test, non-ECS container) → log + skip, no DB write.
+#   * ``curl`` not on PATH (slim image variant) → log + skip.
+#   * Metadata endpoint returns non-zero / non-JSON / missing
+#     ``.TaskARN`` field → log + skip with the response head for
+#     triage.
+#   * DB UPDATE fails (DATABASE_URL transient outage) → log + skip;
+#     the agent row keeps ``agent_task_arn=NULL`` and the daemon's
+#     existing periodic ARN-backfill (#3158) can fill it later.
+#
+# Tests can stub this by setting ``AGENT_RUNNER_SKIP_TASK_ARN_CAPTURE=1``
+# OR by leaving ``ECS_CONTAINER_METADATA_URI_V4`` unset (the natural
+# state for non-ECS runs).
+set_agent_task_arn_from_metadata() {
+    if [[ "${AGENT_RUNNER_SKIP_TASK_ARN_CAPTURE:-0}" == "1" ]]; then
+        log "agent_task_arn_capture_skipped" "reason=env_skip"
+        return 0
+    fi
+    _meta_url="${ECS_CONTAINER_METADATA_URI_V4:-}"
+    if [[ -z "$_meta_url" ]]; then
+        log "agent_task_arn_capture_skipped" "reason=no_metadata_uri"
+        return 0
+    fi
+    if ! command -v curl >/dev/null 2>&1; then
+        log "agent_task_arn_capture_skipped" "reason=curl_missing"
+        return 0
+    fi
+    _meta_body_file="$AGENT_WORKSPACE/ecs-metadata.json"
+    set +e
+    curl --fail --silent --show-error --max-time 5 \
+        "$_meta_url/task" \
+        > "$_meta_body_file" \
+        2> "$AGENT_WORKSPACE/ecs-metadata.stderr.log"
+    _meta_rc=$?
+    set -e
+    if [[ "$_meta_rc" -ne 0 ]]; then
+        _meta_err_tail=$(head -c 200 "$AGENT_WORKSPACE/ecs-metadata.stderr.log" 2>/dev/null \
+            | tr '\n\r\t' '   ')
+        log "agent_task_arn_capture_failed" \
+            "reason=curl_exit_${_meta_rc}" \
+            "stderr_tail=$_meta_err_tail"
+        return 0
+    fi
+    _task_arn=$(jq -r '.TaskARN // empty' "$_meta_body_file" 2>/dev/null || printf '')
+    if [[ -z "$_task_arn" ]]; then
+        _meta_head=$(head -c 200 "$_meta_body_file" 2>/dev/null | tr '\n\r\t' '   ')
+        log "agent_task_arn_capture_failed" \
+            "reason=task_arn_missing" \
+            "body_head=$_meta_head"
+        return 0
+    fi
+    # UPDATE the agent row. Best-effort — if DATABASE_URL is transiently
+    # unreachable we don't want to block the runner. The daemon's periodic
+    # backfill sweep already handles late-arriving ARNs for legacy rows.
+    set +e
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
+        -v agent_id="$AGENT_ID" \
+        -v task_arn="$_task_arn" <<'EOF' >/dev/null 2>&1
+UPDATE dispatcher.agents
+   SET agent_task_arn = :'task_arn'
+ WHERE agent_id = :'agent_id';
+EOF
+    _arn_rc=$?
+    set -e
+    if [[ "$_arn_rc" -ne 0 ]]; then
+        log "agent_task_arn_capture_failed" \
+            "reason=db_update_exit_${_arn_rc}" \
+            "task_arn=$_task_arn"
+        return 0
+    fi
+    log "agent_task_arn_captured" "task_arn=$_task_arn"
+}
+
+# Run the capture as early as possible — right after the DB helpers are
+# defined. Skipped automatically when ``ECS_CONTAINER_METADATA_URI_V4``
+# is unset (subprocess mode + tests).
+set_agent_task_arn_from_metadata
+
 # ── Python helper: phase_transitions bridge --------------------------------
 #
 # The shell script can't import Python, so we expose the pure
@@ -2188,14 +2278,26 @@ handle_scheduled_skill() {
 }
 
 persist_phase_output() {
-    # $1 = phase, $2 = output JSON.
+    # $1 = phase, $2 = output JSON, $3 = optional path to a log-text
+    #     file (worker stdout/stderr tail merged) to persist into
+    #     ``dispatcher.phase_outputs.log_text``. Empty / missing → log_text
+    #     stays NULL (the legacy two-arg behaviour).
     # Stage 1b writes a minimal row shape matching the daemon's
     # phase_outputs schema: (agent_id, phase, output_json) — NOT a
     # `status` column, which does not exist on `dispatcher.phase_outputs`
     # (#3115). The daemon's subprocess-mode persist writes the same
-    # three columns. The `log_text` / `attempt` / token + cost columns
+    # three columns. The `attempt` / token + cost columns
     # stay NULL here; Stage 2 wiring populates them once the daemon-
     # side log-capture path is in place.
+    #
+    # #3694 — log_text capture for the ralph silent-exit case. The
+    # entrypoint now passes the merged stdout/stderr tail of
+    # ``claude-p-ralph.{stdout,stderr}.log`` into this column on every
+    # ralph exit, so a future diagnoser can read the worker's last words
+    # even when ``output_json={}`` (the silent ``ralph_not_ship`` shape
+    # documented in the issue body). Other phases continue to call this
+    # with two args and write log_text=NULL — Stage 2 will widen the
+    # capture to all phases once we've validated the ralph variant.
     #
     # #3219 — ON CONFLICT overwrite. The unique index
     # ``idx_dispatcher_phase_outputs_agent_phase_attempt`` on
@@ -2232,6 +2334,7 @@ persist_phase_output() {
     # set, producing malformed JSONB and a postgres syntax error.
     _phase="$1"
     _output_json="$2"
+    _log_text_path="${3:-}"
     if [[ -z "$_output_json" ]]; then
         _output_json="{}"
     fi
@@ -2292,11 +2395,39 @@ persist_phase_output() {
         set -e
         return 1
     fi
+    # #3694 — when the caller provided a log_text path, INSERT/UPDATE
+    # both ``output_json`` AND ``log_text``. Otherwise keep the legacy
+    # two-column write so untouched phases produce identical SQL. We
+    # branch in the SQL via psql ``\if`` rather than building two
+    # separate heredocs so the bulk of the statement stays one block.
+    _log_text_present=0
+    if [[ -n "$_log_text_path" && -s "$_log_text_path" ]]; then
+        _log_text_present=1
+    fi
     log "db_exec_begin" "fn=persist_phase_output phase=$_phase"
-    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
-        -v agent_id="$AGENT_ID" \
-        -v phase="$_phase" \
-        -v output_path="$_persist_tmpfile" <<'EOF' >/dev/null
+    if [[ "$_log_text_present" -eq 1 ]]; then
+        psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
+            -v agent_id="$AGENT_ID" \
+            -v phase="$_phase" \
+            -v output_path="$_persist_tmpfile" \
+            -v log_text_path="$_log_text_path" <<'EOF' >/dev/null
+\set output_json `cat :'output_path'`
+\set log_text `cat :'log_text_path'`
+INSERT INTO dispatcher.phase_outputs (agent_id, phase, output_json, log_text)
+VALUES (:'agent_id', :'phase', :'output_json'::jsonb, :'log_text')
+ON CONFLICT (agent_id, phase, attempt) DO UPDATE
+  SET output_json = EXCLUDED.output_json,
+      log_text = EXCLUDED.log_text,
+      ts = now();
+INSERT INTO dispatcher.phase_transitions (agent_id, phase)
+VALUES (:'agent_id', :'phase');
+EOF
+        _persist_rc=$?
+    else
+        psql "$DATABASE_URL" -v ON_ERROR_STOP=1 \
+            -v agent_id="$AGENT_ID" \
+            -v phase="$_phase" \
+            -v output_path="$_persist_tmpfile" <<'EOF' >/dev/null
 \set output_json `cat :'output_path'`
 INSERT INTO dispatcher.phase_outputs (agent_id, phase, output_json)
 VALUES (:'agent_id', :'phase', :'output_json'::jsonb)
@@ -2306,7 +2437,8 @@ ON CONFLICT (agent_id, phase, attempt) DO UPDATE
 INSERT INTO dispatcher.phase_transitions (agent_id, phase)
 VALUES (:'agent_id', :'phase');
 EOF
-    _persist_rc=$?
+        _persist_rc=$?
+    fi
     set -e
     rm -f "$_persist_tmpfile"
     log "db_exec_done" "fn=persist_phase_output phase=$_phase rc=$_persist_rc"
@@ -5223,7 +5355,97 @@ while true; do
             if [[ "$_current" == "ralph" ]]; then
                 stop_ralph_head_watcher
             fi
-            persist_phase_output "$_current" "$_output"
+            # #3694 — ralph silent-exit instrumentation. The original
+            # symptom: three consecutive ECS agents on three different
+            # issues exited with ``output_json={}`` and ``stderr_tail=""``,
+            # producing zero diagnostic data. The worker subprocess
+            # terminated cleanly without writing a verdict marker, so the
+            # daemon classified the failure as ``ralph_not_ship`` with no
+            # block_reason.
+            #
+            # Layer 1 (this commit) makes the failure self-diagnosing —
+            # capture the worker's stdout/stderr tails into
+            # ``phase_outputs.log_text``, emit a structured
+            # ``ralph_done_marker_missing`` event, and replace the empty
+            # ``output_json`` with a payload carrying the tails as
+            # ``block_reason``. The daemon's ``_collect_failure_details``
+            # already forwards ``block_reason`` → ``failures.details
+            # .stderr_tail`` (see daemon.py ~12420), so the next
+            # occurrence will surface a populated stderr_tail in the
+            # diagnoser's verbatim-quote pull instead of the current
+            # empty string. Layer 2 (the actual fix to whatever is
+            # making the worker exit silently) lands once the new logs
+            # capture self-diagnosing data.
+            _ralph_log_tail_file=""
+            if [[ "$_current" == "ralph" ]]; then
+                _ralph_stdout_file="$AGENT_WORKSPACE/claude-p-ralph.stdout.json"
+                _ralph_stderr_file="$AGENT_WORKSPACE/claude-p-ralph.stderr.log"
+                # Build a merged tail file (last 2000 bytes of stdout +
+                # last 2000 bytes of stderr) for log_text persistence.
+                # Unconditional capture — even SHIP-path runs benefit
+                # from having the worker narrative in the DB for
+                # post-mortem when CI / verify later reveals a problem.
+                _ralph_log_tail_file="$AGENT_WORKSPACE/claude-p-ralph.log_text.txt"
+                {
+                    printf '=== claude-p-ralph.stdout.json (last 2000 bytes) ===\n'
+                    if [[ -s "$_ralph_stdout_file" ]]; then
+                        tail -c 2000 "$_ralph_stdout_file" 2>/dev/null
+                    fi
+                    printf '\n=== claude-p-ralph.stderr.log (last 2000 bytes) ===\n'
+                    if [[ -s "$_ralph_stderr_file" ]]; then
+                        tail -c 2000 "$_ralph_stderr_file" 2>/dev/null
+                    fi
+                    printf '\n'
+                } > "$_ralph_log_tail_file" 2>/dev/null || true
+                # Detect the silent-exit shape — ralph returned ``{}`` (a
+                # string-equal check is sufficient because run_claude_phase
+                # only emits ``{}`` for the non-object .result fallback;
+                # any legitimate ralph output, even an empty BLOCKED, is at
+                # least ``{"verdict": "..."}``).
+                if [[ "$_output" == "{}" ]]; then
+                    _ralph_stdout_tail=""
+                    _ralph_stderr_tail=""
+                    if [[ -s "$_ralph_stdout_file" ]]; then
+                        _ralph_stdout_tail=$(tail -c 500 "$_ralph_stdout_file" 2>/dev/null \
+                            | tr '\n\r\t' '   ' | sed -e 's/\\/\\\\/g')
+                    fi
+                    if [[ -s "$_ralph_stderr_file" ]]; then
+                        _ralph_stderr_tail=$(tail -c 500 "$_ralph_stderr_file" 2>/dev/null \
+                            | tr '\n\r\t' '   ' | sed -e 's/\\/\\\\/g')
+                    fi
+                    # ``run_claude_phase`` already captured the worker's
+                    # exit code into the ``claude_phase_done`` log line;
+                    # we don't have it in scope here directly, so emit a
+                    # placeholder. The stdout/stderr tails are the
+                    # high-value signal (they contain the actual error
+                    # lines if the worker printed any), and a future
+                    # iteration can plumb the rc through if needed.
+                    log "ralph_done_marker_missing" \
+                        "phase=ralph" \
+                        "worker_exit_code=unknown" \
+                        "worker_stdout_tail=$_ralph_stdout_tail" \
+                        "worker_stderr_tail=$_ralph_stderr_tail"
+                    # Replace the empty ``{}`` with a structured payload
+                    # so the daemon's failures.details.stderr_tail (which
+                    # mirrors block_reason for the ralph_not_ship terminal,
+                    # see daemon.py ~12420) carries the diagnostic tails
+                    # rather than "". jq -n -c builds the JSON safely with
+                    # the tails as typed string variables — no shell
+                    # interpolation into the SQL.
+                    _output=$(jq -n -c \
+                        --arg stdout_tail "$_ralph_stdout_tail" \
+                        --arg stderr_tail "$_ralph_stderr_tail" \
+                        '{verdict: "BLOCKED",
+                          category: "ralph_not_ship",
+                          block_reason: ("ralph_done_marker_missing: worker exited 0 with no done-marker. " +
+                                         "stdout_tail=" + $stdout_tail + " stderr_tail=" + $stderr_tail),
+                          worker_stdout_tail: $stdout_tail,
+                          worker_stderr_tail: $stderr_tail,
+                          ralph_done_marker_missing: true}' 2>/dev/null \
+                        || printf '{"category":"ralph_not_ship","block_reason":"ralph_done_marker_missing: jq build failed","ralph_done_marker_missing":true}')
+                fi
+            fi
+            persist_phase_output "$_current" "$_output" "$_ralph_log_tail_file"
             if [[ "$_current" == "ralph" ]]; then
                 # Mirror the daemon's post-SHIP ralph_patches persist.
                 _verdict=$(printf '%s' "$_output" | jq -r '.verdict // ""')

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -9363,6 +9363,248 @@ else
          "output: $T3675_TEST_OUT"
 fi
 
+# ══════════════════════════════════════════════════════════════════════════
+# Test T3694 — silent ralph_not_ship instrumentation (Layer 1).
+#
+# The original symptom (issue #3694): three consecutive ECS agents on
+# three different issues exited the ralph phase with ``output_json={}``
+# and ``stderr_tail=""``, leaving zero diagnostic data. The worker
+# subprocess terminated cleanly without writing a verdict marker, so
+# the daemon classified the failure as ``ralph_not_ship`` with no
+# ``block_reason``.
+#
+# Layer 1 (this regression) instruments the silent-exit path:
+#   1. The merged stdout/stderr tail from
+#      ``$AGENT_WORKSPACE/claude-p-ralph.{stdout,stderr}.log`` is
+#      persisted into ``dispatcher.phase_outputs.log_text``.
+#   2. A structured ``ralph_done_marker_missing`` event is emitted
+#      with ``worker_stdout_tail``, ``worker_stderr_tail``, and
+#      ``worker_exit_code`` fields.
+#   3. The empty ``{}`` output_json is replaced with a
+#      ``{"verdict":"BLOCKED","category":"ralph_not_ship",
+#         "block_reason":"ralph_done_marker_missing: ...","ralph_done_marker_missing":true,
+#         "worker_stdout_tail":"...","worker_stderr_tail":"..."}``
+#      payload so the daemon's ``_collect_failure_details`` forwards
+#      ``block_reason`` → ``failures.details.stderr_tail`` instead of "".
+#
+# The test simulates the silent-exit shape by wiring claude to emit a
+# string ``.result`` for the ralph skill (which run_claude_phase
+# coerces to ``{}`` per the #3131 fallback) AND a non-empty stderr
+# payload (the typical "claude exited with no done-marker" diagnostic
+# output the worker would have written before silently terminating).
+#
+# Pre-fix behaviour:
+#   * ``persist_phase_output ralph "{}"`` is called with no log_text.
+#   * No ``ralph_done_marker_missing`` log event is emitted.
+#   * The ralph terminal-failure ``reason`` is the literal string ""
+#     (passed via ``$_block_reason`` from the empty output).
+#
+# Post-fix behaviour:
+#   * ``ralph_done_marker_missing`` log event is emitted before the
+#     transition runs.
+#   * The persisted output_json carries ``block_reason`` /
+#     ``worker_stdout_tail`` / ``worker_stderr_tail`` keys.
+#   * The merged log_text file path is passed to persist_phase_output.
+#
+# This test must FAIL against the pre-fix entrypoint and PASS against
+# the post-fix entrypoint.
+# ══════════════════════════════════════════════════════════════════════════
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t3694.txt"
+printf 'ralph\n' > "$PHASE_FIXTURE_FILE"
+PRIOR_PATCH_FIXTURE=""
+
+t3694_workspace="$TEST_TMP/t3694-workspace"
+mkdir -p "$t3694_workspace"
+
+# Distinctive stderr payload so the regression test asserts the actual
+# bytes flow into the new captures. The string contains "T3694" so a
+# grep over both the structured log event AND the persist_phase_output
+# heredoc input proves the wire end-to-end.
+t3694_stderr_payload='T3694 ralph worker silent exit: skill returned plain string and exited 0 without writing tmp/ralph/ralph-done.txt — no verdict marker, no diff'
+
+set +e
+T3694_TEST_OUT=$(AGENT_ID="36943694-3694-3694-3694-369436943694" \
+      ISSUE_NUMBER="3694" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t3694_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="$PRIOR_PATCH_FIXTURE" \
+      CLAUDE_VERDICT_FIXTURE="" \
+      CLAUDE_RESULT_OVERRIDE='{"result": "skill exited 0 with no done-marker"}' \
+      CLAUDE_RESULT_OVERRIDE_SKILL="ralph" \
+      CLAUDE_STDERR_OVERRIDE="$t3694_stderr_payload" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_SKIP_TASK_ARN_CAPTURE=1 \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=10 \
+      bash "$ENTRYPOINT" 2>&1)
+T3694_TEST_RC=$?
+set -e
+
+# (1) Exit code 0 — the entrypoint reaches a terminal phase cleanly via
+# agent_runner_reaped_failure (ralph_not_ship), same as today's silent
+# path, so the wrapper exit semantics are preserved.
+if [[ "$T3694_TEST_RC" -eq 0 ]]; then
+    pass "#3694 T3694 — entrypoint exits cleanly (rc=0) on silent ralph_not_ship"
+else
+    fail "#3694 T3694 — entrypoint exits cleanly (rc=0) on silent ralph_not_ship" \
+         "rc=$T3694_TEST_RC, output tail: $(printf '%s' "$T3694_TEST_OUT" | tail -c 1200)"
+fi
+
+# (2) AC — the new ralph_done_marker_missing log event must be emitted
+# when ralph exits with an empty output_json. Its absence in the pre-fix
+# entrypoint is the bug; its presence is the fix.
+if printf '%s' "$T3694_TEST_OUT" | grep -q "ralph_done_marker_missing"; then
+    pass "#3694 T3694 — ralph_done_marker_missing log event emitted"
+else
+    fail "#3694 T3694 — ralph_done_marker_missing log event emitted" \
+         "output tail: $(printf '%s' "$T3694_TEST_OUT" | tail -c 1200)"
+fi
+
+# (3) AC — the structured event must carry the worker's stderr tail so
+# operators have a non-empty ``stderr_tail`` to anchor on.
+T3694_DONE_LINE=$(printf '%s' "$T3694_TEST_OUT" | grep "ralph_done_marker_missing" | head -n 1)
+if printf '%s' "$T3694_DONE_LINE" | grep -q "T3694 ralph worker silent exit"; then
+    pass "#3694 T3694 — ralph_done_marker_missing event carries the worker stderr tail"
+else
+    fail "#3694 T3694 — ralph_done_marker_missing event carries the worker stderr tail" \
+         "done line: $T3694_DONE_LINE"
+fi
+
+# (4) AC — the structured event must carry both worker_stdout_tail AND
+# worker_stderr_tail keys (regardless of value). This locks the field
+# names so future #3694 follow-ups don't drift the schema.
+if printf '%s' "$T3694_DONE_LINE" | grep -q "worker_stdout_tail" \
+   && printf '%s' "$T3694_DONE_LINE" | grep -q "worker_stderr_tail"; then
+    pass "#3694 T3694 — ralph_done_marker_missing event carries worker_stdout_tail + worker_stderr_tail keys"
+else
+    fail "#3694 T3694 — ralph_done_marker_missing event carries worker_stdout_tail + worker_stderr_tail keys" \
+         "done line: $T3694_DONE_LINE"
+fi
+
+# (5) AC — persist_phase_output for ralph must carry log_text into the
+# psql -v var list. The shared psql stub records every -v var as part of
+# the CALL line in psql.log; assert the var name is present on the same
+# line as ``phase=ralph``. The pre-fix entrypoint never sets
+# ``log_text_path`` for any phase, so this assertion fails today.
+if grep -E " phase=ralph " "$INVOCATIONS_DIR/psql.log" 2>/dev/null \
+   | grep -q "log_text_path="; then
+    pass "#3694 T3694 — persist_phase_output for ralph passes log_text_path psql var"
+else
+    fail "#3694 T3694 — persist_phase_output for ralph passes log_text_path psql var" \
+         "psql log (ralph rows): $(grep -E ' phase=ralph ' "$INVOCATIONS_DIR/psql.log" 2>/dev/null | head -3)"
+fi
+
+# (6) AC — the rewritten output_json carries the ralph_done_marker_missing
+# field as JSON ``true``. The persist_phase_output write goes through a
+# tmpfile + psql ``\set`` indirection, so the JSON content lands on a
+# STDIN: line in the recorder's psql.log. We grep the full log for the
+# distinctive key — present after the fix, absent before it.
+if grep -q "ralph_done_marker_missing" "$INVOCATIONS_DIR/psql.log" 2>/dev/null; then
+    pass "#3694 T3694 — output_json persisted for ralph carries ralph_done_marker_missing key"
+else
+    fail "#3694 T3694 — output_json persisted for ralph carries ralph_done_marker_missing key" \
+         "psql log tail: $(tail -c 1500 "$INVOCATIONS_DIR/psql.log" 2>/dev/null)"
+fi
+
+# (7) AC — the rewritten output_json carries block_reason text starting
+# with ``ralph_done_marker_missing:`` so the daemon's
+# ``_collect_failure_details`` forwarder pulls a populated stderr_tail
+# into ``dispatcher.failures.details``.
+if grep -q "ralph_done_marker_missing: worker exited 0 with no done-marker" \
+        "$INVOCATIONS_DIR/psql.log" 2>/dev/null; then
+    pass "#3694 T3694 — output_json carries block_reason starting with ralph_done_marker_missing:"
+else
+    fail "#3694 T3694 — output_json carries block_reason starting with ralph_done_marker_missing:" \
+         "psql log tail: $(tail -c 1500 "$INVOCATIONS_DIR/psql.log" 2>/dev/null)"
+fi
+
+# (8) Negative regression — the entrypoint must NOT emit
+# ``ralph_done_marker_missing`` when ralph SHIPs normally. This guards
+# against future drift that would over-emit the event on every ralph
+# completion. Use a fresh fixtures + happy-path verdict.
+
+setup_fixtures
+PHASE_FIXTURE_FILE="$TEST_TMP/phase-state-t3694b.txt"
+printf 'ralph\n' > "$PHASE_FIXTURE_FILE"
+
+CLAUDE_VERDICT_FIXTURE="$TEST_TMP/verdicts-t3694b.tsv"
+cat > "$CLAUDE_VERDICT_FIXTURE" <<'EOF'
+ralph	SHIP
+EOF
+
+t3694b_workspace="$TEST_TMP/t3694b-workspace"
+mkdir -p "$t3694b_workspace"
+
+set +e
+T3694B_TEST_OUT=$(AGENT_ID="36943694-3694-3694-3694-369436943695" \
+      ISSUE_NUMBER="3694" \
+      DATABASE_URL="postgres://test" \
+      GITHUB_TOKEN="" \
+      AGENT_WORKSPACE="$t3694b_workspace" \
+      REPO_URL="https://example.invalid/repo.git" \
+      PATH="$STUB_BIN:$PATH" \
+      INVOCATIONS_DIR="$INVOCATIONS_DIR" \
+      PHASE_FIXTURE_FILE="$PHASE_FIXTURE_FILE" \
+      PRIOR_PATCH_FIXTURE="" \
+      CLAUDE_VERDICT_FIXTURE="$CLAUDE_VERDICT_FIXTURE" \
+      PHASE_TRANSITIONS_DIR="$REPO_ROOT/scripts/dispatcher" \
+      PHASE_TRANSITIONS_PARENT="$REPO_ROOT" \
+      AGENT_RUNNER_SKIP_TASK_ARN_CAPTURE=1 \
+      AGENT_RUNNER_CI_POLL_INTERVAL=0 \
+      AGENT_RUNNER_DEPLOY_POLL_INTERVAL=0 \
+      AGENT_RUNNER_DEPLOY_GRACE_SECONDS=0 \
+      AGENT_RUNNER_MAX_PHASE_ITERATIONS=40 \
+      GIT_REV_LIST_COUNT=1 \
+      bash "$ENTRYPOINT" 2>&1)
+T3694B_TEST_RC=$?
+set -e
+
+if ! printf '%s' "$T3694B_TEST_OUT" | grep -q "ralph_done_marker_missing"; then
+    pass "#3694 T3694 negative — ralph SHIP path does NOT emit ralph_done_marker_missing"
+else
+    fail "#3694 T3694 negative — ralph SHIP path does NOT emit ralph_done_marker_missing" \
+         "output tail: $(printf '%s' "$T3694B_TEST_OUT" | tail -c 1200)"
+fi
+
+# (9) AC — set_agent_task_arn_from_metadata function exists. Pure source
+# inspection so the test passes without a curl stub or ECS metadata
+# endpoint. The function name is the load-bearing identifier — if it is
+# renamed, this assertion locks the rename to a deliberate change.
+if grep -q "^set_agent_task_arn_from_metadata()" "$ENTRYPOINT"; then
+    pass "#3694 T3694 — set_agent_task_arn_from_metadata function defined in entrypoint"
+else
+    fail "#3694 T3694 — set_agent_task_arn_from_metadata function defined in entrypoint" \
+         "entrypoint head: $(head -c 400 "$ENTRYPOINT")"
+fi
+
+# (10) AC — the function reads from $ECS_CONTAINER_METADATA_URI_V4
+# (the load-bearing env var documented in the issue body's "Fix shape"
+# section). This guards against a refactor that drops the env var
+# reference (e.g. switching to a hard-coded localhost URL).
+if grep -q "ECS_CONTAINER_METADATA_URI_V4" "$ENTRYPOINT"; then
+    pass "#3694 T3694 — entrypoint references ECS_CONTAINER_METADATA_URI_V4 env var"
+else
+    fail "#3694 T3694 — entrypoint references ECS_CONTAINER_METADATA_URI_V4 env var" \
+         "(env var not found in entrypoint source)"
+fi
+
+# (11) AC — the function targets ``dispatcher.agents.agent_task_arn``
+# in a SET clause. Pure source inspection — locks the SQL column name
+# to migration 41.
+if grep -qE "SET[[:space:]]+agent_task_arn[[:space:]]*=" "$ENTRYPOINT"; then
+    pass "#3694 T3694 — entrypoint UPDATE writes dispatcher.agents.agent_task_arn"
+else
+    fail "#3694 T3694 — entrypoint UPDATE writes dispatcher.agents.agent_task_arn" \
+         "(SET agent_task_arn = clause not found)"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 # ── Summary ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Layer 1 (instrumentation) of the silent `ralph_not_ship` regression fix from #3694. Three consecutive ECS agents on three different issues exited with `output_json={}` and `stderr_tail=""`, leaving zero diagnostic data. This PR makes the silent-exit shape self-diagnosing:

- `dispatcher.agents.agent_task_arn` is now populated from the ECS metadata endpoint at entrypoint startup, so future diagnoses can pull CloudWatch.
- Worker stdout/stderr tails are persisted to `dispatcher.phase_outputs.log_text` on every ralph exit (SHIP, BLOCKED, silent-`{}`).
- When ralph exits 0 with `output_json={}`, the entrypoint emits a structured `ralph_done_marker_missing` log event with `worker_stdout_tail` / `worker_stderr_tail` / `worker_exit_code` fields, AND replaces the empty `{}` with a payload carrying `block_reason: "ralph_done_marker_missing: ..."` so the daemon's existing `_collect_failure_details` forwards `block_reason` → `failures.details.stderr_tail` (instead of the current empty string).

Layer 2 (the actual fix to whatever is making the worker exit silently) is intentionally deferred per the issue body — it requires data from Layer 1 to land. Once the new instrumentation captures self-diagnosing data on the next occurrence, a follow-up issue can target the root cause.

Closes #3694

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (Test T3694 in `scripts/tests/test_agent_runner_entrypoint.sh` — 11 sub-tests covering instrumentation + negative path)
- [x] CI green

### Post-deploy verification
- [x] Agent-runner image `855d3a5` deployed to ECR `:latest` (verified via `aws ecr describe-images`).
- [ ] After next ECS-mode ralph agent launch: confirm `dispatcher.agents.agent_task_arn` is non-NULL (validates AC #1) — pending next launch.
- [ ] After next ralph agent's ralph phase completes: confirm `dispatcher.phase_outputs.log_text` is non-NULL (validates AC #2) — pending next launch.
- [ ] If the silent-exit shape recurs after deploy: confirm `dispatcher.failures.details.stderr_tail` is non-empty AND starts with `ralph_done_marker_missing:` (validates AC #3 — diagnostic forwarding) — pending recurrence.
- [x] Verification evidence posted on issue (https://github.com/judgemind/judgemind/issues/3694#issuecomment-4340006374)
