### PR TITLE
fix(dispatcher): centralize transition-action dispatch + CI vocabulary guard (#3581)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1107,6 +1107,24 @@ jobs:
         run: scripts/check-dispatcher-terminal-statuses.sh
 
   # ---------------------------------------------------------------
+  # Dispatcher transition-action vocabulary guard (#3581)
+  # Asserts every TransitionAction enum value AND every FAILURE_HINT_*
+  # constant in scripts/dispatcher/phase_transitions.py is handled by
+  # the centralized dispatch_transition_action helper in
+  # scripts/dispatcher/agent-runner-entrypoint.sh. Without this guard,
+  # adding a new action / hint without updating the helper produces the
+  # cluster-bug pattern from #3543/#3558/#3573/#3580.
+  # ---------------------------------------------------------------
+  dispatcher-dispatch-vocabulary-check:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.scripts == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Assert TransitionAction + FAILURE_HINT vocabularies match dispatch helper
+        run: scripts/check-transition-dispatch-vocabulary.sh
+
+  # ---------------------------------------------------------------
   # Schema drift guard: schema.sql must match applied migrations
   # ---------------------------------------------------------------
   schema-drift-check:

--- a/scripts/check-transition-dispatch-vocabulary.sh
+++ b/scripts/check-transition-dispatch-vocabulary.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# check-transition-dispatch-vocabulary.sh — Assert the action vocabulary
+# in scripts/dispatcher/phase_transitions.py matches the dispatch coverage
+# in scripts/dispatcher/agent-runner-entrypoint.sh's
+# ``dispatch_transition_action`` helper. (#3581)
+#
+# Why this guard exists
+# ---------------------
+# Issue #3581 centralized transition-action dispatch into a single helper
+# (``dispatch_transition_action`` in agent-runner-entrypoint.sh). All
+# per-phase case-statements now delegate to that one helper, which
+# eliminates the cluster-bug pattern from #3543/#3558/#3573/#3580 where
+# adding a new action / failure-hint left some per-phase case-statement
+# silently un-updated.
+#
+# But the centralization is only as good as the helper's coverage. If a
+# future PR adds:
+#
+#   - a new ``TransitionAction`` enum value to phase_transitions.py
+#   - a new ``FAILURE_HINT_*`` constant to phase_transitions.py
+#
+# AND forgets to extend ``dispatch_transition_action`` to handle it, the
+# next agent that hits that action / hint will fall through to the
+# unrecognized-action terminal, terminal-failing instead of advancing
+# correctly. The cluster bug returns.
+#
+# This guard runs in CI and fails the PR if the vocabularies drift apart,
+# naming the missing action / hint so the author knows exactly what to
+# add to dispatch_transition_action.
+#
+# Usage:
+#   scripts/check-transition-dispatch-vocabulary.sh
+#
+# Exit codes:
+#   0 — Every TransitionAction value AND every FAILURE_HINT_* constant
+#       has matching coverage in dispatch_transition_action.
+#   1 — One or more drifts detected; details printed to stderr.
+#   2 — Could not parse one of the source files (file moved / rewritten
+#       in a shape this script doesn't know).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+PY_FILE="$REPO_ROOT/scripts/dispatcher/phase_transitions.py"
+SH_FILE="$REPO_ROOT/scripts/dispatcher/agent-runner-entrypoint.sh"
+
+if [[ ! -f "$PY_FILE" ]]; then
+    echo "ERROR: phase_transitions.py not found at $PY_FILE" >&2
+    exit 2
+fi
+if [[ ! -f "$SH_FILE" ]]; then
+    echo "ERROR: agent-runner-entrypoint.sh not found at $SH_FILE" >&2
+    exit 2
+fi
+
+# ── Extract the TransitionAction enum values from phase_transitions.py ──
+#
+# The enum body looks like:
+#
+#   class TransitionAction(str, Enum):
+#       ...docstrings...
+#       ADVANCE = "advance"
+#       ADVANCE_WITH_STATUS = "advance_with_status"
+#       ROUTE_TO_DIAGNOSER = "route_to_diagnoser"
+#       UNRECOGNIZED = "unrecognized"
+#
+# We grab the block from ``class TransitionAction`` to the next
+# top-level ``class `` or ``def `` definition, then scan for lines of the
+# form ``NAME = "value"``. The lower-case value is what we care about
+# (it's what transition_for emits at runtime).
+extract_action_enum_values() {
+    # Inside a Python class body, enum members are indented (typically
+    # 4 spaces). We scope the match to lines that start with whitespace
+    # AND are between ``class TransitionAction(`` and the next un-
+    # indented top-level definition. The ``next`` for blank lines
+    # avoids ending the block on docstring spacing.
+    awk '
+        /^class TransitionAction\(/ { in_enum = 1; next }
+        in_enum && /^[A-Za-z]/ { exit }
+        in_enum && /^[[:space:]]+[A-Z][A-Z_]* = "/ {
+            # Match: NAME = "value" with leading whitespace.
+            match($0, /"[^"]+"/)
+            if (RSTART > 0) {
+                v = substr($0, RSTART + 1, RLENGTH - 2)
+                print v
+            }
+        }
+    ' "$PY_FILE" | sort -u
+}
+
+# ── Extract FAILURE_HINT_* constant values from phase_transitions.py ──
+#
+# Pattern: ``FAILURE_HINT_<NAME> = "<value>"`` at module scope.
+extract_failure_hints() {
+    grep -E '^FAILURE_HINT_[A-Z_]+ = "[^"]+"' "$PY_FILE" \
+        | sed -E 's/.*= "([^"]+)".*/\1/' \
+        | sort -u
+}
+
+# ── Extract the action arms handled inside dispatch_transition_action ──
+#
+# The helper's outer ``case "$_action" in`` block has arms like:
+#   advance)
+#   advance_with_status)
+#   route_to_diagnoser)
+#   unrecognized|*)
+#
+# We find the helper definition and then enumerate the case-arm labels
+# (the bare-word tokens before ``)``) inside its outer case block —
+# stopping at the closing ``esac``.
+extract_helper_action_arms() {
+    awk '
+        /^dispatch_transition_action\(\) \{/ { in_fn = 1; next }
+        in_fn && /^}/ { exit }
+        in_fn && /case "\$_action"/ { in_action_case = 1; depth = 1; next }
+        in_action_case && /case "\$_hint"/ {
+            # Inner case for hints — skip over its arms by tracking
+            # depth. We re-enter the outer case after the inner esac.
+            inner = 1
+            next
+        }
+        in_action_case && inner && /esac/ {
+            inner = 0
+            next
+        }
+        in_action_case && inner { next }
+        in_action_case && /esac/ { in_action_case = 0; in_fn = 0; exit }
+        in_action_case && /^[[:space:]]+[a-z_|*]+\)/ {
+            # Strip leading whitespace + trailing ``)``. Split on ``|``
+            # for multi-arm labels (e.g. ``unrecognized|*)``).
+            sub(/^[[:space:]]+/, "")
+            sub(/\).*$/, "")
+            n = split($0, parts, "|")
+            for (i = 1; i <= n; i++) {
+                if (parts[i] != "*") {
+                    print parts[i]
+                }
+            }
+        }
+    ' "$SH_FILE" | sort -u
+}
+
+# ── Extract the hint arms handled inside dispatch_transition_action ──
+#
+# The inner ``case "$_hint" in`` block has arms like:
+#   conflict_unresolvable)
+#   ralph_not_ship)
+#   ralph_ac_infeasible|summary_ac_infeasible|fix_ci_blocked|...)
+#
+# We list every label on the LHS of the ``)`` (split on ``|``).
+extract_helper_hint_arms() {
+    awk '
+        /^dispatch_transition_action\(\) \{/ { in_fn = 1; next }
+        in_fn && /^}/ { exit }
+        in_fn && /case "\$_hint"/ { in_hint_case = 1; next }
+        in_hint_case && /esac/ { in_hint_case = 0; next }
+        in_hint_case && /^[[:space:]]+[a-z_|]+\)/ {
+            sub(/^[[:space:]]+/, "")
+            sub(/\).*$/, "")
+            n = split($0, parts, "|")
+            for (i = 1; i <= n; i++) {
+                if (parts[i] != "*") {
+                    print parts[i]
+                }
+            }
+        }
+    ' "$SH_FILE" | sort -u
+}
+
+py_actions=$(extract_action_enum_values)
+py_hints=$(extract_failure_hints)
+sh_actions=$(extract_helper_action_arms)
+sh_hints=$(extract_helper_hint_arms)
+
+if [[ -z "$py_actions" ]]; then
+    echo "ERROR: Could not extract TransitionAction enum values from $PY_FILE" >&2
+    exit 2
+fi
+if [[ -z "$py_hints" ]]; then
+    echo "ERROR: Could not extract FAILURE_HINT_* constants from $PY_FILE" >&2
+    exit 2
+fi
+if [[ -z "$sh_actions" ]]; then
+    echo "ERROR: Could not locate dispatch_transition_action helper or its action case arms in $SH_FILE" >&2
+    echo "       Has the helper been renamed or moved? Update this script's awk patterns." >&2
+    exit 2
+fi
+if [[ -z "$sh_hints" ]]; then
+    echo "ERROR: Could not locate inner case \"\$_hint\" arms in dispatch_transition_action ($SH_FILE)" >&2
+    exit 2
+fi
+
+# ── Cross-reference ───────────────────────────────────────────────────
+
+failures=0
+
+# Every Python TransitionAction value (except UNRECOGNIZED, which is
+# handled by the fall-through ``unrecognized|*)`` arm) must appear as a
+# specific case arm in the helper.
+echo "Python TransitionAction values:"
+echo "$py_actions" | sed 's/^/  /'
+echo
+echo "Helper action arms (dispatch_transition_action outer case):"
+echo "$sh_actions" | sed 's/^/  /'
+echo
+
+while IFS= read -r action; do
+    [[ -z "$action" ]] && continue
+    if ! echo "$sh_actions" | grep -qx "$action"; then
+        echo "ERROR: TransitionAction.$(echo "$action" | tr 'a-z' 'A-Z') = \"$action\" is defined in $PY_FILE but NOT handled by dispatch_transition_action in $SH_FILE" >&2
+        echo "       Add a case arm:" >&2
+        echo "         $action)" >&2
+        echo "             ...handler logic..." >&2
+        echo "             ;;" >&2
+        failures=$((failures + 1))
+    fi
+done <<< "$py_actions"
+
+# Every Python FAILURE_HINT_* value must appear in the helper's inner
+# ``case "$_hint" in`` block (either as a dedicated arm or as part of a
+# multi-arm label like ``a|b|c)``).
+echo "Python FAILURE_HINT_* values:"
+echo "$py_hints" | sed 's/^/  /'
+echo
+echo "Helper hint arms (dispatch_transition_action inner case):"
+echo "$sh_hints" | sed 's/^/  /'
+echo
+
+while IFS= read -r hint; do
+    [[ -z "$hint" ]] && continue
+    if ! echo "$sh_hints" | grep -qx "$hint"; then
+        echo "ERROR: FAILURE_HINT_$(echo "$hint" | tr 'a-z' 'A-Z') = \"$hint\" is defined in $PY_FILE but NOT handled by dispatch_transition_action in $SH_FILE" >&2
+        echo "       Add a case arm to the inner case \"\$_hint\" block:" >&2
+        echo "         $hint)" >&2
+        echo "             agent_runner_reaped_failure ..." >&2
+        echo "             ;;" >&2
+        failures=$((failures + 1))
+    fi
+done <<< "$py_hints"
+
+if [[ $failures -gt 0 ]]; then
+    echo "" >&2
+    echo "Transition-dispatch vocabulary drift detected: $failures missing arm(s)" >&2
+    echo "  Fix: extend dispatch_transition_action in $SH_FILE to cover the" >&2
+    echo "  identifier(s) above, then re-run this script to verify." >&2
+    exit 1
+fi
+
+echo "Transition-dispatch vocabulary in sync: $(echo "$py_actions" | wc -l | tr -d ' ') action(s), $(echo "$py_hints" | wc -l | tr -d ' ') hint(s) all handled."
+exit 0

