### PR TITLE
fix(scraping): handle combined role labels and Case No. variants in LA parser

### DIFF
--- a/packages/scraper-framework/src/framework/la_parser_utils.py
+++ b/packages/scraper-framework/src/framework/la_parser_utils.py
@@ -24,9 +24,12 @@ import re
 
 # Role prefixes to strip from party names.  Matches role labels followed by
 # comma and/or whitespace (e.g. "Defendant ", "Plaintiffs, ").
+_ONE_ROLE = (
+    r"(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
+    r"|Cross-Complainants?|Cross-Defendants?)"
+)
 ROLE_PREFIX_RE = re.compile(
-    r"^(?:Defendants?|Plaintiffs?|Petitioners?|Respondents?"
-    r"|Cross-Complainants?|Cross-Defendants?)[,\s]+",
+    r"^(?:" + _ONE_ROLE + r"(?:/|&|\s+(?:and|&)\s+))*" + _ONE_ROLE + r"[,\s]+",
     re.IGNORECASE,
 )
 
@@ -129,6 +132,7 @@ CASE_NAME_FIELD_RE = re.compile(
     r"(?:"
     r"\s+(?:COMP|COMPLAINT|PET|PETITION|FAC)\.?\s*FILED"
     r"|\s+CASE\s+NUMBER"
+    r"|\s+Case\s+No\.?:?"
     r"|\s*$"
     r")",
     re.IGNORECASE | re.MULTILINE,

--- a/packages/scraper-framework/tests/test_la_parser_utils.py
+++ b/packages/scraper-framework/tests/test_la_parser_utils.py
@@ -7,6 +7,8 @@ See #1465 for deduplication rationale.
 
 from __future__ import annotations
 
+import pytest
+
 from framework.la_parser_utils import (
     BARE_ROLE_LABELS,
     CASE_NAME_FIELD_RE,
@@ -77,6 +79,23 @@ class TestRolePrefixRe:
     def test_case_insensitive(self) -> None:
         result = ROLE_PREFIX_RE.sub("", "DEFENDANT Acme Corp")
         assert result == "Acme Corp"
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            (
+                "Plaintiffs and Cross-Defendants Jane Does 1\u20135 and John Doe 1",
+                "Jane Does 1\u20135 and John Doe 1",
+            ),
+            ("Defendant/Cross-Complainant Foo", "Foo"),
+            ("Plaintiff/Cross-Defendant Weinreb", "Weinreb"),
+            ("Defendants and Cross-Complainants William Robinson, Jr.", "William Robinson, Jr."),
+            ("Plaintiff & Cross-Defendant Bar Corp", "Bar Corp"),
+        ],
+    )
+    def test_role_prefix_combined_labels(self, raw: str, expected: str) -> None:
+        result = ROLE_PREFIX_RE.sub("", raw)
+        assert result == expected
 
 
 # ---------------------------------------------------------------------------
@@ -248,6 +267,23 @@ class TestCaseNameFieldRe:
         assert m is not None
         title = m.group("title").strip()
         assert title == "In re Smith"
+
+    @pytest.mark.parametrize(
+        "boundary",
+        [
+            "Case No.:",
+            "Case No:",
+            "Case No.",
+            "Case Number",
+        ],
+    )
+    def test_case_name_field_boundaries(self, boundary: str) -> None:
+        text = f"CASE NAME: Smith v. Jones  {boundary} 25SMCV01234"
+        m = CASE_NAME_FIELD_RE.search(text)
+        assert m is not None, f"No match for boundary {boundary!r}"
+        title = m.group("title").strip()
+        assert title == "Smith v. Jones", f"title={title!r} for boundary {boundary!r}"
+        assert "25SMCV01234" not in title
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixed two bugs in LA court case title extraction. Extended `CASE_NAME_FIELD_RE` boundary alternation to recognize `Case No.:`, `Case No.`, and `Case No` forms, resolving Strategy 2 failures caused by lazy-match overshoot. Rebuilt `ROLE_PREFIX_RE` to strip arbitrary chains of role labels joined by slash, `and`, or `&`, preventing case titles from being contaminated with labels like "And Cross-Defendants" and "Plaintiff/Cross-Defendant".

Closes #3726

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`)
  - `test_case_name_field_boundaries`: 4 parametrized boundary forms (Case No.:, Case No:, Case No., Case Number)
  - `test_role_prefix_combined_labels`: 5 parametrized cases (and-conjoined, slash-conjoined, ampersand-conjoined)
  - All 53 tests in test_la_parser_utils.py pass
- [x] CI green (pre-push hook exit 0, ruff clean)

### Post-deploy verification

- [ ] Run `scripts/reingest_from_s3.py --county los_angeles --case-numbers 21STCV44716,24STCV05772,24STCV09653,25CHCV01318,25STCP01661,...` (all 25 contaminated case numbers from issue #3726)
- [ ] Verify `SELECT case_title FROM derived.cases WHERE case_title ~* '^(And\\s+)?Cross-(Defendant|Complainant)' OR case_title ~* '(Defendant|Plaintiff|Cross-(Defendant|Complainant))/(Defendant|Plaintiff|Cross-(Defendant|Complainant))'` returns 0 rows
- [ ] Confirm `SELECT case_title FROM derived.cases WHERE case_number = '25STCP01661'` returns a clean title (e.g., "Doe 1 v. Robinson, Jr." or the `Case Name:` field value) not starting with "And Cross-" or any role label
- [ ] Verification evidence posted on #3726 (see /task-v2-verify output)