### PR TITLE
fix(dispatcher): verify PR merge before writing merged_at (#3752)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -14405,7 +14405,7 @@ class DispatcherDaemon:
             "--repo",
             self._cfg.github_repo,
             "--json",
-            "statusCheckRollup,mergeable,mergeStateStatus,headRefOid,mergeCommit",
+            "statusCheckRollup,mergeable,mergeStateStatus,headRefOid,mergeCommit,state,mergedAt",
         ]
         # Issue #3089: hot-path PR status poll — retry transient flakes
         # so a single GitHub 502 doesn't waste a supervisor tick.
@@ -14461,6 +14461,24 @@ class DispatcherDaemon:
                 },
             )
             return None
+
+    @staticmethod
+    def _pr_observed_as_merged(pr_status: dict[str, Any] | None) -> bool:
+        """Return True only when the PR status payload confirms a real merge.
+
+        Requires ``state == 'MERGED'`` AND ``mergedAt`` non-null/non-empty.
+        A ``None`` payload (gh flake) returns ``False`` — fail-closed so a
+        transient GitHub 502 never lets a false-shipped PR advance.
+
+        Issue #3752: guards both ``_merge_pr_and_advance`` and
+        ``_reap_finalize_ecs_success`` against writing ``merged_at`` for a
+        PR that GitHub did not actually accept.
+        """
+        if pr_status is None:
+            return False
+        state = pr_status.get("state")
+        merged_at = pr_status.get("mergedAt")
+        return state == "MERGED" and bool(merged_at)
 
     def _merge_pr_and_advance(
         self, agent: dict[str, Any], pr_status: dict[str, Any]
@@ -14558,13 +14576,32 @@ class DispatcherDaemon:
             )
             return
 
-        # Extract the merge commit SHA from the PR status if available;
-        # fall back to re-fetching once after the merge.
-        merge_sha = self._extract_merge_sha(pr_status)
-        if not merge_sha:
-            refreshed = self._fetch_pr_status(pr_number)
-            if refreshed is not None:
-                merge_sha = self._extract_merge_sha(refreshed)
+        # Issue #3752: re-fetch and verify PR state before stamping
+        # merged_at. GitHub's merge API occasionally returns exit 0 but
+        # then the PR stays in OPEN state (race during squash, 422 ghost).
+        # Verify state == MERGED + mergedAt non-null before writing; if
+        # unverified skip both the stamp and the phase advance so the
+        # next supervisor tick re-polls. Fail-closed: a gh flake
+        # (None payload) also skips rather than stamping.
+        post_merge_status = self._fetch_pr_status(pr_number)
+        if not self._pr_observed_as_merged(post_merge_status):
+            observed_state = (post_merge_status or {}).get("state")
+            observed_merged_at = (post_merge_status or {}).get("mergedAt")
+            self._log.warning(
+                "daemon.pr_merge_unverified",
+                extra={
+                    "event": "pr_merge_unverified",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "pr_number": pr_number,
+                    "observed_state": observed_state,
+                    "observed_merged_at": observed_merged_at,
+                },
+            )
+            return
+
+        # Extract the merge commit SHA from the verified post-merge status.
+        merge_sha = self._extract_merge_sha(post_merge_status or {})
 
         # Issue #2953: flip ``status='succeeded'`` + stamp ``merged_at``
         # the moment the PR squash-merge lands — not at end of retro.
@@ -25112,6 +25149,31 @@ class DispatcherDaemon:
             "reaped_untracked": reaped_untracked,
         }
 
+    def _read_agent_pr_number(self, agent_id: str) -> int | None:
+        """Fetch the ``pr_number`` for an agent row. Best-effort.
+
+        Returns ``None`` on DB error or when the column is NULL — the
+        caller treats that as "no PR to verify".
+        """
+        assert self._conn is not None, "connect() must run before read"
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT pr_number FROM dispatcher.agents WHERE agent_id = %s",
+                    (agent_id,),
+                )
+                row = cur.fetchone()
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return None
+        if row is None:
+            return None
+        return row[0]
+
     def _reap_finalize_ecs_success(
         self, agent_id: str, issue_number: int | None
     ) -> None:
@@ -25160,36 +25222,58 @@ class DispatcherDaemon:
                     "branch": "success_already_terminal",
                 },
             )
-        # Best-effort merged_at stamp. Only stamp when the row already
-        # has a pr_number AND merged_at is currently NULL — both
-        # filters live in the WHERE clause so re-reaps and PR-less
-        # rows are no-ops.
+        # Best-effort merged_at stamp. Issue #3752: verify the PR is
+        # actually MERGED before writing — the agent-runner may have
+        # written status='succeeded' before the GitHub merge API
+        # confirmed the PR. Only stamp when the row has a pr_number AND
+        # merged_at is currently NULL AND the PR state is confirmed MERGED.
         assert self._conn is not None, "connect() must run before reap finalize"
