### PR TITLE
fix(dispatcher): synthesize ralph output from done-marker (Layer 4) (#3782)

### DIFF
--- a/.claude/skills/task-v2-ralph/SKILL.md
+++ b/.claude/skills/task-v2-ralph/SKILL.md
@@ -389,6 +389,8 @@ Capture stdout. If the output is non-empty it is the `## Iteration feedback` sec
 
 Use the Write tool to emit `{worktree}/tmp/dispatcher-output/ralph.json` with the fields above. Exit 0.
 
+**STOP CHECK before exiting (Layer 4 hardening, #3782):** verify that `{worktree}/tmp/dispatcher-output/ralph.json` was successfully written **this turn** by an actual Write tool call. If you have not yet executed the Write, do it now. Do NOT assume the JSON was written. Do NOT pre-emptively summarize the result before the Write. Do NOT exit the conversation while the only evidence of completion is your in-context narrative. The dispatcher reads the JSON from disk — if the file is absent, the wrapper falls back to a Layer-4 synthesis from `{worktree}/tmp/ralph/ralph-done.txt`, which produces a correct verdict but loses the richer fields (full `summary`, `iteration_feedback`, `infeasible_acs` for AC_INFEASIBLE) you assembled in this skill. The Write is the load-bearing final step; everything before it is preparation.
+
 ---
 
 ## Context-budget note (spike 0.3)

--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -4275,6 +4275,24 @@ dispatch_transition_action() {
                         "$_hint" \
                         "phase=${_phase} emitted route_to_diagnoser hint=$_hint"
                     ;;
+                claude_phase_timeout)
+                    # #3766: the ``claude -p`` per-phase timeout fired
+                    # (rc=124). The transition shim returned
+                    # FAILURE_HINT_CLAUDE_PHASE_TIMEOUT so the daemon
+                    # routes to a dedicated diagnoser fix-shape (bump
+                    # the per-phase cap, investigate runaway iteration
+                    # count, etc.) rather than the generic ralph_not_ship
+                    # path. Pull elapsed_seconds + block_reason from the
+                    # phase output JSON for the failures-row reason text.
+                    local _cpt_elapsed
+                    local _cpt_block_reason
+                    _cpt_elapsed=$(printf '%s' "$_output" | jq -r '.elapsed_seconds // "unknown"' 2>/dev/null || printf 'unknown')
+                    _cpt_block_reason=$(printf '%s' "$_output" | jq -r '.block_reason // ""' 2>/dev/null || printf '')
+                    agent_runner_reaped_failure \
+                        "claude_phase_timeout" \
+                        "claude_phase_timeout" \
+                        "phase=${_phase} claude -p timed out (elapsed_seconds=${_cpt_elapsed}); ${_cpt_block_reason}"
+                    ;;
                 *)
                     # Truly novel hint we don't recognize. The CI
                     # guard should have caught this at PR time — if

--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -244,6 +244,21 @@ log "branch_ready" "branch=$BRANCH_NAME"
 source "$(dirname "${BASH_SOURCE[0]}")/agent_runner_install_fargate_hook.sh"
 install_fargate_preflight_hook
 
+# ── Layer 4 silent-ralph fallback helper (#3782) ----------------------------
+#
+# Defines `synthesize_ralph_output_from_done_marker <worktree>` for the
+# phase loop's `_output == "{}"` && `_current == "ralph"` branch. When
+# the inner `/task-v2-ralph` skill completes its conversation cleanly
+# but never executes Step 4 (the Write of `dispatcher-output/ralph.json`),
+# the wrapper falls back to synthesising a structured verdict from the
+# already-written `tmp/ralph/ralph-done.txt`. Layers 1-3 of the saga
+# (#3694, #3757, #3766) reduced the silent-exit cohort from "model
+# stopped early + permission denied + SIGKILL" to just "model stopped
+# early"; Layer 4 closes the residual gap.
+
+# shellcheck source=./agent_runner_synthesize_ralph_output.sh
+source "$(dirname "${BASH_SOURCE[0]}")/agent_runner_synthesize_ralph_output.sh"
+
 # ── Apply prior ralph patch (if any) ---------------------------------------
 #
 # Mirrors the daemon's `_apply_prior_ralph_patch` semantics: pull the
@@ -5675,6 +5690,33 @@ while true; do
                 # only emits ``{}`` for the non-object .result fallback;
                 # any legitimate ralph output, even an empty BLOCKED, is at
                 # least ``{"verdict": "..."}``).
+                if [[ "$_output" == "{}" ]]; then
+                    # Layer 4 silent-ralph fallback (#3782). Before
+                    # falling through to the ``ralph_done_marker_missing``
+                    # path, check whether the inner ``/task-v2-ralph``
+                    # skill DID write its inner ``ralph-done.txt`` (Step
+                    # 3b of the inner SKILL.md is marked CRITICAL — and
+                    # is reliably written) but the outer wrapper's Step
+                    # 4 Write of ``dispatcher-output/ralph.json`` was
+                    # skipped (the model finished its conversation
+                    # without doing the final tool call). Synthesize the
+                    # dispatcher-output JSON from the inner state files.
+                    # On success, ``_output`` carries a structured verdict
+                    # matching what ralph actually achieved; on failure
+                    # (ralph-done.txt missing — the genuinely-silent
+                    # case), the helper returns non-zero and we fall
+                    # through to the original Layer 1 instrumentation.
+                    _layer4_synth=""
+                    if _layer4_synth=$(synthesize_ralph_output_from_done_marker "$REPO_ROOT" 2>>"$AGENT_WORKSPACE/claude-p-ralph.stderr.log"); then
+                        if [[ -n "$_layer4_synth" ]]; then
+                            _output="$_layer4_synth"
+                        fi
+                    fi
+                fi
+                # If the Layer 4 synthesis didn't produce a verdict, fall
+                # through to Layer 1 instrumentation. Re-check
+                # ``_output == "{}"`` so a successful synthesis above
+                # short-circuits this block entirely.
                 if [[ "$_output" == "{}" ]]; then
                     _ralph_stdout_tail=""
                     _ralph_stderr_tail=""

--- a/scripts/dispatcher/agent_runner_synthesize_ralph_output.sh
+++ b/scripts/dispatcher/agent_runner_synthesize_ralph_output.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# agent_runner_synthesize_ralph_output.sh — Sourceable helper that
+# synthesises a structured `dispatcher-output/ralph.json` from
+# `{worktree}/tmp/ralph/ralph-done.txt` when the inner `/task-v2-ralph`
+# skill completes its conversation cleanly but never executes Step 4
+# (the Write of the dispatcher-output file). Layer 4 of the silent-ralph
+# saga (#3782).
+#
+# Layer recap:
+#   * Layer 1 (#3694 / PR #3750) — instrument the silent exit so the
+#     failure became self-diagnosing.
+#   * Layer 2 (#3757 / PR #3761) — Fargate hook swap; permission denials
+#     dropped to zero.
+#   * Layer 3 (#3766 / PR #3772) — per-phase claude-p timeout; SIGKILL
+#     silent exits dropped to zero.
+#   * Layer 4 (this file, #3782) — model finishes the conversation
+#     without doing the Step 4 Write. The wrapper-side fallback
+#     synthesises the dispatcher-output JSON from the inner
+#     `ralph-done.txt` (which IS reliably written — issue #721 SKILL.md
+#     §3b makes it CRITICAL). This converts the silent-exit cohort from
+#     `ralph_done_marker_missing` → `ralph_not_ship` (BLOCKED) into a
+#     proper terminal verdict matching what ralph actually achieved.
+#
+# Contract — `synthesize_ralph_output_from_done_marker <worktree>`:
+#
+#   * Reads `{worktree}/tmp/ralph/ralph-done.txt`. The first non-blank
+#     line is parsed for the verdict token. The expected SKILL.md format
+#     is `status: SHIP|REVISE|BLOCKED|AC_INFEASIBLE` (see
+#     `.claude/skills/ralph/SKILL.md` §3b), but we also tolerate a bare
+#     verdict on the first line (e.g. `SHIP`) for forward-compat with
+#     any future SKILL.md change.
+#   * Reads `{worktree}/tmp/ralph/iteration.txt` for `iterations_used`.
+#     Falls back to `1` when missing/unreadable.
+#   * Runs `git -C <worktree> diff --name-only origin/main...HEAD` to
+#     produce `changed_files`. Falls back to `[]` when the diff fails.
+#   * Tails `{worktree}/tmp/ralph/feedback.md` (last 500 chars, single
+#     line) for `summary`. Falls back to a fixed string naming the
+#     synthesis path.
+#   * Sets `block_reason` to a fixed Layer 4 marker for non-SHIP
+#     verdicts, `null` on SHIP. The marker text contains "Layer 4
+#     synthesis" so CloudWatch Insights queries can grep the synthesis
+#     cohort.
+#   * Writes structured JSON to stdout via `jq -n -c`.
+#   * Logs `ralph_output_synthesized_from_done_marker` with the
+#     resolved verdict and iteration count via the inherited `log()`
+#     function (or the stderr-fallback shim when sourced standalone).
+#   * Returns 0 on success, 1 when `ralph-done.txt` is missing (so the
+#     caller falls through to the existing `ralph_done_marker_missing`
+#     path — there's nothing to synthesize from).
+#
+# Why a separate file vs. inline in the entrypoint:
+#
+#   * Sourceable in tests without dragging in the entrypoint's clone /
+#     checkout / phase-loop side effects (mirrors the precedent set by
+#     `agent_runner_install_fargate_hook.sh`).
+#   * Survives bash 3.2 (no associative arrays, no `mapfile`).
+
+# ── log() shim ─────────────────────────────────────────────────────────────
+#
+# When sourced from `agent-runner-entrypoint.sh`, `log` is already
+# defined and writes structured JSON to fd 3. When sourced from a test
+# (or directly), provide a minimal substitute that writes to stderr so
+# tests can assert on the event names without the synthesised JSON
+# (which goes to stdout) being polluted by log noise.
+
+if ! declare -F log >/dev/null 2>&1; then
+    log() {
+        # $1 = event name, rest = key=value pairs.
+        _ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+        _event="$1"
+        shift
+        _extra=""
+        for kv in "$@"; do
+            _k=${kv%%=*}
+            _v=${kv#*=}
+            _v=$(printf '%s' "$_v" | sed 's/"/\\"/g')
+            _extra="$_extra, \"$_k\": \"$_v\""
+        done
+        # Stderr (not fd 3) so the helper's stdout stays a clean JSON
+        # payload that tests can pipe directly into jq.
+        printf '{"ts": "%s", "event": "agent_runner.%s", "agent_id": "%s"%s}\n' \
+            "$_ts" "$_event" "${AGENT_ID:-unknown}" "$_extra" >&2
+    }
+fi
+
+# ── synthesize_ralph_output_from_done_marker ──────────────────────────────
+
+synthesize_ralph_output_from_done_marker() {
+    # $1 = worktree absolute path. Required.
+    local worktree="${1:-}"
+
+    if [[ -z "$worktree" || ! -d "$worktree" ]]; then
+        log "ralph_output_synthesis_skip" \
+            "reason=worktree_unset_or_missing" \
+            "worktree=$worktree"
+        return 1
+    fi
+
+    local ralph_done="$worktree/tmp/ralph/ralph-done.txt"
+    local iteration_file="$worktree/tmp/ralph/iteration.txt"
+    local feedback_file="$worktree/tmp/ralph/feedback.md"
+
+    if [[ ! -f "$ralph_done" ]]; then
+        # No done-marker means the inner /ralph genuinely never
+        # completed — there's nothing to synthesize from. Fall back to
+        # the existing `ralph_done_marker_missing` path (Layer 1
+        # instrumentation) so the failure stays visible.
+        log "ralph_output_synthesis_skip" \
+            "reason=ralph_done_missing" \
+            "worktree=$worktree"
+        return 1
+    fi
+
+    # ── Parse verdict ──────────────────────────────────────────────────────
+    #
+    # Expected SKILL.md format (`.claude/skills/ralph/SKILL.md` §3b):
+    #
+    #   status: SHIP
+    #   iterations: <N>
+    #   next-steps: ...
+    #
+    # Take the first non-blank line, strip a leading "status:" if
+    # present, uppercase, and trim whitespace.
+
+    local first_line
+    first_line=$(grep -v '^[[:space:]]*$' "$ralph_done" 2>/dev/null | head -1 || printf '')
+    # Strip leading "status:" or "Status:" tokens. Bash `${var#prefix}`
+    # is bash-3.2-compatible; we lowercase via tr first to handle either
+    # case without a regex.
+    local lower_line
+    lower_line=$(printf '%s' "$first_line" | tr '[:upper:]' '[:lower:]')
+    local verdict_raw="$first_line"
+    case "$lower_line" in
+        status:*)
+            verdict_raw="${first_line#*:}"
+            ;;
+    esac
+    # Trim leading/trailing whitespace + uppercase.
+    local verdict
+    verdict=$(printf '%s' "$verdict_raw" \
+        | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' \
+        | tr '[:lower:]' '[:upper:]')
+
+    # Map REVISE → BLOCKED (matches the SKILL.md output-contract table —
+    # REVISE in `ralph-done.txt` translates to BLOCKED in the dispatcher
+    # output with `block_reason="max_iterations reached without SHIP"`).
+    # Anything other than the four canonical verdicts becomes BLOCKED so
+    # the daemon's transition graph can route it.
+    case "$verdict" in
+        SHIP|BLOCKED|AC_INFEASIBLE)
+            : ;;
+        REVISE)
+            verdict="BLOCKED"
+            ;;
+        *)
+            log "ralph_output_synthesis_unknown_verdict" \
+                "first_line=$first_line"
+            verdict="BLOCKED"
+            ;;
+    esac
+
+    # ── Parse iterations_used ─────────────────────────────────────────────
+
+    local iterations_used=1
+    if [[ -f "$iteration_file" ]]; then
+        local raw_iter
+        raw_iter=$(head -1 "$iteration_file" 2>/dev/null \
+            | tr -dc '0-9' || printf '')
+        if [[ -n "$raw_iter" ]]; then
+            iterations_used="$raw_iter"
+        fi
+    fi
+    # Defensive: zero or negative becomes 1; the SKILL.md contract says
+    # iterations_used is `1..max_iterations` for any non-Step-0-blocked
+    # path.
+    if [[ "$iterations_used" -lt 1 ]]; then
+        iterations_used=1
+    fi
+
+    # ── Compute changed_files ─────────────────────────────────────────────
+    #
+    # `git -C <worktree> diff --name-only origin/main...HEAD` produces
+    # one path per line. Best-effort: a missing origin/main ref or a
+    # detached worktree falls back to an empty list. The helper does
+    # not abort on diff failure.
+
+    local changed_files_raw
+    if ! changed_files_raw=$(git -C "$worktree" diff --name-only origin/main...HEAD 2>/dev/null); then
+        changed_files_raw=""
+    fi
+
+    # Build a JSON array via jq. Empty input → `[]`.
+    local changed_files_json
+    if [[ -z "$changed_files_raw" ]]; then
+        changed_files_json='[]'
+    else
+        # `jq -R -s` slurps the entire input as one string, then
+        # `split("\n")` + `map(select(length > 0))` discards trailing
+        # blank lines. Bash 3.2 compatible — no readarray.
+        changed_files_json=$(printf '%s' "$changed_files_raw" \
+            | jq -R -s 'split("\n") | map(select(length > 0))' 2>/dev/null \
+            || printf '[]')
+    fi
+
+    # ── Compose summary ───────────────────────────────────────────────────
+    #
+    # Tail the last 500 chars of feedback.md, collapse newlines to
+    # spaces, and prepend a synthesis-path marker so operators can
+    # quickly distinguish a synthesised summary from a real one written
+    # by the ralph skill.
+
+    local synth_marker="Layer 4 synthesis (Step 4 not executed; synthesised from ralph-done.txt)."
+    local summary
+    if [[ -f "$feedback_file" && -s "$feedback_file" ]]; then
+        local feedback_tail
+        feedback_tail=$(tail -c 500 "$feedback_file" 2>/dev/null \
+            | tr '\n\r\t' '   ' \
+            | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' \
+            || printf '')
+        if [[ -n "$feedback_tail" ]]; then
+            summary="$synth_marker $feedback_tail"
+        else
+            summary="$synth_marker"
+        fi
+    else
+        summary="$synth_marker"
+    fi
+
+    # ── Compose block_reason ──────────────────────────────────────────────
+
+    local block_reason_arg
+    case "$verdict" in
+        SHIP)
+            block_reason_arg=""  # signal to jq to emit null
+            ;;
+        AC_INFEASIBLE)
+            # Daemon reads infeasible_acs separately for AC_INFEASIBLE;
+            # block_reason stays null per the SKILL.md output contract
+            # (block_reason is null on AC_INFEASIBLE; populate
+            # infeasible_acs instead).
+            block_reason_arg=""
+            ;;
+        *)
+            block_reason_arg="Layer 4 synthesis: model completed conversation without Step 4 Write"
+            ;;
+    esac
+
+    # ── Build the JSON ────────────────────────────────────────────────────
+    #
+    # `jq -n -c` builds the JSON safely with typed string variables —
+    # no shell interpolation into the structured output. The
+    # `block_reason` arg is empty when the verdict is SHIP/AC_INFEASIBLE;
+    # we use `(. // null | if . == "" then null else . end)` to coerce
+    # an empty string to JSON null.
+
+    local output
+    output=$(jq -n -c \
+        --arg verdict "$verdict" \
+        --argjson iterations_used "$iterations_used" \
+        --argjson changed_files "$changed_files_json" \
+        --arg summary "$summary" \
+        --arg block_reason "$block_reason_arg" \
+        '{
+            verdict: $verdict,
+            iterations_used: $iterations_used,
+            block_reason: (if $block_reason == "" then null else $block_reason end),
+            changed_files: $changed_files,
+            summary: $summary,
+            infeasible_acs: [],
+            ralph_output_synthesized_from_done_marker: true
+        }' 2>/dev/null) || output=""
+
+    if [[ -z "$output" ]]; then
+        # jq build failed — fall back to a minimal object so the caller
+        # still gets a valid verdict. The `ralph_output_synthesized_from_done_marker`
+        # field is the load-bearing signal that triggers the daemon's
+        # downstream pathways.
+        output='{"verdict":"BLOCKED","iterations_used":1,"block_reason":"Layer 4 synthesis: jq build failed","changed_files":[],"summary":"Layer 4 synthesis fallback","infeasible_acs":[],"ralph_output_synthesized_from_done_marker":true}'
+        log "ralph_output_synthesis_jq_failed" \
+            "verdict=$verdict"
+    fi
+
+    log "ralph_output_synthesized_from_done_marker" \
+        "verdict=$verdict" \
+        "iterations_used=$iterations_used" \
+        "changed_files_count=$(printf '%s' "$changed_files_json" | jq -r 'length' 2>/dev/null || printf '0')"
+
+    printf '%s' "$output"
+    return 0
+}

