### PR TITLE
fix(dispatcher): skip pre-push hook on agent-runner machine pushes (#3800)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ Shell-interactive prompt-prevention rules (`$()`, heredocs, inline `python -c`, 
 - Never close a task or remove a worktree without posting a verification evidence comment on the issue. See §A.8 Step 3.
 - Never merge user-visible affordances that haven't been exercised end-to-end. "The page renders" / "the service returns 200" is not evidence. Half-built behind a flag is fine; half-built and reachable by users is the bug.
 - Never use `--force` (or `--force-with-lease`) to bypass a failing CI check or pre-push hook. `--force-with-lease` IS allowed after an intentional rebase of your own branch — see the `/task` skill A.4.
+- `git push --no-verify` is reserved for agent-runner machine pushes inside `scripts/dispatcher/agent-runner-entrypoint.sh` (where ralph already ran the pre-push hook against the WIP commit). Never add `--no-verify` from interactive `/task` work — that path must run the hook to catch lint, format, test, and coverage regressions before CI.
 - Never run `gh auth switch` without an explicit user instruction.
 
 ### ALWAYS — Before Acting

--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -2974,8 +2974,14 @@ handle_push_and_pr() {
     # ``timeout`` wrapper guarantees ``handle_push_and_pr`` always
     # returns within NETWORK_TIMEOUT_SECONDS + a few seconds of
     # bookkeeping, freeing the cap slot for a fresh agent.
+    # #3800: --no-verify skips the pre-push hook on this machine push.
+    # ralph's worker already ran .githooks/pre-push end-to-end against the
+    # WIP commit during iteration, so re-running it here adds no safety but
+    # costs ~5+ minutes of wall-clock for scraper-framework-sized diffs —
+    # well above the 300s NETWORK_TIMEOUT_SECONDS cap. Human-laptop pushes
+    # are unaffected; only the agent-runner machine push gains the bypass.
     timeout "$NETWORK_TIMEOUT_SECONDS" \
-        git -C "$REPO_ROOT" push -u origin "$BRANCH_NAME" \
+        git -C "$REPO_ROOT" push -u origin "$BRANCH_NAME" --no-verify \
         > "$AGENT_WORKSPACE/git-push.stdout.log" \
         2> "$AGENT_WORKSPACE/git-push.stderr.log"
     _push_rc=$?
@@ -3624,7 +3630,7 @@ handle_fix_ci() {
         # detached-HEAD state somehow snuck in — matches daemon.py line
         # ~13166's ``push origin <branch>`` pattern.
         set +e
-        git -C "$REPO_ROOT" push origin "$BRANCH_NAME" \
+        git -C "$REPO_ROOT" push origin "$BRANCH_NAME" --no-verify \
             > "$AGENT_WORKSPACE/fix-ci-git-push.stdout.log" \
             2> "$AGENT_WORKSPACE/fix-ci-git-push.stderr.log"
         _push_rc=$?
@@ -4959,7 +4965,7 @@ try_auto_unstick_merge() {
         return 1
     fi
     set +e
-    git -C "$REPO_ROOT" push origin "$BRANCH_NAME" \
+    git -C "$REPO_ROOT" push origin "$BRANCH_NAME" --no-verify \
         > "$AGENT_WORKSPACE/merge-unstick-push.stdout.log" \
         2> "$AGENT_WORKSPACE/merge-unstick-push.stderr.log"
     _push_rc=$?

--- a/scripts/dispatcher/tests/test_agent_runner_push_and_pr_timeouts.py
+++ b/scripts/dispatcher/tests/test_agent_runner_push_and_pr_timeouts.py
@@ -351,3 +351,94 @@ class TestTimeoutWrappersPresent:
                     f'``timeout "$<VAR>_TIMEOUT_SECONDS"`` or ``timeout "$_phase_timeout"`` '
                     f"(#3683, #3766). Line: {line!r}"
                 )
+
+
+# ---------------------------------------------------------------------------
+# --no-verify presence tests (#3800)
+# ---------------------------------------------------------------------------
+
+
+class TestPushNoVerify:
+    """Every machine ``git push`` in agent-runner-entrypoint.sh must pass
+    ``--no-verify`` so the pre-push hook (already run by ralph's worker
+    during iteration) is not redundantly re-executed on the Fargate host,
+    where it consumes ~5+ minutes of wall-clock against the 300s
+    NETWORK_TIMEOUT_SECONDS cap (#3800).
+
+    Three push sites are guarded:
+    - ``handle_push_and_pr`` — the bounded timeout-wrapped primary push.
+    - ``handle_fix_ci`` — the CI-fix commit push.
+    - ``merge_unstick`` — the empty-commit push used to unblock stuck merges.
+    """
+
+    def test_push_and_pr_uses_no_verify(self) -> None:
+        """The ``handle_push_and_pr`` push line must include ``--no-verify``
+        (#3800)."""
+        text = _script_text()
+        _, body = _extract_function_body(text, "handle_push_and_pr")
+        logical = _logical_lines(body)
+        push_lines = [
+            (lineno, line)
+            for lineno, line in logical
+            if re.search(r"\bgit\b.*\bpush\b", line)
+            and "origin" in line
+            and "$BRANCH_NAME" in line
+        ]
+        assert push_lines, (
+            "handle_push_and_pr must contain a ``git ... push ... origin ... $BRANCH_NAME`` "
+            "line (#3800)"
+        )
+        for lineno, line in push_lines:
+            assert "--no-verify" in line, (
+                f"L{lineno}: handle_push_and_pr push line must include ``--no-verify`` "
+                f"so the pre-push hook is not redundantly re-run on the Fargate host "
+                f"(#3800). Line: {line!r}"
+            )
+
+    def test_fix_ci_push_uses_no_verify(self) -> None:
+        """The ``handle_fix_ci`` push line must include ``--no-verify``
+        (#3800)."""
+        text = _script_text()
+        _, body = _extract_function_body(text, "handle_fix_ci")
+        logical = _logical_lines(body)
+        push_lines = [
+            (lineno, line)
+            for lineno, line in logical
+            if re.search(r"\bgit\b.*\bpush\b", line)
+            and "origin" in line
+            and "$BRANCH_NAME" in line
+        ]
+        assert push_lines, (
+            "handle_fix_ci must contain a ``git ... push ... origin ... $BRANCH_NAME`` "
+            "line (#3800)"
+        )
+        for lineno, line in push_lines:
+            assert "--no-verify" in line, (
+                f"L{lineno}: handle_fix_ci push line must include ``--no-verify`` "
+                f"so the pre-push hook is not redundantly re-run on the Fargate host "
+                f"(#3800). Line: {line!r}"
+            )
+
+    def test_merge_unstick_push_uses_no_verify(self) -> None:
+        """The ``try_auto_unstick_merge`` push line must include ``--no-verify``
+        (#3800)."""
+        text = _script_text()
+        _, body = _extract_function_body(text, "try_auto_unstick_merge")
+        logical = _logical_lines(body)
+        push_lines = [
+            (lineno, line)
+            for lineno, line in logical
+            if re.search(r"\bgit\b.*\bpush\b", line)
+            and "origin" in line
+            and "$BRANCH_NAME" in line
+        ]
+        assert push_lines, (
+            "try_auto_unstick_merge must contain a ``git ... push ... origin ... $BRANCH_NAME`` "
+            "line (#3800)"
+        )
+        for lineno, line in push_lines:
+            assert "--no-verify" in line, (
+                f"L{lineno}: try_auto_unstick_merge push line must include ``--no-verify`` "
+                f"so the pre-push hook is not redundantly re-run on the Fargate host "
+                f"(#3800). Line: {line!r}"
+            )


### PR DESCRIPTION
## Summary

Added `--no-verify` to all three machine `git push` invocations in `scripts/dispatcher/agent-runner-entrypoint.sh` (handle_push_and_pr, handle_fix_ci, try_auto_unstick_merge) to prevent redundant pre-push hook execution. Ralph's worker already runs `.githooks/pre-push` end-to-end against the WIP commit during iteration; re-running it on Fargate adds no safety but consumes ~5+ minutes of wall-clock for scraper-framework-sized diffs, well above the 300s `NETWORK_TIMEOUT_SECONDS` bound. Updated CLAUDE.md with a documented exception: `--no-verify` is reserved for agent-runner machine pushes only; interactive `/task` work continues to enforce the hook for lint, format, test, and coverage validation.

Closes #3800

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`) — all 18 tests in test_agent_runner_push_and_pr_timeouts.py pass; new TestPushNoVerify class (3 methods) validates --no-verify presence in all three push sites; existing TestTransitionFromPushAndPrPushFailed regression test (from #3789) stays green
- [x] CI green

### Post-deploy verification

- [ ] Monitor `dispatcher.failures` for zero `push_failed` (reason=`push_timeout`) entries in the 7 days following deploy (AC1); /task-v2-verify will query CloudWatch post-deploy
- [ ] Verification evidence posted on #3800 (see /task-v2-verify output)