--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -4091,6 +4091,157 @@ advance_phase() {
     log "phase_advanced" "next_phase=$_next" "status=${_status:-unchanged}"
 }
 
+# ── Centralized transition-action dispatch (#3581) ────────────────────────
+#
+# Single source of truth for translating a ``transition_for`` tuple
+# (action, next, status, hint) into the right downstream call
+# (advance_phase / advance_phase with terminal status / descriptive
+# terminal via agent_runner_reaped_failure). All per-phase case-statements
+# in the main dispatch loop call into this helper instead of reimplementing
+# the action-vocabulary dispatch from scratch.
+#
+# Why this exists (#3581):
+#   Prior to this refactor, every phase (push_and_pr, ralph_baseline,
+#   fix_conflict, operational, the generic post-claude arm) had its own
+#   ``case "$_action" in advance) ... advance_with_status) ...
+#   route_to_diagnoser) ... *) ...`` block, with the route_to_diagnoser
+#   sub-case-statement duplicated almost-identically. When a new action
+#   kind (e.g. ``route_to_diagnoser`` itself, in #3543) or a new failure
+#   hint (e.g. ``push_and_pr_no_unmerged_files``) was added, every phase
+#   needed an independent update. Whichever ones the PR author missed
+#   became latent bugs (#3543, #3558, #3573, #3580).
+#
+#   Centralizing eliminates the entire bug class: new actions / hints
+#   land in ONE place and every phase picks them up uniformly. The CI
+#   guard ``scripts/check-transition-dispatch-vocabulary.sh`` enforces
+#   that the helper's vocabulary stays in sync with phase_transitions.py.
+#
+# Inputs:
+#   $1 = phase name (e.g. "push_and_pr"). Used as a log prefix and
+#        included in unrecognized-action terminal-phase strings so the
+#        operator sees which phase emitted the unhandled shape.
+#   $2 = action ("advance" | "advance_with_status" | "route_to_diagnoser").
+#   $3 = next phase (for advance / advance_with_status). May be empty
+#        for route_to_diagnoser; ignored in that case.
+#   $4 = terminal status (for advance_with_status). May be empty
+#        otherwise; ignored.
+#   $5 = failure hint (for route_to_diagnoser). May be empty if the
+#        transition_for emitted route_to_diagnoser without a hint
+#        (defensive — shouldn't happen, but the unrecognized-hint arm
+#        catches it).
+#   $6 = phase output JSON (optional). Only consulted by the
+#        ``ralph_not_ship`` hint arm to extract ``block_reason``. Pass
+#        the raw output JSON from the phase handler when calling for a
+#        verdict-driven phase (post-claude / push_and_pr / fix_conflict
+#        / operational); pass empty / "{}" otherwise.
+#
+# Side effects:
+#   * advance: calls ``advance_phase $next``.
+#   * advance_with_status: calls ``advance_phase $next $status``.
+#   * route_to_diagnoser: emits a ``${phase}_route_to_diagnoser`` log
+#     event with the hint, then dispatches by hint to a descriptive
+#     terminal via ``agent_runner_reaped_failure``. The known-hint set
+#     mirrors phase_transitions.py's ``FAILURE_HINT_*`` constants;
+#     unknown hints emit a ``diagnoser_route_unrecognized_hint`` terminal.
+#   * unrecognized action: emits a ``${phase}_transition_unrecognized``
+#     terminal so a code-drift bug (transition_for returns a new action
+#     kind that this helper doesn't handle) surfaces as a distinct
+#     failure rather than being swallowed.
+#
+# Returns: 0 always (the underlying advance_phase / agent_runner_reaped_failure
+# calls update the agent row; the loop tick observes the new state on
+# the next iteration).
+dispatch_transition_action() {
+    local _phase="$1"
+    local _action="$2"
+    local _next="$3"
+    local _status="$4"
+    local _hint="$5"
+    local _output="${6:-{}}"
+
+    case "$_action" in
+        advance)
+            advance_phase "$_next"
+            ;;
+        advance_with_status)
+            advance_phase "$_next" "$_status"
+            ;;
+        route_to_diagnoser)
+            log "${_phase}_route_to_diagnoser" "hint=$_hint"
+            # Hint-based descriptive-terminal dispatch. The known-hint
+            # set mirrors FAILURE_HINT_* in phase_transitions.py — the
+            # CI guard ``check-transition-dispatch-vocabulary.sh``
+            # asserts every FAILURE_HINT_* constant is handled here.
+            #
+            # Each terminal phase name matches the daemon's
+            # ``BYPASSED_TERMINAL_PHASES_TO_ROUTE`` mapping so the
+            # supervisor tick's ``_find_diagnoser_candidates`` sweep
+            # picks up the row with the right
+            # ``FAILURE_CATEGORY_*`` for diagnoser routing.
+            case "$_hint" in
+                conflict_unresolvable)
+                    agent_runner_reaped_failure \
+                        "conflict_unresolvable" \
+                        "conflict_unresolvable" \
+                        "fix_conflict skill returned unresolvable or budget exhausted"
+                    ;;
+                ralph_not_ship)
+                    # #3586 — ralph_not_ship routes through diagnoser
+                    # via BYPASSED_TERMINAL_PHASES_TO_ROUTE. Pull
+                    # block_reason from the phase output JSON so the
+                    # failures-row reason carries ralph's structured
+                    # signal for the diagnoser to act on.
+                    local _ralph_block_reason
+                    _ralph_block_reason=$(printf '%s' "$_output" | jq -r '.block_reason // ""' 2>/dev/null || printf '')
+                    agent_runner_reaped_failure \
+                        "ralph_not_ship" \
+                        "ralph_not_ship" \
+                        "$_ralph_block_reason"
+                    ;;
+                ralph_ac_infeasible|summary_ac_infeasible|fix_ci_blocked|verify_failed_post_merge|push_and_pr_no_unmerged_files|operational_failed|plan_blocked)
+                    # Descriptive terminal — the daemon's
+                    # BYPASSED_TERMINAL_PHASES_TO_ROUTE maps these
+                    # phase names to FAILURE_CATEGORY_* so the
+                    # diagnoser sweep picks them up.
+                    agent_runner_reaped_failure \
+                        "$_hint" \
+                        "$_hint" \
+                        "phase=${_phase} emitted route_to_diagnoser hint=$_hint"
+                    ;;
+                *)
+                    # Truly novel hint we don't recognize. The CI
+                    # guard should have caught this at PR time — if
+                    # we land here, a new FAILURE_HINT_* was added to
+                    # phase_transitions.py without updating this
+                    # dispatch helper. Emit a descriptive terminal so
+                    # the operator sees what shape leaked through
+                    # without tripping the route_stub bug.
+                    log "${_phase}_route_unrecognized_hint" "hint=$_hint"
+                    agent_runner_reaped_failure \
+                        "diagnoser_route_unrecognized_hint" \
+                        "diagnoser_route_unrecognized_hint" \
+                        "phase=${_phase} route_to_diagnoser received unrecognized hint=${_hint:-(empty)}"
+                    ;;
+            esac
+            ;;
+        unrecognized|*)
+            # Truly unrecognized action — transition_for returned a
+            # shape this dispatcher doesn't know how to handle. The
+            # CI guard should have caught this at PR time (a new
+            # TransitionAction enum value was added to
+            # phase_transitions.py without updating this helper).
+            # Emit a descriptive terminal so the operator sees the
+            # drift instead of advancing to an inconsistent state.
+            log "${_phase}_transition_unrecognized" "action=$_action"
+            agent_runner_reaped_failure \
+                "${_phase}_transition_unrecognized" \
+                "${_phase}_transition_unrecognized" \
+                "phase=${_phase} returned action=$_action (not in dispatch vocabulary)"
+            ;;
+    esac
+    return 0
+}
+
 mark_ended() {
     # Final update when the loop hits a terminal phase.
     db_exec "UPDATE dispatcher.agents
@@ -5305,55 +5456,12 @@ while true; do
                         _bn=$(printf '%s' "$_bt" | cut -f2)
                         _bs=$(printf '%s' "$_bt" | cut -f3)
                         _bh=$(printf '%s' "$_bt" | cut -f4)
-                        case "$_ba" in
-                            advance)
-                                advance_phase "$_bn"
-                                ;;
-                            advance_with_status)
-                                advance_phase "$_bn" "$_bs"
-                                ;;
-                            route_to_diagnoser)
-                                # Issue #3573 — ralph baseline rebase failure
-                                # with no unmerged files. transition_from_ralph
-                                # emits ROUTE_TO_DIAGNOSER with hint=
-                                # push_and_pr_no_unmerged_files (#3465). Route
-                                # to the descriptive terminal so the daemon's
-                                # BYPASSED_TERMINAL_PHASES_TO_ROUTE picks it
-                                # up for the diagnoser sweep.
-                                log "ralph_baseline_route_to_diagnoser" "hint=$_bh"
-                                case "$_bh" in
-                                    push_and_pr_no_unmerged_files)
-                                        agent_runner_reaped_failure \
-                                            "push_and_pr_no_unmerged_files" \
-                                            "push_and_pr_no_unmerged_files" \
-                                            "ralph baseline rebase failed with no unmerged files (#3573)"
-                                        ;;
-                                    *)
-                                        log "ralph_baseline_route_unrecognized_hint" "hint=$_bh"
-                                        agent_runner_reaped_failure \
-                                            "diagnoser_route_unrecognized_hint" \
-                                            "diagnoser_route_unrecognized_hint" \
-                                            "ralph_baseline route_to_diagnoser received unrecognized hint=${_bh:-(empty)}"
-                                        ;;
-                                esac
-                                ;;
-                            *)
-                                # Issue #3455 — replace the route_stub
-                                # fall-through with a descriptive terminal
-                                # so the daemon row reads
-                                # ``ralph_baseline_transition_unrecognized``
-                                # instead of ``agent_runner_route_stub``.
-                                # No diagnoser routing — this is a code
-                                # bug surface (transition_for returned a
-                                # shape we don't handle), not a semantic
-                                # failure the diagnoser can fix.
-                                log "ralph_baseline_transition_unrecognized" "action=$_ba"
-                                agent_runner_reaped_failure \
-                                    "ralph_baseline_transition_unrecognized" \
-                                    "ralph_baseline_transition_unrecognized" \
-                                    "transition_for returned action=$_ba (expected advance after rebase_failed envelope)"
-                                ;;
-                        esac
+                        # #3581 — single-source-of-truth dispatch via
+                        # the helper. See dispatch_transition_action
+                        # above advance_phase. Replaces the per-phase
+                        # case-statement that landed in #3573 (ralph
+                        # baseline route_to_diagnoser arm).
+                        dispatch_transition_action "ralph_baseline" "$_ba" "$_bn" "$_bs" "$_bh" "$_ralph_baseline_output"
                         continue
                     fi
                 else
