### PR TITLE
fix(scraping): add metadata fallback in multimodal extraction for Orange judge/department resolution (#3722)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -3984,6 +3984,31 @@ def _join_page_rows(
             if not header_date:
                 header_date = _parse_header_date(info)
 
+    # Permissive second pass: when the strict pass did not find a judge or
+    # department, scan case_info of ALL rows (regardless of entry_number or
+    # ruling_text) for the patterns.  OC multimodal PDFs embed this metadata
+    # inside regular ruling rows rather than in a dedicated header row (#3722).
+    # First match wins; strict-pass hits are never overwritten.
+    if not header_judge or not header_dept:
+        for row in rows:
+            info = row.get("case_info") or ""
+            if not info:
+                continue
+            if not header_judge:
+                judge_match = re.search(
+                    r"(?:Hon\.?\s+|Honorable\s+|JUDGE\s+)([A-Z][A-Za-z .'-]{2,80})",
+                    info,
+                    re.IGNORECASE,
+                )
+                if judge_match:
+                    header_judge = judge_match.group(1).strip()
+            if not header_dept:
+                dept_match = re.search(r"(?:Department|Dept\.?)\s+([A-Z0-9]+)", info, re.IGNORECASE)
+                if dept_match:
+                    header_dept = dept_match.group(1).strip()
+            if header_judge and header_dept:
+                break
+
     # Track entry_number -> case_index for cross-reference resolution (#2317).
     entry_number_to_index: dict[int, int] = {}
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -2861,13 +2861,12 @@ class IngestionWorker:
             fallback_text=ruling_text,
         )
 
-        # When a multi-ruling document produces results but every entry is
-        # missing both judge and department, the header metadata was not
+        # When a multi-ruling document produces results but >= 50% of entries
+        # are missing both judge and department, the header metadata was not
         # captured by the LLM — write a best-effort telemetry row so the
-        # failure rate is dashboard-queryable (#3559).
-        if len(converted) > 1 and all(
-            cr.judge_name is None and cr.department is None for cr in converted
-        ):
+        # failure rate is dashboard-queryable (#3559, #3722).
+        null_count = sum(1 for cr in converted if cr.judge_name is None and cr.department is None)
+        if len(converted) > 1 and null_count / len(converted) >= 0.5:
             try:
                 conn = self._get_connection()
                 with conn.cursor() as cur:
@@ -2892,6 +2891,9 @@ class IngestionWorker:
                                         "county": county,
                                         "scraper_id": event_data.get("scraper_id"),
                                         "ruling_count": len(converted),
+                                        "null_count": null_count,
+                                        "total_rulings": len(converted),
+                                        "null_ratio": null_count / len(converted),
                                     }
                                 ),
                             ),

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -6451,6 +6451,10 @@ def test_llm_split_writes_multimodal_all_null_metadata_metric() -> None:
     assert meta["s3_key"] == "ca/orange/superior_court/raw/multi-ruling.pdf"
     assert meta["state"] == "CA"
     assert meta["ruling_count"] == 2
+    # New fields added in #3722.
+    assert meta["null_count"] == 2
+    assert meta["total_rulings"] == 2
+    assert meta["null_ratio"] == 1.0
     # Savepoint must be used for best-effort protection.
     assert any("SAVEPOINT multimodal_null_metadata_metric" in s for s in executed_sql)
 
@@ -6535,3 +6539,170 @@ def test_llm_split_multimodal_null_metadata_insert_failure_swallowed() -> None:
     assert any(
         "ROLLBACK TO SAVEPOINT multimodal_null_metadata_metric" in s for s in executed_sql
     ), "Inner handler must roll back the savepoint on INSERT failure (#3559)."
