### PR TITLE
docs(runbook): refresh registered-scraper IDs table (4 → 19 entries)

### DIFF
--- a/docs/runbooks/scraper-operations.md
+++ b/docs/runbooks/scraper-operations.md
@@ -71,12 +71,32 @@ terraform output scraper_security_group_id
 
 ### Registered Scraper IDs
 
-| ID                          | Court                              |
-| --------------------------- | ---------------------------------- |
-| `ca-la-tentatives-civil`    | LA Superior Court tentative rulings |
-| `ca-oc-tentatives`          | Orange County tentative rulings     |
-| `ca-riverside-tentatives`   | Riverside County tentative rulings  |
-| `ca-sb-tentatives`          | San Bernardino tentative rulings    |
+Authoritative source: `_REGISTRY` in
+`packages/scraper-framework/src/framework/runner.py`. Pass any of these as a
+positional argument to `python -m framework.runner <id> [<id> ...]` to run
+a subset.
+
+| ID                                | Court / source                                    |
+| --------------------------------- | ------------------------------------------------- |
+| `ca-cc-tentatives`                | Contra Costa tentative rulings                    |
+| `ca-cc-tentatives-portal`         | Contra Costa portal (parallel capture path)       |
+| `ca-fresno-tentatives-civil`      | Fresno civil tentative rulings                    |
+| `ca-governor-appointments`        | CA Governor judicial appointments                 |
+| `ca-la-tentatives-civil`          | LA Superior Court civil tentative rulings         |
+| `ca-la-tentatives-appellate`      | LA Court of Appeal tentative rulings              |
+| `ca-oc-tentatives`                | Orange County civil tentative rulings             |
+| `ca-oc-tentatives-family-law`     | Orange County family law tentative rulings        |
+| `ca-oc-tentatives-probate`        | Orange County probate tentative rulings           |
+| `ca-riverside-tentatives`         | Riverside civil tentative rulings                 |
+| `ca-sb-tentatives`                | San Bernardino civil tentative rulings            |
+| `ca-sc-tentatives`                | Santa Clara civil tentative rulings               |
+| `ca-sd-calendar`                  | San Diego civil calendar (Phase 1)                |
+| `ca-sd-pipeline`                  | San Diego ROA pipeline driver (Phase 2)           |
+| `ca-sd-tentatives`                | San Diego ROA tentative rulings (Phase 2)         |
+| `ca-sf-tentatives-civil`          | San Francisco civil tentative rulings             |
+| `ca-sf-tentatives-family-law`     | San Francisco family law tentative rulings        |
+| `ca-ventura-tentatives`           | Ventura tentative rulings                         |
+| `federal-courtlistener-opinions`  | CourtListener federal opinions feed               |
 
 ---
 


### PR DESCRIPTION
## Summary

The `Registered Scraper IDs` table in `docs/runbooks/scraper-operations.md`
listed only 4 scrapers (LA civil, OC, Riverside, San Bernardino). The actual
`_REGISTRY` in `packages/scraper-framework/src/framework/runner.py:380-405`
declares ~20 scrapers. An operator following the runbook to "Run a single
scraper by passing overrides" would have had no idea what IDs existed for
SD (calendar/pipeline/tentatives), SF (civil/family-law), OC family-law &
probate, LA appellate, Santa Clara, Ventura, Contra Costa, Fresno,
governor appointments, or the federal CourtListener feed.

## Root cause

The runbook table was authored when there were 4 scrapers and not refreshed
as the registry grew. There is no test or CI gate keeping the runbook in
sync, so it just drifted.

## Fix

Replaced the table with the current registry contents (alphabetised within
each county family) plus a one-line pointer to `_REGISTRY` so future
readers can verify against the source of truth. Added the explicit
`python -m framework.runner <id>` invocation form that the registry keys
are passed to.

## Test plan
- [x] `scripts/check-markdown-links.sh` clean
- [x] Confirmed each row matches a registry entry in
      `packages/scraper-framework/src/framework/runner.py:380-405`

Found by: /spotcheck (2026-04-30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