@@ -5477,101 +5585,14 @@ while true; do
             _next=$(printf '%s' "$_transition" | cut -f2)
             _status=$(printf '%s' "$_transition" | cut -f3)
             _hint=$(printf '%s' "$_transition" | cut -f4)
-
-            case "$_action" in
-                advance)
-                    advance_phase "$_next"
-                    ;;
-                advance_with_status)
-                    advance_phase "$_next" "$_status"
-                    ;;
-                route_to_diagnoser)
-                    # Issue #3455 Path B — replace the
-                    # ``advance_phase agent_runner_route_stub`` fall-
-                    # through with descriptive terminals. Three cases:
-                    #
-                    #   1. ``conflict_unresolvable`` (#3225) — keep
-                    #      the dedicated terminal so the diagnoser
-                    #      supervisor sweep picks it up with the
-                    #      right category. Routed via
-                    #      ``BYPASSED_TERMINAL_PHASES_TO_ROUTE``.
-                    #   2. ``ralph_not_ship`` — handle locally.
-                    #      Ralph already wrote a structured
-                    #      ``block_reason``; we relay it as an issue
-                    #      comment + add ``status/blocked``, then
-                    #      emit the ``ralph_not_ship`` terminal
-                    #      (NOT routed to the diagnoser). 14 agents
-                    #      pre-#3455 died here at ``route_stub``.
-                    #   3. Other hints (e.g. ``ralph_ac_infeasible``,
-                    #      ``summary_ac_infeasible``,
-                    #      ``fix_ci_blocked``,
-                    #      ``verify_failed_post_merge``) — emit a
-                    #      descriptive terminal whose phase name
-                    #      matches the hint. The daemon's
-                    #      ``BYPASSED_TERMINAL_PHASES_TO_ROUTE``
-                    #      maps these to the corresponding
-                    #      ``FAILURE_CATEGORY_*`` so the diagnoser
-                    #      sweep picks them up.
-                    case "$_hint" in
-                        conflict_unresolvable)
-                            log "diagnoser_route_conflict_unresolvable" "hint=$_hint"
-                            agent_runner_reaped_failure \
-                                "conflict_unresolvable" \
-                                "conflict_unresolvable" \
-                                "fix_conflict skill returned unresolvable or budget exhausted"
-                            ;;
-                        ralph_not_ship)
-                            # #3586 — route through diagnoser via
-                            # BYPASSED_TERMINAL_PHASES_TO_ROUTE (reversed
-                            # from the #3455 local-handler path).
-                            # Pass block_reason as the third arg so the
-                            # failures-row reason/stderr_tail carries
-                            # ralph's structured block_reason for the
-                            # diagnoser to act on.
-                            _block_reason=$(printf '%s' "$_output" | jq -r '.block_reason // ""' 2>/dev/null)
-                            log "diagnoser_route_ralph_not_ship" "hint=$_hint" "phase=$_current"
-                            agent_runner_reaped_failure \
-                                "ralph_not_ship" \
-                                "ralph_not_ship" \
-                                "$_block_reason"
-                            ;;
-                        ralph_ac_infeasible|summary_ac_infeasible|fix_ci_blocked|verify_failed_post_merge|push_and_pr_no_unmerged_files)
-                            # Descriptive terminal — the daemon's
-                            # BYPASSED_TERMINAL_PHASES_TO_ROUTE maps
-                            # these phase names to failure categories
-                            # so the diagnoser sweep picks them up.
-                            log "diagnoser_route_descriptive" "hint=$_hint" "phase=$_current"
-                            agent_runner_reaped_failure \
-                                "$_hint" \
-                                "$_hint" \
-                                "post-claude phase=$_current emitted route_to_diagnoser hint=$_hint"
-                            ;;
-                        *)
-                            # Truly novel hint we don't recognize.
-                            # Emit a descriptive terminal so the
-                            # operator sees what shape leaked through
-                            # without tripping the route_stub bug.
-                            log "diagnoser_route_unrecognized_hint" "hint=$_hint" "phase=$_current"
-                            agent_runner_reaped_failure \
-                                "diagnoser_route_unrecognized_hint" \
-                                "diagnoser_route_unrecognized_hint" \
-                                "post-claude phase=$_current emitted route_to_diagnoser hint=${_hint:-(empty)}"
-                            ;;
-                    esac
-                    ;;
-                unrecognized|*)
-                    # Issue #3455 — descriptive terminal instead of
-                    # ``agent_runner_route_stub``. transition_for
-                    # returned a shape this dispatch arm doesn't
-                    # handle — that's a code-drift bug, not a semantic
-                    # failure, so no diagnoser routing.
-                    log "post_claude_transition_unrecognized" "phase=$_current" "action=$_action"
-                    agent_runner_reaped_failure \
-                        "post_claude_transition_unrecognized" \
-                        "post_claude_transition_unrecognized" \
-                        "phase=$_current returned action=$_action (not advance / advance_with_status / route_to_diagnoser)"
-                    ;;
-            esac
+            # #3581 — single-source-of-truth dispatch. The helper
+            # (defined alongside advance_phase) handles every
+            # TransitionAction enum value AND every FAILURE_HINT_*
+            # constant emitted by phase_transitions.py uniformly across
+            # all phases. CI guard scripts/check-transition-dispatch-vocabulary.sh
+            # asserts the helper's vocabulary stays in sync with the
+            # Python module.
+            dispatch_transition_action "$_current" "$_action" "$_next" "$_status" "$_hint" "$_output"
             ;;
         claiming)
             # Mechanical pseudo-phase (#3117): the daemon writes
