### PR TITLE
fix(scraping): strip trailing connector words from truncated case titles (#3730)

### DIFF
--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -1388,6 +1388,31 @@ _TRAILING_CONNECTOR_RE = re.compile(
 )
 
 
+def strip_trailing_connectors(title: str) -> str:
+    """Strip trailing English connector words from a case title.
+
+    Removes chains like ``', and the'``, ``' of'``, ``' to'`` that appear at
+    the end of a title — typically after a 120-char word-boundary truncation or
+    from an LLM extraction that cut mid-sentence (#3730).
+
+    Well-formed titles are returned unchanged.  Returns the original value (not
+    an empty string) if stripping would leave nothing.
+
+    Args:
+        title: The raw case title string.
+
+    Returns:
+        The title with any trailing connector words removed, or the original
+        string if no connector was found (or if *title* is empty/None).
+    """
+    if not title:
+        return title
+    stripped = _TRAILING_CONNECTOR_RE.sub("", title)
+    if stripped == title:
+        return title
+    return stripped.rstrip(".,;: ") or title
+
+
 def is_plausible_case_title(title: str) -> bool:
     """Return True if *title* looks like a real case title, not motion text.
 
@@ -1687,8 +1712,7 @@ def clean_case_title(raw_title: str) -> str | None:
             if max_def_len > 10:
                 space_idx = parts[1].rfind(" ", 0, max_def_len)
                 if space_idx > 5:
-                    tail = parts[1][:space_idx].rstrip(".,;: ")
-                    tail = _TRAILING_CONNECTOR_RE.sub("", tail).rstrip(".,;: ")
+                    tail = strip_trailing_connectors(parts[1][:space_idx].rstrip(".,;: "))
                     title = parts[0] + " v. " + tail
         if len(title) > _MAX_TITLE_LENGTH:
             return None

--- a/packages/scraper-framework/src/ingestion/extract.py
+++ b/packages/scraper-framework/src/ingestion/extract.py
@@ -1380,6 +1380,13 @@ _IN_THE_NOT_MATTER_RE = re.compile(
 _MIN_TITLE_LENGTH = 3
 _MAX_TITLE_LENGTH = 120
 
+# Trailing English connectors left after 120-char word-boundary truncation (#3730).
+# Greedy so it strips chains like ", and the" in one pass.
+_TRAILING_CONNECTOR_RE = re.compile(
+    r"(?:[\s,;:]+(?:and|or|but|the|for|of|to|in|on|with|by|a|an|as))+$",
+    re.IGNORECASE,
+)
+
 
 def is_plausible_case_title(title: str) -> bool:
     """Return True if *title* looks like a real case title, not motion text.
@@ -1680,7 +1687,9 @@ def clean_case_title(raw_title: str) -> str | None:
             if max_def_len > 10:
                 space_idx = parts[1].rfind(" ", 0, max_def_len)
                 if space_idx > 5:
-                    title = parts[0] + " v. " + parts[1][:space_idx].rstrip(".,;: ")
+                    tail = parts[1][:space_idx].rstrip(".,;: ")
+                    tail = _TRAILING_CONNECTOR_RE.sub("", tail).rstrip(".,;: ")
+                    title = parts[0] + " v. " + tail
         if len(title) > _MAX_TITLE_LENGTH:
             return None
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -85,6 +85,7 @@ from .extract import (
     normalize_outcome,
     strip_case_number_prefix_suffix,
     strip_trailing_case_number,
+    strip_trailing_connectors,
 )
 from .llm_extract import (
     LLMExtractionResult,
@@ -1753,6 +1754,22 @@ class IngestionWorker:
                     },
                 )
                 case_title = without_prefix
