### PR TITLE
fix(dispatcher): add orphan agent/* PR garbage collection to housekeeping tick (#3852)

### DIFF
--- a/scripts/dispatcher/daemon.py
+++ b/scripts/dispatcher/daemon.py
@@ -26225,6 +26225,183 @@ class DispatcherDaemon:
                 )
         return {"checked": checked, "cleared": cleared, "errors": errors}
 
+    def _housekeeping_close_orphan_prs(self) -> dict[str, int]:
+        """Close open ``agent/*`` PRs whose every target issue is CLOSED (#3852).
+
+        Calls ``gh pr list`` to fetch all open PRs, then for each PR on an
+        ``agent/`` branch whose ``closingIssuesReferences`` are all CLOSED,
+        posts a close comment and deletes the branch via ``gh pr close``.
+
+        Skips:
+        * PRs on non-``agent/`` branches (operator-authored branches are
+          untouched).
+        * PRs with no ``closingIssuesReferences`` (no clear target — leave
+          for operator review).
+        * PRs where ANY referenced issue is still OPEN.
+
+        Per-PR try/except so one ``gh pr close`` flake does not starve
+        siblings. Returns ``{closed, scanned, skipped_non_agent,
+        skipped_no_target, skipped_open_target}`` for observability.
+        Failures are caught by the caller (:meth:`_housekeeping_tick`).
+        """
+        list_cmd = [
+            "gh",
+            "pr",
+            "list",
+            "--repo",
+            self._cfg.github_repo,
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,headRefName,closingIssuesReferences",
+        ]
+        list_outcome = self._subprocess_with_retry(
+            list_cmd,
+            event_name="orphan_pr_gc_list",
+            timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+        if not list_outcome["ok"]:
+            self._log.warning(
+                "daemon.orphan_pr_gc_list_failed",
+                extra={
+                    "event": "orphan_pr_gc_list_failed",
+                    "run_id": self._run_id,
+                    "reason": list_outcome.get("reason"),
+                    "exit_code": list_outcome.get("exit_code"),
+                    "stderr_tail": list_outcome.get("stderr_tail"),
+                },
+            )
+            return {
+                "closed": 0,
+                "scanned": 0,
+                "skipped_non_agent": 0,
+                "skipped_no_target": 0,
+                "skipped_open_target": 0,
+            }
+
+        try:
+            pr_rows: list[dict[str, Any]] = json.loads(
+                list_outcome["result"].stdout or "[]"
+            )
+        except json.JSONDecodeError:
+            self._log.warning(
+                "daemon.orphan_pr_gc_list_invalid_json",
+                extra={
+                    "event": "orphan_pr_gc_list_invalid_json",
+                    "run_id": self._run_id,
+                },
+            )
+            return {
+                "closed": 0,
+                "scanned": 0,
+                "skipped_non_agent": 0,
+                "skipped_no_target": 0,
+                "skipped_open_target": 0,
+            }
+
+        scanned = 0
+        closed = 0
+        skipped_non_agent = 0
+        skipped_no_target = 0
+        skipped_open_target = 0
+
+        for pr in pr_rows:
+            scanned += 1
+            pr_number: int = pr.get("number", 0)
+            head_ref: str = pr.get("headRefName", "")
+            refs: list[dict[str, Any]] = pr.get("closingIssuesReferences", [])
+
+            if not head_ref.startswith("agent/"):
+                skipped_non_agent += 1
+                continue
+
+            if not refs:
+                skipped_no_target += 1
+                continue
+
+            if any(r.get("state") != "CLOSED" for r in refs):
+                skipped_open_target += 1
+                continue
+
+            # All referenced issues are CLOSED — close the PR and delete branch.
+            target_numbers = [r.get("number") for r in refs]
+            comment = (
+                f"Closing — target issue(s) {target_numbers} already CLOSED; daemon GC."
+            )
+            try:
+                close_cmd = [
+                    "gh",
+                    "pr",
+                    "close",
+                    str(pr_number),
+                    "--repo",
+                    self._cfg.github_repo,
+                    "--comment",
+                    comment,
+                    "--delete-branch",
+                ]
+                close_outcome = self._subprocess_with_retry(
+                    close_cmd,
+                    event_name="orphan_pr_gc_close",
+                    timeout=GH_POLL_SUBPROCESS_TIMEOUT_SECONDS,
+                    extra_log_fields={"pr_number": pr_number},
+                )
+                if not close_outcome["ok"]:
+                    self._log.warning(
+                        "daemon.orphan_pr_gc_close_failed",
+                        extra={
+                            "event": "orphan_pr_gc_close_failed",
+                            "run_id": self._run_id,
+                            "pr_number": pr_number,
+                            "targets": target_numbers,
+                            "reason": close_outcome.get("reason"),
+                            "exit_code": close_outcome.get("exit_code"),
+                            "stderr_tail": close_outcome.get("stderr_tail"),
+                        },
+                    )
+                    continue
+                closed += 1
+                self._log.info(
+                    "daemon.orphan_pr_closed",
+                    extra={
+                        "event": "orphan_pr_closed",
+                        "run_id": self._run_id,
+                        "pr_number": pr_number,
+                        "targets": target_numbers,
+                    },
+                )
+            except Exception:
+                self._log.exception(
+                    "daemon.orphan_pr_gc_close_error",
+                    extra={
+                        "event": "orphan_pr_gc_close_error",
+                        "run_id": self._run_id,
+                        "pr_number": pr_number,
+                    },
+                )
+
+        self._log.info(
+            "daemon.housekeeping_orphan_pr_gc",
+            extra={
+                "event": "housekeeping_orphan_pr_gc",
+                "run_id": self._run_id,
+                "closed": closed,
+                "scanned": scanned,
+                "skipped_non_agent": skipped_non_agent,
+                "skipped_no_target": skipped_no_target,
+                "skipped_open_target": skipped_open_target,
+            },
+        )
+        return {
+            "closed": closed,
+            "scanned": scanned,
+            "skipped_non_agent": skipped_non_agent,
+            "skipped_no_target": skipped_no_target,
+            "skipped_open_target": skipped_open_target,
+        }
+
     def _housekeeping_tick(self) -> dict[str, int]:
         """Run one housekeeping tick. Prunes stale rows from dispatcher tables.
 
@@ -26348,6 +26525,20 @@ class DispatcherDaemon:
                 "daemon.terminal_ended_at_backfill_failed",
                 extra={
                     "event": "terminal_ended_at_backfill_failed",
+                    "run_id": self._run_id,
+                },
+            )
+
+        # Issue #3852: close open ``agent/*`` PRs whose every target issue
+        # is CLOSED. Runs in its own try/except so a GitHub flake here
+        # does not break the prune loop or the other healers.
+        try:
+            self._housekeeping_close_orphan_prs()
+        except Exception:
+            self._log.exception(
+                "daemon.housekeeping_orphan_pr_gc_failed",
+                extra={
+                    "event": "housekeeping_orphan_pr_gc_failed",
                     "run_id": self._run_id,
                 },
             )

--- a/scripts/dispatcher/tests/test_daemon_housekeeping.py
+++ b/scripts/dispatcher/tests/test_daemon_housekeeping.py
@@ -1350,3 +1350,387 @@ class TestBackfillStampsThreeTerminalRowsAndPreservesRunning:
         assert "succeeded" in statuses
         assert "failed" in statuses
         assert "crashed" in statuses
+
+
+# --------------------------------------------------------------------------
+# _housekeeping_close_orphan_prs (#3852)
+# --------------------------------------------------------------------------
+
+import json as _json  # noqa: E402 — local alias for test helpers below
+
+
+def _make_subprocess_result(stdout: str, returncode: int = 0) -> Any:
+    """Build a minimal CompletedProcess-like object for test stubs."""
+
+    class _FakeResult:
+        def __init__(self, out: str, rc: int) -> None:
+            self.stdout = out
+            self.returncode = rc
+
+    return _FakeResult(stdout, returncode)
+
+
+def _ok_outcome(stdout: str) -> dict[str, Any]:
+    return {"ok": True, "result": _make_subprocess_result(stdout), "attempts": 1}
+
+
+def _fail_outcome(reason: str = "nonzero_exit", exit_code: int = 1) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "reason": reason,
+        "exit_code": exit_code,
+        "stderr_tail": "some error",
+        "attempts": 3,
+    }
+
+
+_THREE_PRS = _json.dumps(
+    [
+        # PR 10: agent/ branch, all issues CLOSED → should be closed.
+        {
+            "number": 10,
+            "headRefName": "agent/foo",
+            "closingIssuesReferences": [{"number": 111, "state": "CLOSED"}],
+        },
+        # PR 20: agent/ branch, one CLOSED + one OPEN → skip (open target).
+        {
+            "number": 20,
+            "headRefName": "agent/bar",
+            "closingIssuesReferences": [
+                {"number": 222, "state": "CLOSED"},
+                {"number": 333, "state": "OPEN"},
+            ],
+        },
+        # PR 30: agent/ branch, empty closingIssuesReferences → skip (no target).
+        {
+            "number": 30,
+            "headRefName": "agent/baz",
+            "closingIssuesReferences": [],
+        },
+    ]
+)
+
+
+class TestHousekeepingCloseOrphanPRs:
+    """``_housekeeping_close_orphan_prs`` closes only ``agent/*`` PRs whose
+    every closing-issue is CLOSED, leaves all others alone (#3852)."""
+
+    def test_regression_fixture_three_prs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Three fake PRs: only the all-CLOSED one triggers ``gh pr close``."""
+        d, _conn, handler = _make_daemon_with_capture()
+
+        close_calls: list[tuple[int, list[str]]] = []
+
+        def fake_subprocess(
+            cmd: list[str],
+            *,
+            event_name: str,
+            timeout: float,
+            extra_log_fields: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            if event_name == "orphan_pr_gc_list":
+                return _ok_outcome(_THREE_PRS)
+            if event_name == "orphan_pr_gc_close":
+                pr_num = int(cmd[cmd.index("close") + 1])
+                close_calls.append((pr_num, list(cmd)))
+                return _ok_outcome("")
+            return _fail_outcome()
+
+        monkeypatch.setattr(d, "_subprocess_with_retry", fake_subprocess)
+
+        result = d._housekeeping_close_orphan_prs()
+
+        # Only PR 10 (all-CLOSED target) should have been closed.
+        assert [c[0] for c in close_calls] == [10]
+
+        # Return dict.
+        assert result["closed"] == 1
+        assert result["scanned"] == 3
+        assert result["skipped_no_target"] == 1
+        assert result["skipped_open_target"] == 1
+        assert result["skipped_non_agent"] == 0
+
+        # Per-close log event.
+        closed_events = handler.events("orphan_pr_closed")
+        assert len(closed_events) == 1
+        assert closed_events[0].pr_number == 10
+
+        # Summary log event.
+        summary_events = handler.events("housekeeping_orphan_pr_gc")
+        assert len(summary_events) == 1
+        rec = summary_events[0]
+        assert rec.closed == 1
+        assert rec.scanned == 3
+        assert rec.run_id == "test-run-id"
+
+    def test_non_agent_branch_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """PRs on non-``agent/`` branches are never closed."""
+        d, _conn, handler = _make_daemon_with_capture()
+
+        pr_data = _json.dumps(
+            [
+                {
+                    "number": 99,
+                    "headRefName": "worktree-agent-x",
+                    "closingIssuesReferences": [{"number": 555, "state": "CLOSED"}],
+                }
+            ]
+        )
+        close_calls: list[int] = []
+
+        def fake_subprocess(
+            cmd: list[str],
+            *,
+            event_name: str,
+            timeout: float,
+            extra_log_fields: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            if event_name == "orphan_pr_gc_list":
+                return _ok_outcome(pr_data)
+            if event_name == "orphan_pr_gc_close":
+                close_calls.append(int(cmd[cmd.index("close") + 1]))
+                return _ok_outcome("")
+            return _fail_outcome()
+
+        monkeypatch.setattr(d, "_subprocess_with_retry", fake_subprocess)
+
+        result = d._housekeeping_close_orphan_prs()
+
+        assert close_calls == []
+        assert result["skipped_non_agent"] == 1
+        assert result["closed"] == 0
+
+    def test_gh_pr_list_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When ``gh pr list`` fails, helper logs and returns zero-count dict."""
+        d, _conn, handler = _make_daemon_with_capture()
+
+        def fake_subprocess(
+            cmd: list[str],
+            *,
+            event_name: str,
+            timeout: float,
+            extra_log_fields: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            return _fail_outcome()
+
+        monkeypatch.setattr(d, "_subprocess_with_retry", fake_subprocess)
+
+        result = d._housekeeping_close_orphan_prs()
+
+        assert result == {
+            "closed": 0,
+            "scanned": 0,
+            "skipped_non_agent": 0,
+            "skipped_no_target": 0,
+            "skipped_open_target": 0,
+        }
+        failure_events = handler.events("orphan_pr_gc_list_failed")
+        assert len(failure_events) == 1
+        closed_events = handler.events("orphan_pr_closed")
+        assert closed_events == []
+
+    def test_gh_pr_close_failure_sibling_continues(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If ``gh pr close`` fails for one PR, sibling PRs are still attempted."""
+        d, _conn, handler = _make_daemon_with_capture()
+
+        # Two PRs that both qualify — close #10 fails, close #11 succeeds.
+        two_prs = _json.dumps(
+            [
+                {
+                    "number": 10,
+                    "headRefName": "agent/foo",
+                    "closingIssuesReferences": [{"number": 100, "state": "CLOSED"}],
+                },
+                {
+                    "number": 11,
+                    "headRefName": "agent/bar",
+                    "closingIssuesReferences": [{"number": 101, "state": "CLOSED"}],
+                },
+            ]
+        )
+
+        def fake_subprocess(
+            cmd: list[str],
+            *,
+            event_name: str,
+            timeout: float,
+            extra_log_fields: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            if event_name == "orphan_pr_gc_list":
+                return _ok_outcome(two_prs)
+            if event_name == "orphan_pr_gc_close":
+                pr_num = int(cmd[cmd.index("close") + 1])
+                if pr_num == 10:
+                    return _fail_outcome()
+                return _ok_outcome("")
+            return _fail_outcome()
+
+        monkeypatch.setattr(d, "_subprocess_with_retry", fake_subprocess)
+
+        result = d._housekeeping_close_orphan_prs()
+
+        # PR 10 failed — but PR 11 still closed.
+        assert result["closed"] == 1
+        assert result["scanned"] == 2
+
+        fail_events = handler.events("orphan_pr_gc_close_failed")
+        assert len(fail_events) == 1
+        assert fail_events[0].pr_number == 10
+
+        closed_events = handler.events("orphan_pr_closed")
+        assert len(closed_events) == 1
+        assert closed_events[0].pr_number == 11
+
+    def test_close_comment_includes_target_numbers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The ``--comment`` passed to ``gh pr close`` cites the target issue numbers."""
+        d, _conn, _handler = _make_daemon_with_capture()
+
+        pr_data = _json.dumps(
+            [
+                {
+                    "number": 42,
+                    "headRefName": "agent/fix-thing",
+                    "closingIssuesReferences": [
+                        {"number": 77, "state": "CLOSED"},
+                        {"number": 88, "state": "CLOSED"},
+                    ],
+                }
+            ]
+        )
+        comments_seen: list[str] = []
+
+        def fake_subprocess(
+            cmd: list[str],
+            *,
+            event_name: str,
+            timeout: float,
+            extra_log_fields: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            if event_name == "orphan_pr_gc_list":
+                return _ok_outcome(pr_data)
+            if event_name == "orphan_pr_gc_close":
+                comment_idx = cmd.index("--comment") + 1
+                comments_seen.append(cmd[comment_idx])
+                return _ok_outcome("")
+            return _fail_outcome()
+
+        monkeypatch.setattr(d, "_subprocess_with_retry", fake_subprocess)
+
+        d._housekeeping_close_orphan_prs()
+
+        assert len(comments_seen) == 1
+        comment = comments_seen[0]
+        # Comment must mention both target numbers.
+        assert "77" in comment
+        assert "88" in comment
+        assert "CLOSED" in comment
+
+    def test_delete_branch_flag_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``gh pr close`` must include ``--delete-branch`` to clean up the ref."""
+        d, _conn, _handler = _make_daemon_with_capture()
+
+        pr_data = _json.dumps(
+            [
+                {
+                    "number": 55,
+                    "headRefName": "agent/cleanup",
+                    "closingIssuesReferences": [{"number": 200, "state": "CLOSED"}],
+                }
+            ]
+        )
+        close_cmds: list[list[str]] = []
+
+        def fake_subprocess(
+            cmd: list[str],
+            *,
+            event_name: str,
+            timeout: float,
+            extra_log_fields: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            if event_name == "orphan_pr_gc_list":
+                return _ok_outcome(pr_data)
+            if event_name == "orphan_pr_gc_close":
+                close_cmds.append(list(cmd))
+                return _ok_outcome("")
+            return _fail_outcome()
+
+        monkeypatch.setattr(d, "_subprocess_with_retry", fake_subprocess)
+
+        d._housekeeping_close_orphan_prs()
+
+        assert len(close_cmds) == 1
+        assert "--delete-branch" in close_cmds[0]
+
+
+class TestHousekeepingTickWiresInOrphanPRGC:
+    """``_housekeeping_tick`` calls ``_housekeeping_close_orphan_prs`` (#3852).
+
+    Regression: an accidental decouple would silently stop GC from running
+    without any test failure in the unit-level healer tests.
+    """
+
+    def test_tick_calls_helper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The tick must invoke the helper exactly once per run."""
+        d, _conn, handler = _make_daemon_with_capture()
+
+        called: dict[str, int] = {"count": 0}
+
+        def fake_gc() -> dict[str, int]:
+            called["count"] += 1
+            return {
+                "closed": 0,
+                "scanned": 0,
+                "skipped_non_agent": 0,
+                "skipped_no_target": 0,
+                "skipped_open_target": 0,
+            }
+
+        monkeypatch.setattr(d, "_housekeeping_close_orphan_prs", fake_gc, raising=True)
+        monkeypatch.setattr(
+            d,
+            "_reconcile_stale_merged_at",
+            lambda: {"checked": 0, "cleared": 0, "errors": 0},
+        )
+        monkeypatch.setattr(d, "_clear_stale_agent_task_arns", lambda: 0, raising=True)
+        monkeypatch.setattr(d, "_backfill_terminal_ended_at", lambda: 0, raising=True)
+
+        d._housekeeping_tick()
+
+        assert called["count"] == 1
+        assert d._housekeeping_ticks == 1
+        assert handler.events("housekeeping_orphan_pr_gc_failed") == []
+
+    def test_tick_catches_helper_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If the helper raises, the tick logs and continues; ticks counter still advances."""
+        d, conn, handler = _make_daemon_with_capture()
+
+        def boom() -> dict[str, int]:
+            raise RuntimeError("gh unavailable")
+
+        monkeypatch.setattr(d, "_housekeeping_close_orphan_prs", boom, raising=True)
+        monkeypatch.setattr(
+            d,
+            "_reconcile_stale_merged_at",
+            lambda: {"checked": 0, "cleared": 0, "errors": 0},
+        )
+        monkeypatch.setattr(d, "_clear_stale_agent_task_arns", lambda: 0, raising=True)
+        monkeypatch.setattr(d, "_backfill_terminal_ended_at", lambda: 0, raising=True)
+
+        target_count = len(daemon.DispatcherDaemon._HOUSEKEEPING_TARGETS)
+        conn.cursor_instance.fetch_queue = [None] * target_count
+
+        # Must not propagate the exception.
+        result = d._housekeeping_tick()
+
+        failure_events = handler.events("housekeeping_orphan_pr_gc_failed")
+        assert len(failure_events) == 1
+        assert "queue_snapshots" in result
+        assert d._housekeeping_ticks == 1


### PR DESCRIPTION
## Summary

Adds `_housekeeping_close_orphan_prs` helper to the daemon's housekeeping tick to close and delete orphan `agent/*` PRs whose target issues are already CLOSED. These PRs accumulate as noise on the open PR list and mislead the queue view; the new housekeeping pass eliminates the entire class by running on every housekeeping cadence (default 3600s).

The helper uses `gh pr list` to query open PRs, filters to those on `agent/` branches with `closingIssuesReferences`, and closes only when ALL referenced issues are CLOSED. Per-PR try/except prevents one GitHub flake from blocking sibling PRs. Includes `orphan_pr_closed` per-close and `housekeeping_orphan_pr_gc` summary logging events.

Closes #3852

## Test plan

### Automated checks

- [x] Lint passes (`ruff check` / `npm run lint`)
- [x] Format check passes (`ruff format --check` / prettier)
- [x] Tests pass (`pytest` / `npm test`)
- [x] CI green

### Post-deploy verification

- [ ] Within one housekeeping cadence (default 3600s) after deploy, run `gh pr list --repo judgemind/judgemind --state open --json number,headRefName,closingIssuesReferences | jq '.[] | select(.headRefName | startswith("agent/")) | select(.closingIssuesReferences != []) | select(.closingIssuesReferences | all(.state == "CLOSED"))' | wc -l` — count should be 0
- [ ] Verification evidence posted on #3852 (see /task-v2-verify output)