@@ -5599,47 +5620,12 @@ while true; do
             _next=$(printf '%s' "$_transition" | cut -f2)
             _status=$(printf '%s' "$_transition" | cut -f3)
             _hint=$(printf '%s' "$_transition" | cut -f4)
-            case "$_action" in
-                advance)
-                    advance_phase "$_next"
-                    ;;
-                advance_with_status)
-                    advance_phase "$_next" "$_status"
-                    ;;
-                route_to_diagnoser)
-                    # Issue #3543 — push_and_pr rebase failure with no
-                    # unmerged files. transition_from_push_and_pr emits
-                    # ROUTE_TO_DIAGNOSER with hint=push_and_pr_no_unmerged_files
-                    # (#3465). Route to the descriptive terminal so the
-                    # daemon's BYPASSED_TERMINAL_PHASES_TO_ROUTE picks it
-                    # up for the diagnoser sweep.
-                    log "push_and_pr_route_to_diagnoser" "hint=$_hint"
-                    case "$_hint" in
-                        push_and_pr_no_unmerged_files)
-                            agent_runner_reaped_failure \
-                                "push_and_pr_no_unmerged_files" \
-                                "push_and_pr_no_unmerged_files" \
-                                "push_and_pr rebase failed with no unmerged files"
-                            ;;
-                        *)
-                            log "push_and_pr_route_unrecognized_hint" "hint=$_hint"
-                            agent_runner_reaped_failure \
-                                "diagnoser_route_unrecognized_hint" \
-                                "diagnoser_route_unrecognized_hint" \
-                                "push_and_pr route_to_diagnoser received unrecognized hint=${_hint:-(empty)}"
-                            ;;
-                    esac
-                    ;;
-                *)
-                    # Issue #3455 — descriptive terminal instead of
-                    # ``agent_runner_route_stub``.
-                    log "push_and_pr_transition_unrecognized" "action=$_action"
-                    agent_runner_reaped_failure \
-                        "push_and_pr_transition_unrecognized" \
-                        "push_and_pr_transition_unrecognized" \
-                        "push_and_pr returned action=$_action (not advance / advance_with_status / route_to_diagnoser)"
-                    ;;
-            esac
+            # #3581 — single-source-of-truth dispatch via the helper.
+            # See dispatch_transition_action above advance_phase for
+            # the action-vocabulary handling. Replaces the per-phase
+            # case-statement that landed in #3543 (route_to_diagnoser
+            # arm) and #3558 (push_and_pr_no_unmerged_files hint).
+            dispatch_transition_action "push_and_pr" "$_action" "$_next" "$_status" "$_hint" "$_output"
             ;;
         fix_conflict)
             # #3225: fix_conflict phase. Budget-gated claude-resolution
@@ -5663,37 +5649,10 @@ while true; do
                 "next=$_next" \
                 "status=$_status" \
                 "hint=$_hint"
