### PR TITLE
fix(dispatcher): hoist ARN-clear to single call site for all 5 reaper terminal branches (#3805)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -25355,6 +25355,20 @@ class DispatcherDaemon:
                     # idempotent (re-reaps must not bump ``merged_at``
                     # or repeat the label call cost).
                     self._reap_finalize_ecs_success(agent_id, issue_number)
+                    # Issue #3805: clear ``agent_task_arn`` at the
+                    # call site (uniform across all five terminal
+                    # branches). Previously the clear was buried
+                    # inside ``_reap_finalize_ecs_success``, which
+                    # early-returns on ``issue_number is None`` — so
+                    # rows for issue-less subagents (audit, daily
+                    # report, startup) were re-selected every tick
+                    # forever. Hoisting the clear here makes it
+                    # unconditional.
+                    self._clear_agent_task_arn(
+                        agent_id=agent_id,
+                        issue_number=issue_number,
+                        branch="success_already_terminal",
+                    )
                     reaped_success += 1
                 else:
                     # Container exited 0 but agent row wasn't marked
@@ -25385,6 +25399,16 @@ class DispatcherDaemon:
                         phase=current_phase or "done",
                         exit_code=0,
                         issue_number=issue_number,
+                    )
+                    # Issue #3805: clear ``agent_task_arn`` at the
+                    # call site. ``_mark_agent_terminal`` writes
+                    # status/phase/ended_at but does not touch
+                    # ``agent_task_arn``, so without this the row
+                    # would be re-selected every tick.
+                    self._clear_agent_task_arn(
+                        agent_id=agent_id,
+                        issue_number=issue_number,
+                        branch="success_row_gap",
                     )
                     reaped_success += 1
             else:
@@ -25436,30 +25460,15 @@ class DispatcherDaemon:
                     # the success-path clear in
                     # ``_reap_finalize_ecs_success`` — same rationale,
                     # same idempotence story.
-                    try:
-                        with self._conn.cursor() as cur:
-                            cur.execute(
-                                "UPDATE dispatcher.agents "
-                                "SET agent_task_arn = NULL "
-                                "WHERE agent_id = %s",
-                                (agent_id,),
-                            )
-                        self._conn.commit()
-                    except Exception:
-                        self._log.exception(
-                            "daemon.agent_runner_reaped_arn_clear_failed",
-                            extra={
-                                "event": "agent_runner_reaped_arn_clear_failed",
-                                "run_id": self._run_id,
-                                "agent_id": agent_id,
-                                "issue_number": issue_number,
-                                "branch": "failure_already_terminal",
-                            },
-                        )
-                        try:
-                            self._conn.rollback()
-                        except Exception:  # pragma: no cover — defensive
-                            pass
+                    #
+                    # Issue #3805: normalized to use the
+                    # ``_clear_agent_task_arn`` helper so all five
+                    # terminal branches use one consistent shape.
+                    self._clear_agent_task_arn(
+                        agent_id=agent_id,
+                        issue_number=issue_number,
+                        branch="failure_already_terminal",
+                    )
                     reaped_failure += 1
                     continue
                 # Real failure — agent-runner died before it could write
@@ -25496,6 +25505,16 @@ class DispatcherDaemon:
                         "exit_codes": exit_codes,
                     },
                     issue_number=issue_number,
+                )
+                # Issue #3805: clear ``agent_task_arn`` at the call
+                # site. ``_handle_agent_failure`` writes the failures
+                # row + invokes the diagnoser path but does not
+                # touch ``agent_task_arn``, so without this the row
+                # would be re-selected every tick (latent leak).
+                self._clear_agent_task_arn(
+                    agent_id=agent_id,
+                    issue_number=issue_number,
+                    branch="failure_not_terminal",
                 )
                 reaped_failure += 1
 
@@ -25564,6 +25583,15 @@ class DispatcherDaemon:
         Idempotent on the GitHub side because
         :meth:`_gh_issue_remove_labels` is a no-op when the label is
         already absent.