+
+        # Strip trailing connector words from LLM-extracted titles that are
+        # already <=120 chars (i.e. they bypass clean_case_title's truncation
+        # path) but still end in a dangling connector (#3730).
+        if case_title:
+            sanitized = strip_trailing_connectors(case_title)
+            if sanitized and sanitized != case_title:
+                logger.info(
+                    "Stripped trailing connector from title",
+                    extra={
+                        "document_id": document_id,
+                        "old_title": case_title[:120],
+                        "new_title": sanitized[:120],
+                    },
+                )
+                case_title = sanitized
 
         # For LLM-extracted events, the LLM-provided case_title can be
         # messy (motion descriptions, case citations, multiple parties).

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -2170,6 +2170,134 @@ class TestCleanCaseTitle:
         if result is not None:
             assert "CVPS" not in result
 
+    # --- Trailing connector stripping after 120-char truncation (#3730) ---
+
+    def test_truncation_strips_trailing_and(self) -> None:
+        """SB example: trailing 'and' is stripped after 120-char truncation."""
+        # "Friends of Fawnskin..." is 134 chars — long enough to trigger truncation.
+        raw = (
+            "Friends of Fawnskin Mountain Communities Foundation"
+            " v. County of San Bernardino and Board of Supervisors"
+            " for the County of San Bernardino"
+        )
+        result = clean_case_title(raw)
+        assert result is not None
+        assert len(result) <= 120
+        last_word = result.rstrip().split()[-1].lower()
+        assert last_word not in {
+            "and",
+            "for",
+            "the",
+            "of",
+            "to",
+            "by",
+            "in",
+            "on",
+            "with",
+            "or",
+            "a",
+            "an",
+            "as",
+        }
+
+    def test_truncation_strips_trailing_for_the(self) -> None:
+        """LA example: trailing connector phrase is stripped after 120-char truncation."""
+        # Pad the plaintiff name to ensure the truncation path runs (>120 chars total).
+        plaintiff = "A" * 45 + " Long Plaintiff Name Inc"
+        raw = plaintiff + " v. City of Los Angeles, a public entity; and Does 1 to 50"
+        # Verify input is long enough to trigger the truncation path
+        assert len(raw) > 120
+        result = clean_case_title(raw)
+        assert result is not None
+        assert len(result) <= 120
+        last_word = result.rstrip().split()[-1].lower()
+        assert last_word not in {
+            "and",
+            "for",
+            "the",
+            "of",
+            "to",
+            "by",
+            "in",
+            "on",
+            "with",
+            "or",
+            "a",
+            "an",
+            "as",
+        }
+
+    def test_truncation_strips_trailing_of(self) -> None:
+        """Orange/UCLA example: trailing 'of' is stripped after 120-char truncation."""
+        # Pad the plaintiff name so the title exceeds 120 chars and truncation
+        # lands on a connector word.
+        plaintiff = "A" * 60 + " Plaintiff"
+        raw = plaintiff + " v. The Regents of the University of California, Los Angeles"
+        assert len(raw) > 120
+        result = clean_case_title(raw)
+        assert result is not None
+        assert len(result) <= 120
+        last_word = result.rstrip().split()[-1].lower()
+        assert last_word not in {
+            "and",
+            "for",
+            "the",
+            "of",
+            "to",
+            "by",
+            "in",
+            "on",
+            "with",
+            "or",
+            "a",
+            "an",
+            "as",
+        }
+
+    def test_truncation_no_op_when_under_limit(self) -> None:
+        """Titles <=120 chars ending in a connector are returned unchanged (no truncation path)."""
+        # This title is short; the 120-char truncation block is never entered.
+        raw = "Smith v. Jones and Partners"
+        result = clean_case_title(raw)
+        # The truncation path must NOT have fired — result is well within limit.
+        assert result is not None
+        assert len(result) <= 120
+        # The connector-stripping regex must NOT have been applied outside the
+        # truncation block; "Partners" should still be present.
+        assert "Partners" in result
+
+    def test_truncation_strips_chained_connectors(self) -> None:
+        """Synthetic: trailing ', and the' chain after truncation is stripped in one pass."""
+        # Build a title where the word-boundary truncation lands on ', and the'
+        # e.g. plaintiff (50 chars) + " v. " + defendant that ends in ", and the XYZ"
+        plaintiff = "A" * 50 + " Plaintiff Corp"
+        # Craft the defendant so the 120-char word-boundary cut leaves ', and the'
+        # parts[0] = plaintiff (65 chars), " v. " = 4, so max_def_len = 120-65-4=51
+        # We want space_idx to land right after ", and the" — fill up 51 chars exactly
+        # so last word before the boundary IS a connector word.
+        defendant = "Defendant Entity, and the " + "X" * 25 + " More Stuff"
+        raw = plaintiff + " v. " + defendant
+        assert len(raw) > 120
+        result = clean_case_title(raw)
+        if result is not None:
+            assert len(result) <= 120
+            last_word = result.rstrip().split()[-1].lower()
+            assert last_word not in {
+                "and",
+                "for",
+                "the",
+                "of",
+                "to",
+                "by",
+                "in",
+                "on",
+                "with",
+                "or",
+                "a",
+                "an",
+                "as",
+            }
+
 
 # ---------------------------------------------------------------------------
 # Ventura-specific fixes (#2370)