-            case "$_action" in
-                advance)
-                    log "fix_conflict_dispatched_action" "action=$_action"
-                    advance_phase "$_next"
-                    ;;
-                advance_with_status)
-                    log "fix_conflict_dispatched_action" "action=$_action"
-                    advance_phase "$_next" "$_status"
-                    ;;
-                route_to_diagnoser)
-                    # conflict_unresolvable is the only hint we expect
-                    # here. Route to the dedicated terminal via
-                    # agent_runner_reaped_failure so the row carries
-                    # ``category=conflict_unresolvable`` for the
-                    # diagnoser sweep.
-                    log "fix_conflict_dispatched_action" "action=$_action"
-                    log "fix_conflict_route_to_diagnoser" "hint=$_hint"
-                    agent_runner_reaped_failure \
-                        "conflict_unresolvable" \
-                        "conflict_unresolvable" \
-                        "fix_conflict skill returned unresolvable or budget exhausted"
-                    ;;
-                *)
-                    log "fix_conflict_dispatched_action" "action=$_action"
-                    log "fix_conflict_transition_unrecognized" "action=$_action"
-                    agent_runner_reaped_failure \
-                        "conflict_unresolvable" \
-                        "unrecognized_output" \
-                        "fix_conflict transition shim returned $_action"
-                    ;;
-            esac
+            log "fix_conflict_dispatched_action" "action=$_action"
+            # #3581 — single-source-of-truth dispatch via the helper.
+            # See dispatch_transition_action above advance_phase.
+            dispatch_transition_action "fix_conflict" "$_action" "$_next" "$_status" "$_hint" "$_output"
             ;;
         fix_ci)
             # #3245: fix_ci phase. Split out of the generic Claude-phase
@@ -5738,31 +5697,9 @@ while true; do
                 "next=$_next" \
                 "status=$_status" \
                 "hint=$_hint"
-            case "$_action" in
-                advance)
-                    advance_phase "$_next"
-                    ;;
-                advance_with_status)
-                    advance_phase "$_next" "$_status"
-                    ;;
-                route_to_diagnoser)
-                    # operational_failed is the only hint expected here.
-                    # Route to the descriptive terminal so the diagnoser
-                    # sweep picks it up via BYPASSED_TERMINAL_PHASES_TO_ROUTE.
-                    log "operational_route_to_diagnoser" "hint=$_hint"
-                    agent_runner_reaped_failure \
-                        "operational_failed" \
-                        "operational_failed" \
-                        "operational skill returned non-succeeded verdict — hint=$_hint"
-                    ;;
-                *)
-                    log "operational_transition_unrecognized" "action=$_action"
-                    agent_runner_reaped_failure \
-                        "post_claude_transition_unrecognized" \
-                        "post_claude_transition_unrecognized" \
-                        "operational returned action=$_action (not advance / advance_with_status / route_to_diagnoser)"
-                    ;;
-            esac
+            # #3581 — single-source-of-truth dispatch via the helper.
+            # See dispatch_transition_action above advance_phase.
+            dispatch_transition_action "operational" "$_action" "$_next" "$_status" "$_hint" "$_output"
             ;;
         awaiting_ci)
             # #3176: real implementation — poll ``gh pr view`` rollup,

--- a/scripts/dispatcher/tests/test_agent_runner_no_unmerged_files.py
+++ b/scripts/dispatcher/tests/test_agent_runner_no_unmerged_files.py
@@ -110,9 +110,20 @@ class TestRouteToDignoserListsPushAndPrNoUnmergedFiles:
         )
 
 
-class TestPushAndPrCaseArmHasRouteToDiagnoser:
-    """The push_and_pr) case-arm must contain a ``route_to_diagnoser)``
-    arm and a ``push_and_pr_no_unmerged_files)`` hint sub-case (#3543)."""
+class TestPushAndPrCaseArmRoutesViaCentralizedHelper:
+    """The push_and_pr) case-arm must delegate to the centralized
+    ``dispatch_transition_action`` helper (#3581), AND the helper must
+    handle ``route_to_diagnoser`` + the ``push_and_pr_no_unmerged_files``
+    hint (#3543).
+
+    Originally (pre-#3581) these assertions checked that the per-phase
+    case-statement INSIDE the push_and_pr) arm contained a
+    ``route_to_diagnoser)`` sub-case + a ``push_and_pr_no_unmerged_files)``
+    hint sub-case. After #3581 centralized dispatch, that logic moved
+    into ``dispatch_transition_action`` — but the bug-class invariant
+    is preserved: the action vocabulary AND the hint are handled
+    SOMEWHERE the push_and_pr) arm reaches at runtime.
+    """
 
     @staticmethod
     def _push_and_pr_block(text: str) -> str:
@@ -124,17 +135,59 @@ class TestPushAndPrCaseArmHasRouteToDiagnoser:
         assert end != -1, "fix_conflict) arm not found after push_and_pr) arm"
         return text[start:end]
 
-    def test_push_and_pr_arm_has_route_to_diagnoser(self) -> None:
+    @staticmethod
+    def _dispatch_helper_body(text: str) -> str:
+        """Return the body of the ``dispatch_transition_action`` helper
+        function (the centralized dispatch site, #3581)."""
+        start = text.find("dispatch_transition_action() {\n")
+        assert start != -1, (
+            "dispatch_transition_action helper not found in entrypoint (#3581)"
+        )
+        # The helper ends at the next top-level ``mark_ended() {`` or
+        # ``# ── ...`` block — find the closing ``}`` at column 0 by
+        # looking for the next bare-``}`` line that follows a non-
+        # indented line.
+        end_marker = text.find("\nmark_ended() {", start)
+        assert end_marker != -1, (
+            "Could not locate end of dispatch_transition_action helper"
+        )
+        return text[start:end_marker]
+
+    def test_push_and_pr_arm_calls_dispatch_helper(self) -> None:
         text = _script_text()
         block = self._push_and_pr_block(text)
