### PR TITLE
fix(scraping): preserve Long Beach dept codes S25–S29 in LA department normalizer

### DIFF
--- a/packages/scraper-framework/src/ingestion/department_normalize.py
+++ b/packages/scraper-framework/src/ingestion/department_normalize.py
@@ -46,6 +46,14 @@ _LA_COURTHOUSE_ALIASES: dict[str, str] = {
     "SEP": "P",
 }
 
+# Long Beach Courthouse identifiers (case-folded).
+# S25–S29 are distinct courtrooms at LB; we skip the letter+digits collapse
+# so these codes survive normalization intact.  The display name comes from
+# ``_OPTION_TEXT_RE`` in ``la_tentatives.py``; ``LBC``/``LBCV`` are the
+# case-number prefixes — included defensively in case they ever appear in the
+# event payload.
+_LA_LB_COURTHOUSE_NAMES: frozenset[str] = frozenset({"long beach courthouse", "lbc", "lbcv"})
+
 # ---------------------------------------------------------------------------
 # Riverside
 # ---------------------------------------------------------------------------
@@ -66,7 +74,12 @@ _SB_HYPHEN_RE = re.compile(r"^([A-Za-z]+)-(\d+)$")
 # ---------------------------------------------------------------------------
 
 
-def normalize_department(county: str, department: str | None) -> str | None:
+def normalize_department(
+    county: str,
+    department: str | None,
+    *,
+    courthouse: str | None = None,
+) -> str | None:
     """Normalize a department name using county-specific rules.
 
     Parameters
@@ -75,6 +88,10 @@ def normalize_department(county: str, department: str | None) -> str | None:
         The county name (e.g. ``"Los Angeles"``, ``"Riverside"``).
     department : str | None
         The raw department value from the scraper or LLM.
+    courthouse : str | None
+        Optional courthouse display name or code.  Used by the LA normalizer
+        to skip the letter+digits collapse for courthouses (e.g. Long Beach)
+        where the combined code is a real identifier, not a glued suffix.
 
     Returns
     -------
@@ -92,7 +109,7 @@ def normalize_department(county: str, department: str | None) -> str | None:
     county_lower = county.lower()
 
     if county_lower == "los angeles":
-        dept = _normalize_la(dept)
+        dept = _normalize_la(dept, courthouse=courthouse)
     elif county_lower == "riverside":
         dept = _normalize_riverside(dept)
     elif county_lower == "san bernardino":
@@ -101,7 +118,7 @@ def normalize_department(county: str, department: str | None) -> str | None:
     return dept if dept else None
 
 
-def _normalize_la(dept: str) -> str:
+def _normalize_la(dept: str, *, courthouse: str | None = None) -> str:
     """Normalize an LA County department name.
 
     Transformations (applied in order):
@@ -109,7 +126,10 @@ def _normalize_la(dept: str) -> str:
     1. Strip ``SSC-`` courthouse prefix (reveals underlying pattern).
     2. Map known courthouse aliases (``SEP`` -> ``P``).
     3. Strip `` #N`` courtroom/calendar suffix.
