### PR TITLE
feat(scripts): add unblock-issue.sh for manual issue unblocking (#3746)

### DIFF
--- a/.claude/skills/diagnose-failure/SKILL.md
+++ b/.claude/skills/diagnose-failure/SKILL.md
@@ -241,6 +241,7 @@ When you decide to take gh side-effects yourself (the preferred path post-#3455)
    - `gh issue comment <N> --repo judgemind/judgemind --body-file {worktree}/tmp/dispatcher-diagnoser/comment.md`
    - `gh issue edit <N> --repo judgemind/judgemind --add-label status/blocked --remove-label agent/ready`
    - `gh issue create --repo judgemind/judgemind --title "<title>" --body-file <body-file> --label "<labels>"`
+   - For manual unblock of a specific issue (prunes stale closed-blocker lines + ALL-blockers label gate): `scripts/unblock-issue.sh <N>` — prefer this over bare `gh issue edit --remove-label status/blocked`, which skips the body cleanup and the ALL-blockers gate.
 2. **Log each gh write to `actions_taken`** via `log_action.py` — `gh_issue_close`, `gh_issue_comment`, `gh_issue_edit`, `gh_issue_create` types.
 3. **Emit `action="terminal"`** in the recommendation with descriptive `action_taken` + `summary`.
 4. **Set `next_directive=terminal`** — the daemon's `_consume_action_terminal` simply records the diagnosis and marks the agent terminal at phase `diagnoser_terminal`. No additional gh writes from the daemon.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,7 @@ See **`docs/agent/code-standards.md`** for the full reference. Highlights:
 See **`docs/agent/task-dependencies.md`** and **`docs/agent/issue-authoring.md`** for the full mechanics. Core rules:
 
 - **Blocking:** use `scripts/block-issue.sh <issue> <blocker>`. Both the `status/blocked` label AND a `Blocked by #N` line in the issue body are required. Label-only blocks never auto-unblock. `Parent: #N` is hierarchy, not a dependency.
-- **Unblocking:** PR merges auto-unblock via `Closes #N`. For non-PR completions, run `scripts/unblock-dependents.sh <your-issue>`.
+- **Unblocking:** PR merges auto-unblock via `Closes #N`. For non-PR completions, run `scripts/unblock-dependents.sh <your-issue>`. For manual unblock of a single issue (rather than auto-unblock of all dependents of a closed issue), use `scripts/unblock-issue.sh <N>` — never bare `gh issue edit --remove-label status/blocked`.
 - **Sub-tasks:** reference the parent as `Parent: #N`; each sub-task should be independently pickup-able.
 - **Acceptance criteria:** concrete and machine-checkable. Each criterion has at least one `Verify:` line. **Data cleanup on `derived.*` defaults to `rebuild_db.py --county <name>`** — surgical scripts are a last resort.
 - **Investigation tasks:** produce documentation and file follow-up issues for every actionable finding, then close.

--- a/docs/agent/task-dependencies.md
+++ b/docs/agent/task-dependencies.md
@@ -38,3 +38,27 @@ This atomically:
 **Implementation tasks (PRs):** dependent issues are unblocked automatically by the `unblock-issues` CI workflow when the PR merges. The PR body must include `Closes #N`.
 
 **Non-PR completions:** unblock dependent issues by running `scripts/unblock-dependents.sh <your-issue>`. The script searches for open issues with `Blocked by #<your-issue>`, checks if all blockers are closed, and if so removes `status/blocked`, adds `agent/ready`, and cleans the `Blocked by` lines from the body. Use `--dry-run` to preview changes first.
+
+## Unblocking an issue manually
+
+Use `scripts/unblock-issue.sh <N>` to manually clean up a specific blocked issue — for example, when one of its blockers has been closed out-of-band and the auto-unblock flow did not fire, or when a `Blocked by` line was added by mistake.
+
+```
+scripts/unblock-issue.sh <N>
+scripts/unblock-issue.sh --dry-run <N>   # preview changes first
+```
+
+**Contrast with `unblock-dependents.sh`:**
+
+| Script | Direction | Use when |
+|---|---|---|
+| `unblock-dependents.sh <closed-issue>` | Reverse: given a *closed* issue, finds everything blocked *by* it | You just finished work on issue X and want to unblock its dependents |
+| `unblock-issue.sh <blocked-issue>` | Forward: given a *blocked* issue, prunes its stale blocker lines | You want to clean up a specific issue that may now be unblockable |
+
+**Safety guarantees:**
+
+- Only `Blocked by #N` lines for *closed* blockers are removed; open-blocker lines are never touched.
+- The `status/blocked` → `agent/ready` label flip only fires when **all** blockers are closed (ALL-blockers gate).
+- Use `--dry-run` to preview what would change before committing.
+
+**Never** run `gh issue edit --remove-label status/blocked` directly — it skips the body cleanup and the ALL-blockers gate, leaving stale `Blocked by` lines that will confuse the auto-unblock CI workflow on the next related PR merge.

--- a/scripts/_unblock_issue.py
+++ b/scripts/_unblock_issue.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Helper for unblock-issue.sh — manually unblock a single issue via GitHub API.
+
+Not meant to be run directly. Called by unblock-issue.sh with environment
+variables: REPO, ISSUE, DRY_RUN, DATA_FILE, WORK_TMPDIR.
+
+DATA_FILE is a JSON file containing {"body": "...", "labels": [...]} as returned
+by ``gh issue view <N> --json body,labels``.
+
+Logic:
+- Parse all blockers from body using ``Blocked by:? #N`` pattern.
+- For each blocker, check if it's closed via ``gh issue view``.
+- Partition into closed_blockers vs open_blockers.
+- Drop only lines for closed blockers from the body (never strip open-blocker lines).
+- If the Dependencies section becomes empty after pruning, drop it.
+- If closed_blockers is non-empty: write updated body via ``gh issue edit --body-file``.
+- If ALL blockers are now closed AND status/blocked is in labels: flip to agent/ready.
+- Honour DRY_RUN=true env var — print intended actions, no writes.
+"""
+
+# permanent: true
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+def gh(*args: str) -> str | None:
+    """Run a gh CLI command and return stdout, or None on error."""
+    r = subprocess.run(["gh", *args], capture_output=True, text=True, timeout=120)  # noqa: S603, S607
+    if r.returncode != 0:
+        print(f"  gh error: {r.stderr.strip()}", file=sys.stderr)
+        return None
+    return r.stdout.strip()
+
+
+def gh_json(*args: str) -> dict | list | None:
+    """Run a gh CLI command and parse stdout as JSON."""
+    out = gh(*args)
+    if not out:
+        return None
+    return json.loads(out)
+
+
+def strip_closed_blocker_lines(body: str, closed_numbers: set[str]) -> str:
+    """Remove 'Blocked by #N' lines only for closed blockers.
+
+    Accepts both the canonical ``Blocked by #N`` form and the colon variant
+    ``Blocked by: #N`` (consistent with _unblock_dependents.py).
+
+    Removes empty ``## Dependencies`` sections after pruning (reuses the same
+    look-ahead logic from strip_blocked_lines in _unblock_dependents.py).
+    """
+    lines = body.splitlines()
+
+    # Remove only the lines for the specified closed-blocker numbers
+    def is_closed_blocker_line(line: str) -> bool:
+        m = re.match(r"\s*Blocked by:?\s+#(\d+)", line)
+        if m and m.group(1) in closed_numbers:
+            return True
+        return False
+
+    lines = [line for line in lines if not is_closed_blocker_line(line)]
+
+    # Remove empty "## Dependencies" section (same look-ahead logic as
+    # _unblock_dependents.strip_blocked_lines)
+    result: list[str] = []
+    i = 0
+    while i < len(lines):
+        if re.match(r"^## Dependencies\s*$", lines[i]):
+            # Look ahead: skip blank lines; if next content is a heading or EOF, drop section
+            j = i + 1
+            while j < len(lines) and not lines[j].strip():
+                j += 1
+            if j >= len(lines) or lines[j].startswith("#"):
+                # Empty section — drop the heading and blank lines
+                i = j
+                continue
+            # Section has remaining content — keep the heading
+        result.append(lines[i])
+        i += 1
+
+    # Remove trailing blank lines
+    while result and not result[-1].strip():
+        result.pop()
+
+    return "\n".join(result)
+
+
+def main() -> None:
+    """Process a single issue and prune stale closed-blocker lines."""
+    repo = os.environ.get("REPO", "judgemind/judgemind")
+    issue = os.environ.get("ISSUE", "")
+    dry_run = os.environ.get("DRY_RUN", "false") == "true"
+    data_file = os.environ.get("DATA_FILE", "")
+    tmpdir = os.environ.get("WORK_TMPDIR", ".")
+
+    if not issue:
+        print("Error: ISSUE env var not set.", file=sys.stderr)
+        sys.exit(1)
+
+    if not data_file:
+        print("Error: DATA_FILE env var not set.", file=sys.stderr)
+        sys.exit(1)
+
+    # Read the JSON data file written by the shell wrapper
+    with open(data_file) as f:
+        data = json.load(f)
+
+    body: str = data.get("body") or ""
+    raw_labels: list = data.get("labels") or []
+
+    # Labels may be dicts {"name": "..."} (gh JSON output) or plain strings
+    label_names: set[str] = set()
+    for lbl in raw_labels:
+        if isinstance(lbl, dict):
+            label_names.add(lbl.get("name", ""))
+        elif isinstance(lbl, str):
+            label_names.add(lbl)
+
+    # Find all blockers in the body (canonical and colon-variant)
+    blockers = re.findall(r"Blocked by:?\s+#(\d+)", body)
+
+    if not blockers:
+        print(f"Issue #{issue}: no 'Blocked by' lines found — nothing to do.")
+        sys.exit(0)
+
+    print(f"Issue #{issue}: found blocker(s): {', '.join('#' + b for b in blockers)}")
+
+    closed_blockers: list[str] = []
+    open_blockers: list[str] = []
+
+    for b in blockers:
+        info = gh_json("issue", "view", b, "--repo", repo, "--json", "state")
+        if not info:
+            state = "FETCH_ERROR"
+        else:
+            state = info.get("state", "UNKNOWN")
+        if state == "CLOSED":
+            print(f"  Blocker #{b} is CLOSED.")
+            closed_blockers.append(b)
+        else:
+            print(f"  Blocker #{b} is {state} — keeping line.")
+            open_blockers.append(b)
+
+    if not closed_blockers:
+        print("No closed blockers to prune — nothing to do.")
+        sys.exit(0)
+
+    print(f"  Pruning {len(closed_blockers)} closed blocker(s): {', '.join('#' + b for b in closed_blockers)}")
+
+    updated_body = strip_closed_blocker_lines(body, set(closed_blockers))
+
+    if dry_run:
+        print("[DRY RUN] Would update issue body (removed closed Blocked by lines).")
+        if not open_blockers and "status/blocked" in label_names:
+            print("[DRY RUN] Would remove label: status/blocked")
+            print("[DRY RUN] Would add label: agent/ready")
+        elif open_blockers:
+            print(
+                f"[DRY RUN] Keeping status/blocked — open blocker(s) remain: "
+                f"{', '.join('#' + b for b in open_blockers)}"
+            )
+        sys.exit(0)
+
+    # Write updated body to temp file and edit the issue
+    body_file = os.path.join(tmpdir, f"_unblock_issue_body_{issue}.txt")
+    with open(body_file, "w") as f:
+        f.write(updated_body)
+
+    result = gh("issue", "edit", issue, "--repo", repo, "--body-file", body_file)
+    if result is None:
+        print("Error: failed to update issue body.", file=sys.stderr)
+        sys.exit(1)
+    print("  Updated issue body (removed closed Blocked by lines).")
+
+    # Flip labels only when ALL blockers are now closed
+    if not open_blockers and "status/blocked" in label_names:
+        flip = gh(
+            "issue",
+            "edit",
+            issue,
+            "--repo",
+            repo,
+            "--remove-label",
+            "status/blocked",
+            "--add-label",
+            "agent/ready",
+        )
+        if flip is None:
+            print("Warning: body updated but label flip failed.", file=sys.stderr)
+        else:
+            print("  Labels updated: -status/blocked, +agent/ready.")
+    elif open_blockers:
+        print(
+            f"  Keeping status/blocked — open blocker(s) remain: "
+            f"{', '.join('#' + b for b in open_blockers)}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_unblock_issue.sh
+++ b/scripts/tests/test_unblock_issue.sh
@@ -1,0 +1,349 @@
+#!/usr/bin/env bash
+# test_unblock_issue.sh — Tests for scripts/unblock-issue.sh and scripts/_unblock_issue.py
+#
+# Uses PATH-mocked gh CLI (pattern from test_check_duplicate_pr.sh) so no real
+# GitHub API calls are made. Each mock writes every invocation to a tempfile
+# so assertions can verify which ``gh issue edit`` args were used.
+#
+# Test cases:
+#   A — Mixed closed/open blockers: only closed-blocker line is pruned; status/blocked stays.
+#   B — All blockers closed: all Blocked by lines pruned; status/blocked → agent/ready.
+#   C — CLI flags: --help exits 0; --dry-run makes no writes; missing arg exits 1; bad arg exits 1.
+#   D — Idempotence: body with no Blocked by lines → no-op exit 0, no writes.
+#
+# Usage:
+#   scripts/tests/test_unblock_issue.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WRAPPER="$SCRIPT_DIR/unblock-issue.sh"
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+ORIG_PATH_SAVE=""
+
+cleanup() {
+    set +eu
+    for d in "${TEMP_DIRS[@]}"; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+    if [[ -n "$ORIG_PATH_SAVE" ]]; then
+        export PATH="$ORIG_PATH_SAVE"
+    fi
+}
+trap cleanup EXIT
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Precondition: wrapper exists and is executable ─────────────────────────
+
+if [[ ! -x "$WRAPPER" ]]; then
+    echo "FAIL: $WRAPPER is not executable (or does not exist)" >&2
+    exit 1
+fi
+
+# ── Test C — CLI flag checks (no gh mock needed for these) ─────────────────
+
+# --help exits 0
+exit_code=0
+"$WRAPPER" --help > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "--help exits 0"
+else
+    fail "--help exits 0" "expected exit 0, got $exit_code"
+fi
+
+# --help prints usage containing 'unblock-issue.sh'
+help_output=$("$WRAPPER" --help 2>/dev/null)
+if [[ "$help_output" == *"unblock-issue.sh"* ]]; then
+    pass "--help prints usage line"
+else
+    fail "--help prints usage line" "expected 'unblock-issue.sh' in output"
+fi
+
+# missing argument exits 1
+exit_code=0
+"$WRAPPER" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "missing argument exits 1"
+else
+    fail "missing argument exits 1" "expected exit 1, got $exit_code"
+fi
+
+# non-numeric argument exits 1
+exit_code=0
+"$WRAPPER" "abc" > /dev/null 2>&1 || exit_code=$?
+if [[ "$exit_code" -eq 1 ]]; then
+    pass "non-numeric argument exits 1"
+else
+    fail "non-numeric argument exits 1" "expected exit 1, got $exit_code"
+fi
+
+# ── Set up a mock gh CLI on PATH for the remaining tests ──────────────────
+
+MOCK_BIN_DIR=$(mktemp -d)
+TEMP_DIRS+=("$MOCK_BIN_DIR")
+ORIG_PATH_SAVE="$PATH"
+export PATH="$MOCK_BIN_DIR:$ORIG_PATH_SAVE"
+
+# ── Test A — Mixed closed/open blockers ────────────────────────────────────
+#
+# Issue 999 body: "Blocked by #100\nBlocked by #200"
+# #100 is closed, #200 is open
+# labels: ["status/blocked"]
+# Expected: body updated with only "Blocked by #200" remaining; NO label flip
+
+INVOCATIONS_A="$MOCK_BIN_DIR/invocations_a.txt"
+WRITTEN_BODY_A="$MOCK_BIN_DIR/written_body_a.txt"
+
+# Write the mock issue data file that gh would return.
+# The shell script calls: gh issue view 999 --repo ... --json body,labels
+# We mock this by writing a gh that, for "issue view 999", emits the JSON.
+cat > "$MOCK_BIN_DIR/gh" << MOCKEOF
+#!/usr/bin/env bash
+echo "\$@" >> "$INVOCATIONS_A"
+# Dispatch on subcommand + args
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
+    ISSUE_NUM="\${3:-}"
+    # Main issue fetch
+    if [[ "\$ISSUE_NUM" == "999" ]]; then
+        printf '%s' '{"body":"Blocked by #100\nBlocked by #200","labels":[{"name":"status/blocked"}]}'
+        exit 0
+    fi
+    # Blocker state checks
+    if [[ "\$ISSUE_NUM" == "100" ]]; then
+        printf '%s' '{"state":"CLOSED"}'
+        exit 0
+    fi
+    if [[ "\$ISSUE_NUM" == "200" ]]; then
+        printf '%s' '{"state":"OPEN"}'
+        exit 0
+    fi
+fi
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "edit" ]]; then
+    # Capture what body file was written (--body-file arg)
+    prev=""
+    for arg in "\$@"; do
+        if [[ "\$prev" == "--body-file" ]]; then
+            cat "\$arg" > "$WRITTEN_BODY_A"
+        fi
+        prev="\$arg"
+    done
+    exit 0
+fi
+exit 0
+MOCKEOF
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+"$WRAPPER" 999 > /dev/null 2>&1 || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "Test A: exits 0 with mixed closed/open blockers"
+else
+    fail "Test A: exits 0 with mixed closed/open blockers" "expected exit 0, got $exit_code"
+fi
+
+# Body written must contain "Blocked by #200" (open blocker kept)
+if [[ -f "$WRITTEN_BODY_A" ]] && grep -q "Blocked by #200" "$WRITTEN_BODY_A"; then
+    pass "Test A: open blocker line (#200) retained in written body"
+else
+    fail "Test A: open blocker line (#200) retained in written body" "written body: $(cat "$WRITTEN_BODY_A" 2>/dev/null || echo '<not written>')"
+fi
+
+# Body written must NOT contain "Blocked by #100" (closed blocker pruned)
+if [[ -f "$WRITTEN_BODY_A" ]] && ! grep -q "Blocked by #100" "$WRITTEN_BODY_A"; then
+    pass "Test A: closed blocker line (#100) pruned from written body"
+else
+    fail "Test A: closed blocker line (#100) pruned from written body" "written body: $(cat "$WRITTEN_BODY_A" 2>/dev/null || echo '<not written>')"
+fi
+
+# No --remove-label status/blocked invocation (open blocker still present)
+if grep -q -- "--remove-label" "$INVOCATIONS_A" 2>/dev/null; then
+    fail "Test A: no label flip when open blockers remain" "found --remove-label in invocations"
+else
+    pass "Test A: no label flip when open blockers remain"
+fi
+
+# ── Test B — All blockers closed ───────────────────────────────────────────
+#
+# Issue 888 body: "Blocked by #100\nBlocked by #200"
+# Both closed; labels: ["status/blocked"]
+# Expected: body has zero Blocked by lines; status/blocked removed, agent/ready added.
+
+INVOCATIONS_B="$MOCK_BIN_DIR/invocations_b.txt"
+WRITTEN_BODY_B="$MOCK_BIN_DIR/written_body_b.txt"
+
+cat > "$MOCK_BIN_DIR/gh" << MOCKEOF
+#!/usr/bin/env bash
+echo "\$@" >> "$INVOCATIONS_B"
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
+    ISSUE_NUM="\${3:-}"
+    if [[ "\$ISSUE_NUM" == "888" ]]; then
+        printf '%s' '{"body":"Blocked by #100\nBlocked by #200","labels":[{"name":"status/blocked"}]}'
+        exit 0
+    fi
+    if [[ "\$ISSUE_NUM" == "100" ]]; then
+        printf '%s' '{"state":"CLOSED"}'
+        exit 0
+    fi
+    if [[ "\$ISSUE_NUM" == "200" ]]; then
+        printf '%s' '{"state":"CLOSED"}'
+        exit 0
+    fi
+fi
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "edit" ]]; then
+    prev=""
+    for arg in "\$@"; do
+        if [[ "\$prev" == "--body-file" ]]; then
+            cat "\$arg" > "$WRITTEN_BODY_B"
+        fi
+        prev="\$arg"
+    done
+    exit 0
+fi
+exit 0
+MOCKEOF
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+"$WRAPPER" 888 > /dev/null 2>&1 || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "Test B: exits 0 when all blockers closed"
+else
+    fail "Test B: exits 0 when all blockers closed" "expected exit 0, got $exit_code"
+fi
+
+# Written body must have zero "Blocked by" lines
+if [[ -f "$WRITTEN_BODY_B" ]] && ! grep -q "Blocked by" "$WRITTEN_BODY_B"; then
+    pass "Test B: all Blocked by lines pruned from written body"
+else
+    fail "Test B: all Blocked by lines pruned from written body" "written body: $(cat "$WRITTEN_BODY_B" 2>/dev/null || echo '<not written>')"
+fi
+
+# Exactly one invocation with --remove-label status/blocked and --add-label agent/ready
+if grep -q -- "--remove-label" "$INVOCATIONS_B" 2>/dev/null; then
+    if grep -q -- "agent/ready" "$INVOCATIONS_B" 2>/dev/null; then
+        pass "Test B: label flip fired (status/blocked removed, agent/ready added)"
+    else
+        fail "Test B: label flip fired" "found --remove-label but not agent/ready in invocations"
+    fi
+else
+    fail "Test B: label flip fired (status/blocked removed, agent/ready added)" "no --remove-label found in invocations"
+fi
+
+# ── Test C — --dry-run makes no gh issue edit writes ─────────────────────
+#
+# Same scenario as Test B (all blockers closed) but with --dry-run.
+# Expected: no gh issue edit calls at all.
+
+INVOCATIONS_C="$MOCK_BIN_DIR/invocations_c.txt"
+
+cat > "$MOCK_BIN_DIR/gh" << MOCKEOF
+#!/usr/bin/env bash
+echo "\$@" >> "$INVOCATIONS_C"
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
+    ISSUE_NUM="\${3:-}"
+    if [[ "\$ISSUE_NUM" == "777" ]]; then
+        printf '%s' '{"body":"Blocked by #100\nBlocked by #200","labels":[{"name":"status/blocked"}]}'
+        exit 0
+    fi
+    if [[ "\$ISSUE_NUM" == "100" ]]; then
+        printf '%s' '{"state":"CLOSED"}'
+        exit 0
+    fi
+    if [[ "\$ISSUE_NUM" == "200" ]]; then
+        printf '%s' '{"state":"CLOSED"}'
+        exit 0
+    fi
+fi
+exit 0
+MOCKEOF
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+"$WRAPPER" --dry-run 777 > /dev/null 2>&1 || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "Test C (dry-run): exits 0"
+else
+    fail "Test C (dry-run): exits 0" "expected exit 0, got $exit_code"
+fi
+
+if grep -q "issue edit" "$INVOCATIONS_C" 2>/dev/null; then
+    fail "Test C (dry-run): no gh issue edit calls made" "found 'issue edit' in invocations"
+else
+    pass "Test C (dry-run): no gh issue edit calls made"
+fi
+
+# ── Test D — Idempotence: body with no Blocked by lines → no-op ────────────
+#
+# Issue 666 body has no Blocked by lines.
+# Expected: exits 0, no gh issue edit calls.
+
+INVOCATIONS_D="$MOCK_BIN_DIR/invocations_d.txt"
+
+cat > "$MOCK_BIN_DIR/gh" << MOCKEOF
+#!/usr/bin/env bash
+echo "\$@" >> "$INVOCATIONS_D"
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
+    ISSUE_NUM="\${3:-}"
+    if [[ "\$ISSUE_NUM" == "666" ]]; then
+        printf '%s' '{"body":"## Summary\n\nNo blockers here.","labels":[]}'
+        exit 0
+    fi
+fi
+exit 0
+MOCKEOF
+chmod +x "$MOCK_BIN_DIR/gh"
+
+exit_code=0
+"$WRAPPER" 666 > /dev/null 2>&1 || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+    pass "Test D (idempotence): exits 0 with no Blocked by lines"
+else
+    fail "Test D (idempotence): exits 0 with no Blocked by lines" "expected exit 0, got $exit_code"
+fi
+
+if grep -q "issue edit" "$INVOCATIONS_D" 2>/dev/null; then
+    fail "Test D (idempotence): no gh issue edit calls made" "found 'issue edit' in invocations"
+else
+    pass "Test D (idempotence): no gh issue edit calls made"
+fi
+
+# Restore PATH
+export PATH="$ORIG_PATH_SAVE"
+
+# ── Summary ───────────────────────────────────────────────────────────────
+
+echo ""
+echo "Results: $((TESTS - FAILURES))/$TESTS passed"
+
+if [[ $FAILURES -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/scripts/unblock-issue.sh
+++ b/scripts/unblock-issue.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# unblock-issue.sh — Manually unblock a single issue by pruning stale closed-blocker lines.
+#
+# For a given issue <N>, fetches its body and labels, checks each "Blocked by #M"
+# line, and removes lines for blockers that are now closed.  If ALL blockers are
+# resolved and the issue carries status/blocked, flips to agent/ready.
+#
+# This is the complement to unblock-dependents.sh (which operates in the opposite
+# direction — given a closed issue, it finds every issue blocked by it).  Use
+# unblock-issue.sh when you want to manually clean up a specific blocked issue
+# rather than triggering the auto-unblock flow.
+#
+# Safety guarantees:
+#   - Only prunes lines for CLOSED blockers; open-blocker lines are never removed.
+#   - The status/blocked → agent/ready label flip requires ALL blockers to be closed.
+#   - --dry-run shows intended actions without writing anything.
+#
+# Usage:
+#   scripts/unblock-issue.sh <issue>
+#   scripts/unblock-issue.sh 1939
+#   scripts/unblock-issue.sh --dry-run 1939
+#   scripts/unblock-issue.sh --help
+#
+# Options:
+#   --dry-run   Show what would be done without making changes
+#   --help      Show this help message
+
+set -euo pipefail
+
+DRY_RUN=false
+
+# Parse options
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: scripts/unblock-issue.sh [--dry-run] <issue>"
+            echo ""
+            echo "Manually unblock a single issue by pruning stale closed-blocker lines."
+            echo ""
+            echo "For each 'Blocked by #M' line in the issue body:"
+            echo "  1. Check if blocker #M is closed"
+            echo "  2. If closed: remove the 'Blocked by #M' line from the body"
+            echo "  3. If the Dependencies section is now empty, remove it too"
+            echo ""
+            echo "Label flip (status/blocked -> agent/ready) only fires when ALL"
+            echo "blockers are closed.  Open-blocker lines are never removed."
+            echo ""
+            echo "Options:"
+            echo "  --dry-run   Show what would be done without making changes"
+            echo "  --help      Show this help message"
+            exit 0
+            ;;
+        -*)
+            echo "Error: Unknown option: $1" >&2
+            echo "Run 'scripts/unblock-issue.sh --help' for usage." >&2
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [ $# -ne 1 ]; then
+    echo "Usage: scripts/unblock-issue.sh [--dry-run] <issue>" >&2
+    echo "Run 'scripts/unblock-issue.sh --help' for full usage." >&2
+    exit 1
+fi
+
+ISSUE="${1#\#}"
+REPO="judgemind/judgemind"
+
+# Validate argument is a number
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+    echo "Error: Argument must be an issue number (digits only)." >&2
+    exit 1
+fi
+
+if [ "$DRY_RUN" = true ]; then
+    echo "[DRY RUN] Would unblock issue #$ISSUE"
+    echo ""
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORK_TMPDIR="${SCRIPT_DIR}/../tmp"
+mkdir -p "$WORK_TMPDIR"
+
+# Fetch issue body and labels into a temp file (avoids shell quoting issues with
+# issue bodies that contain special characters — same pattern as unblock-dependents.sh)
+DATA_FILE="$WORK_TMPDIR/_unblock_issue_data_${ISSUE}.json"
+echo "Fetching issue #$ISSUE..."
+gh issue view "$ISSUE" --repo "$REPO" --json body,labels > "$DATA_FILE" 2>/dev/null || {
+    rm -f "$DATA_FILE"
+    echo "Error: Could not fetch issue #$ISSUE from $REPO." >&2
+    exit 1
+}
+
+# Delegate to Python helper for JSON parsing and body manipulation.
+# Pass the raw JSON file path via env var; the helper reads it directly.
+REPO="$REPO" \
+ISSUE="$ISSUE" \
+DRY_RUN="$DRY_RUN" \
+DATA_FILE="$DATA_FILE" \
+WORK_TMPDIR="$WORK_TMPDIR" \
+python3 "$SCRIPT_DIR/_unblock_issue.py"
+
+EXIT_CODE=$?
+rm -f "$DATA_FILE"
+exit $EXIT_CODE


### PR DESCRIPTION
## Summary

Added `scripts/unblock-issue.sh` to manually unblock a specific issue by pruning stale closed-blocker lines and applying the ALL-blockers label gate (opposite direction from `unblock-dependents.sh`). Solves the real misfire from 2026-04-28 where manual `gh issue edit` bypassed body cleanup and the ALL-blockers check.

Implementation:
- `scripts/unblock-issue.sh <N>` — bash wrapper with --dry-run, --help, arg validation
- `scripts/_unblock_issue.py` — Python helper with JSON parsing, closed-blocker detection, label-flip gate
- `scripts/tests/test_unblock_issue.sh` — 15 test cases covering mixed/all-closed/dry-run/idempotence paths
- CLAUDE.md + docs/agent/task-dependencies.md updated with reference and contrast table

Closes #3746

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (15/15 passing in test_unblock_issue.sh)
- [x] CI green

### Manual verification (pre-deploy)

- [x] `scripts/unblock-issue.sh --help` displays usage
- [x] `scripts/unblock-issue.sh <bad-arg>` exits 1
- [x] `scripts/unblock-issue.sh --dry-run 3615` (dry-run mode)
- [x] Test coverage: mixed blockers (one closed, one open), all closed, idempotence

### Post-deploy verification

- [ ] Stale-blocker-line count drops on next `unblock-dependents.sh --sweep` run (operator observation)
- [ ] Verification evidence posted on #3746