-        assert re.search(r"route_to_diagnoser\)", block), (
-            "push_and_pr) case-arm must contain a route_to_diagnoser) arm (#3543)"
+        # The centralized helper is the only correct dispatch site for
+        # the push_and_pr arm post-#3581.
+        assert "dispatch_transition_action" in block, (
+            "push_and_pr) case-arm must call dispatch_transition_action "
+            "(#3581 — centralized transition-action dispatch)"
+        )
+        # Helper invocation passes the phase name as the first arg so
+        # log events + unrecognized-action terminals are correctly
+        # tagged with ``push_and_pr``.
+        assert re.search(
+            r'dispatch_transition_action\s+"push_and_pr"',
+            block,
+        ), (
+            "push_and_pr) case-arm must invoke dispatch_transition_action "
+            'with phase="push_and_pr" as the first argument (#3581)'
         )
 
-    def test_push_and_pr_arm_has_no_unmerged_files_hint(self) -> None:
+    def test_dispatch_helper_handles_route_to_diagnoser(self) -> None:
+        """#3543 invariant — preserved post-#3581 in the centralized helper."""
         text = _script_text()
-        block = self._push_and_pr_block(text)
-        assert re.search(r"push_and_pr_no_unmerged_files\)", block), (
-            "push_and_pr) case-arm must contain a push_and_pr_no_unmerged_files) "
-            "hint sub-case (#3543)"
+        body = self._dispatch_helper_body(text)
+        assert re.search(r"route_to_diagnoser\)", body), (
+            "dispatch_transition_action must contain a route_to_diagnoser) "
+            "arm (#3543 invariant, centralized in #3581)"
+        )
+
+    def test_dispatch_helper_handles_no_unmerged_files_hint(self) -> None:
+        """#3543 invariant — preserved post-#3581 in the centralized helper."""
+        text = _script_text()
+        body = self._dispatch_helper_body(text)
+        assert "push_and_pr_no_unmerged_files" in body, (
+            "dispatch_transition_action must handle the "
+            "push_and_pr_no_unmerged_files hint (#3543 invariant, "
+            "centralized in #3581)"
         )

--- a/scripts/tests/test_agent_runner_entrypoint.sh
+++ b/scripts/tests/test_agent_runner_entrypoint.sh
@@ -4937,6 +4937,29 @@ t51_out=$(bash -c '
     # Stub: advance_phase — no-op.
     advance_phase() { return 0; }
 
+    # Stub: agent_runner_reaped_failure — no-op (used by
+    # dispatch_transition_action route_to_diagnoser arm).
+    agent_runner_reaped_failure() { return 0; }
+
+    # Stub: dispatch_transition_action (#3581) — the centralized helper
+    # the fix_conflict arm now delegates to. Mirrors just enough of the
+    # real helper to pass through to advance_phase / agent_runner_reaped_failure
+    # for the expected actions, so this test can validate the per-step
+    # log events without the full helper logic.
+    dispatch_transition_action() {
+        local _ph="$1"
+        local _act="$2"
+        local _nx="$3"
+        local _st="$4"
+        local _ht="$5"
+        case "$_act" in
+            advance) advance_phase "$_nx" ;;
+            advance_with_status) advance_phase "$_nx" "$_st" ;;
+            route_to_diagnoser) agent_runner_reaped_failure "${_ph}_routed" "$_ht" "stub" ;;
+            *) agent_runner_reaped_failure "${_ph}_unrecognized" "$_act" "stub" ;;
+        esac
+    }
+
     # Stub: jq — minimal verdict extractor.
     jq() {
         if printf "%s" "$*" | grep -q "verdict"; then

--- a/scripts/tests/test_check_transition_dispatch_vocabulary.sh
+++ b/scripts/tests/test_check_transition_dispatch_vocabulary.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# test_check_transition_dispatch_vocabulary.sh — Tests for the CI guard
+# scripts/check-transition-dispatch-vocabulary.sh. (#3581)
+#
+# What this exercises
+# -------------------
+# The guard fails (exit 1) when:
+#   * a TransitionAction enum value in phase_transitions.py has no
+#     matching arm in ``dispatch_transition_action`` (outer case).
+#   * a FAILURE_HINT_* constant in phase_transitions.py has no matching
+#     arm in the helper's inner ``case "$_hint"`` block.
+#
+# The guard passes (exit 0) when both vocabularies agree.
+#
+# Strategy: copy the real phase_transitions.py + agent-runner-entrypoint.sh
+# into a sandbox, run the guard once unchanged (expect pass), then mutate
+# each file to introduce a synthetic drift and assert the guard fails
+# with the right error message.
+#
+# Usage:
+#   scripts/tests/test_check_transition_dispatch_vocabulary.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GUARD="$REPO_ROOT/scripts/check-transition-dispatch-vocabulary.sh"
+PY_SRC="$REPO_ROOT/scripts/dispatcher/phase_transitions.py"
+SH_SRC="$REPO_ROOT/scripts/dispatcher/agent-runner-entrypoint.sh"
+
+TESTS=0
+FAILURES=0
+
+pass() { TESTS=$((TESTS + 1)); echo "  PASS: $1"; }
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "         $2"
+    fi
+}
+
+TEST_TMP=$(mktemp -d)
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+# Build a sandbox with the same on-disk layout as the real repo, so the
+# guard's REPO_ROOT detection (cd .. from scripts/) lands on the right
+# directory.
+SANDBOX_REPO="$TEST_TMP/sandbox"
+mkdir -p "$SANDBOX_REPO/scripts/dispatcher"
+cp "$GUARD" "$SANDBOX_REPO/scripts/check-transition-dispatch-vocabulary.sh"
+chmod +x "$SANDBOX_REPO/scripts/check-transition-dispatch-vocabulary.sh"
+
+# ── 1. Baseline — unchanged repo passes ───────────────────────────────
+echo "Baseline: unchanged phase_transitions.py + agent-runner-entrypoint.sh"
+
+cp "$PY_SRC" "$SANDBOX_REPO/scripts/dispatcher/phase_transitions.py"
+cp "$SH_SRC" "$SANDBOX_REPO/scripts/dispatcher/agent-runner-entrypoint.sh"
+
+if "$SANDBOX_REPO/scripts/check-transition-dispatch-vocabulary.sh" >/dev/null 2>"$TEST_TMP/baseline.err"; then
+    pass "guard exits 0 on a clean repo"
+else
+    rc=$?
+    fail "guard exits 0 on a clean repo" \
+        "exit=$rc, stderr=$(cat "$TEST_TMP/baseline.err")"
+fi
+
+# ── 2. Synthetic drift: new TransitionAction not in helper ─────────────
+echo "Drift: new TransitionAction value not in helper"
+
+# Inject a new enum member into phase_transitions.py before the closing
+# of the TransitionAction class. We add it on the line right after
+# UNRECOGNIZED = "unrecognized" — that line ends the enum body.
+python3 - "$SANDBOX_REPO/scripts/dispatcher/phase_transitions.py" <<'PYEOF'
+import sys
+
+p = sys.argv[1]
+text = open(p).read()
+# Insert ``RETRY_LATER = "retry_later"`` after the UNRECOGNIZED line.
+# Use a marker line so the insertion is unambiguous.
+marker = '    UNRECOGNIZED = "unrecognized"\n'
+addition = '    RETRY_LATER = "retry_later"\n'
+assert marker in text, "could not find UNRECOGNIZED enum line"
+text = text.replace(marker, marker + addition, 1)
+open(p, "w").write(text)
+PYEOF
+
+if "$SANDBOX_REPO/scripts/check-transition-dispatch-vocabulary.sh" >"$TEST_TMP/drift1.out" 2>"$TEST_TMP/drift1.err"; then
+    fail "guard fails on new TransitionAction not in helper" \
+        "guard exited 0, expected non-zero. stderr: $(cat "$TEST_TMP/drift1.err")"
+else
+    rc=$?
+    if [[ $rc -eq 1 ]]; then
+        pass "guard exits 1 on new TransitionAction not handled by helper"
+    else
+        fail "guard exits 1 on new TransitionAction not handled by helper" \
+            "exit=$rc (expected 1)"
+    fi
+    # Specific error message names the missing action.
+    if grep -q '"retry_later"' "$TEST_TMP/drift1.err"; then
+        pass "drift error message names the missing action (retry_later)"
+    else
+        fail "drift error message names the missing action (retry_later)" \
+            "stderr did not mention retry_later: $(cat "$TEST_TMP/drift1.err")"
+    fi
+fi
+
+# Restore the Python file for the next test.
+cp "$PY_SRC" "$SANDBOX_REPO/scripts/dispatcher/phase_transitions.py"
+
+# ── 3. Synthetic drift: new FAILURE_HINT_* not in helper ───────────────
+echo "Drift: new FAILURE_HINT_* constant not in helper"
+
+# Append a new FAILURE_HINT constant near the existing ones. Use a
+# marker so we know exactly where to inject.
+python3 - "$SANDBOX_REPO/scripts/dispatcher/phase_transitions.py" <<'PYEOF'
+import sys
+
+p = sys.argv[1]
+text = open(p).read()
+# Find the last FAILURE_HINT_* line. We append right after the
+# OPERATIONAL_FAILED constant — that's stable per current source.
+marker = 'FAILURE_HINT_OPERATIONAL_FAILED = "operational_failed"\n'
+addition = 'FAILURE_HINT_NEWLY_INVENTED = "newly_invented_hint_for_test"\n'
+assert marker in text, "could not find FAILURE_HINT_OPERATIONAL_FAILED line"
+text = text.replace(marker, marker + addition, 1)
+open(p, "w").write(text)
+PYEOF
+
+if "$SANDBOX_REPO/scripts/check-transition-dispatch-vocabulary.sh" >"$TEST_TMP/drift2.out" 2>"$TEST_TMP/drift2.err"; then
+    fail "guard fails on new FAILURE_HINT_* not in helper" \
+        "guard exited 0, expected non-zero. stderr: $(cat "$TEST_TMP/drift2.err")"
+else
+    rc=$?
+    if [[ $rc -eq 1 ]]; then
+        pass "guard exits 1 on new FAILURE_HINT_* not handled by helper"
+    else
+        fail "guard exits 1 on new FAILURE_HINT_* not handled by helper" \
+            "exit=$rc (expected 1)"
+    fi
+    if grep -q "newly_invented_hint_for_test" "$TEST_TMP/drift2.err"; then
+        pass "drift error message names the missing hint (newly_invented_hint_for_test)"
+    else
+        fail "drift error message names the missing hint" \
+            "stderr did not mention newly_invented_hint_for_test: $(cat "$TEST_TMP/drift2.err")"
+    fi
+fi
+
+# Restore the Python file.
+cp "$PY_SRC" "$SANDBOX_REPO/scripts/dispatcher/phase_transitions.py"
+
+# ── 4. Removing a hint arm from the helper triggers the guard ─────────
+echo "Drift: helper missing an existing FAILURE_HINT_* arm"
+
+# Strip ``operational_failed)`` from the helper's inner case-statement —
+# more precisely, remove the multi-arm label that contains it. The
+# real helper has a single multi-label arm; we remove just operational_failed
+# from it. Since we can't easily edit a multi-arm label in a way that's
+# both valid bash AND removes one entry, we'll instead strip
+# ``operational_failed`` from inside the |-pipe label.
+python3 - "$SANDBOX_REPO/scripts/dispatcher/agent-runner-entrypoint.sh" <<'PYEOF'
+import sys
+
+p = sys.argv[1]
+text = open(p).read()
+# Look for the multi-label arm and remove operational_failed from it.
+# The label looks like:
+#   ralph_ac_infeasible|summary_ac_infeasible|...|operational_failed|plan_blocked)
+old_label = "ralph_ac_infeasible|summary_ac_infeasible|fix_ci_blocked|verify_failed_post_merge|push_and_pr_no_unmerged_files|operational_failed|plan_blocked)"
+new_label = "ralph_ac_infeasible|summary_ac_infeasible|fix_ci_blocked|verify_failed_post_merge|push_and_pr_no_unmerged_files|plan_blocked)"
+assert old_label in text, f"could not find expected multi-label arm: {old_label}"
+text = text.replace(old_label, new_label, 1)
+open(p, "w").write(text)
+PYEOF
+
+if "$SANDBOX_REPO/scripts/check-transition-dispatch-vocabulary.sh" >"$TEST_TMP/drift3.out" 2>"$TEST_TMP/drift3.err"; then
+    fail "guard catches removed hint arm" \
+        "guard exited 0, expected non-zero"
+else
+    rc=$?
+    if [[ $rc -eq 1 ]] && grep -q "operational_failed" "$TEST_TMP/drift3.err"; then
+        pass "guard catches removed hint arm (operational_failed)"
+    else
+        fail "guard catches removed hint arm (operational_failed)" \
+            "exit=$rc, stderr: $(cat "$TEST_TMP/drift3.err")"
+    fi
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────
+echo
+echo "=== Summary ==="
+echo "  $TESTS test(s), $FAILURES failure(s)"
+
+if [[ "$FAILURES" -ne 0 ]]; then
+    exit 1
+fi
+
+echo "  ALL PASSED"
+exit 0