+
+        Issue #3805: the ``agent_task_arn = NULL`` clear used to live
+        in this function but was unreachable on the
+        ``issue_number is None`` early-return below (audit /
+        dispatcher-daily-report / dispatcher-startup agents). The
+        clear is now hoisted to the ``_reap_completed_agent_tasks``
+        call site (one helper call per terminal branch, all five
+        branches uniform), so this function is purely
+        issue-bookkeeping.
         """
         if issue_number is None:
             return
@@ -25634,38 +25662,13 @@ class DispatcherDaemon:
                     self._conn.rollback()
                 except Exception:  # pragma: no cover — defensive
                     pass
-        # Issue #3329: clear ``agent_task_arn`` so the next reaper tick
-        # excludes this row from the SELECT. Without this clear, the
-        # SELECT (now keyed solely on ``agent_task_arn IS NOT NULL``)
-        # would re-observe the same already-finalized row forever and
-        # the daemon would re-call ``ecs:DescribeTasks`` for it on
-        # every tick. Idempotent — if the column is already NULL the
-        # UPDATE is a no-op. Best-effort: a DB hiccup here just defers
-        # the cleanup to the next successful tick.
-        try:
-            with self._conn.cursor() as cur:
-                cur.execute(
-                    "UPDATE dispatcher.agents "
-                    "SET agent_task_arn = NULL "
-                    "WHERE agent_id = %s",
-                    (agent_id,),
-                )
-            self._conn.commit()
-        except Exception:
-            self._log.exception(
-                "daemon.agent_runner_reaped_arn_clear_failed",
-                extra={
-                    "event": "agent_runner_reaped_arn_clear_failed",
-                    "run_id": self._run_id,
-                    "agent_id": agent_id,
-                    "issue_number": issue_number,
-                    "branch": "success_already_terminal",
-                },
-            )
-            try:
-                self._conn.rollback()
-            except Exception:  # pragma: no cover — defensive
-                pass
+        # Issue #3805: the ``agent_task_arn = NULL`` clear used to live
+        # here, but was unreachable on the ``issue_number is None``
+        # early-return above (audit / dispatcher-daily-report /
+        # dispatcher-startup agents). The clear has been hoisted to
+        # the ``_reap_completed_agent_tasks`` call site so all five
+        # terminal branches clear the ARN uniformly via
+        # :meth:`_clear_agent_task_arn`.
 
     def _read_agent_status_phase(self, agent_id: str) -> tuple[str | None, str | None]:
         """Fetch the current (status, phase) for an agent. Best-effort.

--- a/scripts/dispatcher/tests/test_daemon_merge_verification.py
+++ b/scripts/dispatcher/tests/test_daemon_merge_verification.py
@@ -348,9 +348,15 @@ class TestMergeStampsWhenPrStateMerged:
 class TestReapFinalizeSkipsStampWhenPrOpen:
     """AC1 half 2: _reap_finalize_ecs_success fetches PR state before stamp.
 
-    When state==OPEN: merged_at UPDATE skipped, but label-strip and ARN
-    clear still run (independent invariants).
+    When state==OPEN: merged_at UPDATE skipped, but label-strip still
+    runs (independent invariant).
     This test FAILS against pre-#3752 code (no verification in reap path).
+
+    Issue #3805: ARN clear is no longer the responsibility of this
+    helper — it lives at the ``_reap_completed_agent_tasks`` call site
+    via :meth:`_clear_agent_task_arn` so all five terminal branches
+    clear uniformly. Test updated to no longer assert ARN clear from
+    inside ``_reap_finalize_ecs_success``.
     """
 
     def test_reap_finalize_skips_stamp_when_pr_open(self, tmp_path: Path) -> None:
@@ -390,13 +396,21 @@ class TestReapFinalizeSkipsStampWhenPrOpen:
         assert unverified, "expected reap_finalize_unverified event"
         assert unverified[0].pr_number == 303
 
-        # ARN clear must also still run
+        # Issue #3805: ARN clear is no longer this function's job —
+        # it lives at the ``_reap_completed_agent_tasks`` call site.
+        # ``_reap_finalize_ecs_success`` must NOT issue an
+        # ``agent_task_arn = NULL`` UPDATE. The reaper-level uniform
+        # clear is exercised by
+        # ``test_daemon_reap_completed_agent_tasks.TestReapArnClearAcrossAllTerminalBranches``.
         arn_clears = [
             e
             for e in conn.cursor_instance.executed
             if "SET agent_task_arn = NULL" in e[0]
         ]