-        try:
-            with self._conn.cursor() as cur:
-                cur.execute(
-                    "UPDATE dispatcher.agents "
-                    "SET merged_at = now() "
-                    "WHERE agent_id = %s "
-                    "  AND merged_at IS NULL "
-                    "  AND pr_number IS NOT NULL",
-                    (agent_id,),
+        pr_number_for_verify = self._read_agent_pr_number(agent_id)
+        _do_stamp = False
+        if pr_number_for_verify is not None:
+            verify_status = self._fetch_pr_status(pr_number_for_verify)
+            if self._pr_observed_as_merged(verify_status):
+                _do_stamp = True
+            else:
+                observed_state = (verify_status or {}).get("state")
+                observed_merged_at = (verify_status or {}).get("mergedAt")
+                self._log.warning(
+                    "daemon.reap_finalize_unverified",
+                    extra={
+                        "event": "reap_finalize_unverified",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "pr_number": pr_number_for_verify,
+                        "observed_state": observed_state,
+                        "observed_merged_at": observed_merged_at,
+                    },
                 )
-            self._conn.commit()
-        except Exception:
-            self._log.exception(
-                "daemon.agent_runner_reaped_merged_at_stamp_failed",
-                extra={
-                    "event": "agent_runner_reaped_merged_at_stamp_failed",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "issue_number": issue_number,
-                },
-            )
+        if _do_stamp:
             try:
-                self._conn.rollback()
-            except Exception:  # pragma: no cover — defensive
-                pass
+                with self._conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE dispatcher.agents "
+                        "SET merged_at = now() "
+                        "WHERE agent_id = %s "
+                        "  AND merged_at IS NULL "
+                        "  AND pr_number IS NOT NULL",
+                        (agent_id,),
+                    )
+                self._conn.commit()
+            except Exception:
+                self._log.exception(
+                    "daemon.agent_runner_reaped_merged_at_stamp_failed",
+                    extra={
+                        "event": "agent_runner_reaped_merged_at_stamp_failed",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "issue_number": issue_number,
+                    },
+                )
+                try:
+                    self._conn.rollback()
+                except Exception:  # pragma: no cover — defensive
+                    pass
         # Issue #3329: clear ``agent_task_arn`` so the next reaper tick
         # excludes this row from the SELECT. Without this clear, the
         # SELECT (now keyed solely on ``agent_task_arn IS NOT NULL``)
@@ -25356,6 +25440,91 @@ class DispatcherDaemon:
             return default_days
         return configured
 
