### PR TITLE
fix(dispatcher): add micro-timing logs + per-batch budget for untracked-ARN reaper (#3792)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -721,6 +721,16 @@ DEPLOY_WORKFLOW_NAMES = frozenset(
 #: back to escalate in ``_consume_action_block_on_existing_task``.
 GH_POLL_SUBPROCESS_TIMEOUT_SECONDS = 30
 
+#: Per-batch time budget for the untracked-ARN finalize loop inside
+#: ``_reap_completed_agent_tasks``. When the cumulative elapsed time
+#: across all ``_reap_finalize_ecs_success`` calls for untracked ARNs
+#: exceeds this value the loop breaks early and emits
+#: ``daemon.reap_untracked_budget_exceeded``. Remaining ARNs are picked
+#: up on the next tick (``agent_task_arn IS NOT NULL`` keeps them in the
+#: SELECT), so forward progress is preserved without burning the entire
+#: tick on a stuck batch.
+REAP_UNTRACKED_BATCH_BUDGET_SECONDS = 30
+
 #: Cap on how many ``failing_jobs`` entries we hand the fix-ci skill.
 #: Ten is already an unusually bad CI day and keeps the JSON payload
 #: bounded so the skill's context stays small.
@@ -13693,10 +13703,12 @@ class DispatcherDaemon:
             return 0
 
         resurrected = 0
+        t_sweep_start = time.monotonic()
         for row in candidates:
             agent_id = row["agent_id"]
             pr_number = row["pr_number"]
             issue_number = row["issue_number"]
+            t_candidate_start = time.monotonic()
 
             # Budget check — count past resurrections for this agent_id
             # via the phase_transitions audit log. This avoids needing
@@ -13811,6 +13823,31 @@ class DispatcherDaemon:
             )
             resurrected += 1
 
+            candidate_elapsed = time.monotonic() - t_candidate_start
+            if candidate_elapsed >= 5.0:
+                self._log.warning(
+                    "daemon.orphan_pr_sweep_slow_candidate",
+                    extra={
+                        "event": "orphan_pr_sweep_slow_candidate",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "pr_number": pr_number,
+                        "issue_number": issue_number,
+                        "elapsed_s": round(candidate_elapsed, 3),
+                    },
+                )
+
+        total_elapsed_s = time.monotonic() - t_sweep_start
+        self._log.info(
+            "daemon.orphan_pr_sweep_completed",
+            extra={
+                "event": "orphan_pr_sweep_completed",
+                "run_id": self._run_id,
+                "candidates_seen": len(candidates),
+                "candidates_resurrected": resurrected,
+                "total_elapsed_s": round(total_elapsed_s, 3),
+            },
+        )
         return resurrected
 
     def _list_orphan_pr_failed_agents(self) -> list[dict[str, Any]]:
@@ -19508,6 +19545,15 @@ class DispatcherDaemon:
         cap_updated_at = self._read_cap_updated_at()
         if cap_updated_at is None:
             # No timestamp — be conservative and do nothing this tick.
+            # Log so CloudWatch can confirm the migration #56 hypothesis
+            # (the concurrency_cap config row may not exist yet).
+            self._log.info(
+                "daemon.circuit_breaker_auto_close_skipped_missing_row",
+                extra={
+                    "event": "circuit_breaker_auto_close_skipped_missing_row",
+                    "run_id": self._run_id,
+                },
+            )
             return False
 
         window_minutes = self._cb_config_int(
@@ -25210,6 +25256,8 @@ class DispatcherDaemon:
         untracked_arns = (
             sent_arns - returned_arns_with_status
         ) | returned_arns_empty_status
+        t_loop_start = time.monotonic()
+        budget_breached = False
         for untracked_arn in untracked_arns:
             row = arn_to_row.get(untracked_arn)
             if row is None:
@@ -25230,13 +25278,56 @@ class DispatcherDaemon:
                     ),
                 },
             )
