### PR TITLE
fix(scraping): guard truncator against degenerate half-caption fallback (#3673)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -779,6 +779,8 @@ def _truncate_concatenated_title(title: str | None) -> str | None:
                 # only the first-separator + no defendant — this is the
                 # degenerate case and is rare in real data.
                 result = title[:first_end].rstrip()
+                if re.search(r"\bv[s]?\.?\s*$", result, re.IGNORECASE):
+                    return title  # degenerate fallback would lose defendant; keep fused title
 
     # Final cleanup: strip trailing whitespace and stray connector
     # punctuation that can be left behind at the boundary.

--- a/packages/scraper-framework/tests/test_sc_concatenated_title_guard.py
+++ b/packages/scraper-framework/tests/test_sc_concatenated_title_guard.py
@@ -378,3 +378,42 @@ def test_dev_db_contaminated_titles(
         assert token not in truncated, (
             f"{title!r} -> {truncated!r} still contains later-caption token {token!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Degenerate fallback guard (issue #3673)
+# ---------------------------------------------------------------------------
+
+
+class TestDegenerateFallbackGuard:
+    """Tests that the priority-3 else branch does not produce half-caption titles.
+
+    When the fused middle region is a single token (no whitespace), the old
+    code produced ``title[:first_end].rstrip()`` — e.g. ``"Carrasco vs"`` from
+    ``"Carrasco vs County v. Smith"``.  The guard added by #3673 detects this
+    degenerate shape and returns the original title unchanged instead.
+    """
+
+    def test_carrasco_orange_unchanged(self) -> None:
+        """Orange-county 'vs' fusion: full title returned unchanged (NOT 'Carrasco vs')."""
+        title = "Carrasco vs County v. Smith"
+        result = _truncate_concatenated_title(title)
+        assert result == title, f"Expected unchanged title {title!r}, got {result!r}"
+
+    def test_dotted_initial_unchanged(self) -> None:
+        """Dotted-initial plaintiff: full title returned unchanged (NOT 'C. vs')."""
+        title = "C. vs Foo v. Bar"
+        result = _truncate_concatenated_title(title)
+        assert result == title, f"Expected unchanged title {title!r}, got {result!r}"
+
+    def test_riverside_vs_unchanged(self) -> None:
+        """Riverside-style 'Vs' fusion: full title returned unchanged."""
+        title = "Alfaro Facundo Vs County v. Smith"
+        result = _truncate_concatenated_title(title)
+        assert result == title, f"Expected unchanged title {title!r}, got {result!r}"
+
+    def test_uppercase_vs_unchanged(self) -> None:
+        """Uppercase 'VS.' casing variant: IGNORECASE flag is exercised."""
+        title = "Garcia VS. County v. Smith"
+        result = _truncate_concatenated_title(title)
+        assert result == title, f"Expected unchanged title {title!r}, got {result!r}"


### PR DESCRIPTION
## Summary

Fixed `_truncate_concatenated_title` producing half-caption titles (e.g., "Carrasco vs" with no defendant) by adding a guard that detects when the priority-3 fallback would lose the defendant and returns the original fused title unchanged instead. Fused multi-case captions are incorrect but far more recoverable downstream than half-captions.

Closes #3673

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
  - New: `TestDegenerateFallbackGuard` (4 tests covering Orange vs, Riverside Vs, dotted initial, uppercase VS variants)
  - Existing: 22 tests in `test_sc_concatenated_title_guard.py` unaffected; 21 tests in `test_san_bernardino_multi_case.py` unaffected
- [x] CI green (pre-push hook passed)

### Post-deploy verification

- [ ] Query dev database to confirm affected Orange rows cleaned up post-rebuild: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM derived.cases cs JOIN derived.courts c ON cs.court_id = c.id WHERE c.county = 'Orange' AND cs.case_title ~ '\\sv[s]?\\.?\\s*$' AND length(cs.case_title) < 30"`
- [ ] Verification evidence posted on #3673 (see /task-v2-verify output)