### PR TITLE
fix(dispatcher): add image-freshness guard to detect stale agent-runner deploys (#3754)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -430,6 +430,17 @@ AGENT_RUNNER_RUN_TASK_RETRYABLE_CODES: frozenset[str] = frozenset(
     }
 )
 
+#: Staleness window for the agent-runner image freshness guard (#3754).
+#: When the ECR ``:latest`` image was pushed MORE than this many seconds
+#: after the task-definition was last registered, the guard emits a
+#: ``agent_runner_image_stale`` warning: the task-def is pointing at a
+#: `:latest` tag whose content has changed, which means any long-running
+#: ECS task (e.g., one that spans a deploy window) is running stale code.
+#: Set conservatively large (5 minutes) to absorb normal deploy jitter
+#: (the ``deploy-agent-runner`` workflow takes ~90s) without false-positives
+#: during rolling restarts.
+AGENT_RUNNER_IMAGE_FRESHNESS_WINDOW_SECONDS = 300
+
 #: Killswitch terminal phase name (#2847). When the scheduler observes
 #: ``concurrency_cap=0`` mid-orchestration and the killswitch engages
 #: (not a #2884 graceful ``stop``), the worker thread aborts at the
@@ -23925,6 +23936,209 @@ class DispatcherDaemon:
             config=ecs_cfg,
         )
 
