### PR TITLE
fix(dispatcher): tolerate graphql partial-error responses in blocker_title_fetch (#3808)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -6581,10 +6581,9 @@ class DispatcherDaemon:
         Issues a single batched GitHub GraphQL query that aliases BOTH
         ``issue(number: N)`` and ``pullRequest(number: N)`` per capped
         blocker number. The parser prefers the issue-typed result, falling
-        back to the PR-typed result when the issue side is null. Routed
-        through ``_subprocess_with_retry`` with
-        ``event_name='blocker_title_fetch'``. Returns ``{number: title}``
-        with ``None`` on failure (404, rate-limit, network error).
+        back to the PR-typed result when the issue side is null. Returns
+        ``{number: title}`` with ``None`` on failure (network error,
+        timeout, gh missing, unparseable JSON, or both alias sides null).
 
         Single-tick scope — no cross-tick caching. Issue #2989.
         Issue #3435: batched GraphQL replaces the per-issue loop.
@@ -6595,6 +6594,23 @@ class DispatcherDaemon:
         number of N"``), which surfaced as a non-zero ``gh api graphql``
         exit and failed the whole batch — even when other blockers in the
         batch were valid issues.
+
+        Issue #3808: the union-aliased query *still* exits non-zero
+        whenever a batch mixes issue-only and PR-only blockers — GitHub
+        returns valid ``data.repository`` AND a non-empty ``errors[]``
+        with NOT_FOUND entries for the unresolvable alias side of each
+        number, AND ``gh api graphql`` propagates that as exit 1. Routing
+        through :meth:`_subprocess_with_retry` (which treats non-zero
+        exit as a transient failure) discarded the perfectly-good data
+        and burned three retries on a deterministic outcome — flooding
+        CloudWatch with ``blocker_title_fetch_exhausted`` warnings every
+        ~30s. The fix is surgical: bypass ``_subprocess_with_retry`` for
+        this call and parse ``data.repository`` regardless of exit code.
+        ``errors[]`` is informational; only treat as failure when stdout
+        is empty/unparseable, when ``data.repository`` is missing, or
+        when the subprocess raises ``TimeoutExpired`` / ``FileNotFoundError``.
+        The 3-attempt retry envelope is kept only for those true
+        transient classes.
 
         Caps the number of lookups at ``MAX_BLOCKER_TITLE_FETCH`` to bound
         worst-case query size when GitHub is rate-limited (issue #2989).
@@ -6617,7 +6633,10 @@ class DispatcherDaemon:
         # lookup. GitHub's GraphQL ``issue(number:N)`` only resolves Issue
         # nodes, and ``pullRequest(number:N)`` only resolves PR nodes —
         # so unioning both is the only way to handle a number that could
-        # be either type without triggering a partial GraphQL error.
+        # be either type. When a number is only an Issue, the ``_pr``
+        # alias resolves to null AND the response carries a NOT_FOUND
+        # error for that path; mirror is true for PR-only numbers. The
+        # parser below tolerates these partial errors (#3808).
         alias_fields = " ".join(
             f"i{n}_issue: issue(number: {n}) {{ number title }} "
             f"i{n}_pr: pullRequest(number: {n}) {{ number title }}"
@@ -6629,24 +6648,6 @@ class DispatcherDaemon:
         )
 
         cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
-        outcome = self._subprocess_with_retry(
-            cmd,
-            event_name="blocker_title_fetch",
-            timeout=30,
-            extra_log_fields={"blocker_count": len(capped)},
-        )
-
-        if not outcome["ok"]:
-            self._log.warning(
-                "daemon.blocker_title_fetch_exhausted",
-                extra={
-                    "event": "blocker_title_fetch_exhausted",
-                    "run_id": self._run_id,
-                    "blocker_count": len(capped),
-                    "reason": outcome.get("reason"),
-                },
-            )
-            return {n: None for n in capped}
 
         def _title_from(node: object) -> str | None:
             """Return the ``title`` string from an alias node, or None."""
@@ -6656,19 +6657,122 @@ class DispatcherDaemon:
                     return title
             return None
 
-        try:
-            payload = json.loads(outcome["result"].stdout or "{}")
-            repo_data = payload["data"]["repository"]
-            # Prefer the issue-typed result; fall back to PR-typed.
-            return {
-                n: (
-                    _title_from(repo_data.get(f"i{n}_issue"))
-                    or _title_from(repo_data.get(f"i{n}_pr"))
+        # Retry envelope for *true* transient failures only — timeout,
+        # gh missing, empty stdout, or a payload missing ``data.repository``.
+        # Partial-error responses (errors[] populated, exit 1, but
+        # ``data.repository`` is a dict) are NOT retried — the outcome
+        # is deterministic and the data is already in our hands.
+        #
+        # cold-path (#3089): bypasses ``_subprocess_with_retry`` because
+        # that helper treats *every* non-zero exit as transient (#3808),
+        # which discards perfectly-good ``data.repository`` payloads on
+        # the GraphQL partial-error path. The local retry below preserves
+        # the helper's 1s+2s backoff and ``_flake`` / ``_exhausted`` log
+        # shape for the genuinely-transient classes (timeout, gh missing,
+        # empty stdout, unparseable JSON, missing data) while letting
+        # the deterministic partial-error case return on attempt 1.
+        backoffs_seconds: tuple[float, ...] = (1.0, 2.0)
+        max_attempts = 1 + len(backoffs_seconds)  # 3
+        last_reason: str | None = None
+        last_stderr_tail = ""
+        last_exit_code: int | None = None
+        for attempt in range(1, max_attempts + 1):
+            try:
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    check=False,
                 )
-                for n in capped
-            }
-        except (json.JSONDecodeError, AttributeError, KeyError, TypeError):
-            return {n: None for n in capped}
+            except FileNotFoundError as exc:
+                last_reason = "gh_missing"
+                last_stderr_tail = str(exc)
+                last_exit_code = None
+            except subprocess.TimeoutExpired:
+                last_reason = "timeout"
+                last_stderr_tail = ""
+                last_exit_code = None
+            else:
+                # Always attempt to parse stdout — partial-error responses
+                # (exit 1 with valid ``data.repository``) are the common
+                # case for mixed issue/PR batches and must be honored.
+                stdout = result.stdout or ""
+                if stdout.strip():
+                    try:
+                        payload = json.loads(stdout)
+                    except json.JSONDecodeError:
+                        last_reason = "unparseable_json"
+                        last_stderr_tail = _stderr_tail(result.stderr)
+                        last_exit_code = result.returncode
+                    else:
+                        repo_data = (
+                            payload.get("data", {}).get("repository")
+                            if isinstance(payload, dict)
+                            else None
+                        )
+                        if isinstance(repo_data, dict):
+                            # Happy path — data is present. ``errors[]``
+                            # in the payload is informational (typically
+                            # NOT_FOUND for the unused alias side of each
+                            # blocker) and is intentionally ignored.
+                            return {
+                                n: (
+                                    _title_from(repo_data.get(f"i{n}_issue"))
+                                    or _title_from(repo_data.get(f"i{n}_pr"))
+                                )
+                                for n in capped
+                            }
+                        # ``data.repository`` is missing/null — treat as
+                        # transient (rate limit, auth scope drop, etc.).
+                        last_reason = "missing_data"
+                        last_stderr_tail = _stderr_tail(result.stderr)
+                        last_exit_code = result.returncode
+                else:
+                    # Empty stdout on either zero or non-zero exit —
+                    # treat as transient flake.
+                    last_reason = "empty_stdout"
+                    last_stderr_tail = _stderr_tail(result.stderr)
+                    last_exit_code = result.returncode
+
+            # Transient failure — emit flake WARNING and (if attempts
+            # remain) back off. Mirrors the
+            # :meth:`_subprocess_with_retry` log shape so operators see
+            # one consistent event in CloudWatch.
+            self._log.warning(
+                "daemon.blocker_title_fetch_flake (attempt %d/%d): %s",
+                attempt,
+                max_attempts,
+                last_reason,
+                extra={
+                    "event": "blocker_title_fetch_flake",
+                    "run_id": self._run_id,
+                    "attempt": attempt,
+                    "max_attempts": max_attempts,
+                    "reason": last_reason,
+                    "stderr_tail": last_stderr_tail,
+                    "blocker_count": len(capped),
+                },
+            )
+            if attempt < max_attempts:
+                time.sleep(backoffs_seconds[attempt - 1])
+
+        # All attempts exhausted on a true transient failure. Emit the
+        # exhausted WARNING and return the all-None map. Existing
+        # behavior is preserved for genuinely flaky outcomes.
+        self._log.warning(
+            "daemon.blocker_title_fetch_exhausted",
+            extra={
+                "event": "blocker_title_fetch_exhausted",
+                "run_id": self._run_id,
+                "blocker_count": len(capped),
+                "reason": last_reason,
+                "stderr_tail": last_stderr_tail,
+                "exit_code": last_exit_code,
+                "attempts": max_attempts,
+            },
+        )
+        return {n: None for n in capped}
 
     @staticmethod
     def _parse_parent_issue(body: str) -> int | None:

--- a/scripts/dispatcher/tests/test_blocker_title_fetch_pr_numbers.py
+++ b/scripts/dispatcher/tests/test_blocker_title_fetch_pr_numbers.py
@@ -1,38 +1,41 @@
 # ruff: noqa: I001
-"""Regression tests for issue #3759.
+"""Regression tests for ``_fetch_issue_titles_for_blockers``.
 
-``_fetch_issue_titles_for_blockers`` previously issued a batched GraphQL
-query that aliased ``issue(number: N)`` for each blocker number. GitHub's
-GraphQL ``issue`` field only resolves Issue nodes — when a blocker number
-refers to a PR (e.g. ``Blocked by #3710`` where #3710 is a PR), the field
-returns null AND the GraphQL response carries a top-level error:
+Two related bugs are exercised here:
 
-    "Could not resolve to an Issue with the number of N"
+#3759 — the original ``issue(number:N)``-only query failed the whole
+batch on a single PR-numbered blocker, because ``gh api graphql``
+exits non-zero when GitHub returns a top-level
+``Could not resolve to an Issue with the number of N`` error. The fix
+union-aliases ``issue(number:N)`` AND ``pullRequest(number:N)`` for
+each blocker so the parser can fall back from one to the other.
 
-``gh api graphql`` surfaces partial errors as a non-zero exit code, which
-``_subprocess_with_retry`` treats as failure → 3× retry → exhausted.
-The whole batch fails on a single PR-numbered blocker, even when other
-blockers in the batch are valid issues.
+#3808 — even with the union-aliased query, ``gh api graphql`` still
+exits 1 whenever a batch mixes issue-only and PR-only blockers,
+because GitHub returns valid ``data.repository`` AND a non-empty
+``errors[]`` (NOT_FOUND for the unused alias side of each blocker).
+Routing through ``_subprocess_with_retry`` (which treats non-zero
+exit as transient failure) discarded the perfectly-good data and
+burned three retries on a deterministic outcome — flooding CloudWatch
+with ``blocker_title_fetch_exhausted`` warnings every ~30s. The fix
+bypasses ``_subprocess_with_retry`` for this one call and parses
+``data.repository`` regardless of exit code; the retry envelope is
+kept only for true transient failures (timeout / gh missing /
+empty stdout / unparseable JSON / ``data.repository`` missing).
 
-The fix (Option A from the issue): query BOTH ``issue(number:N)`` and
-``pullRequest(number:N)`` for each blocker number, with aliased fields
-``i<n>_issue`` and ``i<n>_pr``. The parser prefers the issue-typed
-result; when it's null, it falls back to the PR-typed result. The query
-remains a single batched call.
-
-These tests stub ``_subprocess_with_retry`` to return the new union shape
-and assert the function returns the right title regardless of whether the
-blocker resolves as an Issue or a PR.
+These tests stub ``subprocess.run`` so they exercise the real
+parser end-to-end, including the partial-error path (#3808).
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -138,18 +141,59 @@ def _make_daemon_with_capture() -> tuple[
     return d, conn, handler
 
 
+def _stub_subprocess_run(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stdout: str = "",
+    stderr: str = "",
+    returncode: int = 0,
+    raises: BaseException | None = None,
+    call_log: list[list[str]] | None = None,
+    sleep_log: list[float] | None = None,
+) -> None:
+    """Patch ``subprocess.run`` (used inside ``_fetch_issue_titles_for_blockers``)
+    and ``time.sleep`` (used in the retry envelope).
+
+    ``raises`` lets a test inject a transient exception path; otherwise the
+    call returns a stubbed ``CompletedProcess``-like object.
+
+    Patches ``daemon.subprocess.run`` and ``daemon.time.sleep`` (the names
+    ``daemon`` actually resolves at import time) rather than the global
+    modules so other dispatcher tests in the same xdist worker stay clean.
+    """
+
+    def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+        if call_log is not None:
+            call_log.append(list(cmd))
+        if raises is not None:
+            raise raises
+        return SimpleNamespace(
+            stdout=stdout,
+            stderr=stderr,
+            returncode=returncode,
+        )
+
+    def fake_sleep(seconds: float) -> None:
+        if sleep_log is not None:
+            sleep_log.append(seconds)
+
+    monkeypatch.setattr(daemon.subprocess, "run", fake_run)
+    monkeypatch.setattr(daemon.time, "sleep", fake_sleep)
+
+
 # --------------------------------------------------------------------------
-# Regression tests for the union-shape GraphQL query (#3759).
+# #3759 — union-shape parser preserves PR-numbered blockers.
 # --------------------------------------------------------------------------
 
 
 class TestBlockerTitleFetchPrNumbers:
     """``_fetch_issue_titles_for_blockers`` resolves PR-numbered blockers.
 
-    These tests assert the union-shape behaviour required by the fix:
-    each blocker is queried as both ``issue(number:N)`` and
-    ``pullRequest(number:N)``; the parser prefers the issue-typed result
-    and falls back to the PR-typed result when the issue side is null.
+    These tests assert the union-shape behaviour required by the #3759
+    fix: each blocker is queried as both ``issue(number:N)`` and
+    ``pullRequest(number:N)``; the parser prefers the issue-typed
+    result and falls back to the PR-typed result when the issue side
+    is null.
     """
 
     def test_mixed_issue_and_pr_blockers(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -157,40 +201,34 @@ class TestBlockerTitleFetchPrNumbers:
         d, _conn, _handler = _make_daemon_with_capture()
 
         call_log: list[list[str]] = []
-
-        def fake_retry(
-            cmd: list[str],
-            *,
-            event_name: str,
-            timeout: float,
-            extra_log_fields: dict | None = None,
-        ) -> dict:
-            call_log.append(cmd)
-            result = MagicMock()
-            result.returncode = 0
-            # Union-shape response: each number has BOTH ``i<n>_issue`` and
-            # ``i<n>_pr``. PRs return non-null for ``_pr`` only; issues
-            # return non-null for ``_issue`` only.
-            result.stdout = json.dumps(
+        _stub_subprocess_run(
+            monkeypatch,
+            call_log=call_log,
+            returncode=0,
+            stdout=json.dumps(
                 {
                     "data": {
                         "repository": {
-                            # PR — issue side null, PR side resolves.
                             "i3710_issue": None,
-                            "i3710_pr": {"number": 3710, "title": "PR title"},
-                            # PR — issue side null, PR side resolves.
+                            "i3710_pr": {
+                                "number": 3710,
+                                "title": "PR title",
+                            },
                             "i3714_issue": None,
-                            "i3714_pr": {"number": 3714, "title": "PR title 2"},
-                            # Issue — issue side resolves, PR side null.
-                            "i3015_issue": {"number": 3015, "title": "Issue title"},
+                            "i3714_pr": {
+                                "number": 3714,
+                                "title": "PR title 2",
+                            },
+                            "i3015_issue": {
+                                "number": 3015,
+                                "title": "Issue title",
+                            },
                             "i3015_pr": None,
                         }
                     }
                 }
-            )
-            return {"ok": True, "result": result, "attempts": 1}
-
-        monkeypatch.setattr(d, "_subprocess_with_retry", fake_retry)
+            ),
+        )
 
         titles = d._fetch_issue_titles_for_blockers({3710, 3714, 3015})
 
@@ -204,7 +242,9 @@ class TestBlockerTitleFetchPrNumbers:
         # Single batched GraphQL call (key correctness invariant — see #3435).
         assert len(call_log) == 1
         # Query string mentions both issue and pullRequest fields per number.
-        query_arg = call_log[0][4]
+        cmd = call_log[0]
+        assert cmd[:3] == ["gh", "api", "graphql"]
+        query_arg = cmd[4]
         assert "query=" in query_arg
         for n in [3710, 3714, 3015]:
             assert f"i{n}_issue:" in query_arg
@@ -218,38 +258,35 @@ class TestBlockerTitleFetchPrNumbers:
         d, _conn, handler = _make_daemon_with_capture()
 
         call_log: list[list[str]] = []
-
-        def fake_retry(
-            cmd: list[str],
-            *,
-            event_name: str,
-            timeout: float,
-            extra_log_fields: dict | None = None,
-        ) -> dict:
-            call_log.append(cmd)
-            result = MagicMock()
-            result.returncode = 0
-            # All blockers are PRs — every ``i<n>_issue`` is null, every
-            # ``i<n>_pr`` resolves.
-            result.stdout = json.dumps(
+        _stub_subprocess_run(
+            monkeypatch,
+            call_log=call_log,
+            returncode=0,
+            stdout=json.dumps(
                 {
                     "data": {
                         "repository": {
                             "i3710_issue": None,
-                            "i3710_pr": {"number": 3710, "title": "PR #3710 title"},
+                            "i3710_pr": {
+                                "number": 3710,
+                                "title": "PR #3710 title",
+                            },
                             "i3714_issue": None,
-                            "i3714_pr": {"number": 3714, "title": "PR #3714 title"},
+                            "i3714_pr": {
+                                "number": 3714,
+                                "title": "PR #3714 title",
+                            },
                             "i3500_issue": None,
-                            "i3500_pr": {"number": 3500, "title": "PR #3500 title"},
+                            "i3500_pr": {
+                                "number": 3500,
+                                "title": "PR #3500 title",
+                            },
                         }
                     }
                 }
-            )
-            return {"ok": True, "result": result, "attempts": 1}
+            ),
+        )
 
-        monkeypatch.setattr(d, "_subprocess_with_retry", fake_retry)
-
-        # No exception, all PR titles returned.
         titles = d._fetch_issue_titles_for_blockers({3710, 3714, 3500})
 
         assert titles == {
@@ -262,13 +299,7 @@ class TestBlockerTitleFetchPrNumbers:
         # No ``blocker_title_fetch_exhausted`` warning fired — the call
         # succeeded with the union-shape response (regression: this was
         # the bug surface in #3759 production logs).
-        exhausted_warnings = [
-            r
-            for r in handler.records
-            if r.levelno == logging.WARNING
-            and getattr(r, "event", None) == "blocker_title_fetch_exhausted"
-        ]
-        assert exhausted_warnings == []
+        assert handler.events("blocker_title_fetch_exhausted") == []
 
     def test_pr_side_takes_over_when_issue_side_null(
         self, monkeypatch: pytest.MonkeyPatch
@@ -276,28 +307,23 @@ class TestBlockerTitleFetchPrNumbers:
         """Single PR blocker — parser falls back to the PR-typed result."""
         d, _conn, _handler = _make_daemon_with_capture()
 
-        def fake_retry(
-            cmd: list[str],
-            *,
-            event_name: str,
-            timeout: float,
-            extra_log_fields: dict | None = None,
-        ) -> dict:
-            result = MagicMock()
-            result.returncode = 0
-            result.stdout = json.dumps(
+        _stub_subprocess_run(
+            monkeypatch,
+            returncode=0,
+            stdout=json.dumps(
                 {
                     "data": {
                         "repository": {
                             "i3710_issue": None,
-                            "i3710_pr": {"number": 3710, "title": "Fallback PR title"},
+                            "i3710_pr": {
+                                "number": 3710,
+                                "title": "Fallback PR title",
+                            },
                         }
                     }
                 }
-            )
-            return {"ok": True, "result": result, "attempts": 1}
-
-        monkeypatch.setattr(d, "_subprocess_with_retry", fake_retry)
+            ),
+        )
 
         titles = d._fetch_issue_titles_for_blockers({3710})
         assert titles[3710] == "Fallback PR title"
@@ -309,28 +335,26 @@ class TestBlockerTitleFetchPrNumbers:
         the issue-typed title wins. Verifies parser preference order."""
         d, _conn, _handler = _make_daemon_with_capture()
 
-        def fake_retry(
-            cmd: list[str],
-            *,
-            event_name: str,
-            timeout: float,
-            extra_log_fields: dict | None = None,
-        ) -> dict:
-            result = MagicMock()
-            result.returncode = 0
-            result.stdout = json.dumps(
+        _stub_subprocess_run(
+            monkeypatch,
+            returncode=0,
+            stdout=json.dumps(
                 {
                     "data": {
                         "repository": {
-                            "i42_issue": {"number": 42, "title": "Issue-side title"},
-                            "i42_pr": {"number": 42, "title": "PR-side title"},
+                            "i42_issue": {
+                                "number": 42,
+                                "title": "Issue-side title",
+                            },
+                            "i42_pr": {
+                                "number": 42,
+                                "title": "PR-side title",
+                            },
                         }
                     }
                 }
-            )
-            return {"ok": True, "result": result, "attempts": 1}
-
-        monkeypatch.setattr(d, "_subprocess_with_retry", fake_retry)
+            ),
+        )
 
         titles = d._fetch_issue_titles_for_blockers({42})
         # Parser prefers the issue-typed result.
@@ -343,16 +367,10 @@ class TestBlockerTitleFetchPrNumbers:
         deleted/transferred), the title is None — no crash."""
         d, _conn, _handler = _make_daemon_with_capture()
 
-        def fake_retry(
-            cmd: list[str],
-            *,
-            event_name: str,
-            timeout: float,
-            extra_log_fields: dict | None = None,
-        ) -> dict:
-            result = MagicMock()
-            result.returncode = 0
-            result.stdout = json.dumps(
+        _stub_subprocess_run(
+            monkeypatch,
+            returncode=0,
+            stdout=json.dumps(
                 {
                     "data": {
                         "repository": {
@@ -361,10 +379,439 @@ class TestBlockerTitleFetchPrNumbers:
                         }
                     }
                 }
-            )
-            return {"ok": True, "result": result, "attempts": 1}
-
-        monkeypatch.setattr(d, "_subprocess_with_retry", fake_retry)
+            ),
+        )
 
         titles = d._fetch_issue_titles_for_blockers({9999})
         assert titles == {9999: None}
+
+
+# --------------------------------------------------------------------------
+# #3808 — partial-error response (exit 1 with valid data) is honored.
+# --------------------------------------------------------------------------
+
+
+class TestBlockerTitleFetchPartialErrors:
+    """``_fetch_issue_titles_for_blockers`` parses ``data.repository``
+    regardless of subprocess exit code (#3808).
+
+    The seven blockers in the failing production batch right now:
+    - ``2595, 2609, 2610, 3373, 3660`` — exist as **issues** only.
+    - ``3710, 3714`` — exist as **PRs** only.
+
+    GitHub's GraphQL returns valid ``data.repository`` with the resolved
+    alias side of each, AND ``errors[]`` populated with NOT_FOUND for
+    the unresolvable side, AND ``gh api graphql`` propagates that as
+    exit 1. The fix is to parse ``data.repository`` anyway.
+    """
+
+    def test_partial_graphql_errors_returns_data(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Partial-error response (valid data + errors[] + exit 1) → titles
+        returned. **This test must FAIL against pre-fix code** because the
+        old implementation routed through ``_subprocess_with_retry``,
+        which treats exit 1 as transient failure and retries 3× before
+        returning all-None.
+        """
+        d, _conn, handler = _make_daemon_with_capture()
+
+        # Mirror the production payload shape: ``data.repository`` is
+        # populated AND ``errors[]`` carries NOT_FOUND entries AND
+        # ``gh api graphql`` exits 1. Issue #3808 is closed by the
+        # parser tolerating this exact shape.
+        partial_error_stdout = json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "i2595_issue": {
+                            "number": 2595,
+                            "title": "decision: redesign cockpit refresh",
+                        },
+                        "i2595_pr": None,
+                        "i3710_issue": None,
+                        "i3710_pr": {
+                            "number": 3710,
+                            "title": "chore(api): drop unused columns",
+                        },
+                    }
+                },
+                "errors": [
+                    {
+                        "type": "NOT_FOUND",
+                        "path": ["repository", "i2595_pr"],
+                        "message": (
+                            "Could not resolve to a PullRequest "
+                            "with the number of 2595."
+                        ),
+                    },
+                    {
+                        "type": "NOT_FOUND",
+                        "path": ["repository", "i3710_issue"],
+                        "message": (
+                            "Could not resolve to an Issue with the number of 3710."
+                        ),
+                    },
+                ],
+            }
+        )
+        call_log: list[list[str]] = []
+        sleep_log: list[float] = []
+        _stub_subprocess_run(
+            monkeypatch,
+            call_log=call_log,
+            sleep_log=sleep_log,
+            returncode=1,  # gh exits 1 because errors[] is populated
+            stdout=partial_error_stdout,
+            stderr=(
+                "gh: Could not resolve to a PullRequest with the "
+                "number of 2595. (NOT_FOUND)"
+            ),
+        )
+
+        titles = d._fetch_issue_titles_for_blockers({2595, 3710})
+
+        # Both blockers resolve from ``data.repository`` even though
+        # ``gh`` exited 1.
+        assert titles == {
+            2595: "decision: redesign cockpit refresh",
+            3710: "chore(api): drop unused columns",
+        }
+
+        # Exactly one subprocess call — partial errors are deterministic,
+        # retrying is wasteful (the production bug surface).
+        assert len(call_log) == 1
+        # No backoff sleeps — happy path returned on attempt 1.
+        assert sleep_log == []
+
+        # No ``_exhausted`` warning AND no ``_flake`` warning. The call
+        # succeeded with valid data; ``errors[]`` is informational.
+        assert handler.events("blocker_title_fetch_exhausted") == []
+        assert handler.events("blocker_title_fetch_flake") == []
+
+    def test_seven_production_blockers_all_resolve(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The seven production blockers from issue #3808 all resolve
+        from a single partial-error response. ``2595, 2609, 2610, 3373,
+        3660`` are issue-only; ``3710, 3714`` are PR-only.
+        """
+        d, _conn, handler = _make_daemon_with_capture()
+
+        partial_error_stdout = json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        # Issue-only blockers — issue side resolves.
+                        "i2595_issue": {
+                            "number": 2595,
+                            "title": "issue 2595 title",
+                        },
+                        "i2595_pr": None,
+                        "i2609_issue": {
+                            "number": 2609,
+                            "title": "issue 2609 title",
+                        },
+                        "i2609_pr": None,
+                        "i2610_issue": {
+                            "number": 2610,
+                            "title": "issue 2610 title",
+                        },
+                        "i2610_pr": None,
+                        "i3373_issue": {
+                            "number": 3373,
+                            "title": "issue 3373 title",
+                        },
+                        "i3373_pr": None,
+                        "i3660_issue": {
+                            "number": 3660,
+                            "title": "issue 3660 title",
+                        },
+                        "i3660_pr": None,
+                        # PR-only blockers — PR side resolves.
+                        "i3710_issue": None,
+                        "i3710_pr": {
+                            "number": 3710,
+                            "title": "pr 3710 title",
+                        },
+                        "i3714_issue": None,
+                        "i3714_pr": {
+                            "number": 3714,
+                            "title": "pr 3714 title",
+                        },
+                    }
+                },
+                "errors": [
+                    # 5× issue-only blockers contribute one NOT_FOUND each
+                    # for the PR alias; 2× PR-only blockers contribute
+                    # one NOT_FOUND each for the issue alias. 7 total.
+                    {"type": "NOT_FOUND", "path": ["repository", "i2595_pr"]},
+                    {"type": "NOT_FOUND", "path": ["repository", "i2609_pr"]},
+                    {"type": "NOT_FOUND", "path": ["repository", "i2610_pr"]},
+                    {"type": "NOT_FOUND", "path": ["repository", "i3373_pr"]},
+                    {"type": "NOT_FOUND", "path": ["repository", "i3660_pr"]},
+                    {"type": "NOT_FOUND", "path": ["repository", "i3710_issue"]},
+                    {"type": "NOT_FOUND", "path": ["repository", "i3714_issue"]},
+                ],
+            }
+        )
+        _stub_subprocess_run(
+            monkeypatch,
+            returncode=1,
+            stdout=partial_error_stdout,
+        )
+
+        titles = d._fetch_issue_titles_for_blockers(
+            {2595, 2609, 2610, 3373, 3660, 3710, 3714}
+        )
+
+        assert titles == {
+            2595: "issue 2595 title",
+            2609: "issue 2609 title",
+            2610: "issue 2610 title",
+            3373: "issue 3373 title",
+            3660: "issue 3660 title",
+            3710: "pr 3710 title",
+            3714: "pr 3714 title",
+        }
+        # All warning events stayed silent — production CloudWatch noise
+        # disappears once the parser tolerates partial errors.
+        assert handler.events("blocker_title_fetch_exhausted") == []
+        assert handler.events("blocker_title_fetch_flake") == []
+
+    def test_issue_only_batch_no_errors_returns_titles(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A batch of pure-issue blockers (no PR-only entries) still has
+        ``errors[]`` for every ``_pr`` alias. Parser ignores ``errors[]``
+        and returns the issue-side title for each blocker."""
+        d, _conn, handler = _make_daemon_with_capture()
+
+        _stub_subprocess_run(
+            monkeypatch,
+            returncode=1,  # errors[] populated → gh exit 1
+            stdout=json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "i100_issue": {"number": 100, "title": "issue 100"},
+                            "i100_pr": None,
+                            "i200_issue": {"number": 200, "title": "issue 200"},
+                            "i200_pr": None,
+                        }
+                    },
+                    "errors": [
+                        {"type": "NOT_FOUND", "path": ["repository", "i100_pr"]},
+                        {"type": "NOT_FOUND", "path": ["repository", "i200_pr"]},
+                    ],
+                }
+            ),
+        )
+
+        titles = d._fetch_issue_titles_for_blockers({100, 200})
+        assert titles == {100: "issue 100", 200: "issue 200"}
+        assert handler.events("blocker_title_fetch_exhausted") == []
+
+    def test_pr_only_batch_no_errors_returns_titles(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A batch of pure-PR blockers also has ``errors[]`` for every
+        ``_issue`` alias. Parser falls back to the ``_pr`` side for each."""
+        d, _conn, handler = _make_daemon_with_capture()
+
+        _stub_subprocess_run(
+            monkeypatch,
+            returncode=1,
+            stdout=json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "i100_issue": None,
+                            "i100_pr": {"number": 100, "title": "pr 100"},
+                            "i200_issue": None,
+                            "i200_pr": {"number": 200, "title": "pr 200"},
+                        }
+                    },
+                    "errors": [
+                        {"type": "NOT_FOUND", "path": ["repository", "i100_issue"]},
+                        {"type": "NOT_FOUND", "path": ["repository", "i200_issue"]},
+                    ],
+                }
+            ),
+        )
+
+        titles = d._fetch_issue_titles_for_blockers({100, 200})
+        assert titles == {100: "pr 100", 200: "pr 200"}
+        assert handler.events("blocker_title_fetch_exhausted") == []
+
+
+# --------------------------------------------------------------------------
+# #3808 — true transient failures still emit the exhausted log.
+# --------------------------------------------------------------------------
+
+
+class TestBlockerTitleFetchExhaustedPath:
+    """Genuine transient failures still hit the 3-attempt retry envelope
+    and emit the ``blocker_title_fetch_exhausted`` warning. The fix only
+    skips retries for the deterministic partial-error case.
+    """
+
+    def test_timeout_returns_all_none_and_emits_exhausted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``subprocess.TimeoutExpired`` is transient — retry 3×, then
+        return ``{n: None}`` and emit ``_exhausted``."""
+        d, _conn, handler = _make_daemon_with_capture()
+
+        sleep_log: list[float] = []
+        _stub_subprocess_run(
+            monkeypatch,
+            sleep_log=sleep_log,
+            raises=subprocess.TimeoutExpired(cmd="gh", timeout=30),
+        )
+
+        titles = d._fetch_issue_titles_for_blockers({42, 43})
+        assert titles == {42: None, 43: None}
+
+        # 3 attempts → 2 sleeps (after attempts 1 and 2).
+        assert sleep_log == [1.0, 2.0]
+
+        # Per-attempt flake warnings + final exhausted warning.
+        flake_events = handler.events("blocker_title_fetch_flake")
+        assert len(flake_events) == 3
+        for record in flake_events:
+            assert record.reason == "timeout"
+
+        exhausted_events = handler.events("blocker_title_fetch_exhausted")
+        assert len(exhausted_events) == 1
+        assert exhausted_events[0].reason == "timeout"
+        assert exhausted_events[0].attempts == 3
+        assert exhausted_events[0].blocker_count == 2
+
+    def test_empty_stdout_returns_all_none_and_emits_exhausted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty stdout (with either zero or non-zero exit) is treated
+        as a transient flake — retry 3×, then return ``{n: None}`` and
+        emit ``_exhausted``."""
+        d, _conn, handler = _make_daemon_with_capture()
+
+        _stub_subprocess_run(
+            monkeypatch,
+            returncode=0,
+            stdout="",
+            stderr="connection closed by peer",
+        )
+
+        titles = d._fetch_issue_titles_for_blockers({99})
+        assert titles == {99: None}
+
+        flake_events = handler.events("blocker_title_fetch_flake")
+        assert len(flake_events) == 3
+        for record in flake_events:
+            assert record.reason == "empty_stdout"
+
+        exhausted_events = handler.events("blocker_title_fetch_exhausted")
+        assert len(exhausted_events) == 1
+        assert exhausted_events[0].reason == "empty_stdout"
+
+    def test_unparseable_json_returns_all_none_and_emits_exhausted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Malformed stdout (not JSON) is treated as transient — retry
+        3× then return ``{n: None}`` and emit ``_exhausted``."""
+        d, _conn, handler = _make_daemon_with_capture()
+
+        _stub_subprocess_run(
+            monkeypatch,
+            returncode=1,
+            stdout="<html>504 Gateway Timeout</html>",
+        )
+
+        titles = d._fetch_issue_titles_for_blockers({77})
+        assert titles == {77: None}
+
+        flake_events = handler.events("blocker_title_fetch_flake")
+        assert len(flake_events) == 3
+        for record in flake_events:
+            assert record.reason == "unparseable_json"
+
+        exhausted_events = handler.events("blocker_title_fetch_exhausted")
+        assert len(exhausted_events) == 1
+        assert exhausted_events[0].reason == "unparseable_json"
+
+    def test_gh_missing_returns_all_none_and_emits_exhausted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``FileNotFoundError`` (gh CLI missing on PATH) is transient —
+        retry 3×, then return ``{n: None}`` and emit ``_exhausted``."""
+        d, _conn, handler = _make_daemon_with_capture()
+
+        _stub_subprocess_run(
+            monkeypatch,
+            raises=FileNotFoundError("gh: command not found"),
+        )
+
+        titles = d._fetch_issue_titles_for_blockers({1})
+        assert titles == {1: None}
+
+        flake_events = handler.events("blocker_title_fetch_flake")
+        assert len(flake_events) == 3
+        for record in flake_events:
+            assert record.reason == "gh_missing"
+
+        exhausted_events = handler.events("blocker_title_fetch_exhausted")
+        assert len(exhausted_events) == 1
+        assert exhausted_events[0].reason == "gh_missing"
+
+    def test_missing_data_repository_returns_all_none_and_emits_exhausted(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Payload parses as JSON but ``data.repository`` is missing
+        (e.g., auth scope drop, rate-limit response shape). Treated as
+        transient — retry 3×, then return ``{n: None}`` and emit
+        ``_exhausted``."""
+        d, _conn, handler = _make_daemon_with_capture()
+
+        _stub_subprocess_run(
+            monkeypatch,
+            returncode=1,
+            stdout=json.dumps(
+                {
+                    # No ``data.repository`` — only top-level errors.
+                    "errors": [{"message": "Bad credentials"}],
+                }
+            ),
+        )
+
+        titles = d._fetch_issue_titles_for_blockers({5})
+        assert titles == {5: None}
+
+        flake_events = handler.events("blocker_title_fetch_flake")
+        assert len(flake_events) == 3
+        for record in flake_events:
+            assert record.reason == "missing_data"
+
+        exhausted_events = handler.events("blocker_title_fetch_exhausted")
+        assert len(exhausted_events) == 1
+        assert exhausted_events[0].reason == "missing_data"
+
+    def test_empty_input_short_circuits_with_no_subprocess(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty input → empty output, no subprocess call, no logs."""
+        d, _conn, handler = _make_daemon_with_capture()
+
+        call_log: list[list[str]] = []
+        _stub_subprocess_run(
+            monkeypatch,
+            call_log=call_log,
+            returncode=0,
+            stdout="{}",
+        )
+
+        titles = d._fetch_issue_titles_for_blockers(set())
+        assert titles == {}
+        assert call_log == []
+        assert handler.events("blocker_title_fetch_flake") == []
+        assert handler.events("blocker_title_fetch_exhausted") == []

--- a/scripts/dispatcher/tests/test_daemon_enrichment.py
+++ b/scripts/dispatcher/tests/test_daemon_enrichment.py
@@ -624,16 +624,11 @@ class TestFetchIssueTitlesForBlockers:
 
         call_log: list[list[str]] = []
 
-        def fake_retry(
-            cmd: list[str],
-            *,
-            event_name: str,
-            timeout: float,
-            extra_log_fields: dict | None = None,
-        ) -> dict:
-            call_log.append(cmd)
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            call_log.append(list(cmd))
             result = MagicMock()
             result.returncode = 0
+            result.stderr = ""
             # Issue #3759: union-shape response with both ``i<n>_issue``
             # and ``i<n>_pr``. Issues resolve on the issue side; PRs on
             # the PR side.
@@ -649,9 +644,14 @@ class TestFetchIssueTitlesForBlockers:
                     }
                 }
             )
