### PR TITLE
fix(scraping): remove petition→probate mapping, too broad for civil/federal cases (#3691)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -1146,7 +1146,9 @@ _MOTION_TYPE_CASE_TYPE_MAP: dict[str, str] = {
     "lis_pendens": "civil",
     "request_for_dismissal": "civil",
     # Probate-specific motion types
-    "petition": "probate",
+    # NOTE: bare "petition" is intentionally excluded — it is the catch-all
+    # label used in civil, limited-civil, federal, and Watermaster cases and
+    # therefore cannot be reliably mapped to probate (#3691).
     "petition_for_probate": "probate",
     "guardianship_petition": "probate",
     "trust_petition": "probate",

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -958,8 +958,33 @@ class TestExtractCaseTypeFromMotionType:
 
     # --- Probate motion types ---
 
-    def test_petition(self) -> None:
-        assert extract_case_type_from_motion_type("petition") == "probate"
+    def test_petition_too_broad_returns_none(self) -> None:
+        """Bare 'petition' is ambiguous — civil/limited-civil/federal/Watermaster
+        cases all use this label, so it must NOT map to probate."""
+        assert extract_case_type_from_motion_type("petition") is None
+
+    @pytest.mark.parametrize(
+        "motion_type,case_number,scraper_id",
+        [
+            # Contra Costa limited-civil
+            ("petition", "L25-03538", "ca-cc-tentatives"),
+            # Federal generic
+            ("petition", "24CV12345", "federal-pacer"),
+            # Fresno civil
+            ("petition", "2024CV019999", "ca-fresno-tentatives"),
+        ],
+    )
+    def test_petition_non_probate_fixtures_return_none(
+        self, motion_type: str, case_number: str, scraper_id: str
+    ) -> None:
+        """Regression: petition + non-probate case numbers/scrapers all return None.
+
+        These fixtures previously incorrectly mapped to 'probate' via the
+        bare 'petition' entry that has now been removed (#3691).
+        """
+        _ = case_number  # context only — extract_case_type_from_motion_type is motion-type-only
+        _ = scraper_id
+        assert extract_case_type_from_motion_type(motion_type) is None
 
     def test_petition_for_probate(self) -> None:
         assert extract_case_type_from_motion_type("petition_for_probate") == "probate"

--- a/packages/scraper-framework/tests/test_reingest_from_s3.py
+++ b/packages/scraper-framework/tests/test_reingest_from_s3.py
@@ -4941,6 +4941,9 @@ class TestFullReparseDocument:
         When the case number has no embedded type code (e.g. Ventura's
         ``202300574258``), the case_type should be derived from the
         motion_type via ``extract_case_type_from_motion_type()``.
+
+        Bare ``petition`` no longer maps to probate (#3691) — all-digit case
+        numbers with motion_type ``petition`` produce case_type ``None``.
         """
         from courts.ca.fresno_tentatives import SplitRuling
 
@@ -4965,9 +4968,9 @@ class TestFullReparseDocument:
             # demurrer => civil
             assert result[0]["case_type"] == "civil"
             assert result[0]["extraction_methods"]["case_type"] == "motion_type"
-            # petition => probate
-            assert result[1]["case_type"] == "probate"
-            assert result[1]["extraction_methods"]["case_type"] == "motion_type"
+            # petition => None (bare "petition" is ambiguous — removed from map in #3691)
+            assert result[1]["case_type"] is None
+            assert "case_type" not in result[1]["extraction_methods"]
         finally:
             reingest._SPLIT_REGISTRY.pop("test-ct-mt", None)
 


### PR DESCRIPTION
## Summary

Removed the overly-broad `"petition": "probate"` mapping from the motion-type fallback in extract.py. This mapping was catching ~290 civil, limited-civil, federal, and Watermaster cases that happen to use the generic "petition" label, incorrectly marking them as probate. Added comprehensive unit tests with fixtures for Contra Costa limited-civil, federal, and Fresno civil cases, all asserting the function returns None.

Closes #3691

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — 899 scraper-framework tests pass
- [x] CI green — pre-push hook exited 0 against committed state

### Post-deploy verification

- [ ] Rebuild affected counties:
  ```bash
  scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county Federal
  scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county "Contra Costa"
  scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county Fresno
  scripts/ecs-run-task.sh scripts/rebuild_db.py -- --county "Los Angeles"
  ```
- [ ] Post-rebuild verification: `no_probate_prefix` count drops to ≤5 across all rows:
  ```bash
  scripts/dev-db-query.sh "SELECT ct.county, COUNT(*) FILTER (WHERE cs.case_number !~* '(^.*PR|^.*BP|^.*CP|^P\\d|^\\d{8,}PR)' AND cs.case_number NOT LIKE 'UNKNOWN-%') AS no_probate_prefix FROM derived.rulings r JOIN derived.cases cs ON r.case_id = cs.id JOIN derived.courts ct ON r.court_id = ct.id WHERE r.motion_type = 'petition' AND cs.case_type = 'probate' GROUP BY ct.county ORDER BY no_probate_prefix DESC;"
  ```
- [ ] Regression check: Ventura `petition+probate` count stays within ±5% of baseline (~160 → 155-165 expected)
- [ ] Verification evidence posted on #3691