-    4. Strip single-letter + digits glue (``X14`` -> ``X``).
+    4. Strip single-letter + digits glue (``X14`` -> ``X``), **unless**
+       the courthouse is a Long Beach courthouse — at LB these combined
+       codes (``S25``–``S29``) identify distinct courtrooms and must be
+       preserved.
     """
     # 1. Strip SSC- prefix first to reveal underlying patterns
     m = _LA_SSC_PREFIX_RE.match(dept)
@@ -124,10 +144,13 @@ def _normalize_la(dept: str) -> str:
     # 3. Strip " #N" suffix
     dept = _LA_COURTROOM_SUFFIX_RE.sub("", dept).strip()
 
-    # 4. Single letter + digits -> letter only
-    m = _LA_LETTER_PLUS_DIGITS_RE.match(dept)
-    if m:
-        dept = m.group(1)
+    # 4. Single letter + digits -> letter only.
+    # Skip for Long Beach Courthouse where the combined code is meaningful.
+    is_lb = (courthouse or "").strip().lower() in _LA_LB_COURTHOUSE_NAMES
+    if not is_lb:
+        m = _LA_LETTER_PLUS_DIGITS_RE.match(dept)
+        if m:
+            dept = m.group(1)
 
     return dept
 

--- a/packages/scraper-framework/src/ingestion/worker.py
+++ b/packages/scraper-framework/src/ingestion/worker.py
@@ -1890,7 +1890,11 @@ class IngestionWorker:
         # Normalize department name before it's used for lookups or DB
         # writes (#2141).  Placed here so the dept-to-judge lookup below
         # sees the canonical department name.
-        department = normalize_department(county, department)
+        department = normalize_department(
+            county,
+            department,
+            courthouse=event_data.get("courthouse"),
+        )
 
         # Apply Contra Costa department reassignment mapping (#2612).
         # Runs after normalization so both sides of the comparison are in

--- a/packages/scraper-framework/tests/test_department_normalize.py
+++ b/packages/scraper-framework/tests/test_department_normalize.py
@@ -338,3 +338,43 @@ class TestAlphanumericDepartmentCodes:
         """Orange uses alphanumeric codes (CX*, CM*, N*, W*, L*, C*) — all
         must pass through."""
         assert normalize_department("Orange", raw) == raw
+
+
+# ---------------------------------------------------------------------------
+# LA County — Long Beach courthouse (S25–S29 must survive, #3741)
+# ---------------------------------------------------------------------------
+
+
+class TestLALongBeach:
+    """S25–S29 dept codes survive when courthouse is Long Beach.
+
+    These are distinct courtrooms at the Long Beach Courthouse.  The generic
+    LA letter+digits collapse rule must be skipped for LB courthouses so that
+    analytics can distinguish S25 from S27 etc.
+
+    See: https://github.com/judgemind/judgemind/issues/3741
+    """
+
+    @pytest.mark.parametrize("dept", ["S25", "S26", "S27", "S28", "S29"])
+    @pytest.mark.parametrize(
+        "courthouse",
+        [
+            "Long Beach Courthouse",
+            "long beach courthouse",
+            "LBC",
+            "LBCV",
+            "lbc",
+            "lbcv",
+        ],
+    )
+    def test_lb_dept_codes_survive(self, dept: str, courthouse: str) -> None:
+        """S25–S29 must not be collapsed to 'S' for Long Beach Courthouse."""
+        assert normalize_department("Los Angeles", dept, courthouse=courthouse) == dept
+
+    def test_pomona_l10_still_collapses(self) -> None:
+        """Non-LB courthouse: L10 must still collapse to 'L'."""
+        assert normalize_department("Los Angeles", "L10", courthouse="Pomona Courthouse") == "L"
+
+    def test_courthouse_omitted_back_compat(self) -> None:
+        """Omitting courthouse kwarg preserves existing collapse behaviour."""
+        assert normalize_department("Los Angeles", "X14") == "X"


### PR DESCRIPTION
## Summary

Preserve Long Beach Courthouse letter+digit department codes (S25–S29) in the LA department normalizer. The normalizer was unconditionally collapsing these codes to single letters (S27→S), destroying the distinction between Long Beach's distinct courtrooms.

Added optional `courthouse` parameter to normalize_department() and _normalize_la() to skip the collapse for Long Beach Courthouse. Updated worker.py to pass courthouse context. Added 30 parametrized regression tests covering all LB codes with 6 courthouse name variants.

Closes #3741

## Test plan

### Automated checks

- [x] Lint passes (`ruff check`)
- [x] Format check passes (`ruff format --check`)
- [x] Tests pass (`pytest` — 6891 tests, all green)
- [x] CI green

### Post-deploy verification

- [ ] `scripts/dev-db-query.sh` returns 0 for count of dept='S' LB rulings with Dept: S2x in source
- [ ] `scripts/dev-db-query.sh` returns distinct depts {S25, S27, S28, ...} for LB courthouses (no bare 'S')
- [ ] Verification evidence posted on #3741 (see /task-v2-verify output)