+    def _make_ecr_client(self) -> Any:
+        """Build a boto3 ECR client. Isolated so tests can mock it.
+
+        Mirrors :meth:`_make_ecs_client` — lazy boto3 import so tests
+        that don't exercise the freshness-guard path do not have to
+        install boto3. Same timeout budget as the ECS client: 5s connect
+        + 10s read, 2 attempts. ECR ``DescribeImages`` is a lightweight
+        metadata call so the ECS budget is more than adequate.
+
+        Used by :meth:`_check_agent_runner_image_freshness` (#3754).
+        """
+        import boto3  # noqa: PLC0415 — lazy import
+        import botocore.config  # noqa: PLC0415 — lazy import
+
+        ecr_cfg = botocore.config.Config(
+            connect_timeout=ECS_CLIENT_CONNECT_TIMEOUT_SECONDS,
+            read_timeout=ECS_CLIENT_READ_TIMEOUT_SECONDS,
+            retries={
+                "max_attempts": ECS_CLIENT_MAX_ATTEMPTS,
+                "mode": "standard",
+            },
+        )
+        return boto3.client(
+            "ecr",
+            region_name=self._cfg.aws_region,
+            config=ecr_cfg,
+        )
+
+    def _check_agent_runner_image_freshness(self) -> bool:
+        """Guard: verify the ECR ``:latest`` agent-runner image is not stale.
+
+        Called from :meth:`_launch_agent_ecs_task` before ``ecs:RunTask``
+        to detect the image-lag failure mode documented in issue #3754:
+
+        - PR #3750 merged at 2026-04-29T00:11:12Z, pushing a new
+          ``:latest`` image to ECR.
+        - Agent ``d7041874`` was launched in an ECS task that started
+          BEFORE the deploy completed.  The task's container pulled the
+          pre-#3750 image and ran with stale code for its entire lifetime
+          (one ECS task per agent, all phases in the same container).
+        - None of the Layer-1 instrumentation (``agent_task_arn``,
+          ``log_text``, ``ralph_done_marker_missing``) fired because the
+          entrypoint code predated the instrumentation.
+
+        **What this guard checks:**
+
+        1. Calls ``ecs:DescribeTaskDefinition`` to get the task-def's
+           ``registeredAt`` timestamp and the image URI (with tag).
+        2. Extracts the ECR repository name and image tag from the URI.
+        3. Calls ``ecr:DescribeImages`` to get the ``:latest`` tag's
+           ``imagePushedAt`` timestamp and ``imageDigest``.
+        4. If the task-def image URI contains an explicit digest
+           (``@sha256:...``) AND that digest does not match the current
+           ECR ``:latest`` digest → the task-def is pinned to a stale
+           image → returns ``False`` (caller refuses launch).
+        5. If the ECR ``:latest`` was pushed MORE THAN
+           :data:`AGENT_RUNNER_IMAGE_FRESHNESS_WINDOW_SECONDS` seconds
+           AFTER the task-def was last registered → the ``:latest`` tag
+           has rolled forward since the task-def was created, meaning
+           any long-running ECS task started before the new push would
+           be running stale code → emits ``agent_runner_image_stale``
+           warning and returns ``False`` (caller refuses launch).
+
+        **Fail-open contract:** any AWS API error (AccessDenied,
+        missing repo, throttle, timeout) is caught and logged at WARNING
+        level; the method returns ``True`` so a transient AWS hiccup
+        never blocks agent launches. The guard is a best-effort
+        observability + safety net, not a hard dependency.
+
+        Returns ``True`` (fresh / skip-check) or ``False`` (stale →
+        caller should refuse to launch).
+        """
+        if not self._cfg.agent_runner_task_definition_family:
+            # Wiring not configured — skip (unit-test or local-dev mode).
+            return True
+
+        try:
+            # ── Step 1: task-def metadata ─────────────────────────────────
+            if self._ecs_client is None:
+                self._ecs_client = self._make_ecs_client()
+            td_resp = self._ecs_client.describe_task_definition(
+                taskDefinition=self._cfg.agent_runner_task_definition_family,
+            )
+            td = td_resp.get("taskDefinition") or {}
+            # ``registeredAt`` is a datetime object from boto3.
+            td_registered_at = td.get("registeredAt")
+            containers = td.get("containerDefinitions") or []
+            td_image_uri = containers[0].get("image", "") if containers else ""
+
+            # ── Step 2: extract ECR repo + tag/digest from image URI ──────
+            # URI forms:
+            #   <account>.dkr.ecr.<region>.amazonaws.com/<repo>:<tag>
+            #   <account>.dkr.ecr.<region>.amazonaws.com/<repo>@sha256:<digest>
+            td_image_digest: str | None = None
+            ecr_repo_name: str | None = None
+            if td_image_uri:
+                # Split off the registry host (everything before the first /)
+                _slash = td_image_uri.find("/")
+                _rest = td_image_uri[_slash + 1 :] if _slash != -1 else td_image_uri
+                # Digest-pinned form: repo@sha256:...
+                if "@sha256:" in _rest:
+                    _repo_part, _digest_part = _rest.split("@sha256:", 1)
+                    ecr_repo_name = _repo_part
+                    td_image_digest = "sha256:" + _digest_part
+                elif ":" in _rest:
+                    _repo_part, _ = _rest.rsplit(":", 1)
+                    ecr_repo_name = _repo_part
+                else:
+                    ecr_repo_name = _rest
+
+            if not ecr_repo_name:
+                # Cannot parse the image URI → skip check.
+                return True
+
+            # ── Step 3: ECR ``:latest`` metadata ─────────────────────────
+            ecr_client = self._make_ecr_client()
+            ecr_resp = ecr_client.describe_images(
+                repositoryName=ecr_repo_name,
+                imageIds=[{"imageTag": "latest"}],
+            )
+            ecr_images = ecr_resp.get("imageDetails") or []
+            if not ecr_images:
+                # No image found under ``:latest`` — skip check.
+                return True
+            ecr_img = ecr_images[0]
+            ecr_digest = ecr_img.get("imageDigest", "")
+            ecr_pushed_at = ecr_img.get("imagePushedAt")
+
+        except Exception:  # noqa: BLE001 — fail-open
+            self._log.warning(
+                "daemon.agent_runner_image_freshness_check_failed",
+                extra={
+                    "event": "agent_runner_image_freshness_check_failed",
+                    "run_id": self._run_id,
+                    "task_definition_family": (
+                        self._cfg.agent_runner_task_definition_family
+                    ),
+                },
+                exc_info=True,
+            )
+            return True  # fail-open: don't block launches on AWS errors
+
+        # ── Step 4: digest mismatch (pinned task-def vs ECR latest) ──────
+        if td_image_digest and ecr_digest and td_image_digest != ecr_digest:
+            self._log.error(
+                "daemon.agent_runner_image_stale",
+                extra={
+                    "event": "agent_runner_image_stale",
+                    "run_id": self._run_id,
+                    "reason": "digest_mismatch",
+                    "task_def_image_digest": td_image_digest,
+                    "ecr_latest_digest": ecr_digest,
+                    "ecr_latest_pushed_at": (
+                        ecr_pushed_at.isoformat() if ecr_pushed_at else ""
+                    ),
+                    "task_def_registered_at": (
+                        td_registered_at.isoformat() if td_registered_at else ""
+                    ),
+                    "task_definition_family": (
+                        self._cfg.agent_runner_task_definition_family
+                    ),
+                },
+            )
+            return False  # stale → refuse launch
+
+        # ── Step 5: timestamp-based staleness (`:latest` tag task-defs) ──
+        # If ECR `:latest` was pushed more than FRESHNESS_WINDOW seconds
+        # AFTER the task-def was registered, the `:latest` content has
+        # rolled forward since the task-def was created. Any long-running
+        # ECS task launched before the new push would be running stale code.
+        if td_registered_at is not None and ecr_pushed_at is not None:
+            # Normalise both to UTC-aware datetimes. ``UTC`` is the
+            # module-level sentinel (``from datetime import UTC``) —
+            # identical to ``timezone.utc`` but already imported.
+
+            def _to_utc(dt: Any) -> Any:
+                if dt.tzinfo is None:
+                    return dt.replace(tzinfo=UTC)
+                return dt
+
+            td_ts = _to_utc(td_registered_at)
+            ecr_ts = _to_utc(ecr_pushed_at)
+            staleness_seconds = (ecr_ts - td_ts).total_seconds()
+            if staleness_seconds > AGENT_RUNNER_IMAGE_FRESHNESS_WINDOW_SECONDS:
+                self._log.error(
+                    "daemon.agent_runner_image_stale",
+                    extra={
+                        "event": "agent_runner_image_stale",
+                        "run_id": self._run_id,
+                        "reason": "ecr_pushed_after_task_def_registered",
+                        "staleness_seconds": int(staleness_seconds),
+                        "ecr_latest_digest": ecr_digest,
+                        "ecr_latest_pushed_at": ecr_ts.isoformat(),
+                        "task_def_registered_at": td_ts.isoformat(),
+                        "task_definition_family": (
+                            self._cfg.agent_runner_task_definition_family
+                        ),
+                    },
+                )
+                return False  # stale → refuse launch
+
+        return True  # fresh
+
     def _cb_config_str(self, key: str, default: str) -> str:
         """Read a string key from ``dispatcher.config`` with a fallback.
 
@@ -24059,6 +24273,28 @@ class DispatcherDaemon:
                         "AGENT_RUNNER_TASK_DEFINITION_FAMILY / "
                         "AGENT_RUNNER_SUBNET_IDS / "
                         "AGENT_RUNNER_SECURITY_GROUP_ID not fully wired"
+                    ),
+                },
+            )
+            return None
+
+        # #3754 — image-freshness guard. Verify the ECR ``:latest`` image
+        # is not stale before launching a new ECS task. If the guard detects
+        # that the task-def's image is stale (either pinned to an old digest
+        # or `:latest` has rolled forward since the task-def was registered),
+        # it logs ``agent_runner_image_stale`` and we fail the launch so the
+        # caller can route through ``_handle_agent_failure``. Fail-open on
+        # AWS API errors so transient ECR/ECS hiccups do not block launches.
+        if not self._check_agent_runner_image_freshness():
+            self._log.error(
+                "daemon.agent_runner_launch_refused_stale_image",
+                extra={
+                    "event": "agent_runner_launch_refused_stale_image",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "task_definition_family": (
+                        self._cfg.agent_runner_task_definition_family
                     ),
                 },
             )

--- a/scripts/dispatcher/tests/test_daemon_image_freshness_guard.py
+++ b/scripts/dispatcher/tests/test_daemon_image_freshness_guard.py
@@ -1,0 +1,530 @@
+"""Unit tests for issue #3754 — agent-runner image-freshness guard.
+
+The guard lives in ``DispatcherDaemon._check_agent_runner_image_freshness``
+and is called from ``_launch_agent_ecs_task`` before ``ecs:RunTask``.
+
+Test coverage:
+
+* Digest mismatch (task-def pinned to an old ``@sha256:`` digest, ECR
+  ``:latest`` has a newer digest) → ``_check_agent_runner_image_freshness``
+  returns ``False`` and ``_launch_agent_ecs_task`` returns ``None``.
+* Timestamp staleness (task-def registered at T, ECR ``:latest`` pushed at
+  T + FRESHNESS_WINDOW + 1s) → same refuse-launch outcome.
+* Fresh image (ECR ``:latest`` pushed within the freshness window) → guard
+  returns ``True`` and launch proceeds.
+* AWS API error in the freshness check → fail-open (guard returns ``True``).
+* Task-def wiring missing (empty family) → guard returns ``True`` (skip).
+
+Fakes follow the ``test_daemon_launch_agent_ecs_task.py`` pattern:
+bypass ``__init__`` via ``__new__``, stub psycopg via conftest, use
+``MagicMock`` ECS + ECR clients.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from pathlib import Path
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from dispatcher import daemon  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — minimal cursor + conn that records executed SQL.
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        return None
+
+
+class _FakeConn:
+    def __init__(self) -> None:
+        self.cursor_obj = _FakeCursor()
+        self.committed = 0
+        self.rolled_back = 0
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_obj
+
+    def commit(self) -> None:
+        self.committed += 1
+
+    def rollback(self) -> None:
+        self.rolled_back += 1
+
+
+_ECR_REPO = "judgemind/dispatcher-agent-runner"
+_TASK_DEF_FAMILY = "judgemind-dispatcher-agent-runner-dev"
+_CLUSTER_ARN = "arn:aws:ecs:us-west-2:123:cluster/judgemind-dev"
+_TASK_ARN = "arn:aws:ecs:us-west-2:123:task/judgemind-dev/abc"
+
+
+def _make_daemon(
+    *,
+    task_def_family: str = _TASK_DEF_FAMILY,
+    cluster_arn: str = _CLUSTER_ARN,
+    subnets: tuple[str, ...] = ("subnet-a",),
+    sg: str = "sg-abc",
+    aws_region: str = "us-west-2",
+) -> tuple[daemon.DispatcherDaemon, _FakeConn]:
+    d = daemon.DispatcherDaemon.__new__(daemon.DispatcherDaemon)
+    d._thread_state = threading.local()  # type: ignore[attr-defined]
+    conn = _FakeConn()
+    d._main_conn = conn  # type: ignore[attr-defined]
+    d._cfg = MagicMock(  # type: ignore[attr-defined]
+        aws_region=aws_region,
+        ecs_cluster_arn=cluster_arn,
+        agent_runner_task_definition_family=task_def_family,
+        agent_runner_subnet_ids=subnets,
+        agent_runner_security_group_id=sg,
+    )
+    d._log = logging.getLogger("test.daemon_image_freshness_guard")  # type: ignore[attr-defined]
+    d._run_id = "test-run-id"  # type: ignore[attr-defined]
+    d._ecs_client = None  # type: ignore[attr-defined]
+    return d, conn
+
+
+# UTC-aware timestamps for building test fixtures.
+_DEPLOY_TIME = datetime(2026, 4, 29, 0, 12, 40, tzinfo=UTC)  # post-#3750
+_TASK_DEF_TIME = datetime(2026, 4, 24, 3, 25, 19, tzinfo=UTC)  # pre-#3750
+
+_OLD_DIGEST = (
+    "sha256:aaa000000000000000000000000000000000000000000000000000000000000001"
+)
+_NEW_DIGEST = (
+    "sha256:bbb000000000000000000000000000000000000000000000000000000000000002"
+)
+
+
+def _ecs_describe_task_definition_response(
+    *,
+    registered_at: datetime = _TASK_DEF_TIME,
+    image: str = (
+        "155326049300.dkr.ecr.us-west-2.amazonaws.com/" + _ECR_REPO + ":latest"
+    ),
+) -> dict[str, Any]:
+    """Build a minimal ``ecs:DescribeTaskDefinition`` response."""
+    return {
+        "taskDefinition": {
+            "taskDefinitionArn": (
+                f"arn:aws:ecs:us-west-2:123:task-definition/{_TASK_DEF_FAMILY}:2"
+            ),
+            "containerDefinitions": [{"name": "agent-runner", "image": image}],
+            "registeredAt": registered_at,
+            "revision": 2,
+        },
+    }
+
+
+def _ecr_describe_images_response(
+    *,
+    pushed_at: datetime = _DEPLOY_TIME,
+    digest: str = _NEW_DIGEST,
+) -> dict[str, Any]:
+    """Build a minimal ``ecr:DescribeImages`` response."""
+    return {
+        "imageDetails": [
+            {
+                "imageDigest": digest,
+                "imageTags": ["latest"],
+                "imagePushedAt": pushed_at,
+            }
+        ],
+    }
+
+
+# --------------------------------------------------------------------------
+# _check_agent_runner_image_freshness — unit tests
+# --------------------------------------------------------------------------
+
+
+class TestImageFreshnessGuardDigestMismatch:
+    """Task-def pinned to old digest; ECR latest has a newer digest → STALE."""
+
+    def test_stale_digest_refuses_launch(self, caplog: Any) -> None:
+        """AC2: guard detects digest mismatch and returns False."""
+        d, _ = _make_daemon()
+        caplog.set_level(logging.ERROR, logger="test.daemon_image_freshness_guard")
+
+        pinned_image = (
+            "155326049300.dkr.ecr.us-west-2.amazonaws.com/"
+            + _ECR_REPO
+            + "@"
+            + _OLD_DIGEST
+        )
+        fake_ecs = MagicMock()
+        fake_ecs.describe_task_definition.return_value = (
+            _ecs_describe_task_definition_response(image=pinned_image)
+        )
+        fake_ecr = MagicMock()
+        fake_ecr.describe_images.return_value = _ecr_describe_images_response(
+            digest=_NEW_DIGEST
+        )
+
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_ecs),
+            patch.object(d, "_make_ecr_client", return_value=fake_ecr),
+        ):
+            result = d._check_agent_runner_image_freshness()
+
+        assert result is False
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_image_stale" in events
+
+    def test_stale_log_carries_both_digests(self, caplog: Any) -> None:
+        """The structured log event includes both old and new digest."""
+        d, _ = _make_daemon()
+        caplog.set_level(logging.ERROR, logger="test.daemon_image_freshness_guard")
+
+        pinned_image = (
+            "155326049300.dkr.ecr.us-west-2.amazonaws.com/"
+            + _ECR_REPO
+            + "@"
+            + _OLD_DIGEST
+        )
+        fake_ecs = MagicMock()
+        fake_ecs.describe_task_definition.return_value = (
+            _ecs_describe_task_definition_response(image=pinned_image)
+        )
+        fake_ecr = MagicMock()
+        fake_ecr.describe_images.return_value = _ecr_describe_images_response(
+            digest=_NEW_DIGEST
+        )
+
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_ecs),
+            patch.object(d, "_make_ecr_client", return_value=fake_ecr),
+        ):
+            d._check_agent_runner_image_freshness()
+
+        stale_records = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "agent_runner_image_stale"
+        ]
+        assert len(stale_records) == 1
+        rec = stale_records[0]
+        assert rec.task_def_image_digest == _OLD_DIGEST  # type: ignore[attr-defined]
+        assert rec.ecr_latest_digest == _NEW_DIGEST  # type: ignore[attr-defined]
+        assert rec.reason == "digest_mismatch"  # type: ignore[attr-defined]
+
+    def test_same_digest_returns_true(self) -> None:
+        """Matching digests → fresh → True."""
+        d, _ = _make_daemon()
+
+        pinned_image = (
+            "155326049300.dkr.ecr.us-west-2.amazonaws.com/"
+            + _ECR_REPO
+            + "@"
+            + _NEW_DIGEST
+        )
+        fake_ecs = MagicMock()
+        fake_ecs.describe_task_definition.return_value = (
+            _ecs_describe_task_definition_response(image=pinned_image)
+        )
+        fake_ecr = MagicMock()
+        fake_ecr.describe_images.return_value = _ecr_describe_images_response(
+            digest=_NEW_DIGEST,
+            # pushed slightly after task-def but digests match → fresh
+            pushed_at=_TASK_DEF_TIME + timedelta(seconds=60),
+        )
+
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_ecs),
+            patch.object(d, "_make_ecr_client", return_value=fake_ecr),
+        ):
+            result = d._check_agent_runner_image_freshness()
+
+        assert result is True
+
+
+class TestImageFreshnessGuardTimestampStaleness:
+    """ECR :latest pushed > FRESHNESS_WINDOW after task-def registered → STALE."""
+
+    def test_ecr_pushed_after_freshness_window_refuses_launch(
+        self, caplog: Any
+    ) -> None:
+        """Staleness > FRESHNESS_WINDOW triggers refuse-launch."""
+        d, _ = _make_daemon()
+        caplog.set_level(logging.ERROR, logger="test.daemon_image_freshness_guard")
+
+        # ECR pushed FRESHNESS_WINDOW + 60 seconds after task-def registered.
+        stale_push = _TASK_DEF_TIME + timedelta(
+            seconds=daemon.AGENT_RUNNER_IMAGE_FRESHNESS_WINDOW_SECONDS + 60
+        )
+        fake_ecs = MagicMock()
+        fake_ecs.describe_task_definition.return_value = (
+            _ecs_describe_task_definition_response(
+                registered_at=_TASK_DEF_TIME,
+                # :latest tag (no pinned digest)
+                image=(
+                    "155326049300.dkr.ecr.us-west-2.amazonaws.com/"
+                    + _ECR_REPO
+                    + ":latest"
+                ),
+            )
+        )
+        fake_ecr = MagicMock()
+        fake_ecr.describe_images.return_value = _ecr_describe_images_response(
+            pushed_at=stale_push,
+            digest=_NEW_DIGEST,
+        )
+
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_ecs),
+            patch.object(d, "_make_ecr_client", return_value=fake_ecr),
+        ):
+            result = d._check_agent_runner_image_freshness()
+
+        assert result is False
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_image_stale" in events
+
+    def test_stale_log_carries_staleness_seconds(self, caplog: Any) -> None:
+        """Structured log on timestamp-based staleness includes staleness_seconds."""
+        d, _ = _make_daemon()
+        caplog.set_level(logging.ERROR, logger="test.daemon_image_freshness_guard")
+
+        extra_seconds = 600
+        stale_push = _TASK_DEF_TIME + timedelta(
+            seconds=daemon.AGENT_RUNNER_IMAGE_FRESHNESS_WINDOW_SECONDS + extra_seconds
+        )
+        fake_ecs = MagicMock()
+        fake_ecs.describe_task_definition.return_value = (
+            _ecs_describe_task_definition_response(
+                registered_at=_TASK_DEF_TIME,
+                image=(
+                    "155326049300.dkr.ecr.us-west-2.amazonaws.com/"
+                    + _ECR_REPO
+                    + ":latest"
+                ),
+            )
+        )
+        fake_ecr = MagicMock()
+        fake_ecr.describe_images.return_value = _ecr_describe_images_response(
+            pushed_at=stale_push,
+            digest=_NEW_DIGEST,
+        )
+
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_ecs),
+            patch.object(d, "_make_ecr_client", return_value=fake_ecr),
+        ):
+            d._check_agent_runner_image_freshness()
+
+        stale_records = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "agent_runner_image_stale"
+        ]
+        assert len(stale_records) == 1
+        rec = stale_records[0]
+        assert rec.reason == "ecr_pushed_after_task_def_registered"  # type: ignore[attr-defined]
+        expected_staleness = (
+            daemon.AGENT_RUNNER_IMAGE_FRESHNESS_WINDOW_SECONDS + extra_seconds
+        )
+        assert rec.staleness_seconds == expected_staleness  # type: ignore[attr-defined]
+
+    def test_ecr_pushed_within_freshness_window_is_fresh(self) -> None:
+        """Staleness within window → fresh → True."""
+        d, _ = _make_daemon()
+
+        # ECR pushed FRESHNESS_WINDOW - 1 seconds after task-def → within window.
+        fresh_push = _TASK_DEF_TIME + timedelta(
+            seconds=daemon.AGENT_RUNNER_IMAGE_FRESHNESS_WINDOW_SECONDS - 1
+        )
+        fake_ecs = MagicMock()
+        fake_ecs.describe_task_definition.return_value = (
+            _ecs_describe_task_definition_response(
+                registered_at=_TASK_DEF_TIME,
+                image=(
+                    "155326049300.dkr.ecr.us-west-2.amazonaws.com/"
+                    + _ECR_REPO
+                    + ":latest"
+                ),
+            )
+        )
+        fake_ecr = MagicMock()
+        fake_ecr.describe_images.return_value = _ecr_describe_images_response(
+            pushed_at=fresh_push,
+            digest=_NEW_DIGEST,
+        )
+
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_ecs),
+            patch.object(d, "_make_ecr_client", return_value=fake_ecr),
+        ):
+            result = d._check_agent_runner_image_freshness()
+
+        assert result is True
+
+    def test_ecr_pushed_before_task_def_is_fresh(self) -> None:
+        """ECR older than task-def registration → no staleness → True."""
+        d, _ = _make_daemon()
+
+        # Task-def registered after ECR push → ECR is "older" → no staleness.
+        late_td_time = _DEPLOY_TIME + timedelta(hours=1)
+        fake_ecs = MagicMock()
+        fake_ecs.describe_task_definition.return_value = (
+            _ecs_describe_task_definition_response(
+                registered_at=late_td_time,
+                image=(
+                    "155326049300.dkr.ecr.us-west-2.amazonaws.com/"
+                    + _ECR_REPO
+                    + ":latest"
+                ),
+            )
+        )
+        fake_ecr = MagicMock()
+        fake_ecr.describe_images.return_value = _ecr_describe_images_response(
+            pushed_at=_DEPLOY_TIME,
+            digest=_NEW_DIGEST,
+        )
+
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_ecs),
+            patch.object(d, "_make_ecr_client", return_value=fake_ecr),
+        ):
+            result = d._check_agent_runner_image_freshness()
+
+        assert result is True
+
+
+class TestImageFreshnessGuardFailOpen:
+    """AWS API errors → fail-open → True (launch proceeds)."""
+
+    def test_ecr_access_denied_returns_true(self, caplog: Any) -> None:
+        """An ECR AccessDenied error is caught and the guard fails open."""
+        d, _ = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_image_freshness_guard")
+
+        fake_ecs = MagicMock()
+        fake_ecs.describe_task_definition.return_value = (
+            _ecs_describe_task_definition_response()
+        )
+        fake_ecr = MagicMock()
+        fake_ecr.describe_images.side_effect = RuntimeError("AccessDenied")
+
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_ecs),
+            patch.object(d, "_make_ecr_client", return_value=fake_ecr),
+        ):
+            result = d._check_agent_runner_image_freshness()
+
+        assert result is True
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_image_freshness_check_failed" in events
+
+    def test_ecs_describe_error_returns_true(self, caplog: Any) -> None:
+        """An ECS DescribeTaskDefinition error also fails open."""
+        d, _ = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_image_freshness_guard")
+
+        fake_ecs = MagicMock()
+        fake_ecs.describe_task_definition.side_effect = RuntimeError("Throttle")
+
+        with patch.object(d, "_make_ecs_client", return_value=fake_ecs):
+            result = d._check_agent_runner_image_freshness()
+
+        assert result is True
+
+    def test_empty_ecr_image_list_returns_true(self) -> None:
+        """No imageDetails in ECR response → skip → True."""
+        d, _ = _make_daemon()
+
+        fake_ecs = MagicMock()
+        fake_ecs.describe_task_definition.return_value = (
+            _ecs_describe_task_definition_response()
+        )
+        fake_ecr = MagicMock()
+        fake_ecr.describe_images.return_value = {"imageDetails": []}
+
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_ecs),
+            patch.object(d, "_make_ecr_client", return_value=fake_ecr),
+        ):
+            result = d._check_agent_runner_image_freshness()
+
+        assert result is True
+
+
+class TestImageFreshnessGuardSkipConditions:
+    """Guard skips its checks when wiring is absent."""
+
+    def test_empty_task_def_family_skips_check(self) -> None:
+        """No task-def family → skip → True (unit-test / local-dev mode)."""
+        d, _ = _make_daemon(task_def_family="")
+        with patch.object(d, "_make_ecs_client") as mock_make:
+            result = d._check_agent_runner_image_freshness()
+        assert result is True
+        mock_make.assert_not_called()
+
+
+class TestLaunchAgentECSTaskFreshnessIntegration:
+    """_launch_agent_ecs_task refuses launch when guard returns False."""
+
+    def test_stale_image_causes_launch_to_return_none(self, caplog: Any) -> None:
+        """Guard returning False → _launch_agent_ecs_task returns None."""
+        d, _ = _make_daemon()
+        caplog.set_level(logging.ERROR, logger="test.daemon_image_freshness_guard")
+
+        fake_ecs = MagicMock()
+        # run_task should NOT be called when the guard refuses.
+        fake_ecs.run_task.return_value = {
+            "tasks": [{"taskArn": _TASK_ARN}],
+            "failures": [],
+        }
+
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_ecs),
+            patch.object(d, "_check_agent_runner_image_freshness", return_value=False),
+        ):
+            result = d._launch_agent_ecs_task("agent-stale", 99)
+
+        assert result is None
+        fake_ecs.run_task.assert_not_called()
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_launch_refused_stale_image" in events
+
+    def test_fresh_image_proceeds_to_run_task(self) -> None:
+        """Guard returning True → _launch_agent_ecs_task calls run_task."""
+        d, _ = _make_daemon()
+
+        fake_ecs = MagicMock()
+        fake_ecs.run_task.return_value = {
+            "tasks": [{"taskArn": _TASK_ARN}],
+            "failures": [],
+        }
+
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_ecs),
+            patch.object(d, "_check_agent_runner_image_freshness", return_value=True),
+        ):
+            result = d._launch_agent_ecs_task("agent-fresh", 42)
+
+        assert result == _TASK_ARN
+        fake_ecs.run_task.assert_called_once()


### PR DESCRIPTION
## Summary

Confirmed that silent-exit regression in #3754 was caused by image lag: ECS task d7041874 launched before PR #3750 deployed, pulling stale pre-instrumentation code. Added daemon-side image-freshness guard (`_check_agent_runner_image_freshness` in `scripts/dispatcher/daemon.py`) that refuses to launch ralph when the task-definition image is stale. Guard detects both digest mismatches and timestamp-based staleness (ECR `:latest` pushed >300s after task-def registered), fails open on AWS errors.

Closes #3754

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — 13 tests in `test_daemon_image_freshness_guard.py` covering digest mismatch, timestamp staleness, fail-open, skip conditions
- [ ] CI green

### Post-deploy verification

- [ ] Monitor logs for `agent_runner_image_stale` events (should be rare/zero on fresh deploys)
- [ ] Verify task-definition stays fresh post-deploy via CloudWatch Insights on agent-runner task launches
- [ ] AC1–AC5 verification tracked in follow-up issues (AC1 = post-deploy dev-env check, AC4–AC5 = root-cause investigation pending new failure data)