### PR TITLE
fix(scraping): add OC multi-line case_number prompt rule and header fallback (#3729)

### DIFF
--- a/packages/scraper-framework/src/framework/llm_extractor.py
+++ b/packages/scraper-framework/src/framework/llm_extractor.py
@@ -311,6 +311,18 @@ PDF_PER_PAGE_PROMPT = (
     "with entry_number / case_number / case_title populated and "
     '`ruling_text=""`. Downstream filters will drop these rows; do '
     "NOT copy the case caption or motion label into ruling_text.\n\n"
+    "**Orange County multi-line tabular layout** (OC Superior Court "
+    "PDFs): The case number sits in a right-hand column next to the "
+    "case name. In many OC PDFs, the case number column wraps across "
+    "two visual lines — the case name appears on one line and the "
+    "case number appears on the next line in the same row. Additionally, "
+    "the printed number may show only the year-and-sequence portion "
+    "(e.g. ``2023-01329371``) without the ``30-`` court prefix. Always "
+    "capture the full case number as printed in case_number even when "
+    "the layout splits it visually across lines. Return empty string "
+    "ONLY when the case number is genuinely illegible — not when it is "
+    "merely hard to align with the case name because of the multi-line "
+    "table layout.\n\n"
     "## Formatting rules\n\n"
     "- Transcribe ruling_text as **Markdown** preserving formatting:\n"
     "  - Use **bold** for bold text and headings\n"
@@ -3854,6 +3866,8 @@ def _append_ruling_from_case(
     header_judge: str | None,
     header_dept: str | None,
     header_date: str | None,
+    header_case_number: str | None = None,
+    single_ruling_doc: bool = False,
     entry_number: int | None = None,
 ) -> None:
     """Append one ``ExtractedRuling`` built from a single case_info string.
@@ -3862,8 +3876,17 @@ def _append_ruling_from_case(
     Extracted from the main conversion loop in ``_join_page_rows`` so the
     fused-row splitter (#2500) can emit one ruling per sub-case while
     reusing the same post-processing.
+
+    When ``_extract_case_number_from_info`` returns None AND
+    ``single_ruling_doc=True``, ``header_case_number`` is used as a fallback
+    to avoid UNKNOWN-synthetic case numbers on OC pages where the case number
+    appears in the document header rather than inline in case_info (#3729).
+    The ``single_ruling_doc`` gate prevents mis-attributing one
+    document-header case_number to multiple cases on the same page.
     """
     case_number = _extract_case_number_from_info(case_info)
+    if case_number is None and single_ruling_doc and header_case_number:
+        case_number = header_case_number
     case_title = _extract_case_title_from_info(case_info)
     text = ruling_text.strip() if ruling_text else None
     text = text or None
@@ -3962,13 +3985,14 @@ def _join_page_rows(
     # Group rows into cases.
     cases: list[dict] = []  # Each: {case_info, ruling_text}
 
-    # Extract judge/department/hearing_date from header rows before
+    # Extract judge/department/hearing_date/case_number from header rows before
     # skipping them.  Header rows typically have entry_number=null,
     # empty ruling_text, and case_info containing metadata.  These
     # are emitted by _parse_page_rows when it encounters a page_header.
     header_judge: str | None = None
     header_dept: str | None = None
     header_date: str | None = None
+    header_case_number: str | None = None
     for row in rows:
         if row["entry_number"] is None and not row["ruling_text"] and row.get("case_info"):
             info = row["case_info"]
@@ -3983,13 +4007,17 @@ def _join_page_rows(
             # Extract hearing date from header (ISO, month-name, or slash formats).
             if not header_date:
                 header_date = _parse_header_date(info)
+            # Extract case number from header case_info (#3729 — OC single-ruling docs
+            # sometimes encode the case number in the document header rather than inline).
+            if not header_case_number:
+                header_case_number = _extract_case_number_from_info(info)
 
     # Permissive second pass: when the strict pass did not find a judge or
     # department, scan case_info of ALL rows (regardless of entry_number or
     # ruling_text) for the patterns.  OC multimodal PDFs embed this metadata
     # inside regular ruling rows rather than in a dedicated header row (#3722).
     # First match wins; strict-pass hits are never overwritten.
-    if not header_judge or not header_dept:
+    if not header_judge or not header_dept or not header_case_number:
         for row in rows:
             info = row.get("case_info") or ""
             if not info:
@@ -4006,7 +4034,9 @@ def _join_page_rows(
                 dept_match = re.search(r"(?:Department|Dept\.?)\s+([A-Z0-9]+)", info, re.IGNORECASE)
                 if dept_match:
                     header_dept = dept_match.group(1).strip()
-            if header_judge and header_dept:
+            if not header_case_number:
+                header_case_number = _extract_case_number_from_info(info)
+            if header_judge and header_dept and header_case_number:
                 break
 
     # Track entry_number -> case_index for cross-reference resolution (#2317).
@@ -4074,6 +4104,14 @@ def _join_page_rows(
             # entry_number — subsequent sub-cases stay None because the
             # original entry_number unambiguously refers to the first ruling.
             sub_entry_number = case["entry_number"] if idx == 0 else None
+            # Pass header_case_number + single_ruling_doc only when there
+            # is exactly one case AND no fused-row split occurred (#3729).
+            # Fused-split sub-cases (idx > 0) must never inherit the header
+            # case_number — the number belongs to the first sub-case, not
+            # the continuation block that was merged by the LLM.
+            _effective_header_cn = (
+                header_case_number if len(cases) == 1 and len(sub_case_infos) == 1 else None
+            )
             _append_ruling_from_case(
                 rulings,
                 sub_info,
@@ -4082,6 +4120,8 @@ def _join_page_rows(
                 header_judge=header_judge,
                 header_dept=header_dept,
                 header_date=header_date,
+                header_case_number=_effective_header_cn,
+                single_ruling_doc=(len(cases) == 1 and len(sub_case_infos) == 1),
                 entry_number=sub_entry_number,
             )
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -2908,6 +2908,53 @@ class IngestionWorker:
                     exc_info=True,
                 )
 
+        # When a document produces results but >= 30% of entries have a missing
+        # or UNKNOWN- synthetic case_number, write a best-effort telemetry row
+        # so the OC case_number miss rate is dashboard-queryable (#3729).
+        miss_count = sum(
+            1 for cr in converted if not cr.case_number or cr.case_number.startswith("UNKNOWN-")
+        )
+        if len(converted) > 0 and miss_count / len(converted) >= 0.3:
+            try:
+                conn = self._get_connection()
+                with conn.cursor() as cur:
+                    cur.execute("SAVEPOINT multimodal_case_number_miss_metric")
+                    try:
+                        cur.execute(
+                            """
+                            INSERT INTO data_quality_metrics
+                                (recorded_at, county, metric_name,
+                                 metric_value, metadata)
+                            VALUES (now(), %s, %s, %s, %s::jsonb)
+                            """,
+                            (
+                                county,
+                                "multimodal_case_number_miss",
+                                1,
+                                json.dumps(
+                                    {
+                                        "document_id": document_id,
+                                        "s3_key": event_data.get("s3_key"),
+                                        "state": state,
+                                        "county": county,
+                                        "scraper_id": event_data.get("scraper_id"),
+                                        "ruling_count": len(converted),
+                                        "miss_count": miss_count,
+                                        "miss_ratio": miss_count / len(converted),
+                                    }
+                                ),
+                            ),
+                        )
+                        cur.execute("RELEASE SAVEPOINT multimodal_case_number_miss_metric")
+                    except Exception:  # noqa: BLE001 — best-effort
+                        cur.execute("ROLLBACK TO SAVEPOINT multimodal_case_number_miss_metric")
+                        raise
+            except Exception:  # noqa: BLE001 — telemetry is best-effort
+                logger.debug(
+                    "multimodal_case_number_miss telemetry write failed",
+                    exc_info=True,
+                )
+
         # Clean up stale split-child documents from a previous processing run
         # that produced more rulings than this run (#2295).  The new split IDs
         # will be upserted cleanly; any old IDs beyond the new count are

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -6979,8 +6979,5 @@ def test_multimodal_case_number_miss_telemetry_db_error_swallowed() -> None:
     executed_sql = [call[0][0] for call in mock_cur.execute.call_args_list]
     assert any("SAVEPOINT multimodal_case_number_miss_metric" in s for s in executed_sql)
     assert any(
-        "ROLLBACK TO SAVEPOINT multimodal_case_number_miss_metric" in s
-        for s in executed_sql
-    ), (
-        "Inner except must execute ROLLBACK TO SAVEPOINT when INSERT raises (#3729)."
-    )
+        "ROLLBACK TO SAVEPOINT multimodal_case_number_miss_metric" in s for s in executed_sql
+    ), "Inner except must execute ROLLBACK TO SAVEPOINT when INSERT raises (#3729)."

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -6978,6 +6978,9 @@ def test_multimodal_case_number_miss_telemetry_db_error_swallowed() -> None:
     assert result is True, "DB error in telemetry write must not propagate — best-effort"
     executed_sql = [call[0][0] for call in mock_cur.execute.call_args_list]
     assert any("SAVEPOINT multimodal_case_number_miss_metric" in s for s in executed_sql)
-    assert any("ROLLBACK TO SAVEPOINT multimodal_case_number_miss_metric" in s for s in executed_sql), (
+    assert any(
+        "ROLLBACK TO SAVEPOINT multimodal_case_number_miss_metric" in s
+        for s in executed_sql
+    ), (
         "Inner except must execute ROLLBACK TO SAVEPOINT when INSERT raises (#3729)."
     )

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -6706,3 +6706,197 @@ def test_llm_split_skips_metric_below_threshold() -> None:
     assert not any("INSERT INTO data_quality_metrics" in s for s in executed_sql), (
         "20% null rate (1/5) must NOT trigger the multimodal_all_null_metadata metric (#3722)."
     )
+
+
+# ---------------------------------------------------------------------------
+# #3729 — multimodal_case_number_miss telemetry
+# ---------------------------------------------------------------------------
+
+
+def test_multimodal_case_number_miss_telemetry_emitted_at_30pct() -> None:
+    """When >= 30% of converted rulings have UNKNOWN- case_number, write telemetry (#3729).
+
+    Feeds a synthetic event through ``_llm_split_document`` where 3 of 10
+    rulings have ``case_number`` starting with ``UNKNOWN-``.  Asserts that one
+    ``data_quality_metrics`` row with ``metric_name="multimodal_case_number_miss"``
+    is written inside a savepoint-protected block.
+    """
+    from framework.llm_schema import ExtractedRuling
+
+    worker, _ = _make_worker()
+    worker._llm_client = MagicMock()
+
+    def _make_ruling(case_num: str) -> ExtractedRuling:
+        return ExtractedRuling(
+            extracted_case_number=case_num,
+            extracted_case_title="Foo v. Bar",
+            extracted_judge_name="Smith",
+            department="C28",
+            motion_type=None,
+            outcome=None,
+            hearing_date="2026-03-16",
+            extracted_parties=[],
+            ruling_text="GRANTED.",
+            case_type=None,
+        )
+
+    rulings = [
+        _make_ruling("30-2024-30000001"),
+        _make_ruling("30-2024-30000002"),
+        _make_ruling("30-2024-30000003"),
+        _make_ruling("30-2024-30000004"),
+        _make_ruling("30-2024-30000005"),
+        _make_ruling("30-2024-30000006"),
+        _make_ruling("30-2024-30000007"),
+        # 3 of 10 rulings have UNKNOWN- case_number (30% miss rate)
+        _make_ruling("UNKNOWN-aaaaaaaa-0000-0000-0000-000000000101"),
+        _make_ruling("UNKNOWN-aaaaaaaa-0000-0000-0000-000000000102"),
+        _make_ruling("UNKNOWN-aaaaaaaa-0000-0000-0000-000000000103"),
+    ]
+
+    mock_extractor = MagicMock()
+    mock_extractor.extract.return_value = rulings
+
+    event = _make_event(
+        document_id="multimodal-doc-0000-0000-000000000070",
+        scraper_id="ca-oc-tentatives",
+        state="CA",
+        county="Orange",
+        s3_key="ca/orange/superior_court/raw/miss-30pct.pdf",
+        ruling_text="Some multipage ruling text",
+        judge_name=None,
+        department=None,
+    )
+
+    mock_conn, mock_cur = _make_mock_conn()
+
+    with (
+        patch.object(worker, "_get_framework_extractor", return_value=mock_extractor),
+        patch.object(worker, "_get_multimodal_extractor", return_value=None),
+        patch.object(worker, "_get_connection", return_value=mock_conn),
+        patch("ingestion.worker.delete_stale_split_children", return_value=0),
+        patch.object(worker, "process_event"),
+    ):
+        result = worker._llm_split_document(
+            event,
+            event["document_id"],
+            event["ruling_text"],
+            event["state"],
+            event["county"],
+            raw_pdf_bytes=None,
+        )
+
+    assert result is True
+    executed_sql = [call[0][0] for call in mock_cur.execute.call_args_list]
+    assert any("INSERT INTO data_quality_metrics" in s for s in executed_sql), (
+        "30% UNKNOWN case_number rate (3/10) must trigger the "
+        "multimodal_case_number_miss metric (#3729)."
+    )
+    metric_calls = [
+        c for c in mock_cur.execute.call_args_list if "INSERT INTO data_quality_metrics" in c[0][0]
+    ]
+    # At least one metric row for case_number_miss must exist
+    assert any(
+        len(c[0]) > 1 and isinstance(c[0][1], tuple) and c[0][1][1] == "multimodal_case_number_miss"
+        for c in metric_calls
+    ), "metric_name must be 'multimodal_case_number_miss'"
+    # Verify metadata fields
+    cn_miss_call = next(
+        c
+        for c in metric_calls
+        if len(c[0]) > 1
+        and isinstance(c[0][1], tuple)
+        and c[0][1][1] == "multimodal_case_number_miss"
+    )
+    params = cn_miss_call[0][1]
+    assert params[0] == "Orange"
+    assert params[1] == "multimodal_case_number_miss"
+    assert params[2] == 1
+    meta = json.loads(params[3])
+    assert meta["document_id"] == "multimodal-doc-0000-0000-000000000070"
+    assert meta["s3_key"] == "ca/orange/superior_court/raw/miss-30pct.pdf"
+    assert meta["state"] == "CA"
+    assert meta["ruling_count"] == 10
+    assert meta["miss_count"] == 3
+    assert abs(meta["miss_ratio"] - 0.3) < 1e-9
+    # Savepoint must be used for best-effort protection.
+    assert any("SAVEPOINT multimodal_case_number_miss_metric" in s for s in executed_sql)
+
+
+def test_multimodal_case_number_miss_skipped_below_threshold() -> None:
+    """Telemetry does NOT fire when miss ratio < 0.30 (#3729).
+
+    1 of 10 rulings with UNKNOWN- case_number (10% miss rate) must NOT trigger
+    the multimodal_case_number_miss metric.
+    """
+    from framework.llm_schema import ExtractedRuling
+
+    worker, _ = _make_worker()
+    worker._llm_client = MagicMock()
+
+    def _make_ruling(case_num: str) -> ExtractedRuling:
+        return ExtractedRuling(
+            extracted_case_number=case_num,
+            extracted_case_title="Foo v. Bar",
+            extracted_judge_name="Smith",
+            department="C28",
+            motion_type=None,
+            outcome=None,
+            hearing_date="2026-03-16",
+            extracted_parties=[],
+            ruling_text="GRANTED.",
+            case_type=None,
+        )
+
+    rulings = [
+        _make_ruling("30-2024-40000001"),
+        _make_ruling("30-2024-40000002"),
+        _make_ruling("30-2024-40000003"),
+        _make_ruling("30-2024-40000004"),
+        _make_ruling("30-2024-40000005"),
+        _make_ruling("30-2024-40000006"),
+        _make_ruling("30-2024-40000007"),
+        _make_ruling("30-2024-40000008"),
+        _make_ruling("30-2024-40000009"),
+        # Only 1 of 10 has UNKNOWN- (10% miss rate — below threshold)
+        _make_ruling("UNKNOWN-aaaaaaaa-0000-0000-0000-000000000201"),
+    ]
+
+    mock_extractor = MagicMock()
+    mock_extractor.extract.return_value = rulings
+
+    event = _make_event(
+        document_id="multimodal-doc-0000-0000-000000000080",
+        scraper_id="ca-oc-tentatives",
+        state="CA",
+        county="Orange",
+        s3_key="ca/orange/superior_court/raw/miss-below-threshold.pdf",
+        ruling_text="Some multipage ruling text",
+        judge_name=None,
+        department=None,
+    )
+
+    mock_conn, mock_cur = _make_mock_conn()
+
+    with (
+        patch.object(worker, "_get_framework_extractor", return_value=mock_extractor),
+        patch.object(worker, "_get_multimodal_extractor", return_value=None),
+        patch.object(worker, "_get_connection", return_value=mock_conn),
+        patch("ingestion.worker.delete_stale_split_children", return_value=0),
+        patch.object(worker, "process_event"),
+    ):
+        result = worker._llm_split_document(
+            event,
+            event["document_id"],
+            event["ruling_text"],
+            event["state"],
+            event["county"],
+            raw_pdf_bytes=None,
+        )
+
+    assert result is True
+    executed_sql = [call[0][0] for call in mock_cur.execute.call_args_list]
+    # No case_number_miss metric should be written
+    assert not any("multimodal_case_number_miss" in s for s in executed_sql), (
+        "10% miss rate (1/10) must NOT trigger the multimodal_case_number_miss metric (#3729)."
+    )

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -6900,3 +6900,84 @@ def test_multimodal_case_number_miss_skipped_below_threshold() -> None:
     assert not any("multimodal_case_number_miss" in s for s in executed_sql), (
         "10% miss rate (1/10) must NOT trigger the multimodal_case_number_miss metric (#3729)."
     )
+
+
+def test_multimodal_case_number_miss_telemetry_db_error_swallowed() -> None:
+    """INSERT failure triggers ROLLBACK TO SAVEPOINT and is swallowed (#3729).
+
+    When the INSERT INTO data_quality_metrics raises an exception, the inner
+    except block must execute ROLLBACK TO SAVEPOINT and re-raise; the outer
+    except block swallows it so _llm_split_document still returns True.
+    """
+    from framework.llm_schema import ExtractedRuling
+
+    worker, _ = _make_worker()
+    worker._llm_client = MagicMock()
+
+    def _make_ruling(case_num: str) -> ExtractedRuling:
+        return ExtractedRuling(
+            extracted_case_number=case_num,
+            extracted_case_title="Foo v. Bar",
+            extracted_judge_name="Smith",
+            department="C28",
+            motion_type=None,
+            outcome=None,
+            hearing_date="2026-03-16",
+            extracted_parties=[],
+            ruling_text="GRANTED.",
+            case_type=None,
+        )
+
+    rulings = [
+        _make_ruling("UNKNOWN-aaaaaaaa-0000-0000-0000-000000000301"),
+        _make_ruling("UNKNOWN-aaaaaaaa-0000-0000-0000-000000000302"),
+        _make_ruling("UNKNOWN-aaaaaaaa-0000-0000-0000-000000000303"),
+        _make_ruling("30-2024-50000001"),
+    ]
+
+    mock_extractor = MagicMock()
+    mock_extractor.extract.return_value = rulings
+
+    event = _make_event(
+        document_id="multimodal-doc-0000-0000-000000000090",
+        scraper_id="ca-oc-tentatives",
+        state="CA",
+        county="Orange",
+        s3_key="ca/orange/superior_court/raw/miss-db-error.pdf",
+        ruling_text="Some multipage ruling text",
+        judge_name=None,
+        department=None,
+    )
+
+    mock_conn, mock_cur = _make_mock_conn()
+
+    db_error = Exception("simulated DB error")
+
+    def _execute_side_effect(sql: str, *args: object, **kwargs: object) -> None:
+        if "INSERT INTO data_quality_metrics" in sql:
+            raise db_error
+
+    mock_cur.execute.side_effect = _execute_side_effect
+
+    with (
+        patch.object(worker, "_get_framework_extractor", return_value=mock_extractor),
+        patch.object(worker, "_get_multimodal_extractor", return_value=None),
+        patch.object(worker, "_get_connection", return_value=mock_conn),
+        patch("ingestion.worker.delete_stale_split_children", return_value=0),
+        patch.object(worker, "process_event"),
+    ):
+        result = worker._llm_split_document(
+            event,
+            event["document_id"],
+            event["ruling_text"],
+            event["state"],
+            event["county"],
+            raw_pdf_bytes=None,
+        )
+
+    assert result is True, "DB error in telemetry write must not propagate — best-effort"
+    executed_sql = [call[0][0] for call in mock_cur.execute.call_args_list]
+    assert any("SAVEPOINT multimodal_case_number_miss_metric" in s for s in executed_sql)
+    assert any("ROLLBACK TO SAVEPOINT multimodal_case_number_miss_metric" in s for s in executed_sql), (
+        "Inner except must execute ROLLBACK TO SAVEPOINT when INSERT raises (#3729)."
+    )

--- a/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
+++ b/packages/scraper-framework/tests/test_llm_extractor_multimodal.py
@@ -22,7 +22,9 @@ import anthropic
 import pytest
 
 from framework.llm_extractor import (
+    PDF_PER_PAGE_PROMPT,
     LlmExtractor,
+    _append_ruling_from_case,
     _create_google_client,
     _deduplicate_ruling_texts,
     _drop_calendar_listing_rulings,
@@ -716,6 +718,16 @@ class TestExtractCaseNumberFromInfo:
         """County prefix is stripped from case number."""
         result = _extract_case_number_from_info("30-2024-01393434 Smith v. Jones")
         assert result == "2024-01393434"
+
+    def test_oc_multi_line_layout_returns_full_number(self) -> None:
+        """OC multi-line layout: case number on second line is extracted correctly (#3729).
+
+        In OC tabular PDFs the case number column may wrap to a second line so
+        the LLM emits ``case_info`` as ``"OCMH Inc. v. Daniel\\n2023-01329371"``.
+        _extract_case_number_from_info must return the full number.
+        """
+        result = _extract_case_number_from_info("OCMH Inc. v. Daniel\n2023-01329371")
+        assert result == "2023-01329371"
 
 
 # ---------------------------------------------------------------------------
@@ -4797,3 +4809,70 @@ class TestRoleLiteralOrphanDrop:
         )
         result = _drop_short_unsubstantive_rulings([noise])
         assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Per-page prompt content — OC multi-line case number layout (#3729)
+# ---------------------------------------------------------------------------
+
+
+class TestPdfPerPagePromptContent:
+    """Verify the per-page prompt explicitly covers OC case number column layout."""
+
+    def test_oc_multi_line_case_number_rule(self) -> None:
+        """Prompt must describe the OC case number column / multi-line layout (#3729).
+
+        The OC tabular PDFs place case numbers in a right-hand column that may
+        wrap visually across two lines.  The LLM prompt must contain an explicit
+        rule so the model does not leave case_number empty when the number is on
+        the second visual line.
+        """
+        assert "case number column" in PDF_PER_PAGE_PROMPT or "multi-line" in PDF_PER_PAGE_PROMPT, (
+            "PDF_PER_PAGE_PROMPT must mention the OC case number column / multi-line layout rule "
+            "so the LLM does not return empty case_number for wrapped numbers (#3729)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# _append_ruling_from_case — header_case_number fallback (#3729)
+# ---------------------------------------------------------------------------
+
+
+class TestAppendRulingFromCaseMetadataFallback:
+    """Verify header_case_number fallback in _append_ruling_from_case (#3729)."""
+
+    def test_metadata_case_number_used_when_extract_returns_none_single_ruling(self) -> None:
+        """header_case_number is used as fallback when case_info has no number
+        and single_ruling_doc=True (#3729)."""
+        rulings: list[ExtractedRuling] = []
+        _append_ruling_from_case(
+            rulings,
+            "Daniel only no number",
+            "",
+            metadata=None,
+            header_judge=None,
+            header_dept=None,
+            header_date=None,
+            header_case_number="2023-01329371",
+            single_ruling_doc=True,
+        )
+        assert len(rulings) == 1
+        assert rulings[0].extracted_case_number == "2023-01329371"
+
+    def test_header_case_number_not_used_when_multiple_rulings(self) -> None:
+        """header_case_number is NOT used when single_ruling_doc=False to avoid
+        mis-attributing one document-header case_number to multiple cases (#3729)."""
+        rulings: list[ExtractedRuling] = []
+        _append_ruling_from_case(
+            rulings,
+            "Daniel only no number",
+            "",
+            metadata=None,
+            header_judge=None,
+            header_dept=None,
+            header_date=None,
+            header_case_number="2023-01329371",
+            single_ruling_doc=False,
+        )
+        assert len(rulings) == 1
+        assert rulings[0].extracted_case_number is None


### PR DESCRIPTION
## Summary

Fixed 27–40% UNKNOWN-case_number rate on OC Superior Court multimodal extraction (departments C28/C44/CX/C21) by adding an explicit OC multi-line case-number column layout rule to the per-page LLM prompt, implementing a header_case_number fallback in _append_ruling_from_case (gated by single_ruling_doc to prevent mis-attribution on fused-split documents), and adding per-ruling telemetry to surface the miss rate.

Closes #3729

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`) 
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest`)
  - New tests verify: (1) OC multi-line case-number extraction from wrapped layouts (`test_oc_multi_line_layout_returns_full_number`), (2) header_case_number fallback behavior with single_ruling_doc gate (`test_metadata_case_number_used_when_extract_returns_none_single_ruling`, `test_header_case_number_not_used_when_multiple_rulings`), (3) prompt content rule presence (`test_oc_multi_line_case_number_rule`), (4) telemetry threshold at 30% (`test_multimodal_case_number_miss_telemetry_emitted_at_30pct`, `test_multimodal_case_number_miss_skipped_below_threshold`)
- [x] CI green

### Post-deploy verification

- [ ] (post-deploy) Run targeted reingest: `scripts/ecs-run-task.sh scripts/reingest_from_s3.py -- --county Orange --department-in C28 C44 CX C21 C15 --case-number-like 'UNKNOWN-%' --bust-llm-cache`
- [ ] (post-deploy) Verify C28/C44/CX/C21/C15 UNKNOWN rates each drop below 10%: `scripts/dev-db-query.sh "SELECT r.department, COUNT(*) FILTER (WHERE cs.case_number LIKE 'UNKNOWN-%') AS unknown, COUNT(*) AS total, ROUND(100.0 * COUNT(*) FILTER (WHERE cs.case_number LIKE 'UNKNOWN-%') / COUNT(*), 1) AS pct FROM derived.rulings r JOIN derived.cases cs ON r.case_id = cs.id JOIN derived.courts ct ON ct.id = r.court_id WHERE ct.county = 'Orange' AND r.department IN ('C28','C44','CX','C21','C15') GROUP BY r.department ORDER BY pct DESC"`
- [ ] (post-deploy) Verify two PDF-verified false UNKNOWNs resolve: `scripts/dev-db-query.sh "SELECT id::text, cs.case_number FROM derived.rulings r JOIN derived.cases cs ON r.case_id = cs.id WHERE r.id IN ('6f0d0d0c-af9b-432f-a03d-748877e66e7f', '54a54fbf-18cb-43b9-96e4-db81b08d9436')"`
- [ ] Verification evidence posted on #3729 (see /task-v2-verify output)