+    def _reconcile_stale_merged_at(self) -> dict[str, int]:
+        """Hourly guard that clears false-shipped ``merged_at`` stamps (#3752).
+
+        SELECTs agents with ``merged_at IS NOT NULL AND pr_number IS NOT NULL``
+        written within the last 24 hours. For each row, fetches the current
+        PR state via GitHub. If the PR is NOT actually MERGED AND the fetch
+        payload is non-None (distinguishes OPEN from a gh flake — fail-closed
+        on flake), clears ``merged_at = NULL`` and logs
+        ``daemon.merged_at_reconcile_cleared``.
+
+        Per-row try/except + commit/rollback for failure isolation so one
+        DB hiccup doesn't starve siblings. Returns ``{checked, cleared,
+        errors}`` for observability.
+        """
+        assert self._conn is not None, "connect() must run before reconcile"
+        rows: list[tuple[str, int]] = []
+        try:
+            with self._conn.cursor() as cur:
+                cur.execute(
+                    "SELECT agent_id, pr_number FROM dispatcher.agents "
+                    "WHERE merged_at IS NOT NULL "
+                    "  AND pr_number IS NOT NULL "
+                    "  AND merged_at > now() - INTERVAL '24 hours'",
+                )
+                rows = list(cur.fetchall())
+            self._conn.commit()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            return {"checked": 0, "cleared": 0, "errors": 1}
+
+        checked = 0
+        cleared = 0
+        errors = 0
+        for row in rows:
+            agent_id_r: str = row[0]
+            pr_number_r: int = row[1]
+            checked += 1
+            try:
+                verify_status = self._fetch_pr_status(pr_number_r)
+                if verify_status is None:
+                    # gh flake — fail-closed, skip this row.
+                    continue
+                if self._pr_observed_as_merged(verify_status):
+                    # PR is genuinely merged — leave merged_at in place.
+                    continue
+                # PR is OPEN (or CLOSED without merge) — clear the stale stamp.
+                with self._conn.cursor() as cur:
+                    cur.execute(
+                        "UPDATE dispatcher.agents "
+                        "SET merged_at = NULL "
+                        "WHERE agent_id = %s",
+                        (agent_id_r,),
+                    )
+                self._conn.commit()
+                cleared += 1
+                self._log.warning(
+                    "daemon.merged_at_reconcile_cleared",
+                    extra={
+                        "event": "merged_at_reconcile_cleared",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id_r,
+                        "pr_number": pr_number_r,
+                        "observed_state": verify_status.get("state"),
+                    },
+                )
+            except Exception:
+                errors += 1
+                try:
+                    self._conn.rollback()
+                except Exception:  # pragma: no cover — best-effort
+                    pass
+                self._log.exception(
+                    "daemon.merged_at_reconcile_error",
+                    extra={
+                        "event": "merged_at_reconcile_error",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id_r,
+                        "pr_number": pr_number_r,
+                    },
+                )
+        return {"checked": checked, "cleared": cleared, "errors": errors}
+
     def _housekeeping_tick(self) -> dict[str, int]:
         """Run one housekeeping tick. Prunes stale rows from dispatcher tables.
 
@@ -25419,6 +25588,20 @@ class DispatcherDaemon:
                     "table": table,
                     "rows_deleted": rows_deleted,
                     "cutoff_days": cutoff_days,
+                },
+            )
+
+        # Issue #3752: after the prune loop, reconcile any stale
+        # merged_at stamps. Runs in its own try/except so a reconcile
+        # failure does not break the prune results or increment logic.
+        try:
+            self._reconcile_stale_merged_at()
+        except Exception:
+            self._log.exception(
+                "daemon.reconcile_stale_merged_at_failed",
+                extra={
+                    "event": "reconcile_stale_merged_at_failed",
+                    "run_id": self._run_id,
                 },
             )
 

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -25158,6 +25158,8 @@ class DispatcherDaemon:
         assert self._conn is not None, "connect() must run before read"
         try:
             with self._conn.cursor() as cur:
+                # exec-mode-agnostic (#3158): reads pr_number for merge-state
+                # verification; pr_number is set by both ECS and subprocess lanes.
                 cur.execute(
                     "SELECT pr_number FROM dispatcher.agents WHERE agent_id = %s",
                     (agent_id,),
@@ -25458,6 +25460,9 @@ class DispatcherDaemon:
         rows: list[tuple[str, int]] = []
         try:
             with self._conn.cursor() as cur:
+                # exec-mode-agnostic (#3158): merged_at reconcile scans all
+                # agents; pr_number semantics are identical across ECS and
+                # subprocess lanes — both set it after the gh pr merge call.
                 cur.execute(
                     "SELECT agent_id, pr_number FROM dispatcher.agents "
                     "WHERE merged_at IS NOT NULL "
@@ -25490,6 +25495,8 @@ class DispatcherDaemon:
                     continue
                 # PR is OPEN (or CLOSED without merge) — clear the stale stamp.
                 with self._conn.cursor() as cur:
+                    # exec-mode-agnostic (#3158): clears merged_at for any
+                    # agent with a stale stamp; not conditioned on execution mode.
                     cur.execute(
                         "UPDATE dispatcher.agents "
                         "SET merged_at = NULL "

--- a/scripts/dispatcher/helpers/fleet-status.sh
+++ b/scripts/dispatcher/helpers/fleet-status.sh
@@ -313,6 +313,27 @@ terminals_json=$(query "$q_terminals")
 config_json=$(query "$q_config")
 diagnoses_json=$(query "$q_diagnoses")
 greens_json=$(query "$q_greens")
+
+# Issue #3752: filter greens to rows where the PR is actually MERGED.
+# Each row may have a pr_number; verify via gh before including in the output.
+# Rows without a pr_number are kept (defensive — they should never appear
+# in the greens window, but we don't want to silently drop them).
+verified_greens="[]"
+green_count=$(printf '%s' "$greens_json" | jq 'length')
+for (( i=0; i<green_count; i++ )); do
+    row=$(printf '%s' "$greens_json" | jq ".[$i]")
+    pr=$(printf '%s' "$row" | jq -r '.pr_number // empty')
+    if [[ -z "$pr" ]]; then
+        verified_greens=$(printf '%s\n%s' "$verified_greens" "$row" | jq -s '.[0] + [.[1]]')
+        continue
+    fi
+    pr_state=$(gh pr view "$pr" --repo judgemind/judgemind --json state -q .state 2>/dev/null || true)
+    if [[ "$pr_state" == "MERGED" ]]; then
+        verified_greens=$(printf '%s\n%s' "$verified_greens" "$row" | jq -s '.[0] + [.[1]]')
+    fi
+done
+greens_json="$verified_greens"
+
 pending_json=$(query "$q_pending")
 totals_json=$(query "$q_totals")
 

--- a/scripts/dispatcher/tests/test_daemon_merge_verification.py
+++ b/scripts/dispatcher/tests/test_daemon_merge_verification.py
@@ -1,0 +1,551 @@
+"""Unit tests for PR merge-state verification before stamping merged_at (#3752).
+
+Covers three surfaces:
+
+1. ``_merge_pr_and_advance`` — after gh pr merge succeeds, the daemon
+   re-fetches the PR state and verifies state==MERGED+mergedAt non-null
+   before calling ``_write_merged_at`` and advancing phase.
+
+2. ``_reap_finalize_ecs_success`` — before the merged_at UPDATE, the
+   daemon fetches the PR state. Label-strip and ARN clear STILL run even
+   when the PR state is unverified (independent invariants).
+
+3. ``_reconcile_stale_merged_at`` — SELECT agents with merged_at set,
+   fetch PR state, clear merged_at=NULL when state is not MERGED. Fail-
+   closed on gh flake (None payload → no clear). Called from
+   ``_housekeeping_tick`` inside a try/except.
+
+All external calls (gh pr view, gh pr merge) and DB writes are mocked —
+no real GitHub / DB interaction.
+
+Tests are written to FAIL against the pre-#3752 code and PASS after the
+fix — each test asserts on the verification logic that the fix introduces.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+# Make ``scripts`` importable without installing the repo as a package.
+_SCRIPTS = Path(__file__).resolve().parents[2]
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+
+from dispatcher import daemon  # noqa: E402 — sys.path mutation above
+
+
+# --------------------------------------------------------------------------
+# Shared fakes — mirrors test_daemon_merge_auto_unstick.py exactly
+# --------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, Any]] = []
+        self.fetch_queue: list[Any] = []
+        self.fetchall_queue: list[list[Any]] = []
+        self.rowcount = 0
+
+    def __enter__(self) -> _FakeCursor:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def execute(self, sql: str, params: Any = None) -> None:
+        self.executed.append((sql, params))
+
+    def fetchone(self) -> Any:
+        if not self.fetch_queue:
+            return None
+        return self.fetch_queue.pop(0)
+
+    def fetchall(self) -> list[Any]:
+        if not self.fetchall_queue:
+            return []
+        return self.fetchall_queue.pop(0)
+
+
+class _FakeConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = _FakeCursor()
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+        self.autocommit = False
+
+    def cursor(self) -> _FakeCursor:
+        return self.cursor_instance
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:
+        self.rollbacks += 1
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _CapturingLogHandler(logging.Handler):
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.records: list[logging.LogRecord] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.records.append(record)
+
+    def events(self, name: str) -> list[logging.LogRecord]:
+        return [r for r in self.records if getattr(r, "event", None) == name]
+
+
+def _make_daemon(
+    tmp_path: Path,
+) -> tuple[daemon.DispatcherDaemon, _FakeConnection, _CapturingLogHandler]:
+    handler = _CapturingLogHandler()
+    logger = logging.getLogger(f"dispatcher.test.merge_verification.{id(tmp_path)}")
+    logger.handlers = [handler]
+    logger.propagate = False
+    logger.setLevel(logging.DEBUG)
+
+    conn = _FakeConnection()
+    cfg = daemon.DaemonConfig(
+        database_url="postgres://fake",
+        version_sha="deadbee",
+        host="test-host",
+        pid=9999,
+        github_repo="judgemind/judgemind",
+        dispatcher_service_name="judgemind-dispatcher-test",
+    )
+    d = daemon.DispatcherDaemon(cfg, logger)
+    d._conn = conn  # type: ignore[assignment]
+    d._run_id = "test-run-id"
+    return d, conn, handler
+
+
+def _pr_status_green_open() -> dict[str, Any]:
+    """Build a gh pr view payload that is green but NOT yet merged (state=OPEN)."""
+    return {
+        "statusCheckRollup": [
+            {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "ci-passed"},
+        ],
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "CLEAN",
+        "headRefOid": "head-sha",
+        "mergeCommit": None,
+        "state": "OPEN",
+        "mergedAt": None,
+    }
+
+
+def _pr_status_merged() -> dict[str, Any]:
+    """Build a gh pr view payload for a fully merged PR."""
+    return {
+        "statusCheckRollup": [
+            {"status": "COMPLETED", "conclusion": "SUCCESS", "name": "ci-passed"},
+        ],
+        "mergeable": "MERGED",
+        "mergeStateStatus": "MERGED",
+        "headRefOid": "head-sha",
+        "mergeCommit": {"oid": "abc123merged"},
+        "state": "MERGED",
+        "mergedAt": "2026-04-29T12:00:00Z",
+    }
+
+
+# --------------------------------------------------------------------------
+# _pr_observed_as_merged — unit tests for the static helper
+# --------------------------------------------------------------------------
+
+
+class TestPrObservedAsMerged:
+    def test_none_payload_returns_false(self) -> None:
+        assert daemon.DispatcherDaemon._pr_observed_as_merged(None) is False
+
+    def test_state_open_returns_false(self) -> None:
+        assert (
+            daemon.DispatcherDaemon._pr_observed_as_merged(
+                {"state": "OPEN", "mergedAt": None}
+            )
+            is False
+        )
+
+    def test_state_merged_no_merged_at_returns_false(self) -> None:
+        assert (
+            daemon.DispatcherDaemon._pr_observed_as_merged(
+                {"state": "MERGED", "mergedAt": None}
+            )
+            is False
+        )
+
+    def test_state_merged_with_merged_at_returns_true(self) -> None:
+        assert (
+            daemon.DispatcherDaemon._pr_observed_as_merged(
+                {"state": "MERGED", "mergedAt": "2026-04-29T12:00:00Z"}
+            )
+            is True
+        )
+
+    def test_empty_dict_returns_false(self) -> None:
+        assert daemon.DispatcherDaemon._pr_observed_as_merged({}) is False
+
+
+# --------------------------------------------------------------------------
+# _merge_pr_and_advance — verification guard
+# --------------------------------------------------------------------------
+
+
+class TestMergeSkipsStampWhenPrStateOpen:
+    """AC1 half 1: gh pr merge succeeds exit-0, but PR state is OPEN.
+
+    Assert: merged_at NOT written, pr_merged event NOT fired,
+    pr_merge_unverified event IS fired, phase NOT advanced.
+    This test FAILS against pre-#3752 code (no verification guard).
+    """
+
+    def test_merge_skips_stamp_when_pr_state_open(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # Stub _fetch_pr_status to return OPEN after merge
+        fetch_calls: list[int] = []
+
+        def fake_fetch(pr_number: int) -> dict[str, Any]:
+            fetch_calls.append(pr_number)
+            return _pr_status_green_open()
+
+        d._fetch_pr_status = fake_fetch  # type: ignore[method-assign]
+
+        # Stub subprocess so gh pr merge returns exit 0
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        # Stub _write_merged_at to detect calls
+        write_merged_at_calls: list[str] = []
+        d._write_merged_at = lambda agent_id, **kw: write_merged_at_calls.append(  # type: ignore[method-assign]
+            agent_id
+        )
+
+        # Stub _update_agent_phase to detect calls
+        phase_advances: list[str] = []
+        d._update_agent_phase = lambda agent_id, phase: phase_advances.append(phase)  # type: ignore[method-assign]
+
+        agent = {
+            "agent_id": "agent-verify-open",
+            "issue_number": 3752,
+            "phase": "awaiting_ci",
+            "pr_number": 101,
+            "worktree_path": str(tmp_path),
+            "retries_used": 0,
+            "merge_unstick_attempts": 0,
+        }
+
+        d._merge_pr_and_advance(agent, _pr_status_green_open())
+
+        # Verification fetch must have been called
+        assert fetch_calls, "expected _fetch_pr_status call after merge"
+
+        # merged_at must NOT be written
+        assert write_merged_at_calls == [], (
+            "merged_at must not be written when PR state is OPEN"
+        )
+
+        # Phase must NOT be advanced
+        assert phase_advances == [], "phase must not be advanced when PR state is OPEN"
+
+        # pr_merged event must NOT fire
+        assert handler.events("pr_merged") == [], (
+            "pr_merged must not fire when PR state is OPEN"
+        )
+
+        # pr_merge_unverified event MUST fire
+        unverified = handler.events("pr_merge_unverified")
+        assert unverified, "expected pr_merge_unverified event"
+        assert unverified[0].pr_number == 101
+
+
+class TestMergeStampsWhenPrStateMerged:
+    """AC1 normal path: after a real merge, state==MERGED → stamp + advance.
+
+    This test PASSES against both old and new code (it tests the happy path).
+    Included to lock in that the verification guard does not regress green merges.
+    """
+
+    def test_merge_stamps_when_pr_state_merged(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        def fake_fetch(pr_number: int) -> dict[str, Any]:
+            return _pr_status_merged()
+
+        d._fetch_pr_status = fake_fetch  # type: ignore[method-assign]
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = ""
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        write_merged_at_calls: list[str] = []
+        d._write_merged_at = lambda agent_id, **kw: write_merged_at_calls.append(  # type: ignore[method-assign]
+            agent_id
+        )
+
+        phase_advances: list[str] = []
+        d._update_agent_phase = lambda agent_id, phase: phase_advances.append(phase)  # type: ignore[method-assign]
+
+        agent = {
+            "agent_id": "agent-verify-merged",
+            "issue_number": 3752,
+            "phase": "awaiting_ci",
+            "pr_number": 202,
+            "worktree_path": str(tmp_path),
+            "retries_used": 0,
+            "merge_unstick_attempts": 0,
+        }
+
+        d._merge_pr_and_advance(agent, _pr_status_merged())
+
+        # merged_at MUST be written
+        assert write_merged_at_calls == ["agent-verify-merged"], (
+            "merged_at must be written when PR state is MERGED"
+        )
+
+        # Phase MUST be advanced to awaiting_deploy
+        assert "awaiting_deploy" in phase_advances
+
+        # pr_merged event must fire
+        merged = handler.events("pr_merged")
+        assert merged, "expected pr_merged event on verified merge"
+        assert merged[0].pr_number == 202
+
+        # No unverified event
+        assert handler.events("pr_merge_unverified") == []
+
+
+# --------------------------------------------------------------------------
+# _reap_finalize_ecs_success — verification guard
+# --------------------------------------------------------------------------
+
+
+class TestReapFinalizeSkipsStampWhenPrOpen:
+    """AC1 half 2: _reap_finalize_ecs_success fetches PR state before stamp.
+
+    When state==OPEN: merged_at UPDATE skipped, but label-strip and ARN
+    clear still run (independent invariants).
+    This test FAILS against pre-#3752 code (no verification in reap path).
+    """
+
+    def test_reap_finalize_skips_stamp_when_pr_open(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # _read_agent_pr_number must return a pr_number so verification runs
+        d._read_agent_pr_number = lambda agent_id: 303  # type: ignore[method-assign]
+
+        # _fetch_pr_status returns OPEN
+        d._fetch_pr_status = lambda pr_number: _pr_status_green_open()  # type: ignore[method-assign]
+
+        # Stub label-strip and ARN clear with call tracking
+        label_strip_calls: list[int] = []
+        d._gh_issue_remove_labels = lambda issue_number, labels: (
+            label_strip_calls.append(  # type: ignore[method-assign]
+                issue_number
+            )
+        )
+
+        d._reap_finalize_ecs_success("agent-reap-open", issue_number=3752)
+
+        # merged_at must NOT be written — look for the UPDATE in executed SQL
+        merged_at_updates = [
+            e for e in conn.cursor_instance.executed if "SET merged_at = now()" in e[0]
+        ]
+        assert merged_at_updates == [], (
+            "merged_at must not be stamped when PR state is OPEN"
+        )
+
+        # Label strip MUST still run — independent invariant
+        assert label_strip_calls == [3752], (
+            "label strip must still run even when merged_at stamp is skipped"
+        )
+
+        # reap_finalize_unverified event MUST fire
+        unverified = handler.events("reap_finalize_unverified")
+        assert unverified, "expected reap_finalize_unverified event"
+        assert unverified[0].pr_number == 303
+
+        # ARN clear must also still run
+        arn_clears = [
+            e
+            for e in conn.cursor_instance.executed
+            if "SET agent_task_arn = NULL" in e[0]
+        ]
+        assert arn_clears, "ARN clear must still run even when stamp is skipped"
+
+
+# --------------------------------------------------------------------------
+# _reconcile_stale_merged_at — reconciliation housekeeping
+# --------------------------------------------------------------------------
+
+
+class TestReconcileClearsWhenPrOpen:
+    """AC2: seed agent row with merged_at set, PR state OPEN → merged_at cleared.
+
+    This test FAILS against pre-#3752 code (no reconcile method).
+    """
+
+    def test_reconcile_clears_when_pr_open(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # Seed one row: agent-x with pr_number 999 (merged_at set)
+        conn.cursor_instance.fetchall_queue.append([("agent-x", 999)])
+
+        # _fetch_pr_status returns OPEN (non-None → clear is allowed)
+        d._fetch_pr_status = lambda pr_number: _pr_status_green_open()  # type: ignore[method-assign]
+
+        result = d._reconcile_stale_merged_at()
+
+        assert result["checked"] == 1
+        assert result["cleared"] == 1
+        assert result["errors"] == 0
+
+        # merged_at=NULL UPDATE must have been issued
+        null_updates = [
+            e for e in conn.cursor_instance.executed if "SET merged_at = NULL" in e[0]
+        ]
+        assert null_updates, "expected SET merged_at = NULL for stale row"
+        assert null_updates[0][1] == ("agent-x",)
+
+        # structured log event fired
+        cleared_events = handler.events("merged_at_reconcile_cleared")
+        assert cleared_events, "expected merged_at_reconcile_cleared event"
+        assert cleared_events[0].agent_id == "agent-x"
+        assert cleared_events[0].pr_number == 999
+
+
+class TestReconcileNoOpWhenPrMerged:
+    """AC2 pass-through: state==MERGED → merged_at stays, no UPDATE.
+
+    This test PASSES on both old and new code, but verifies the guard doesn't
+    over-clear legitimate rows.
+    """
+
+    def test_reconcile_no_op_when_pr_merged(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        conn.cursor_instance.fetchall_queue.append([("agent-merged", 777)])
+
+        d._fetch_pr_status = lambda pr_number: _pr_status_merged()  # type: ignore[method-assign]
+
+        result = d._reconcile_stale_merged_at()
+
+        assert result["checked"] == 1
+        assert result["cleared"] == 0
+        assert result["errors"] == 0
+
+        null_updates = [
+            e for e in conn.cursor_instance.executed if "SET merged_at = NULL" in e[0]
+        ]
+        assert null_updates == [], "must not clear merged_at for a genuinely MERGED PR"
+
+        assert handler.events("merged_at_reconcile_cleared") == []
+
+
+class TestReconcileNoOpOnGhFlake:
+    """AC2 fail-closed: _fetch_pr_status returns None (gh flake) → no clear.
+
+    This test FAILS against pre-#3752 code (no reconcile method).
+    """
+
+    def test_reconcile_no_op_on_gh_flake(self, tmp_path: Path) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        conn.cursor_instance.fetchall_queue.append([("agent-flake", 888)])
+
+        # Simulate gh 502 — fetch returns None
+        d._fetch_pr_status = lambda pr_number: None  # type: ignore[method-assign]
+
+        result = d._reconcile_stale_merged_at()
+
+        assert result["checked"] == 1
+        assert result["cleared"] == 0  # fail-closed: flake → skip
+
+        null_updates = [
+            e for e in conn.cursor_instance.executed if "SET merged_at = NULL" in e[0]
+        ]
+        assert null_updates == [], "must not clear merged_at on gh flake"
+
+        assert handler.events("merged_at_reconcile_cleared") == []
+
+
+# --------------------------------------------------------------------------
+# _housekeeping_tick — calls _reconcile_stale_merged_at
+# --------------------------------------------------------------------------
+
+
+class TestHousekeepingCallsReconcile:
+    """AC2: housekeeping tick invokes _reconcile_stale_merged_at once per tick.
+
+    This test FAILS against pre-#3752 code (no call in housekeeping).
+    """
+
+    def test_housekeeping_calls_reconcile(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        d, conn, handler = _make_daemon(tmp_path)
+
+        # Provide config fetch queue for each housekeeping target
+        target_count = len(daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS)
+        conn.cursor_instance.fetch_queue = [None] * target_count
+
+        reconcile_calls: list[int] = []
+
+        def fake_reconcile() -> dict[str, int]:
+            reconcile_calls.append(1)
+            return {"checked": 0, "cleared": 0, "errors": 0}
+
+        d._reconcile_stale_merged_at = fake_reconcile  # type: ignore[method-assign]
+
+        d._housekeeping_tick()
+
+        assert len(reconcile_calls) == 1, (
+            "_reconcile_stale_merged_at must be called exactly once per housekeeping tick"
+        )
+
+    def test_housekeeping_reconcile_failure_does_not_break_prune(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """A reconcile crash must not stop the prune or increment logic."""
+        d, conn, handler = _make_daemon(tmp_path)
+
+        target_count = len(daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS)
+        conn.cursor_instance.fetch_queue = [None] * target_count
+
+        def failing_reconcile() -> dict[str, int]:
+            raise RuntimeError("simulated reconcile crash")
+
+        d._reconcile_stale_merged_at = failing_reconcile  # type: ignore[method-assign]
+
+        # Must not raise
+        result = d._housekeeping_tick()
+
+        # Prune still returned results (even if all zero-rowcount)
+        assert isinstance(result, dict)
+        # Counter still advanced
+        assert d._housekeeping_ticks == 1

--- a/scripts/dispatcher/tests/test_daemon_milestone_columns.py
+++ b/scripts/dispatcher/tests/test_daemon_milestone_columns.py
@@ -641,7 +641,13 @@ class TestMergePrAndAdvanceMilestone:
                 r.stdout = ""
                 return r
             if cmd[:3] == ["gh", "pr", "view"]:
-                r.stdout = json.dumps({"mergeCommit": {"oid": "merge-sha"}})
+                r.stdout = json.dumps(
+                    {
+                        "mergeCommit": {"oid": "merge-sha"},
+                        "state": "MERGED",
+                        "mergedAt": "2026-04-29T12:00:00Z",
+                    }
+                )
                 return r
             raise AssertionError(f"unexpected subprocess call: {cmd}")
 

--- a/scripts/dispatcher/tests/test_daemon_phase3b.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3b.py
@@ -781,6 +781,8 @@ class TestAwaitingCiGreen:
                         "mergeStateStatus": "CLEAN",
                         "headRefOid": "head-sha",
                         "mergeCommit": {"oid": "merge-sha-abc"},
+                        "state": "MERGED",
+                        "mergedAt": "2026-04-29T12:00:00Z",
                     }
                 )
                 return r

--- a/scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py
+++ b/scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py
@@ -111,6 +111,11 @@ class TestReapCompletedAgentTasks:
     def test_stopped_success_terminal_row_logs_only(self, caplog: Any) -> None:
         """STOPPED exit_code=0, row already ``succeeded`` -> reaped_success++."""
         d, conn = _make_daemon()
+        d._read_agent_pr_number = lambda agent_id: 101  # type: ignore[method-assign]
+        d._fetch_pr_status = lambda pr_number: {
+            "state": "MERGED",
+            "mergedAt": "2026-04-29T12:00:00Z",
+        }  # type: ignore[method-assign]
         caplog.set_level(logging.INFO, logger="test.daemon_reap")
         # First cursor: the active-agents SELECT returns one row.
         select_cur = _FakeCursor(
@@ -197,6 +202,11 @@ class TestReapCompletedAgentTasks:
         a future refactor can't silently strip it.
         """
         d, conn = _make_daemon()
+        d._read_agent_pr_number = lambda agent_id: 102  # type: ignore[method-assign]
+        d._fetch_pr_status = lambda pr_number: {
+            "state": "MERGED",
+            "mergedAt": "2026-04-29T12:00:00Z",
+        }  # type: ignore[method-assign]
         caplog.set_level(logging.INFO, logger="test.daemon_reap")
         select_cur = _FakeCursor(
             rows=[
@@ -604,6 +614,11 @@ class TestReapSelectScope:
         clear).
         """
         d, conn = _make_daemon()
+        d._read_agent_pr_number = lambda agent_id: 501  # type: ignore[method-assign]
+        d._fetch_pr_status = lambda pr_number: {
+            "state": "MERGED",
+            "mergedAt": "2026-04-29T12:00:00Z",
+        }  # type: ignore[method-assign]
         caplog.set_level(logging.INFO, logger="test.daemon_reap")
         select_cur = _FakeCursor(
             rows=[
@@ -822,6 +837,11 @@ class TestReapUntrackedArns:
         The 2 returned rows follow the regular STOPPED-success path.
         """
         d, conn = _make_daemon()
+        d._read_agent_pr_number = lambda agent_id: int(agent_id.split("-")[1]) + 1000  # type: ignore[method-assign]
+        d._fetch_pr_status = lambda pr_number: {
+            "state": "MERGED",
+            "mergedAt": "2026-04-29T12:00:00Z",
+        }  # type: ignore[method-assign]
         caplog.set_level(logging.INFO, logger="test.daemon_reap")
 
         all_arns = [f"arn:aws:ecs:us-west-2:123:task/jm/{i}" for i in range(5)]
@@ -933,6 +953,11 @@ class TestReapUntrackedArns:
         ``still_running``.
         """
         d, conn = _make_daemon()
+        d._read_agent_pr_number = lambda agent_id: 4242  # type: ignore[method-assign]
+        d._fetch_pr_status = lambda pr_number: {
+            "state": "MERGED",
+            "mergedAt": "2026-04-29T12:00:00Z",
+        }  # type: ignore[method-assign]
         caplog.set_level(logging.INFO, logger="test.daemon_reap")
 
         arn = "arn:aws:ecs:us-west-2:123:task/jm/empty-status"


### PR DESCRIPTION
## Summary

Fixed false-shipped metric corruption by adding PR merge state verification before stamping `merged_at`. Daemon now re-fetches PR state after calling `gh pr merge` and only writes the timestamp if GitHub confirms `state == 'MERGED'` and `mergedAt` is non-null. Added hourly reconciliation housekeeping to clear stale stamps. Fleet-status.sh now filters greens to confirmed-MERGED PRs only.

Closes #3752

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest scripts/dispatcher/tests/test_daemon_merge_verification.py`)
- [x] CI green

### Post-deploy verification

- [ ] `fleet-status.sh --since 24h` reports no false-shipped PRs (merged_at set with PR state OPEN)
- [ ] `dispatcher.agents` rows with merged_at set have confirmed-MERGED PR state on GitHub
- [ ] Reconciliation housekeeping logs `merged_at_reconcile_cleared` events when stale stamps are found and fixed
- [ ] Verification evidence posted on #3752 (see /task-v2-verify output)