-        assert arn_clears, "ARN clear must still run even when stamp is skipped"
+        assert arn_clears == [], (
+            "post-#3805: _reap_finalize_ecs_success must NOT clear "
+            "agent_task_arn — the clear lives at the reaper call site"
+        )
 
 
 # --------------------------------------------------------------------------

--- a/scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py
+++ b/scripts/dispatcher/tests/test_daemon_reap_completed_agent_tasks.py
@@ -1001,3 +1001,247 @@ class TestReapUntrackedArns:
             "still_running": 0,
             "reaped_untracked": 0,
         }
+
+
+# --------------------------------------------------------------------------
+# Issue #3805 — every terminal branch must clear ``agent_task_arn``,
+# including rows where ``issue_number IS NULL`` (audit / dispatcher-
+# daily-report / dispatcher-startup subagents — non-issue subagents are
+# valid).
+#
+# Pre-fix only 2 of the 5 terminal branches cleared the ARN:
+#  - Branch 2 (success_already_terminal) called
+#    ``_reap_finalize_ecs_success`` which early-returned on
+#    ``issue_number is None`` BEFORE the buried ARN clear could fire,
+#    so issue-less rows were re-selected ~10 events/min forever.
+#  - Branch 3 (success_row_gap) called ``_mark_agent_terminal`` which
+#    never touched ``agent_task_arn`` (latent leak).
+#  - Branch 5 (failure_not_terminal) called ``_handle_agent_failure``
+#    which never touched ``agent_task_arn`` (latent leak).
+#
+# Post-fix the ``_clear_agent_task_arn`` helper is invoked at the call
+# site of all 5 terminal branches uniformly. These regression tests
+# pin the new behavior — each FAILS against the pre-#3805 code and
+# PASSES post-fix.
+# --------------------------------------------------------------------------
+
+
+class TestReapArnClearAcrossAllTerminalBranches:
+    """Issue #3805 — ARN clear must be uniform across all 5 terminal branches."""
+
+    def test_success_already_terminal_clears_arn_when_issue_number_is_none(
+        self, caplog: Any
+    ) -> None:
+        """Branch 2: row with ``status='succeeded'``, ``phase='done'``, AND
+        ``issue_number IS NULL`` (e.g. audit / daily-report / startup
+        subagent).
+
+        Pre-fix: ``_reap_finalize_ecs_success`` early-returned on
+        ``issue_number is None`` (line 25568 pre-#3805) and the
+        ARN clear was buried after the early-return — so the row's
+        ``agent_task_arn`` was never nulled and the SELECT
+        re-observed it every tick (~10 events/min, observed
+        2026-04-29 on agent_id ``89ab37bb...``).
+
+        Post-fix: ``_clear_agent_task_arn`` is called at the
+        ``_reap_completed_agent_tasks`` call site, AFTER
+        ``_reap_finalize_ecs_success`` — so the clear fires
+        regardless of whether ``issue_number`` is None.
+        """
+        d, conn = _make_daemon()
+        caplog.set_level(logging.INFO, logger="test.daemon_reap")
+        # SELECT returns one row with issue_number=None (audit /
+        # daily-report / startup subagent — agent has no GitHub issue).
+        select_cur = _FakeCursor(
+            rows=[
+                (
+                    "agent-noiss",
+                    None,  # ← the load-bearing field for this regression
+                    "arn:aws:ecs:us-west-2:123:task/jm/audit",
+                    "done",
+                    "succeeded",
+                ),
+            ]
+        )
+        conn.queue_cursor(select_cur)
+        # Re-read post-STOPPED returns terminal status — branch 2.
+        status_cur = _FakeCursor()
+        status_cur.fetchone_queue = [("succeeded", "done")]
+        conn.queue_cursor(status_cur)
+        # ``_reap_finalize_ecs_success`` early-returns on
+        # ``issue_number is None`` so it consumes NO cursors. The next
+        # cursor goes to ``_clear_agent_task_arn``.
+        arn_clear_cur = _FakeCursor()
+        conn.queue_cursor(arn_clear_cur)
+
+        fake_client = MagicMock()
+        fake_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": "arn:aws:ecs:us-west-2:123:task/jm/audit",
+                    "lastStatus": "STOPPED",
+                    "stopCode": "EssentialContainerExited",
+                    "containers": [{"exitCode": 0}],
+                }
+            ]
+        }
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch.object(d, "_gh_issue_remove_labels") as remove_labels_mock,
+        ):
+            summary = d._reap_completed_agent_tasks()
+
+        assert summary["reaped_success"] == 1
+        # Branch 2 took the ``success_already_terminal`` path and logged
+        # the success event.
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_reaped_success" in events
+        # No GitHub label strip — issue_number is None.
+        remove_labels_mock.assert_not_called()
+        # CRITICAL: ARN clear MUST have run — this is what the
+        # regression pins. Pre-fix the buried clear inside
+        # ``_reap_finalize_ecs_success`` was unreachable for
+        # issue_number=None rows; post-fix the helper runs at the
+        # call site unconditionally.
+        arn_sqls = [sql for sql, _ in arn_clear_cur.executed]
+        assert any("SET agent_task_arn = NULL" in sql for sql in arn_sqls), arn_sqls
+        assert [params for _, params in arn_clear_cur.executed] == [("agent-noiss",)]
+
+    def test_success_row_gap_clears_arn_when_issue_number_is_none(
+        self, caplog: Any
+    ) -> None:
+        """Branch 3: container exit 0 but DB row not yet terminal, AND
+        ``issue_number IS NULL``.
+
+        Pre-fix: ``_mark_agent_terminal`` writes
+        ``status``/``phase``/``ended_at`` but never touches
+        ``agent_task_arn`` — latent leak: any row of this shape would
+        be re-selected forever.
+
+        Post-fix: ``_clear_agent_task_arn`` runs at the call site
+        immediately after ``_mark_agent_terminal``.
+        """
+        d, conn = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_reap")
+        select_cur = _FakeCursor(
+            rows=[
+                (
+                    "agent-gap-noiss",
+                    None,  # ← issue_number IS NULL
+                    "arn:aws:ecs:us-west-2:123:task/gap-noiss",
+                    "verify",
+                    "running",
+                ),
+            ]
+        )
+        conn.queue_cursor(select_cur)
+        # Re-read returns NON-terminal — forces the row_gap branch.
+        status_cur = _FakeCursor()
+        status_cur.fetchone_queue = [("running", "verify")]
+        conn.queue_cursor(status_cur)
+        # ``_mark_agent_terminal`` is mocked below — consumes no
+        # cursor. Next cursor goes to ``_clear_agent_task_arn``.
+        arn_clear_cur = _FakeCursor()
+        conn.queue_cursor(arn_clear_cur)
+
+        fake_client = MagicMock()
+        fake_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": "arn:aws:ecs:us-west-2:123:task/gap-noiss",
+                    "lastStatus": "STOPPED",
+                    "stopCode": "EssentialContainerExited",
+                    "containers": [{"exitCode": 0}],
+                }
+            ]
+        }
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch.object(d, "_mark_agent_terminal") as mark_mock,
+        ):
+            summary = d._reap_completed_agent_tasks()
+
+        assert summary["reaped_success"] == 1
+        # Branch 3 took the row_gap path.
+        mark_mock.assert_called_once()
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_reaped_success_row_gap" in events
+        # CRITICAL: ARN clear MUST have run. Pre-#3805
+        # ``_mark_agent_terminal`` did not touch ``agent_task_arn``
+        # so the row would re-fire on every tick.
+        arn_sqls = [sql for sql, _ in arn_clear_cur.executed]
+        assert any("SET agent_task_arn = NULL" in sql for sql in arn_sqls), arn_sqls
+        assert [params for _, params in arn_clear_cur.executed] == [
+            ("agent-gap-noiss",)
+        ]
+
+    def test_failure_not_terminal_clears_arn_when_issue_number_is_none(
+        self, caplog: Any
+    ) -> None:
+        """Branch 5: container exit non-zero, DB row not yet terminal,
+        AND ``issue_number IS NULL``.
+
+        Pre-fix: ``_handle_agent_failure`` writes a
+        ``dispatcher.failures`` row + invokes the diagnoser path but
+        never touches ``agent_task_arn`` — latent leak: any failure
+        of this shape would be re-selected forever.
+
+        Post-fix: ``_clear_agent_task_arn`` runs at the call site
+        immediately after ``_handle_agent_failure``.
+        """
+        d, conn = _make_daemon()
+        caplog.set_level(logging.WARNING, logger="test.daemon_reap")
+        select_cur = _FakeCursor(
+            rows=[
+                (
+                    "agent-fail-noiss",
+                    None,  # ← issue_number IS NULL
+                    "arn:aws:ecs:us-west-2:123:task/fail-noiss",
+                    "ralph",
+                    "running",
+                ),
+            ]
+        )
+        conn.queue_cursor(select_cur)
+        # Re-read returns NON-terminal — forces failure-not-terminal.
+        status_cur = _FakeCursor()
+        status_cur.fetchone_queue = [("running", "ralph")]
+        conn.queue_cursor(status_cur)
+        # ``_handle_agent_failure`` is mocked below. Next cursor
+        # goes to ``_clear_agent_task_arn``.
+        arn_clear_cur = _FakeCursor()
+        conn.queue_cursor(arn_clear_cur)
+
+        fake_client = MagicMock()
+        fake_client.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "taskArn": "arn:aws:ecs:us-west-2:123:task/fail-noiss",
+                    "lastStatus": "STOPPED",
+                    "stopCode": "ContainerRuntimeError",
+                    "containers": [{"exitCode": 137}],
+                }
+            ]
+        }
+        with (
+            patch.object(d, "_make_ecs_client", return_value=fake_client),
+            patch.object(d, "_handle_agent_failure") as fail_mock,
+        ):
+            summary = d._reap_completed_agent_tasks()
+
+        assert summary["reaped_failure"] == 1
+        # Branch 5 took the failure-not-terminal path.
+        fail_mock.assert_called_once()
+        kw = fail_mock.call_args.kwargs
+        assert kw["category"] == "agent_task_stopped_unexpectedly"
+        assert kw["issue_number"] is None
+        events = [getattr(r, "event", None) for r in caplog.records]
+        assert "agent_runner_reaped_failure" in events
+        # CRITICAL: ARN clear MUST have run. Pre-#3805
+        # ``_handle_agent_failure`` did not touch ``agent_task_arn``
+        # so the row would re-fire on every tick.
+        arn_sqls = [sql for sql, _ in arn_clear_cur.executed]
+        assert any("SET agent_task_arn = NULL" in sql for sql in arn_sqls), arn_sqls
+        assert [params for _, params in arn_clear_cur.executed] == [
+            ("agent-fail-noiss",)
+        ]