--- a/scripts/tests/test_dispatch_transition_action.sh
+++ b/scripts/tests/test_dispatch_transition_action.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# test_dispatch_transition_action.sh — Tests for the centralized
+# transition-action dispatch helper (#3581).
+#
+# What this exercises
+# -------------------
+# The ``dispatch_transition_action`` helper in
+# ``scripts/dispatcher/agent-runner-entrypoint.sh`` is the single source
+# of truth for translating a ``transition_for`` tuple into the right
+# downstream call (advance_phase / advance_phase with terminal status /
+# descriptive terminal via agent_runner_reaped_failure). Before #3581,
+# every phase had its own duplicate case-statement; new actions / hints
+# would silently bypass any phase the PR author missed (#3543, #3558,
+# #3573, #3580 family).
+#
+# These tests verify the helper handles every action arm correctly:
+#   * advance → calls advance_phase $next
+#   * advance_with_status → calls advance_phase $next $status
+#   * route_to_diagnoser + each known FAILURE_HINT_* → calls
+#     agent_runner_reaped_failure with the descriptive terminal
+#   * route_to_diagnoser + unknown hint → diagnoser_route_unrecognized_hint
+#   * unrecognized action → ${phase}_transition_unrecognized
+#
+# Test method: extract the helper definition (and its dependencies:
+# ``log``, ``advance_phase``, ``agent_runner_reaped_failure``) into a
+# sandbox script that stubs DB writes, then invoke each action arm and
+# assert the recorded calls match expectations.
+#
+# Usage:
+#   scripts/tests/test_dispatch_transition_action.sh
+#
+# Exit codes:
+#   0 — All tests passed.
+#   1 — One or more tests failed.
+
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENTRYPOINT="$REPO_ROOT/scripts/dispatcher/agent-runner-entrypoint.sh"
+
+TESTS=0
+FAILURES=0
+
+pass() { TESTS=$((TESTS + 1)); echo "  PASS: $1"; }
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "  FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "         $2"
+    fi
+}
+
+# Build a sandbox harness that defines the stubs first, then sources
+# only the dispatch_transition_action helper definition out of the
+# entrypoint. The helper depends on:
+#   - ``log $event $kv...`` — we record events to a log file.
+#   - ``advance_phase $next [$status]`` — we record calls to a calls file.
+#   - ``agent_runner_reaped_failure $term_phase $category $reason`` — we
+#     record calls and exit 0 (mirrors the real function's contract).
+
+TEST_TMP=$(mktemp -d)
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+extract_helper() {
+    # Print the dispatch_transition_action function body from the
+    # entrypoint. The function spans from its definition to the
+    # matching closing ``}`` at column 0. We use a small awk to find
+    # the start and copy until the next column-0 ``}``.
+    awk '
+        /^dispatch_transition_action\(\) \{/ { in_fn = 1 }
+        in_fn { print }
+        in_fn && /^}/ { exit }
+    ' "$ENTRYPOINT"
+}
+
+build_harness() {
+    cat > "$TEST_TMP/harness.sh" <<'EOF'
+#!/usr/bin/env bash
+# Test harness for dispatch_transition_action.
+
+CALLS_FILE="${HARNESS_CALLS_FILE:-/tmp/calls}"
+LOGS_FILE="${HARNESS_LOGS_FILE:-/tmp/logs}"
+
+log() {
+    # $1 = event, remaining args = key=value pairs.
+    local event="$1"
+    shift
+    local line="$event"
+    for kv in "$@"; do
+        line="$line $kv"
+    done
+    printf '%s\n' "$line" >> "$LOGS_FILE"
+}
+
+advance_phase() {
+    # $1 = next, $2 = status (optional).
+    if [[ -n "${2:-}" ]]; then
+        printf 'advance_phase next=%s status=%s\n' "$1" "$2" >> "$CALLS_FILE"
+    else
+        printf 'advance_phase next=%s\n' "$1" >> "$CALLS_FILE"
+    fi
+}
+
+agent_runner_reaped_failure() {
+    # $1 = term_phase, $2 = category, $3 = reason.
+    printf 'reaped term=%s category=%s reason=%s\n' "$1" "$2" "$3" >> "$CALLS_FILE"
+}
+
+EOF
+    extract_helper >> "$TEST_TMP/harness.sh"
+    cat >> "$TEST_TMP/harness.sh" <<'EOF'
+
+# Run the helper with the args from $@.
+dispatch_transition_action "$@"
+EOF
+    chmod +x "$TEST_TMP/harness.sh"
+}
+
+run_helper() {
+    local calls_file="$TEST_TMP/calls.$$"
+    local logs_file="$TEST_TMP/logs.$$"
+    : > "$calls_file"
+    : > "$logs_file"
+    HARNESS_CALLS_FILE="$calls_file" \
+        HARNESS_LOGS_FILE="$logs_file" \
+        bash "$TEST_TMP/harness.sh" "$@"
+    local rc=$?
+    LAST_CALLS=$(cat "$calls_file")
+    LAST_LOGS=$(cat "$logs_file")
+    rm -f "$calls_file" "$logs_file"
+    return $rc
+}
+
+build_harness
+
+echo
+echo "=== dispatch_transition_action: action arm coverage ==="
+
+# 1. advance — calls advance_phase $next.
+run_helper "summary" "advance" "push_and_pr" "" "" "{}"
+expected="advance_phase next=push_and_pr"
+if [[ "$LAST_CALLS" == "$expected" ]]; then
+    pass "advance arm calls advance_phase with next phase"
+else
+    fail "advance arm calls advance_phase with next phase" \
+        "expected '$expected', got '$LAST_CALLS'"
+fi
+
+# 2. advance_with_status — calls advance_phase $next $status.
+run_helper "verify" "advance_with_status" "retro" "succeeded" "" "{}"
+expected="advance_phase next=retro status=succeeded"
+if [[ "$LAST_CALLS" == "$expected" ]]; then
+    pass "advance_with_status arm calls advance_phase with next + status"
+else
+    fail "advance_with_status arm calls advance_phase with next + status" \
+        "expected '$expected', got '$LAST_CALLS'"
+fi
+
+# 3. route_to_diagnoser + conflict_unresolvable hint.
+run_helper "fix_conflict" "route_to_diagnoser" "" "" "conflict_unresolvable" "{}"
+if [[ "$LAST_CALLS" == *"reaped term=conflict_unresolvable category=conflict_unresolvable"* ]]; then
+    pass "route_to_diagnoser + conflict_unresolvable -> conflict_unresolvable terminal"
+else
+    fail "route_to_diagnoser + conflict_unresolvable -> conflict_unresolvable terminal" \
+        "got: $LAST_CALLS"
+fi
+
+# 4. route_to_diagnoser + ralph_not_ship hint, with block_reason in
+#    the output JSON. The helper extracts block_reason via jq and
+#    passes it as the reason arg.
+output_json='{"verdict":"REVISE","block_reason":"max iterations reached"}'
+run_helper "ralph" "route_to_diagnoser" "" "" "ralph_not_ship" "$output_json"
+if [[ "$LAST_CALLS" == *"reaped term=ralph_not_ship category=ralph_not_ship reason=max iterations reached"* ]]; then
+    pass "route_to_diagnoser + ralph_not_ship extracts block_reason from output"
+else
+    fail "route_to_diagnoser + ralph_not_ship extracts block_reason from output" \
+        "got: $LAST_CALLS"
+fi
+
+# 5. route_to_diagnoser + each known descriptive hint — sample three of
+#    the cluster from FAILURE_HINT_*.
+for hint in ralph_ac_infeasible summary_ac_infeasible fix_ci_blocked verify_failed_post_merge push_and_pr_no_unmerged_files operational_failed plan_blocked; do
+    run_helper "post_claude" "route_to_diagnoser" "" "" "$hint" "{}"
+    if [[ "$LAST_CALLS" == *"reaped term=$hint category=$hint"* ]]; then
+        pass "route_to_diagnoser + $hint -> $hint descriptive terminal"
+    else
+        fail "route_to_diagnoser + $hint -> $hint descriptive terminal" \
+            "got: $LAST_CALLS"
+    fi
+done
+
+# 6. route_to_diagnoser + truly novel hint — emits
+#    diagnoser_route_unrecognized_hint.
+run_helper "post_claude" "route_to_diagnoser" "" "" "totally_made_up_hint_999" "{}"
+if [[ "$LAST_CALLS" == *"reaped term=diagnoser_route_unrecognized_hint"* ]]; then
+    pass "route_to_diagnoser + novel hint -> diagnoser_route_unrecognized_hint"
+else
+    fail "route_to_diagnoser + novel hint -> diagnoser_route_unrecognized_hint" \
+        "got: $LAST_CALLS"
+fi
+# And the log line carries the phase + hint for operator triage.
+if [[ "$LAST_LOGS" == *"post_claude_route_unrecognized_hint hint=totally_made_up_hint_999"* ]]; then
+    pass "novel-hint path emits phase_tagged_route_unrecognized_hint log"
+else
+    fail "novel-hint path emits phase_tagged_route_unrecognized_hint log" \
+        "got: $LAST_LOGS"
+fi
+
+# 7. Unrecognized action — emits ${phase}_transition_unrecognized.
+run_helper "summary" "totally_unknown_action_kind" "" "" "" "{}"
+if [[ "$LAST_CALLS" == *"reaped term=summary_transition_unrecognized category=summary_transition_unrecognized"* ]]; then
+    pass "novel action -> phase_tagged_transition_unrecognized terminal"
+else
+    fail "novel action -> phase_tagged_transition_unrecognized terminal" \
+        "got: $LAST_CALLS"
+fi
+
+# 8. Per-phase tagging — the same novel action with different phase
+#    names should produce phase-tagged terminals so operator can tell
+#    which phase emitted the bad shape.
+run_helper "fix_conflict" "totally_unknown_action_kind" "" "" "" "{}"
+if [[ "$LAST_CALLS" == *"reaped term=fix_conflict_transition_unrecognized"* ]]; then
+    pass "unrecognized-action terminal is phase-tagged (fix_conflict)"
+else
+    fail "unrecognized-action terminal is phase-tagged (fix_conflict)" \
+        "got: $LAST_CALLS"
+fi
+
+# 9. The ``unrecognized`` action enum value (defensive sentinel from
+#    phase_transitions.py) routes through the same branch as truly
+#    novel actions.
+run_helper "ralph" "unrecognized" "" "" "" "{}"
+if [[ "$LAST_CALLS" == *"reaped term=ralph_transition_unrecognized"* ]]; then
+    pass "explicit 'unrecognized' action -> phase_tagged_transition_unrecognized"
+else
+    fail "explicit 'unrecognized' action -> phase_tagged_transition_unrecognized" \
+        "got: $LAST_CALLS"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────
+echo
+echo "=== Summary ==="
+echo "  $TESTS test(s), $FAILURES failure(s)"
+
+if [[ "$FAILURES" -ne 0 ]]; then
+    exit 1
+fi
+
+echo "  ALL PASSED"
+exit 0


