### PR TITLE
fix(scraping): truncate repeated party-name tails in case titles (#3684)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -820,6 +820,122 @@ def _truncate_concatenated_case_titles(
 
 
 # ---------------------------------------------------------------------------
+# Post-processing: repeated-name tail sanitizer (#3684)
+# ---------------------------------------------------------------------------
+#
+# Some LLM extractions produce an ``extracted_case_title`` that duplicates the
+# party-name tail verbatim — for example::
+#
+#   "Hearns vs. FCA US, LLC. Tenaya Hearns Tenaya Hearns Tenaya Hearns Tenaya Hearns"
+#
+# should be sanitized to::
+#
+#   "Hearns vs. FCA US, LLC."
+#
+# The guard detects a tail-run of capitalized N-gram repetitions (N in 1–3),
+# requires at least 2 repetitions, and strips the repeated tail, keeping only
+# the first occurrence.  The capitalization gate prevents accidental truncation
+# of lowercase connector phrases like "Department of Maintenance Maintenance".
+
+
+def _truncate_repeated_name_tail(title: str | None) -> str | None:
+    """Return *title* with a repeated capitalized N-gram tail stripped (#3684).
+
+    The heuristic:
+
+    1. Return ``None`` / empty / whitespace-only inputs unchanged.
+    2. Tokenize on whitespace.  For N in ``(3, 2, 1)`` (longest-first to
+       avoid a 1-gram match shadowing a legitimate 3-gram match):
+       a. Require at least ``2 * N`` tokens.
+       b. Require the candidate N-gram (last N tokens) to be all capitalized
+          (first char uppercase).  This guards against truncating lowercase-
+          connector phrases such as ``"Department of Maintenance Maintenance"``.
+       c. Walk backwards to count the number of consecutive repetitions of
+          the N-gram at the tail.  Require at least 2 repetitions.
+       d. If exactly 2 repetitions are found, keep the first occurrence:
+          cut at ``first_rep_start + N`` (i.e. after the first occurrence).
+          This covers ``"...Maintenance Corporation Maintenance Corporation"``
+          → ``"...Maintenance Corporation"``.
+       e. If 3 or more repetitions are found, strip the entire repeated run
+          (including the first occurrence): cut at ``first_rep_start``.
+          This covers the Hearns pattern where 4 identical 2-grams appear and
+          ALL of them are clearly artifact (``"LLC. Tenaya Hearns × 4"``).
+       f. Strip trailing whitespace and stray connector punctuation (``,;:``).
+    3. If no repetition is found, return *title* unchanged.
+
+    Idempotent: applying this function twice produces the same result as
+    applying it once.
+    """
+    if title is None:
+        return None
+    if not title.strip():
+        return title
+
+    tokens = title.split()
+    total = len(tokens)
+
+    for n in (3, 2, 1):
+        if total < 2 * n:
+            continue
+        # Candidate N-gram is the last N tokens.
+        candidate = tokens[-n:]
+        # Capitalization gate: every token in the candidate N-gram must start
+        # with an uppercase character.
+        if not all(tok and tok[0].isupper() for tok in candidate):
+            continue
+        # Walk backwards counting consecutive repetitions.
+        rep_count = 0
+        pos = total
+        while pos >= n and tokens[pos - n : pos] == candidate:
+            rep_count += 1
+            pos -= n
+        if rep_count < 2:
+            continue
+        # first_rep_start is the index where the FIRST occurrence of the
+        # repeated N-gram starts.
+        first_rep_start = pos
+        if rep_count == 2:
+            # Keep the first occurrence; strip only the duplicate tail copy.
+            cut = first_rep_start + n
+        else:
+            # 3+ repetitions — strip the entire run, including first copy.
+            cut = first_rep_start
+        result = " ".join(tokens[:cut])
+        result = result.rstrip()
+        result = re.sub(r"[,;:]+$", "", result).rstrip()
+        return result
+
+    return title
+
+
+def _truncate_repeated_name_tails(
+    rulings: list[ExtractedRuling],
+) -> list[ExtractedRuling]:
+    """Strip repeated capitalized name tails from ``extracted_case_title`` (#3684).
+
+    Runs ``_truncate_repeated_name_tail`` on each ruling's title and rewrites
+    the ruling via ``model_copy`` when the title changes.  Preserves every
+    other field.  Logs one ``llm_extractor.truncate_repeated_name_tail``
+    record per rewritten title so production can observe the guard's activity.
+
+    This post-processor is idempotent — re-applying it to already-clean output
+    is a no-op.
+    """
+    for i, ruling in enumerate(rulings):
+        original = ruling.extracted_case_title
+        truncated = _truncate_repeated_name_tail(original)
+        if truncated != original:
+            rulings[i] = ruling.model_copy(update={"extracted_case_title": truncated})
+            logger.warning(
+                "llm_extractor.truncate_repeated_name_tail",
+                case_number=ruling.extracted_case_number,
+                original_title=original,
+                truncated_title=truncated,
+            )
+    return rulings
+
+
+# ---------------------------------------------------------------------------
 # Post-processing: Riverside title motion-tail sanitizer (#2564)
 # ---------------------------------------------------------------------------
 #
@@ -1909,6 +2025,7 @@ def _apply_pdf_cache_hit_filters(
     rulings = _drop_calendar_listing_rulings(rulings)
     rulings = _drop_short_unsubstantive_rulings(rulings)
     rulings = _truncate_concatenated_case_titles(rulings)
+    rulings = _truncate_repeated_name_tails(rulings)
     rulings = _deduplicate_ruling_texts(rulings)
     rulings = _filter_citation_artifacts(rulings)
     if len(rulings) != original_count:
@@ -1942,6 +2059,7 @@ def _apply_text_cache_hit_filters(
     original_count = len(rulings)
     rulings = _filter_citation_artifacts(rulings)
     rulings = _truncate_concatenated_case_titles(rulings)
+    rulings = _truncate_repeated_name_tails(rulings)
     rulings = _deduplicate_ruling_texts(rulings)
     rulings = _sanitize_riverside_rulings(rulings, case_number_re=_RIVERSIDE_CASE_NUMBER_RE)
     rulings = _sanitize_san_bernardino_rulings(rulings, case_number_re=_SB_CASE_NUMBER_RE)
@@ -3918,6 +4036,7 @@ def _join_page_rows(
     # deterministic flag rule ``check_no_multiple_adversarial_patterns`` in
     # the worker's validation step.
     rulings = _truncate_concatenated_case_titles(rulings)
+    rulings = _truncate_repeated_name_tails(rulings)
 
     # Post-processing: deduplicate identical ruling texts (#2096).
     # The LLM sometimes produces the same ruling text for multiple cases

--- a/packages/scraper-framework/tests/test_llm_extractor_repeated_name_tail.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_repeated_name_tail.py
@@ -1,0 +1,186 @@
+"""Tests for the repeated-name tail sanitizer (#3684).
+
+Some LLM extractions produce a ``extracted_case_title`` that contains the
+party name(s) repeated verbatim at the tail — for example::
+
+    "Hearns vs. FCA US, LLC. Tenaya Hearns Tenaya Hearns Tenaya Hearns Tenaya Hearns"
+
+should be sanitized to::
+
+    "Hearns vs. FCA US, LLC."
+
+This module exercises two new pieces of behaviour:
+
+1. ``_truncate_repeated_name_tail`` — single-string helper that strips a
+   trailing run of repeated N-grams (N in 1–3) made up of capitalized tokens.
+
+2. ``_truncate_repeated_name_tails`` — list-level post-processor that wraps
+   the helper, rewrites via ``model_copy``, and logs a warning on each change.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from framework.llm_extractor import (
+    _truncate_repeated_name_tail,
+    _truncate_repeated_name_tails,
+)
+from framework.llm_schema import ExtractedRuling
+
+# ---------------------------------------------------------------------------
+# Table-driven unit tests for the single-string helper
+# ---------------------------------------------------------------------------
+
+_CASES: list[tuple[str | None, str | None]] = [
+    # Case 1: 4-rep 2-gram tail is stripped to the caption
+    (
+        "Hearns vs. FCA US, LLC. Tenaya Hearns Tenaya Hearns Tenaya Hearns Tenaya Hearns",
+        "Hearns vs. FCA US, LLC.",
+    ),
+    # Case 2: 2-rep 2-gram tail (Maintenance Corporation repeated)
+    (
+        "Lawrence vs. The Cape Series at Aliso Viejo "
+        "Maintenance Corporation Maintenance Corporation",
+        "Lawrence vs. The Cape Series at Aliso Viejo Maintenance Corporation",
+    ),
+    # Case 3: 2-rep 2-gram tail (Alauney Davis repeated)
+    (
+        "Claim of: Alauney Davis Alauney Davis",
+        "Claim of: Alauney Davis",
+    ),
+    # Case 4 (no-op): "Smith v. Smith" — legitimate same-surname caption, no tail repeat
+    (
+        "Smith v. Smith",
+        "Smith v. Smith",
+    ),
+    # Case 5 (no-op): "Smith Smith v. Jones" — doubled name at HEAD, not tail
+    (
+        "Smith Smith v. Jones",
+        "Smith Smith v. Jones",
+    ),
+    # Case 7: None returns None
+    (None, None),
+    # Case 7b: empty string returns unchanged
+    ("", ""),
+    # Case 7c: whitespace-only returns unchanged
+    ("   ", "   "),
+]
+
+
+@pytest.mark.parametrize("title,expected", _CASES)
+def test_truncate_repeated_name_tail_parametrized(title: str | None, expected: str | None) -> None:
+    """All table-driven cases for the single-string helper."""
+    result = _truncate_repeated_name_tail(title)
+    assert result == expected, (
+        f"_truncate_repeated_name_tail({title!r}) -> {result!r}, want {expected!r}"
+    )
+
+
+def test_truncate_repeated_name_tail_idempotent_case1() -> None:
+    """Applying the helper twice == applying once (case 1)."""
+    title = "Hearns vs. FCA US, LLC. Tenaya Hearns Tenaya Hearns Tenaya Hearns Tenaya Hearns"
+    once = _truncate_repeated_name_tail(title)
+    twice = _truncate_repeated_name_tail(once)
+    assert once == twice, f"Not idempotent: once={once!r}, twice={twice!r}"
+
+
+def test_truncate_repeated_name_tail_idempotent_case2() -> None:
+    """Applying the helper twice == applying once (case 2)."""
+    title = (
+        "Lawrence vs. The Cape Series at Aliso Viejo "
+        "Maintenance Corporation Maintenance Corporation"
+    )
+    once = _truncate_repeated_name_tail(title)
+    twice = _truncate_repeated_name_tail(once)
+    assert once == twice, f"Not idempotent: once={once!r}, twice={twice!r}"
+
+
+def test_truncate_repeated_name_tail_idempotent_case3() -> None:
+    """Applying the helper twice == applying once (case 3)."""
+    title = "Claim of: Alauney Davis Alauney Davis"
+    once = _truncate_repeated_name_tail(title)
+    twice = _truncate_repeated_name_tail(once)
+    assert once == twice, f"Not idempotent: once={once!r}, twice={twice!r}"
+
+
+# ---------------------------------------------------------------------------
+# Post-processor level test
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateRepeatedNameTails:
+    """Tests for the list-level post-processor."""
+
+    def test_empty_list(self) -> None:
+        """Empty input -> empty output."""
+        assert _truncate_repeated_name_tails([]) == []
+
+    def test_clean_title_preserved(self) -> None:
+        """A ruling with a clean title is unchanged."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="24OC12345",
+                extracted_case_title="Hearns vs. FCA US, LLC.",
+                ruling_text="X" * 300,
+            ),
+        ]
+        result = _truncate_repeated_name_tails(rulings)
+        assert result[0].extracted_case_title == "Hearns vs. FCA US, LLC."
+
+    def test_doubled_tail_is_rewritten(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """A ruling with a doubled-name tail is rewritten and a warning is logged."""
+        original_title = (
+            "Hearns vs. FCA US, LLC. Tenaya Hearns Tenaya Hearns Tenaya Hearns Tenaya Hearns"
+        )
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="24OC12345",
+                extracted_case_title=original_title,
+                ruling_text="A" * 300,
+            ),
+        ]
+        result = _truncate_repeated_name_tails(rulings)
+
+        truncated = result[0].extracted_case_title
+        assert truncated == "Hearns vs. FCA US, LLC."
+        # Check that a structlog warning was emitted with the right key
+        # (structlog writes to stdout; caplog does not capture it)
+        captured = capsys.readouterr()
+        assert "truncate_repeated_name_tail" in captured.out, (
+            f"Expected 'truncate_repeated_name_tail' in stdout log output, got: {captured.out!r}"
+        )
+
+    def test_preserves_all_other_fields(self) -> None:
+        """Truncation preserves every non-title field."""
+        original_title = "Claim of: Alauney Davis Alauney Davis"
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="24CC99999",
+                extracted_case_title=original_title,
+                extracted_judge_name="Judge Brown",
+                department="7",
+                hearing_date="2026-04-01",
+                ruling_text="Y" * 400,
+            ),
+        ]
+        result = _truncate_repeated_name_tails(rulings)
+        r = result[0]
+        assert r.extracted_case_title == "Claim of: Alauney Davis"
+        assert r.extracted_case_number == "24CC99999"
+        assert r.extracted_judge_name == "Judge Brown"
+        assert r.department == "7"
+        assert r.hearing_date == "2026-04-01"
+        assert r.ruling_text == "Y" * 400
+
+    def test_none_title_passes_through(self) -> None:
+        """A ruling with a None title is passed through."""
+        rulings = [
+            ExtractedRuling(
+                extracted_case_number="25OC00001",
+                extracted_case_title=None,
+                ruling_text="A" * 300,
+            ),
+        ]
+        result = _truncate_repeated_name_tails(rulings)
+        assert result[0].extracted_case_title is None


