### PR TITLE
fix(infra): SSM-source desired container_definitions for deploy-api (#3765)

### DIFF
--- a/.github/actions/ecs-deploy/action.yml
+++ b/.github/actions/ecs-deploy/action.yml
@@ -1,9 +1,10 @@
 name: "ECS Deploy"
 description: >
-  Shared ECS deployment logic: fetches the current task definition, updates
-  the container image, registers a new revision (preserving execution role,
-  task role, network mode, etc.), and either updates an ECS service or an
-  EventBridge Scheduler target.
+  Shared ECS deployment logic: fetches the desired-state container_definitions
+  (from terraform-managed SSM when configured, otherwise from the current
+  running task definition), substitutes the new image URI, registers a new
+  revision, and either updates an ECS service or an EventBridge Scheduler
+  target.
 
 inputs:
   task-family:
@@ -28,6 +29,16 @@ inputs:
     default: ""
   scheduler-name:
     description: "EventBridge Scheduler name (required for 'scheduler' mode)"
+    required: false
+    default: ""
+  desired-container-definitions-ssm-parameter:
+    description: >
+      Optional SSM Parameter Store name (or ARN) holding the terraform-rendered
+      container_definitions JSON. When set, the action reads desired
+      container_definitions from this parameter instead of from the running
+      task definition — preventing the deploy-* preserve-secrets bug where a
+      revision registered from stale running content silently re-introduces
+      fields terraform has since removed. See #3765 / #2840.
     required: false
     default: ""
 
@@ -57,70 +68,32 @@ runs:
           exit 1
         fi
 
-    - name: Get current task definition
-      id: current-task-def
-      shell: bash
-      run: |
-        aws ecs describe-task-definition \
-          --task-definition "${{ inputs.task-family }}" \
-          --query 'taskDefinition' \
-          --output json > current-task-def.json
-
-        echo "Current task definition:"
-        cat current-task-def.json | jq '.taskDefinitionArn'
-
-    - name: Register new task definition revision
+    - name: Render and register new task definition revision
       id: register
       shell: bash
       env:
         IMAGE_URI: ${{ inputs.image-uri }}
         CONTAINER_NAME: ${{ inputs.container-name }}
         TASK_FAMILY: ${{ inputs.task-family }}
+        SSM_PARAMETER: ${{ inputs.desired-container-definitions-ssm-parameter }}
       run: |
-        # Update the container image in the task definition
-        jq --arg image "$IMAGE_URI" --arg container "$CONTAINER_NAME" \
-          '.containerDefinitions |= map(if .name == $container then .image = $image else . end)' \
-          current-task-def.json > updated-containers.json
-
-        # Build register-task-definition args, always including task role if present.
-        # Self-heal: if the current revision lacks a task role (legacy revisions from
-        # before the IAM role was added), look it up by the Terraform naming convention
-        # so the role is attached on the next deploy.
-        TASK_ROLE=$(jq -r '.taskRoleArn // empty' updated-containers.json)
-
-        if [ -z "$TASK_ROLE" ]; then
-          # Derive role name from task family: judgemind-<svc>-<env> -> judgemind-<svc>-task-<env>
-          ENV_SUFFIX="${TASK_FAMILY##*-}"
-          SVC_PREFIX="${TASK_FAMILY%-*}"
-          ROLE_NAME="${SVC_PREFIX}-task-${ENV_SUFFIX}"
-          echo "Task role ARN missing from current revision — looking up role '$ROLE_NAME'..."
-          TASK_ROLE=$(aws iam get-role --role-name "$ROLE_NAME" --query 'Role.Arn' --output text 2>/dev/null || true)
-          if [ -n "$TASK_ROLE" ] && [ "$TASK_ROLE" != "None" ]; then
-            echo "Resolved task role: $TASK_ROLE"
-          else
-            echo "WARNING: Could not resolve task role '$ROLE_NAME' — proceeding without it."
-            TASK_ROLE=""
-          fi
-        fi
-
-        REGISTER_ARGS=(
-          --family "$TASK_FAMILY"
-          --requires-compatibilities $(jq -r '.requiresCompatibilities[]' updated-containers.json)
-          --network-mode $(jq -r '.networkMode' updated-containers.json)
-          --cpu $(jq -r '.cpu' updated-containers.json)
-          --memory $(jq -r '.memory' updated-containers.json)
-          --execution-role-arn $(jq -r '.executionRoleArn' updated-containers.json)
-          --container-definitions "$(jq -c '.containerDefinitions' updated-containers.json)"
+        # Source the new container_definitions from terraform-managed SSM
+        # (when configured) or from the running task-definition (legacy).
+        # See scripts/ecs-render-task-def.sh and #3765 / #2840 for the
+        # full rationale on why the SSM source path exists.
+        SCRIPT_ARGS=(
+          --task-family "$TASK_FAMILY"
+          --container-name "$CONTAINER_NAME"
+          --image-uri "$IMAGE_URI"
         )
-
-        if [ -n "$TASK_ROLE" ]; then
-          REGISTER_ARGS+=(--task-role-arn "$TASK_ROLE")
+        if [ -n "$SSM_PARAMETER" ]; then
+          SCRIPT_ARGS+=(--desired-container-definitions-ssm-parameter "$SSM_PARAMETER")
+          echo "Using terraform-managed SSM parameter as desired-state source: $SSM_PARAMETER"
+        else
+          echo "Using running task-definition as desired-state source (legacy)."
         fi
 
-        NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
-          "${REGISTER_ARGS[@]}" \
-          --query 'taskDefinition.taskDefinitionArn' \
-          --output text)
+        NEW_TASK_DEF_ARN=$("${GITHUB_WORKSPACE}/scripts/ecs-render-task-def.sh" "${SCRIPT_ARGS[@]}")
 
         echo "New task definition ARN: $NEW_TASK_DEF_ARN"
         echo "arn=$NEW_TASK_DEF_ARN" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -35,6 +35,12 @@ env:
   ECS_SERVICE: judgemind-api-dev
   TASK_FAMILY: judgemind-api-dev
   CONTAINER_NAME: api
+  # Terraform-managed source of truth for container_definitions. See #3765 /
+  # #2840 — without this, deploy-api re-registers the running task-def's
+  # content and silently re-introduces fields terraform has removed. The
+  # parameter name follows the convention defined in
+  # `infra/terraform/modules/api-service/main.tf::aws_ssm_parameter.container_definitions`.
+  CONTAINER_DEFS_SSM_PARAMETER: /judgemind/api/dev/container-definitions
 
 jobs:
   build-and-push:
@@ -127,6 +133,7 @@ jobs:
           deploy-mode: service
           ecs-cluster: ${{ env.ECS_CLUSTER }}
           ecs-service: ${{ env.ECS_SERVICE }}
+          desired-container-definitions-ssm-parameter: ${{ env.CONTAINER_DEFS_SSM_PARAMETER }}
 
       - name: Set deployment status
         if: always()

--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -145,6 +145,32 @@ A regression test fixture lives in `infra/terraform/modules/dispatcher-daemon/te
 
 **Workaround for past silent drops.** If you encounter a deployed task-def revision that's missing a secret despite the HCL being correct: register a corrected revision out-of-band via `aws ecs register-task-definition` with the missing entry injected, then `aws ecs update-service --task-definition <family>:<rev> --force-new-deployment`. The next terraform apply will reconcile to a clean state once the postcondition catches any remaining drift.
 
+### Terraform task-def edits — deploy-* preserve-secrets gotcha
+
+**Background.** Parent issue #2840 surfaced a sibling failure mode to the silent-drop above: `.github/actions/ecs-deploy/action.yml` (consumed by `deploy-api.yml`, `deploy-scraper.yml`, `deploy-production.yml`) historically read the *currently registered* task-definition revision via `aws ecs describe-task-definition`, swapped the image, and re-registered. That implicitly preserved every other field — including secrets, env vars, and IAM role ARNs that terraform may have *removed* in the interim.
+
+The concrete symptom: PR #2820 removed `GITHUB_TOKEN` from the API task-def in terraform. Subsequent `deploy-api` runs re-registered task-def revisions that still contained `GITHUB_TOKEN` — sourced from the *previous* revision deploy-api itself had registered before #2820 merged. Terraform's removal never propagated end-to-end because every merge to `main` re-ran deploy-api with the previous revision as the base.
+
+**Architectural decision (#3765 — chunk B of #2840): Option 1 — Terraform writes the rendered `container_definitions` JSON to an SSM parameter; `ecs-deploy` reads the desired state from there.** Terraform becomes the single source of truth for non-image task-definition fields (secrets, env vars, log config, port mappings). The deploy-* workflows substitute the new image URI into the named container at deploy time and register a new revision based on terraform's intent — not on whatever stale content the running revision happens to carry.
+
+The hybrid pragmatism: family-level metadata (`cpu`, `memory`, `network_mode`, `execution_role_arn`, `requires_compatibilities`) still comes from `describe-task-definition`. Those fields rarely change and live on the task-definition itself, not the container_definitions array, so reading them from the running revision is harmless. Only the `container_definitions` array — where the silent-preserve bug manifests — switches to the SSM source.
+
+**Why not Option 2** (terraform manages only the initial revision, deploy-* owns subsequent edits via template files in the repo)? It splits desired-state ownership across two systems with two versioning models — terraform's HCL conditionals + provider rendering, versus deploy-* templates that are not exercised on every infra apply. The SSM-source approach (Option 1) keeps the desired state computed once, by terraform, and shipped to the deploy job at read time.
+
+**Mechanism.**
+
+1. Each terraform module that owns a task-definition publishes `aws_ssm_parameter "container_definitions"` with `value = aws_ecs_task_definition.<svc>.container_definitions`. Currently wired:
+   - `infra/terraform/modules/api-service/main.tf` → `/judgemind/api/<env>/container-definitions`
+2. `dev-apply` in `terraform.yml` runs on every `push:main` that touches `infra/terraform/**`, so the SSM parameter is always in sync with the latest committed terraform render.
+3. `.github/actions/ecs-deploy/action.yml` accepts an optional input `desired-container-definitions-ssm-parameter`. When set, the action invokes `scripts/ecs-render-task-def.sh` with that parameter name; the script reads the JSON from SSM, substitutes the new image into the named container, and registers the new revision.
+4. When the input is empty, the action falls back to the legacy `describe-task-definition` source — preserving behaviour for any deploy-* workflow that has not yet opted in.
+
+**Coverage and follow-ups.** Wired today: `deploy-api.yml`. Not yet wired: `deploy-scraper.yml`, `deploy-production.yml`. Migrating the remaining workflows is straightforward: add the SSM parameter resource to the relevant module (compute, scraper-zero-record-check, dispatcher-agent-runner, etc.), pass the parameter name to the composite action. File a follow-up issue when migrating each so the SSM parameter creation lands in the same PR as the workflow opt-in.
+
+**Operator gotcha.** When adding a new env var or secret to an SSM-source-mode task-definition, the change must land via terraform — direct edits to `register-task-definition` calls or one-off CLI tweaks will be silently overwritten by the next deploy. The SSM parameter is rendered from `aws_ecs_task_definition.<svc>.container_definitions`, so any change to that resource flows through automatically.
+
+**Test fixture.** `scripts/tests/test_ecs_render_task_def.sh` exercises the SSM-source path with a mock AWS CLI: it stages a "running" task-def that contains a secret terraform has since removed, points the script at an SSM-parameter response that omits the secret, and asserts the registered revision does **not** include the removed secret. This is the regression test for the #3765 preserve-bug class — it would have failed against the pre-fix action.
+
 ## Dispatcher v2 Cutover
 
 The dispatcher v2 daemon is an opt-in production replacement for the laptop-dispatcher's `/dispatcher` skill. It runs on Fargate, claims `agent/ready` issues from GitHub, and drives each one end-to-end through `claude -p '/task-v2-*'` subprocesses (plan → ralph → summary → push → CI watch → merge → deploy watch → verify → retro → cleanup). Phase 3 (#2782) shipped all the orchestration code; Phase 3E (#2798) was the final code piece. **The cutover from `concurrency_cap=0` (cold) to `concurrency_cap=1` (one in-flight agent) is an explicit operator action — not part of any PR.**

--- a/infra/terraform/modules/api-service/main.tf
+++ b/infra/terraform/modules/api-service/main.tf
@@ -369,6 +369,31 @@ resource "aws_ecs_task_definition" "api" {
   ])
 }
 
+# ─── SSM: terraform-managed container_definitions for deploy-api ────────────
+# Stores the rendered container_definitions JSON that terraform considers the
+# desired state. The deploy-api workflow's `ecs-deploy` composite action reads
+# this parameter (instead of the running task-def) when registering a new
+# revision, so secrets / env vars terraform has removed can never leak back
+# in via the legacy "preserve current task-def content" path. See #3765 /
+# parent #2840 for the bug class this prevents.
+#
+# The parameter is updated on every terraform apply that produces a new
+# `container_definitions` rendering. deploy-api uses the parameter value as
+# the base for its register-task-definition call, substitutes the new image
+# URI into the named container, and registers. This makes terraform the
+# single source of truth for the non-image fields (secrets, env, log config,
+# port mappings, etc.).
+resource "aws_ssm_parameter" "container_definitions" {
+  name        = "/judgemind/api/${var.environment}/container-definitions"
+  description = "Terraform-rendered container_definitions JSON for the ${var.environment} API task. Read by .github/actions/ecs-deploy when --desired-container-definitions-ssm-parameter is set. See #3765 / #2840."
+  type        = "String"
+  # Tier "Advanced" supports values up to 8KB (Standard caps at 4KB). The
+  # rendered JSON for the API container is currently <2KB but Advanced gives
+  # headroom for future env-var / secret additions without a tier bump.
+  tier  = "Advanced"
+  value = aws_ecs_task_definition.api.container_definitions
+}
+
 # ─── ECS Service ────────────────────────────────────────────────────────────
 
 resource "aws_ecs_service" "api" {

--- a/infra/terraform/modules/api-service/outputs.tf
+++ b/infra/terraform/modules/api-service/outputs.tf
@@ -52,3 +52,8 @@ output "target_group_arn_suffix" {
   description = "ARN suffix of the API target group (used as CloudWatch dimension)"
   value       = aws_lb_target_group.api.arn_suffix
 }
+
+output "container_definitions_ssm_parameter_name" {
+  description = "SSM parameter holding terraform-rendered container_definitions JSON. Pass to .github/actions/ecs-deploy as `desired-container-definitions-ssm-parameter` to make terraform the source of truth on deploy. See #3765."
+  value       = aws_ssm_parameter.container_definitions.name
+}

--- a/scripts/ecs-render-task-def.sh
+++ b/scripts/ecs-render-task-def.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# ecs-render-task-def.sh — Build and register an ECS task-definition revision
+# that combines a new container image with the rest of the desired-state
+# task-definition fields.
+#
+# Background — #3765 / parent #2840:
+#
+#   The legacy `.github/actions/ecs-deploy/action.yml` always reads the
+#   "current" task-definition via `aws ecs describe-task-definition`,
+#   swaps the image, and re-registers. That has a silent failure mode:
+#   if a previous deploy-* workflow registered a revision with stale
+#   content (e.g. a secret terraform has since removed), the next deploy
+#   re-registers the same stale content with just a new image tag —
+#   silently undoing terraform's removal forever. This is the
+#   GITHUB_TOKEN drift documented in #2840.
+#
+#   This script supports an opt-in alternative: an SSM-parameter source
+#   for the desired `container_definitions` JSON. Terraform writes the
+#   rendered container_definitions to that parameter on every apply, so
+#   reading from SSM gives deploy-* workflows access to terraform's
+#   intent without reaching back into terraform state. The image URI is
+#   substituted into the named container at deploy time. Other
+#   task-definition fields (cpu, memory, network mode, exec/task role
+#   ARNs, requires-compatibilities) still come from
+#   `describe-task-definition` because they are stable across image
+#   bumps and live on the task-definition itself, not the container.
+#
+# Usage:
+#
+#   ecs-render-task-def.sh \
+#     --task-family judgemind-api-dev \
+#     --container-name api \
+#     --image-uri 111.dkr.ecr.us-west-2.amazonaws.com/judgemind/api:abcd123 \
+#     [--desired-container-definitions-ssm-parameter /judgemind/api/dev/container-definitions]
+#
+# Outputs:
+#
+#   The newly-registered task-definition ARN is written to stdout (one line).
+#   Callers running inside a GitHub Action are expected to capture the ARN
+#   from stdout and append `arn=<ARN>` to `$GITHUB_OUTPUT` themselves — that
+#   contract keeps the script reusable from non-Actions contexts.
+#
+# Exit codes:
+#
+#   0 — Registered successfully.
+#   1 — Argument validation error or AWS call failed.
+#   2 — SSM parameter contained invalid JSON or did not include the named
+#       container.
+
+set -euo pipefail
+
+# ── Argument parsing ──────────────────────────────────────────────────────
+
+TASK_FAMILY=""
+CONTAINER_NAME=""
+IMAGE_URI=""
+SSM_PARAMETER=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --task-family)
+            TASK_FAMILY="$2"
+            shift 2
+            ;;
+        --container-name)
+            CONTAINER_NAME="$2"
+            shift 2
+            ;;
+        --image-uri)
+            IMAGE_URI="$2"
+            shift 2
+            ;;
+        --desired-container-definitions-ssm-parameter)
+            SSM_PARAMETER="$2"
+            shift 2
+            ;;
+        -h|--help)
+            sed -n '1,/^set -euo pipefail$/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$TASK_FAMILY" ]]; then
+    echo "ERROR: --task-family is required" >&2
+    exit 1
+fi
+if [[ -z "$CONTAINER_NAME" ]]; then
+    echo "ERROR: --container-name is required" >&2
+    exit 1
+fi
+if [[ -z "$IMAGE_URI" ]]; then
+    echo "ERROR: --image-uri is required" >&2
+    exit 1
+fi
+
+# ── Step 1: fetch the current task-definition for family-level metadata ──
+#
+# Even on the SSM-source path, we still pull cpu / memory / execution-role /
+# network-mode / requires-compatibilities from describe-task-definition.
+# Those fields are stable across image bumps and aren't part of the
+# container_definitions JSON. The SSM source only replaces
+# `container_definitions`.
+CURRENT_JSON=$(aws ecs describe-task-definition \
+    --task-definition "$TASK_FAMILY" \
+    --query 'taskDefinition' \
+    --output json)
+
+# ── Step 2: compute the desired container_definitions ────────────────────
+
+if [[ -n "$SSM_PARAMETER" ]]; then
+    # SSM-source path (#3765): terraform is the single source of truth.
+    SSM_JSON=$(aws ssm get-parameter \
+        --name "$SSM_PARAMETER" \
+        --query 'Parameter.Value' \
+        --output text)
+
+    # The SSM parameter stores a JSON-array string. Validate before use; bail
+    # if it's malformed so a corrupt SSM write never produces a bad revision.
+    if ! echo "$SSM_JSON" | jq empty >/dev/null 2>&1; then
+        echo "ERROR: SSM parameter '$SSM_PARAMETER' did not contain valid JSON" >&2
+        exit 2
+    fi
+
+    # Substitute the new image URI into the named container.
+    CONTAINER_DEFS=$(echo "$SSM_JSON" | jq --arg image "$IMAGE_URI" --arg container "$CONTAINER_NAME" \
+        'map(if .name == $container then .image = $image else . end)')
+
+    # Verify the named container exists in the SSM JSON; otherwise the image
+    # swap silently no-ops and we'd register a revision with the placeholder
+    # image. Fail loudly instead.
+    MATCHED=$(echo "$CONTAINER_DEFS" | jq --arg container "$CONTAINER_NAME" \
+        '[.[] | select(.name == $container)] | length')
+    if [[ "$MATCHED" -lt 1 ]]; then
+        echo "ERROR: container '$CONTAINER_NAME' not found in SSM parameter '$SSM_PARAMETER'" >&2
+        exit 2
+    fi
+else
+    # Legacy path: take container_definitions from the running task-def.
+    # Preserves the historical (potentially stale) content. Acceptable for
+    # services that have not opted in to SSM-source mode yet.
+    CONTAINER_DEFS=$(echo "$CURRENT_JSON" | jq --arg image "$IMAGE_URI" --arg container "$CONTAINER_NAME" \
+        '.containerDefinitions | map(if .name == $container then .image = $image else . end)')
+fi
+
+# ── Step 3: resolve task role (with self-heal for legacy revisions) ──────
+#
+# Older revisions registered before the IAM role landed lack a taskRoleArn.
+# Look up the role by Terraform's naming convention so the next deploy
+# attaches it. (Same logic as the legacy inline action; preserved here so
+# behaviour is unchanged on non-SSM consumers.)
+TASK_ROLE=$(echo "$CURRENT_JSON" | jq -r '.taskRoleArn // empty')
+if [[ -z "$TASK_ROLE" ]]; then
+    ENV_SUFFIX="${TASK_FAMILY##*-}"
+    SVC_PREFIX="${TASK_FAMILY%-*}"
+    ROLE_NAME="${SVC_PREFIX}-task-${ENV_SUFFIX}"
+    echo "Task role ARN missing from current revision — looking up role '$ROLE_NAME'..." >&2
+    TASK_ROLE=$(aws iam get-role --role-name "$ROLE_NAME" --query 'Role.Arn' --output text 2>/dev/null || true)
+    if [[ -n "$TASK_ROLE" && "$TASK_ROLE" != "None" ]]; then
+        echo "Resolved task role: $TASK_ROLE" >&2
+    else
+        echo "WARNING: could not resolve task role '$ROLE_NAME' — proceeding without it." >&2
+        TASK_ROLE=""
+    fi
+fi
+
+# ── Step 4: register the new revision ────────────────────────────────────
+
+REQUIRES_COMPAT=$(echo "$CURRENT_JSON" | jq -r '.requiresCompatibilities[]')
+NETWORK_MODE=$(echo "$CURRENT_JSON" | jq -r '.networkMode')
+CPU=$(echo "$CURRENT_JSON" | jq -r '.cpu')
+MEMORY=$(echo "$CURRENT_JSON" | jq -r '.memory')
+EXEC_ROLE=$(echo "$CURRENT_JSON" | jq -r '.executionRoleArn')
+
+REGISTER_ARGS=(
+    --family "$TASK_FAMILY"
+    --network-mode "$NETWORK_MODE"
+    --cpu "$CPU"
+    --memory "$MEMORY"
+    --execution-role-arn "$EXEC_ROLE"
+    --container-definitions "$(echo "$CONTAINER_DEFS" | jq -c .)"
+)
+
+# `--requires-compatibilities` is a list; expand each value as a separate arg.
+while IFS= read -r compat; do
+    if [[ -n "$compat" ]]; then
+        REGISTER_ARGS+=(--requires-compatibilities "$compat")
+    fi
+done <<< "$REQUIRES_COMPAT"
+
+if [[ -n "$TASK_ROLE" ]]; then
+    REGISTER_ARGS+=(--task-role-arn "$TASK_ROLE")
+fi
+
+NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
+    "${REGISTER_ARGS[@]}" \
+    --query 'taskDefinition.taskDefinitionArn' \
+    --output text)
+
+echo "$NEW_TASK_DEF_ARN"

--- a/scripts/tests/test_ecs_render_task_def.sh
+++ b/scripts/tests/test_ecs_render_task_def.sh
@@ -1,0 +1,462 @@
+#!/usr/bin/env bash
+# test_ecs_render_task_def.sh — Unit tests for scripts/ecs-render-task-def.sh
+#
+# Exercises the register-task-definition pre-flight against a mock aws CLI.
+# Verifies:
+#
+#   1. SSM-source path: when a desired-container-definitions SSM parameter name
+#      is provided, the script fetches container_definitions from SSM (terraform-
+#      managed source of truth) instead of from describe-task-definition. This
+#      is the regression test for #3765 — the deploy-api preserve-secrets bug
+#      class where the running task-def has stale fields that terraform has
+#      since removed.
+#
+#   2. Legacy path: when no SSM parameter is provided, the script falls back to
+#      describe-task-definition (preserves existing deploy-scraper /
+#      deploy-production behavior).
+#
+#   3. Image swap: in both modes, the named container's image field is replaced
+#      with the input image URI.
+#
+#   4. Conflict scenario (the #3765 regression): SSM-source mode with a
+#      describe-task-definition response that still contains a removed secret —
+#      the rendered output must NOT contain that secret (terraform's removal
+#      wins).
+#
+# Usage:
+#   scripts/tests/test_ecs_render_task_def.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_ROOT/scripts/ecs-render-task-def.sh"
+
+if [[ ! -x "$SCRIPT_UNDER_TEST" ]]; then
+    echo "FATAL: $SCRIPT_UNDER_TEST is not executable." >&2
+    exit 1
+fi
+
+FAILURES=0
+TESTS=0
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+TEMP_DIRS=()
+# shellcheck disable=SC2329
+cleanup() {
+    set +e
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+make_temp_dir() {
+    local dir
+    dir=$(mktemp -d)
+    TEMP_DIRS+=("$dir")
+    echo "$dir"
+}
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Set up a mock `aws` CLI that emits canned responses for describe-task-
+# definition, ssm get-parameter, and register-task-definition. The mock writes
+# every invocation's args to $CALL_LOG so tests can assert which path was
+# taken.
+#
+# Files in $tmpdir/:
+#   describe-task-def.json   — emitted on `aws ecs describe-task-definition`
+#   ssm-param.json           — emitted on `aws ssm get-parameter`
+#   register-args.log        — captures the register-task-definition arg list
+#   register-output.json     — emitted on `aws ecs register-task-definition`
+#   call.log                 — full arg log (one line per call)
+setup_mock_aws() {
+    local tmpdir="$1"
+    local mock="$tmpdir/aws"
+
+    cat > "$mock" << 'MOCK'
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMPDIR="${MOCK_TMPDIR:?MOCK_TMPDIR required}"
+echo "$*" >> "$TMPDIR/call.log"
+
+case "$1 $2" in
+    "ecs describe-task-definition")
+        # Honor a `--query 'taskDefinition'` flag the way the real CLI does:
+        # strip the outer wrapper and emit just the inner object.
+        if [[ "$*" == *"--query taskDefinition"* ]]; then
+            jq '.taskDefinition' < "$TMPDIR/describe-task-def.json"
+        else
+            cat "$TMPDIR/describe-task-def.json"
+        fi
+        ;;
+    "ssm get-parameter")
+        # Honor `--query 'Parameter.Value' --output text`: emit just the string.
+        if [[ "$*" == *"--query Parameter.Value"* && "$*" == *"--output text"* ]]; then
+            jq -r '.Parameter.Value' < "$TMPDIR/ssm-param.json"
+        else
+            cat "$TMPDIR/ssm-param.json"
+        fi
+        ;;
+    "ecs register-task-definition")
+        # Capture all args verbatim so the test can verify what got registered.
+        # Use a stable separator so we can re-split at assertion time.
+        printf '%s\n' "$@" > "$TMPDIR/register-args.log"
+        if [[ "$*" == *"--query taskDefinition.taskDefinitionArn"* && "$*" == *"--output text"* ]]; then
+            jq -r '.taskDefinition.taskDefinitionArn' < "$TMPDIR/register-output.json"
+        else
+            cat "$TMPDIR/register-output.json"
+        fi
+        ;;
+    "iam get-role")
+        # Emit a synthetic role ARN so the legacy "self-heal task-role" branch
+        # can flow through tests that exercise it.
+        echo "arn:aws:iam::123456789012:role/${5:-judgemind-api-task-dev}"
+        ;;
+    *)
+        echo "MOCK ERROR: unhandled aws call: $*" >&2
+        exit 99
+        ;;
+esac
+MOCK
+    chmod +x "$mock"
+    echo "$mock"
+}
+
+# Build the synthetic "current task-def" response. Includes a GITHUB_TOKEN
+# secret to simulate the #3765 stale-content scenario where the running
+# revision still has a secret terraform has since removed.
+write_describe_task_def() {
+    local file="$1"
+    local include_github_token="${2:-true}"
+
+    local secrets='[{"name":"DATABASE_URL","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:db-AAA:url::"},{"name":"JWT_SECRET","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:jwt-BBB:secret::"}]'
+    if [[ "$include_github_token" == "true" ]]; then
+        secrets='[{"name":"DATABASE_URL","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:db-AAA:url::"},{"name":"JWT_SECRET","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:jwt-BBB:secret::"},{"name":"GITHUB_TOKEN","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:gh-CCC:token::"}]'
+    fi
+
+    cat > "$file" << JSON
+{
+  "taskDefinition": {
+    "taskDefinitionArn": "arn:aws:ecs:us-west-2:111:task-definition/judgemind-api-dev:99",
+    "family": "judgemind-api-dev",
+    "executionRoleArn": "arn:aws:iam::111:role/exec-role",
+    "taskRoleArn": "arn:aws:iam::111:role/judgemind-api-task-dev",
+    "networkMode": "awsvpc",
+    "requiresCompatibilities": ["FARGATE"],
+    "cpu": "512",
+    "memory": "1024",
+    "containerDefinitions": [
+      {
+        "name": "api",
+        "image": "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/api:OLDSHA",
+        "essential": true,
+        "secrets": $secrets,
+        "environment": [{"name":"NODE_ENV","value":"production"}]
+      }
+    ]
+  }
+}
+JSON
+}
+
+# Build the synthetic SSM-parameter response: terraform has rendered the
+# desired container_definitions JSON (without GITHUB_TOKEN) and stored it as
+# an SSM string parameter. The shape mirrors `aws ssm get-parameter --name X`.
+write_ssm_param() {
+    local file="$1"
+
+    # The Value field is a JSON string containing the container_definitions
+    # array. We embed it as a JSON-encoded string (escaped quotes).
+    cat > "$file" << 'JSON'
+{
+  "Parameter": {
+    "Name": "/judgemind/api/dev/container-definitions",
+    "Type": "String",
+    "Value": "[{\"name\":\"api\",\"image\":\"PLACEHOLDER\",\"essential\":true,\"secrets\":[{\"name\":\"DATABASE_URL\",\"valueFrom\":\"arn:aws:secretsmanager:us-west-2:111:secret:db-AAA:url::\"},{\"name\":\"JWT_SECRET\",\"valueFrom\":\"arn:aws:secretsmanager:us-west-2:111:secret:jwt-BBB:secret::\"}],\"environment\":[{\"name\":\"NODE_ENV\",\"value\":\"production\"}]}]"
+  }
+}
+JSON
+}
+
+# Build the synthetic register-task-definition response.
+write_register_output() {
+    local file="$1"
+    cat > "$file" << 'JSON'
+{
+  "taskDefinition": {
+    "taskDefinitionArn": "arn:aws:ecs:us-west-2:111:task-definition/judgemind-api-dev:100",
+    "family": "judgemind-api-dev",
+    "revision": 100
+  }
+}
+JSON
+}
+
+# Run the script under test with the given environment and args. Captures
+# stdout, stderr, and exit code into the temp dir.
+run_script() {
+    local tmpdir="$1"
+    shift
+    local mock_aws
+    mock_aws=$(setup_mock_aws "$tmpdir")
+    local mock_dir
+    mock_dir=$(dirname "$mock_aws")
+
+    write_register_output "$tmpdir/register-output.json"
+
+    set +e
+    PATH="$mock_dir:$PATH" \
+        MOCK_TMPDIR="$tmpdir" \
+        "$SCRIPT_UNDER_TEST" "$@" \
+        > "$tmpdir/stdout.log" 2> "$tmpdir/stderr.log"
+    local ec=$?
+    set -e
+    echo "$ec" > "$tmpdir/exit_code"
+}
+
+assert_exit() {
+    local tmpdir="$1"
+    local expected="$2"
+    local label="$3"
+    local actual
+    actual=$(cat "$tmpdir/exit_code")
+    if [[ "$actual" != "$expected" ]]; then
+        fail "$label" "expected exit $expected, got $actual. stderr: $(cat "$tmpdir/stderr.log")"
+        return 1
+    fi
+    return 0
+}
+
+assert_register_args_contain() {
+    local tmpdir="$1"
+    local needle="$2"
+    local label="$3"
+    if [[ ! -f "$tmpdir/register-args.log" ]]; then
+        fail "$label" "register-task-definition was never called"
+        return 1
+    fi
+    if ! grep -q -F "$needle" "$tmpdir/register-args.log"; then
+        fail "$label" "register-args.log does not contain '$needle'. Contents: $(cat "$tmpdir/register-args.log")"
+        return 1
+    fi
+    return 0
+}
+
+assert_register_args_NOT_contain() {
+    local tmpdir="$1"
+    local needle="$2"
+    local label="$3"
+    if [[ ! -f "$tmpdir/register-args.log" ]]; then
+        fail "$label" "register-task-definition was never called"
+        return 1
+    fi
+    if grep -q -F "$needle" "$tmpdir/register-args.log"; then
+        fail "$label" "register-args.log unexpectedly contains '$needle' (terraform-removed field clobbered through). Contents: $(cat "$tmpdir/register-args.log")"
+        return 1
+    fi
+    return 0
+}
+
+assert_call_log_contains() {
+    local tmpdir="$1"
+    local needle="$2"
+    local label="$3"
+    if ! grep -q -F "$needle" "$tmpdir/call.log"; then
+        fail "$label" "call.log does not contain '$needle'. Contents: $(cat "$tmpdir/call.log")"
+        return 1
+    fi
+    return 0
+}
+
+# ─── Test 1: legacy path (no SSM param) ───────────────────────────────────
+test_legacy_path_uses_describe_task_def() {
+    local label="legacy path (no SSM param) reads from describe-task-definition"
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    write_describe_task_def "$tmpdir/describe-task-def.json" "true"
+
+    run_script "$tmpdir" \
+        --task-family judgemind-api-dev \
+        --container-name api \
+        --image-uri "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/api:NEWSHA"
+
+    assert_exit "$tmpdir" "0" "$label" || return
+    assert_call_log_contains "$tmpdir" "describe-task-definition" "$label" || return
+    # Legacy path: GITHUB_TOKEN preserved (this is the bug the SSM path fixes).
+    assert_register_args_contain "$tmpdir" "GITHUB_TOKEN" "$label" || return
+    # Image swap happened.
+    assert_register_args_contain "$tmpdir" "judgemind/api:NEWSHA" "$label" || return
+
+    pass "$label"
+}
+
+# ─── Test 2: SSM-source path drops terraform-removed fields ──────────────
+# This is the #3765 regression test.
+test_ssm_path_does_not_clobber_terraform_removal() {
+    local label="SSM source path: terraform-removed GITHUB_TOKEN does NOT come back"
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    # The CURRENTLY RUNNING task-def still has GITHUB_TOKEN (stale content).
+    write_describe_task_def "$tmpdir/describe-task-def.json" "true"
+    # But the SSM parameter (terraform-managed source of truth) does NOT.
+    write_ssm_param "$tmpdir/ssm-param.json"
+
+    run_script "$tmpdir" \
+        --task-family judgemind-api-dev \
+        --container-name api \
+        --image-uri "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/api:NEWSHA" \
+        --desired-container-definitions-ssm-parameter "/judgemind/api/dev/container-definitions"
+
+    assert_exit "$tmpdir" "0" "$label" || return
+    # SSM was queried.
+    assert_call_log_contains "$tmpdir" "ssm get-parameter" "$label" || return
+    # GITHUB_TOKEN must NOT have leaked through from the running task-def.
+    assert_register_args_NOT_contain "$tmpdir" "GITHUB_TOKEN" "$label" || return
+    # Image swap still happened.
+    assert_register_args_contain "$tmpdir" "judgemind/api:NEWSHA" "$label" || return
+    # Terraform-managed secrets ARE present.
+    assert_register_args_contain "$tmpdir" "DATABASE_URL" "$label" || return
+    assert_register_args_contain "$tmpdir" "JWT_SECRET" "$label" || return
+
+    pass "$label"
+}
+
+# ─── Test 3: SSM path swaps image (placeholder replaced) ─────────────────
+test_ssm_path_swaps_image() {
+    local label="SSM source path: image PLACEHOLDER replaced with input image-uri"
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    write_describe_task_def "$tmpdir/describe-task-def.json" "false"
+    write_ssm_param "$tmpdir/ssm-param.json"
+
+    run_script "$tmpdir" \
+        --task-family judgemind-api-dev \
+        --container-name api \
+        --image-uri "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/api:abc1234" \
+        --desired-container-definitions-ssm-parameter "/judgemind/api/dev/container-definitions"
+
+    assert_exit "$tmpdir" "0" "$label" || return
+    assert_register_args_contain "$tmpdir" "judgemind/api:abc1234" "$label" || return
+    # The PLACEHOLDER from the SSM template must NOT appear in the registered
+    # container_definitions.
+    assert_register_args_NOT_contain "$tmpdir" "PLACEHOLDER" "$label" || return
+
+    pass "$label"
+}
+
+# ─── Test 4: SSM path still fetches family-level metadata ────────────────
+# Some fields (cpu, memory, network mode, exec role, task role) live on the
+# task-definition itself, not container_definitions. The SSM-source path
+# still needs `describe-task-definition` to read those — only the
+# container_definitions array is sourced from SSM. Verify the metadata is
+# preserved.
+test_ssm_path_preserves_task_metadata() {
+    local label="SSM source path: cpu/memory/exec-role still come from describe-task-definition"
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    write_describe_task_def "$tmpdir/describe-task-def.json" "false"
+    write_ssm_param "$tmpdir/ssm-param.json"
+
+    run_script "$tmpdir" \
+        --task-family judgemind-api-dev \
+        --container-name api \
+        --image-uri "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/api:NEWSHA" \
+        --desired-container-definitions-ssm-parameter "/judgemind/api/dev/container-definitions"
+
+    assert_exit "$tmpdir" "0" "$label" || return
+    # Both data sources were consulted.
+    assert_call_log_contains "$tmpdir" "describe-task-definition" "$label" || return
+    assert_call_log_contains "$tmpdir" "ssm get-parameter" "$label" || return
+    # Metadata from the running task-def made it into the register call.
+    assert_register_args_contain "$tmpdir" "FARGATE" "$label" || return
+    assert_register_args_contain "$tmpdir" "awsvpc" "$label" || return
+
+    pass "$label"
+}
+
+# ─── Test 5: missing required arg ────────────────────────────────────────
+test_missing_required_arg_fails() {
+    local label="missing --image-uri exits non-zero"
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    write_describe_task_def "$tmpdir/describe-task-def.json" "false"
+
+    run_script "$tmpdir" \
+        --task-family judgemind-api-dev \
+        --container-name api
+
+    local ec
+    ec=$(cat "$tmpdir/exit_code")
+    if [[ "$ec" == "0" ]]; then
+        fail "$label" "expected non-zero exit, got 0"
+        return
+    fi
+    pass "$label"
+}
+
+# ─── Test 6: container name not found in SSM JSON fails ──────────────────
+test_ssm_path_unknown_container_fails() {
+    local label="SSM path: unknown container-name in SSM JSON exits non-zero"
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    write_describe_task_def "$tmpdir/describe-task-def.json" "false"
+    write_ssm_param "$tmpdir/ssm-param.json"
+
+    run_script "$tmpdir" \
+        --task-family judgemind-api-dev \
+        --container-name not-a-real-container \
+        --image-uri "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/api:NEWSHA" \
+        --desired-container-definitions-ssm-parameter "/judgemind/api/dev/container-definitions"
+
+    local ec
+    ec=$(cat "$tmpdir/exit_code")
+    if [[ "$ec" == "0" ]]; then
+        fail "$label" "expected non-zero exit when container-name not found in SSM JSON, got 0. stderr: $(cat "$tmpdir/stderr.log")"
+        return
+    fi
+    pass "$label"
+}
+
+# ─── Run all tests ───────────────────────────────────────────────────────
+
+test_legacy_path_uses_describe_task_def
+test_ssm_path_does_not_clobber_terraform_removal
+test_ssm_path_swaps_image
+test_ssm_path_preserves_task_metadata
+test_missing_required_arg_fails
+test_ssm_path_unknown_container_fails
+
+echo
+echo "Tests: $TESTS, Failures: $FAILURES"
+
+if [[ "$FAILURES" -gt 0 ]]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes the deploy-api preserve-secrets conflict half of #2840 by making terraform the single source of truth for the API task's `container_definitions`. Terraform writes the rendered JSON to a new SSM parameter `/judgemind/api/<env>/container-definitions`; the `ecs-deploy` composite action reads from there (when configured) instead of from `describe-task-definition`, substitutes the new image URI, and registers a clean revision. This prevents the bug class where deploy-api re-registers stale running content and silently re-introduces fields terraform has removed (e.g. the `GITHUB_TOKEN` drift documented in #2840).

Closes #3765

## Architectural decision

**Option 1 from the #2840 issue body — terraform writes desired container_definitions to SSM; deploy-api reads from there.** The change is additive and backwards-compatible: a new optional input `desired-container-definitions-ssm-parameter` on the composite action switches the desired-state source. `deploy-api.yml` opts in. Other consumers (`deploy-scraper.yml`, `deploy-production.yml`) keep legacy describe-task-definition behaviour — wiring SSM parameters into their respective modules is documented as a follow-up.

Full rationale, mechanism, coverage, operator gotcha, and test-fixture path are in `docs/agent/infrastructure-reference.md` → "Terraform task-def edits — deploy-* preserve-secrets gotcha".

## Why not Option 2

Option 2 (terraform manages only the initial revision; deploy-api owns subsequent edits via repo template files) splits desired-state ownership across two systems with two versioning models — terraform's HCL conditionals + provider rendering, vs. deploy-api templates not exercised on every infra apply. Option 1 keeps a single rendering path: HCL → rendered JSON → SSM → deploy.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (new `scripts/tests/test_ecs_render_task_def.sh` is auto-discovered by `scripts/run-scripts-tests.sh`)
- [x] CI green

### Post-deploy verification
- [x] After merge, `terraform.yml dev-apply` runs and creates the SSM parameter `/judgemind/api/dev/container-definitions`.
- [x] Next `deploy-api` invocation runs the SSM-source path (workflow log line: `Using terraform-managed SSM parameter as desired-state source: /judgemind/api/dev/container-definitions`).
- [x] `aws ecs describe-task-definition --task-definition judgemind-api-dev` shows the registered revision has no `GITHUB_TOKEN` entry — confirms the preserve-bug class is closed end-to-end.
- [x] Verification evidence posted on issue #3765.