+            # Check per-batch budget before each finalize call so a
+            # stuck batch cannot hold the whole tick hostage. Remaining
+            # ARNs stay in the SELECT and are picked up next tick.
+            loop_elapsed = time.monotonic() - t_loop_start
+            if loop_elapsed >= REAP_UNTRACKED_BATCH_BUDGET_SECONDS:
+                arns_remaining = len(untracked_arns) - reaped_untracked
+                self._log.warning(
+                    "daemon.reap_untracked_budget_exceeded",
+                    extra={
+                        "event": "reap_untracked_budget_exceeded",
+                        "run_id": self._run_id,
+                        "arns_processed": reaped_untracked,
+                        "arns_remaining": arns_remaining,
+                        "elapsed_seconds": round(loop_elapsed, 3),
+                    },
+                )
+                budget_breached = True
+                break
             # Reuse the success-branch finalize: label strip (best-effort),
             # merged_at stamp (idempotent + gated by pr_number IS NOT NULL),
             # agent_task_arn clear. The merged_at WHERE filter handles the
             # no-PR case naturally — the UPDATE is a no-op when there is
             # no PR row.
+            t_arn_start = time.monotonic()
             self._reap_finalize_ecs_success(u_agent_id, u_issue_number)
+            step_elapsed_s = time.monotonic() - t_arn_start
+            if step_elapsed_s >= 1.0:
+                self._log.info(
+                    "daemon.reap_finalize_arn_duration",
+                    extra={
+                        "event": "reap_finalize_arn_duration",
+                        "run_id": self._run_id,
+                        "agent_id": u_agent_id,
+                        "issue_number": u_issue_number,
+                        "task_arn": untracked_arn,
+                        "step_elapsed_s": round(step_elapsed_s, 3),
+                    },
+                )
             reaped_untracked += 1
+        total_elapsed_s = time.monotonic() - t_loop_start
+        self._log.info(
+            "daemon.reap_untracked_loop_completed",
+            extra={
+                "event": "reap_untracked_loop_completed",
+                "run_id": self._run_id,
+                "arns_processed": reaped_untracked,
+                "total_elapsed_s": round(total_elapsed_s, 3),
+                "budget_breached": budget_breached,
+            },
+        )
 
         for task in tasks:
             task_arn = task.get("taskArn", "")
@@ -25585,6 +25676,7 @@ class DispatcherDaemon:
             return
         # Best-effort label strip first — this is the operator-visible
         # leak.
+        _t0 = time.monotonic()
         try:
             self._gh_issue_remove_labels(issue_number, [STATUS_IN_PROGRESS_LABEL])
         except Exception:
@@ -25598,6 +25690,19 @@ class DispatcherDaemon:
                     "branch": "success_already_terminal",
                 },
             )
+        _label_strip_elapsed = time.monotonic() - _t0
+        if _label_strip_elapsed >= 5.0:
+            self._log.warning(
+                "daemon.reap_finalize_step",
+                extra={
+                    "event": "reap_finalize_step",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "step": "label_strip",
+                    "elapsed_s": round(_label_strip_elapsed, 3),
+                },
+            )
         # Best-effort merged_at stamp. Issue #3752: verify the PR is
         # actually MERGED before writing — the agent-runner may have
         # written status='succeeded' before the GitHub merge API
@@ -25607,7 +25712,21 @@ class DispatcherDaemon:
         pr_number_for_verify = self._read_agent_pr_number(agent_id)
         _do_stamp = False
         if pr_number_for_verify is not None:
+            _t1 = time.monotonic()
             verify_status = self._fetch_pr_status(pr_number_for_verify)
+            _pr_status_elapsed = time.monotonic() - _t1
+            if _pr_status_elapsed >= 5.0:
+                self._log.warning(
+                    "daemon.reap_finalize_step",
+                    extra={
+                        "event": "reap_finalize_step",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "issue_number": issue_number,
+                        "step": "pr_status_fetch",
+                        "elapsed_s": round(_pr_status_elapsed, 3),
+                    },
+                )
             if self._pr_observed_as_merged(verify_status):
                 _do_stamp = True
             else:
@@ -25625,6 +25744,7 @@ class DispatcherDaemon:
                     },
                 )
         if _do_stamp:
