### PR TITLE
fix(dispatcher): filter out status/needs-human in queue scan (#3825)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -4147,18 +4147,24 @@ class DispatcherDaemon:
                 f"gh issue list returned non-list JSON: {type(issues).__name__}"
             )
 
-        # Defensive filter: drop rows that also carry ``status/blocked``
-        # or ``status/in-progress``. The ``gh --label agent/ready`` call
-        # returns issues that carry the label; a blocked or in-progress
-        # issue that still has ``agent/ready`` attached (e.g. mid-
-        # transition) should not inflate the queue depth because the
-        # daemon would never spawn on it. ``status/in-progress`` is the
-        # /task-skill↔daemon interlock signal — after #2927 the /task
-        # subagent uses label-only coordination (add
+        # Defensive filter: drop rows that also carry ``status/blocked``,
+        # ``status/in-progress``, or ``status/needs-human``. The
+        # ``gh --label agent/ready`` call returns issues that carry the
+        # label; a blocked, in-progress, or human-flagged issue that
+        # still has ``agent/ready`` attached (e.g. mid-transition or
+        # mid-escalation) should not inflate the queue depth because
+        # the daemon would never spawn on it. ``status/in-progress`` is
+        # the /task-skill↔daemon interlock signal — after #2927 the
+        # /task subagent uses label-only coordination (add
         # ``status/in-progress`` BEFORE removing ``agent/ready``), so
         # the label here is the sole race-defense primitive. The
         # daemon's pre-claim recheck in ``_atomic_claim`` re-reads the
         # label set at claim time to close the ~100ms propagation race.
+        # ``status/needs-human`` is the diagnoser's escalation signal
+        # (see ``_diagnose_and_escalate``); without this consumer-side
+        # filter the daemon would re-claim a needs-human issue every
+        # tick and waste a full agent run before reaching
+        # ``push_and_pr_no_unmerged_files`` (#3825).
         filtered: list[dict[str, Any]] = []
         for issue in issues:
             if not isinstance(issue, dict):
@@ -4170,6 +4176,8 @@ class DispatcherDaemon:
             if "status/blocked" in label_names:
                 continue
             if STATUS_IN_PROGRESS_LABEL in label_names:
+                continue
+            if "status/needs-human" in label_names:
                 continue
             filtered.append(issue)
         return filtered

--- a/scripts/dispatcher/tests/test_daemon_phase3a.py
+++ b/scripts/dispatcher/tests/test_daemon_phase3a.py
@@ -3788,6 +3788,66 @@ class TestQueueScanExcludesInProgressLabel:
         assert [i["number"] for i in issues] == [1, 3]
 
 
+class TestQueueScanExcludesNeedsHumanLabel:
+    """``_fetch_agent_ready_issues`` filters out ``status/needs-human`` (#3825).
+
+    The diagnoser writes ``status/needs-human`` whenever it escalates an
+    issue to operator attention (``daemon.py`` ``_diagnose_and_escalate``
+    path). Before #3825, the queue-scan filter only dropped
+    ``status/blocked`` and ``status/in-progress`` — the daemon would
+    re-claim a needs-human issue every tick, costing ~10 minutes of
+    agent runtime per claim before terminating at
+    ``push_and_pr_no_unmerged_files``. The fix mirrors the existing
+    ``status/blocked`` / ``status/in-progress`` filter: one literal
+    string check inside the same loop.
+    """
+
+    def test_needs_human_label_excludes_issue_from_candidate_list(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """Issues carrying ``status/needs-human`` alongside ``agent/ready`` drop.
+
+        The diagnoser-side write is the producer; this filter is the
+        consumer side. Without it, the daemon's queue-scan keeps
+        returning the issue and the dispatcher keeps spawning agents
+        on it.
+        """
+        d, _conn, _handler = _make_daemon(tmp_path)
+
+        def fake_run(cmd: list[str], **_kwargs: Any) -> Any:
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = ""
+            r.stdout = json.dumps(
+                [
+                    {
+                        "number": 1,
+                        "labels": [{"name": "agent/ready"}],
+                        "title": "ok",
+                    },
+                    {
+                        "number": 2,
+                        "labels": [
+                            {"name": "agent/ready"},
+                            {"name": "status/needs-human"},
+                        ],
+                        "title": "needs-human",
+                    },
+                    {
+                        "number": 3,
+                        "labels": [{"name": "agent/ready"}],
+                        "title": "ok2",
+                    },
+                ]
+            )
+            return r
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        issues = d._fetch_agent_ready_issues()
+        # #2 drops; #1 + #3 remain.
+        assert [i["number"] for i in issues] == [1, 3]
+
+
 class TestGhIssueRemoveLabelsHelper:
     """Thin helper tests for :meth:`_gh_issue_remove_labels` (#2866)."""
 


### PR DESCRIPTION
## Summary

The diagnoser writes `status/needs-human` to flag issues for operator attention, but `_fetch_agent_ready_issues` was only filtering `status/blocked` and `status/in-progress` — so the daemon kept re-claiming human-flagged issues every queue scan, burning ~10 minutes per claim before terminating at `push_and_pr_no_unmerged_files`. Cost 2 daemon-shipped greens in 20 minutes (#3660 and #3587). One-line consumer-side gate to honor the existing diagnoser signal.

Closes #3825

## Test plan

### Automated checks
- [ ] Lint passes
- [ ] Format check passes
- [ ] Tests pass
- [ ] CI green

### Post-deploy verification
- [ ] CloudWatch query for `candidate_picked` events with `issue_number` in [3660, 3587] over the next 60min — count must be 0
- [ ] Verification evidence posted on issue (see A.8)
