### PR TITLE
fix(dispatcher): stamp ended_at on terminal-status writes (#3822)

### DIFF
--- a/scripts/dispatcher/agent-runner-entrypoint.sh
+++ b/scripts/dispatcher/agent-runner-entrypoint.sh
@@ -4193,9 +4193,30 @@ advance_phase() {
     _next="$1"
     _status="${2:-}"
     if [[ -n "$_status" ]]; then
-        db_exec "UPDATE dispatcher.agents
-                    SET phase = '$_next', status = '$_status'
-                  WHERE agent_id = '$AGENT_ID';"
+        # #3822 — when the new status is a TERMINAL_STATUSES member, also
+        # stamp ``ended_at`` so the admin cockpit's "Recently Completed"
+        # query (filters on ``status terminal AND ended_at IS NOT NULL``,
+        # see packages/api/src/graphql/dispatcher/resolvers.ts:534-548)
+        # actually surfaces the row. Without this, the merge handler's
+        # ``advance_phase awaiting_deploy succeeded`` write leaves
+        # ended_at NULL — the next outer-loop iteration sees a terminal
+        # status and exits via ``external_terminal_observed`` BEFORE
+        # ``mark_ended`` runs (see lines around the main loop's
+        # is_terminal_status check). The same shape leaks via
+        # ``agent_runner_reaped_failure`` below. ``COALESCE(ended_at,
+        # now())`` is idempotent + race-safe with the daemon's
+        # housekeeping-side bulk backfill.
+        if is_terminal_status "$_status"; then
+            db_exec "UPDATE dispatcher.agents
+                        SET phase = '$_next',
+                            status = '$_status',
+                            ended_at = COALESCE(ended_at, now())
+                      WHERE agent_id = '$AGENT_ID';"
+        else
+            db_exec "UPDATE dispatcher.agents
+                        SET phase = '$_next', status = '$_status'
+                      WHERE agent_id = '$AGENT_ID';"
+        fi
     else
         db_exec "UPDATE dispatcher.agents
                     SET phase = '$_next'
@@ -4787,8 +4808,14 @@ ON CONFLICT (agent_id, phase, attempt) DO UPDATE
       ts = now();
 EOF
     set -e
+    # #3822 — same shape as ``advance_phase``'s terminal write: stamp
+    # ``ended_at`` so the admin cockpit's "Recently Completed" query
+    # surfaces this row. ``COALESCE(ended_at, now())`` is idempotent +
+    # race-safe with the daemon's housekeeping bulk backfill.
     db_exec "UPDATE dispatcher.agents
-                SET phase = '$_term_phase', status = 'failed'
+                SET phase = '$_term_phase',
+                    status = 'failed',
+                    ended_at = COALESCE(ended_at, now())
               WHERE agent_id = '$AGENT_ID';"
     log "phase_advanced" "next_phase=$_term_phase" "status=failed"
     # #3494 — exit unconditionally after marking the agent terminal in

--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -26071,6 +26071,62 @@ class DispatcherDaemon:
         )
         return rows_cleared
 
+    def _backfill_terminal_ended_at(self) -> int:
+        """Bulk-stamp ``ended_at`` for terminal-status rows missing it (#3822).
+
+        Mirrors :meth:`_clear_stale_agent_task_arns`'s shape: a single
+        ``UPDATE dispatcher.agents`` round-trip that heals every row whose
+        status is in :data:`TERMINAL_AGENT_STATUSES` but whose ``ended_at``
+        is still NULL. The agent-runner-side fix (``advance_phase`` and
+        ``agent_runner_reaped_failure`` in
+        ``scripts/dispatcher/agent-runner-entrypoint.sh``) is the primary
+        — it stamps ``ended_at`` synchronously with the terminal status
+        write. This bulk backfill is the safety net that catches:
+
+        * existing terminal rows written before the agent-runner fix
+          shipped (so the admin cockpit's "Recently Completed" panel
+          backfills retroactively),
+        * future races where the agent-runner crashes between the
+          status write and any potential later ``ended_at`` write
+          (defense in depth).
+
+        The invariant the admin cockpit query depends on
+        (``packages/api/src/graphql/dispatcher/resolvers.ts:534-548``) is
+        ``status terminal ⇒ ended_at NOT NULL``. Both fixes together
+        enforce it.
+
+        Returns the number of rows stamped (``cur.rowcount``). Logs
+        ``daemon.terminal_ended_at_backfilled`` with the count for
+        observability. Failures are caught by the caller
+        (:meth:`_housekeeping_tick`).
+        """
+        assert self._conn is not None, "connect() must run before housekeeping"
+        # ``TERMINAL_AGENT_STATUSES`` is the daemon-internal frozenset
+        # mirrored by ``phase_transitions.TERMINAL_STATUSES``. The values
+        # are class constants (never user-controlled), but we still pass
+        # them via psycopg parameter substitution to keep parity with the
+        # other housekeeping helpers.
+        terminal_statuses = sorted(TERMINAL_AGENT_STATUSES)
+        with self._conn.cursor() as cur:
+            cur.execute(
+                "UPDATE dispatcher.agents "
+                "SET ended_at = now() "
+                "WHERE status = ANY(%s::text[]) "
+                "  AND ended_at IS NULL",
+                (terminal_statuses,),
+            )
+            rows_stamped = cur.rowcount or 0
+        self._conn.commit()
+        self._log.info(
+            "daemon.terminal_ended_at_backfilled",
+            extra={
+                "event": "terminal_ended_at_backfilled",
+                "run_id": self._run_id,
+                "rows_stamped": rows_stamped,
+            },
+        )
+        return rows_stamped
+
     def _reconcile_stale_merged_at(self) -> dict[str, int]:
         """Hourly guard that clears false-shipped ``merged_at`` stamps (#3752).
 
@@ -26262,6 +26318,28 @@ class DispatcherDaemon:
                 "daemon.stale_arn_bulk_clear_failed",
                 extra={
                     "event": "stale_arn_bulk_clear_failed",
+                    "run_id": self._run_id,
+                },
+            )
+
+        # Issue #3822: stamp ``ended_at`` on terminal-status rows that
+        # were missed by the agent-runner-side write. Healing pass for
+        # the admin cockpit's "Recently Completed" panel — see
+        # :meth:`_backfill_terminal_ended_at` for the full rationale.
+        # Runs in its own try/except so a DB hiccup here does not
+        # affect the prune loop, merged_at reconcile, or the stale-ARN
+        # bulk-clear.
+        try:
+            self._backfill_terminal_ended_at()
+        except Exception:
+            try:
+                self._conn.rollback()
+            except Exception:  # pragma: no cover — best-effort
+                pass
+            self._log.exception(
+                "daemon.terminal_ended_at_backfill_failed",
+                extra={
+                    "event": "terminal_ended_at_backfill_failed",
                     "run_id": self._run_id,
                 },
             )

--- a/scripts/dispatcher/tests/test_agent_runner_terminal_ended_at.py
+++ b/scripts/dispatcher/tests/test_agent_runner_terminal_ended_at.py
@@ -1,0 +1,227 @@
+"""Issue #3822 — verify ``agent-runner-entrypoint.sh`` stamps ``ended_at``
+in the SQL UPDATE whenever it writes a terminal status to
+``dispatcher.agents``.
+
+Symptom: every recent daemon-shipped green has ``ended_at IS NULL``,
+making the row invisible to the admin cockpit's "Recently Completed"
+GraphQL query in ``packages/api/src/graphql/dispatcher/resolvers.ts:534``,
+which filters by ``status terminal AND ended_at IS NOT NULL``.
+
+Root cause (two code sites, both in the agent-runner entrypoint):
+
+1. ``advance_phase`` writes ``phase = $next, status = $status`` but NOT
+   ``ended_at``. The merge handler calls
+   ``advance_phase "awaiting_deploy" "succeeded"`` after a squash-merge
+   lands. The next outer-loop iteration sees a terminal status and
+   exits via ``external_terminal_observed`` BEFORE ``mark_ended`` runs.
+2. ``agent_runner_reaped_failure`` writes ``phase = $term_phase, status
+   = 'failed'`` and exits — same shape.
+
+Fix shape: when the new status is in ``TERMINAL_STATUSES``, the UPDATE
+must also write ``ended_at = COALESCE(ended_at, now())``. The
+``COALESCE`` keeps the write idempotent (preserves any earlier stamp,
+e.g. from the diagnoser/killswitch external-writer paths) and race-safe
+with the daemon-side housekeeping bulk backfill in
+``daemon._backfill_terminal_ended_at``.
+
+This is a static lint of the shell script — it parses specific patterns
+in the file text rather than executing the script. The intent is to
+catch regressions where one of the two terminal-write sites loses the
+``ended_at`` stamp clause.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_ENTRYPOINT_PATH = Path(__file__).resolve().parents[1] / "agent-runner-entrypoint.sh"
+
+
+def _script_text() -> str:
+    return _ENTRYPOINT_PATH.read_text(encoding="utf-8")
+
+
+def _function_body(func_name: str) -> str:
+    """Return the body of a top-level shell function as a single string.
+
+    Walks brace depth from the opening ``{`` to the matching ``}`` so
+    nested ``if``/``case`` blocks don't fool the extractor. Used to scope
+    SQL-shape assertions to the exact function under test instead of the
+    whole 6000-line file.
+    """
+    text = _script_text()
+    pattern = rf"^{re.escape(func_name)}\s*\(\s*\)\s*\{{"
+    m = re.search(pattern, text, re.MULTILINE)
+    assert m is not None, f"function {func_name}() not found in entrypoint"
+    start = m.end()
+    body_chars: list[str] = []
+    depth = 1
+    for ch in text[start:]:
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        body_chars.append(ch)
+    return "".join(body_chars)
+
+
+class TestEntrypointScriptExists:
+    def test_entrypoint_script_exists(self) -> None:
+        assert _ENTRYPOINT_PATH.exists(), (
+            f"agent-runner-entrypoint.sh not found at {_ENTRYPOINT_PATH}"
+        )
+
+
+class TestAdvancePhaseStampsEndedAtOnTerminalStatus:
+    """``advance_phase`` must include ``ended_at = COALESCE(ended_at,
+    now())`` in the UPDATE when ``_status`` is in TERMINAL_STATUSES."""
+
+    def test_advance_phase_function_exists(self) -> None:
+        body = _function_body("advance_phase")
+        assert body.strip(), "advance_phase function body is empty"
+
+    def test_advance_phase_branches_on_is_terminal_status(self) -> None:
+        """The function must branch on ``is_terminal_status`` so the
+        terminal write gets the ``ended_at`` stamp and the non-terminal
+        write does not (the latter is an in-progress phase advance and
+        must NOT stamp ended_at — that would lock the row out of the
+        scheduler's status reads)."""
+        body = _function_body("advance_phase")
+        assert "is_terminal_status" in body, (
+            "advance_phase must call is_terminal_status to gate the ended_at "
+            "stamp on terminal-status writes (#3822). Without the gate, "
+            "every status write would stamp ended_at — locking in-flight "
+            "agents out of scheduler reads."
+        )
+
+    def test_advance_phase_terminal_branch_writes_ended_at(self) -> None:
+        """The terminal branch's UPDATE must include
+        ``ended_at = COALESCE(ended_at, now())``. The COALESCE preserves
+        any earlier stamp (idempotent + race-safe with the daemon-side
+        backfill)."""
+        body = _function_body("advance_phase")
+        # The branching shape must contain a COALESCE-stamping UPDATE.
+        # Whitespace is variable due to bash heredoc-style indentation,
+        # so match the key tokens flexibly.
+        assert re.search(
+            r"ended_at\s*=\s*COALESCE\(\s*ended_at\s*,\s*now\(\)\s*\)",
+            body,
+        ), (
+            "advance_phase terminal branch must write "
+            "`ended_at = COALESCE(ended_at, now())` in the UPDATE (#3822). "
+            "Without this, every daemon-shipped green has ended_at=NULL "
+            "and is invisible to the admin cockpit's Recently Completed "
+            "panel."
+        )
+
+    def test_advance_phase_non_terminal_branch_does_not_stamp_ended_at(
+        self,
+    ) -> None:
+        """The non-terminal branch (status given but not in TERMINAL_STATUSES)
+        and the no-status branch (phase-only advance) must NOT stamp
+        ``ended_at``. Stamping there would mark in-flight agents as ended.
+
+        We verify by counting ``COALESCE(ended_at, now())`` occurrences
+        in the function body — there must be exactly one (the terminal
+        branch). More than one means a non-terminal branch accidentally
+        gained the stamp.
+        """
+        body = _function_body("advance_phase")
+        coalesce_count = len(
+            re.findall(
+                r"ended_at\s*=\s*COALESCE\(\s*ended_at\s*,\s*now\(\)\s*\)",
+                body,
+            )
+        )
+        assert coalesce_count == 1, (
+            "advance_phase must contain exactly one "
+            "`ended_at = COALESCE(ended_at, now())` clause — the terminal "
+            f"branch only. Found {coalesce_count} occurrences (#3822)."
+        )
+
+
+class TestAgentRunnerReapedFailureStampsEndedAt:
+    """``agent_runner_reaped_failure`` must include ``ended_at =
+    COALESCE(ended_at, now())`` in its terminal UPDATE.
+
+    Without this, every reaped-failure path leaves ``ended_at`` NULL —
+    same invisibility bug as the success path. The reaper's terminal
+    UPDATE is unconditionally terminal (the function exits 0
+    immediately after the UPDATE per #3494), so no branching guard is
+    needed.
+    """
+
+    def test_function_exists(self) -> None:
+        body = _function_body("agent_runner_reaped_failure")
+        assert body.strip(), "agent_runner_reaped_failure function body is empty"
+
+    def test_terminal_update_writes_ended_at(self) -> None:
+        body = _function_body("agent_runner_reaped_failure")
+        # Find the UPDATE to dispatcher.agents inside the function.
+        # There may be multiple SQL statements (phase_outputs INSERT first,
+        # then agents UPDATE) — we want the one against
+        # ``dispatcher.agents``.
+        m = re.search(
+            r"UPDATE\s+dispatcher\.agents[\s\S]*?WHERE\s+agent_id",
+            body,
+        )
+        assert m is not None, (
+            "agent_runner_reaped_failure must contain an "
+            "`UPDATE dispatcher.agents ... WHERE agent_id` statement"
+        )
+        update_sql = m.group(0)
+        assert "status = 'failed'" in update_sql, (
+            "agent_runner_reaped_failure UPDATE must set `status = 'failed'`"
+        )
+        assert re.search(
+            r"ended_at\s*=\s*COALESCE\(\s*ended_at\s*,\s*now\(\)\s*\)",
+            update_sql,
+        ), (
+            "agent_runner_reaped_failure UPDATE must write "
+            "`ended_at = COALESCE(ended_at, now())` (#3822). Without this, "
+            "reaped-failure rows have ended_at=NULL and are invisible to "
+            "the admin cockpit's Recently Completed panel."
+        )
+
+
+class TestSchedulerStatusReadsStillSeeRunningAgents:
+    """Belt-and-suspenders: the no-status branch of ``advance_phase``
+    (phase-only advance, e.g. mid-loop transitions) must remain
+    ``ended_at``-untouched.
+
+    This test pins the shape: the no-status branch issues a UPDATE that
+    sets only ``phase = '$_next'`` (no ``status`` column, no
+    ``ended_at`` column).
+    """
+
+    def test_no_status_branch_does_not_set_status_or_ended_at(self) -> None:
+        body = _function_body("advance_phase")
+        # The no-status `else` branch is the third UPDATE block (the
+        # terminal-status branch is first, the non-terminal-status
+        # branch is second). Find all UPDATE statements inside the
+        # function.
+        updates = re.findall(
+            r"db_exec\s+\"UPDATE dispatcher\.agents[\s\S]*?WHERE agent_id = '\$AGENT_ID';\"",
+            body,
+        )
+        # Should be exactly 3 UPDATE call sites in the function:
+        # 1. terminal-status branch (with status + ended_at COALESCE)
+        # 2. non-terminal-status branch (with status, no ended_at)
+        # 3. no-status branch (phase only)
+        assert len(updates) == 3, (
+            f"advance_phase must contain exactly 3 db_exec UPDATE call sites "
+            f"(terminal, non-terminal-with-status, phase-only). Got {len(updates)}."
+        )
+        # The phase-only branch (3rd) must NOT contain `status` or `ended_at`.
+        phase_only_update = updates[2]
+        assert "status" not in phase_only_update, (
+            "advance_phase phase-only branch must not write the `status` "
+            "column (would clobber an earlier status). Got: " + phase_only_update
+        )
+        assert "ended_at" not in phase_only_update, (
+            "advance_phase phase-only branch must not stamp `ended_at` "
+            "(would mark in-flight agents as ended). Got: " + phase_only_update
+        )

--- a/scripts/dispatcher/tests/test_daemon_housekeeping.py
+++ b/scripts/dispatcher/tests/test_daemon_housekeeping.py
@@ -1066,3 +1066,287 @@ class TestStaleArnConfigPlumbing:
         """
         assert not hasattr(daemon, "DEFAULT_BACKUP_WATCHDOG_EXIT_THRESHOLD_SECONDS")
         assert not hasattr(daemon, "BACKUP_WATCHDOG_POLL_INTERVAL_SECONDS")
+
+
+# --------------------------------------------------------------------------
+# _backfill_terminal_ended_at — bulk heal terminal rows missing ended_at
+# (#3822)
+# --------------------------------------------------------------------------
+
+
+class TestBackfillTerminalEndedAt:
+    """Bulk-stamp ``ended_at`` for terminal-status rows missing it (#3822).
+
+    The agent-runner-side write (``advance_phase`` /
+    ``agent_runner_reaped_failure``) is the primary fix; this housekeeping
+    method is the daemon-side healer that picks up rows leaked before the
+    agent-runner change shipped AND any future races where the agent-runner
+    crashes between the status write and any ``ended_at`` write.
+    """
+
+    def test_issues_single_update_with_terminal_status_filter(self) -> None:
+        """One UPDATE round-trip — not one per row. The WHERE clause
+        filters by ``status = ANY(...)`` and ``ended_at IS NULL`` so
+        non-terminal rows and already-stamped rows are untouched."""
+        d, conn, handler = _make_daemon_with_capture()
+
+        original_execute = conn.cursor_instance.execute
+
+        def patched_execute(sql: str, params: Any = None) -> None:
+            original_execute(sql, params)
+            if "UPDATE dispatcher.agents" in sql and "ended_at = now()" in sql:
+                # Pretend 3 stale terminal rows were stamped.
+                conn.cursor_instance.rowcount = 3
+
+        conn.cursor_instance.execute = patched_execute  # type: ignore[method-assign]
+
+        stamped = d._backfill_terminal_ended_at()
+
+        # ONE UPDATE — bulk heal in a single round-trip.
+        updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if sql.startswith("UPDATE dispatcher.agents")
+        ]
+        assert len(updates) == 1
+        sql, params = updates[0]
+
+        # Guards against accidentally stamping rows that are still running
+        # (would mask in-flight agents) and re-stamping rows that already
+        # have ended_at.
+        assert "SET ended_at = now()" in sql
+        assert "ended_at IS NULL" in sql
+        assert "status = ANY(%s::text[])" in sql
+
+        # The bound parameter is the sorted list of terminal statuses.
+        assert params is not None
+        passed_statuses = params[0]
+        assert set(passed_statuses) == set(daemon.TERMINAL_AGENT_STATUSES)
+        # ``running`` and ``retrying`` are non-terminal — must NOT be
+        # in the filter list (otherwise we'd stamp in-flight agents).
+        assert "running" not in passed_statuses
+        assert "retrying" not in passed_statuses
+
+        # rowcount surfaces.
+        assert stamped == 3
+
+        # Structured log event with rows_stamped.
+        events = handler.events("terminal_ended_at_backfilled")
+        assert len(events) == 1
+        rec = events[0]
+        assert rec.rows_stamped == 3
+        assert rec.run_id == "test-run-id"
+
+    def test_zero_rows_stamped_emits_zero_event(self) -> None:
+        """Steady-state: when the agent-runner-side fix is doing its job,
+        each tick stamps zero rows. The event must still emit so operators
+        can see the housekeeping ran."""
+        d, conn, handler = _make_daemon_with_capture()
+        # rowcount stays at 0 — nothing to stamp.
+
+        stamped = d._backfill_terminal_ended_at()
+        assert stamped == 0
+
+        events = handler.events("terminal_ended_at_backfilled")
+        assert len(events) == 1
+        assert events[0].rows_stamped == 0
+
+    def test_does_not_touch_running_rows(self) -> None:
+        """The UPDATE filters by ``status = ANY(terminal)`` so rows whose
+        status is ``running`` or ``retrying`` are unaffected.
+
+        Static SQL-shape pin: the actual filter behaviour against real
+        rows is covered by the integration shard. Here we just guard
+        against an accidental drop of the ``status = ANY(...)`` clause
+        that would null-stamp every NULL-ended-at row including in-flight
+        agents.
+        """
+        d, conn, _handler = _make_daemon_with_capture()
+
+        d._backfill_terminal_ended_at()
+
+        updates = [
+            sql
+            for sql, _params in conn.cursor_instance.executed
+            if sql.startswith("UPDATE dispatcher.agents")
+        ]
+        assert len(updates) == 1
+        # Both filters present.
+        assert "ended_at IS NULL" in updates[0]
+        assert "status = ANY(%s::text[])" in updates[0]
+
+
+class TestHousekeepingTickWiresInBackfillTerminalEndedAt:
+    """``_housekeeping_tick`` calls ``_backfill_terminal_ended_at`` (#3822).
+
+    Regression: an accidental decouple (e.g. removing the call in
+    ``_housekeeping_tick``) would silently break the cockpit-visibility
+    healer for any rows leaked by future agent-runner regressions.
+    """
+
+    def test_housekeeping_tick_calls_backfill_terminal_ended_at(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        d, _conn, handler = _make_daemon_with_capture()
+
+        called = {"count": 0}
+
+        def fake_backfill() -> int:
+            called["count"] += 1
+            return 5
+
+        monkeypatch.setattr(
+            d,
+            "_backfill_terminal_ended_at",
+            fake_backfill,
+            raising=True,
+        )
+        # Stub out the other healers so the tick doesn't try to talk to
+        # GitHub or run the bulk ARN clear.
+        monkeypatch.setattr(
+            d,
+            "_reconcile_stale_merged_at",
+            lambda: {"checked": 0, "cleared": 0, "errors": 0},
+        )
+        monkeypatch.setattr(
+            d,
+            "_clear_stale_agent_task_arns",
+            lambda: 0,
+            raising=True,
+        )
+
+        d._housekeeping_tick()
+        # Backfill MUST have been called exactly once per tick.
+        assert called["count"] == 1
+        # The tick-level counter still advances.
+        assert d._housekeeping_ticks == 1
+        # No failure events.
+        assert handler.events("terminal_ended_at_backfill_failed") == []
+
+    def test_housekeeping_tick_isolates_backfill_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If ``_backfill_terminal_ended_at`` raises, the tick logs and
+        continues. Per-target prune results and other healers are not
+        affected."""
+        d, conn, handler = _make_daemon_with_capture()
+
+        def boom() -> int:
+            raise RuntimeError("connection lost")
+
+        monkeypatch.setattr(
+            d,
+            "_backfill_terminal_ended_at",
+            boom,
+            raising=True,
+        )
+        monkeypatch.setattr(
+            d,
+            "_reconcile_stale_merged_at",
+            lambda: {"checked": 0, "cleared": 0, "errors": 0},
+        )
+        monkeypatch.setattr(
+            d,
+            "_clear_stale_agent_task_arns",
+            lambda: 0,
+            raising=True,
+        )
+
+        # Make the per-target prune trivially succeed.
+        target_count = len(daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS)
+        conn.cursor_instance.fetch_queue = [None] * target_count
+
+        # MUST NOT raise.
+        result = d._housekeeping_tick()
+
+        # Failure event surfaced.
+        failures = handler.events("terminal_ended_at_backfill_failed")
+        assert len(failures) == 1
+        # Per-target sweeps still ran.
+        assert "queue_snapshots" in result
+        # Counter still advances.
+        assert d._housekeeping_ticks == 1
+
+
+class TestBackfillStampsThreeTerminalRowsAndPreservesRunning:
+    """End-to-end-style stub test for the AC #3822 case.
+
+    Stages 4 rows in the fake DB:
+      * 3 with terminal status + ended_at=NULL (succeeded, failed, crashed).
+      * 1 with status='running' + ended_at=NULL (control — must not be
+        stamped).
+
+    Runs the housekeeping tick once. Asserts:
+      * The 3 terminal rows have ended_at stamped (rowcount=3 returned by
+        the stub UPDATE).
+      * The 1 running row's ended_at remains NULL (the SQL filter
+        excludes it; rowcount surfaced by the stub doesn't include it).
+
+    This is a stub-driven test — the production behaviour (filter
+    correctness against real Postgres) is asserted in the integration
+    shard. The lint-style assertion here is on the SQL shape: the WHERE
+    clause MUST contain ``status = ANY(...)`` so the running control row
+    is filtered out by the database.
+    """
+
+    def test_three_terminals_stamped_running_untouched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        d, conn, handler = _make_daemon_with_capture()
+
+        # Stub the other healers so the tick stays focused.
+        monkeypatch.setattr(
+            d,
+            "_reconcile_stale_merged_at",
+            lambda: {"checked": 0, "cleared": 0, "errors": 0},
+        )
+        monkeypatch.setattr(
+            d,
+            "_clear_stale_agent_task_arns",
+            lambda: 0,
+            raising=True,
+        )
+
+        # Per-target prune lookups all return None (default cutoff used).
+        target_count = len(daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS)
+        conn.cursor_instance.fetch_queue = [None] * target_count
+
+        original_execute = conn.cursor_instance.execute
+
+        def patched_execute(sql: str, params: Any = None) -> None:
+            original_execute(sql, params)
+            # Fake DB: the backfill UPDATE matches the 3 terminal rows
+            # and stamps them. The control 'running' row's status fails
+            # the WHERE filter at the database, so rowcount is 3 (not 4).
+            if (
+                "UPDATE dispatcher.agents" in sql
+                and "ended_at = now()" in sql
+                and "ended_at IS NULL" in sql
+            ):
+                conn.cursor_instance.rowcount = 3
+
+        conn.cursor_instance.execute = patched_execute  # type: ignore[method-assign]
+
+        d._housekeeping_tick()
+
+        # The structured log event reports 3 rows stamped.
+        events = handler.events("terminal_ended_at_backfilled")
+        assert len(events) == 1
+        assert events[0].rows_stamped == 3
+
+        # The SQL filter explicitly excludes non-terminal statuses by
+        # passing only the terminal set as the ANY() bind. This is what
+        # protects the 'running' control row at the database level.
+        backfill_updates = [
+            (sql, params)
+            for sql, params in conn.cursor_instance.executed
+            if sql.startswith("UPDATE dispatcher.agents") and "ended_at = now()" in sql
+        ]
+        assert len(backfill_updates) == 1
+        _, params = backfill_updates[0]
+        assert params is not None
+        statuses = params[0]
+        assert "running" not in statuses
+        assert "succeeded" in statuses
+        assert "failed" in statuses
+        assert "crashed" in statuses


### PR DESCRIPTION
## Summary

Three small surgical fixes that enforce the invariant `status terminal => ended_at NOT NULL`. The agent-runner's terminal-status writes (`advance_phase` + `agent_runner_reaped_failure`) now stamp `ended_at = COALESCE(ended_at, now())` alongside `status`. A new daemon-side bulk healer in `_housekeeping_tick` heals already-leaked rows and any future races. Together they restore visibility of daemon-shipped greens in the admin cockpit's "Recently Completed" panel.

Closes #3822

## Test plan

### Automated checks
- [x] Lint passes
- [x] Format check passes
- [x] Tests pass
- [x] CI green

### Post-deploy verification
- [ ] After dispatcher deploys, query CloudWatch `/ecs/judgemind-dispatcher-dev` for `event="terminal_ended_at_backfilled"` — first hit should appear within one housekeeping cadence (~1h) and report `rows_stamped > 0` (heals every leaked daemon-shipped green).
- [ ] After agent-runner deploys, query CloudWatch `/ecs/judgemind-dispatcher-agent-runner-dev` for `event="agent_runner_reaped_success" issue_number not null` rows — every matched agent_id should have `ended_at NOT NULL` in `dispatcher.agents` after the next housekeeping tick.
- [ ] Admin cockpit's "Recently Completed" panel surfaces the recent #3813 / #3815 / #3817 / #3820 / #3821 daemon-shipped greens AND any new ones shipped post-deploy.
- [ ] Verification evidence posted on issue #3822 (see A.8).
