### PR TITLE
fix(dispatcher): agent-runner installs Fargate-narrowed preflight hook (#3757)

### DIFF
--- a/Dockerfile.dispatcher-agent-runner
+++ b/Dockerfile.dispatcher-agent-runner
@@ -152,6 +152,7 @@ COPY .claude/hooks/preflight_cross_worktree.py /app/fargate-hooks/preflight_cros
 RUN chmod +x /app/scripts/check-issue-author.sh \
     && chmod +x /app/fargate-hooks/preflight-bash.sh \
     && chmod +x /app/scripts/dispatcher/agent-runner-entrypoint.sh \
+    && chmod +x /app/scripts/dispatcher/agent_runner_install_fargate_hook.sh \
     && chown -R dispatcher:dispatcher /app
 ENV DISPATCHER_FARGATE_HOOKS_DIR=/app/fargate-hooks
 

--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -225,6 +225,25 @@ cd "$REPO_ROOT"
 git checkout -B "$BRANCH_NAME" origin/main
 log "branch_ready" "branch=$BRANCH_NAME"
 
+# ── Install Fargate-narrowed preflight hook (#3757) -------------------------
+#
+# The repo ships `.claude/hooks/preflight-bash.sh` with the FULL
+# operator-laptop ruleset, which blocks `;`+double-quoted-string Bash
+# patterns the ralph Step 2.5 pre-push command uses. On the daemon
+# (subprocess execution), `daemon.py::_install_fargate_preflight_hook`
+# swaps in the narrowed `scripts/preflight-bash-fargate.sh` after each
+# `git worktree add`. The agent-runner ECS image needs the equivalent
+# in shell because the entrypoint clones into `$REPO_ROOT` directly.
+#
+# Without this swap, ECS-mode ralph workers exit silently at the pre-push
+# gate (root cause of #3757). The Dockerfile stages the narrowed hook at
+# `/app/fargate-hooks/` and exports `DISPATCHER_FARGATE_HOOKS_DIR`; the
+# helper does the rest. Operator-laptop runs (env unset) skip the swap.
+
+# shellcheck source=./agent_runner_install_fargate_hook.sh
+source "$(dirname "${BASH_SOURCE[0]}")/agent_runner_install_fargate_hook.sh"
+install_fargate_preflight_hook
+
 # ── Apply prior ralph patch (if any) ---------------------------------------
 #
 # Mirrors the daemon's `_apply_prior_ralph_patch` semantics: pull the

--- a/scripts/dispatcher/agent_runner_install_fargate_hook.sh
+++ b/scripts/dispatcher/agent_runner_install_fargate_hook.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# agent_runner_install_fargate_hook.sh — Sourceable helper that swaps
+# the Fargate-narrowed preflight hook over the worktree's tracked
+# `.claude/hooks/preflight-bash.sh` and `.claude/hooks/preflight_cross_worktree.py`.
+#
+# Mirrors `daemon.py::_install_fargate_preflight_hook` (lines ~6224-6349)
+# verbatim — the daemon-side worktrees (subprocess execution mode) get
+# this swap via the Python helper; the agent-runner ECS image needs the
+# equivalent in shell because the entrypoint is a Bash script.
+#
+# Without this swap, ECS-mode ralph workers run with the FULL operator-
+# laptop hook ruleset and the `;`+double-quoted-string Bash patterns the
+# ralph Step 2.5 pre-push command uses get blocked, producing silent
+# `ralph_not_ship` terminals (root cause of #3757).
+#
+# Contract — env vars read by `install_fargate_preflight_hook`:
+#
+#   DISPATCHER_FARGATE_HOOKS_DIR  — directory containing the staged
+#                                   `preflight-bash.sh` + `preflight_cross_worktree.py`.
+#                                   Set by `Dockerfile.dispatcher-agent-runner` to
+#                                   `/app/fargate-hooks`. Unset on operator
+#                                   laptops → swap is a no-op + warning.
+#   REPO_ROOT                     — per-agent clone root. The function operates
+#                                   on `$REPO_ROOT/.claude/hooks/`.
+#   AGENT_ID                      — used in the structured log line. Optional.
+#
+# Logging — uses the `log()` function defined by the calling
+# entrypoint when present. When sourced standalone (e.g. from tests),
+# falls back to a minimal stderr-printer so tests can still assert on
+# the log shape.
+#
+# Why a separate file vs. inline in the entrypoint:
+#
+#   * Sourceable in tests without dragging in the entrypoint's clone /
+#     checkout / phase-loop side effects.
+#   * Mirrors the precedent set by `scripts/preflight.sh` — function
+#     library + per-check wrappers.
+#   * Survives bash 3.2 (no associative arrays, no `mapfile`).
+
+# ── log() shim ─────────────────────────────────────────────────────────────
+#
+# When sourced from `agent-runner-entrypoint.sh`, `log` is already
+# defined and writes structured JSON to fd 3. When sourced from a test
+# (or directly), we provide a minimal substitute so callers don't crash
+# and tests can assert on the event names.
+
+if ! declare -F log >/dev/null 2>&1; then
+    log() {
+        # $1 = event name, rest = key=value pairs.
+        _ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        _event="$1"
+        shift
+        _extra=""
+        for kv in "$@"; do
+            _k=${kv%%=*}
+            _v=${kv#*=}
+            _v=$(printf '%s' "$_v" | sed 's/"/\\"/g')
+            _extra="$_extra, \"$_k\": \"$_v\""
+        done
+        printf '{"ts": "%s", "event": "agent_runner.%s", "agent_id": "%s"%s}\n' \
+            "$_ts" "$_event" "${AGENT_ID:-unknown}" "$_extra"
+    }
+fi
+
+# ── install_fargate_preflight_hook ─────────────────────────────────────────
+
+install_fargate_preflight_hook() {
+    # Validate the contract. `${VAR:-}` keeps `set -u` callers happy.
+    local stage_dir="${DISPATCHER_FARGATE_HOOKS_DIR:-}"
+    local repo_root="${REPO_ROOT:-}"
+
+    if [[ -z "$stage_dir" ]]; then
+        # Operator-laptop fallback. The full hook stays in place — devs
+        # see the same prompt-stalling rules they'd see locally. Mirrors
+        # daemon.py's `fargate_hook_skip` branch.
+        log "fargate_hook_skip" \
+            "reason=DISPATCHER_FARGATE_HOOKS_DIR_unset"
+        return 0
+    fi
+
+    if [[ -z "$repo_root" ]]; then
+        log "fargate_hook_skip" \
+            "reason=REPO_ROOT_unset"
+        return 0
+    fi
+
+    local source_hook="$stage_dir/preflight-bash.sh"
+    local source_helper="$stage_dir/preflight_cross_worktree.py"
+
+    if [[ ! -f "$source_hook" || ! -f "$source_helper" ]]; then
+        # Stage dir set but files missing — rogue local image or test
+        # harness mistake. Don't fail; the operator-laptop hook is a
+        # safe fallback.
+        log "fargate_hook_skip" \
+            "reason=stage_files_missing" \
+            "stage_dir=$stage_dir"
+        return 0
+    fi
+
+    local hooks_dir="$repo_root/.claude/hooks"
+    local target_hook="$hooks_dir/preflight-bash.sh"
+    local target_helper="$hooks_dir/preflight_cross_worktree.py"
+
+    # `git checkout -B "$BRANCH_NAME" origin/main` recreates the tracked
+    # `.claude/hooks/` tree so the targets normally exist. Defensive
+    # mkdir covers the divergence case without making the common case
+    # slower.
+    mkdir -p "$hooks_dir"
+
+    # Copy the hook + helper from the stage dir over the tracked
+    # files. `cp -p` preserves mode; we also force +x as a belt-and-
+    # braces measure (the Dockerfile already chmods +x the source).
+    if ! cp -p "$source_hook" "$target_hook" 2>/dev/null; then
+        log "fargate_hook_copy_failed" \
+            "path=$target_hook"
+        return 0
+    fi
+    chmod +x "$target_hook" 2>/dev/null || true
+
+    if ! cp -p "$source_helper" "$target_helper" 2>/dev/null; then
+        log "fargate_hook_copy_failed" \
+            "path=$target_helper"
+        return 0
+    fi
+
+    # `git update-index --skip-worktree` tells git to pretend the file
+    # is unchanged. Without this, the diff would show up in every ralph
+    # Step 2.5 pre-push run, in `git status`, and in the PR diff (which
+    # would fail the paths-filter gate on `.claude/hooks/` and
+    # potentially replace the operator-local hook on merge).
+    # Best-effort: failure means status/diff carries the swap as a noise
+    # change but the hook is still swapped. Mirrors daemon.py.
+    if ! git -C "$repo_root" update-index --skip-worktree \
+            .claude/hooks/preflight-bash.sh >/dev/null 2>&1; then
+        log "fargate_hook_skip_worktree_failed" \
+            "path=.claude/hooks/preflight-bash.sh"
+    fi
+
+    if ! git -C "$repo_root" update-index --skip-worktree \
+            .claude/hooks/preflight_cross_worktree.py >/dev/null 2>&1; then
+        log "fargate_hook_skip_worktree_failed" \
+            "path=.claude/hooks/preflight_cross_worktree.py"
+    fi
+
+    log "fargate_hook_installed" \
+        "stage_dir=$stage_dir" \
+        "repo_root=$repo_root"
+
+    return 0
+}

--- a/scripts/dispatcher/tests/test_agent_runner_hook_swap.sh
+++ b/scripts/dispatcher/tests/test_agent_runner_hook_swap.sh
@@ -1,0 +1,405 @@
+#!/usr/bin/env bash
+# test_agent_runner_hook_swap.sh — Regression test for issue #3757.
+#
+# The Fargate `Dockerfile.dispatcher-agent-runner` stages a narrowed
+# preflight hook at `/app/fargate-hooks/preflight-bash.sh` and sets
+# `DISPATCHER_FARGATE_HOOKS_DIR=/app/fargate-hooks`. The agent-runner
+# entrypoint must swap that narrowed hook over the worktree's tracked
+# `.claude/hooks/preflight-bash.sh` after cloning the repo, mirroring
+# `daemon.py::_install_fargate_preflight_hook` (which performs the same
+# swap on the daemon-side worktree path).
+#
+# Without the swap, ECS-mode ralph workers run with the FULL operator-
+# laptop hook ruleset, which blocks the `;`+double-quoted-string Bash
+# patterns that the ralph Step 2.5 pre-push command uses. Claude sees
+# `permission_denied`, exits cleanly, and never writes the ralph SHIP
+# marker → silent ralph_not_ship terminals (root cause of #3757).
+#
+# Acceptance criterion (#3757): "set AGENT_WORKSPACE to a tmpdir, set
+# DISPATCHER_FARGATE_HOOKS_DIR to a fixture dir containing a stub
+# preflight-bash.sh with a recognizable marker, run the entrypoint's
+# hook-swap function in isolation (sourceable), assert the marker exists
+# in $REPO_ROOT/.claude/hooks/preflight-bash.sh. Test must FAIL against
+# current code (no swap)."
+#
+# Usage:
+#   scripts/dispatcher/tests/test_agent_runner_hook_swap.sh
+#
+# Exit codes:
+#   0 — all assertions passed.
+#   1 — one or more assertions failed (regression).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$SCRIPT_DIR/dispatcher/agent_runner_install_fargate_hook.sh"
+
+FAILURES=0
+TESTS=0
+
+TEMP_DIRS=()
+cleanup() {
+    set +e
+    # ${arr[@]+...} expansion guards against unbound under set -u when
+    # cleanup runs before any temp dir was added (early-exit path).
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# ── Precondition: the sourceable helper exists ────────────────────────────
+
+if [[ ! -f "$HELPER" ]]; then
+    fail "helper script exists" "expected $HELPER to be present"
+    echo
+    echo "Tests: $TESTS, Failures: $FAILURES"
+    exit 1
+fi
+pass "helper script $HELPER exists"
+
+# Sourceable helper must define `install_fargate_preflight_hook` without
+# side effects when sourced. Source it under a subshell so the test
+# script's environment isn't perturbed.
+if ! ( set +u; source "$HELPER"; type install_fargate_preflight_hook >/dev/null 2>&1 ); then
+    fail "helper defines install_fargate_preflight_hook" \
+        "sourcing $HELPER did not define the function"
+    echo
+    echo "Tests: $TESTS, Failures: $FAILURES"
+    exit 1
+fi
+pass "helper defines install_fargate_preflight_hook function"
+
+# ── Test 1: marker swap (the happy path) ──────────────────────────────────
+#
+# Build a fake worktree containing a stock operator-laptop hook (with
+# `OPERATOR_VARIANT_MARKER`), then build a fixture stage dir containing
+# a stub Fargate hook (with `FARGATE_VARIANT_MARKER`) plus a stub
+# preflight_cross_worktree.py. Invoke the swap function. Assert the
+# Fargate marker now lives in the worktree's hook file and the operator
+# marker is gone.
+
+run_swap_marker_test() {
+    local tmp
+    tmp=$(mktemp -d)
+    TEMP_DIRS+=("$tmp")
+
+    local repo="$tmp/repo"
+    local hooks_dir="$repo/.claude/hooks"
+    local stage="$tmp/fargate-hooks"
+
+    mkdir -p "$hooks_dir"
+    mkdir -p "$stage"
+
+    # The pre-existing operator-laptop hook (what the clone left behind).
+    cat > "$hooks_dir/preflight-bash.sh" <<'EOF'
+#!/usr/bin/env bash
+# OPERATOR_VARIANT_MARKER — stand-in for the full operator-laptop ruleset.
+exit 0
+EOF
+    chmod +x "$hooks_dir/preflight-bash.sh"
+
+    cat > "$hooks_dir/preflight_cross_worktree.py" <<'EOF'
+# OPERATOR_HELPER_MARKER
+EOF
+
+    # The narrowed Fargate hook + helper that should land in the worktree.
+    cat > "$stage/preflight-bash.sh" <<'EOF'
+#!/usr/bin/env bash
+# FARGATE_VARIANT_MARKER — narrowed Fargate hook ruleset.
+exit 0
+EOF
+    chmod +x "$stage/preflight-bash.sh"
+
+    cat > "$stage/preflight_cross_worktree.py" <<'EOF'
+# FARGATE_HELPER_MARKER
+EOF
+
+    # init a tiny git repo so update-index --skip-worktree has somewhere
+    # to land; the helper must tolerate update-index failures, but the
+    # happy path should succeed.
+    git -C "$repo" init -q --initial-branch main
+    git -C "$repo" config user.email "test@example.com"
+    git -C "$repo" config user.name "Test"
+    git -C "$repo" add .
+    git -C "$repo" commit -q -m "init"
+
+    # Source the helper and call the function. The function reads
+    # DISPATCHER_FARGATE_HOOKS_DIR + REPO_ROOT (or accepts REPO_ROOT as
+    # the first arg) to know which paths to operate on. Use a subshell
+    # so the source doesn't leak into the test script's environment.
+    (
+        set +u
+        # shellcheck disable=SC1090
+        source "$HELPER"
+        export DISPATCHER_FARGATE_HOOKS_DIR="$stage"
+        export REPO_ROOT="$repo"
+        export AGENT_ID="test-agent"
+        install_fargate_preflight_hook >/dev/null 2>&1
+    )
+
+    # Assert: the Fargate marker is present in the worktree's hook file.
+    if ! grep -q "FARGATE_VARIANT_MARKER" "$hooks_dir/preflight-bash.sh"; then
+        fail "swap copies Fargate hook over worktree hook" \
+            "FARGATE_VARIANT_MARKER missing from $hooks_dir/preflight-bash.sh"
+        return
+    fi
+    pass "swap copies Fargate hook over worktree hook"
+
+    # Assert: the operator marker is gone (full overwrite, not append).
+    if grep -q "OPERATOR_VARIANT_MARKER" "$hooks_dir/preflight-bash.sh"; then
+        fail "swap fully overwrites operator hook" \
+            "OPERATOR_VARIANT_MARKER still present in $hooks_dir/preflight-bash.sh"
+        return
+    fi
+    pass "swap fully overwrites operator hook"
+
+    # Assert: the helper python file is also swapped.
+    if ! grep -q "FARGATE_HELPER_MARKER" "$hooks_dir/preflight_cross_worktree.py"; then
+        fail "swap copies Fargate helper over worktree helper" \
+            "FARGATE_HELPER_MARKER missing from $hooks_dir/preflight_cross_worktree.py"
+        return
+    fi
+    pass "swap copies Fargate helper over worktree helper"
+
+    # Assert: the worktree hook is executable (chmod preserved).
+    if [[ ! -x "$hooks_dir/preflight-bash.sh" ]]; then
+        fail "swap preserves executable bit on hook" \
+            "$hooks_dir/preflight-bash.sh is not executable after swap"
+        return
+    fi
+    pass "swap preserves executable bit on hook"
+}
+
+# ── Test 2: missing-stage skip ────────────────────────────────────────────
+#
+# When `DISPATCHER_FARGATE_HOOKS_DIR` is unset (operator-laptop fallback),
+# the helper must not touch the worktree hook. Mirrors daemon.py's
+# `fargate_hook_skip` branch.
+
+run_skip_when_unset_test() {
+    local tmp
+    tmp=$(mktemp -d)
+    TEMP_DIRS+=("$tmp")
+
+    local repo="$tmp/repo"
+    local hooks_dir="$repo/.claude/hooks"
+
+    mkdir -p "$hooks_dir"
+    cat > "$hooks_dir/preflight-bash.sh" <<'EOF'
+#!/usr/bin/env bash
+# OPERATOR_LAPTOP_FALLBACK_MARKER
+exit 0
+EOF
+    chmod +x "$hooks_dir/preflight-bash.sh"
+
+    (
+        set +u
+        # shellcheck disable=SC1090
+        source "$HELPER"
+        unset DISPATCHER_FARGATE_HOOKS_DIR
+        export REPO_ROOT="$repo"
+        export AGENT_ID="test-agent"
+        install_fargate_preflight_hook >/dev/null 2>&1
+    )
+
+    if ! grep -q "OPERATOR_LAPTOP_FALLBACK_MARKER" "$hooks_dir/preflight-bash.sh"; then
+        fail "swap is no-op when DISPATCHER_FARGATE_HOOKS_DIR unset" \
+            "operator hook was modified — should have been left untouched"
+        return
+    fi
+    pass "swap is no-op when DISPATCHER_FARGATE_HOOKS_DIR unset"
+}
+
+# ── Test 3: missing-stage-file skip ───────────────────────────────────────
+#
+# When `DISPATCHER_FARGATE_HOOKS_DIR` is set but the source files are
+# missing (e.g. a rogue local image), the helper must warn and continue,
+# leaving the operator hook in place.
+
+run_skip_when_stage_missing_test() {
+    local tmp
+    tmp=$(mktemp -d)
+    TEMP_DIRS+=("$tmp")
+
+    local repo="$tmp/repo"
+    local hooks_dir="$repo/.claude/hooks"
+    local stage="$tmp/fargate-hooks"
+
+    mkdir -p "$hooks_dir"
+    mkdir -p "$stage"  # exists but empty — no preflight-bash.sh inside
+
+    cat > "$hooks_dir/preflight-bash.sh" <<'EOF'
+#!/usr/bin/env bash
+# OPERATOR_STAGE_MISSING_MARKER
+exit 0
+EOF
+    chmod +x "$hooks_dir/preflight-bash.sh"
+
+    (
+        set +u
+        # shellcheck disable=SC1090
+        source "$HELPER"
+        export DISPATCHER_FARGATE_HOOKS_DIR="$stage"
+        export REPO_ROOT="$repo"
+        export AGENT_ID="test-agent"
+        install_fargate_preflight_hook >/dev/null 2>&1
+    )
+
+    if ! grep -q "OPERATOR_STAGE_MISSING_MARKER" "$hooks_dir/preflight-bash.sh"; then
+        fail "swap is no-op when stage files missing" \
+            "operator hook was modified — should have been left untouched"
+        return
+    fi
+    pass "swap is no-op when stage files missing"
+}
+
+# ── Test 4: entrypoint sources the helper ─────────────────────────────────
+#
+# The agent-runner entrypoint must invoke the swap (directly or via
+# `source`) AFTER the `git checkout -B "$BRANCH_NAME" origin/main` line.
+# Static lint of the entrypoint text — same shape as
+# scripts/dispatcher/tests/test_agent_runner_no_unmerged_files.py.
+
+run_entrypoint_invokes_swap_test() {
+    local entrypoint="$SCRIPT_DIR/dispatcher/agent-runner-entrypoint.sh"
+
+    if [[ ! -f "$entrypoint" ]]; then
+        fail "agent-runner-entrypoint.sh exists" "expected at $entrypoint"
+        return
+    fi
+
+    if ! grep -q "install_fargate_preflight_hook" "$entrypoint"; then
+        fail "entrypoint invokes install_fargate_preflight_hook" \
+            "the entrypoint must call install_fargate_preflight_hook so the swap runs in production"
+        return
+    fi
+    pass "entrypoint invokes install_fargate_preflight_hook"
+
+    # The invocation must come after the branch checkout and before
+    # apply_prior_patch (per #3757's fix-shape spec). Use awk to find
+    # the line numbers and assert the ordering.
+    local checkout_line
+    local install_line
+    local apply_prior_line
+    checkout_line=$(grep -n "^git checkout -B \"\$BRANCH_NAME\" origin/main" "$entrypoint" | head -1 | cut -d: -f1 || true)
+    install_line=$(grep -n "install_fargate_preflight_hook" "$entrypoint" | grep -v "^[^:]*:#" | head -1 | cut -d: -f1 || true)
+    apply_prior_line=$(grep -n "^apply_prior_patch$" "$entrypoint" | head -1 | cut -d: -f1 || true)
+
+    if [[ -z "$checkout_line" || -z "$install_line" || -z "$apply_prior_line" ]]; then
+        fail "entrypoint ordering: all three landmarks present" \
+            "checkout=$checkout_line install=$install_line apply_prior=$apply_prior_line"
+        return
+    fi
+    pass "entrypoint ordering: all three landmarks present"
+
+    if (( install_line <= checkout_line )); then
+        fail "swap runs after branch checkout" \
+            "install_fargate_preflight_hook (line $install_line) must come after git checkout -B (line $checkout_line)"
+        return
+    fi
+    pass "swap runs after branch checkout"
+
+    if (( install_line >= apply_prior_line )); then
+        fail "swap runs before apply_prior_patch" \
+            "install_fargate_preflight_hook (line $install_line) must come before apply_prior_patch (line $apply_prior_line)"
+        return
+    fi
+    pass "swap runs before apply_prior_patch"
+}
+
+# ── Test 5: helper logs fargate_hook_installed event on success ───────────
+#
+# AC: "Logs emit fargate_hook_installed event on every ECS agent
+# startup". The helper must emit a structured log line with that event
+# name when the swap runs successfully.
+
+run_helper_logs_installed_event_test() {
+    local tmp
+    tmp=$(mktemp -d)
+    TEMP_DIRS+=("$tmp")
+
+    local repo="$tmp/repo"
+    local hooks_dir="$repo/.claude/hooks"
+    local stage="$tmp/fargate-hooks"
+    local logfile="$tmp/log.out"
+
+    mkdir -p "$hooks_dir"
+    mkdir -p "$stage"
+
+    cat > "$hooks_dir/preflight-bash.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$hooks_dir/preflight-bash.sh"
+
+    cat > "$hooks_dir/preflight_cross_worktree.py" <<'EOF'
+# helper
+EOF
+
+    cat > "$stage/preflight-bash.sh" <<'EOF'
+#!/usr/bin/env bash
+# FARGATE_VARIANT_MARKER
+exit 0
+EOF
+    chmod +x "$stage/preflight-bash.sh"
+
+    cat > "$stage/preflight_cross_worktree.py" <<'EOF'
+# FARGATE_HELPER_MARKER
+EOF
+
+    git -C "$repo" init -q --initial-branch main
+    git -C "$repo" config user.email "test@example.com"
+    git -C "$repo" config user.name "Test"
+    git -C "$repo" add .
+    git -C "$repo" commit -q -m "init"
+
+    (
+        set +u
+        # shellcheck disable=SC1090
+        source "$HELPER"
+        export DISPATCHER_FARGATE_HOOKS_DIR="$stage"
+        export REPO_ROOT="$repo"
+        export AGENT_ID="test-agent"
+        install_fargate_preflight_hook
+    ) > "$logfile" 2>&1 || true
+
+    if ! grep -q "fargate_hook_installed" "$logfile"; then
+        fail "helper logs fargate_hook_installed event on success" \
+            "expected 'fargate_hook_installed' in helper output. Output was: $(cat "$logfile")"
+        return
+    fi
+    pass "helper logs fargate_hook_installed event on success"
+}
+
+# ── Run tests ─────────────────────────────────────────────────────────────
+
+run_swap_marker_test
+run_skip_when_unset_test
+run_skip_when_stage_missing_test
+run_entrypoint_invokes_swap_test
+run_helper_logs_installed_event_test
+
+echo
+echo "Tests: $TESTS, Failures: $FAILURES"
+
+if (( FAILURES > 0 )); then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

The ECS agent-runner Dockerfile stages a narrowed Fargate preflight hook at `/app/fargate-hooks/` and sets `DISPATCHER_FARGATE_HOOKS_DIR`, but the entrypoint never performed the swap after cloning the repo. ECS-mode ralph workers ran with the FULL operator-laptop hook ruleset, which blocks `;`+double-quoted-string Bash patterns (e.g. ralph's Step 2.5 pre-push command), producing silent `ralph_not_ship` terminals that tripped the circuit breaker to `concurrency_cap=0`. This PR adds a sourceable shell helper that mirrors `daemon.py::_install_fargate_preflight_hook` verbatim, wires it into `agent-runner-entrypoint.sh` after `git checkout -B "$BRANCH_NAME" origin/main` and before `apply_prior_patch`, and adds a 13-assertion regression test that was confirmed FAILING against pre-fix code.

Closes #3757

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass (full dispatcher suite: 1989 passed, 1 skipped locally)
- [ ] CI green
- [ ] `scripts/dispatcher/tests/test_agent_runner_hook_swap.sh` — 13/13 pass locally
- [ ] `scripts/check-bash-compat.sh` — 184 shell scripts scanned, all clean

### Post-deploy verification
- [ ] After `image-deploy.yml` ships the new agent-runner image, query `/ecs/judgemind-dispatcher-agent-runner-dev` for `agent_runner.fargate_hook_installed` events on every new ECS-mode agent startup
- [ ] Query `agent_runner.ralph_done_marker_missing` events for the next 24h — `permission_denials` for `;`/quoted-string Bash commands should be absent
- [ ] Silent ralph_not_ship rate drops to near-zero (was 7+ in 4 hours pre-fix; expect <1 per 24h post-fix, residual is genuine BLOCKED scenarios not silent-exit)
- [ ] Verification evidence posted on issue (see A.8)