--- a/scripts/dispatcher/tests/test_ralph_output_synthesis.sh
+++ b/scripts/dispatcher/tests/test_ralph_output_synthesis.sh
@@ -1,0 +1,496 @@
+#!/usr/bin/env bash
+# test_ralph_output_synthesis.sh — Regression test for issue #3782
+# (Layer 4 of the silent-ralph saga).
+#
+# Symptom: claude-p subprocess for the `ralph` phase completes a normal
+# conversation (exit_code=0, terminal_reason=completed, no permission
+# denials, well under timeout cap) but the model never executes Step 4
+# of `.claude/skills/task-v2-ralph/SKILL.md` — the `Write` of
+# `{worktree}/tmp/dispatcher-output/ralph.json`. The agent-runner wrapper
+# sees `_output == "{}"` and falls through to `ralph_done_marker_missing`
+# with empty buffers, even though the inner /ralph subagent successfully
+# wrote `{worktree}/tmp/ralph/ralph-done.txt`.
+#
+# Fix shape (Layer 4 — wrapper-side fallback): when the wrapper sees
+# `_output == "{}"` AND phase == "ralph", BEFORE emitting
+# `ralph_done_marker_missing`, check whether
+# `{worktree}/tmp/ralph/ralph-done.txt` exists. If yes, synthesize a
+# structured dispatcher-output/ralph.json from:
+#   * verdict — first non-blank line of `ralph-done.txt` (parses
+#     `status: SHIP|REVISE|BLOCKED|AC_INFEASIBLE`)
+#   * iterations_used — `iteration.txt` first line, integer
+#   * changed_files — `git diff --name-only origin/main...HEAD`
+#   * summary — `feedback.md` tail or "Step 4 not executed; synthesized
+#     from ralph-done.txt"
+#   * block_reason — "Layer 4 synthesis: model completed conversation
+#     without Step 4 Write" for non-SHIP verdicts; null for SHIP
+# Logs `ralph_output_synthesized_from_done_marker` event with the
+# resolved verdict.
+#
+# This test exercises the sourceable helper
+# `scripts/dispatcher/agent_runner_synthesize_ralph_output.sh` which
+# defines `synthesize_ralph_output_from_done_marker <worktree>`. It also
+# performs a static lint asserting that `agent-runner-entrypoint.sh`
+# wires the helper into the `_output == "{}"` && `_current == "ralph"`
+# branch of `run_claude_phase`'s caller.
+#
+# Test must FAIL against current code: the helper file does not exist
+# yet, and the entrypoint does not source it. Each test case asserts a
+# specific contract (exit code, JSON shape, logged event) so the failures
+# point at the missing piece.
+#
+# Usage:
+#   scripts/dispatcher/tests/test_ralph_output_synthesis.sh
+#
+# Exit codes:
+#   0 — all assertions passed.
+#   1 — one or more assertions failed (regression).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER="$SCRIPT_DIR/dispatcher/agent_runner_synthesize_ralph_output.sh"
+ENTRYPOINT="$SCRIPT_DIR/dispatcher/agent-runner-entrypoint.sh"
+
+FAILURES=0
+TESTS=0
+
+TEMP_DIRS=()
+cleanup() {
+    set +e
+    # ${arr[@]+...} expansion guards against unbound under set -u when
+    # cleanup runs before any temp dir was added (early-exit path).
+    for d in ${TEMP_DIRS[@]+"${TEMP_DIRS[@]}"}; do
+        if [[ -n "$d" && -d "$d" ]]; then
+            rm -rf "$d"
+        fi
+    done
+}
+trap cleanup EXIT
+
+pass() {
+    TESTS=$((TESTS + 1))
+    echo "PASS: $1"
+}
+
+fail() {
+    TESTS=$((TESTS + 1))
+    FAILURES=$((FAILURES + 1))
+    echo "FAIL: $1"
+    if [[ -n "${2:-}" ]]; then
+        echo "  $2"
+    fi
+}
+
+# Build a fake worktree containing the ralph state files the helper
+# reads. Returns the worktree path on stdout.
+make_fake_worktree() {
+    local verdict="$1"
+    local iteration_count="$2"
+    local tmp
+    tmp=$(mktemp -d)
+    TEMP_DIRS+=("$tmp")
+
+    local worktree="$tmp/worktree"
+    mkdir -p "$worktree/tmp/ralph"
+
+    # Bootstrap a real git repo so `git diff --name-only origin/main...HEAD`
+    # produces predictable output. The "remote" is just a local bare
+    # repo; the worktree branch contains exactly the files the test
+    # cares about.
+    local bare="$tmp/bare.git"
+    git init -q --bare "$bare"
+
+    git -C "$worktree" init -q --initial-branch main
+    git -C "$worktree" config user.email "test@example.com"
+    git -C "$worktree" config user.name "Test"
+    # Seed an empty initial commit on main so origin/main has a known
+    # base.
+    printf 'baseline\n' > "$worktree/baseline.txt"
+    git -C "$worktree" add baseline.txt
+    git -C "$worktree" commit -q -m "init"
+    git -C "$worktree" remote add origin "$bare"
+    git -C "$worktree" push -q origin main
+    git -C "$worktree" checkout -q -b feature
+
+    # Add two known changed files so the helper's
+    # `git diff --name-only origin/main...HEAD` returns a deterministic
+    # list.
+    mkdir -p "$worktree/packages/scraper"
+    printf 'changed line\n' > "$worktree/packages/scraper/foo.py"
+    printf 'test line\n' > "$worktree/packages/scraper/test_foo.py"
+    git -C "$worktree" add packages/scraper/foo.py packages/scraper/test_foo.py
+    git -C "$worktree" commit -q -m "feature work"
+
+    # Write the ralph state files.
+    cat > "$worktree/tmp/ralph/ralph-done.txt" <<EOF
+status: $verdict
+iterations: $iteration_count
+next-steps: The /task workflow MUST now continue with: A.2b (process summary), A.3 ...
+EOF
+    printf '%s\n' "$iteration_count" > "$worktree/tmp/ralph/iteration.txt"
+    cat > "$worktree/tmp/ralph/feedback.md" <<'EOF'
+No prior feedback. This is the first iteration.
+
+## Iteration 2 worker progress
+
+Worker fixed the leading-zero loss in Orange County department regex
+and added a regression test asserting department='03' round-trips.
+EOF
+
+    printf '%s' "$worktree"
+}
+
+# Check helper file exists.
+
+if [[ ! -f "$HELPER" ]]; then
+    fail "helper script exists" "expected $HELPER to be present"
+    echo
+    echo "Tests: $TESTS, Failures: $FAILURES"
+    exit 1
+fi
+pass "helper script $HELPER exists"
+
+# Helper must define the synthesis function when sourced.
+
+if ! ( set +u; source "$HELPER"; type synthesize_ralph_output_from_done_marker >/dev/null 2>&1 ); then
+    fail "helper defines synthesize_ralph_output_from_done_marker" \
+        "sourcing $HELPER did not define the function"
+    echo
+    echo "Tests: $TESTS, Failures: $FAILURES"
+    exit 1
+fi
+pass "helper defines synthesize_ralph_output_from_done_marker function"
+
+# ── Test 1: SHIP verdict synthesis ────────────────────────────────────────
+#
+# Stage a worktree with ralph-done.txt = SHIP, iteration.txt = 3, and a
+# known set of changed files. Invoke the helper. Assert the JSON it
+# emits has verdict=SHIP, iterations_used=3, the expected changed_files,
+# block_reason=null, and a non-empty summary.
+
+run_ship_synthesis_test() {
+    local worktree
+    worktree=$(make_fake_worktree "SHIP" 3)
+
+    local logfile
+    local logdir
+    logdir=$(mktemp -d)
+    TEMP_DIRS+=("$logdir")
+    logfile="$logdir/log.out"
+
+    local jsonfile
+    jsonfile="$logdir/json.out"
+
+    (
+        set +u
+        # shellcheck disable=SC1090
+        source "$HELPER"
+        export AGENT_ID="test-agent-ship"
+        synthesize_ralph_output_from_done_marker "$worktree"
+    ) > "$jsonfile" 2> "$logfile" || true
+
+    # The helper writes structured logs via log() (which goes to fd 3 →
+    # stdout in production, but in our isolated source it goes to stdout
+    # too via the shim). Function output goes to stdout. Tests need both,
+    # so the helper splits: log() writes via a fallback to stderr in the
+    # shim path so jsonfile captures only the synthesised JSON.
+    local json_content
+    json_content=$(cat "$jsonfile")
+
+    # Assert: jq parses the JSON.
+    if ! printf '%s' "$json_content" | jq -e . >/dev/null 2>&1; then
+        fail "SHIP synthesis emits valid JSON" \
+            "got: $json_content"
+        return
+    fi
+    pass "SHIP synthesis emits valid JSON"
+
+    # Assert: verdict=SHIP.
+    local verdict
+    verdict=$(printf '%s' "$json_content" | jq -r '.verdict')
+    if [[ "$verdict" != "SHIP" ]]; then
+        fail "SHIP synthesis: verdict=SHIP" \
+            "got verdict=$verdict, json=$json_content"
+        return
+    fi
+    pass "SHIP synthesis: verdict=SHIP"
+
+    # Assert: iterations_used=3 (integer).
+    local iterations
+    iterations=$(printf '%s' "$json_content" | jq -r '.iterations_used')
+    if [[ "$iterations" != "3" ]]; then
+        fail "SHIP synthesis: iterations_used=3" \
+            "got iterations_used=$iterations"
+        return
+    fi
+    pass "SHIP synthesis: iterations_used=3"
+
+    # Assert: changed_files contains both expected paths.
+    local changed_count
+    changed_count=$(printf '%s' "$json_content" | jq -r '.changed_files | length')
+    if [[ "$changed_count" != "2" ]]; then
+        fail "SHIP synthesis: changed_files length=2" \
+            "got length=$changed_count, files=$(printf '%s' "$json_content" | jq -c '.changed_files')"
+        return
+    fi
+    pass "SHIP synthesis: changed_files length=2"
+
+    if ! printf '%s' "$json_content" \
+            | jq -e '.changed_files | index("packages/scraper/foo.py")' >/dev/null 2>&1; then
+        fail "SHIP synthesis: changed_files contains packages/scraper/foo.py" \
+            "got: $(printf '%s' "$json_content" | jq -c '.changed_files')"
+        return
+    fi
+    pass "SHIP synthesis: changed_files contains packages/scraper/foo.py"
+
+    # Assert: block_reason is null on SHIP.
+    local block_reason
+    block_reason=$(printf '%s' "$json_content" | jq -r '.block_reason')
+    if [[ "$block_reason" != "null" ]]; then
+        fail "SHIP synthesis: block_reason=null" \
+            "got block_reason=$block_reason"
+        return
+    fi
+    pass "SHIP synthesis: block_reason=null"
+
+    # Assert: summary is a non-empty string.
+    local summary
+    summary=$(printf '%s' "$json_content" | jq -r '.summary')
+    if [[ -z "$summary" || "$summary" == "null" ]]; then
+        fail "SHIP synthesis: summary is non-empty" \
+            "got summary=$summary"
+        return
+    fi
+    pass "SHIP synthesis: summary is non-empty"
+
+    # Assert: ralph_output_synthesized_from_done_marker event was logged
+    # with verdict=SHIP. The helper's log shim writes to stderr when
+    # there's no fd 3, so we check the logfile.
+    if ! grep -q "ralph_output_synthesized_from_done_marker" "$logfile"; then
+        fail "SHIP synthesis: ralph_output_synthesized_from_done_marker logged" \
+            "logfile contents: $(cat "$logfile")"
+        return
+    fi
+    pass "SHIP synthesis: ralph_output_synthesized_from_done_marker logged"
+
+    if ! grep -q "verdict.*SHIP" "$logfile"; then
+        fail "SHIP synthesis: log line includes verdict=SHIP" \
+            "logfile contents: $(cat "$logfile")"
+        return
+    fi
+    pass "SHIP synthesis: log line includes verdict=SHIP"
+}
+
+# ── Test 2: BLOCKED verdict synthesis sets block_reason ───────────────────
+
+run_blocked_synthesis_test() {
+    local worktree
+    worktree=$(make_fake_worktree "BLOCKED" 5)
+
+    local logfile
+    local logdir
+    logdir=$(mktemp -d)
+    TEMP_DIRS+=("$logdir")
+    logfile="$logdir/log.out"
+
+    local jsonfile
+    jsonfile="$logdir/json.out"
+
+    (
+        set +u
+        # shellcheck disable=SC1090
+        source "$HELPER"
+        export AGENT_ID="test-agent-blocked"
+        synthesize_ralph_output_from_done_marker "$worktree"
+    ) > "$jsonfile" 2> "$logfile" || true
+
+    local json_content
+    json_content=$(cat "$jsonfile")
+
+    if ! printf '%s' "$json_content" | jq -e . >/dev/null 2>&1; then
+        fail "BLOCKED synthesis emits valid JSON" \
+            "got: $json_content"
+        return
+    fi
+    pass "BLOCKED synthesis emits valid JSON"
+
+    local verdict
+    verdict=$(printf '%s' "$json_content" | jq -r '.verdict')
+    if [[ "$verdict" != "BLOCKED" ]]; then
+        fail "BLOCKED synthesis: verdict=BLOCKED" \
+            "got verdict=$verdict"
+        return
+    fi
+    pass "BLOCKED synthesis: verdict=BLOCKED"
+
+    # Assert: block_reason names the Layer 4 synthesis path. Must mention
+    # "Layer 4" and "Step 4" so operators can grep for the synthesis
+    # cohort in CloudWatch.
+    local block_reason
+    block_reason=$(printf '%s' "$json_content" | jq -r '.block_reason')
+    if [[ "$block_reason" == "null" || -z "$block_reason" ]]; then
+        fail "BLOCKED synthesis: block_reason is non-null" \
+            "got block_reason=$block_reason"
+        return
+    fi
+    pass "BLOCKED synthesis: block_reason is non-null"
+
+    if ! printf '%s' "$block_reason" | grep -q "Layer 4 synthesis"; then
+        fail "BLOCKED synthesis: block_reason mentions Layer 4 synthesis" \
+            "got block_reason=$block_reason"
+        return
+    fi
+    pass "BLOCKED synthesis: block_reason mentions Layer 4 synthesis"
+
+    # Assert: ralph_output_synthesized_from_done_marker event with
+    # verdict=BLOCKED logged.
+    if ! grep -q "ralph_output_synthesized_from_done_marker" "$logfile"; then
+        fail "BLOCKED synthesis: synthesis event logged" \
+            "logfile contents: $(cat "$logfile")"
+        return
+    fi
+    pass "BLOCKED synthesis: synthesis event logged"
+}
+
+# ── Test 3: missing ralph-done.txt → helper returns non-zero ──────────────
+#
+# When the inner /ralph never wrote ralph-done.txt at all, there's
+# nothing to synthesize from. The helper must signal this by returning
+# non-zero so the wrapper falls through to the existing
+# `ralph_done_marker_missing` log path (Layer 1 instrumentation).
+
+run_missing_ralph_done_test() {
+    local tmp
+    tmp=$(mktemp -d)
+    TEMP_DIRS+=("$tmp")
+
+    local worktree="$tmp/worktree"
+    mkdir -p "$worktree/tmp/ralph"
+    # Deliberately do NOT create ralph-done.txt.
+
+    local rc=0
+    (
+        set +u
+        # shellcheck disable=SC1090
+        source "$HELPER"
+        export AGENT_ID="test-agent-missing"
+        synthesize_ralph_output_from_done_marker "$worktree"
+    ) > /dev/null 2>&1 || rc=$?
+
+    if [[ "$rc" -eq 0 ]]; then
+        fail "missing ralph-done.txt: helper returns non-zero" \
+            "expected non-zero exit, got 0"
+        return
+    fi
+    pass "missing ralph-done.txt: helper returns non-zero"
+}
+
+# ── Test 4: AC_INFEASIBLE verdict passes through verbatim ─────────────────
+#
+# The Layer 4 synthesis must not silently flatten AC_INFEASIBLE into
+# BLOCKED — the daemon's diagnoser routes those to a different path
+# (see daemon.py ralph_ac_infeasible).
+
+run_ac_infeasible_synthesis_test() {
+    local worktree
+    worktree=$(make_fake_worktree "AC_INFEASIBLE" 2)
+
+    local logdir
+    logdir=$(mktemp -d)
+    TEMP_DIRS+=("$logdir")
+    local jsonfile="$logdir/json.out"
+
+    (
+        set +u
+        # shellcheck disable=SC1090
+        source "$HELPER"
+        export AGENT_ID="test-agent-ac-infeasible"
+        synthesize_ralph_output_from_done_marker "$worktree"
+    ) > "$jsonfile" 2>/dev/null || true
+
+    local verdict
+    verdict=$(cat "$jsonfile" | jq -r '.verdict' 2>/dev/null || printf 'parse-fail')
+    if [[ "$verdict" != "AC_INFEASIBLE" ]]; then
+        fail "AC_INFEASIBLE synthesis: verdict passes through" \
+            "got verdict=$verdict"
+        return
+    fi
+    pass "AC_INFEASIBLE synthesis: verdict passes through"
+}
+
+# ── Test 5: entrypoint sources the synthesis helper ───────────────────────
+#
+# The agent-runner-entrypoint.sh script must source
+# `agent_runner_synthesize_ralph_output.sh` near the top (alongside the
+# fargate-hook helper) AND must call
+# `synthesize_ralph_output_from_done_marker` inside the
+# `_output == "{}"` && `_current == "ralph"` block of the phase loop,
+# BEFORE the `ralph_done_marker_missing` log fires. Without this wiring,
+# the synthesis function exists but is dead code.
+
+run_entrypoint_wires_helper_test() {
+    if [[ ! -f "$ENTRYPOINT" ]]; then
+        fail "agent-runner-entrypoint.sh exists" "expected at $ENTRYPOINT"
+        return
+    fi
+
+    if ! grep -q "agent_runner_synthesize_ralph_output.sh" "$ENTRYPOINT"; then
+        fail "entrypoint sources agent_runner_synthesize_ralph_output.sh" \
+            "the entrypoint must source the synthesis helper so it's available at runtime"
+        return
+    fi
+    pass "entrypoint sources agent_runner_synthesize_ralph_output.sh"
+
+    if ! grep -q "synthesize_ralph_output_from_done_marker" "$ENTRYPOINT"; then
+        fail "entrypoint calls synthesize_ralph_output_from_done_marker" \
+            "the entrypoint must invoke the synthesis function in the silent-exit branch"
+        return
+    fi
+    pass "entrypoint calls synthesize_ralph_output_from_done_marker"
+
+    # The synthesis call must come BEFORE the
+    # `ralph_done_marker_missing` log line so a successful synthesis
+    # short-circuits the missing-marker path. We pin the comparison to
+    # the actual `log "ralph_done_marker_missing"` invocation rather
+    # than any string mention of the event name (the file has comments
+    # referencing the event name elsewhere, including inside
+    # `run_claude_phase` ~2119 and the synthesis comment block above the
+    # call).
+    local synth_line
+    local missing_line
+    synth_line=$(grep -n 'synthesize_ralph_output_from_done_marker "\$REPO_ROOT"' "$ENTRYPOINT" \
+        | head -1 | cut -d: -f1 || true)
+    missing_line=$(grep -n '^[[:space:]]*log "ralph_done_marker_missing"' "$ENTRYPOINT" \
+        | head -1 | cut -d: -f1 || true)
+
+    if [[ -z "$synth_line" || -z "$missing_line" ]]; then
+        fail "entrypoint ordering: synth + missing-marker landmarks present" \
+            "synth=$synth_line missing=$missing_line"
+        return
+    fi
+    pass "entrypoint ordering: synth + missing-marker landmarks present"
+
+    if (( synth_line >= missing_line )); then
+        fail "synthesis runs before ralph_done_marker_missing log" \
+            "synthesize_ralph_output_from_done_marker (line $synth_line) must come before ralph_done_marker_missing (line $missing_line)"
+        return
+    fi
+    pass "synthesis runs before ralph_done_marker_missing log"
+}
+
+# ── Run tests ─────────────────────────────────────────────────────────────
+
+run_ship_synthesis_test
+run_blocked_synthesis_test
+run_missing_ralph_done_test
+run_ac_infeasible_synthesis_test
+run_entrypoint_wires_helper_test
+
+echo
+echo "Tests: $TESTS, Failures: $FAILURES"
+
+if (( FAILURES > 0 )); then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Layer 4 of the silent-ralph saga: when the inner `/task-v2-ralph` skill's claude-p subprocess completes a clean conversation (exit_code=0, no permission denials, well under the 90-min timeout cap) but the model never executes Step 4 of the SKILL.md (the `Write` of `tmp/dispatcher-output/ralph.json`), the agent-runner wrapper now synthesizes a structured `ralph.json` from the inner `tmp/ralph/ralph-done.txt`. SKILL.md Step 4 also gains a STOP CHECK guard.

Closes #3782

Layer recap (silent-ralph saga, #3694):
- Layer 1 (PR #3750) — instrumentation
- Layer 2 (PR #3761) — Fargate hook swap
- Layer 3 (PR #3772) — per-phase claude-p timeout
- **Layer 4 (this PR, #3782)** — model completes conversation without Step 4 Write

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass (new regression test `test_ralph_output_synthesis.sh` plus existing dispatcher pytest suites)
- [ ] CI green

### Post-deploy verification
- [ ] CloudWatch Insights query against `/ecs/judgemind-dispatcher-agent-runner-dev` shows `ralph_output_synthesized_from_done_marker` event firing on at least one ralph run, OR `ralph_done_marker_missing` events with non-empty stdout/stderr tails (confirming Layer 4 caught the silent-exit cohort).
- [ ] Verification evidence posted on issue (see A.8)