+
+
+def test_llm_split_writes_metric_at_50pct_null() -> None:
+    """Telemetry fires when null_count / total_rulings >= 0.50 (#3722).
+
+    1 populated ruling + 2 null rulings (66% null) should trigger the metric.
+    """
+    from framework.llm_schema import ExtractedRuling
+
+    worker, _ = _make_worker()
+    worker._llm_client = MagicMock()
+
+    populated_ruling = ExtractedRuling(
+        extracted_case_number="30-2024-10000001",
+        extracted_case_title="Alpha v. Beta",
+        extracted_judge_name="Smith",
+        department="C25",
+        motion_type=None,
+        outcome=None,
+        hearing_date="2026-03-16",
+        extracted_parties=[],
+        ruling_text="GRANTED.",
+        case_type=None,
+    )
+    null_ruling_1 = ExtractedRuling(
+        extracted_case_number="30-2024-10000002",
+        extracted_case_title="Gamma v. Delta",
+        extracted_judge_name=None,
+        department=None,
+        motion_type=None,
+        outcome=None,
+        hearing_date="2026-03-16",
+        extracted_parties=[],
+        ruling_text="DENIED.",
+        case_type=None,
+    )
+    null_ruling_2 = ExtractedRuling(
+        extracted_case_number="30-2024-10000003",
+        extracted_case_title="Epsilon v. Zeta",
+        extracted_judge_name=None,
+        department=None,
+        motion_type=None,
+        outcome=None,
+        hearing_date="2026-03-16",
+        extracted_parties=[],
+        ruling_text="OVERRULED.",
+        case_type=None,
+    )
+
+    mock_extractor = MagicMock()
+    mock_extractor.extract.return_value = [populated_ruling, null_ruling_1, null_ruling_2]
+
+    event = _make_event(
+        document_id="multimodal-doc-0000-0000-000000000050",
+        scraper_id="ca-oc-tentatives",
+        state="CA",
+        county="Orange",
+        s3_key="ca/orange/superior_court/raw/multi-50pct-null.pdf",
+        ruling_text="Some multipage ruling text",
+        judge_name=None,
+        department=None,
+    )
+
+    mock_conn, mock_cur = _make_mock_conn()
+
+    with (
+        patch.object(worker, "_get_framework_extractor", return_value=mock_extractor),
+        patch.object(worker, "_get_multimodal_extractor", return_value=None),
+        patch.object(worker, "_get_connection", return_value=mock_conn),
+        patch("ingestion.worker.delete_stale_split_children", return_value=0),
+        patch.object(worker, "process_event"),
+    ):
+        result = worker._llm_split_document(
+            event,
+            event["document_id"],
+            event["ruling_text"],
+            event["state"],
+            event["county"],
+            raw_pdf_bytes=None,
+        )
+
+    assert result is True
+    executed_sql = [call[0][0] for call in mock_cur.execute.call_args_list]
+    assert any("INSERT INTO data_quality_metrics" in s for s in executed_sql), (
+        "50% null rate (2/3) must trigger the multimodal_all_null_metadata metric (#3722)."
+    )
+    metric_calls = [
+        call
+        for call in mock_cur.execute.call_args_list
+        if "INSERT INTO data_quality_metrics" in call[0][0]
+    ]
+    params = metric_calls[0][0][1]
+    meta = json.loads(params[3])
+    assert meta["null_count"] == 2
+    assert meta["total_rulings"] == 3
+    assert abs(meta["null_ratio"] - 2 / 3) < 1e-9
+
+
+def test_llm_split_skips_metric_below_threshold() -> None:
+    """Telemetry does NOT fire when null_count / total_rulings < 0.50 (#3722).
+
+    4 populated rulings + 1 null ruling (20% null) must NOT trigger the metric.
+    """
+    from framework.llm_schema import ExtractedRuling
+
+    worker, _ = _make_worker()
+    worker._llm_client = MagicMock()
+
+    def _make_ruling(case_num: str, *, null: bool) -> ExtractedRuling:
+        return ExtractedRuling(
+            extracted_case_number=case_num,
+            extracted_case_title="Foo v. Bar",
+            extracted_judge_name=None if null else "Smith",
+            department=None if null else "C25",
+            motion_type=None,
+            outcome=None,
+            hearing_date="2026-03-16",
+            extracted_parties=[],
+            ruling_text="GRANTED.",
+            case_type=None,
+        )
+
+    rulings = [
+        _make_ruling("30-2024-20000001", null=False),
+        _make_ruling("30-2024-20000002", null=False),
+        _make_ruling("30-2024-20000003", null=False),
+        _make_ruling("30-2024-20000004", null=False),
+        _make_ruling("30-2024-20000005", null=True),
+    ]
+
+    mock_extractor = MagicMock()
+    mock_extractor.extract.return_value = rulings
+
+    event = _make_event(
+        document_id="multimodal-doc-0000-0000-000000000060",
+        scraper_id="ca-oc-tentatives",
+        state="CA",
+        county="Orange",
+        s3_key="ca/orange/superior_court/raw/multi-below-threshold.pdf",
+        ruling_text="Some multipage ruling text",
+        judge_name=None,
+        department=None,
+    )
+
+    mock_conn, mock_cur = _make_mock_conn()
+
+    with (
+        patch.object(worker, "_get_framework_extractor", return_value=mock_extractor),
+        patch.object(worker, "_get_multimodal_extractor", return_value=None),
+        patch.object(worker, "_get_connection", return_value=mock_conn),
+        patch("ingestion.worker.delete_stale_split_children", return_value=0),
+        patch.object(worker, "process_event"),
+    ):
+        result = worker._llm_split_document(
+            event,
+            event["document_id"],
+            event["ruling_text"],
+            event["state"],
+            event["county"],
+            raw_pdf_bytes=None,
+        )
+
+    assert result is True
+    executed_sql = [call[0][0] for call in mock_cur.execute.call_args_list]
+    assert not any("INSERT INTO data_quality_metrics" in s for s in executed_sql), (
+        "20% null rate (1/5) must NOT trigger the multimodal_all_null_metadata metric (#3722)."
+    )

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -1098,6 +1098,106 @@ class TestJoinPageRows:
         """
         assert _parse_header_date("13/05/2026") is None
 
+    def test_metadata_fallback_judge_via_permissive_scan(self) -> None:
+        """Permissive second pass picks up judge name from a non-header row (#3722).
+
+        When 'Hon. Smith' appears only inside an entry_number=1 row's case_info
+        (not a strict header row), the permissive scan must still populate
+        extracted_judge_name for all returned rulings.
+        """
+        rows = [
+            # Non-header row (has entry_number) with judge info on its own line in case_info.
+            # This mirrors OC PDFs where the judge name is embedded in the first ruling row.
+            {
+                "entry_number": 1,
+                "case_info": "Hon. Smith\n2024-00001 Alpha v. Beta",
+                "ruling_text": "GRANTED.",
+            },
+            {
+                "entry_number": 2,
+                "case_info": "2024-00002 Gamma v. Delta",
+                "ruling_text": "DENIED.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 2
+        assert rulings[0].extracted_judge_name == "Smith"
+        assert rulings[1].extracted_judge_name == "Smith"
+
+    def test_metadata_fallback_dept_via_permissive_scan(self) -> None:
+        """Permissive second pass picks up department from a non-header row (#3722).
+
+        When 'Department C44' appears only inside an entry_number=1 row's case_info
+        (not a strict header row), the permissive scan must populate department
+        for all returned rulings.
+        """
+        rows = [
+            # Non-header row (has entry_number) with dept info embedded in case_info.
+            {
+                "entry_number": 1,
+                "case_info": "Department C44\n2024-00001 Alpha v. Beta",
+                "ruling_text": "GRANTED.",
+            },
+            {
+                "entry_number": 2,
+                "case_info": "2024-00002 Gamma v. Delta",
+                "ruling_text": "DENIED.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 2
+        assert rulings[0].department == "C44"
+        assert rulings[1].department == "C44"
+
+    def test_strict_header_takes_precedence_over_permissive(self) -> None:
+        """Strict header scan result wins when both strict and permissive matches exist (#3722).
+
+        A genuine header row (entry_number=None, empty ruling_text) with 'JUDGE STRICT'
+        must win over 'Hon. Permissive' found in a regular row's case_info.
+        """
+        rows = [
+            # Strict header row — should populate header_judge = "STRICT".
+            {
+                "entry_number": None,
+                "case_info": "JUDGE STRICT",
+                "ruling_text": "",
+            },
+            # Non-header row with a different judge name — permissive pass must NOT overwrite.
+            {
+                "entry_number": 1,
+                "case_info": "Hon. Permissive\n2024-00001 Alpha v. Beta",
+                "ruling_text": "GRANTED.",
+            },
+        ]
+        rulings = _join_page_rows(rows)
+        assert len(rulings) == 1
+        assert rulings[0].extracted_judge_name == "STRICT"
+
+    def test_metadata_kwarg_overrides_both(self) -> None:
+        """metadata kwarg wins over both strict header and permissive scan (#3722).
+
+        When metadata={"judge_name": "Override"} is passed, neither the strict
+        header row nor the permissive scan result should appear in the ruling.
+        """
+        rows = [
+            # Strict header row.
+            {
+                "entry_number": None,
+                "case_info": "JUDGE STRICT",
+                "ruling_text": "",
+            },
+            # Non-header row with yet another judge name in case_info.
+            {
+                "entry_number": 1,
+                "case_info": "Hon. Permissive\n2024-00001 Alpha v. Beta",
+                "ruling_text": "GRANTED.",
+            },
+        ]
+        metadata = {"judge_name": "Override"}
+        rulings = _join_page_rows(rows, metadata=metadata)
+        assert len(rulings) == 1
+        assert rulings[0].extracted_judge_name == "Override"
+
 
 # ---------------------------------------------------------------------------
 # Calendar header detection tests (#2096)


### PR DESCRIPTION
## Summary

Added a permissive second-pass header scan in `_join_page_rows` to catch judge/department info from any row's case_info when the strict header-only regex miss (common in Orange multimodal PDFs). Replaced the all-null telemetry predicate with a 50% ratio threshold so partial-failure documents alarm.

Closes #3722

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`) — pre-push hook clean per ralph summary
- [x] Format check passes (`ruff format --check` / prettier) — pre-push hook clean per ralph summary
- [x] Tests pass (`pytest` / `npm test`) — 6827 tests pass at 96% coverage per ralph summary
- [x] CI green — all three reviewers shipped iteration 1

### Post-deploy verification

- [ ] Telemetry metric fires on 50%+ null Orange PDFs; row appears in `telemetry.data_quality_metrics` with new `null_count/total_rulings/null_ratio` fields
- [ ] After rebuild with `scripts/rebuild_db.py --county Orange`, the per-county `null_both` rate for Orange drops below 5% (verify via `scripts/dev-db-query.sh` with the query from issue acceptance criteria #3)
- [ ] Verification evidence posted on #3722 (see /task-v2-verify output)