### PR TITLE
fix(infra): SSM-source desired container_definitions for deploy-scraper + deploy-production (#3770)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -19,6 +19,15 @@ env:
   TASK_FAMILY: judgemind-scraper-production
   SCHEDULER_NAME: judgemind-scraper-production
   CONTAINER_NAME: scraper
+  # Terraform-managed source of truth for the production scraper task's
+  # container_definitions. See #3770 / parent #2840 — without this, the
+  # deploy-* path re-registers the running task-def's content and silently
+  # re-introduces fields terraform has removed. The parameter name follows
+  # the convention defined in
+  # `infra/terraform/modules/compute/main.tf::aws_ssm_parameter.scraper_container_definitions`,
+  # populated for `environment = "production"` on the next production
+  # terraform apply.
+  SCRAPER_CONTAINER_DEFS_SSM_PARAMETER: /judgemind/scraper/production/container-definitions
 
 jobs:
   deploy-production:
@@ -81,6 +90,7 @@ jobs:
           image-uri: ${{ steps.verify-image.outputs.image_uri }}
           deploy-mode: scheduler
           scheduler-name: ${{ env.SCHEDULER_NAME }}
+          desired-container-definitions-ssm-parameter: ${{ env.SCRAPER_CONTAINER_DEFS_SSM_PARAMETER }}
 
       - name: Set deployment status
         if: always()

--- a/.github/workflows/deploy-scraper.yml
+++ b/.github/workflows/deploy-scraper.yml
@@ -35,6 +35,16 @@ env:
   TASK_FAMILY: judgemind-scraper-dev
   SCHEDULER_NAME: judgemind-scraper-dev
   CONTAINER_NAME: scraper
+  # Terraform-managed source of truth for the per-court scraper task's
+  # container_definitions. See #3770 / parent #2840 — without this, the
+  # deploy-* path re-registers the running task-def's content and silently
+  # re-introduces fields terraform has removed. The parameter name follows
+  # the convention defined in
+  # `infra/terraform/modules/compute/main.tf::aws_ssm_parameter.scraper_container_definitions`.
+  SCRAPER_CONTAINER_DEFS_SSM_PARAMETER: /judgemind/scraper/dev/container-definitions
+  # Same source-of-truth pattern, ingestion-worker task. See
+  # `infra/terraform/modules/compute/main.tf::aws_ssm_parameter.ingestion_worker_container_definitions`.
+  INGESTION_WORKER_CONTAINER_DEFS_SSM_PARAMETER: /judgemind/ingestion-worker/dev/container-definitions
 
 jobs:
   build-and-push:
@@ -126,6 +136,7 @@ jobs:
           image-uri: ${{ needs.build-and-push.outputs.image_uri }}
           deploy-mode: scheduler
           scheduler-name: ${{ env.SCHEDULER_NAME }}
+          desired-container-definitions-ssm-parameter: ${{ env.SCRAPER_CONTAINER_DEFS_SSM_PARAMETER }}
 
       - name: Set deployment status
         if: always()
@@ -190,6 +201,7 @@ jobs:
           deploy-mode: service
           ecs-cluster: ${{ env.ECS_CLUSTER }}
           ecs-service: ${{ env.INGESTION_SERVICE }}
+          desired-container-definitions-ssm-parameter: ${{ env.INGESTION_WORKER_CONTAINER_DEFS_SSM_PARAMETER }}
 
       - name: Set deployment status
         if: always()

--- a/docs/agent/infrastructure-reference.md
+++ b/docs/agent/infrastructure-reference.md
@@ -161,11 +161,13 @@ The hybrid pragmatism: family-level metadata (`cpu`, `memory`, `network_mode`, `
 
 1. Each terraform module that owns a task-definition publishes `aws_ssm_parameter "container_definitions"` with `value = aws_ecs_task_definition.<svc>.container_definitions`. Currently wired:
    - `infra/terraform/modules/api-service/main.tf` → `/judgemind/api/<env>/container-definitions`
+   - `infra/terraform/modules/compute/main.tf` (per-court scraper) → `/judgemind/scraper/<env>/container-definitions`
+   - `infra/terraform/modules/compute/main.tf` (ingestion-worker) → `/judgemind/ingestion-worker/<env>/container-definitions`
 2. `dev-apply` in `terraform.yml` runs on every `push:main` that touches `infra/terraform/**`, so the SSM parameter is always in sync with the latest committed terraform render.
 3. `.github/actions/ecs-deploy/action.yml` accepts an optional input `desired-container-definitions-ssm-parameter`. When set, the action invokes `scripts/ecs-render-task-def.sh` with that parameter name; the script reads the JSON from SSM, substitutes the new image into the named container, and registers the new revision.
 4. When the input is empty, the action falls back to the legacy `describe-task-definition` source — preserving behaviour for any deploy-* workflow that has not yet opted in.
 
-**Coverage and follow-ups.** Wired today: `deploy-api.yml`. Not yet wired: `deploy-scraper.yml`, `deploy-production.yml`. Migrating the remaining workflows is straightforward: add the SSM parameter resource to the relevant module (compute, scraper-zero-record-check, dispatcher-agent-runner, etc.), pass the parameter name to the composite action. File a follow-up issue when migrating each so the SSM parameter creation lands in the same PR as the workflow opt-in.
+**Coverage and follow-ups.** Wired today: `deploy-api.yml` (#3769), `deploy-scraper.yml` (#3770 — both the scraper job and the ingestion-worker job), `deploy-production.yml` (#3770 — production scraper). Every workflow that consumes `.github/actions/ecs-deploy/action.yml` is now on the SSM-source path. The `infra/terraform/modules/scraper-zero-record-check/` task-def is launched directly by EventBridge Scheduler (and one-shot via `scripts/ecs-run-task.sh`), not through the composite action, so it does not need migration. New deploy-* workflows that adopt `ecs-deploy/action.yml` should opt in to SSM-source mode as part of their first PR — add the `aws_ssm_parameter` to the owning module and pass the name to the composite action via `desired-container-definitions-ssm-parameter`.
 
 **Operator gotcha.** When adding a new env var or secret to an SSM-source-mode task-definition, the change must land via terraform — direct edits to `register-task-definition` calls or one-off CLI tweaks will be silently overwritten by the next deploy. The SSM parameter is rendered from `aws_ecs_task_definition.<svc>.container_definitions`, so any change to that resource flows through automatically.
 

--- a/infra/terraform/modules/compute/main.tf
+++ b/infra/terraform/modules/compute/main.tf
@@ -198,6 +198,25 @@ resource "aws_ecs_task_definition" "scraper" {
   ])
 }
 
+# ─── SSM: terraform-managed container_definitions for deploy-scraper ────────
+# Stores the rendered container_definitions JSON that terraform considers the
+# desired state for the per-court scraper task. The deploy-scraper workflow's
+# `ecs-deploy` composite action reads this parameter (instead of the running
+# task-def) when registering a new revision, so secrets / env vars terraform
+# has removed can never leak back in via the legacy "preserve current task-def
+# content" path. See #3770 / parent #2840 for the bug class this prevents and
+# #3769 for the deploy-api precedent.
+#
+# Tier "Advanced" supports values up to 8KB (Standard caps at 4KB) — gives
+# headroom for future env-var / secret additions without a tier bump.
+resource "aws_ssm_parameter" "scraper_container_definitions" {
+  name        = "/judgemind/scraper/${var.environment}/container-definitions"
+  description = "Terraform-rendered container_definitions JSON for the ${var.environment} scraper task. Read by .github/actions/ecs-deploy when --desired-container-definitions-ssm-parameter is set. See #3770 / #2840."
+  type        = "String"
+  tier        = "Advanced"
+  value       = aws_ecs_task_definition.scraper.container_definitions
+}
+
 # ─── EventBridge Scheduler ──────────────────────────────────────────────────
 # Runs the scraper task on a twice-daily schedule. EventBridge Scheduler replaces
 # the legacy CloudWatch Events / EventBridge Rules pattern and supports
@@ -502,6 +521,27 @@ resource "aws_ecs_task_definition" "ingestion_worker" {
       }
     }
   ])
+}
+
+# ─── SSM: terraform-managed container_definitions for ingestion-worker ──────
+# Same pattern as `aws_ssm_parameter.scraper_container_definitions` above:
+# terraform writes the rendered container_definitions JSON to SSM so the
+# ingestion-worker job in deploy-scraper.yml can read it via `ecs-deploy`'s
+# `desired-container-definitions-ssm-parameter` input. Closes the
+# preserve-secrets bug class for ingestion-worker. See #3770 / parent #2840
+# and the deploy-api precedent in #3769.
+#
+# Conditional on local.deploy_ingestion mirrors the gate on the task-def
+# resource — when ingestion is not deployed (no DB connection secret), the
+# SSM parameter is also absent so terraform doesn't churn on an unused write.
+resource "aws_ssm_parameter" "ingestion_worker_container_definitions" {
+  count = local.deploy_ingestion ? 1 : 0
+
+  name        = "/judgemind/ingestion-worker/${var.environment}/container-definitions"
+  description = "Terraform-rendered container_definitions JSON for the ${var.environment} ingestion-worker task. Read by .github/actions/ecs-deploy when --desired-container-definitions-ssm-parameter is set. See #3770 / #2840."
+  type        = "String"
+  tier        = "Advanced"
+  value       = aws_ecs_task_definition.ingestion_worker[0].container_definitions
 }
 
 resource "aws_ecs_service" "ingestion_worker" {

--- a/infra/terraform/modules/compute/outputs.tf
+++ b/infra/terraform/modules/compute/outputs.tf
@@ -47,3 +47,13 @@ output "ingestion_worker_log_group" {
   description = "CloudWatch log group for ingestion worker output (empty if not deployed)"
   value       = local.deploy_ingestion ? aws_cloudwatch_log_group.ingestion_worker[0].name : ""
 }
+
+output "scraper_container_definitions_ssm_parameter_name" {
+  description = "SSM parameter holding terraform-rendered container_definitions JSON for the per-court scraper task. Pass to .github/actions/ecs-deploy as `desired-container-definitions-ssm-parameter` to make terraform the source of truth on deploy. See #3770."
+  value       = aws_ssm_parameter.scraper_container_definitions.name
+}
+
+output "ingestion_worker_container_definitions_ssm_parameter_name" {
+  description = "SSM parameter holding terraform-rendered container_definitions JSON for the ingestion-worker task (empty if ingestion is not deployed). Pass to .github/actions/ecs-deploy as `desired-container-definitions-ssm-parameter` to make terraform the source of truth on deploy. See #3770."
+  value       = local.deploy_ingestion ? aws_ssm_parameter.ingestion_worker_container_definitions[0].name : ""
+}

--- a/scripts/tests/test_ecs_render_task_def.sh
+++ b/scripts/tests/test_ecs_render_task_def.sh
@@ -199,6 +199,119 @@ write_ssm_param() {
 JSON
 }
 
+# Build a synthetic "current task-def" response for the ingestion-worker
+# family. Mirrors the shape produced by `infra/terraform/modules/compute`:
+# container name is "ingestion-worker", a `command` field is present, and the
+# secrets set is a superset of the api task-def. Used by the #3770 follow-up
+# tests that verify the SSM-source path generalizes beyond the api task.
+write_describe_task_def_ingestion_worker() {
+    local file="$1"
+    local include_legacy_secret="${2:-true}"
+
+    local secrets='[{"name":"DATABASE_URL","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:db-AAA:url::"},{"name":"OPENSEARCH_PASSWORD","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:os-DDD:password::"},{"name":"ANTHROPIC_API_KEY","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:anth-EEE"}]'
+    if [[ "$include_legacy_secret" == "true" ]]; then
+        secrets='[{"name":"DATABASE_URL","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:db-AAA:url::"},{"name":"OPENSEARCH_PASSWORD","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:os-DDD:password::"},{"name":"ANTHROPIC_API_KEY","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:anth-EEE"},{"name":"LEGACY_REMOVED_SECRET","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:legacy-FFF"}]'
+    fi
+
+    cat > "$file" << JSON
+{
+  "taskDefinition": {
+    "taskDefinitionArn": "arn:aws:ecs:us-west-2:111:task-definition/judgemind-ingestion-worker-dev:42",
+    "family": "judgemind-ingestion-worker-dev",
+    "executionRoleArn": "arn:aws:iam::111:role/exec-role",
+    "taskRoleArn": "arn:aws:iam::111:role/judgemind-ingestion-worker-task-dev",
+    "networkMode": "awsvpc",
+    "requiresCompatibilities": ["FARGATE"],
+    "cpu": "256",
+    "memory": "512",
+    "containerDefinitions": [
+      {
+        "name": "ingestion-worker",
+        "image": "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/scraper:OLDSHA",
+        "command": ["ingestion"],
+        "essential": true,
+        "secrets": $secrets,
+        "environment": [{"name":"ENVIRONMENT","value":"dev"},{"name":"LLM_PROVIDER","value":"gemini"}]
+      }
+    ]
+  }
+}
+JSON
+}
+
+# SSM-parameter response for the ingestion-worker task. Terraform-managed
+# desired state — does NOT include LEGACY_REMOVED_SECRET (so the SSM-source
+# path provably drops it). Container name is "ingestion-worker", matching the
+# resource in `infra/terraform/modules/compute/main.tf::aws_ecs_task_definition.ingestion_worker`.
+write_ssm_param_ingestion_worker() {
+    local file="$1"
+
+    cat > "$file" << 'JSON'
+{
+  "Parameter": {
+    "Name": "/judgemind/ingestion-worker/dev/container-definitions",
+    "Type": "String",
+    "Value": "[{\"name\":\"ingestion-worker\",\"image\":\"PLACEHOLDER\",\"command\":[\"ingestion\"],\"essential\":true,\"secrets\":[{\"name\":\"DATABASE_URL\",\"valueFrom\":\"arn:aws:secretsmanager:us-west-2:111:secret:db-AAA:url::\"},{\"name\":\"OPENSEARCH_PASSWORD\",\"valueFrom\":\"arn:aws:secretsmanager:us-west-2:111:secret:os-DDD:password::\"},{\"name\":\"ANTHROPIC_API_KEY\",\"valueFrom\":\"arn:aws:secretsmanager:us-west-2:111:secret:anth-EEE\"}],\"environment\":[{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"},{\"name\":\"LLM_PROVIDER\",\"value\":\"gemini\"}]}]"
+  }
+}
+JSON
+}
+
+# Build a synthetic "current task-def" response for the scraper family. Per-
+# court scraper running off the same image, container name "scraper". Mirrors
+# `infra/terraform/modules/compute/main.tf::aws_ecs_task_definition.scraper`.
+write_describe_task_def_scraper() {
+    local file="$1"
+    local include_legacy_secret="${2:-true}"
+
+    local secrets='[{"name":"DATABASE_URL","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:db-AAA:url::"},{"name":"COURTLISTENER_API_TOKEN","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:cl-GGG"}]'
+    if [[ "$include_legacy_secret" == "true" ]]; then
+        secrets='[{"name":"DATABASE_URL","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:db-AAA:url::"},{"name":"COURTLISTENER_API_TOKEN","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:cl-GGG"},{"name":"LEGACY_REMOVED_SECRET","valueFrom":"arn:aws:secretsmanager:us-west-2:111:secret:legacy-FFF"}]'
+    fi
+
+    cat > "$file" << JSON
+{
+  "taskDefinition": {
+    "taskDefinitionArn": "arn:aws:ecs:us-west-2:111:task-definition/judgemind-scraper-dev:55",
+    "family": "judgemind-scraper-dev",
+    "executionRoleArn": "arn:aws:iam::111:role/exec-role",
+    "taskRoleArn": "arn:aws:iam::111:role/judgemind-scraper-task-dev",
+    "networkMode": "awsvpc",
+    "requiresCompatibilities": ["FARGATE"],
+    "cpu": "1024",
+    "memory": "2048",
+    "containerDefinitions": [
+      {
+        "name": "scraper",
+        "image": "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/scraper:OLDSHA",
+        "essential": true,
+        "stopTimeout": 120,
+        "secrets": $secrets,
+        "environment": [{"name":"ENVIRONMENT","value":"dev"}]
+      }
+    ]
+  }
+}
+JSON
+}
+
+# SSM-parameter response for the scraper task. Terraform-managed desired
+# state without LEGACY_REMOVED_SECRET. Container name is "scraper", matching
+# the resource in `infra/terraform/modules/compute/main.tf::aws_ecs_task_definition.scraper`.
+write_ssm_param_scraper() {
+    local file="$1"
+
+    cat > "$file" << 'JSON'
+{
+  "Parameter": {
+    "Name": "/judgemind/scraper/dev/container-definitions",
+    "Type": "String",
+    "Value": "[{\"name\":\"scraper\",\"image\":\"PLACEHOLDER\",\"essential\":true,\"stopTimeout\":120,\"secrets\":[{\"name\":\"DATABASE_URL\",\"valueFrom\":\"arn:aws:secretsmanager:us-west-2:111:secret:db-AAA:url::\"},{\"name\":\"COURTLISTENER_API_TOKEN\",\"valueFrom\":\"arn:aws:secretsmanager:us-west-2:111:secret:cl-GGG\"}],\"environment\":[{\"name\":\"ENVIRONMENT\",\"value\":\"dev\"}]}]"
+  }
+}
+JSON
+}
+
 # Build the synthetic register-task-definition response.
 write_register_output() {
     local file="$1"
@@ -444,6 +557,73 @@ test_ssm_path_unknown_container_fails() {
     pass "$label"
 }
 
+# ─── Test 7: SSM-source path generalises to the ingestion-worker task ────
+# Regression test for #3770 (chunk C of #2840). The SSM-source path was
+# wired into deploy-api by #3769; this test asserts the same script handles
+# the ingestion-worker task family — different container name
+# ("ingestion-worker"), different secret set, additional `command` field —
+# without regressing the bug-class fix.
+test_ssm_path_ingestion_worker_drops_legacy_secret() {
+    local label="SSM source path: ingestion-worker family — terraform-removed LEGACY_REMOVED_SECRET does NOT come back"
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    # Currently running ingestion-worker task-def still has LEGACY_REMOVED_SECRET.
+    write_describe_task_def_ingestion_worker "$tmpdir/describe-task-def.json" "true"
+    # Terraform-managed SSM parameter omits it.
+    write_ssm_param_ingestion_worker "$tmpdir/ssm-param.json"
+
+    run_script "$tmpdir" \
+        --task-family judgemind-ingestion-worker-dev \
+        --container-name ingestion-worker \
+        --image-uri "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/scraper:NEWSHA" \
+        --desired-container-definitions-ssm-parameter "/judgemind/ingestion-worker/dev/container-definitions"
+
+    assert_exit "$tmpdir" "0" "$label" || return
+    assert_call_log_contains "$tmpdir" "ssm get-parameter" "$label" || return
+    # LEGACY_REMOVED_SECRET must NOT have leaked through from the running task-def.
+    assert_register_args_NOT_contain "$tmpdir" "LEGACY_REMOVED_SECRET" "$label" || return
+    # Image swap still happened.
+    assert_register_args_contain "$tmpdir" "judgemind/scraper:NEWSHA" "$label" || return
+    # Terraform-managed secrets ARE present.
+    assert_register_args_contain "$tmpdir" "DATABASE_URL" "$label" || return
+    assert_register_args_contain "$tmpdir" "ANTHROPIC_API_KEY" "$label" || return
+    # The `command` field from the SSM render survives.
+    assert_register_args_contain "$tmpdir" "ingestion" "$label" || return
+
+    pass "$label"
+}
+
+# ─── Test 8: SSM-source path generalises to the scraper task ─────────────
+# Same #3770 regression-class as test 7, but for the per-court scraper
+# task-def. Container name is "scraper" and the task carries different
+# secrets (DATABASE_URL + COURTLISTENER_API_TOKEN).
+test_ssm_path_scraper_drops_legacy_secret() {
+    local label="SSM source path: scraper family — terraform-removed LEGACY_REMOVED_SECRET does NOT come back"
+    local tmpdir
+    tmpdir=$(make_temp_dir)
+
+    write_describe_task_def_scraper "$tmpdir/describe-task-def.json" "true"
+    write_ssm_param_scraper "$tmpdir/ssm-param.json"
+
+    run_script "$tmpdir" \
+        --task-family judgemind-scraper-dev \
+        --container-name scraper \
+        --image-uri "111.dkr.ecr.us-west-2.amazonaws.com/judgemind/scraper:NEWSHA" \
+        --desired-container-definitions-ssm-parameter "/judgemind/scraper/dev/container-definitions"
+
+    assert_exit "$tmpdir" "0" "$label" || return
+    assert_call_log_contains "$tmpdir" "ssm get-parameter" "$label" || return
+    assert_register_args_NOT_contain "$tmpdir" "LEGACY_REMOVED_SECRET" "$label" || return
+    # Image swap still happened.
+    assert_register_args_contain "$tmpdir" "judgemind/scraper:NEWSHA" "$label" || return
+    # Terraform-managed secrets ARE present.
+    assert_register_args_contain "$tmpdir" "DATABASE_URL" "$label" || return
+    assert_register_args_contain "$tmpdir" "COURTLISTENER_API_TOKEN" "$label" || return
+
+    pass "$label"
+}
+
 # ─── Run all tests ───────────────────────────────────────────────────────
 
 test_legacy_path_uses_describe_task_def
@@ -452,6 +632,8 @@ test_ssm_path_swaps_image
 test_ssm_path_preserves_task_metadata
 test_missing_required_arg_fails
 test_ssm_path_unknown_container_fails
+test_ssm_path_ingestion_worker_drops_legacy_secret
+test_ssm_path_scraper_drops_legacy_secret
 
 echo
 echo "Tests: $TESTS, Failures: $FAILURES"


### PR DESCRIPTION
## Summary

Extends the SSM-source `container_definitions` pattern (shipped for `deploy-api.yml` in #3769) to every remaining workflow that consumes `.github/actions/ecs-deploy/action.yml`. Terraform now writes the rendered `container_definitions` JSON to SSM for the per-court scraper task and the ingestion-worker task; `deploy-scraper.yml` and `deploy-production.yml` opt into SSM-source mode so terraform's intent — not the running revision's stale content — is the source of truth on every deploy.

This closes the deploy-* preserve-secrets bug class for all three task families that flow through the composite action: api (#3769), scraper (this PR), ingestion-worker (this PR).

Closes #3770

## What's in the diff

**Terraform — `infra/terraform/modules/compute/`**
- `aws_ssm_parameter.scraper_container_definitions` → `/judgemind/scraper/<env>/container-definitions`
- `aws_ssm_parameter.ingestion_worker_container_definitions` → `/judgemind/ingestion-worker/<env>/container-definitions` (count-gated on `local.deploy_ingestion`, mirroring the task-def's own gate)
- Two new outputs (`scraper_container_definitions_ssm_parameter_name`, `ingestion_worker_container_definitions_ssm_parameter_name`)
- Both parameters use `tier = "Advanced"` for 8KB headroom — same pattern as `api-service`

**Workflows**
- `deploy-scraper.yml` opts both jobs into SSM-source mode (scraper + ingestion-worker)
- `deploy-production.yml` opts the production scraper into SSM-source mode (production parameter is created on the next human-driven production terraform apply)

**Tests** — `scripts/tests/test_ecs_render_task_def.sh` gains tests 7 & 8: each stages a "running" task-def with `LEGACY_REMOVED_SECRET`, points the script at an SSM-parameter response that omits it, and asserts the registered revision does NOT include the removed secret. Same regression-class as the deploy-api `GITHUB_TOKEN` test from #3769, generalized to the ingestion-worker and scraper container shapes.

**Docs** — `docs/agent/infrastructure-reference.md` Coverage subsection updated.

## Out of scope (documented)

`infra/terraform/modules/scraper-zero-record-check/` is NOT migrated. Its task-def is launched directly by EventBridge Scheduler (and by `scripts/ecs-run-task.sh`), never via `ecs-deploy/action.yml` — so the preserve-secrets bug class does not apply. Recorded in `docs/agent/infrastructure-reference.md` so a future agent doesn't file it as a missed follow-up.

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes (`terraform fmt -check` clean locally)
- [x] Tests pass (extended `scripts/tests/test_ecs_render_task_def.sh` — 8/8 pass locally)
- [x] CI green

### Post-deploy verification
- [x] After merge, `terraform.yml dev-apply` runs and creates the SSM parameters `/judgemind/scraper/dev/container-definitions` and `/judgemind/ingestion-worker/dev/container-definitions`.
- [x] Next `deploy-scraper` invocation logs `Using terraform-managed SSM parameter as desired-state source: /judgemind/scraper/dev/container-definitions` (scraper job) AND `/judgemind/ingestion-worker/dev/container-definitions` (ingestion-worker job).
- [x] `aws ecs describe-task-definition --task-definition judgemind-scraper-dev` and `judgemind-ingestion-worker-dev` show registered revisions whose `secrets` list matches terraform's render — no preserved fields from prior revisions.
- [x] Verification evidence comment posted on issue #3770 with `aws ecs describe-task-definition` output for each updated task family.
