### PR TITLE
fix(scraping): remove bare HEARING IN RE from probate calendar-listing detector (#3699)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -1497,16 +1497,16 @@ _PLACEHOLDER_RE = re.compile(
 # They are identified by EITHER:
 #   (a) a time-prefixed "HEARING IN RE" phrase (``9:00 AM HEARING IN RE:``)
 #   (b) the literal pointer phrase ``see also alternate sheet`` / ``see alt sheet``
+# The bare "HEARING IN RE" phrase (without a time prefix or alt-sheet pointer)
+# is intentionally excluded — non-CC courts also use this phrase in real rulings
+# with verbs like ``ruled``, ``ordered``, ``found``, ``held`` that are absent
+# from ``_RULING_VERB_RE`` and would cause false-positive drops (#3699).
 # These rows may be 110-180 chars — well above _CALENDAR_LISTING_MAX_LENGTH —
 # so they MUST be matched by an explicit pointer check that bypasses the
-# length gate.  The disposition-verb guard (_RULING_VERB_RE) is applied
-# *after* this check to preserve any real one-liner ruling that incidentally
-# contains "HEARING IN RE" as part of its text.
+# length gate.
 _PROBATE_CALENDAR_LISTING_RE = re.compile(
     r"(?:"
     r"\d{1,2}:\d{2}\s*(?:AM|PM)\s+HEARING\s+IN\s+RE\b"
-    r"|"
-    r"HEARING\s+IN\s+RE\b"
     r"|"
     r"see\s+also\s+alt(?:ernate)?\s*sheet"
     r")",
@@ -1658,8 +1658,9 @@ def _is_calendar_listing_only(text: str | None) -> bool:
     if not stripped:
         return False
     # Step 0: Explicit CC probate calendar-pointer signals bypass the length
-    # gate.  A real ruling that incidentally mentions "HEARING IN RE" will
-    # still be preserved because the disposition-verb guard fires first.
+    # gate.  Only time-prefixed HEARING IN RE and alt-sheet pointer phrases
+    # match; the bare phrase is excluded to avoid false-positive drops on
+    # non-CC rulings that use verbs absent from _RULING_VERB_RE (#3699).
     if _PROBATE_CALENDAR_LISTING_RE.search(stripped) and not _RULING_VERB_RE.search(stripped):
         return True
     # Too long to be a calendar listing.

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -1547,6 +1547,26 @@ class TestIsCalendarListingOnly:
         )
         assert _is_calendar_listing_only(text) is False
 
+    def test_non_cc_ruling_with_bare_hearing_in_re_preserved(self) -> None:
+        """Non-CC rulings with bare 'Hearing in re' are preserved (#3699).
+
+        The bare HEARING IN RE alternative was removed from
+        _PROBATE_CALENDAR_LISTING_RE because non-CC courts use this phrase
+        in real rulings with verbs like 'ruled' that are absent from
+        _RULING_VERB_RE.  Without the fix the text below was incorrectly
+        dropped as a CC calendar-listing pointer.
+        """
+        # >100 chars so the length-gate bypass path is exercised.
+        # Uses only 'ruled' which is NOT in _RULING_VERB_RE — no GRANTED/DENIED/etc.
+        # This is the exact bug vector: old regex matched bare HEARING IN RE,
+        # _RULING_VERB_RE did not fire, so the real ruling was falsely dropped.
+        text = (
+            "Hearing in re petition for approval of minor's compromise; "
+            "the court has considered all papers submitted and ruled on the merits.  "
+            "Counsel to prepare and submit a proposed order within ten days."
+        )
+        assert _is_calendar_listing_only(text) is False
+
 
 class TestIsCalendarListingOnlyWidened2489:
     """Additional widened-filter cases for #2489.


### PR DESCRIPTION
## Summary

Removed the overly-broad bare `HEARING\s+IN\s+RE\b` alternative from the `_PROBATE_CALENDAR_LISTING_RE` regex that was incorrectly matching non-CC probate rulings. The regex now contains only the time-prefixed variant (`9:00 AM HEARING IN RE`) and alt-sheet-pointer pattern (`see also alternate sheet`), which correctly scope to Contra Costa calendar-listing detection as documented.

Closes #3699

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — 416 tests passed
- [x] CI green

### Post-deploy verification

- [ ] Manual spot-check: search for any recent non-CC probate rulings with "Hearing in re" phrasing and uncommon disposition verbs in the database to verify they were captured (not dropped)
- [ ] Verify no spike in dropped-ruling rate on dev dashboard post-deploy
- [ ] Verification evidence posted on #3699