### PR DESCRIPTION
## Summary

Hoists the `agent_task_arn = NULL` clear out of the per-branch helpers in `scripts/dispatcher/daemon.py:_reap_completed_agent_tasks` to a single uniform `self._clear_agent_task_arn(...)` call at every terminal-branch call site. All five terminal branches (bypassed, success-already-terminal, success-row-gap, failure-already-terminal, failure-not-terminal) now invoke the same helper exactly once, replacing one buried-and-unreachable inline UPDATE plus one branch-4 inline UPDATE plus two latent-leak branches that didn't clear at all. Net: 5/5 branches uniform, 3 duplicated UPDATE patterns collapsed into 1.

The bug we observed: branch 2 called `_reap_finalize_ecs_success` which early-returns on `issue_number is None` (audit / daily-report / startup subagents) — short-circuiting the buried ARN clear and leaving the row to be re-selected every scheduler tick forever (~10 events/min on a single agent_id post-#3802).

Closes #3805

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/dispatcher/tests/`)
- [x] CI green

### Post-deploy verification
- [x] CloudWatch Insights query against `/ecs/judgemind-dispatcher-dev`: pre-deploy ~10/min on a single `agent_id`; post-deploy 22:04 bin shows 1 event then silence (one final reap, then ARN cleared, row drops out of SELECT). See verification-evidence comment on #3805.
- [x] Verification evidence posted on #3805.
