### PR TITLE
fix(dispatcher): route push_failed envelope to diagnoser (#3789)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -4275,6 +4275,27 @@ dispatch_transition_action() {
                         "$_hint" \
                         "phase=${_phase} emitted route_to_diagnoser hint=$_hint"
                     ;;
+                push_failed)
+                    # #3789: ``handle_push_and_pr`` emitted
+                    # ``{"push_failed": true, "reason": "..."}``
+                    # because ``git push`` failed (timeout, PAT
+                    # scope, pre-push hook reject, etc.). The
+                    # transition shim returned
+                    # FAILURE_HINT_PUSH_FAILED so the daemon routes
+                    # to a dedicated diagnoser fix-shape (bump
+                    # push timeout, fix PAT scope, investigate
+                    # hook) rather than the generic advance-to-
+                    # awaiting_ci that previously left the agent
+                    # reaping as missing_pr (#3663). Pull
+                    # ``push_reason`` from the transition context
+                    # for the failures-row reason text.
+                    local _pf_reason
+                    _pf_reason=$(printf '%s' "$_output" | jq -r '.reason // "unknown"' 2>/dev/null || printf 'unknown')
+                    agent_runner_reaped_failure \
+                        "push_failed" \
+                        "push_failed" \
+                        "phase=${_phase} git push failed (reason=${_pf_reason})"
+                    ;;
                 claude_phase_timeout)
                     # #3766: the ``claude -p`` per-phase timeout fired
                     # (rc=124). The transition shim returned

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -1498,6 +1498,14 @@ BYPASSED_TERMINAL_PHASES_TO_ROUTE: dict[str, str] = {
     "verify_failed_post_merge": FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
     # #3465 — rebase exited non-zero with no unmerged files.
     "push_and_pr_no_unmerged_files": FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
+    # #3789 — handle_push_and_pr emitted ``push_failed=true`` (timeout,
+    # PAT scope, pre-push hook reject, etc.). Pre-#3789 this advanced
+    # to awaiting_ci with ``pr_number=NULL`` and reaped as
+    # ``awaiting_ci_failed/missing_pr`` (#3663). Now the transition
+    # shim emits ``FAILURE_HINT_PUSH_FAILED`` and the entrypoint
+    # advances to descriptive terminal ``push_failed``; the diagnoser
+    # picks it up via this map and routes per cause.
+    "push_failed": FAILURE_CATEGORY_PUSH_FAILED,
     # #3507 — operational skill returned failed/unrecognized verdict.
     "operational_failed": FAILURE_CATEGORY_OPERATIONAL_FAILED,
     # #3586 — ralph returned non-SHIP verdict; diagnoser takes over from

--- a/scripts/dispatcher/phase_transitions.py
+++ b/scripts/dispatcher/phase_transitions.py
@@ -504,6 +504,26 @@ FAILURE_HINT_CONFLICT_UNRESOLVABLE = "conflict_unresolvable"
 #: ``FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES`` in daemon.py.
 FAILURE_HINT_PUSH_AND_PR_NO_UNMERGED_FILES = "push_and_pr_no_unmerged_files"
 
+#: #3789 — ``handle_push_and_pr`` in ``agent-runner-entrypoint.sh``
+#: emits ``{"no_op": false, "push_failed": true, "reason": "..."}`` when
+#: ``git push`` fails (timeout exit 124, or any non-zero exit). Pre-#3789
+#: ``transition_from_push_and_pr`` only checked ``no_op`` and
+#: ``rebase_failed`` — every other shape (including ``push_failed``)
+#: silently fell through the catch-all advance arm, sending the agent to
+#: ``awaiting_ci`` with ``pr_number=NULL`` where the reaper terminal-
+#: failed it as ``awaiting_ci_failed/missing_pr``. The same cluster-bug
+#: family as #3581/PR #3773 (action vocabulary) but for output-field
+#: vocabulary. See #3663 for the recurring instance pattern (4× hits in
+#: a single session).
+#:
+#: Maps to ``FAILURE_CATEGORY_PUSH_FAILED`` in daemon.py — already
+#: defined since the per-PR-create reaper distinguishes push outcomes
+#: from network errors. The diagnoser receives the original
+#: ``reason`` (``push_timeout``, ``pat_scope``, ``pre_push_hook``,
+#: missing) via ``context.push_reason`` so it can pick a fix-shape per
+#: cause (bump push timeout, fix PAT scope, investigate hook).
+FAILURE_HINT_PUSH_FAILED = "push_failed"
+
 #: #3766 — ``run_claude_phase`` in ``agent-runner-entrypoint.sh``
 #: short-circuited the post-claude output resolution because the
 #: ``timeout`` wrapper fired (rc=124) on the ``claude -p`` subprocess.
@@ -879,6 +899,16 @@ def transition_from_push_and_pr(
       ``fix_conflict`` phase, where a claude skill semantically
       resolves the conflict and either re-enters push_and_pr or
       routes to ``conflict_unresolvable``.
+    * ``push_failed=True`` (#3789) — the entrypoint emitted
+      ``{"no_op": false, "push_failed": true, "reason": "..."}``
+      because ``git push`` failed (timeout, PAT scope, pre-push
+      hook reject, etc.). No PR was opened. Pre-#3789 this fell
+      through the catch-all advance arm and the agent reached
+      awaiting_ci with ``pr_number=NULL`` where the reaper
+      terminal-failed it as ``awaiting_ci_failed/missing_pr``
+      (see #3663 for the recurring instance pattern). Route to
+      diagnoser with ``FAILURE_HINT_PUSH_FAILED`` so it can pick
+      a fix-shape per cause.
     * otherwise — PR was opened; advance to ``awaiting_ci``.
     """
     if output and output.get("no_op"):
@@ -916,6 +946,25 @@ def transition_from_push_and_pr(
             reason="push_and_pr rebase conflict — routing to fix_conflict (#3225)",
             context={
                 "conflict_files": output.get("conflict_files") or [],
+                "source_phase": "push_and_pr",
+            },
+        )
+    # #3789: ``git push`` failed (timeout, PAT scope, pre-push hook
+    # reject, etc.). The entrypoint emits
+    # ``{"no_op": false, "push_failed": true, "reason": "..."}``
+    # without an associated PR. MUST come before the catch-all advance
+    # so the agent doesn't enter awaiting_ci with ``pr_number=NULL``
+    # and reap as ``awaiting_ci_failed/missing_pr`` (#3663). This is
+    # the OUTPUT-FIELD vocabulary parallel to the ACTION vocabulary
+    # cluster-bug fix landed in PR #3773 (#3581).
+    if output and output.get("push_failed"):
+        push_reason = output.get("reason")
+        return PhaseTransition(
+            action=TransitionAction.ROUTE_TO_DIAGNOSER,
+            failure_hint=FAILURE_HINT_PUSH_FAILED,
+            reason=f"push_and_pr push failed: {push_reason or 'unknown'}",
+            context={
+                "push_reason": push_reason,
                 "source_phase": "push_and_pr",
             },
         )
@@ -1504,6 +1553,7 @@ __all__ = [
     "FAILURE_HINT_PLAN_BLOCKED",
     "FAILURE_HINT_CONFLICT_UNRESOLVABLE",
     "FAILURE_HINT_PUSH_AND_PR_NO_UNMERGED_FILES",
+    "FAILURE_HINT_PUSH_FAILED",
     "FAILURE_HINT_OPERATIONAL_FAILED",
     "FAILURE_HINT_CLAUDE_PHASE_TIMEOUT",
     # Transition dataclass + enum

--- a/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
+++ b/scripts/dispatcher/tests/test_handle_agent_failure_routing.py
@@ -135,6 +135,7 @@ class TestBypassedTerminalConstants:
             FAILURE_CATEGORY_CLAUDE_PHASE_TIMEOUT,
             FAILURE_CATEGORY_FIX_CI_BLOCKED,
             FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
+            FAILURE_CATEGORY_PUSH_FAILED,
             FAILURE_CATEGORY_RALPH_AC_INFEASIBLE,
             FAILURE_CATEGORY_RALPH_NOT_SHIP,
             FAILURE_CATEGORY_SUMMARY_AC_INFEASIBLE,
@@ -149,6 +150,11 @@ class TestBypassedTerminalConstants:
             "fix_ci_blocked": FAILURE_CATEGORY_FIX_CI_BLOCKED,
             "verify_failed_post_merge": FAILURE_CATEGORY_VERIFY_FAILED_POST_MERGE,
             "push_and_pr_no_unmerged_files": FAILURE_CATEGORY_PUSH_AND_PR_NO_UNMERGED_FILES,
+            # #3789 — handle_push_and_pr push_failed envelope
+            # routes through the diagnoser (was advancing to
+            # awaiting_ci with pr_number=NULL and reaping as
+            # missing_pr; see #3663).
+            "push_failed": FAILURE_CATEGORY_PUSH_FAILED,
             "operational_failed": FAILURE_CATEGORY_OPERATIONAL_FAILED,
             "ralph_not_ship": FAILURE_CATEGORY_RALPH_NOT_SHIP,
             # #3777

--- a/scripts/dispatcher/tests/test_phase_transitions.py
+++ b/scripts/dispatcher/tests/test_phase_transitions.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 # Make ``scripts`` importable without installing the repo as a package.
 _SCRIPTS = Path(__file__).resolve().parents[2]
 if str(_SCRIPTS) not in sys.path:
@@ -832,6 +834,82 @@ class TestTransitionFromPushAndPrNoUnmergedFiles:
         )
         assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
         assert result.next_phase != pt.PHASE_FIX_CONFLICT
+
+
+# --------------------------------------------------------------------------
+# transition_from_push_and_pr — push_failed branch (#3789)
+# --------------------------------------------------------------------------
+
+
+class TestTransitionFromPushAndPrPushFailed:
+    """#3789: push_and_pr emits ``push_failed=true`` (timeout, PAT scope,
+    pre-push hook, etc.) → route to diagnoser, NOT advance to awaiting_ci.
+
+    Pre-#3789 the catch-all advance arm silently treated push_failed as
+    "PR opened" and the agent reaped as ``awaiting_ci_failed/missing_pr``
+    with ``pr_number=NULL``. See #3663 for the recurring instance pattern.
+    """
+
+    def test_push_failed_with_push_timeout_routes_to_diagnoser(self) -> None:
+        # The exact envelope handle_push_and_pr emits on a 300s timeout.
+        result = pt.transition_from_push_and_pr(
+            {"no_op": False, "push_failed": True, "reason": "push_timeout"}
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_PUSH_FAILED
+        assert result.context["push_reason"] == "push_timeout"
+        assert result.context["source_phase"] == "push_and_pr"
+
+    @pytest.mark.parametrize(
+        "reason",
+        [
+            "push_timeout",
+            "pat_scope",
+            "pre_push_hook",
+            None,  # entrypoint may emit push_failed without a reason
+        ],
+    )
+    def test_push_failed_routes_for_each_reason(self, reason: str | None) -> None:
+        envelope: dict[str, object] = {"no_op": False, "push_failed": True}
+        if reason is not None:
+            envelope["reason"] = reason
+        result = pt.transition_from_push_and_pr(envelope)
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.failure_hint == pt.FAILURE_HINT_PUSH_FAILED
+        assert result.context["push_reason"] == reason
+        assert result.context["source_phase"] == "push_and_pr"
+
+    def test_push_failed_takes_precedence_over_advance(self) -> None:
+        # Catch-all advance arm must NOT win when push_failed is set —
+        # the agent never opened a PR, so awaiting_ci would reap as
+        # missing_pr. (#3789)
+        result = pt.transition_from_push_and_pr(
+            {"push_failed": True, "reason": "push_timeout"}
+        )
+        assert result.action == pt.TransitionAction.ROUTE_TO_DIAGNOSER
+        assert result.next_phase != pt.PHASE_AWAITING_CI
+
+    def test_push_failed_does_not_override_no_op(self) -> None:
+        # If both no_op and push_failed are present (shouldn't happen,
+        # but defensive), no_op SHIP wins because it signals "nothing
+        # to push" — push_failed is moot.
+        result = pt.transition_from_push_and_pr({"no_op": True, "push_failed": True})
+        assert result.action == pt.TransitionAction.ADVANCE_WITH_STATUS
+        assert result.next_phase == pt.PHASE_NO_OP
+
+    def test_push_failed_does_not_override_rebase_failed(self) -> None:
+        # rebase_failed is the more specific signal (the conflict needs
+        # fix_conflict, not the diagnoser). When both are present, the
+        # earlier rebase_failed branch wins.
+        result = pt.transition_from_push_and_pr(
+            {
+                "rebase_failed": True,
+                "conflict_files": ["a.py"],
+                "push_failed": True,
+            }
+        )
+        assert result.action == pt.TransitionAction.ADVANCE
+        assert result.next_phase == pt.PHASE_FIX_CONFLICT
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Routes `push_failed=true` envelopes from `handle_push_and_pr` to the diagnoser via `FAILURE_HINT_PUSH_FAILED` instead of falling through the catch-all advance arm to `awaiting_ci`. Pre-fix, push timeouts (and other push failures) silently advanced the agent to `awaiting_ci` with `pr_number=NULL`, where the reaper terminal-failed it as `awaiting_ci_failed/missing_pr` — the recurring pattern that hit #3663 four times in a single session.

Same cluster-bug architectural family as #3581/PR #3773 (action vocabulary drift) but for the OUTPUT-FIELD vocabulary that bash → python emits.

Closes #3789

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass (8 new tests in `TestTransitionFromPushAndPrPushFailed`, parametrized over reasons)
- [ ] CI green
- [ ] Vocabulary guard `scripts/check-transition-dispatch-vocabulary.sh` reports parity

### Post-deploy verification
- [ ] After dispatcher redeploy, query `dispatcher.agents` for new rows matching `phase=awaiting_ci_failed AND status=failed AND pr_number IS NULL AND failure_category='missing_pr'` — confirm rate drops to near-zero compared to pre-fix observation in #3663.
- [ ] Verification evidence posted on issue #3789 (see A.8)

## Implementation notes

Three layers updated for symmetry with the existing `claude_phase_timeout` / `push_and_pr_no_unmerged_files` patterns:

1. `scripts/dispatcher/phase_transitions.py` — new `FAILURE_HINT_PUSH_FAILED` constant + new branch in `transition_from_push_and_pr`.
2. `scripts/dispatcher/agent-runner-entrypoint.sh` — new `push_failed)` arm in `dispatch_transition_action` inner `case "$_hint"`.
3. `scripts/dispatcher/daemon.py` — new `"push_failed": FAILURE_CATEGORY_PUSH_FAILED` entry in `BYPASSED_TERMINAL_PHASES_TO_ROUTE`. (`FAILURE_CATEGORY_PUSH_FAILED` already existed since #2902.)

Tests written FIRST (TDD): 6 of 8 new tests fail against unfixed code with `assert advance == route_to_diagnoser`; all pass after fix.

Part 2 of the issue (extending the CI vocabulary guard to cover output-field keys) is deferred to a follow-up — the issue body marks it optional and Part 1 is the load-bearing fix.
