### PR TITLE
fix(infra): grant dispatcher task role ecr:DescribeImages for agent-runner image-freshness check (#3762)

### DIFF
--- a/infra/terraform/environments/dev/main.tf
+++ b/infra/terraform/environments/dev/main.tf
@@ -342,6 +342,7 @@ module "dispatcher_daemon" {
   agent_runner_task_role_arn          = module.dispatcher_agent_runner.task_role_arn
   agent_runner_subnet_ids             = module.networking.private_subnet_ids
   agent_runner_security_group_id      = module.dispatcher_agent_runner.security_group_id
+  agent_runner_ecr_repository_arn     = module.ecr.dispatcher_agent_runner_repository_arn
 }
 
 # ─── Dispatcher agent-runner task def (Stage 1b, #3090) ─────────────────────

--- a/infra/terraform/modules/dispatcher-daemon/main.tf
+++ b/infra/terraform/modules/dispatcher-daemon/main.tf
@@ -681,6 +681,21 @@ resource "aws_iam_role_policy" "task_launch_agent_runner" {
   })
 }
 
+resource "aws_iam_role_policy" "task_describe_agent_runner_image" {
+  count = var.agent_runner_ecr_repository_arn != "" ? 1 : 0
+  name  = "${local.service_name}-task-describe-agent-runner-image"
+  role  = aws_iam_role.task.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Sid      = "AllowDescribeAgentRunnerImage"
+      Effect   = "Allow"
+      Action   = "ecr:DescribeImages"
+      Resource = var.agent_runner_ecr_repository_arn
+    }]
+  })
+}
+
 # ─── ECS Task Definition ────────────────────────────────────────────────────
 # 1 vCPU / 2 GB RAM matches §14 of the spec. Ephemeral storage is pinned to
 # 50 GB per spike 0.6 (realistic mixed peak is ~10 GB across 5 concurrent

--- a/infra/terraform/modules/dispatcher-daemon/variables.tf
+++ b/infra/terraform/modules/dispatcher-daemon/variables.tf
@@ -243,6 +243,12 @@ variable "agent_runner_security_group_id" {
   default     = ""
 }
 
+variable "agent_runner_ecr_repository_arn" {
+  description = "ARN of the agent-runner ECR repository (judgemind/dispatcher-agent-runner). When set alongside agent_runner_task_definition_family, the daemon's task role is granted ecr:DescribeImages so _check_agent_runner_image_freshness (#3754) can resolve the latest pushed digest. Empty disables the grant — freshness check fails-open with the existing AccessDenied warning."
+  type        = string
+  default     = ""
+}
+
 # ─── Document-archive S3 census access (#3050) ──────────────────────────────
 
 variable "document_archive_bucket_arn" {

--- a/infra/terraform/modules/dispatcher-daemon/variables.tf
+++ b/infra/terraform/modules/dispatcher-daemon/variables.tf
@@ -244,7 +244,7 @@ variable "agent_runner_security_group_id" {
 }
 
 variable "agent_runner_ecr_repository_arn" {
-  description = "ARN of the agent-runner ECR repository (judgemind/dispatcher-agent-runner). When set alongside agent_runner_task_definition_family, the daemon's task role is granted ecr:DescribeImages so _check_agent_runner_image_freshness (#3754) can resolve the latest pushed digest. Empty disables the grant — freshness check fails-open with the existing AccessDenied warning."
+  description = "ARN of the agent-runner ECR repository (judgemind/dispatcher-agent-runner). When set alongside agent_runner_task_definition_family, the daemon's task role is granted ecr:DescribeImages so _check_agent_runner_image_freshness (#3754) can resolve the latest pushed digest. Empty disables the grant -- freshness check fails-open with the existing AccessDenied warning."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Summary

Added `ecr:DescribeImages` permission grant to the dispatcher task IAM role for the agent-runner ECR repository. This fixes the AccessDenied errors in `daemon.py::_check_agent_runner_image_freshness()` so the image freshness check can actually run and detect stale agent-runner deploys.

Closes #3762

## Test plan

### Automated checks

- [x] Terraform validation and formatting (pre-push hook)
- [x] CI green

### Post-deploy verification

- [ ] `agent_runner_image_freshness_check_failed` warnings drop to zero in `/ecs/judgemind-dispatcher-dev` CloudWatch Insights over 1 hour post-deployment
- [ ] Daemon emits `agent_runner_image_freshness_check_passed` event on next agent spawn (confirming freshness check runs end-to-end)