+            _t2 = time.monotonic()
             try:
                 with self._conn.cursor() as cur:
                     cur.execute(
@@ -25650,6 +25770,19 @@ class DispatcherDaemon:
                     self._conn.rollback()
                 except Exception:  # pragma: no cover — defensive
                     pass
+            _merged_at_elapsed = time.monotonic() - _t2
+            if _merged_at_elapsed >= 5.0:
+                self._log.warning(
+                    "daemon.reap_finalize_step",
+                    extra={
+                        "event": "reap_finalize_step",
+                        "run_id": self._run_id,
+                        "agent_id": agent_id,
+                        "issue_number": issue_number,
+                        "step": "merged_at_stamp",
+                        "elapsed_s": round(_merged_at_elapsed, 3),
+                    },
+                )
         # Issue #3329: clear ``agent_task_arn`` so the next reaper tick
         # excludes this row from the SELECT. Without this clear, the
         # SELECT (now keyed solely on ``agent_task_arn IS NOT NULL``)
@@ -25658,6 +25791,7 @@ class DispatcherDaemon:
         # every tick. Idempotent — if the column is already NULL the
         # UPDATE is a no-op. Best-effort: a DB hiccup here just defers
         # the cleanup to the next successful tick.
+        _t3 = time.monotonic()
         try:
             with self._conn.cursor() as cur:
                 cur.execute(
@@ -25682,6 +25816,19 @@ class DispatcherDaemon:
                 self._conn.rollback()
             except Exception:  # pragma: no cover — defensive
                 pass
+        _arn_clear_elapsed = time.monotonic() - _t3
+        if _arn_clear_elapsed >= 5.0:
+            self._log.warning(
+                "daemon.reap_finalize_step",
+                extra={
+                    "event": "reap_finalize_step",
+                    "run_id": self._run_id,
+                    "agent_id": agent_id,
+                    "issue_number": issue_number,
+                    "step": "arn_clear",
+                    "elapsed_s": round(_arn_clear_elapsed, 3),
+                },
+            )
 
     def _read_agent_status_phase(self, agent_id: str) -> tuple[str | None, str | None]:
         """Fetch the current (status, phase) for an agent. Best-effort.

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -13876,6 +13876,9 @@ class DispatcherDaemon:
                 # a hard-coded ``interval '24 hours'`` into the SQL —
                 # makes the constant the single source of truth and
                 # keeps the query tunable from one place.
+                # exec-mode-agnostic (#3158): candidates are selected
+                # regardless of mode; the resurrection path sets
+                # execution_mode='subprocess' unconditionally.
                 cur.execute(
                     "SELECT agent_id, pr_number, issue_number "
                     "FROM dispatcher.agents "

--- a/scripts/dispatcher/tests/test_daemon_circuit_breaker.py
+++ b/scripts/dispatcher/tests/test_daemon_circuit_breaker.py
@@ -1171,3 +1171,44 @@ class TestInfraPreemptionFilter:
         opened = handler.events("circuit_breaker_opened")
         assert len(opened) == 1
         assert opened[0].bad_count == 5  # type: ignore[attr-defined]
+
+
+# --------------------------------------------------------------------------
+# Issue #3792 — _check_circuit_breaker_auto_close logs when
+# _read_cap_updated_at() returns None (migration #56 hypothesis probe).
+# --------------------------------------------------------------------------
+
+
+class TestAutoCloseMissingRow:
+    """Auto-close path logs when cap_updated_at row is missing."""
+
+    def test_auto_close_logs_when_target_cap_row_missing(self, tmp_path: Path) -> None:
+        """Simulate _read_cap_updated_at() returning None (no concurrency_cap row).
+
+        The auto-close function must emit
+        ``daemon.circuit_breaker_auto_close_skipped_missing_row`` so
+        CloudWatch can confirm or deny the migration #56 hypothesis.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+        # cap_flipped_by = 'circuit_breaker' so we enter the time-based path.
+        conn.cursor_instance.fetch_queue = [
+            ("circuit_breaker",),  # _read_cap_flipped_by
+            (True,),  # _cb_enabled
+            # _read_cap_updated_at: returns None (no row).
+            # The function queries for updated_at; returning None simulates
+            # no concurrency_cap row in dispatcher.config.
+            None,
+        ]
+
+        closed = d._check_circuit_breaker_auto_close(current_cap=0)
+
+        # Must return False (conservative — do nothing).
+        assert closed is False
+        # Must have logged the missing-row event.
+        skipped_events = handler.events(
+            "circuit_breaker_auto_close_skipped_missing_row"
+        )
+        assert len(skipped_events) == 1, (
+            f"expected exactly one circuit_breaker_auto_close_skipped_missing_row "
+            f"event, got {len(skipped_events)}"
+        )

--- a/scripts/dispatcher/tests/test_daemon_orphan_pr_resurrection.py
+++ b/scripts/dispatcher/tests/test_daemon_orphan_pr_resurrection.py
@@ -35,6 +35,7 @@ import sys
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 # Make ``scripts`` importable without installing the repo as a package.
 _SCRIPTS = Path(__file__).resolve().parents[2]
@@ -769,3 +770,98 @@ class TestDbErrorPaths:
 
         assert rows == []
         assert handler.events("orphan_pr_list_failed")
+
+
+# --------------------------------------------------------------------------
+# Issue #3792 — per-candidate timing in _resurrect_orphan_pr_agents.
+# A candidate whose loop body takes ≥5s must emit
+# ``daemon.orphan_pr_sweep_slow_candidate`` WARNING.
+# --------------------------------------------------------------------------
+
+
+class TestOrphanPrSweepTiming:
+    """Per-candidate slow-candidate WARNING + sweep-completed INFO."""
+
+    def test_slow_candidate_fires_warning(self, tmp_path: Path) -> None:
+        """One resurrected candidate taking ≥5s → slow_candidate warning fires.
+
+        Monkeypatches ``time.monotonic`` to return a value 6s after the
+        per-candidate start so the ≥5s threshold fires.
+        """
+        d, conn, handler = _make_daemon(tmp_path)
+
+        agent_id = "agent-slow-resurrect"
+        pr_number = 5001
+        issue_number = 5000
+
+        conn.cursor_instance.fetchall_queue.append(
+            [(agent_id, pr_number, issue_number)]
+        )
+        # _count_orphan_pr_resurrections: 0 prior attempts.
+        conn.cursor_instance.fetch_queue.append((0,))
+
+        d._fetch_pr_status = lambda pr: _pr_status_green()  # type: ignore[method-assign]
+        d._mark_agent_resurrected_for_orphan_pr = lambda agent: True  # type: ignore[method-assign]
+
+        # Simulate the per-candidate loop body taking 6s.
+        # time.monotonic is called:
+        #   1. t_sweep_start = time.monotonic()    → returns 1000.0
+        #   2. t_candidate_start = time.monotonic() → returns 1000.0
+        #   3. candidate_elapsed = time.monotonic() - t_candidate_start → returns 1006.0 (6s elapsed)
+        #   4. total_elapsed = time.monotonic() - t_sweep_start → returns 1006.0
+        mono_values = iter([1000.0, 1000.0, 1006.0, 1006.0])
+
+        from dispatcher import daemon as daemon_mod
+
+        with patch.object(daemon_mod.time, "monotonic", side_effect=mono_values):
+            n = d._resurrect_orphan_pr_agents()
+
+        assert n == 1, "expected one resurrection"
+
+        # Per-candidate slow-candidate WARNING must have fired.
+        slow_events = handler.events("orphan_pr_sweep_slow_candidate")
+        assert slow_events, (
+            "expected daemon.orphan_pr_sweep_slow_candidate WARNING to fire "
+            "for a candidate that takes ≥5s"
+        )
+        ev = slow_events[0]
+        assert ev.agent_id == agent_id  # type: ignore[attr-defined]
+        assert ev.pr_number == pr_number  # type: ignore[attr-defined]
+        assert ev.issue_number == issue_number  # type: ignore[attr-defined]
+        assert getattr(ev, "elapsed_s", 0) >= 5.0  # type: ignore[attr-defined]
+
+        # End-of-sweep INFO must also fire.
+        completed_events = handler.events("orphan_pr_sweep_completed")
+        assert completed_events, (
+            "expected daemon.orphan_pr_sweep_completed INFO to fire"
+        )
+        ce = completed_events[0]
+        assert ce.candidates_seen == 1  # type: ignore[attr-defined]
+        assert ce.candidates_resurrected == 1  # type: ignore[attr-defined]
+
+    def test_fast_candidate_no_slow_warning(self, tmp_path: Path) -> None:
+        """A fast candidate (< 5s) must NOT emit orphan_pr_sweep_slow_candidate."""
+        d, conn, handler = _make_daemon(tmp_path)
+
+        conn.cursor_instance.fetchall_queue.append(
+            [("agent-fast-resurrect", 6001, 6000)]
+        )
+        conn.cursor_instance.fetch_queue.append((0,))
+        d._fetch_pr_status = lambda pr: _pr_status_green()  # type: ignore[method-assign]
+        d._mark_agent_resurrected_for_orphan_pr = lambda agent: True  # type: ignore[method-assign]
+
+        # All monotonic calls return the same base time (0 elapsed).
+        from dispatcher import daemon as daemon_mod
+
+        with patch.object(daemon_mod.time, "monotonic", return_value=1000.0):
+            n = d._resurrect_orphan_pr_agents()
+
+        assert n == 1
+        # No slow-candidate warning.
+        assert handler.events("orphan_pr_sweep_slow_candidate") == [], (
+            "fast candidate must not trigger slow_candidate warning"
+        )
+        # Completed INFO must fire.
+        assert handler.events("orphan_pr_sweep_completed"), (
+            "orphan_pr_sweep_completed must always fire"
+        )

--- a/scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py
+++ b/scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py
@@ -1050,3 +1050,165 @@ class TestReapUntrackedArns:
             "still_running": 0,
             "reaped_untracked": 0,
         }
+
+
+# --------------------------------------------------------------------------
+# Issue #3792 — per-batch budget enforcement for the untracked-ARN loop.
+#
+# The wedge post-mortem (tick #26: reap_untracked=71, tick_elapsed=7.559)
+# showed the untracked finalize loop could run for the entire tick budget.
+# The fix adds REAP_UNTRACKED_BATCH_BUDGET_SECONDS and breaks out early,
+# emitting ``daemon.reap_untracked_budget_exceeded``.
+# --------------------------------------------------------------------------
+
+
+class TestReapUntrackedBatchBudget:
+    """Batch-budget enforcement for the untracked-ARN finalize loop."""
+
+    def _build_untracked_rows(self, n: int) -> tuple[list[Any], list[str]]:
+        """Build ``n`` agent rows and their corresponding ARNs."""
+        arns = [f"arn:aws:ecs:us-west-2:123:task/jm/untracked-{i}" for i in range(n)]
+        rows = [
+            (f"agent-{i}", 9000 + i, arns[i], "done", "succeeded") for i in range(n)
+        ]
+        return rows, arns
+
+    def test_reap_untracked_batch_budget_exceeded(self, caplog: Any) -> None:
+        """75 untracked ARNs, slow finalize (0.5s each) → budget fires + early bail.
+
+        Monkeypatches ``time.monotonic`` to simulate elapsed time so the test
+        runs instantly. Also patches ``_reap_finalize_ecs_success`` to avoid
+        real DB calls and assert the call count stays below 75.
+        """
+        d, conn = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_reap")
+
+        n_arns = 75
+        rows, arns = self._build_untracked_rows(n_arns)
+
+        select_cur = _FakeCursor(rows=rows)
+        conn.queue_cursor(select_cur)
+
+        fake_client = MagicMock()
+        # DescribeTasks returns all ARNs with empty lastStatus so they all
+        # fall into the untracked path.
+        fake_client.describe_tasks.return_value = {
+            "tasks": [{"taskArn": arn, "lastStatus": ""} for arn in arns]
+        }
+
+        finalize_calls: list[str] = []
+
+        # Simulate monotonic advancing 0.5s per finalize call: each call to
+        # time.monotonic inside the loop returns a value 0.5s larger.
+        # Budget is REAP_UNTRACKED_BATCH_BUDGET_SECONDS (30s), so after
+        # 60 finalize calls the loop would breach (30 / 0.5 = 60).
+        # Since we check BEFORE calling finalize, the budget check fires
+        # once elapsed >= 30s, which happens when the loop has processed
+        # 60 items (60 * 0.5 = 30s elapsed before the 61st iteration).
+        _call_count = [0]
+        _base_time = 1000.0
+
+        def fake_monotonic() -> float:
+            # Returns a time that advances 0.5s per finalize-related call.
+            # We need to advance on each call inside the loop.
+            t = _base_time + _call_count[0] * 0.5
+            _call_count[0] += 1
+            return t
+
+        def fake_finalize(agent_id: str, issue_number: Any) -> None:
+            finalize_calls.append(agent_id)
+
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch.object(d, "_gh_issue_remove_labels"),
+            patch.object(d, "_reap_finalize_ecs_success", side_effect=fake_finalize),
+            patch.object(daemon.time, "monotonic", side_effect=fake_monotonic),
+        ):
+            summary = d._reap_completed_agent_tasks()
+
+        # The budget log must have fired.
+        budget_events = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "reap_untracked_budget_exceeded"
+        ]
+        assert budget_events, (
+            "expected daemon.reap_untracked_budget_exceeded WARNING to fire"
+        )
+        # We must have bailed early — not all 75 finalize calls ran.
+        assert summary["reaped_untracked"] < n_arns, (
+            f"expected early bail: reaped_untracked={summary['reaped_untracked']} "
+            f"should be < {n_arns}"
+        )
+        # arns_remaining in the log event must be > 0.
+        evt = budget_events[0]
+        assert getattr(evt, "arns_remaining", 0) > 0, (
+            "budget event must carry arns_remaining > 0"
+        )
+        assert getattr(evt, "arns_processed", -1) == summary["reaped_untracked"]
+
+    def test_reap_untracked_loop_completes_under_budget(self, caplog: Any) -> None:
+        """70 untracked ARNs, fast finalize → loop completes with budget_breached=False.
+
+        Monkeypatches ``time.monotonic`` to return fast times (no elapsed time)
+        so the budget is never triggered, verifying the happy path.
+        """
+        d, conn = _make_daemon()
+        caplog.set_level(logging.INFO, logger="test.daemon_reap")
+
+        n_arns = 70
+        rows, arns = self._build_untracked_rows(n_arns)
+
+        select_cur = _FakeCursor(rows=rows)
+        conn.queue_cursor(select_cur)
+
+        fake_client = MagicMock()
+        fake_client.describe_tasks.return_value = {
+            "tasks": [{"taskArn": arn, "lastStatus": ""} for arn in arns]
+        }
+
+        finalize_calls: list[str] = []
+
+        # Monotonic always returns the same base time (no elapsed time) so
+        # the budget check never fires.
+        def fake_monotonic_fast() -> float:
+            return 1000.0
+
+        def fake_finalize(agent_id: str, issue_number: Any) -> None:
+            finalize_calls.append(agent_id)
+
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch.object(d, "_gh_issue_remove_labels"),
+            patch.object(d, "_reap_finalize_ecs_success", side_effect=fake_finalize),
+            patch.object(daemon.time, "monotonic", side_effect=fake_monotonic_fast),
+        ):
+            summary = d._reap_completed_agent_tasks()
+
+        # All 70 ARNs must have been finalized.
+        assert summary["reaped_untracked"] == n_arns, (
+            f"expected all {n_arns} ARNs processed, got {summary['reaped_untracked']}"
+        )
+        # No budget-exceeded event.
+        budget_events = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "reap_untracked_budget_exceeded"
+        ]
+        assert budget_events == [], (
+            f"expected no budget_exceeded event, got: {budget_events!r}"
+        )
+        # Completion log must fire with budget_breached=False.
+        completion_events = [
+            r
+            for r in caplog.records
+            if getattr(r, "event", None) == "reap_untracked_loop_completed"
+        ]
+        assert completion_events, (
+            "expected daemon.reap_untracked_loop_completed INFO to fire"
+        )
+        evt = completion_events[0]
+        assert getattr(evt, "budget_breached", True) is False, (
+            "completion event must carry budget_breached=False"
+        )
+        assert getattr(evt, "arns_processed", -1) == n_arns


### PR DESCRIPTION
## Summary

Added comprehensive micro-timing instrumentation to diagnose the dispatcher daemon wedge that occurs ~50 seconds post-PR-#3786. Implemented per-batch budget enforcement (30s) on the untracked-ARN finalization loop to prevent a stuck batch from holding the entire scheduler tick. Added regression tests covering both the budget-exceeded path (75 ARNs) and happy path (70 ARNs).

Closes #3792

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
- [x] CI green

### Post-deploy verification

- [ ] Dispatcher daemon sustains operation for ≥1 hour without scheduler_tick gap > 60s
- [ ] CloudWatch Insights query confirms median/max gap between consecutive scheduler_tick events ≤ 60 seconds
- [ ] Verification evidence posted on #3792 (see /task-v2-verify output)