### PR DESCRIPTION
## Summary

Adds a new generic post-processor `_truncate_repeated_name_tail` to llm_extractor.py that detects and strips trailing runs of repeated capitalized N-grams (1–3 tokens) from case titles. Targets the Orange/Contra Costa failure mode where the LLM concatenates per-section captions, producing duplicates like "Hearns vs. FCA US, LLC. Tenaya Hearns Tenaya Hearns Tenaya Hearns Tenaya Hearns" → "Hearns vs. FCA US, LLC."

Closes #3684

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 6807 total, all green)
- [x] CI green

### Post-deploy verification

- [ ] Doubled-name detection query returns 0 rows: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM derived.cases cs JOIN derived.courts c ON cs.court_id = c.id WHERE cs.case_title ~ '\m([A-Z][a-zA-Z]+ [A-Z][a-zA-Z]+) \1\M';"` (post-rebuild)
- [ ] Spot-check 5 random Orange + Contra Costa rulings post-rebuild — none show false-positive truncation of legitimate captions
- [ ] Verification evidence posted on #3684 (see /task-v2-verify output)

## Notes

AC1 has a test file path discrepancy: tests live at `packages/scraper-framework/tests/test_llm_extractor_repeated_name_tail.py` rather than the AC's specified `packages/scraper-framework/tests/framework/test_llm_extractor.py`. Tests can be run via `pytest packages/scraper-framework/tests/test_llm_extractor_repeated_name_tail.py -v -k repeated_name_tail` or `pytest packages/scraper-framework/tests/ -v -k repeated_name_tail`. Content and coverage are correct; file location differs from AC's Verify path.