-            return {"ok": True, "result": result, "attempts": 1}
+            return result
 
-        monkeypatch.setattr(d, "_subprocess_with_retry", fake_retry)
+        # Issue #3808: ``_fetch_issue_titles_for_blockers`` no longer
+        # routes through ``_subprocess_with_retry`` (partial-error
+        # responses must not be retried). Stub ``subprocess.run`` to
+        # exercise the real parser end-to-end.
+        monkeypatch.setattr(daemon.subprocess, "run", fake_run)
+        monkeypatch.setattr(daemon.time, "sleep", lambda _s: None)
 
         titles = d._fetch_issue_titles_for_blockers({42, 100})
 
@@ -666,33 +666,28 @@ class TestFetchIssueTitlesForBlockers:
     def test_returns_none_on_subprocess_failure(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """A genuine transient failure (subprocess timeout) still emits
+        the ``_exhausted`` warning. Issue #3808 only changed the
+        partial-error path — true transient failures retain the
+        3-attempt retry envelope.
+        """
         d, _conn, handler = _make_daemon_with_capture()
 
         call_count = 0
 
-        def fake_retry(
-            cmd: list[str],
-            *,
-            event_name: str,
-            timeout: float,
-            extra_log_fields: dict | None = None,
-        ) -> dict:
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
             nonlocal call_count
             call_count += 1
-            return {
-                "ok": False,
-                "reason": "nonzero_exit",
-                "stderr_tail": "404",
-                "exit_code": 1,
-                "attempts": 3,
-            }
+            raise subprocess.TimeoutExpired(cmd="gh", timeout=30)
 
-        monkeypatch.setattr(d, "_subprocess_with_retry", fake_retry)
+        monkeypatch.setattr(daemon.subprocess, "run", fake_run)
+        monkeypatch.setattr(daemon.time, "sleep", lambda _s: None)
 
         titles = d._fetch_issue_titles_for_blockers({99})
         assert titles[99] is None
-        # Single batched call, not one per number.
-        assert call_count == 1
+        # 3 attempts on a true transient failure (post-#3808 the
+        # retry envelope is local but unchanged in shape).
+        assert call_count == 3
         # Warning logged at WARNING level.
         warn_events = [
             r
@@ -708,11 +703,16 @@ class TestFetchIssueTitlesForBlockers:
         d, _conn, _handler = _make_daemon_with_capture()
         calls: list = []
 
-        def fake_retry(*_a: object, **_kw: object) -> dict:  # pragma: no cover
+        def fake_run(*_a: object, **_kw: object) -> Any:  # pragma: no cover
             calls.append(1)
-            return {"ok": True, "result": MagicMock(), "attempts": 1}
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "{}"
+            result.stderr = ""
+            return result
 
-        monkeypatch.setattr(d, "_subprocess_with_retry", fake_retry)
+        monkeypatch.setattr(daemon.subprocess, "run", fake_run)
+        monkeypatch.setattr(daemon.time, "sleep", lambda _s: None)
 
         titles = d._fetch_issue_titles_for_blockers(set())
         assert titles == {}
@@ -726,16 +726,11 @@ class TestFetchIssueTitlesForBlockers:
 
         call_log: list[list[str]] = []
 
-        def fake_retry(
-            cmd: list[str],
-            *,
-            event_name: str,
-            timeout: float,
-            extra_log_fields: dict | None = None,
-        ) -> dict:
-            call_log.append(cmd)
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            call_log.append(list(cmd))
             result = MagicMock()
             result.returncode = 0
+            result.stderr = ""
             # Issue #3759: union-shape response.
             result.stdout = json.dumps(
                 {
@@ -749,9 +744,10 @@ class TestFetchIssueTitlesForBlockers:
                     }
                 }
             )
-            return {"ok": True, "result": result, "attempts": 1}
+            return result
 
-        monkeypatch.setattr(d, "_subprocess_with_retry", fake_retry)
+        monkeypatch.setattr(daemon.subprocess, "run", fake_run)
+        monkeypatch.setattr(daemon.time, "sleep", lambda _s: None)
 
         # Pass a set — duplicates are already deduplicated by set semantics.
         # This verifies we only make ONE call even when the same number
@@ -775,16 +771,11 @@ class TestFetchIssueTitlesForBlockers:
 
         call_log: list[list[str]] = []
 
-        def fake_retry(
-            cmd: list[str],
-            *,
-            event_name: str,
-            timeout: float,
-            extra_log_fields: dict | None = None,
-        ) -> dict:
-            call_log.append(cmd)
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            call_log.append(list(cmd))
             result = MagicMock()
             result.returncode = 0
+            result.stderr = ""
             # Issue #3759: union-shape response. Build entries for both
             # ``i<n>_issue`` (resolves) and ``i<n>_pr`` (null) per number.
             repo_data: dict[str, object] = {}
@@ -792,9 +783,10 @@ class TestFetchIssueTitlesForBlockers:
                 repo_data[f"i{n}_issue"] = {"number": n, "title": f"T#{n}"}
                 repo_data[f"i{n}_pr"] = None
             result.stdout = json.dumps({"data": {"repository": repo_data}})
-            return {"ok": True, "result": result, "attempts": 1}
+            return result
 
-        monkeypatch.setattr(d, "_subprocess_with_retry", fake_retry)
+        monkeypatch.setattr(daemon.subprocess, "run", fake_run)
+        monkeypatch.setattr(daemon.time, "sleep", lambda _s: None)
 
         titles = d._fetch_issue_titles_for_blockers({1, 2, 3, 4, 5})
 
@@ -1023,14 +1015,8 @@ class TestFetchIssuesTitleCap:
 
         call_log: list[list[str]] = []
 
-        def fake_subprocess_with_retry(
-            cmd: list[str],
-            *,
-            event_name: str,
-            timeout: int = 30,
-            extra_log_fields: dict | None = None,
-        ) -> dict:
-            call_log.append(cmd)
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            call_log.append(list(cmd))
             # Build a GraphQL response for the capped numbers only.
             # Parse alias names from the query to know which numbers to return.
             # Issue #3759: query now uses ``i<n>_issue`` / ``i<n>_pr`` union
@@ -1041,19 +1027,17 @@ class TestFetchIssuesTitleCap:
             for n in aliases:
                 repo_data[f"i{n}_issue"] = {"number": int(n), "title": f"T{n}"}
                 repo_data[f"i{n}_pr"] = None
-            return {
-                "ok": True,
-                "result": type(
-                    "CP",
-                    (),
-                    {"stdout": json.dumps({"data": {"repository": repo_data}})},
-                )(),
-            }
+            result = MagicMock()
+            result.returncode = 0
+            result.stderr = ""
+            result.stdout = json.dumps({"data": {"repository": repo_data}})
+            return result
 
         # Build a set with MAX_BLOCKER_TITLE_FETCH + 5 unique numbers.
         big_set: set[int] = set(range(1, MAX_BLOCKER_TITLE_FETCH + 6))
 
-        monkeypatch.setattr(d, "_subprocess_with_retry", fake_subprocess_with_retry)
+        monkeypatch.setattr(daemon.subprocess, "run", fake_run)
+        monkeypatch.setattr(daemon.time, "sleep", lambda _s: None)
         result = d._fetch_issue_titles_for_blockers(big_set)
 
         # Exactly ONE batched GraphQL call regardless of how many numbers.


### PR DESCRIPTION
## Summary

Fix `_fetch_issue_titles_for_blockers` so it parses `data.repository` from `gh api graphql` stdout regardless of subprocess exit code. The union-aliased query returns valid data + populated `errors[]` (NOT_FOUND for the unused alias side of each blocker) + exit 1 whenever a batch mixes issue-only and PR-only blockers — and the previous routing through `_subprocess_with_retry` discarded the data and burned three retries on a deterministic outcome, flooding CloudWatch with `blocker_title_fetch_exhausted` warnings every ~30s.

The fix is surgical: bypass `_subprocess_with_retry` for this one call. The 3-attempt retry envelope is preserved locally but only fires for genuinely-transient classes (timeout / gh missing / empty stdout / unparseable JSON / `data.repository` missing). `_subprocess_with_retry` is unchanged.

Closes #3808

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [x] CloudWatch query `filter event in ["blocker_title_fetch_exhausted","blocker_title_fetch_flake"]` over a 30m window after deploy — count drops from ~hundreds to zero (modulo genuine network flakes). Pre-deploy 35m window: 192 exhausted + 288 flake. Post-deploy 73m window: 0 + 0.
- [x] Verification evidence posted on issue (#3808 comment)