--- a/packages/scraper-framework/tests/test_extract.py
+++ b/packages/scraper-framework/tests/test_extract.py
@@ -21,6 +21,7 @@ from ingestion.extract import (
     is_valid_case_number,
     normalize_motion_type,
     normalize_outcome,
+    strip_trailing_connectors,
 )
 
 
@@ -2297,6 +2298,61 @@ class TestCleanCaseTitle:
                 "an",
                 "as",
             }
+
+
+# ---------------------------------------------------------------------------
+# strip_trailing_connectors helper (#3730)
+# ---------------------------------------------------------------------------
+
+
+class TestStripTrailingConnectors:
+    """Unit tests for strip_trailing_connectors() — the module-level helper
+    that removes dangling English connector words from case titles (#3730).
+
+    These cover the stand-alone helper, independent of the 120-char truncation
+    path exercised by TestCleanCaseTitle.
+    """
+
+    def test_strips_trailing_and(self) -> None:
+        """Simple case: 'Smith v. Jones and' → 'Smith v. Jones'."""
+        assert strip_trailing_connectors("Smith v. Jones and") == "Smith v. Jones"
+
+    def test_strips_trailing_to_on_la_shaped_title(self) -> None:
+        """115-char LA-shaped title ending in connector word is stripped."""
+        # Real-world shape: 115 chars, ends in ' to' (AC #3 detection query hits this)
+        title = "Smith v. City of Los Angeles, a public entity; and Does 1 to"
+        assert len(title) <= 120
+        result = strip_trailing_connectors(title)
+        assert result is not None
+        last_word = result.rstrip().split()[-1].lower()
+        assert last_word not in {"to", "and"}
+        assert "Does 1" in result
+
+    def test_strips_trailing_of(self) -> None:
+        """Trailing 'of' is stripped correctly."""
+        title = "Smith v. The Regents of the University of"
+        result = strip_trailing_connectors(title)
+        assert result == "Smith v. The Regents of the University"
+
+    def test_noop_connector_mid_string(self) -> None:
+        """Connector mid-string does not cause truncation — 'Partners' is preserved."""
+        title = "Smith v. Jones and Partners"
+        assert strip_trailing_connectors(title) == "Smith v. Jones and Partners"
+
+    def test_noop_no_connector(self) -> None:
+        """Title with no trailing connector is returned unchanged."""
+        title = "Smith v. Jones"
+        assert strip_trailing_connectors(title) == "Smith v. Jones"
+
+    def test_strips_chained_connector(self) -> None:
+        """Chained connectors like ', and the' are stripped in one pass."""
+        title = "Smith v. Jones, and the"
+        result = strip_trailing_connectors(title)
+        assert result == "Smith v. Jones"
+
+    def test_empty_string_passthrough(self) -> None:
+        """Empty string is returned unchanged (no crash)."""
+        assert strip_trailing_connectors("") == ""
 
 
 # ---------------------------------------------------------------------------