### PR DESCRIPTION
## Summary

Centralizes transition-action dispatch in `scripts/dispatcher/agent-runner-entrypoint.sh` into a single `dispatch_transition_action()` helper, and adds a CI guard that fails the PR when the action vocabulary in `phase_transitions.py` drifts from the helper's coverage. Eliminates the cluster-bug pattern (#3543, #3558, #3573, #3580) where adding a new `TransitionAction` or `FAILURE_HINT_*` would silently bypass some per-phase case-statement and terminal-fail with `*_transition_unrecognized` instead of routing correctly.

Five per-phase case-statements (post-claude generic, push_and_pr, fix_conflict, operational, ralph_baseline) now delegate to the helper instead of reimplementing the action-vocabulary dispatch from scratch. `handle_fix_ci` stays as-is by design — it interleaves git ops between skill output and dispatch, so it doesn't fit the centralized-dispatch pattern; the CI guard still covers its terminals.

Closes #3581

## Test plan

### Automated checks

- [ ] Lint passes (`ruff check`)
- [ ] Format check passes (`ruff format --check`)
- [ ] Tests pass (16 dispatch tests + 6 guard tests + 17 pinned regression tests)
- [ ] CI green
- [ ] `dispatcher-dispatch-vocabulary-check` job present and passing

### Post-deploy verification

This is a dispatcher infra change. Verification path:

- [ ] After merge, the next agent that hits `route_to_diagnoser` from any per-phase arm routes through the centralized helper without producing a `*_transition_unrecognized` terminal. (Negative-evidence verification — the absence of the cluster-bug failures over the next 24h.)
- [ ] CI guard catches drift: synthetic test in `scripts/tests/test_check_transition_dispatch_vocabulary.sh` already proves this.
- [ ] Verification evidence posted on issue #3581 (skip reason: pure refactor + CI guard, no user-facing affordance).
