### PR TITLE
fix(dispatcher): emit agent_ecs_retry_not_supported once per agent (#3809)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -2703,6 +2703,24 @@ class DispatcherDaemon:
         # existing ``verify_already_completed`` short-circuit and the
         # recovery-path code in ``_run_verify_and_complete``).
         self._phase_subprocess_inflight: dict[str, dict] = {}
+        # #3809 — per-process emission gate for the
+        # ``agent_ecs_retry_not_supported`` operator-visible warning.
+        #
+        # ``_warn_on_ecs_retrying_rows`` runs every supervisor tick
+        # (~10s) and re-reads every ECS-mode ``status='retrying'`` row.
+        # Pre-#3809 every read re-emitted the WARN, flooding
+        # CloudWatch with ~360 lines/hour for a single stuck row. The
+        # signal — "this ECS agent needs operator cleanup" — is
+        # legitimate but only useful ONCE per ``(run_id, agent_id)``
+        # pair; after the first emission, subsequent ticks observe
+        # the same row without re-warning.
+        #
+        # Set is in-memory only; daemon restart resets it (and a
+        # fresh WARN fires on the first tick after boot — also the
+        # right cadence). Bounded by the number of distinct ECS-mode
+        # retrying agent_ids the daemon ever sees in its lifetime,
+        # which is small (operator-cleanup-driven, not autoscaled).
+        self._observed_ecs_retrying: set[str] = set()
 
     # ------------------------------------------------------------------
     # Thread-aware connection accessor (#2847).
@@ -10212,6 +10230,18 @@ class DispatcherDaemon:
         stuck in ``retrying`` is invisible work that will never advance
         without intervention.
 
+        #3809. Emission is gated by the per-process
+        :attr:`_observed_ecs_retrying` set. The supervisor tick
+        cadence (~10s) plus persistently stuck rows (operator action
+        required → may stay for hours/days) pre-#3809 produced ~360
+        WARN lines/hour for a single row. The legitimate signal is
+        "this row needs operator cleanup," which is useful ONCE per
+        ``(run_id, agent_id)`` pair — every subsequent tick on the
+        same row is noise. After the first emission per ``agent_id``
+        the row is observed silently. Daemon restart resets the
+        in-memory set, so a long-stuck row will re-emit one WARN per
+        boot — also the right cadence.
+
         Best-effort: a DB read failure here logs but does not propagate
         — the scheduler tick must not stall on this diagnostic.
         """
@@ -10234,12 +10264,18 @@ class DispatcherDaemon:
                 pass
             return
         for row in rows or []:
+            agent_id = str(row[0])
+            # #3809 — first-detection gate. Skip silently on any
+            # subsequent tick that re-observes the same agent_id.
+            if agent_id in self._observed_ecs_retrying:
+                continue
+            self._observed_ecs_retrying.add(agent_id)
             self._log.warning(
                 "daemon.agent_ecs_retry_not_supported",
                 extra={
                     "event": "agent_ecs_retry_not_supported",
                     "run_id": self._run_id,
-                    "agent_id": str(row[0]),
+                    "agent_id": agent_id,
                     "issue_number": (int(row[1]) if row[1] is not None else None),
                     "detail": (
                         "ECS-mode agent in status='retrying'; the "
@@ -10248,7 +10284,10 @@ class DispatcherDaemon:
                         "not yet wired (audit follow-up #3168). "
                         "Operator action required: either manually "
                         "terminate (force_stop + agent/ready relabel) "
-                        "or wait for #3168."
+                        "or wait for #3168. This warning is emitted "
+                        "once per (run_id, agent_id) pair — daemon "
+                        "restart re-emits one line per stuck row "
+                        "(#3809)."
                     ),
                 },
             )

--- a/scripts/dispatcher/tests/test_daemon_execution_mode_audit.py
+++ b/scripts/dispatcher/tests/test_daemon_execution_mode_audit.py
@@ -353,6 +353,80 @@ class TestResumeRetryingAgentExecutionModeFilter:
 
 
 # --------------------------------------------------------------------------
+# #3809 — _warn_on_ecs_retrying_rows must emit at most once per agent_id
+# --------------------------------------------------------------------------
+
+
+class TestWarnOnEcsRetryingRowsOnceShotPerAgent:
+    """The ``agent_ecs_retry_not_supported`` WARNING must fire once per agent.
+
+    Pre-#3809, :meth:`_warn_on_ecs_retrying_rows` re-emitted the WARN
+    on every supervisor tick (~every 10s) for every ECS-mode retrying
+    row in the table. With two such rows persistently stuck this
+    floods CloudWatch with ~720 WARN lines/hour for the same two
+    rows. The legitimate signal is "two ECS agents need cleanup" —
+    fire that ONCE per ``(run_id, agent_id)`` pair, not every tick.
+
+    #3809 introduces a per-process ``_observed_ecs_retrying`` set that
+    gates emission: an ``agent_id`` already in the set is skipped on
+    subsequent ticks. The set is in-memory only — daemon restart
+    resets it (and re-emits one WARN per row), which is the right
+    cadence for an operator-visible signal.
+    """
+
+    def test_warning_emits_once_per_agent_across_five_ticks(
+        self, tmp_path: Path
+    ) -> None:
+        """Stage two ECS-retrying rows, run 5 supervisor ticks, expect 2 warns."""
+        d, conn, handler = _make_daemon(tmp_path)
+        # Each call to _warn_on_ecs_retrying_rows issues ONE SELECT
+        # (`fetchall`) returning the same two rows. Five ticks → five
+        # SELECTs returning the same payload.
+        rows = [
+            ("agent-ecs-1", 3778),
+            ("agent-ecs-2", 3641),
+        ]
+        conn.cursor_instance.fetchall_queue = [rows for _ in range(5)]
+
+        for _ in range(5):
+            d._warn_on_ecs_retrying_rows()
+
+        warn_events = handler.events("agent_ecs_retry_not_supported")
+        # Exactly TWO warnings — one per distinct agent_id — across
+        # all five ticks. Pre-#3809 this asserted-against-10
+        # (5 ticks × 2 rows).
+        assert len(warn_events) == 2, (
+            f"#3809 — expected 2 warnings (one per agent_id) across 5 "
+            f"ticks, got {len(warn_events)}. The warning must be gated "
+            f"on a per-process set so persistent ECS-retrying rows "
+            f"don't flood CloudWatch every tick."
+        )
+        emitted_agent_ids = sorted(getattr(r, "agent_id") for r in warn_events)
+        assert emitted_agent_ids == ["agent-ecs-1", "agent-ecs-2"]
+
+    def test_new_agent_after_first_emission_still_warns(self, tmp_path: Path) -> None:
+        """A new ECS-retrying row appearing later still produces a warning."""
+        d, conn, handler = _make_daemon(tmp_path)
+        # Tick 1: only agent-ecs-1 is retrying.
+        # Tick 2: agent-ecs-2 also retrying. Should warn for agent-ecs-2 only.
+        # Tick 3: both rows still retrying. No new warnings.
+        conn.cursor_instance.fetchall_queue = [
+            [("agent-ecs-1", 3778)],
+            [("agent-ecs-1", 3778), ("agent-ecs-2", 3641)],
+            [("agent-ecs-1", 3778), ("agent-ecs-2", 3641)],
+        ]
+
+        for _ in range(3):
+            d._warn_on_ecs_retrying_rows()
+
+        warn_events = handler.events("agent_ecs_retry_not_supported")
+        emitted_agent_ids = sorted(getattr(r, "agent_id") for r in warn_events)
+        assert emitted_agent_ids == ["agent-ecs-1", "agent-ecs-2"], (
+            f"#3809 — expected one WARN per distinct agent_id, got {emitted_agent_ids}"
+        )
+
+
+# --------------------------------------------------------------------------
 # Fix 3 — _handle_force_stop branches on execution_mode for signal delivery
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Gate `daemon.agent_ecs_retry_not_supported` WARN emission on a per-process `_observed_ecs_retrying: set[str]` so persistently stuck ECS-mode `status='retrying'` rows produce exactly one WARN per `(run_id, agent_id)` pair instead of one per ~10s supervisor tick (~720 WARN lines/h pre-fix → 1 per row per daemon-lifetime). Operator-cleanup signal preserved; CloudWatch noise eliminated.

Closes #3809

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass (`scripts/dispatcher/tests/test_daemon_execution_mode_audit.py::TestWarnOnEcsRetryingRowsOnceShotPerAgent`)
- [x] CI green

### Post-deploy verification
- [x] CloudWatch query `filter event="agent_ecs_retry_not_supported"` over a 30m window shows count drop from ~hundreds to <= number of distinct ECS-mode retrying rows (0 over 50+ min while 2 rows still stuck)
- [x] Verification evidence posted on issue (see A.8)