--- a/packages/scraper-framework/tests/test_ingestion.py
+++ b/packages/scraper-framework/tests/test_ingestion.py
@@ -5687,6 +5687,52 @@ def test_process_event_oc_prefix_suffix_not_stripped_when_prefix_none(
 
 
 @patch("ingestion.worker.resolve_judge", return_value=None)
+@patch("ingestion.worker.psycopg")
+def test_process_event_strips_trailing_connector_from_case_title(
+    mock_psycopg: MagicMock,
+    mock_resolve_judge: MagicMock,
+) -> None:
+    """Worker strips trailing connector words from case_title (#3730).
+
+    Covers worker.py lines 1764 and 1772 — the logger.info call and the
+    ``case_title = sanitized`` assignment in the connector-stripping block.
+    """
+    worker, _ = _make_worker()
+    worker._llm_client = None  # prevent any LLM calls
+
+    mock_conn, mock_cur = _make_mock_conn()
+    mock_psycopg.connect.return_value = mock_conn
+    mock_cur.fetchone.side_effect = [
+        ("court-uuid-1",),
+        ("case-uuid-1",),
+        (True,),
+    ]
+    mock_cur.fetchall.return_value = []
+    mock_cur.nextset.side_effect = [True, False]
+    mock_cur.rowcount = 1
+
+    dirty_title = "Smith v. Jones and"
+    event = _make_event(
+        case_title=dirty_title,
+        hearing_date=None,
+    )
+    with patch.object(worker, "_llm_split_document", return_value=False):
+        worker.process_event(event)
+
+    all_sql_args = []
+    for call in mock_cur.execute.call_args_list:
+        args = call[0]
+        if len(args) > 1 and args[1] is not None:
+            all_sql_args.extend(args[1] if isinstance(args[1], (list, tuple)) else [])
+    # The clean title (without trailing "and") should appear in SQL args.
+    assert "Smith v. Jones" in all_sql_args
+    # The dirty title must not have leaked into any SQL parameter.
+    for a in all_sql_args:
+        if isinstance(a, str):
+            assert a != dirty_title, f"Unstripped title leaked into SQL: {a!r}"
+
+
+@patch("ingestion.worker.resolve_judge", return_value=None)
 @patch("ingestion.worker.extract_fields_llm")
 @patch("ingestion.worker.psycopg")
 def test_process_event_rejects_probate_decedent_as_judge(


### PR DESCRIPTION
## Summary

Adds `strip_trailing_connectors()` helper to remove dangling English connector words that appear after 120-char word-boundary truncation or LLM extraction. Integrates the sanitizer into `clean_case_title()` truncation path and into `worker.py` before the `is_plausible_case_title` gate, fixing both >120-char truncations (SB, LA, Orange, Federal examples) and <120-char LLM-extracted titles that end with connectors. All 4733 tests pass with no regressions.

Closes #3730

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest`) — 4733 tests pass, 7 new tests in TestStripTrailingConnectors and 5 in TestCleanCaseTitle cover SB/LA/Orange examples plus no-op cases
- [x] CI green

### Post-deploy verification

- [ ] Rebuild affected counties: `scripts/ecs-run-task.sh scripts/rebuild_db.py --county 'Los Angeles'` (29 rows), then `--county Orange` (10), `--county Federal` (4), `--county Riverside` (1), `--county Fresno` (1), `--county 'San Bernardino'` (1)
- [ ] Detection query returns 0: `scripts/dev-db-query.sh "SELECT COUNT(*) FROM derived.cases cs JOIN derived.courts c ON cs.court_id = c.id WHERE cs.case_title ~ '\\s(the|for|of|and|to|by|in|on|with)$';"`
- [ ] Verification evidence posted on #3730